### PR TITLE
docs(runner): correct service drain wait semantics

### DIFF
--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -885,7 +885,7 @@ async fn resume_with_ops(
 
 /// `service drain` — send SIGUSR1 and disable the unit without waiting for active jobs.
 ///
-/// The command may wait for bounded systemd operations and drain-signal
+/// The command may wait for systemd operations and bounded drain-signal
 /// convergence before returning.
 pub(super) async fn run_drain(args: DrainArgs) -> RunnerResult<()> {
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;

--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -883,7 +883,10 @@ async fn resume_with_ops(
     resume_after_preflight_with_ops(unit, &base_dir, status.started_at, ops).await
 }
 
-/// `service drain` — send SIGUSR1 and disable the unit without waiting for jobs.
+/// `service drain` — send SIGUSR1 and disable the unit without waiting for active jobs.
+///
+/// The command may wait for bounded systemd operations and drain-signal
+/// convergence before returning.
 pub(super) async fn run_drain(args: DrainArgs) -> RunnerResult<()> {
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;
     let home = HomePaths::new()?;

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -59,7 +59,7 @@ enum ServiceCommand {
     Install(ServiceRunArgs),
     /// Uninstall the runner service (stop + disable + remove unit)
     Uninstall(ServiceUninstallArgs),
-    /// Drain without waiting for active jobs (may wait for bounded systemd/signal coordination)
+    /// Drain without waiting for active jobs (may wait for systemd operations and bounded signal convergence)
     Drain(drain_resume::DrainArgs),
     /// Resume a draining runner (SIGUSR2, reverses `drain` before teardown begins)
     Resume(drain_resume::ResumeArgs),

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -59,7 +59,7 @@ enum ServiceCommand {
     Install(ServiceRunArgs),
     /// Uninstall the runner service (stop + disable + remove unit)
     Uninstall(ServiceUninstallArgs),
-    /// Drain the runner (SIGUSR1, non-blocking — returns immediately)
+    /// Drain without waiting for active jobs (may wait for bounded systemd/signal coordination)
     Drain(drain_resume::DrainArgs),
     /// Resume a draining runner (SIGUSR2, reverses `drain` before teardown begins)
     Resume(drain_resume::ResumeArgs),

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -384,7 +384,6 @@ mod tests {
         assert!(normalized_help.contains(
             "drain Drain without waiting for active jobs (may wait for systemd operations and bounded signal convergence)"
         ));
-        assert!(!normalized_help.contains("returns immediately"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -369,6 +369,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn service_drain_help_describes_bounded_coordination() {
+        let error = Cli::try_parse_from(["runner", "service", "--help"])
+            .err()
+            .expect("service --help should exit through clap");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let normalized_help = error
+            .to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(normalized_help.contains(
+            "drain Drain without waiting for active jobs (may wait for bounded systemd/signal coordination)"
+        ));
+        assert!(!normalized_help.contains("returns immediately"));
+    }
+
     #[tokio::test]
     async fn runner_help_hides_token_environment_values() {
         for subcommand in ["config", "start"] {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -382,7 +382,7 @@ mod tests {
             .join(" ");
 
         assert!(normalized_help.contains(
-            "drain Drain without waiting for active jobs (may wait for bounded systemd/signal coordination)"
+            "drain Drain without waiting for active jobs (may wait for systemd operations and bounded signal convergence)"
         ));
         assert!(!normalized_help.contains("returns immediately"));
     }


### PR DESCRIPTION
## Summary

- correct `runner service drain` help to distinguish active-job draining from systemd operations and bounded signal convergence
- keep the command-level Rust documentation aligned with generated Clap help
- add a top-level CLI regression assertion that pins the corrected generated help

## Scope

- documentation and generated CLI help only
- no drain runtime, API, protocol, configuration, persisted-state, or deployment behavior changes

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p runner --all-targets --all-features`
- `cd crates && cargo doc -p runner --all-features --no-deps`
- `cd crates && cargo test -p runner tests::service_drain_help_describes_bounded_coordination -- --exact`
- `cd crates && cargo test -p runner`
- pre-commit workspace Rust formatting, documentation, and Clippy hooks

Closes #26812
