### PR TITLE
refactor(python): separate auth.base transport

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -20,17 +20,19 @@ import flow_metadata_keys as metadata_keys
 import http_local_responses
 import matching
 from auth_base_forwarder import (
-    MAX_AUTH_BASE_REQUEST_BODY_BYTES,
     AuthBaseForwardingSaturatedError,
+    forward_request,
+    release_forward_request_admission_from_flow,
+    take_forward_request_admission_from_flow,
+)
+from auth_base_transport import (
+    MAX_AUTH_BASE_REQUEST_BODY_BYTES,
     ForwardedRequestTooLargeError,
     InvalidAuthBaseRequestHeadersError,
     InvalidResolvedAuthHeaderError,
-    forward_request,
     forwarded_auth_base_client_header_pairs,
     header_pairs,
-    release_forward_request_admission_from_flow,
     resolved_auth_header_pairs,
-    take_forward_request_admission_from_flow,
 )
 from aws_sigv4 import (
     AwsSigV4BodyHash,

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -1,60 +1,48 @@
-"""HTTPS forwarding for auth.base URL rewrites.
+"""Async lifecycle and admission for auth.base HTTPS forwarding.
 
 The addon forwards auth.base requests itself because mitmproxy's eager
-connection has already connected to the placeholder IP. This module owns
-the low-level HTTP details for that forward path.
+connection has already connected to the placeholder IP. This module is the
+public forwarding facade and owns worker lifecycle and admission state.
 """
 
 import asyncio
 import contextvars
-import errno
-import http.client as http_client
-import ipaddress
 import socket
-import ssl
 import sys
 import threading
 import time
-import urllib.parse
 from collections.abc import Callable
 from concurrent.futures import Future, InvalidStateError
 from contextlib import suppress
 from enum import Enum, auto
-from typing import NamedTuple, Protocol
+from typing import NamedTuple
 
-import mitmproxy_rs
 from mitmproxy import http
 
+import auth_base_transport
 import flow_metadata_keys as metadata_keys
-import public_destination
 import request_body_admission
-from authority_utils import (
-    IPV6_VERSION,
-    authority_has_empty_port,
-    format_url_host,
-    percent_decode_host,
-    raw_authority_host,
-)
-from host_normalization import normalize_idna_hostname
-from http_header_syntax import has_forbidden_header_value_control, is_http_header_name
-from runtime_url_parsing import split_runtime_url
 
-HOP_BY_HOP: frozenset[str] = frozenset(
-    (
-        "connection",
-        "keep-alive",
-        "proxy-connection",
-        "proxy-authenticate",
-        "proxy-authorization",
-        "transfer-encoding",
-        "te",
-        "trailer",
-        "upgrade",
-    )
+DEFAULT_HTTPS_PORT = auth_base_transport.DEFAULT_HTTPS_PORT
+HOP_BY_HOP = auth_base_transport.HOP_BY_HOP
+MAX_AUTH_BASE_REQUEST_BODY_BYTES = auth_base_transport.MAX_AUTH_BASE_REQUEST_BODY_BYTES
+MAX_AUTH_BASE_RESPONSE_BODY_BYTES = auth_base_transport.MAX_AUTH_BASE_RESPONSE_BODY_BYTES
+AuthBaseForwardingDeadlineExceededError = (
+    auth_base_transport.AuthBaseForwardingDeadlineExceededError
 )
-DEFAULT_HTTPS_PORT = 443
-MAX_AUTH_BASE_REQUEST_BODY_BYTES = 32 * 1024 * 1024
-MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
+ForwardedRequestTooLargeError = auth_base_transport.ForwardedRequestTooLargeError
+ForwardedResponseTooLargeError = auth_base_transport.ForwardedResponseTooLargeError
+InvalidAuthBaseRequestHeadersError = auth_base_transport.InvalidAuthBaseRequestHeadersError
+InvalidResolvedAuthHeaderError = auth_base_transport.InvalidResolvedAuthHeaderError
+UnsafeAuthBaseDestinationError = auth_base_transport.UnsafeAuthBaseDestinationError
+forwarded_auth_base_client_header_pairs = (
+    auth_base_transport.forwarded_auth_base_client_header_pairs
+)
+forwarded_request_header_pairs = auth_base_transport.forwarded_request_header_pairs
+header_pairs = auth_base_transport.header_pairs
+resolved_auth_header_pairs = auth_base_transport.resolved_auth_header_pairs
+trusted_request_header_pairs = auth_base_transport.trusted_request_header_pairs
+
 MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
 MAX_ADMITTED_AUTH_BASE_FORWARDS = 16
 MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES = 128 * 1024 * 1024
@@ -67,8 +55,6 @@ _FORWARD_REQUEST_CLEANUP_EXCEPTIONS: tuple[type[BaseException], ...] = (
     SystemExit,
     GeneratorExit,
 )
-_PERCENT_DECODED_UPSTREAM_HOST_SYNTAX_CHARS = frozenset("{}*.\u3002\uff0e\uff61,")
-_UPSTREAM_HOST_FORBIDDEN_CHARS = frozenset("{}*")
 _forward_request_accepting = True
 _forward_request_lifecycle_lock = threading.Lock()
 _forward_request_workers: set[threading.Thread] = set()
@@ -82,14 +68,6 @@ _forward_request_budget = request_body_admission.RequestBodyAdmissionBudget(
 )
 _forward_request_active_handles: set["_ForwardRequestAbortHandle"] = set()
 _forward_request_active_handles_lock = threading.Lock()
-_https_context: ssl.SSLContext | None = None
-_https_context_lock = threading.Lock()
-_dns_resolver: "_AddressResolver | None" = None
-
-
-class _AddressResolver(Protocol):
-    async def lookup_ip(self, host: str) -> list[str]:
-        raise NotImplementedError
 
 
 class _ForwardRequestAdmissionState(NamedTuple):
@@ -170,15 +148,10 @@ def _join_forward_request_workers() -> None:
 
 def reset_forward_request_state_for_tests() -> None:
     """Reset forwarder worker state between tests."""
-    global _dns_resolver
     global _forward_request_accepting
-    global _https_context
 
     shutdown_forward_request_workers(wait=True)
     _forward_request_budget.reset_for_tests()
-    with _https_context_lock:
-        _https_context = None
-    _dns_resolver = None
     _forward_request_accepting = True
 
 
@@ -198,32 +171,8 @@ def shutdown_forward_request_workers(*, wait: bool) -> None:
         _join_forward_request_workers()
 
 
-class ForwardedResponseTooLargeError(Exception):
-    """Raised when an auth.base upstream response exceeds the local body cap."""
-
-
-class ForwardedRequestTooLargeError(Exception):
-    """Raised when an auth.base forwarded request body exceeds the local cap."""
-
-
 class AuthBaseForwardingSaturatedError(Exception):
     """Raised when auth.base forwarding admission is saturated."""
-
-
-class AuthBaseForwardingDeadlineExceededError(Exception):
-    """Raised when one auth.base forwarding attempt exceeds its total lifetime."""
-
-
-class UnsafeAuthBaseDestinationError(Exception):
-    """Raised when an auth.base upstream destination is not public internet."""
-
-
-class InvalidResolvedAuthHeaderError(Exception):
-    """Raised when resolved auth data contains an invalid HTTP header."""
-
-
-class InvalidAuthBaseRequestHeadersError(Exception):
-    """Raised when client representation headers cannot be forwarded safely."""
 
 
 class _ForwardRequestTerminalState(Enum):
@@ -355,376 +304,6 @@ class _ForwardRequestAbortHandle:
         raise RuntimeError("auth.base forwarding attempt is already completed")
 
 
-class _ValidatedAddress(NamedTuple):
-    family: socket.AddressFamily
-    host: str
-    port: int
-
-
-class _PreparedForwardRequest(NamedTuple):
-    host: str
-    port: int | None
-    target: str
-
-
-type _SocketAddress = tuple[str, int] | tuple[str, int, int, int]
-
-
-def _validated_socket_address(address: _ValidatedAddress) -> _SocketAddress:
-    if address.family == socket.AF_INET6:
-        return address.host, address.port, 0, 0
-    return address.host, address.port
-
-
-def _remaining_deadline_seconds(deadline: float) -> float:
-    remaining = deadline - time.monotonic()
-    if remaining <= 0:
-        raise AuthBaseForwardingDeadlineExceededError("auth.base forwarding deadline exceeded")
-    return remaining
-
-
-def _create_https_context() -> ssl.SSLContext:
-    context = ssl.create_default_context()
-    context.set_alpn_protocols(["http/1.1"])
-    if context.post_handshake_auth is not None:
-        context.post_handshake_auth = True
-    return context
-
-
-def _get_https_context() -> ssl.SSLContext:
-    global _https_context
-
-    context = _https_context
-    if context is not None:
-        return context
-
-    with _https_context_lock:
-        context = _https_context
-        if context is None:
-            context = _create_https_context()
-            _https_context = context
-        return context
-
-
-class _ValidatedTLSConnection(http_client.HTTPConnection):
-    default_port = DEFAULT_HTTPS_PORT
-
-    def __init__(
-        self,
-        host: str,
-        port: int | None,
-        *,
-        deadline: float,
-        abort_handle: _ForwardRequestAbortHandle,
-        validated_addresses: tuple[_ValidatedAddress, ...],
-    ) -> None:
-        super().__init__(
-            host,
-            port=port,
-            timeout=_remaining_deadline_seconds(deadline),
-        )
-        self._abort_handle = abort_handle
-        self._deadline = deadline
-        self._validated_addresses = validated_addresses
-        self._context = _get_https_context()
-
-    def _close_and_clear_socket(self, sock: socket.socket) -> None:
-        self._abort_handle.clear_socket(sock)
-        with suppress(Exception):
-            sock.close()
-
-    def _connect_raw_socket(self) -> socket.socket:
-        last_error: OSError | None = None
-        for address in self._validated_addresses:
-            self._abort_handle.raise_if_aborted()
-            raw_sock = socket.socket(address.family, socket.SOCK_STREAM)
-            try:
-                self._abort_handle.register_socket(raw_sock)
-                raw_sock.settimeout(_remaining_deadline_seconds(self._deadline))
-                raw_sock.connect(_validated_socket_address(address))
-                self._abort_handle.raise_if_aborted()
-            except OSError as exc:
-                last_error = exc
-                self._close_and_clear_socket(raw_sock)
-                continue
-            except Exception:
-                self._close_and_clear_socket(raw_sock)
-                raise
-            return raw_sock
-        if last_error is not None:
-            raise last_error
-        raise OSError("address resolver returned an empty list")
-
-    def connect(self) -> None:
-        raw_sock = self._connect_raw_socket()
-        try:
-            raw_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        except OSError as exc:
-            if exc.errno != errno.ENOPROTOOPT:
-                self._close_and_clear_socket(raw_sock)
-                raise
-        try:
-            wrapped_sock = self._context.wrap_socket(
-                raw_sock,
-                server_hostname=self.host,
-                do_handshake_on_connect=False,
-            )
-            if wrapped_sock is not raw_sock:
-                self._abort_handle.replace_socket(raw_sock, wrapped_sock)
-            self.sock = wrapped_sock
-            self.set_remaining_timeout()
-            wrapped_sock.do_handshake()
-        except Exception:
-            current_sock = self.sock
-            self.sock = None
-            self._close_and_clear_socket(current_sock if current_sock is not None else raw_sock)
-            raise
-
-    def set_remaining_timeout(self) -> None:
-        self._abort_handle.raise_if_aborted()
-        if self.sock is not None:
-            self.sock.settimeout(_remaining_deadline_seconds(self._deadline))
-
-    def close(self) -> None:
-        sock = self.sock
-        try:
-            super().close()
-        finally:
-            if sock is not None:
-                self._abort_handle.clear_socket(sock)
-
-
-def _make_validated_https_connection(
-    host: str,
-    port: int | None,
-    *,
-    deadline: float,
-    abort_handle: _ForwardRequestAbortHandle,
-    validated_addresses: tuple[_ValidatedAddress, ...],
-) -> _ValidatedTLSConnection:
-    return _ValidatedTLSConnection(
-        host,
-        port=port,
-        deadline=deadline,
-        abort_handle=abort_handle,
-        validated_addresses=validated_addresses,
-    )
-
-
-def header_pairs(headers) -> list[tuple[str, str]]:
-    """Normalize a supported header container into ordered header pairs.
-
-    Plain dict inputs use their normal items. Header containers with an
-    ``items`` method use ``items(multi=True)`` when supported, preserving
-    repeated mitmproxy headers, then fall back to ``items()``. Other inputs
-    are treated as iterable ``(name, value)`` pairs.
-    """
-    if isinstance(headers, dict):
-        return list(headers.items())
-    if hasattr(headers, "items"):
-        try:
-            return list(headers.items(multi=True))
-        except TypeError:
-            return list(headers.items())
-    return list(headers)
-
-
-def _connection_header_names(headers: list[tuple[str, str]]) -> set[str]:
-    names: set[str] = set()
-    for header_name, header_value in headers:
-        if header_name.lower() != "connection":
-            continue
-        for token in header_value.split(","):
-            token = token.strip().lower()
-            if token:
-                names.add(token)
-    return names
-
-
-def _filter_header_pairs(
-    headers,
-    *,
-    extra_excluded: set[str] | None = None,
-) -> list[tuple[str, str]]:
-    pairs = header_pairs(headers)
-    excluded = set(HOP_BY_HOP)
-    excluded.update(_connection_header_names(pairs))
-    if extra_excluded:
-        excluded.update(extra_excluded)
-    return [(name, value) for name, value in pairs if name.lower() not in excluded]
-
-
-def forwarded_request_header_pairs(headers) -> list[tuple[str, str]]:
-    """Return request headers that can be forwarded to an auth.base target.
-
-    Hop-by-hop headers and headers named by ``Connection`` are removed.
-    ``Host``, ``Content-Length``, and ``Transfer-Encoding`` are also excluded
-    because the forwarder recomputes request authority and framing.
-    """
-    return _filter_header_pairs(
-        headers,
-        extra_excluded={"host", "content-length", "transfer-encoding"},
-    )
-
-
-def forwarded_auth_base_client_header_pairs(
-    headers,
-) -> list[tuple[str, str]]:
-    """Select representation metadata allowed to cross an auth.base rewrite."""
-    raw_pairs = header_pairs(headers)
-    content_type_count = sum(1 for name, _value in raw_pairs if name.lower() == "content-type")
-    if content_type_count > 1:
-        raise InvalidAuthBaseRequestHeadersError(
-            "auth.base requests must contain at most one Content-Type header"
-        )
-
-    return [
-        (name, value)
-        for name, value in forwarded_request_header_pairs(raw_pairs)
-        if name.lower() in {"content-type", "content-encoding"}
-    ]
-
-
-def _validate_resolved_auth_header_pair(header_name: str, header_value: str) -> None:
-    if not isinstance(header_name, str) or not is_http_header_name(header_name):
-        raise InvalidResolvedAuthHeaderError("Resolved auth header name is invalid")
-    if not isinstance(header_value, str) or has_forbidden_header_value_control(header_value):
-        raise InvalidResolvedAuthHeaderError(f"Resolved auth header {header_name} value is invalid")
-    try:
-        header_value.encode("latin-1")
-    except UnicodeEncodeError as exc:
-        raise InvalidResolvedAuthHeaderError(
-            f"Resolved auth header {header_name} value is invalid"
-        ) from exc
-
-
-def resolved_auth_header_pairs(headers) -> list[tuple[str, str]]:
-    """Validate and filter resolved auth headers before outbound injection.
-
-    Each resolved header name and value is validated before any pair is
-    returned; invalid pairs raise ``InvalidResolvedAuthHeaderError``. Transport,
-    authority, and framing headers are then dropped. This helper does not merge
-    with or replace client headers; callers that combine resolved and client
-    headers own that policy.
-    """
-    pairs = header_pairs(headers)
-    for name, value in pairs:
-        _validate_resolved_auth_header_pair(name, value)
-    return _filter_header_pairs(
-        pairs,
-        extra_excluded={"host", "content-length", "transfer-encoding"},
-    )
-
-
-def trusted_request_header_pairs(headers) -> list[tuple[str, str]]:
-    """Validate and filter trusted injected headers through the resolved-auth path."""
-    return resolved_auth_header_pairs(headers)
-
-
-def _filter_response_headers(headers: list[tuple[str, str]]) -> http.Headers:
-    """Strip hop-by-hop headers from an upstream response.
-
-    The response body is fully read, so headers like transfer-encoding must
-    not be forwarded. Headers named by Connection are hop-by-hop too.
-
-    ``HTTPResponse.getheaders()`` exposes raw field octets through a one-to-one
-    ISO-8859-1 decode. Encode with the same codec to restore those octets for
-    mitmproxy's byte-backed header container.
-    """
-    return http.Headers(
-        (name.encode("latin-1"), value.encode("latin-1"))
-        for name, value in _filter_header_pairs(headers)
-    )
-
-
-def _normalized_forward_request_host(parsed: urllib.parse.SplitResult) -> str:
-    raw_host = raw_authority_host(parsed.netloc)
-    if raw_host is None:
-        if parsed.netloc:
-            raise ValueError("Invalid upstream URL: invalid host")
-        raise ValueError("Invalid upstream URL: missing host")
-
-    decoded = percent_decode_host(
-        raw_host.hostname,
-        syntax_chars=_PERCENT_DECODED_UPSTREAM_HOST_SYNTAX_CHARS,
-    )
-    if decoded.invalid_encoding or decoded.decoded_syntax:
-        raise ValueError("Invalid upstream URL: invalid host")
-    if any(char in decoded.value for char in _UPSTREAM_HOST_FORBIDDEN_CHARS):
-        raise ValueError("Invalid upstream URL: invalid host")
-
-    if raw_host.bracketed:
-        try:
-            parsed_ip = ipaddress.ip_address(decoded.value)
-        except ValueError as exc:
-            raise ValueError("Invalid upstream URL: invalid host") from exc
-        if parsed_ip.version != IPV6_VERSION or parsed_ip.scope_id is not None:
-            raise ValueError("Invalid upstream URL: invalid host")
-        return parsed_ip.compressed.lower()
-
-    try:
-        return normalize_idna_hostname(decoded.value)
-    except (UnicodeError, ValueError) as exc:
-        raise ValueError("Invalid upstream URL: invalid host") from exc
-
-
-def _host_header(host: str, port: int | None) -> str:
-    formatted_host = format_url_host(host)
-    if port is None or port == DEFAULT_HTTPS_PORT:
-        return formatted_host
-    return f"{formatted_host}:{port}"
-
-
-def _request_target(parsed: urllib.parse.SplitResult) -> str:
-    path = parsed.path or "/"
-    if parsed.query:
-        return f"{path}?{parsed.query}"
-    return path
-
-
-def _connection_factory(scheme: str):
-    if scheme == "https":
-        return _make_validated_https_connection
-    raise ValueError(f"Unsupported URL scheme: {scheme}")
-
-
-def _reject_userinfo(parsed: urllib.parse.SplitResult) -> None:
-    if parsed.username is not None or parsed.password is not None:
-        raise ValueError("Unsupported URL authority: userinfo is not allowed")
-
-
-def _outbound_request_headers(
-    headers: list[tuple[str, str]],
-    host: str,
-    port: int | None,
-    body: bytes | None,
-) -> list[tuple[str, str]]:
-    filtered = forwarded_request_header_pairs(headers)
-    outbound = [("Host", _host_header(host, port)), *filtered]
-    if body is not None:
-        outbound.append(("Content-Length", str(len(body))))
-    return outbound
-
-
-def _read_response_body(resp) -> bytes:
-    body = resp.read(MAX_AUTH_BASE_RESPONSE_BODY_BYTES + 1)
-    if len(body) > MAX_AUTH_BASE_RESPONSE_BODY_BYTES:
-        raise ForwardedResponseTooLargeError("Forwarded auth.base response body too large")
-    remaining = resp.length
-    if remaining is not None and remaining > 0:
-        raise http_client.IncompleteRead(body, remaining)
-    return body
-
-
-def _validate_request_body_size(body: bytes | None) -> None:
-    if body is not None and len(body) > MAX_AUTH_BASE_REQUEST_BODY_BYTES:
-        raise ForwardedRequestTooLargeError("Forwarded auth.base request body too large")
-
-
-def _request_body_size(body: bytes | None) -> int:
-    return len(body) if body is not None else 0
-
-
 def reserve_forward_request_admission(
     body_bytes: int,
 ) -> request_body_admission.RequestBodyAdmissionLease:
@@ -800,129 +379,6 @@ def forward_request_admission_state_for_tests() -> tuple[int, int]:
     return _forward_request_budget.state_for_tests()
 
 
-def _is_public_unicast_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-    return public_destination.ip_address_is_public(address)
-
-
-def _raise_unsafe_destination() -> None:
-    raise UnsafeAuthBaseDestinationError("Unsafe auth.base upstream destination")
-
-
-def _get_dns_resolver() -> _AddressResolver:
-    global _dns_resolver
-
-    resolver = _dns_resolver
-    if resolver is None:
-        resolver = mitmproxy_rs.dns.DnsResolver()
-        _dns_resolver = resolver
-    return resolver
-
-
-def _validated_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address, port: int):
-    family = socket.AF_INET6 if address.version == IPV6_VERSION else socket.AF_INET
-    return _ValidatedAddress(family, address.compressed, port)
-
-
-async def _resolve_validated_addresses(
-    host: str,
-    port: int,
-    abort_handle: _ForwardRequestAbortHandle,
-) -> tuple[_ValidatedAddress, ...]:
-    try:
-        literal_address = ipaddress.ip_address(host)
-    except ValueError:
-        lookup_future = asyncio.ensure_future(_get_dns_resolver().lookup_ip(host))
-
-        def cancel_lookup() -> object:
-            return lookup_future.cancel()
-
-        abort_handle.register_async_cancel(cancel_lookup)
-        try:
-            resolved_hosts = await lookup_future
-        finally:
-            abort_handle.clear_async_cancel(cancel_lookup)
-    else:
-        resolved_hosts = [literal_address.compressed]
-
-    seen: set[str] = set()
-    addresses: list[_ValidatedAddress] = []
-    for resolved_host in resolved_hosts:
-        address = ipaddress.ip_address(resolved_host)
-        key = address.compressed
-        if key in seen:
-            continue
-        seen.add(key)
-        if not _is_public_unicast_address(address):
-            _raise_unsafe_destination()
-        addresses.append(_validated_address(address, port))
-    if not addresses:
-        raise ValueError("Invalid upstream URL: host did not resolve")
-    return tuple(addresses)
-
-
-def _prepare_forward_request(url: str) -> _PreparedForwardRequest:
-    parsed = split_runtime_url(url)
-    _connection_factory(parsed.scheme.lower())
-    _reject_userinfo(parsed)
-    host = _normalized_forward_request_host(parsed)
-    if authority_has_empty_port(parsed.netloc):
-        raise ValueError("Invalid upstream URL: invalid port")
-    try:
-        port = parsed.port
-    except ValueError as exc:
-        raise ValueError("Invalid upstream URL: invalid port") from exc
-    return _PreparedForwardRequest(host, port, _request_target(parsed))
-
-
-def _forward_request_sync(
-    prepared: _PreparedForwardRequest,
-    method: str,
-    headers: list[tuple[str, str]],
-    body: bytes | None,
-    validated_addresses: tuple[_ValidatedAddress, ...],
-    abort_handle: _ForwardRequestAbortHandle,
-    deadline: float,
-) -> tuple[int, bytes, http.Headers]:
-    """Forward an HTTPS request to the real URL and return (status, body, headers).
-
-    Security: only https URLs are allowed, and redirects are returned
-    to the sandbox client instead of being followed inside the addon.
-    """
-    abort_handle.raise_if_aborted()
-    conn = _make_validated_https_connection(
-        prepared.host,
-        port=prepared.port,
-        deadline=deadline,
-        abort_handle=abort_handle,
-        validated_addresses=validated_addresses,
-    )
-    resp = None
-    try:
-        conn.putrequest(
-            method,
-            prepared.target,
-            skip_host=True,
-            skip_accept_encoding=True,
-        )
-        for header_name, header_value in _outbound_request_headers(
-            headers,
-            prepared.host,
-            prepared.port,
-            body,
-        ):
-            conn.putheader(header_name, header_value)
-        conn.endheaders(body)
-        conn.set_remaining_timeout()
-        resp = conn.getresponse()
-        conn.set_remaining_timeout()
-        resp_body = _read_response_body(resp)
-        return resp.status, resp_body, _filter_response_headers(resp.getheaders())
-    finally:
-        if resp is not None:
-            resp.close()
-        conn.close()
-
-
 def _get_forward_request_admission_semaphore() -> asyncio.Semaphore:
     global _forward_request_admission_state
 
@@ -985,16 +441,16 @@ def _release_forward_request_resources(
 
 def _forward_request_sync_in_context(
     context: contextvars.Context,
-    prepared: _PreparedForwardRequest,
+    prepared: auth_base_transport._PreparedForwardRequest,
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
-    validated_addresses: tuple[_ValidatedAddress, ...],
+    validated_addresses: tuple[auth_base_transport._ValidatedAddress, ...],
     abort_handle: _ForwardRequestAbortHandle,
     deadline: float,
 ) -> tuple[int, bytes, http.Headers]:
     return context.run(
-        _forward_request_sync,
+        auth_base_transport._forward_request_sync,
         prepared,
         method,
         headers,
@@ -1035,11 +491,11 @@ def _set_forward_request_terminal_exception(
 def _run_forward_request_worker(
     future: Future[tuple[int, bytes, http.Headers]],
     context: contextvars.Context,
-    prepared: _PreparedForwardRequest,
+    prepared: auth_base_transport._PreparedForwardRequest,
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
-    validated_addresses: tuple[_ValidatedAddress, ...],
+    validated_addresses: tuple[auth_base_transport._ValidatedAddress, ...],
     abort_handle: _ForwardRequestAbortHandle,
     deadline: float,
 ) -> None:
@@ -1087,11 +543,11 @@ def _run_forward_request_worker(
 
 def _start_forward_request_worker(
     context: contextvars.Context,
-    prepared: _PreparedForwardRequest,
+    prepared: auth_base_transport._PreparedForwardRequest,
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
-    validated_addresses: tuple[_ValidatedAddress, ...],
+    validated_addresses: tuple[auth_base_transport._ValidatedAddress, ...],
     abort_handle: _ForwardRequestAbortHandle,
     deadline: float,
 ) -> Future[tuple[int, bytes, http.Headers]]:
@@ -1158,9 +614,9 @@ async def forward_request(
     Request body size, admission saturation, shutdown, URL/header/destination validation, upstream
     forwarding, and response processing failures propagate to the caller.
     """
-    body_bytes = _request_body_size(body)
+    body_bytes = auth_base_transport._request_body_size(body)
     try:
-        _validate_request_body_size(body)
+        auth_base_transport._validate_request_body_size(body)
     except _FORWARD_REQUEST_CLEANUP_EXCEPTIONS:
         if admission is not None:
             release_forward_request_admission(admission)
@@ -1184,7 +640,7 @@ async def forward_request(
         semaphore = _get_forward_request_admission_semaphore()
         context = contextvars.copy_context()
         try:
-            async with asyncio.timeout(_remaining_deadline_seconds(deadline)):
+            async with asyncio.timeout(auth_base_transport._remaining_deadline_seconds(deadline)):
                 await semaphore.acquire()
                 semaphore_acquired = True
         except TimeoutError as exc:
@@ -1199,11 +655,11 @@ async def forward_request(
             abort_handle.abort_for_shutdown()
             raise RuntimeError("auth.base forwarding workers are shut down")
 
-        prepared = _prepare_forward_request(url)
+        prepared = auth_base_transport._prepare_forward_request(url)
         effective_port = prepared.port if prepared.port is not None else DEFAULT_HTTPS_PORT
         try:
-            async with asyncio.timeout(_remaining_deadline_seconds(deadline)):
-                validated_addresses = await _resolve_validated_addresses(
+            async with asyncio.timeout(auth_base_transport._remaining_deadline_seconds(deadline)):
+                validated_addresses = await auth_base_transport._resolve_validated_addresses(
                     prepared.host,
                     effective_port,
                     abort_handle,
@@ -1219,7 +675,7 @@ async def forward_request(
             raise
 
         deadline_timer = loop.call_later(
-            _remaining_deadline_seconds(deadline),
+            auth_base_transport._remaining_deadline_seconds(deadline),
             abort_handle.abort_for_deadline,
         )
         future = _start_forward_request_worker(

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -441,16 +441,16 @@ def _release_forward_request_resources(
 
 def _forward_request_sync_in_context(
     context: contextvars.Context,
-    prepared: auth_base_transport._PreparedForwardRequest,
+    prepared: auth_base_transport.PreparedForwardRequest,
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
-    validated_addresses: tuple[auth_base_transport._ValidatedAddress, ...],
+    validated_addresses: tuple[auth_base_transport.ValidatedAddress, ...],
     abort_handle: _ForwardRequestAbortHandle,
     deadline: float,
 ) -> tuple[int, bytes, http.Headers]:
     return context.run(
-        auth_base_transport._forward_request_sync,
+        auth_base_transport.forward_request_sync,
         prepared,
         method,
         headers,
@@ -491,11 +491,11 @@ def _set_forward_request_terminal_exception(
 def _run_forward_request_worker(
     future: Future[tuple[int, bytes, http.Headers]],
     context: contextvars.Context,
-    prepared: auth_base_transport._PreparedForwardRequest,
+    prepared: auth_base_transport.PreparedForwardRequest,
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
-    validated_addresses: tuple[auth_base_transport._ValidatedAddress, ...],
+    validated_addresses: tuple[auth_base_transport.ValidatedAddress, ...],
     abort_handle: _ForwardRequestAbortHandle,
     deadline: float,
 ) -> None:
@@ -543,11 +543,11 @@ def _run_forward_request_worker(
 
 def _start_forward_request_worker(
     context: contextvars.Context,
-    prepared: auth_base_transport._PreparedForwardRequest,
+    prepared: auth_base_transport.PreparedForwardRequest,
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
-    validated_addresses: tuple[auth_base_transport._ValidatedAddress, ...],
+    validated_addresses: tuple[auth_base_transport.ValidatedAddress, ...],
     abort_handle: _ForwardRequestAbortHandle,
     deadline: float,
 ) -> Future[tuple[int, bytes, http.Headers]]:
@@ -614,9 +614,9 @@ async def forward_request(
     Request body size, admission saturation, shutdown, URL/header/destination validation, upstream
     forwarding, and response processing failures propagate to the caller.
     """
-    body_bytes = auth_base_transport._request_body_size(body)
+    body_bytes = auth_base_transport.request_body_size(body)
     try:
-        auth_base_transport._validate_request_body_size(body)
+        auth_base_transport.validate_request_body_size(body)
     except _FORWARD_REQUEST_CLEANUP_EXCEPTIONS:
         if admission is not None:
             release_forward_request_admission(admission)
@@ -640,7 +640,7 @@ async def forward_request(
         semaphore = _get_forward_request_admission_semaphore()
         context = contextvars.copy_context()
         try:
-            async with asyncio.timeout(auth_base_transport._remaining_deadline_seconds(deadline)):
+            async with asyncio.timeout(auth_base_transport.remaining_deadline_seconds(deadline)):
                 await semaphore.acquire()
                 semaphore_acquired = True
         except TimeoutError as exc:
@@ -655,11 +655,11 @@ async def forward_request(
             abort_handle.abort_for_shutdown()
             raise RuntimeError("auth.base forwarding workers are shut down")
 
-        prepared = auth_base_transport._prepare_forward_request(url)
+        prepared = auth_base_transport.prepare_forward_request(url)
         effective_port = prepared.port if prepared.port is not None else DEFAULT_HTTPS_PORT
         try:
-            async with asyncio.timeout(auth_base_transport._remaining_deadline_seconds(deadline)):
-                validated_addresses = await auth_base_transport._resolve_validated_addresses(
+            async with asyncio.timeout(auth_base_transport.remaining_deadline_seconds(deadline)):
+                validated_addresses = await auth_base_transport.resolve_validated_addresses(
                     prepared.host,
                     effective_port,
                     abort_handle,
@@ -675,7 +675,7 @@ async def forward_request(
             raise
 
         deadline_timer = loop.call_later(
-            auth_base_transport._remaining_deadline_seconds(deadline),
+            auth_base_transport.remaining_deadline_seconds(deadline),
             abort_handle.abort_for_deadline,
         )
         future = _start_forward_request_worker(

--- a/crates/runner/mitm-addon/src/auth_base_transport.py
+++ b/crates/runner/mitm-addon/src/auth_base_transport.py
@@ -61,7 +61,7 @@ class _AddressResolver(Protocol):
         raise NotImplementedError
 
 
-class _ForwardRequestAbortHandle(Protocol):
+class ForwardRequestAbort(Protocol):
     """Cancellation and socket ownership consumed by auth.base transport."""
 
     def register_async_cancel(self, cancel: Callable[[], object]) -> None:
@@ -107,13 +107,13 @@ class InvalidAuthBaseRequestHeadersError(Exception):
     """Raised when client representation headers cannot be forwarded safely."""
 
 
-class _ValidatedAddress(NamedTuple):
+class ValidatedAddress(NamedTuple):
     family: socket.AddressFamily
     host: str
     port: int
 
 
-class _PreparedForwardRequest(NamedTuple):
+class PreparedForwardRequest(NamedTuple):
     host: str
     port: int | None
     target: str
@@ -132,13 +132,13 @@ def reset_transport_state_for_tests() -> None:
     _dns_resolver = None
 
 
-def _validated_socket_address(address: _ValidatedAddress) -> _SocketAddress:
+def _validated_socket_address(address: ValidatedAddress) -> _SocketAddress:
     if address.family == socket.AF_INET6:
         return address.host, address.port, 0, 0
     return address.host, address.port
 
 
-def _remaining_deadline_seconds(deadline: float) -> float:
+def remaining_deadline_seconds(deadline: float) -> float:
     remaining = deadline - time.monotonic()
     if remaining <= 0:
         raise AuthBaseForwardingDeadlineExceededError("auth.base forwarding deadline exceeded")
@@ -177,13 +177,13 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
         port: int | None,
         *,
         deadline: float,
-        abort_handle: _ForwardRequestAbortHandle,
-        validated_addresses: tuple[_ValidatedAddress, ...],
+        abort_handle: ForwardRequestAbort,
+        validated_addresses: tuple[ValidatedAddress, ...],
     ) -> None:
         super().__init__(
             host,
             port=port,
-            timeout=_remaining_deadline_seconds(deadline),
+            timeout=remaining_deadline_seconds(deadline),
         )
         self._abort_handle = abort_handle
         self._deadline = deadline
@@ -202,7 +202,7 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
             raw_sock = socket.socket(address.family, socket.SOCK_STREAM)
             try:
                 self._abort_handle.register_socket(raw_sock)
-                raw_sock.settimeout(_remaining_deadline_seconds(self._deadline))
+                raw_sock.settimeout(remaining_deadline_seconds(self._deadline))
                 raw_sock.connect(_validated_socket_address(address))
                 self._abort_handle.raise_if_aborted()
             except OSError as exc:
@@ -245,7 +245,7 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
     def set_remaining_timeout(self) -> None:
         self._abort_handle.raise_if_aborted()
         if self.sock is not None:
-            self.sock.settimeout(_remaining_deadline_seconds(self._deadline))
+            self.sock.settimeout(remaining_deadline_seconds(self._deadline))
 
     def close(self) -> None:
         sock = self.sock
@@ -261,8 +261,8 @@ def _make_validated_https_connection(
     port: int | None,
     *,
     deadline: float,
-    abort_handle: _ForwardRequestAbortHandle,
-    validated_addresses: tuple[_ValidatedAddress, ...],
+    abort_handle: ForwardRequestAbort,
+    validated_addresses: tuple[ValidatedAddress, ...],
 ) -> _ValidatedTLSConnection:
     return _ValidatedTLSConnection(
         host,
@@ -478,12 +478,12 @@ def _read_response_body(resp) -> bytes:
     return body
 
 
-def _validate_request_body_size(body: bytes | None) -> None:
+def validate_request_body_size(body: bytes | None) -> None:
     if body is not None and len(body) > MAX_AUTH_BASE_REQUEST_BODY_BYTES:
         raise ForwardedRequestTooLargeError("Forwarded auth.base request body too large")
 
 
-def _request_body_size(body: bytes | None) -> int:
+def request_body_size(body: bytes | None) -> int:
     return len(body) if body is not None else 0
 
 
@@ -507,14 +507,14 @@ def _get_dns_resolver() -> _AddressResolver:
 
 def _validated_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address, port: int):
     family = socket.AF_INET6 if address.version == IPV6_VERSION else socket.AF_INET
-    return _ValidatedAddress(family, address.compressed, port)
+    return ValidatedAddress(family, address.compressed, port)
 
 
-async def _resolve_validated_addresses(
+async def resolve_validated_addresses(
     host: str,
     port: int,
-    abort_handle: _ForwardRequestAbortHandle,
-) -> tuple[_ValidatedAddress, ...]:
+    abort_handle: ForwardRequestAbort,
+) -> tuple[ValidatedAddress, ...]:
     try:
         literal_address = ipaddress.ip_address(host)
     except ValueError:
@@ -532,7 +532,7 @@ async def _resolve_validated_addresses(
         resolved_hosts = [literal_address.compressed]
 
     seen: set[str] = set()
-    addresses: list[_ValidatedAddress] = []
+    addresses: list[ValidatedAddress] = []
     for resolved_host in resolved_hosts:
         address = ipaddress.ip_address(resolved_host)
         key = address.compressed
@@ -547,7 +547,7 @@ async def _resolve_validated_addresses(
     return tuple(addresses)
 
 
-def _prepare_forward_request(url: str) -> _PreparedForwardRequest:
+def prepare_forward_request(url: str) -> PreparedForwardRequest:
     parsed = split_runtime_url(url)
     _connection_factory(parsed.scheme.lower())
     _reject_userinfo(parsed)
@@ -558,16 +558,16 @@ def _prepare_forward_request(url: str) -> _PreparedForwardRequest:
         port = parsed.port
     except ValueError as exc:
         raise ValueError("Invalid upstream URL: invalid port") from exc
-    return _PreparedForwardRequest(host, port, _request_target(parsed))
+    return PreparedForwardRequest(host, port, _request_target(parsed))
 
 
-def _forward_request_sync(
-    prepared: _PreparedForwardRequest,
+def forward_request_sync(
+    prepared: PreparedForwardRequest,
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
-    validated_addresses: tuple[_ValidatedAddress, ...],
-    abort_handle: _ForwardRequestAbortHandle,
+    validated_addresses: tuple[ValidatedAddress, ...],
+    abort_handle: ForwardRequestAbort,
     deadline: float,
 ) -> tuple[int, bytes, http.Headers]:
     """Forward an HTTPS request to the real URL and return (status, body, headers).

--- a/crates/runner/mitm-addon/src/auth_base_transport.py
+++ b/crates/runner/mitm-addon/src/auth_base_transport.py
@@ -1,0 +1,610 @@
+"""Request preparation and HTTPS transport for auth.base URL rewrites.
+
+The addon forwards auth.base requests itself because mitmproxy's eager
+connection has already connected to the placeholder IP. This module owns
+the low-level HTTP and destination-validation details for that forward path.
+"""
+
+import asyncio
+import errno
+import http.client as http_client
+import ipaddress
+import socket
+import ssl
+import threading
+import time
+import urllib.parse
+from collections.abc import Callable
+from contextlib import suppress
+from typing import NamedTuple, Protocol
+
+import mitmproxy_rs
+from mitmproxy import http
+
+import public_destination
+from authority_utils import (
+    IPV6_VERSION,
+    authority_has_empty_port,
+    format_url_host,
+    percent_decode_host,
+    raw_authority_host,
+)
+from host_normalization import normalize_idna_hostname
+from http_header_syntax import has_forbidden_header_value_control, is_http_header_name
+from runtime_url_parsing import split_runtime_url
+
+HOP_BY_HOP: frozenset[str] = frozenset(
+    (
+        "connection",
+        "keep-alive",
+        "proxy-connection",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "transfer-encoding",
+        "te",
+        "trailer",
+        "upgrade",
+    )
+)
+DEFAULT_HTTPS_PORT = 443
+MAX_AUTH_BASE_REQUEST_BODY_BYTES = 32 * 1024 * 1024
+MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
+_PERCENT_DECODED_UPSTREAM_HOST_SYNTAX_CHARS = frozenset("{}*.\u3002\uff0e\uff61,")
+_UPSTREAM_HOST_FORBIDDEN_CHARS = frozenset("{}*")
+_https_context: ssl.SSLContext | None = None
+_https_context_lock = threading.Lock()
+_dns_resolver: "_AddressResolver | None" = None
+
+
+class _AddressResolver(Protocol):
+    async def lookup_ip(self, host: str) -> list[str]:
+        raise NotImplementedError
+
+
+class _ForwardRequestAbortHandle(Protocol):
+    """Cancellation and socket ownership consumed by auth.base transport."""
+
+    def register_async_cancel(self, cancel: Callable[[], object]) -> None:
+        raise NotImplementedError
+
+    def clear_async_cancel(self, cancel: Callable[[], object]) -> None:
+        raise NotImplementedError
+
+    def register_socket(self, sock: socket.socket) -> None:
+        raise NotImplementedError
+
+    def replace_socket(self, current: socket.socket, replacement: socket.socket) -> None:
+        raise NotImplementedError
+
+    def clear_socket(self, sock: socket.socket) -> None:
+        raise NotImplementedError
+
+    def raise_if_aborted(self) -> None:
+        raise NotImplementedError
+
+
+class ForwardedResponseTooLargeError(Exception):
+    """Raised when an auth.base upstream response exceeds the local body cap."""
+
+
+class ForwardedRequestTooLargeError(Exception):
+    """Raised when an auth.base forwarded request body exceeds the local cap."""
+
+
+class AuthBaseForwardingDeadlineExceededError(Exception):
+    """Raised when one auth.base forwarding attempt exceeds its total lifetime."""
+
+
+class UnsafeAuthBaseDestinationError(Exception):
+    """Raised when an auth.base upstream destination is not public internet."""
+
+
+class InvalidResolvedAuthHeaderError(Exception):
+    """Raised when resolved auth data contains an invalid HTTP header."""
+
+
+class InvalidAuthBaseRequestHeadersError(Exception):
+    """Raised when client representation headers cannot be forwarded safely."""
+
+
+class _ValidatedAddress(NamedTuple):
+    family: socket.AddressFamily
+    host: str
+    port: int
+
+
+class _PreparedForwardRequest(NamedTuple):
+    host: str
+    port: int | None
+    target: str
+
+
+type _SocketAddress = tuple[str, int] | tuple[str, int, int, int]
+
+
+def reset_transport_state_for_tests() -> None:
+    """Reset auth.base resolver and TLS caches between tests."""
+    global _dns_resolver
+    global _https_context
+
+    with _https_context_lock:
+        _https_context = None
+    _dns_resolver = None
+
+
+def _validated_socket_address(address: _ValidatedAddress) -> _SocketAddress:
+    if address.family == socket.AF_INET6:
+        return address.host, address.port, 0, 0
+    return address.host, address.port
+
+
+def _remaining_deadline_seconds(deadline: float) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise AuthBaseForwardingDeadlineExceededError("auth.base forwarding deadline exceeded")
+    return remaining
+
+
+def _create_https_context() -> ssl.SSLContext:
+    context = ssl.create_default_context()
+    context.set_alpn_protocols(["http/1.1"])
+    if context.post_handshake_auth is not None:
+        context.post_handshake_auth = True
+    return context
+
+
+def _get_https_context() -> ssl.SSLContext:
+    global _https_context
+
+    context = _https_context
+    if context is not None:
+        return context
+
+    with _https_context_lock:
+        context = _https_context
+        if context is None:
+            context = _create_https_context()
+            _https_context = context
+        return context
+
+
+class _ValidatedTLSConnection(http_client.HTTPConnection):
+    default_port = DEFAULT_HTTPS_PORT
+
+    def __init__(
+        self,
+        host: str,
+        port: int | None,
+        *,
+        deadline: float,
+        abort_handle: _ForwardRequestAbortHandle,
+        validated_addresses: tuple[_ValidatedAddress, ...],
+    ) -> None:
+        super().__init__(
+            host,
+            port=port,
+            timeout=_remaining_deadline_seconds(deadline),
+        )
+        self._abort_handle = abort_handle
+        self._deadline = deadline
+        self._validated_addresses = validated_addresses
+        self._context = _get_https_context()
+
+    def _close_and_clear_socket(self, sock: socket.socket) -> None:
+        self._abort_handle.clear_socket(sock)
+        with suppress(Exception):
+            sock.close()
+
+    def _connect_raw_socket(self) -> socket.socket:
+        last_error: OSError | None = None
+        for address in self._validated_addresses:
+            self._abort_handle.raise_if_aborted()
+            raw_sock = socket.socket(address.family, socket.SOCK_STREAM)
+            try:
+                self._abort_handle.register_socket(raw_sock)
+                raw_sock.settimeout(_remaining_deadline_seconds(self._deadline))
+                raw_sock.connect(_validated_socket_address(address))
+                self._abort_handle.raise_if_aborted()
+            except OSError as exc:
+                last_error = exc
+                self._close_and_clear_socket(raw_sock)
+                continue
+            except Exception:
+                self._close_and_clear_socket(raw_sock)
+                raise
+            return raw_sock
+        if last_error is not None:
+            raise last_error
+        raise OSError("address resolver returned an empty list")
+
+    def connect(self) -> None:
+        raw_sock = self._connect_raw_socket()
+        try:
+            raw_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        except OSError as exc:
+            if exc.errno != errno.ENOPROTOOPT:
+                self._close_and_clear_socket(raw_sock)
+                raise
+        try:
+            wrapped_sock = self._context.wrap_socket(
+                raw_sock,
+                server_hostname=self.host,
+                do_handshake_on_connect=False,
+            )
+            if wrapped_sock is not raw_sock:
+                self._abort_handle.replace_socket(raw_sock, wrapped_sock)
+            self.sock = wrapped_sock
+            self.set_remaining_timeout()
+            wrapped_sock.do_handshake()
+        except Exception:
+            current_sock = self.sock
+            self.sock = None
+            self._close_and_clear_socket(current_sock if current_sock is not None else raw_sock)
+            raise
+
+    def set_remaining_timeout(self) -> None:
+        self._abort_handle.raise_if_aborted()
+        if self.sock is not None:
+            self.sock.settimeout(_remaining_deadline_seconds(self._deadline))
+
+    def close(self) -> None:
+        sock = self.sock
+        try:
+            super().close()
+        finally:
+            if sock is not None:
+                self._abort_handle.clear_socket(sock)
+
+
+def _make_validated_https_connection(
+    host: str,
+    port: int | None,
+    *,
+    deadline: float,
+    abort_handle: _ForwardRequestAbortHandle,
+    validated_addresses: tuple[_ValidatedAddress, ...],
+) -> _ValidatedTLSConnection:
+    return _ValidatedTLSConnection(
+        host,
+        port=port,
+        deadline=deadline,
+        abort_handle=abort_handle,
+        validated_addresses=validated_addresses,
+    )
+
+
+def header_pairs(headers) -> list[tuple[str, str]]:
+    """Normalize a supported header container into ordered header pairs.
+
+    Plain dict inputs use their normal items. Header containers with an
+    ``items`` method use ``items(multi=True)`` when supported, preserving
+    repeated mitmproxy headers, then fall back to ``items()``. Other inputs
+    are treated as iterable ``(name, value)`` pairs.
+    """
+    if isinstance(headers, dict):
+        return list(headers.items())
+    if hasattr(headers, "items"):
+        try:
+            return list(headers.items(multi=True))
+        except TypeError:
+            return list(headers.items())
+    return list(headers)
+
+
+def _connection_header_names(headers: list[tuple[str, str]]) -> set[str]:
+    names: set[str] = set()
+    for header_name, header_value in headers:
+        if header_name.lower() != "connection":
+            continue
+        for token in header_value.split(","):
+            token = token.strip().lower()
+            if token:
+                names.add(token)
+    return names
+
+
+def _filter_header_pairs(
+    headers,
+    *,
+    extra_excluded: set[str] | None = None,
+) -> list[tuple[str, str]]:
+    pairs = header_pairs(headers)
+    excluded = set(HOP_BY_HOP)
+    excluded.update(_connection_header_names(pairs))
+    if extra_excluded:
+        excluded.update(extra_excluded)
+    return [(name, value) for name, value in pairs if name.lower() not in excluded]
+
+
+def forwarded_request_header_pairs(headers) -> list[tuple[str, str]]:
+    """Return request headers that can be forwarded to an auth.base target.
+
+    Hop-by-hop headers and headers named by ``Connection`` are removed.
+    ``Host``, ``Content-Length``, and ``Transfer-Encoding`` are also excluded
+    because the forwarder recomputes request authority and framing.
+    """
+    return _filter_header_pairs(
+        headers,
+        extra_excluded={"host", "content-length", "transfer-encoding"},
+    )
+
+
+def forwarded_auth_base_client_header_pairs(
+    headers,
+) -> list[tuple[str, str]]:
+    """Select representation metadata allowed to cross an auth.base rewrite."""
+    raw_pairs = header_pairs(headers)
+    content_type_count = sum(1 for name, _value in raw_pairs if name.lower() == "content-type")
+    if content_type_count > 1:
+        raise InvalidAuthBaseRequestHeadersError(
+            "auth.base requests must contain at most one Content-Type header"
+        )
+
+    return [
+        (name, value)
+        for name, value in forwarded_request_header_pairs(raw_pairs)
+        if name.lower() in {"content-type", "content-encoding"}
+    ]
+
+
+def _validate_resolved_auth_header_pair(header_name: str, header_value: str) -> None:
+    if not isinstance(header_name, str) or not is_http_header_name(header_name):
+        raise InvalidResolvedAuthHeaderError("Resolved auth header name is invalid")
+    if not isinstance(header_value, str) or has_forbidden_header_value_control(header_value):
+        raise InvalidResolvedAuthHeaderError(f"Resolved auth header {header_name} value is invalid")
+    try:
+        header_value.encode("latin-1")
+    except UnicodeEncodeError as exc:
+        raise InvalidResolvedAuthHeaderError(
+            f"Resolved auth header {header_name} value is invalid"
+        ) from exc
+
+
+def resolved_auth_header_pairs(headers) -> list[tuple[str, str]]:
+    """Validate and filter resolved auth headers before outbound injection.
+
+    Each resolved header name and value is validated before any pair is
+    returned; invalid pairs raise ``InvalidResolvedAuthHeaderError``. Transport,
+    authority, and framing headers are then dropped. This helper does not merge
+    with or replace client headers; callers that combine resolved and client
+    headers own that policy.
+    """
+    pairs = header_pairs(headers)
+    for name, value in pairs:
+        _validate_resolved_auth_header_pair(name, value)
+    return _filter_header_pairs(
+        pairs,
+        extra_excluded={"host", "content-length", "transfer-encoding"},
+    )
+
+
+def trusted_request_header_pairs(headers) -> list[tuple[str, str]]:
+    """Validate and filter trusted injected headers through the resolved-auth path."""
+    return resolved_auth_header_pairs(headers)
+
+
+def _filter_response_headers(headers: list[tuple[str, str]]) -> http.Headers:
+    """Strip hop-by-hop headers from an upstream response.
+
+    The response body is fully read, so headers like transfer-encoding must
+    not be forwarded. Headers named by Connection are hop-by-hop too.
+
+    ``HTTPResponse.getheaders()`` exposes raw field octets through a one-to-one
+    ISO-8859-1 decode. Encode with the same codec to restore those octets for
+    mitmproxy's byte-backed header container.
+    """
+    return http.Headers(
+        (name.encode("latin-1"), value.encode("latin-1"))
+        for name, value in _filter_header_pairs(headers)
+    )
+
+
+def _normalized_forward_request_host(parsed: urllib.parse.SplitResult) -> str:
+    raw_host = raw_authority_host(parsed.netloc)
+    if raw_host is None:
+        if parsed.netloc:
+            raise ValueError("Invalid upstream URL: invalid host")
+        raise ValueError("Invalid upstream URL: missing host")
+
+    decoded = percent_decode_host(
+        raw_host.hostname,
+        syntax_chars=_PERCENT_DECODED_UPSTREAM_HOST_SYNTAX_CHARS,
+    )
+    if decoded.invalid_encoding or decoded.decoded_syntax:
+        raise ValueError("Invalid upstream URL: invalid host")
+    if any(char in decoded.value for char in _UPSTREAM_HOST_FORBIDDEN_CHARS):
+        raise ValueError("Invalid upstream URL: invalid host")
+
+    if raw_host.bracketed:
+        try:
+            parsed_ip = ipaddress.ip_address(decoded.value)
+        except ValueError as exc:
+            raise ValueError("Invalid upstream URL: invalid host") from exc
+        if parsed_ip.version != IPV6_VERSION or parsed_ip.scope_id is not None:
+            raise ValueError("Invalid upstream URL: invalid host")
+        return parsed_ip.compressed.lower()
+
+    try:
+        return normalize_idna_hostname(decoded.value)
+    except (UnicodeError, ValueError) as exc:
+        raise ValueError("Invalid upstream URL: invalid host") from exc
+
+
+def _host_header(host: str, port: int | None) -> str:
+    formatted_host = format_url_host(host)
+    if port is None or port == DEFAULT_HTTPS_PORT:
+        return formatted_host
+    return f"{formatted_host}:{port}"
+
+
+def _request_target(parsed: urllib.parse.SplitResult) -> str:
+    path = parsed.path or "/"
+    if parsed.query:
+        return f"{path}?{parsed.query}"
+    return path
+
+
+def _connection_factory(scheme: str):
+    if scheme == "https":
+        return _make_validated_https_connection
+    raise ValueError(f"Unsupported URL scheme: {scheme}")
+
+
+def _reject_userinfo(parsed: urllib.parse.SplitResult) -> None:
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("Unsupported URL authority: userinfo is not allowed")
+
+
+def _outbound_request_headers(
+    headers: list[tuple[str, str]],
+    host: str,
+    port: int | None,
+    body: bytes | None,
+) -> list[tuple[str, str]]:
+    filtered = forwarded_request_header_pairs(headers)
+    outbound = [("Host", _host_header(host, port)), *filtered]
+    if body is not None:
+        outbound.append(("Content-Length", str(len(body))))
+    return outbound
+
+
+def _read_response_body(resp) -> bytes:
+    body = resp.read(MAX_AUTH_BASE_RESPONSE_BODY_BYTES + 1)
+    if len(body) > MAX_AUTH_BASE_RESPONSE_BODY_BYTES:
+        raise ForwardedResponseTooLargeError("Forwarded auth.base response body too large")
+    remaining = resp.length
+    if remaining is not None and remaining > 0:
+        raise http_client.IncompleteRead(body, remaining)
+    return body
+
+
+def _validate_request_body_size(body: bytes | None) -> None:
+    if body is not None and len(body) > MAX_AUTH_BASE_REQUEST_BODY_BYTES:
+        raise ForwardedRequestTooLargeError("Forwarded auth.base request body too large")
+
+
+def _request_body_size(body: bytes | None) -> int:
+    return len(body) if body is not None else 0
+
+
+def _is_public_unicast_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return public_destination.ip_address_is_public(address)
+
+
+def _raise_unsafe_destination() -> None:
+    raise UnsafeAuthBaseDestinationError("Unsafe auth.base upstream destination")
+
+
+def _get_dns_resolver() -> _AddressResolver:
+    global _dns_resolver
+
+    resolver = _dns_resolver
+    if resolver is None:
+        resolver = mitmproxy_rs.dns.DnsResolver()
+        _dns_resolver = resolver
+    return resolver
+
+
+def _validated_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address, port: int):
+    family = socket.AF_INET6 if address.version == IPV6_VERSION else socket.AF_INET
+    return _ValidatedAddress(family, address.compressed, port)
+
+
+async def _resolve_validated_addresses(
+    host: str,
+    port: int,
+    abort_handle: _ForwardRequestAbortHandle,
+) -> tuple[_ValidatedAddress, ...]:
+    try:
+        literal_address = ipaddress.ip_address(host)
+    except ValueError:
+        lookup_future = asyncio.ensure_future(_get_dns_resolver().lookup_ip(host))
+
+        def cancel_lookup() -> object:
+            return lookup_future.cancel()
+
+        abort_handle.register_async_cancel(cancel_lookup)
+        try:
+            resolved_hosts = await lookup_future
+        finally:
+            abort_handle.clear_async_cancel(cancel_lookup)
+    else:
+        resolved_hosts = [literal_address.compressed]
+
+    seen: set[str] = set()
+    addresses: list[_ValidatedAddress] = []
+    for resolved_host in resolved_hosts:
+        address = ipaddress.ip_address(resolved_host)
+        key = address.compressed
+        if key in seen:
+            continue
+        seen.add(key)
+        if not _is_public_unicast_address(address):
+            _raise_unsafe_destination()
+        addresses.append(_validated_address(address, port))
+    if not addresses:
+        raise ValueError("Invalid upstream URL: host did not resolve")
+    return tuple(addresses)
+
+
+def _prepare_forward_request(url: str) -> _PreparedForwardRequest:
+    parsed = split_runtime_url(url)
+    _connection_factory(parsed.scheme.lower())
+    _reject_userinfo(parsed)
+    host = _normalized_forward_request_host(parsed)
+    if authority_has_empty_port(parsed.netloc):
+        raise ValueError("Invalid upstream URL: invalid port")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("Invalid upstream URL: invalid port") from exc
+    return _PreparedForwardRequest(host, port, _request_target(parsed))
+
+
+def _forward_request_sync(
+    prepared: _PreparedForwardRequest,
+    method: str,
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+    validated_addresses: tuple[_ValidatedAddress, ...],
+    abort_handle: _ForwardRequestAbortHandle,
+    deadline: float,
+) -> tuple[int, bytes, http.Headers]:
+    """Forward an HTTPS request to the real URL and return (status, body, headers).
+
+    Security: only https URLs are allowed, and redirects are returned
+    to the sandbox client instead of being followed inside the addon.
+    """
+    abort_handle.raise_if_aborted()
+    conn = _make_validated_https_connection(
+        prepared.host,
+        port=prepared.port,
+        deadline=deadline,
+        abort_handle=abort_handle,
+        validated_addresses=validated_addresses,
+    )
+    resp = None
+    try:
+        conn.putrequest(
+            method,
+            prepared.target,
+            skip_host=True,
+            skip_accept_encoding=True,
+        )
+        for header_name, header_value in _outbound_request_headers(
+            headers,
+            prepared.host,
+            prepared.port,
+            body,
+        ):
+            conn.putheader(header_name, header_value)
+        conn.endheaders(body)
+        conn.set_remaining_timeout()
+        resp = conn.getresponse()
+        conn.set_remaining_timeout()
+        resp_body = _read_response_body(resp)
+        return resp.status, resp_body, _filter_response_headers(resp.getheaders())
+    finally:
+        if resp is not None:
+            resp.close()
+        conn.close()

--- a/crates/runner/mitm-addon/src/public_destination.py
+++ b/crates/runner/mitm-addon/src/public_destination.py
@@ -22,7 +22,7 @@ this policy. Authoritative sources:
 ``request_classification.py`` validates concrete request destinations before
 credentials are used; it may defer an ordinary hostname during header
 processing, but request processing must later validate concrete endpoint
-evidence. ``auth_base_forwarder.py`` validates every resolved address before
+evidence. ``auth_base_transport.py`` validates every resolved address before
 connecting. A hostname classification is therefore a deferral, never proof
 that its eventual address is public.
 

--- a/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 from mitmproxy import http
 
-import auth_base_forwarder as forwarder
+import auth_base_transport as transport
 
 __all__ = [
     "FakeForwarderUpstream",
@@ -254,7 +254,7 @@ class FakeForwarderUpstream:
     The class is public so the context manager's return value and stable fields
     are explicit. Tests should still obtain instances from
     ``fake_forwarder_upstream`` because direct construction does not patch
-    ``auth_base_forwarder``.
+    ``auth_base_transport``.
 
     Stable assertion state includes DNS calls, connection calls, created
     sockets, TLS contexts, and the most recent socket via ``socket``.
@@ -461,8 +461,8 @@ def fake_forwarder_upstream(
     """Patch auth.base DNS/connect/TLS boundaries and yield an upstream handle.
 
     The context manager patches only the forwarder's external resolver,
-    ``auth_base_forwarder.socket.socket``, and
-    ``auth_base_forwarder.ssl.create_default_context``. ``addresses`` controls
+    ``auth_base_transport.socket.socket``, and
+    ``auth_base_transport.ssl.create_default_context``. ``addresses`` controls
     the DNS answers returned to the real forwarder before any socket is opened.
     Socket and TLS side effects raise at their matching fake boundary.
 
@@ -486,14 +486,14 @@ def fake_forwarder_upstream(
         socket_factory=socket_factory,
     )
     with (
-        patch.object(forwarder, "_dns_resolver", upstream),
+        patch.object(transport, "_dns_resolver", upstream),
         patch.object(
-            forwarder.socket,
+            transport.socket,
             "socket",
             side_effect=upstream.create_socket,
         ),
         patch.object(
-            forwarder.ssl,
+            transport.ssl,
             "create_default_context",
             side_effect=upstream.create_default_context,
         ),

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -28,6 +28,7 @@ from mitmproxy.test import tflow, tutils
 import anthropic_accounting
 import auth
 import auth_base_forwarder
+import auth_base_transport
 import aws_sigv4_body_admission
 import builtin_connector_diagnostics
 import claude_output_timing
@@ -60,6 +61,7 @@ def _reset_module_state() -> Iterator[None]:
     reset them around each case to avoid cross-test callbacks.
     """
     auth_base_forwarder.reset_forward_request_state_for_tests()
+    auth_base_transport.reset_transport_state_for_tests()
     firewall_auth_client.reset_transport_state_for_tests()
     aws_sigv4_body_admission.reset_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()
@@ -87,6 +89,7 @@ def _reset_module_state() -> Iterator[None]:
     codex_output_timing.reset_for_tests()
     logging_utils.reset_log_writer_for_tests()
     auth_base_forwarder.reset_forward_request_state_for_tests()
+    auth_base_transport.reset_transport_state_for_tests()
     firewall_auth_client.reset_transport_state_for_tests()
     aws_sigv4_body_admission.reset_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder_lifecycle.py
@@ -13,6 +13,7 @@ import pytest
 from mitmproxy import http
 
 import auth_base_forwarder as forwarder
+import auth_base_transport as transport
 from tests.auth_base_forwarder_helpers import (
     FakeResponseFile,
     FakeSocket,
@@ -613,6 +614,7 @@ class TestForwardRequestAsyncWrapper:
                     10,
                 ),
                 patch.object(forwarder, "time", clock),
+                patch.object(transport, "time", clock),
                 patch.object(
                     loop,
                     "call_later",
@@ -671,7 +673,7 @@ class TestForwardRequestAsyncWrapper:
             forwarder._run_forward_request_worker(
                 future,
                 contextvars.copy_context(),
-                forwarder._prepare_forward_request("https://example.com"),
+                transport._prepare_forward_request("https://example.com"),
                 "GET",
                 [],
                 None,
@@ -693,9 +695,9 @@ class TestForwardRequestAsyncWrapper:
 
     async def test_rejects_body_over_limit_before_forwarding(self):
         with (
-            patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            patch.object(transport, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
             fake_forwarder_upstream() as upstream,
-            pytest.raises(forwarder.ForwardedRequestTooLargeError),
+            pytest.raises(transport.ForwardedRequestTooLargeError),
         ):
             await forwarder.forward_request(
                 "https://example.com",
@@ -952,7 +954,7 @@ class TestForwardRequestAsyncWrapper:
             forwarder._run_forward_request_worker(
                 future,
                 contextvars.copy_context(),
-                forwarder._prepare_forward_request("https://example.com"),
+                transport._prepare_forward_request("https://example.com"),
                 "GET",
                 [],
                 None,

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder_lifecycle.py
@@ -673,7 +673,7 @@ class TestForwardRequestAsyncWrapper:
             forwarder._run_forward_request_worker(
                 future,
                 contextvars.copy_context(),
-                transport._prepare_forward_request("https://example.com"),
+                transport.prepare_forward_request("https://example.com"),
                 "GET",
                 [],
                 None,
@@ -954,7 +954,7 @@ class TestForwardRequestAsyncWrapper:
             forwarder._run_forward_request_worker(
                 future,
                 contextvars.copy_context(),
-                transport._prepare_forward_request("https://example.com"),
+                transport.prepare_forward_request("https://example.com"),
                 "GET",
                 [],
                 None,

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder_protocol.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder_protocol.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 import auth_base_forwarder as forwarder
+import auth_base_transport as transport
 from tests.auth_base_forwarder_helpers import FakeSocket, fake_forwarder_upstream
 
 
@@ -254,7 +255,7 @@ class TestAuthBaseForwarderRequestBehavior:
 class TestAuthBaseForwarderResponseBodyLimit:
     async def test_accepts_body_at_limit(self):
         with (
-            patch.object(forwarder, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
+            patch.object(transport, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
             fake_forwarder_upstream(body=b"1234") as upstream,
         ):
             status, body, _headers = await forwarder.forward_request(
@@ -271,7 +272,7 @@ class TestAuthBaseForwarderResponseBodyLimit:
 
     async def test_accepts_complete_fixed_length_body_at_limit(self):
         with (
-            patch.object(forwarder, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
+            patch.object(transport, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
             fake_forwarder_upstream(
                 body=b"1234",
                 headers=[("Content-Length", "4")],
@@ -289,9 +290,9 @@ class TestAuthBaseForwarderResponseBodyLimit:
 
     async def test_rejects_body_over_limit_and_closes_resources(self):
         with (
-            patch.object(forwarder, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
+            patch.object(transport, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
             fake_forwarder_upstream(body=b"12345") as upstream,
-            pytest.raises(forwarder.ForwardedResponseTooLargeError),
+            pytest.raises(transport.ForwardedResponseTooLargeError),
         ):
             await forwarder.forward_request("https://example.com", "GET", [], None)
 
@@ -302,7 +303,7 @@ class TestAuthBaseForwarderResponseBodyLimit:
 
     async def test_rejects_truncated_fixed_length_body_and_closes_resources(self):
         with (
-            patch.object(forwarder, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
+            patch.object(transport, "MAX_AUTH_BASE_RESPONSE_BODY_BYTES", 4),
             fake_forwarder_upstream(
                 body=b"123",
                 headers=[("Content-Length", "4")],
@@ -345,7 +346,7 @@ class TestAuthBaseForwarderResponseBodyLimit:
 class TestAuthBaseForwarderRequestBodyLimit:
     async def test_accepts_body_at_limit(self):
         with (
-            patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            patch.object(transport, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
             fake_forwarder_upstream() as upstream,
         ):
             status, body, _headers = await forwarder.forward_request(
@@ -361,9 +362,9 @@ class TestAuthBaseForwarderRequestBodyLimit:
 
     async def test_rejects_body_over_limit_before_connection_setup(self):
         with (
-            patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            patch.object(transport, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
             fake_forwarder_upstream() as upstream,
-            pytest.raises(forwarder.ForwardedRequestTooLargeError),
+            pytest.raises(transport.ForwardedRequestTooLargeError),
         ):
             await forwarder.forward_request(
                 "https://example.com",
@@ -397,14 +398,14 @@ class TestAuthBaseForwarderResourceCleanup:
 
     async def test_oversized_body_releases_supplied_admission_before_upstream_setup(self):
         with (
-            patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            patch.object(transport, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
             patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 1),
             patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES", 4),
             fake_forwarder_upstream() as upstream,
         ):
             admission = forwarder.reserve_forward_request_admission(4)
 
-            with pytest.raises(forwarder.ForwardedRequestTooLargeError):
+            with pytest.raises(transport.ForwardedRequestTooLargeError):
                 await forwarder.forward_request(
                     "https://example.com",
                     "POST",

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder_security.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder_security.py
@@ -271,7 +271,7 @@ class TestAuthBaseForwarderTransportSecurity:
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                transport._ValidatedAddress(
+                transport.ValidatedAddress(
                     transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
@@ -314,7 +314,7 @@ class TestAuthBaseForwarderTransportSecurity:
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                transport._ValidatedAddress(
+                transport.ValidatedAddress(
                     transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
@@ -355,12 +355,12 @@ class TestAuthBaseForwarderTransportSecurity:
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                transport._ValidatedAddress(
+                transport.ValidatedAddress(
                     transport.socket.AF_INET6,
                     "2001:4860:4860::8888",
                     443,
                 ),
-                transport._ValidatedAddress(
+                transport.ValidatedAddress(
                     transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
@@ -419,7 +419,7 @@ class TestAuthBaseForwarderTransportSecurity:
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                transport._ValidatedAddress(
+                transport.ValidatedAddress(
                     transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
@@ -453,7 +453,7 @@ class TestAuthBaseForwarderTransportSecurity:
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                transport._ValidatedAddress(
+                transport.ValidatedAddress(
                     transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
@@ -484,7 +484,7 @@ class TestAuthBaseForwarderTransportSecurity:
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                transport._ValidatedAddress(
+                transport.ValidatedAddress(
                     transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
@@ -513,7 +513,7 @@ class TestAuthBaseForwarderTransportSecurity:
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                transport._ValidatedAddress(
+                transport.ValidatedAddress(
                     transport.socket.AF_INET,
                     "93.184.216.34",
                     443,

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder_security.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder_security.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 import auth_base_forwarder as forwarder
+import auth_base_transport as transport
 from tests.auth_base_forwarder_helpers import FakeSocket, fake_forwarder_upstream
 
 
@@ -68,7 +69,7 @@ class TestAuthBaseForwarderSecurity:
         with (
             fake_forwarder_upstream(addresses=(resolved_address,)) as upstream,
             pytest.raises(
-                forwarder.UnsafeAuthBaseDestinationError,
+                transport.UnsafeAuthBaseDestinationError,
                 match=r"Unsafe auth\.base upstream destination",
             ),
         ):
@@ -80,7 +81,7 @@ class TestAuthBaseForwarderSecurity:
     async def test_rejects_dns_private_destination_without_opening_connection(self):
         with (
             fake_forwarder_upstream(addresses=("10.0.0.1",)) as upstream,
-            pytest.raises(forwarder.UnsafeAuthBaseDestinationError),
+            pytest.raises(transport.UnsafeAuthBaseDestinationError),
         ):
             await forwarder.forward_request("https://hooks.example.com/path", "GET", [], None)
 
@@ -90,7 +91,7 @@ class TestAuthBaseForwarderSecurity:
     async def test_rejects_mixed_dns_answers_without_opening_connection(self):
         with (
             fake_forwarder_upstream(addresses=("93.184.216.34", "127.0.0.1")) as upstream,
-            pytest.raises(forwarder.UnsafeAuthBaseDestinationError),
+            pytest.raises(transport.UnsafeAuthBaseDestinationError),
         ):
             await forwarder.forward_request("https://hooks.example.com/path", "GET", [], None)
 
@@ -264,14 +265,14 @@ class TestAuthBaseForwarderTransportSecurity:
         context = MagicMock()
         context.wrap_socket.return_value = wrapped_sock
         abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
-        conn = forwarder._make_validated_https_connection(
+        conn = transport._make_validated_https_connection(
             "hooks.example.com",
             port=None,
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                forwarder._ValidatedAddress(
-                    forwarder.socket.AF_INET,
+                transport._ValidatedAddress(
+                    transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
                 ),
@@ -279,17 +280,17 @@ class TestAuthBaseForwarderTransportSecurity:
         )
         vars(conn)["_context"] = context
 
-        with patch.object(forwarder.socket, "socket", return_value=raw_sock) as create_socket:
+        with patch.object(transport.socket, "socket", return_value=raw_sock) as create_socket:
             conn.connect()
 
         create_socket.assert_called_once_with(
-            forwarder.socket.AF_INET,
-            forwarder.socket.SOCK_STREAM,
+            transport.socket.AF_INET,
+            transport.socket.SOCK_STREAM,
         )
         raw_sock.connect.assert_called_once_with(("93.184.216.34", 443))
         raw_sock.setsockopt.assert_called_once_with(
-            forwarder.socket.IPPROTO_TCP,
-            forwarder.socket.TCP_NODELAY,
+            transport.socket.IPPROTO_TCP,
+            transport.socket.TCP_NODELAY,
             1,
         )
         context.wrap_socket.assert_called_once_with(
@@ -307,14 +308,14 @@ class TestAuthBaseForwarderTransportSecurity:
         context = MagicMock()
         context.wrap_socket.return_value = wrapped_sock
         abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
-        conn = forwarder._make_validated_https_connection(
+        conn = transport._make_validated_https_connection(
             "hooks.example.com",
             port=None,
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                forwarder._ValidatedAddress(
-                    forwarder.socket.AF_INET,
+                transport._ValidatedAddress(
+                    transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
                 ),
@@ -323,7 +324,7 @@ class TestAuthBaseForwarderTransportSecurity:
         vars(conn)["_context"] = context
 
         with (
-            patch.object(forwarder.socket, "socket", return_value=raw_sock),
+            patch.object(transport.socket, "socket", return_value=raw_sock),
             pytest.raises(ssl.SSLError) as raised,
         ):
             conn.request("GET", "/")
@@ -348,19 +349,19 @@ class TestAuthBaseForwarderTransportSecurity:
         context = MagicMock()
         context.wrap_socket.return_value = wrapped_sock
         abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
-        conn = forwarder._make_validated_https_connection(
+        conn = transport._make_validated_https_connection(
             "hooks.example.com",
             port=None,
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                forwarder._ValidatedAddress(
-                    forwarder.socket.AF_INET6,
+                transport._ValidatedAddress(
+                    transport.socket.AF_INET6,
                     "2001:4860:4860::8888",
                     443,
                 ),
-                forwarder._ValidatedAddress(
-                    forwarder.socket.AF_INET,
+                transport._ValidatedAddress(
+                    transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
                 ),
@@ -369,7 +370,7 @@ class TestAuthBaseForwarderTransportSecurity:
         vars(conn)["_context"] = context
 
         with patch.object(
-            forwarder.socket,
+            transport.socket,
             "socket",
             side_effect=[failed_sock, raw_sock],
         ) as create_socket:
@@ -377,16 +378,16 @@ class TestAuthBaseForwarderTransportSecurity:
 
         create_socket.assert_has_calls(
             [
-                call(forwarder.socket.AF_INET6, forwarder.socket.SOCK_STREAM),
-                call(forwarder.socket.AF_INET, forwarder.socket.SOCK_STREAM),
+                call(transport.socket.AF_INET6, transport.socket.SOCK_STREAM),
+                call(transport.socket.AF_INET, transport.socket.SOCK_STREAM),
             ]
         )
         failed_sock.connect.assert_called_once_with(("2001:4860:4860::8888", 443, 0, 0))
         failed_sock.close.assert_called_once_with()
         raw_sock.connect.assert_called_once_with(("93.184.216.34", 443))
         raw_sock.setsockopt.assert_called_once_with(
-            forwarder.socket.IPPROTO_TCP,
-            forwarder.socket.TCP_NODELAY,
+            transport.socket.IPPROTO_TCP,
+            transport.socket.TCP_NODELAY,
             1,
         )
         context.wrap_socket.assert_called_once_with(
@@ -398,7 +399,7 @@ class TestAuthBaseForwarderTransportSecurity:
         assert conn.sock is wrapped_sock
 
     def test_validated_connection_context_keeps_https_security_defaults(self):
-        context = forwarder._create_https_context()
+        context = transport._create_https_context()
 
         assert context.verify_mode is ssl.CERT_REQUIRED
         assert context.check_hostname is True
@@ -412,14 +413,14 @@ class TestAuthBaseForwarderTransportSecurity:
         context = MagicMock()
         context.wrap_socket.return_value = wrapped_sock
         abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
-        conn = forwarder._make_validated_https_connection(
+        conn = transport._make_validated_https_connection(
             "hooks.example.com",
             port=None,
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                forwarder._ValidatedAddress(
-                    forwarder.socket.AF_INET,
+                transport._ValidatedAddress(
+                    transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
                 ),
@@ -427,7 +428,7 @@ class TestAuthBaseForwarderTransportSecurity:
         )
         vars(conn)["_context"] = context
 
-        with patch.object(forwarder.socket, "socket", return_value=raw_sock):
+        with patch.object(transport.socket, "socket", return_value=raw_sock):
             conn.connect()
 
         raw_sock.close.assert_not_called()
@@ -446,14 +447,14 @@ class TestAuthBaseForwarderTransportSecurity:
         raw_sock.close.side_effect = OSError("close failed")
         context = MagicMock()
         abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
-        conn = forwarder._make_validated_https_connection(
+        conn = transport._make_validated_https_connection(
             "hooks.example.com",
             port=None,
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                forwarder._ValidatedAddress(
-                    forwarder.socket.AF_INET,
+                transport._ValidatedAddress(
+                    transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
                 ),
@@ -462,7 +463,7 @@ class TestAuthBaseForwarderTransportSecurity:
         vars(conn)["_context"] = context
 
         with (
-            patch.object(forwarder.socket, "socket", return_value=raw_sock),
+            patch.object(transport.socket, "socket", return_value=raw_sock),
             pytest.raises(OSError, match="setsockopt failed"),
         ):
             conn.connect()
@@ -477,14 +478,14 @@ class TestAuthBaseForwarderTransportSecurity:
         context = MagicMock()
         context.wrap_socket.side_effect = OSError("tls failed")
         abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
-        conn = forwarder._make_validated_https_connection(
+        conn = transport._make_validated_https_connection(
             "hooks.example.com",
             port=None,
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                forwarder._ValidatedAddress(
-                    forwarder.socket.AF_INET,
+                transport._ValidatedAddress(
+                    transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
                 ),
@@ -493,7 +494,7 @@ class TestAuthBaseForwarderTransportSecurity:
         vars(conn)["_context"] = context
 
         with (
-            patch.object(forwarder.socket, "socket", return_value=raw_sock),
+            patch.object(transport.socket, "socket", return_value=raw_sock),
             pytest.raises(OSError, match="tls failed"),
         ):
             conn.connect()
@@ -506,14 +507,14 @@ class TestAuthBaseForwarderTransportSecurity:
         context = MagicMock()
         context.wrap_socket.side_effect = OSError("tls failed")
         abort_handle = forwarder._ForwardRequestAbortHandle(MagicMock())
-        conn = forwarder._make_validated_https_connection(
+        conn = transport._make_validated_https_connection(
             "hooks.example.com",
             port=None,
             deadline=time.monotonic() + 30,
             abort_handle=abort_handle,
             validated_addresses=(
-                forwarder._ValidatedAddress(
-                    forwarder.socket.AF_INET,
+                transport._ValidatedAddress(
+                    transport.socket.AF_INET,
                     "93.184.216.34",
                     443,
                 ),
@@ -522,7 +523,7 @@ class TestAuthBaseForwarderTransportSecurity:
         vars(conn)["_context"] = context
 
         with (
-            patch.object(forwarder.socket, "socket", return_value=raw_sock),
+            patch.object(transport.socket, "socket", return_value=raw_sock),
             pytest.raises(OSError, match="tls failed"),
         ):
             conn.connect()


### PR DESCRIPTION
## Summary

- extract auth.base URL preparation, public-destination validation, header policy, body bounds, validated TCP/TLS setup, and synchronous HTTP exchange into `auth_base_transport.py`
- keep admission, absolute-deadline creation, abort terminal state, workers, futures, cancellation, shutdown, and the public async facade in `auth_base_forwarder.py`
- define the minimal structural cancellation/socket interface consumed by transport without introducing a second lifecycle owner or reverse dependency
- move security/protocol test patch targets and transport-cache reset to the new owner while preserving facade-level integration coverage

## Behavior preserved

- HTTPS-only auth.base destinations and all-address public-destination validation before connect
- validated-IP connections with the original normalized hostname for TLS SNI, certificate validation, and `Host`
- one absolute deadline across queue wait, DNS, connect, TLS, request, and response work
- shutdown-aware DNS cancellation and active-socket abort
- header filtering, request/response body bounds, redirect pass-through, response framing, and exception identity

## Explicit exclusions

- no API, database, queue, persisted-state, runner/guest protocol, dependency, or generated-policy changes
- no shared general-purpose transport for webhook, firewall-auth API, or other HTTP clients
- no configurable transport object or additional lifecycle registry

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_auth_base_forwarder_security.py tests/test_auth_base_forwarder_protocol.py tests/test_auth_base_forwarder_lifecycle.py` — 119 passed
- `uv run --no-sync python -m pytest tests/` — 5360 passed
- `cargo check -p runner`

Closes #26833
