### PR TITLE
perf(api): bound unified unread indicators

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -22,7 +22,12 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import { createApp } from "../../../app-factory";
 import { stubTestTimezone } from "../../../__tests__/env-stub";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
-import { clearMockNow, mockNow, now } from "../../../lib/time";
+import {
+  clearMockNow,
+  mockNow,
+  now,
+  withMockNowForTest,
+} from "../../../lib/time";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
@@ -1722,6 +1727,97 @@ describe("CHAT-01 chat thread read state", () => {
       },
     });
   }, 120_000);
+
+  it("limits unified unread indicators to seven days without limiting active threads", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor(
+      "Bounded indicator window agent",
+    );
+    const currentTime = now();
+
+    await withMockNowForTest(currentTime, async () => {
+      mockNow(currentTime - 7 * DAY_MS - 1);
+      const expiredRun = await completeChatRunInThread(actor, runnerGroup, {
+        agentId,
+        prompt: "expired unread indicator",
+      });
+
+      mockNow(currentTime);
+      const recentRun = await completeChatRunInThread(actor, runnerGroup, {
+        agentId,
+        prompt: "recent unread indicator",
+      });
+
+      mockNow(currentTime - 7 * DAY_MS - 1);
+      const activeRun = await sendChatRun(actor, {
+        agentId,
+        prompt: "old active indicator",
+      });
+
+      mockNow(currentTime);
+      expect(new Set(await chat.listUnreadChatThreadIds(actor))).toStrictEqual(
+        new Set([expiredRun.threadId, recentRun.threadId]),
+      );
+      await expect(chat.listIndicators(actor)).resolves.toStrictEqual({
+        agents: { [agentId]: "active" },
+        threads: {
+          [recentRun.threadId]: "unread",
+          [activeRun.threadId]: "active",
+        },
+      });
+    });
+  }, 120_000);
+
+  it("returns the 50 newest unread indicators across the organization", async () => {
+    const {
+      actor,
+      agentId: agentA,
+      runnerGroup,
+    } = await entitledChatActor("Bounded indicator agent A");
+    const agentB = (
+      await bdd.createAgent(actor, {
+        displayName: "Bounded indicator agent B",
+        visibility: "private",
+      })
+    ).agentId;
+    const firstCompletedAt = now() - 60_000;
+
+    await withMockNowForTest(firstCompletedAt, async () => {
+      const runs: { readonly runId: string; readonly threadId: string }[] = [];
+      for (let index = 0; index < 51; index += 1) {
+        mockNow(firstCompletedAt + index * 1000);
+        runs.push(
+          await completeChatRunInThread(actor, runnerGroup, {
+            agentId: index % 2 === 0 ? agentA : agentB,
+            prompt: `bounded unread indicator ${index}`,
+          }),
+        );
+      }
+
+      mockNow(firstCompletedAt + 60_000);
+      expect(new Set(await chat.listUnreadChatThreadIds(actor))).toStrictEqual(
+        new Set(
+          runs.map((run) => {
+            return run.threadId;
+          }),
+        ),
+      );
+
+      const indicators = await chat.listIndicators(actor);
+      expect(indicators.agents).toStrictEqual({
+        [agentA]: "unread",
+        [agentB]: "unread",
+      });
+      expect(Object.keys(indicators.threads)).toHaveLength(50);
+      const oldestRun = runs[0];
+      if (!oldestRun) {
+        throw new Error("Expected an oldest completed run");
+      }
+      expect(indicators.threads).not.toHaveProperty(oldestRun.threadId);
+      for (const run of runs.slice(1)) {
+        expect(indicators.threads[run.threadId]).toBe("unread");
+      }
+    });
+  }, 240_000);
 
   it("excludes unread chat threads that have active runs or goals", async () => {
     const {

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -69,6 +69,7 @@ import {
   pgIntegerDecoder,
   zodEnumDriverValueDecoder,
 } from "../../lib/db-structured-result";
+import { now } from "../../lib/time";
 import { type Db, db$, type ReadonlyDb, writeDb$ } from "../external/db";
 import {
   canonicalChatEventContent,
@@ -317,6 +318,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
+const INDICATOR_UNREAD_LIMIT = 50;
+const INDICATOR_UNREAD_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
 const zeroIndicatorDecoder = zodEnumDriverValueDecoder(zeroIndicatorSchema);
 
 function noActiveRunsForCurrentThreadCondition(db: Pick<Db, "select">): SQL {
@@ -496,8 +499,10 @@ export function zeroChatThreadUnreadThreadIds(args: {
 
 /**
  * Active and unread indicators for the user's agents and threads in the
- * current organization. Active threads are computed once and reused to keep
- * unread classification and indicator precedence within one database snapshot.
+ * current organization. Active threads are complete; unread threads are the
+ * latest 50 terminal markers from the last seven days. Active threads are
+ * computed once and reused to keep unread classification and indicator
+ * precedence within one database snapshot.
  */
 export function zeroChatIndicators(args: {
   readonly userId: string;
@@ -505,6 +510,7 @@ export function zeroChatIndicators(args: {
 }): Computed<Promise<ZeroIndicators>> {
   return computed(async (get): Promise<ZeroIndicators> => {
     const db = get(db$);
+    const unreadCutoff = new Date(now() - INDICATOR_UNREAD_LOOKBACK_MS);
     const activeThreads = db.$with("active_threads").as(
       db
         .selectDistinct({
@@ -539,13 +545,21 @@ export function zeroChatIndicators(args: {
             eq(chatThreads.userId, args.userId),
             eq(zeroAgents.orgId, args.orgId),
             isNull(activeThreads.threadId),
+            gte(chatThreads.lastMessageAt, unreadCutoff),
+            or(
+              isNull(chatThreads.lastReadAt),
+              gt(chatThreads.lastMessageAt, chatThreads.lastReadAt),
+            ),
+            gte(lastRunFinish.createdAt, unreadCutoff),
             or(
               isNull(chatThreads.lastReadAt),
               gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
             ),
             noActiveGoalsForCurrentThreadCondition(db),
           ),
-        ),
+        )
+        .orderBy(desc(lastRunFinish.createdAt), desc(chatThreads.id))
+        .limit(INDICATOR_UNREAD_LIMIT),
     );
     const indicatorRows = db.$with("indicator_rows").as(
       unionAll(


### PR DESCRIPTION
## Summary

- prefilter unified unread indicator candidates by the thread read watermark and a seven-day `last_message_at` window
- select the latest 50 unread threads across the organization using the latest terminal event timestamp
- keep active indicators complete and preserve the existing legacy unread endpoint behavior

## Test plan

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@vm0/app'`
- `pnpm --filter @vm0/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'lists active chat thread ids|limits unified unread indicators|returns the 50 newest unread indicators'`
