### PR TITLE
refactor(platform): replace steer acknowledgement timer

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/steer-acknowledgement.ts
+++ b/turbo/apps/platform/src/signals/zero-page/steer-acknowledgement.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import { timeout } from "signal-timers";
 import { onRef } from "../utils.ts";
 
 // Keep in sync with the transition duration in views/css/index.css.
@@ -53,17 +54,17 @@ const sweepSteerAcknowledgementOnRef$ = command(
     el.style.width = `${String(incomingWidth)}px`;
     el.style.setProperty("--zero-steer-ack-sweep", "0%");
 
-    const timer = window.setTimeout(() => {
-      delete el.dataset.steerAcknowledgementSweeping;
-      // Drop back to the intrinsic width so later font or zoom changes keep the
-      // rule beside the label, and stop the spent wording from being selectable.
-      el.style.removeProperty("width");
-      outgoing.textContent = "";
-    }, STEER_ACKNOWLEDGEMENT_SWEEP_MS);
-
-    signal.addEventListener("abort", () => {
-      window.clearTimeout(timer);
-    });
+    timeout(
+      () => {
+        delete el.dataset.steerAcknowledgementSweeping;
+        // Drop back to the intrinsic width so later font or zoom changes keep the
+        // rule beside the label, and stop the spent wording from being selectable.
+        el.style.removeProperty("width");
+        outgoing.textContent = "";
+      },
+      STEER_ACKNOWLEDGEMENT_SWEEP_MS,
+      { signal },
+    );
   },
 );
 


### PR DESCRIPTION
## Summary

- replace the native steer acknowledgement sweep timer with signal-timers
- use the AbortSignal supplied by onRef so unmounting the acknowledgement element cancels the delayed cleanup
- preserve the existing 520 ms sweep and DOM cleanup behavior

## Violation and ownership

The daily Platform timer audit found window.setTimeout and window.clearTimeout in steer-acknowledgement.ts. The acknowledgement DOM element owns this one-shot callback. onRef creates its lifecycle AbortSignal and aborts it when the ref unmounts, so the same signal is passed directly to timeout without adding a placeholder controller.

## Validation

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- staged Turbo, Platform, and API type checks
- pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-run-actions.test.tsx (11 passed)
- manual-loop scan only matches the shared setLoop implementation
- native timer scan is empty
- Lefthook pre-commit and commitlint passed

Full repository validation is delegated to the PR pipeline.