### PR TITLE
docs(sandbox-fc): correct prewarm credential comment

### DIFF
--- a/crates/sandbox-fc/src/factory/invariant.rs
+++ b/crates/sandbox-fc/src/factory/invariant.rs
@@ -6,7 +6,9 @@ use crate::network::{GUEST_NETWORK, generate_boot_args};
 /// Changing this invalidates all cached snapshots (included in [`config_hash`]).
 ///
 /// **Note:** Do NOT wrap this in another user transition — the vsock-guest exec
-/// handler already uses non-login `su` with an explicit `/bin/sh` in release builds.
+/// handler already applies the sandbox credentials directly (`setgroups`,
+/// `setgid`, and `setuid`) before executing an explicit non-login `/bin/sh` in
+/// release builds.
 /// Double-wrapping creates nested sessions where inner processes escape the
 /// process group, surviving SIGKILL on timeout as orphans frozen into the
 /// snapshot.


### PR DESCRIPTION
## Summary

- correct the snapshot prewarm invariant comment to describe direct sandbox credential application with `setgroups`, `setgid`, and `setuid`
- retain the explicit non-login `/bin/sh` boundary and the nested-session/process-group warning

## Scope

- documentation only
- no runtime behavior, `PREWARM_SCRIPT`, test, or configuration-hash input changes

## Validation

- `cargo fmt --all --check`
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p sandbox-fc --test prewarm_script`
- `git diff --check`
- verified that the extracted `PREWARM_SCRIPT` content hash matches `main`

Closes #26914
