### PR TITLE
refactor(python): require cli agent type in proxy registry

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -30,8 +30,8 @@ Request context
   request/response bodies.
 - ``SUPPRESS_REQUEST_BODY_CAPTURE``: ``bool`` written by auth.base request-size
   handling. Read by body capture to mark oversized request bodies truncated.
-- ``CLI_AGENT_TYPE``: ``str`` copied from registry VM info, defaulting to
-  ``"claude-code"``. Read by model-provider usage protocol selection.
+- ``CLI_AGENT_TYPE``: ``str`` copied from validated registry VM info. Read by
+  model-provider usage protocol selection.
 - ``BROWSER_USER_AGENT``: ``bool`` written during request classification when
   the request matches the short-term browser passthrough User-Agent heuristic.
   Read by request dispatch to skip connector firewall handling and managed

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -268,6 +268,27 @@ def _classify_registry_vms(
             )
             continue
 
+        if "cliAgentType" not in vm:
+            invalid_vms[client_ip] = InvalidVmEntry(
+                "missing_cli_agent_type",
+                "proxy registry VM entry is missing cliAgentType",
+            )
+            continue
+
+        cli_agent_type = vm["cliAgentType"]
+        if not isinstance(cli_agent_type, str):
+            invalid_vms[client_ip] = InvalidVmEntry(
+                "invalid_cli_agent_type",
+                "proxy registry VM entry cliAgentType must be a string",
+            )
+            continue
+        if not cli_agent_type:
+            invalid_vms[client_ip] = InvalidVmEntry(
+                "empty_cli_agent_type",
+                "proxy registry VM entry cliAgentType must be non-empty",
+            )
+            continue
+
         if (
             "firewalls" in vm
             and vm["firewalls"] is not None

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -608,7 +608,7 @@ def _store_registered_request_metadata(
     flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = vm_info.get("proxyLogPath", "")
     flow.metadata[metadata_keys.CAPTURE_BODY] = vm_info.get("captureNetworkBodies", False)
     flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = vm_info.get("sandboxToken", "")
-    flow.metadata[metadata_keys.CLI_AGENT_TYPE] = vm_info.get("cliAgentType") or "claude-code"
+    flow.metadata[metadata_keys.CLI_AGENT_TYPE] = vm_info["cliAgentType"]
 
 
 def _store_trusted_authority_metadata(

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -547,6 +547,7 @@ def registry_file(tmp_path):
             "10.200.0.1": {
                 "runId": "run-abc-123",
                 "billableFirewalls": [],
+                "cliAgentType": "claude-code",
                 "sandboxToken": "tok-xyz",
                 "registeredAt": 1700000000000,
                 "networkLogPath": str(tmp_path / "network.jsonl"),
@@ -555,6 +556,7 @@ def registry_file(tmp_path):
             "10.200.0.2": {
                 "runId": "run-def-456",
                 "billableFirewalls": [],
+                "cliAgentType": "claude-code",
                 "sandboxToken": "tok-abc",
                 "registeredAt": 1700000000000,
                 "networkLogPath": str(tmp_path / "network-2.jsonl"),

--- a/crates/runner/mitm-addon/tests/registry_helpers.py
+++ b/crates/runner/mitm-addon/tests/registry_helpers.py
@@ -27,7 +27,13 @@ def write_trusted_catalog_cache_text(path: Path, content: str) -> None:
 
 def write_simple_registry(path, *, run_id="run-one"):
     data = {
-        "vms": {"10.200.0.1": {"runId": run_id, "billableFirewalls": []}},
+        "vms": {
+            "10.200.0.1": {
+                "runId": run_id,
+                "billableFirewalls": [],
+                "cliAgentType": "claude-code",
+            }
+        },
         "updatedAt": 0,
     }
     path.write_text(json.dumps(data, sort_keys=True))
@@ -43,6 +49,7 @@ def write_firewall_registry(path, *, rule="/items"):
             "10.200.0.1": {
                 "runId": "run-abc-123",
                 "billableFirewalls": [],
+                "cliAgentType": "claude-code",
                 "firewalls": [
                     {
                         "kind": "inline",
@@ -88,6 +95,7 @@ def write_builtin_firewall_registry(
                     "10.200.0.1": {
                         "runId": run_id,
                         "billableFirewalls": [],
+                        "cliAgentType": "claude-code",
                         "firewalls": [
                             {
                                 "kind": "builtin",
@@ -111,13 +119,19 @@ def builtin_vm(run_id: str, name: str, base_url_vars: dict[str, str] | None = No
     entry: dict[str, object] = {"kind": "builtin", "name": name}
     if base_url_vars is not None:
         entry["baseUrlVars"] = base_url_vars
-    return {"runId": run_id, "billableFirewalls": [], "firewalls": [entry]}
+    return {
+        "runId": run_id,
+        "billableFirewalls": [],
+        "cliAgentType": "claude-code",
+        "firewalls": [entry],
+    }
 
 
 def inline_vm(run_id: str) -> dict:
     return {
         "runId": run_id,
         "billableFirewalls": [],
+        "cliAgentType": "claude-code",
         "firewalls": [
             {
                 "kind": "inline",

--- a/crates/runner/mitm-addon/tests/request_handler_helpers.py
+++ b/crates/runner/mitm-addon/tests/request_handler_helpers.py
@@ -36,6 +36,7 @@ def _single_firewall_vm(
         firewall_entry["customConnectorId"] = custom_connector_id
     vm_info: dict[str, object] = {
         "runId": run_id,
+        "cliAgentType": "claude-code",
         "billableFirewalls": billable_firewalls or [],
         "sandboxToken": sandbox_marker,
         "networkLogPath": str(tmp_path / "net.jsonl"),
@@ -87,6 +88,7 @@ def _shared_route_vm(tmp_path: Path, *, reverse: bool = False) -> dict[str, obje
     return {
         "runId": "run-shared-route",
         "billableFirewalls": [],
+        "cliAgentType": "claude-code",
         "sandboxToken": "tok-shared-route",
         "encryptedSecrets": "iv:tag:data",
         "networkLogPath": str(tmp_path / "net.jsonl"),
@@ -120,6 +122,7 @@ def _vm_without_firewalls(
     vm_info: dict[str, object] = {
         "runId": run_id,
         "billableFirewalls": [],
+        "cliAgentType": "claude-code",
         "sandboxToken": sandbox_marker,
         "networkLogPath": str(tmp_path / "net.jsonl"),
         "proxyLogPath": str(tmp_path / "proxy.jsonl"),

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
@@ -206,6 +206,7 @@ def _builtin_shared_registry(tmp_path, *, capture_network_bodies: bool = False):
         vm_info={
             "runId": "run-shared",
             "billableFirewalls": [],
+            "cliAgentType": "claude-code",
             "sandboxToken": "sandbox-shared",
             "encryptedSecrets": "iv:tag:data",
             "networkLogPath": str(tmp_path / "net.jsonl"),

--- a/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
+++ b/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
@@ -58,7 +58,13 @@ class TestRegistryAuthCacheEviction:
 
         # Update registry: remove run-abc-123, add run-other
         new_data = {
-            "vms": {"10.200.0.99": {"runId": "run-other", "billableFirewalls": []}},
+            "vms": {
+                "10.200.0.99": {
+                    "runId": "run-other",
+                    "billableFirewalls": [],
+                    "cliAgentType": "claude-code",
+                }
+            },
             "updatedAt": 0,
         }
         registry_file.write_text(json.dumps(new_data))
@@ -226,6 +232,7 @@ class TestRegistryAuthCacheEviction:
                         "10.200.0.3": {
                             "runId": "run-active",
                             "billableFirewalls": [],
+                            "cliAgentType": "claude-code",
                         },
                         "10.200.0.4": {"runId": "  \t", "billableFirewalls": []},
                         "10.200.0.5": {
@@ -302,6 +309,7 @@ class TestRegistryAuthCacheEviction:
                         "10.200.0.1": {
                             "runId": "run-active",
                             "billableFirewalls": [],
+                            "cliAgentType": "claude-code",
                         },
                         "10.200.0.2": None,
                         "10.200.0.3": "broken",

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -1022,6 +1022,7 @@ class TestRegistryBuiltinBaseUrlVars:
                         "10.200.0.1": {
                             "runId": "run-zendesk",
                             "billableFirewalls": [],
+                            "cliAgentType": "claude-code",
                             "vars": {"ZENDESK_SUBDOMAIN": "top-level"},
                             "firewalls": [{"kind": "builtin", "name": "zendesk"}],
                         }

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_resolution.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_resolution.py
@@ -191,6 +191,7 @@ class TestRegistryBuiltinCatalogResolution:
         vm = {
             "runId": "run-overlap",
             "billableFirewalls": [],
+            "cliAgentType": "claude-code",
             "connectorRuntimeTargets": [
                 {"kind": "builtin", "connectorSlug": builtin_name},
                 {"kind": "custom", "customConnectorId": custom_connector_id},
@@ -365,6 +366,7 @@ class TestRegistryBuiltinCatalogResolution:
             }
             vm: dict[str, object] = {
                 "runId": "run-dynamic-owner",
+                "cliAgentType": "claude-code",
                 "connectorRuntimeTargets": [
                     {"kind": "builtin", "connectorSlug": builtin_name},
                     {"kind": "custom", "customConnectorId": custom_connector_id},

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_core_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_core_cache.py
@@ -98,6 +98,7 @@ class TestRegistryBuiltinCoreCache:
             return {
                 "runId": run_id,
                 "billableFirewalls": [],
+                "cliAgentType": "claude-code",
                 "firewalls": firewalls,
             }
 

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_snapshot.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_snapshot.py
@@ -323,6 +323,7 @@ class TestRegistryBuiltinSnapshot:
                 "10.200.0.1": {
                     "runId": "run-pinned-cache",
                     "billableFirewalls": [],
+                    "cliAgentType": "claude-code",
                     "firewalls": [
                         {"kind": "builtin", "name": "alpha"},
                         {"kind": "builtin", "name": "beta"},

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -29,6 +29,7 @@ class TestGetVmInfo:
                         "10.200.0.1": {
                             "runId": "good-run",
                             "billableFirewalls": [],
+                            "cliAgentType": "claude-code",
                         },
                         "10.200.0.2": "broken",
                     },
@@ -65,6 +66,7 @@ class TestGetVmInfo:
                         "10.200.0.1": {
                             "runId": "run-recovered",
                             "billableFirewalls": [],
+                            "cliAgentType": "claude-code",
                         },
                     },
                     "updatedAt": 1,
@@ -80,6 +82,7 @@ class TestGetVmInfo:
         assert registry.get_vm_info("10.200.0.1", str(path)) == {
             "runId": "run-recovered",
             "billableFirewalls": [],
+            "cliAgentType": "claude-code",
         }
 
 
@@ -139,6 +142,7 @@ class TestGetVmContext:
                         "10.200.0.1": {
                             "runId": "good-run",
                             "billableFirewalls": [],
+                            "cliAgentType": "claude-code",
                         },
                         "10.200.0.2": "broken",
                     },

--- a/crates/runner/mitm-addon/tests/test_registry_context_state.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context_state.py
@@ -62,6 +62,7 @@ class TestRegistryContextState:
                         "10.200.0.1": {
                             "runId": "run-abc-123",
                             "billableFirewalls": [],
+                            "cliAgentType": "claude-code",
                             "networkPolicies": {
                                 "example": {
                                     "allow": [],

--- a/crates/runner/mitm-addon/tests/test_registry_loading.py
+++ b/crates/runner/mitm-addon/tests/test_registry_loading.py
@@ -30,6 +30,7 @@ class TestLoadRegistry:
                         "10.200.0.1": {
                             "runId": "run-active",
                             "billableFirewalls": [],
+                            "cliAgentType": "claude-code",
                         },
                         "10.200.0.2": "broken",
                         "10.200.0.3": {"billableFirewalls": []},
@@ -87,7 +88,13 @@ class TestLoadRegistry:
 
         # Modify the file
         new_data = {
-            "vms": {"10.200.0.99": {"runId": "new-run", "billableFirewalls": []}},
+            "vms": {
+                "10.200.0.99": {
+                    "runId": "new-run",
+                    "billableFirewalls": [],
+                    "cliAgentType": "claude-code",
+                }
+            },
             "updatedAt": 0,
         }
         registry_file.write_text(json.dumps(new_data))
@@ -153,6 +160,7 @@ class TestLoadRegistry:
                         "10.200.0.1": {
                             "runId": "good-run",
                             "billableFirewalls": [],
+                            "cliAgentType": "claude-code",
                         },
                         "10.200.0.2": None,
                         "10.200.0.3": "broken",
@@ -170,7 +178,11 @@ class TestLoadRegistry:
             cached = registry.load_registry(str(path))
 
         assert result == {
-            "10.200.0.1": {"runId": "good-run", "billableFirewalls": []},
+            "10.200.0.1": {
+                "runId": "good-run",
+                "billableFirewalls": [],
+                "cliAgentType": "claude-code",
+            }
         }
         assert cached is result
         assert log.warn.call_count == 1
@@ -383,7 +395,13 @@ class TestLoadRegistry:
     def test_read_failure_after_open_does_not_poison_file_key(self, registry_file):
         registry.load_registry(str(registry_file))
         new_registry = {
-            "vms": {"10.200.0.99": {"runId": "new-run", "billableFirewalls": []}},
+            "vms": {
+                "10.200.0.99": {
+                    "runId": "new-run",
+                    "billableFirewalls": [],
+                    "cliAgentType": "claude-code",
+                }
+            },
             "updatedAt": 0,
         }
         registry_file.write_text(json.dumps(new_registry))
@@ -411,7 +429,11 @@ class TestLoadRegistry:
 
         assert failed == {}
         assert recovered == {
-            "10.200.0.99": {"runId": "new-run", "billableFirewalls": []},
+            "10.200.0.99": {
+                "runId": "new-run",
+                "billableFirewalls": [],
+                "cliAgentType": "claude-code",
+            }
         }
         assert spy.call_count == 3
         assert log.warn.call_count == 1
@@ -420,7 +442,13 @@ class TestLoadRegistry:
     def test_read_failure_clears_previous_failed_key(self, tmp_path):
         path = tmp_path / "registry.json"
         valid_registry = {
-            "vms": {"10.0.0.1": {"runId": "r1", "billableFirewalls": []}},
+            "vms": {
+                "10.0.0.1": {
+                    "runId": "r1",
+                    "billableFirewalls": [],
+                    "cliAgentType": "claude-code",
+                }
+            }
         }
         valid_bytes = json.dumps(valid_registry, separators=(",", ":")).encode()
         path.write_bytes(b"{" + b" " * (len(valid_bytes) - 1))
@@ -451,7 +479,11 @@ class TestLoadRegistry:
             recovered = registry.load_registry(str(path))
 
         assert recovered == {
-            "10.0.0.1": {"runId": "r1", "billableFirewalls": []},
+            "10.0.0.1": {
+                "runId": "r1",
+                "billableFirewalls": [],
+                "cliAgentType": "claude-code",
+            }
         }
         assert log.warn.call_count == 2
         assert "Failed to parse" in log.warn.call_args_list[0].args[0]
@@ -474,6 +506,7 @@ class TestLoadRegistry:
                             "10.0.0.1": {
                                 "runId": "r1",
                                 "billableFirewalls": [],
+                                "cliAgentType": "claude-code",
                             }
                         }
                     }

--- a/crates/runner/mitm-addon/tests/test_request_handler_builtin_host_policy.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_builtin_host_policy.py
@@ -78,6 +78,7 @@ def _write_resolved_host_policy_registry(
         vm_info={
             "runId": "run-resolved-host-policy",
             "billableFirewalls": [],
+            "cliAgentType": "claude-code",
             "sandboxToken": "tok-resolved-host-policy",
             "encryptedSecrets": "iv:tag:data",
             "networkLogPath": str(tmp_path / "net.jsonl"),

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -131,6 +131,7 @@ def _candidate_precedence_vm(tmp_path: Path, *, custom_available: bool) -> dict[
     }
     vm: dict[str, object] = {
         "runId": _ORIGINAL_RUN_ID,
+        "cliAgentType": "claude-code",
         "sandboxToken": "candidate-precedence-token",
         "networkLogPath": str(tmp_path / "net.jsonl"),
         "proxyLogPath": str(tmp_path / "proxy.jsonl"),

--- a/crates/runner/mitm-addon/tests/test_request_handler_registry_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_registry_admission.py
@@ -110,6 +110,124 @@ async def test_invalid_registered_vm_blocks_before_auth_injection(
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_vm"
 
 
+@pytest.mark.parametrize(
+    ("field_present", "cli_agent_type", "expected_reason", "expected_message"),
+    [
+        (
+            False,
+            None,
+            "missing_cli_agent_type",
+            "proxy registry VM entry is missing cliAgentType",
+        ),
+        (
+            True,
+            "",
+            "empty_cli_agent_type",
+            "proxy registry VM entry cliAgentType must be non-empty",
+        ),
+        (
+            True,
+            None,
+            "invalid_cli_agent_type",
+            "proxy registry VM entry cliAgentType must be a string",
+        ),
+        (
+            True,
+            123,
+            "invalid_cli_agent_type",
+            "proxy registry VM entry cliAgentType must be a string",
+        ),
+    ],
+)
+async def test_invalid_cli_agent_type_blocks_before_auth_injection(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    field_present,
+    cli_agent_type,
+    expected_reason,
+    expected_message,
+):
+    vm_info = _single_firewall_vm(
+        tmp_path,
+        api_entry={
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer secret"}},
+            "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+        },
+        network_policy={
+            "allow": ["full-access"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "allow",
+        },
+    )
+    if field_present:
+        vm_info["cliAgentType"] = cli_agent_type
+    else:
+        del vm_info["cliAgentType"]
+    reg_path = _write_registry(tmp_path, client_ip="10.200.0.5", vm_info=vm_info)
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content) == {
+        "error": "invalid_registry_vm",
+        "message": expected_message,
+        "reason": expected_reason,
+    }
+    auth_fetch.assert_not_called()
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.CLI_AGENT_TYPE not in flow.metadata
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_vm"
+
+
+@pytest.mark.parametrize("cli_agent_type", ["claude-code", "codex", "custom-agent"])
+async def test_valid_cli_agent_type_is_copied_to_request_metadata(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    cli_agent_type,
+):
+    vm_info = _single_firewall_vm(
+        tmp_path,
+        api_entry={
+            "base": "https://api.github.com",
+            "auth": {"headers": {"Authorization": "Bearer secret"}},
+            "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+        },
+        network_policy={
+            "allow": ["full-access"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "allow",
+        },
+        vm_fields={"cliAgentType": cli_agent_type},
+    )
+    reg_path = _write_registry(tmp_path, client_ip="10.200.0.5", vm_info=vm_info)
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.VM_RUN_ID] == vm_info["runId"]
+    assert flow.metadata[metadata_keys.CLI_AGENT_TYPE] == cli_agent_type
+
+
 async def test_invalid_registered_vm_non_object_blocks_before_auth_injection(
     tmp_path,
     real_flow,


### PR DESCRIPTION
## Summary

- reject proxy-registry VM entries whose `cliAgentType` is missing, empty, or not a string through the existing per-VM invalid-registry path
- remove the addon-side Claude Code fallback and copy only the validated registry value into request metadata
- update current-schema registry fixtures and add request-entry regression coverage for invalid, canonical, and unknown non-empty values

## Scope

- keeps invalidity isolated to the malformed VM so unrelated registry entries remain usable
- preserves unknown non-empty framework handling outside the registry boundary
- does not add a Rust Serde default, API migration, feature switch, or cross-version registry reader

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/` (5,384 passed)
- `git diff --check`

Closes #26889
