### PR TITLE
test(api): isolate same-thread reuse scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3835,13 +3835,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(completed.status).toBe("completed");
   });
 
-  it("selects same-thread reuse preferences from runner heartbeats", async () => {
+  it("validates same-thread reuse heartbeat inventory shapes", async () => {
     const {
       reuseRunnerId,
       api,
       cliAgentSessionId,
-      first,
-      heartbeatHolder,
       nextReuseSnapshotSequence,
       pollFollowUp,
       reuseKey,
@@ -3924,6 +3922,19 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       kind: "noPreference",
       reason: "noViableHolder",
     });
+  });
+
+  it("selects workspace and reusable-sandbox preferences from runner heartbeats", async () => {
+    const {
+      reuseRunnerId,
+      api,
+      cliAgentSessionId,
+      heartbeatHolder,
+      nextReuseSnapshotSequence,
+      pollFollowUp,
+      reuseKey,
+      runnerGroup,
+    } = await setupSameThreadReuseScenario();
 
     await api.requestHeartbeatRunner(true, [200], {
       runnerId: reuseRunnerId,
@@ -4019,6 +4030,40 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       mode: "stopping",
     });
 
+    for (const { runId, resolution, tier } of [
+      {
+        runId: reusableOverWorkspace.run.runId,
+        resolution: "matching_reusable_sandbox",
+        tier: "reusableSandbox",
+      },
+      {
+        runId: capableWorkspaceHolder.run.runId,
+        resolution: "matching_workspace_cache",
+        tier: "workspaceCache",
+      },
+    ]) {
+      for (const actionType of [
+        "runner_notification_affinity_lookup",
+        "runner_poll_pending_job_lookup",
+      ]) {
+        const events = sandboxOperationEventsForRunByAction(runId, actionType);
+        expect(events).toHaveLength(1);
+        expect(events[0]).toStrictEqual(
+          expect.objectContaining({
+            runner_preference_resolution: resolution,
+            runner_preference_decision_kind: "preference",
+            runner_preference_tier: tier,
+            reuse_key_kind: "thread",
+          }),
+        );
+      }
+    }
+  });
+
+  it("selects reusable-sandbox preferences by profile and history generation", async () => {
+    const { reuseRunnerId, first, heartbeatHolder, pollFollowUp } =
+      await setupSameThreadReuseScenario();
+
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
       workspaceCaches: [{ profile: "vm0/large", workspaceAffinityVersion: 1 }],
@@ -4070,35 +4115,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       tier: "exactSandbox",
       expiresAt: expect.any(String),
     });
-
-    for (const { runId, resolution, tier } of [
-      {
-        runId: reusableOverWorkspace.run.runId,
-        resolution: "matching_reusable_sandbox",
-        tier: "reusableSandbox",
-      },
-      {
-        runId: capableWorkspaceHolder.run.runId,
-        resolution: "matching_workspace_cache",
-        tier: "workspaceCache",
-      },
-    ]) {
-      for (const actionType of [
-        "runner_notification_affinity_lookup",
-        "runner_poll_pending_job_lookup",
-      ]) {
-        const events = sandboxOperationEventsForRunByAction(runId, actionType);
-        expect(events).toHaveLength(1);
-        expect(events[0]).toStrictEqual(
-          expect.objectContaining({
-            runner_preference_resolution: resolution,
-            runner_preference_decision_kind: "preference",
-            runner_preference_tier: tier,
-            reuse_key_kind: "thread",
-          }),
-        );
-      }
-    }
   });
 
   it("prefers the live finalizing source before generic reuse without renewing its deadline", async () => {


### PR DESCRIPTION
## Summary

- split the oversized same-thread runner-reuse scenario into three independently owned API integration tests
- preserve heartbeat validation, workspace and sandbox preference ranking, Ably publication, and sandbox-operation telemetry assertions
- keep the production contract and the 5-second Vitest timeout unchanged

## Root cause

The original test serialized several independent heartbeat and follow-up-run scenarios under one 5-second test budget. In [Turbo run 31691150491, attempt 1](https://github.com/vm0-ai/vm0/actions/runs/31691150491/attempts/1), the test reached 5.024 seconds under CI load and timed out without an assertion failure. The same SHA passed the unchanged test in 1.423 seconds on the rerun, confirming that aggregate wall-clock scheduling, rather than a product outcome race, made the result intermittent.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- targeted Vitest attempted with the three new test names; local execution stopped in `beforeAll` with `ECONNREFUSED 127.0.0.1:5432` because this environment has no PostgreSQL service (all 159 tests were skipped)

## Exclusions

- no production behavior changes
- no timeout increase, retry, sleep, fake timer, or manual detached-work cleanup
