### PR TITLE
fix(platform): show seo in credit usage

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4588,6 +4588,7 @@
       "imageRecognize": "Bilderkennung",
       "maps": "Karten",
       "peopleSearch": "Personensuche",
+      "seo": "SEO",
       "translation": "Übersetzung",
       "usage": "Nutzung",
       "weather": "Wetter",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4588,6 +4588,7 @@
       "imageRecognize": "Image Recognize",
       "maps": "Maps",
       "peopleSearch": "People Search",
+      "seo": "SEO",
       "translation": "Translation",
       "usage": "Usage",
       "weather": "Weather",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -4640,6 +4640,7 @@
       "imageRecognize": "Reconocimiento de imágenes",
       "maps": "Mapas",
       "peopleSearch": "Búsqueda de personas",
+      "seo": "SEO",
       "translation": "Traducción",
       "usage": "Uso",
       "weather": "Tiempo",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -4640,6 +4640,7 @@
       "imageRecognize": "Reconnaissance d'images",
       "maps": "Cartes",
       "peopleSearch": "Recherche de personnes",
+      "seo": "SEO",
       "translation": "Traduction",
       "usage": "Utilisation",
       "weather": "Météo",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4588,6 +4588,7 @@
       "imageRecognize": "छवि पहचान",
       "maps": "एमएपीएस",
       "peopleSearch": "लोग खोजें",
+      "seo": "SEO",
       "translation": "अनुवाद",
       "usage": "उपयोग",
       "weather": "मौसम",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4587,6 +4587,7 @@
       "imageRecognize": "Pengenalan Gambar",
       "maps": "Peta",
       "peopleSearch": "Pencarian Orang",
+      "seo": "SEO",
       "translation": "Terjemahan",
       "usage": "Penggunaan",
       "weather": "Cuaca",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -4640,6 +4640,7 @@
       "imageRecognize": "Riconoscimento immagini",
       "maps": "Mappe",
       "peopleSearch": "Ricerca persone",
+      "seo": "SEO",
       "translation": "Traduzione",
       "usage": "Utilizzo",
       "weather": "Meteo",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4587,6 +4587,7 @@
       "imageRecognize": "画像認識",
       "maps": "地図",
       "peopleSearch": "人物検索",
+      "seo": "SEO",
       "translation": "翻訳",
       "usage": "使用量",
       "weather": "天気",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4587,6 +4587,7 @@
       "imageRecognize": "이미지 인식",
       "maps": "지도",
       "peopleSearch": "사람 검색",
+      "seo": "SEO",
       "translation": "번역",
       "usage": "사용량",
       "weather": "날씨",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4640,6 +4640,7 @@
       "imageRecognize": "Reconhecimento de imagem",
       "maps": "Mapas",
       "peopleSearch": "Pesquisa de pessoas",
+      "seo": "SEO",
       "translation": "Tradução",
       "usage": "Uso",
       "weather": "Clima",

--- a/turbo/apps/platform/src/lib/credit-usage-display.ts
+++ b/turbo/apps/platform/src/lib/credit-usage-display.ts
@@ -27,6 +27,11 @@ const USAGE_DISPLAY_NAMES = {
       return $.usage.displayNames.peopleSearch;
     });
   },
+  seo(): string {
+    return i18n.t(($) => {
+      return $.usage.displayNames.seo;
+    });
+  },
   translation(): string {
     return i18n.t(($) => {
       return $.usage.displayNames.translation;
@@ -55,6 +60,7 @@ const MANAGED_USAGE_KIND_DISPLAY_NAMES: Readonly<Record<string, () => string>> =
     maps: USAGE_DISPLAY_NAMES.maps,
     "web-search": USAGE_DISPLAY_NAMES.webSearch,
     "people-search": USAGE_DISPLAY_NAMES.peopleSearch,
+    seo: USAGE_DISPLAY_NAMES.seo,
     finance: USAGE_DISPLAY_NAMES.finance,
     weather: USAGE_DISPLAY_NAMES.weather,
     "image-recognition": USAGE_DISPLAY_NAMES.imageRecognize,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -41,12 +41,12 @@ function usageRows(): UsageRecordRow[] {
       threadId: "thread-planning",
       runId: null,
       title: "Quarterly planning chat",
-      credits: 983,
+      credits: 1083,
       tokens: 2200,
       breakdown: [
         {
           kind: "other",
-          credits: 983,
+          credits: 1083,
           providers: [
             {
               provider: "firecrawl",
@@ -65,6 +65,11 @@ function usageRows(): UsageRecordRow[] {
                 { kind: "people-search", credits: 80 },
                 { kind: "web-search", credits: 120 },
               ],
+            },
+            {
+              provider: "dataforseo",
+              credits: 100,
+              usageKinds: [{ kind: "seo", credits: 100 }],
             },
             {
               provider: "apidojo",
@@ -631,7 +636,7 @@ describe("personal usage settings", () => {
       expect(screen.getByText("Quarterly planning chat")).toBeInTheDocument();
       expect(screen.getByText("Slack customer follow-up")).toBeInTheDocument();
     });
-    expect(screen.getByText("983")).toBeInTheDocument();
+    expect(screen.getByText("1.1K")).toBeInTheDocument();
     expect(screen.queryByText("Extended agent audit")).not.toBeInTheDocument();
     expect(screen.queryByText("All sources")).not.toBeInTheDocument();
     expect(requestedRanges).toContain("today");
@@ -657,6 +662,11 @@ describe("personal usage settings", () => {
           return element.parentElement?.textContent === "Web Search120";
         }),
       ).toBeTruthy();
+      expect(
+        screen.getAllByText("SEO").some((element) => {
+          return element.parentElement?.textContent === "SEO100";
+        }),
+      ).toBeTruthy();
       expect(screen.getAllByText("Finance").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Weather").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Translation").length).toBeGreaterThanOrEqual(
@@ -665,6 +675,7 @@ describe("personal usage settings", () => {
       expect(screen.queryByText("Firecrawl")).not.toBeInTheDocument();
       expect(screen.queryByText("Google Maps")).not.toBeInTheDocument();
       expect(screen.queryByText("Perplexity")).not.toBeInTheDocument();
+      expect(screen.queryByText("Dataforseo")).not.toBeInTheDocument();
       expect(screen.queryByText("Apidojo")).not.toBeInTheDocument();
       expect(screen.queryByText("Google Weather")).not.toBeInTheDocument();
       expect(


### PR DESCRIPTION
## Summary

- show the SEO product name for SEO credit usage instead of the DataForSEO provider
- add the localized SEO display label across supported locales
- cover DataForSEO-backed SEO usage in the Settings credit usage page test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/personal-usage-tab.test.tsx`

Local dev server and browser walkthrough were not run per repository guidance.
