### PR TITLE
test(e2e): isolate attachment continuation from sandbox reuse

### DIFF
--- a/e2e/tests/03-runner/run-t13-chat-attachments.bats
+++ b/e2e/tests/03-runner/run-t13-chat-attachments.bats
@@ -112,11 +112,17 @@ EOF
     local continuation_prompt
     continuation_prompt=$(cat <<'EOF'
 set -euo pipefail
-grep -F '__CONTENT_MARKER__' /tmp/runner-content.txt
-test ! -s /tmp/runner-empty.txt
+# Continuation can restore session history in a fresh sandbox, so re-download
+# the attachments instead of depending on runner-local files from the first run.
+npx --yes --package="${CLI_PKG_URL}" okou web download-file '__CONTENT_ID__' -o /tmp/runner-content-continuation.txt
+npx --yes --package="${CLI_PKG_URL}" okou web download-file '__EMPTY_ID__' -o /tmp/runner-empty-continuation.txt
+grep -F '__CONTENT_MARKER__' /tmp/runner-content-continuation.txt
+test ! -s /tmp/runner-empty-continuation.txt
 printf '__CONTINUATION_MARKER__\n'
 EOF
 )
+    continuation_prompt=${continuation_prompt//__CONTENT_ID__/$content_id}
+    continuation_prompt=${continuation_prompt//__EMPTY_ID__/$empty_id}
     continuation_prompt=${continuation_prompt//__CONTENT_MARKER__/$content_marker}
     continuation_prompt=${continuation_prompt//__CONTINUATION_MARKER__/$continuation_marker}
     run runner_e2e_continue_chat_run \


### PR DESCRIPTION
## Summary

- re-download the ordinary and empty attachments inside the continuation run
- verify their content in continuation-owned paths instead of reading files left by the previous sandbox
- retain the same-thread `agentSessionId` assertion

## Root cause

Classification: test isolation / persisted-state assumption.

[Turbo run 31665341467](https://github.com/vm0-ai/vm0/actions/runs/31665341467) failed in [runner E2E shard 4](https://github.com/vm0-ai/vm0/actions/runs/31665341467/job/94339332993). The first run downloaded both files successfully, but the continuation received a different sandbox (`fbef1e4b...` then `05934d80...`) while preserving the same application `agentSessionId`. The test then read `/tmp/runner-content.txt` without creating it in the continuation sandbox.

Same-thread runner reuse is an optimization: an idle-pool miss explicitly falls back to a fresh sandbox. Session continuation restores Pi's SQLite session history, not arbitrary runner-local `/tmp` files. The test therefore depended on a filesystem-affinity guarantee the product does not make.

The final marker timeout and `ci-gate-turbo` failure were consequences of the missing file. The first run's trailing shell syntax error occurred after `ATTACHMENTS_OK_*` because attachment context was appended to the mock shell prompt; it neither removed the file nor caused the continuation to receive a fresh sandbox.

The immediately preceding [PR-head shard](https://github.com/vm0-ai/vm0/actions/runs/31664957768/job/94338297599) passed when idle sandbox reuse happened to preserve the files. The triggering PR changed only Python firewall-auth code, and the failing merge SHA, PR head, merge-group base, and current `main` all contained the same Bats test blob.

## Product contract

The initial run still proves that ordinary and empty chat attachments can be downloaded through the canonical Okou CLI. The continuation now proves that the same uploaded files remain downloadable in the continued session, including when scheduling selects a fresh sandbox, while the existing assertion continues to verify application-session continuity.

## Validation

- `bats --count e2e/tests/03-runner/run-t13-chat-attachments.bats`
- `scripts/check-file-size.sh e2e/tests/03-runner/run-t13-chat-attachments.bats`
- `git diff --check`
- `okou web download-file` integration test: 4 tests passed in each of 5 independent Vitest runs
- [PR Turbo run 31666665125](https://github.com/vm0-ai/vm0/actions/runs/31666665125): passed, including `ci-gate-turbo`
- [deployed runner E2E shard](https://github.com/vm0-ai/vm0/actions/runs/31666665125/job/94343309415): `Okou CLI and chat attachments work across continuation` passed in 18.219 seconds against head `9e60fa76b5a7b7cfc451ccf7f6e6acdbc38fb482`
- actual App preview: https://pr-26799-app.omby.ai — authenticated chat loaded and `realAgentInPreview` was enabled ([chat screenshot](https://cdn.vm0.io/artifacts/gmt8x8rpyz.png), [Lab screenshot](https://cdn.vm0.io/artifacts/tmrno7k5xj.png))
- actual API preview: https://pr-26799-api.vm6.ai — the deployed API returned its application-level authentication response after the preview protection boundary ([screenshot](https://cdn.vm0.io/artifacts/ngihcnusmj.png))

The runner Bats suite is documented as CI-only and provisions the App, API, CLI, and runner services, so the deployed end-to-end check was not independently re-run five times. The non-service download-file regression test was run as five separate processes instead; all five passed.

Trigger: https://github.com/vm0-ai/vm0/actions/runs/31665341467

TURBO_FLAKY_KEY: `cli-e2e-runner-run-t13-chat-attachments-continuation-tmp-files-missing`
