### PR TITLE
fix(ci): stabilize stripe checkout runner bootstrap

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -52,10 +52,21 @@ workflow = YAML.load_file(ARGV.fetch(0))
 jobs = workflow.fetch("jobs")
 prepare = jobs.fetch("prepare")
 stripe_listener = jobs.fetch("deploy-stripe-listener")
+playwright = jobs.fetch("cli-e2e-02-playwright")
 account_prepare = jobs.fetch("cli-e2e-03-runner-prepare")
 bootstrap = jobs.fetch("cli-e2e-03-runner-bootstrap")
 runner = jobs.fetch("cli-e2e-03-runner")
 account_cleanup = jobs.fetch("cli-e2e-03-runner-cleanup")
+
+playwright_step_names = playwright.fetch("steps").map { |step| step["name"] }
+browser_install_index = playwright_step_names.index("Install Playwright browsers")
+fixture_test_index = playwright_step_names.index(
+  "Run Playwright fixture integration tests",
+)
+unless browser_install_index && fixture_test_index &&
+    browser_install_index < fixture_test_index
+  raise "Playwright browsers must be installed before browser fixture tests"
+end
 
 unless prepare.dig("outputs", "turbo-runner-consumer-needed") ==
     "${{ steps.runner-e2e.outputs.turbo-runner-consumer-needed }}"
@@ -180,6 +191,20 @@ end
 unless token_step.dig("env", "E2E_RUNNER_MOCK_CLAUDE_ORGANIZATION_ID") ==
     "${{ steps.account.outputs.mock-claude-organization-id }}"
   raise "runner E2E token generation must receive the mock Claude organization"
+end
+
+diagnostic_upload_step = account_prepare.fetch("steps").find do |step|
+  step["name"] == "Upload runner E2E Checkout diagnostics"
+end
+raise "missing runner E2E Checkout diagnostic upload" unless diagnostic_upload_step
+unless diagnostic_upload_step.fetch("if") == "failure()" &&
+    diagnostic_upload_step.dig("with", "name") ==
+      "runner-e2e-checkout-diagnostics" &&
+    diagnostic_upload_step.dig("with", "path") ==
+      "/tmp/e2e-runner-checkout-diagnostics" &&
+    diagnostic_upload_step.dig("with", "if-no-files-found") == "ignore" &&
+    diagnostic_upload_step.dig("with", "retention-days") == 1
+  raise "runner E2E Checkout diagnostics must be failure-only and short-lived"
 end
 
 upload_step = account_prepare.fetch("steps").find do |step|

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1853,10 +1853,10 @@ jobs:
         run: cd e2e && pnpm install --frozen-lockfile
       - name: Check Playwright E2E types
         run: cd e2e && pnpm check-types
-      - name: Run Playwright fixture integration tests
-        run: cd e2e && pnpm test
       - name: Install Playwright browsers
         run: cd e2e && pnpm exec playwright install --with-deps chromium
+      - name: Run Playwright fixture integration tests
+        run: cd e2e && pnpm test
       - name: Start Stripe webhook forwarding
         # Staging receives webhooks from the Dashboard endpoint; PR previews use
         # the long-running listener from deploy-stripe-listener.
@@ -2632,6 +2632,14 @@ jobs:
           E2E_RUNNER_CLAUDE_ORGANIZATION_ID: ${{ steps.account.outputs.claude-organization-id }}
           E2E_RUNNER_MOCK_CLAUDE_ORGANIZATION_ID: ${{ steps.account.outputs.mock-claude-organization-id }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      - name: Upload runner E2E Checkout diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: runner-e2e-checkout-diagnostics
+          path: /tmp/e2e-runner-checkout-diagnostics
+          if-no-files-found: ignore
+          retention-days: 1
       - name: Upload runner E2E API tokens
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/e2e/playwright/lib/stripe-checkout.test.ts
+++ b/e2e/playwright/lib/stripe-checkout.test.ts
@@ -102,7 +102,9 @@ function checkoutDocument(layout: CheckoutLayout): string {
             return;
           }
           if (document.body.dataset.layout === "wallet") {
-            window.setTimeout(renderCardForm, 100);
+            window.requestAnimationFrame(() => {
+              window.requestAnimationFrame(renderCardForm);
+            });
           } else {
             renderCardForm();
           }

--- a/e2e/playwright/lib/stripe-checkout.test.ts
+++ b/e2e/playwright/lib/stripe-checkout.test.ts
@@ -11,6 +11,7 @@ import {
 type CheckoutLayout =
   | "accordion"
   | "expanded"
+  | "framed-accordion"
   | "iframe"
   | "late-frame"
   | "wallet";
@@ -30,6 +31,7 @@ test("fills and submits every supported Stripe Checkout card layout", async (con
       "late-frame",
       "wallet",
       "accordion",
+      "framed-accordion",
     ] as const) {
       await context.test(layout, async () => {
         const page = await browser.newPage();
@@ -43,6 +45,16 @@ test("fills and submits every supported Stripe Checkout card layout", async (con
           await fillStripeCheckout(page);
 
           await assertCheckoutWasSubmitted(page);
+          if (layout === "framed-accordion") {
+            const cardFrame = page.frame({ name: "stripe-card" });
+            assert.ok(cardFrame, "expected the Stripe card frame to remain");
+            assert.equal(
+              await cardFrame
+                .locator("body")
+                .getAttribute("data-activation-count"),
+              "1",
+            );
+          }
         } finally {
           await page.close();
         }
@@ -69,7 +81,10 @@ async function openCheckoutFixture(
 
 function checkoutDocument(layout: CheckoutLayout): string {
   const cardControl =
-    layout === "expanded" || layout === "iframe" || layout === "late-frame"
+    layout === "expanded" ||
+    layout === "framed-accordion" ||
+    layout === "iframe" ||
+    layout === "late-frame"
       ? ""
       : `<button id="pay-with-card" type="button"${
           layout === "accordion"
@@ -134,6 +149,18 @@ function checkoutDocument(layout: CheckoutLayout): string {
           }, { once: true });
         });
         host.append(cardFrame);
+      } else if (document.body.dataset.layout === "framed-accordion") {
+        for (let index = 0; index < 32; index += 1) {
+          const unrelatedFrame = document.createElement("iframe");
+          unrelatedFrame.title = "unrelated-frame-" + index;
+          unrelatedFrame.srcdoc = "<p>Unrelated frame " + index + "</p>";
+          host.append(unrelatedFrame);
+        }
+        const cardFrame = document.createElement("iframe");
+        cardFrame.name = "stripe-card";
+        cardFrame.title = "Stripe card entry";
+        cardFrame.srcdoc = ${JSON.stringify(framedAccordionDocument())};
+        host.append(cardFrame);
       } else {
         document.querySelector("#pay-with-card").addEventListener("click", (event) => {
           if (document.body.dataset.layout === "wallet" && !event.isTrusted) {
@@ -152,6 +179,25 @@ function checkoutDocument(layout: CheckoutLayout): string {
         document.body.dataset.submitted = "true";
       });
     </script>
+  </body>
+</html>`;
+}
+
+function framedAccordionDocument(): string {
+  return `<!doctype html>
+<html>
+  <body data-activation-count="0">
+    <button
+      type="button"
+      style="height: 0; overflow: hidden; padding: 0; border: 0"
+      onclick="
+        document.body.dataset.activationCount = String(
+          Number(document.body.dataset.activationCount) + 1
+        );
+        document.querySelector('#card-fields').hidden = false;
+      "
+    >Pay with card</button>
+    <div id="card-fields" hidden>${CARD_FIELDS}</div>
   </body>
 </html>`;
 }

--- a/e2e/playwright/lib/stripe-checkout.test.ts
+++ b/e2e/playwright/lib/stripe-checkout.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { chromium, type Page } from "@playwright/test";
+
+import {
+  collectStripeCheckoutState,
+  fillStripeCheckout,
+} from "./stripe-checkout";
+
+type CheckoutLayout = "accordion" | "expanded" | "iframe" | "wallet";
+
+const CARD_FIELDS = `
+  <label>Card number <input name="cardNumber" placeholder="1234 1234 1234 1234"></label>
+  <label>Expiration <input name="cardExpiry" placeholder="MM / YY"></label>
+  <label>Security code <input name="cardCvc" placeholder="CVC"></label>
+`;
+
+test("fills and submits every supported Stripe Checkout card layout", async (context) => {
+  const browser = await chromium.launch();
+  try {
+    for (const layout of [
+      "expanded",
+      "iframe",
+      "wallet",
+      "accordion",
+    ] as const) {
+      await context.test(layout, async () => {
+        const page = await browser.newPage();
+        try {
+          await openCheckoutFixture(page, layout);
+          const state = await collectStripeCheckoutState(page);
+          assert.equal(state.pageOrigin, "https://checkout.stripe.com");
+          assert.equal(state.title, "Checkout fixture");
+          assert.doesNotMatch(JSON.stringify(state), /\/c\/pay\//u);
+
+          await fillStripeCheckout(page);
+
+          await assertCheckoutWasSubmitted(page);
+        } finally {
+          await page.close();
+        }
+      });
+    }
+  } finally {
+    await browser.close();
+  }
+});
+
+async function openCheckoutFixture(
+  page: Page,
+  layout: CheckoutLayout,
+): Promise<void> {
+  await page.route("https://checkout.stripe.com/**", async (route) => {
+    await route.fulfill({
+      body: checkoutDocument(layout),
+      contentType: "text/html",
+      status: 200,
+    });
+  });
+  await page.goto(`https://checkout.stripe.com/c/pay/${layout}`);
+}
+
+function checkoutDocument(layout: CheckoutLayout): string {
+  const cardControl =
+    layout === "expanded" || layout === "iframe"
+      ? ""
+      : `<button id="pay-with-card" type="button"${
+          layout === "accordion"
+            ? ' style="height: 0; overflow: hidden; position: absolute; width: 0"'
+            : ""
+        }>Pay with card</button>`;
+
+  return `<!doctype html>
+<html>
+  <head><title>Checkout fixture</title></head>
+  <body data-layout="${layout}">
+    <label>Email <input name="email"></label>
+    <label><input aria-label="Save my information" type="checkbox" checked> Save my information</label>
+    <label>Cardholder name <input name="billingName"></label>
+    <label>Postal code <input name="billingPostalCode"></label>
+    ${cardControl}
+    <div id="card-host"></div>
+    <button id="submit" type="button">Subscribe</button>
+    <script>
+      const cardFields = ${JSON.stringify(CARD_FIELDS)};
+      const host = document.querySelector("#card-host");
+      const renderCardForm = () => {
+        host.innerHTML = cardFields;
+      };
+      if (document.body.dataset.layout === "expanded") {
+        renderCardForm();
+      } else if (document.body.dataset.layout === "iframe") {
+        const frame = document.createElement("iframe");
+        frame.srcdoc = ${JSON.stringify(
+          `<!doctype html><html><body>${CARD_FIELDS}</body></html>`,
+        )};
+        host.append(frame);
+      } else {
+        document.querySelector("#pay-with-card").addEventListener("click", (event) => {
+          if (document.body.dataset.layout === "wallet" && !event.isTrusted) {
+            return;
+          }
+          if (document.body.dataset.layout === "wallet") {
+            window.setTimeout(renderCardForm, 100);
+          } else {
+            renderCardForm();
+          }
+        }, { once: true });
+      }
+      document.querySelector("#submit").addEventListener("click", () => {
+        document.body.dataset.submitted = "true";
+      });
+    </script>
+  </body>
+</html>`;
+}
+
+async function assertCheckoutWasSubmitted(page: Page): Promise<void> {
+  assert.equal(await stripeFieldValue(page, "cardNumber"), "4242424242424242");
+  assert.equal(await stripeFieldValue(page, "cardExpiry"), "1234");
+  assert.equal(await stripeFieldValue(page, "cardCvc"), "123");
+  assert.equal(
+    await page.locator('input[name="billingName"]').inputValue(),
+    "VM0 Billing E2E",
+  );
+  assert.equal(
+    await page.locator('input[name="billingPostalCode"]').inputValue(),
+    "94107",
+  );
+  assert.match(
+    await page.locator('input[name="email"]').inputValue(),
+    /^billing-e2e-\d+@vm0-e2e\.ai$/u,
+  );
+  assert.equal(
+    await page
+      .getByRole("checkbox", { name: /save my information/i })
+      .isChecked(),
+    false,
+  );
+  assert.equal(
+    await page.locator("body").getAttribute("data-submitted"),
+    "true",
+  );
+}
+
+async function stripeFieldValue(page: Page, name: string): Promise<string> {
+  for (const frame of page.frames()) {
+    const field = frame.locator(`input[name="${name}"]`);
+    if ((await field.count()) > 0) {
+      return await field.inputValue();
+    }
+  }
+  throw new Error(`Missing Stripe fixture field ${name}`);
+}

--- a/e2e/playwright/lib/stripe-checkout.test.ts
+++ b/e2e/playwright/lib/stripe-checkout.test.ts
@@ -103,10 +103,12 @@ function checkoutDocument(layout: CheckoutLayout): string {
         )};
         host.append(frame);
       } else if (document.body.dataset.layout === "late-frame") {
+        const unrelatedFrames = [];
         for (let index = 0; index < 32; index += 1) {
           const unrelatedFrame = document.createElement("iframe");
           unrelatedFrame.title = \`Unrelated frame \${index}\`;
           host.append(unrelatedFrame);
+          unrelatedFrames.push(unrelatedFrame);
         }
 
         const cardFrame = document.createElement("iframe");
@@ -120,8 +122,13 @@ function checkoutDocument(layout: CheckoutLayout): string {
               return;
             }
             window.requestAnimationFrame(() => {
+              for (const unrelatedFrame of unrelatedFrames) {
+                unrelatedFrame.remove();
+              }
               window.requestAnimationFrame(() => {
-                cardHost.innerHTML = cardFields;
+                const fieldsFrame = cardDocument.createElement("iframe");
+                fieldsFrame.srcdoc = cardFields;
+                cardHost.append(fieldsFrame);
               });
             });
           }, { once: true });

--- a/e2e/playwright/lib/stripe-checkout.test.ts
+++ b/e2e/playwright/lib/stripe-checkout.test.ts
@@ -8,7 +8,12 @@ import {
   fillStripeCheckout,
 } from "./stripe-checkout";
 
-type CheckoutLayout = "accordion" | "expanded" | "iframe" | "wallet";
+type CheckoutLayout =
+  | "accordion"
+  | "expanded"
+  | "iframe"
+  | "late-frame"
+  | "wallet";
 
 const CARD_FIELDS = `
   <label>Card number <input name="cardNumber" placeholder="1234 1234 1234 1234"></label>
@@ -22,6 +27,7 @@ test("fills and submits every supported Stripe Checkout card layout", async (con
     for (const layout of [
       "expanded",
       "iframe",
+      "late-frame",
       "wallet",
       "accordion",
     ] as const) {
@@ -63,7 +69,7 @@ async function openCheckoutFixture(
 
 function checkoutDocument(layout: CheckoutLayout): string {
   const cardControl =
-    layout === "expanded" || layout === "iframe"
+    layout === "expanded" || layout === "iframe" || layout === "late-frame"
       ? ""
       : `<button id="pay-with-card" type="button"${
           layout === "accordion"
@@ -96,6 +102,31 @@ function checkoutDocument(layout: CheckoutLayout): string {
           `<!doctype html><html><body>${CARD_FIELDS}</body></html>`,
         )};
         host.append(frame);
+      } else if (document.body.dataset.layout === "late-frame") {
+        for (let index = 0; index < 32; index += 1) {
+          const unrelatedFrame = document.createElement("iframe");
+          unrelatedFrame.title = \`Unrelated frame \${index}\`;
+          host.append(unrelatedFrame);
+        }
+
+        const cardFrame = document.createElement("iframe");
+        cardFrame.title = "Late card frame";
+        cardFrame.srcdoc = '<button id="pay-with-card" type="button">Pay with card</button><div id="card-host"></div>';
+        cardFrame.addEventListener("load", () => {
+          const cardDocument = cardFrame.contentDocument;
+          const cardHost = cardDocument.querySelector("#card-host");
+          cardDocument.querySelector("#pay-with-card").addEventListener("click", (event) => {
+            if (!event.isTrusted) {
+              return;
+            }
+            window.requestAnimationFrame(() => {
+              window.requestAnimationFrame(() => {
+                cardHost.innerHTML = cardFields;
+              });
+            });
+          }, { once: true });
+        });
+        host.append(cardFrame);
       } else {
         document.querySelector("#pay-with-card").addEventListener("click", (event) => {
           if (document.body.dataset.layout === "wallet" && !event.isTrusted) {

--- a/e2e/playwright/lib/stripe-checkout.test.ts
+++ b/e2e/playwright/lib/stripe-checkout.test.ts
@@ -14,6 +14,7 @@ type CheckoutLayout =
   | "framed-accordion"
   | "iframe"
   | "late-frame"
+  | "replaced-field-frame"
   | "wallet";
 
 const CARD_FIELDS = `
@@ -29,6 +30,7 @@ test("fills and submits every supported Stripe Checkout card layout", async (con
       "expanded",
       "iframe",
       "late-frame",
+      "replaced-field-frame",
       "wallet",
       "accordion",
       "framed-accordion",
@@ -52,6 +54,12 @@ test("fills and submits every supported Stripe Checkout card layout", async (con
               await cardFrame
                 .locator("body")
                 .getAttribute("data-activation-count"),
+              "1",
+            );
+          }
+          if (layout === "replaced-field-frame") {
+            assert.equal(
+              await page.locator("body").getAttribute("data-activation-count"),
               "1",
             );
           }
@@ -84,7 +92,8 @@ function checkoutDocument(layout: CheckoutLayout): string {
     layout === "expanded" ||
     layout === "framed-accordion" ||
     layout === "iframe" ||
-    layout === "late-frame"
+    layout === "late-frame" ||
+    layout === "replaced-field-frame"
       ? ""
       : `<button id="pay-with-card" type="button"${
           layout === "accordion"
@@ -149,6 +158,29 @@ function checkoutDocument(layout: CheckoutLayout): string {
           }, { once: true });
         });
         host.append(cardFrame);
+      } else if (document.body.dataset.layout === "replaced-field-frame") {
+        document.body.dataset.activationCount = "0";
+        const payWithCard = document.createElement("button");
+        payWithCard.type = "button";
+        payWithCard.textContent = "Pay with card";
+        const initialFieldsFrame = document.createElement("iframe");
+        initialFieldsFrame.title = "Initial hidden card fields";
+        initialFieldsFrame.srcdoc = ${JSON.stringify(
+          `<div hidden>${CARD_FIELDS}</div>`,
+        )};
+        payWithCard.addEventListener("click", () => {
+          document.body.dataset.activationCount = String(
+            Number(document.body.dataset.activationCount) + 1
+          );
+          initialFieldsFrame.remove();
+          window.requestAnimationFrame(() => {
+            const replacementFieldsFrame = document.createElement("iframe");
+            replacementFieldsFrame.title = "Replacement card fields";
+            replacementFieldsFrame.srcdoc = cardFields;
+            host.append(replacementFieldsFrame);
+          });
+        }, { once: true });
+        host.append(payWithCard, initialFieldsFrame);
       } else if (document.body.dataset.layout === "framed-accordion") {
         for (let index = 0; index < 32; index += 1) {
           const unrelatedFrame = document.createElement("iframe");

--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -29,6 +29,11 @@ interface StripeFrameState {
   readonly payWithCard: StripeLocatorState;
 }
 
+interface StripeCardMethodControl {
+  readonly activation: "click" | "dispatch";
+  readonly locator: Locator;
+}
+
 export interface StripeCheckoutState {
   readonly frames: readonly StripeFrameState[];
   readonly pageOrigin: string;
@@ -156,20 +161,26 @@ async function findMatchingFrameLocator(
   return candidates.find((_, index) => matches[index])?.locator ?? null;
 }
 
-async function findPayWithCard(page: Page): Promise<Locator | null> {
+async function findPayWithCard(
+  page: Page,
+): Promise<StripeCardMethodControl | null> {
   const visiblePayWithCard = await findMatchingFrameLocator(
     page,
     (frame) => payWithCardLocator(frame).filter({ visible: true }).first(),
     async (locator) => await locator.isVisible(),
   );
-  return (
-    visiblePayWithCard ??
-    (await findMatchingFrameLocator(
-      page,
-      (frame) => payWithCardLocator(frame).first(),
-      async (locator) => (await locator.count()) > 0,
-    ))
+  if (visiblePayWithCard) {
+    return { activation: "click", locator: visiblePayWithCard };
+  }
+
+  const attachedPayWithCard = await findMatchingFrameLocator(
+    page,
+    (frame) => payWithCardLocator(frame).first(),
+    async (locator) => (await locator.count()) > 0,
   );
+  return attachedPayWithCard
+    ? { activation: "dispatch", locator: attachedPayWithCard }
+    : null;
 }
 
 async function findVisibleStripeField(
@@ -206,7 +217,7 @@ async function fillVisibleStripeField(
 }
 
 async function activateCardMethod(
-  payWithCard: Locator,
+  control: StripeCardMethodControl,
   deadline: number,
 ): Promise<void> {
   const timeout = deadline - Date.now();
@@ -214,15 +225,15 @@ async function activateCardMethod(
     return;
   }
 
-  if (await payWithCard.isVisible()) {
-    await payWithCard.click({ timeout });
+  if (control.activation === "click") {
+    await control.locator.click({ timeout });
     return;
   }
 
   // Stripe's accordion layout keeps the Card control attached with a
   // zero-height box. It cannot pass normal actionability checks, so this is
   // the only layout that uses synthetic activation.
-  await payWithCard.dispatchEvent("click", undefined, { timeout });
+  await control.locator.dispatchEvent("click", undefined, { timeout });
 }
 
 async function fillCardNumber(page: Page, value: string): Promise<void> {

--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -79,6 +79,13 @@ function stripeFieldLocator(
     .or(frame.locator(`input[name="${field.name}"]`));
 }
 
+function visibleStripeFieldLocator(
+  frame: Frame,
+  field: StripeFieldDefinition,
+): Locator {
+  return stripeFieldLocator(frame, field).filter({ visible: true }).first();
+}
+
 function payWithCardLocator(frame: Frame): Locator {
   return frame.getByRole("button", { name: /pay with card/i });
 }
@@ -96,8 +103,8 @@ async function waitForVisibleStripeField(
   const timeout = Math.min(FIELD_DISCOVERY_WINDOW_MS, remaining);
   const frames = page.frames();
   const candidates = frames.map(async (frame): Promise<Locator> => {
-    const locator = stripeFieldLocator(frame, field).first();
-    await locator.waitFor({ state: "visible", timeout });
+    const locator = visibleStripeFieldLocator(frame, field);
+    await locator.waitFor({ state: "attached", timeout });
     return locator;
   });
 
@@ -150,10 +157,18 @@ async function findMatchingFrameLocator(
 }
 
 async function findPayWithCard(page: Page): Promise<Locator | null> {
-  return await findMatchingFrameLocator(
+  const visiblePayWithCard = await findMatchingFrameLocator(
     page,
-    (frame) => payWithCardLocator(frame).first(),
-    async (locator) => (await locator.count()) > 0,
+    (frame) => payWithCardLocator(frame).filter({ visible: true }).first(),
+    async (locator) => await locator.isVisible(),
+  );
+  return (
+    visiblePayWithCard ??
+    (await findMatchingFrameLocator(
+      page,
+      (frame) => payWithCardLocator(frame).first(),
+      async (locator) => (await locator.count()) > 0,
+    ))
   );
 }
 
@@ -163,8 +178,8 @@ async function findVisibleStripeField(
 ): Promise<Locator | null> {
   return await findMatchingFrameLocator(
     page,
-    (frame) => stripeFieldLocator(frame, field).first(),
-    async (locator) => await locator.isVisible(),
+    (frame) => visibleStripeFieldLocator(frame, field),
+    async (locator) => (await locator.count()) > 0,
   );
 }
 
@@ -293,7 +308,7 @@ async function locatorState(locator: Locator): Promise<StripeLocatorState> {
   const count = await locator.count();
   return {
     count,
-    visible: count > 0 && (await locator.first().isVisible()),
+    visible: count > 0 && (await locator.filter({ visible: true }).count()) > 0,
   };
 }
 

--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -94,7 +94,8 @@ async function waitForVisibleStripeField(
   }
 
   const timeout = Math.min(FIELD_DISCOVERY_WINDOW_MS, remaining);
-  const candidates = page.frames().map(async (frame): Promise<Locator> => {
+  const frames = page.frames();
+  const candidates = frames.map(async (frame): Promise<Locator> => {
     const locator = stripeFieldLocator(frame, field).first();
     await locator.waitFor({ state: "visible", timeout });
     return locator;
@@ -108,40 +109,63 @@ async function waitForVisibleStripeField(
     }
 
     const failures: readonly unknown[] = error.errors;
-    const unexpectedFailure = failures.find(
-      (failure): failure is Error =>
-        failure instanceof Error && !(failure instanceof errors.TimeoutError),
+    const unexpectedFailureIndex = failures.findIndex(
+      (failure, index) =>
+        !(failure instanceof errors.TimeoutError) &&
+        !frameDetachedDuringDiscovery(page, frames[index]),
     );
-    if (unexpectedFailure) {
-      throw unexpectedFailure;
+    if (unexpectedFailureIndex >= 0) {
+      throw failures[unexpectedFailureIndex];
     }
     return null;
   }
 }
 
+function frameDetachedDuringDiscovery(page: Page, frame: Frame): boolean {
+  return !page.isClosed() && frame.isDetached();
+}
+
+async function findMatchingFrameLocator(
+  page: Page,
+  createLocator: (frame: Frame) => Locator,
+  isMatch: (locator: Locator) => Promise<boolean>,
+): Promise<Locator | null> {
+  const candidates = page.frames().map((frame) => ({
+    frame,
+    locator: createLocator(frame),
+  }));
+  const matches = await Promise.all(
+    candidates.map(async ({ frame, locator }): Promise<boolean> => {
+      try {
+        return await isMatch(locator);
+      } catch (error: unknown) {
+        if (frameDetachedDuringDiscovery(page, frame)) {
+          return false;
+        }
+        throw error;
+      }
+    }),
+  );
+  return candidates.find((_, index) => matches[index])?.locator ?? null;
+}
+
 async function findPayWithCard(page: Page): Promise<Locator | null> {
-  for (const frame of page.frames()) {
-    const locator = payWithCardLocator(frame);
-    if ((await locator.count()) > 0) {
-      return locator.first();
-    }
-  }
-  return null;
+  return await findMatchingFrameLocator(
+    page,
+    (frame) => payWithCardLocator(frame).first(),
+    async (locator) => (await locator.count()) > 0,
+  );
 }
 
 async function findVisibleStripeField(
   page: Page,
   field: StripeFieldDefinition,
 ): Promise<Locator | null> {
-  const locators = page
-    .frames()
-    .map((frame) => stripeFieldLocator(frame, field).first());
-  const visibility = await Promise.all(
-    locators.map(
-      async (locator): Promise<boolean> => await locator.isVisible(),
-    ),
+  return await findMatchingFrameLocator(
+    page,
+    (frame) => stripeFieldLocator(frame, field).first(),
+    async (locator) => await locator.isVisible(),
   );
-  return locators.find((_, index) => visibility[index]) ?? null;
 }
 
 async function fillVisibleStripeField(

--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -7,7 +7,7 @@ import {
 } from "@playwright/test";
 
 const FIELD_TIMEOUT_MS = 15_000;
-const LOCATOR_ATTEMPT_TIMEOUT_MS = 500;
+const FIELD_DISCOVERY_WINDOW_MS = 500;
 
 interface StripeFieldDefinition {
   readonly label: RegExp;
@@ -83,28 +83,40 @@ function payWithCardLocator(frame: Frame): Locator {
   return frame.getByRole("button", { name: /pay with card/i });
 }
 
-async function tryFillStripeField(
+async function waitForVisibleStripeField(
   page: Page,
   field: StripeFieldDefinition,
-  value: string,
   deadline: number,
-): Promise<boolean> {
-  for (const frame of page.frames()) {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) {
-      return false;
-    }
-    if (
-      await fillFirst(
-        stripeFieldLocator(frame, field),
-        value,
-        Math.min(LOCATOR_ATTEMPT_TIMEOUT_MS, remaining),
-      )
-    ) {
-      return true;
-    }
+): Promise<Locator | null> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    return null;
   }
-  return false;
+
+  const timeout = Math.min(FIELD_DISCOVERY_WINDOW_MS, remaining);
+  const candidates = page.frames().map(async (frame): Promise<Locator> => {
+    const locator = stripeFieldLocator(frame, field).first();
+    await locator.waitFor({ state: "visible", timeout });
+    return locator;
+  });
+
+  try {
+    return await Promise.any(candidates);
+  } catch (error: unknown) {
+    if (!(error instanceof AggregateError)) {
+      throw error;
+    }
+
+    const failures: readonly unknown[] = error.errors;
+    const unexpectedFailure = failures.find(
+      (failure): failure is Error =>
+        failure instanceof Error && !(failure instanceof errors.TimeoutError),
+    );
+    if (unexpectedFailure) {
+      throw unexpectedFailure;
+    }
+    return null;
+  }
 }
 
 async function findPayWithCard(page: Page): Promise<Locator | null> {
@@ -121,13 +133,37 @@ async function findVisibleStripeField(
   page: Page,
   field: StripeFieldDefinition,
 ): Promise<Locator | null> {
-  for (const frame of page.frames()) {
-    const locator = stripeFieldLocator(frame, field).first();
-    if (await locator.isVisible()) {
-      return locator;
-    }
+  const locators = page
+    .frames()
+    .map((frame) => stripeFieldLocator(frame, field).first());
+  const visibility = await Promise.all(
+    locators.map(
+      async (locator): Promise<boolean> => await locator.isVisible(),
+    ),
+  );
+  return locators.find((_, index) => visibility[index]) ?? null;
+}
+
+async function fillVisibleStripeField(
+  page: Page,
+  field: StripeFieldDefinition,
+  locator: Locator,
+  value: string,
+  deadline: number,
+): Promise<void> {
+  const timeout = deadline - Date.now();
+  if (timeout <= 0) {
+    throw await stripeFieldError(page, field);
   }
-  return null;
+
+  try {
+    await locator.fill(value, { timeout });
+  } catch (error: unknown) {
+    if (error instanceof errors.TimeoutError) {
+      throw await stripeFieldError(page, field);
+    }
+    throw error;
+  }
 }
 
 async function activateCardMethod(
@@ -160,17 +196,14 @@ async function fillCardNumber(page: Page, value: string): Promise<void> {
       CARD_NUMBER_FIELD,
     );
     if (visibleCardNumber) {
-      const remaining = deadline - Date.now();
-      if (
-        remaining > 0 &&
-        (await fillFirst(
-          visibleCardNumber,
-          value,
-          Math.min(LOCATOR_ATTEMPT_TIMEOUT_MS, remaining),
-        ))
-      ) {
-        return;
-      }
+      await fillVisibleStripeField(
+        page,
+        CARD_NUMBER_FIELD,
+        visibleCardNumber,
+        value,
+        deadline,
+      );
+      return;
     }
 
     if (!visibleCardNumber && !cardMethodActivated) {
@@ -182,7 +215,19 @@ async function fillCardNumber(page: Page, value: string): Promise<void> {
       }
     }
 
-    if (await tryFillStripeField(page, CARD_NUMBER_FIELD, value, deadline)) {
+    const discoveredCardNumber = await waitForVisibleStripeField(
+      page,
+      CARD_NUMBER_FIELD,
+      deadline,
+    );
+    if (discoveredCardNumber) {
+      await fillVisibleStripeField(
+        page,
+        CARD_NUMBER_FIELD,
+        discoveredCardNumber,
+        value,
+        deadline,
+      );
       return;
     }
   }
@@ -198,7 +243,11 @@ async function fillStripeField(
   const deadline = Date.now() + FIELD_TIMEOUT_MS;
 
   while (Date.now() < deadline) {
-    if (await tryFillStripeField(page, field, value, deadline)) {
+    const visibleField =
+      (await findVisibleStripeField(page, field)) ??
+      (await waitForVisibleStripeField(page, field, deadline));
+    if (visibleField) {
+      await fillVisibleStripeField(page, field, visibleField, value, deadline);
       return;
     }
   }

--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -379,17 +379,49 @@ async function fillCardNumber(
   );
   const payWithCard = await findPayWithCard(page);
   if (payWithCard) {
-    if (attachedCardNumber) {
-      await activateCardMethod(payWithCard, deadline);
-      if (await fillLocatedStripeField(attachedCardNumber, value, deadline)) {
-        return attachedCardNumber;
-      }
-      throw await stripeFieldError(page, CARD_NUMBER_FIELD);
-    }
-
     const baseline = await createStripeFrameBaseline(payWithCard.frame);
     try {
       await activateCardMethod(payWithCard, deadline);
+      if (attachedCardNumber) {
+        const visibleAfterActivation = await findStripeField(
+          page,
+          CARD_NUMBER_FIELD,
+          "visible",
+        );
+        if (
+          visibleAfterActivation &&
+          (await fillLocatedStripeField(
+            visibleAfterActivation,
+            value,
+            deadline,
+          ))
+        ) {
+          return visibleAfterActivation;
+        }
+
+        try {
+          if (
+            await fillLocatedStripeField(attachedCardNumber, value, deadline)
+          ) {
+            return attachedCardNumber;
+          }
+          throw await stripeFieldError(page, CARD_NUMBER_FIELD);
+        } catch (error: unknown) {
+          if (!attachedCardNumber.frame.isDetached()) {
+            throw error;
+          }
+          // Stripe replaced the exact field frame during Card activation.
+          // Transfer ownership to the newly attached descendant once; do not
+          // replay activation or retry the detached locator.
+          return await fillRevealedCardNumber(
+            page,
+            payWithCard,
+            baseline,
+            value,
+            deadline,
+          );
+        }
+      }
       return await fillRevealedCardNumber(
         page,
         payWithCard,

--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -117,6 +117,19 @@ async function findPayWithCard(page: Page): Promise<Locator | null> {
   return null;
 }
 
+async function findVisibleStripeField(
+  page: Page,
+  field: StripeFieldDefinition,
+): Promise<Locator | null> {
+  for (const frame of page.frames()) {
+    const locator = stripeFieldLocator(frame, field).first();
+    if (await locator.isVisible()) {
+      return locator;
+    }
+  }
+  return null;
+}
+
 async function activateCardMethod(
   payWithCard: Locator,
   deadline: number,
@@ -142,16 +155,35 @@ async function fillCardNumber(page: Page, value: string): Promise<void> {
   let cardMethodActivated = false;
 
   while (Date.now() < deadline) {
-    if (await tryFillStripeField(page, CARD_NUMBER_FIELD, value, deadline)) {
-      return;
+    const visibleCardNumber = await findVisibleStripeField(
+      page,
+      CARD_NUMBER_FIELD,
+    );
+    if (visibleCardNumber) {
+      const remaining = deadline - Date.now();
+      if (
+        remaining > 0 &&
+        (await fillFirst(
+          visibleCardNumber,
+          value,
+          Math.min(LOCATOR_ATTEMPT_TIMEOUT_MS, remaining),
+        ))
+      ) {
+        return;
+      }
     }
 
-    if (!cardMethodActivated) {
+    if (!visibleCardNumber && !cardMethodActivated) {
       const payWithCard = await findPayWithCard(page);
       if (payWithCard) {
         await activateCardMethod(payWithCard, deadline);
         cardMethodActivated = true;
+        continue;
       }
+    }
+
+    if (await tryFillStripeField(page, CARD_NUMBER_FIELD, value, deadline)) {
+      return;
     }
   }
 

--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -1,4 +1,57 @@
-import { expect, type Locator, type Page } from "@playwright/test";
+import {
+  errors,
+  expect,
+  type Frame,
+  type Locator,
+  type Page,
+} from "@playwright/test";
+
+const FIELD_TIMEOUT_MS = 15_000;
+const LOCATOR_ATTEMPT_TIMEOUT_MS = 500;
+
+interface StripeFieldDefinition {
+  readonly label: RegExp;
+  readonly name: string;
+  readonly placeholder: RegExp;
+}
+
+interface StripeLocatorState {
+  readonly count: number;
+  readonly visible: boolean;
+}
+
+interface StripeFrameState {
+  readonly cardCvc: StripeLocatorState;
+  readonly cardExpiry: StripeLocatorState;
+  readonly cardNumber: StripeLocatorState;
+  readonly main: boolean;
+  readonly origin: string;
+  readonly payWithCard: StripeLocatorState;
+}
+
+export interface StripeCheckoutState {
+  readonly frames: readonly StripeFrameState[];
+  readonly pageOrigin: string;
+  readonly title: string;
+}
+
+const CARD_NUMBER_FIELD: StripeFieldDefinition = {
+  label: /card number/i,
+  name: "cardNumber",
+  placeholder: /1234 1234 1234 1234/i,
+};
+
+const CARD_EXPIRY_FIELD: StripeFieldDefinition = {
+  label: /expiration|expiry/i,
+  name: "cardExpiry",
+  placeholder: /MM\s*\/\s*YY/i,
+};
+
+const CARD_CVC_FIELD: StripeFieldDefinition = {
+  label: /security code|cvc/i,
+  name: "cardCvc",
+  placeholder: /CVC/i,
+};
 
 async function fillFirst(
   locator: Locator,
@@ -8,49 +61,173 @@ async function fillFirst(
   try {
     await locator.first().fill(value, { timeout });
     return true;
-  } catch {
-    return false;
+  } catch (error: unknown) {
+    if (error instanceof errors.TimeoutError) {
+      return false;
+    }
+    throw error;
   }
 }
 
-async function fillStripeFrameField(
+function stripeFieldLocator(
+  frame: Frame,
+  field: StripeFieldDefinition,
+): Locator {
+  return frame
+    .getByLabel(field.label)
+    .or(frame.getByPlaceholder(field.placeholder))
+    .or(frame.locator(`input[name="${field.name}"]`));
+}
+
+function payWithCardLocator(frame: Frame): Locator {
+  return frame.getByRole("button", { name: /pay with card/i });
+}
+
+async function tryFillStripeField(
   page: Page,
-  fallbackPlaceholder: RegExp,
+  field: StripeFieldDefinition,
   value: string,
+  deadline: number,
 ): Promise<boolean> {
-  const deadline = Date.now() + 10_000;
-
-  while (Date.now() < deadline) {
-    for (const frame of page.frames()) {
-      if (
-        await fillFirst(frame.getByPlaceholder(fallbackPlaceholder), value, 500)
-      ) {
-        return true;
-      }
+  for (const frame of page.frames()) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      return false;
     }
+    if (
+      await fillFirst(
+        stripeFieldLocator(frame, field),
+        value,
+        Math.min(LOCATOR_ATTEMPT_TIMEOUT_MS, remaining),
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
 
-    await page.waitForTimeout(250);
+async function findPayWithCard(page: Page): Promise<Locator | null> {
+  for (const frame of page.frames()) {
+    const locator = payWithCardLocator(frame);
+    if ((await locator.count()) > 0) {
+      return locator.first();
+    }
+  }
+  return null;
+}
+
+async function activateCardMethod(
+  payWithCard: Locator,
+  deadline: number,
+): Promise<void> {
+  const timeout = deadline - Date.now();
+  if (timeout <= 0) {
+    return;
   }
 
-  return false;
+  if (await payWithCard.isVisible()) {
+    await payWithCard.click({ timeout });
+    return;
+  }
+
+  // Stripe's accordion layout keeps the Card control attached with a
+  // zero-height box. It cannot pass normal actionability checks, so this is
+  // the only layout that uses synthetic activation.
+  await payWithCard.dispatchEvent("click", undefined, { timeout });
+}
+
+async function fillCardNumber(page: Page, value: string): Promise<void> {
+  const deadline = Date.now() + FIELD_TIMEOUT_MS;
+  let cardMethodActivated = false;
+
+  while (Date.now() < deadline) {
+    if (await tryFillStripeField(page, CARD_NUMBER_FIELD, value, deadline)) {
+      return;
+    }
+
+    if (!cardMethodActivated) {
+      const payWithCard = await findPayWithCard(page);
+      if (payWithCard) {
+        await activateCardMethod(payWithCard, deadline);
+        cardMethodActivated = true;
+      }
+    }
+  }
+
+  throw await stripeFieldError(page, CARD_NUMBER_FIELD);
 }
 
 async function fillStripeField(
   page: Page,
-  locator: Locator,
-  fallbackPlaceholder: RegExp,
+  field: StripeFieldDefinition,
   value: string,
 ): Promise<void> {
-  if (await fillFirst(locator, value)) {
-    return;
-  }
-  if (await fillStripeFrameField(page, fallbackPlaceholder, value)) {
-    return;
+  const deadline = Date.now() + FIELD_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    if (await tryFillStripeField(page, field, value, deadline)) {
+      return;
+    }
   }
 
-  throw new Error(
-    `Unable to fill Stripe field with placeholder ${fallbackPlaceholder}`,
+  throw await stripeFieldError(page, field);
+}
+
+async function stripeFieldError(
+  page: Page,
+  field: StripeFieldDefinition,
+): Promise<Error> {
+  const state = await collectStripeCheckoutState(page).catch(() => null);
+  return new Error(
+    `Unable to fill Stripe field ${field.name}; state=${state ? JSON.stringify(state) : "unavailable"}`,
   );
+}
+
+async function locatorState(locator: Locator): Promise<StripeLocatorState> {
+  const count = await locator.count();
+  return {
+    count,
+    visible: count > 0 && (await locator.first().isVisible()),
+  };
+}
+
+function sanitizedOrigin(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return "unavailable";
+  }
+}
+
+export async function collectStripeCheckoutState(
+  page: Page,
+): Promise<StripeCheckoutState> {
+  const mainFrame = page.mainFrame();
+  const frames = await Promise.all(
+    page.frames().map(async (frame): Promise<StripeFrameState> => {
+      const [cardNumber, cardExpiry, cardCvc, payWithCard] = await Promise.all([
+        locatorState(stripeFieldLocator(frame, CARD_NUMBER_FIELD)),
+        locatorState(stripeFieldLocator(frame, CARD_EXPIRY_FIELD)),
+        locatorState(stripeFieldLocator(frame, CARD_CVC_FIELD)),
+        locatorState(payWithCardLocator(frame)),
+      ]);
+      return {
+        cardCvc,
+        cardExpiry,
+        cardNumber,
+        main: frame === mainFrame,
+        origin: sanitizedOrigin(frame.url()),
+        payWithCard,
+      };
+    }),
+  );
+
+  return {
+    frames,
+    pageOrigin: sanitizedOrigin(page.url()),
+    title: await page.title(),
+  };
 }
 
 async function disableLinkSaveInfo(page: Page): Promise<void> {
@@ -63,48 +240,6 @@ async function disableLinkSaveInfo(page: Page): Promise<void> {
   }
 }
 
-// Stripe Checkout serves three card-entry layouts, and which one a run gets
-// depends on the browser and on the payment methods Stripe resolves for the
-// detected locale:
-//   1. expanded    - no toggle at all, card fields are already present
-//   2. wallet      - a visible "Pay with card" toggle collapsing the card form
-//   3. accordion   - a payment-method picker whose "Pay with card" entry is in
-//                    the DOM with a zero-height box, so it is not "visible"
-// Waiting for the toggle unconditionally fails layout 1, and gating the click
-// on visibility skips layout 3. Attachment is the signal that covers all three:
-// `dispatchEvent` bypasses actionability checks, so it drives the accordion
-// entry just as well as the wallet toggle.
-async function revealCardForm(page: Page, cardNumber: Locator): Promise<void> {
-  const payWithCard = page
-    .getByRole("button", { name: /pay with card/i })
-    .first();
-
-  // Settle on whichever layout Stripe rendered before deciding, so layout 1
-  // proceeds as soon as the card fields exist instead of burning the whole
-  // timeout waiting for a toggle that will never appear.
-  await payWithCard
-    .or(cardNumber)
-    .first()
-    .waitFor({ state: "attached", timeout: 10_000 })
-    .catch(() => {});
-
-  // Layout 1 has nothing to click. Layouts 2 and 3 both need exactly one
-  // dispatched click before the card fields render.
-  if ((await payWithCard.count()) === 0) {
-    return;
-  }
-  if (
-    await cardNumber
-      .first()
-      .isVisible()
-      .catch(() => false)
-  ) {
-    return;
-  }
-
-  await payWithCard.dispatchEvent("click", undefined, { timeout: 10_000 });
-}
-
 export async function fillStripeCheckout(page: Page): Promise<void> {
   await expect(page).toHaveURL(/checkout\.stripe\.com/, { timeout: 30_000 });
 
@@ -114,37 +249,9 @@ export async function fillStripeCheckout(page: Page): Promise<void> {
   );
   await disableLinkSaveInfo(page);
 
-  const cardNumber = page
-    .getByLabel(/card number/i)
-    .or(page.getByPlaceholder(/1234 1234 1234 1234/i))
-    .or(page.locator('input[name="cardNumber"]'));
-
-  await revealCardForm(page, cardNumber);
-
-  await fillStripeField(
-    page,
-    cardNumber,
-    /1234 1234 1234 1234/i,
-    "4242424242424242",
-  );
-  await fillStripeField(
-    page,
-    page
-      .getByLabel(/expiration|expiry/i)
-      .or(page.getByPlaceholder(/MM\s*\/\s*YY/i))
-      .or(page.locator('input[name="cardExpiry"]')),
-    /MM\s*\/\s*YY/i,
-    "1234",
-  );
-  await fillStripeField(
-    page,
-    page
-      .getByLabel(/security code|cvc/i)
-      .or(page.getByPlaceholder(/CVC/i))
-      .or(page.locator('input[name="cardCvc"]')),
-    /CVC/i,
-    "123",
-  );
+  await fillCardNumber(page, "4242424242424242");
+  await fillStripeField(page, CARD_EXPIRY_FIELD, "1234");
+  await fillStripeField(page, CARD_CVC_FIELD, "123");
   await fillFirst(
     page
       .getByLabel(/cardholder name|name on card/i)

--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -6,8 +6,7 @@ import {
   type Page,
 } from "@playwright/test";
 
-const FIELD_TIMEOUT_MS = 15_000;
-const FIELD_DISCOVERY_WINDOW_MS = 500;
+const FIELD_TIMEOUT_MS = 10_000;
 
 interface StripeFieldDefinition {
   readonly label: RegExp;
@@ -29,9 +28,18 @@ interface StripeFrameState {
   readonly payWithCard: StripeLocatorState;
 }
 
-interface StripeCardMethodControl {
-  readonly activation: "click" | "dispatch";
+interface LocatedStripeControl {
+  readonly frame: Frame;
   readonly locator: Locator;
+}
+
+interface StripeCardMethodControl extends LocatedStripeControl {
+  readonly activation: "click" | "dispatch";
+}
+
+interface StripeFrameBaseline {
+  readonly addedFrames: Locator;
+  readonly attributeName: string;
 }
 
 export interface StripeCheckoutState {
@@ -57,6 +65,8 @@ const CARD_CVC_FIELD: StripeFieldDefinition = {
   name: "cardCvc",
   placeholder: /CVC/i,
 };
+
+let stripeFrameBaselineSequence = 0;
 
 async function fillFirst(
   locator: Locator,
@@ -95,122 +105,128 @@ function payWithCardLocator(frame: Frame): Locator {
   return frame.getByRole("button", { name: /pay with card/i });
 }
 
-async function waitForVisibleStripeField(
-  page: Page,
-  field: StripeFieldDefinition,
-  deadline: number,
-): Promise<Locator | null> {
-  const remaining = deadline - Date.now();
-  if (remaining <= 0) {
-    return null;
-  }
-
-  const timeout = Math.min(FIELD_DISCOVERY_WINDOW_MS, remaining);
-  const frames = page.frames();
-  const candidates = frames.map(async (frame): Promise<Locator> => {
-    const locator = visibleStripeFieldLocator(frame, field);
-    await locator.waitFor({ state: "attached", timeout });
-    return locator;
-  });
-
-  try {
-    return await Promise.any(candidates);
-  } catch (error: unknown) {
-    if (!(error instanceof AggregateError)) {
-      throw error;
-    }
-
-    const failures: readonly unknown[] = error.errors;
-    const unexpectedFailureIndex = failures.findIndex(
-      (failure, index) =>
-        !(failure instanceof errors.TimeoutError) &&
-        !frameDetachedDuringDiscovery(page, frames[index]),
-    );
-    if (unexpectedFailureIndex >= 0) {
-      throw failures[unexpectedFailureIndex];
-    }
-    return null;
-  }
-}
-
 function frameDetachedDuringDiscovery(page: Page, frame: Frame): boolean {
   return !page.isClosed() && frame.isDetached();
 }
 
-async function findMatchingFrameLocator(
+async function locatorCount(
   page: Page,
-  createLocator: (frame: Frame) => Locator,
-  isMatch: (locator: Locator) => Promise<boolean>,
-): Promise<Locator | null> {
-  const candidates = page.frames().map((frame) => ({
-    frame,
-    locator: createLocator(frame),
-  }));
-  const matches = await Promise.all(
-    candidates.map(async ({ frame, locator }): Promise<boolean> => {
-      try {
-        return await isMatch(locator);
-      } catch (error: unknown) {
-        if (frameDetachedDuringDiscovery(page, frame)) {
-          return false;
-        }
-        throw error;
-      }
-    }),
-  );
-  return candidates.find((_, index) => matches[index])?.locator ?? null;
+  frame: Frame,
+  locator: Locator,
+): Promise<number> {
+  try {
+    return await locator.count();
+  } catch (error: unknown) {
+    if (frameDetachedDuringDiscovery(page, frame)) {
+      return 0;
+    }
+    throw error;
+  }
+}
+
+async function locatorIsVisible(
+  page: Page,
+  frame: Frame,
+  locator: Locator,
+): Promise<boolean> {
+  try {
+    return await locator.isVisible();
+  } catch (error: unknown) {
+    if (frameDetachedDuringDiscovery(page, frame)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function findStripeFieldInFrames(
+  page: Page,
+  frames: readonly Frame[],
+  field: StripeFieldDefinition,
+  visibility: "attached" | "visible",
+): Promise<LocatedStripeControl | null> {
+  for (const frame of frames) {
+    const locator = stripeFieldLocator(frame, field).first();
+    if ((await locatorCount(page, frame, locator)) === 0) {
+      continue;
+    }
+    if (
+      visibility === "visible" &&
+      !(await locatorIsVisible(page, frame, locator))
+    ) {
+      continue;
+    }
+    return { frame, locator };
+  }
+  return null;
+}
+
+async function findStripeField(
+  page: Page,
+  field: StripeFieldDefinition,
+  visibility: "attached" | "visible",
+): Promise<LocatedStripeControl | null> {
+  return await findStripeFieldInFrames(page, page.frames(), field, visibility);
 }
 
 async function findPayWithCard(
   page: Page,
 ): Promise<StripeCardMethodControl | null> {
-  const visiblePayWithCard = await findMatchingFrameLocator(
-    page,
-    (frame) => payWithCardLocator(frame).filter({ visible: true }).first(),
-    async (locator) => await locator.isVisible(),
-  );
-  if (visiblePayWithCard) {
-    return { activation: "click", locator: visiblePayWithCard };
+  for (const frame of page.frames()) {
+    const locator = payWithCardLocator(frame).first();
+    if (
+      (await locatorCount(page, frame, locator)) > 0 &&
+      (await locatorIsVisible(page, frame, locator))
+    ) {
+      return { activation: "click", frame, locator };
+    }
   }
 
-  const attachedPayWithCard = await findMatchingFrameLocator(
-    page,
-    (frame) => payWithCardLocator(frame).first(),
-    async (locator) => (await locator.count()) > 0,
-  );
-  return attachedPayWithCard
-    ? { activation: "dispatch", locator: attachedPayWithCard }
-    : null;
+  for (const frame of page.frames()) {
+    const locator = payWithCardLocator(frame).first();
+    if ((await locatorCount(page, frame, locator)) > 0) {
+      return { activation: "dispatch", frame, locator };
+    }
+  }
+  return null;
 }
 
-async function findVisibleStripeField(
-  page: Page,
-  field: StripeFieldDefinition,
-): Promise<Locator | null> {
-  return await findMatchingFrameLocator(
-    page,
-    (frame) => visibleStripeFieldLocator(frame, field),
-    async (locator) => (await locator.count()) > 0,
-  );
+async function createStripeFrameBaseline(
+  frame: Frame,
+): Promise<StripeFrameBaseline> {
+  stripeFrameBaselineSequence += 1;
+  const attributeName =
+    `data-vm0-stripe-frame-baseline-${Date.now()}-` +
+    stripeFrameBaselineSequence;
+  await frame.locator("iframe").evaluateAll((elements, attribute) => {
+    for (const element of elements) {
+      element.setAttribute(attribute, "");
+    }
+  }, attributeName);
+  return {
+    addedFrames: frame.locator(`iframe:not([${attributeName}])`),
+    attributeName,
+  };
 }
 
-async function fillVisibleStripeField(
-  page: Page,
-  field: StripeFieldDefinition,
-  locator: Locator,
-  value: string,
-  deadline: number,
+async function removeStripeFrameBaseline(
+  frame: Frame,
+  baseline: StripeFrameBaseline,
 ): Promise<void> {
-  const timeout = deadline - Date.now();
-  if (timeout <= 0) {
-    throw await stripeFieldError(page, field);
+  if (frame.isDetached()) {
+    return;
   }
-
   try {
-    await locator.fill(value, { timeout });
+    await frame
+      .locator(`iframe[${baseline.attributeName}]`)
+      .evaluateAll((elements, attribute) => {
+        for (const element of elements) {
+          element.removeAttribute(attribute);
+        }
+      }, baseline.attributeName);
   } catch (error: unknown) {
-    if (error instanceof errors.TimeoutError) {
-      throw await stripeFieldError(page, field);
+    if (frame.isDetached()) {
+      return;
     }
     throw error;
   }
@@ -220,11 +236,7 @@ async function activateCardMethod(
   control: StripeCardMethodControl,
   deadline: number,
 ): Promise<void> {
-  const timeout = deadline - Date.now();
-  if (timeout <= 0) {
-    return;
-  }
-
+  const timeout = remainingTimeout(deadline);
   if (control.activation === "click") {
     await control.locator.click({ timeout });
     return;
@@ -236,73 +248,201 @@ async function activateCardMethod(
   await control.locator.dispatchEvent("click", undefined, { timeout });
 }
 
-async function fillCardNumber(page: Page, value: string): Promise<void> {
+async function addedStripeFrames(
+  baseline: StripeFrameBaseline,
+): Promise<readonly Frame[]> {
+  const handles = await baseline.addedFrames.elementHandles();
+  const frames = await Promise.all(
+    handles.map(async (handle) => await handle.contentFrame()),
+  );
+  return frames.filter((frame): frame is Frame => frame !== null);
+}
+
+async function fillAddedStripeFrame(
+  page: Page,
+  baseline: StripeFrameBaseline,
+  value: string,
+  deadline: number,
+): Promise<LocatedStripeControl | null> {
+  const frames = await addedStripeFrames(baseline);
+  const locatedField =
+    (await findStripeFieldInFrames(
+      page,
+      frames,
+      CARD_NUMBER_FIELD,
+      "visible",
+    )) ??
+    (await findStripeFieldInFrames(
+      page,
+      frames,
+      CARD_NUMBER_FIELD,
+      "attached",
+    ));
+  if (locatedField) {
+    return (await fillLocatedStripeField(locatedField, value, deadline))
+      ? locatedField
+      : null;
+  }
+
+  if (frames.length !== 1) {
+    return null;
+  }
+  const frame = frames[0];
+  const candidate = {
+    frame,
+    locator: stripeFieldLocator(frame, CARD_NUMBER_FIELD).first(),
+  };
+  return (await fillLocatedStripeField(candidate, value, deadline))
+    ? candidate
+    : null;
+}
+
+async function fillRevealedCardNumber(
+  page: Page,
+  control: StripeCardMethodControl,
+  baseline: StripeFrameBaseline,
+  value: string,
+  deadline: number,
+): Promise<LocatedStripeControl> {
+  const immediateCardNumber = await findStripeField(
+    page,
+    CARD_NUMBER_FIELD,
+    "visible",
+  );
+  if (
+    immediateCardNumber &&
+    (await fillLocatedStripeField(immediateCardNumber, value, deadline))
+  ) {
+    return immediateCardNumber;
+  }
+
+  // Card activation has exactly two valid lifecycle outcomes: the semantic
+  // field becomes visible in the control's frame, or Stripe replaces/adds a
+  // child field frame. Wait once on that observable boundary.
+  try {
+    await visibleStripeFieldLocator(control.frame, CARD_NUMBER_FIELD)
+      .or(baseline.addedFrames)
+      .first()
+      .waitFor({ state: "attached", timeout: remainingTimeout(deadline) });
+  } catch (error: unknown) {
+    if (error instanceof errors.TimeoutError) {
+      throw await stripeFieldError(page, CARD_NUMBER_FIELD);
+    }
+    throw error;
+  }
+
+  const revealedCardNumber = await findStripeField(
+    page,
+    CARD_NUMBER_FIELD,
+    "visible",
+  );
+  if (
+    revealedCardNumber &&
+    (await fillLocatedStripeField(revealedCardNumber, value, deadline))
+  ) {
+    return revealedCardNumber;
+  }
+
+  const addedFrameCardNumber = await fillAddedStripeFrame(
+    page,
+    baseline,
+    value,
+    deadline,
+  );
+  if (addedFrameCardNumber) {
+    return addedFrameCardNumber;
+  }
+  throw await stripeFieldError(page, CARD_NUMBER_FIELD);
+}
+
+async function fillCardNumber(
+  page: Page,
+  value: string,
+): Promise<LocatedStripeControl> {
   const deadline = Date.now() + FIELD_TIMEOUT_MS;
-  let cardMethodActivated = false;
-
-  while (Date.now() < deadline) {
-    const visibleCardNumber = await findVisibleStripeField(
-      page,
-      CARD_NUMBER_FIELD,
-    );
-    if (visibleCardNumber) {
-      await fillVisibleStripeField(
-        page,
-        CARD_NUMBER_FIELD,
-        visibleCardNumber,
-        value,
-        deadline,
-      );
-      return;
+  const visibleCardNumber = await findStripeField(
+    page,
+    CARD_NUMBER_FIELD,
+    "visible",
+  );
+  if (visibleCardNumber) {
+    if (await fillLocatedStripeField(visibleCardNumber, value, deadline)) {
+      return visibleCardNumber;
     }
+    throw await stripeFieldError(page, CARD_NUMBER_FIELD);
+  }
 
-    if (!visibleCardNumber && !cardMethodActivated) {
-      const payWithCard = await findPayWithCard(page);
-      if (payWithCard) {
-        await activateCardMethod(payWithCard, deadline);
-        cardMethodActivated = true;
-        continue;
+  const attachedCardNumber = await findStripeField(
+    page,
+    CARD_NUMBER_FIELD,
+    "attached",
+  );
+  const payWithCard = await findPayWithCard(page);
+  if (payWithCard) {
+    if (attachedCardNumber) {
+      await activateCardMethod(payWithCard, deadline);
+      if (await fillLocatedStripeField(attachedCardNumber, value, deadline)) {
+        return attachedCardNumber;
       }
+      throw await stripeFieldError(page, CARD_NUMBER_FIELD);
     }
 
-    const discoveredCardNumber = await waitForVisibleStripeField(
-      page,
-      CARD_NUMBER_FIELD,
-      deadline,
-    );
-    if (discoveredCardNumber) {
-      await fillVisibleStripeField(
+    const baseline = await createStripeFrameBaseline(payWithCard.frame);
+    try {
+      await activateCardMethod(payWithCard, deadline);
+      return await fillRevealedCardNumber(
         page,
-        CARD_NUMBER_FIELD,
-        discoveredCardNumber,
+        payWithCard,
+        baseline,
         value,
         deadline,
       );
-      return;
+    } finally {
+      await removeStripeFrameBaseline(payWithCard.frame, baseline);
     }
   }
 
+  if (
+    attachedCardNumber &&
+    (await fillLocatedStripeField(attachedCardNumber, value, deadline))
+  ) {
+    return attachedCardNumber;
+  }
   throw await stripeFieldError(page, CARD_NUMBER_FIELD);
 }
 
 async function fillStripeField(
   page: Page,
+  preferredFrame: Frame,
   field: StripeFieldDefinition,
   value: string,
-): Promise<void> {
+): Promise<LocatedStripeControl> {
   const deadline = Date.now() + FIELD_TIMEOUT_MS;
-
-  while (Date.now() < deadline) {
-    const visibleField =
-      (await findVisibleStripeField(page, field)) ??
-      (await waitForVisibleStripeField(page, field, deadline));
-    if (visibleField) {
-      await fillVisibleStripeField(page, field, visibleField, value, deadline);
-      return;
-    }
+  const preferredFrames = preferredFrame.isDetached() ? [] : [preferredFrame];
+  const locatedField =
+    (await findStripeFieldInFrames(page, preferredFrames, field, "visible")) ??
+    (await findStripeFieldInFrames(page, preferredFrames, field, "attached")) ??
+    (await findStripeField(page, field, "visible")) ??
+    (await findStripeField(page, field, "attached"));
+  if (
+    locatedField &&
+    (await fillLocatedStripeField(locatedField, value, deadline))
+  ) {
+    return locatedField;
   }
-
   throw await stripeFieldError(page, field);
+}
+
+async function fillLocatedStripeField(
+  field: LocatedStripeControl,
+  value: string,
+  deadline: number,
+): Promise<boolean> {
+  return await fillFirst(field.locator, value, remainingTimeout(deadline));
+}
+
+function remainingTimeout(deadline: number): number {
+  return Math.max(1, deadline - Date.now());
 }
 
 async function stripeFieldError(
@@ -380,9 +520,14 @@ export async function fillStripeCheckout(page: Page): Promise<void> {
   );
   await disableLinkSaveInfo(page);
 
-  await fillCardNumber(page, "4242424242424242");
-  await fillStripeField(page, CARD_EXPIRY_FIELD, "1234");
-  await fillStripeField(page, CARD_CVC_FIELD, "123");
+  const cardNumber = await fillCardNumber(page, "4242424242424242");
+  const cardExpiry = await fillStripeField(
+    page,
+    cardNumber.frame,
+    CARD_EXPIRY_FIELD,
+    "1234",
+  );
+  await fillStripeField(page, cardExpiry.frame, CARD_CVC_FIELD, "123");
   await fillFirst(
     page
       .getByLabel(/cardholder name|name on card/i)

--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -162,18 +162,30 @@ async function captureStripeCheckoutFailure(
   const fileStem = target.fileName.replace(/\.json$/u, "");
   await mkdir(diagnosticDirectory, { recursive: true });
 
-  const state = await collectStripeCheckoutState(page);
-  await Promise.all([
-    writeFile(
+  const results = await Promise.allSettled([
+    writeStripeCheckoutState(
+      page,
       join(diagnosticDirectory, `${fileStem}.json`),
-      `${JSON.stringify(state, null, 2)}\n`,
-      { encoding: "utf8", mode: 0o600 },
     ),
     page.screenshot({
       fullPage: true,
       path: join(diagnosticDirectory, `${fileStem}.png`),
     }),
   ]);
+  if (!results.some((result) => result.status === "fulfilled")) {
+    throw new Error("Unable to capture any Stripe Checkout diagnostic");
+  }
+}
+
+async function writeStripeCheckoutState(
+  page: Page,
+  path: string,
+): Promise<void> {
+  const state = await collectStripeCheckoutState(page);
+  await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
 }
 
 function requiredEnvironmentVariable(name: string): string {

--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
-import { chromium } from "@playwright/test";
+import { chromium, type Page } from "@playwright/test";
 
 import {
   refreshClerkSessionToken,
@@ -14,7 +14,10 @@ import {
   startVideoOnboardingCheckout,
   waitForPaidOnboardingCompletion,
 } from "./lib/onboarding";
-import { fillStripeCheckout } from "./lib/stripe-checkout";
+import {
+  collectStripeCheckoutState,
+  fillStripeCheckout,
+} from "./lib/stripe-checkout";
 
 interface RunnerCredentialTarget {
   readonly email: string;
@@ -92,9 +95,7 @@ async function main(): Promise<void> {
           { activeOrganizationId: target.organizationId },
         );
         if (target.upgradeToPro) {
-          await startVideoOnboardingCheckout(page, { appUrl });
-          await fillStripeCheckout(page);
-          await waitForPaidOnboardingCompletion(page, { appUrl });
+          await completePaidOnboarding(page, target, appUrl, outputDirectory);
           clerkSessionToken = await refreshClerkSessionToken(page, {
             activeOrganizationId: target.organizationId,
           });
@@ -121,6 +122,58 @@ async function main(): Promise<void> {
   } finally {
     await browser.close();
   }
+}
+
+async function completePaidOnboarding(
+  page: Page,
+  target: RunnerCredentialTarget,
+  appUrl: string,
+  outputDirectory: string,
+): Promise<void> {
+  await startVideoOnboardingCheckout(page, { appUrl });
+  try {
+    await fillStripeCheckout(page);
+  } catch (error: unknown) {
+    try {
+      await captureStripeCheckoutFailure(page, target, outputDirectory);
+    } catch (diagnosticError: unknown) {
+      console.error("Unable to capture Stripe Checkout diagnostics", {
+        diagnosticErrorType:
+          diagnosticError instanceof Error
+            ? diagnosticError.name
+            : typeof diagnosticError,
+        target: target.fileName,
+      });
+    }
+    throw error;
+  }
+  await waitForPaidOnboardingCompletion(page, { appUrl });
+}
+
+async function captureStripeCheckoutFailure(
+  page: Page,
+  target: RunnerCredentialTarget,
+  outputDirectory: string,
+): Promise<void> {
+  const diagnosticDirectory = join(
+    outputDirectory,
+    "e2e-runner-checkout-diagnostics",
+  );
+  const fileStem = target.fileName.replace(/\.json$/u, "");
+  await mkdir(diagnosticDirectory, { recursive: true });
+
+  const state = await collectStripeCheckoutState(page);
+  await Promise.all([
+    writeFile(
+      join(diagnosticDirectory, `${fileStem}.json`),
+      `${JSON.stringify(state, null, 2)}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    ),
+    page.screenshot({
+      fullPage: true,
+      path: join(diagnosticDirectory, `${fileStem}.png`),
+    }),
+  ]);
 }
 
 function requiredEnvironmentVariable(name: string): string {


### PR DESCRIPTION
## Summary

- discover the exact semantic Stripe card controls across the main document and current frames without spending an action timeout on absent locators
- activate an actionable Card control with one real click, retain the zero-height accordion's one synthetic activation, and wait once on the observable owning-frame postcondition: the exact card field becomes visible or Stripe adds/replaces its child field iframe
- retain field ownership for expiry/CVC, and transfer it exactly once only when the previously matched card field frame is confirmed detached; activation and the detached locator are never replayed
- retain failure-only runner Checkout screenshots plus sanitized field/frame state JSON for one day, preserving either diagnostic independently
- exercise expanded, iframe, wallet, zero-height accordion, late field-frame, target field-frame replacement, and framed-accordion layouts through the exported helper in Chromium

This preserves the real Clerk, onboarding, organization, Stripe Checkout, billing, and credential-generation contracts. It adds no purchase retry, sleep, polling loop, timeout increase, forced action, skipped check, or weakened assertion.

## Root cause

The old helper scanned `page.frames()` serially and attempted a bounded `fill()` in every frame. Each unrelated frame could consume 500 ms before the intended Stripe frame was inspected, so enough frames exhausted the shared deadline even when the exact target field was already attached and visible. A deterministic Chromium reproduction on the earlier PR head placed the correct framed fields after 32 unrelated frames: card-number activation succeeded, then expiry failed after 17.18 seconds while captured state showed all three intended fields as `count=1, visible=true`.

Card activation also lacked an owned lifecycle postcondition. Attachment of a control or iframe was treated as readiness even though Stripe may reveal a field asynchronously or replace its field iframe. The repaired helper performs immediate, non-waiting semantic discovery, executes Card activation once, and assigns the remaining action budget only to the matching field or the one lifecycle-owned replacement frame.

## Recurrence evidence

The same failure occurred across independent Checkout sessions, runner accounts, consumers, merge-group SHAs, and unrelated source PRs:

- [31672665112 / 94360807648](https://github.com/vm0-ai/vm0/actions/runs/31672665112/job/94360807648) — `runner-mock-claude`
- [31679632611 / 94382423785](https://github.com/vm0-ai/vm0/actions/runs/31679632611/job/94382423785) — `runner-real-codex`
- [31680082377 / 94383885225](https://github.com/vm0-ai/vm0/actions/runs/31680082377/job/94383885225) — `runner-real-codex`
- [31680899271 / 94386379379](https://github.com/vm0-ai/vm0/actions/runs/31680899271/job/94386379379) — `runner-real-codex`
- [31681225510 / 94387376761](https://github.com/vm0-ai/vm0/actions/runs/31681225510/job/94387376761) — `runner-real-claude`
- [31681546296 / 94388499730](https://github.com/vm0-ai/vm0/actions/runs/31681546296/job/94388499730) — `paid-onboarding`
- [31681967178 / 94389737735](https://github.com/vm0-ai/vm0/actions/runs/31681967178/job/94389737735) — `runner-mock-claude`
- [31681965779 / 94389957076](https://github.com/vm0-ai/vm0/actions/runs/31681965779/job/94389957076) — `paid-onboarding`

The invariant is successful Clerk authentication and arrival at `/onboarding`, followed about 34.6–35.5 seconds later by the same card-number field error. Adjacent queue runs provide a strong A/B: run 31681965779 failed paid-onboarding on SHA `e9027385`; run 31681967178 then used that SHA as its queue baseline and failed runner bootstrap instead. Failure location drifted across four runner-account positions and paid-onboarding while the other consumer passed.

## Local validation

- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` — 24/24 passing
- `cd e2e && pnpm exec tsx --test playwright/lib/stripe-checkout.test.ts` — five consecutive runs passing across all seven layouts, plus one final run after making replacement-frame ownership transfer explicit
- `cd turbo && pnpm format`
- targeted Prettier for both changed E2E files
- `cd turbo && pnpm turbo run lint --concurrency=1 --log-order grouped`
- `cd turbo && pnpm knip`
- all non-API/App package type checks, Platform App type checks, and API type checks
- `./.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `./.github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `./.github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `actionlint` 1.7.12 against all workflows
- `git diff --check`

The local shell-compatibility fixture could not execute because this container has no `/dev/fd`; the submitted-head Workflow Lint job passed it on Ubuntu.

## Preview validation

Mode C browser validation passed on head `f0b298e19d` using the deployments reported by the workflow:

- App: https://pr-26874-app.omby.ai (`9269a384.okou-app.pages.dev`)
- API: https://pr-26874-api.vm6.ai (`vm0-5jq3e29j9.vm6.ai`)
- fresh Clerk TEST sign-up and OTP; no onboarding bypass or feature-switch override
- public video onboarding reached a Stripe `cs_test_` Checkout whose Card method began collapsed
- one real `Pay with card` click exposed the exact fields; test-card submission returned to the same preview chat and ran the selected template prompt
- [browser report and screenshots](https://github.com/vm0-ai/vm0/pull/26874#issuecomment-5278588278)

## Submitted-head validation

- [Turbo run 31686593817](https://github.com/vm0-ai/vm0/actions/runs/31686593817) passed `cli-e2e-02-playwright`, all three paid runner-account Checkout sessions in `cli-e2e-03-runner-prepare`, runner bootstrap, 12/12 runner shards, cleanup, and `ci-gate-turbo`
- the one manual Checkout plus four submitted-head CI Checkout sessions provide five successful real preview sessions on the final head
- all submitted-head checks are terminal: 89 passed, 5 intentionally skipped, 0 failed, 0 pending

Closes #26866
