### PR TITLE
fix(platform): render 100 initial sidebar threads

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
@@ -22,6 +22,7 @@ import {
 } from "./sidebar-chat-thread-item.ts";
 
 const CHAT_THREAD_VIRTUAL_OVERSCAN = 8;
+const CHAT_THREAD_VIRTUAL_FALLBACK_WINDOW_SIZE = 100;
 
 export interface SidebarChatThreadWindow {
   readonly startIndex: number;
@@ -85,10 +86,10 @@ export const sidebarChatThreadWindow$ = computed(
       scrollViewport,
       virtualListElement,
     );
+    const measuredViewportHeight =
+      scrollMetrics.clientHeight || scrollViewport?.clientHeight;
     const viewportHeight =
-      scrollMetrics.clientHeight ||
-      scrollViewport?.clientHeight ||
-      CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT;
+      measuredViewportHeight || CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT;
     const scrollTop = scrollMetrics.scrollTop;
     const { startIndex, endIndex } = getFixedVirtualRange({
       itemCount: chatThreads.length,
@@ -96,6 +97,15 @@ export const sidebarChatThreadWindow$ = computed(
       scrollTop,
       viewportHeight,
     });
+    const resolvedEndIndex = measuredViewportHeight
+      ? endIndex
+      : Math.min(
+          chatThreads.length,
+          Math.max(
+            endIndex,
+            startIndex + CHAT_THREAD_VIRTUAL_FALLBACK_WINDOW_SIZE,
+          ),
+        );
     const itemSignals = get(sidebarChatThreadItemSignalsRegistry$).reconcile(
       chatThreads.map((thread) => {
         return thread.id;
@@ -104,7 +114,7 @@ export const sidebarChatThreadWindow$ = computed(
 
     return {
       startIndex,
-      items: itemSignals.slice(startIndex, endIndex),
+      items: itemSignals.slice(startIndex, resolvedEndIndex),
     };
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1406,6 +1406,32 @@ describe("zero sidebar", () => {
     });
   });
 
+  it("renders 100 chat threads before the sidebar viewport is measured", async () => {
+    prepareDefaultAgent();
+    const firstThread = createThread(EXISTING_THREAD_ID, "Fallback chat 1");
+    const threads = [
+      firstThread,
+      ...Array.from({ length: 119 }, (_, index) => {
+        return createThread(
+          `b3200000-0000-4000-a000-${String(index).padStart(12, "0")}`,
+          `Fallback chat ${index + 2}`,
+        );
+      }),
+    ];
+    mockSidebarThreadStory(threads);
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${firstThread.id}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId("sidebar-chat-thread-virtual-row"),
+      ).toHaveLength(100);
+    });
+  });
+
   it("aligns the current virtualized chat row with the sidebar scroll area top on page setup", async () => {
     prepareDefaultAgent();
     const leadingThreads = Array.from({ length: 24 }, (_, index) => {


### PR DESCRIPTION
## Summary

- render 100 sidebar chat thread rows while the viewport height is not yet measured
- preserve the existing measured viewport overscan and fallback scroll-position behavior
- cover the initial virtual window size with a page-level sidebar regression test

## Verification

- `pnpm format`
- `pnpm --filter @okouai/app run lint`
- `pnpm knip`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx` (55 tests passed)
