### PR TITLE
fix(e2e): select visible stripe checkout controls

### DIFF
--- a/e2e/playwright/lib/stripe-checkout.test.ts
+++ b/e2e/playwright/lib/stripe-checkout.test.ts
@@ -12,6 +12,7 @@ type CheckoutLayout =
   | "accordion"
   | "expanded"
   | "framed-accordion"
+  | "hidden-duplicates"
   | "iframe"
   | "late-frame"
   | "replaced-field-frame"
@@ -29,6 +30,7 @@ test("fills and submits every supported Stripe Checkout card layout", async (con
     for (const layout of [
       "expanded",
       "iframe",
+      "hidden-duplicates",
       "late-frame",
       "replaced-field-frame",
       "wallet",
@@ -57,7 +59,10 @@ test("fills and submits every supported Stripe Checkout card layout", async (con
               "1",
             );
           }
-          if (layout === "replaced-field-frame") {
+          if (
+            layout === "hidden-duplicates" ||
+            layout === "replaced-field-frame"
+          ) {
             assert.equal(
               await page.locator("body").getAttribute("data-activation-count"),
               "1",
@@ -95,11 +100,14 @@ function checkoutDocument(layout: CheckoutLayout): string {
     layout === "late-frame" ||
     layout === "replaced-field-frame"
       ? ""
-      : `<button id="pay-with-card" type="button"${
-          layout === "accordion"
-            ? ' style="height: 0; overflow: hidden; position: absolute; width: 0"'
-            : ""
-        }>Pay with card</button>`;
+      : layout === "hidden-duplicates"
+        ? `<button type="button" style="border: 0; height: 0; overflow: hidden; padding: 0; position: absolute; width: 0">Pay with card</button>
+           <button id="pay-with-card" type="button">Pay with card</button>`
+        : `<button id="pay-with-card" type="button"${
+            layout === "accordion"
+              ? ' style="height: 0; overflow: hidden; position: absolute; width: 0"'
+              : ""
+          }>Pay with card</button>`;
 
   return `<!doctype html>
 <html>
@@ -116,8 +124,13 @@ function checkoutDocument(layout: CheckoutLayout): string {
       const cardFields = ${JSON.stringify(CARD_FIELDS)};
       const host = document.querySelector("#card-host");
       const renderCardForm = () => {
-        host.innerHTML = cardFields;
+        host.innerHTML = document.body.dataset.layout === "hidden-duplicates"
+          ? "<div hidden>" + cardFields + "</div>" + cardFields
+          : cardFields;
       };
+      if (document.body.dataset.layout === "hidden-duplicates") {
+        document.body.dataset.activationCount = "0";
+      }
       if (document.body.dataset.layout === "expanded") {
         renderCardForm();
       } else if (document.body.dataset.layout === "iframe") {
@@ -195,10 +208,19 @@ function checkoutDocument(layout: CheckoutLayout): string {
         host.append(cardFrame);
       } else {
         document.querySelector("#pay-with-card").addEventListener("click", (event) => {
-          if (document.body.dataset.layout === "wallet" && !event.isTrusted) {
+          if (
+            (document.body.dataset.layout === "wallet" ||
+              document.body.dataset.layout === "hidden-duplicates") &&
+            !event.isTrusted
+          ) {
             return;
           }
-          if (document.body.dataset.layout === "wallet") {
+          if (document.body.dataset.layout === "hidden-duplicates") {
+            document.body.dataset.activationCount = String(
+              Number(document.body.dataset.activationCount) + 1
+            );
+            renderCardForm();
+          } else if (document.body.dataset.layout === "wallet") {
             window.requestAnimationFrame(() => {
               window.requestAnimationFrame(renderCardForm);
             });
@@ -264,7 +286,10 @@ async function assertCheckoutWasSubmitted(page: Page): Promise<void> {
 
 async function stripeFieldValue(page: Page, name: string): Promise<string> {
   for (const frame of page.frames()) {
-    const field = frame.locator(`input[name="${name}"]`);
+    const field = frame
+      .locator(`input[name="${name}"]`)
+      .filter({ visible: true })
+      .first();
     if ((await field.count()) > 0) {
       return await field.inputValue();
     }

--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -124,21 +124,6 @@ async function locatorCount(
   }
 }
 
-async function locatorIsVisible(
-  page: Page,
-  frame: Frame,
-  locator: Locator,
-): Promise<boolean> {
-  try {
-    return await locator.isVisible();
-  } catch (error: unknown) {
-    if (frameDetachedDuringDiscovery(page, frame)) {
-      return false;
-    }
-    throw error;
-  }
-}
-
 async function findStripeFieldInFrames(
   page: Page,
   frames: readonly Frame[],
@@ -146,14 +131,11 @@ async function findStripeFieldInFrames(
   visibility: "attached" | "visible",
 ): Promise<LocatedStripeControl | null> {
   for (const frame of frames) {
-    const locator = stripeFieldLocator(frame, field).first();
+    const locator =
+      visibility === "visible"
+        ? visibleStripeFieldLocator(frame, field)
+        : stripeFieldLocator(frame, field).first();
     if ((await locatorCount(page, frame, locator)) === 0) {
-      continue;
-    }
-    if (
-      visibility === "visible" &&
-      !(await locatorIsVisible(page, frame, locator))
-    ) {
       continue;
     }
     return { frame, locator };
@@ -173,11 +155,8 @@ async function findPayWithCard(
   page: Page,
 ): Promise<StripeCardMethodControl | null> {
   for (const frame of page.frames()) {
-    const locator = payWithCardLocator(frame).first();
-    if (
-      (await locatorCount(page, frame, locator)) > 0 &&
-      (await locatorIsVisible(page, frame, locator))
-    ) {
+    const locator = payWithCardLocator(frame).filter({ visible: true }).first();
+    if ((await locatorCount(page, frame, locator)) > 0) {
       return { activation: "click", frame, locator };
     }
   }


### PR DESCRIPTION
## Summary

- filter the complete semantic Stripe field and Card-control locators for visibility before selecting their first match
- preserve the attached zero-height accordion fallback while keeping actionable controls on the real-click path
- add a Chromium regression with an earlier zero-height Card control and earlier hidden card fields before their visible matches

## Scope

- no Checkout timeout increase, retry, polling loop, or activation replay
- no API, runner protocol, billing, or purchase-flow contract changes

## Validation

- `cd turbo && pnpm exec prettier --check ../e2e/playwright/lib/stripe-checkout.ts ../e2e/playwright/lib/stripe-checkout.test.ts`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` — 27/27 passing
- `./scripts/check-file-size.sh e2e/playwright/lib/stripe-checkout.ts e2e/playwright/lib/stripe-checkout.test.ts`
- `git diff --check`

Follow-up to #26874.

Relates to #26866.
