### PR TITLE
test(e2e): bound guest mock shell prompts

### DIFF
--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -33,6 +33,7 @@ const EVENT_DELIVERY_LARGE_EVENT_BYTES: usize = 2 * 1024 * 1024;
 const SECONDARY_THREAD_ID: &str = "00000000-0000-4000-8000-000000000def";
 const SECONDARY_ITEM_STARTED_AT_MS: u64 = 1_700_000_000_000;
 const SHELL_PROMPT_PREFIX: &str = "@shell@\n";
+const SHELL_PROMPT_END_SEPARATOR: &str = "\n@end-shell@";
 const CHECKPOINTED_SHELL_PROMPT_PREFIX: &str = "@shell-checkpoint@\n";
 const CHECKPOINTED_SHELL_SEPARATOR: &str = "\n@continue@\n";
 
@@ -661,7 +662,13 @@ fn mock_turn_output<'a>(inputs: impl IntoIterator<Item = &'a str>) -> io::Result
             continuation_script: continuation_script.to_string(),
         });
     }
-    if let Some(script) = prompt.strip_prefix(SHELL_PROMPT_PREFIX) {
+    if let Some(script_with_suffix) = prompt.strip_prefix(SHELL_PROMPT_PREFIX) {
+        let Some((script, _)) = script_with_suffix.split_once(SHELL_PROMPT_END_SEPARATOR) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "shell prompt is missing @end-shell@ separator",
+            ));
+        };
         return shell_response_text(script).map(MockTurnOutput::Complete);
     }
     Ok(MockTurnOutput::Complete(format!(

--- a/crates/guest-mock-codex/tests/integration/app_server.rs
+++ b/crates/guest-mock-codex/tests/integration/app_server.rs
@@ -405,7 +405,7 @@ fn app_server_turn_steer_can_complete_runtime_turn_after_success() -> std::io::R
 }
 
 #[test]
-fn app_server_shell_prompt_executes_inherited_environment() -> std::io::Result<()> {
+fn app_server_shell_prompt_excludes_trailing_prompt_content() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server_with_env(
         dir.path(),
@@ -432,7 +432,9 @@ fn app_server_shell_prompt_executes_inherited_environment() -> std::io::Result<(
         "turn/start",
         json!({
             "threadId": thread_id,
-            "input": [text_input("@shell@\nprintf 'shell:%s' \"$MOCK_SHELL_VALUE\"")]
+            "input": [text_input(
+                "@shell@\nprintf 'shell:%s' \"$MOCK_SHELL_VALUE\"\n@end-shell@\n\n[Web file] runner-content.txt (text/plain)\n   [ID] file-123"
+            )]
         }),
     )?;
 
@@ -481,7 +483,7 @@ fn app_server_shell_prompt_reports_stderr_and_failure() -> std::io::Result<()> {
         json!({
             "threadId": thread_id,
             "input": [text_input(
-                "@shell@\nprintf stdout; printf stderr >&2; exit 7"
+                "@shell@\nprintf stdout; printf stderr >&2; exit 7\n@end-shell@"
             )]
         }),
     )?;
@@ -500,6 +502,42 @@ fn app_server_shell_prompt_reports_stderr_and_failure() -> std::io::Result<()> {
     }
 
     assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
+fn app_server_shell_prompt_requires_end_marker() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--listen", "stdio://"],
+        Some("runtime-turn-complete"),
+    )?;
+
+    server.request(1, "initialize", initialize_params())?;
+    server.send(&json!({
+        "id": 2,
+        "method": "thread/start",
+        "params": { "cwd": "/tmp" }
+    }))?;
+    let thread_started = server.read_required()?;
+    assert_eq!(thread_started["method"], "thread/started");
+    let started = server.read_required()?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    server.send(&json!({
+        "id": 3,
+        "method": "turn/start",
+        "params": {
+            "threadId": thread_id,
+            "input": [text_input("@shell@\nprintf unbounded")]
+        }
+    }))?;
+
+    assert!(server.read_message()?.is_none());
+    assert_ne!(server.close_and_wait()?, 0);
     Ok(())
 }
 

--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -141,12 +141,17 @@ runner_e2e_wait_for_run_status() {
     return 1
 }
 
+runner_e2e_shell_prompt() {
+    local script="$1"
+    printf '@shell@\n%s\n@end-shell@' "$script"
+}
+
 runner_e2e_start_chat_run() {
     local agent_id="$1"
     local prompt="$2"
     local capture_network_bodies="${3:-false}"
     local shell_prompt
-    shell_prompt=$(printf '@shell@\n%s' "$prompt")
+    shell_prompt=$(runner_e2e_shell_prompt "$prompt")
     runner_chat_send \
         "$agent_id" \
         "$shell_prompt" \
@@ -161,7 +166,7 @@ runner_e2e_continue_chat_run() {
     local thread_id="$2"
     local prompt="$3"
     local shell_prompt
-    shell_prompt=$(printf '@shell@\n%s' "$prompt")
+    shell_prompt=$(runner_e2e_shell_prompt "$prompt")
     runner_chat_send "$agent_id" "$shell_prompt" "$thread_id" ""
 }
 

--- a/e2e/tests/03-runner/run-t13-chat-attachments.bats
+++ b/e2e/tests/03-runner/run-t13-chat-attachments.bats
@@ -57,7 +57,7 @@ EOF
     first_prompt=${first_prompt//__EMPTY_ID__/$empty_id}
     first_prompt=${first_prompt//__CONTENT_MARKER__/$content_marker}
     first_prompt=${first_prompt//__FIRST_MARKER__/$first_marker}
-    shell_prompt=$(printf '@shell@\n%s' "$first_prompt")
+    shell_prompt=$(runner_e2e_shell_prompt "$first_prompt")
     parts=$(jq -nc \
         --arg prompt "$shell_prompt" \
         --arg contentId "$content_id" \
@@ -107,6 +107,7 @@ EOF
     echo "$output"
     assert_success
     assert_output --partial "$content_marker"
+    refute_output --partial "mock shell exited with"
 
     local continuation_marker="ATTACHMENT_CONTINUED_${TEST_ID}"
     local continuation_prompt


### PR DESCRIPTION
## Summary

- require regular guest-mock `@shell@` prompts to end with `@end-shell@`
- execute only the bounded script and fail fast when the marker is missing
- centralize runner E2E prompt framing and reject hidden mock-shell failures in the attachment journey

## Scope

This changes only the test-only guest-mock directive and its in-repository producers. Production structured-message projection, attachment annotations, APIs, runner payloads, and persisted state are unchanged. Attachment continuation in a fresh sandbox remains owned by #26799.

## Validation

- `cd crates && cargo test -p guest-mock-codex app_server_shell_prompt`
- `cd crates && cargo test -p guest-mock-codex`
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `bash -n e2e/helpers/runner-api.bash`
- `./e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/run-t13-chat-attachments.bats`
- `./scripts/check-file-size.sh crates/guest-mock-codex/src/app_server/handlers.rs crates/guest-mock-codex/tests/integration/app_server.rs e2e/helpers/runner-api.bash e2e/tests/03-runner/run-t13-chat-attachments.bats`
- `git diff --check`

The deployed runner attachment journey is validated by PR CI.

Closes #26791
