### PR TITLE
test(mitm-addon): cover non-string inline custom connector ids

### DIFF
--- a/crates/runner/mitm-addon/tests/test_registry_inline_firewalls.py
+++ b/crates/runner/mitm-addon/tests/test_registry_inline_firewalls.py
@@ -141,3 +141,33 @@ class TestRegistryInlineFirewalls:
         assert valid_context is not None
         _, compiled_firewalls, _ = valid_context
         assert compiled_firewalls is not None
+
+    def test_non_string_inline_custom_connector_id_rejects_only_affected_vm(
+        self, tmp_path, mitm_ctx
+    ):
+        path = tmp_path / "registry.json"
+        malformed_vm = inline_vm("run-malformed")
+        malformed_vm["firewalls"][0]["customConnectorId"] = 1
+        write_multi_vm_registry(
+            path,
+            {
+                "10.200.0.1": malformed_vm,
+                "10.200.0.2": inline_vm("run-valid"),
+            },
+        )
+
+        with mitm_ctx():
+            state = registry.load_registry_state(str(path))
+            malformed_context = registry.get_vm_context("10.200.0.1", str(path))
+            valid_context = registry.get_vm_context("10.200.0.2", str(path))
+
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert set(state.vms) == {"10.200.0.2"}
+        assert set(state.invalid_vms) == {"10.200.0.1"}
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert invalid_vm.message == "inline firewall customConnectorId must be a UUID"
+        assert malformed_context is None
+        assert valid_context is not None
+        _, compiled_firewalls, _ = valid_context
+        assert compiled_firewalls is not None


### PR DESCRIPTION
## Summary

- add an end-to-end registry regression for a non-string inline `customConnectorId`
- verify the malformed VM is isolated as `invalid_firewalls` while a valid peer keeps a compiled firewall context
- pin the stable validation message and make the regression sensitive to removal of the explicit string guard

## Scope

- test-only change; no production behavior, API, schema, dependency, migration, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` — 0 errors
- `uv run --no-sync python -m pytest tests/test_registry_inline_firewalls.py -v` — 5 passed
- `uv run --no-sync python -m pytest tests/test_registry_builtin_catalog_resolution.py -v` — 24 passed
- `uv run --no-sync python -m pytest tests/` — 5361 passed
- controlled mutation probe: temporarily removing the string guard made the new test fail at registry loading with `AttributeError`; restoring the guard made it pass

Closes #26863
