### PR TITLE
refactor(chat): read search from durable message projection

### DIFF
--- a/turbo/apps/api/src/lib/chat-search-bigram.ts
+++ b/turbo/apps/api/src/lib/chat-search-bigram.ts
@@ -128,7 +128,7 @@ export function chatSearchMatchRanges(
   return merged;
 }
 
-/** Normalized form stored in chat_event_search_docs.text_bigram. */
+/** Normalized form stored in both search projections during dual-writing. */
 export function chatSearchIndexText(text: string): string {
   return tokenGroups(text)
     .flatMap((group) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from "node:crypto";
+
+import { testChatEventSearchProjectionContract } from "@okouai/api-contracts/contracts/test-chat-event-search-projection";
+import { describe, expect, it } from "vitest";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import {
+  insertChatSearchProjectionCoverageFixture,
+  insertSearchablePromptFixture,
+  removeChatSearchSourceEventsFixture,
+  renameChatSearchAgentComposeFixture,
+  updateChatSearchSourceThreadFixture,
+} from "../../../test-fixtures/chat-event-search";
+import { testChatEventSearchProjectionRoutes } from "../test-chat-event-search-projection";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
+
+const context = testContext();
+const bdd = createBddApi(context);
+const chat = createChatFilesBddApi(context);
+
+async function projectChatSearchMessages(
+  chatThreadIds: readonly string[],
+): Promise<void> {
+  const client = setupApp({
+    context,
+    routes: testChatEventSearchProjectionRoutes,
+  })(testChatEventSearchProjectionContract);
+  const response = await accept(
+    client.project({ body: { chat_thread_ids: [...chatThreadIds] } }),
+    [200],
+  );
+  expect(response.body.durableProjectionAvailable).toBeTruthy();
+  expect(response.body.convergence.durableCaughtUpThreads).toBe(
+    chatThreadIds.length,
+  );
+}
+
+async function createSearchThread(
+  actor: ApiTestUser,
+  agentName: string,
+): Promise<{ readonly agentId: string; readonly threadId: string }> {
+  const compose = await chat.createComposeForChatThread(actor, agentName);
+  const thread = await chat.createThread(actor, {
+    agentId: compose.composeId,
+    title: `Search reader ${randomUUID()}`,
+  });
+  return { agentId: compose.composeId, threadId: thread.id };
+}
+
+describe("GET /api/okou/chat/search durable reader", () => {
+  it("serves message identities and context after source events are deleted", async () => {
+    const owner = bdd.user();
+    const source = await createSearchThread(
+      owner,
+      `durable-reader-${randomUUID().slice(0, 8)}`,
+    );
+    const keyword = `durablereader${randomUUID().replaceAll("-", "")}`;
+    const first = await insertChatSearchProjectionCoverageFixture({
+      chatThreadId: source.threadId,
+      promptText: "context user before",
+      assistantText: "context assistant before",
+      errorText: `excludederror${randomUUID().replaceAll("-", "")}`,
+      terminalText: `excludedterminal${randomUUID().replaceAll("-", "")}`,
+    });
+    const secondError = `seconderror${randomUUID().replaceAll("-", "")}`;
+    const secondTerminal = `secondterminal${randomUUID().replaceAll("-", "")}`;
+    const second = await insertChatSearchProjectionCoverageFixture({
+      chatThreadId: source.threadId,
+      promptText: `find ${keyword}`,
+      assistantText: "context assistant after",
+      errorText: secondError,
+      terminalText: secondTerminal,
+    });
+
+    await projectChatSearchMessages([source.threadId]);
+    await expect(
+      removeChatSearchSourceEventsFixture([source.threadId]),
+    ).resolves.toBeGreaterThan(0);
+
+    const search = await chat.searchChat(owner, keyword, {
+      before: 10,
+      after: 10,
+    });
+    expect(search).toMatchObject({ hasMore: false });
+    expect(search.results).toHaveLength(1);
+    const result = search.results[0];
+    if (!result) {
+      throw new Error("Expected one durable chat search result");
+    }
+
+    expect(result.matchedMessage).toStrictEqual({
+      messageId: `${source.threadId}:${second.prompt.seqId}`,
+      chatThreadId: source.threadId,
+      role: "user",
+      content: `find ${keyword}`,
+      createdAt: expect.any(String),
+      seqId: second.prompt.seqId,
+      sequenceNumber: null,
+      runId: null,
+    });
+    expect(
+      result.contextBefore.map((message) => {
+        return message.content;
+      }),
+    ).toStrictEqual(["context user before", "context assistant before"]);
+    expect(
+      result.contextAfter.map((message) => {
+        return message.content;
+      }),
+    ).toStrictEqual(["context assistant after"]);
+
+    expect(result.contextBefore[0]).toMatchObject({
+      messageId: `${source.threadId}:${first.prompt.seqId}`,
+      role: "user",
+      seqId: first.prompt.seqId,
+      sequenceNumber: null,
+      runId: null,
+    });
+    expect(result.contextBefore[1]).toMatchObject({
+      messageId: `${source.threadId}:${first.assistant.seqId}`,
+      role: "assistant",
+      seqId: first.assistant.seqId,
+      sequenceNumber: null,
+      runId: first.assistantRunId,
+    });
+    expect(result.contextAfter[0]).toMatchObject({
+      messageId: `${source.threadId}:${second.assistant.seqId}`,
+      role: "assistant",
+      seqId: second.assistant.seqId,
+      sequenceNumber: null,
+      runId: second.assistantRunId,
+    });
+
+    for (const excluded of [secondError, secondTerminal]) {
+      const excludedSearch = await chat.searchChat(owner, excluded);
+      expect(excludedSearch.results).toStrictEqual([]);
+    }
+  });
+
+  it("uses projected scope and agent identity while resolving the current name", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const owner = bdd.user({ orgId });
+    const peer = bdd.user({ orgId });
+    const primary = await createSearchThread(
+      owner,
+      `projected-primary-${randomUUID().slice(0, 8)}`,
+    );
+    const replacement = await chat.createComposeForChatThread(
+      owner,
+      `source-replacement-${randomUUID().slice(0, 8)}`,
+    );
+    const keyword = `projectedscope${randomUUID().replaceAll("-", "")}`;
+    const prompt = await insertSearchablePromptFixture({
+      chatThreadId: primary.threadId,
+      text: keyword,
+    });
+    await projectChatSearchMessages([primary.threadId]);
+
+    const currentAgentName = `current-${randomUUID().slice(0, 8)}`;
+    await renameChatSearchAgentComposeFixture({
+      agentComposeId: primary.agentId,
+      name: currentAgentName,
+    });
+    await updateChatSearchSourceThreadFixture({
+      chatThreadId: primary.threadId,
+      userId: peer.userId,
+      agentComposeId: replacement.composeId,
+    });
+
+    const byProjectedAgent = await chat.searchChat(owner, keyword, {
+      agentId: primary.agentId,
+    });
+    expect(byProjectedAgent.results).toHaveLength(1);
+    expect(byProjectedAgent.results[0]).toMatchObject({
+      chatThreadId: primary.threadId,
+      agentName: currentAgentName,
+      matchedMessage: {
+        messageId: `${primary.threadId}:${prompt.seqId}`,
+        seqId: prompt.seqId,
+      },
+    });
+
+    const bySourceThreadAgent = await chat.searchChat(owner, keyword, {
+      agentId: replacement.composeId,
+    });
+    expect(bySourceThreadAgent.results).toStrictEqual([]);
+    const peerSearch = await chat.searchChat(peer, keyword);
+    expect(peerSearch.results).toStrictEqual([]);
+    const sameUserOtherOrg = bdd.user({ userId: owner.userId });
+    const otherOrgSearch = await chat.searchChat(sameUserOtherOrg, keyword);
+    expect(otherOrgSearch.results).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -386,8 +386,8 @@ async function allThreadEvents(actor: ApiTestUser) {
   return response.body.events;
 }
 
-/** Cheapest visible message writer: the no-credit send persists a user and an
- * assistant row without creating a run. */
+/** Cheapest visible message writer: the no-credit send persists a searchable
+ * user row plus a non-searchable output.error without creating a run. */
 async function sendNoCreditMessage(
   actor: ApiTestUser,
   body: {
@@ -2708,18 +2708,16 @@ describe("CHAT-01 chat search", () => {
       throw new Error("Expected one okapi match");
     }
     expect(match.matchedMessage.content).toBe("the okapi was here");
-    expect(match.contextBefore).toHaveLength(2);
-    expect(match.contextAfter).toHaveLength(2);
     expect(
       match.contextBefore.map((message) => {
         return message.content;
       }),
-    ).toContain("context round one");
+    ).toStrictEqual(["context round one"]);
     expect(
       match.contextAfter.map((message) => {
         return message.content;
       }),
-    ).toContain("context round three");
+    ).toStrictEqual(["context round three"]);
     const matchedAt = Date.parse(match.matchedMessage.createdAt);
     for (const message of match.contextBefore) {
       expect(Date.parse(message.createdAt)).toBeLessThan(matchedAt);
@@ -2848,9 +2846,20 @@ describe("CHAT-01 chat search", () => {
     expect(beta.chatThreadId).toBe(threadA);
     expect(gamma.chatThreadId).toBe(threadB);
 
+    const expectedContextLengths = new Map([
+      [alphaPrompt, { before: 1, after: 2 }],
+      [betaPrompt, { before: 2, after: 1 }],
+      [gammaPrompt, { before: 1, after: 1 }],
+    ]);
     for (const match of contextual.results) {
-      expect(match.contextBefore).toHaveLength(2);
-      expect(match.contextAfter).toHaveLength(2);
+      const expectedLengths = expectedContextLengths.get(
+        match.matchedMessage.content,
+      );
+      if (!expectedLengths) {
+        throw new Error("Unexpected batched chat-search match");
+      }
+      expect(match.contextBefore).toHaveLength(expectedLengths.before);
+      expect(match.contextAfter).toHaveLength(expectedLengths.after);
       expect(
         [...match.contextBefore, ...match.contextAfter].every((message) => {
           return message.chatThreadId === match.chatThreadId;

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -18,7 +18,6 @@ import {
   googleDriveArtifactStatusLookup,
 } from "../services/google-drive-artifact-sync.service";
 import {
-  zeroChatSearch,
   zeroChatIndicators,
   zeroChatThreadActiveRunThreadIds,
   zeroChatThreadArtifacts,
@@ -29,6 +28,7 @@ import {
   zeroChatThreadUnreadThreadIds,
   zeroChatThreadUnreads,
 } from "../services/zero-chat-thread.service";
+import { zeroChatSearch } from "../services/zero-chat-search.service";
 import {
   zeroChatThreadEventRows,
   zeroChatThreadEventSnapshot,

--- a/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
@@ -1,10 +1,6 @@
-import { CHAT_GOAL_MARKER_EVENT_TYPES } from "@okouai/api-contracts/contracts/chat-events";
-import { not, type SQL } from "drizzle-orm";
-
-import { chatEventTypeIn } from "./zero-chat-event-type.service";
+import type { Tx } from "../../lib/db-types";
 import { insertChatEvent } from "./zero-chat-event.service";
 import { nonEmptyGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
-import type { Tx } from "../../lib/db-types";
 
 type DbTransaction = Tx;
 
@@ -35,13 +31,4 @@ export async function appendGoalCloseMarker(
     eventType: "goal.close",
     content: null,
   });
-}
-
-/**
- * Exclude goal marker rows from queries where control rows must not affect
- * user-visible chat semantics. The message-list endpoint does not apply this
- * because the client needs markers to fold active-goal display state.
- */
-export function excludeGoalMarkerCondition() {
-  return not(chatEventTypeIn(CHAT_GOAL_MARKER_EVENT_TYPES) as SQL);
 }

--- a/turbo/apps/api/src/signals/services/zero-chat-search.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-search.service.ts
@@ -1,0 +1,341 @@
+import { computed, type Computed } from "ccstate";
+import type {
+  ChatSearchMessage,
+  ChatSearchResult,
+} from "@okouai/api-contracts/contracts/chat-threads";
+import { agentComposes } from "@okouai/db/schema/agent-compose";
+import { chatEventSearchMessages } from "@okouai/db/schema/chat-event-search";
+import { alias } from "drizzle-orm/pg-core";
+import { and, asc, desc, eq, gt, gte, lt, type SQL, sql } from "drizzle-orm";
+
+import {
+  chatSearchBigramTsquery,
+  chatSearchMatchRanges,
+} from "../../lib/chat-search-bigram";
+import {
+  pgBooleanDecoder,
+  pgIntegerDecoder,
+} from "../../lib/db-structured-result";
+import { db$, type ReadonlyDb } from "../external/db";
+
+type ChatSearchMessageRow = {
+  readonly chatThreadId: string;
+  readonly seqId: number;
+  readonly runId: string | null;
+  readonly role: "user" | "assistant";
+  readonly createdAt: Date;
+  readonly text: string;
+};
+
+type ChatSearchMatchRow = ChatSearchMessageRow & {
+  readonly agentName: string;
+};
+
+interface ChatSearchContext {
+  readonly before: ChatSearchMessage[];
+  readonly after: ChatSearchMessage[];
+}
+
+const contextSearchMessage = alias(
+  chatEventSearchMessages,
+  "context_search_message",
+);
+
+const searchMessageColumns = {
+  chatThreadId: chatEventSearchMessages.chatThreadId,
+  seqId: chatEventSearchMessages.seqId,
+  runId: chatEventSearchMessages.runId,
+  role: chatEventSearchMessages.role,
+  createdAt: chatEventSearchMessages.createdAt,
+  text: chatEventSearchMessages.text,
+} as const;
+
+const contextSearchMessageColumns = {
+  chatThreadId: contextSearchMessage.chatThreadId,
+  seqId: contextSearchMessage.seqId,
+  runId: contextSearchMessage.runId,
+  role: contextSearchMessage.role,
+  createdAt: contextSearchMessage.createdAt,
+  text: contextSearchMessage.text,
+} as const;
+
+function chatSearchMessageId(
+  row: Pick<ChatSearchMessageRow, "chatThreadId" | "seqId">,
+): string {
+  return `${row.chatThreadId}:${row.seqId}`;
+}
+
+function toChatSearchMessage(row: ChatSearchMessageRow): ChatSearchMessage {
+  return {
+    // Already-open App builds still use messageId as their React key. Keep the
+    // field during rollout, but derive it from the durable canonical identity.
+    messageId: chatSearchMessageId(row),
+    chatThreadId: row.chatThreadId,
+    role: row.role,
+    content: row.text,
+    createdAt: row.createdAt.toISOString(),
+    seqId: row.seqId,
+    sequenceNumber: null,
+    runId: row.runId,
+  };
+}
+
+/**
+ * Selects keyword matches, ownership, agent scope, `since`, ordering and the
+ * limit entirely from the durable message projection. The outer join only
+ * resolves the agent's current name after the bounded match set is selected.
+ */
+async function chatSearchIndexedMatches(
+  db: ReadonlyDb,
+  args: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly keyword: string;
+    readonly agentId?: string;
+    readonly since?: Date;
+    readonly limit: number;
+  },
+): Promise<ChatSearchMatchRow[]> {
+  const tsquery = chatSearchBigramTsquery(args.keyword);
+  if (tsquery === null) {
+    return [];
+  }
+
+  const indexedMatches = db
+    .select({
+      ...searchMessageColumns,
+      agentComposeId: chatEventSearchMessages.agentComposeId,
+    })
+    .from(chatEventSearchMessages)
+    .where(
+      and(
+        eq(chatEventSearchMessages.userId, args.userId),
+        eq(chatEventSearchMessages.orgId, args.orgId),
+        sql`${chatEventSearchMessages.tsv} @@ to_tsquery('simple', ${tsquery})`,
+        args.agentId
+          ? eq(chatEventSearchMessages.agentComposeId, args.agentId)
+          : undefined,
+        args.since
+          ? gte(chatEventSearchMessages.createdAt, args.since)
+          : undefined,
+      ),
+    )
+    .orderBy(desc(chatEventSearchMessages.createdAt))
+    .limit(args.limit)
+    .as("chat_search_indexed_matches");
+
+  return await db
+    .select({
+      chatThreadId: indexedMatches.chatThreadId,
+      seqId: indexedMatches.seqId,
+      runId: indexedMatches.runId,
+      role: indexedMatches.role,
+      createdAt: indexedMatches.createdAt,
+      text: indexedMatches.text,
+      agentName: agentComposes.name,
+    })
+    .from(indexedMatches)
+    .innerJoin(
+      agentComposes,
+      eq(indexedMatches.agentComposeId, agentComposes.id),
+    )
+    .orderBy(desc(indexedMatches.createdAt));
+}
+
+function chatSearchMatchesTable(matches: readonly ChatSearchMessageRow[]): SQL {
+  return sql`unnest(
+      ${sql.param(
+        matches.map((match) => {
+          return match.chatThreadId;
+        }),
+      )}::uuid[],
+      ${sql.param(
+        matches.map((match) => {
+          return match.seqId;
+        }),
+      )}::bigint[]
+    ) WITH ORDINALITY AS chat_search_matches(
+      chat_thread_id,
+      seq_id,
+      result_ordinality
+    )`;
+}
+
+function chatSearchContextSideQuery(
+  db: ReadonlyDb,
+  args: {
+    readonly isBefore: boolean;
+    readonly limit: number;
+  },
+) {
+  return db
+    .select({
+      isBefore: sql`${args.isBefore}::boolean`
+        .mapWith(pgBooleanDecoder)
+        .as("is_before"),
+      ...contextSearchMessageColumns,
+    })
+    .from(contextSearchMessage)
+    .where(
+      and(
+        eq(
+          contextSearchMessage.chatThreadId,
+          sql`chat_search_matches.chat_thread_id`,
+        ),
+        args.isBefore
+          ? lt(contextSearchMessage.seqId, sql`chat_search_matches.seq_id`)
+          : gt(contextSearchMessage.seqId, sql`chat_search_matches.seq_id`),
+      ),
+    )
+    .orderBy(
+      args.isBefore
+        ? desc(contextSearchMessage.seqId)
+        : asc(contextSearchMessage.seqId),
+    )
+    .limit(args.limit);
+}
+
+async function loadChatSearchContexts(
+  db: ReadonlyDb,
+  args: {
+    readonly matches: readonly ChatSearchMessageRow[];
+    readonly before: number;
+    readonly after: number;
+  },
+): Promise<ReadonlyMap<string, ChatSearchContext>> {
+  const contextsByMessageId = new Map<string, ChatSearchContext>(
+    args.matches.map((match): readonly [string, ChatSearchContext] => {
+      return [chatSearchMessageId(match), { before: [], after: [] }];
+    }),
+  );
+  if (args.matches.length === 0 || (args.before === 0 && args.after === 0)) {
+    return contextsByMessageId;
+  }
+
+  const contextQuery =
+    args.before > 0
+      ? args.after > 0
+        ? chatSearchContextSideQuery(db, {
+            isBefore: true,
+            limit: args.before,
+          }).unionAll(
+            chatSearchContextSideQuery(db, {
+              isBefore: false,
+              limit: args.after,
+            }),
+          )
+        : chatSearchContextSideQuery(db, {
+            isBefore: true,
+            limit: args.before,
+          })
+      : chatSearchContextSideQuery(db, {
+          isBefore: false,
+          limit: args.after,
+        });
+
+  const context = contextQuery.as("chat_search_context");
+  const resultOrdinality = sql`chat_search_matches.result_ordinality::integer`
+    .mapWith(pgIntegerDecoder)
+    .as("result_ordinality");
+  const matchedChatThreadId = sql`chat_search_matches.chat_thread_id`
+    .mapWith(chatEventSearchMessages.chatThreadId)
+    .as("matched_chat_thread_id");
+  const matchedSeqId = sql`chat_search_matches.seq_id`
+    .mapWith(chatEventSearchMessages.seqId)
+    .as("matched_seq_id");
+  const rows = await db
+    .select({
+      resultOrdinality,
+      matchedChatThreadId,
+      matchedSeqId,
+      isBefore: context.isBefore,
+      chatThreadId: context.chatThreadId,
+      seqId: context.seqId,
+      runId: context.runId,
+      role: context.role,
+      createdAt: context.createdAt,
+      text: context.text,
+    })
+    .from(chatSearchMatchesTable(args.matches))
+    .crossJoinLateral(context)
+    .orderBy(resultOrdinality, asc(context.seqId));
+
+  for (const row of rows) {
+    const matchedMessageId = chatSearchMessageId({
+      chatThreadId: row.matchedChatThreadId,
+      seqId: row.matchedSeqId,
+    });
+    const matchedContext = contextsByMessageId.get(matchedMessageId);
+    if (!matchedContext) {
+      throw new Error(
+        "chat search context returned an unknown matched message",
+      );
+    }
+    const message = toChatSearchMessage(row);
+    if (row.isBefore) {
+      matchedContext.before.push(message);
+    } else {
+      matchedContext.after.push(message);
+    }
+  }
+
+  return contextsByMessageId;
+}
+
+export function zeroChatSearch(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly keyword: string;
+  readonly agentId?: string;
+  readonly since?: number;
+  readonly limit: number;
+  readonly before: number;
+  readonly after: number;
+}): Computed<
+  Promise<{
+    readonly results: readonly ChatSearchResult[];
+    readonly hasMore: boolean;
+  }>
+> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const sinceDate = args.since ? new Date(args.since) : undefined;
+    const matches = await chatSearchIndexedMatches(db, {
+      userId: args.userId,
+      orgId: args.orgId,
+      keyword: args.keyword,
+      agentId: args.agentId,
+      since: sinceDate,
+      limit: args.limit + 1,
+    });
+
+    const hasMore = matches.length > args.limit;
+    const truncated = hasMore ? matches.slice(0, args.limit) : matches;
+    const contextsByMessageId = await loadChatSearchContexts(db, {
+      matches: truncated,
+      before: args.before,
+      after: args.after,
+    });
+    const results = truncated.map((match): ChatSearchResult => {
+      const messageId = chatSearchMessageId(match);
+      const context = contextsByMessageId.get(messageId);
+      if (!context) {
+        throw new Error("chat search context is missing a matched message");
+      }
+      const matchedMessage = toChatSearchMessage(match);
+      return {
+        chatThreadId: match.chatThreadId,
+        agentName: match.agentName,
+        matchedMessage,
+        matchedRanges: chatSearchMatchRanges(
+          matchedMessage.content,
+          args.keyword,
+        ),
+        contextBefore: context.before,
+        contextAfter: context.after,
+      };
+    });
+
+    return { results, hasMore };
+  });
+}

--- a/turbo/apps/api/src/signals/services/zero-chat-search.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-search.service.ts
@@ -67,8 +67,10 @@ function chatSearchMessageId(
 
 function toChatSearchMessage(row: ChatSearchMessageRow): ChatSearchMessage {
   return {
-    // Already-open App builds still use messageId as their React key. Keep the
-    // field during rollout, but derive it from the durable canonical identity.
+    // Old Platform/App clients can use messageId as a React key for up to the
+    // ~2-day client-skew window. Keep it derived from durable identity until
+    // #26921 migrates current clients to (chatThreadId, seqId), then remove
+    // messageId/sequenceNumber after that client deploy has aged past 2 days.
     messageId: chatSearchMessageId(row),
     chatThreadId: row.chatThreadId,
     role: row.role,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1,17 +1,10 @@
 import { command, computed, type Computed } from "ccstate";
 import {
-  chatEventCompatibilityRole,
-  type ChatEventType,
-} from "@okouai/api-contracts/contracts/chat-events";
-import {
-  type ChatSearchMessage,
-  type ChatSearchResult,
   type ChatThreadDraft,
   type ChatThreadArtifactRun,
   type ChatThreadDetail,
   type CodexServiceTier,
   type PersistedAttachment,
-  type UserMessageDocument,
   type UserMessageInputDocument,
   type ZeroIndicator,
   type ZeroIndicators,
@@ -28,10 +21,8 @@ import {
   type HostedArtifactKind,
   hostedArtifactKindSchema,
 } from "@okouai/api-contracts/contracts/zero-host";
-import { agentComposes } from "@okouai/db/schema/agent-compose";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatEvents } from "@okouai/db/schema/chat-event";
-import { chatEventSearchDocs } from "@okouai/db/schema/chat-event-search";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { threadGoals } from "@okouai/db/schema/thread-goal";
 import {
@@ -40,7 +31,7 @@ import {
 } from "@okouai/db/schema/run-uploaded-file";
 import { zeroAgents } from "@okouai/db/schema/zero-agent";
 import { zeroRuns } from "@okouai/db/schema/zero-run";
-import { alias, unionAll } from "drizzle-orm/pg-core";
+import { unionAll } from "drizzle-orm/pg-core";
 import {
   and,
   asc,
@@ -52,73 +43,25 @@ import {
   inArray,
   isNotNull,
   isNull,
-  lt,
   notExists,
   or,
   type SQL,
   sql,
 } from "drizzle-orm";
 
-import {
-  chatSearchBigramTsquery,
-  chatSearchMatchRanges,
-} from "../../lib/chat-search-bigram";
-import {
-  nullableDriverValueDecoder,
-  pgBooleanDecoder,
-  pgIntegerDecoder,
-  zodEnumDriverValueDecoder,
-} from "../../lib/db-structured-result";
+import { zodEnumDriverValueDecoder } from "../../lib/db-structured-result";
 import { now } from "../../lib/time";
 import { type Db, db$, type ReadonlyDb, writeDb$ } from "../external/db";
-import {
-  canonicalChatEventContent,
-  canonicalChatEventUserMessage,
-} from "./canonical-chat-event-read.service";
-import {
-  inferMimetype,
-  visibleChatEventCondition,
-} from "./zero-chat-event-shared.service";
+import { inferMimetype } from "./zero-chat-event-shared.service";
 import { latestRunFinishEventSubquery } from "./zero-chat-thread-read-state-query";
 import {
   appendChatThreadEvent,
   chatThreadServiceTierFromCodex,
 } from "./zero-chat-thread-event.service";
-import { excludeGoalMarkerCondition } from "./zero-chat-goal-marker.service";
 import { cancelRun$, type CancelRunResult } from "./zero-run-cancel.service";
-import {
-  projectUserMessage,
-  requiredUserMessageForEvent,
-} from "./zero-chat-user-message.service";
-import {
-  chatEventTextCondition,
-  runOwnedChatEventForRunCondition,
-} from "./zero-chat-event-type.service";
+import { runOwnedChatEventForRunCondition } from "./zero-chat-event-type.service";
 import { cancellationRecoveryPendingForThread } from "./zero-chat-active-run.service";
 import { listPendingChatQueueEvents } from "./chat-event-queue.service";
-
-const matchedChatEvent = alias(chatEvents, "matched_chat_event");
-
-type ChatSearchMessageRow = {
-  readonly messageId: string;
-  readonly chatThreadId: string;
-  readonly eventType: ChatEventType;
-  readonly content: string | null;
-  readonly userMessage: UserMessageDocument | null;
-  readonly createdAt: Date;
-  readonly seqId: number;
-  readonly sequenceNumber: number | null;
-  readonly runId: string | null;
-};
-
-type ChatSearchMatchRow = ChatSearchMessageRow & {
-  readonly agentName: string;
-};
-
-interface ChatSearchContext {
-  readonly before: ChatSearchMessage[];
-  readonly after: ChatSearchMessage[];
-}
 
 type ChatThreadRow = {
   readonly id: string;
@@ -144,38 +87,6 @@ type ChatThreadRow = {
 type ChatThreadDetailRow = {
   readonly lastReadAt: Date | null;
 };
-
-function publicChatEventRunId() {
-  // Public ChatEvent responses preserve their established shape: an interrupt
-  // exposes its canonical target as interruptsRunId, never as run ownership.
-  return sql`CASE
-    WHEN ${chatEvents.eventType} = 'control.interrupt' THEN NULL
-    ELSE ${chatEvents.runId}
-  END`
-    .mapWith(nullableDriverValueDecoder(chatEvents.runId))
-    .as("effective_run_id");
-}
-
-const searchMessageColumns = {
-  messageId: chatEvents.id,
-  chatThreadId: chatEvents.chatThreadId,
-  eventType: chatEvents.eventType,
-  content: canonicalChatEventContent(),
-  userMessage: canonicalChatEventUserMessage(),
-  createdAt: chatEvents.createdAt,
-  seqId: chatEvents.seqId,
-  sequenceNumber: chatEvents.runEventSequenceNumber,
-  runId: publicChatEventRunId(),
-} as const;
-
-const searchContextMessageColumns = {
-  ...searchMessageColumns,
-  eventType: sql`${chatEvents.eventType}`
-    .mapWith(chatEvents.eventType)
-    .as("context_event_type"),
-  content: canonicalChatEventContent().as("context_content"),
-  userMessage: canonicalChatEventUserMessage().as("context_user_message"),
-} as const;
 
 function parseHostedArtifactKind(
   value: unknown,
@@ -806,296 +717,6 @@ export function zeroChatThreadArtifacts(args: {
       });
     },
   );
-}
-
-function toChatSearchMessage(row: ChatSearchMessageRow): ChatSearchMessage {
-  const userMessage = requiredUserMessageForEvent(
-    row.eventType,
-    row.userMessage,
-  );
-  const content = userMessage
-    ? projectUserMessage(userMessage).displayText
-    : row.content;
-  if (content === null) {
-    throw new Error(
-      "chat search invariant violated: searchable message text is null",
-    );
-  }
-
-  return {
-    messageId: row.messageId,
-    chatThreadId: row.chatThreadId,
-    role: chatEventCompatibilityRole(row.eventType),
-    content,
-    createdAt: row.createdAt.toISOString(),
-    seqId: row.seqId,
-    sequenceNumber: row.sequenceNumber,
-    runId: row.runId,
-  };
-}
-
-/**
- * Resolves matches from the chat_event_search_docs projection alone: keyword,
- * ownership, agent scope, `since`, ordering and the limit are all answered by
- * the projection, so no chat_events predicate can pull the planner away from
- * the tsvector index. Keywords without a bigram-indexable form cannot match.
- */
-async function chatSearchIndexedEventIds(
-  db: ReadonlyDb,
-  args: {
-    readonly userId: string;
-    readonly orgId: string;
-    readonly keyword: string;
-    readonly agentId?: string;
-    readonly since?: Date;
-    readonly limit: number;
-  },
-): Promise<readonly string[]> {
-  const tsquery = chatSearchBigramTsquery(args.keyword);
-  if (tsquery === null) {
-    return [];
-  }
-  const docs = await db
-    .select({ eventId: chatEventSearchDocs.eventId })
-    .from(chatEventSearchDocs)
-    .where(
-      and(
-        eq(chatEventSearchDocs.userId, args.userId),
-        eq(chatEventSearchDocs.orgId, args.orgId),
-        sql`${chatEventSearchDocs.tsv} @@ to_tsquery('simple', ${tsquery})`,
-        args.agentId
-          ? eq(chatEventSearchDocs.agentComposeId, args.agentId)
-          : undefined,
-        args.since ? gte(chatEventSearchDocs.createdAt, args.since) : undefined,
-      ),
-    )
-    .orderBy(desc(chatEventSearchDocs.createdAt))
-    .limit(args.limit);
-  return docs.map((doc) => {
-    return doc.eventId;
-  });
-}
-
-/**
- * Decorates already-selected matches with the columns the response needs. The
- * joins run over at most `limit + 1` primary-key lookups, so they never take
- * part in selecting rows. Ownership is re-asserted against the authoritative
- * thread and compose rows, because the projection only holds a copy of it.
- */
-async function chatSearchIndexedMatches(
-  db: ReadonlyDb,
-  args: {
-    readonly userId: string;
-    readonly orgId: string;
-    readonly eventIds: readonly string[];
-  },
-): Promise<ChatSearchMatchRow[]> {
-  if (args.eventIds.length === 0) {
-    return [];
-  }
-  return await db
-    .select({
-      ...searchMessageColumns,
-      agentName: agentComposes.name,
-    })
-    .from(chatEvents)
-    .innerJoin(chatThreads, eq(chatEvents.chatThreadId, chatThreads.id))
-    .innerJoin(agentComposes, eq(chatThreads.agentComposeId, agentComposes.id))
-    .where(
-      and(
-        inArray(chatEvents.id, [...args.eventIds]),
-        eq(chatThreads.userId, args.userId),
-        eq(agentComposes.orgId, args.orgId),
-      ),
-    )
-    .orderBy(desc(chatEvents.createdAt));
-}
-
-function chatSearchMatchesTable(messageIds: readonly string[]): SQL {
-  return sql`unnest(${sql.param([...messageIds])}::uuid[])
-    WITH ORDINALITY AS chat_search_matches(message_id, result_ordinality)`;
-}
-
-function chatSearchContextSideQuery(
-  db: ReadonlyDb,
-  args: {
-    readonly isBefore: boolean;
-    readonly limit: number;
-  },
-) {
-  return db
-    .select({
-      isBefore: sql`${args.isBefore}::boolean`
-        .mapWith(pgBooleanDecoder)
-        .as("is_before"),
-      ...searchContextMessageColumns,
-    })
-    .from(chatEvents)
-    .where(
-      and(
-        eq(chatEvents.chatThreadId, matchedChatEvent.chatThreadId),
-        args.isBefore
-          ? lt(chatEvents.seqId, matchedChatEvent.seqId)
-          : gt(chatEvents.seqId, matchedChatEvent.seqId),
-        chatEventTextCondition(),
-        visibleChatEventCondition(db),
-        excludeGoalMarkerCondition(),
-      ),
-    )
-    .orderBy(args.isBefore ? desc(chatEvents.seqId) : asc(chatEvents.seqId))
-    .limit(args.limit);
-}
-
-async function loadChatSearchContexts(
-  db: ReadonlyDb,
-  args: {
-    readonly matches: readonly ChatSearchMessageRow[];
-    readonly before: number;
-    readonly after: number;
-  },
-): Promise<ReadonlyMap<string, ChatSearchContext>> {
-  const contextsByMessageId = new Map<string, ChatSearchContext>(
-    args.matches.map((match): readonly [string, ChatSearchContext] => {
-      return [match.messageId, { before: [], after: [] }];
-    }),
-  );
-  if (args.matches.length === 0 || (args.before === 0 && args.after === 0)) {
-    return contextsByMessageId;
-  }
-
-  const contextQuery =
-    args.before > 0
-      ? args.after > 0
-        ? chatSearchContextSideQuery(db, {
-            isBefore: true,
-            limit: args.before,
-          }).unionAll(
-            chatSearchContextSideQuery(db, {
-              isBefore: false,
-              limit: args.after,
-            }),
-          )
-        : chatSearchContextSideQuery(db, {
-            isBefore: true,
-            limit: args.before,
-          })
-      : chatSearchContextSideQuery(db, {
-          isBefore: false,
-          limit: args.after,
-        });
-
-  const context = contextQuery.as("chat_search_context");
-  const resultOrdinality = sql`chat_search_matches.result_ordinality::integer`
-    .mapWith(pgIntegerDecoder)
-    .as("result_ordinality");
-  const rows = await db
-    .select({
-      resultOrdinality,
-      matchedMessageId: matchedChatEvent.id,
-      isBefore: context.isBefore,
-      messageId: context.messageId,
-      chatThreadId: context.chatThreadId,
-      eventType: context.eventType,
-      content: context.content,
-      userMessage: context.userMessage,
-      createdAt: context.createdAt,
-      seqId: context.seqId,
-      sequenceNumber: context.sequenceNumber,
-      runId: context.runId,
-    })
-    .from(
-      chatSearchMatchesTable(
-        args.matches.map((match) => {
-          return match.messageId;
-        }),
-      ),
-    )
-    .innerJoin(
-      matchedChatEvent,
-      eq(matchedChatEvent.id, sql`chat_search_matches.message_id`),
-    )
-    .crossJoinLateral(context)
-    .orderBy(resultOrdinality, asc(context.seqId));
-
-  for (const row of rows) {
-    const matchedContext = contextsByMessageId.get(row.matchedMessageId);
-    if (!matchedContext) {
-      throw new Error(
-        "chat search context returned an unknown matched message",
-      );
-    }
-    const message = toChatSearchMessage(row);
-    if (row.isBefore) {
-      matchedContext.before.push(message);
-    } else {
-      matchedContext.after.push(message);
-    }
-  }
-
-  return contextsByMessageId;
-}
-
-export function zeroChatSearch(args: {
-  readonly userId: string;
-  readonly orgId: string;
-  readonly keyword: string;
-  readonly agentId?: string;
-  readonly since?: number;
-  readonly limit: number;
-  readonly before: number;
-  readonly after: number;
-}): Computed<
-  Promise<{
-    readonly results: readonly ChatSearchResult[];
-    readonly hasMore: boolean;
-  }>
-> {
-  return computed(async (get) => {
-    const db = get(db$);
-    const sinceDate = args.since ? new Date(args.since) : undefined;
-
-    const matches = await chatSearchIndexedMatches(db, {
-      userId: args.userId,
-      orgId: args.orgId,
-      eventIds: await chatSearchIndexedEventIds(db, {
-        userId: args.userId,
-        orgId: args.orgId,
-        keyword: args.keyword,
-        agentId: args.agentId,
-        since: sinceDate,
-        limit: args.limit + 1,
-      }),
-    });
-
-    const hasMore = matches.length > args.limit;
-    const truncated = hasMore ? matches.slice(0, args.limit) : matches;
-
-    const contextsByMessageId = await loadChatSearchContexts(db, {
-      matches: truncated,
-      before: args.before,
-      after: args.after,
-    });
-    const results = truncated.map((match): ChatSearchResult => {
-      const context = contextsByMessageId.get(match.messageId);
-      if (!context) {
-        throw new Error("chat search context is missing a matched message");
-      }
-      const matchedMessage = toChatSearchMessage(match);
-      return {
-        chatThreadId: match.chatThreadId,
-        agentName: match.agentName,
-        matchedMessage,
-        matchedRanges: chatSearchMatchRanges(
-          matchedMessage.content,
-          args.keyword,
-        ),
-        contextBefore: context.before,
-        contextAfter: context.after,
-      };
-    });
-
-    return { results, hasMore };
-  });
 }
 
 export function zeroChatThreadQueuedEvents(args: {

--- a/turbo/apps/api/src/test-fixtures/chat-event-search.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-event-search.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 
+import { agentComposes } from "@okouai/db/schema/agent-compose";
+import { chatEvents } from "@okouai/db/schema/chat-event";
 import {
   chatEventSearchDocs,
   chatEventSearchMessages,
@@ -7,7 +9,7 @@ import {
   chatEventSearchWatermarks,
 } from "@okouai/db/schema/chat-event-search";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
-import { asc, eq } from "drizzle-orm";
+import { asc, eq, inArray, sql } from "drizzle-orm";
 
 import { db } from "../lib/db";
 import {
@@ -102,22 +104,29 @@ export async function insertChatSearchProjectionCoverageFixture(args: {
   readonly assistantText: string;
   readonly errorText: string;
   readonly terminalText: string;
-}): Promise<{ readonly assistantRunId: string }> {
+}): Promise<{
+  readonly prompt: { readonly id: string; readonly seqId: number };
+  readonly assistant: { readonly id: string; readonly seqId: number };
+  readonly assistantRunId: string;
+}> {
   const assistantRunId = randomUUID();
-  await db().transaction(async (tx) => {
-    await insertChatEvent(tx, {
+  const messages = await db().transaction(async (tx) => {
+    const prompt = await insertChatEvent(tx, {
       chatThreadId: args.chatThreadId,
       eventType: "input.prompt",
       contextType: "web",
       userMessage: createUserMessageDocument({ text: args.promptText }),
       runId: null,
     });
-    await insertChatEvent(tx, {
+    const assistant = await insertChatEvent(tx, {
       chatThreadId: args.chatThreadId,
       eventType: "output.message",
       content: args.assistantText,
       runId: assistantRunId,
     });
+    if (!prompt || !assistant) {
+      throw new Error("Expected chat search coverage messages");
+    }
     await insertChatEvent(tx, {
       chatThreadId: args.chatThreadId,
       eventType: "output.message",
@@ -137,8 +146,63 @@ export async function insertChatSearchProjectionCoverageFixture(args: {
       content: args.terminalText,
       runId: randomUUID(),
     });
+    return { prompt, assistant };
   });
-  return { assistantRunId };
+  return { ...messages, assistantRunId };
+}
+
+/**
+ * Simulates retention after the durable projection has caught up. Product APIs
+ * cannot delete append-only source events, so the fixture removes only rows
+ * owned by the test's unique threads while preserving both search projections.
+ */
+export async function removeChatSearchSourceEventsFixture(
+  chatThreadIds: readonly string[],
+): Promise<number> {
+  const removed = await db().transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL session_replication_role = replica`);
+    return await tx
+      .delete(chatEvents)
+      .where(inArray(chatEvents.chatThreadId, [...chatThreadIds]))
+      .returning({ id: chatEvents.id });
+  });
+  return removed.length;
+}
+
+/**
+ * Changes source-thread ownership and agent metadata after projection so a
+ * reader test can prove those fields are not reloaded from chat_threads.
+ */
+export async function updateChatSearchSourceThreadFixture(args: {
+  readonly chatThreadId: string;
+  readonly userId: string;
+  readonly agentComposeId: string;
+}): Promise<void> {
+  const updated = await db()
+    .update(chatThreads)
+    .set({
+      userId: args.userId,
+      agentComposeId: args.agentComposeId,
+    })
+    .where(eq(chatThreads.id, args.chatThreadId))
+    .returning({ id: chatThreads.id });
+  if (updated.length !== 1) {
+    throw new Error("Expected one chat search source thread to update");
+  }
+}
+
+export async function renameChatSearchAgentComposeFixture(args: {
+  readonly agentComposeId: string;
+  readonly name: string;
+}): Promise<void> {
+  const updated = await db()
+    .update(agentComposes)
+    .set({ name: args.name })
+    .where(eq(agentComposes.id, args.agentComposeId))
+    .returning({ id: agentComposes.id });
+  if (updated.length !== 1) {
+    throw new Error("Expected one chat search agent compose to rename");
+  }
 }
 
 export async function insertSearchablePromptFixture(args: {

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1486,9 +1486,10 @@ export const chatEventsContract = c.router({
 /**
  * Single chat message in a search result.
  * `(chatThreadId, seqId)` is the stable identity and `runId` carries optional
- * run ownership. `messageId` and `sequenceNumber` remain temporarily for
- * already-open App builds; the durable reader synthesizes the former from the
- * stable identity and returns null for the latter.
+ * run ownership. `messageId` and `sequenceNumber` bridge old Platform/App
+ * clients for the ~2-day client-skew window. #26921 migrates current clients
+ * to the stable identity and removes these fields after that deployment has
+ * aged past 2 days.
  */
 const chatSearchMessageSchema = z.object({
   messageId: z.string(),

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1485,8 +1485,10 @@ export const chatEventsContract = c.router({
 
 /**
  * Single chat message in a search result.
- * `content` is guaranteed non-null because the search route filters out
- * placeholder rows where content is NULL.
+ * `(chatThreadId, seqId)` is the stable identity and `runId` carries optional
+ * run ownership. `messageId` and `sequenceNumber` remain temporarily for
+ * already-open App builds; the durable reader synthesizes the former from the
+ * stable identity and returns null for the latter.
  */
 const chatSearchMessageSchema = z.object({
   messageId: z.string(),


### PR DESCRIPTION
## Summary

- serve chat-search keyword matches and before/after context entirely from `chat_event_search_messages`
- enforce ownership and agent scope from projected `user_id`, `org_id`, and `agent_compose_id`, joining only `agent_composes` for the current agent name
- use `(chat_thread_id, seq_id)` as the durable message identity, expose `seqId`/nullable `runId`, and keep the existing response fields needed by already-open App builds
- limit context to projected user and assistant messages, without replaying visibility or revocation rules during reads
- keep Phase 1 dual-writing, the legacy search projection, and both watermark paths intact for rollback

Phase 1: #26759

## Tests

- `pnpm exec prettier --check <changed files>`
- `pnpm -F api lint`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm knip --workspace api --workspace @okouai/api-contracts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-search-reader.test.ts --maxWorkers=1` (2 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'CHAT-01 chat search' --maxWorkers=1` (8 passed, 27 skipped)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-project-chat-event-search.test.ts --maxWorkers=1` (5 passed)

## Deployment compatibility

- no schema migration or table removal
- the Phase 1 projector continues writing both durable and legacy projections and watermarks
- `messageId` remains available for current App consumers and is synthesized from the durable identity; `sequenceNumber` remains nullable
- rollback can restore the legacy reader while the retained dual-write paths continue to provide fresh data

## Fallbacks

- `toChatSearchMessage` / `chatSearchMessageSchema` retain synthesized `messageId` and nullable `sequenceNumber` for old Platform/App clients during the maximum ~2-day client-skew window. Remove them through #26921 after the current client uses `(chatThreadId, seqId)` and that client deployment has aged past two days.

## Out of scope

- archive v5 / #26697
- historical model fallback cleanup
- duplicate UUID normalization
- physical `chat_events` deletion
