### PR TITLE
fix(ci): preserve runner credentials across failed-job reruns

### DIFF
--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -68,19 +68,44 @@ unless runner_condition.include?("always()") &&
     !runner_condition.include?("!= 'cancelled'")
   raise "runner cleanup must remain eligible after cancelled preparation"
 end
-runner_cleanup_step = runner_cleanup.fetch("steps").find do |step|
-  step["name"] == "Cleanup runner E2E accounts"
+runner_cleanup_steps = runner_cleanup.fetch("steps")
+runner_scope_step = runner_cleanup_steps.find do |step|
+  step["id"] == "cleanup-scope"
 end
-raise "missing runner E2E account finalizer" unless runner_cleanup_step
-unless runner_cleanup_step.fetch("run").end_with?("runner-account.ts cleanup")
-  raise "runner cleanup must use generation reconciliation"
+raise "missing runner E2E cleanup scope" unless runner_scope_step
+unless runner_scope_step.dig("env", "PREPARE_RESULT") ==
+    "${{ needs.cli-e2e-03-runner-prepare.result }}" &&
+    runner_scope_step.dig("env", "RUNNER_RESULT") ==
+      "${{ needs.cli-e2e-03-runner.result }}"
+  raise "runner cleanup scope must use exact upstream results"
+end
+runner_generation_cleanup = runner_cleanup_steps.find do |step|
+  step["name"] == "Cleanup current runner E2E generation"
+end
+runner_run_cleanup = runner_cleanup_steps.find do |step|
+  step["name"] == "Cleanup runner E2E workflow run"
+end
+unless runner_generation_cleanup&.fetch("run", "")&.end_with?(
+    "runner-account.ts cleanup-generation",
+  ) && runner_generation_cleanup["if"] ==
+    "steps.cleanup-scope.outputs.scope == 'generation'"
+  raise "failed preparation must reconcile only its current generation"
+end
+unless runner_run_cleanup&.fetch("run", "")&.end_with?(
+    "runner-account.ts cleanup-run",
+  ) && runner_run_cleanup["if"] ==
+    "steps.cleanup-scope.outputs.scope == 'run'"
+  raise "successful runner work must reconcile its exact workflow run"
 end
 legacy_output_environment = %w[
   E2E_RUNNER_ORGANIZATION_ID
   E2E_RUNNER_CODEX_ORGANIZATION_ID
   E2E_RUNNER_CLAUDE_ORGANIZATION_ID
 ]
-if legacy_output_environment.any? { |name| runner_cleanup_step.fetch("env", {}).key?(name) }
+runner_account_cleanup_steps = [runner_generation_cleanup, runner_run_cleanup]
+if runner_account_cleanup_steps.any? do |step|
+    legacy_output_environment.any? { |name| step.fetch("env", {}).key?(name) }
+  end
   raise "runner cleanup must not depend on complete preparation outputs"
 end
 
@@ -121,13 +146,32 @@ unless stale_checkout.dig("with", "ref") == "${{ github.event.repository.default
     stale_checkout.dig("with", "persist-credentials") == false
   raise "stale Clerk cleanup must execute credential-free default-branch code"
 end
-stale_step = stale_cleanup.fetch("steps").find do |step|
-  step["name"] == "Delete stale marked Clerk test resources"
+stale_non_runner_step = stale_cleanup.fetch("steps").find do |step|
+  step["name"] == "Delete stale non-runner Clerk test resources"
 end
-raise "missing stale Clerk cleanup command" unless stale_step
-unless stale_step.fetch("run").include?("cleanup-stale --older-than-hours 6") &&
-    stale_step.dig("env", "DRY_RUN") == "${{ env.DRY_RUN }}"
-  raise "stale Clerk cleanup must retain the six-hour marker gate and dry-run"
+stale_runner_step = stale_cleanup.fetch("steps").find do |step|
+  step["name"] == "Delete stale runner Clerk test resources"
+end
+raise "missing non-runner stale Clerk cleanup command" unless stale_non_runner_step
+raise "missing runner stale Clerk cleanup command" unless stale_runner_step
+unless stale_non_runner_step.fetch("run").include?(
+    "cleanup-stale browser,playwright,paid-onboarding --older-than-hours 6",
+  ) && stale_non_runner_step.dig("env", "DRY_RUN") == "${{ env.DRY_RUN }}"
+  raise "non-runner Clerk resources must retain the six-hour stale policy"
+end
+unless stale_runner_step.fetch("run").include?(
+    "cleanup-stale runner,runner-real-codex,runner-real-claude,runner-mock-claude --older-than-hours 30",
+  ) && stale_runner_step.dig("env", "DRY_RUN") == "${{ env.DRY_RUN }}"
+  raise "runner resources must outlive the one-day token artifact"
+end
+runner_token_upload = turbo_jobs.fetch("cli-e2e-03-runner-prepare").fetch("steps").find do |step|
+  step["name"] == "Upload runner E2E API tokens"
+end
+raise "missing runner token artifact upload" unless runner_token_upload
+artifact_retention_hours = runner_token_upload.dig("with", "retention-days").to_i * 24
+runner_stale_hours = stale_runner_step.fetch("run")[/--older-than-hours (\d+)/, 1]&.to_i
+unless runner_stale_hours && runner_stale_hours > artifact_retention_hours
+  raise "runner stale cleanup must start after token artifact expiry"
 end
 
 cleanup_sources = [File.read(ARGV.fetch(1)), File.read(ARGV.fetch(2))].join("\n")

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -47,7 +47,7 @@ if [[ "$(grep -Fc 'upgradeToPro: false' "$RUNNER_TOKEN")" -ne 1 ]]; then
   fail "the default mock runner account must remain on limited-free"
 fi
 
-ruby -ryaml - "$WORKFLOW" "$RUNNER_MOCK_CLAUDE_BOOTSTRAP" <<'RUBY'
+ruby -ryaml -ropen3 -rtempfile - "$WORKFLOW" "$RUNNER_MOCK_CLAUDE_BOOTSTRAP" <<'RUBY'
 workflow = YAML.load_file(ARGV.fetch(0))
 jobs = workflow.fetch("jobs")
 prepare = jobs.fetch("prepare")
@@ -362,21 +362,102 @@ unless runner.fetch("steps").any? do |step|
   raise "every runner shard must upload its JUnit report"
 end
 
-cleanup_step = account_cleanup.fetch("steps").find do |step|
-  step["name"] == "Cleanup runner E2E accounts"
+cleanup_steps = account_cleanup.fetch("steps")
+cleanup_scope_step = cleanup_steps.find do |step|
+  step["id"] == "cleanup-scope"
 end
-raise "missing runner E2E account cleanup" unless cleanup_step
+raise "missing runner E2E cleanup scope" unless cleanup_scope_step
 unless account_cleanup.fetch("if").include?("always()")
   raise "runner E2E account cleanup must run after shard failures"
 end
 unless Array(account_cleanup["needs"]).include?("cli-e2e-03-runner")
   raise "runner E2E account cleanup must wait for every shard"
 end
-unless cleanup_step.fetch("run").end_with?("runner-account.ts cleanup")
-  raise "runner E2E account cleanup must use the shared lifecycle entry point"
-end
 if account_cleanup.fetch("if").include?("!= 'cancelled'")
   raise "runner E2E cleanup must run after cancelled account preparation"
+end
+
+unless cleanup_scope_step.dig("env", "PREPARE_RESULT") ==
+    "${{ needs.cli-e2e-03-runner-prepare.result }}" &&
+    cleanup_scope_step.dig("env", "RUNNER_RESULT") ==
+      "${{ needs.cli-e2e-03-runner.result }}"
+  raise "runner cleanup scope must use exact upstream results"
+end
+resolve_cleanup_scope = lambda do |prepare_result, runner_result|
+  Tempfile.create("runner-cleanup-scope") do |output|
+    stdout, stderr, status = Open3.capture3(
+      {
+        "GITHUB_OUTPUT" => output.path,
+        "PREPARE_RESULT" => prepare_result,
+        "RUNNER_RESULT" => runner_result,
+      },
+      "bash",
+      "-c",
+      cleanup_scope_step.fetch("run"),
+    )
+    unless status.success?
+      raise "runner cleanup scope script failed: #{stdout}#{stderr}"
+    end
+    scope_line = File.readlines(output.path, chomp: true).find do |line|
+      line.start_with?("scope=")
+    end
+    raise "runner cleanup scope script did not emit a scope" unless scope_line
+    scope_line.delete_prefix("scope=")
+  end
+end
+{
+  ["failure", "skipped"] => "generation",
+  ["cancelled", "success"] => "generation",
+  ["success", "success"] => "run",
+  ["success", "failure"] => "retain",
+  ["success", "cancelled"] => "retain",
+  ["success", "skipped"] => "retain",
+}.each do |results, expected_scope|
+  actual_scope = resolve_cleanup_scope.call(*results)
+  unless actual_scope == expected_scope
+    raise "#{results.join('/')} must select #{expected_scope}, got #{actual_scope}"
+  end
+end
+
+retain_step = cleanup_steps.find do |step|
+  step["name"] == "Retain runner E2E accounts for failed-job rerun"
+end
+unless retain_step &&
+    retain_step["if"] == "steps.cleanup-scope.outputs.scope == 'retain'" &&
+    retain_step.fetch("run").include?("successful rerun or fallback cleanup")
+  raise "failed runner work must retain reusable accounts explicitly"
+end
+
+conditional_setup_steps = [
+  cleanup_steps.find { |step| step.fetch("uses", "").start_with?("actions/checkout@") },
+  cleanup_steps.find { |step| step.fetch("uses", "").start_with?("actions/setup-node@") },
+  cleanup_steps.find { |step| step["name"] == "Install pnpm" },
+  cleanup_steps.find { |step| step["name"] == "Install E2E dependencies" },
+]
+unless conditional_setup_steps.all? do |step|
+    step && step["if"] == "steps.cleanup-scope.outputs.scope != 'retain'"
+  end
+  raise "retained accounts must skip checkout and dependency setup"
+end
+
+generation_cleanup_step = cleanup_steps.find do |step|
+  step["name"] == "Cleanup current runner E2E generation"
+end
+run_cleanup_step = cleanup_steps.find do |step|
+  step["name"] == "Cleanup runner E2E workflow run"
+end
+unless generation_cleanup_step &&
+    generation_cleanup_step["if"] ==
+      "steps.cleanup-scope.outputs.scope == 'generation'" &&
+    generation_cleanup_step.fetch("run").end_with?(
+      "runner-account.ts cleanup-generation",
+    )
+  raise "incomplete preparation must reconcile only the current generation"
+end
+unless run_cleanup_step &&
+    run_cleanup_step["if"] == "steps.cleanup-scope.outputs.scope == 'run'" &&
+    run_cleanup_step.fetch("run").end_with?("runner-account.ts cleanup-run")
+  raise "successful runner work must reconcile the exact workflow run"
 end
 %w[
   E2E_RUNNER_ORGANIZATION_ID
@@ -384,7 +465,9 @@ end
   E2E_RUNNER_CLAUDE_ORGANIZATION_ID
   E2E_RUNNER_MOCK_CLAUDE_ORGANIZATION_ID
 ].each do |environment_name|
-  if cleanup_step.fetch("env", {}).key?(environment_name)
+  if [generation_cleanup_step, run_cleanup_step].any? do |step|
+      step.fetch("env", {}).key?(environment_name)
+    end
     raise "runner E2E cleanup must not depend on #{environment_name}"
   end
 end

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -354,10 +354,18 @@ jobs:
         run: corepack enable pnpm
       - name: Install E2E dependencies
         run: cd e2e && pnpm install --frozen-lockfile
-      - name: Delete stale marked Clerk test resources
+      - name: Delete stale non-runner Clerk test resources
         run: >-
           cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
-          cleanup-stale --older-than-hours 6
+          cleanup-stale browser,playwright,paid-onboarding --older-than-hours 6
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          DRY_RUN: ${{ env.DRY_RUN }}
+      - name: Delete stale runner Clerk test resources
+        run: >-
+          cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
+          cleanup-stale runner,runner-real-codex,runner-real-claude,runner-mock-claude
+          --older-than-hours 30
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           DRY_RUN: ${{ env.DRY_RUN }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2996,16 +2996,47 @@ jobs:
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.cli-e2e-03-runner-prepare.result != 'skipped'
     steps:
+      - name: Determine runner E2E cleanup scope
+        id: cleanup-scope
+        shell: bash
+        env:
+          PREPARE_RESULT: ${{ needs.cli-e2e-03-runner-prepare.result }}
+          RUNNER_RESULT: ${{ needs.cli-e2e-03-runner.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$PREPARE_RESULT" != "success" ]]; then
+            scope="generation"
+          elif [[ "$RUNNER_RESULT" == "success" ]]; then
+            scope="run"
+          else
+            scope="retain"
+          fi
+          echo "Runner E2E cleanup scope: $scope"
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+      - name: Retain runner E2E accounts for failed-job rerun
+        if: steps.cleanup-scope.outputs.scope == 'retain'
+        run: echo "Retaining runner E2E accounts until a successful rerun or fallback cleanup"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.cleanup-scope.outputs.scope != 'retain'
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        if: steps.cleanup-scope.outputs.scope != 'retain'
         with:
           node-version: 22
       - name: Install pnpm
+        if: steps.cleanup-scope.outputs.scope != 'retain'
         run: corepack enable pnpm
       - name: Install E2E dependencies
+        if: steps.cleanup-scope.outputs.scope != 'retain'
         run: cd e2e && pnpm install --frozen-lockfile
-      - name: Cleanup runner E2E accounts
-        run: cd e2e && pnpm exec tsx playwright/runner-account.ts cleanup
+      - name: Cleanup current runner E2E generation
+        if: steps.cleanup-scope.outputs.scope == 'generation'
+        run: cd e2e && pnpm exec tsx playwright/runner-account.ts cleanup-generation
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+      - name: Cleanup runner E2E workflow run
+        if: steps.cleanup-scope.outputs.scope == 'run'
+        run: cd e2e && pnpm exec tsx playwright/runner-account.ts cleanup-run
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}

--- a/e2e/playwright/clerk-test-resources.ts
+++ b/e2e/playwright/clerk-test-resources.ts
@@ -16,32 +16,32 @@ async function main(): Promise<void> {
   let result: ClerkCleanupResult;
 
   switch (command) {
-    case "cleanup-generation":
-      result = await cleanupCurrentClerkTestGeneration(
-        parseRoles(requiredArgument(3, "role list")),
-        { dryRun },
-      );
+    case "cleanup-generation": {
+      const roles = parseRoles(requiredArgument(3, "role list"));
       assertNoExtraArguments(4);
+      result = await cleanupCurrentClerkTestGeneration(roles, { dryRun });
       break;
+    }
     case "cleanup-job-ref":
       assertNoExtraArguments(3);
       result = await cleanupClerkTestJobRef(currentClerkTestJobRef(), {
         dryRun,
       });
       break;
-    case "cleanup-stale":
+    case "cleanup-stale": {
+      const roles = parseRoles(requiredArgument(3, "role list"));
       if (process.argv[4] !== STALE_CLEANUP_ARGUMENT) {
         throw new Error(
           `cleanup-stale requires <roles> ${STALE_CLEANUP_ARGUMENT} <hours>`,
         );
       }
-      result = await cleanupStaleClerkTestResources(
-        parseRoles(requiredArgument(3, "role list")),
-        staleCutoff(requiredArgument(5, "stale age")),
-        { dryRun },
-      );
+      const createdBefore = staleCutoff(requiredArgument(5, "stale age"));
       assertNoExtraArguments(6);
+      result = await cleanupStaleClerkTestResources(roles, createdBefore, {
+        dryRun,
+      });
       break;
+    }
     default:
       throw new Error(
         "Usage: clerk-test-resources.ts cleanup-generation <roles> | cleanup-job-ref | cleanup-stale <roles> --older-than-hours <hours>",

--- a/e2e/playwright/clerk-test-resources.ts
+++ b/e2e/playwright/clerk-test-resources.ts
@@ -21,6 +21,7 @@ async function main(): Promise<void> {
         parseRoles(requiredArgument(3, "role list")),
         { dryRun },
       );
+      assertNoExtraArguments(4);
       break;
     case "cleanup-job-ref":
       assertNoExtraArguments(3);
@@ -29,20 +30,21 @@ async function main(): Promise<void> {
       });
       break;
     case "cleanup-stale":
-      if (process.argv[3] !== STALE_CLEANUP_ARGUMENT) {
+      if (process.argv[4] !== STALE_CLEANUP_ARGUMENT) {
         throw new Error(
-          `cleanup-stale requires ${STALE_CLEANUP_ARGUMENT} <hours>`,
+          `cleanup-stale requires <roles> ${STALE_CLEANUP_ARGUMENT} <hours>`,
         );
       }
       result = await cleanupStaleClerkTestResources(
-        staleCutoff(requiredArgument(4, "stale age")),
+        parseRoles(requiredArgument(3, "role list")),
+        staleCutoff(requiredArgument(5, "stale age")),
         { dryRun },
       );
-      assertNoExtraArguments(5);
+      assertNoExtraArguments(6);
       break;
     default:
       throw new Error(
-        "Usage: clerk-test-resources.ts cleanup-generation <roles> | cleanup-job-ref | cleanup-stale --older-than-hours <hours>",
+        "Usage: clerk-test-resources.ts cleanup-generation <roles> | cleanup-job-ref | cleanup-stale <roles> --older-than-hours <hours>",
       );
   }
 
@@ -66,7 +68,6 @@ function parseRoles(value: string): readonly ClerkTestRole[] {
   if (roles.length === 0) {
     throw new Error("At least one Clerk test role is required");
   }
-  assertNoExtraArguments(4);
   return roles;
 }
 

--- a/e2e/playwright/lib/clerk-api.test.ts
+++ b/e2e/playwright/lib/clerk-api.test.ts
@@ -492,7 +492,7 @@ test("job-ref cleanup rejects fuzzy lookalikes and deletes organizations first",
   );
 });
 
-test("stale cleanup requires strict markers and supports dry-run", async () => {
+test("stale cleanup isolates roles, requires strict markers, and supports dry-run", async () => {
   const cutoff = new Date(10_000);
   await withClerkServer(
     (request, response) => {
@@ -518,6 +518,11 @@ test("stale cleanup requires strict markers and supports dry-run", async () => {
             "user_at_cutoff",
             "staging+clerk_test+3000-1+runner@vm0-e2e.ai",
             10_000,
+          ),
+          clerkUser(
+            "user_old_runner",
+            "staging+clerk_test+3000-1+runner-real-codex@vm0-e2e.ai",
+            1_000,
           ),
           clerkUser(
             "user_before_owned_org_cutoff",
@@ -557,21 +562,28 @@ test("stale cleanup requires strict markers and supports dry-run", async () => {
               10_000,
             ),
             clerkOrganization(
+              "org_old_runner",
+              clerkOwner("staging", "3000-1", "runner-real-codex"),
+              1_000,
+            ),
+            clerkOrganization(
               "org_after_user_cutoff",
               clerkOwner("staging", "3000-1", "paid-onboarding"),
               11_000,
             ),
           ],
-          total_count: 5,
+          total_count: 6,
         });
         return;
       }
       sendJson(response, 500, { unexpected: request.url });
     },
     async (requests) => {
-      const result = await cleanupStaleClerkTestResources(cutoff, {
-        dryRun: true,
-      });
+      const result = await cleanupStaleClerkTestResources(
+        ["browser", "paid-onboarding"],
+        cutoff,
+        { dryRun: true },
+      );
       assert.equal(result.selectedOrganizations, 1);
       assert.equal(result.selectedUsers, 1);
       assert.equal(result.deletedOrganizations, 0);

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -84,8 +84,18 @@ type ClerkCleanupSelection =
       readonly generation: string;
       readonly roles: readonly ClerkTestRole[];
     }
+  | {
+      readonly kind: "run";
+      readonly jobRef: string;
+      readonly runId: string;
+      readonly roles: readonly ClerkTestRole[];
+    }
   | { readonly kind: "job-ref"; readonly jobRef: string }
-  | { readonly kind: "stale"; readonly createdBeforeMs: number };
+  | {
+      readonly kind: "stale";
+      readonly createdBeforeMs: number;
+      readonly roles: readonly ClerkTestRole[];
+    };
 
 function getClerkApiBase(): string {
   const testApiBase = process.env.CLERK_API_TEST_BASE_URL;
@@ -303,14 +313,28 @@ export async function cleanupCurrentClerkTestGeneration(
   roles: readonly ClerkTestRole[],
   options: ClerkCleanupOptions = {},
 ): Promise<ClerkCleanupResult> {
-  if (roles.length === 0) {
-    throw new Error("At least one Clerk test role is required for cleanup");
-  }
+  assertCleanupRoles(roles);
   return await cleanupClerkTestResources(
     {
       kind: "generation",
       jobRef: currentClerkTestJobRef(),
       generation: currentClerkTestGeneration(),
+      roles,
+    },
+    options,
+  );
+}
+
+export async function cleanupCurrentClerkTestRun(
+  roles: readonly ClerkTestRole[],
+  options: ClerkCleanupOptions = {},
+): Promise<ClerkCleanupResult> {
+  assertCleanupRoles(roles);
+  return await cleanupClerkTestResources(
+    {
+      kind: "run",
+      jobRef: currentClerkTestJobRef(),
+      runId: clerkTestRunId(currentClerkTestGeneration()),
       roles,
     },
     options,
@@ -328,15 +352,17 @@ export async function cleanupClerkTestJobRef(
 }
 
 export async function cleanupStaleClerkTestResources(
+  roles: readonly ClerkTestRole[],
   createdBefore: Date,
   options: ClerkCleanupOptions = {},
 ): Promise<ClerkCleanupResult> {
+  assertCleanupRoles(roles);
   const createdBeforeMs = createdBefore.getTime();
   if (!Number.isFinite(createdBeforeMs)) {
     throw new Error("Stale Clerk cleanup cutoff must be a valid date");
   }
   return await cleanupClerkTestResources(
-    { kind: "stale", createdBeforeMs },
+    { kind: "stale", createdBeforeMs, roles },
     options,
   );
 }
@@ -439,11 +465,31 @@ function cleanupSelectionMatches(
         owner.generation === selection.generation &&
         selection.roles.includes(owner.role)
       );
+    case "run":
+      return (
+        owner.jobRef === selection.jobRef &&
+        clerkTestRunId(owner.generation) === selection.runId &&
+        selection.roles.includes(owner.role)
+      );
     case "job-ref":
       return owner.jobRef === selection.jobRef;
     case "stale":
-      return createdAt !== undefined && createdAt < selection.createdBeforeMs;
+      return (
+        selection.roles.includes(owner.role) &&
+        createdAt !== undefined &&
+        createdAt < selection.createdBeforeMs
+      );
   }
+}
+
+function assertCleanupRoles(roles: readonly ClerkTestRole[]): void {
+  if (roles.length === 0) {
+    throw new Error("At least one Clerk test role is required for cleanup");
+  }
+}
+
+function clerkTestRunId(generation: string): string {
+  return generation.slice(0, generation.lastIndexOf("-"));
 }
 
 function clerkTestOwnerKey(owner: ClerkTestOwner): string {

--- a/e2e/playwright/lib/clerk-test-resources.test.ts
+++ b/e2e/playwright/lib/clerk-test-resources.test.ts
@@ -7,7 +7,9 @@ import { test } from "node:test";
 const execFileAsync = promisify(execFile);
 
 test("runs generation and stale cleanup through the command entry point", async () => {
+  let requestCount = 0;
   const server = createServer((request, response) => {
+    requestCount += 1;
     const url = new URL(request.url ?? "", "http://clerk.test");
     if (request.method === "GET" && url.pathname === "/v1/users") {
       sendJson(response, []);
@@ -57,6 +59,23 @@ test("runs generation and stale cleanup through the command entry point", async 
       ),
       /Unknown Clerk test role: unknown/,
     );
+
+    const requestCountBeforeInvalidArguments = requestCount;
+    await assert.rejects(
+      runClerkCommand(
+        ["cleanup-generation", "playwright", "unexpected"],
+        environment,
+      ),
+      /Unexpected argument: unexpected/,
+    );
+    await assert.rejects(
+      runClerkCommand(
+        ["cleanup-stale", "runner", "--older-than-hours", "30", "unexpected"],
+        environment,
+      ),
+      /Unexpected argument: unexpected/,
+    );
+    assert.equal(requestCount, requestCountBeforeInvalidArguments);
   } finally {
     await closeServer(server);
   }

--- a/e2e/playwright/lib/clerk-test-resources.test.ts
+++ b/e2e/playwright/lib/clerk-test-resources.test.ts
@@ -33,7 +33,12 @@ test("runs generation and stale cleanup through the command entry point", async 
     assert.match(jobRef.stdout, /selectedUsers: 0/);
 
     const stale = await runClerkCommand(
-      ["cleanup-stale", "--older-than-hours", "6"],
+      [
+        "cleanup-stale",
+        "browser,playwright,paid-onboarding",
+        "--older-than-hours",
+        "6",
+      ],
       { ...environment, DRY_RUN: "true" },
     );
     assert.match(stale.stdout, /dryRun: true/);
@@ -41,6 +46,13 @@ test("runs generation and stale cleanup through the command entry point", async 
     await assert.rejects(
       runClerkCommand(
         ["cleanup-generation", "playwright,unknown"],
+        environment,
+      ),
+      /Unknown Clerk test role: unknown/,
+    );
+    await assert.rejects(
+      runClerkCommand(
+        ["cleanup-stale", "runner,unknown", "--older-than-hours", "30"],
         environment,
       ),
       /Unknown Clerk test role: unknown/,

--- a/e2e/playwright/lib/runner-account.test.ts
+++ b/e2e/playwright/lib/runner-account.test.ts
@@ -245,6 +245,20 @@ test("run cleanup removes every runner generation for the exact workflow run", a
   }
 });
 
+test("cleanup commands require an explicit job ref", async () => {
+  const environment: Readonly<NodeJS.ProcessEnv> = {
+    ...runnerEnvironment("http://127.0.0.1:1/v1"),
+    JOB_REF: undefined,
+  };
+
+  for (const command of ["cleanup-generation", "cleanup-run"] as const) {
+    await assert.rejects(
+      runRunnerAccount(command, environment),
+      /JOB_REF environment variable is required/,
+    );
+  }
+});
+
 test("partial runner preparation cleans resources without outputs", async () => {
   const fixture = await startClerkFixture({ failUserCreateAt: 2 });
   const tempDirectory = await mkdtemp(
@@ -493,7 +507,7 @@ function runnerEnvironment(
 
 async function runRunnerAccount(
   command: "prepare" | "cleanup-generation" | "cleanup-run",
-  environment: Readonly<Record<string, string>>,
+  environment: Readonly<NodeJS.ProcessEnv>,
 ): Promise<void> {
   await execFileAsync(
     process.execPath,

--- a/e2e/playwright/lib/runner-account.test.ts
+++ b/e2e/playwright/lib/runner-account.test.ts
@@ -115,7 +115,10 @@ test("prepares and cleans one generation of runner accounts", async () => {
       },
     });
 
-    await runRunnerAccount("cleanup", runnerEnvironment(fixture.apiUrl));
+    await runRunnerAccount(
+      "cleanup-generation",
+      runnerEnvironment(fixture.apiUrl),
+    );
 
     assert.deepEqual(fixture.state.deletionEvents, [
       "organization:org_1",
@@ -136,6 +139,105 @@ test("prepares and cleans one generation of runner accounts", async () => {
     assert.deepEqual(
       fixture.state.organizations.map((organization) => organization.id),
       ["org_foreign"],
+    );
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+    await closeServer(fixture.server);
+  }
+});
+
+test("run cleanup removes every runner generation for the exact workflow run", async () => {
+  const fixture = await startClerkFixture();
+  const tempDirectory = await mkdtemp(
+    join(tmpdir(), "runner-account-run-cleanup-test-"),
+  );
+  try {
+    await runRunnerAccount(
+      "prepare",
+      runnerEnvironment(fixture.apiUrl, {
+        GITHUB_OUTPUT: join(tempDirectory, "github-output-1"),
+        GITHUB_RUN_ATTEMPT: "1",
+      }),
+    );
+    await runRunnerAccount(
+      "prepare",
+      runnerEnvironment(fixture.apiUrl, {
+        GITHUB_OUTPUT: join(tempDirectory, "github-output-2"),
+        GITHUB_RUN_ATTEMPT: "2",
+      }),
+    );
+
+    const retainedResources = [
+      {
+        id: "other_run",
+        email: "pr-123+clerk_test+90010-1+runner@vm0-e2e.ai",
+        owner: {
+          jobRef: "pr-123",
+          generation: "90010-1",
+          role: "runner",
+        },
+      },
+      {
+        id: "other_job_ref",
+        email: "pr-124+clerk_test+9001-1+runner@vm0-e2e.ai",
+        owner: {
+          jobRef: "pr-124",
+          generation: "9001-1",
+          role: "runner",
+        },
+      },
+      {
+        id: "other_role",
+        email: "pr-123+clerk_test+9001-1+browser@vm0-e2e.ai",
+        owner: {
+          jobRef: "pr-123",
+          generation: "9001-1",
+          role: "browser",
+        },
+      },
+    ] as const;
+    for (const resource of retainedResources) {
+      fixture.state.users.push({
+        id: `user_${resource.id}`,
+        email: resource.email,
+      });
+      fixture.state.organizations.push({
+        id: `org_${resource.id}`,
+        request: {
+          created_by: `user_${resource.id}`,
+          name: resource.id,
+          private_metadata: { vm0CiTest: resource.owner },
+        },
+      });
+    }
+
+    await runRunnerAccount("cleanup-run", runnerEnvironment(fixture.apiUrl));
+
+    assert.deepEqual(fixture.state.deletionEvents, [
+      "organization:org_1",
+      "organization:org_2",
+      "organization:org_3",
+      "organization:org_4",
+      "organization:org_5",
+      "organization:org_6",
+      "organization:org_7",
+      "organization:org_8",
+      "user:user_1",
+      "user:user_2",
+      "user:user_3",
+      "user:user_4",
+      "user:user_5",
+      "user:user_6",
+      "user:user_7",
+      "user:user_8",
+    ]);
+    assert.deepEqual(
+      fixture.state.users.map((user) => user.id),
+      retainedResources.map((resource) => `user_${resource.id}`),
+    );
+    assert.deepEqual(
+      fixture.state.organizations.map((organization) => organization.id),
+      retainedResources.map((resource) => `org_${resource.id}`),
     );
   } finally {
     await rm(tempDirectory, { recursive: true, force: true });
@@ -390,7 +492,7 @@ function runnerEnvironment(
 }
 
 async function runRunnerAccount(
-  command: "prepare" | "cleanup",
+  command: "prepare" | "cleanup-generation" | "cleanup-run",
   environment: Readonly<Record<string, string>>,
 ): Promise<void> {
   await execFileAsync(

--- a/e2e/playwright/runner-account.ts
+++ b/e2e/playwright/runner-account.ts
@@ -2,6 +2,7 @@ import { appendFile } from "node:fs/promises";
 
 import {
   cleanupCurrentClerkTestGeneration,
+  cleanupCurrentClerkTestRun,
   createOrganization,
   createUser,
   runnerTestAccounts,
@@ -18,17 +19,23 @@ const RUNNER_TEST_ROLES = [
 
 async function main(): Promise<void> {
   const command = process.argv[2];
-  if (command !== "prepare" && command !== "cleanup") {
-    throw new Error("Usage: runner-account.ts <prepare|cleanup>");
-  }
-
-  const jobRef = requiredEnvironmentVariable("JOB_REF");
-  const accounts = runnerTestAccounts();
-
-  if (command === "prepare") {
-    await prepareRunnerAccounts(accounts, jobRef);
-  } else {
-    await cleanupRunnerAccounts();
+  switch (command) {
+    case "prepare":
+      await prepareRunnerAccounts(
+        runnerTestAccounts(),
+        requiredEnvironmentVariable("JOB_REF"),
+      );
+      break;
+    case "cleanup-generation":
+      await cleanupRunnerAccountGeneration();
+      break;
+    case "cleanup-run":
+      await cleanupRunnerAccountRun();
+      break;
+    default:
+      throw new Error(
+        "Usage: runner-account.ts <prepare|cleanup-generation|cleanup-run>",
+      );
   }
 }
 
@@ -86,14 +93,19 @@ async function prepareRunnerAccounts(
       ...runnerAccounts,
     });
   } catch (cause) {
-    await cleanupRunnerAccounts();
+    await cleanupRunnerAccountGeneration();
     throw cause;
   }
 }
 
-async function cleanupRunnerAccounts(): Promise<void> {
+async function cleanupRunnerAccountGeneration(): Promise<void> {
   const result = await cleanupCurrentClerkTestGeneration(RUNNER_TEST_ROLES);
-  console.log("Cleaned up runner E2E accounts", result);
+  console.log("Cleaned up runner E2E account generation", result);
+}
+
+async function cleanupRunnerAccountRun(): Promise<void> {
+  const result = await cleanupCurrentClerkTestRun(RUNNER_TEST_ROLES);
+  console.log("Cleaned up runner E2E workflow run", result);
 }
 
 function requiredEnvironmentVariable(name: string): string {

--- a/e2e/playwright/runner-account.ts
+++ b/e2e/playwright/runner-account.ts
@@ -99,11 +99,13 @@ async function prepareRunnerAccounts(
 }
 
 async function cleanupRunnerAccountGeneration(): Promise<void> {
+  requiredEnvironmentVariable("JOB_REF");
   const result = await cleanupCurrentClerkTestGeneration(RUNNER_TEST_ROLES);
   console.log("Cleaned up runner E2E account generation", result);
 }
 
 async function cleanupRunnerAccountRun(): Promise<void> {
+  requiredEnvironmentVariable("JOB_REF");
   const result = await cleanupCurrentClerkTestRun(RUNNER_TEST_ROLES);
   console.log("Cleaned up runner E2E workflow run", result);
 }


### PR DESCRIPTION
## Summary

- retain successfully prepared runner E2E Clerk identities when downstream work fails, is cancelled, or is skipped, so failed-job reruns can reuse valid outputs and token artifacts
- clean every runner generation for the exact job ref and workflow run after success, while preserving generation-only reconciliation for incomplete preparation
- split scheduled stale cleanup into a six-hour non-runner policy and a 30-hour runner policy that begins after the one-day token artifact expires
- validate cleanup command arguments before issuing Clerk requests, require explicit runner cleanup job refs, and add command-entry and workflow contract coverage for cleanup scope transitions, multiple attempts, deletion ordering, and ownership isolation

## Scope

This keeps the existing prepare/bootstrap/matrix topology, identity grammar, artifact name, and one-day artifact retention. It does not add artifact API coordination, `actions:write`, runner test skips, or timeout changes.

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` (18 tests)
- `bash .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash -n .github/scripts/tests/clerk-test-resource-workflow-test.sh .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `shellcheck .github/scripts/tests/clerk-test-resource-workflow-test.sh .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `actionlint v1.7.12`
- Prettier check for all changed TypeScript and workflow YAML files
- `git diff --check`

Closes #26795
