### PR TITLE
test(python): cover non-object tweet-create json bodies

### DIFF
--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -921,6 +921,37 @@ def test_tweet_create_unparseable_body_stays_conservative(x_usage, tmp_path, rea
 @pytest.mark.parametrize(
     "request_body",
     [
+        pytest.param(b"[]", id="array"),
+        pytest.param(b"null", id="null"),
+        pytest.param(b"123", id="number"),
+        pytest.param(b'"text"', id="string"),
+    ],
+)
+def test_tweet_create_non_object_json_body_stays_conservative(
+    x_usage, tmp_path, real_flow, request_body
+):
+    """Valid non-object JSON cannot refine tweet-create billing."""
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+    )
+    flow.request.method = "POST"
+    flow.request.content = request_body
+
+    p = x_usage.call_and_get_single_billing(flow)
+
+    assert p["category"] == "content.create_with_url"
+    assert p["quantity"] == 1
+
+
+@pytest.mark.parametrize(
+    "request_body",
+    [
         pytest.param(json_body_that_exceeds_nesting_limit(), id="excessive-nesting"),
         pytest.param(json_body_that_exceeds_integer_digit_limit(), id="integer-digit-limit"),
     ],


### PR DESCRIPTION
## Summary

- add dispatcher-level X billing coverage for valid top-level array, null, number, and string tweet-create JSON bodies
- verify every case emits one conservative `content.create_with_url` billing event
- protect the existing non-object guard with a mutation-sensitive regression test

## Scope

- test-only change in the mitm-addon X connector usage suite
- no production billing behavior, dependency, API, schema, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/x_connector_usage/test_writes.py -k non_object -v` (4 passed)
- guard-removal mutation: all 4 new cases failed with `AttributeError`; restored guard: all 4 passed
- `uv run --no-sync python -m pytest tests/` (5,368 passed)

Closes #26897
