### PR TITLE
test(e2e): synchronize clerk first-factor submission

### DIFF
--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -21,6 +21,47 @@ if JOB_REF="invalid_ref" bash -c \
   echo "browser helper accepted a JOB_REF that its cleanup rejects" >&2
   exit 1
 fi
+
+first_factor_barrier="$(
+  bash -c '
+    source "$1"
+    wait_for_browser_target() {
+      printf "%s\n" "$*"
+    }
+    wait_for_sign_in_email_code_ready
+  ' _ "$browser_helper"
+)"
+for required_state in \
+  "firstFactorVerification" \
+  "strategy === 'email_code'" \
+  "status === 'unverified'"; do
+  if [[ "$first_factor_barrier" != *"$required_state"* ]]; then
+    echo "browser helper does not wait for prepared email-code first factor" >&2
+    exit 1
+  fi
+done
+
+otp_call_log="$(mktemp)"
+trap 'rm -f "$otp_call_log"' EXIT
+OTP_CALL_LOG="$otp_call_log" bash -c '
+  source "$1"
+  wait_for_browser_target() {
+    return 0
+  }
+  agent-browser() {
+    printf "%s\n" "$*" >> "$OTP_CALL_LOG"
+    if [[ "$1" == "get" && "$2" == "count" ]]; then
+      printf "1\n"
+    fi
+  }
+  enter_otp "424242"
+' _ "$browser_helper"
+expected_otp_calls=$'get count input[autocomplete="one-time-code"], input[name="code"], input[inputmode="numeric"]\nfill input[autocomplete="one-time-code"], input[name="code"], input[inputmode="numeric"] 424242'
+if [[ "$(<"$otp_call_log")" != "$expected_otp_calls" ]]; then
+  echo "browser helper must leave OTP submission to Clerk" >&2
+  exit 1
+fi
+
 if [[ "$(grep -c '^[[:space:]]*delete_e2e_account_if_exists' "$browser_test")" -ne 2 ]]; then
   echo "browser E2E must clean its exact account before and after the test" >&2
   exit 1

--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -305,6 +305,22 @@ wait_for_auth_next_step() {
 }
 
 # ---------------------------------------------------------------------------
+# wait_for_sign_in_email_code_ready — Wait for Clerk to finish preparing the
+# email-code first factor before entering the code. The OTP input mounts while
+# prepareFirstFactor is still in flight, so its presence is not a readiness
+# signal for attemptFirstFactor.
+# ---------------------------------------------------------------------------
+wait_for_sign_in_email_code_ready() {
+  wait_for_browser_target --fn \
+    "(() => {
+      const verification =
+        window.Clerk?.client?.signIn?.firstFactorVerification;
+      return verification?.strategy === 'email_code'
+        && verification.status === 'unverified';
+    })()"
+}
+
+# ---------------------------------------------------------------------------
 # accept_legal_consent — Check legal consent checkbox if present
 # Clerk renders this when legal_consent_enabled is on. Safe to call always.
 # ---------------------------------------------------------------------------
@@ -338,7 +354,6 @@ dismiss_cookie_banner() {
 # ---------------------------------------------------------------------------
 enter_otp() {
   local code="$1"
-  local auth_path="$2"
   local otp_selector='input[autocomplete="one-time-code"], input[name="code"], input[inputmode="numeric"]'
 
   wait_for_browser_target "$otp_selector"
@@ -350,21 +365,6 @@ enter_otp() {
     for digit in $(echo "$code" | grep -o .); do
       agent-browser press "$digit"
     done
-  fi
-
-  wait_for_browser_target --fn \
-    "(() => {
-      if (!window.location.pathname.includes('/${auth_path}')) return true;
-      return Array.from(document.querySelectorAll('button')).some((button) => {
-        const label = button.textContent?.trim() ?? '';
-        return !button.disabled && /^(Continue|Verify)$/i.test(label);
-      });
-    })()"
-
-  if [[ "$(agent-browser eval "window.location.pathname.includes('/${auth_path}')")" == "true" ]]; then
-    if ! agent-browser find role button click --name "Continue" --exact 2>/dev/null; then
-      agent-browser find role button click --name "Verify" --exact
-    fi
   fi
 }
 

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -203,7 +203,7 @@ open_auth_form() {
   local sign_up_state
   sign_up_state="$(wait_for_auth_next_step "sign-up")"
   if [[ "$sign_up_state" == "otp" ]]; then
-    enter_otp "$OTP" "sign-up"
+    enter_otp "$OTP"
     wait_for_auth_completion "sign-up"
   fi
   touch "$SIGN_UP_COMPLETE_FILE"
@@ -265,7 +265,8 @@ open_auth_form() {
     agent-browser find text "Email code" click
   fi
 
-  enter_otp "$OTP" "sign-in"
+  wait_for_sign_in_email_code_ready
+  enter_otp "$OTP"
   wait_for_auth_completion "sign-in"
   echo "# Sign-in successful!" >&3
 }


### PR DESCRIPTION
## Trigger

Fingerprint: `cli-e2e-02-browser-brw-t01-sign-out-sign-in-same-account-clerk-first-factor-rejected`

- Turbo run [31686100999](https://github.com/vm0-ai/vm0/actions/runs/31686100999), main SHA `6b22a4d16d55fe367fd16df39b1fb26afedcbfee`
- Substantive failure: [`cli-e2e-02-browser`](https://github.com/vm0-ai/vm0/actions/runs/31686100999/job/94403112947), test `sign out and sign in with same account`
- The same SHA passed this test in merge-group run [31685545803](https://github.com/vm0-ai/vm0/actions/runs/31685545803/job/94401186034) in 10.1 seconds. The following main run [31686507970](https://github.com/vm0-ai/vm0/actions/runs/31686507970/job/94404491261) also passed.
- The source merge, #26804, changed only chat steer handling and did not touch auth, browser E2E, or the workflow.

## Root cause

Classification: missing test synchronization at the external Clerk first-factor boundary.

The failed sign-in mounted the OTP UI and the test immediately entered `424242`, but Clerk's `prepare_first_factor` request was still in flight for 3194 ms. The pinned `@clerk/ui@1.27.0` implementation mounts the code input before that asynchronous preparation completes and automatically calls `attemptFirstFactor` as soon as all six digits are present.

That explains the causal request sequence:

1. `prepare_first_factor` started and later returned 200.
2. OTP entry raced its completion and the first `attempt_first_factor` returned 400 after 2372 ms.
3. The helper waited for the primary button to become enabled after the rejected automatic attempt, then clicked it. Clerk's pinned `onFakeContinue` implementation submits an empty code, so the second attempt returned the expected missing-parameter 422 after 158 ms.
4. The page then remained on `/sign-in/factor-one` until the 60-second completion wait expired.

The job did not retain response bodies, so the specific first 400 code cannot be recovered. Clerk's documented contract requires first-factor preparation before an attempt, and its `verification_missing` and `verification_not_sent` errors are both 400. The second empty submission is directly established by the pinned UI source and Clerk's 422 missing-parameter contract.

The repeated `Enter code.` text is the code prompt plus the inline validation produced by the empty submission in the same Clerk card, not evidence of two OTP controls. The final completion timeout, post-failure account lookup, and aggregate `ci-gate-turbo` failure are downstream effects.

## Fix

- wait for Clerk's explicit `firstFactorVerification` state to be `email_code` and `unverified` before entering the sign-in OTP; this is the domain barrier that preparation has completed
- leave six-digit OTP submission to Clerk's code control and remove the helper's synthetic second Continue/Verify click
- lock both ownership rules into the existing Clerk workflow contract test

The user-visible invariant remains unchanged: a newly registered user signs out and signs back in to the same account successfully. No retry, sleep, timeout increase, skipped assertion, force action, or accepted Clerk failure was added.

## Local validation

- `bash .github/scripts/tests/clerk-test-resource-workflow-test.sh` — 5 consecutive passes, plus one final pass after formatting cleanup
- `npx --yes shellcheck -x -s bash e2e/helpers/browser.bash e2e/tests/02-browser/brw-t01-platform-e2e.bats .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `./e2e/test/libs/bats/bin/bats --count ./e2e/tests/02-browser/brw-t01-platform-e2e.bats` — 2 tests discovered
- Prettier 3.6.2 with `--ignore-unknown`
- `bash scripts/check-file-size.sh` for all changed files
- `git diff --check`

## Preview validation

Validated deployed head `d6627cb46778e456bd1539dfc81a0416dd67c7db` against the URLs emitted by this PR's deployment jobs:

- app/auth gateway: https://pr-26904-app.omby.ai
- API alias: https://pr-26904-api.vm6.ai
- browser: Headless Chromium 151, 1440 x 1000 viewport
- account shape: one synthetic Clerk test-mode email/password account; no feature-switch overrides or onboarding bypass; the E2E redirect target remained `/_/skeleton`

After one successful sign-up, the same account completed five real Clerk sign-out/sign-in cycles. Every cycle waited for `firstFactorVerification.strategy === "email_code"` and `status === "unverified"`, entered `424242` once, received one successful `attempt_first_factor`, and reached the configured app redirect. No 400 or 422 first-factor response occurred.

| Cycle | Preparation barrier | Auth completion | Clerk result |
| --- | ---: | ---: | --- |
| 1 | 398 ms | 1520 ms | `attempt_first_factor=200`, one submission |
| 2 | 452 ms | 1420 ms | `prepare_first_factor=200`, `attempt_first_factor=200`, one submission |
| 3 | 394 ms | 1485 ms | `prepare_first_factor=200`, `attempt_first_factor=200`, one submission |
| 4 | 490 ms | 1406 ms | `prepare_first_factor=200`, `attempt_first_factor=200`, one submission |
| 5 | 432 ms | 1494 ms | `prepare_first_factor=200`, `attempt_first_factor=200`, one submission |

The PR's exact [`cli-e2e-02-browser`](https://github.com/vm0-ai/vm0/actions/runs/31688073057/job/94409296864) job also passed: sign-up in 10.205 seconds and same-account sign-in in 9.920 seconds.
