### PR TITLE
fix(ci): wait for cli artifact before runner e2e

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -94,13 +94,18 @@ end
 required_needs = %w[
   prepare
   deploy-api
+  deploy-cli
   deploy-runner-prepare
   deploy-runner-start
   cli-e2e-03-runner-prepare
   cli-e2e-03-runner-bootstrap
 ]
 unless required_needs.all? { |job_name| Array(runner["needs"]).include?(job_name) }
-  raise "runner E2E shards must wait for accounts, API, and runner deployment"
+  raise "runner E2E shards must wait for accounts, API, CLI, and runner deployment"
+end
+
+unless runner.fetch("if").include?("needs.deploy-cli.result == 'success'")
+  raise "runner E2E shards must require a published CLI artifact"
 end
 
 unless account_prepare.fetch("if").include?("turbo-runner-consumer-needed == 'true'")

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2852,6 +2852,7 @@ jobs:
     needs:
       - prepare
       - deploy-api
+      - deploy-cli
       - deploy-runner-prepare
       - deploy-runner-start
       - cli-e2e-03-runner-prepare
@@ -2861,6 +2862,7 @@ jobs:
       needs.prepare.outputs.job-ref != '' &&
       needs.prepare.outputs.turbo-runner-consumer-needed == 'true' &&
       needs.deploy-api.result == 'success' &&
+      needs.deploy-cli.result == 'success' &&
       needs.deploy-runner-prepare.result == 'success' &&
       needs.deploy-runner-start.result == 'success' &&
       needs.cli-e2e-03-runner-prepare.result == 'success' &&


### PR DESCRIPTION
## Summary

- make runner E2E shards wait for the commit-addressed CLI package to be published
- require a successful `deploy-cli` job before runner shards start
- lock the dependency and success condition into the workflow contract test

## Scope

- keeps API and CLI deployment parallel; only runner E2E consumption is gated
- does not change the separate partial-rerun test-account lifecycle behavior
- introduces no API, runner protocol, or persisted-state changes

## Validation

- `bash .github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `bash .github/scripts/tests/audit-okou-cli-cutover-test.sh`
- `bash .github/scripts/tests/cancel-superseded-merge-group-runs-test.sh`
- `bash .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `bash .github/scripts/tests/deploy-cli-workflow-test.sh`
- `bash .github/scripts/tests/deploy-desktop-workflow-test.sh`
- `bash .github/scripts/tests/deploy-okou-pages-workflow-test.sh`
- `bash .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash .github/scripts/tests/wait-production-deploy-queue-test.sh`
- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `shellcheck .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash .github/scripts/check-workflow-shell-compatibility.sh .github/workflows/turbo.yml`
- `actionlint 1.7.12 .github/workflows/turbo.yml`
- `bash scripts/check-file-size.sh .github/workflows/turbo.yml .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`

Closes #26878
