### PR TITLE
test(rust): cover invalid guest storage manifest mount combinations

### DIFF
--- a/crates/guest-contracts/src/storage_manifest.rs
+++ b/crates/guest-contracts/src/storage_manifest.rs
@@ -430,6 +430,78 @@ mod tests {
     }
 
     #[test]
+    fn manifest_rejects_fields_for_wrong_mount_category() {
+        for (name, invalid_mount, expected_error, valid_mount) in [
+            (
+                "writeback extractPath",
+                json!({
+                    "mountPath": "/workspace",
+                    "extractPath": "/run/storage-instructions/0",
+                    "writeback": true
+                }),
+                "writeback storage mount cannot contain instruction normalization fields",
+                json!({
+                    "mountPath": "/data",
+                    "extractPath": "/run/storage-instructions/0"
+                }),
+            ),
+            (
+                "writeback instructionsTargetFilename",
+                json!({
+                    "mountPath": "/workspace",
+                    "instructionsTargetFilename": "AGENTS.md",
+                    "writeback": true
+                }),
+                "writeback storage mount cannot contain instruction normalization fields",
+                json!({
+                    "mountPath": "/data",
+                    "instructionsTargetFilename": "AGENTS.md"
+                }),
+            ),
+            (
+                "read-only empty",
+                json!({
+                    "mountPath": "/data",
+                    "empty": true
+                }),
+                "read-only storage mount cannot be empty",
+                json!({
+                    "mountPath": "/workspace",
+                    "empty": true,
+                    "writeback": true
+                }),
+            ),
+            (
+                "read-only missingRootPolicy",
+                json!({
+                    "mountPath": "/data",
+                    "missingRootPolicy": "preserveParentVersion"
+                }),
+                "read-only storage mount cannot contain missingRootPolicy",
+                json!({
+                    "mountPath": "/workspace",
+                    "missingRootPolicy": "preserveParentVersion",
+                    "writeback": true
+                }),
+            ),
+        ] {
+            let result = serde_json::from_value::<Manifest>(json!({
+                "storageMounts": [invalid_mount]
+            }));
+            let error = result.unwrap_err().to_string();
+            assert!(
+                error.contains(expected_error),
+                "{name}: expected {expected_error:?} in {error:?}"
+            );
+
+            let result = serde_json::from_value::<Manifest>(json!({
+                "storageMounts": [valid_mount]
+            }));
+            assert!(result.is_ok(), "{name}: valid control failed: {result:?}");
+        }
+    }
+
+    #[test]
     fn manifest_rejects_legacy_representations() {
         for value in [
             json!({ "storages": [], "artifacts": [] }),


### PR DESCRIPTION
## Summary

- add table-driven deserialization coverage for all four invalid storage mount category/field combinations
- pair every rejected payload with the same field on its supported read-only or writeback category
- assert the stable validation diagnostic for each rejection case

## Scope

This is a test-only change in `guest-contracts`. It does not change serialization, deserialization, diagnostics, public types, runtime behavior, the wire format, generated files, documentation, or dependencies.

Turbo/Vitest checks and a local development server are excluded because the change affects only a Rust test module.

## Validation

- `cargo test -p guest-contracts storage_manifest::tests --manifest-path crates/Cargo.toml` (5 passed)
- `cargo fmt --all --manifest-path crates/Cargo.toml -- --check`
- `cargo clippy --locked -p guest-contracts --all-targets --all-features --manifest-path crates/Cargo.toml -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked -p guest-contracts --all-features --no-deps --manifest-path crates/Cargo.toml`
- `cargo test --locked -p guest-contracts --all-targets --all-features --manifest-path crates/Cargo.toml` (103 passed)

Closes #26886
