### PR TITLE
fix(connectors): require pinned custom runtime registrations

### DIFF
--- a/crates/runner/src/provider/connector_runtime_sync.rs
+++ b/crates/runner/src/provider/connector_runtime_sync.rs
@@ -104,10 +104,9 @@ struct ActiveRunConnectorRuntimeState {
 }
 
 struct ActiveConnectorSyncState {
+    registration: ConnectorRuntimeTargetRegistration,
     generation: u64,
     consecutive_failures: u32,
-    // Custom-only routing inputs pinned for this run. They are not target identity.
-    pinned_base_url_vars: Option<HashMap<String, String>>,
 }
 
 struct ScheduledSyncTask {
@@ -156,7 +155,6 @@ struct ConnectorSyncTarget {
 struct PreparedConnectorRuntimePublication {
     target: ConnectorSyncTarget,
     deadline: Option<tokio::time::Instant>,
-    candidate_base_url_vars: Option<HashMap<String, String>>,
     update: ConnectorRuntimeRegistryUpdate,
 }
 
@@ -280,9 +278,9 @@ impl ConnectorRuntimeSyncCore {
                     (
                         registration.target(),
                         ActiveConnectorSyncState {
+                            registration: registration.clone(),
                             generation: 0,
                             consecutive_failures: 0,
-                            pinned_base_url_vars: registration.custom_base_url_vars().cloned(),
                         },
                     )
                 })
@@ -772,11 +770,10 @@ impl ConnectorRuntimeSyncCore {
                 ) => {
                     let routing_variables =
                         if matches!(state, ConnectorRuntimeSyncState::Available { .. }) {
-                            let Some(Some(routing_variables)) = self
+                            let Some(routing_variables) = self
                                 .custom_base_url_vars_for_publication(
                                     run_id,
                                     target,
-                                    candidate_base_url_vars.as_ref(),
                                     registration_cancel,
                                 )
                                 .await
@@ -838,7 +835,6 @@ impl ConnectorRuntimeSyncCore {
             prepared_publications.push(PreparedConnectorRuntimePublication {
                 target: target.clone(),
                 deadline,
-                candidate_base_url_vars,
                 update,
             });
         }
@@ -878,7 +874,6 @@ impl ConnectorRuntimeSyncCore {
                                 run_id,
                                 &prepared.target,
                                 prepared.deadline,
-                                prepared.candidate_base_url_vars.as_ref(),
                                 registration_cancel,
                             )
                             .await
@@ -1093,19 +1088,16 @@ impl ConnectorRuntimeSyncCore {
                 if connector.generation != target.generation {
                     return None;
                 }
-                let registration = match &target.target {
-                    ConnectorRuntimeTarget::Builtin { connector_slug } => {
+                let registration = match &connector.registration {
+                    ConnectorRuntimeTargetRegistration::Builtin { connector_slug, .. } => {
                         ConnectorRuntimeTargetRegistration::Builtin {
                             connector_slug: connector_slug.clone(),
                             base_url_vars: None,
                         }
                     }
-                    ConnectorRuntimeTarget::Custom {
-                        custom_connector_id,
-                    } => ConnectorRuntimeTargetRegistration::Custom {
-                        custom_connector_id: custom_connector_id.clone(),
-                        base_url_vars: connector.pinned_base_url_vars.clone(),
-                    },
+                    ConnectorRuntimeTargetRegistration::Custom { .. } => {
+                        connector.registration.clone()
+                    }
                 };
                 Some((target.clone(), registration))
             })
@@ -1175,9 +1167,9 @@ impl ConnectorRuntimeSyncCore {
         let connector = active.connectors.get(&target.target)?;
         Some(
             connector
-                .pinned_base_url_vars
-                .as_ref()
-                .is_none_or(|pinned| pinned == candidate),
+                .registration
+                .custom_base_url_vars()
+                .is_some_and(|pinned| pinned == candidate),
         )
     }
 
@@ -1185,9 +1177,8 @@ impl ConnectorRuntimeSyncCore {
         &self,
         run_id: RunId,
         target: &ConnectorSyncTarget,
-        candidate: Option<&HashMap<String, String>>,
         registration_cancel: &CancellationToken,
-    ) -> Option<Option<HashMap<String, String>>> {
+    ) -> Option<HashMap<String, String>> {
         let active_runs = self.inner.active_runs.lock().await;
         let active = active_runs.get(&run_id)?;
         if &active.cancel != registration_cancel {
@@ -1197,12 +1188,7 @@ impl ConnectorRuntimeSyncCore {
         if connector.generation != target.generation {
             return None;
         }
-        Some(
-            connector
-                .pinned_base_url_vars
-                .clone()
-                .or_else(|| candidate.cloned()),
-        )
+        connector.registration.custom_base_url_vars().cloned()
     }
 
     async fn complete_successful_sync(
@@ -1210,7 +1196,6 @@ impl ConnectorRuntimeSyncCore {
         run_id: RunId,
         target: &ConnectorSyncTarget,
         deadline: Option<tokio::time::Instant>,
-        candidate_base_url_vars: Option<&HashMap<String, String>>,
         registration_cancel: &CancellationToken,
     ) -> bool {
         let mut active_runs = self.inner.active_runs.lock().await;
@@ -1225,13 +1210,6 @@ impl ConnectorRuntimeSyncCore {
         };
         if connector.generation != target.generation {
             return false;
-        }
-        if let Some(candidate) = candidate_base_url_vars {
-            match &connector.pinned_base_url_vars {
-                Some(pinned) if pinned != candidate => return false,
-                Some(_) => {}
-                None => connector.pinned_base_url_vars = Some(candidate.clone()),
-            }
         }
         connector.consecutive_failures = 0;
         self.replace_schedule_locked(active, run_id, target, deadline)
@@ -1736,10 +1714,23 @@ mod tests {
         }
     }
 
-    fn runtime_target_registration(
-        target: &ConnectorRuntimeTarget,
+    fn builtin_runtime_target_registration(
+        connector_slug: &str,
     ) -> ConnectorRuntimeTargetRegistration {
-        target.clone().into()
+        ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: connector_slug.to_string(),
+            base_url_vars: None,
+        }
+    }
+
+    fn custom_runtime_target_registration(
+        custom_connector_id: &str,
+        base_url_vars: HashMap<String, String>,
+    ) -> ConnectorRuntimeTargetRegistration {
+        ConnectorRuntimeTargetRegistration::Custom {
+            custom_connector_id: custom_connector_id.to_string(),
+            base_url_vars,
+        }
     }
 
     fn custom_runtime_firewall(custom_connector_id: &str) -> FirewallEntry {
@@ -2122,14 +2113,16 @@ mod tests {
             connectors: connector_slugs
                 .into_iter()
                 .map(|connector_slug| {
+                    let registration = ConnectorRuntimeTargetRegistration::Builtin {
+                        connector_slug: connector_slug.into(),
+                        base_url_vars: None,
+                    };
                     (
-                        ConnectorRuntimeTarget::Builtin {
-                            connector_slug: connector_slug.into(),
-                        },
+                        registration.target(),
                         ActiveConnectorSyncState {
+                            registration,
                             generation: 0,
                             consecutive_failures: 0,
-                            pinned_base_url_vars: None,
                         },
                     )
                 })
@@ -2254,7 +2247,7 @@ mod tests {
                     ..
                 } => Some(ConnectorRuntimeTargetRegistration::Custom {
                     custom_connector_id: custom_connector_id.clone(),
-                    base_url_vars: None,
+                    base_url_vars: HashMap::new(),
                 }),
                 FirewallEntry::Inline { .. } => None,
             })
@@ -2340,9 +2333,9 @@ mod tests {
             .iter()
             .map(|connector_slug| builtin_target(connector_slug))
             .collect::<Vec<_>>();
-        let registrations = targets
+        let registrations = connector_slugs
             .iter()
-            .map(runtime_target_registration)
+            .map(|connector_slug| builtin_runtime_target_registration(connector_slug))
             .collect::<Vec<_>>();
         let firewalls = connector_slugs
             .iter()
@@ -2406,7 +2399,7 @@ mod tests {
         run_id: RunId,
     ) -> (tempfile::TempDir, std::path::PathBuf) {
         let (dir, registry, registry_path, _lock_path) = registered_slack_registry(run_id).await;
-        let targets = [runtime_target_registration(&builtin_target("slack"))];
+        let targets = [builtin_runtime_target_registration("slack")];
         handle
             .register_run(ConnectorRuntimeSyncRegistration {
                 run_id,
@@ -2812,7 +2805,7 @@ mod tests {
         let handle = ConnectorRuntimeSyncHandle::new(api_client_for_url(api_url));
         let run_id = RunId::nil();
         let (_dir, registry, registry_path, lock_path) = registered_slack_registry(run_id).await;
-        let targets = [runtime_target_registration(&builtin_target("slack"))];
+        let targets = [builtin_runtime_target_registration("slack")];
         handle
             .register_run(ConnectorRuntimeSyncRegistration {
                 run_id,
@@ -3061,7 +3054,7 @@ mod tests {
                 next_refresh_at: "2999-01-01T00:00:00Z".to_string(),
             },
         )]);
-        let targets = [runtime_target_registration(&builtin_target("slack"))];
+        let targets = [builtin_runtime_target_registration("slack")];
         handle
             .core
             .register_run(ConnectorRuntimeSyncRegistration {
@@ -3094,7 +3087,7 @@ mod tests {
             dir.path().join("proxy-registry.json"),
             dir.path().join("proxy-registry.lock"),
         );
-        let targets = [runtime_target_registration(&builtin_target("slack"))];
+        let targets = [builtin_runtime_target_registration("slack")];
 
         handle
             .core
@@ -3160,7 +3153,7 @@ mod tests {
             run_id,
             source_ip: "10.200.0.2",
             registry,
-            targets: std::slice::from_ref(&runtime_target_registration(&target)),
+            targets: std::slice::from_ref(&builtin_runtime_target_registration("slack")),
             refreshes: Some(&refreshes),
         })
         .await;
@@ -3421,10 +3414,11 @@ mod tests {
         let run_id = RunId::nil();
         let custom_connector_id = "550e8400-e29b-41d4-a716-446655440000";
         let target = custom_target(custom_connector_id);
+        let registration = custom_runtime_target_registration(custom_connector_id, HashMap::new());
         let absent_sync = server.mock(|when, then| {
             when.method(POST)
                 .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
-                .json_body(json!({ "targets": [target.clone()] }));
+                .json_body(json!({ "targets": [registration.clone()] }));
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -3438,7 +3432,6 @@ mod tests {
         let firewall = custom_runtime_firewall(custom_connector_id);
         let empty_firewalls = Vec::new();
         let empty_policies = HashMap::new();
-        let registration = runtime_target_registration(&target);
         let (_dir, registry, registry_path) = registered_runtime_registry_with_targets(
             run_id,
             &empty_firewalls,
@@ -3483,7 +3476,7 @@ mod tests {
         let available_sync = server.mock(|when, then| {
             when.method(POST)
                 .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
-                .json_body(json!({ "targets": [target.clone()] }));
+                .json_body(json!({ "targets": [registration.clone()] }));
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -3575,7 +3568,10 @@ mod tests {
             run_id,
             source_ip: "10.200.0.2",
             registry,
-            targets: std::slice::from_ref(&runtime_target_registration(&target)),
+            targets: std::slice::from_ref(&custom_runtime_target_registration(
+                custom_connector_id,
+                HashMap::new(),
+            )),
             refreshes: None,
         })
         .await;
@@ -3600,19 +3596,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn custom_target_pins_first_routing_values_and_forwards_them_after_wakeup() {
+    async fn custom_target_forwards_pinned_routing_values_after_wakeup() {
         let server = MockServer::start();
         let (core, mut requests) = core_without_worker(&server);
         let run_id = RunId::nil();
         let custom_connector_id = "550e8400-e29b-41d4-a716-446655440000";
         let target = custom_target(custom_connector_id);
-        let registration = runtime_target_registration(&target);
-        let firewall = custom_runtime_firewall(custom_connector_id);
         let base_url_vars = HashMap::from([("subdomain".to_string(), "acme".to_string())]);
-        let first_sync = server.mock(|when, then| {
+        let registration =
+            custom_runtime_target_registration(custom_connector_id, base_url_vars.clone());
+        let firewall = custom_runtime_firewall(custom_connector_id);
+        let available_sync = server.mock(|when, then| {
             when.method(POST)
                 .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
-                .json_body(json!({ "targets": [target.clone()] }));
+                .json_body(json!({
+                    "targets": [{
+                        "kind": "custom",
+                        "customConnectorId": custom_connector_id,
+                        "baseUrlVars": base_url_vars,
+                    }],
+                }));
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -3654,10 +3657,10 @@ mod tests {
                 .await
         );
 
-        first_sync.assert_calls(1);
+        available_sync.assert_calls(1);
         assert_eq!(
-            core.inner.active_runs.lock().await[&run_id].connectors[&target].pinned_base_url_vars,
-            Some(base_url_vars.clone())
+            core.inner.active_runs.lock().await[&run_id].connectors[&target].registration,
+            registration
         );
         let registry_after_available = tokio::fs::read(&registry_path).await.unwrap();
         let registry_json: serde_json::Value =
@@ -3668,7 +3671,7 @@ mod tests {
             json!(base_url_vars)
         );
 
-        first_sync.delete_async().await;
+        available_sync.delete_async().await;
         let unresolved_sync = server.mock(|when, then| {
             when.method(POST)
                 .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
@@ -3704,10 +3707,7 @@ mod tests {
         );
         let active_runs = core.inner.active_runs.lock().await;
         let active = &active_runs[&run_id];
-        assert_eq!(
-            active.connectors[&target].pinned_base_url_vars,
-            Some(base_url_vars)
-        );
+        assert_eq!(active.connectors[&target].registration, registration);
         assert_eq!(active.connectors[&target].consecutive_failures, 1);
         assert!(active.sync_tasks.contains_key(&target));
         drop(active_runs);
@@ -3726,7 +3726,7 @@ mod tests {
             HashMap::from([("subdomain".to_string(), "other".to_string())]);
         let registration = ConnectorRuntimeTargetRegistration::Custom {
             custom_connector_id: custom_connector_id.to_string(),
-            base_url_vars: Some(pinned_base_url_vars.clone()),
+            base_url_vars: pinned_base_url_vars.clone(),
         };
         let firewall = custom_runtime_firewall(custom_connector_id);
         server.mock(|when, then| {
@@ -3792,10 +3792,7 @@ mod tests {
         );
         let active_runs = core.inner.active_runs.lock().await;
         let active = &active_runs[&run_id];
-        assert_eq!(
-            active.connectors[&target].pinned_base_url_vars,
-            Some(pinned_base_url_vars)
-        );
+        assert_eq!(active.connectors[&target].registration, registration);
         assert_eq!(active.connectors[&target].consecutive_failures, 1);
         assert!(active.sync_tasks.contains_key(&target));
         drop(active_runs);
@@ -3849,7 +3846,10 @@ mod tests {
             run_id,
             source_ip: "10.200.0.2",
             registry,
-            targets: std::slice::from_ref(&runtime_target_registration(&target)),
+            targets: std::slice::from_ref(&custom_runtime_target_registration(
+                custom_connector_id,
+                HashMap::new(),
+            )),
             refreshes: None,
         })
         .await;
@@ -3904,7 +3904,7 @@ mod tests {
             run_id,
             source_ip: "10.200.0.2",
             registry,
-            targets: std::slice::from_ref(&runtime_target_registration(&target)),
+            targets: std::slice::from_ref(&builtin_runtime_target_registration("slack")),
             refreshes: None,
         })
         .await;
@@ -3962,7 +3962,10 @@ mod tests {
             run_id,
             source_ip: "10.200.0.2",
             registry,
-            targets: std::slice::from_ref(&runtime_target_registration(&target)),
+            targets: std::slice::from_ref(&custom_runtime_target_registration(
+                custom_connector_id,
+                HashMap::new(),
+            )),
             refreshes: None,
         })
         .await;
@@ -4013,7 +4016,7 @@ mod tests {
                 unknown_policy: "allow".to_string(),
             },
         )]);
-        let registration = runtime_target_registration(&target);
+        let registration = builtin_runtime_target_registration("slack");
         let (_dir, registry, registry_path) = registered_runtime_registry_with_targets(
             run_id,
             &[],
@@ -4572,7 +4575,7 @@ mod tests {
             },
             ConnectorRuntimeTargetRegistration::Custom {
                 custom_connector_id: custom_connector_id.to_string(),
-                base_url_vars: None,
+                base_url_vars: HashMap::new(),
             },
         ];
         let (_dir, registry, registry_path) =
@@ -5368,7 +5371,7 @@ mod tests {
                 next_refresh_at: "not-a-date".to_string(),
             },
         )]);
-        let targets = [runtime_target_registration(&builtin_target("slack"))];
+        let targets = [builtin_runtime_target_registration("slack")];
 
         core.register_run(ConnectorRuntimeSyncRegistration {
             run_id,

--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -477,6 +477,7 @@ fn initial_connector_routing_variables(
 ) -> RunnerResult<HashMap<String, HashMap<String, String>>> {
     let mut routing_variables = HashMap::new();
     let run_vars = registration.vars;
+    let firewalls = registration.firewalls.unwrap_or_default();
     let builtin_connector_slugs = registration
         .connector_runtime_targets
         .unwrap_or_default()
@@ -488,7 +489,17 @@ fn initial_connector_routing_variables(
             ConnectorRuntimeTargetRegistration::Custom { .. } => None,
         })
         .collect::<HashSet<_>>();
-    for firewall in registration.firewalls.unwrap_or_default() {
+    let active_custom_connector_ids = firewalls
+        .iter()
+        .filter_map(|firewall| match firewall {
+            FirewallEntry::Inline {
+                custom_connector_id: Some(custom_connector_id),
+                ..
+            } => Some(custom_connector_id.as_str()),
+            FirewallEntry::Builtin { .. } | FirewallEntry::Inline { .. } => None,
+        })
+        .collect::<HashSet<_>>();
+    for firewall in firewalls {
         if let FirewallEntry::Builtin {
             name,
             base_url_vars,
@@ -521,8 +532,9 @@ fn initial_connector_routing_variables(
     for target in registration.connector_runtime_targets.unwrap_or_default() {
         if let ConnectorRuntimeTargetRegistration::Custom {
             custom_connector_id,
-            base_url_vars: Some(base_url_vars),
+            base_url_vars,
         } = target
+            && active_custom_connector_ids.contains(custom_connector_id.as_str())
         {
             routing_variables.insert(
                 custom_connector_routing_key(custom_connector_id),
@@ -1255,11 +1267,11 @@ mod tests {
             },
             ConnectorRuntimeTargetRegistration::Custom {
                 custom_connector_id: available_custom_id.to_string(),
-                base_url_vars: Some(HashMap::new()),
+                base_url_vars: HashMap::new(),
             },
             ConnectorRuntimeTargetRegistration::Custom {
                 custom_connector_id: omitted_custom_id.to_string(),
-                base_url_vars: None,
+                base_url_vars: HashMap::new(),
             },
         ];
 
@@ -1384,7 +1396,7 @@ mod tests {
             },
             ConnectorRuntimeTargetRegistration::Custom {
                 custom_connector_id: custom_connector_id.to_string(),
-                base_url_vars: None,
+                base_url_vars: HashMap::new(),
             },
         ];
         harness
@@ -1469,7 +1481,7 @@ mod tests {
             },
             ConnectorRuntimeTargetRegistration::Custom {
                 custom_connector_id: custom_connector_id.to_string(),
-                base_url_vars: Some(pinned_routing_variables.clone()),
+                base_url_vars: pinned_routing_variables.clone(),
             },
         ];
         harness
@@ -1986,7 +1998,7 @@ mod tests {
         let runtime_targets = vec![
             ConnectorRuntimeTargetRegistration::Custom {
                 custom_connector_id: custom_connector_id.to_string(),
-                base_url_vars: None,
+                base_url_vars: HashMap::new(),
             },
             ConnectorRuntimeTargetRegistration::Builtin {
                 connector_slug: "slack".to_string(),

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1324,8 +1324,7 @@ pub enum ConnectorRuntimeTargetRegistration {
     #[serde(rename_all = "camelCase")]
     Custom {
         custom_connector_id: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        base_url_vars: Option<HashMap<String, String>>,
+        base_url_vars: HashMap<String, String>,
     },
 }
 
@@ -1346,25 +1345,8 @@ impl ConnectorRuntimeTargetRegistration {
 
     pub(crate) fn custom_base_url_vars(&self) -> Option<&HashMap<String, String>> {
         match self {
-            Self::Custom { base_url_vars, .. } => base_url_vars.as_ref(),
+            Self::Custom { base_url_vars, .. } => Some(base_url_vars),
             Self::Builtin { .. } => None,
-        }
-    }
-}
-
-impl From<ConnectorRuntimeTarget> for ConnectorRuntimeTargetRegistration {
-    fn from(target: ConnectorRuntimeTarget) -> Self {
-        match target {
-            ConnectorRuntimeTarget::Builtin { connector_slug } => Self::Builtin {
-                connector_slug,
-                base_url_vars: None,
-            },
-            ConnectorRuntimeTarget::Custom {
-                custom_connector_id,
-            } => Self::Custom {
-                custom_connector_id,
-                base_url_vars: None,
-            },
         }
     }
 }
@@ -2268,6 +2250,43 @@ mod tests {
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
         assert!(ctx.cli_agent_session_id().is_none());
+    }
+
+    #[test]
+    fn execution_context_requires_custom_connector_routing_values() {
+        let execution_context = |target: serde_json::Value| {
+            json!({
+                "runId": "550e8400-e29b-41d4-a716-446655440000",
+                "prompt": "hello",
+                "sandboxToken": "tok",
+                "cliAgentType": "claude_code",
+                "billableFirewalls": [],
+                "connectorRuntimeTargets": [target]
+            })
+        };
+        let custom_connector_id = "550e8400-e29b-41d4-a716-446655440001";
+
+        assert!(
+            serde_json::from_value::<ExecutionContext>(execution_context(json!({
+                "kind": "custom",
+                "customConnectorId": custom_connector_id
+            })))
+            .is_err()
+        );
+
+        let context = serde_json::from_value::<ExecutionContext>(execution_context(json!({
+            "kind": "custom",
+            "customConnectorId": custom_connector_id,
+            "baseUrlVars": {}
+        })))
+        .expect("empty custom connector routing values should be accepted");
+        assert_eq!(
+            context.connector_runtime_targets,
+            vec![ConnectorRuntimeTargetRegistration::Custom {
+                custom_connector_id: custom_connector_id.to_string(),
+                base_url_vars: HashMap::new(),
+            }]
+        );
     }
 
     #[test]

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -11,6 +11,7 @@ import {
   CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
   CONNECTOR_RUNTIME_SYNC_TARGETS_MAX,
   type ConnectorRuntimeSyncResult,
+  type ExecutionContext,
   type Job as RunnerJob,
 } from "@okouai/api-contracts/contracts/runners";
 import type { CreateCustomConnectorBody } from "@okouai/api-contracts/contracts/zero-custom-connectors";
@@ -430,8 +431,6 @@ const CUSTOM_CONNECTOR_RUNTIME_BUCKET_DIMENSION_KEYS = [
   "custom_connector_runtime_missing_required_count_bucket",
   "custom_connector_runtime_no_auth_injection_count_bucket",
   "custom_connector_runtime_invalid_prefix_count_bucket",
-  "custom_connector_runtime_pinned_routing_count_bucket",
-  "custom_connector_runtime_unpinned_routing_count_bucket",
 ] as const;
 const API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES = [
   "api_dispatch_prepare_context_load_builtin_permission_indexes",
@@ -628,6 +627,24 @@ type AvailableCustomConnectorRuntime = Extract<
   ConnectorRuntimeSyncResult,
   { readonly state: "available"; readonly target: { readonly kind: "custom" } }
 >;
+
+function customConnectorRuntimeRegistration(
+  context: ExecutionContext,
+  customConnectorId: string,
+): Extract<
+  ExecutionContext["connectorRuntimeTargets"][number],
+  { readonly kind: "custom" }
+> {
+  const registration = context.connectorRuntimeTargets.find((target) => {
+    return (
+      target.kind === "custom" && target.customConnectorId === customConnectorId
+    );
+  });
+  if (!registration || registration.kind !== "custom") {
+    throw new Error("Expected a custom connector runtime registration");
+  }
+  return registration;
+}
 
 function availableCustomConnectorRuntime(
   result: ConnectorRuntimeSyncResult | undefined,
@@ -9482,7 +9499,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const expiredClaim = await api.claimRunnerJob(expiredRun.runId);
     expect(expiredClaim.connectorRuntimeTargets).toContainEqual(target);
     const [runtimeResult] = await api.syncConnectorRuntime(expiredRun.runId, {
-      targets: [{ kind: "custom", customConnectorId: custom.id }],
+      targets: [customConnectorRuntimeRegistration(expiredClaim, custom.id)],
     });
     const runtime = availableCustomConnectorRuntime(runtimeResult);
     const { body: authBody } = customConnectorRuntimeAuthBody(
@@ -9619,7 +9636,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       "Bearer custom-oauth-initial-access-token",
     );
     const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
-      targets: [{ kind: "custom", customConnectorId: custom.id }],
+      targets: [customConnectorRuntimeRegistration(claim, custom.id)],
     });
     const runtime = availableCustomConnectorRuntime(runtimeResult);
     const { body: currentAuthBody } = customConnectorRuntimeAuthBody(
@@ -9859,7 +9876,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(firstRun.runId);
     const [runtimeResult] = await api.syncConnectorRuntime(firstRun.runId, {
-      targets: [{ kind: "custom", customConnectorId: custom.id }],
+      targets: [customConnectorRuntimeRegistration(claim, custom.id)],
     });
     const runtime = availableCustomConnectorRuntime(runtimeResult);
     const { body: currentAuthBody } = customConnectorRuntimeAuthBody(
@@ -9885,7 +9902,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     const [reconnectRuntimeResult] = await api.syncConnectorRuntime(
       firstRun.runId,
-      { targets: [{ kind: "custom", customConnectorId: custom.id }] },
+      { targets: [customConnectorRuntimeRegistration(claim, custom.id)] },
     );
     const reconnectRuntime = availableCustomConnectorRuntime(
       reconnectRuntimeResult,
@@ -9928,7 +9945,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     const [secondRuntimeResult] = await api.syncConnectorRuntime(
       secondRun.runId,
-      { targets: [{ kind: "custom", customConnectorId: custom.id }] },
+      {
+        targets: [customConnectorRuntimeRegistration(secondClaim, custom.id)],
+      },
     );
     const secondRuntime = availableCustomConnectorRuntime(secondRuntimeResult);
     const { body: secondAuthBody } = customConnectorRuntimeAuthBody(
@@ -10453,7 +10472,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
 
     const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
-      targets: [{ kind: "custom", customConnectorId: saved.connector.id }],
+      targets: [customConnectorRuntimeRegistration(claim, saved.connector.id)],
     });
     const runtime = availableCustomConnectorRuntime(runtimeResult);
     const { api: runtimeApi, body: runtimeAuthBody } =
@@ -10978,7 +10997,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(claim.networkPolicies?.[internalName]?.unknownPolicy).toBe("allow");
 
     const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
-      targets: [{ kind: "custom", customConnectorId: saved.connector.id }],
+      targets: [customConnectorRuntimeRegistration(claim, saved.connector.id)],
     });
     const runtime = availableCustomConnectorRuntime(runtimeResult);
     expect(runtime.firewall.customConnectorId).toBe(saved.connector.id);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3888,8 +3888,6 @@ class CustomConnectorRuntimeBuildStats {
   private missingRequiredCount = 0;
   private noAuthInjectionCount = 0;
   private invalidPrefixCount = 0;
-  private pinnedRoutingCount = 0;
-  private unpinnedRoutingCount = 0;
 
   constructor(rows: CustomConnectorRuntimeDataRows) {
     this.connectorCount = rows.length;
@@ -3928,19 +3926,6 @@ class CustomConnectorRuntimeBuildStats {
 
   recordInvalidPrefix(): void {
     this.invalidPrefixCount += 1;
-  }
-
-  recordTarget(
-    target: Extract<
-      ConnectorRuntimeTargetRegistration,
-      { readonly kind: "custom" }
-    >,
-  ): void {
-    if (target.baseUrlVars === undefined) {
-      this.unpinnedRoutingCount += 1;
-    } else {
-      this.pinnedRoutingCount += 1;
-    }
   }
 
   flush(timing: ApiDispatchTimingCollector | undefined): void {
@@ -3987,12 +3972,6 @@ class CustomConnectorRuntimeBuildStats {
       custom_connector_runtime_invalid_prefix_count_bucket: countBucket(
         this.invalidPrefixCount,
       ),
-      custom_connector_runtime_pinned_routing_count_bucket: countBucket(
-        this.pinnedRoutingCount,
-      ),
-      custom_connector_runtime_unpinned_routing_count_bucket: countBucket(
-        this.unpinnedRoutingCount,
-      ),
     };
   }
 }
@@ -4031,13 +4010,10 @@ function buildCustomConnectorRuntimeApis(args: {
   readonly row: CustomConnectorRuntimeDataRows[number];
   readonly headers: Record<string, string>;
   readonly query: Record<string, string>;
-  readonly baseUrlVars: Readonly<Record<string, string>> | undefined;
+  readonly baseUrlVars: Readonly<Record<string, string>>;
   readonly permissionBundle: CustomConnectorPermissionBundle | null;
   readonly stats: CustomConnectorRuntimeBuildStats;
 }): ExpandedFirewallConfig["apis"] {
-  if (args.baseUrlVars === undefined) {
-    return [];
-  }
   const prefixStartedAt = now();
   const connector = args.row.connector;
   if (connector.kind === "mcp") {
@@ -4179,15 +4155,26 @@ interface BuildCustomConnectorRuntimeContextArgs {
   readonly timing?: ApiDispatchTimingCollector;
 }
 
-interface BuiltCustomConnectorRuntimeRow {
-  readonly target: Extract<
-    ConnectorRuntimeTargetRegistration,
-    { readonly kind: "custom" }
-  >;
-  readonly skill: CustomConnectorRuntimeContext["skills"][number] | undefined;
-  readonly firewall: ExpandedFirewallConfig | undefined;
-  readonly permissionPolicy: FirewallPolicy | undefined;
-}
+type BuiltCustomConnectorRuntimeRow =
+  | {
+      readonly registration: Extract<
+        ConnectorRuntimeTargetRegistration,
+        { readonly kind: "custom" }
+      >;
+      readonly skill:
+        | CustomConnectorRuntimeContext["skills"][number]
+        | undefined;
+      readonly firewall: ExpandedFirewallConfig;
+      readonly permissionPolicy: FirewallPolicy | undefined;
+    }
+  | {
+      readonly registration: undefined;
+      readonly skill:
+        | CustomConnectorRuntimeContext["skills"][number]
+        | undefined;
+      readonly firewall: undefined;
+      readonly permissionPolicy: undefined;
+    };
 
 function customConnectorRuntimeSkill(
   row: CustomConnectorRuntimeDataRows[number],
@@ -4215,11 +4202,10 @@ function customConnectorRequiredMemberCredentialsAreComplete(
 }
 
 function unavailableCustomConnectorRuntimeRow(
-  target: BuiltCustomConnectorRuntimeRow["target"],
   skill: BuiltCustomConnectorRuntimeRow["skill"],
 ): BuiltCustomConnectorRuntimeRow {
   return {
-    target,
+    registration: undefined,
     skill,
     firewall: undefined,
     permissionPolicy: undefined,
@@ -4282,14 +4268,6 @@ async function buildCustomConnectorRuntimeRow(args: {
     provided: args.context.baseUrlVarsByConnectorId?.get(args.row.connector.id),
     hasProvided: hasProvidedBaseUrlVars,
   });
-  const targetIdentity = {
-    kind: "custom" as const,
-    customConnectorId: args.row.connector.id,
-  };
-  const target: BuiltCustomConnectorRuntimeRow["target"] = {
-    ...targetIdentity,
-    ...(baseUrlVars === undefined ? {} : { baseUrlVars: { ...baseUrlVars } }),
-  };
   const skill = customConnectorRuntimeSkill(args.row);
   const missingRequiredStartedAt = now();
   const missingRequired = !customConnectorRequiredMemberCredentialsAreComplete(
@@ -4307,15 +4285,18 @@ async function buildCustomConnectorRuntimeRow(args: {
   if (Object.keys(headers).length === 0 && Object.keys(query).length === 0) {
     args.stats.recordNoAuthInjectionConnector();
     if (args.row.connector.kind === "mcp") {
-      return unavailableCustomConnectorRuntimeRow(target, skill);
+      return unavailableCustomConnectorRuntimeRow(skill);
     }
+  }
+  if (baseUrlVars === undefined) {
+    return unavailableCustomConnectorRuntimeRow(skill);
   }
   const permissionBundle = await loadEffectiveCustomConnectorPermissionBundle({
     row: args.row,
     snapshot: args.context.connectorCatalogSnapshot,
   });
   if (permissionBundle === undefined) {
-    return unavailableCustomConnectorRuntimeRow(target, skill);
+    return unavailableCustomConnectorRuntimeRow(skill);
   }
   const apisResult = safeSync(() => {
     return buildCustomConnectorRuntimeApis({
@@ -4332,14 +4313,18 @@ async function buildCustomConnectorRuntimeRow(args: {
       throw apisResult.error;
     }
     args.stats.recordInvalidPrefix();
-    return unavailableCustomConnectorRuntimeRow(targetIdentity, skill);
+    return unavailableCustomConnectorRuntimeRow(skill);
   }
   const apis = apisResult.ok;
   if (apis.length === 0) {
-    return unavailableCustomConnectorRuntimeRow(target, skill);
+    return unavailableCustomConnectorRuntimeRow(skill);
   }
   return {
-    target,
+    registration: {
+      kind: "custom",
+      customConnectorId: args.row.connector.id,
+      baseUrlVars: { ...baseUrlVars },
+    },
     skill,
     firewall: {
       name: customConnectorInternalName(args.row.connector.id),
@@ -4383,15 +4368,14 @@ export async function buildCustomConnectorRuntimeContext(
       stats,
     });
     const assemblyStartedAt = now();
-    stats.recordTarget(built.target);
-    targets.push(built.target);
     if (built.skill) {
       skills.push(built.skill);
     }
-    if (!built.firewall) {
+    if (!built.registration) {
       stats.recordPhaseDuration("assembleFirewalls", assemblyStartedAt);
       continue;
     }
+    targets.push(built.registration);
     firewalls.push(built.firewall);
     customConnectorIdByFirewallName[built.firewall.name] = row.connector.id;
     if (row.connector.kind === "mcp") {
@@ -4441,18 +4425,8 @@ async function buildNewRunCustomConnectorRuntimeContext(
       );
     }),
   });
-  const admittedConnectorIds = new Set(
-    Object.values(context.customConnectorIdByFirewallName),
-  );
   return {
     ...context,
-    targets: context.targets.filter((target) => {
-      return (
-        target.kind === "custom" &&
-        target.baseUrlVars !== undefined &&
-        admittedConnectorIds.has(target.customConnectorId)
-      );
-    }),
     skills: args.rows.flatMap((row) => {
       const skill = customConnectorRuntimeSkill(row);
       return skill ? [skill] : [];

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -170,12 +170,9 @@ async function resolveCustomTarget(args: {
     return customUnresolvedResult(target, "permission-bundle-unavailable");
   }
 
-  const baseUrlVarsByConnectorId =
-    args.registration.baseUrlVars === undefined
-      ? undefined
-      : new Map([
-          [target.customConnectorId, args.registration.baseUrlVars] as const,
-        ]);
+  const baseUrlVarsByConnectorId = new Map([
+    [target.customConnectorId, args.registration.baseUrlVars] as const,
+  ]);
 
   const context = await buildCustomConnectorRuntimeContext({
     rows: [row],
@@ -199,11 +196,7 @@ async function resolveCustomTarget(args: {
       candidate.customConnectorId === target.customConnectorId
     );
   });
-  if (
-    !state ||
-    resolvedTarget?.kind !== "custom" ||
-    resolvedTarget.baseUrlVars === undefined
-  ) {
+  if (!state || resolvedTarget?.kind !== "custom") {
     return customUnresolvedResult(target, "runtime-configuration-unavailable");
   }
   return {
@@ -289,9 +282,6 @@ export async function resolveConnectorRuntimeTargets(args: {
     targetCount: args.targets.length,
     builtinTargetCount: builtinConnectorSlugs.length,
     customTargetCount: customConnectorIds.length,
-    customPinnedTargetCount: args.targets.filter((target) => {
-      return target.kind === "custom" && target.baseUrlVars !== undefined;
-    }).length,
     availableCount: stateCounts.available,
     absentCount: stateCounts.absent,
     unresolvedCount: stateCounts.unresolved,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -314,7 +314,7 @@ describe("connector runtime synchronization contract", () => {
     ).toBe(false);
   });
 
-  it("preserves optional custom routing values in target registrations", () => {
+  it("requires custom routing values in target registrations", () => {
     const fixture = executionContextSchema.parse(
       loadRunnerClaimResponseFixture(),
     );
@@ -337,6 +337,11 @@ describe("connector runtime synchronization contract", () => {
     expect(
       runnersConnectorRuntimeSyncContract.sync.body.safeParse({
         targets: [{ kind: "custom", customConnectorId }],
+      }).success,
+    ).toBe(false);
+    expect(
+      runnersConnectorRuntimeSyncContract.sync.body.safeParse({
+        targets: [{ kind: "custom", customConnectorId, baseUrlVars: {} }],
       }).success,
     ).toBe(true);
   });

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -197,7 +197,7 @@ export const connectorRuntimeTargetSchema = z.discriminatedUnion("kind", [
 
 export const connectorRuntimeCustomTargetRegistrationSchema =
   connectorRuntimeCustomTargetSchema.extend({
-    baseUrlVars: z.record(z.string(), z.string()).optional(),
+    baseUrlVars: z.record(z.string(), z.string()),
   });
 
 export const connectorRuntimeBuiltinTargetRegistrationSchema =
@@ -214,7 +214,9 @@ export const connectorRuntimeTargetRegistrationSchema = z.discriminatedUnion(
 );
 
 export function connectorRuntimeTargetKey(
-  target: z.infer<typeof connectorRuntimeTargetRegistrationSchema>,
+  target:
+    | z.infer<typeof connectorRuntimeTargetSchema>
+    | z.infer<typeof connectorRuntimeTargetRegistrationSchema>,
 ): string {
   return target.kind === "builtin"
     ? `builtin:${target.connectorSlug}`


### PR DESCRIPTION
## Summary

- require every custom connector runtime registration to carry its pinned `baseUrlVars`, including an empty object
- emit custom registrations only after routing, permission, and firewall admission succeeds; remove the unpinned fallback and its misleading telemetry
- retain the canonical registration in the runner, forward and publish the original pin, reject changed routing values, and preserve pinned absent-to-available restoration

## Compatibility and rollout

- builtin connector behavior is unchanged
- a new API remains compatible with old runners because it always supplies the previously optional field
- a new runner intentionally rejects legacy custom registrations without `baseUrlVars`; deploy only after the #25962 writer is confirmed in production and old contexts/runs that could contain the legacy shape have drained
- the issue's `deferred` production-evidence gate remains in force; this PR must not merge until that gate is satisfied

## Validation

- `pnpm -F @okouai/api-contracts test`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api --workspace @okouai/api-contracts`
- changed-file Prettier check
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner`
- repository pre-commit and commit-message hooks

## Scope exclusions

- no builtin connector behavior changes
- no database migration or persisted-context rewrite
- no temporary compatibility reader for the legacy unpinned shape

Closes #26835

Parent: #25312
