### PR TITLE
fix(runner): centralize parent-death process setup

### DIFF
--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -56,15 +56,9 @@ pub(super) fn rootfs_script_command(script: &Path) -> tokio::process::Command {
     cmd.process_group(0);
     cmd.kill_on_drop(true);
 
-    // SAFETY: `set_pdeathsig` calls `prctl(PR_SET_PDEATHSIG)`, which is
-    // async-signal-safe. It narrows the window where a parent runner crash
-    // releases flocks while a rootfs script keeps mutating staging files.
-    unsafe {
-        cmd.pre_exec(|| {
-            nix::sys::prctl::set_pdeathsig(nix::sys::signal::Signal::SIGKILL)
-                .map_err(std::io::Error::from)
-        });
-    }
+    // Prevent scripts from continuing to mutate staging files after a runner
+    // crash releases the associated locks.
+    crate::parent_death::configure_parent_death_signal(&mut cmd);
 
     cmd
 }

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -120,7 +120,6 @@ async fn try_start(
     interface_pattern: &str,
     network_log_manager: NetworkLogManager,
 ) -> std::io::Result<DnsProxy> {
-    let expected_parent = nix::unistd::getpid();
     let mut command = tokio::process::Command::new("dnsmasq");
     command
         .args(dnsmasq_args(port, interface_pattern))
@@ -128,20 +127,9 @@ async fn try_start(
         .stderr(Stdio::piped())
         .kill_on_drop(true);
 
-    // SAFETY: `set_pdeathsig` and `getppid` are async-signal-safe. Checking the
-    // parent after installing the signal closes the fork-to-prctl race: if the
-    // runner already exited, the child fails before exec instead of creating an
-    // unowned wildcard listener.
-    unsafe {
-        command.pre_exec(move || {
-            nix::sys::prctl::set_pdeathsig(nix::sys::signal::Signal::SIGKILL)
-                .map_err(std::io::Error::from)?;
-            if nix::unistd::getppid() != expected_parent {
-                return Err(std::io::Error::from_raw_os_error(nix::libc::ESRCH));
-            }
-            Ok(())
-        });
-    }
+    // Prevent dnsmasq from creating an unowned wildcard listener if the runner
+    // exits during spawn.
+    crate::parent_death::configure_parent_death_signal(&mut command);
 
     let mut child = command.spawn()?;
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -35,6 +35,7 @@ mod network_log_manager;
 mod network_log_process;
 mod network_logs;
 mod org_name;
+mod parent_death;
 mod paths;
 mod prefetch;
 mod private_fs;

--- a/crates/runner/src/parent_death.rs
+++ b/crates/runner/src/parent_death.rs
@@ -1,0 +1,51 @@
+//! Linux parent-death setup for runner-owned child commands.
+
+use nix::unistd::Pid;
+
+/// Configure a command with the runner's parent-death contract.
+pub(crate) fn configure_parent_death_signal(command: &mut tokio::process::Command) {
+    configure_parent_death_signal_for(command, nix::unistd::getpid());
+}
+
+fn configure_parent_death_signal_for(command: &mut tokio::process::Command, expected_parent: Pid) {
+    // SAFETY: `set_pdeathsig` and `getppid` are async-signal-safe. Installing
+    // the signal before checking the captured parent closes the fork-to-prctl
+    // race: a reparented child fails before exec instead of running unowned.
+    unsafe {
+        command.pre_exec(move || {
+            nix::sys::prctl::set_pdeathsig(nix::sys::signal::Signal::SIGKILL)
+                .map_err(std::io::Error::from)?;
+            if nix::unistd::getppid() != expected_parent {
+                return Err(std::io::Error::from_raw_os_error(nix::libc::ESRCH));
+            }
+            Ok(())
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn configured_child_spawns_with_expected_parent() {
+        let mut command = tokio::process::Command::new("/bin/true");
+        configure_parent_death_signal(&mut command);
+
+        let status = command.status().await.unwrap();
+
+        assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn changed_parent_rejects_child_before_exec() {
+        let unexpected_parent = nix::unistd::getppid();
+        assert_ne!(unexpected_parent, nix::unistd::getpid());
+        let mut command = tokio::process::Command::new("/bin/true");
+        configure_parent_death_signal_for(&mut command, unexpected_parent);
+
+        let error = command.status().await.unwrap_err();
+
+        assert_eq!(error.raw_os_error(), Some(nix::libc::ESRCH));
+    }
+}

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -563,16 +563,9 @@ async fn spawn_mitmdump(
         .process_group(0);
     cmd.kill_on_drop(true);
 
-    // SAFETY: `set_pdeathsig` calls `prctl(PR_SET_PDEATHSIG)` which is
-    // async-signal-safe. This covers the direct PyInstaller bootloader; its
-    // forked application child is covered by managed process-group shutdown
-    // and marker-based reconciliation.
-    unsafe {
-        cmd.pre_exec(|| {
-            nix::sys::prctl::set_pdeathsig(nix::sys::signal::Signal::SIGKILL)
-                .map_err(std::io::Error::from)
-        });
-    }
+    // This covers the direct PyInstaller bootloader; managed process-group
+    // shutdown and marker reconciliation cover its forked application child.
+    crate::parent_death::configure_parent_death_signal(&mut cmd);
 
     info!(port, bin = %config.mitmdump_bin.display(), "starting mitmdump");
 


### PR DESCRIPTION
## Summary

- centralize the runner's Linux `PR_SET_PDEATHSIG(SIGKILL)` setup in one parent-death module
- close the fork-to-`prctl` reparenting race for mitmdump and rootfs scripts by verifying the captured parent after signal installation
- cover successful setup and the parent-changed `ESRCH` failure through real Tokio child spawns

## Scope

- preserve DNS, mitmdump, and rootfs-script stdio and process-group configuration
- preserve mitmdump retry and marker reconciliation behavior
- preserve existing direct-child and process-group drop cleanup
- no API, database, protocol, persisted-state, or deployment compatibility changes

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features` (3094 passed, 20 existing ignored)

Closes #26892
