### PR TITLE
perf(nbd-cow): coalesce contiguous flush writes

### DIFF
--- a/crates/nbd-cow/Cargo.toml
+++ b/crates/nbd-cow/Cargo.toml
@@ -14,7 +14,7 @@ bench = ["dep:serde_json", "dep:tempfile"]
 [dependencies]
 bitvec = { workspace = true }
 libc = { workspace = true }
-nix = { workspace = true, features = ["fs", "socket"] }
+nix = { workspace = true, features = ["fs", "socket", "uio"] }
 serde_json = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -7,6 +7,7 @@
 
 use std::collections::BTreeMap;
 use std::fs::File;
+use std::io::{self, IoSlice};
 use std::ops::Range;
 use std::os::unix::fs::FileExt;
 use std::path::Path;
@@ -18,6 +19,8 @@ use bitvec::prelude::*;
 use crate::error::{NbdCowError, Result};
 
 mod bitmap;
+
+const MAX_WRITE_IOVECS: usize = libc::UIO_MAXIOV as usize;
 
 #[cfg(test)]
 pub(crate) use bitmap::bitmap_tmp_path_for;
@@ -360,8 +363,9 @@ impl CowLayer {
 
     /// Flush the write buffer to the COW file.
     ///
-    /// BTreeMap iterates in key order, giving sequential I/O for free.
-    /// On I/O failure, unwritten blocks are restored to the buffer so no data is lost.
+    /// Adjacent blocks are submitted in bounded positioned batches. On I/O
+    /// failure, the first incomplete block and all later blocks are restored
+    /// to the buffer so no data is lost.
     pub fn flush(&mut self) -> Result<()> {
         if self.write_buffer.is_empty() {
             return Ok(());
@@ -372,35 +376,81 @@ impl CowLayer {
             .cow_fd
             .take()
             .ok_or_else(|| NbdCowError::Io(std::io::Error::other("cow_fd missing after ensure")))?;
-        let result = self.flush_buffered(|offset, data| cow_fd.write_all_at(data, offset));
+        let result =
+            self.flush_buffered(|offset, buffers| write_block_batch_at(&cow_fd, offset, buffers));
         self.cow_fd = Some(cow_fd);
         result
     }
 
-    /// Drain `write_buffer` through `write_fn`. On failure, restores the failed
-    /// block and all unprocessed blocks to `write_buffer`, recomputes
-    /// `buffer_bytes`, and returns the error. Dirty bits are set only for blocks
-    /// the writer accepted.
+    /// Drain `write_buffer` through `write_fn` in contiguous batches. The
+    /// writer returns the number of bytes accepted from the concatenated
+    /// buffers. On failure, restores the first incomplete block and all
+    /// unprocessed blocks to `write_buffer`, recomputes `buffer_bytes`, and
+    /// returns the error. Dirty bits are set only for complete blocks.
     ///
-    /// The writer boundary is a closure so tests can cover partial-success-then-fail
-    /// at arbitrary index, which real-I/O injection (/dev/full, file seals,
-    /// RLIMIT_FSIZE) cannot reproduce.
+    /// The writer boundary is a closure so tests can cover short writes and
+    /// partial-success-then-fail at arbitrary byte offsets, which real-I/O
+    /// injection (/dev/full, file seals, RLIMIT_FSIZE) cannot reproduce.
     fn flush_buffered<W>(&mut self, mut write_fn: W) -> Result<()>
     where
-        W: FnMut(u64, &[u8]) -> std::io::Result<()>,
+        W: FnMut(u64, &[IoSlice<'_>]) -> io::Result<usize>,
     {
         let block_size = self.block_size;
-        let mut blocks = std::mem::take(&mut self.write_buffer).into_iter();
+        let mut blocks = std::mem::take(&mut self.write_buffer)
+            .into_iter()
+            .peekable();
+        let mut batch: Vec<(u64, Vec<u8>)> = Vec::new();
 
-        while let Some((block_idx, block_data)) = blocks.next() {
-            let offset = block_idx * block_size as u64;
-            if let Err(e) = write_fn(offset, &block_data) {
-                self.write_buffer.insert(block_idx, block_data);
-                self.write_buffer.extend(blocks);
-                self.buffer_bytes = self.write_buffer.len() * block_size;
-                return Err(e.into());
+        while let Some(first_block) = blocks.next() {
+            let first_block_idx = first_block.0;
+            let mut previous_block_idx = first_block_idx;
+            batch.push(first_block);
+            while batch.len() < MAX_WRITE_IOVECS {
+                let Some(next_block_idx) = blocks.peek().map(|(block_idx, _)| *block_idx) else {
+                    break;
+                };
+                if previous_block_idx.checked_add(1) != Some(next_block_idx) {
+                    break;
+                }
+                let Some(next_block) = blocks.next() else {
+                    break;
+                };
+                previous_block_idx = next_block_idx;
+                batch.push(next_block);
             }
-            self.set_dirty(block_idx);
+
+            let offset = first_block_idx * block_size as u64;
+            let batch_result = if let [(_, block_data)] = batch.as_slice() {
+                let mut single_buffer = [IoSlice::new(block_data)];
+                write_block_slices(offset, block_size, &mut single_buffer, &mut write_fn)
+            } else {
+                let mut buffers: Vec<IoSlice<'_>> = batch
+                    .iter()
+                    .map(|(_, block_data)| IoSlice::new(block_data))
+                    .collect();
+                write_block_slices(offset, block_size, buffers.as_mut_slice(), &mut write_fn)
+            };
+
+            match batch_result {
+                Ok(()) => {
+                    for (block_idx, _) in &batch {
+                        self.set_dirty(*block_idx);
+                    }
+                    batch.clear();
+                }
+                Err((error, first_incomplete_block)) => {
+                    for (position, (block_idx, block_data)) in batch.into_iter().enumerate() {
+                        if position < first_incomplete_block {
+                            self.set_dirty(block_idx);
+                        } else {
+                            self.write_buffer.insert(block_idx, block_data);
+                        }
+                    }
+                    self.write_buffer.extend(blocks);
+                    self.buffer_bytes = self.write_buffer.len() * block_size;
+                    return Err(error.into());
+                }
+            }
         }
 
         self.buffer_bytes = 0;
@@ -558,6 +608,55 @@ impl CowLayer {
     pub(crate) fn save_bitmap(&self, path: &Path) -> Result<()> {
         bitmap::save_bitmap(&self.dirty, path)
     }
+}
+
+fn write_block_slices<W>(
+    mut offset: u64,
+    block_size: usize,
+    buffers: &mut [IoSlice<'_>],
+    write_fn: &mut W,
+) -> std::result::Result<(), (io::Error, usize)>
+where
+    W: FnMut(u64, &[IoSlice<'_>]) -> io::Result<usize>,
+{
+    let mut remaining = buffers;
+    let mut completed_bytes = 0;
+
+    loop {
+        let written = match write_fn(offset, remaining) {
+            Ok(0) => {
+                return Err((
+                    io::Error::new(io::ErrorKind::WriteZero, "failed to flush COW write batch"),
+                    completed_bytes / block_size,
+                ));
+            }
+            Ok(written) => written,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err((error, completed_bytes / block_size)),
+        };
+
+        completed_bytes += written;
+        offset += written as u64;
+        IoSlice::advance_slices(&mut remaining, written);
+        if remaining.is_empty() {
+            return Ok(());
+        }
+    }
+}
+
+fn write_block_batch_at(cow_fd: &File, offset: u64, buffers: &[IoSlice<'_>]) -> io::Result<usize> {
+    if let [buffer] = buffers {
+        cow_fd.write_all_at(buffer, offset)?;
+        return Ok(buffer.len());
+    }
+
+    let offset = libc::off_t::try_from(offset).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("COW write offset {offset} exceeds off_t"),
+        )
+    })?;
+    nix::sys::uio::pwritev(cow_fd, buffers, offset).map_err(io::Error::from)
 }
 
 #[cfg(test)]

--- a/crates/nbd-cow/src/cow/tests.rs
+++ b/crates/nbd-cow/src/cow/tests.rs
@@ -154,6 +154,32 @@ fn flush_writes_to_cow_file() {
 }
 
 #[test]
+fn default_threshold_flush_persists_one_contiguous_batch() {
+    let data_len = crate::DEFAULT_FLUSH_THRESHOLD;
+    let base = create_base_image(&vec![0x00; data_len]);
+    let cow_file = NamedTempFile::new().unwrap();
+    let mut cow = make_cow(&base, &cow_file, data_len as u64, data_len);
+    let mut data = vec![0u8; data_len];
+    for (block_idx, block) in data.chunks_mut(crate::BLOCK_SIZE).enumerate() {
+        block.fill((block_idx % 251) as u8);
+    }
+
+    assert!(cow.write(0, &data).unwrap());
+    cow.flush().unwrap();
+
+    let mut persisted = vec![0u8; data_len];
+    cow_file.as_file().read_exact_at(&mut persisted, 0).unwrap();
+    assert!(persisted == data, "persisted contiguous batch differs");
+    assert_eq!(cow.dirty_block_count(), data_len / crate::BLOCK_SIZE);
+    assert_eq!(cow.buffered_block_count(), 0);
+    assert_eq!(cow.buffer_bytes(), 0);
+
+    let mut read_back = vec![0u8; data_len];
+    cow.read(0, &mut read_back).unwrap();
+    assert!(read_back == data, "COW read-back differs");
+}
+
+#[test]
 fn multiblock_dirty_cow_read_uses_one_file_read() {
     let base = create_base_image(&vec![0x00; 4 * 4096]);
     let cow_file = NamedTempFile::new().unwrap();
@@ -717,7 +743,7 @@ fn create_with_dirty_bitmap_beyond_cow_file_errors() {
 //
 // flush_buffered is driven directly with a controllable writer closure.
 // Real error injection (/dev/full, file seals, RLIMIT_FSIZE) cannot
-// reproduce partial-success-then-fail at arbitrary index, which is the
+// reproduce partial-success-then-fail at arbitrary byte offset, which is the
 // scenario the recovery logic protects against.
 
 // Returns the two `NamedTempFile` handles alongside the `CowLayer` so the
@@ -735,22 +761,105 @@ fn seed_cow_with_writes(blocks: &[(u64, u8)]) -> (NamedTempFile, NamedTempFile, 
     (base, cow_file, cow)
 }
 
+fn buffered_len(buffers: &[IoSlice<'_>]) -> usize {
+    buffers.iter().map(|buffer| buffer.len()).sum()
+}
+
+fn buffered_fills(buffers: &[IoSlice<'_>]) -> Vec<u8> {
+    buffers.iter().map(|buffer| buffer[0]).collect()
+}
+
 #[test]
 fn flush_buffered_success_path_drains_buffer() {
     let (_b, _c, mut cow) = seed_cow_with_writes(&[(0, 0xAA), (1, 0xBB), (5, 0xCC)]);
 
-    let mut calls: Vec<(u64, u8)> = Vec::new();
-    cow.flush_buffered(|offset, data| {
-        calls.push((offset, data[0]));
-        Ok(())
+    let mut calls = Vec::new();
+    cow.flush_buffered(|offset, buffers| {
+        calls.push((offset, buffered_fills(buffers)));
+        Ok(buffered_len(buffers))
     })
     .unwrap();
 
     assert_eq!(cow.buffered_block_count(), 0);
     assert_eq!(cow.buffer_bytes(), 0);
     assert_eq!(cow.dirty_block_count(), 3);
-    // BTreeMap iterates in key order: offsets ascend.
-    assert_eq!(calls, vec![(0, 0xAA), (4096, 0xBB), (5 * 4096, 0xCC)]);
+    assert_eq!(calls, vec![(0, vec![0xAA, 0xBB]), (5 * 4096, vec![0xCC])]);
+}
+
+#[test]
+fn flush_buffered_default_threshold_uses_one_writer_call() {
+    const BLOCK_SIZE: usize = 4096;
+    let block_count = crate::DEFAULT_FLUSH_THRESHOLD / BLOCK_SIZE;
+    assert_eq!(block_count, MAX_WRITE_IOVECS);
+    let base = create_base_image(&vec![0x00; crate::DEFAULT_FLUSH_THRESHOLD]);
+    let cow_file = NamedTempFile::new().unwrap();
+    let mut cow = make_cow(
+        &base,
+        &cow_file,
+        crate::DEFAULT_FLUSH_THRESHOLD as u64,
+        crate::DEFAULT_FLUSH_THRESHOLD,
+    );
+    cow.write(0, &vec![0xA5; crate::DEFAULT_FLUSH_THRESHOLD])
+        .unwrap();
+
+    let mut calls = Vec::new();
+    cow.flush_buffered(|offset, buffers| {
+        calls.push((offset, buffers.len(), buffered_len(buffers)));
+        Ok(buffered_len(buffers))
+    })
+    .unwrap();
+
+    assert_eq!(
+        calls,
+        vec![(0, block_count, crate::DEFAULT_FLUSH_THRESHOLD)]
+    );
+    assert_eq!(cow.buffered_block_count(), 0);
+    assert_eq!(cow.dirty_block_count(), block_count);
+}
+
+#[test]
+fn flush_buffered_splits_contiguous_data_at_iov_max() {
+    const BLOCK_SIZE: usize = 4096;
+    let block_count = MAX_WRITE_IOVECS + 1;
+    let data_len = block_count * BLOCK_SIZE;
+    let base = create_base_image(&vec![0x00; data_len]);
+    let cow_file = NamedTempFile::new().unwrap();
+    let mut cow = make_cow(&base, &cow_file, data_len as u64, data_len + 1);
+    cow.write(0, &vec![0xA5; data_len]).unwrap();
+
+    let mut calls = Vec::new();
+    cow.flush_buffered(|offset, buffers| {
+        calls.push((offset, buffers.len()));
+        Ok(buffered_len(buffers))
+    })
+    .unwrap();
+
+    assert_eq!(
+        calls,
+        vec![
+            (0, MAX_WRITE_IOVECS),
+            ((MAX_WRITE_IOVECS * BLOCK_SIZE) as u64, 1)
+        ]
+    );
+    assert_eq!(cow.buffered_block_count(), 0);
+    assert_eq!(cow.dirty_block_count(), block_count);
+}
+
+#[test]
+fn flush_buffered_isolated_blocks_keep_one_call_each() {
+    let (_b, _c, mut cow) = seed_cow_with_writes(&[(0, 0xA0), (2, 0xA2), (4, 0xA4), (6, 0xA6)]);
+
+    let mut calls = Vec::new();
+    cow.flush_buffered(|offset, buffers| {
+        calls.push((offset, buffers.len()));
+        Ok(buffered_len(buffers))
+    })
+    .unwrap();
+
+    assert_eq!(
+        calls,
+        vec![(0, 1), (2 * 4096, 1), (4 * 4096, 1), (6 * 4096, 1)]
+    );
 }
 
 #[test]
@@ -775,63 +884,53 @@ fn flush_buffered_fails_on_first_block_preserves_everything() {
 }
 
 #[test]
-fn flush_buffered_fails_mid_drain_splits_state() {
+fn flush_buffered_partial_block_failure_restores_full_block_and_retries() {
     let (_b, _c, mut cow) = seed_cow_with_writes(&[(0, 0xA0), (1, 0xA1), (2, 0xA2), (3, 0xA3)]);
 
-    let mut call_count = 0;
+    let mut calls = Vec::new();
     let err = cow
-        .flush_buffered(|_off, _data| {
-            call_count += 1;
-            if call_count <= 2 {
-                Ok(())
+        .flush_buffered(|offset, buffers| {
+            calls.push((
+                offset,
+                buffers
+                    .iter()
+                    .map(|buffer| buffer.len())
+                    .collect::<Vec<_>>(),
+            ));
+            if calls.len() == 1 {
+                Ok(2 * 4096 + 512)
             } else {
-                // Fail on the 3rd call.
                 Err(std::io::Error::from(std::io::ErrorKind::StorageFull))
             }
         })
         .unwrap_err();
     assert!(matches!(err, NbdCowError::Io(_)));
 
-    // Written blocks [0,1] stay dirty, gone from buffer. Unwritten [2,3] restored.
+    assert_eq!(
+        calls,
+        vec![(0, vec![4096; 4]), (2 * 4096 + 512, vec![4096 - 512, 4096])]
+    );
     assert_eq!(cow.dirty_block_count(), 2);
     assert_eq!(cow.buffered_block_count(), 2);
     assert_eq!(cow.buffer_bytes(), 2 * 4096);
-    // Buffer still holds the unwritten survivors' data.
+
     let mut buf = vec![0u8; 4096];
     cow.read(2 * 4096, &mut buf).unwrap();
     assert!(buf.iter().all(|&b| b == 0xA2));
     cow.read(3 * 4096, &mut buf).unwrap();
     assert!(buf.iter().all(|&b| b == 0xA3));
-}
 
-#[test]
-fn flush_buffered_recovers_on_retry_after_mid_drain_failure() {
-    let (_b, _c, mut cow) = seed_cow_with_writes(&[(0, 0xA0), (1, 0xA1), (2, 0xA2), (3, 0xA3)]);
-
-    // Stage 1: mid-drain failure on the 3rd call.
-    let mut call_count = 0;
-    let _ = cow.flush_buffered(|_off, _data| {
-        call_count += 1;
-        if call_count <= 2 {
-            Ok(())
-        } else {
-            Err(std::io::Error::from(std::io::ErrorKind::StorageFull))
-        }
-    });
-
-    // Stage 2: retry with successful writer.
     let mut retry_calls = Vec::new();
-    cow.flush_buffered(|offset, data| {
-        retry_calls.push((offset, data[0]));
-        Ok(())
+    cow.flush_buffered(|offset, buffers| {
+        retry_calls.push((offset, buffered_fills(buffers)));
+        Ok(buffered_len(buffers))
     })
     .unwrap();
 
     assert_eq!(cow.buffered_block_count(), 0);
     assert_eq!(cow.buffer_bytes(), 0);
     assert_eq!(cow.dirty_block_count(), 4);
-    // Retry drained exactly the two survivors.
-    assert_eq!(retry_calls, vec![(2 * 4096, 0xA2), (3 * 4096, 0xA3)]);
+    assert_eq!(retry_calls, vec![(2 * 4096, vec![0xA2, 0xA3])]);
 }
 
 #[test]
@@ -840,12 +939,11 @@ fn flush_buffered_fails_on_last_block_preserves_only_last() {
 
     let mut call_count = 0;
     let err = cow
-        .flush_buffered(|_off, _data| {
+        .flush_buffered(|_off, _buffers| {
             call_count += 1;
-            if call_count <= 3 {
-                Ok(())
+            if call_count == 1 {
+                Ok(3 * 4096)
             } else {
-                // Fail on the 4th call, which is the last block.
                 Err(std::io::Error::from(std::io::ErrorKind::StorageFull))
             }
         })
@@ -861,6 +959,53 @@ fn flush_buffered_fails_on_last_block_preserves_only_last() {
     let mut buf = vec![0u8; 4096];
     cow.read(3 * 4096, &mut buf).unwrap();
     assert!(buf.iter().all(|&b| b == 0xA3));
+}
+
+#[test]
+fn flush_buffered_retries_interrupted_and_advances_short_writes() {
+    let (_b, _c, mut cow) = seed_cow_with_writes(&[(0, 0xA0), (1, 0xA1)]);
+
+    let mut calls = Vec::new();
+    cow.flush_buffered(|offset, buffers| {
+        calls.push((
+            offset,
+            buffers
+                .iter()
+                .map(|buffer| buffer.len())
+                .collect::<Vec<_>>(),
+        ));
+        match calls.len() {
+            1 => Err(std::io::Error::from(std::io::ErrorKind::Interrupted)),
+            2 => Ok(4096 + 7),
+            _ => Ok(buffered_len(buffers)),
+        }
+    })
+    .unwrap();
+
+    assert_eq!(
+        calls,
+        vec![
+            (0, vec![4096, 4096]),
+            (0, vec![4096, 4096]),
+            (4096 + 7, vec![4096 - 7])
+        ]
+    );
+    assert_eq!(cow.buffered_block_count(), 0);
+    assert_eq!(cow.dirty_block_count(), 2);
+}
+
+#[test]
+fn flush_buffered_write_zero_preserves_everything() {
+    let (_b, _c, mut cow) = seed_cow_with_writes(&[(0, 0xA0), (1, 0xA1)]);
+
+    let err = cow.flush_buffered(|_, _| Ok(0)).unwrap_err();
+
+    assert!(
+        matches!(&err, NbdCowError::Io(error) if error.kind() == std::io::ErrorKind::WriteZero)
+    );
+    assert_eq!(cow.buffered_block_count(), 2);
+    assert_eq!(cow.buffer_bytes(), 2 * 4096);
+    assert_eq!(cow.dirty_block_count(), 0);
 }
 
 #[test]
@@ -885,10 +1030,10 @@ fn flush_ensure_cow_fd_failure_preserves_buffer() {
     assert_eq!(cow.dirty_block_count(), 0);
 }
 
-// Sanity check that the full flush() wiring — ensure_cow_fd, try_clone,
-// closure routing to write_all_at — survives an end-to-end real I/O failure.
-// /dev/full always returns ENOSPC on write, so this covers "fail on first block"
-// through the public API. Mid-drain coverage stays on the closure tests above.
+// Sanity check that the full flush() wiring — ensure_cow_fd and the positioned
+// batch writer — survives an end-to-end real I/O failure. /dev/full always
+// returns ENOSPC on write, so this covers "fail on first batch" through the
+// public API. Mid-drain coverage stays on the closure tests above.
 #[test]
 fn flush_with_dev_full_preserves_buffer() {
     if !std::path::Path::new("/dev/full").exists() {


### PR DESCRIPTION
## Summary

- coalesce adjacent buffered COW blocks into bounded positioned vectored writes
- preserve block-granular recovery across short writes and errors while keeping isolated writes on `write_all_at`
- cover contiguous ranges, gaps, `IOV_MAX`, partial failures, retries, and real-file persistence

## Performance evidence

- the deterministic writer boundary for the default 4 MiB threshold drops from 1,024 calls to 1 call for 1,024 contiguous 4 KiB blocks
- isolated blocks retain one call each and continue through the existing single-buffer physical write path
- a public-API real-file test exercises and verifies the full 1,024-buffer vectored write
- local root-required `fio`/`strace` benchmarking is unavailable, so this PR makes no wall-clock performance claim

## Compatibility

- no public API, runner protocol, persisted format, rollout, or deployment-order changes
- rollback remains compatible with files written by this implementation

## Exclusions

- no change to `CowIo` operation serialization
- no new benchmark infrastructure or extent-based buffering redesign

## Testing

- `cargo check --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow cow::tests`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow default_threshold`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow --test dispatch`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow --all-features` (274 passed; 12 existing root-only integration tests ignored)
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p nbd-cow --all-features --no-deps`
- `lefthook run pre-commit`

Closes #26861
