### PR TITLE
feat(api): add request public brand context

### DIFF
--- a/turbo/apps/api/src/lib/cors.ts
+++ b/turbo/apps/api/src/lib/cors.ts
@@ -19,7 +19,7 @@ const STATIC_ALLOWED_ORIGINS = Object.freeze(
 );
 const OKOU_PAGES_PREVIEW_HOST_SUFFIX = ".okou-app.pages.dev";
 
-function getAllowedOrigin(origin: string | undefined): string | null {
+export function allowedCorsOrigin(origin: string | undefined): string | null {
   if (!origin) {
     return null;
   }
@@ -76,7 +76,7 @@ function getAllowedOrigin(origin: string | undefined): string | null {
 
 export const corsMiddleware: MiddlewareHandler = cors({
   origin: (origin) => {
-    return getAllowedOrigin(origin);
+    return allowedCorsOrigin(origin);
   },
   credentials: true,
   allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],

--- a/turbo/apps/api/src/signals/context/__tests__/public-brand.test.ts
+++ b/turbo/apps/api/src/signals/context/__tests__/public-brand.test.ts
@@ -1,0 +1,152 @@
+import {
+  CLIENT_PRODUCT_HEADER,
+  CLIENT_TYPE_APP,
+  CLIENT_TYPE_DESKTOP,
+  CLIENT_TYPE_HEADER,
+  DESKTOP_PRODUCT_OKOU,
+  DESKTOP_PRODUCT_ZERO,
+} from "@okouai/api-contracts/contracts/client-headers";
+import { initContract } from "@okouai/api-contracts/contracts/trpc-contract";
+import { computed } from "ccstate";
+import { z } from "zod";
+
+import { createApp } from "../../../app-factory";
+import { testContext } from "../../../__tests__/test-context";
+import { mockEnv } from "../../../lib/env";
+import { publicBrand$, type PublicBrand } from "../hono";
+
+const context = testContext();
+const c = initContract();
+
+const publicBrandTestContract = c.router({
+  read: {
+    method: "GET",
+    path: "/__test/public-brand",
+    responses: {
+      200: z.object({ publicBrand: z.enum(["vm0", "okou"]) }),
+    },
+  },
+});
+
+const readPublicBrand$ = computed((get) => {
+  return {
+    status: 200 as const,
+    body: { publicBrand: get(publicBrand$) },
+  };
+});
+
+interface PublicBrandRequestCase {
+  readonly name: string;
+  readonly environment: "development" | "preview" | "production";
+  readonly url: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly expected: PublicBrand;
+}
+
+const PUBLIC_BRAND_REQUEST_CASES: readonly PublicBrandRequestCase[] = [
+  {
+    name: "prefers the Okou API hostname over conflicting VM0 signals",
+    environment: "production",
+    url: "https://api.okou.ai/__test/public-brand",
+    headers: {
+      origin: "https://app.vm0.ai",
+      [CLIENT_TYPE_HEADER]: CLIENT_TYPE_DESKTOP,
+      [CLIENT_PRODUCT_HEADER]: DESKTOP_PRODUCT_ZERO,
+    },
+    expected: "okou",
+  },
+  {
+    name: "prefers the VM0 API hostname over conflicting Okou signals",
+    environment: "production",
+    url: "https://api.vm0.ai/__test/public-brand",
+    headers: {
+      origin: "https://app.okou.ai",
+      [CLIENT_TYPE_HEADER]: CLIENT_TYPE_DESKTOP,
+      [CLIENT_PRODUCT_HEADER]: DESKTOP_PRODUCT_OKOU,
+    },
+    expected: "vm0",
+  },
+  {
+    name: "uses a trusted Okou origin on a neutral API hostname",
+    environment: "production",
+    url: "https://api.test/__test/public-brand",
+    headers: { origin: "https://app.okou.ai" },
+    expected: "okou",
+  },
+  {
+    name: "uses an Okou preview origin on the shared preview API domain",
+    environment: "preview",
+    url: "https://pr-22085-api.vm6.ai/__test/public-brand",
+    headers: { origin: "https://pr-22085-app.omby.ai" },
+    expected: "okou",
+  },
+  {
+    name: "prefers a trusted VM0 origin over the Desktop product header",
+    environment: "production",
+    url: "https://api.test/__test/public-brand",
+    headers: {
+      origin: "https://app.vm0.ai",
+      [CLIENT_TYPE_HEADER]: CLIENT_TYPE_DESKTOP,
+      [CLIENT_PRODUCT_HEADER]: DESKTOP_PRODUCT_OKOU,
+    },
+    expected: "vm0",
+  },
+  {
+    name: "falls through an untrusted origin to the Desktop product header",
+    environment: "production",
+    url: "https://api.test/__test/public-brand",
+    headers: {
+      origin: "https://app.okou.ai.evil.example",
+      [CLIENT_TYPE_HEADER]: CLIENT_TYPE_DESKTOP,
+      [CLIENT_PRODUCT_HEADER]: DESKTOP_PRODUCT_OKOU,
+    },
+    expected: "okou",
+  },
+  {
+    name: "keeps legacy Desktop requests on VM0",
+    environment: "production",
+    url: "https://api.test/__test/public-brand",
+    headers: { [CLIENT_TYPE_HEADER]: CLIENT_TYPE_DESKTOP },
+    expected: "vm0",
+  },
+  {
+    name: "ignores product headers from non-Desktop clients",
+    environment: "production",
+    url: "https://api.test/__test/public-brand",
+    headers: {
+      [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
+      [CLIENT_PRODUCT_HEADER]: DESKTOP_PRODUCT_OKOU,
+    },
+    expected: "vm0",
+  },
+  {
+    name: "defaults requests without brand signals to VM0",
+    environment: "production",
+    url: "https://api.test/__test/public-brand",
+    expected: "vm0",
+  },
+];
+
+describe("publicBrand$", () => {
+  it.each(PUBLIC_BRAND_REQUEST_CASES)(
+    "$name",
+    async ({ environment, url, headers, expected }) => {
+      mockEnv("ENV", environment);
+      const app = createApp({
+        signal: context.signal,
+        routes: [
+          {
+            route: publicBrandTestContract.read,
+            handler: readPublicBrand$,
+          },
+        ],
+      });
+
+      const response = await app.request(url, { headers });
+
+      expect(response.status).toBe(200);
+      const body: unknown = await response.json();
+      expect(body).toStrictEqual({ publicBrand: expected });
+    },
+  );
+});

--- a/turbo/apps/api/src/signals/context/hono.ts
+++ b/turbo/apps/api/src/signals/context/hono.ts
@@ -1,17 +1,79 @@
 import type { AppRoute } from "@okouai/api-contracts/contracts/trpc-contract";
-import { CLIENT_PRODUCT_HEADER } from "@okouai/api-contracts/contracts/client-headers";
+import {
+  CLIENT_PRODUCT_HEADER,
+  CLIENT_TYPE_DESKTOP,
+  CLIENT_TYPE_HEADER,
+  DESKTOP_PRODUCT_OKOU,
+  desktopProductFromClientHeader,
+} from "@okouai/api-contracts/contracts/client-headers";
 import { command, computed, state } from "ccstate";
 import type { Context } from "hono";
 import { RedirectStatusCode } from "hono/utils/http-status";
 
+import { allowedCorsOrigin } from "../../lib/cors";
 import {
   previewAutomationBypassSecret,
   requestHasPreviewAutomationBypassHeaderOrCookie,
 } from "../../lib/preview-automation-bypass";
 
+// Presentation identity only. PublicBrand must not be used as an authorization,
+// tenancy, or billing boundary.
+export type PublicBrand = "vm0" | "okou";
+
+const VM0_PRODUCTION_DOMAIN = "vm0.ai";
+const OKOU_PRODUCTION_DOMAIN = "okou.ai";
+const OKOU_ORIGIN_ROOT_DOMAINS = [
+  OKOU_PRODUCTION_DOMAIN,
+  "omby.ai",
+  "okou-app.pages.dev",
+] as const;
+
 const innerHonoContext$ = state<Context>({} as Context);
 const innerRoute$ = state<AppRoute | null>(null);
 const innerApiStartTime$ = state<number | null>(null);
+
+function belongsToDomain(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+function publicBrandFromApiHostname(hostname: string): PublicBrand | undefined {
+  const normalizedHostname = hostname.toLowerCase();
+  if (belongsToDomain(normalizedHostname, OKOU_PRODUCTION_DOMAIN)) {
+    return "okou";
+  }
+  if (belongsToDomain(normalizedHostname, VM0_PRODUCTION_DOMAIN)) {
+    return "vm0";
+  }
+  return undefined;
+}
+
+function publicBrandFromTrustedOrigin(
+  origin: string | null,
+): PublicBrand | undefined {
+  const allowedOrigin = allowedCorsOrigin(origin ?? undefined);
+  if (!allowedOrigin) {
+    return undefined;
+  }
+
+  const hostname = new URL(allowedOrigin).hostname.toLowerCase();
+  return OKOU_ORIGIN_ROOT_DOMAINS.some((domain) => {
+    return belongsToDomain(hostname, domain);
+  })
+    ? "okou"
+    : "vm0";
+}
+
+function publicBrandFromDesktopHeaders(
+  headers: Headers,
+): PublicBrand | undefined {
+  if (headers.get(CLIENT_TYPE_HEADER) !== CLIENT_TYPE_DESKTOP) {
+    return undefined;
+  }
+  return desktopProductFromClientHeader(headers.get(CLIENT_PRODUCT_HEADER)) ===
+    DESKTOP_PRODUCT_OKOU
+    ? "okou"
+    : "vm0";
+}
 
 export const initHono$ = command(
   ({ set }, context: Context, route: AppRoute, apiStartTime: number): void => {
@@ -54,6 +116,18 @@ export const resUserAgent$ = resHeader("User-Agent");
 export const request$ = computed((get) => {
   const context = get(innerHonoContext$);
   return context.req;
+});
+
+export const publicBrand$ = computed((get): PublicBrand => {
+  const request = get(request$).raw;
+  // A branded production hostname is authoritative. Neutral preview and local
+  // API hosts fall through to the browser Origin or first-party Desktop header.
+  return (
+    publicBrandFromApiHostname(new URL(request.url).hostname) ??
+    publicBrandFromTrustedOrigin(request.headers.get("origin")) ??
+    publicBrandFromDesktopHeaders(request.headers) ??
+    "vm0"
+  );
 });
 
 export const requestSignal$ = computed((get) => {


### PR DESCRIPTION
## Summary

- expose a request-scoped `PublicBrand` signal for API handlers
- resolve brand from branded API hostname, trusted browser Origin, Desktop product header, then the legacy VM0 default
- reuse the existing CORS allowlist so untrusted Origins cannot select a brand

## Scope

- infrastructure only; no route or business consumer changes
- no persistence or database schema changes
- presentation identity only, never an authorization, tenancy, or billing boundary
- explicit API hostname wins when signals conflict, preserving deterministic domain isolation

## Fallbacks

- `turbo/apps/api/src/signals/context/hono.ts:publicBrandFromDesktopHeaders` maps a missing or unrecognized first-party Desktop product header to VM0 presentation for legacy Desktop callers. Surface: Desktop clients, which are outside the frontend/backend/runner rollout-window model in `docs/deployment-compatibility.md`; no bounded version-skew window applies. This is an intentional permanent presentational default, so no removal condition applies.
- `turbo/apps/api/src/signals/context/hono.ts:publicBrand$` maps requests with no recognized brand signal to VM0 presentation for generic API callers. Surface: generic API clients; no cross-version rollout window applies. This is the intentional canonical presentation default, so no removal condition applies.

## Verification

- `pnpm --filter api lint`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/context/__tests__/public-brand.test.ts` (9 cases, with a migrated temporary PostgreSQL database)
- repository format, lint, Knip, and workspace type-check suites also passed before the final version-only main rebase
