### PR TITLE
fix(chat): delay thread skeleton reveal

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -66,7 +66,7 @@ export interface MessageListSignals {
   readonly readyScrollAfterRenderRequest$: Computed<
     Promise<ReadyScrollAfterRenderRequest | null>
   >;
-  readonly chatSkeletonVisible$: Computed<boolean>;
+  readonly initialEventsReady$: Computed<boolean>;
   readonly assistantErrorRecovery$: Computed<
     Promise<AssistantErrorRecovery | null>
   >;
@@ -127,7 +127,6 @@ export interface ChatPanelSignals {
   readonly threadTitle$: Computed<string | null>;
   readonly threadTitleEmoji$: Computed<string | null>;
   readonly threadTitleText$: Computed<string>;
-  readonly threadSettledInServer$: Computed<boolean>;
   readonly assistantErrorRecovery$: Computed<
     Promise<AssistantErrorRecovery | null>
   >;
@@ -185,7 +184,7 @@ export interface ChatPanelSignals {
   // -- Paged events (sole rendering path) ----------------------------------
   readonly latestRunFinishCreatedAt$: Computed<Promise<string | undefined>>;
   readonly latestAssistantTextCreatedAt$: Computed<Promise<string | undefined>>;
-  readonly chatSkeletonVisible$: Computed<boolean>;
+  readonly initialEventsReady$: Computed<boolean>;
   readonly visibleRenderedChatGroups$: Computed<Promise<ChatEventGroup[]>>;
   readonly visibleRenderedChatGroupsReady$: Computed<Promise<boolean>>;
   readonly eventImageGroups$: Computed<Promise<EventImageGroupProjection[]>>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -429,14 +429,6 @@ function createThreadTitleParts(threadMeta$: Computed<ThreadMeta | null>) {
   return { threadTitle$, threadTitleEmoji$, threadTitleText$ };
 }
 
-function createThreadSettledInServer(threadId: string) {
-  const optimisticCreateUnsettled$ =
-    optimisticChatThreadCreateUnsettled(threadId);
-  return computed((get): boolean => {
-    return !get(optimisticCreateUnsettled$);
-  });
-}
-
 // ---------------------------------------------------------------------------
 // Sub-factory: composer model override
 // ---------------------------------------------------------------------------
@@ -2251,8 +2243,8 @@ function createChatThreadMessagePipeline(
     },
     ownerSignal,
   );
-  const chatSkeletonVisible$ = computed((get): boolean => {
-    return !get(initialEventsReady$);
+  const initialEventsReadyView$ = computed((get): boolean => {
+    return get(initialEventsReady$);
   });
   const lifecycle = createChatEventPresentationLifecycle({
     chatEvents,
@@ -2290,7 +2282,7 @@ function createChatThreadMessagePipeline(
     scroll,
     sidebar: effects.sidebar,
     ...lifecycle,
-    chatSkeletonVisible$,
+    initialEventsReady$: initialEventsReadyView$,
     ...assistantErrorRecovery,
     ...projections,
     ...resources.publicSignals,
@@ -3610,7 +3602,7 @@ function publicChatThreadEventSignals(events: MessageListSignals) {
     visibleRenderedChatGroups$: events.visibleRenderedChatGroups$,
     visibleRenderedChatGroupsReady$: events.visibleRenderedChatGroupsReady$,
     readyScrollAfterRenderRequest$: events.readyScrollAfterRenderRequest$,
-    chatSkeletonVisible$: events.chatSkeletonVisible$,
+    initialEventsReady$: events.initialEventsReady$,
     assistantErrorRecovery$: events.assistantErrorRecovery$,
     retryAssistantError$: events.retryAssistantError$,
     resetCodexSubscriptionAndRetry$: events.resetCodexSubscriptionAndRetry$,
@@ -3861,7 +3853,6 @@ function createChatPanelSignalsWithDraft(
   const threadDraft$ = createRemoteChatThreadDraft(threadId);
   const threadMeta$ = createThreadMeta(threadId);
   const threadTitle = createThreadTitleParts(threadMeta$);
-  const threadSettledInServer$ = createThreadSettledInServer(threadId);
   const container = createChatThreadContainerSignals();
   const threadOwned = createThreadOwnedSignals(threadId);
   const cancellationRecovery = createCancellationRecoverySignals(threadId);
@@ -3906,7 +3897,6 @@ function createChatPanelSignalsWithDraft(
     threadDraft$,
     threadMeta$,
     ...threadTitle,
-    threadSettledInServer$,
     scrollContainerOnRef$: messages.scroll.scrollContainerOnRef$,
     scrollContentOnRef$: messages.scroll.scrollContentOnRef$,
     scrollCommitOnRef$: messages.scroll.scrollCommitOnRef$,

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -386,6 +386,17 @@ body {
   animation: zero-thinking-in 0.3s ease-out;
 }
 
+@keyframes zero-chat-skeleton-reveal {
+  to {
+    opacity: 1;
+  }
+}
+.zero-chat-skeleton-reveal {
+  /* Avoid flashing the skeleton when cached chat events resolve immediately. */
+  opacity: 0;
+  animation: zero-chat-skeleton-reveal 0s 100ms forwards;
+}
+
 /* Thinking indicator: 3-block loader */
 .zero-blocks {
   display: inline-grid;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -958,6 +958,10 @@ describe("chat lifecycle", () => {
         screen.queryByText("Existing context before follow-up"),
       ).not.toBeInTheDocument();
       expect(screen.queryByText("Pending follow-up")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Send a message to start the conversation"),
+      ).not.toBeInTheDocument();
+      expect(document.querySelector("[data-chat-skeleton]")).not.toBeNull();
     });
 
     otherThreadMessagesGate.resolve(undefined);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -44,10 +44,7 @@ function observeEmptyThreadMessage(): {
 } {
   let wasShown = false;
   const record = () => {
-    if (
-      document.querySelector("[data-chat-skeleton]") === null &&
-      document.body.textContent?.includes(EMPTY_THREAD_MESSAGE)
-    ) {
+    if (document.body.textContent?.includes(EMPTY_THREAD_MESSAGE)) {
       wasShown = true;
     }
   };

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4356,7 +4356,7 @@ function ChatThreadSkeletonOverlay({ thread }: { thread: ChatPanelSignals }) {
   return (
     <div
       data-chat-skeleton
-      className="absolute inset-0 z-10 overflow-hidden pointer-events-none bg-background"
+      className="zero-chat-skeleton-reveal absolute inset-0 z-10 overflow-hidden pointer-events-none bg-background"
     >
       <main className={CHAT_THREAD_CONTENT_MAIN_CLASS}>
         <div className="w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3148,11 +3148,9 @@ function ChatThreadSessionError({ thread }: { thread: ChatPanelSignals }) {
 
 function ChatThreadEmptyState({ thread }: { thread: ChatPanelSignals }) {
   const { t } = useTranslation();
-  const renderedGroupsReady =
-    useLastResolved(thread.visibleRenderedChatGroupsReady$) ?? false;
-  const threadSettledInServer = useGet(thread.threadSettledInServer$);
+  const initialEventsReady = useGet(thread.initialEventsReady$);
   const hasEvents = useLastResolved(thread.hasEvents$);
-  if (!renderedGroupsReady || !threadSettledInServer || hasEvents !== false) {
+  if (!initialEventsReady || hasEvents !== false) {
     return null;
   }
   return (
@@ -4348,18 +4346,18 @@ function RunGroupFoldRow({
 }
 
 function ChatThreadSkeletonOverlay({ thread }: { thread: ChatPanelSignals }) {
-  const chatSkeletonVisible = useGet(thread.chatSkeletonVisible$);
-  if (!chatSkeletonVisible) {
+  const initialEventsReady = useGet(thread.initialEventsReady$);
+  if (initialEventsReady) {
     return null;
   }
 
   return (
     <div
       data-chat-skeleton
-      className="zero-chat-skeleton-reveal absolute inset-0 z-10 overflow-hidden pointer-events-none bg-background"
+      className="absolute inset-0 z-10 overflow-hidden pointer-events-none bg-background"
     >
       <main className={CHAT_THREAD_CONTENT_MAIN_CLASS}>
-        <div className="w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4">
+        <div className="zero-chat-skeleton-reveal w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4">
           <ChatSkeleton />
         </div>
       </main>


### PR DESCRIPTION
## Summary

- keep the chat thread skeleton overlay transparent for its first 100 ms
- reveal the overlay immediately after the delay for slower initial event hydration
- leave history backfill skeleton behavior unchanged

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged Turbo, platform, and API type checks
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx`
- `pnpm --filter @okouai/app run build`
- browser CSS timing sample: opacity 0 at 0 ms and 52 ms, then 1 at 122 ms