### PR TITLE
refactor(rust): centralize nbd orphan cleanup ownership

### DIFF
--- a/crates/nbd-cow/src/bin/bench/devices/nbd.rs
+++ b/crates/nbd-cow/src/bin/bench/devices/nbd.rs
@@ -6,133 +6,37 @@
 pub(crate) fn cleanup_stale_nbd_devices() {
     let max = nbd_cow::netlink::nbds_max();
     for i in 0..max {
-        let Some(candidate) = read_nbd_device_state(i) else {
+        let Some(candidate) = nbd_cow::orphan::observe(
+            i,
+            nbd_cow::orphan::NbdOrphanPolicy::DeadOrCurrentProcessOwnerWithNonZeroSize,
+        ) else {
             continue;
         };
-        if !nbd_cleanup_candidate(candidate) {
-            continue;
-        }
-
-        let claim = match nbd_cow::device_lock::try_acquire_device_claim(i) {
-            Ok(Some(claim)) => claim,
-            Ok(None) => continue,
-            Err(e) => {
-                eprintln!("  Skipping stale /dev/nbd{i} cleanup; lock failed: {e}");
-                continue;
+        match nbd_cow::orphan::disconnect(candidate) {
+            nbd_cow::orphan::NbdOrphanDisconnect::Disconnected(current) => {
+                match current.size_sectors() {
+                    Some(size) => eprintln!(
+                        "  Cleaned up stale /dev/nbd{i} (size={size}, pid={})",
+                        current.owner_tid()
+                    ),
+                    None => eprintln!(
+                        "  Cleaned up stale /dev/nbd{i} (pid={})",
+                        current.owner_tid()
+                    ),
+                }
             }
-        };
-
-        let Some(current) = read_nbd_device_state(i) else {
-            continue;
-        };
-        if !nbd_cleanup_candidate(current) {
-            continue;
+            nbd_cow::orphan::NbdOrphanDisconnect::Failed(error) => {
+                eprintln!("  Stale /dev/nbd{i} cleanup failed: {error}");
+            }
+            nbd_cow::orphan::NbdOrphanDisconnect::Locked
+            | nbd_cow::orphan::NbdOrphanDisconnect::Changed
+            | nbd_cow::orphan::NbdOrphanDisconnect::Live => {}
         }
-
-        eprintln!(
-            "  Cleaning up stale /dev/nbd{i} (size={}, pid={})...",
-            current.size, current.pid
-        );
-        let _ = nbd_cow::netlink::disconnect(i);
-        drop(claim);
     }
-}
-
-#[derive(Clone, Copy)]
-struct NbdDeviceState {
-    size: u64,
-    pid: u32,
-}
-
-fn read_nbd_device_state(index: u32) -> Option<NbdDeviceState> {
-    let size_path = format!("/sys/block/nbd{index}/size");
-    let pid_path = format!("/sys/block/nbd{index}/pid");
-    let size = std::fs::read_to_string(&size_path)
-        .ok()?
-        .trim()
-        .parse()
-        .ok()?;
-    let pid = std::fs::read_to_string(&pid_path)
-        .ok()?
-        .trim()
-        .parse()
-        .ok()?;
-    Some(NbdDeviceState { size, pid })
-}
-
-fn nbd_cleanup_candidate(state: NbdDeviceState) -> bool {
-    state.size != 0 && nbd_cleanup_candidate_owner(state.pid)
-}
-
-fn nbd_cleanup_candidate_owner(pid: u32) -> bool {
-    pid != 0
-        && (nbd_cow::is_our_thread(pid) || !std::path::Path::new(&format!("/proc/{pid}")).exists())
 }
 
 pub(crate) fn nbd_module_loaded() -> bool {
     std::fs::read_to_string("/proc/modules")
         .map(|s| s.lines().any(|l| l.starts_with("nbd ")))
         .unwrap_or(false)
-}
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn nbd_cleanup_candidate_owner_requires_known_dead_or_current_owner() {
-        assert!(!nbd_cleanup_candidate_owner(0));
-        assert!(nbd_cleanup_candidate_owner(std::process::id()));
-        assert!(nbd_cleanup_candidate_owner(u32::MAX));
-    }
-
-    #[test]
-    fn nbd_cleanup_candidate_rejects_live_foreign_owner() {
-        struct ChildGuard(std::process::Child);
-
-        impl Drop for ChildGuard {
-            fn drop(&mut self) {
-                let _ = self.0.kill();
-                let _ = self.0.wait();
-            }
-        }
-
-        let mut child = ChildGuard(
-            std::process::Command::new("cat")
-                .stdin(std::process::Stdio::piped())
-                .spawn()
-                .expect("spawn live foreign owner"),
-        );
-        let pid = child.0.id();
-
-        assert_ne!(pid, std::process::id());
-        assert!(
-            child
-                .0
-                .try_wait()
-                .expect("check live foreign owner")
-                .is_none()
-        );
-        assert!(!nbd_cleanup_candidate_owner(pid));
-        assert!(!nbd_cleanup_candidate(NbdDeviceState { size: 1, pid }));
-        assert!(
-            child
-                .0
-                .try_wait()
-                .expect("recheck live foreign owner")
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn nbd_cleanup_candidate_requires_nonzero_size_and_cleanup_owner() {
-        assert!(!nbd_cleanup_candidate(NbdDeviceState {
-            size: 0,
-            pid: std::process::id()
-        }));
-        assert!(!nbd_cleanup_candidate(NbdDeviceState { size: 1, pid: 0 }));
-        assert!(nbd_cleanup_candidate(NbdDeviceState {
-            size: 1,
-            pid: std::process::id()
-        }));
-    }
 }

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -14,6 +14,7 @@
 //! - [`cow`] for COW storage and dirty bitmap persistence.
 //! - [`cow_io`] for the async boundary around blocking COW storage operations.
 //! - [`pool`] for host-locked `/dev/nbdN` device claim allocation.
+//! - [`orphan`] for lock-aware orphan observation and cleanup.
 //! - [`netlink`] for Linux NBD generic netlink setup and disconnect.
 //! - [`server`] for the in-process NBD dispatch loop.
 //! - an internal NBD transmission protocol parser and serializer.
@@ -29,6 +30,7 @@ mod device;
 pub mod device_lock;
 pub mod error;
 pub mod netlink;
+pub mod orphan;
 pub mod pool;
 #[path = "protocol.rs"]
 mod protocol_impl;

--- a/crates/nbd-cow/src/orphan.rs
+++ b/crates/nbd-cow/src/orphan.rs
@@ -95,6 +95,7 @@ pub enum NbdOrphanError {
 }
 
 /// Result of revalidating an observed orphan without disconnecting it.
+#[must_use = "orphan probe outcomes must be checked before reporting the device"]
 #[derive(Debug)]
 pub enum NbdOrphanProbe {
     /// The exact observed owner still satisfies the selected policy.
@@ -110,6 +111,7 @@ pub enum NbdOrphanProbe {
 }
 
 /// Result of revalidating and attempting to disconnect an observed orphan.
+#[must_use = "orphan disconnect outcomes must be checked for skipped or failed cleanup"]
 #[derive(Debug)]
 pub enum NbdOrphanDisconnect {
     /// Netlink disconnected the exact revalidated orphan.

--- a/crates/nbd-cow/src/orphan.rs
+++ b/crates/nbd-cow/src/orphan.rs
@@ -1,0 +1,750 @@
+//! Lock-aware NBD orphan observation and cleanup.
+//!
+//! Linux records the task ID (TID) that connected an NBD device in
+//! `/sys/block/nbdN/pid`. The helpers in this module observe that state, apply
+//! an explicit cleanup policy, and then revalidate the exact observed TID while
+//! holding the cooperative per-index claim. Destructive cleanup keeps the
+//! claim held through the netlink disconnect call.
+//!
+//! The claim coordinates only processes that use the same claim mechanism.
+//! Exact sysfs revalidation under that claim is therefore required before any
+//! disconnect; non-cooperating device users are still outside its protection.
+
+use std::path::Path;
+
+use crate::error::NbdCowError;
+
+/// Owner and size policy for one NBD orphan-cleanup caller.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NbdOrphanPolicy {
+    /// Accept only an owner TID that no longer exists, without reading size.
+    DeadOwner,
+    /// Accept a dead or current-process owner TID only when size is non-zero.
+    DeadOrCurrentProcessOwnerWithNonZeroSize,
+}
+
+impl NbdOrphanPolicy {
+    const fn requires_non_zero_size(self) -> bool {
+        matches!(self, Self::DeadOrCurrentProcessOwnerWithNonZeroSize)
+    }
+}
+
+/// One policy-eligible NBD state observed before cooperative claim acquisition.
+///
+/// This value is evidence to revalidate, not proof of current ownership. Pass
+/// it to [`probe`] or [`disconnect`] before reporting or mutating the device.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NbdOrphanCandidate {
+    device_index: u32,
+    owner_tid: u32,
+    size_sectors: Option<u64>,
+    policy: NbdOrphanPolicy,
+}
+
+impl NbdOrphanCandidate {
+    /// Reconstruct a previously persisted dead-owner observation.
+    ///
+    /// [`probe`] and [`disconnect`] still acquire the cooperative claim and
+    /// revalidate this exact TID before returning an eligible outcome.
+    pub const fn from_dead_owner_observation(device_index: u32, owner_tid: u32) -> Self {
+        Self {
+            device_index,
+            owner_tid,
+            size_sectors: None,
+            policy: NbdOrphanPolicy::DeadOwner,
+        }
+    }
+
+    /// N in `/dev/nbdN`.
+    pub const fn device_index(self) -> u32 {
+        self.device_index
+    }
+
+    /// TID observed in `/sys/block/nbdN/pid`.
+    pub const fn owner_tid(self) -> u32 {
+        self.owner_tid
+    }
+
+    /// Observed `/sys/block/nbdN/size` in 512-byte sectors when required.
+    pub const fn size_sectors(self) -> Option<u64> {
+        self.size_sectors
+    }
+}
+
+/// Failure while acquiring a cooperative claim or disconnecting an orphan.
+#[derive(Debug, thiserror::Error)]
+pub enum NbdOrphanError {
+    /// The per-index cooperative claim could not be acquired.
+    #[error("failed to acquire cooperative claim for /dev/nbd{device_index}: {source}")]
+    Claim {
+        /// N in `/dev/nbdN`.
+        device_index: u32,
+        /// Underlying lock-file error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Netlink failed while the revalidated cooperative claim was held.
+    #[error("failed to disconnect /dev/nbd{device_index}: {source}")]
+    Disconnect {
+        /// N in `/dev/nbdN`.
+        device_index: u32,
+        /// Underlying NBD netlink error.
+        #[source]
+        source: NbdCowError,
+    },
+}
+
+/// Result of revalidating an observed orphan without disconnecting it.
+#[derive(Debug)]
+pub enum NbdOrphanProbe {
+    /// The exact observed owner still satisfies the selected policy.
+    Orphan(NbdOrphanCandidate),
+    /// Another cooperating process currently holds the per-index claim.
+    Locked,
+    /// The owner or policy-relevant device state changed after observation.
+    Changed,
+    /// The exact observed owner now exists and is ineligible under the policy.
+    Live,
+    /// Cooperative claim acquisition failed.
+    Failed(NbdOrphanError),
+}
+
+/// Result of revalidating and attempting to disconnect an observed orphan.
+#[derive(Debug)]
+pub enum NbdOrphanDisconnect {
+    /// Netlink disconnected the exact revalidated orphan.
+    Disconnected(NbdOrphanCandidate),
+    /// Another cooperating process currently holds the per-index claim.
+    Locked,
+    /// The owner or policy-relevant device state changed after observation.
+    Changed,
+    /// The exact observed owner now exists and is ineligible under the policy.
+    Live,
+    /// Cooperative claim acquisition or netlink disconnect failed.
+    Failed(NbdOrphanError),
+}
+
+#[derive(Clone, Copy)]
+struct NbdDeviceState {
+    owner_tid: u32,
+    size_sectors: Option<u64>,
+}
+
+enum RevalidatedCandidate<Guard> {
+    Ready(NbdOrphanCandidate, Guard),
+    Locked,
+    Changed,
+    Live,
+    Failed(NbdOrphanError),
+}
+
+/// Observe one policy-eligible NBD orphan candidate without acquiring its claim.
+///
+/// Missing, released, malformed, unreadable, or policy-ineligible sysfs state
+/// returns `None`. The returned candidate must be passed to [`probe`] or
+/// [`disconnect`] before it is treated as current.
+pub fn observe(device_index: u32, policy: NbdOrphanPolicy) -> Option<NbdOrphanCandidate> {
+    observe_with(
+        device_index,
+        policy,
+        read_nbd_device_state,
+        proc_tid_exists,
+        crate::is_our_thread,
+    )
+}
+
+/// Acquire the cooperative claim and revalidate an observed candidate.
+///
+/// The claim is released before this function returns, so the outcome records
+/// the locked observation rather than reserving the device for a later action.
+pub fn probe(candidate: NbdOrphanCandidate) -> NbdOrphanProbe {
+    probe_with(
+        candidate,
+        crate::device_lock::try_acquire_device_claim,
+        read_nbd_device_state,
+        proc_tid_exists,
+        crate::is_our_thread,
+    )
+}
+
+/// Acquire the cooperative claim, revalidate an observed candidate, and
+/// disconnect it while the claim remains held.
+pub fn disconnect(candidate: NbdOrphanCandidate) -> NbdOrphanDisconnect {
+    disconnect_with(
+        candidate,
+        crate::device_lock::try_acquire_device_claim,
+        read_nbd_device_state,
+        proc_tid_exists,
+        crate::is_our_thread,
+        crate::netlink::disconnect,
+    )
+}
+
+fn observe_with(
+    device_index: u32,
+    policy: NbdOrphanPolicy,
+    read_state: impl FnOnce(u32, NbdOrphanPolicy) -> Option<NbdDeviceState>,
+    owner_exists: impl FnOnce(u32) -> bool,
+    current_process_owns: impl FnOnce(u32) -> bool,
+) -> Option<NbdOrphanCandidate> {
+    let state = read_state(device_index, policy)?;
+    if !size_is_eligible(state, policy)
+        || !owner_is_eligible(state.owner_tid, policy, owner_exists, current_process_owns)
+    {
+        return None;
+    }
+
+    Some(candidate_from_state(device_index, state, policy))
+}
+
+fn probe_with<Guard>(
+    candidate: NbdOrphanCandidate,
+    try_claim: impl FnOnce(u32) -> std::io::Result<Option<Guard>>,
+    read_state: impl FnOnce(u32, NbdOrphanPolicy) -> Option<NbdDeviceState>,
+    owner_exists: impl FnOnce(u32) -> bool,
+    current_process_owns: impl FnOnce(u32) -> bool,
+) -> NbdOrphanProbe {
+    match revalidate_with(
+        candidate,
+        try_claim,
+        read_state,
+        owner_exists,
+        current_process_owns,
+    ) {
+        RevalidatedCandidate::Ready(current, claim) => {
+            drop(claim);
+            NbdOrphanProbe::Orphan(current)
+        }
+        RevalidatedCandidate::Locked => NbdOrphanProbe::Locked,
+        RevalidatedCandidate::Changed => NbdOrphanProbe::Changed,
+        RevalidatedCandidate::Live => NbdOrphanProbe::Live,
+        RevalidatedCandidate::Failed(error) => NbdOrphanProbe::Failed(error),
+    }
+}
+
+fn disconnect_with<Guard>(
+    candidate: NbdOrphanCandidate,
+    try_claim: impl FnOnce(u32) -> std::io::Result<Option<Guard>>,
+    read_state: impl FnOnce(u32, NbdOrphanPolicy) -> Option<NbdDeviceState>,
+    owner_exists: impl FnOnce(u32) -> bool,
+    current_process_owns: impl FnOnce(u32) -> bool,
+    disconnect_device: impl FnOnce(u32) -> crate::error::Result<()>,
+) -> NbdOrphanDisconnect {
+    match revalidate_with(
+        candidate,
+        try_claim,
+        read_state,
+        owner_exists,
+        current_process_owns,
+    ) {
+        RevalidatedCandidate::Ready(current, claim) => {
+            let result = match disconnect_device(candidate.device_index) {
+                Ok(()) => NbdOrphanDisconnect::Disconnected(current),
+                Err(source) => NbdOrphanDisconnect::Failed(NbdOrphanError::Disconnect {
+                    device_index: candidate.device_index,
+                    source,
+                }),
+            };
+            drop(claim);
+            result
+        }
+        RevalidatedCandidate::Locked => NbdOrphanDisconnect::Locked,
+        RevalidatedCandidate::Changed => NbdOrphanDisconnect::Changed,
+        RevalidatedCandidate::Live => NbdOrphanDisconnect::Live,
+        RevalidatedCandidate::Failed(error) => NbdOrphanDisconnect::Failed(error),
+    }
+}
+
+fn revalidate_with<Guard>(
+    candidate: NbdOrphanCandidate,
+    try_claim: impl FnOnce(u32) -> std::io::Result<Option<Guard>>,
+    read_state: impl FnOnce(u32, NbdOrphanPolicy) -> Option<NbdDeviceState>,
+    owner_exists: impl FnOnce(u32) -> bool,
+    current_process_owns: impl FnOnce(u32) -> bool,
+) -> RevalidatedCandidate<Guard> {
+    let claim = match try_claim(candidate.device_index) {
+        Ok(Some(claim)) => claim,
+        Ok(None) => return RevalidatedCandidate::Locked,
+        Err(source) => {
+            return RevalidatedCandidate::Failed(NbdOrphanError::Claim {
+                device_index: candidate.device_index,
+                source,
+            });
+        }
+    };
+
+    let Some(current) = read_state(candidate.device_index, candidate.policy) else {
+        return RevalidatedCandidate::Changed;
+    };
+    if current.owner_tid != candidate.owner_tid || !size_is_eligible(current, candidate.policy) {
+        return RevalidatedCandidate::Changed;
+    }
+    if !owner_is_eligible(
+        current.owner_tid,
+        candidate.policy,
+        owner_exists,
+        current_process_owns,
+    ) {
+        return RevalidatedCandidate::Live;
+    }
+
+    RevalidatedCandidate::Ready(
+        candidate_from_state(candidate.device_index, current, candidate.policy),
+        claim,
+    )
+}
+
+fn read_nbd_device_state(device_index: u32, policy: NbdOrphanPolicy) -> Option<NbdDeviceState> {
+    read_nbd_device_state_with(device_index, policy, |path| std::fs::read_to_string(path))
+}
+
+fn read_nbd_device_state_with(
+    device_index: u32,
+    policy: NbdOrphanPolicy,
+    mut read: impl FnMut(&Path) -> std::io::Result<String>,
+) -> Option<NbdDeviceState> {
+    let size_sectors = if policy.requires_non_zero_size() {
+        let size_path = format!("/sys/block/nbd{device_index}/size");
+        Some(read(Path::new(&size_path)).ok()?.trim().parse().ok()?)
+    } else {
+        None
+    };
+
+    let owner_path = format!("/sys/block/nbd{device_index}/pid");
+    let owner_tid = parse_owner_tid(&read(Path::new(&owner_path)).ok()?)?;
+    Some(NbdDeviceState {
+        owner_tid,
+        size_sectors,
+    })
+}
+
+fn parse_owner_tid(contents: &str) -> Option<u32> {
+    let owner = contents.trim();
+    if owner.is_empty() || owner == "-1" || owner == "0" {
+        return None;
+    }
+    owner.parse().ok()
+}
+
+fn proc_tid_exists(owner_tid: u32) -> bool {
+    Path::new(&format!("/proc/{owner_tid}")).exists()
+}
+
+fn size_is_eligible(state: NbdDeviceState, policy: NbdOrphanPolicy) -> bool {
+    !policy.requires_non_zero_size() || state.size_sectors.is_some_and(|size| size != 0)
+}
+
+fn owner_is_eligible(
+    owner_tid: u32,
+    policy: NbdOrphanPolicy,
+    owner_exists: impl FnOnce(u32) -> bool,
+    current_process_owns: impl FnOnce(u32) -> bool,
+) -> bool {
+    match policy {
+        NbdOrphanPolicy::DeadOwner => !owner_exists(owner_tid),
+        NbdOrphanPolicy::DeadOrCurrentProcessOwnerWithNonZeroSize => {
+            current_process_owns(owner_tid) || !owner_exists(owner_tid)
+        }
+    }
+}
+
+const fn candidate_from_state(
+    device_index: u32,
+    state: NbdDeviceState,
+    policy: NbdOrphanPolicy,
+) -> NbdOrphanCandidate {
+    NbdOrphanCandidate {
+        device_index,
+        owner_tid: state.owner_tid,
+        size_sectors: state.size_sectors,
+        policy,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::process::{Command, Stdio};
+    use std::rc::Rc;
+
+    use super::*;
+
+    struct DropGuard(Rc<Cell<bool>>);
+
+    impl Drop for DropGuard {
+        fn drop(&mut self) {
+            self.0.set(true);
+        }
+    }
+
+    struct ChildGuard(std::process::Child);
+
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    const fn state(owner_tid: u32, size_sectors: Option<u64>) -> NbdDeviceState {
+        NbdDeviceState {
+            owner_tid,
+            size_sectors,
+        }
+    }
+
+    const fn local_or_dead_candidate(
+        device_index: u32,
+        owner_tid: u32,
+        size_sectors: u64,
+    ) -> NbdOrphanCandidate {
+        NbdOrphanCandidate {
+            device_index,
+            owner_tid,
+            size_sectors: Some(size_sectors),
+            policy: NbdOrphanPolicy::DeadOrCurrentProcessOwnerWithNonZeroSize,
+        }
+    }
+
+    #[test]
+    fn state_reader_reads_only_policy_required_fields() {
+        let dead = read_nbd_device_state_with(7, NbdOrphanPolicy::DeadOwner, |path| {
+            assert_eq!(path, Path::new("/sys/block/nbd7/pid"));
+            Ok("42\n".to_string())
+        });
+        assert!(
+            matches!(dead, Some(state) if state.owner_tid == 42 && state.size_sectors.is_none())
+        );
+
+        let reads = Cell::new(0);
+        let local = read_nbd_device_state_with(
+            7,
+            NbdOrphanPolicy::DeadOrCurrentProcessOwnerWithNonZeroSize,
+            |path| {
+                reads.set(reads.get() + 1);
+                match path.file_name().and_then(|name| name.to_str()) {
+                    Some("size") => Ok("8\n".to_string()),
+                    Some("pid") => Ok("42\n".to_string()),
+                    other => panic!("unexpected sysfs file {other:?}"),
+                }
+            },
+        );
+        assert!(
+            matches!(local, Some(state) if state.owner_tid == 42 && state.size_sectors == Some(8))
+        );
+        assert_eq!(reads.get(), 2);
+    }
+
+    #[test]
+    fn state_reader_rejects_released_and_malformed_owners() {
+        for policy in [
+            NbdOrphanPolicy::DeadOwner,
+            NbdOrphanPolicy::DeadOrCurrentProcessOwnerWithNonZeroSize,
+        ] {
+            for owner in ["", "0\n", "-1\n", "not-a-tid\n"] {
+                let state = read_nbd_device_state_with(7, policy, |path| {
+                    match path.file_name().and_then(|name| name.to_str()) {
+                        Some("size") => Ok("8\n".to_string()),
+                        Some("pid") => Ok(owner.to_string()),
+                        other => panic!("unexpected sysfs file {other:?}"),
+                    }
+                });
+                assert!(
+                    state.is_none(),
+                    "owner contents {owner:?} must be rejected for {policy:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dead_owner_policy_ignores_size_and_rejects_live_owner() {
+        let dead = observe_with(
+            3,
+            NbdOrphanPolicy::DeadOwner,
+            |_, _| Some(state(123, None)),
+            |_| false,
+            |_| panic!("dead-owner policy must not inspect current-process membership"),
+        );
+        assert!(
+            matches!(dead, Some(candidate) if candidate.owner_tid() == 123 && candidate.size_sectors().is_none())
+        );
+
+        let live = observe_with(
+            3,
+            NbdOrphanPolicy::DeadOwner,
+            |_, _| Some(state(123, None)),
+            |_| true,
+            |_| panic!("dead-owner policy must not inspect current-process membership"),
+        );
+        assert!(live.is_none());
+    }
+
+    #[test]
+    fn local_or_dead_policy_requires_non_zero_size() {
+        let policy = NbdOrphanPolicy::DeadOrCurrentProcessOwnerWithNonZeroSize;
+        let zero_size = observe_with(
+            3,
+            policy,
+            |_, _| Some(state(123, Some(0))),
+            |_| panic!("zero size must be rejected before owner liveness"),
+            |_| panic!("zero size must be rejected before owner membership"),
+        );
+        assert!(zero_size.is_none());
+
+        let dead = observe_with(
+            3,
+            policy,
+            |_, _| Some(state(123, Some(8))),
+            |_| false,
+            |_| false,
+        );
+        assert!(matches!(dead, Some(candidate) if candidate.size_sectors() == Some(8)));
+    }
+
+    #[test]
+    fn local_or_dead_policy_accepts_current_process_and_rejects_live_foreign_owner() {
+        let policy = NbdOrphanPolicy::DeadOrCurrentProcessOwnerWithNonZeroSize;
+        let local = observe_with(
+            3,
+            policy,
+            |_, _| Some(state(123, Some(8))),
+            |_| panic!("current-process owner must short-circuit liveness"),
+            |_| true,
+        );
+        assert!(local.is_some());
+
+        let foreign = observe_with(
+            3,
+            policy,
+            |_, _| Some(state(123, Some(8))),
+            |_| true,
+            |_| false,
+        );
+        assert!(foreign.is_none());
+    }
+
+    #[test]
+    fn owner_policies_classify_real_processes() {
+        let mut child = ChildGuard(
+            Command::new("cat")
+                .stdin(Stdio::piped())
+                .spawn()
+                .expect("spawn live foreign owner"),
+        );
+        let foreign_tid = child.0.id();
+        assert_ne!(foreign_tid, std::process::id());
+        assert!(
+            child
+                .0
+                .try_wait()
+                .expect("check live foreign owner")
+                .is_none()
+        );
+
+        let broad_policy = NbdOrphanPolicy::DeadOrCurrentProcessOwnerWithNonZeroSize;
+        assert!(
+            observe_with(
+                3,
+                broad_policy,
+                |_, _| Some(state(std::process::id(), Some(8))),
+                proc_tid_exists,
+                crate::is_our_thread,
+            )
+            .is_some()
+        );
+        assert!(
+            observe_with(
+                3,
+                broad_policy,
+                |_, _| Some(state(foreign_tid, Some(8))),
+                proc_tid_exists,
+                crate::is_our_thread,
+            )
+            .is_none()
+        );
+        assert!(
+            observe_with(
+                3,
+                broad_policy,
+                |_, _| Some(state(u32::MAX, Some(8))),
+                proc_tid_exists,
+                crate::is_our_thread,
+            )
+            .is_some()
+        );
+        assert!(
+            observe_with(
+                3,
+                NbdOrphanPolicy::DeadOwner,
+                |_, _| Some(state(foreign_tid, None)),
+                proc_tid_exists,
+                crate::is_our_thread,
+            )
+            .is_none()
+        );
+        assert!(
+            child
+                .0
+                .try_wait()
+                .expect("recheck live foreign owner")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn probe_reports_locked_and_claim_failure() {
+        let candidate = NbdOrphanCandidate::from_dead_owner_observation(3, 123);
+        let locked = probe_with(
+            candidate,
+            |_| Ok::<Option<()>, std::io::Error>(None),
+            |_, _| panic!("locked candidate must not be re-read"),
+            |_| panic!("locked candidate must not check liveness"),
+            |_| panic!("locked candidate must not check membership"),
+        );
+        assert!(matches!(locked, NbdOrphanProbe::Locked));
+
+        let failed = probe_with(
+            candidate,
+            |_| Err::<Option<()>, std::io::Error>(std::io::Error::other("boom")),
+            |_, _| panic!("failed claim must not be re-read"),
+            |_| panic!("failed claim must not check liveness"),
+            |_| panic!("failed claim must not check membership"),
+        );
+        match failed {
+            NbdOrphanProbe::Failed(NbdOrphanError::Claim {
+                device_index,
+                source,
+            }) => {
+                assert_eq!(device_index, 3);
+                assert_eq!(source.to_string(), "boom");
+            }
+            other => panic!("expected claim failure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probe_reports_changed_when_owner_changes_or_clears() {
+        let candidate = NbdOrphanCandidate::from_dead_owner_observation(3, 123);
+        let changed = probe_with(
+            candidate,
+            |_| Ok(Some(())),
+            |_, _| Some(state(456, None)),
+            |_| panic!("changed owner must not check liveness"),
+            |_| panic!("changed owner must not check membership"),
+        );
+        assert!(matches!(changed, NbdOrphanProbe::Changed));
+
+        let cleared = probe_with(
+            candidate,
+            |_| Ok(Some(())),
+            |_, _| None,
+            |_| panic!("cleared owner must not check liveness"),
+            |_| panic!("cleared owner must not check membership"),
+        );
+        assert!(matches!(cleared, NbdOrphanProbe::Changed));
+    }
+
+    #[test]
+    fn probe_reports_live_when_same_dead_policy_owner_revives() {
+        let outcome = probe_with(
+            NbdOrphanCandidate::from_dead_owner_observation(3, 123),
+            |_| Ok(Some(())),
+            |_, _| Some(state(123, None)),
+            |_| true,
+            |_| panic!("dead-owner policy must not inspect current-process membership"),
+        );
+        assert!(matches!(outcome, NbdOrphanProbe::Live));
+    }
+
+    #[test]
+    fn probe_reapplies_current_process_and_size_policy() {
+        let candidate = local_or_dead_candidate(3, 123, 8);
+        let local = probe_with(
+            candidate,
+            |_| Ok(Some(())),
+            |_, _| Some(state(123, Some(16))),
+            |_| panic!("current-process owner must short-circuit liveness"),
+            |_| true,
+        );
+        assert!(
+            matches!(local, NbdOrphanProbe::Orphan(current) if current.size_sectors() == Some(16))
+        );
+
+        let zero_size = probe_with(
+            candidate,
+            |_| Ok(Some(())),
+            |_, _| Some(state(123, Some(0))),
+            |_| panic!("zero size must be rejected before liveness"),
+            |_| panic!("zero size must be rejected before membership"),
+        );
+        assert!(matches!(zero_size, NbdOrphanProbe::Changed));
+    }
+
+    #[test]
+    fn probe_holds_claim_through_revalidation() {
+        let dropped = Rc::new(Cell::new(false));
+        let dropped_for_claim = dropped.clone();
+        let dropped_for_read = dropped.clone();
+        let dropped_for_owner = dropped.clone();
+        let outcome = probe_with(
+            NbdOrphanCandidate::from_dead_owner_observation(3, 123),
+            |_| Ok(Some(DropGuard(dropped_for_claim))),
+            |_, _| {
+                assert!(!dropped_for_read.get());
+                Some(state(123, None))
+            },
+            |_| {
+                assert!(!dropped_for_owner.get());
+                false
+            },
+            |_| panic!("dead-owner policy must not inspect current-process membership"),
+        );
+        assert!(matches!(outcome, NbdOrphanProbe::Orphan(_)));
+        assert!(dropped.get());
+    }
+
+    #[test]
+    fn disconnect_holds_claim_through_netlink_and_returns_revalidated_state() {
+        let dropped = Rc::new(Cell::new(false));
+        let dropped_for_claim = dropped.clone();
+        let dropped_for_disconnect = dropped.clone();
+        let outcome = disconnect_with(
+            local_or_dead_candidate(3, 123, 8),
+            |_| Ok(Some(DropGuard(dropped_for_claim))),
+            |_, _| Some(state(123, Some(16))),
+            |_| false,
+            |_| false,
+            |_| {
+                assert!(!dropped_for_disconnect.get());
+                Ok(())
+            },
+        );
+        assert!(
+            matches!(outcome, NbdOrphanDisconnect::Disconnected(current) if current.size_sectors() == Some(16))
+        );
+        assert!(dropped.get());
+    }
+
+    #[test]
+    fn disconnect_returns_sourced_netlink_failure() {
+        let outcome = disconnect_with(
+            NbdOrphanCandidate::from_dead_owner_observation(3, 123),
+            |_| Ok(Some(())),
+            |_, _| Some(state(123, None)),
+            |_| false,
+            |_| panic!("dead-owner policy must not inspect current-process membership"),
+            |_| Err(NbdCowError::Io(std::io::Error::other("netlink failed"))),
+        );
+        match outcome {
+            NbdOrphanDisconnect::Failed(NbdOrphanError::Disconnect {
+                device_index,
+                source,
+            }) => {
+                assert_eq!(device_index, 3);
+                assert!(source.to_string().contains("netlink failed"));
+            }
+            other => panic!("expected disconnect failure, got {other:?}"),
+        }
+    }
+}

--- a/crates/runner/src/cmd/gc/nbd.rs
+++ b/crates/runner/src/cmd/gc/nbd.rs
@@ -57,7 +57,7 @@ where
             };
 
             match result {
-                NbdOrphanDisconnect::Disconnected => {
+                NbdOrphanDisconnect::Disconnected(_) => {
                     info!(
                         "disconnected orphan NBD device /dev/nbd{device_index} (owner PID {pid} dead)"
                     );
@@ -66,7 +66,7 @@ where
                 NbdOrphanDisconnect::Locked => {
                     info!("nbd{device_index}: skipping disconnect, NBD device lock is held");
                 }
-                NbdOrphanDisconnect::Changed => {
+                NbdOrphanDisconnect::Changed | NbdOrphanDisconnect::Live => {
                     info!(
                         "nbd{device_index}: skipping disconnect, device state changed since scan"
                     );
@@ -93,6 +93,15 @@ mod tests {
     };
 
     use super::*;
+
+    fn disconnected(device_index: u32, owner_tid: u32) -> NbdOrphanDisconnect {
+        NbdOrphanDisconnect::Disconnected(
+            nbd_cow::orphan::NbdOrphanCandidate::from_dead_owner_observation(
+                device_index,
+                owner_tid,
+            ),
+        )
+    }
 
     #[tokio::test]
     async fn gc_nbd_orphans_returns_empty_report_without_candidates() {
@@ -125,11 +134,16 @@ mod tests {
         let report = gc_nbd_orphans_with(
             false,
             || (8, vec![(0, 100), (1, 101), (2, 102), (3, 103), (4, 104)]),
-            |device_index, _| match device_index {
-                0 | 4 => NbdOrphanDisconnect::Disconnected,
+            |device_index, owner_tid| match device_index {
+                0 | 4 => disconnected(device_index, owner_tid),
                 1 => NbdOrphanDisconnect::Locked,
                 2 => NbdOrphanDisconnect::Changed,
-                3 => NbdOrphanDisconnect::Failed("netlink failed".to_string()),
+                3 => NbdOrphanDisconnect::Failed(nbd_cow::orphan::NbdOrphanError::Disconnect {
+                    device_index,
+                    source: nbd_cow::error::NbdCowError::Io(std::io::Error::other(
+                        "netlink failed",
+                    )),
+                }),
                 other => panic!("unexpected device index {other}"),
             },
         )
@@ -164,12 +178,12 @@ mod tests {
         let report = gc_nbd_orphans_with(
             false,
             || (8, vec![(0, 100), (1, 101)]),
-            move |device_index, _| {
+            move |device_index, owner_tid| {
                 attempts_for_disconnect.fetch_add(1, Ordering::Relaxed);
                 if device_index == 0 {
                     panic!("disconnect task failed");
                 }
-                NbdOrphanDisconnect::Disconnected
+                disconnected(device_index, owner_tid)
             },
         )
         .await

--- a/crates/runner/src/cmd/nbd.rs
+++ b/crates/runner/src/cmd/nbd.rs
@@ -1,23 +1,7 @@
-//! Shared NBD sysfs helpers used by `gc` and `doctor`.
+//! Shared NBD scan helpers used by `gc` and `doctor`.
 
-use std::path::Path;
-
-#[derive(Debug, Eq, PartialEq)]
-enum NbdOrphanProbe {
-    Orphan,
-    Locked,
-    Changed,
-    Live,
-    LockFailed(String),
-}
-
-#[derive(Debug)]
-pub(crate) enum NbdOrphanDisconnect {
-    Disconnected,
-    Locked,
-    Changed,
-    Failed(String),
-}
+pub(crate) use nbd_cow::orphan::NbdOrphanDisconnect;
+use nbd_cow::orphan::{self, NbdOrphanCandidate, NbdOrphanPolicy, NbdOrphanProbe};
 
 /// Read the maximum number of NBD devices from the kernel module parameter.
 /// Delegates to `nbd_cow::netlink::nbds_max()` which reads sysfs and falls
@@ -26,49 +10,22 @@ pub(crate) fn read_nbds_max() -> u32 {
     nbd_cow::netlink::nbds_max()
 }
 
-/// Parse the PID/TID from `/sys/block/nbd{i}/pid`. Returns `None` if the file
-/// doesn't exist, is empty, or contains a non-positive value (-1, 0).
-pub(crate) fn read_nbd_pid(device_index: u32) -> Option<u32> {
-    let content = std::fs::read_to_string(format!("/sys/block/nbd{device_index}/pid")).ok()?;
-    let trimmed = content.trim();
-    if trimmed.is_empty() || trimmed == "-1" || trimmed == "0" {
-        return None;
-    }
-    trimmed.parse::<u32>().ok()
-}
-
-fn proc_pid_exists(pid: u32) -> bool {
-    Path::new(&format!("/proc/{pid}")).exists()
-}
-
-/// Recheck one NBD candidate with the per-index lock held.
-pub(crate) fn nbd_orphan_is_reportable(device_index: u32, pid: u32) -> bool {
-    let mut try_lock = nbd_cow::device_lock::try_acquire_device_claim;
-    let mut read_pid = read_nbd_pid;
-    let mut pid_exists = proc_pid_exists;
-    nbd_orphan_is_reportable_with(
+/// Recheck one previously observed dead-owner candidate with its claim held.
+pub(crate) fn nbd_orphan_is_reportable(device_index: u32, owner_tid: u32) -> bool {
+    nbd_orphan_candidate_is_reportable(NbdOrphanCandidate::from_dead_owner_observation(
         device_index,
-        pid,
-        &mut try_lock,
-        &mut read_pid,
-        &mut pid_exists,
-    )
+        owner_tid,
+    ))
 }
 
-fn nbd_orphan_is_reportable_with<Guard>(
-    device_index: u32,
-    pid: u32,
-    try_lock: &mut impl FnMut(u32) -> std::io::Result<Option<Guard>>,
-    read_pid: &mut impl FnMut(u32) -> Option<u32>,
-    pid_exists: &mut impl FnMut(u32) -> bool,
-) -> bool {
-    match classify_nbd_orphan_candidate_with(device_index, pid, try_lock, read_pid, pid_exists) {
-        NbdOrphanProbe::Orphan => true,
-        NbdOrphanProbe::LockFailed(message) => {
+fn nbd_orphan_candidate_is_reportable(candidate: NbdOrphanCandidate) -> bool {
+    match orphan::probe(candidate) {
+        NbdOrphanProbe::Orphan(_) => true,
+        NbdOrphanProbe::Failed(error) => {
             tracing::warn!(
-                device_index,
-                pid,
-                error = %message,
+                device_index = candidate.device_index(),
+                owner_tid = candidate.owner_tid(),
+                error = %error,
                 "skipping NBD orphan candidate because device lock probe failed"
             );
             false
@@ -77,380 +34,31 @@ fn nbd_orphan_is_reportable_with<Guard>(
     }
 }
 
-fn classify_nbd_orphan_candidate_with<Guard>(
-    device_index: u32,
-    pid: u32,
-    try_lock: &mut impl FnMut(u32) -> std::io::Result<Option<Guard>>,
-    read_pid: &mut impl FnMut(u32) -> Option<u32>,
-    pid_exists: &mut impl FnMut(u32) -> bool,
-) -> NbdOrphanProbe {
-    let _guard = match try_lock(device_index) {
-        Ok(Some(guard)) => guard,
-        Ok(None) => return NbdOrphanProbe::Locked,
-        Err(e) => return NbdOrphanProbe::LockFailed(e.to_string()),
-    };
-
-    match read_pid(device_index) {
-        Some(current_pid) if current_pid == pid && !pid_exists(current_pid) => {
-            NbdOrphanProbe::Orphan
-        }
-        Some(current_pid) if current_pid == pid => NbdOrphanProbe::Live,
-        _ => NbdOrphanProbe::Changed,
-    }
-}
-
 /// Scan all NBD devices for reportable orphans: lock-free devices whose
 /// recorded owner task has exited.
 ///
-/// Returns `(max_devs_scanned, orphans)` where each orphan is `(device_index, pid)`.
+/// Returns `(max_devs_scanned, orphans)` where each orphan is
+/// `(device_index, owner_tid)`.
 pub(crate) fn find_nbd_orphans() -> (u32, Vec<(u32, u32)>) {
     let max_devs = read_nbds_max();
-    let orphans = find_nbd_orphans_with(
-        max_devs,
-        nbd_cow::device_lock::try_acquire_device_claim,
-        read_nbd_pid,
-        proc_pid_exists,
-    );
+    let mut orphans = Vec::new();
+    for device_index in 0..max_devs {
+        if let Some(candidate) = orphan::observe(device_index, NbdOrphanPolicy::DeadOwner)
+            && nbd_orphan_candidate_is_reportable(candidate)
+        {
+            orphans.push((candidate.device_index(), candidate.owner_tid()));
+        }
+    }
     (max_devs, orphans)
 }
 
-fn find_nbd_orphans_with<Guard>(
-    max_devs: u32,
-    mut try_lock: impl FnMut(u32) -> std::io::Result<Option<Guard>>,
-    mut read_pid: impl FnMut(u32) -> Option<u32>,
-    mut pid_exists: impl FnMut(u32) -> bool,
-) -> Vec<(u32, u32)> {
-    let mut orphans: Vec<(u32, u32)> = Vec::new();
-    for i in 0..max_devs {
-        if let Some(pid) = read_pid(i)
-            && !pid_exists(pid)
-            && nbd_orphan_is_reportable_with(i, pid, &mut try_lock, &mut read_pid, &mut pid_exists)
-        {
-            orphans.push((i, pid));
-        }
-    }
-    orphans
-}
-
-/// Disconnect an orphan-looking NBD device only while holding its per-index
-/// host lock and after confirming the PID is still the same dead process.
-pub(crate) fn disconnect_orphan_if_still_dead(device_index: u32, pid: u32) -> NbdOrphanDisconnect {
-    disconnect_orphan_if_still_dead_with(
-        device_index,
-        pid,
-        nbd_cow::device_lock::try_acquire_device_claim,
-        read_nbd_pid,
-        proc_pid_exists,
-        nbd_cow::netlink::disconnect,
-    )
-}
-
-fn disconnect_orphan_if_still_dead_with<Guard>(
+/// Disconnect a dead-owner candidate only after claim-protected revalidation.
+pub(crate) fn disconnect_orphan_if_still_dead(
     device_index: u32,
-    pid: u32,
-    try_lock: impl FnOnce(u32) -> std::io::Result<Option<Guard>>,
-    read_pid: impl FnOnce(u32) -> Option<u32>,
-    pid_exists: impl FnOnce(u32) -> bool,
-    disconnect: impl FnOnce(u32) -> nbd_cow::error::Result<()>,
+    owner_tid: u32,
 ) -> NbdOrphanDisconnect {
-    let guard = match try_lock(device_index) {
-        Ok(Some(guard)) => guard,
-        Ok(None) => return NbdOrphanDisconnect::Locked,
-        Err(e) => return NbdOrphanDisconnect::Failed(format!("lock failed: {e}")),
-    };
-
-    let result = match read_pid(device_index) {
-        Some(current_pid) if current_pid == pid && !pid_exists(pid) => {
-            match disconnect(device_index) {
-                Ok(()) => NbdOrphanDisconnect::Disconnected,
-                Err(e) => NbdOrphanDisconnect::Failed(e.to_string()),
-            }
-        }
-        _ => NbdOrphanDisconnect::Changed,
-    };
-
-    drop(guard);
-    result
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::cell::Cell;
-    use std::rc::Rc;
-
-    struct DropGuard(Rc<Cell<bool>>);
-
-    impl Drop for DropGuard {
-        fn drop(&mut self) {
-            self.0.set(true);
-        }
-    }
-
-    #[test]
-    fn find_nbd_orphans_skips_locked_dead_pid() {
-        let orphans = find_nbd_orphans_with(
-            1,
-            |_| Ok::<Option<()>, std::io::Error>(None),
-            |_| Some(123),
-            |_| false,
-        );
-
-        assert!(orphans.is_empty());
-    }
-
-    #[test]
-    fn find_nbd_orphans_reports_lock_free_dead_pid() {
-        let orphans = find_nbd_orphans_with(
-            1,
-            |_| Ok::<Option<()>, std::io::Error>(Some(())),
-            |_| Some(123),
-            |_| false,
-        );
-
-        assert_eq!(orphans, vec![(0, 123)]);
-    }
-
-    #[test]
-    fn find_nbd_orphans_does_not_lock_live_pid_candidates() {
-        let lock_attempts = Cell::new(0);
-        let orphans = find_nbd_orphans_with(
-            1,
-            |_| {
-                lock_attempts.set(lock_attempts.get() + 1);
-                Ok::<Option<()>, std::io::Error>(Some(()))
-            },
-            |_| Some(123),
-            |_| true,
-        );
-
-        assert!(orphans.is_empty());
-        assert_eq!(lock_attempts.get(), 0);
-    }
-
-    #[test]
-    fn orphan_probe_clears_when_pid_changes_after_lock() {
-        let mut try_lock = |_| Ok::<Option<()>, std::io::Error>(Some(()));
-        let mut read_pid = |_| Some(456);
-        let mut pid_exists = |_| false;
-
-        let status = classify_nbd_orphan_candidate_with(
-            3,
-            123,
-            &mut try_lock,
-            &mut read_pid,
-            &mut pid_exists,
-        );
-
-        assert_eq!(status, NbdOrphanProbe::Changed);
-    }
-
-    #[test]
-    fn orphan_probe_clears_when_pid_clears_after_lock() {
-        let mut try_lock = |_| Ok::<Option<()>, std::io::Error>(Some(()));
-        let mut read_pid = |_| None;
-        let mut pid_exists = |_| panic!("pid_exists should not run after pid is cleared");
-
-        let status = classify_nbd_orphan_candidate_with(
-            3,
-            123,
-            &mut try_lock,
-            &mut read_pid,
-            &mut pid_exists,
-        );
-
-        assert_eq!(status, NbdOrphanProbe::Changed);
-    }
-
-    #[test]
-    fn orphan_probe_clears_when_same_pid_is_live_after_lock() {
-        let mut try_lock = |_| Ok::<Option<()>, std::io::Error>(Some(()));
-        let mut read_pid = |_| Some(123);
-        let mut pid_exists = |_| true;
-
-        let status = classify_nbd_orphan_candidate_with(
-            3,
-            123,
-            &mut try_lock,
-            &mut read_pid,
-            &mut pid_exists,
-        );
-
-        assert_eq!(status, NbdOrphanProbe::Live);
-    }
-
-    #[test]
-    fn orphan_probe_reports_lock_error_as_not_reportable() {
-        let mut try_lock = |_| Err::<Option<()>, std::io::Error>(std::io::Error::other("boom"));
-        let mut read_pid = |_| panic!("read_pid should not run after lock failure");
-        let mut pid_exists = |_| panic!("pid_exists should not run after lock failure");
-
-        assert!(!nbd_orphan_is_reportable_with(
-            3,
-            123,
-            &mut try_lock,
-            &mut read_pid,
-            &mut pid_exists,
-        ));
-    }
-
-    #[test]
-    fn orphan_probe_holds_lock_through_recheck() {
-        let dropped = Rc::new(Cell::new(false));
-        let dropped_for_lock = dropped.clone();
-        let dropped_for_read = dropped.clone();
-        let dropped_for_pid = dropped.clone();
-        let mut try_lock = move |_| {
-            Ok::<Option<DropGuard>, std::io::Error>(Some(DropGuard(dropped_for_lock.clone())))
-        };
-        let mut read_pid = |_| {
-            assert!(
-                !dropped_for_read.get(),
-                "lock must be held while sysfs pid is re-read"
-            );
-            Some(123)
-        };
-        let mut pid_exists = |_| {
-            assert!(
-                !dropped_for_pid.get(),
-                "lock must be held while pid liveness is rechecked"
-            );
-            false
-        };
-
-        let status = classify_nbd_orphan_candidate_with(
-            3,
-            123,
-            &mut try_lock,
-            &mut read_pid,
-            &mut pid_exists,
-        );
-
-        assert_eq!(status, NbdOrphanProbe::Orphan);
-        assert!(dropped.get(), "lock should drop after orphan probe");
-    }
-
-    #[test]
-    fn orphan_disconnect_skips_when_lock_is_held() {
-        let result = disconnect_orphan_if_still_dead_with(
-            3,
-            123,
-            |_| Ok::<Option<()>, std::io::Error>(None),
-            |_| Some(123),
-            |_| false,
-            |_| panic!("disconnect should not run without lock"),
-        );
-
-        assert!(matches!(result, NbdOrphanDisconnect::Locked));
-    }
-
-    #[test]
-    fn orphan_disconnect_reports_lock_error() {
-        let result = disconnect_orphan_if_still_dead_with(
-            3,
-            123,
-            |_| Err::<Option<()>, std::io::Error>(std::io::Error::other("boom")),
-            |_| Some(123),
-            |_| false,
-            |_| panic!("disconnect should not run without lock"),
-        );
-
-        match result {
-            NbdOrphanDisconnect::Failed(message) => {
-                assert!(message.contains("lock failed"));
-                assert!(message.contains("boom"));
-            }
-            other => panic!("expected lock failure, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn orphan_disconnect_reports_disconnect_error() {
-        let result = disconnect_orphan_if_still_dead_with(
-            3,
-            123,
-            |_| Ok(Some(())),
-            |_| Some(123),
-            |_| false,
-            |_| {
-                Err(nbd_cow::error::NbdCowError::Io(std::io::Error::other(
-                    "netlink failed",
-                )))
-            },
-        );
-
-        match result {
-            NbdOrphanDisconnect::Failed(message) => {
-                assert!(message.contains("netlink failed"));
-            }
-            other => panic!("expected disconnect failure, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn orphan_disconnect_rechecks_pid_after_lock() {
-        let result = disconnect_orphan_if_still_dead_with(
-            3,
-            123,
-            |_| Ok(Some(())),
-            |_| Some(456),
-            |_| false,
-            |_| panic!("disconnect should not run after pid change"),
-        );
-
-        assert!(matches!(result, NbdOrphanDisconnect::Changed));
-    }
-
-    #[test]
-    fn orphan_disconnect_skips_when_pid_cleared_after_lock() {
-        let result = disconnect_orphan_if_still_dead_with(
-            3,
-            123,
-            |_| Ok(Some(())),
-            |_| None,
-            |_| panic!("pid_exists should not run after pid is cleared"),
-            |_| panic!("disconnect should not run after pid is cleared"),
-        );
-
-        assert!(matches!(result, NbdOrphanDisconnect::Changed));
-    }
-
-    #[test]
-    fn orphan_disconnect_skips_when_same_pid_is_live_after_lock() {
-        let result = disconnect_orphan_if_still_dead_with(
-            3,
-            123,
-            |_| Ok(Some(())),
-            |_| Some(123),
-            |_| true,
-            |_| panic!("disconnect should not run for a live pid"),
-        );
-
-        assert!(matches!(result, NbdOrphanDisconnect::Changed));
-    }
-
-    #[test]
-    fn orphan_disconnect_holds_lock_through_disconnect() {
-        let dropped = Rc::new(Cell::new(false));
-        let dropped_for_lock = dropped.clone();
-        let dropped_for_disconnect = dropped.clone();
-
-        let result = disconnect_orphan_if_still_dead_with(
-            3,
-            123,
-            |_| Ok(Some(DropGuard(dropped_for_lock))),
-            |_| Some(123),
-            |_| false,
-            |_| {
-                assert!(
-                    !dropped_for_disconnect.get(),
-                    "lock must be held while disconnect runs"
-                );
-                Ok(())
-            },
-        );
-
-        assert!(matches!(result, NbdOrphanDisconnect::Disconnected));
-        assert!(dropped.get(), "lock should drop after disconnect decision");
-    }
+    orphan::disconnect(NbdOrphanCandidate::from_dead_owner_observation(
+        device_index,
+        owner_tid,
+    ))
 }


### PR DESCRIPTION
## Summary

- centralize NBD orphan observation, owner policy, cooperative-claim revalidation, and disconnect handling in `nbd-cow`
- preserve runner doctor/GC's dead-owner, size-independent behavior and benchmark cleanup's dead-or-current-process, non-zero-size behavior
- revalidate the exact observed owner TID while holding the per-device claim through disconnect, and return structured lock/state/netlink outcomes

## Scope

- add a focused public `nbd_cow::orphan` module with the two caller policies and typed probe/disconnect results
- require callers to handle probe and disconnect outcomes so skipped or failed cleanup cannot be silently discarded
- migrate runner and benchmark cleanup callers off their duplicated sysfs, procfs, lock, and disconnect state machines
- report benchmark claim/netlink failures while preserving silent skips and runner GC accounting/operator messages
- cover policy transitions, malformed state, contention, owner changes, live/dead/current-process owners, size changes, sourced failures, real procfs classification, and claim lifetime

## Explicit exclusions

- no changes to normal connected-device ownership, allocator/pool behavior, or destroy/cancel cleanup
- no API, runner protocol, persistence, migration, feature flag, deployment configuration, or coordinated rollout change

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `TMPDIR=/home/vscode/t8 cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets --all-features`
- `TMPDIR=/home/vscode/t8 cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `TMPDIR=/home/vscode/t8 cargo test --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features`
- `TMPDIR=/home/vscode/t8 cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `TMPDIR=/home/vscode/t8 cargo build --manifest-path crates/Cargo.toml -p nbd-cow -p runner --all-targets --all-features`
- `TMPDIR=/home/vscode/t8 cargo test --manifest-path crates/Cargo.toml --workspace --all-targets --all-features -- --quiet`
- `TMPDIR=/home/vscode/t8 cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow -p runner --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' TMPDIR=/home/vscode/t8 cargo doc --manifest-path crates/Cargo.toml -p nbd-cow --all-features --no-deps`
- `TMPDIR=/home/vscode/t8 cargo test --manifest-path crates/Cargo.toml -p nbd-cow orphan`
- `TMPDIR=/home/vscode/t8 cargo test --manifest-path crates/Cargo.toml -p runner cmd::gc::nbd`

Closes #26860
