### PR TITLE
fix(sandbox-fc): reject symlinked snapshot markers

### DIFF
--- a/crates/sandbox-fc/src/snapshot/output.rs
+++ b/crates/sandbox-fc/src/snapshot/output.rs
@@ -28,7 +28,7 @@ pub enum SnapshotOutputValidation {
     Complete,
     /// A required artifact or the completion marker is absent.
     MissingFile(PathBuf),
-    /// A required snapshot artifact exists but is not a regular file.
+    /// A required snapshot artifact or the completion marker is not a regular file.
     NotRegularFile(PathBuf),
     /// The completion marker exists but does not contain the exact expected bytes.
     InvalidCompleteMarker(PathBuf),
@@ -101,6 +101,21 @@ pub async fn validate_snapshot_output(
     output: &SnapshotOutputPaths,
 ) -> io::Result<SnapshotOutputValidation> {
     let marker = output.complete_marker();
+    match tokio::fs::symlink_metadata(&marker).await {
+        Ok(metadata) if metadata.file_type().is_file() => {}
+        Ok(_) => return Ok(SnapshotOutputValidation::NotRegularFile(marker)),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            return Ok(SnapshotOutputValidation::MissingFile(marker));
+        }
+        Err(e) => {
+            return Err(io_error_with_path(
+                "stat snapshot complete marker",
+                &marker,
+                e,
+            ));
+        }
+    }
+
     match tokio::fs::read(&marker).await {
         Ok(content) if content == SNAPSHOT_COMPLETE_MARKER_CONTENT => {}
         Ok(_) => return Ok(SnapshotOutputValidation::InvalidCompleteMarker(marker)),
@@ -662,16 +677,56 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn validate_snapshot_output_propagates_marker_read_errors() {
+    async fn validate_snapshot_output_reports_non_regular_marker() {
         let dir = tempfile::tempdir().expect("tempdir");
         let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
         tokio::fs::create_dir_all(output.complete_marker())
             .await
             .expect("create marker directory");
 
+        assert_eq!(
+            validate_snapshot_output(&output)
+                .await
+                .expect("validate directory marker"),
+            SnapshotOutputValidation::NotRegularFile(output.complete_marker())
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_snapshot_output_rejects_symlinked_marker() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output = SnapshotOutputPaths::new(dir.path().to_path_buf());
+        write_required_snapshot_artifacts(&output).await;
+        let target = dir.path().join("complete-marker-target");
+        tokio::fs::write(&target, SNAPSHOT_COMPLETE_MARKER_CONTENT)
+            .await
+            .expect("write marker symlink target");
+        std::os::unix::fs::symlink(&target, output.complete_marker())
+            .expect("create complete marker symlink");
+
+        assert_eq!(
+            validate_snapshot_output(&output)
+                .await
+                .expect("validate symlinked marker"),
+            SnapshotOutputValidation::NotRegularFile(output.complete_marker())
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_snapshot_output_propagates_marker_metadata_errors() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let output_dir = dir.path().join("snapshot-output");
+        std::os::unix::fs::symlink("snapshot-output", &output_dir)
+            .expect("create output directory symlink loop");
+        let output = SnapshotOutputPaths::new(output_dir);
+
         let err = validate_snapshot_output(&output)
             .await
-            .expect_err("marker directory should fail to read as marker content");
+            .expect_err("marker metadata should fail through a symlink loop");
+        assert!(
+            err.to_string().contains("stat snapshot complete marker"),
+            "error should include metadata action: {err}"
+        );
         assert!(
             err.to_string()
                 .contains(&output.complete_marker().display().to_string()),

--- a/crates/sandbox-fc/src/snapshot/provider.rs
+++ b/crates/sandbox-fc/src/snapshot/provider.rs
@@ -139,6 +139,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn snapshot_provider_rejects_symlinked_complete_marker() {
+        let fixture = SnapshotOutputFixture::new().await;
+        let output = &fixture.output;
+        fixture.write_required_snapshot_artifacts().await;
+        let target = output.dir().join("complete-marker-target");
+        tokio::fs::write(&target, SNAPSHOT_COMPLETE_MARKER_CONTENT)
+            .await
+            .expect("write marker symlink target");
+        std::os::unix::fs::symlink(&target, output.complete_marker())
+            .expect("create complete marker symlink");
+
+        let provider = FirecrackerSnapshotProvider;
+        assert!(
+            !provider.is_complete(output.dir()).await.unwrap(),
+            "symlinked complete marker must not commit the snapshot"
+        );
+    }
+
+    #[tokio::test]
     async fn snapshot_provider_rejects_valid_marker_with_missing_artifact() {
         let fixture = SnapshotOutputFixture::new().await;
         let output = &fixture.output;


### PR DESCRIPTION
## Summary

- validate `.snapshot-complete` with no-follow metadata before reading its exact marker bytes
- reject symlinked, directory, and other non-regular completion markers as incomplete while preserving missing, malformed, and filesystem-error distinctions
- cover the shared validator and `FirecrackerSnapshotProvider::is_complete` with focused marker-symlink regressions

## Scope and compatibility

- no snapshot marker byte, output layout, public enum shape, provider API, runner code, schema, protocol, or migration changes
- valid regular markers and existing data-artifact integrity checks remain unchanged
- atomic `O_NOFOLLOW` protection against concurrent path replacement is outside this stable-path integrity fix

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot::output`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc snapshot::provider`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --all-features --no-deps`

Closes #26857
