### PR TITLE
chore: remove unused vite_zero_host_domain env template entry

### DIFF
--- a/turbo/apps/platform/.env.local.tpl
+++ b/turbo/apps/platform/.env.local.tpl
@@ -4,7 +4,6 @@ VITE_CLERK_PUBLISHABLE_KEY_PREVIEW=op://Development/clerk/CLERK_PUBLISHABLE_KEY
 VITE_CLERK_PUBLISHABLE_KEY_PROD=
 VITE_API_URL=http://localhost:3000
 PUBLIC_ARTIFACTS_BASE_URL=https://cdn.vm7.io
-VITE_ZERO_HOST_DOMAIN=sites.vm7.io
 
 # Web Push (VAPID public key for push subscription)
 VITE_VAPID_PUBLIC_KEY_PREVIEW=op://Development/vapid/VAPID_PUBLIC_KEY


### PR DESCRIPTION
## Summary

Removes the dead `VITE_ZERO_HOST_DOMAIN=sites.vm7.io` entry from `turbo/apps/platform/.env.local.tpl`. It is a template-only leftover with no consumer anywhere in the repo.

## Why this is safe

- `rg -n 'VITE_ZERO_HOST_DOMAIN' --hidden -g '!.git'` returns exactly one hit — the template line itself. Nothing reads it.
- The platform host domain is **hardcoded, not env-driven**: `zeroHostDomain` in `turbo/apps/platform/src/lib/platform-host.ts` is a literal union `"sites.vm0.io" | "sites.vm7.io"` selected by runtime environment (`resolveZeroHostDomain`). Deleting the template entry cannot change behavior.
- `turbo/apps/platform` has no dynamic env access (`import.meta.env[...]` / `process.env[...]` indexing), so the static search above is conclusive.
- Vite only exposes `VITE_`-prefixed variables that code actually references; an unreferenced one is inert.
- `.env.local.tpl` files are consumed only by generic scripts (`scripts/sync-env.sh`, `scripts/fix-env-sync.sh`) that iterate over whatever entries are present, so no script depends on this specific key.

## Scope

One line deleted, nothing else. This change is **independent of the in-flight Okou branding migration** — no other `ZERO_`/`VM0_`/`OKOU_` variable is renamed or touched here; that migration owns those and has its own staging gates.
