### PR TITLE
fix(platform): deduplicate foreground account refreshes

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -17,6 +17,7 @@ import {
   setAblyLoop$,
   setAblyMessageLoop$,
   setAblyPayloadLoop$,
+  subscribeRealtimeReadyCatchUp$,
 } from "../realtime.ts";
 import { authRecovery$, setupClerk$ } from "../auth.ts";
 import { foregroundReady$ } from "../auth-retry.ts";
@@ -407,6 +408,80 @@ describe("realtime signals", () => {
     await waitFor(() => {
       expect(runs).toBe(2);
     });
+  });
+
+  it("awaits resource catch-up after rebuilding the realtime client", async () => {
+    mockSignedInUser();
+    const topic = "test:ordered-resource-catch-up";
+    const subscriber = testSubscriber();
+    const catchUpCanFinish = context.mocks.deferred<void>();
+    let catchUps = 0;
+    let subscribedDuringCatchUp = false;
+    const resourceCatchUp$ = command(
+      async (_ctx, signal: AbortSignal): Promise<void> => {
+        catchUps += 1;
+        subscribedDuringCatchUp = context.mocks.ably.hasSubscription(topic);
+        await catchUpCanFinish.promise;
+        signal.throwIfAborted();
+      },
+    );
+
+    await setupAuthAndRealtime();
+    context.store.set(
+      subscribeRealtimeReadyCatchUp$,
+      resourceCatchUp$,
+      subscriber.signal,
+    );
+    const loopPromise = context.store.set(
+      setAblyLoop$,
+      { topic, loopCommand$: keepAliveLoop$ },
+      subscriber.signal,
+    );
+    context.track(loopPromise);
+    await waitFor(() => {
+      expect(context.mocks.ably.hasSubscription(topic)).toBeTruthy();
+    });
+
+    context.mocks.ably.triggerFailure("terminal connection failure");
+    mockedClerk.sessionTouch.mockClear();
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() => {
+      expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+      expect(catchUps).toBe(1);
+    });
+    expect(subscribedDuringCatchUp).toBeTruthy();
+    const foregroundReady = context.store.get(foregroundReady$);
+    expect(foregroundReady.pending).toBeTruthy();
+
+    catchUpCanFinish.resolve();
+    await foregroundReady.promise;
+    expect(context.store.get(foregroundReady$).pending).toBeFalsy();
+  });
+
+  it("removes aborted realtime-ready catch-up subscribers", async () => {
+    mockSignedInUser();
+    const subscriber = testSubscriber();
+    let catchUps = 0;
+    const resourceCatchUp$ = command((_ctx, _signal: AbortSignal) => {
+      catchUps += 1;
+    });
+
+    await setupAuthAndRealtime();
+    context.store.set(
+      subscribeRealtimeReadyCatchUp$,
+      resourceCatchUp$,
+      subscriber.signal,
+    );
+    subscriber.abort();
+
+    mockedClerk.sessionTouch.mockClear();
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() => {
+      expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+    });
+    const foregroundReady = context.store.get(foregroundReady$);
+    await foregroundReady.promise;
+    expect(catchUps).toBe(0);
   });
 
   it("rebuilds a failed realtime client after foreground auth and pokes once", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -364,6 +364,51 @@ describe("realtime signals", () => {
     });
   });
 
+  it("keeps a foreground opt-out loop live and initially primed", async () => {
+    mockSignedInUser();
+    const topic = "test:foreground-opt-out";
+    const subscriber = testSubscriber();
+    let runs = 0;
+    const loop$ = command((_ctx, _signal: AbortSignal) => {
+      runs += 1;
+      return false;
+    });
+
+    await setupAuthAndRealtime();
+    const loopPromise = context.store.set(
+      setAblyLoop$,
+      {
+        topic,
+        loopCommand$: loop$,
+        options: {
+          runOnForegroundCatchUp: false,
+          runOnSubscribe: true,
+        },
+      },
+      subscriber.signal,
+    );
+    context.track(loopPromise);
+
+    await waitFor(() => {
+      expect(context.mocks.ably.hasSubscription(topic)).toBeTruthy();
+      expect(runs).toBe(1);
+    });
+
+    mockedClerk.sessionTouch.mockClear();
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() => {
+      expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+    });
+    const foregroundReady = await context.store.get(foregroundReady$);
+    await foregroundReady.promise;
+    expect(runs).toBe(1);
+
+    context.mocks.ably.trigger(topic);
+    await waitFor(() => {
+      expect(runs).toBe(2);
+    });
+  });
+
   it("rebuilds a failed realtime client after foreground auth and pokes once", async () => {
     mockSignedInUser();
     const loopTopic = "test:failed-foreground-loop";

--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -3,6 +3,7 @@ import { clerk$ } from "./auth.ts";
 import {
   subscribeChatThreadReadCursorUpdated$,
   subscribeThreadListChanged$,
+  setupChatIndicatorForegroundCatchUp$,
 } from "./chat-thread-list-reload.ts";
 import { subscribeEventDrivenChatThreads$ } from "./chat-page/chat-thread-event-sourcing.ts";
 import { setupChatEventBackgroundSync$ } from "./chat-page/chat-event-background-sync.ts";
@@ -25,6 +26,7 @@ export const setupAuthenticatedDaemons$ = command(
       set(setupRealtime$, signal),
       set(subscribeThreadListChanged$, signal),
       set(subscribeChatThreadReadCursorUpdated$, signal),
+      set(setupChatIndicatorForegroundCatchUp$, signal),
       set(subscribeEventDrivenChatThreads$, signal),
       set(subscribePermissionUpdate$, signal),
       set(setupBillingRealtime$, signal),

--- a/turbo/apps/platform/src/signals/chat-thread-list-reload.ts
+++ b/turbo/apps/platform/src/signals/chat-thread-list-reload.ts
@@ -1,6 +1,5 @@
 import { command, computed, state } from "ccstate";
-import { subscribeForegroundCatchUp$ } from "./auth-retry.ts";
-import { setAblyLoop$ } from "./realtime.ts";
+import { setAblyLoop$, subscribeRealtimeReadyCatchUp$ } from "./realtime.ts";
 
 const internalReloadChatIndicators$ = state(0);
 
@@ -65,6 +64,10 @@ export const subscribeChatThreadReadCursorUpdated$ = command(
 
 export const setupChatIndicatorForegroundCatchUp$ = command(
   ({ set }, signal: AbortSignal) => {
-    set(subscribeForegroundCatchUp$, reloadChatIndicatorsOnForeground$, signal);
+    set(
+      subscribeRealtimeReadyCatchUp$,
+      reloadChatIndicatorsOnForeground$,
+      signal,
+    );
   },
 );

--- a/turbo/apps/platform/src/signals/chat-thread-list-reload.ts
+++ b/turbo/apps/platform/src/signals/chat-thread-list-reload.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { subscribeForegroundCatchUp$ } from "./auth-retry.ts";
 import { setAblyLoop$ } from "./realtime.ts";
 
 const internalReloadChatIndicators$ = state(0);
@@ -13,6 +14,18 @@ export const reloadChatIndicators$ = command(({ set }) => {
   });
 });
 
+const reloadChatIndicatorsFromRealtime$ = command(({ set }) => {
+  set(reloadChatIndicators$);
+  return false;
+});
+
+const reloadChatIndicatorsOnForeground$ = command(
+  ({ set }, signal: AbortSignal) => {
+    signal.throwIfAborted();
+    set(reloadChatIndicators$);
+  },
+);
+
 /**
  * Subscribe to the user-level `threadListChanged` topic and invalidate the
  * indicator snapshot. Event-sourced thread data has its own incremental
@@ -24,13 +37,13 @@ export const reloadChatIndicators$ = command(({ set }) => {
  */
 export const subscribeThreadListChanged$ = command(
   async ({ set }, signal: AbortSignal) => {
-    const onChanged$ = command(({ set }) => {
-      set(reloadChatIndicators$);
-      return false;
-    });
     await set(
       setAblyLoop$,
-      { topic: "threadListChanged", loopCommand$: onChanged$ },
+      {
+        topic: "threadListChanged",
+        loopCommand$: reloadChatIndicatorsFromRealtime$,
+        options: { runOnForegroundCatchUp: false },
+      },
       signal,
     );
   },
@@ -38,14 +51,20 @@ export const subscribeThreadListChanged$ = command(
 
 export const subscribeChatThreadReadCursorUpdated$ = command(
   async ({ set }, signal: AbortSignal) => {
-    const onChanged$ = command(({ set }) => {
-      set(reloadChatIndicators$);
-      return false;
-    });
     await set(
       setAblyLoop$,
-      { topic: "chatThreadReadCursorUpdated", loopCommand$: onChanged$ },
+      {
+        topic: "chatThreadReadCursorUpdated",
+        loopCommand$: reloadChatIndicatorsFromRealtime$,
+        options: { runOnForegroundCatchUp: false },
+      },
       signal,
     );
+  },
+);
+
+export const setupChatIndicatorForegroundCatchUp$ = command(
+  ({ set }, signal: AbortSignal) => {
+    set(subscribeForegroundCatchUp$, reloadChatIndicatorsOnForeground$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -117,6 +117,7 @@ const pendingAblySubscriptions$ = state<readonly PendingAblySubscription[]>([]);
 
 interface RealtimeSubscribeOptions {
   readonly onSubscribed?: () => void;
+  readonly runOnForegroundCatchUp?: boolean;
   readonly runOnSubscribe?: boolean;
 }
 
@@ -196,6 +197,7 @@ async function waitForTransientRetry(
 
 interface SubscribeChannelArgs {
   readonly channel: StableRealtimeChannel;
+  readonly listenForForegroundCatchUp: boolean;
   readonly topic: string | null;
   readonly callback: ChannelCallback;
   readonly poke: () => void;
@@ -206,6 +208,7 @@ interface SubscribeChannelArgs {
 async function subscribeChannel(
   {
     channel,
+    listenForForegroundCatchUp,
     topic,
     callback,
     poke,
@@ -225,9 +228,11 @@ async function subscribeChannel(
     unsubscribeChannel();
   };
 
-  subscriberPokeTarget.addEventListener(SUBSCRIBER_POKE_EVENT, poke, {
-    signal,
-  });
+  if (listenForForegroundCatchUp) {
+    subscriberPokeTarget.addEventListener(SUBSCRIBER_POKE_EVENT, poke, {
+      signal,
+    });
+  }
   signal.addEventListener("abort", unsubscribeChannel, { once: true });
 
   await onRejection(channel.subscribe(topic, callback), release);
@@ -274,6 +279,7 @@ const runWithChannel$ = command(
     await subscribeChannel(
       {
         channel,
+        listenForForegroundCatchUp: options?.runOnForegroundCatchUp !== false,
         topic,
         callback,
         poke: requestCatchUp,
@@ -524,6 +530,7 @@ const runWithChannelPayload$ = command(
     await subscribeChannel(
       {
         channel,
+        listenForForegroundCatchUp: options?.runOnForegroundCatchUp !== false,
         topic,
         callback,
         poke: requestCatchUp,

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -104,6 +104,48 @@ const internalRealtimeSession$ = state<RealtimeSession | null>(null);
 
 const subscriberPokeTarget$ = state(new EventTarget());
 const SUBSCRIBER_POKE_EVENT = "poke";
+type RealtimeReadyCatchUpCommand = Command<Promise<void> | void, [AbortSignal]>;
+const realtimeReadyCatchUpCommands$ = state<
+  ReadonlySet<RealtimeReadyCatchUpCommand>
+>(new Set());
+
+/**
+ * Register snapshot catch-up that runs after realtime recovery and before the
+ * shared foreground-ready barrier resolves.
+ */
+export const subscribeRealtimeReadyCatchUp$ = command(
+  (
+    { get, set },
+    callback$: RealtimeReadyCatchUpCommand,
+    signal: AbortSignal,
+  ) => {
+    set(
+      realtimeReadyCatchUpCommands$,
+      new Set([...get(realtimeReadyCatchUpCommands$), callback$]),
+    );
+    signal.addEventListener(
+      "abort",
+      () => {
+        const commands = new Set(get(realtimeReadyCatchUpCommands$));
+        commands.delete(callback$);
+        set(realtimeReadyCatchUpCommands$, commands);
+      },
+      { once: true },
+    );
+  },
+);
+
+const runRealtimeReadyCatchUp$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    await Promise.all(
+      [...get(realtimeReadyCatchUpCommands$)].map(async (callback$) => {
+        await set(callback$, signal);
+        signal.throwIfAborted();
+      }),
+    );
+    signal.throwIfAborted();
+  },
+);
 
 interface PendingAblySubscription {
   topic: string;
@@ -1017,6 +1059,8 @@ const foregroundRealtimeCatchUp$ = command(
 
     L.debug("foreground catch-up ready, poking subscribers");
     subscriberPokeTarget.dispatchEvent(new Event(SUBSCRIBER_POKE_EVENT));
+    await set(runRealtimeReadyCatchUp$, signal);
+    signal.throwIfAborted();
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -28,7 +28,11 @@ import { replaceSearchParams$, searchParams$ } from "../route.ts";
 import { reloadUsageRecords$ } from "./settings/personal-usage-record.ts";
 import { reloadQueueData$ } from "../queue-page/queue-signals.ts";
 import { setAblyLoop$ } from "../realtime.ts";
-import { tapError } from "../utils.ts";
+import {
+  foregroundReady$,
+  subscribeForegroundCatchUp$,
+} from "../auth-retry.ts";
+import { settle, tapError } from "../utils.ts";
 import { accept } from "../../lib/accept.ts";
 import {
   applyStoredAdAttribution$,
@@ -228,6 +232,7 @@ const maybeShowPendingRestoreToast$ = command(
 // ---------------------------------------------------------------------------
 
 const billingReload$ = state(0);
+const completedForegroundBillingReload$ = state<number | null>(null);
 const usagePackManagementReload$ = state(0);
 const usagePackMigrationReload$ = state(0);
 const internalDowngradeDialogOpen$ = state(false);
@@ -423,6 +428,27 @@ export const reloadBillingStatus$ = command(({ set }) => {
   });
 });
 
+export const reloadAccountMenuBillingStatus$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    signal.throwIfAborted();
+    const foregroundReady = get(foregroundReady$);
+    if (!foregroundReady.pending) {
+      set(reloadBillingStatus$);
+      return;
+    }
+
+    const foregroundResult = await settle(foregroundReady.promise, signal);
+    signal.throwIfAborted();
+    const currentReloadVersion = get(billingReload$);
+    if (
+      !foregroundResult.ok ||
+      get(completedForegroundBillingReload$) !== currentReloadVersion
+    ) {
+      set(reloadBillingStatus$);
+    }
+  },
+);
+
 export const reloadUsagePackManagement$ = command(({ set }) => {
   set(usagePackManagementReload$, (value) => {
     return value + 1;
@@ -520,25 +546,52 @@ export const handleBillingRedirect$ = command(
   },
 );
 
-const reloadBillingStatusFromRealtime$ = command(
+const reloadBillingStatusFromRemoteChange$ = command(
   async ({ set }, signal: AbortSignal) => {
     set(reloadBillingStatus$);
     set(reloadQueueData$);
     set(reloadUsagePackManagement$);
     set(reloadUsageRecords$);
     await set(reconcilePendingBillingPayment$, signal);
+  },
+);
+
+const reloadBillingStatusFromRealtime$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    await set(reloadBillingStatusFromRemoteChange$, signal);
+    signal.throwIfAborted();
     return false;
+  },
+);
+
+const reloadBillingStatusOnForeground$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const reloadResult = await settle(
+      (async () => {
+        await set(reloadBillingStatusFromRemoteChange$, signal);
+        signal.throwIfAborted();
+        const reloadVersion = get(billingReload$);
+        await get(billingStatusAsync$);
+        signal.throwIfAborted();
+        return reloadVersion;
+      })(),
+      signal,
+    );
+    if (reloadResult.ok) {
+      set(completedForegroundBillingReload$, reloadResult.value);
+    }
   },
 );
 
 export const setupBillingRealtime$ = command(
   async ({ set }, signal: AbortSignal) => {
+    set(subscribeForegroundCatchUp$, reloadBillingStatusOnForeground$, signal);
     await set(
       setAblyLoop$,
       {
         topic: "billing:changed",
         loopCommand$: reloadBillingStatusFromRealtime$,
-        options: { runOnSubscribe: true },
+        options: { runOnForegroundCatchUp: false, runOnSubscribe: true },
       },
       signal,
     );

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -437,13 +437,10 @@ export const reloadAccountMenuBillingStatus$ = command(
       return;
     }
 
-    const foregroundResult = await settle(foregroundReady.promise, signal);
+    await settle(foregroundReady.promise, signal);
     signal.throwIfAborted();
     const currentReloadVersion = get(billingReload$);
-    if (
-      !foregroundResult.ok ||
-      get(completedForegroundBillingReload$) !== currentReloadVersion
-    ) {
+    if (get(completedForegroundBillingReload$) !== currentReloadVersion) {
       set(reloadBillingStatus$);
     }
   },

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -232,7 +232,7 @@ const maybeShowPendingRestoreToast$ = command(
 // ---------------------------------------------------------------------------
 
 const billingReload$ = state(0);
-const completedForegroundBillingReload$ = state<number | null>(null);
+const handledRemoteBillingReload$ = state<number | null>(null);
 const usagePackManagementReload$ = state(0);
 const usagePackMigrationReload$ = state(0);
 const internalDowngradeDialogOpen$ = state(false);
@@ -437,10 +437,18 @@ export const reloadAccountMenuBillingStatus$ = command(
       return;
     }
 
+    const reloadVersion = get(billingReload$);
     await settle(foregroundReady.promise, signal);
     signal.throwIfAborted();
     const currentReloadVersion = get(billingReload$);
-    if (get(completedForegroundBillingReload$) !== currentReloadVersion) {
+    if (
+      currentReloadVersion === reloadVersion ||
+      get(handledRemoteBillingReload$) !== currentReloadVersion
+    ) {
+      set(reloadBillingStatus$);
+    }
+    const billingResult = await settle(get(billingStatusAsync$), signal);
+    if (!billingResult.ok) {
       set(reloadBillingStatus$);
     }
   },
@@ -544,12 +552,14 @@ export const handleBillingRedirect$ = command(
 );
 
 const reloadBillingStatusFromRemoteChange$ = command(
-  async ({ set }, signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     set(reloadBillingStatus$);
     set(reloadQueueData$);
     set(reloadUsagePackManagement$);
     set(reloadUsageRecords$);
     await set(reconcilePendingBillingPayment$, signal);
+    signal.throwIfAborted();
+    set(handledRemoteBillingReload$, get(billingReload$));
   },
 );
 
@@ -562,21 +572,8 @@ const reloadBillingStatusFromRealtime$ = command(
 );
 
 const reloadBillingStatusOnForeground$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const reloadResult = await settle(
-      (async () => {
-        await set(reloadBillingStatusFromRemoteChange$, signal);
-        signal.throwIfAborted();
-        const reloadVersion = get(billingReload$);
-        await get(billingStatusAsync$);
-        signal.throwIfAborted();
-        return reloadVersion;
-      })(),
-      signal,
-    );
-    if (reloadResult.ok) {
-      set(completedForegroundBillingReload$, reloadResult.value);
-    }
+  async ({ set }, signal: AbortSignal) => {
+    await settle(set(reloadBillingStatusFromRemoteChange$, signal), signal);
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -29,6 +29,7 @@ import { reloadUsageRecords$ } from "./settings/personal-usage-record.ts";
 import { reloadQueueData$ } from "../queue-page/queue-signals.ts";
 import { setAblyLoop$, subscribeRealtimeReadyCatchUp$ } from "../realtime.ts";
 import { foregroundReady$ } from "../auth-retry.ts";
+import { isOrgAdmin$ } from "../org.ts";
 import { settle, tapError, withCleanup } from "../utils.ts";
 import { accept } from "../../lib/accept.ts";
 import {
@@ -450,6 +451,11 @@ export const reloadAccountMenuBillingStatus$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     signal.throwIfAborted();
     const foregroundReady = get(foregroundReady$);
+    if (!(await get(isOrgAdmin$))) {
+      signal.throwIfAborted();
+      return;
+    }
+    signal.throwIfAborted();
     if (!foregroundReady.pending) {
       const resource = get(billingStatusResource$);
       if (resource.pending()) {

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -27,12 +27,9 @@ import { zeroClient$ } from "../api-client.ts";
 import { replaceSearchParams$, searchParams$ } from "../route.ts";
 import { reloadUsageRecords$ } from "./settings/personal-usage-record.ts";
 import { reloadQueueData$ } from "../queue-page/queue-signals.ts";
-import { setAblyLoop$ } from "../realtime.ts";
-import {
-  foregroundReady$,
-  subscribeForegroundCatchUp$,
-} from "../auth-retry.ts";
-import { settle, tapError } from "../utils.ts";
+import { setAblyLoop$, subscribeRealtimeReadyCatchUp$ } from "../realtime.ts";
+import { foregroundReady$ } from "../auth-retry.ts";
+import { bestEffort, settle, tapError } from "../utils.ts";
 import { accept } from "../../lib/accept.ts";
 import {
   applyStoredAdAttribution$,
@@ -232,7 +229,6 @@ const maybeShowPendingRestoreToast$ = command(
 // ---------------------------------------------------------------------------
 
 const billingReload$ = state(0);
-const handledRemoteBillingReload$ = state<number | null>(null);
 const usagePackManagementReload$ = state(0);
 const usagePackMigrationReload$ = state(0);
 const internalDowngradeDialogOpen$ = state(false);
@@ -437,16 +433,14 @@ export const reloadAccountMenuBillingStatus$ = command(
       return;
     }
 
-    const reloadVersion = get(billingReload$);
+    const reloadVersionBeforeForeground = get(billingReload$);
     await settle(foregroundReady.promise, signal);
     signal.throwIfAborted();
-    const currentReloadVersion = get(billingReload$);
-    if (
-      currentReloadVersion === reloadVersion ||
-      get(handledRemoteBillingReload$) !== currentReloadVersion
-    ) {
+    if (get(billingReload$) === reloadVersionBeforeForeground) {
       set(reloadBillingStatus$);
     }
+    // Join the mounted view's async load, or start it when this menu is the
+    // first billing consumer. A failed foreground load gets one fresh retry.
     const billingResult = await settle(get(billingStatusAsync$), signal);
     if (!billingResult.ok) {
       set(reloadBillingStatus$);
@@ -552,14 +546,12 @@ export const handleBillingRedirect$ = command(
 );
 
 const reloadBillingStatusFromRemoteChange$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     set(reloadBillingStatus$);
     set(reloadQueueData$);
     set(reloadUsagePackManagement$);
     set(reloadUsageRecords$);
     await set(reconcilePendingBillingPayment$, signal);
-    signal.throwIfAborted();
-    set(handledRemoteBillingReload$, get(billingReload$));
   },
 );
 
@@ -573,13 +565,17 @@ const reloadBillingStatusFromRealtime$ = command(
 
 const reloadBillingStatusOnForeground$ = command(
   async ({ set }, signal: AbortSignal) => {
-    await settle(set(reloadBillingStatusFromRemoteChange$, signal), signal);
+    await bestEffort(set(reloadBillingStatusFromRemoteChange$, signal), signal);
   },
 );
 
 export const setupBillingRealtime$ = command(
   async ({ set }, signal: AbortSignal) => {
-    set(subscribeForegroundCatchUp$, reloadBillingStatusOnForeground$, signal);
+    set(
+      subscribeRealtimeReadyCatchUp$,
+      reloadBillingStatusOnForeground$,
+      signal,
+    );
     await set(
       setAblyLoop$,
       {

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -19,6 +19,7 @@ import {
   type ConcurrencySubscriptionChangePreviewResponse,
   type CreditPurchasePreviewResponse,
   type MemberUsagePack,
+  type UsagePackCreditsResponse,
   type UsagePackMigrationStateResponse,
 } from "@okouai/api-contracts/contracts/zero-billing";
 import { FeatureSwitchKey } from "@okouai/core";
@@ -230,6 +231,8 @@ const maybeShowPendingRestoreToast$ = command(
 // ---------------------------------------------------------------------------
 
 const billingReload$ = state(0);
+const accountMenuBillingStatusReload$ = state(0);
+const accountMenuUsagePackCreditsReload$ = state(0);
 const completedForegroundBillingCatchUp$ = state<Promise<void> | null>(null);
 const usagePackManagementReload$ = state(0);
 const usagePackMigrationReload$ = state(0);
@@ -367,37 +370,59 @@ export const setConcurrencyTargetQuantity$ = command(
     });
   },
 );
-/**
- * Async computed signal that fetches billing status on first access.
- * Use with useLastLoadable() in views for automatic loading.
- */
-interface BillingStatusResource {
+/** Track whether a ccstate-owned async load is still available for joining. */
+interface TrackedAsyncResource<T> {
   readonly pending: () => boolean;
-  readonly promise: Promise<BillingStatusResponse>;
+  readonly promise: Promise<T>;
 }
 
-const billingStatusResource$ = computed((get): BillingStatusResource => {
-  get(billingReload$);
-  const createClient = get(zeroClient$);
-  const client = createClient(zeroBillingStatusContract);
+function trackAsyncResource<T>(promise: Promise<T>): TrackedAsyncResource<T> {
   let pending = true;
-  const load = async (): Promise<BillingStatusResponse> => {
-    const result = await accept(client.get(), [200]);
-    return result.body;
-  };
-  const promise = withCleanup(load(), () => {
+  const trackedPromise = withCleanup(promise, () => {
     pending = false;
   });
   return {
     pending: () => {
       return pending;
     },
-    promise,
+    promise: trackedPromise,
   };
-});
+}
+
+const billingStatusResource$ = computed(
+  (get): TrackedAsyncResource<BillingStatusResponse> => {
+    get(billingReload$);
+    get(accountMenuBillingStatusReload$);
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroBillingStatusContract);
+    const load = async (): Promise<BillingStatusResponse> => {
+      const result = await accept(client.get(), [200]);
+      return result.body;
+    };
+    return trackAsyncResource(load());
+  },
+);
+
+const usagePackCreditsResource$ = computed(
+  (get): TrackedAsyncResource<UsagePackCreditsResponse> => {
+    get(billingReload$);
+    get(accountMenuUsagePackCreditsReload$);
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroBillingUsagePackCreditsContract);
+    const load = async (): Promise<UsagePackCreditsResponse> => {
+      const result = await accept(client.get(), [200]);
+      return result.body;
+    };
+    return trackAsyncResource(load());
+  },
+);
 
 export const billingStatusAsync$ = computed((get) => {
   return get(billingStatusResource$).promise;
+});
+
+export const usagePackCreditsAsync$ = computed((get) => {
+  return get(usagePackCreditsResource$).promise;
 });
 
 export const usagePackCatalogAsync$ = computed(async (get) => {
@@ -413,14 +438,6 @@ export const usagePackManagementAsync$ = computed(async (get) => {
   const client = createClient(zeroBillingUsagePackManagementContract);
   const result = await accept(client.get(), [200, 404]);
   return result.status === 200 ? result.body : null;
-});
-
-export const usagePackCreditsAsync$ = computed(async (get) => {
-  get(billingReload$);
-  const createClient = get(zeroClient$);
-  const client = createClient(zeroBillingUsagePackCreditsContract);
-  const result = await accept(client.get(), [200]);
-  return result.body;
 });
 
 export const usagePackMigrationAsync$ = computed(
@@ -447,25 +464,105 @@ export const reloadBillingStatus$ = command(({ set }) => {
   });
 });
 
-export const reloadAccountMenuBillingStatus$ = command(
+const reloadAccountMenuBillingStatusResource$ = command(({ set }) => {
+  set(accountMenuBillingStatusReload$, (value) => {
+    return value + 1;
+  });
+});
+
+const reloadAccountMenuUsagePackCreditsResource$ = command(({ set }) => {
+  set(accountMenuUsagePackCreditsReload$, (value) => {
+    return value + 1;
+  });
+});
+
+interface AccountMenuCreditResources {
+  readonly billing: TrackedAsyncResource<BillingStatusResponse> | null;
+  readonly usagePack: TrackedAsyncResource<UsagePackCreditsResponse> | null;
+}
+
+const readAccountMenuCreditResources$ = command(
+  (
+    { get },
+    options: {
+      readonly isAdmin: boolean;
+      readonly usagePackPlansEnabled: boolean;
+    },
+  ): AccountMenuCreditResources => {
+    return {
+      billing: options.isAdmin ? get(billingStatusResource$) : null,
+      usagePack: options.usagePackPlansEnabled
+        ? get(usagePackCreditsResource$)
+        : null,
+    };
+  },
+);
+
+const reloadSettledAccountMenuCreditResources$ = command(
+  (
+    { set },
+    resources: AccountMenuCreditResources,
+  ): AccountMenuCreditResources => {
+    const billingPending = resources.billing?.pending() ?? false;
+    const usagePackPending = resources.usagePack?.pending() ?? false;
+    if (resources.billing && !billingPending) {
+      set(reloadAccountMenuBillingStatusResource$);
+    }
+    if (resources.usagePack && !usagePackPending) {
+      set(reloadAccountMenuUsagePackCreditsResource$);
+    }
+    return {
+      billing: billingPending ? resources.billing : null,
+      usagePack: usagePackPending ? resources.usagePack : null,
+    };
+  },
+);
+
+const joinAccountMenuCreditResources$ = command(
+  async (
+    { set },
+    resources: AccountMenuCreditResources,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const [billingResult, usagePackResult] = await Promise.all([
+      resources.billing
+        ? settle(resources.billing.promise, signal)
+        : Promise.resolve(null),
+      resources.usagePack
+        ? settle(resources.usagePack.promise, signal)
+        : Promise.resolve(null),
+    ]);
+    signal.throwIfAborted();
+    if (billingResult && !billingResult.ok) {
+      set(reloadAccountMenuBillingStatusResource$);
+    }
+    if (usagePackResult && !usagePackResult.ok) {
+      set(reloadAccountMenuUsagePackCreditsResource$);
+    }
+  },
+);
+
+export const reloadAccountMenuCreditBalances$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     signal.throwIfAborted();
     const foregroundReady = get(foregroundReady$);
-    if (!(await get(isOrgAdmin$))) {
-      signal.throwIfAborted();
+    const isAdmin = await get(isOrgAdmin$);
+    signal.throwIfAborted();
+    const usagePackPlansEnabled =
+      get(featureSwitch$)[FeatureSwitchKey.UsagePackPlans] ?? false;
+    if (!isAdmin && !usagePackPlansEnabled) {
       return;
     }
-    signal.throwIfAborted();
+    const options = { isAdmin, usagePackPlansEnabled };
+
     if (!foregroundReady.pending) {
-      const resource = get(billingStatusResource$);
-      if (resource.pending()) {
-        const result = await settle(resource.promise, signal);
-        if (!result.ok) {
-          set(reloadBillingStatus$);
-        }
-        return;
-      }
-      set(reloadBillingStatus$);
+      const resources = set(readAccountMenuCreditResources$, options);
+      const pendingResources = set(
+        reloadSettledAccountMenuCreditResources$,
+        resources,
+      );
+      await set(joinAccountMenuCreditResources$, pendingResources, signal);
+      signal.throwIfAborted();
       return;
     }
 
@@ -473,14 +570,16 @@ export const reloadAccountMenuBillingStatus$ = command(
     await settle(foregroundCatchUp, signal);
     signal.throwIfAborted();
     if (get(completedForegroundBillingCatchUp$) !== foregroundCatchUp) {
-      set(reloadBillingStatus$);
+      if (isAdmin) {
+        set(reloadAccountMenuBillingStatusResource$);
+      }
+      if (usagePackPlansEnabled) {
+        set(reloadAccountMenuUsagePackCreditsResource$);
+      }
     }
-    // Join the mounted view's async load, or start it when this menu is the
-    // first billing consumer. A failed foreground load gets one fresh retry.
-    const billingResult = await settle(get(billingStatusAsync$), signal);
-    if (!billingResult.ok) {
-      set(reloadBillingStatus$);
-    }
+    const resources = set(readAccountMenuCreditResources$, options);
+    await set(joinAccountMenuCreditResources$, resources, signal);
+    signal.throwIfAborted();
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -29,7 +29,7 @@ import { reloadUsageRecords$ } from "./settings/personal-usage-record.ts";
 import { reloadQueueData$ } from "../queue-page/queue-signals.ts";
 import { setAblyLoop$, subscribeRealtimeReadyCatchUp$ } from "../realtime.ts";
 import { foregroundReady$ } from "../auth-retry.ts";
-import { bestEffort, settle, tapError } from "../utils.ts";
+import { settle, tapError } from "../utils.ts";
 import { accept } from "../../lib/accept.ts";
 import {
   applyStoredAdAttribution$,
@@ -229,6 +229,7 @@ const maybeShowPendingRestoreToast$ = command(
 // ---------------------------------------------------------------------------
 
 const billingReload$ = state(0);
+const completedForegroundBillingCatchUp$ = state<Promise<void> | null>(null);
 const usagePackManagementReload$ = state(0);
 const usagePackMigrationReload$ = state(0);
 const internalDowngradeDialogOpen$ = state(false);
@@ -433,10 +434,10 @@ export const reloadAccountMenuBillingStatus$ = command(
       return;
     }
 
-    const reloadVersionBeforeForeground = get(billingReload$);
-    await settle(foregroundReady.promise, signal);
+    const foregroundCatchUp = foregroundReady.promise;
+    await settle(foregroundCatchUp, signal);
     signal.throwIfAborted();
-    if (get(billingReload$) === reloadVersionBeforeForeground) {
+    if (get(completedForegroundBillingCatchUp$) !== foregroundCatchUp) {
       set(reloadBillingStatus$);
     }
     // Join the mounted view's async load, or start it when this menu is the
@@ -564,8 +565,15 @@ const reloadBillingStatusFromRealtime$ = command(
 );
 
 const reloadBillingStatusOnForeground$ = command(
-  async ({ set }, signal: AbortSignal) => {
-    await bestEffort(set(reloadBillingStatusFromRemoteChange$, signal), signal);
+  async ({ get, set }, signal: AbortSignal) => {
+    const foregroundCatchUp = get(foregroundReady$).promise;
+    const result = await settle(
+      set(reloadBillingStatusFromRemoteChange$, signal),
+      signal,
+    );
+    if (result.ok) {
+      set(completedForegroundBillingCatchUp$, foregroundCatchUp);
+    }
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -29,7 +29,7 @@ import { reloadUsageRecords$ } from "./settings/personal-usage-record.ts";
 import { reloadQueueData$ } from "../queue-page/queue-signals.ts";
 import { setAblyLoop$, subscribeRealtimeReadyCatchUp$ } from "../realtime.ts";
 import { foregroundReady$ } from "../auth-retry.ts";
-import { settle, tapError } from "../utils.ts";
+import { settle, tapError, withCleanup } from "../utils.ts";
 import { accept } from "../../lib/accept.ts";
 import {
   applyStoredAdAttribution$,
@@ -370,12 +370,33 @@ export const setConcurrencyTargetQuantity$ = command(
  * Async computed signal that fetches billing status on first access.
  * Use with useLastLoadable() in views for automatic loading.
  */
-export const billingStatusAsync$ = computed(async (get) => {
+interface BillingStatusResource {
+  readonly pending: () => boolean;
+  readonly promise: Promise<BillingStatusResponse>;
+}
+
+const billingStatusResource$ = computed((get): BillingStatusResource => {
   get(billingReload$);
   const createClient = get(zeroClient$);
   const client = createClient(zeroBillingStatusContract);
-  const result = await accept(client.get(), [200]);
-  return result.body;
+  let pending = true;
+  const load = async (): Promise<BillingStatusResponse> => {
+    const result = await accept(client.get(), [200]);
+    return result.body;
+  };
+  const promise = withCleanup(load(), () => {
+    pending = false;
+  });
+  return {
+    pending: () => {
+      return pending;
+    },
+    promise,
+  };
+});
+
+export const billingStatusAsync$ = computed((get) => {
+  return get(billingStatusResource$).promise;
 });
 
 export const usagePackCatalogAsync$ = computed(async (get) => {
@@ -430,6 +451,14 @@ export const reloadAccountMenuBillingStatus$ = command(
     signal.throwIfAborted();
     const foregroundReady = get(foregroundReady$);
     if (!foregroundReady.pending) {
+      const resource = get(billingStatusResource$);
+      if (resource.pending()) {
+        const result = await settle(resource.promise, signal);
+        if (!result.ok) {
+          set(reloadBillingStatus$);
+        }
+        return;
+      }
       set(reloadBillingStatus$);
       return;
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { command } from "ccstate";
 import { HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
@@ -24,6 +25,7 @@ import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 import { mockNow } from "../../../__tests__/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { foregroundReady$ } from "../../../signals/auth-retry.ts";
+import { subscribeRealtimeReadyCatchUp$ } from "../../../signals/realtime.ts";
 
 const context = testContext();
 
@@ -624,6 +626,81 @@ describe("zero sidebar account menu", () => {
     await waitFor(() => {
       expect(within(menu).getByText("125 credits")).toBeInTheDocument();
       expect(billingRequests).toBe(2);
+    });
+  });
+
+  it("joins a foreground billing refresh that already started", async () => {
+    let billingRequests = 0;
+    mockAdminAccountSidebar();
+    mockAdminBillingStatus(12_500, {
+      onRequest: () => {
+        billingRequests += 1;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("billing:changed"),
+      ).toBeTruthy();
+      expect(billingRequests).toBeGreaterThan(0);
+    });
+
+    const initialMenu = await openAccountMenu();
+    await waitFor(() => {
+      expect(
+        within(initialMenu).getByText("12,500 credits"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    const catchUpCanFinish = context.mocks.deferred<void>();
+    const holdForegroundCatchUp$ = command(
+      async (_ctx, signal: AbortSignal): Promise<void> => {
+        await catchUpCanFinish.promise;
+        signal.throwIfAborted();
+      },
+    );
+    context.store.set(
+      subscribeRealtimeReadyCatchUp$,
+      holdForegroundCatchUp$,
+      context.signal,
+    );
+
+    mockAdminBillingStatus(500, {
+      onRequest: () => {
+        billingRequests += 1;
+      },
+    });
+    billingRequests = 0;
+
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() => {
+      expect(billingRequests).toBe(1);
+    });
+    const foregroundReady = context.store.get(foregroundReady$);
+    expect(foregroundReady.pending).toBeTruthy();
+
+    const menu = await openAccountMenu();
+    expect(billingRequests).toBe(1);
+
+    catchUpCanFinish.resolve();
+    await foregroundReady.promise;
+    await waitFor(() => {
+      expect(within(menu).getByText("500 credits")).toBeInTheDocument();
+      expect(billingRequests).toBe(1);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -608,7 +608,6 @@ describe("zero sidebar account menu", () => {
         fullName: "Alex Rivera",
         email: "alex.rivera@example.test",
       },
-      featureSwitches: { [FeatureSwitchKey.UnifiedIndicatorApi]: true },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -381,9 +381,13 @@ describe("zero sidebar account menu", () => {
     expect(usagePackCreditRequests).toBe(0);
   });
 
-  it("shows member usage pack credits and opens their credit usage", async () => {
+  it("refreshes member usage pack credits without requesting org billing", async () => {
     mockMemberAccountSidebar();
+    let usagePackCredits = 20_400;
+    let usagePackCreditRequests = 0;
+    let billingRequests = 0;
     context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      billingRequests += 1;
       return respond(200, {
         tier: "pro",
         credits: 12_500,
@@ -404,9 +408,10 @@ describe("zero sidebar account menu", () => {
     context.mocks.api(
       zeroBillingUsagePackCreditsContract.get,
       ({ respond }) => {
+        usagePackCreditRequests += 1;
         return respond(200, {
-          totalCredits: 20_400,
-          purchasedCredits: 20_000,
+          totalCredits: usagePackCredits,
+          purchasedCredits: Math.max(0, usagePackCredits - 400),
           bonusCredits: 400,
           creditGrants: [],
         });
@@ -424,6 +429,13 @@ describe("zero sidebar account menu", () => {
       featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
     });
 
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("billing:changed"),
+      ).toBeTruthy();
+      expect(billingRequests).toBeGreaterThan(0);
+    });
+    billingRequests = 0;
     const menu = await openAccountMenu();
     const usagePackItem = await within(menu).findByTestId(
       "account-menu-credit-balance",
@@ -433,7 +445,25 @@ describe("zero sidebar account menu", () => {
     ).toBeInTheDocument();
     expect(within(menu).queryByText("32,900 credits")).toBeNull();
 
-    click(usagePackItem);
+    usagePackCredits = 500;
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    const refreshedMenu = await openAccountMenu();
+    const refreshedUsagePackItem = await within(refreshedMenu).findByTestId(
+      "account-menu-credit-balance",
+    );
+    await waitFor(() => {
+      expect(
+        within(refreshedUsagePackItem).getByText("500 credits"),
+      ).toBeInTheDocument();
+    });
+    expect(usagePackCreditRequests).toBe(2);
+    expect(billingRequests).toBe(0);
+
+    click(refreshedUsagePackItem);
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -321,6 +321,26 @@ describe("zero sidebar account menu", () => {
 
   it("does not request or show member usage pack credits when the switch is disabled", async () => {
     mockMemberAccountSidebar();
+    let billingRequests = 0;
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      billingRequests += 1;
+      return respond(200, {
+        tier: "pro",
+        credits: 12_500,
+        onboardingPaymentPending: false,
+        subscriptionStatus: "active",
+        currentPeriodEnd: "2026-04-01T00:00:00Z",
+        cancelAtPeriodEnd: false,
+        scheduledChange: null,
+        hasSubscription: true,
+        autoRecharge: { enabled: false, threshold: null, amount: null },
+        creditExpiry: { expiringNextCycle: 0, nextExpiryDate: null },
+        creditBreakdown: [],
+        creditGrants: [],
+        concurrencyLimit: 0,
+        concurrencySubscriptions: [],
+      });
+    });
     let usagePackCreditRequests = 0;
     context.mocks.api(
       zeroBillingUsagePackCreditsContract.get,
@@ -345,11 +365,18 @@ describe("zero sidebar account menu", () => {
       },
     });
 
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("billing:changed"),
+      ).toBeTruthy();
+    });
+    billingRequests = 0;
     const menu = await openAccountMenu();
     expect(within(menu).getByText("Settings")).toBeInTheDocument();
     expect(
       within(menu).queryByTestId("account-menu-credit-balance"),
     ).toBeNull();
+    expect(billingRequests).toBe(0);
     expect(usagePackCreditRequests).toBe(0);
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -23,6 +23,7 @@ import {
 import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 import { mockNow } from "../../../__tests__/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { foregroundReady$ } from "../../../signals/auth-retry.ts";
 
 const context = testContext();
 
@@ -623,6 +624,49 @@ describe("zero sidebar account menu", () => {
     await waitFor(() => {
       expect(within(menu).getByText("125 credits")).toBeInTheDocument();
       expect(billingRequests).toBe(2);
+    });
+  });
+
+  it("defers minimal-layout billing refresh until the account menu opens", async () => {
+    let billingRequests = 0;
+    mockAdminAccountSidebar();
+    mockAdminBillingStatus(500, {
+      onRequest: () => {
+        billingRequests += 1;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/github/connect?agentId=${AGENT_ID}`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+    });
+
+    await screen.findByText("Zero needs GitHub to proceed");
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("billing:changed"),
+      ).toBeTruthy();
+    });
+    expect(billingRequests).toBe(0);
+
+    mockedClerk.sessionTouch.mockClear();
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() => {
+      expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+    });
+    const foregroundReady = context.store.get(foregroundReady$);
+    await foregroundReady.promise;
+    expect(billingRequests).toBe(0);
+
+    const menu = await openAccountMenu();
+    await waitFor(() => {
+      expect(within(menu).getByText("500 credits")).toBeInTheDocument();
+      expect(billingRequests).toBe(1);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -4,6 +4,7 @@ import { HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
 import type { ModelProviderResponse } from "@okouai/api-contracts/contracts/model-providers";
+import { chatThreadsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import {
   zeroBillingStatusContract,
   zeroBillingUsagePackCreditsContract,
@@ -197,8 +198,27 @@ async function openAccountMenu(): Promise<HTMLElement> {
   return screen.findByRole("menu");
 }
 
-function mockAdminBillingStatus(credits: number): void {
+interface MockAdminBillingStatusOptions {
+  readonly failFirstRequest?: boolean;
+  readonly onRequest?: () => void;
+}
+
+function mockAdminBillingStatus(
+  credits: number,
+  options: MockAdminBillingStatusOptions = {},
+): void {
+  let requestCount = 0;
   context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+    requestCount += 1;
+    options.onRequest?.();
+    if (options.failFirstRequest && requestCount === 1) {
+      return respond(500, {
+        error: {
+          message: "Failed to load billing status",
+          code: "INTERNAL_SERVER_ERROR",
+        },
+      });
+    }
     return respond(200, {
       tier: "pro",
       credits,
@@ -492,6 +512,116 @@ describe("zero sidebar account menu", () => {
       expect(within(menu).getByText("500 credits")).toBeInTheDocument();
     });
     expect(within(menu).queryByText("12,500 credits")).not.toBeInTheDocument();
+  });
+
+  it("shares foreground indicator and billing refreshes with the account menu", async () => {
+    let billingRequests = 0;
+    let indicatorRequests = 0;
+    mockAdminAccountSidebar();
+    mockAdminBillingStatus(12_500, {
+      onRequest: () => {
+        billingRequests += 1;
+      },
+    });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      indicatorRequests += 1;
+      return respond(200, { agents: {}, threads: {} });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+      featureSwitches: { [FeatureSwitchKey.UnifiedIndicatorApi]: true },
+    });
+
+    await waitFor(() => {
+      expect(context.mocks.ably.hasSubscription("billing:changed")).toBe(true);
+      expect(context.mocks.ably.hasSubscription("threadListChanged")).toBe(
+        true,
+      );
+      expect(
+        context.mocks.ably.hasSubscription("chatThreadReadCursorUpdated"),
+      ).toBe(true);
+      expect(billingRequests).toBeGreaterThan(0);
+      expect(indicatorRequests).toBeGreaterThan(0);
+    });
+
+    let previousIndicatorRequests = indicatorRequests;
+    context.mocks.ably.trigger("threadListChanged");
+    await waitFor(() => {
+      expect(indicatorRequests).toBe(previousIndicatorRequests + 1);
+    });
+    previousIndicatorRequests = indicatorRequests;
+    context.mocks.ably.trigger("chatThreadReadCursorUpdated");
+    await waitFor(() => {
+      expect(indicatorRequests).toBe(previousIndicatorRequests + 1);
+    });
+
+    mockedClerk.sessionTouch.mockClear();
+    mockAdminBillingStatus(500, {
+      onRequest: () => {
+        billingRequests += 1;
+      },
+    });
+    billingRequests = 0;
+    indicatorRequests = 0;
+
+    const accountName = screen.getByText("Alex Rivera");
+    const accountButton = accountName.closest("button");
+    if (!accountButton) {
+      throw new Error("Expected account menu trigger");
+    }
+    window.dispatchEvent(new Event("focus"));
+    fireEvent.click(accountButton);
+    let menu = await screen.findByRole("menu");
+    await waitFor(() => {
+      expect(mockedClerk.sessionTouch).toHaveBeenCalledTimes(1);
+      expect(within(menu).getByText("500 credits")).toBeInTheDocument();
+      expect(billingRequests).toBe(1);
+      expect(indicatorRequests).toBe(1);
+    });
+
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+    mockAdminBillingStatus(250, {
+      onRequest: () => {
+        billingRequests += 1;
+      },
+    });
+    billingRequests = 0;
+
+    menu = await openAccountMenu();
+    await waitFor(() => {
+      expect(within(menu).getByText("250 credits")).toBeInTheDocument();
+      expect(billingRequests).toBe(1);
+    });
+
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+    billingRequests = 0;
+    mockAdminBillingStatus(125, {
+      failFirstRequest: true,
+      onRequest: () => {
+        billingRequests += 1;
+      },
+    });
+
+    window.dispatchEvent(new Event("focus"));
+    fireEvent.click(accountButton);
+    menu = await screen.findByRole("menu");
+    await waitFor(() => {
+      expect(within(menu).getByText("125 credits")).toBeInTheDocument();
+      expect(billingRequests).toBe(2);
+    });
   });
 
   it("hides account menu subscriptions when the feature switch is disabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -369,6 +369,7 @@ describe("zero sidebar account menu", () => {
       expect(
         context.mocks.ably.hasSubscription("billing:changed"),
       ).toBeTruthy();
+      expect(billingRequests).toBeGreaterThan(0);
     });
     billingRequests = 0;
     const menu = await openAccountMenu();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -203,6 +203,10 @@ async function openAccountMenu(): Promise<HTMLElement> {
 
 interface MockAdminBillingStatusOptions {
   readonly failFirstRequest?: boolean;
+  readonly firstRequestGate?: {
+    readonly onStarted: () => void;
+    readonly waitUntil: Promise<void>;
+  };
   readonly onRequest?: () => void;
 }
 
@@ -211,49 +215,56 @@ function mockAdminBillingStatus(
   options: MockAdminBillingStatusOptions = {},
 ): void {
   let requestCount = 0;
-  context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
-    requestCount += 1;
-    options.onRequest?.();
-    if (options.failFirstRequest && requestCount === 1) {
-      return respond(500, {
-        error: {
-          message: "Failed to load billing status",
-          code: "INTERNAL_SERVER_ERROR",
+  context.mocks.api(
+    zeroBillingStatusContract.get,
+    async ({ respond, withSignal }) => {
+      requestCount += 1;
+      options.onRequest?.();
+      if (requestCount === 1 && options.firstRequestGate) {
+        options.firstRequestGate.onStarted();
+        await withSignal(options.firstRequestGate.waitUntil);
+      }
+      if (options.failFirstRequest && requestCount === 1) {
+        return respond(500, {
+          error: {
+            message: "Failed to load billing status",
+            code: "INTERNAL_SERVER_ERROR",
+          },
+        });
+      }
+      return respond(200, {
+        tier: "pro",
+        credits,
+        onboardingPaymentPending: false,
+        subscriptionStatus: "active",
+        currentPeriodEnd: "2026-04-01T00:00:00Z",
+        cancelAtPeriodEnd: false,
+        scheduledChange: null,
+        hasSubscription: true,
+        autoRecharge: { enabled: false, threshold: null, amount: null },
+        creditExpiry: {
+          expiringNextCycle: 0,
+          nextExpiryDate: null,
         },
+        creditBreakdown: [
+          {
+            category: "plan",
+            tier: "pro",
+            label: "Pro credits",
+            credits: 10_000,
+          },
+          {
+            category: "promotional",
+            label: "Launch bonus",
+            credits: 2500,
+          },
+        ],
+        creditGrants: [],
+        concurrencyLimit: 0,
+        concurrencySubscriptions: [],
       });
-    }
-    return respond(200, {
-      tier: "pro",
-      credits,
-      onboardingPaymentPending: false,
-      subscriptionStatus: "active",
-      currentPeriodEnd: "2026-04-01T00:00:00Z",
-      cancelAtPeriodEnd: false,
-      scheduledChange: null,
-      hasSubscription: true,
-      autoRecharge: { enabled: false, threshold: null, amount: null },
-      creditExpiry: {
-        expiringNextCycle: 0,
-        nextExpiryDate: null,
-      },
-      creditBreakdown: [
-        {
-          category: "plan",
-          tier: "pro",
-          label: "Pro credits",
-          credits: 10_000,
-        },
-        {
-          category: "promotional",
-          label: "Launch bonus",
-          credits: 2500,
-        },
-      ],
-      creditGrants: [],
-      concurrencyLimit: 0,
-      concurrencySubscriptions: [],
-    });
-  });
+    },
+  );
 }
 
 function mockAdminAccountSidebar(): void {
@@ -698,6 +709,72 @@ describe("zero sidebar account menu", () => {
 
     catchUpCanFinish.resolve();
     await foregroundReady.promise;
+    await waitFor(() => {
+      expect(within(menu).getByText("500 credits")).toBeInTheDocument();
+      expect(billingRequests).toBe(1);
+    });
+  });
+
+  it("joins a foreground billing request after the catch-up barrier settles", async () => {
+    let billingRequests = 0;
+    mockAdminAccountSidebar();
+    mockAdminBillingStatus(12_500, {
+      onRequest: () => {
+        billingRequests += 1;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("billing:changed"),
+      ).toBeTruthy();
+      expect(billingRequests).toBeGreaterThan(0);
+    });
+
+    const initialMenu = await openAccountMenu();
+    await waitFor(() => {
+      expect(
+        within(initialMenu).getByText("12,500 credits"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    const foregroundRequestStarted = context.mocks.deferred<void>();
+    const foregroundResponseReady = context.mocks.deferred<void>();
+    mockAdminBillingStatus(500, {
+      firstRequestGate: {
+        onStarted: () => {
+          foregroundRequestStarted.resolve();
+        },
+        waitUntil: foregroundResponseReady.promise,
+      },
+      onRequest: () => {
+        billingRequests += 1;
+      },
+    });
+    billingRequests = 0;
+
+    window.dispatchEvent(new Event("focus"));
+    await foregroundRequestStarted.promise;
+    await waitFor(() => {
+      expect(context.store.get(foregroundReady$).pending).toBeFalsy();
+    });
+
+    const menu = await openAccountMenu();
+    foregroundResponseReady.resolve();
     await waitFor(() => {
       expect(within(menu).getByText("500 credits")).toBeInTheDocument();
       expect(billingRequests).toBe(1);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -540,13 +540,15 @@ describe("zero sidebar account menu", () => {
     });
 
     await waitFor(() => {
-      expect(context.mocks.ably.hasSubscription("billing:changed")).toBe(true);
-      expect(context.mocks.ably.hasSubscription("threadListChanged")).toBe(
-        true,
-      );
+      expect(
+        context.mocks.ably.hasSubscription("billing:changed"),
+      ).toBeTruthy();
+      expect(
+        context.mocks.ably.hasSubscription("threadListChanged"),
+      ).toBeTruthy();
       expect(
         context.mocks.ably.hasSubscription("chatThreadReadCursorUpdated"),
-      ).toBe(true);
+      ).toBeTruthy();
       expect(billingRequests).toBeGreaterThan(0);
       expect(indicatorRequests).toBeGreaterThan(0);
     });

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -51,7 +51,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
   billingStatusAsync$,
-  reloadBillingStatus$,
+  reloadAccountMenuBillingStatus$,
   usagePackCreditsAsync$,
 } from "../../signals/zero-page/billing.ts";
 import {
@@ -806,7 +806,7 @@ export function AccountDropdown({
     consumePendingAccountMenuSettingsSection$,
   );
   const reloadSubscriptions = useSet(reloadAccountMenuSubscriptionUsageRows$);
-  const reloadBilling = useSet(reloadBillingStatus$);
+  const reloadBilling = useSet(reloadAccountMenuBillingStatus$);
   const resetCodexSubscriptionUsage = useSet(
     resetPersonalCodexSubscriptionUsage$,
   );
@@ -922,7 +922,11 @@ export function AccountDropdown({
     }
     // Refresh credit balances every time the menu opens so the displayed
     // remaining credits reflect the latest usage.
-    reloadBilling();
+    detach(
+      reloadBilling(pageSignal),
+      Reason.DomCallback,
+      "reload account menu billing",
+    );
     if (!subscriptionsEnabled) {
       return;
     }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -51,7 +51,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
   billingStatusAsync$,
-  reloadAccountMenuBillingStatus$,
+  reloadAccountMenuCreditBalances$,
   usagePackCreditsAsync$,
 } from "../../signals/zero-page/billing.ts";
 import {
@@ -806,7 +806,7 @@ export function AccountDropdown({
     consumePendingAccountMenuSettingsSection$,
   );
   const reloadSubscriptions = useSet(reloadAccountMenuSubscriptionUsageRows$);
-  const reloadBilling = useSet(reloadAccountMenuBillingStatus$);
+  const reloadCreditBalances = useSet(reloadAccountMenuCreditBalances$);
   const resetCodexSubscriptionUsage = useSet(
     resetPersonalCodexSubscriptionUsage$,
   );
@@ -923,9 +923,9 @@ export function AccountDropdown({
     // Refresh credit balances every time the menu opens so the displayed
     // remaining credits reflect the latest usage.
     detach(
-      reloadBilling(pageSignal),
+      reloadCreditBalances(pageSignal),
       Reason.DomCallback,
-      "reload account menu billing",
+      "reload account menu credit balances",
     );
     if (!subscriptionsEnabled) {
       return;


### PR DESCRIPTION
## Summary

- let realtime consumers opt out of the shared foreground poke while preserving live events and initial priming
- run one awaited indicator and billing snapshot catch-up after realtime recovery, before foreground readiness resolves
- make account-menu credit refreshes join current in-flight resources, retry failed loads, refresh member usage-pack credits, and avoid unused org-billing prefetch

## Testing

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run --maxWorkers=4 --silent=passed-only` (133 files, 1,620 tests)
- `pnpm knip --workspace @okouai/app`
- focused realtime and account-menu tests (55 tests)
- full-repository TypeScript and Knip pre-commit checks

Closes #26868
