### PR TITLE
refactor(connectors): reuse shared oauth state primitives for github connect

### DIFF
--- a/turbo/apps/api/src/lib/connector-oauth-state.ts
+++ b/turbo/apps/api/src/lib/connector-oauth-state.ts
@@ -1,7 +1,9 @@
+import { nowDate } from "./time";
+
 const CONNECTOR_OAUTH_STATE_COOKIE_NAME = "connector_oauth_state";
 const CONNECTOR_OAUTH_PKCE_COOKIE_NAME = "connector_oauth_pkce";
 const CONNECTOR_OAUTH_CONTEXT_COOKIE_NAME = "connector_oauth_context";
-export const CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS = 15 * 60;
+const CONNECTOR_OAUTH_STATE_TTL_MS = 15 * 60 * 1000;
 
 const CONNECTOR_OAUTH_REDIRECT_STATUS = 307;
 
@@ -11,6 +13,10 @@ export function generateConnectorOAuthState(): string {
   return Array.from(array, (byte) => {
     return byte.toString(16).padStart(2, "0");
   }).join("");
+}
+
+export function connectorOAuthStateExpiresAt(): Date {
+  return new Date(nowDate().getTime() + CONNECTOR_OAUTH_STATE_TTL_MS);
 }
 
 function buildDeleteConnectorOAuthCookieHeader(name: string): string {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -5602,6 +5602,8 @@ describe("CONN-02: OAuth callback validation and state claiming", () => {
     expect(stable.id).toBe(connected.id);
     expect(stable.externalUsername).toBe("bdd-github-user");
 
+    const expiringStartedAt = now();
+    mockNow(expiringStartedAt);
     const expiringStart = await connectorsApi.startOauth(
       actor,
       "github",
@@ -5610,7 +5612,7 @@ describe("CONN-02: OAuth callback validation and state claiming", () => {
     const expiringState = stateFromAuthorizationUrl(
       expiringStart.authorizationUrl,
     );
-    mockNow(now() + 16 * 60 * 1000);
+    mockNow(expiringStartedAt + 15 * 60 * 1000);
     const expired = await connectorsApi.completeOauthCallback("github", {
       code: "github-late-code",
       state: expiringState,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -5429,6 +5429,40 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
     );
   });
 
+  it("starts configured GitHub user OAuth with connector state", async () => {
+    mockEnv("APP_URL", "https://app.vm0.test");
+    mockEnv("VM0_WEB_URL", "https://www.vm0.test");
+    integrations.clearGithubAppProvider();
+    mockOptionalEnv("GH_OAUTH_CLIENT_ID", "bdd-github-client-id");
+    mockOptionalEnv("GH_OAUTH_CLIENT_SECRET", "bdd-github-client-secret");
+    await installApiTestConnectorCatalog();
+
+    const actor = integrations.user();
+    const response = await integrations.requestGithubOauthConnect(
+      actor,
+      {},
+      [307],
+    );
+    const location = response.headers.get("location");
+    if (!location) {
+      throw new Error("Expected GitHub authorization redirect");
+    }
+    const authorizationUrl = new URL(location);
+    expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(
+      "https://github.com/login/oauth/authorize",
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "bdd-github-client-id",
+    );
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      "https://www.vm0.test/api/connectors/github/callback",
+    );
+    expect(authorizationUrl.searchParams.get("state")).toMatch(
+      /^[0-9a-f]{64}$/u,
+    );
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
   it("keeps GitHub user OAuth callback errors visible through redirects", async () => {
     const githubError = await integrations.requestGithubOauthConnectCallback(
       {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -22,7 +22,6 @@ import {
   providerUnavailable,
 } from "../../lib/error";
 import { optionalEnv } from "../../lib/env";
-import { nowDate } from "../../lib/time";
 import { writeDb$ } from "../external/db";
 import {
   authorizeConnectedConnector$,
@@ -50,7 +49,7 @@ import {
   getConnectorOAuthCallbackUrlForMethod,
   getConnectorOpenIdCallbackOriginForMethod,
 } from "./connector-oauth-origin";
-import { CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS } from "../../lib/connector-oauth-state";
+import { connectorOAuthStateExpiresAt } from "../../lib/connector-oauth-state";
 import {
   buildConnectorAuthCodeAuthUrlWithMethod,
   prepareConnectorAuthCodeStartWithMethod,
@@ -533,9 +532,7 @@ const startConnectorOauthInner$ = command(
       authorizationUrl: authResult.url,
       codeVerifier: authResult.codeVerifier,
       oauthContext: authResult.oauthContext,
-      expiresAt: new Date(
-        nowDate().getTime() + CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS * 1000,
-      ),
+      expiresAt: connectorOAuthStateExpiresAt(),
     });
     signal.throwIfAborted();
 
@@ -633,9 +630,7 @@ const startConnectorOpenIdInner$ = command(
       redirectUri: prepared.expectedReturnTo,
       codeVerifier: authResult.codeVerifier,
       oauthContext: JSON.stringify({ realm: prepared.realm }),
-      expiresAt: new Date(
-        nowDate().getTime() + CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS * 1000,
-      ),
+      expiresAt: connectorOAuthStateExpiresAt(),
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -25,7 +25,7 @@ import {
 import { badRequestMessage, notFound } from "../../lib/error";
 import { nowDate } from "../../lib/time";
 import {
-  CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS,
+  connectorOAuthStateExpiresAt,
   generateConnectorOAuthState,
 } from "../../lib/connector-oauth-state";
 import { createDeferredPromise, safeJsonParse, settle } from "../utils";
@@ -558,9 +558,7 @@ export const startCustomConnectorOAuth2$ = command(
         authorizationUrl,
         codeVerifier,
         oauthContext: JSON.stringify(context),
-        expiresAt: new Date(
-          nowDate().getTime() + CONNECTOR_OAUTH_COOKIE_MAX_AGE_SECONDS * 1000,
-        ),
+        expiresAt: connectorOAuthStateExpiresAt(),
       });
     signal.throwIfAborted();
     return { authorizationUrl };

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -1,10 +1,5 @@
 import { Buffer } from "node:buffer";
-import {
-  createHmac,
-  createSign,
-  randomBytes,
-  timingSafeEqual,
-} from "node:crypto";
+import { createHmac, createSign, timingSafeEqual } from "node:crypto";
 
 import { and, eq } from "drizzle-orm";
 import { buildConnectorAuthCodeAuthorizationUrlWithMethod } from "@okouai/connectors/auth-providers";
@@ -25,7 +20,11 @@ import { githubUserLinks } from "@okouai/db/schema/github-user-link";
 
 import type { Db } from "../external/db";
 import { safeJsonParse, tapError } from "../utils";
-import { now, nowDate } from "../../lib/time";
+import {
+  connectorOAuthStateExpiresAt,
+  generateConnectorOAuthState,
+} from "../../lib/connector-oauth-state";
+import { now } from "../../lib/time";
 import { logger } from "../../lib/log";
 import { encryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
@@ -33,7 +32,6 @@ import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 const L = logger("GithubOAuth");
 const INSTALLATION_ID_RE = /^\d+$/;
 const MAX_GITHUB_CONNECT_AGE_SECONDS = 10 * 60;
-const GITHUB_CONNECT_OAUTH_STATE_TTL_SECONDS = 15 * 60;
 const GITHUB_OAUTH_AUTH_METHOD = "oauth";
 
 interface AppInstallation {
@@ -404,10 +402,6 @@ function normalizeAuthUrlResult(result: string | AuthUrlResult): AuthUrlResult {
   return typeof result === "string" ? { url: result } : result;
 }
 
-function generateConnectorOAuthState(): string {
-  return randomBytes(32).toString("hex");
-}
-
 export async function buildGithubUserConnectAuthorizationUrl(
   args: {
     readonly db: Db;
@@ -453,9 +447,7 @@ export async function buildGithubUserConnectAuthorizationUrl(
     redirectUri,
     codeVerifier: authResult.codeVerifier,
     oauthContext: authResult.oauthContext,
-    expiresAt: new Date(
-      nowDate().getTime() + GITHUB_CONNECT_OAUTH_STATE_TTL_SECONDS * 1000,
-    ),
+    expiresAt: connectorOAuthStateExpiresAt(),
   });
   signal.throwIfAborted();
 


### PR DESCRIPTION
## Summary

- centralize the 15-minute persisted connector OAuth state expiration behind the repository clock abstraction
- reuse the shared 32-byte hexadecimal state generator for GitHub user-connect
- migrate Builtin auth-code, Builtin OpenID, Custom OAuth, and GitHub state writers to the same expiration helper
- cover configured GitHub user-connect state and the exact expiration boundary through API integration tests

## Scope

This is a behavior-preserving refactor. It does not change API contracts, database schema or stored representation, authorization or callback URLs, PKCE/context handling, provider exchange, installation linking, credential persistence, or rollout compatibility.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts src/signals/routes/__tests__/connectors-openid.bdd.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/integrations.bdd.test.ts` — 132 tests passed
- staged pre-commit hooks, including full Turbo Knip and type checking

Closes #26836

Parent context: #25312
