### PR TITLE
docs(python): document content-length parse result semantics

### DIFF
--- a/crates/runner/mitm-addon/src/content_length.py
+++ b/crates/runner/mitm-addon/src/content_length.py
@@ -9,12 +9,46 @@ ContentLengthKind = Literal["missing", "valid", "invalid", "conflicting", "over_
 
 @dataclass(frozen=True, slots=True)
 class ContentLengthResult:
+    """Result of bounded Content-Length field parsing.
+
+    In this contract, ``max_value`` is the limit supplied to ``parse()``.
+    ``kind`` describes the parser outcome:
+
+    - ``missing``: no field values were supplied.
+    - ``valid``: every part is valid, agrees after normalization, and does not exceed
+      ``max_value``.
+    - ``invalid``: parsing encountered an empty part or a part that is not an ASCII decimal
+      after surrounding HTTP optional whitespace was trimmed.
+    - ``conflicting``: parsing encountered a normalized decimal value that differs from the
+      first value.
+    - ``over_limit``: valid parts agree on a value greater than ``max_value``.
+
+    Parsing stops at the first ``invalid`` or ``conflicting`` part. Numeric limit
+    classification occurs only after every part has been scanned and agrees.
+
+    ``value`` is the exact normalized integer for ``valid``. It remains the default zero for
+    ``missing``, ``invalid``, and ``conflicting``. For ``over_limit``, it is exact when the
+    normalized numeral's significant digit count does not exceed that of ``max_value``;
+    otherwise, it is the bounded ``max_value + 1`` sentinel rather than a guaranteed exact
+    declared value. Always interpret ``value`` through ``kind`` because a valid zero also has
+    value zero.
+    """
+
     kind: ContentLengthKind
     value: int = 0
 
 
 def parse(values: Iterable[str], *, max_value: int) -> ContentLengthResult:
-    """Parse repeated Content-Length fields without converting unbounded integers."""
+    """Parse repeated Content-Length fields with a bounded integer result.
+
+    The parser scans comma-separated parts across repeated fields after trimming only surrounding
+    HTTP optional whitespace (space and horizontal tab). Parts must be nonempty ASCII decimals.
+    Leading zeroes are ignored when comparing parts, and all normalized values must agree.
+
+    Integer conversion is limited to normalized values whose significant digit count does not
+    exceed that of ``max_value``; longer agreed values use the bounded ``over_limit`` sentinel
+    described by ``ContentLengthResult``.
+    """
     first_value: str | None = None
     first_start = 0
     first_end = 0

--- a/crates/runner/mitm-addon/src/content_length.py
+++ b/crates/runner/mitm-addon/src/content_length.py
@@ -17,8 +17,8 @@ class ContentLengthResult:
     - ``missing``: no field values were supplied.
     - ``valid``: every part is valid, agrees after normalization, and does not exceed
       ``max_value``.
-    - ``invalid``: parsing encountered an empty part or a part that is not an ASCII decimal
-      after surrounding HTTP optional whitespace was trimmed.
+    - ``invalid``: after trimming surrounding HTTP optional whitespace, parsing encountered
+      an empty part or a character outside the ASCII digits ``0`` through ``9``.
     - ``conflicting``: parsing encountered a normalized decimal value that differs from the
       first value.
     - ``over_limit``: valid parts agree on a value greater than ``max_value``.
@@ -41,9 +41,10 @@ class ContentLengthResult:
 def parse(values: Iterable[str], *, max_value: int) -> ContentLengthResult:
     """Parse repeated Content-Length fields with a bounded integer result.
 
-    The parser scans comma-separated parts across repeated fields after trimming only surrounding
-    HTTP optional whitespace (space and horizontal tab). Parts must be nonempty ASCII decimals.
-    Leading zeroes are ignored when comparing parts, and all normalized values must agree.
+    For each comma-separated part across repeated fields, the parser trims only surrounding HTTP
+    optional whitespace (space and horizontal tab). The remaining part must be nonempty and contain
+    only ASCII digits ``0`` through ``9``. Leading zeroes are ignored when comparing parts, and all
+    normalized values must agree.
 
     Integer conversion is limited to normalized values whose significant digit count does not
     exceed that of ``max_value``; longer agreed values use the bounded ``over_limit`` sentinel


### PR DESCRIPTION
## Summary

- document all five `ContentLengthResult` kinds and the meaning of `value` for each outcome
- explain OWS trimming, ASCII decimal validation, leading-zero normalization, and agreement across repeated and comma-joined field values
- clarify early invalid/conflict classification and when an over-limit payload is exact versus the bounded `max_value + 1` sentinel

## Scope

- documentation-only change in `crates/runner/mitm-addon/src/content_length.py`
- no executable behavior, type signature, consumer policy, dependency, configuration, schema, persisted data, queue, runner protocol, migration, or rollout change

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_content_length.py` (36 passed)
- `uv run --no-sync python -m pytest tests/` (5357 passed)

Closes #26828
