### PR TITLE
fix(platform): keep async card shells stable

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -489,7 +489,10 @@ describe("chat event action cards", () => {
     });
 
     const loadingCard = await screen.findByTestId("mail-draft-card-loading");
-    expect(loadingCard).toHaveClass("h-[76px]");
+    const mailCardShell = screen.getByTestId("mail-draft-card-shell");
+    expect(mailCardShell.tagName).toBe("DIV");
+    expect(mailCardShell).toHaveClass("h-[76px]");
+    expect(loadingCard).toHaveClass("h-full");
     await waitFor(() => {
       expect(draftRequestStarted).toBeTruthy();
     });
@@ -498,7 +501,9 @@ describe("chat event action cards", () => {
     const mailCard = await screen.findByLabelText(
       `Open sent email: ${MAIL_DRAFT_SUBJECT}`,
     );
-    expect(mailCard).toHaveClass("h-[76px]");
+    expect(screen.getByTestId("mail-draft-card-shell")).toBe(mailCardShell);
+    expect(mailCard.tagName).toBe("BUTTON");
+    expect(mailCard).toHaveClass("h-full");
     expect(
       screen.queryByTestId("mail-draft-card-loading"),
     ).not.toBeInTheDocument();
@@ -507,6 +512,83 @@ describe("chat event action cards", () => {
     await user.click(mailCard);
     const sidebar = await screen.findByTestId("mail-draft-sidebar");
     expect(queryButtonByText("Follow up", sidebar)).toBeNull();
+  });
+
+  it("keeps the browser card div shell mounted while the session loads", async () => {
+    const threadId = "c0000000-0000-4000-a000-000000000078";
+    const browserUrl = `https://app.vm0.ai/browsers/${threadId}`;
+    let browserRequestStarted = false;
+    let resolveBrowser = (): void => {
+      throw new Error("Browser request did not start");
+    };
+    const browser: ZeroBrowserSession = {
+      threadId,
+      name: "loading-shell",
+      status: "active",
+      viewerUrl: browserUrl,
+      liveUrl: "https://live.browser-use.com/?wss=loading-shell-token",
+      screenshotUrl: null,
+      proxyCountryCode: null,
+      timeoutMinutes: 240,
+      idleExpiresAt: "2026-07-30T10:10:00.000Z",
+      suspendedAt: null,
+      suspensionReason: null,
+      createdAt: "2026-07-30T10:00:00.000Z",
+      updatedAt: "2026-07-30T10:00:00.000Z",
+    };
+    context.mocks.api(
+      zeroBrowserContract.get,
+      async ({ deferred, params, respond }) => {
+        expect(params.threadId).toBe(threadId);
+        const browserDeferred = deferred<void>();
+        resolveBrowser = () => {
+          browserDeferred.resolve();
+        };
+        browserRequestStarted = true;
+        await browserDeferred.promise;
+        return respond(200, { browser });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Browser loading shell",
+      chatEvents: [
+        {
+          id: `${threadId}-message`,
+          role: "assistant",
+          content: browserUrl,
+          runId: `${threadId}-run`,
+          createdAt: "2026-07-30T10:00:00.000Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+    });
+
+    const loadingCard = await screen.findByTestId(
+      "browser-session-card-loading",
+    );
+    const browserCardShell = screen.getByTestId("browser-session-card-shell");
+    expect(browserCardShell.tagName).toBe("DIV");
+    expect(loadingCard).toBeInTheDocument();
+    await waitFor(() => {
+      expect(browserRequestStarted).toBeTruthy();
+    });
+    resolveBrowser();
+
+    const browserCard = await screen.findByLabelText(
+      "Open loading-shell browser",
+    );
+    expect(screen.getByTestId("browser-session-card-shell")).toBe(
+      browserCardShell,
+    );
+    expect(browserCard.tagName).toBe("BUTTON");
+    expect(
+      screen.queryByTestId("browser-session-card-loading"),
+    ).not.toBeInTheDocument();
   });
 
   it("opens a shared mail draft without reloading and refreshes after sending", async () => {

--- a/turbo/apps/platform/src/views/zero-page/browser-session-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/browser-session-card.tsx
@@ -2,6 +2,7 @@ import { AppWindow } from "lucide-react";
 import { cn } from "@okouai/ui";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
+import type { ReactNode } from "react";
 
 import type { BrowserSessionSignals } from "../../signals/chat-page/browser-session-block.ts";
 import type { ImageLoadSignals } from "../../signals/image-load.ts";
@@ -17,10 +18,27 @@ interface BrowserSessionCardProps {
   readonly signals: BrowserSessionSignals;
 }
 
+const BROWSER_SESSION_CARD_SHELL_CLASS =
+  "inline-flex w-[min(100%,400px)] align-top";
 const BROWSER_SESSION_CARD_CLASS =
-  "inline-flex w-[min(100%,400px)] flex-col overflow-hidden rounded-lg border border-foreground/10 bg-background text-left align-top text-foreground transition-all duration-200";
+  "flex w-full flex-col overflow-hidden rounded-lg border border-foreground/10 bg-background text-left text-foreground transition-all duration-200";
 const BROWSER_SESSION_CARD_HOVER_CLASS =
   "hover:scale-[1.015] hover:border-foreground/20";
+
+function BrowserSessionCardShell({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  return (
+    <div
+      data-testid="browser-session-card-shell"
+      className={BROWSER_SESSION_CARD_SHELL_CLASS}
+    >
+      {children}
+    </div>
+  );
+}
 
 function BrowserSessionStatus({ live }: { readonly live: boolean }) {
   const { t } = useTranslation();
@@ -85,6 +103,7 @@ function BrowserSessionPreview({
 function BrowserSessionCardSkeleton() {
   return (
     <div
+      data-testid="browser-session-card-loading"
       className={cn(
         BROWSER_SESSION_CARD_CLASS,
         "animate-pulse border-border/70",
@@ -156,53 +175,67 @@ export function BrowserSessionCard({ signals }: BrowserSessionCardProps) {
   const start = useSet(signals.start$);
 
   if (sessionLoadable.state === "loading") {
-    return <BrowserSessionCardSkeleton />;
+    return (
+      <BrowserSessionCardShell>
+        <BrowserSessionCardSkeleton />
+      </BrowserSessionCardShell>
+    );
   }
   if (sessionLoadable.state === "hasError") {
-    return <BrowserSessionUnavailable />;
+    return (
+      <BrowserSessionCardShell>
+        <BrowserSessionUnavailable />
+      </BrowserSessionCardShell>
+    );
   }
   if (sessionLoadable.data === null) {
-    return <BrowserSessionUnavailable signals={signals} />;
+    return (
+      <BrowserSessionCardShell>
+        <BrowserSessionUnavailable signals={signals} />
+      </BrowserSessionCardShell>
+    );
   }
 
   const session = sessionLoadable.data;
   const selected = selectedBrowserThreadId === signals.threadId;
   const live = session.status === "active";
   return (
-    <button
-      type="button"
-      data-browser-session-card
-      data-browser-session-status={session.status}
-      aria-label={t(
-        ($) => {
-          return $.browserSession.open;
-        },
-        { name: session.name },
-      )}
-      onClick={() => {
-        if (live && !selected) {
-          detach(start(pageSignal), Reason.DomCallback);
-        }
-        openSidebar(signals.threadId);
-      }}
-      className={cn(
-        BROWSER_SESSION_CARD_CLASS,
-        BROWSER_SESSION_CARD_HOVER_CLASS,
-        selected && "border-ring/60 bg-muted/20",
-      )}
-    >
-      <span className="flex min-h-10 w-full items-center gap-2 border-b border-border/60 bg-background/95 px-3 py-2">
-        <span className="min-w-0 flex-1 truncate text-sm font-medium">
-          {t(($) => {
-            return $.browserSession.cardTitle;
-          })}
+    <BrowserSessionCardShell>
+      <button
+        type="button"
+        data-browser-session-card
+        data-browser-session-status={session.status}
+        aria-label={t(
+          ($) => {
+            return $.browserSession.open;
+          },
+          { name: session.name },
+        )}
+        onClick={() => {
+          if (live && !selected) {
+            detach(start(pageSignal), Reason.DomCallback);
+          }
+          openSidebar(signals.threadId);
+        }}
+        className={cn(
+          BROWSER_SESSION_CARD_CLASS,
+          BROWSER_SESSION_CARD_HOVER_CLASS,
+          selected && "border-ring/60 bg-muted/20",
+        )}
+      >
+        <span className="flex min-h-10 w-full items-center gap-2 border-b border-border/60 bg-background/95 px-3 py-2">
+          <span className="min-w-0 flex-1 truncate text-sm font-medium">
+            {t(($) => {
+              return $.browserSession.cardTitle;
+            })}
+          </span>
+          <BrowserSessionStatus live={live} />
         </span>
-        <BrowserSessionStatus live={live} />
-      </span>
-      <BrowserSessionPreview
-        screenshotUrl={session.screenshotUrl ?? undefined}
-        load={signals.screenshotImageLoad}
-      />
-    </button>
+        <BrowserSessionPreview
+          screenshotUrl={session.screenshotUrl ?? undefined}
+          load={signals.screenshotImageLoad}
+        />
+      </button>
+    </BrowserSessionCardShell>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -7,6 +7,7 @@ import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts
 import { cn } from "@okouai/ui";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
+import type { ReactNode } from "react";
 
 import { i18n } from "../../i18n/index.ts";
 import type { MailDraftSignals } from "../../signals/chat-page/mail-draft.ts";
@@ -22,6 +23,17 @@ interface MailDraftCardProps {
 }
 
 const MAIL_DRAFT_CARD_HEIGHT_CLASS = "h-[76px]";
+
+function MailDraftCardShell({ children }: { readonly children: ReactNode }) {
+  return (
+    <div
+      data-testid="mail-draft-card-shell"
+      className={cn("w-full max-w-xl", MAIL_DRAFT_CARD_HEIGHT_CLASS)}
+    >
+      {children}
+    </div>
+  );
+}
 
 function statusLabel(status: ZeroMailDraftStatus): string {
   switch (status) {
@@ -47,10 +59,7 @@ function MailDraftCardSkeleton() {
   return (
     <div
       data-testid="mail-draft-card-loading"
-      className={cn(
-        "flex w-full max-w-xl items-center gap-3 rounded-[var(--zero-card-radius)] border border-border/70 bg-card px-4 py-3",
-        MAIL_DRAFT_CARD_HEIGHT_CLASS,
-      )}
+      className="flex h-full w-full items-center gap-3 rounded-[var(--zero-card-radius)] border border-border/70 bg-card px-4 py-3"
     >
       <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted/60">
         <Loader2 className="animate-spin text-muted-foreground" size={16} />
@@ -162,10 +171,7 @@ function DeletedMailDraftCard({
       )}
       data-mail-draft-card
       data-mail-draft-status="deleted"
-      className={cn(
-        "flex w-full max-w-xl cursor-default items-center gap-3 rounded-[var(--zero-card-radius)] border border-border/60 bg-card px-4 py-3 opacity-70",
-        MAIL_DRAFT_CARD_HEIGHT_CLASS,
-      )}
+      className="flex h-full w-full cursor-default items-center gap-3 rounded-[var(--zero-card-radius)] border border-border/60 bg-card px-4 py-3 opacity-70"
     >
       <MailDraftCardContent
         draft={draft}
@@ -186,7 +192,11 @@ export function MailDraftCard({ signals }: MailDraftCardProps) {
     useGmailReconnect(reloadDraft);
 
   if (draftLoadable.state === "loading") {
-    return <MailDraftCardSkeleton />;
+    return (
+      <MailDraftCardShell>
+        <MailDraftCardSkeleton />
+      </MailDraftCardShell>
+    );
   }
   if (draftLoadable.state === "hasError" || draftLoadable.data === null) {
     return null;
@@ -214,64 +224,66 @@ export function MailDraftCard({ signals }: MailDraftCardProps) {
 
   if (deleted) {
     return (
-      <DeletedMailDraftCard
-        draft={draft}
-        gmailIcon={connectorIcon}
-        subject={subject}
-      />
+      <MailDraftCardShell>
+        <DeletedMailDraftCard
+          draft={draft}
+          gmailIcon={connectorIcon}
+          subject={subject}
+        />
+      </MailDraftCardShell>
     );
   }
 
   if (needsReconnect) {
     return (
+      <MailDraftCardShell>
+        <button
+          type="button"
+          disabled={reconnectDisabled}
+          onClick={reconnect}
+          aria-label={t(
+            ($) => {
+              return $.chat.mail.reconnectToAccess;
+            },
+            {
+              subject,
+            },
+          )}
+          data-mail-draft-card
+          data-mail-draft-status={draft.status}
+          className="flex h-full w-full items-center gap-3 rounded-[var(--zero-card-radius)] border border-border/70 bg-card px-4 py-3 text-left transition-colors hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-wait disabled:opacity-70"
+        >
+          {content}
+        </button>
+      </MailDraftCardShell>
+    );
+  }
+
+  return (
+    <MailDraftCardShell>
       <button
         type="button"
-        disabled={reconnectDisabled}
-        onClick={reconnect}
         aria-label={t(
           ($) => {
-            return $.chat.mail.reconnectToAccess;
+            return $.chat.mail.openEmail;
           },
           {
+            status: statusLabel(draft.status).toLocaleLowerCase(
+              i18n.resolvedLanguage,
+            ),
             subject,
           },
         )}
         data-mail-draft-card
         data-mail-draft-status={draft.status}
+        onClick={openDraft}
         className={cn(
-          "flex w-full max-w-xl items-center gap-3 rounded-[var(--zero-card-radius)] border border-border/70 bg-card px-4 py-3 text-left transition-colors hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-wait disabled:opacity-70",
-          MAIL_DRAFT_CARD_HEIGHT_CLASS,
+          "flex h-full w-full items-center gap-3 rounded-[var(--zero-card-radius)] border bg-card px-4 py-3 text-left transition-colors hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+          selected ? "border-ring/60 bg-muted/20" : "border-border/70",
         )}
       >
         {content}
       </button>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      aria-label={t(
-        ($) => {
-          return $.chat.mail.openEmail;
-        },
-        {
-          status: statusLabel(draft.status).toLocaleLowerCase(
-            i18n.resolvedLanguage,
-          ),
-          subject,
-        },
-      )}
-      data-mail-draft-card
-      data-mail-draft-status={draft.status}
-      onClick={openDraft}
-      className={cn(
-        "flex w-full max-w-xl items-center gap-3 rounded-[var(--zero-card-radius)] border bg-card px-4 py-3 text-left transition-colors hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-        MAIL_DRAFT_CARD_HEIGHT_CLASS,
-        selected ? "border-ring/60 bg-muted/20" : "border-border/70",
-      )}
-    >
-      {content}
-    </button>
+    </MailDraftCardShell>
   );
 }


### PR DESCRIPTION
## Summary

- keep a persistent div shell around mail draft cards while draft data resolves
- keep the same stable shell around browser session cards across loading, error, and ready states
- preserve the existing card geometry and keep interactive behavior on inner buttons
- add page-level regression coverage for shell identity across async resolution

## Why

Mobile Safari can move the chat scroll position when an async card replaces its root div with a button. Mail and browser cards now update only the contents of a stable outer div.

## Verification

- `pnpm exec prettier --check` on changed files
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `chat-event-action-cards.test.tsx`: 41 passed
- targeted browser inactive/sidebar regression: 1 passed