### PR TITLE
fix(runner): avoid world-writable kvm access

### DIFF
--- a/.github/scripts/tests/provision-runner-kvm-test.sh
+++ b/.github/scripts/tests/provision-runner-kvm-test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+ansible_config="$repo_root/ansible/ansible.cfg"
+playbook="$repo_root/ansible/playbooks/provision-runner.yml"
+
+if ! command -v ansible-playbook >/dev/null; then
+  echo "ansible-playbook is required" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null; then
+  echo "python3 is required" >&2
+  exit 1
+fi
+
+ANSIBLE_CONFIG="$ansible_config" \
+  ANSIBLE_NOCOLOR=1 \
+  ansible-playbook \
+  -i "localhost," \
+  --connection=local \
+  --syntax-check \
+  -e "ansible_user=test" \
+  "$playbook" >/dev/null
+
+python3 - "$playbook" <<'PY'
+from pathlib import Path
+import sys
+
+import yaml
+
+playbook_path = Path(sys.argv[1])
+plays = yaml.safe_load(playbook_path.read_text(encoding="utf-8"))
+kvm_file_tasks = [
+    task["file"]
+    for play in plays
+    for task in play.get("tasks", [])
+    if isinstance(task.get("file"), dict) and task["file"].get("path") == "/dev/kvm"
+]
+
+if len(kvm_file_tasks) != 1:
+    raise SystemExit(f"expected exactly one /dev/kvm file task, got {len(kvm_file_tasks)}")
+
+actual = kvm_file_tasks[0]
+expected = {
+    "path": "/dev/kvm",
+    "owner": "root",
+    "group": "kvm",
+    "mode": "0660",
+}
+if actual != expected:
+    raise SystemExit(f"unexpected /dev/kvm file task: {actual!r}")
+PY
+
+echo "provision-runner-kvm-test: ok"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -264,6 +264,7 @@ jobs:
             .github/scripts/tests/download-verified-test.sh \
             .github/scripts/tests/fetch-okou-desktop-artifact-test.sh \
             .github/scripts/tests/okou-desktop-artifact-test.sh \
+            .github/scripts/tests/provision-runner-kvm-test.sh \
             .github/scripts/tests/release-tool-downloads-test.sh \
             .github/scripts/tests/resolve-desktop-version-change-test.sh \
             .github/scripts/tests/runner-promotion-ansible-test.sh \

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -2,7 +2,7 @@
 #
 # Idempotent playbook that installs all system-level dependencies required by
 # the VM0 runner on runner hosts. Safe to run repeatedly — all tasks use
-# idempotent operations (apt state=present, group append, chmod).
+# idempotent operations (apt state=present, group append, file metadata convergence).
 #
 # Usage:
 #   ansible-playbook -i "host1,host2," playbooks/provision-runner.yml \
@@ -123,7 +123,9 @@
     - name: Ensure /dev/kvm is accessible
       file:
         path: /dev/kvm
-        mode: '0666'
+        owner: root
+        group: kvm
+        mode: '0660'
       become: true
 
     # Write options BEFORE enabling auto-load so that a reboot between

--- a/crates/runner/src/cmd/setup/mod.rs
+++ b/crates/runner/src/cmd/setup/mod.rs
@@ -895,17 +895,27 @@ fn check_system_ca_bundle() -> RunnerResult<()> {
 }
 
 fn check_kvm() {
-    use std::fs::File;
+    let result = File::options()
+        .read(true)
+        .write(true)
+        .open("/dev/kvm")
+        .map(drop);
+    report_kvm_check(result);
+}
 
-    match File::options().read(true).write(true).open("/dev/kvm") {
-        Ok(_) => {
+fn report_kvm_check(result: std::io::Result<()>) {
+    match result {
+        Ok(()) => {
             tracing::info!("[OK] KVM accessible");
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             tracing::warn!("/dev/kvm not found — ensure bare-metal with KVM enabled");
         }
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-            tracing::warn!("/dev/kvm not accessible — run: sudo chmod 666 /dev/kvm");
+            tracing::warn!(
+                "/dev/kvm permission denied — expected root:kvm ownership with mode 0660; \
+                 verify device permissions and host/container KVM access: {e}"
+            );
         }
         Err(e) => {
             tracing::warn!("/dev/kvm check failed: {e}");
@@ -925,6 +935,37 @@ mod tests {
     use flate2::write::GzEncoder;
     use nix::sys::stat::Mode;
     use tokio::sync::oneshot;
+    use tracing::Level;
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::CapturedEvents;
+
+    #[test]
+    fn kvm_permission_denied_reports_least_privilege_guidance() {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::callsite::rebuild_interest_cache();
+            report_kvm_check(Err(std::io::Error::from(
+                std::io::ErrorKind::PermissionDenied,
+            )));
+        });
+
+        let events = captured.entries();
+        assert_eq!(events.len(), 1, "captured events: {events:#?}");
+        let event = &events[0];
+        assert_eq!(event.level, Level::WARN);
+        let message = event
+            .fields
+            .get("message")
+            .unwrap_or_else(|| panic!("missing message field; event={event:#?}"));
+        assert!(message.contains("root:kvm"));
+        assert!(message.contains("0660"));
+        assert!(message.contains("host/container KVM access"));
+        assert!(message.contains("permission denied"));
+        assert!(!message.contains("chmod 666"));
+        assert!(!message.contains("0666"));
+    }
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777


### PR DESCRIPTION
## Summary

- replace the runner setup diagnostic that recommended world-writable KVM access with least-privilege guidance
- converge `/dev/kvm` to `root:kvm` ownership and mode `0660` during runner host provisioning
- add CI regression coverage for the Ansible KVM file task and the Rust permission-denied diagnostic

## Compatibility and scope

- preserves setup's warning-only behavior for unavailable KVM access
- preserves the current root-runner service model and does not change runner protocols or persisted state
- does not restart runner services or mutate production hosts as part of this change
- a read-only check on `prod-3` confirmed the live device is already `root:kvm` with mode `0660`, while the root runner and active Firecracker processes retain KVM access

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features`
- `cd crates && cargo doc -p runner --all-features --no-deps`
- `cd crates && cargo test -p runner`
- `bash -n .github/scripts/tests/provision-runner-kvm-test.sh`
- `bash .github/scripts/tests/provision-runner-kvm-test.sh`
- parsed `.github/workflows/security.yml` with PyYAML

Local `shellcheck` and `actionlint` binaries were unavailable; the required PR workflow runs both checks.

Closes #26774
