### PR TITLE
refactor(python): require billing firewall registry field

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -215,7 +215,7 @@ class _ResolvedFirewallAuth:
 
 def is_billable_firewall(firewall_name: str, vm_info: dict) -> bool:
     """Return whether this firewall should emit connector/model usage."""
-    return firewall_name in (vm_info.get("billableFirewalls") or [])
+    return firewall_name in vm_info["billableFirewalls"]
 
 
 def _prepare_firewall_metadata(
@@ -227,8 +227,6 @@ def _prepare_firewall_metadata(
     api_entry = allow.api_entry
     firewall_base = api_entry["base"]
     api_id = api_entry.get("id", firewall_base)
-    # billableFirewalls is optional in the TS schema; runner may omit the
-    # field entirely for non-vm0 / no-billable-connector runs.
     firewall_billable = is_billable_firewall(allow.name, vm_info)
 
     flow.metadata[metadata_keys.FIREWALL_BASE] = firewall_base

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -258,6 +258,16 @@ def _classify_registry_vms(
             )
             continue
 
+        billable_firewalls = vm.get("billableFirewalls")
+        if not isinstance(billable_firewalls, list) or any(
+            not isinstance(firewall_name, str) for firewall_name in billable_firewalls
+        ):
+            invalid_vms[client_ip] = InvalidVmEntry(
+                "invalid_billable_firewalls",
+                "proxy registry VM entry billableFirewalls must be a list of strings",
+            )
+            continue
+
         if (
             "firewalls" in vm
             and vm["firewalls"] is not None

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -546,6 +546,7 @@ def registry_file(tmp_path):
         "vms": {
             "10.200.0.1": {
                 "runId": "run-abc-123",
+                "billableFirewalls": [],
                 "sandboxToken": "tok-xyz",
                 "registeredAt": 1700000000000,
                 "networkLogPath": str(tmp_path / "network.jsonl"),
@@ -553,6 +554,7 @@ def registry_file(tmp_path):
             },
             "10.200.0.2": {
                 "runId": "run-def-456",
+                "billableFirewalls": [],
                 "sandboxToken": "tok-abc",
                 "registeredAt": 1700000000000,
                 "networkLogPath": str(tmp_path / "network-2.jsonl"),

--- a/crates/runner/mitm-addon/tests/registry_helpers.py
+++ b/crates/runner/mitm-addon/tests/registry_helpers.py
@@ -27,7 +27,7 @@ def write_trusted_catalog_cache_text(path: Path, content: str) -> None:
 
 def write_simple_registry(path, *, run_id="run-one"):
     data = {
-        "vms": {"10.200.0.1": {"runId": run_id}},
+        "vms": {"10.200.0.1": {"runId": run_id, "billableFirewalls": []}},
         "updatedAt": 0,
     }
     path.write_text(json.dumps(data, sort_keys=True))
@@ -42,6 +42,7 @@ def write_firewall_registry(path, *, rule="/items"):
         "vms": {
             "10.200.0.1": {
                 "runId": "run-abc-123",
+                "billableFirewalls": [],
                 "firewalls": [
                     {
                         "kind": "inline",
@@ -86,6 +87,7 @@ def write_builtin_firewall_registry(
                 "vms": {
                     "10.200.0.1": {
                         "runId": run_id,
+                        "billableFirewalls": [],
                         "firewalls": [
                             {
                                 "kind": "builtin",
@@ -109,12 +111,13 @@ def builtin_vm(run_id: str, name: str, base_url_vars: dict[str, str] | None = No
     entry: dict[str, object] = {"kind": "builtin", "name": name}
     if base_url_vars is not None:
         entry["baseUrlVars"] = base_url_vars
-    return {"runId": run_id, "firewalls": [entry]}
+    return {"runId": run_id, "billableFirewalls": [], "firewalls": [entry]}
 
 
 def inline_vm(run_id: str) -> dict:
     return {
         "runId": run_id,
+        "billableFirewalls": [],
         "firewalls": [
             {
                 "kind": "inline",

--- a/crates/runner/mitm-addon/tests/request_handler_helpers.py
+++ b/crates/runner/mitm-addon/tests/request_handler_helpers.py
@@ -86,6 +86,7 @@ def _shared_route_vm(tmp_path: Path, *, reverse: bool = False) -> dict[str, obje
         firewalls.reverse()
     return {
         "runId": "run-shared-route",
+        "billableFirewalls": [],
         "sandboxToken": "tok-shared-route",
         "encryptedSecrets": "iv:tag:data",
         "networkLogPath": str(tmp_path / "net.jsonl"),
@@ -118,6 +119,7 @@ def _vm_without_firewalls(
 ) -> dict[str, object]:
     vm_info: dict[str, object] = {
         "runId": run_id,
+        "billableFirewalls": [],
         "sandboxToken": sandbox_marker,
         "networkLogPath": str(tmp_path / "net.jsonl"),
         "proxyLogPath": str(tmp_path / "proxy.jsonl"),

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
@@ -205,6 +205,7 @@ def _builtin_shared_registry(tmp_path, *, capture_network_bodies: bool = False):
         tmp_path,
         vm_info={
             "runId": "run-shared",
+            "billableFirewalls": [],
             "sandboxToken": "sandbox-shared",
             "encryptedSecrets": "iv:tag:data",
             "networkLogPath": str(tmp_path / "net.jsonl"),

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
@@ -132,7 +132,6 @@ def _vm_info(
     encrypted_secrets: str = "iv:tag:data",
     include_encrypted_secrets: bool = True,
     billable_firewalls: list[str] | None = None,
-    include_billable_firewalls: bool = True,
     network_log_path: str | None = None,
 ) -> dict:
     if network_log_path is None:
@@ -144,11 +143,10 @@ def _vm_info(
         "runId": run_id,
         "sandboxToken": sandbox_marker,
         "networkLogPath": network_log_path,
+        "billableFirewalls": list(billable_firewalls or []),
     }
     if include_encrypted_secrets:
         vm_info["encryptedSecrets"] = encrypted_secrets
-    if include_billable_firewalls:
-        vm_info["billableFirewalls"] = list(billable_firewalls or [])
     return vm_info
 
 
@@ -871,14 +869,12 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
 
-    async def test_missing_billable_firewalls_falls_back_to_empty(
+    async def test_empty_billable_firewalls_is_not_billable(
         self, real_flow, headers, mitm_ctx, tmp_path
     ):
-        """billableFirewalls is optional in the TS schema — a vm_info without
-        the key must not KeyError; firewall_billable should be False."""
         flow = _firewall_flow(real_flow)
         api_entry = _api_entry(api_id="run-1:0")
-        vm_info = _vm_info(tmp_path, include_billable_firewalls=False)
+        vm_info = _vm_info(tmp_path)
         allow = _allow(api_entry, rule="GET /repos")
         token_meta = _token_meta()
 

--- a/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
+++ b/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
@@ -57,7 +57,10 @@ class TestRegistryAuthCacheEviction:
         set_last_force_refresh_monotonic_at(retained_key, 200.0)
 
         # Update registry: remove run-abc-123, add run-other
-        new_data = {"vms": {"10.200.0.99": {"runId": "run-other"}}, "updatedAt": 0}
+        new_data = {
+            "vms": {"10.200.0.99": {"runId": "run-other", "billableFirewalls": []}},
+            "updatedAt": 0,
+        }
         registry_file.write_text(json.dumps(new_data))
 
         registry.load_registry(str(registry_file))  # reload triggers eviction
@@ -218,11 +221,17 @@ class TestRegistryAuthCacheEviction:
             json.dumps(
                 {
                     "vms": {
-                        "10.200.0.1": {"runId": ""},
-                        "10.200.0.2": {},
-                        "10.200.0.3": {"runId": "run-active"},
-                        "10.200.0.4": {"runId": "  \t"},
-                        "10.200.0.5": {"runId": " run-active "},
+                        "10.200.0.1": {"runId": "", "billableFirewalls": []},
+                        "10.200.0.2": {"billableFirewalls": []},
+                        "10.200.0.3": {
+                            "runId": "run-active",
+                            "billableFirewalls": [],
+                        },
+                        "10.200.0.4": {"runId": "  \t", "billableFirewalls": []},
+                        "10.200.0.5": {
+                            "runId": " run-active ",
+                            "billableFirewalls": [],
+                        },
                     },
                     "updatedAt": 0,
                 }
@@ -290,7 +299,10 @@ class TestRegistryAuthCacheEviction:
             json.dumps(
                 {
                     "vms": {
-                        "10.200.0.1": {"runId": "run-active"},
+                        "10.200.0.1": {
+                            "runId": "run-active",
+                            "billableFirewalls": [],
+                        },
                         "10.200.0.2": None,
                         "10.200.0.3": "broken",
                     },

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -1021,6 +1021,7 @@ class TestRegistryBuiltinBaseUrlVars:
                     "vms": {
                         "10.200.0.1": {
                             "runId": "run-zendesk",
+                            "billableFirewalls": [],
                             "vars": {"ZENDESK_SUBDOMAIN": "top-level"},
                             "firewalls": [{"kind": "builtin", "name": "zendesk"}],
                         }

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_resolution.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_resolution.py
@@ -190,6 +190,7 @@ class TestRegistryBuiltinCatalogResolution:
         custom_name = "custom_connector_550e8400e29b41d4a716446655440000"
         vm = {
             "runId": "run-overlap",
+            "billableFirewalls": [],
             "connectorRuntimeTargets": [
                 {"kind": "builtin", "connectorSlug": builtin_name},
                 {"kind": "custom", "customConnectorId": custom_connector_id},

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_core_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_core_cache.py
@@ -95,7 +95,11 @@ class TestRegistryBuiltinCoreCache:
             firewalls = [builtin_entry, inline_entry]
             if builtin_index == 1:
                 firewalls.reverse()
-            return {"runId": run_id, "firewalls": firewalls}
+            return {
+                "runId": run_id,
+                "billableFirewalls": [],
+                "firewalls": firewalls,
+            }
 
         path, cache_path = write_registry_with_cache(
             tmp_path,

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_snapshot.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_snapshot.py
@@ -322,6 +322,7 @@ class TestRegistryBuiltinSnapshot:
             {
                 "10.200.0.1": {
                     "runId": "run-pinned-cache",
+                    "billableFirewalls": [],
                     "firewalls": [
                         {"kind": "builtin", "name": "alpha"},
                         {"kind": "builtin", "name": "beta"},

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -26,7 +26,10 @@ class TestGetVmInfo:
             json.dumps(
                 {
                     "vms": {
-                        "10.200.0.1": {"runId": "good-run"},
+                        "10.200.0.1": {
+                            "runId": "good-run",
+                            "billableFirewalls": [],
+                        },
                         "10.200.0.2": "broken",
                     },
                     "updatedAt": 0,
@@ -59,7 +62,10 @@ class TestGetVmInfo:
             json.dumps(
                 {
                     "vms": {
-                        "10.200.0.1": {"runId": "run-recovered"},
+                        "10.200.0.1": {
+                            "runId": "run-recovered",
+                            "billableFirewalls": [],
+                        },
                     },
                     "updatedAt": 1,
                 }
@@ -71,7 +77,10 @@ class TestGetVmInfo:
         assert not isinstance(recovered_state, registry.RegistryUnavailable)
         assert recovered_state.vms["10.200.0.1"]["runId"] == "run-recovered"
         assert recovered_state.invalid_vms == {}
-        assert registry.get_vm_info("10.200.0.1", str(path)) == {"runId": "run-recovered"}
+        assert registry.get_vm_info("10.200.0.1", str(path)) == {
+            "runId": "run-recovered",
+            "billableFirewalls": [],
+        }
 
 
 class TestGetVmContext:
@@ -127,7 +136,10 @@ class TestGetVmContext:
             json.dumps(
                 {
                     "vms": {
-                        "10.200.0.1": {"runId": "good-run"},
+                        "10.200.0.1": {
+                            "runId": "good-run",
+                            "billableFirewalls": [],
+                        },
                         "10.200.0.2": "broken",
                     },
                     "updatedAt": 0,

--- a/crates/runner/mitm-addon/tests/test_registry_context_state.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context_state.py
@@ -61,6 +61,7 @@ class TestRegistryContextState:
                     "vms": {
                         "10.200.0.1": {
                             "runId": "run-abc-123",
+                            "billableFirewalls": [],
                             "networkPolicies": {
                                 "example": {
                                     "allow": [],

--- a/crates/runner/mitm-addon/tests/test_registry_loading.py
+++ b/crates/runner/mitm-addon/tests/test_registry_loading.py
@@ -27,13 +27,19 @@ class TestLoadRegistry:
             json.dumps(
                 {
                     "vms": {
-                        "10.200.0.1": {"runId": "run-active"},
+                        "10.200.0.1": {
+                            "runId": "run-active",
+                            "billableFirewalls": [],
+                        },
                         "10.200.0.2": "broken",
-                        "10.200.0.3": {},
-                        "10.200.0.4": {"runId": ""},
-                        "10.200.0.5": {"runId": 123},
-                        "10.200.0.6": {"runId": "  \t"},
-                        "10.200.0.7": {"runId": " run-active "},
+                        "10.200.0.3": {"billableFirewalls": []},
+                        "10.200.0.4": {"runId": "", "billableFirewalls": []},
+                        "10.200.0.5": {"runId": 123, "billableFirewalls": []},
+                        "10.200.0.6": {"runId": "  \t", "billableFirewalls": []},
+                        "10.200.0.7": {
+                            "runId": " run-active ",
+                            "billableFirewalls": [],
+                        },
                     },
                     "updatedAt": 0,
                 }
@@ -80,7 +86,10 @@ class TestLoadRegistry:
         assert "10.200.0.1" in result1
 
         # Modify the file
-        new_data = {"vms": {"10.200.0.99": {"runId": "new-run"}}, "updatedAt": 0}
+        new_data = {
+            "vms": {"10.200.0.99": {"runId": "new-run", "billableFirewalls": []}},
+            "updatedAt": 0,
+        }
         registry_file.write_text(json.dumps(new_data))
 
         result2 = registry.load_registry(str(registry_file))
@@ -141,7 +150,10 @@ class TestLoadRegistry:
             json.dumps(
                 {
                     "vms": {
-                        "10.200.0.1": {"runId": "good-run"},
+                        "10.200.0.1": {
+                            "runId": "good-run",
+                            "billableFirewalls": [],
+                        },
                         "10.200.0.2": None,
                         "10.200.0.3": "broken",
                         "10.200.0.4": ["broken"],
@@ -157,7 +169,9 @@ class TestLoadRegistry:
             result = registry.load_registry(str(path))
             cached = registry.load_registry(str(path))
 
-        assert result == {"10.200.0.1": {"runId": "good-run"}}
+        assert result == {
+            "10.200.0.1": {"runId": "good-run", "billableFirewalls": []},
+        }
         assert cached is result
         assert log.warn.call_count == 1
         warning = log.warn.call_args_list[0].args[0]
@@ -368,7 +382,10 @@ class TestLoadRegistry:
 
     def test_read_failure_after_open_does_not_poison_file_key(self, registry_file):
         registry.load_registry(str(registry_file))
-        new_registry = {"vms": {"10.200.0.99": {"runId": "new-run"}}, "updatedAt": 0}
+        new_registry = {
+            "vms": {"10.200.0.99": {"runId": "new-run", "billableFirewalls": []}},
+            "updatedAt": 0,
+        }
         registry_file.write_text(json.dumps(new_registry))
         read_results = iter(
             [
@@ -393,14 +410,18 @@ class TestLoadRegistry:
             recovered = registry.load_registry(str(registry_file))
 
         assert failed == {}
-        assert recovered == {"10.200.0.99": {"runId": "new-run"}}
+        assert recovered == {
+            "10.200.0.99": {"runId": "new-run", "billableFirewalls": []},
+        }
         assert spy.call_count == 3
         assert log.warn.call_count == 1
         assert "Failed to read" in log.warn.call_args_list[0].args[0]
 
     def test_read_failure_clears_previous_failed_key(self, tmp_path):
         path = tmp_path / "registry.json"
-        valid_registry = {"vms": {"10.0.0.1": {"runId": "r1"}}}
+        valid_registry = {
+            "vms": {"10.0.0.1": {"runId": "r1", "billableFirewalls": []}},
+        }
         valid_bytes = json.dumps(valid_registry, separators=(",", ":")).encode()
         path.write_bytes(b"{" + b" " * (len(valid_bytes) - 1))
         first_stat = path.stat()
@@ -429,7 +450,9 @@ class TestLoadRegistry:
             )
             recovered = registry.load_registry(str(path))
 
-        assert recovered == {"10.0.0.1": {"runId": "r1"}}
+        assert recovered == {
+            "10.0.0.1": {"runId": "r1", "billableFirewalls": []},
+        }
         assert log.warn.call_count == 2
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
         assert "Failed to read" in log.warn.call_args_list[1].args[0]
@@ -444,7 +467,18 @@ class TestLoadRegistry:
             assert log.warn.call_count == 1
 
             # File becomes valid → successful load clears the flag.
-            path.write_text(json.dumps({"vms": {"10.0.0.1": {"runId": "r1"}}}))
+            path.write_text(
+                json.dumps(
+                    {
+                        "vms": {
+                            "10.0.0.1": {
+                                "runId": "r1",
+                                "billableFirewalls": [],
+                            }
+                        }
+                    }
+                )
+            )
             result = registry.load_registry(str(path))
             assert "10.0.0.1" in result
             assert log.warn.call_count == 1  # no new warn on success

--- a/crates/runner/mitm-addon/tests/test_request_handler_builtin_host_policy.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_builtin_host_policy.py
@@ -77,6 +77,7 @@ def _write_resolved_host_policy_registry(
         client_ip="10.200.0.5",
         vm_info={
             "runId": "run-resolved-host-policy",
+            "billableFirewalls": [],
             "sandboxToken": "tok-resolved-host-policy",
             "encryptedSecrets": "iv:tag:data",
             "networkLogPath": str(tmp_path / "net.jsonl"),

--- a/crates/runner/mitm-addon/tests/test_request_handler_registry_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_registry_admission.py
@@ -140,6 +140,66 @@ async def test_invalid_registered_vm_non_object_blocks_before_auth_injection(
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_vm"
 
 
+@pytest.mark.parametrize(
+    ("billable_firewalls", "include_field"),
+    [
+        pytest.param(None, False, id="missing"),
+        pytest.param(None, True, id="null"),
+        pytest.param("github", True, id="string"),
+        pytest.param({}, True, id="object"),
+        pytest.param(["github", 1], True, id="non-string-element"),
+    ],
+)
+async def test_invalid_billable_firewalls_blocks_before_auth_injection(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    billable_firewalls,
+    include_field,
+):
+    vm_info = _single_firewall_vm(
+        tmp_path,
+        api_entry={
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer secret"}},
+            "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+        },
+        network_policy={
+            "allow": ["full-access"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "allow",
+        },
+    )
+    if include_field:
+        vm_info["billableFirewalls"] = billable_firewalls
+    else:
+        del vm_info["billableFirewalls"]
+    reg_path = _write_registry(tmp_path, client_ip="10.200.0.5", vm_info=vm_info)
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content) == {
+        "error": "invalid_registry_vm",
+        "message": "proxy registry VM entry billableFirewalls must be a list of strings",
+        "reason": "invalid_billable_firewalls",
+    }
+    auth_fetch.assert_not_called()
+    assert flow.request.headers.get("Authorization") is None
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_vm"
+
+
 async def test_invalid_connector_routing_variables_block_before_auth_injection(
     tmp_path,
     real_flow,

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -246,6 +246,7 @@ def registry_file(tmp_path):
         "vms": {
             "10.200.0.1": {
                 "runId": "run-abc-123",
+                "billableFirewalls": [],
                 "sandboxToken": "tok-xyz",
                 "networkLogPath": str(tmp_path / "network.jsonl"),
             },


### PR DESCRIPTION
## Summary

- require each usable proxy-registry VM entry to provide `billableFirewalls` as a list of strings
- reject missing or malformed values through the existing per-VM `invalid_registry_vm` path before auth injection
- remove the auth-layer fallback, preserve canonical `[]`, and update current-shape test/documentation fixtures

## Compatibility

- the backend execution-context claim remains optional and Rust still normalizes omission to an empty vector
- the Rust local registry writer always serializes `billableFirewalls`, including canonical `[]`, and the current Rust reader already requires the field
- the registry writer and embedded Python addon ship in one runner artifact; runner startup recreates both the addon files and local registry before mitmdump starts, so no supported rollout pairs this addon with an old writer
- no API, queue, database, Rust deserialization, feature-switch, or rollout behavior changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_request_handler_registry_admission.py tests/test_firewall_auth_handling.py` (98 passed)
- focused stale-fixture verification across 10 affected test files (198 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5373 passed)

Closes #26890
