### PR TITLE
feat: roll out saved-billing credit purchases

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -153,7 +153,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.LatestWebsiteTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SavedBillingCreditPurchase]).toBe(
-      false,
+      true,
     );
   });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -338,8 +338,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "yuma@vm0.ai",
     description:
       "Preview saved-billing credit purchases and confirm them in the app.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- enable `SavedBillingCreditPurchase` globally for every organization
- remove the staff-org allowlist from the switch registry
- update the rollout-matrix coverage for non-staff organizations

## Rollout boundary

- #26806 introduced the saved-billing preview and in-app confirmation flow behind this switch.
- This PR makes that flow the global default while retaining the switch and disabled-path compatibility during the documented old-client drain window.
- #26842 tracks removing the switch and rollout-only compatibility after the approximately two-day web/app client window and older CLI execution contexts have drained.

## Fallbacks

- No new fallback paths. The existing hosted Checkout behavior for unavailable saved billing and mixed deployments is unchanged.

## Testing

- `corepack pnpm exec prettier --write packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `corepack pnpm -F @okouai/core lint`
- `corepack pnpm -F @okouai/core check-types`
- `corepack pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --silent=passed-only` (24 tests passed)
- `corepack pnpm knip` (baseline and final both exited 0 with the same 45 configuration hints)
- `git diff --check`