### PR TITLE
test(e2e): own playwright route teardown

### DIFF
--- a/e2e/playwright/fixtures.ts
+++ b/e2e/playwright/fixtures.ts
@@ -27,6 +27,17 @@ export const test = base.extend({
       });
     }
 
-    await use(context);
+    try {
+      await use(context);
+    } finally {
+      await context.unrouteAll({ behavior: "ignoreErrors" });
+    }
+  },
+  page: async ({ page }, use) => {
+    try {
+      await use(page);
+    } finally {
+      await page.unrouteAll({ behavior: "ignoreErrors" });
+    }
   },
 });


### PR DESCRIPTION
<!-- turbo-flaky-repair -->
TURBO_FLAKY_KEY: cli-e2e-02-playwright-chat-fast-action-billing-route-fetch-context-closed

## Summary

- unroute test-owned page handlers before the page fixture is released
- unroute shared context handlers before the context fixture is released
- limit ignored errors to callbacks still running after fixture teardown begins

## Root cause

The test `[features] › playwright/tests/chat.spec.ts:968:5 › Fast action stays rightmost across selection states and previews deactivation` installs a billing-status route that calls `route.fetch()`. The app can begin another billing-status request after the final UI assertion. The shared fixtures previously released the page and context without first unregistering their routes, so context shutdown could interrupt that request and surface `route.fetch: Target page, context or browser has been closed` from the route callback.

The deterministic invariant restored here is: every route handler is unregistered by its owning page or context fixture before the underlying browser resource closes. Handler failures during the active test still propagate; only callbacks left in flight after teardown unregisters them are ignored through Playwright's scoped `unrouteAll` behavior.

The aggregate `ci-gate-turbo` failure was downstream fallout. Source PR #26797 changes runner KVM provisioning and security files and does not touch this fixture.

## Original failure

- Turbo run: https://github.com/vm0-ai/vm0/actions/runs/31670084812
- Failed job: https://github.com/vm0-ai/vm0/actions/runs/31670084812/job/94353632358
- Merge-group SHA: `6c0621231285344c858bbcfbec01b171bea4f231`

## Validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` — 16 passed
- temporary in-flight route teardown scenario, serial `--repeat-each=5` — 5 passed
- `npx --yes prettier@3.6.2 --check e2e/playwright/fixtures.ts`
- `./scripts/check-file-size.sh e2e/playwright/fixtures.ts`
- `git diff --check`

The deployed-preview Playwright test is left to the PR pipeline because its real Clerk and preview services are not available locally. No full Vitest suite or local development server was run.
