### PR TITLE
chore(connectors): remove stale first-admission wording

### DIFF
--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1367,8 +1367,8 @@ impl ConnectorRuntimeTarget {
 pub struct ConnectorRuntimeSyncResult {
     pub target: ConnectorRuntimeTarget,
     pub next_sync_at: Option<String>,
-    /// First-admission Custom routing inputs. The scheduler pins these only
-    /// after the accompanying executable state publishes successfully.
+    /// Custom routing inputs echoed by an available synchronization result. The
+    /// scheduler accepts them only when they match the run-pinned registration.
     #[serde(default)]
     pub base_url_vars: Option<HashMap<String, String>>,
     #[serde(flatten)]

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -10836,7 +10836,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const saved = await connectors.saveCustomConnectorProposal(actor, {
       proposal: {
         operation: "create",
-        displayName: "BDD Unpinned Recovery Runtime",
+        displayName: "BDD Full Recovery Runtime",
         prefixTemplates: [
           `https://{{variables.subdomain}}.${rand}.recovery.test/v1/`,
         ],


### PR DESCRIPTION
## Summary

- replace the obsolete Runner first-admission documentation with the current run-pin validation behavior
- rename the API recovery fixture so it describes later-run admission after full recovery
- leave runtime behavior, wire contracts, and test assertions unchanged

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'admits a custom connector only in runs created after full recovery' --silent=passed-only`
- `pnpm knip --workspace api`
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner`
- repository pre-commit and commit-message hooks, including repository-wide Knip, TypeScript checks, Rust formatting, docs, and Clippy
- repeated the focused API test and formatting checks after rebasing onto the latest `origin/main`

## Scope exclusions

- no connector admission, recovery, synchronization, or authentication behavior changes
- no API or Runner protocol changes
- no database or deployment compatibility changes

Closes #26835

Parent: #25312
