### PR TITLE
test(api): isolate chat event snapshot cron fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -1,18 +1,18 @@
 import { createHash, randomUUID } from "node:crypto";
 import { gunzipSync } from "node:zlib";
 
-import {
-  cronProjectChatEventSearchContract,
-  cronSnapshotChatEventsContract,
-} from "@vm0/api-contracts/contracts/cron";
+import { cronSnapshotChatEventsContract } from "@vm0/api-contracts/contracts/cron";
+import { testChatEventSearchProjectionContract } from "@vm0/api-contracts/contracts/test-chat-event-search-projection";
+import { testChatEventSnapshotContract } from "@vm0/api-contracts/contracts/test-chat-event-snapshot";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import { createDeferredPromise } from "../../utils";
-import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
 import { cronSnapshotChatEventsRoutes } from "../cron-snapshot-chat-events";
+import { testChatEventSearchProjectionRoutes } from "../test-chat-event-search-projection";
+import { testChatEventSnapshotRoutes } from "../test-chat-event-snapshot";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
@@ -33,7 +33,6 @@ const bdd = createBddApi(context);
 const api = createRunsApi(context);
 const chat = createChatFilesBddApi(context);
 
-const CRON_SECRET = "test-cron-secret";
 const RETIRED_ARCHIVE_SCHEMA_VERSION = 1;
 const PREVIOUS_ARCHIVE_SCHEMA_VERSION = 4;
 const OBJECT_KEY_PATTERN =
@@ -47,25 +46,36 @@ function snapshotCronClient() {
   );
 }
 
-async function runSnapshotCron() {
+async function runSnapshotCron(
+  chatThreadIds: readonly string[],
+  r2ObjectKeys: readonly string[] = [],
+) {
+  const client = setupApp({
+    context,
+    routes: testChatEventSnapshotRoutes,
+  })(testChatEventSnapshotContract);
   const response = await accept(
-    snapshotCronClient().snapshot({
-      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    client.snapshot({
+      body: {
+        chat_thread_ids: [...chatThreadIds],
+        r2_object_keys: [...r2ObjectKeys],
+      },
     }),
     [200],
   );
   return response.body;
 }
 
-async function projectChatEventSearch(): Promise<void> {
+async function projectChatEventSearch(...chatThreadIds: readonly string[]) {
   const client = setupApp({
     context,
-    routes: cronProjectChatEventSearchRoutes,
-  })(cronProjectChatEventSearchContract);
-  await accept(
-    client.project({ headers: { authorization: `Bearer ${CRON_SECRET}` } }),
+    routes: testChatEventSearchProjectionRoutes,
+  })(testChatEventSearchProjectionContract);
+  const response = await accept(
+    client.project({ body: { chat_thread_ids: [...chatThreadIds] } }),
     [200],
   );
+  return response.body;
 }
 
 async function sendNoCreditMessage(
@@ -160,10 +170,6 @@ describe("cron snapshot chat events", () => {
   beforeEach(() => {
     installFakeChatEventR2(context, recordedPuts);
     recordedPuts.length = 0;
-    // Drain every candidate thread in the shared test database in one pass so
-    // assertions about this file's threads never depend on batch ordering.
-    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_BATCH_SIZE", "10000");
-    mockOptionalEnv("CHAT_EVENT_SEARCH_PROJECTION_BATCH_SIZE", "10000");
   });
 
   it("requires the cron secret", async () => {
@@ -193,9 +199,9 @@ describe("cron snapshot chat events", () => {
       threadId,
       prompt: `${marker} second`,
     });
-    await projectChatEventSearch();
+    await projectChatEventSearch(threadId);
 
-    const first = await runSnapshotCron();
+    const first = await runSnapshotCron([threadId]);
     expect(first.success).toBeTruthy();
     expect(first.snapshots).toBeGreaterThanOrEqual(1);
 
@@ -214,7 +220,7 @@ describe("cron snapshot chat events", () => {
     expect(firstHead.object_key).toBe(firstPut.key);
 
     // Nothing new to archive: the same pass again must not touch the thread.
-    await runSnapshotCron();
+    await runSnapshotCron([threadId]);
     expect(putsForThread(threadId)).toHaveLength(1);
 
     // A new Postgres tail beyond the projected watermark triggers another
@@ -225,8 +231,8 @@ describe("cron snapshot chat events", () => {
       threadId,
       prompt: `${marker} third`,
     });
-    await projectChatEventSearch();
-    const second = await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    const second = await runSnapshotCron([threadId]);
     expect(second.success).toBeTruthy();
 
     const secondPuts = putsForThread(threadId);
@@ -245,8 +251,33 @@ describe("cron snapshot chat events", () => {
     expect(secondHead.archive_schema_version).toBe(5);
     expect(secondHead.object_key).toBe(secondPut.key);
 
-    await runSnapshotCron();
+    await runSnapshotCron([threadId]);
     expect(putsForThread(threadId)).toHaveLength(2);
+  }, 60_000);
+
+  it("limits projection and snapshots to explicitly owned threads", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Scoped snapshot agent",
+    });
+    const ownedThreadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `scoped-snapshot-owned-${randomUUID()}`,
+    });
+    const unownedThreadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `scoped-snapshot-unowned-${randomUUID()}`,
+    });
+
+    const projection = await projectChatEventSearch(ownedThreadId);
+    expect(projection.threads).toBe(1);
+    const snapshot = await runSnapshotCron([ownedThreadId]);
+    expect(snapshot.snapshots).toBe(1);
+    expect(putsForThread(ownedThreadId)).toHaveLength(1);
+    expect(putsForThread(unownedThreadId)).toHaveLength(0);
+
+    const unownedRows = await chat.listThreadEventRows(owner, unownedThreadId);
+    expect(unownedRows.length).toBeGreaterThan(0);
   }, 60_000);
 
   it("publishes sparse indexed coverage and tails later rows", async () => {
@@ -266,8 +297,8 @@ describe("cron snapshot chat events", () => {
     const coveredSeqId = lastPhysicalRow.seqId + 1;
 
     await advanceChatEventSequenceAsPreviousApi(context, threadId, 1);
-    await projectChatEventSearch();
-    const result = await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    const result = await runSnapshotCron([threadId]);
     expect(result.success).toBeTruthy();
 
     const put = putsForThread(threadId)[0];
@@ -307,8 +338,8 @@ describe("cron snapshot chat events", () => {
       agentId: agent.agentId,
       prompt: `version-only-${randomUUID()}`,
     });
-    await projectChatEventSearch();
-    await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    await runSnapshotCron([threadId]);
 
     const firstPut = putsForThread(threadId)[0];
     if (firstPut === undefined) {
@@ -321,7 +352,7 @@ describe("cron snapshot chat events", () => {
       PREVIOUS_ARCHIVE_SCHEMA_VERSION,
     );
 
-    const rebuilt = await runSnapshotCron();
+    const rebuilt = await runSnapshotCron([threadId]);
     expect(rebuilt.success).toBeTruthy();
     expect(rebuilt.nonV4SnapshotHeads).toBe(0);
     expect(putsForThread(threadId)).toHaveLength(2);
@@ -333,7 +364,7 @@ describe("cron snapshot chat events", () => {
     expect(rebuiltHead.object_key).toBe(firstPut.key);
     expect(rebuiltHead.snapshot_count).toBe(firstHead.snapshot_count);
 
-    await runSnapshotCron();
+    await runSnapshotCron([threadId]);
     expect(putsForThread(threadId)).toHaveLength(2);
   }, 60_000);
 
@@ -347,8 +378,8 @@ describe("cron snapshot chat events", () => {
       agentId: agent.agentId,
       prompt: `corruption-${randomUUID()}`,
     });
-    await projectChatEventSearch();
-    await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    await runSnapshotCron([threadId]);
 
     const headPut = putsForThread(threadId)[0];
     if (headPut === undefined) {
@@ -367,8 +398,8 @@ describe("cron snapshot chat events", () => {
       threadId,
       prompt: `corruption-tail-${randomUUID()}`,
     });
-    await projectChatEventSearch();
-    const rebuilt = await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    const rebuilt = await runSnapshotCron([threadId]);
     expect(rebuilt.success).toBeTruthy();
     expect(rebuilt.unreadableParents).toBeGreaterThanOrEqual(1);
     expect(putsForThread(threadId)).toHaveLength(2);
@@ -389,8 +420,8 @@ describe("cron snapshot chat events", () => {
         });
       }),
     );
-    await projectChatEventSearch();
-    await runSnapshotCron();
+    await projectChatEventSearch(...threadIds);
+    await runSnapshotCron(threadIds);
 
     const retiredObjectKeys: string[] = [];
     for (const threadId of threadIds) {
@@ -411,7 +442,7 @@ describe("cron snapshot chat events", () => {
     }
 
     mockOptionalEnv("CHAT_EVENT_SNAPSHOT_BATCH_SIZE", "1");
-    const firstPass = await runSnapshotCron();
+    const firstPass = await runSnapshotCron(threadIds);
     expect(firstPass).toMatchObject({
       snapshots: 1,
       nonV4SnapshotHeads: 0,
@@ -423,7 +454,7 @@ describe("cron snapshot chat events", () => {
       expect(readFakeChatEventObject(objectKey)).toBeUndefined();
     }
 
-    const secondPass = await runSnapshotCron();
+    const secondPass = await runSnapshotCron(threadIds);
     expect(secondPass).toMatchObject({
       snapshots: 1,
       nonV4SnapshotHeads: 0,
@@ -443,8 +474,8 @@ describe("cron snapshot chat events", () => {
       agentId: agent.agentId,
       prompt: `snapshot-cas-${randomUUID()}`,
     });
-    await projectChatEventSearch();
-    await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    await runSnapshotCron([threadId]);
     const parentHead = await readChatEventSnapshotHead(context, threadId);
 
     await sendNoCreditMessage(owner, {
@@ -452,7 +483,7 @@ describe("cron snapshot chat events", () => {
       threadId,
       prompt: `snapshot-cas-tail-${randomUUID()}`,
     });
-    await projectChatEventSearch();
+    await projectChatEventSearch(threadId);
 
     const publicationGate = createDeferredPromise<void>(context.signal);
     let arrivals = 0;
@@ -467,11 +498,12 @@ describe("cron snapshot chat events", () => {
       await publicationGate.promise;
     });
 
-    await Promise.all([runSnapshotCron(), runSnapshotCron()]);
+    await Promise.all([
+      runSnapshotCron([threadId]),
+      runSnapshotCron([threadId]),
+    ]);
     expect(arrivals).toBe(2);
     const head = await readChatEventSnapshotHead(context, threadId);
-    // Cron result counts cover every candidate in the shared test database;
-    // the persisted generation count scopes the CAS assertion to this thread.
     expect(head.snapshot_count).toBe(parentHead.snapshot_count + 1);
     expect(head.archive_schema_version).toBe(5);
     expect(head.last_seq_id).toBeGreaterThan(parentHead.last_seq_id);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
@@ -7,18 +7,15 @@ import {
   chatThreadEventsContract,
   type UserMessageDocument,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import {
-  cronProjectChatEventSearchContract,
-  cronSnapshotChatEventsContract,
-} from "@vm0/api-contracts/contracts/cron";
+import { testChatEventSearchProjectionContract } from "@vm0/api-contracts/contracts/test-chat-event-search-projection";
+import { testChatEventSnapshotContract } from "@vm0/api-contracts/contracts/test-chat-event-snapshot";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now } from "../../../lib/time";
-import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
-import { cronSnapshotChatEventsRoutes } from "../cron-snapshot-chat-events";
+import { testChatEventSearchProjectionRoutes } from "../test-chat-event-search-projection";
+import { testChatEventSnapshotRoutes } from "../test-chat-event-snapshot";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
@@ -49,7 +46,6 @@ const trackFakeChatEventObject = createFixtureTracker(
   deleteFakeChatEventObject,
 );
 
-const CRON_SECRET = "test-cron-secret";
 const R2_GC_SLOT_MS = 10 * 60 * 1000;
 const R2_GC_SHARD_GROUP_COUNT = 16 ** 2;
 
@@ -85,24 +81,35 @@ function eventsClient() {
   );
 }
 
-async function runSnapshotCron() {
-  const client = setupApp({ context, routes: cronSnapshotChatEventsRoutes })(
-    cronSnapshotChatEventsContract,
-  );
+async function runSnapshotCron(
+  chatThreadIds: readonly string[],
+  r2ObjectKeys: readonly string[] = [],
+) {
+  const client = setupApp({
+    context,
+    routes: testChatEventSnapshotRoutes,
+  })(testChatEventSnapshotContract);
   const response = await accept(
-    client.snapshot({ headers: { authorization: `Bearer ${CRON_SECRET}` } }),
+    client.snapshot({
+      body: {
+        chat_thread_ids: [...chatThreadIds],
+        r2_object_keys: [...r2ObjectKeys],
+      },
+    }),
     [200],
   );
   return response.body;
 }
 
-async function projectChatEventSearch(): Promise<void> {
+async function projectChatEventSearch(
+  ...chatThreadIds: readonly string[]
+): Promise<void> {
   const client = setupApp({
     context,
-    routes: cronProjectChatEventSearchRoutes,
-  })(cronProjectChatEventSearchContract);
+    routes: testChatEventSearchProjectionRoutes,
+  })(testChatEventSearchProjectionContract);
   await accept(
-    client.project({ headers: { authorization: `Bearer ${CRON_SECRET}` } }),
+    client.project({ body: { chat_thread_ids: [...chatThreadIds] } }),
     [200],
   );
 }
@@ -142,10 +149,6 @@ async function replaceHeadWithRetiredVersion(
 describe("chat event snapshot read endpoints", () => {
   beforeEach(() => {
     installFakeChatEventR2(context);
-    // Drain every candidate thread in the shared test database in one pass so
-    // assertions about this file's threads never depend on batch ordering.
-    mockOptionalEnv("CHAT_EVENT_SNAPSHOT_BATCH_SIZE", "10000");
-    mockOptionalEnv("CHAT_EVENT_SEARCH_PROJECTION_BATCH_SIZE", "10000");
   });
 
   it("serves a presigned download only for a current-version head", async () => {
@@ -184,8 +187,8 @@ describe("chat event snapshot read endpoints", () => {
       },
     });
 
-    await projectChatEventSearch();
-    await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    await runSnapshotCron([threadId]);
     const head = await readChatEventSnapshotHead(context, threadId);
 
     const download = await accept(
@@ -406,11 +409,11 @@ describe("chat event snapshot read endpoints", () => {
       prompt: `snapshot-version-retirement-${randomUUID()}`,
     });
 
-    await projectChatEventSearch();
-    await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    await runSnapshotCron([threadId]);
     const retiredKey = await replaceHeadWithRetiredVersion(threadId);
 
-    const retired = await runSnapshotCron();
+    const retired = await runSnapshotCron([threadId]);
     expect(retired.retiredSnapshotReferencesDeleted).toBeGreaterThanOrEqual(1);
     expect(readFakeChatEventObject(retiredKey)).toBeUndefined();
     const current = await readChatEventSnapshotHead(context, threadId);
@@ -430,14 +433,14 @@ describe("chat event snapshot read endpoints", () => {
       prompt: `snapshot-best-effort-${randomUUID()}`,
     });
 
-    await projectChatEventSearch();
-    await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    await runSnapshotCron([threadId]);
     const retiredKey = await replaceHeadWithRetiredVersion(threadId);
     installFakeChatEventR2(context, undefined, undefined, () => {
       return Promise.reject(new Error("R2 delete unavailable"));
     });
 
-    const retired = await runSnapshotCron();
+    const retired = await runSnapshotCron([threadId]);
     expect(retired.retiredSnapshotReferencesDeleted).toBeGreaterThanOrEqual(1);
     expect(readFakeChatEventObject(retiredKey)).toBeDefined();
     const current = await readChatEventSnapshotHead(context, threadId);
@@ -457,9 +460,8 @@ describe("chat event snapshot read endpoints", () => {
       prompt: `snapshot-maintenance-${randomUUID()}`,
     });
 
-    await projectChatEventSearch();
-    // The cron scope is global, so only this thread's own head is asserted.
-    await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    await runSnapshotCron([threadId]);
 
     const head = await readChatEventSnapshotHead(context, threadId);
     expect(readFakeChatEventObject(head.object_key)).toBeDefined();
@@ -472,7 +474,7 @@ describe("chat event snapshot read endpoints", () => {
       head.object_key,
       new Date(future.getTime() - 8 * 24 * 60 * 60 * 1000),
     );
-    const protectedHead = await runSnapshotCron();
+    const protectedHead = await runSnapshotCron([threadId], [head.object_key]);
     expect(protectedHead.r2ObjectsDeleted).toBe(0);
     expect(readFakeChatEventObject(head.object_key)).toBeDefined();
 
@@ -483,7 +485,7 @@ describe("chat event snapshot read endpoints", () => {
       orphanKey,
       new Date(future.getTime() - 8 * 24 * 60 * 60 * 1000),
     );
-    const orphanGc = await runSnapshotCron();
+    const orphanGc = await runSnapshotCron([threadId], [orphanKey]);
     expect(orphanGc).toMatchObject({
       r2ObjectsMeasured: 1,
       r2ObjectsDeleted: 1,
@@ -495,8 +497,8 @@ describe("chat event snapshot read endpoints", () => {
       threadId,
       prompt: `snapshot-replacement-${randomUUID()}`,
     });
-    await projectChatEventSearch();
-    const replacement = await runSnapshotCron();
+    await projectChatEventSearch(threadId);
+    const replacement = await runSnapshotCron([threadId], [head.object_key]);
     expect(replacement.r2ObjectsDeleted).toBe(1);
     expect(readFakeChatEventObject(head.object_key)).toBeUndefined();
     const newHead = await readChatEventSnapshotHead(context, threadId);
@@ -520,7 +522,7 @@ describe("chat event snapshot read endpoints", () => {
       new Date(now() + 8 * 24 * 60 * 60 * 1000),
     );
 
-    const result = await runSnapshotCron();
+    const result = await runSnapshotCron([], keys);
 
     expect(
       result.retiredSnapshotReferencesDeleted + result.r2ObjectsDeleted,

--- a/turbo/apps/api/src/signals/routes/cron-snapshot-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/cron-snapshot-chat-events.ts
@@ -11,7 +11,7 @@ const snapshotChatEventsRoute$ = command(
       return cronUnauthorized();
     }
 
-    const result = await set(snapshotChatEvents$, signal);
+    const result = await set(snapshotChatEvents$, { kind: "global" }, signal);
     signal.throwIfAborted();
     return {
       status: 200 as const,

--- a/turbo/apps/api/src/signals/routes/test-chat-event-snapshot.ts
+++ b/turbo/apps/api/src/signals/routes/test-chat-event-snapshot.ts
@@ -1,0 +1,47 @@
+import { testChatEventSnapshotContract } from "@vm0/api-contracts/contracts/test-chat-event-snapshot";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { snapshotChatEvents$ } from "../services/cron-snapshot-chat-events.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const snapshotBody$ = bodyResultOf(testChatEventSnapshotContract.snapshot);
+
+const snapshotChatEventFixturesRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(snapshotBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    const result = await set(
+      snapshotChatEvents$,
+      {
+        kind: "fixtures",
+        chatThreadIds: bodyResult.data.chat_thread_ids,
+        r2ObjectKeys: bodyResult.data.r2_object_keys,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    return {
+      status: 200 as const,
+      body: { success: true as const, ...result },
+    };
+  },
+);
+
+export const testChatEventSnapshotRoutes: readonly RouteEntry[] = [
+  {
+    route: testChatEventSnapshotContract.snapshot,
+    handler: snapshotChatEventFixturesRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -68,6 +68,14 @@ interface ChatEventSnapshotConvergence {
   readonly snapshotHeadVersions: readonly ChatEventSnapshotHeadVersion[];
 }
 
+type ChatEventSnapshotScope =
+  | { readonly kind: "global" }
+  | {
+      readonly kind: "fixtures";
+      readonly chatThreadIds: readonly string[];
+      readonly r2ObjectKeys: readonly string[];
+    };
+
 interface SnapshotCandidate {
   readonly chatThreadId: string;
   readonly indexedSeqId: number;
@@ -470,6 +478,7 @@ async function archiveThread(
 
 async function chatEventSnapshotConvergence(
   db: Db,
+  chatThreadIds: readonly string[] | null,
 ): Promise<ChatEventSnapshotConvergence> {
   const versions = await db
     .select({
@@ -477,7 +486,14 @@ async function chatEventSnapshotConvergence(
       heads: count(),
     })
     .from(chatEventSnapshots)
-    .where(eq(chatEventSnapshots.isHead, true))
+    .where(
+      and(
+        eq(chatEventSnapshots.isHead, true),
+        chatThreadIds === null
+          ? undefined
+          : inArray(chatEventSnapshots.chatThreadId, chatThreadIds),
+      ),
+    )
     .groupBy(chatEventSnapshots.archiveSchemaVersion)
     .orderBy(asc(chatEventSnapshots.archiveSchemaVersion));
   const snapshotHeads = versions.reduce((total, version) => {
@@ -505,9 +521,19 @@ interface R2GcStats {
   readonly subpartitionedShards: number;
 }
 
+interface R2GcOptions {
+  readonly deleteQuota: number;
+  readonly ownedObjectKeys: ReadonlySet<string> | null;
+}
+
 interface RetiredSnapshotVersionGcStats {
   readonly selected: number;
   readonly referencesDeleted: number;
+}
+
+interface RetiredSnapshotVersionGcOptions {
+  readonly deleteQuota: number;
+  readonly chatThreadIds: readonly string[] | null;
 }
 
 const deleteRetiredSnapshotVersions$ = command(
@@ -515,7 +541,7 @@ const deleteRetiredSnapshotVersions$ = command(
     { get },
     db: Db,
     bucket: string,
-    deleteQuota: number,
+    options: RetiredSnapshotVersionGcOptions,
     signal: AbortSignal,
   ): Promise<RetiredSnapshotVersionGcStats> => {
     const candidates = await db
@@ -525,12 +551,17 @@ const deleteRetiredSnapshotVersions$ = command(
       })
       .from(chatEventSnapshots)
       .where(
-        lt(
-          chatEventSnapshots.archiveSchemaVersion,
-          MIN_SUPPORTED_ARCHIVE_SCHEMA_VERSION,
+        and(
+          lt(
+            chatEventSnapshots.archiveSchemaVersion,
+            MIN_SUPPORTED_ARCHIVE_SCHEMA_VERSION,
+          ),
+          options.chatThreadIds === null
+            ? undefined
+            : inArray(chatEventSnapshots.chatThreadId, options.chatThreadIds),
         ),
       )
-      .limit(deleteQuota);
+      .limit(options.deleteQuota);
     signal.throwIfAborted();
     if (candidates.length === 0) {
       return { selected: 0, referencesDeleted: 0 };
@@ -607,7 +638,7 @@ async function collectR2SnapshotGarbage(
   get: ComputedGetter,
   db: Db,
   bucket: string,
-  deleteQuota: number,
+  options: R2GcOptions,
   signal: AbortSignal,
 ): Promise<R2GcStats> {
   const now = nowDate();
@@ -619,9 +650,10 @@ async function collectR2SnapshotGarbage(
   let bytesDeleted = 0;
   let shardsScanned = 0;
   let subpartitionedShards = 0;
-  let remainingDeleteQuota = deleteQuota;
+  let remainingDeleteQuota = options.deleteQuota;
+  const ownedObjectKeys = options.ownedObjectKeys;
 
-  if (remainingDeleteQuota === 0) {
+  if (remainingDeleteQuota === 0 || ownedObjectKeys?.size === 0) {
     return {
       scanned,
       measured,
@@ -641,8 +673,14 @@ async function collectR2SnapshotGarbage(
       subpartitionedShards += 1;
     }
     for (const objects of pages) {
-      scanned += objects.length;
-      const oldObjects = objects.filter((object) => {
+      const scopedObjects =
+        ownedObjectKeys === null
+          ? objects
+          : objects.filter((object) => {
+              return ownedObjectKeys.has(object.key);
+            });
+      scanned += scopedObjects.length;
+      const oldObjects = scopedObjects.filter((object) => {
         return object.lastModified < olderThan;
       });
       if (oldObjects.length === 0) {
@@ -735,10 +773,14 @@ async function collectR2SnapshotGarbage(
 export const snapshotChatEvents$ = command(
   async (
     { get, set },
+    scope: ChatEventSnapshotScope,
     signal: AbortSignal,
   ): Promise<ChatEventSnapshotStats> => {
     const db = set(writeDb$);
     const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const chatThreadIds = scope.kind === "global" ? null : scope.chatThreadIds;
+    const ownedObjectKeys =
+      scope.kind === "global" ? null : new Set(scope.r2ObjectKeys);
     const candidates = await db
       .select({
         chatThreadId: chatThreads.id,
@@ -765,6 +807,9 @@ export const snapshotChatEvents$ = command(
       // are reported by the convergence check instead of being overwritten.
       .where(
         and(
+          chatThreadIds === null
+            ? undefined
+            : inArray(chatThreads.id, chatThreadIds),
           or(
             isNull(chatEventSnapshots.archiveSchemaVersion),
             lte(
@@ -807,17 +852,23 @@ export const snapshotChatEvents$ = command(
       deleteRetiredSnapshotVersions$,
       db,
       bucket,
-      SNAPSHOT_GC_DELETE_QUOTA,
+      {
+        deleteQuota: SNAPSHOT_GC_DELETE_QUOTA,
+        chatThreadIds,
+      },
       signal,
     );
     signal.throwIfAborted();
-    const convergence = await chatEventSnapshotConvergence(db);
+    const convergence = await chatEventSnapshotConvergence(db, chatThreadIds);
     signal.throwIfAborted();
     const r2Gc = await collectR2SnapshotGarbage(
       get,
       db,
       bucket,
-      SNAPSHOT_GC_DELETE_QUOTA - retiredSnapshots.selected,
+      {
+        deleteQuota: SNAPSHOT_GC_DELETE_QUOTA - retiredSnapshots.selected,
+        ownedObjectKeys,
+      },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -598,6 +598,7 @@ export {
   cleanupResultSchema,
   cleanupResponseSchema,
   cronCompactChatThreadSnapshotsResponseSchema,
+  cronSnapshotChatEventsResponseSchema,
   cronProcessUsageEventsResponseSchema,
   cronReconcileBillingEntitlementsResponseSchema,
   cronTelegramCleanupResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -393,6 +393,11 @@ export {
   type TestCronCleanupSandboxesStateContract,
 } from "./test-cron-cleanup-sandboxes-state";
 export {
+  testChatEventSnapshotBodySchema,
+  testChatEventSnapshotContract,
+  type TestChatEventSnapshotContract,
+} from "./test-chat-event-snapshot";
+export {
   testSlackStateContract,
   testSlackStateErrorSchema,
   testSlackStateResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-chat-event-snapshot.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-chat-event-snapshot.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import { cronSnapshotChatEventsResponseSchema } from "./cron";
+
+const c = initContract();
+
+export const testChatEventSnapshotBodySchema = z.object({
+  chat_thread_ids: z.array(z.uuid()).max(100),
+  r2_object_keys: z.array(z.string().min(1)).max(2000),
+});
+
+export const testChatEventSnapshotContract = c.router({
+  snapshot: {
+    method: "POST",
+    path: "/api/test/snapshot-chat-events",
+    body: testChatEventSnapshotBodySchema,
+    responses: {
+      200: cronSnapshotChatEventsResponseSchema,
+      404: z.string(),
+    },
+    summary: "Snapshot explicitly owned chat event test fixtures",
+  },
+});
+
+export type TestChatEventSnapshotContract =
+  typeof testChatEventSnapshotContract;


### PR DESCRIPTION
## Summary

- add a test-only snapshot route that scopes chat event snapshot candidates, retired-version cleanup, convergence metrics, and R2 garbage collection to explicitly owned fixtures
- keep the production snapshot cron global while reusing the existing fixture-scoped search projection route
- migrate snapshot suites away from global 10,000-row sweeps and add an owned/unowned regression that preserves raw cursor reads for unrelated threads

## Root cause

Turbo run [31664211488](https://github.com/vm0-ai/vm0/actions/runs/31664211488) failed in [test-api (5)](https://github.com/vm0-ai/vm0/actions/runs/31664211488/job/94335263599) because a concurrent snapshot test globally projected and snapshotted the workflow queue test's thread. The queue test then read raw rows from `sinceSeqId=0` and correctly received `410 CHAT_EVENTS_EXPIRED`. The triggering change was CLI-only, and the same shard passed on the source PR head.

## Verification

- `pnpm format`
- `pnpm --filter @vm0/api-contracts lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- after rebasing onto current `main`: `pnpm --filter @vm0/api-contracts check-types` and `pnpm --filter api check-types`
- `git diff --check origin/main...HEAD`

Targeted API integration files were not run locally because PostgreSQL was unavailable at `localhost:5432`; PR CI provides the required database-backed test environment.
