### PR TITLE
test(python): cover overrange ipv4 hostname octets

### DIFF
--- a/crates/runner/mitm-addon/tests/host_normalization_cases.py
+++ b/crates/runner/mitm-addon/tests/host_normalization_cases.py
@@ -4,6 +4,11 @@ import pytest
 
 ONLY_DOTS_HOSTNAME = "..."
 
+OVERRANGE_IPV4_HOSTNAME_CASES = (
+    pytest.param("256.0.0.1", id="overrange-first-ipv4-octet"),
+    pytest.param("1.2.3.999", id="overrange-last-ipv4-octet"),
+)
+
 INVALID_IDNA_HOSTNAME_CASES = (
     pytest.param("\uff21.example", id="fullwidth-latin"),
     pytest.param(ONLY_DOTS_HOSTNAME, id="dots"),
@@ -45,6 +50,7 @@ INVALID_IDNA_HOSTNAME_CASES = (
     pytest.param("a\u0663\u0664.example", id="latin-arabic-digits"),
     pytest.param("1\u0663.example", id="ascii-and-arabic-digits"),
     pytest.param("!\u0663!.example", id="punctuation-arabic-digit"),
+    *OVERRANGE_IPV4_HOSTNAME_CASES,
     pytest.param("0177.0.0.1", id="octal-ipv4"),
     pytest.param("127\u30020\u30020\u30021", id="ideographic-dot-ipv4"),
     pytest.param("127.0.0.1\u3002", id="trailing-ideographic-dot-ipv4"),

--- a/crates/runner/mitm-addon/tests/test_host_normalization.py
+++ b/crates/runner/mitm-addon/tests/test_host_normalization.py
@@ -5,7 +5,10 @@ from unittest.mock import patch
 import pytest
 
 import host_normalization
-from tests.host_normalization_cases import INVALID_IDNA_HOSTNAME_CASES
+from tests.host_normalization_cases import (
+    INVALID_IDNA_HOSTNAME_CASES,
+    OVERRANGE_IPV4_HOSTNAME_CASES,
+)
 
 
 def test_ascii_hostname_bypasses_unicode_pipeline():
@@ -55,6 +58,15 @@ def test_ascii_label_contract(label, expected):
 def test_rejects_invalid_idna_hostname(hostname):
     with pytest.raises(UnicodeError):
         host_normalization.normalize_idna_hostname(hostname)
+
+
+@pytest.mark.parametrize("hostname", OVERRANGE_IPV4_HOSTNAME_CASES)
+def test_rejects_overrange_ipv4_hostname_octet(hostname):
+    with pytest.raises(UnicodeError) as exc_info:
+        host_normalization.normalize_idna_hostname(hostname)
+
+    assert type(exc_info.value) is UnicodeError
+    assert str(exc_info.value) == "non-canonical IPv4 address"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add first- and last-octet overrange IPv4 cases to the shared invalid-hostname contract
- reuse the semantic case subset for an exact `UnicodeError("non-canonical IPv4 address")` assertion
- exercise both cases through the existing trusted-authority Host and SNI rejection matrix

## Scope

- test-only change; production hostname normalization remains unchanged
- no API, migration, deployment, or standalone firewall-fixture changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 5,372 passed
- focused overrange selection — 8 passed with the guard present
- mutation check — the same 8 tests failed when the octet upper-bound guard was temporarily removed, then passed after restoration

Closes #26899
