### PR TITLE
perf(mitm-addon): bound path validation work

### DIFF
--- a/crates/runner/mitm-addon/src/path_security.py
+++ b/crates/runner/mitm-addon/src/path_security.py
@@ -10,10 +10,15 @@ _DOT_SEGMENTS = {".", ".."}
 _HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
 _MAX_PERCENT_DECODE_PASSES = 5
 _PERCENT_ESCAPE_LENGTH = 3
+# Match the addon's existing 64 KiB request-work scale. Character count bounds
+# Python string processing without first scanning and allocating encoded bytes.
+MAX_PATH_VALIDATION_CHARACTERS = 64 * 1024
 
 
 def has_unsafe_path(path: str) -> bool:
-    """Return True when a URL path contains or may hide unsafe path syntax."""
+    """Return True when a URL path exceeds the validation budget or may hide unsafe syntax."""
+    if len(path) > MAX_PATH_VALIDATION_CHARACTERS:
+        return True
     if "\\" in path:
         return True
     raw_segments = path.split("/")

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_unknown_policy.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_unknown_policy.py
@@ -214,7 +214,7 @@ def test_compiled_blocks_path_beyond_validation_budget():
         ],
         name="example",
     )
-    nested_encoding = "%25252525252e"
+    nested_encoding = "%2525252561"
     path = "/" + nested_encoding
     path += "a" * (path_security.MAX_PATH_VALIDATION_CHARACTERS + 1 - len(path))
     policies = {"example": {"allow": [], "deny": [], "unknownPolicy": "allow"}}

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_unknown_policy.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_unknown_policy.py
@@ -3,6 +3,7 @@
 import pytest
 
 import matching
+import path_security
 from tests.firewall_helpers import compile_firewalls_or_fail, wrap_firewalls
 
 
@@ -200,6 +201,33 @@ def test_compiled_blocks_unsafe_path(url):
     assert isinstance(compiled, matching.FirewallBlock)
     assert compiled.reason == "unsafe_path"
     assert compiled.permissions == ()
+
+
+def test_compiled_blocks_path_beyond_validation_budget():
+    fws = wrap_firewalls(
+        [
+            {
+                "base": "https://api.example.com",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [],
+            }
+        ],
+        name="example",
+    )
+    nested_encoding = "%25252525252e"
+    path = "/" + nested_encoding
+    path += "a" * (path_security.MAX_PATH_VALIDATION_CHARACTERS + 1 - len(path))
+    policies = {"example": {"allow": [], "deny": [], "unknownPolicy": "allow"}}
+
+    result = matching.match_compiled_firewall_request(
+        "https://api.example.com" + path,
+        "GET",
+        compile_firewalls_or_fail(fws),
+        policies,
+    )
+
+    assert isinstance(result, matching.FirewallBlock)
+    assert result.reason == "unsafe_path"
 
 
 def test_compiled_allows_encoded_backslash_in_query():

--- a/crates/runner/mitm-addon/tests/test_path_security.py
+++ b/crates/runner/mitm-addon/tests/test_path_security.py
@@ -1,5 +1,6 @@
 """Tests for URL path safety helpers."""
 
+import urllib.parse
 from unittest.mock import patch
 
 import pytest
@@ -150,6 +151,36 @@ def test_has_unsafe_path_blocks_invalid_percent_encoded_utf8(path):
 )
 def test_has_unsafe_path_allows_regular_segments(path):
     assert path_security.has_unsafe_path(path) is False
+
+
+def test_has_unsafe_path_allows_maximum_length_nested_encoding():
+    encoded = "%61"
+    for _ in range(4):
+        encoded = urllib.parse.quote(encoded, safe="")
+    path = "/" + encoded
+    path += "a" * (path_security.MAX_PATH_VALIDATION_CHARACTERS - len(path))
+
+    assert len(path) == path_security.MAX_PATH_VALIDATION_CHARACTERS
+    assert path_security.has_unsafe_path(path) is False
+
+
+def test_has_unsafe_path_blocks_over_budget_before_compatibility_pipeline():
+    encoded = "%2e"
+    for _ in range(5):
+        encoded = urllib.parse.quote(encoded, safe="")
+    path = "/" + encoded
+    path += "a" * (path_security.MAX_PATH_VALIDATION_CHARACTERS + 1 - len(path))
+
+    with (
+        patch.object(path_security.urllib.parse, "unquote_to_bytes") as percent_decode,
+        patch.object(path_security.unicodedata, "normalize") as unicode_normalize,
+    ):
+        unsafe = path_security.has_unsafe_path(path)
+
+    assert len(path) == path_security.MAX_PATH_VALIDATION_CHARACTERS + 1
+    assert unsafe is True
+    percent_decode.assert_not_called()
+    unicode_normalize.assert_not_called()
 
 
 def test_plain_ascii_path_bypasses_compatibility_pipeline():

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -309,7 +309,9 @@ async def test_sigv4_request_target_inspection_boundary(
         content_length="0",
         content_hash="UNSIGNED-PAYLOAD",
     )
-    flow.request.path = "/" + "a" * (target_size - 1)
+    target_prefix = "/?padding="
+    flow.request.path = target_prefix + "a" * (target_size - len(target_prefix))
+    assert len(flow.request.data.path) == target_size
     get_headers = AsyncMock(return_value=_resolved_token_meta())
 
     with (

--- a/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_connector_diagnostics.py
@@ -99,41 +99,6 @@ async def test_replaces_unauthenticated_connector_401_body(tmp_path, real_flow, 
     assert "url_original_char_count" not in proxy_entry
 
 
-async def test_omits_oversized_connector_diagnostic_url_once(tmp_path, real_flow, mitm_ctx):
-    reg_path = write_connector_diagnostic_capture_registry(tmp_path)
-    flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="fal.run",
-        path=f"/fal-ai/{'x' * 1_000_000}",
-        method="POST",
-    )
-
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        record_connector_diagnostic_requestheaders_context(flow)
-        flow.response = tutils.tresp(
-            status_code=401,
-            headers=header_map({"content-type": "text/plain", "content-length": "8"}),
-            content=b"upstream",
-        )
-        mitm_addon.response(flow)
-
-    raw_url = flow.metadata[metadata_keys.ORIGINAL_URL]
-    proxy_entries = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
-    assert [entry["type"] for entry in proxy_entries] == ["connector_diagnostic", "http_error"]
-    connector_entry, http_error_entry = proxy_entries
-    assert connector_entry["message"].endswith(": [truncated]")
-    assert connector_entry["url"] == "[truncated]"
-    assert connector_entry["url_truncated"] is True
-    assert connector_entry["url_original_char_count"] == len(raw_url)
-    assert http_error_entry["message"] == "Response 401: [truncated]"
-    assert http_error_entry["url_truncated"] is True
-    assert http_error_entry["url_original_char_count"] == len(raw_url)
-    serialized_entries = json.dumps(proxy_entries)
-    assert "x" * 100 not in serialized_entries
-    assert len(serialized_entries.encode()) < 2_000
-
-
 async def test_replaces_buffered_head_401_with_bodyless_diagnostic(tmp_path, real_flow, mitm_ctx):
     reg_path = write_connector_diagnostic_capture_registry(tmp_path)
     flow = real_flow(


### PR DESCRIPTION
## Summary

- reject URL paths above a 64 KiB character budget before nested percent decoding and Unicode normalization
- preserve existing path compatibility at and below the boundary, and reuse the existing `unsafe_path` firewall result above it
- keep the SigV4 raw request-target boundary test focused on the full target and remove an oversized connector-diagnostic path case that is no longer reachable

## Behavior and compatibility

- Paths up to and including 65,536 characters keep the existing validation behavior.
- Longer paths fail closed after a firewall base matches; query characters do not count toward this path budget.
- The shared helper also applies the budget to configuration, template, and rewrite validation callers.
- The budget is character-based so checking it is constant-time and does not allocate an encoded copy first.
- This bounds the expensive compatibility pipeline, not all request processing: URL parsing still scales with the request target.

## Performance evidence

Local `uv` environment, median of 7 calls over repeated nested percent encoding:

| Path characters | Base | This PR |
| ---: | ---: | ---: |
| 16,381 | 2.3452 ms | 2.3059 ms |
| 65,534 | 9.1298 ms | 9.0563 ms |
| 262,133 | 37.2852 ms | 0.0001 ms |
| 1,048,568 | 154.8572 ms | 0.0001 ms |

Sample common-path helper calls remained within 80 ns / 2.4% of the base measurement. The end-to-end matcher still spent about 1.66 ms parsing a 1 MiB request target before rejecting it.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`5362 passed`)

## Out of scope

- a global request-target or protocol-level size limit
- a new firewall block reason or response status
- a permanent benchmark framework

Closes #26832
