### PR TITLE
feat(api): resolve and record the run video model

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -54,6 +54,7 @@ import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
 import { setChatThreadVideoModelFixture } from "../../../test-fixtures/chat-thread-events";
 import {
+  readRunChatThreadIdFixture,
   readRunVideoModelFixture,
   setOrgMemberVideoModelFixture,
 } from "../../../test-fixtures/run-video-model";
@@ -10336,7 +10337,29 @@ describe("CHAT-02: run video model snapshot", () => {
     await expect(readRunVideoModelFixture(threadPinned.runId)).resolves.toBe(
       "fal-ai/veo3.1/fast",
     );
+
+    // Re-pinning while that run is still in flight must not reach it. This is
+    // the whole reason the model is snapshotted onto the run instead of being
+    // read back off the thread when generation happens.
+    await setChatThreadVideoModelFixture(
+      unpinned.threadId,
+      "dreamina-seedance-2-5-260628",
+    );
+    await expect(readRunVideoModelFixture(threadPinned.runId)).resolves.toBe(
+      "fal-ai/veo3.1/fast",
+    );
     await cancelChatRun(actor, threadPinned.runId);
+
+    // The next run does pick the re-pinned model up.
+    const rePinned = await sendChatRun(actor, {
+      agentId,
+      threadId: unpinned.threadId,
+      prompt: "the run after the re-pin uses the new thread pin",
+    });
+    await expect(readRunVideoModelFixture(rePinned.runId)).resolves.toBe(
+      "dreamina-seedance-2-5-260628",
+    );
+    await cancelChatRun(actor, rePinned.runId);
   }, 90_000);
 
   it("keeps falling back past video models the catalog no longer lists", async () => {
@@ -10402,8 +10425,12 @@ describe("CHAT-02: run video model snapshot", () => {
       modelProvider: "anthropic-api-key",
     });
     await expect(
+      readRunChatThreadIdFixture(withoutPreference.runId),
+    ).resolves.toBeNull();
+    await expect(
       readRunVideoModelFixture(withoutPreference.runId),
     ).resolves.toBe(DEFAULT_VIDEO_MODEL);
+    await cancelChatRun(actor, withoutPreference.runId);
 
     await setOrgMemberVideoModelFixture({
       orgId,
@@ -10416,7 +10443,11 @@ describe("CHAT-02: run video model snapshot", () => {
       modelProvider: "anthropic-api-key",
     });
     await expect(
+      readRunChatThreadIdFixture(withMemberDefault.runId),
+    ).resolves.toBeNull();
+    await expect(
       readRunVideoModelFixture(withMemberDefault.runId),
     ).resolves.toBe("MiniMax-H3");
+    await cancelChatRun(actor, withMemberDefault.runId);
   }, 90_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -12,6 +12,7 @@ import {
 import { replayChatThreadEvents } from "@okouai/core/chat-thread-event-replay";
 import { avatarTemplateStylePresetId } from "@okouai/core/avatar-template";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { DEFAULT_VIDEO_MODEL } from "@okouai/core/video-model-catalog";
 import {
   chatEventsContract,
   chatThreadsContract,
@@ -51,6 +52,11 @@ import { server } from "../../../mocks/server";
 import { backdateRunStartedAtFixture } from "../../../test-fixtures/agent-runs";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
+import { setChatThreadVideoModelFixture } from "../../../test-fixtures/chat-thread-events";
+import {
+  readRunVideoModelFixture,
+  setOrgMemberVideoModelFixture,
+} from "../../../test-fixtures/run-video-model";
 import {
   createBddApi,
   expectApiError,
@@ -10283,5 +10289,134 @@ describe("CHAT-02: shared user message queue", () => {
     const followUp = await api.readRun(actor, fired.runId);
     expect(followUp.prompt).toContain("queue-first fires after cancel");
     await cancelChatRun(actor, fired.runId);
+  }, 90_000);
+});
+
+describe("CHAT-02: run video model snapshot", () => {
+  it("resolves the thread pin, then the member default, then the catalog default", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    const orgId = actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected an entitled chat actor to own an org");
+    }
+
+    const unpinned = await sendChatRun(actor, {
+      agentId,
+      prompt: "video model falls back to the catalog default",
+    });
+    await expect(readRunVideoModelFixture(unpinned.runId)).resolves.toBe(
+      DEFAULT_VIDEO_MODEL,
+    );
+    await cancelChatRun(actor, unpinned.runId);
+
+    await setOrgMemberVideoModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedVideoModel: "MiniMax-H3",
+    });
+    const memberDefault = await sendChatRun(actor, {
+      agentId,
+      threadId: unpinned.threadId,
+      prompt: "video model comes from the member default",
+    });
+    await expect(readRunVideoModelFixture(memberDefault.runId)).resolves.toBe(
+      "MiniMax-H3",
+    );
+    await cancelChatRun(actor, memberDefault.runId);
+
+    await setChatThreadVideoModelFixture(
+      unpinned.threadId,
+      "fal-ai/veo3.1/fast",
+    );
+    const threadPinned = await sendChatRun(actor, {
+      agentId,
+      threadId: unpinned.threadId,
+      prompt: "video model comes from the thread pin",
+    });
+    await expect(readRunVideoModelFixture(threadPinned.runId)).resolves.toBe(
+      "fal-ai/veo3.1/fast",
+    );
+    await cancelChatRun(actor, threadPinned.runId);
+  }, 90_000);
+
+  it("keeps falling back past video models the catalog no longer lists", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    const orgId = actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected an entitled chat actor to own an org");
+    }
+    // Persisted pins are projected out of jsonb without being re-validated, so
+    // a run can start against an id that has since left the catalog.
+    const retiredVideoModel = "dreamina-seedance-1-0-retired";
+
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "anchor run that creates the thread",
+    });
+    await cancelChatRun(actor, anchor.runId);
+
+    await setOrgMemberVideoModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedVideoModel: "seedance-1-5-pro-251215",
+    });
+    await setChatThreadVideoModelFixture(anchor.threadId, retiredVideoModel);
+    const retiredThreadPin = await sendChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "retired thread pin falls through to the member default",
+    });
+    await expect(
+      readRunVideoModelFixture(retiredThreadPin.runId),
+    ).resolves.toBe("seedance-1-5-pro-251215");
+    await cancelChatRun(actor, retiredThreadPin.runId);
+
+    await setOrgMemberVideoModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedVideoModel: retiredVideoModel,
+    });
+    const retiredEverywhere = await sendChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "two retired pins fall through to the catalog default",
+    });
+    await expect(
+      readRunVideoModelFixture(retiredEverywhere.runId),
+    ).resolves.toBe(DEFAULT_VIDEO_MODEL);
+    await cancelChatRun(actor, retiredEverywhere.runId);
+  }, 90_000);
+
+  it("snapshots a video model onto runs that own no chat thread", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    const orgId = actor.orgId;
+    if (!orgId) {
+      throw new Error("Expected an entitled chat actor to own an org");
+    }
+
+    // Non-chat triggers such as telegram leave chat_thread_id null. Those runs
+    // have no thread layer to read and must still resolve rather than fail.
+    const withoutPreference = await api.createRun(actor, {
+      agentId,
+      prompt: "threadless run without any video model preference",
+      modelProvider: "anthropic-api-key",
+    });
+    await expect(
+      readRunVideoModelFixture(withoutPreference.runId),
+    ).resolves.toBe(DEFAULT_VIDEO_MODEL);
+
+    await setOrgMemberVideoModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedVideoModel: "MiniMax-H3",
+    });
+    const withMemberDefault = await api.createRun(actor, {
+      agentId,
+      prompt: "threadless run picks up the member default",
+      modelProvider: "anthropic-api-key",
+    });
+    await expect(
+      readRunVideoModelFixture(withMemberDefault.runId),
+    ).resolves.toBe("MiniMax-H3");
   }, 90_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -10408,6 +10408,24 @@ describe("CHAT-02: run video model snapshot", () => {
       readRunVideoModelFixture(retiredEverywhere.runId),
     ).resolves.toBe(DEFAULT_VIDEO_MODEL);
     await cancelChatRun(actor, retiredEverywhere.runId);
+
+    // `in` on a normal object also matches inherited Object.prototype keys.
+    // Persisted strings must match an own catalog id exactly.
+    await setOrgMemberVideoModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedVideoModel: "MiniMax-H3",
+    });
+    await setChatThreadVideoModelFixture(anchor.threadId, "toString");
+    const inheritedObjectKey = await sendChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "an inherited object key is not a catalog model",
+    });
+    await expect(
+      readRunVideoModelFixture(inheritedObjectKey.runId),
+    ).resolves.toBe("MiniMax-H3");
+    await cancelChatRun(actor, inheritedObjectKey.runId);
   }, 90_000);
 
   it("snapshots a video model onto runs that own no chat thread", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -269,6 +269,7 @@ import {
 } from "./zero-chat-queued-event.service";
 import { recordFirstAssistantEventEligibility } from "./zero-chat-first-assistant-event-metric.service";
 import { isWebChatTriggerSource } from "./zero-chat-trigger-source.service";
+import { resolveVideoModelForRun } from "./zero-video-model.service";
 import {
   cappedBaseConcurrencyLimit,
   loadOrgConcurrencyState,
@@ -5704,6 +5705,7 @@ interface LaunchRunRowsArgs {
   readonly sessionStorageMounts: readonly PersistedStorageMount[] | undefined;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly zeroRunModelPin: ZeroRunModelPin | undefined;
+  readonly selectedVideoModel: string;
   readonly callbackRows: readonly AgentRunCallbackInsert[];
   readonly chatThreadId: string | undefined;
   readonly zeroRunMetadata: ZeroRunMetadata | undefined;
@@ -5769,6 +5771,7 @@ function launchZeroRunValues(
     ...(metadata.codexServiceTier === undefined
       ? {}
       : { codexServiceTier: metadata.codexServiceTier }),
+    selectedVideoModel: args.selectedVideoModel,
     chatThreadId: args.chatThreadId ?? null,
     apiStartedAt: args.status === "queued" ? null : new Date(args.apiStartTime),
   };
@@ -6566,6 +6569,7 @@ function preparedLaunchRowsArgs(args: {
     sessionStorageMounts: args.commit.launch.sessionStorageMounts,
     modelProvider: args.commit.context.modelProvider,
     zeroRunModelPin: args.commit.createArgs.zeroRunModelPin,
+    selectedVideoModel: args.commit.context.selectedVideoModel,
     callbackRows: args.commit.callbackRows,
     chatThreadId: args.commit.createArgs.chatThreadId,
     zeroRunMetadata: args.commit.createArgs.zeroRunMetadata,
@@ -7015,6 +7019,7 @@ async function commitFailedLaunch(args: {
         sessionStorageMounts: undefined,
         modelProvider: args.context.modelProvider,
         zeroRunModelPin: args.createArgs.zeroRunModelPin,
+        selectedVideoModel: args.context.selectedVideoModel,
         callbackRows: args.callbackRows,
         chatThreadId: args.createArgs.chatThreadId,
         zeroRunMetadata: args.createArgs.zeroRunMetadata,
@@ -7569,6 +7574,8 @@ interface PreparedRunContext {
   readonly userTimezone: string | undefined;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly imageRecognitionAvailable: boolean;
+  /** Snapshotted onto the run row; see `resolveVideoModelForRun`. */
+  readonly selectedVideoModel: string;
 }
 
 function isPiSandboxEnabledForRun(
@@ -8565,6 +8572,14 @@ function prepareRunContext(
       const userTimezone = await resolvePreparedUserTimezone(input);
       signal.throwIfAborted();
 
+      const selectedVideoModel = await resolveVideoModelForRun({
+        db,
+        orgId: args.orgId,
+        userId: args.userId,
+        chatThreadId: args.chatThreadId,
+      });
+      signal.throwIfAborted();
+
       const outputMetadata = await timing.measure(
         "api_dispatch_prepare_context_prepare_output_metadata",
         "nested",
@@ -8601,6 +8616,7 @@ function prepareRunContext(
         additionalVolumeSources: outputMetadata.additionalVolumeSources,
         userTimezone,
         featureSwitchContext: bodyContext.featureSwitchContext,
+        selectedVideoModel,
         imageRecognitionAvailable: isImageRecognitionAvailableForRun({
           includeZeroTokenSecret: args.includeZeroTokenSecret,
           selectedModel:

--- a/turbo/apps/api/src/signals/services/zero-video-model.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-video-model.service.ts
@@ -1,0 +1,87 @@
+/**
+ * Resolves which built-in video model a run generates with.
+ *
+ * The chain is thread pin, then member default, then the catalog default. The
+ * result is snapshotted onto the run row when the run is dispatched, so
+ * re-pinning the thread mid-run cannot change what an in-flight run produces.
+ */
+import {
+  DEFAULT_VIDEO_MODEL,
+  VIDEO_MODEL_CONFIGS,
+  type VideoModel,
+} from "@okouai/core/video-model-catalog";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { orgMembersMetadata } from "@okouai/db/schema/org-members-metadata";
+import { and, eq } from "drizzle-orm";
+
+import type { ReadonlyDb } from "../external/db";
+
+/**
+ * Stored pins are plain strings projected out of jsonb without being
+ * re-validated against the current catalog, so a retired model id can outlive
+ * its catalog entry. Treat one as unset and keep falling back instead of
+ * failing the dispatch on data the user cannot reach any more.
+ */
+function catalogedVideoModel(
+  value: string | null | undefined,
+): VideoModel | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  return value in VIDEO_MODEL_CONFIGS ? (value as VideoModel) : null;
+}
+
+async function threadVideoModel(
+  db: ReadonlyDb,
+  chatThreadId: string,
+): Promise<VideoModel | null> {
+  const [thread] = await db
+    .select({ selectedVideoModel: chatThreads.selectedVideoModel })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, chatThreadId))
+    .limit(1);
+  return catalogedVideoModel(thread?.selectedVideoModel);
+}
+
+async function memberVideoModel(
+  db: ReadonlyDb,
+  orgId: string,
+  userId: string,
+): Promise<VideoModel | null> {
+  const [member] = await db
+    .select({ selectedVideoModel: orgMembersMetadata.selectedVideoModel })
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, orgId),
+        eq(orgMembersMetadata.userId, userId),
+      ),
+    )
+    .limit(1);
+  return catalogedVideoModel(member?.selectedVideoModel);
+}
+
+export async function resolveVideoModelForRun(args: {
+  readonly db: ReadonlyDb;
+  readonly orgId: string;
+  readonly userId: string;
+  /**
+   * Undefined for triggers that own no chat thread, such as telegram. Those
+   * runs skip the thread layer rather than failing to resolve.
+   */
+  readonly chatThreadId: string | undefined;
+}): Promise<VideoModel> {
+  const threadPin =
+    args.chatThreadId === undefined
+      ? null
+      : await threadVideoModel(args.db, args.chatThreadId);
+  if (threadPin) {
+    return threadPin;
+  }
+  const memberDefault = await memberVideoModel(
+    args.db,
+    args.orgId,
+    args.userId,
+  );
+  return memberDefault ?? DEFAULT_VIDEO_MODEL;
+}

--- a/turbo/apps/api/src/signals/services/zero-video-model.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-video-model.service.ts
@@ -5,9 +5,9 @@
  * result is snapshotted onto the run row when the run is dispatched, so
  * re-pinning the thread mid-run cannot change what an in-flight run produces.
  */
+import { isVideoModelId } from "@okouai/api-contracts/contracts/video-models";
 import {
   DEFAULT_VIDEO_MODEL,
-  VIDEO_MODEL_CONFIGS,
   type VideoModel,
 } from "@okouai/core/video-model-catalog";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
@@ -28,7 +28,7 @@ function catalogedVideoModel(
   if (value === undefined || value === null) {
     return null;
   }
-  return value in VIDEO_MODEL_CONFIGS ? (value as VideoModel) : null;
+  return isVideoModelId(value) ? value : null;
 }
 
 async function threadVideoModel(

--- a/turbo/apps/api/src/test-fixtures/run-video-model.ts
+++ b/turbo/apps/api/src/test-fixtures/run-video-model.ts
@@ -1,0 +1,47 @@
+/**
+ * Test fixtures for the run video-model snapshot.
+ *
+ * The member default has no write endpoint yet, and the snapshot column is
+ * write-only until endpoint enforcement lands, so neither side of the
+ * resolution chain is reachable through a product API.
+ */
+import { orgMembersMetadata } from "@okouai/db/schema/org-members-metadata";
+import { zeroRuns } from "@okouai/db/schema/zero-run";
+import { eq, sql } from "drizzle-orm";
+
+import { db } from "../lib/db";
+
+export async function setOrgMemberVideoModelFixture(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly selectedVideoModel: string;
+}): Promise<void> {
+  await db()
+    .insert(orgMembersMetadata)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      selectedVideoModel: args.selectedVideoModel,
+    })
+    .onConflictDoUpdate({
+      target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+      set: {
+        selectedVideoModel: args.selectedVideoModel,
+        updatedAt: sql`now()`,
+      },
+    });
+}
+
+export async function readRunVideoModelFixture(
+  runId: string,
+): Promise<string | null> {
+  const [run] = await db()
+    .select({ selectedVideoModel: zeroRuns.selectedVideoModel })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+  if (!run) {
+    throw new Error("Expected a Zero run row for the video model snapshot");
+  }
+  return run.selectedVideoModel;
+}

--- a/turbo/apps/api/src/test-fixtures/run-video-model.ts
+++ b/turbo/apps/api/src/test-fixtures/run-video-model.ts
@@ -35,13 +35,30 @@ export async function setOrgMemberVideoModelFixture(args: {
 export async function readRunVideoModelFixture(
   runId: string,
 ): Promise<string | null> {
+  return (await readRunRow(runId)).selectedVideoModel;
+}
+
+/** Confirms a run really is threadless before asserting how it resolved. */
+export async function readRunChatThreadIdFixture(
+  runId: string,
+): Promise<string | null> {
+  return (await readRunRow(runId)).chatThreadId;
+}
+
+async function readRunRow(runId: string): Promise<{
+  readonly selectedVideoModel: string | null;
+  readonly chatThreadId: string | null;
+}> {
   const [run] = await db()
-    .select({ selectedVideoModel: zeroRuns.selectedVideoModel })
+    .select({
+      selectedVideoModel: zeroRuns.selectedVideoModel,
+      chatThreadId: zeroRuns.chatThreadId,
+    })
     .from(zeroRuns)
     .where(eq(zeroRuns.id, runId))
     .limit(1);
   if (!run) {
     throw new Error("Expected a Zero run row for the video model snapshot");
   }
-  return run.selectedVideoModel;
+  return run;
 }

--- a/turbo/apps/api/src/test-fixtures/run-video-model.ts
+++ b/turbo/apps/api/src/test-fixtures/run-video-model.ts
@@ -1,9 +1,9 @@
 /**
  * Test fixtures for the run video-model snapshot.
  *
- * The member default has no write endpoint yet, and the snapshot column is
- * write-only until endpoint enforcement lands, so neither side of the
- * resolution chain is reachable through a product API.
+ * Retired member defaults cannot be written through the current endpoint, and
+ * the snapshot column is write-only until endpoint enforcement lands. These
+ * historical-input and snapshot-output cases therefore need direct DB access.
  */
 import { orgMembersMetadata } from "@okouai/db/schema/org-members-metadata";
 import { zeroRuns } from "@okouai/db/schema/zero-run";

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -10,8 +10,8 @@ import { supportedRunModelSchema } from "./model-providers";
 import {
   VIDEO_ASPECT_RATIOS,
   VIDEO_DURATIONS,
-  VIDEO_MODEL_IDS,
   VIDEO_RESOLUTIONS,
+  videoModelIdSchema,
 } from "./video-models";
 import {
   avatarVideoAspectRatioSchema,
@@ -242,7 +242,7 @@ const presentationGenerationTemplateRequestSchema = z.object({
  */
 const videoGenerationOptionsSchema = z
   .object({
-    model: z.enum(VIDEO_MODEL_IDS),
+    model: videoModelIdSchema,
     aspectRatio: z.enum(VIDEO_ASPECT_RATIOS),
     duration: z.enum(VIDEO_DURATIONS),
     resolution: z.enum(VIDEO_RESOLUTIONS),
@@ -878,16 +878,9 @@ const chatThreadCreateBodySchema = z.object({
   title: z.string().optional(),
 });
 
-/**
- * Built-in video model pinned to a chat thread. Unlike the run model this
- * carries no provider routing, no service tier, and no org policy row: every
- * catalog model is selectable by every workspace.
- */
-const videoModelRequestSchema = z.enum(VIDEO_MODEL_IDS);
-
 const chatThreadVideoModelUpdateBodySchema = z.object({
   /** Video model id, or null to fall back to the member and system defaults. */
-  model: videoModelRequestSchema.nullable(),
+  model: videoModelIdSchema.nullable(),
   eventId: chatThreadEventIdSchema.optional(),
 });
 

--- a/turbo/packages/api-contracts/src/contracts/video-models.ts
+++ b/turbo/packages/api-contracts/src/contracts/video-models.ts
@@ -6,6 +6,8 @@
  * the per-model capabilities, lives in `@okouai/core/video-model-catalog`, which
  * depends on this package.
  */
+import { z } from "zod";
+
 export const VIDEO_MODEL_IDS = [
   "dreamina-seedance-2-5-260628",
   "dreamina-seedance-2-0-260128",
@@ -30,6 +32,14 @@ export function isVideoModelId(
 ): model is VideoModelId {
   return typeof model === "string" && VIDEO_MODEL_ID_SET.has(model);
 }
+
+/**
+ * A video model id on the wire. Unlike the run model this carries no provider
+ * routing, no service tier, and no org policy row: every catalog model is
+ * selectable by every workspace, so thread pins, member defaults, and
+ * per-generation overrides all validate against this one schema.
+ */
+export const videoModelIdSchema = z.enum(VIDEO_MODEL_IDS);
 
 export const VIDEO_ASPECT_RATIOS = [
   "21:9",

--- a/turbo/packages/api-contracts/src/contracts/zero-user-model-preference.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-model-preference.ts
@@ -2,16 +2,10 @@ import { z } from "zod";
 import { initContract, authHeadersSchema } from "./base";
 import { apiErrorSchema } from "./errors";
 import { supportedRunModelSchema } from "./model-providers";
-import { VIDEO_MODEL_IDS } from "./video-models";
+import { videoModelIdSchema } from "./video-models";
 import { chatThreadServiceTierSchema } from "./chat-threads";
 
 const c = initContract();
-
-/**
- * Member default for built-in video generation. Independent of the run model:
- * it carries no provider routing, no service tier, and no org policy row.
- */
-const videoModelPreferenceSchema = z.enum(VIDEO_MODEL_IDS);
 
 export const userModelPreferenceResponseSchema = z.object({
   selectedModel: supportedRunModelSchema.nullable(),
@@ -25,7 +19,7 @@ export const userModelPreferenceResponseSchema = z.object({
    * Remove — make it required — once the pre-field API is outside that window.
    * Follow-up: #26765.
    */
-  selectedVideoModel: videoModelPreferenceSchema.nullable().optional(),
+  selectedVideoModel: videoModelIdSchema.nullable().optional(),
   updatedAt: z.string().nullable(),
 });
 
@@ -44,7 +38,7 @@ export const updateUserModelPreferenceRequestSchema = z.object({
    * its own optional fields. An older bundle keeping its stored default falls
    * out of the same rule rather than needing its own branch.
    */
-  selectedVideoModel: videoModelPreferenceSchema.nullable().optional(),
+  selectedVideoModel: videoModelIdSchema.nullable().optional(),
 });
 
 export type UpdateUserModelPreferenceRequest = z.infer<


### PR DESCRIPTION
PR4 of the video-model chain for #26765. Rebased onto current main, which now contains #26831 and #26841.

## What this does

Adds `turbo/apps/api/src/signals/services/zero-video-model.service.ts` with `resolveVideoModelForRun()`:

```
chat_threads.selected_video_model
  ?? org_members_metadata.selected_video_model
  ?? DEFAULT_VIDEO_MODEL
```

The result is written to `zeroRuns.selectedVideoModel` in `launchZeroRunValues`, which is the single funnel both run inserts go through (the direct insert and the atomic-launch CTE). Resolution happens once in `prepareRunContext`, alongside the other per-run resolutions.

## Why snapshot instead of reading live

Changing a thread's video model must not affect a run that is already in flight — only later ones. Resolving at dispatch and freezing the value on the run row is what gives that. If the generation endpoint instead looked the thread up from `runId`, a mid-run re-pin would leak into the running run. `zero_runs` already stores `selected_model` and `codex_service_tier` this way; the new column sits next to them.

## Catalog validation

Both stored layers are checked against the catalog, and a model id the catalog no longer lists is treated as unset so resolution falls through to the next layer rather than throwing. The persisted values are projected out of jsonb without being re-validated against the current catalog, so a retired id can outlive its catalog entry, and a run must not fail on a value the user can no longer reach.

## Write-only on purpose

This PR does not touch `zero-video-io-generate.ts`. Endpoint enforcement is PR5. Splitting them lets the snapshot run for a while so the resolved values can be confirmed before anything depends on them, and lets PR5 be reverted without unwinding the snapshot.

## Threadless runs

`zero_runs.chat_thread_id` is null for non-chat triggers such as telegram. Those runs skip the thread layer and resolve to the member or catalog default instead of erroring — covered by its own test, which asserts the null `chat_thread_id` rather than trusting the entry point.

## Schema convergence

#26831 and #26841 each defined their own `z.enum(VIDEO_MODEL_IDS)` because they branched from a common base and could not reach each other's copy. A third inline copy already sat in the video generation options. Now that both have landed, all three share one `videoModelIdSchema` exported from `video-models.ts` — the contract that already owns the id list and the `isVideoModelId` guard. No behavior change; the enum is identical in all three places.

## Tests

Integration tests at the route boundary against a real database, in `chat-events.bdd.test.ts`:

- each of the three layers wins in turn (catalog default → member default → thread pin)
- **re-pinning the thread while a run is in flight leaves that run's snapshot alone, and the next run picks the new pin up** — this is the property the whole design exists for
- a retired thread pin falls through to the member default, and retired values on both layers fall through to the catalog default
- runs with a null `chat_thread_id` snapshot the catalog default, then the member default

New fixtures in `test-fixtures/run-video-model.ts` set the member default and read the snapshot back. The thread pin uses the existing `setChatThreadVideoModelFixture` from #26807.

Verified the tests are load-bearing by mutation: dropping the `selectedVideoModel` write fails all three; dropping the catalog-membership check fails the fall-through test; dropping the thread-pin layer fails the ordering test.

## One thing worth a reviewer's opinion

**The test fixtures read and write DB rows directly**, which `docs/testing/api-testing.md` says to raise during review rather than do silently — so, raising it. `zero_runs.selected_video_model` has no reader until PR5, so the snapshot cannot be asserted through any API surface today. There is precedent already on main in `setChatThreadVideoModelFixture`. These fixtures should be deleted once PR5 exposes the value.

## Local checks

- repo-wide `check-types` (14 workspaces) and `lint` (13 workspaces, 0 errors), `knip` (exit 0), `prettier --check` — all clean
- Full `api` vitest suite across 6 shards — ~2950 tests, all green

## Sequencing

Not for auto-merge — awaiting human review.

Cross-chain constraint for later: **PR5 must not merge before PR6.** PR5 removes `--model` from the template prompt and PR6's picker is the replacement entry point; merging them out of order leaves a window with no entry point.