### PR TITLE
test(python): cover http 408 usage webhook retries

### DIFF
--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -329,6 +329,21 @@ def test_retry_success_logs_body_free_payload_summary_with_colliding_fields(
         )
 
 
+def test_http_408_is_retryable(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
+    flow = model_usage_flow(real_flow, tmp_path)
+
+    with (
+        usage_webhook_api() as webhook,
+        patch.object(time, "sleep") as mock_sleep,
+    ):
+        webhook.queue_response(408)
+        webhook.queue_response(204)
+        _report_and_flush_model_usage(flow)
+
+    assert webhook.request_count == 2
+    mock_sleep.assert_called_once_with(0.5)
+
+
 def test_http_429_is_retryable(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
     flow = model_usage_flow(real_flow, tmp_path)
     proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])


### PR DESCRIPTION
## Summary

- add an integration regression for an HTTP 408 usage webhook response followed by HTTP 204
- assert the delivery makes a second request and observes the configured 0.5-second retry delay
- prove the regression fails when HTTP 408 is temporarily removed from the retryable-status contract

## Scope

- test-only change in `crates/runner/mitm-addon/tests/test_webhook_http_delivery.py`
- no production behavior, shared helper, dependency, API, schema, migration, documentation, or rollout changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- mutation check: temporarily removed 408 from `_RETRYABLE_HTTP_STATUS_CODES`; the targeted test failed with one request instead of two; restored the constant before final validation
- `uv run --no-sync python -m pytest tests/test_webhook_http_delivery.py::test_http_408_is_retryable` — 1 passed
- `uv run --no-sync python -m pytest tests/test_webhook_http_delivery.py` — 19 passed
- `uv run --no-sync ruff format --check .` — passed
- `uv run --no-sync ruff check .` — passed
- `uv run --no-sync basedpyright -p .` — passed
- `uv run --no-sync python -m pytest tests/` — 5365 passed

Closes #26898
