### PR TITLE
feat(api): show source run on chat-run-finished automations

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
@@ -236,6 +236,63 @@ async function expectAutomationFired(automationId: string): Promise<void> {
     .toBeTruthy();
 }
 
+async function expectAutomationSourceAnnotation(
+  fixture: ChatAutomationFixture,
+  automationId: string,
+  sourceRun: { readonly runId: string; readonly threadId: string },
+): Promise<void> {
+  const automation = await accept(
+    automationsClient().get({
+      headers: authHeaders(),
+      params: { id: automationId },
+    }),
+    [200],
+  );
+  const automationThreadId = automation.body.chatThreadId;
+  if (!automationThreadId) {
+    throw new Error("Expected the automation chat thread");
+  }
+  const automationRun = await readLatestWorkflowAutomationRunFixture(
+    context,
+    automationId,
+  );
+  if (!automationRun) {
+    throw new Error("Expected the triggered automation run");
+  }
+  const automationEvents = await chat.listThreadEvents(
+    fixture.actor,
+    automationThreadId,
+  );
+  const automationInput = automationEvents.events.find((event) => {
+    return (
+      event.eventType === "input.prompt" && event.runId === automationRun.runId
+    );
+  });
+  if (!automationInput || automationInput.eventType !== "input.prompt") {
+    throw new Error("Expected the triggered automation input");
+  }
+  expect(
+    automationInput.userMessage.parts.filter((part) => {
+      return (
+        part.type === "source" ||
+        part.type === "automation" ||
+        part.type === "goal" ||
+        part.type === "morning_brief"
+      );
+    }),
+  ).toStrictEqual([
+    {
+      type: "source",
+      kind: "agent",
+      runId: sourceRun.runId,
+      threadId: sourceRun.threadId,
+      agentId: fixture.agentId,
+      titleSnapshot: WATCHED_THREAD_TITLE,
+      href: `/chats/${sourceRun.threadId}#run-${sourceRun.runId}`,
+    },
+  ]);
+}
+
 describe("chat-run-finished workflow automations", () => {
   it("requires the watched chat thread to belong to the automation owner", async () => {
     const fixture = await setupChatAutomationFixture();
@@ -391,57 +448,7 @@ describe("chat-run-finished workflow automations", () => {
         readLatestWorkflowAutomationRunFixture(context, patternMatch),
       ).resolves.toMatchObject({ autonomyBudget: 1 });
 
-      const fireAlwaysAutomation = await accept(
-        automationsClient().get({
-          headers: authHeaders(),
-          params: { id: fireAlways },
-        }),
-        [200],
-      );
-      const automationThreadId = fireAlwaysAutomation.body.chatThreadId;
-      if (!automationThreadId) {
-        throw new Error("Expected the automation chat thread");
-      }
-      const automationRun = await readLatestWorkflowAutomationRunFixture(
-        context,
-        fireAlways,
-      );
-      if (!automationRun) {
-        throw new Error("Expected the triggered automation run");
-      }
-      const automationEvents = await chat.listThreadEvents(
-        fixture.actor,
-        automationThreadId,
-      );
-      const automationInput = automationEvents.events.find((event) => {
-        return (
-          event.eventType === "input.prompt" &&
-          event.runId === automationRun.runId
-        );
-      });
-      if (!automationInput || automationInput.eventType !== "input.prompt") {
-        throw new Error("Expected the triggered automation input");
-      }
-      expect(
-        automationInput.userMessage.parts.filter((part) => {
-          return (
-            part.type === "source" ||
-            part.type === "automation" ||
-            part.type === "goal" ||
-            part.type === "morning_brief"
-          );
-        }),
-      ).toStrictEqual([
-        {
-          type: "source",
-          kind: "agent",
-          runId: run.runId,
-          threadId: run.threadId,
-          agentId: fixture.agentId,
-          titleSnapshot: WATCHED_THREAD_TITLE,
-          href: `/chats/${run.threadId}#run-${run.runId}`,
-        },
-      ]);
+      await expectAutomationSourceAnnotation(fixture, fireAlways, run);
 
       const automationRuns = await api.listAgentRuns(fixture.actor, {
         status: "pending",
@@ -543,6 +550,7 @@ describe("chat-run-finished workflow automations", () => {
       );
 
       await expectAutomationFired(failedOnly);
+      await expectAutomationSourceAnnotation(fixture, failedOnly, run);
       await expect(automationLastRunAt(completedOnly)).resolves.toBeNull();
       // Error messages are not matchable output, so pattern automations stay
       // silent even when the error text would match.

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
@@ -32,6 +32,7 @@ const chat = createChatFilesBddApi(context);
 const webhooks = createWebhookCallbackApi(context);
 const chatCallbacks = createChatCallbacksApi(context);
 const wf = createWorkflowsBddApi(context);
+const WATCHED_THREAD_TITLE = "Watched chat run";
 
 function automationsClient() {
   return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
@@ -148,6 +149,11 @@ async function startWatchedChatRun(
   if (sent.status !== 201 || sent.body.runId === null) {
     throw new Error("Expected the chat send to create a run");
   }
+  await chat.renameThread(
+    fixture.actor,
+    sent.body.threadId,
+    WATCHED_THREAD_TITLE,
+  );
   return { runId: sent.body.runId, threadId: sent.body.threadId };
 }
 
@@ -384,6 +390,58 @@ describe("chat-run-finished workflow automations", () => {
       await expect(
         readLatestWorkflowAutomationRunFixture(context, patternMatch),
       ).resolves.toMatchObject({ autonomyBudget: 1 });
+
+      const fireAlwaysAutomation = await accept(
+        automationsClient().get({
+          headers: authHeaders(),
+          params: { id: fireAlways },
+        }),
+        [200],
+      );
+      const automationThreadId = fireAlwaysAutomation.body.chatThreadId;
+      if (!automationThreadId) {
+        throw new Error("Expected the automation chat thread");
+      }
+      const automationRun = await readLatestWorkflowAutomationRunFixture(
+        context,
+        fireAlways,
+      );
+      if (!automationRun) {
+        throw new Error("Expected the triggered automation run");
+      }
+      const automationEvents = await chat.listThreadEvents(
+        fixture.actor,
+        automationThreadId,
+      );
+      const automationInput = automationEvents.events.find((event) => {
+        return (
+          event.eventType === "input.prompt" &&
+          event.runId === automationRun.runId
+        );
+      });
+      if (!automationInput || automationInput.eventType !== "input.prompt") {
+        throw new Error("Expected the triggered automation input");
+      }
+      expect(
+        automationInput.userMessage.parts.filter((part) => {
+          return (
+            part.type === "source" ||
+            part.type === "automation" ||
+            part.type === "goal" ||
+            part.type === "morning_brief"
+          );
+        }),
+      ).toStrictEqual([
+        {
+          type: "source",
+          kind: "agent",
+          runId: run.runId,
+          threadId: run.threadId,
+          agentId: fixture.agentId,
+          titleSnapshot: WATCHED_THREAD_TITLE,
+          href: `/chats/${run.threadId}#run-${run.runId}`,
+        },
+      ]);
 
       const automationRuns = await api.listAgentRuns(fixture.actor, {
         status: "pending",

--- a/turbo/apps/api/src/signals/services/chat-run-finished-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-finished-automation-event.service.ts
@@ -24,6 +24,7 @@ import type { WorkflowAutomationContext } from "./workflow-automation-context.se
 import { ensureWorkflowUserAutomationThread } from "./zero-workflow-user-automation-thread.service";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { touchChatThreadLastMessageAt } from "./zero-chat-event-shared.service";
+import { agentRunSourceTitleSnapshot } from "./zero-chat-user-message.service";
 
 const CHAT_RUN_FINISHED_EVENT_TYPE = "chat-run-finished";
 // Bounds the finished run's output copied into the triggered run's context.
@@ -258,6 +259,12 @@ export const dispatchChatRunFinishedAutomationEvents$ = command(
           },
           automationContext: context,
           apiStartTime: now(),
+          agentRunSource: {
+            runId: event.runId,
+            threadId: event.chatThreadId,
+            agentId: event.sourceAgentId,
+            titleSnapshot: agentRunSourceTitleSnapshot(event.sourceThreadTitle),
+          },
           triggerSource: "automation-event",
           triggerBrief: `Chat run ${event.runStatus} in watched thread`,
           dispatchFailedCallbacks: dispatchFailedRunCallbacks,

--- a/turbo/apps/api/src/signals/services/chat-run-finished-event.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-finished-event.ts
@@ -5,4 +5,6 @@ export interface ChatRunFinishedEvent {
   readonly runId: string;
   readonly runStatus: ChatRunFinishedRunStatus;
   readonly lastResultText: string | null;
+  readonly sourceAgentId: string;
+  readonly sourceThreadTitle: string | null;
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -626,6 +626,8 @@ interface ChatThreadForRunRow {
   readonly chatThreadId: string;
   readonly userId: string;
   readonly orgId: string;
+  readonly agentId: string;
+  readonly title: string | null;
 }
 
 interface ChatRunInfo {
@@ -2053,6 +2055,8 @@ async function runCompletedChatCallbackSideEffects(
       runId: args.runId,
       runStatus: "completed",
       lastResultText: args.lastResultText,
+      sourceAgentId: args.chatThread.agentId,
+      sourceThreadTitle: args.chatThread.title,
     },
     signal,
   );
@@ -2185,6 +2189,8 @@ async function runFailedChatCallbackSideEffects(
       // Failed runs surface their error separately; patterns only ever match
       // assistant output, so terminal errors dispatch with no matchable text.
       lastResultText: null,
+      sourceAgentId: args.chatThread.agentId,
+      sourceThreadTitle: args.chatThread.title,
     },
     signal,
   );
@@ -2440,6 +2446,8 @@ async function chatThreadForRunFromDb(
       chatThreadId: zeroRuns.chatThreadId,
       userId: chatThreads.userId,
       orgId: agentRuns.orgId,
+      agentId: chatThreads.agentComposeId,
+      title: chatThreads.title,
     })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
@@ -2454,6 +2462,8 @@ async function chatThreadForRunFromDb(
     chatThreadId: row.chatThreadId,
     userId: row.userId,
     orgId: row.orgId,
+    agentId: row.agentId,
+    title: row.title,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -21,7 +21,11 @@ import {
 } from "./chat-event-queue.service";
 import { insertChatEvent, replaceChatEvent } from "./zero-chat-event.service";
 import { chatEventTypeIn } from "./zero-chat-event-type.service";
-import { createUserMessageDocument } from "./zero-chat-user-message.service";
+import {
+  createUserMessageDocument,
+  withAgentRunSourceAnnotation,
+  type ChatAgentRunSourceAnnotation,
+} from "./zero-chat-user-message.service";
 import type {
   WorkflowAutomationEventPayload,
   WorkflowAutomationEventType,
@@ -105,6 +109,7 @@ interface WorkflowQueueAdmissionArgs {
   readonly automation: typeof zeroWorkflowAutomations.$inferSelect;
   readonly workflowName: string;
   readonly displayPrompt: string;
+  readonly agentRunSource?: ChatAgentRunSourceAnnotation;
   readonly workflowAutomationEventType?: WorkflowAutomationEventType;
   readonly workflowAutomationEventPayload?: WorkflowAutomationEventPayload;
   readonly chatThreadId: string;
@@ -134,21 +139,25 @@ async function attemptWorkflowQueueAdmission(
       return { kind: "coalesced" };
     }
 
+    const automationUserMessage = createUserMessageDocument({
+      text: args.displayPrompt,
+      nonContentPart: {
+        type: "automation",
+        workflowName: args.workflowName,
+        workflowId: automation.workflowId,
+        ...(args.triggerBrief === undefined
+          ? {}
+          : { automationBrief: args.triggerBrief }),
+      },
+    });
+    const userMessage = args.agentRunSource
+      ? withAgentRunSourceAnnotation(automationUserMessage, args.agentRunSource)
+      : automationUserMessage;
     const inserted = await insertChatEvent(tx, {
       chatThreadId: args.chatThreadId,
       eventType: "input.automation",
       content: null,
-      userMessage: createUserMessageDocument({
-        text: args.displayPrompt,
-        nonContentPart: {
-          type: "automation",
-          workflowName: args.workflowName,
-          workflowId: automation.workflowId,
-          ...(args.triggerBrief === undefined
-            ? {}
-            : { automationBrief: args.triggerBrief }),
-        },
-      }),
+      userMessage,
       runId: null,
       automationId: automation.id,
       workflowName: args.workflowName,

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -84,6 +84,7 @@ import {
 } from "./zero-chat-event.service";
 import { chatThreadAdmissionBlocked } from "./zero-chat-active-run.service";
 import {
+  agentRunSourceTitleSnapshot,
   hasAgentRunSourceAnnotation,
   projectUserMessage,
   userMessageFileParts,
@@ -303,14 +304,6 @@ async function resolveChatAgentRunSource(
     return null;
   }
   return await resolveChatAgentRunSourceById(db, auth, auth.runId);
-}
-
-function agentRunSourceTitleSnapshot(title: string | null): string {
-  const normalizedTitle = title?.trim();
-  if (!normalizedTitle || normalizedTitle.toLowerCase() === "now") {
-    return "New thread";
-  }
-  return normalizedTitle;
 }
 
 async function resolveNormalSendAgentRunSource(params: {

--- a/turbo/apps/api/src/signals/services/zero-chat-user-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-user-message.service.ts
@@ -49,6 +49,14 @@ export interface ChatAgentRunSourceAnnotation {
   readonly titleSnapshot: string;
 }
 
+export function agentRunSourceTitleSnapshot(title: string | null): string {
+  const normalizedTitle = title?.trim();
+  if (!normalizedTitle || normalizedTitle.toLowerCase() === "now") {
+    return "New thread";
+  }
+  return normalizedTitle;
+}
+
 function chatAgentRunSourceHref(
   source: Pick<ChatAgentRunSourceAnnotation, "runId" | "threadId">,
 ): string {

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-launch.service.ts
@@ -25,6 +25,7 @@ import { createQueueFirstZeroRun$ } from "./zero-runs-create.service";
 import { workflowAutomationCanFire } from "./zero-workflow-automation-access.service";
 import { loadComputerUseHostGrantForAutoSend } from "./zero-chat-computer-use-host.service";
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
+import type { ChatAgentRunSourceAnnotation } from "./zero-chat-user-message.service";
 
 export type AutomationRow = typeof zeroWorkflowAutomations.$inferSelect;
 
@@ -79,7 +80,8 @@ export interface RunWorkflowAutomationNowArgs {
   readonly due: DueWorkflowAutomation;
   readonly automationContext: WorkflowAutomationContext;
   readonly apiStartTime: number;
-  // Display-only source context stored in the user-message automation part.
+  readonly agentRunSource?: ChatAgentRunSourceAnnotation;
+  // Display-only trigger summary used by workflow annotations and run history.
   readonly triggerBrief?: string;
   readonly triggerSource?: TriggerSource;
   // Automated schedule ticks coalesce while pending. Explicit manual runs set

--- a/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-automation-run.service.ts
@@ -48,6 +48,7 @@ export const runWorkflowAutomationNow$ = command(
           automation,
           workflowName: args.automationContext.workflowName,
           displayPrompt: workflowAutomationPrompt(args.automationContext),
+          agentRunSource: args.agentRunSource,
           workflowAutomationEventType: args.automationContext.eventType,
           workflowAutomationEventPayload:
             persistedWorkflowAutomationEventPayload(


### PR DESCRIPTION
## Summary

- Annotate new chat-run-finished workflow messages with the watched run source agent and thread title.
- Keep workflow automation metadata in canonical event context while replacing the visible workflow annotation with exactly one agent-run source annotation.
- Reuse the existing source-run avatar, title, and navigation renderer; no frontend change or historical data migration is needed.

## Behavior

Only newly fired chat-run-finished automations use the source annotation. Other automation types retain their existing workflow annotation.

## Testing

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@vm0/app
- pnpm --filter @vm0/app run check-types
- pnpm --filter api run check-types
- pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts