### PR TITLE
feat(runner): migrate pi child environment to okou

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -1934,7 +1934,10 @@ mod tests {
             "NODE_OPTIONS".to_string(),
             "--require /tmp/user-script.js".to_string(),
         )]);
-        let runtime = runtime_for_command_test(env::Framework::Pi, "prompt", "", &user_env);
+        let mut runtime = runtime_for_command_test(env::Framework::Pi, "prompt", "", &user_env);
+        runtime.pi_session_id = Cow::Borrowed("22222222-2222-4222-8222-222222222222");
+        runtime.pi_system_prompt = Cow::Borrowed("immutable Pi prompt");
+        runtime.pi_model_config = Cow::Borrowed(r#"{"provider":"deepseek"}"#);
         let mut values = child_env::values_for_runtime(&runtime);
         values.extend(pi_child_env_values(&runtime));
         let values = child_env::normalize_values(values);
@@ -1963,6 +1966,28 @@ mod tests {
             .map(|(_, value)| value.as_str());
         assert_eq!(canonical_run_id, Some(runtime.run_id.as_ref()));
         assert_eq!(legacy_run_id, canonical_run_id);
+        for (key, expected) in [
+            (
+                guest_contracts::env::PI_SESSION_ID_ENV,
+                runtime.pi_session_id.as_ref(),
+            ),
+            (
+                guest_contracts::env::PI_SYSTEM_PROMPT_ENV,
+                runtime.pi_system_prompt.as_ref(),
+            ),
+            (
+                guest_contracts::env::PI_MODEL_CONFIG_ENV,
+                runtime.pi_model_config.as_ref(),
+            ),
+        ] {
+            assert_eq!(
+                values
+                    .iter()
+                    .find(|(candidate, _)| candidate == key)
+                    .map(|(_, value)| value.as_str()),
+                Some(expected)
+            );
+        }
     }
 
     #[test]

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -135,6 +135,16 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert!(!cli_env.contains_key("VM0_USER_ENV_FILE"));
     assert!(!cli_env.contains_key(guest_contracts::env::RUN_ID_ENV));
     assert!(!cli_env.contains_key("VM0_RUN_ID"));
+    for key in [
+        guest_contracts::env::PI_SESSION_ID_ENV,
+        guest_contracts::env::PI_SYSTEM_PROMPT_ENV,
+        guest_contracts::env::PI_MODEL_CONFIG_ENV,
+    ] {
+        assert!(
+            !cli_env.contains_key(key),
+            "Claude child env contains {key}"
+        );
+    }
     assert!(!cli_env.contains_key("VM0_PROMPT"));
     assert!(!cli_env.contains_key("VM0_APPEND_SYSTEM_PROMPT"));
     assert!(!cli_env.contains_key("VM0_SANDBOX_ID"));

--- a/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
@@ -121,6 +121,13 @@ async fn codex_app_server_backend_uses_runtime_snapshot_and_preserves_large_prom
             .and_then(Value::as_str),
         Some("gpt-runtime-model")
     );
+    for key in [
+        "child_env_has_pi_session_id",
+        "child_env_has_pi_system_prompt",
+        "child_env_has_pi_model_config",
+    ] {
+        assert_eq!(input_event.get(key).and_then(Value::as_bool), Some(false));
+    }
 
     Ok(())
 }

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -158,13 +158,13 @@ pub const FEATURE_FLAGS_ENV: &str = "VM0_FEATURE_FLAGS";
 pub const CODEX_RUNTIME_CONFIG_ENV: &str = "VM0_CODEX_RUNTIME_CONFIG";
 
 /// Logical run-payload field name for the immutable Pi system prompt.
-pub const PI_SYSTEM_PROMPT_ENV: &str = "VM0_PI_SYSTEM_PROMPT";
+pub const PI_SYSTEM_PROMPT_ENV: &str = "OKOU_PI_SYSTEM_PROMPT";
 
 /// Logical run-payload field name for non-secret Pi model metadata.
-pub const PI_MODEL_CONFIG_ENV: &str = "VM0_PI_MODEL_CONFIG";
+pub const PI_MODEL_CONFIG_ENV: &str = "OKOU_PI_MODEL_CONFIG";
 
 /// Logical run-payload field name for the Chat Thread-owned Pi session id.
-pub const PI_SESSION_ID_ENV: &str = "VM0_PI_SESSION_ID";
+pub const PI_SESSION_ID_ENV: &str = "OKOU_PI_SESSION_ID";
 
 /// Runner-owned variable-length run payload sent through
 /// [`RUN_PAYLOAD_FILE_ENV`].
@@ -373,6 +373,9 @@ pub const GUEST_AGENT_TUNING_ENV_KEYS: &[&str] = &[
 
 const EXPLICIT_RUNNER_OWNED_ENV_KEYS: &[&str] = &[
     RUN_ID_ENV,
+    PI_SESSION_ID_ENV,
+    PI_SYSTEM_PROMPT_ENV,
+    PI_MODEL_CONFIG_ENV,
     CLI_AGENT_TYPE_ENV,
     USE_MOCK_CLAUDE_ENV,
     USE_MOCK_CODEX_ENV,
@@ -444,6 +447,9 @@ mod tests {
     fn contract_names_match_wire_values() {
         assert_eq!(API_URL_ENV, "VM0_API_BACKEND_URL");
         assert_eq!(RUN_ID_ENV, "OKOU_RUN_ID");
+        assert_eq!(PI_SESSION_ID_ENV, "OKOU_PI_SESSION_ID");
+        assert_eq!(PI_SYSTEM_PROMPT_ENV, "OKOU_PI_SYSTEM_PROMPT");
+        assert_eq!(PI_MODEL_CONFIG_ENV, "OKOU_PI_MODEL_CONFIG");
         assert_eq!(CLI_AGENT_TYPE_ENV, "CLI_AGENT_TYPE");
         assert_eq!(
             AGENT_EXECUTION_TIMEOUT_SECS_ENV,
@@ -632,6 +638,9 @@ mod tests {
         for key in [
             API_URL_ENV,
             RUN_ID_ENV,
+            PI_SESSION_ID_ENV,
+            PI_SYSTEM_PROMPT_ENV,
+            PI_MODEL_CONFIG_ENV,
             WORKING_DIR_ENV,
             USER_ENV_FILE_ENV,
             RUN_PAYLOAD_FILE_ENV,
@@ -643,6 +652,7 @@ mod tests {
             assert!(is_runner_owned_env_key(key), "{key} should be runner-owned");
         }
         assert!(!is_runner_owned_env_key("OKOU_TOKEN"));
+        assert!(!is_runner_owned_env_key("OKOU_UNRELATED"));
         assert!(!is_runner_owned_env_key("CUSTOM_ENV"));
     }
 

--- a/crates/guest-mock-codex/src/app_server/persistence.rs
+++ b/crates/guest-mock-codex/src/app_server/persistence.rs
@@ -42,6 +42,9 @@ pub(super) fn persist_input_events(
                 "child_env_custom_user_env": std::env::var("CUSTOM_USER_ENV").ok(),
                 "child_env_openai_model": std::env::var("OPENAI_MODEL").ok(),
                 "child_env_openai_base_url": std::env::var("OPENAI_BASE_URL").ok(),
+                "child_env_has_pi_session_id": std::env::var_os(guest_contracts::env::PI_SESSION_ID_ENV).is_some(),
+                "child_env_has_pi_system_prompt": std::env::var_os(guest_contracts::env::PI_SYSTEM_PROMPT_ENV).is_some(),
+                "child_env_has_pi_model_config": std::env::var_os(guest_contracts::env::PI_MODEL_CONFIG_ENV).is_some(),
             })
         })
         .collect::<Vec<_>>();

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -211,6 +211,18 @@ fn execution_context_validation_ignores_runner_owned_user_env_before_sandbox() {
             guest_contracts::env::RUN_ID_ENV.into(),
             "ignored\0run-identity".into(),
         ),
+        (
+            guest_contracts::env::PI_SESSION_ID_ENV.into(),
+            "ignored\0pi-session".into(),
+        ),
+        (
+            guest_contracts::env::PI_SYSTEM_PROMPT_ENV.into(),
+            "ignored\0pi-prompt".into(),
+        ),
+        (
+            guest_contracts::env::PI_MODEL_CONFIG_ENV.into(),
+            "ignored\0pi-model".into(),
+        ),
         ("CUSTOM_ENV".into(), "kept".into()),
     ]));
 
@@ -219,6 +231,9 @@ fn execution_context_validation_ignores_runner_owned_user_env_before_sandbox() {
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
     assert!(!user_env.contains_key("VM0_PROMPT"));
     assert!(!user_env.contains_key(guest_contracts::env::RUN_ID_ENV));
+    assert!(!user_env.contains_key(guest_contracts::env::PI_SESSION_ID_ENV));
+    assert!(!user_env.contains_key(guest_contracts::env::PI_SYSTEM_PROMPT_ENV));
+    assert!(!user_env.contains_key(guest_contracts::env::PI_MODEL_CONFIG_ENV));
 }
 
 #[test]
@@ -550,6 +565,18 @@ fn build_env_json_scrubs_user_provided_runner_owned_env() {
             "user-controlled-run-id".into(),
         ),
         (
+            guest_contracts::env::PI_SESSION_ID_ENV.into(),
+            "user-controlled-pi-session".into(),
+        ),
+        (
+            guest_contracts::env::PI_SYSTEM_PROMPT_ENV.into(),
+            "user-controlled-pi-prompt".into(),
+        ),
+        (
+            guest_contracts::env::PI_MODEL_CONFIG_ENV.into(),
+            "user-controlled-pi-model".into(),
+        ),
+        (
             guest_contracts::env::PROMPT_ENV.into(),
             "user prompt".into(),
         ),
@@ -634,6 +661,9 @@ fn build_env_json_scrubs_user_provided_runner_owned_env() {
     assert_eq!(user_env.get("OKOU_TOKEN").unwrap(), "legitimate-okou-token");
     for key in [
         guest_contracts::env::RUN_ID_ENV,
+        guest_contracts::env::PI_SESSION_ID_ENV,
+        guest_contracts::env::PI_SYSTEM_PROMPT_ENV,
+        guest_contracts::env::PI_MODEL_CONFIG_ENV,
         guest_contracts::env::PROMPT_ENV,
         guest_contracts::env::API_TOKEN_ENV,
         guest_contracts::env::WORKING_DIR_ENV,
@@ -713,6 +743,9 @@ fn emitted_bootstrap_env_keys_classify_as_runner_owned() {
     }
     for key in [
         guest_contracts::env::RUN_ID_ENV,
+        guest_contracts::env::PI_SESSION_ID_ENV,
+        guest_contracts::env::PI_SYSTEM_PROMPT_ENV,
+        guest_contracts::env::PI_MODEL_CONFIG_ENV,
         guest_contracts::env::CLI_AGENT_TYPE_ENV,
         guest_contracts::env::USE_MOCK_CLAUDE_ENV,
         guest_contracts::env::USE_MOCK_CODEX_ENV,
@@ -724,6 +757,7 @@ fn emitted_bootstrap_env_keys_classify_as_runner_owned() {
         );
     }
     assert!(!is_runner_owned_env_key("OKOU_TOKEN"));
+    assert!(!is_runner_owned_env_key("OKOU_UNRELATED"));
 }
 
 #[test]
@@ -1222,6 +1256,26 @@ fn build_run_payload_for_run_omits_absent_codex_runtime_config() {
     let payload = build_run_payload_for_run(&ctx).unwrap();
 
     assert!(payload.codex_runtime_config.is_empty());
+}
+
+#[test]
+fn non_pi_execution_contexts_do_not_require_pi_resources() {
+    for framework in ["claude-code", "codex"] {
+        let mut ctx = minimal_context();
+        ctx.cli_agent_type = framework.to_string();
+        ctx.pi_session_id = None;
+        ctx.pi_system_prompt = None;
+        ctx.pi_model_config = None;
+
+        assert!(
+            validate_context_for_test(&ctx).is_ok(),
+            "{framework} context should not require Pi resources"
+        );
+        let payload = build_run_payload_for_run(&ctx).unwrap();
+        assert!(payload.pi_session_id.is_empty());
+        assert!(payload.pi_system_prompt.is_empty());
+        assert!(payload.pi_model_config.is_empty());
+    }
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1389,7 +1389,7 @@ async fn execute_job_pi_system_prompt_validation_failure_skips_sandbox_create() 
 
     assert_ne!(outcome.exit_code(), 0);
     let error = outcome.error().unwrap();
-    assert!(error.contains("VM0_PI_SYSTEM_PROMPT"));
+    assert!(error.contains(guest_contracts::env::PI_SYSTEM_PROMPT_ENV));
     assert!(error.contains("NUL"));
     assert!(!error.contains(secret));
     assert!(outcome.sandbox.is_none());

--- a/turbo/apps/cli/src/commands/zero/__tests__/__agent-loop.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/__agent-loop.test.ts
@@ -13,10 +13,10 @@ it("fails closed with a values-free error when run identities differ", async () 
   const legacyRunId = "legacy-sensitive-run-id";
   vi.stubEnv("OKOU_RUN_ID", canonicalRunId);
   vi.stubEnv("VM0_RUN_ID", legacyRunId);
-  vi.stubEnv("VM0_PI_SESSION_ID", "11111111-1111-4111-8111-111111111111");
-  vi.stubEnv("VM0_PI_SYSTEM_PROMPT", "system prompt");
+  vi.stubEnv("OKOU_PI_SESSION_ID", "11111111-1111-4111-8111-111111111111");
+  vi.stubEnv("OKOU_PI_SYSTEM_PROMPT", "system prompt");
   vi.stubEnv(
-    "VM0_PI_MODEL_CONFIG",
+    "OKOU_PI_MODEL_CONFIG",
     JSON.stringify({
       provider: "deepseek",
       baseUrl: "https://api.deepseek.com/",

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -31,9 +31,9 @@ const CONFIG: PiSandboxAgentConfig = {
 function piEnv(runIdEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return {
     ...runIdEnv,
-    VM0_PI_SESSION_ID: SESSION_ID,
-    VM0_PI_SYSTEM_PROMPT: CONFIG.systemPrompt,
-    VM0_PI_MODEL_CONFIG: JSON.stringify({
+    OKOU_PI_SESSION_ID: SESSION_ID,
+    OKOU_PI_SYSTEM_PROMPT: CONFIG.systemPrompt,
+    OKOU_PI_MODEL_CONFIG: JSON.stringify({
       provider: "deepseek",
       baseUrl: "https://api.deepseek.com/",
       model: "deepseek-v4-flash",
@@ -148,6 +148,22 @@ describe("sandbox Pi agent loop", () => {
     expect(() => {
       return piSandboxAgentConfigFromEnv(piEnv({}));
     }).toThrowError("OKOU_RUN_ID is required for Pi execution");
+  });
+
+  it("names the canonical variable without exposing invalid model config", () => {
+    const invalidModelConfig = "credential-like-model-config{";
+    const env = piEnv({ OKOU_RUN_ID: RUN_ID });
+    env.OKOU_PI_MODEL_CONFIG = invalidModelConfig;
+
+    expect(() => {
+      return piSandboxAgentConfigFromEnv(env);
+    }).toThrowError("OKOU_PI_MODEL_CONFIG must contain valid JSON");
+    try {
+      piSandboxAgentConfigFromEnv(env);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).not.toContain(invalidModelConfig);
+    }
   });
 
   it("runs one native SQLite turn and emits only the chat projection", async () => {

--- a/turbo/apps/cli/src/lib/pi-agent-loop.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.ts
@@ -19,9 +19,9 @@ const RUN_ID_ENV = "OKOU_RUN_ID";
 // Remove after the Phase 1 release is promoted, previous Runner artifacts have
 // drained, and no queued or active context can retain the legacy guest shape.
 const LEGACY_RUN_ID_ENV = "VM0_RUN_ID";
-const PI_SESSION_ID_ENV = "VM0_PI_SESSION_ID";
-const PI_SYSTEM_PROMPT_ENV = "VM0_PI_SYSTEM_PROMPT";
-const PI_MODEL_CONFIG_ENV = "VM0_PI_MODEL_CONFIG";
+const PI_SESSION_ID_ENV = "OKOU_PI_SESSION_ID";
+const PI_SYSTEM_PROMPT_ENV = "OKOU_PI_SYSTEM_PROMPT";
+const PI_MODEL_CONFIG_ENV = "OKOU_PI_MODEL_CONFIG";
 
 const userFrameSchema = z
   .object({


### PR DESCRIPTION
## Summary

- cold-cut the three Pi child-process variables from `VM0_PI_*` to `OKOU_PI_*` with no fallback or dual write
- classify exactly the three `OKOU_PI_*` keys as Runner-owned while preserving generic retired `VM0_*` protection and allowing unrelated names such as `OKOU_TOKEN`
- keep private RunPayload fields and wire types unchanged
- retain bounded model-config validation diagnostics without exposing system prompts or credentials

## Rollout risk

Pi is internal and still in development, so this PR intentionally accepts a transient Pi-only failure during the next normal production rollout. It does not add compatibility aliases and does not deploy or release production. Regressions outside Pi remain hard blockers.

## Non-Pi isolation

- the Pi child environment extension remains gated by `Framework::Pi`
- a real Claude child integration test proves all three `OKOU_PI_*` keys remain absent and its command/environment contract is unchanged
- a real Codex app-server integration test proves all three keys remain absent and its configuration/environment contract is unchanged
- Runner coverage proves Claude and Codex contexts validate without Pi resources
- the complete Okou CLI integration suite and packed ordinary `--help` entry point remain green

## Dependency gate

PR #26796 merged at `2026-08-13T04:28:21Z` as `88850c33b9bb20018d9e0fd12097cc5eb7fb2bde`. The implementation started only after that SHA was an ancestor of fetched `origin/main` and the canonical guest-contract `RUN_ID_ENV` was verified as `OKOU_RUN_ID`. This PR does not change that behavior.

## Validation

- Linux Rust: `cargo fmt --all -- --check`
- Linux Rust: Clippy, docs, and tests for `guest-contracts`, `guest-agent`, `guest-mock-codex`, and `runner` with all features
- Runner: 3,099 tests passed, 0 failed, 20 ignored
- Okou CLI: lint, type check, Knip, build, and Prettier check
- Okou CLI: 99 test files passed; 946 tests passed; 1 existing test skipped
- packed CLI: ordinary `okou --help` exits 0; invalid model JSON exits 1 with the new bounded variable name and no secret value
- production-source residual audit: no active `VM0_PI_*` references