### PR TITLE
perf(guest-agent): prevent overdue heartbeat replay

### DIFF
--- a/crates/guest-agent/src/heartbeat.rs
+++ b/crates/guest-agent/src/heartbeat.rs
@@ -10,6 +10,7 @@ use crate::http::HttpClient;
 use guest_common::{log_error, log_info, log_warn};
 use serde_json::json;
 use std::time::Duration;
+use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
@@ -52,6 +53,8 @@ pub async fn heartbeat_loop_for_run_with_interval(
     let heartbeat_url = http.heartbeat_url()?;
 
     let mut interval = tokio::time::interval(interval);
+    // Drop timer debt after slow HTTP cycles and restore a full-period cadence.
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let mut is_first = true;
     let mut consecutive_failures: u32 = 0;
 

--- a/crates/guest-agent/tests/integration/heartbeat.rs
+++ b/crates/guest-agent/tests/integration/heartbeat.rs
@@ -9,22 +9,25 @@ use tokio_util::sync::CancellationToken;
 // Heartbeat
 // =========================================================================
 
-async fn wait_for_heartbeat_requests(
-    server: &crate::common::ControlledHttpServer,
-    expected: usize,
-) {
+async fn wait_for_count(count: impl Fn() -> usize, expected: usize, context: &str) {
     for _ in 0..1_000 {
-        if server.request_count() >= expected {
+        if count() >= expected {
             return;
         }
         tokio::task::yield_now().await;
     }
 
     assert!(
-        server.request_count() >= expected,
-        "expected at least {expected} heartbeat requests, observed {}",
-        server.request_count(),
+        count() >= expected,
+        "expected at least {expected} {context}, observed {}",
+        count(),
     );
+}
+
+async fn settle_runnable_tasks() {
+    for _ in 0..1_000 {
+        tokio::task::yield_now().await;
+    }
 }
 
 #[tokio::test]
@@ -110,7 +113,7 @@ async fn heartbeat_does_not_replay_overdue_ticks_after_slow_request() {
     });
 
     let started_at = Instant::now();
-    wait_for_heartbeat_requests(&server, 1).await;
+    wait_for_count(|| server.request_count(), 1, "heartbeat requests").await;
     let first_request = server
         .next_request(MOCK_CALL_TIMEOUT)
         .await
@@ -122,7 +125,7 @@ async fn heartbeat_does_not_replay_overdue_ticks_after_slow_request() {
         .respond(200)
         .expect("release slow initial heartbeat");
 
-    wait_for_heartbeat_requests(&server, 2).await;
+    wait_for_count(|| server.request_count(), 2, "heartbeat requests").await;
     let second_request = server
         .next_request(MOCK_CALL_TIMEOUT)
         .await
@@ -134,11 +137,21 @@ async fn heartbeat_does_not_replay_overdue_ticks_after_slow_request() {
     second_request
         .respond(200)
         .expect("complete overdue heartbeat");
+    wait_for_count(
+        || server.completed_response_count(),
+        2,
+        "completed heartbeat responses",
+    )
+    .await;
+    settle_runnable_tasks().await;
+    assert_eq!(
+        server.request_count(),
+        2,
+        "completing the overdue heartbeat must not replay another overdue tick"
+    );
 
     tokio::time::advance(INTERVAL - Duration::from_millis(1)).await;
-    for _ in 0..32 {
-        tokio::task::yield_now().await;
-    }
+    settle_runnable_tasks().await;
     assert_eq!(
         server.request_count(),
         2,
@@ -146,7 +159,7 @@ async fn heartbeat_does_not_replay_overdue_ticks_after_slow_request() {
     );
 
     tokio::time::advance(Duration::from_millis(1)).await;
-    wait_for_heartbeat_requests(&server, 3).await;
+    wait_for_count(|| server.request_count(), 3, "heartbeat requests").await;
     let third_request = server
         .next_request(MOCK_CALL_TIMEOUT)
         .await
@@ -160,6 +173,12 @@ async fn heartbeat_does_not_replay_overdue_ticks_after_slow_request() {
         .expect("complete resumed heartbeat");
 
     shutdown.cancel();
+    wait_for_count(
+        || usize::from(handle.is_finished()),
+        1,
+        "finished heartbeat tasks",
+    )
+    .await;
     let result = handle.await.expect("heartbeat task should not panic");
     clock_guard.abort();
     assert!(result.is_ok(), "heartbeat should stop cleanly: {result:?}");

--- a/crates/guest-agent/tests/integration/heartbeat.rs
+++ b/crates/guest-agent/tests/integration/heartbeat.rs
@@ -2,11 +2,30 @@ use crate::support::*;
 use httpmock::prelude::*;
 use serde_json::json;
 use std::time::Duration;
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 // =========================================================================
 // Heartbeat
 // =========================================================================
+
+async fn wait_for_heartbeat_requests(
+    server: &crate::common::ControlledHttpServer,
+    expected: usize,
+) {
+    for _ in 0..1_000 {
+        if server.request_count() >= expected {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    assert!(
+        server.request_count() >= expected,
+        "expected at least {expected} heartbeat requests, observed {}",
+        server.request_count(),
+    );
+}
 
 #[tokio::test]
 async fn heartbeat_first_success() {
@@ -55,6 +74,95 @@ async fn heartbeat_first_success() {
         .expect("initial-success heartbeat loop should stop after cancellation within 30 seconds")
         .expect("initial-success heartbeat task should not panic");
     assert!(result.is_ok());
+}
+
+#[tokio::test(start_paused = true)]
+async fn heartbeat_does_not_replay_overdue_ticks_after_slow_request() {
+    const INTERVAL: Duration = Duration::from_millis(20);
+    const SLOW_REQUEST_DURATION: Duration = Duration::from_millis(55);
+
+    let mut server = crate::common::ControlledHttpServer::start()
+        .await
+        .expect("start controlled heartbeat server");
+    let http = guest_agent::http::HttpClient::with_api_config(
+        server.base_url.clone(),
+        "test-token-abc123",
+        "test-bypass-value",
+        TEST_RUN_ID,
+        Duration::ZERO,
+    )
+    .expect("build heartbeat HTTP client");
+    let shutdown = CancellationToken::new();
+    let shutdown_clone = shutdown.clone();
+    let handle = tokio::spawn(async move {
+        guest_agent::heartbeat::heartbeat_loop_for_run_with_interval(
+            TEST_RUN_ID.to_string(),
+            http,
+            shutdown_clone,
+            INTERVAL,
+        )
+        .await
+    });
+    let clock_guard = tokio::spawn(async {
+        loop {
+            tokio::task::yield_now().await;
+        }
+    });
+
+    let started_at = Instant::now();
+    wait_for_heartbeat_requests(&server, 1).await;
+    let first_request = server
+        .next_request(MOCK_CALL_TIMEOUT)
+        .await
+        .expect("initial heartbeat should arrive immediately");
+    assert_eq!(Instant::now(), started_at);
+
+    tokio::time::advance(SLOW_REQUEST_DURATION).await;
+    first_request
+        .respond(200)
+        .expect("release slow initial heartbeat");
+
+    wait_for_heartbeat_requests(&server, 2).await;
+    let second_request = server
+        .next_request(MOCK_CALL_TIMEOUT)
+        .await
+        .expect("one overdue heartbeat should run after the slow request");
+    assert_eq!(
+        Instant::now().duration_since(started_at),
+        SLOW_REQUEST_DURATION
+    );
+    second_request
+        .respond(200)
+        .expect("complete overdue heartbeat");
+
+    tokio::time::advance(INTERVAL - Duration::from_millis(1)).await;
+    for _ in 0..32 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        server.request_count(),
+        2,
+        "the next heartbeat must wait a full interval instead of replaying another overdue tick"
+    );
+
+    tokio::time::advance(Duration::from_millis(1)).await;
+    wait_for_heartbeat_requests(&server, 3).await;
+    let third_request = server
+        .next_request(MOCK_CALL_TIMEOUT)
+        .await
+        .expect("heartbeat should resume after one full interval");
+    assert_eq!(
+        Instant::now().duration_since(started_at),
+        SLOW_REQUEST_DURATION + INTERVAL
+    );
+    third_request
+        .respond(200)
+        .expect("complete resumed heartbeat");
+
+    shutdown.cancel();
+    let result = handle.await.expect("heartbeat task should not panic");
+    clock_guard.abort();
+    assert!(result.is_ok(), "heartbeat should stop cleanly: {result:?}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- configure the Guest heartbeat interval with Tokio `MissedTickBehavior::Delay`
- discard accumulated timer debt after a slow HTTP cycle and restore a full-period cadence
- add a paused-time TCP integration regression that distinguishes `Delay` from both `Burst` and `Skip`

Closes #26773

## Behavior

The immediate initial heartbeat, healthy one-minute cadence, HTTP retry budget, consecutive-failure accounting, shutdown, and cancellation behavior are unchanged. When an HTTP cycle crosses interval deadlines, the loop still processes one overdue heartbeat immediately, then waits one complete interval before the next request instead of replaying accumulated ticks.

`Delay` is intentional rather than `Skip`: `Skip` can retain the original phase and schedule another request shortly after recovery, while `Delay` restores a full post-recovery interval.

## Compatibility

- no database schema or persisted-data changes
- no API, queue, Runner protocol, or Guest artifact contract changes
- no feature switch or rollout coordination required

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration heartbeat`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- repository pre-commit hooks: workspace Cargo fmt, rustdoc, Clippy, file-size check, and commitlint
