### PR TITLE
fix: disable codex image generation

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -79,11 +79,12 @@ const ZERO_AGENT_ID_ENV_KEY: &str = "ZERO_AGENT_ID";
 const OKOU_AGENT_ID_ENV_KEY: &str = "OKOU_AGENT_ID";
 const CLI_PACKAGE_URL_ENV_KEY: &str = "CLI_PKG_URL";
 const WEB_SEARCH_TOOL_NAME: &str = "WebSearch";
-const CODEX_FIXED_STARTUP_CONFIGS: [&str; 4] = [
+const CODEX_FIXED_STARTUP_CONFIGS: [&str; 5] = [
     "analytics.enabled=false",
     "features.plugins=false",
     "features.apps=false",
     "features.goals=false",
+    "features.image_generation=false",
 ];
 const CODEX_FAST_MODE_STARTUP_CONFIGS: [&str; 2] =
     ["features.fast_mode=true", r#"service_tier="fast""#];

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -12,11 +12,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-const CODEX_FIXED_STARTUP_CONFIGS: [&str; 4] = [
+const CODEX_FIXED_STARTUP_CONFIGS: [&str; 5] = [
     "analytics.enabled=false",
     "features.plugins=false",
     "features.apps=false",
     "features.goals=false",
+    "features.image_generation=false",
 ];
 
 #[tokio::test]

--- a/crates/guest-agent/tests/common/codex_app_server_startup.rs
+++ b/crates/guest-agent/tests/common/codex_app_server_startup.rs
@@ -6,11 +6,12 @@ use std::time::Duration;
 
 use crate::common;
 
-const CODEX_FIXED_STARTUP_CONFIGS: [&str; 4] = [
+const CODEX_FIXED_STARTUP_CONFIGS: [&str; 5] = [
     "analytics.enabled=false",
     "features.plugins=false",
     "features.apps=false",
     "features.goals=false",
+    "features.image_generation=false",
 ];
 const CODEX_FAST_MODE_STARTUP_CONFIGS: [&str; 2] =
     ["features.fast_mode=true", r#"service_tier="fast""#];


### PR DESCRIPTION
## Summary

- disable Codex's native `image_generation` feature for every app-server run through the existing fixed startup configuration
- update the app-server startup integration expectations for standard, fast-mode, and custom-provider runs

## Testing

- `(cd crates && cargo fmt --all)`
- `(cd crates && cargo clippy -p guest-agent --all-targets --all-features -- -D warnings)`
- `(cd crates && RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --no-deps --all-features)`
- `(cd crates && cargo test -p guest-agent --test codex_app_server_backend --test codex_app_server_standard_mode --test codex_app_server_fast_mode --test codex_app_server_fast_mode_without_chatgpt)`
- `npx --yes @openai/codex@0.147.0 --disable image_generation features list | rg '^image_generation\b'`
