### PR TITLE
test(e2e): isolate firewall placeholders from public dns

### DIFF
--- a/e2e/tests/03-runner/run-t02-firewall-discord-webhook.bats
+++ b/e2e/tests/03-runner/run-t02-firewall-discord-webhook.bats
@@ -27,10 +27,15 @@ teardown() {
     echo "$output"
     assert_success
 
+    # Raw DNS has dedicated runner coverage. Pin the synthetic placeholder's
+    # public sink so this test owns only firewall classification and rewriting.
     local prompt
     prompt=$(cat <<'EOF'
 printf 'DISCORD_WEBHOOK_URL=%s\n' "$DISCORD_WEBHOOK_URL"
-curl --silent --show-error --max-time 5 --output /dev/null "$DISCORD_WEBHOOK_URL" || true
+curl --silent --show-error --max-time 5 \
+    --resolve 'firewall-placeholder.vm3.ai:443:8.8.8.8' \
+    --output /dev/null \
+    "$DISCORD_WEBHOOK_URL" || true
 printf 'DISCORD_REQUEST_SENT\n'
 EOF
 )

--- a/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
+++ b/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
@@ -28,6 +28,8 @@ teardown() {
     echo "$output"
     assert_success
 
+    # Raw DNS has dedicated runner coverage. Pin the synthetic placeholder's
+    # public sink so this test owns only firewall permission transitions.
     local request_url="https://firewall-placeholder.vm3.ai/algolia/write/1/indexes/vm0-e2e-${TEST_ID}"
     local checkpoint_script
     checkpoint_script=$(cat <<'EOF'
@@ -35,6 +37,7 @@ set -euo pipefail
 response_file=$(mktemp)
 trap 'rm -f "$response_file"' EXIT
 status=$(curl --silent --show-error --max-time 5 \
+    --resolve 'firewall-placeholder.vm3.ai:443:8.8.8.8' \
     --output "$response_file" \
     --write-out '%{http_code}' \
     --request POST \
@@ -57,6 +60,7 @@ deadline=$((SECONDS + 90))
 while ((SECONDS < deadline)); do
     : > "$response_file"
     curl --silent --show-error --max-time 5 \
+        --resolve 'firewall-placeholder.vm3.ai:443:8.8.8.8' \
         --output "$response_file" \
         --request POST \
         --header 'content-type: application/json' \


### PR DESCRIPTION
## Summary

- pin the synthetic firewall placeholder transport in the Discord auth.base and Algolia permission E2E probes with curl `--resolve`
- keep the placeholder URL, Host/SNI authority, production firewall classification, auth resolution, URL rewrite, and run-owned telemetry assertions unchanged
- remove only the public DNS lookup that neither test owns; add no retries, sleeps, timeout increases, skips, or weaker assertions

## Root cause

[Turbo run 31674640774](https://github.com/vm0-ai/vm0/actions/runs/31674640774) failed in [cli-e2e-03-runner shard 4](https://github.com/vm0-ai/vm0/actions/runs/31674640774/job/94367914693). The sandbox curl reported `Resolving timed out after 5000 milliseconds` before any HTTP request reached the proxy:

- the placeholder A query was emitted at `06:47:03.094Z`
- its first observed A response (`8.8.8.8`) arrived only after the resolver retransmit at `06:47:08.107Z`, beyond curl's unchanged five-second total deadline
- the run completed and uploaded telemetry normally, but no Discord firewall event existed for the Bats helper to observe; its later polling timeout was secondary

The source PR, [#26809](https://github.com/vm0-ai/vm0/pull/26809), changes generated-image CDN transforms and does not touch runner firewall behavior. Its PR-head run [31673437675](https://github.com/vm0-ai/vm0/actions/runs/31673437675/job/94363660505) passed this test in 8.208 seconds. The immediately preceding base merge-group run [31674620705](https://github.com/vm0-ai/vm0/actions/runs/31674620705/job/94367735952) passed it in 8.034 seconds.

The failing SHA already includes [#26787](https://github.com/vm0-ai/vm0/pull/26787), which staggers TCP address attempts inside the firewall-auth client. That code runs only after a request reaches firewall classification and auth fetch; this failure stopped during guest DNS resolution, so #26787 was never on the causal path.

## Deterministic invariant

`--resolve` supplies only curl's transport address for `firewall-placeholder.vm3.ai:443`. Curl still uses the original HTTPS URL and placeholder authority, so the request must traverse the production proxy, match the intended firewall, resolve the connector credential, rewrite auth.base, and produce the same run-scoped firewall event. The Algolia permission-transition test uses the same synthetic authority and receives the same isolation.

## Validation

- target Bats parse/count: 5 consecutive passes, 2 tests each
- ShellCheck 0.11.0 on both changed Bats files: 5 consecutive passes
- all `e2e/tests/03-runner/*.bats` parse/count: 23 tests
- `.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `git diff --check`

The deployed `03-runner` suite is CI-only by repository contract; this draft provisions the real PR API/runner environment for live validation.
