### PR TITLE
refactor(python): separate x response inspection

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -9,9 +9,9 @@ delegates to the matching per-connector ``report_usage`` function.
 
 Billable connector metadata comes from the accepted connector catalog and
 reaches the runner through the claim's ``billableFirewalls`` list. Adding a new
-billable connector means marking its catalog firewall billable, adding a
-connector module here, and registering its reporter plus optional
-response-inspection capability in :data:`_REGISTRATIONS`.
+billable connector means marking its catalog firewall billable, adding its
+reporter and any focused response-inspection owner here, and registering those
+capabilities in :data:`_REGISTRATIONS`.
 Response inspection owns both parser creation and buffered-fallback selection,
 so those decisions cannot drift across independent registries.
 """
@@ -24,7 +24,7 @@ from mitmproxy import http
 import flow_metadata
 
 from ...underbilling import log_usage_underbilling
-from . import x
+from . import x, x_response_inspection
 from .response_parser import ConnectorResponseParser
 
 _ConnectorUsageHandler = Callable[[http.HTTPFlow, str, str], None]
@@ -51,7 +51,7 @@ _REGISTRATIONS: dict[str, _ConnectorUsageRegistration] = {
     "x": _ConnectorUsageRegistration(
         report_usage=x.report_usage,
         response_inspection=_ConnectorResponseInspection(
-            create_parser=x.create_response_parser,
+            create_parser=x_response_inspection.create_response_parser,
             needs_buffered_fallback=x.needs_response_buffer_fallback,
         ),
     ),

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -1,13 +1,12 @@
-"""X (Twitter) connector billing.
+"""X (Twitter) connector billing and usage reporting.
 
 Computes per-permission billable resource counts from successful requests
 through the X firewall and buffers them for aggregate platform upload.
 """
 
-import re
 import urllib.parse
 from collections.abc import Callable
-from typing import Literal, NamedTuple, TypedDict
+from typing import NamedTuple
 
 from mitmproxy import http
 
@@ -25,44 +24,25 @@ from logging_utils import log_proxy_entry
 
 from ...buffer import UsageEvent, buffer_usage_events
 from ...idempotency import USAGE_EVENT_NAMESPACE_CONNECTOR, derive_usage_idempotency_key
-from ...json_selective import (
-    JsonExtractionResult,
-    JsonSelectiveExtractor,
-    ScalarField,
-)
 from ...reporting_context import usage_reporting_context
 from ...underbilling import log_usage_underbilling
-from .response_parser import ConnectorResponseParser
 from .x_billing import (
+    INCLUDES_OVERFLOW_CATEGORY,
+    MAX_UNKNOWN_INCLUDE_CATEGORIES,
     bucket_needs_body_refinement,
     classify_bucket,
-    classify_includes_bucket,
+    include_billing_category,
     refine_bucket_with_body,
 )
+from .x_response_inspection import parse_json_response_fields_from_body
 
-# HTTP 2xx success range (RFC 9110).  Also defined in ``response_streaming.py``;
-# kept local to avoid introducing a constants module for two callers.  The upper
-# bound is ``REDIRECT_MIN`` (300) because 300 is the first 3xx status — using
-# ``status < _HTTP_STATUS_REDIRECT_MIN`` reads as "still in 2xx" without the
-# ambiguity of an ``OK_MAX`` that is itself excluded from the OK range.
+# HTTP 2xx success range (RFC 9110). Also defined in ``response_streaming.py``
+# and ``x_response_inspection.py``; kept local to avoid a constants module for a
+# simple bound. The upper bound is ``REDIRECT_MIN`` (300) because 300 is the
+# first 3xx — using ``status < _HTTP_STATUS_REDIRECT_MIN`` reads as "still in
+# 2xx" without the ambiguity of an ``OK_MAX`` that is itself excluded.
 _HTTP_STATUS_OK_MIN = 200
 _HTTP_STATUS_REDIRECT_MIN = 300
-
-# X v2 NDJSON streaming endpoint paths (exact match — ``/2/tweets/search/stream/rules``
-# is a regular request/response endpoint for rules management, NOT a stream).
-# Streams deliver one JSON object per line, possibly for hours. The shared
-# response streaming wrapper feeds the X NDJSON parser incrementally so billing
-# extraction does not retain the response body. Capture mode independently keeps
-# a capped raw-wire prefix.
-_STREAM_ENDPOINTS = frozenset(
-    {
-        "/2/tweets/search/stream",
-        "/2/tweets/sample/stream",
-        "/2/tweets/sample10/stream",
-        "/2/tweets/compliance/stream",
-        "/2/users/compliance/stream",
-    }
-)
 
 _COUNT_ENDPOINTS = frozenset(
     {
@@ -70,15 +50,6 @@ _COUNT_ENDPOINTS = frozenset(
         "/2/tweets/counts/all",
     }
 )
-
-
-def _is_stream_path(path: str) -> bool:
-    """Return True when *path* is one of the X v2 NDJSON streaming endpoints.
-
-    Exact match only — ``/2/tweets/search/stream/rules`` (rules management)
-    must NOT match because it's a regular JSON request/response, not a stream.
-    """
-    return path in _STREAM_ENDPOINTS
 
 
 def _is_count_path(path: str) -> bool:
@@ -96,18 +67,6 @@ def _strip_request_target_query(request_target: str) -> str:
     return path_or_url
 
 
-# Single NDJSON line cap matches ``LARGE_RESPONSE_DECOMPRESS_LIMIT``. A real X
-# tweet line (``data`` + ``includes`` +
-# ``matching_rules`` with full expansion) should never approach this size;
-# exceeding it indicates malformed or hostile upstream data, so the parser
-# discards that row through its terminating newline to protect memory.
-_MAX_NDJSON_LINE_BYTES = LARGE_RESPONSE_DECOMPRESS_LIMIT
-# Bound dense syntax and slow scalar inspection across one non-streaming X JSON
-# response while retaining the selective parser's bulk discarded-string path.
-_MAX_JSON_RESPONSE_WORK_UNITS = 65_536
-# Bound dense syntax and slow scalar inspection while keeping multi-megabyte
-# ordinary discarded strings on the selective parser's bulk-scan path.
-_MAX_NDJSON_ROW_WORK_UNITS = 65_536
 _REQUEST_BODY_REFINEMENT_LIMIT = REQUEST_BODY_BILLING_INSPECTION_LIMIT
 _REQUEST_QUERY_HINT_MAX_BYTES = 64 * 1024
 _REQUEST_QUERY_HINT_KEY_MAX_CHARS = 128
@@ -115,21 +74,6 @@ _REQUEST_QUERY_HINT_VALUE_MAX_BYTES = 16 * 1024
 _REQUEST_ID_LIKE_QUERY_KEYS = frozenset({"ids", "usernames"})
 _REQUEST_MAX_RESULTS_QUERY_KEY = "max_results"
 _ASCII_CODEPOINT_LIMIT = 128
-_MAX_UNKNOWN_INCLUDE_CATEGORIES = 64
-_MAX_USAGE_CATEGORY_CHARS = 100
-_SYNTHETIC_INCLUDE_CATEGORY_PREFIX = "includes."
-_INCLUDES_OVERFLOW_CATEGORY = "includes.__overflow__"
-_SAFE_SYNTHETIC_INCLUDE_KEY_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
-
-_X_JSON_RESULT_COUNT_FIELDS = {
-    ("meta", "result_count"): ScalarField("int", max_bytes=64),
-    ("meta", "total_tweet_count"): ScalarField("int", max_bytes=64),
-}
-
-
-class _IncludeBillingCategory(NamedTuple):
-    category: str
-    kind: Literal["known", "synthetic", "overflow"]
 
 
 class _RequestFallbackHintPolicy(NamedTuple):
@@ -137,6 +81,12 @@ class _RequestFallbackHintPolicy(NamedTuple):
     id_count_max: int | None
     max_results_min: int | None
     max_results_max: int | None
+
+
+class _ResponseUsageContext(NamedTuple):
+    permission: str
+    request_path: str
+    endpoint_bucket: str
 
 
 _REQUEST_IDS_100_HINT_POLICY = _RequestFallbackHintPolicy("ids", 100, None, None)
@@ -214,332 +164,6 @@ _REQUEST_FALLBACK_HINT_POLICIES = _compile_request_fallback_hint_policies(
 
 def _as_non_bool_int(value: object) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) else None
-
-
-def _synthetic_include_category(key: str) -> str | None:
-    max_key_chars = _MAX_USAGE_CATEGORY_CHARS - len(_SYNTHETIC_INCLUDE_CATEGORY_PREFIX)
-    if not key or len(key) > max_key_chars:
-        return None
-    if _SAFE_SYNTHETIC_INCLUDE_KEY_RE.fullmatch(key) is None:
-        return None
-    if f"{_SYNTHETIC_INCLUDE_CATEGORY_PREFIX}{key}" == _INCLUDES_OVERFLOW_CATEGORY:
-        return None
-    return f"{_SYNTHETIC_INCLUDE_CATEGORY_PREFIX}{key}"
-
-
-def _include_billing_category(key: str) -> _IncludeBillingCategory:
-    bucket = classify_includes_bucket(key)
-    if bucket is not None:
-        return _IncludeBillingCategory(bucket, "known")
-
-    category = _synthetic_include_category(key)
-    if category is None:
-        return _IncludeBillingCategory(_INCLUDES_OVERFLOW_CATEGORY, "overflow")
-    return _IncludeBillingCategory(category, "synthetic")
-
-
-def _create_x_json_selective_extractor() -> JsonSelectiveExtractor:
-    return JsonSelectiveExtractor(
-        scalar_fields=_X_JSON_RESULT_COUNT_FIELDS,
-        array_count_paths={("data",), ("errors",)},
-        wildcard_array_count_paths={("includes", "*")},
-        object_presence_paths={(), ("data",)},
-        max_work_units=_MAX_JSON_RESPONSE_WORK_UNITS,
-    )
-
-
-def _create_x_ndjson_row_extractor() -> JsonSelectiveExtractor:
-    return JsonSelectiveExtractor(
-        wildcard_array_count_paths={("includes", "*")},
-        object_presence_paths={("data",)},
-        max_work_units=_MAX_NDJSON_ROW_WORK_UNITS,
-    )
-
-
-def _parse_x_json_response_fields(extracted: JsonExtractionResult) -> dict:
-    result: dict = {}
-
-    data_count = extracted.array_counts.get(("data",))
-    if data_count is not None:
-        result["response_data_count"] = data_count
-    elif ("data",) in extracted.object_present:
-        result["response_data_count"] = 1
-
-    errors_count = extracted.array_counts.get(("errors",), 0)
-    if errors_count:
-        result["response_errors_count"] = errors_count
-
-    includes = extracted.wildcard_array_counts.get(("includes", "*"), {})
-    if includes:
-        result["response_includes"] = dict(includes)
-
-    result_count = _as_non_bool_int(extracted.values.get(("meta", "result_count")))
-    if result_count is not None:
-        result["response_result_count"] = result_count
-
-    total_tweet_count = _as_non_bool_int(extracted.values.get(("meta", "total_tweet_count")))
-    if total_tweet_count is not None:
-        result["response_total_tweet_count"] = total_tweet_count
-
-    return result
-
-
-def _parse_x_json_response_fields_from_body(body: bytes) -> dict | None:
-    extractor = _create_x_json_selective_extractor()
-    extractor.feed(body)
-    extracted = extractor.finish()
-    if not extracted.complete or () not in extracted.object_present:
-        return None
-    return _parse_x_json_response_fields(extracted)
-
-
-class _NdjsonState(TypedDict):
-    """Accumulated parser state for an X NDJSON stream.
-
-    Populated by :class:`_NdjsonExtractor` and read by
-    :func:`_parse_response_metadata` when emitting the billing log entry.
-    """
-
-    data_count: int
-    """Number of lines whose top-level ``data`` is a dict (one tweet per line)."""
-    includes: dict[str, int]
-    """Running sum of ``len(includes.<key>)`` across all lines, per key."""
-    unknown_includes_overflow_count: int
-    """Unknown include quantities routed to the bounded overflow category."""
-    lines_parsed: int
-    """JSON-parseable non-blank lines."""
-    lines_failed: int
-    """Lines that failed JSON decoding or exceeded the single-line safety cap."""
-
-
-class _ResponseUsageContext(NamedTuple):
-    permission: str
-    request_path: str
-    endpoint_bucket: str
-
-
-class _NdjsonExtractor:
-    """Incremental NDJSON parser for X v2 streaming responses.
-
-    X v2 streaming endpoints deliver one JSON object per line separated by
-    ``\\n`` (or ``\\r\\n``), with blank lines as keep-alives.  Each tweet
-    line typically has the shape::
-
-        {"data": {...tweet...}, "includes": {...}, "matching_rules": [...]}
-
-    ``feed`` processes raw response bytes incrementally so billing extraction
-    does not buffer the full body.  The shared response streaming wrapper may
-    still maintain a capped forensic ``stream_buffer`` independently. ``state``
-    is a dict that accumulates:
-
-    - ``data_count``: int — number of lines whose top-level ``data`` is a
-      dict (one tweet per line).  Lines whose ``data`` is an array or
-      absent contribute 0 to this counter but still bump ``lines_parsed``.
-    - ``includes``: dict[str, int] — running sum across all lines of
-      ``len(includes.<key>)`` for known expansion keys and the first bounded
-      set of safe unknown keys.
-    - ``unknown_includes_overflow_count``: int — running sum of unknown
-      include quantities that are unsafe for category emission or exceed the
-      per-stream unknown-category budget.
-    - ``lines_parsed``: int — JSON-parseable non-blank lines.
-    - ``lines_failed``: int — lines that failed JSON validation or exceeded a
-      single-line inspection bound.
-
-    The parser keeps a ``line_buf`` holding the in-flight partial line across
-    chunk boundaries. If a single line ever exceeds
-    :data:`_MAX_NDJSON_LINE_BYTES`, the whole line is discarded until its
-    terminating newline. Complete rows are validated with bounded selective
-    extraction so unrelated fields are not materialized. ``finish`` finalizes a
-    complete trailing line that arrived without a final ``\\n`` and treats
-    malformed, incomplete, or inspection-bound-exceeding trailing data as a
-    failed, unbilled line.
-    """
-
-    def __init__(self) -> None:
-        self.state: _NdjsonState = {
-            "data_count": 0,
-            "includes": {},
-            "unknown_includes_overflow_count": 0,
-            "lines_parsed": 0,
-            "lines_failed": 0,
-        }
-        self._unknown_include_keys: set[str] = set()
-        self._line_buf = bytearray()
-        self._discarding_overlong_line = False
-        self._finished = False
-
-    def feed(self, chunk: bytes) -> None:
-        """Process one decoded response-body chunk."""
-        start = 0
-        while start < len(chunk):
-            newline = chunk.find(b"\n", start)
-            end = len(chunk) if newline == -1 else newline
-            fragment_len = end - start
-
-            if self._discarding_overlong_line:
-                if newline == -1:
-                    return
-                self._discarding_overlong_line = False
-                start = newline + 1
-                continue
-
-            if len(self._line_buf) + fragment_len > _MAX_NDJSON_LINE_BYTES:
-                self._line_buf.clear()
-                self.state["lines_failed"] += 1
-                if newline == -1:
-                    self._discarding_overlong_line = True
-                    return
-                start = newline + 1
-                continue
-
-            self._line_buf.extend(chunk[start:end])
-            if newline == -1:
-                return
-
-            line = bytes(self._line_buf)
-            self._line_buf.clear()
-            self._parse_line(line)
-            start = newline + 1
-
-    def finish(self) -> None:
-        """Finalize a complete trailing line that was not newline-terminated."""
-        if self._finished:
-            return
-        self._finished = True
-        if self._discarding_overlong_line:
-            self._line_buf.clear()
-            self._discarding_overlong_line = False
-            return
-        if not self._line_buf:
-            return
-        line = bytes(self._line_buf)
-        self._line_buf.clear()
-        self._parse_line(line)
-
-    def _parse_line(self, raw_line: bytes) -> None:
-        line = raw_line.rstrip(b"\r")
-        if not line:
-            return  # keep-alive blank line
-        extractor = _create_x_ndjson_row_extractor()
-        extractor.feed(line)
-        extracted = extractor.finish()
-        if not extracted.complete:
-            self.state["lines_failed"] += 1
-            return
-        self.state["lines_parsed"] += 1
-        if ("data",) in extracted.object_present:
-            self.state["data_count"] += 1
-        includes = extracted.wildcard_array_counts.get(("includes", "*"), {})
-        for key, count in includes.items():
-            self._record_include_count(key, count)
-
-    def _record_include_count(self, key: str, count: int) -> None:
-        if count <= 0:
-            return
-
-        billing_category = _include_billing_category(key)
-        if billing_category.kind == "known":
-            self.state["includes"][key] = self.state["includes"].get(key, 0) + count
-            return
-
-        if billing_category.kind == "synthetic" and (
-            key in self._unknown_include_keys
-            or len(self._unknown_include_keys) < _MAX_UNKNOWN_INCLUDE_CATEGORIES
-        ):
-            self._unknown_include_keys.add(key)
-            self.state["includes"][key] = self.state["includes"].get(key, 0) + count
-            return
-
-        self.state["unknown_includes_overflow_count"] += count
-
-
-class _XJsonResponseExtractor:
-    """Incrementally extract billing metadata from non-streaming X JSON."""
-
-    def __init__(self) -> None:
-        self._extractor = _create_x_json_selective_extractor()
-
-    def feed(self, chunk: bytes) -> None:
-        self._extractor.feed(chunk)
-
-    def accepts_more_input(self) -> bool:
-        """Return whether the document parser can still consume input."""
-
-        return self._extractor.accepts_more_input()
-
-    def finish(self) -> tuple[dict, str | None]:
-        result: dict = {"body_parsed": False, "body_truncated": False}
-        extracted = self._extractor.finish()
-        if not extracted.complete:
-            return result, extracted.error
-        if () not in extracted.object_present:
-            return result, None
-
-        result["body_parsed"] = True
-        result.update(_parse_x_json_response_fields(extracted))
-        return result, None
-
-
-def create_response_parser(
-    flow: http.HTTPFlow, original_url: str
-) -> ConnectorResponseParser | None:
-    """Create the X response-body parser needed for this flow, if any."""
-    if not flow.response:
-        return None
-
-    status_code = flow.response.status_code
-    if _HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN:
-        # Use the dispatcher-required original URL so parser registration and
-        # final request metadata cannot diverge.
-        stream_path = urllib.parse.urlparse(original_url).path
-        if _is_stream_path(stream_path):
-            extractor = _NdjsonExtractor()
-            # Deliberately NOT "model_provider_usage" — that key routes through
-            # report_model_provider_usage and triggers the model-provider webhook.
-            # x_ndjson_state is only consumed by report_connector_usage.
-            flow.metadata[metadata_keys.X_NDJSON_STATE] = extractor.state
-
-            def finish_ndjson_decode_error(error: str) -> None:
-                flow.metadata.pop(metadata_keys.X_NDJSON_STATE, None)
-                flow.metadata[metadata_keys.X_JSON_STATE] = {
-                    "body_parsed": False,
-                    "body_truncated": False,
-                    "body_format": "ndjson",
-                    "parse_error": error,
-                }
-
-            return ConnectorResponseParser(
-                feed=extractor.feed,
-                report_on_interruption=True,
-                finish=extractor.finish,
-                finish_decode_error=finish_ndjson_decode_error,
-            )
-
-    if not (_HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN):
-        return None
-
-    extractor = _XJsonResponseExtractor()
-
-    def finish_json_state() -> None:
-        state, error = extractor.finish()
-        if error:
-            state["parse_error"] = error
-        flow.metadata[metadata_keys.X_JSON_STATE] = state
-
-    def finish_json_decode_error(error: str) -> None:
-        flow.metadata[metadata_keys.X_JSON_STATE] = {
-            "body_parsed": False,
-            "body_truncated": False,
-            "parse_error": error,
-        }
-
-    return ConnectorResponseParser(
-        feed=extractor.feed,
-        report_on_interruption=False,
-        finish=finish_json_state,
-        finish_decode_error=finish_json_decode_error,
-        should_continue=extractor.accepts_more_input,
-    )
 
 
 def _count_bounded_non_empty_comma_segments(value: str, max_count: int) -> int | None:
@@ -824,7 +448,7 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
     if decode_error is not None:
         result["parse_error"] = decode_error
         return result
-    fields = _parse_x_json_response_fields_from_body(body)
+    fields = parse_json_response_fields_from_body(body)
     if fields is None:
         return result
 
@@ -886,7 +510,7 @@ def _compute_billable_counts(
       trusted hints we emit no ``usage_event`` row; :func:`report_usage`
       detects that state and writes an error log so ops can audit.
     - **Includes**: each ``includes.<key>`` is normalized to a billing
-      bucket via :func:`classify_includes_bucket`, a bounded safe synthetic
+      bucket through :func:`include_billing_category`, a bounded safe synthetic
       ``includes.<key>`` category, or the fixed overflow category used for
       server-side fallback pricing.  Counts at the same bucket are summed.
     """
@@ -929,11 +553,11 @@ def _compute_billable_counts(
     for key, n in includes.items():
         if n <= 0:
             continue
-        include_category = _include_billing_category(key)
+        include_category = include_billing_category(key)
         if include_category.kind == "synthetic":
             if (
                 include_category.category in synthetic_include_categories
-                or len(synthetic_include_categories) < _MAX_UNKNOWN_INCLUDE_CATEGORIES
+                or len(synthetic_include_categories) < MAX_UNKNOWN_INCLUDE_CATEGORIES
             ):
                 synthetic_include_categories.add(include_category.category)
             else:
@@ -960,14 +584,14 @@ def _compute_billable_counts(
 
     overflow_includes_count += resp_meta.get("response_unknown_includes_overflow_count") or 0
     if overflow_includes_count > 0:
-        counts[_INCLUDES_OVERFLOW_CATEGORY] = (
-            counts.get(_INCLUDES_OVERFLOW_CATEGORY, 0) + overflow_includes_count
+        counts[INCLUDES_OVERFLOW_CATEGORY] = (
+            counts.get(INCLUDES_OVERFLOW_CATEGORY, 0) + overflow_includes_count
         )
         log_warn(
             "X includes overflow — emitting bounded category for server-side fallback",
             {
                 "includes_count": overflow_includes_count,
-                "category": _INCLUDES_OVERFLOW_CATEGORY,
+                "category": INCLUDES_OVERFLOW_CATEGORY,
             },
         )
 

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -53,7 +53,7 @@ sheet for drift.
 import json
 import re
 from collections.abc import Callable
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 import matching
 from host_normalization import UnsafeIdnaCompatibilityMappingError, normalize_idna_label
@@ -271,6 +271,17 @@ _INCLUDES_TO_BUCKET: dict[str, str] = {
     "spaces": "space.read",
 }
 
+MAX_UNKNOWN_INCLUDE_CATEGORIES = 64
+INCLUDES_OVERFLOW_CATEGORY = "includes.__overflow__"
+_MAX_USAGE_CATEGORY_CHARS = 100
+_SYNTHETIC_INCLUDE_CATEGORY_PREFIX = "includes."
+_SAFE_SYNTHETIC_INCLUDE_KEY_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+class IncludeBillingCategory(NamedTuple):
+    category: str
+    kind: Literal["known", "synthetic", "overflow"]
+
 
 def classify_includes_bucket(key: str) -> str | None:
     """Return the billing bucket for an ``includes.<key>`` resource type.
@@ -282,6 +293,29 @@ def classify_includes_bucket(key: str) -> str | None:
     categories, records ``fallback_pricing``, and emits underbilling telemetry.
     """
     return _INCLUDES_TO_BUCKET.get(key)
+
+
+def _synthetic_include_category(key: str) -> str | None:
+    max_key_chars = _MAX_USAGE_CATEGORY_CHARS - len(_SYNTHETIC_INCLUDE_CATEGORY_PREFIX)
+    if not key or len(key) > max_key_chars:
+        return None
+    if _SAFE_SYNTHETIC_INCLUDE_KEY_RE.fullmatch(key) is None:
+        return None
+    if f"{_SYNTHETIC_INCLUDE_CATEGORY_PREFIX}{key}" == INCLUDES_OVERFLOW_CATEGORY:
+        return None
+    return f"{_SYNTHETIC_INCLUDE_CATEGORY_PREFIX}{key}"
+
+
+def include_billing_category(key: str) -> IncludeBillingCategory:
+    """Classify one known, safe synthetic, or overflow include category."""
+    bucket = classify_includes_bucket(key)
+    if bucket is not None:
+        return IncludeBillingCategory(bucket, "known")
+
+    category = _synthetic_include_category(key)
+    if category is None:
+        return IncludeBillingCategory(INCLUDES_OVERFLOW_CATEGORY, "overflow")
+    return IncludeBillingCategory(category, "synthetic")
 
 
 # URL detector for tweet body refinement.  Billing needs a conservative

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_response_inspection.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_response_inspection.py
@@ -1,0 +1,373 @@
+"""X connector response inspection.
+
+Incrementally extracts billing-relevant fields from X JSON and NDJSON
+responses and publishes parser-owned flow metadata for X usage reporting.
+"""
+
+import urllib.parse
+from typing import TypedDict
+
+from mitmproxy import http
+
+import flow_metadata_keys as metadata_keys
+from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
+
+from ...json_selective import (
+    JsonExtractionResult,
+    JsonSelectiveExtractor,
+    ScalarField,
+)
+from .response_parser import ConnectorResponseParser
+from .x_billing import MAX_UNKNOWN_INCLUDE_CATEGORIES, include_billing_category
+
+# HTTP 2xx success range (RFC 9110). Also defined in ``response_streaming.py``
+# and ``x.py``; kept local to avoid a constants module for a simple bound.
+_HTTP_STATUS_OK_MIN = 200
+_HTTP_STATUS_REDIRECT_MIN = 300
+
+# X v2 NDJSON streaming endpoint paths (exact match — ``/2/tweets/search/stream/rules``
+# is a regular request/response endpoint for rules management, NOT a stream).
+# Streams deliver one JSON object per line, possibly for hours. The shared
+# response streaming wrapper feeds the X NDJSON parser incrementally so billing
+# extraction does not retain the response body. Capture mode independently keeps
+# a capped raw-wire prefix.
+_STREAM_ENDPOINTS = frozenset(
+    {
+        "/2/tweets/search/stream",
+        "/2/tweets/sample/stream",
+        "/2/tweets/sample10/stream",
+        "/2/tweets/compliance/stream",
+        "/2/users/compliance/stream",
+    }
+)
+
+
+def _is_stream_path(path: str) -> bool:
+    """Return True when *path* is one of the X v2 NDJSON streaming endpoints.
+
+    Exact match only — ``/2/tweets/search/stream/rules`` (rules management)
+    must NOT match because it's a regular JSON request/response, not a stream.
+    """
+    return path in _STREAM_ENDPOINTS
+
+
+# Single NDJSON line cap matches ``LARGE_RESPONSE_DECOMPRESS_LIMIT``. A real X
+# tweet line (``data`` + ``includes`` +
+# ``matching_rules`` with full expansion) should never approach this size;
+# exceeding it indicates malformed or hostile upstream data, so the parser
+# discards that row through its terminating newline to protect memory.
+_MAX_NDJSON_LINE_BYTES = LARGE_RESPONSE_DECOMPRESS_LIMIT
+# Bound dense syntax and slow scalar inspection across one non-streaming X JSON
+# response while retaining the selective parser's bulk discarded-string path.
+_MAX_JSON_RESPONSE_WORK_UNITS = 65_536
+# Bound dense syntax and slow scalar inspection while keeping multi-megabyte
+# ordinary discarded strings on the selective parser's bulk-scan path.
+_MAX_NDJSON_ROW_WORK_UNITS = 65_536
+
+_X_JSON_RESULT_COUNT_FIELDS = {
+    ("meta", "result_count"): ScalarField("int", max_bytes=64),
+    ("meta", "total_tweet_count"): ScalarField("int", max_bytes=64),
+}
+
+
+def _as_non_bool_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _create_x_json_selective_extractor() -> JsonSelectiveExtractor:
+    return JsonSelectiveExtractor(
+        scalar_fields=_X_JSON_RESULT_COUNT_FIELDS,
+        array_count_paths={("data",), ("errors",)},
+        wildcard_array_count_paths={("includes", "*")},
+        object_presence_paths={(), ("data",)},
+        max_work_units=_MAX_JSON_RESPONSE_WORK_UNITS,
+    )
+
+
+def _create_x_ndjson_row_extractor() -> JsonSelectiveExtractor:
+    return JsonSelectiveExtractor(
+        wildcard_array_count_paths={("includes", "*")},
+        object_presence_paths={("data",)},
+        max_work_units=_MAX_NDJSON_ROW_WORK_UNITS,
+    )
+
+
+def _parse_x_json_response_fields(extracted: JsonExtractionResult) -> dict:
+    result: dict = {}
+
+    data_count = extracted.array_counts.get(("data",))
+    if data_count is not None:
+        result["response_data_count"] = data_count
+    elif ("data",) in extracted.object_present:
+        result["response_data_count"] = 1
+
+    errors_count = extracted.array_counts.get(("errors",), 0)
+    if errors_count:
+        result["response_errors_count"] = errors_count
+
+    includes = extracted.wildcard_array_counts.get(("includes", "*"), {})
+    if includes:
+        result["response_includes"] = dict(includes)
+
+    result_count = _as_non_bool_int(extracted.values.get(("meta", "result_count")))
+    if result_count is not None:
+        result["response_result_count"] = result_count
+
+    total_tweet_count = _as_non_bool_int(extracted.values.get(("meta", "total_tweet_count")))
+    if total_tweet_count is not None:
+        result["response_total_tweet_count"] = total_tweet_count
+
+    return result
+
+
+def parse_json_response_fields_from_body(body: bytes) -> dict | None:
+    """Extract billing-relevant fields from one complete X JSON body."""
+    extractor = _create_x_json_selective_extractor()
+    extractor.feed(body)
+    extracted = extractor.finish()
+    if not extracted.complete or () not in extracted.object_present:
+        return None
+    return _parse_x_json_response_fields(extracted)
+
+
+class _NdjsonState(TypedDict):
+    """Accumulated parser state for an X NDJSON stream.
+
+    Populated by :class:`_NdjsonExtractor` and read by X usage reporting when
+    emitting the billing log entry.
+    """
+
+    data_count: int
+    """Number of lines whose top-level ``data`` is a dict (one tweet per line)."""
+    includes: dict[str, int]
+    """Running sum of ``len(includes.<key>)`` across all lines, per key."""
+    unknown_includes_overflow_count: int
+    """Unknown include quantities routed to the bounded overflow category."""
+    lines_parsed: int
+    """JSON-parseable non-blank lines."""
+    lines_failed: int
+    """Lines that failed JSON decoding or exceeded the single-line safety cap."""
+
+
+class _NdjsonExtractor:
+    """Incremental NDJSON parser for X v2 streaming responses.
+
+    X v2 streaming endpoints deliver one JSON object per line separated by
+    ``\\n`` (or ``\\r\\n``), with blank lines as keep-alives. Each tweet
+    line typically has the shape::
+
+        {"data": {...tweet...}, "includes": {...}, "matching_rules": [...]}
+
+    ``feed`` processes raw response bytes incrementally so billing extraction
+    does not buffer the full body. The shared response streaming wrapper may
+    still maintain a capped forensic ``stream_buffer`` independently. ``state``
+    is a dict that accumulates:
+
+    - ``data_count``: int — number of lines whose top-level ``data`` is a
+      dict (one tweet per line). Lines whose ``data`` is an array or
+      absent contribute 0 to this counter but still bump ``lines_parsed``.
+    - ``includes``: dict[str, int] — running sum across all lines of
+      ``len(includes.<key>)`` for known expansion keys and the first bounded
+      set of safe unknown keys.
+    - ``unknown_includes_overflow_count``: int — running sum of unknown
+      include quantities that are unsafe for category emission or exceed the
+      per-stream unknown-category budget.
+    - ``lines_parsed``: int — JSON-parseable non-blank lines.
+    - ``lines_failed``: int — lines that failed JSON validation or exceeded a
+      single-line inspection bound.
+
+    The parser keeps a ``line_buf`` holding the in-flight partial line across
+    chunk boundaries. If a single line ever exceeds
+    :data:`_MAX_NDJSON_LINE_BYTES`, the whole line is discarded until its
+    terminating newline. Complete rows are validated with bounded selective
+    extraction so unrelated fields are not materialized. ``finish`` finalizes a
+    complete trailing line that arrived without a final ``\\n`` and treats
+    malformed, incomplete, or inspection-bound-exceeding trailing data as a
+    failed, unbilled line.
+    """
+
+    def __init__(self) -> None:
+        self.state: _NdjsonState = {
+            "data_count": 0,
+            "includes": {},
+            "unknown_includes_overflow_count": 0,
+            "lines_parsed": 0,
+            "lines_failed": 0,
+        }
+        self._unknown_include_keys: set[str] = set()
+        self._line_buf = bytearray()
+        self._discarding_overlong_line = False
+        self._finished = False
+
+    def feed(self, chunk: bytes) -> None:
+        """Process one decoded response-body chunk."""
+        start = 0
+        while start < len(chunk):
+            newline = chunk.find(b"\n", start)
+            end = len(chunk) if newline == -1 else newline
+            fragment_len = end - start
+
+            if self._discarding_overlong_line:
+                if newline == -1:
+                    return
+                self._discarding_overlong_line = False
+                start = newline + 1
+                continue
+
+            if len(self._line_buf) + fragment_len > _MAX_NDJSON_LINE_BYTES:
+                self._line_buf.clear()
+                self.state["lines_failed"] += 1
+                if newline == -1:
+                    self._discarding_overlong_line = True
+                    return
+                start = newline + 1
+                continue
+
+            self._line_buf.extend(chunk[start:end])
+            if newline == -1:
+                return
+
+            line = bytes(self._line_buf)
+            self._line_buf.clear()
+            self._parse_line(line)
+            start = newline + 1
+
+    def finish(self) -> None:
+        """Finalize a complete trailing line that was not newline-terminated."""
+        if self._finished:
+            return
+        self._finished = True
+        if self._discarding_overlong_line:
+            self._line_buf.clear()
+            self._discarding_overlong_line = False
+            return
+        if not self._line_buf:
+            return
+        line = bytes(self._line_buf)
+        self._line_buf.clear()
+        self._parse_line(line)
+
+    def _parse_line(self, raw_line: bytes) -> None:
+        line = raw_line.rstrip(b"\r")
+        if not line:
+            return  # keep-alive blank line
+        extractor = _create_x_ndjson_row_extractor()
+        extractor.feed(line)
+        extracted = extractor.finish()
+        if not extracted.complete:
+            self.state["lines_failed"] += 1
+            return
+        self.state["lines_parsed"] += 1
+        if ("data",) in extracted.object_present:
+            self.state["data_count"] += 1
+        includes = extracted.wildcard_array_counts.get(("includes", "*"), {})
+        for key, count in includes.items():
+            self._record_include_count(key, count)
+
+    def _record_include_count(self, key: str, count: int) -> None:
+        if count <= 0:
+            return
+
+        billing_category = include_billing_category(key)
+        if billing_category.kind == "known":
+            self.state["includes"][key] = self.state["includes"].get(key, 0) + count
+            return
+
+        if billing_category.kind == "synthetic" and (
+            key in self._unknown_include_keys
+            or len(self._unknown_include_keys) < MAX_UNKNOWN_INCLUDE_CATEGORIES
+        ):
+            self._unknown_include_keys.add(key)
+            self.state["includes"][key] = self.state["includes"].get(key, 0) + count
+            return
+
+        self.state["unknown_includes_overflow_count"] += count
+
+
+class _XJsonResponseExtractor:
+    """Incrementally extract billing metadata from non-streaming X JSON."""
+
+    def __init__(self) -> None:
+        self._extractor = _create_x_json_selective_extractor()
+
+    def feed(self, chunk: bytes) -> None:
+        self._extractor.feed(chunk)
+
+    def accepts_more_input(self) -> bool:
+        """Return whether the document parser can still consume input."""
+
+        return self._extractor.accepts_more_input()
+
+    def finish(self) -> tuple[dict, str | None]:
+        result: dict = {"body_parsed": False, "body_truncated": False}
+        extracted = self._extractor.finish()
+        if not extracted.complete:
+            return result, extracted.error
+        if () not in extracted.object_present:
+            return result, None
+
+        result["body_parsed"] = True
+        result.update(_parse_x_json_response_fields(extracted))
+        return result, None
+
+
+def create_response_parser(
+    flow: http.HTTPFlow, original_url: str
+) -> ConnectorResponseParser | None:
+    """Create the X response-body parser needed for this flow, if any."""
+    if not flow.response:
+        return None
+
+    status_code = flow.response.status_code
+    if _HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN:
+        # Use the dispatcher-required original URL so parser registration and
+        # final request metadata cannot diverge.
+        stream_path = urllib.parse.urlparse(original_url).path
+        if _is_stream_path(stream_path):
+            extractor = _NdjsonExtractor()
+            # Deliberately NOT "model_provider_usage" — that key routes through
+            # report_model_provider_usage and triggers the model-provider webhook.
+            # x_ndjson_state is only consumed by report_connector_usage.
+            flow.metadata[metadata_keys.X_NDJSON_STATE] = extractor.state
+
+            def finish_ndjson_decode_error(error: str) -> None:
+                flow.metadata.pop(metadata_keys.X_NDJSON_STATE, None)
+                flow.metadata[metadata_keys.X_JSON_STATE] = {
+                    "body_parsed": False,
+                    "body_truncated": False,
+                    "body_format": "ndjson",
+                    "parse_error": error,
+                }
+
+            return ConnectorResponseParser(
+                feed=extractor.feed,
+                report_on_interruption=True,
+                finish=extractor.finish,
+                finish_decode_error=finish_ndjson_decode_error,
+            )
+
+    if not (_HTTP_STATUS_OK_MIN <= status_code < _HTTP_STATUS_REDIRECT_MIN):
+        return None
+
+    extractor = _XJsonResponseExtractor()
+
+    def finish_json_state() -> None:
+        state, error = extractor.finish()
+        if error:
+            state["parse_error"] = error
+        flow.metadata[metadata_keys.X_JSON_STATE] = state
+
+    def finish_json_decode_error(error: str) -> None:
+        flow.metadata[metadata_keys.X_JSON_STATE] = {
+            "body_parsed": False,
+            "body_truncated": False,
+            "parse_error": error,
+        }
+
+    return ConnectorResponseParser(
+        feed=extractor.feed,
+        report_on_interruption=False,
+        finish=finish_json_state,
+        finish_decode_error=finish_json_decode_error,
+        should_continue=extractor.accepts_more_input,
+    )


### PR DESCRIPTION
## Summary

- move X JSON/NDJSON parser construction, state machines, response-field extraction, and metadata finalization into `x_response_inspection.py`
- keep request fallback, count computation, body refinement, diagnostics, and usage-event emission in `x.py`
- centralize the known/synthetic/overflow include-category policy in `x_billing.py` and wire parser/reporting hooks from their explicit owners

## Scope

This is a behavior-neutral ownership refactor inside the runner mitmproxy addon. It preserves `X_NDJSON_STATE` / `X_JSON_STATE`, interruption handling, bounded inspection limits, buffered fallback, billing categories, diagnostics, and idempotency inputs. It does not change APIs, persisted state, runner protocols, or billing behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_connector_usage.py tests/test_x_response_parsers.py tests/test_x_connector_pipeline.py tests/x_connector_usage/ tests/test_x_billing.py` (339 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` (0 errors, 0 warnings)
- `uv run --no-sync python -m pytest tests/` (5360 passed, 59 pre-existing warnings)

Closes #26858
