### PR TITLE
fix(api): preserve firewall execution metadata in run context

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -10237,6 +10237,42 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(customApi.auth?.query?.scope).toBe(
       `\${{ secrets.${scopeVariableKey} }}`,
     );
+    const runContextSnapshot = runContextSnapshotForRun(run.runId);
+    expect(runContextSnapshot.firewalls).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "inline",
+          name: internalName,
+          customConnectorId: saved.connector.id,
+          apis: expect.arrayContaining([
+            expect.objectContaining({
+              base: `https://xn--mnich-kva.${rand}.test/v1/`,
+              auth: {
+                headerEntries: [
+                  {
+                    name: "Authorization",
+                    value: `Bearer \${{ secrets.${secretKey} }}`,
+                  },
+                ],
+                queryEntries: [
+                  {
+                    name: "tenant",
+                    value: `\${{ secrets.${variableKey} }}`,
+                  },
+                  {
+                    name: "scope",
+                    value: `\${{ secrets.${scopeVariableKey} }}`,
+                  },
+                ],
+              },
+            }),
+          ]),
+        }),
+      ]),
+    );
+    expect(JSON.stringify(runContextSnapshot)).not.toContain(
+      "runtime-proposal-secret",
+    );
 
     const authBody = {
       encryptedSecrets: fw.encryptedSecretsBody({}),
@@ -11074,6 +11110,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       }),
     ).toContain("zendesk");
     expect(findFirewallEntry(claim.firewalls, "zendesk")).toStrictEqual({
+      kind: "builtin",
+      name: "zendesk",
+      baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },
+    });
+    expect(runContextSnapshotForRun(run.runId).firewalls).toContainEqual({
       kind: "builtin",
       name: "zendesk",
       baseUrlVars: { ZENDESK_SUBDOMAIN: "xn--mnich-kva" },

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -2470,13 +2470,68 @@ describe("RUN-04: agent run telemetry families", () => {
             ],
             firewalls: [
               {
+                kind: "inline",
                 name: "test-fw",
+                customConnectorId: "11111111-1111-4111-8111-111111111111",
                 apis: [
                   {
+                    id: "test-fw:0",
                     base: "https://api.example.com",
+                    hostPolicy: { kind: "publicDestination" },
+                    auth: {
+                      headerEntries: [
+                        {
+                          name: "Authorization",
+                          value: `Bearer \${{ secrets.TEST_TOKEN }}`,
+                        },
+                      ],
+                      base: "https://auth.example.com",
+                      queryEntries: [
+                        {
+                          name: "api_key",
+                          value: `\${{ secrets.TEST_QUERY_TOKEN }}`,
+                        },
+                      ],
+                    },
                     permissions: [{ name: "read", rules: ["GET /users/*"] }],
                   },
+                  {
+                    id: "test-fw:1",
+                    base: "https://aws.example.com",
+                    auth: {
+                      awsSigv4: {
+                        accessKeyId: `\${{ secrets.AWS_ACCESS_KEY_ID }}`,
+                        secretAccessKey: `\${{ secrets.AWS_SECRET_ACCESS_KEY }}`,
+                        sessionToken: `\${{ secrets.AWS_SESSION_TOKEN }}`,
+                      },
+                    },
+                  },
                 ],
+              },
+              {
+                kind: "inline",
+                name: "fallback-fw",
+                apis: [
+                  {
+                    base: "https://fallback.example.com",
+                    auth: {
+                      headerEntries: [
+                        { name: "Authorization", value: "conflicting-auth" },
+                      ],
+                      awsSigv4: {
+                        accessKeyId: "access-key",
+                        secretAccessKey: "secret-key",
+                      },
+                    },
+                    permissions: [
+                      { name: "fallback", rules: ["GET /fallback"] },
+                    ],
+                  },
+                ],
+              },
+              {
+                name: "historical-fw",
+                apis: [{ base: "https://historical.example.com" }],
               },
             ],
             volumes: [
@@ -2559,7 +2614,54 @@ describe("RUN-04: agent run telemetry families", () => {
     expect(Object.keys(contextRead.body.networkPolicies ?? {})).toStrictEqual([
       "github",
     ]);
-    expect(contextRead.body.firewalls).toHaveLength(1);
+    expect(contextRead.body.firewalls).toStrictEqual([
+      {
+        kind: "inline",
+        customConnectorId: "11111111-1111-4111-8111-111111111111",
+        firewall: {
+          name: "test-fw",
+          apis: [
+            {
+              id: "test-fw:0",
+              base: "https://api.example.com",
+              hostPolicy: { kind: "publicDestination" },
+              auth: {
+                headers: {
+                  Authorization: `Bearer \${{ secrets.TEST_TOKEN }}`,
+                },
+                base: "https://auth.example.com",
+                query: { api_key: `\${{ secrets.TEST_QUERY_TOKEN }}` },
+              },
+              permissions: [{ name: "read", rules: ["GET /users/*"] }],
+            },
+            {
+              id: "test-fw:1",
+              base: "https://aws.example.com",
+              auth: {
+                awsSigv4: {
+                  accessKeyId: `\${{ secrets.AWS_ACCESS_KEY_ID }}`,
+                  secretAccessKey: `\${{ secrets.AWS_SECRET_ACCESS_KEY }}`,
+                  sessionToken: `\${{ secrets.AWS_SESSION_TOKEN }}`,
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        name: "fallback-fw",
+        apis: [
+          {
+            base: "https://fallback.example.com",
+            permissions: [{ name: "fallback", rules: ["GET /fallback"] }],
+          },
+        ],
+      },
+      {
+        name: "historical-fw",
+        apis: [{ base: "https://historical.example.com" }],
+      },
+    ]);
     expect(contextRead.body.volumes).toHaveLength(1);
 
     // Legacy dynamic map fields are ignored now that run context snapshots

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -2614,39 +2614,39 @@ describe("RUN-04: agent run telemetry families", () => {
     expect(Object.keys(contextRead.body.networkPolicies ?? {})).toStrictEqual([
       "github",
     ]);
+    // New inline responses retain the previous top-level name/apis shape so
+    // already-loaded web clients can parse them as sanitized firewalls.
     expect(contextRead.body.firewalls).toStrictEqual([
       {
         kind: "inline",
         customConnectorId: "11111111-1111-4111-8111-111111111111",
-        firewall: {
-          name: "test-fw",
-          apis: [
-            {
-              id: "test-fw:0",
-              base: "https://api.example.com",
-              hostPolicy: { kind: "publicDestination" },
-              auth: {
-                headers: {
-                  Authorization: `Bearer \${{ secrets.TEST_TOKEN }}`,
-                },
-                base: "https://auth.example.com",
-                query: { api_key: `\${{ secrets.TEST_QUERY_TOKEN }}` },
+        name: "test-fw",
+        apis: [
+          {
+            id: "test-fw:0",
+            base: "https://api.example.com",
+            hostPolicy: { kind: "publicDestination" },
+            auth: {
+              headers: {
+                Authorization: `Bearer \${{ secrets.TEST_TOKEN }}`,
               },
-              permissions: [{ name: "read", rules: ["GET /users/*"] }],
+              base: "https://auth.example.com",
+              query: { api_key: `\${{ secrets.TEST_QUERY_TOKEN }}` },
             },
-            {
-              id: "test-fw:1",
-              base: "https://aws.example.com",
-              auth: {
-                awsSigv4: {
-                  accessKeyId: `\${{ secrets.AWS_ACCESS_KEY_ID }}`,
-                  secretAccessKey: `\${{ secrets.AWS_SECRET_ACCESS_KEY }}`,
-                  sessionToken: `\${{ secrets.AWS_SESSION_TOKEN }}`,
-                },
+            permissions: [{ name: "read", rules: ["GET /users/*"] }],
+          },
+          {
+            id: "test-fw:1",
+            base: "https://aws.example.com",
+            auth: {
+              awsSigv4: {
+                accessKeyId: `\${{ secrets.AWS_ACCESS_KEY_ID }}`,
+                secretAccessKey: `\${{ secrets.AWS_SECRET_ACCESS_KEY }}`,
+                sessionToken: `\${{ secrets.AWS_SESSION_TOKEN }}`,
               },
             },
-          ],
-        },
+          },
+        ],
       },
       {
         name: "fallback-fw",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-check.test.ts
@@ -844,7 +844,7 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
     });
   });
 
-  it("diagnoses sanitized inline entries without exposing their source snapshot", async () => {
+  it("diagnoses historical and execution inline entries without exposing their source snapshot", async () => {
     const actor = bdd.user();
     const runId = await createOwnedRun(actor);
     await seedZeroMembership(actor);
@@ -869,10 +869,21 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
             ],
           },
           {
+            kind: "inline",
             name: "github",
             apis: [
               {
+                id: "github:inline:0",
                 base: inlineBase,
+                hostPolicy: { kind: "publicDestination" },
+                auth: {
+                  headerEntries: [
+                    {
+                      name: "Authorization",
+                      value: `Bearer \${{ secrets.GITHUB_TOKEN }}`,
+                    },
+                  ],
+                },
                 permissions: [
                   {
                     name: "issues.write",
@@ -948,6 +959,8 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
       '"ask":',
       "repository.read",
       "unknown-non-connector",
+      "Authorization",
+      "secrets.GITHUB_TOKEN",
     ]) {
       expect(serialized).not.toContain(forbidden);
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-provider-gateways.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-provider-gateways.test.ts
@@ -42,6 +42,25 @@ function byIdClient() {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function runContextSnapshotForRun(runId: string): Record<string, unknown> {
+  for (const [dataset, events] of context.mocks.axiom.ingest.mock.calls) {
+    if (dataset !== "run-context" || !Array.isArray(events)) {
+      continue;
+    }
+    const snapshot = events.find((event) => {
+      return isRecord(event) && event.runId === runId;
+    });
+    if (isRecord(snapshot)) {
+      return snapshot;
+    }
+  }
+  throw new Error(`Expected a run-context snapshot for ${runId}`);
+}
+
 describe("custom model provider gateway routes", () => {
   it("requires authentication and admin access for mutations", async () => {
     const unauthenticated = await accept(
@@ -376,6 +395,29 @@ describe("custom model provider gateway routes", () => {
         ],
       },
     });
+    const runContextSnapshot = runContextSnapshotForRun(runId);
+    expect(runContextSnapshot.firewalls).toContainEqual({
+      kind: "inline",
+      name: firewallName,
+      apis: [
+        {
+          base: "https://gateway.example.com/anthropic/v1/messages",
+          hostPolicy: { kind: "publicDestination" },
+          auth: {
+            headerEntries: [
+              {
+                name: "Authorization",
+                value: `Bearer \${{ secrets.VM0_MODEL_PROVIDER_API_KEY }}`,
+              },
+            ],
+          },
+          permissions: [],
+        },
+      ],
+    });
+    expect(JSON.stringify(runContextSnapshot)).not.toContain(
+      "runtime-gateway-secret",
+    );
     expect(claim.secretValues).not.toContain("runtime-gateway-secret");
 
     await runs.requestCancelRun(actor, runId, [200]);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -15,7 +15,6 @@ import {
 } from "@okouai/api-contracts/contracts/runners";
 import type { TriggerSource } from "@okouai/api-contracts/contracts/logs";
 import type { CodexServiceTier } from "@okouai/api-contracts/contracts/chat-threads";
-import type { RunContextResponse } from "@okouai/api-contracts/contracts/zero-runs";
 import type { AgentCustomConnectorGrant } from "@okouai/api-contracts/contracts/zero-agent-custom-connectors";
 import { customConnectorSlugSchema } from "@okouai/api-contracts/contracts/zero-custom-connectors";
 import {
@@ -171,6 +170,7 @@ import { generateZeroToken } from "../auth/tokens";
 import { onRejection, safeSync, settle, tapError } from "../utils";
 import {
   environmentRecordToEntries,
+  executionFirewallsToAxiomEntries,
   featureFlagsRecordToEntries,
   networkPoliciesRecordToEntries,
   type RunContextAxiomSnapshot,
@@ -5983,48 +5983,6 @@ function sanitizeEnvironment(
   return sanitized;
 }
 
-function sanitizedFirewallSnapshot(
-  firewall: Firewall,
-): Extract<RunContextResponse["firewalls"][number], { apis: unknown }> {
-  return {
-    name: firewall.name,
-    apis: firewall.apis.map((api) => {
-      return {
-        base: api.base,
-        permissions: api.permissions?.map((permission) => {
-          return {
-            name: permission.name,
-            description: permission.description,
-            rules: permission.rules,
-          };
-        }),
-      };
-    }),
-  };
-}
-
-function firewallSnapshotEntry(
-  entry: ExecutionFirewallEntry,
-): RunContextResponse["firewalls"][number] {
-  if (entry.kind === "inline") {
-    return sanitizedFirewallSnapshot(entry.firewall);
-  }
-  return entry.baseUrlVars
-    ? { kind: "builtin", name: entry.name, baseUrlVars: entry.baseUrlVars }
-    : { kind: "builtin", name: entry.name };
-}
-
-function firewallSnapshots(
-  firewalls: ExecutionFirewalls | null | undefined,
-): RunContextResponse["firewalls"] {
-  if (!firewalls) {
-    return [];
-  }
-  return firewalls.map((entry) => {
-    return firewallSnapshotEntry(entry);
-  });
-}
-
 function buildRunContextSnapshot(args: {
   readonly runId: string;
   readonly userId: string;
@@ -6048,7 +6006,7 @@ function buildRunContextSnapshot(args: {
     cliAgentType: storedContext.cliAgentType,
     secretNames: [...args.builtContext.secretNames],
     environmentEntries: environmentRecordToEntries(sanitizedEnvironment),
-    firewalls: firewallSnapshots(storedContext.firewalls),
+    firewalls: executionFirewallsToAxiomEntries(storedContext.firewalls),
     networkPolicyEntries: networkPoliciesRecordToEntries(
       storedContext.networkPolicies,
     ),

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -112,13 +112,7 @@ type RunContextBuiltinFirewall = Extract<
   RunContextFirewall,
   { kind: "builtin" }
 >;
-type RunContextExecutionInlineFirewall = Extract<
-  RunContextFirewall,
-  { kind: "inline" }
->;
-type RunContextInlineFirewall =
-  | Extract<RunContextFirewall, { apis: unknown }>
-  | RunContextExecutionInlineFirewall["firewall"];
+type RunContextInlineFirewall = Extract<RunContextFirewall, { apis: unknown }>;
 type RunContextInlinePermission =
   RunContextInlineFirewall["apis"][number]["permissions"] extends
     | readonly (infer Permission)[]
@@ -487,12 +481,6 @@ function completeRunBaseUrlVars(
   return values;
 }
 
-function runContextFirewallName(firewall: RunContextFirewall): string {
-  return "kind" in firewall && firewall.kind === "inline"
-    ? firewall.firewall.name
-    : firewall.name;
-}
-
 async function loadRunRoutingConfigs(
   runContext: RunContextResponse,
   snapshot: ConnectorRuntimeSnapshot,
@@ -517,18 +505,11 @@ async function loadRunRoutingConfigs(
 
   const configs: ConnectorCheckRoutingConfig[] = [];
   for (const firewall of runContext.firewalls) {
-    const firewallName = runContextFirewallName(firewall);
-    if (!snapshot.serverFirewalls.has(firewallName)) {
+    if (!snapshot.serverFirewalls.has(firewall.name)) {
       continue;
     }
-    const connectorSlug = firewallName;
+    const connectorSlug = firewall.name;
     const view = await loadView(connectorSlug);
-    if ("kind" in firewall && firewall.kind === "inline") {
-      configs.push(
-        configFromInlineRunContext(firewall.firewall, connectorSlug, view),
-      );
-      continue;
-    }
     if ("apis" in firewall) {
       configs.push(configFromInlineRunContext(firewall, connectorSlug, view));
       continue;

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -108,7 +108,17 @@ interface DecisionPermission {
 }
 
 type RunContextFirewall = RunContextResponse["firewalls"][number];
-type RunContextInlineFirewall = Extract<RunContextFirewall, { apis: unknown }>;
+type RunContextBuiltinFirewall = Extract<
+  RunContextFirewall,
+  { kind: "builtin" }
+>;
+type RunContextExecutionInlineFirewall = Extract<
+  RunContextFirewall,
+  { kind: "inline" }
+>;
+type RunContextInlineFirewall =
+  | Extract<RunContextFirewall, { apis: unknown }>
+  | RunContextExecutionInlineFirewall["firewall"];
 type RunContextInlinePermission =
   RunContextInlineFirewall["apis"][number]["permissions"] extends
     | readonly (infer Permission)[]
@@ -457,7 +467,7 @@ function configFromInlineRunContext(
 }
 
 function completeRunBaseUrlVars(
-  firewall: Exclude<RunContextFirewall, { apis: unknown }>,
+  firewall: RunContextBuiltinFirewall,
   requiredNames: readonly string[],
 ): Readonly<Record<string, string>> | null {
   if (requiredNames.length === 0) {
@@ -475,6 +485,12 @@ function completeRunBaseUrlVars(
     values[name] = value;
   }
   return values;
+}
+
+function runContextFirewallName(firewall: RunContextFirewall): string {
+  return "kind" in firewall && firewall.kind === "inline"
+    ? firewall.firewall.name
+    : firewall.name;
 }
 
 async function loadRunRoutingConfigs(
@@ -501,11 +517,18 @@ async function loadRunRoutingConfigs(
 
   const configs: ConnectorCheckRoutingConfig[] = [];
   for (const firewall of runContext.firewalls) {
-    if (!snapshot.serverFirewalls.has(firewall.name)) {
+    const firewallName = runContextFirewallName(firewall);
+    if (!snapshot.serverFirewalls.has(firewallName)) {
       continue;
     }
-    const connectorSlug = firewall.name;
+    const connectorSlug = firewallName;
     const view = await loadView(connectorSlug);
+    if ("kind" in firewall && firewall.kind === "inline") {
+      configs.push(
+        configFromInlineRunContext(firewall.firewall, connectorSlug, view),
+      );
+      continue;
+    }
     if ("apis" in firewall) {
       configs.push(configFromInlineRunContext(firewall, connectorSlug, view));
       continue;

--- a/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
@@ -328,7 +328,16 @@ function executionInlineFirewallFromUnknown(
   };
   const normalized =
     executionFirewallInlineEntrySchema.safeParse(executionEntry);
-  return normalized.success ? normalized.data : undefined;
+  if (!normalized.success) {
+    return undefined;
+  }
+  return {
+    kind: "inline",
+    ...normalized.data.firewall,
+    ...(normalized.data.customConnectorId === undefined
+      ? {}
+      : { customConnectorId: normalized.data.customConnectorId }),
+  };
 }
 
 function firewallsFromUnknown(value: unknown): RunContextResponse["firewalls"] {

--- a/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
@@ -1,5 +1,14 @@
 import type { RunContextResponse } from "@okouai/api-contracts/contracts/zero-runs";
-import type { NetworkPolicies } from "@okouai/connectors/firewall-types";
+import {
+  executionFirewallInlineEntrySchema,
+  firewallAwsSigv4AuthSchema,
+  firewallBaseHostPolicySchema,
+  firewallPermissionSchema,
+  type ExecutionFirewallInlineEntry,
+  type ExecutionFirewalls,
+  type NetworkPolicies,
+} from "@okouai/connectors/firewall-types";
+import { z } from "zod";
 
 type UnknownRecord = Record<string, unknown>;
 type NetworkPolicy = NetworkPolicies[string];
@@ -12,6 +21,10 @@ type RunContextBuiltinFirewall = Extract<
 type RunContextSanitizedFirewall = Extract<
   RunContextFirewall,
   { apis: unknown }
+>;
+type RunContextExecutionInlineFirewall = Extract<
+  RunContextFirewall,
+  { kind: "inline" }
 >;
 type RunContextFirewallApi = RunContextSanitizedFirewall["apis"][number];
 type RunContextFirewallPermission = NonNullable<
@@ -34,14 +47,49 @@ export interface RunContextFeatureFlagEntry {
   readonly enabled: boolean;
 }
 
+const runContextAxiomAuthEntrySchema = z.object({
+  name: z.string(),
+  value: z.string(),
+});
+
+const runContextAxiomFirewallAuthSchema = z.object({
+  headerEntries: z.array(runContextAxiomAuthEntrySchema).optional(),
+  base: z.string().min(1).optional(),
+  queryEntries: z.array(runContextAxiomAuthEntrySchema).optional(),
+  awsSigv4: firewallAwsSigv4AuthSchema.optional(),
+});
+
+const runContextAxiomInlineFirewallSchema = z.object({
+  kind: z.literal("inline"),
+  name: z.string().min(1),
+  customConnectorId: z.uuid().optional(),
+  apis: z.array(
+    z.object({
+      id: z.string().min(1).optional(),
+      base: z.string(),
+      hostPolicy: firewallBaseHostPolicySchema.optional(),
+      auth: runContextAxiomFirewallAuthSchema,
+      permissions: z.array(firewallPermissionSchema).optional(),
+    }),
+  ),
+});
+
+type RunContextAxiomInlineFirewall = z.infer<
+  typeof runContextAxiomInlineFirewallSchema
+>;
+type RunContextAxiomFirewall =
+  | RunContextBuiltinFirewall
+  | RunContextAxiomInlineFirewall;
+
 export type RunContextAxiomSnapshot = Omit<
   RunContextResponse,
-  "vars" | "environment" | "networkPolicies" | "featureFlags"
+  "vars" | "environment" | "firewalls" | "networkPolicies" | "featureFlags"
 > & {
   readonly _time: string;
   readonly userId: string;
   readonly cliAgentType?: string;
   readonly environmentEntries: readonly RunContextEnvironmentEntry[];
+  readonly firewalls: readonly RunContextAxiomFirewall[];
   readonly networkPolicyEntries: readonly RunContextNetworkPolicyEntry[];
   readonly featureFlagEntries: readonly RunContextFeatureFlagEntry[];
 };
@@ -226,6 +274,63 @@ function sanitizedFirewallFromUnknown(
   };
 }
 
+function authEntriesToRecord(
+  entries:
+    | readonly z.infer<typeof runContextAxiomAuthEntrySchema>[]
+    | undefined,
+): Record<string, string> | undefined {
+  return entries === undefined
+    ? undefined
+    : Object.fromEntries(
+        entries.map((entry) => {
+          return [entry.name, entry.value];
+        }),
+      );
+}
+
+function executionInlineFirewallFromUnknown(
+  value: UnknownRecord,
+): RunContextExecutionInlineFirewall | undefined {
+  const parsed = runContextAxiomInlineFirewallSchema.safeParse(value);
+  if (!parsed.success) {
+    return undefined;
+  }
+  const executionEntry = {
+    kind: "inline",
+    ...(parsed.data.customConnectorId === undefined
+      ? {}
+      : { customConnectorId: parsed.data.customConnectorId }),
+    firewall: {
+      name: parsed.data.name,
+      apis: parsed.data.apis.map((api) => {
+        const headers = authEntriesToRecord(api.auth.headerEntries);
+        const query = authEntriesToRecord(api.auth.queryEntries);
+        return {
+          ...(api.id === undefined ? {} : { id: api.id }),
+          base: api.base,
+          ...(api.hostPolicy === undefined
+            ? {}
+            : { hostPolicy: api.hostPolicy }),
+          auth: {
+            ...(headers === undefined ? {} : { headers }),
+            ...(api.auth.base === undefined ? {} : { base: api.auth.base }),
+            ...(query === undefined ? {} : { query }),
+            ...(api.auth.awsSigv4 === undefined
+              ? {}
+              : { awsSigv4: api.auth.awsSigv4 }),
+          },
+          ...(api.permissions === undefined
+            ? {}
+            : { permissions: api.permissions }),
+        };
+      }),
+    },
+  };
+  const normalized =
+    executionFirewallInlineEntrySchema.safeParse(executionEntry);
+  return normalized.success ? normalized.data : undefined;
+}
+
 function firewallsFromUnknown(value: unknown): RunContextResponse["firewalls"] {
   if (!Array.isArray(value)) {
     return [];
@@ -241,6 +346,13 @@ function firewallsFromUnknown(value: unknown): RunContextResponse["firewalls"] {
         firewalls.push(normalized);
       }
       continue;
+    }
+    if (item.kind === "inline") {
+      const normalized = executionInlineFirewallFromUnknown(item);
+      if (normalized) {
+        firewalls.push(normalized);
+        continue;
+      }
     }
     const normalized = sanitizedFirewallFromUnknown(item);
     if (normalized) {
@@ -335,6 +447,56 @@ export function featureFlagsRecordToEntries(
   }
   return Object.entries(featureFlags).map(([name, enabled]) => {
     return { name, enabled };
+  });
+}
+
+function authRecordToEntries(
+  values: Record<string, string> | undefined,
+): z.infer<typeof runContextAxiomAuthEntrySchema>[] | undefined {
+  return values === undefined
+    ? undefined
+    : Object.entries(values).map(([name, value]) => {
+        return { name, value };
+      });
+}
+
+function inlineFirewallToAxiomEntry(
+  entry: ExecutionFirewallInlineEntry,
+): RunContextAxiomInlineFirewall {
+  return {
+    kind: "inline",
+    name: entry.firewall.name,
+    ...(entry.customConnectorId === undefined
+      ? {}
+      : { customConnectorId: entry.customConnectorId }),
+    apis: entry.firewall.apis.map((api) => {
+      const headerEntries = authRecordToEntries(api.auth.headers);
+      const queryEntries = authRecordToEntries(api.auth.query);
+      return {
+        ...(api.id === undefined ? {} : { id: api.id }),
+        base: api.base,
+        ...(api.hostPolicy === undefined ? {} : { hostPolicy: api.hostPolicy }),
+        auth: {
+          ...(headerEntries === undefined ? {} : { headerEntries }),
+          ...(api.auth.base === undefined ? {} : { base: api.auth.base }),
+          ...(queryEntries === undefined ? {} : { queryEntries }),
+          ...(api.auth.awsSigv4 === undefined
+            ? {}
+            : { awsSigv4: api.auth.awsSigv4 }),
+        },
+        ...(api.permissions === undefined
+          ? {}
+          : { permissions: api.permissions }),
+      };
+    }),
+  };
+}
+
+export function executionFirewallsToAxiomEntries(
+  firewalls: ExecutionFirewalls | null | undefined,
+): RunContextAxiomFirewall[] {
+  return (firewalls ?? []).map((entry) => {
+    return entry.kind === "inline" ? inlineFirewallToAxiomEntry(entry) : entry;
   });
 }
 

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -152,9 +152,18 @@ const runContextSanitizedFirewallSchema = z.object({
   ),
 });
 
+// Keep name/apis at the top level so the previous web client can parse a new
+// inline response through runContextSanitizedFirewallSchema during rollout.
+const runContextExecutionInlineFirewallSchema =
+  executionFirewallInlineEntrySchema.shape.firewall.extend({
+    kind: z.literal("inline"),
+    customConnectorId:
+      executionFirewallInlineEntrySchema.shape.customConnectorId,
+  });
+
 const runContextFirewallSchema = z.union([
   executionFirewallBuiltinEntrySchema,
-  executionFirewallInlineEntrySchema,
+  runContextExecutionInlineFirewallSchema,
   runContextSanitizedFirewallSchema,
 ]);
 

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -3,6 +3,7 @@ import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
 import {
   executionFirewallBuiltinEntrySchema,
+  executionFirewallInlineEntrySchema,
   networkPoliciesSchema,
 } from "@okouai/connectors/firewall-types";
 import {
@@ -114,7 +115,9 @@ export const zeroRunsQueueContract = c.router({
 });
 
 /**
- * Run context snapshot — sanitized execution context for debugging.
+ * Run context snapshot — launch-time execution context for debugging.
+ * Environment secret values are redacted. Firewall auth retains the prepared
+ * execution templates, including secret references, but never resolves them.
  * Dynamic fields (environment, firewalls, volumes, artifact) are stored in Axiom.
  * Static fields (prompt, vars, secretNames) are merged from agent_runs at query time.
  */
@@ -151,6 +154,7 @@ const runContextSanitizedFirewallSchema = z.object({
 
 const runContextFirewallSchema = z.union([
   executionFirewallBuiltinEntrySchema,
+  executionFirewallInlineEntrySchema,
   runContextSanitizedFirewallSchema,
 ]);
 
@@ -172,7 +176,7 @@ export const runContextResponseSchema = z.object({
 
 /**
  * Zero run context contract (GET /api/okou/runs/:id/context)
- * Returns sanitized execution context snapshot for debugging
+ * Returns a launch-time execution context snapshot for debugging
  */
 export const zeroRunContextContract = c.router({
   getContext: {


### PR DESCRIPTION
## Summary

- preserve prepared inline firewall execution metadata and unresolved auth references in run-context snapshots
- encode dynamic auth header/query keys as Axiom entry arrays while keeping the legacy top-level `name`/`apis` storage fallback
- return enriched inline firewalls at the compatible top level so previous API readers and already-loaded web clients degrade to the historical sanitized view
- keep historical, builtin, and connector diagnostic behavior compatible

## Security and compatibility

- credentials are never resolved into the snapshot; integration tests assert actual custom connector and model provider secret values are absent
- old and new API readers can consume each other's Axiom rows, and old and new web clients can consume each other's response shapes
- runner payloads, claim-time policy, and catalog identity/version remain unchanged

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm check-types`
- focused API integration tests: 4 files, 196 tests passed
- API contract tests: 28 files, 543 tests passed
- `pnpm knip`
- `pnpm turbo run build --filter=api --filter=@okouai/app`

Closes #26825
