### PR TITLE
fix(platform): recover realtime when network reconnects

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -403,6 +403,39 @@ describe("realtime signals", () => {
     expect(payloadCatchUps).toBe(1);
   });
 
+  it("rebuilds a failed realtime client when the network comes back", async () => {
+    mockSignedInUser();
+    const topic = "test:failed-online-recovery";
+    const subscriber = testSubscriber();
+    let runs = 0;
+    const loop$ = command((_ctx, _signal: AbortSignal) => {
+      runs += 1;
+      return false;
+    });
+
+    await setupAuthAndRealtime();
+    const loopPromise = context.store.set(
+      setAblyLoop$,
+      { topic, loopCommand$: loop$ },
+      subscriber.signal,
+    );
+    context.track(loopPromise);
+
+    await waitFor(() => {
+      expect(context.mocks.ably.hasSubscription(topic)).toBeTruthy();
+    });
+    context.mocks.ably.triggerFailure("terminal connection failure");
+    expect(context.mocks.ably.hasSubscription(topic)).toBeFalsy();
+
+    window.dispatchEvent(new Event("online"));
+
+    await waitFor(() => {
+      expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+      expect(context.mocks.ably.hasSubscription(topic)).toBeTruthy();
+      expect(runs).toBe(1);
+    });
+  });
+
   it("waits for the next foreground catch-up after rebuilding fails", async () => {
     mockSignedInUser();
     const topic = "test:failed-rebuild-retry";

--- a/turbo/apps/platform/src/signals/auth-retry.ts
+++ b/turbo/apps/platform/src/signals/auth-retry.ts
@@ -120,7 +120,8 @@ export function createAuthRecovery(
 }
 
 /**
- * Route visibility, focus, and realtime reconnect through one catch-up task.
+ * Route visibility, focus, network restoration, and realtime reconnect through
+ * one catch-up task.
  */
 export const setupAuthCatchUp$ = command(
   ({ get, set }, authRecovery: AuthRecovery, signal: AbortSignal): void => {
@@ -208,6 +209,7 @@ export const setupAuthCatchUp$ = command(
       signal,
     });
     window.addEventListener("focus", requestCatchUp, { signal });
+    window.addEventListener("online", requestCatchUp, { signal });
   },
 );
 


### PR DESCRIPTION
## Summary

- route the browser `online` event through the existing foreground catch-up task
- rebuild a terminally failed Ably client after network restoration without requiring a visibility or focus change
- cover the network-only recovery path with a regression test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/realtime.test.ts` (26 tests passed)
