### PR TITLE
docs(rust): document batch write result truncation

### DIFF
--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -288,6 +288,9 @@ pub fn encode_write_file_result(success: bool, error: &str) -> Vec<u8> {
 }
 
 /// Encode write_files_result payload: `[1B success][2B error_len][error]`.
+///
+/// Like [`encode_write_file_result`], the error message is truncated to at most
+/// 65535 bytes at a UTF-8 boundary.
 pub fn encode_write_files_result(success: bool, error: &str) -> Vec<u8> {
     encode_write_file_result(success, error)
 }

--- a/crates/vsock-proto/tests/write_file_properties.rs
+++ b/crates/vsock-proto/tests/write_file_properties.rs
@@ -135,6 +135,22 @@ fn assert_strict_prefixes_rejected(
     Ok(())
 }
 
+#[test]
+fn write_files_result_truncates_oversized_utf8_at_character_boundary() {
+    let prefix = "A".repeat(u16::MAX as usize - 1);
+    let error = format!("{prefix}é");
+    let payload = encode_write_files_result(false, &error);
+
+    assert_eq!(payload.first(), Some(&0));
+    let declared_len = u16::from_be_bytes(payload.get(1..3).unwrap().try_into().unwrap());
+    assert_eq!(declared_len as usize, prefix.len());
+    assert_eq!(payload.len(), 3 + prefix.len());
+
+    let (success, decoded_error) = decode_write_files_result(&payload).unwrap();
+    assert!(!success);
+    assert_eq!(decoded_error, prefix);
+}
+
 proptest! {
     #![proptest_config(property_config())]
 


### PR DESCRIPTION
## Summary

- document that `encode_write_files_result` shares the single-file encoder's 65,535-byte UTF-8-boundary truncation contract
- add deterministic public-API coverage for an over-limit multibyte batch diagnostic

## Exclusions

- no wire-format, encoder implementation, truncation behavior, dependency, or lockfile changes

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto write_files_result_truncates_oversized_utf8_at_character_boundary`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-proto --all-features --no-deps`

Closes #26887
