### PR TITLE
refactor(steam): neutralize the steam player vertical slice

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -170,7 +170,7 @@ import { zeroFeishuBrowserConnectRoutes } from "./routes/zero-feishu-browser-con
 import { zeroFeishuConnectRoutes } from "./routes/zero-feishu-connect";
 import { zeroFeishuEventsRoutes } from "./routes/zero-feishu-events";
 import { zeroFeishuOauthRoutes } from "./routes/zero-feishu-oauth";
-import { zeroSteamPlayerRoutes } from "./routes/zero-steam-player";
+import { steamPlayerRoutes } from "./routes/steam-player";
 import { zeroTeamsBrowserConnectRoutes } from "./routes/zero-teams-browser-connect";
 import { zeroTeamsBotRoutes } from "./routes/zero-teams-bot";
 import { zeroTeamsConnectRoutes } from "./routes/zero-teams-connect";
@@ -370,7 +370,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroIntegrationsTeamsUploadCompleteRoutes,
   ...zeroIntegrationsTeamsUploadInitRoutes,
   ...zeroSlackChannelsRoutes,
-  ...zeroSteamPlayerRoutes,
+  ...steamPlayerRoutes,
   ...zeroIntegrationsTelegramRoutes,
   ...zeroIntegrationsTelegramMessageRoutes,
   ...zeroIntegrationsTelegramUploadCompleteRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
@@ -6,7 +6,7 @@ import {
   zeroConnectorsBySlugContract,
 } from "@okouai/api-contracts/contracts/zero-connectors";
 import { zeroConnectorCatalogContract } from "@okouai/api-contracts/contracts/zero-connector-catalog";
-import { zeroSteamPlayerContract } from "@okouai/api-contracts/contracts/zero-steam-player";
+import { steamPlayerContract } from "@okouai/api-contracts/contracts/steam-player";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -18,7 +18,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { connectorsSlugCallbackRoutes } from "../connectors-slug-callback";
 import { zeroConnectorCatalogRoutes } from "../zero-connector-catalog";
 import { zeroConnectorsRoutes } from "../zero-connectors";
-import { zeroSteamPlayerRoutes } from "../zero-steam-player";
+import { steamPlayerRoutes } from "../steam-player";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -474,8 +474,8 @@ describe("Steam OpenID connector", () => {
 
     mockSession(actor);
     const response = await accept(
-      setupApp({ context, routes: zeroSteamPlayerRoutes })(
-        zeroSteamPlayerContract,
+      setupApp({ context, routes: steamPlayerRoutes })(
+        steamPlayerContract,
       ).getPlayer({
         headers: authHeaders(),
       }),
@@ -540,8 +540,8 @@ describe("Steam OpenID connector", () => {
 
     mockSession(actor);
     const response = await accept(
-      setupApp({ context, routes: zeroSteamPlayerRoutes })(
-        zeroSteamPlayerContract,
+      setupApp({ context, routes: steamPlayerRoutes })(
+        steamPlayerContract,
       ).getPlayer({
         headers: authHeaders(),
       }),
@@ -572,8 +572,8 @@ describe("Steam OpenID connector", () => {
 
     mockSession(actor);
     const response = await accept(
-      setupApp({ context, routes: zeroSteamPlayerRoutes })(
-        zeroSteamPlayerContract,
+      setupApp({ context, routes: steamPlayerRoutes })(
+        steamPlayerContract,
       ).getPlayer({
         headers: authHeaders(),
       }),
@@ -599,8 +599,8 @@ describe("Steam OpenID connector", () => {
 
     mockSession(actor);
     const response = await accept(
-      setupApp({ context, routes: zeroSteamPlayerRoutes })(
-        zeroSteamPlayerContract,
+      setupApp({ context, routes: steamPlayerRoutes })(
+        steamPlayerContract,
       ).getPlayer({
         headers: authHeaders(),
       }),

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -5,7 +5,7 @@ import { cronConnectorCatalogContract } from "@okouai/api-contracts/contracts/cr
 import { connectorsSlugCallbackContract } from "@okouai/api-contracts/contracts/connectors-slug-callback";
 import { MODEL_PROVIDER_FIREWALL_CONFIGS } from "@okouai/api-contracts/contracts/model-provider-firewalls";
 import { runnersBuiltinFirewallsResolveContract } from "@okouai/api-contracts/contracts/runners";
-import { zeroSteamPlayerContract } from "@okouai/api-contracts/contracts/zero-steam-player";
+import { steamPlayerContract } from "@okouai/api-contracts/contracts/steam-player";
 import {
   testSystemStoragePresignedUrlCacheStateContract,
   type TestSystemStoragePresignedUrlCacheStateActionBody,
@@ -96,7 +96,7 @@ import { zeroConnectorCatalogRoutes } from "../zero-connector-catalog";
 import { zeroConnectorCheckRoutes } from "../zero-connector-check";
 import { zeroConnectorsRoutes } from "../zero-connectors";
 import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
-import { zeroSteamPlayerRoutes } from "../zero-steam-player";
+import { steamPlayerRoutes } from "../steam-player";
 import { zeroUserPermissionGrantsRoutes } from "../zero-user-permission-grants";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
 import { zeroWorkflowsRoutes } from "../zero-workflows";
@@ -110,7 +110,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...zeroConnectorCheckRoutes,
   ...zeroConnectorsRoutes,
   ...zeroFeatureSwitchesRoutes,
-  ...zeroSteamPlayerRoutes,
+  ...steamPlayerRoutes,
   ...zeroUserPermissionGrantsRoutes,
   ...zeroWorkflowAutomationsRoutes,
   ...zeroWorkflowsRoutes,
@@ -3625,8 +3625,8 @@ describe("connector catalog valid lifecycle", () => {
     );
     mockSteamPlayerApisForCatalog();
     const player = await accept(
-      setupApp({ context, routes: zeroSteamPlayerRoutes })(
-        zeroSteamPlayerContract,
+      setupApp({ context, routes: steamPlayerRoutes })(
+        steamPlayerContract,
       ).getPlayer({ headers }),
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/steam-player.ts
+++ b/turbo/apps/api/src/signals/routes/steam-player.ts
@@ -1,4 +1,4 @@
-import { zeroSteamPlayerContract } from "@okouai/api-contracts/contracts/zero-steam-player";
+import { steamPlayerContract } from "@okouai/api-contracts/contracts/steam-player";
 import { createErrorResponse } from "@okouai/api-contracts/contracts/errors";
 import { command } from "ccstate";
 
@@ -49,9 +49,9 @@ const getSteamPlayerInner$ = command(
   },
 );
 
-export const zeroSteamPlayerRoutes: readonly RouteEntry[] = [
+export const steamPlayerRoutes: readonly RouteEntry[] = [
   {
-    route: zeroSteamPlayerContract.getPlayer,
+    route: steamPlayerContract.getPlayer,
     handler: authRoute(connectorReadAuth, getSteamPlayerInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/steam-player.service.ts
+++ b/turbo/apps/api/src/signals/services/steam-player.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import type { ZeroSteamPlayerResponse } from "@okouai/api-contracts/contracts/zero-steam-player";
+import type { SteamPlayerResponse } from "@okouai/api-contracts/contracts/steam-player";
 import { z } from "zod";
 
 import { env } from "../../lib/env";
@@ -136,7 +136,7 @@ function steamTimestampToIso(timestamp: number | undefined): string | null {
 
 function steamGameToResponse(
   game: z.infer<typeof steamOwnedGameSchema>,
-): NonNullable<ZeroSteamPlayerResponse["ownedGames"]>["games"][number] {
+): NonNullable<SteamPlayerResponse["ownedGames"]>["games"][number] {
   return {
     appId: game.appid,
     name: game.name ?? null,
@@ -148,7 +148,7 @@ function steamGameToResponse(
 
 function steamWishlistItemToResponse(
   item: z.infer<typeof steamWishlistItemSchema>,
-): NonNullable<ZeroSteamPlayerResponse["wishlist"]>["items"][number] {
+): NonNullable<SteamPlayerResponse["wishlist"]>["items"][number] {
   return {
     appId: item.appid,
     priority: item.priority ?? null,
@@ -198,7 +198,7 @@ async function fetchSteamJson<T>(
 async function fetchSteamProfile(
   steamId: string,
   signal: AbortSignal,
-): Promise<ZeroSteamPlayerResponse["profile"]> {
+): Promise<SteamPlayerResponse["profile"]> {
   const result = await fetchSteamJson(
     "/ISteamUser/GetPlayerSummaries/v0002/",
     { steamids: steamId },
@@ -223,7 +223,7 @@ async function fetchSteamProfile(
 async function fetchSteamOwnedGames(
   steamId: string,
   signal: AbortSignal,
-): Promise<ZeroSteamPlayerResponse["ownedGames"]> {
+): Promise<SteamPlayerResponse["ownedGames"]> {
   const result = await fetchSteamJson(
     "/IPlayerService/GetOwnedGames/v0001/",
     {
@@ -250,7 +250,7 @@ async function fetchSteamOwnedGames(
 async function fetchSteamRecentlyPlayedGames(
   steamId: string,
   signal: AbortSignal,
-): Promise<ZeroSteamPlayerResponse["recentlyPlayedGames"]> {
+): Promise<SteamPlayerResponse["recentlyPlayedGames"]> {
   const result = await fetchSteamJson(
     "/IPlayerService/GetRecentlyPlayedGames/v0001/",
     { steamid: steamId },
@@ -273,7 +273,7 @@ async function fetchSteamRecentlyPlayedGames(
 async function fetchSteamLevel(
   steamId: string,
   signal: AbortSignal,
-): Promise<ZeroSteamPlayerResponse["level"]> {
+): Promise<SteamPlayerResponse["level"]> {
   const result = await fetchSteamJson(
     "/IPlayerService/GetSteamLevel/v1/",
     { steamid: steamId },
@@ -286,7 +286,7 @@ async function fetchSteamLevel(
 async function fetchSteamBadges(
   steamId: string,
   signal: AbortSignal,
-): Promise<ZeroSteamPlayerResponse["badges"]> {
+): Promise<SteamPlayerResponse["badges"]> {
   const result = await fetchSteamJson(
     "/IPlayerService/GetBadges/v1/",
     { steamid: steamId },
@@ -317,7 +317,7 @@ async function fetchSteamBadges(
 async function fetchSteamWishlist(
   steamId: string,
   signal: AbortSignal,
-): Promise<ZeroSteamPlayerResponse["wishlist"]> {
+): Promise<SteamPlayerResponse["wishlist"]> {
   const [wishlist, itemCount] = await Promise.all([
     fetchSteamJson(
       "/IWishlistService/GetWishlist/v1/",
@@ -348,7 +348,7 @@ async function fetchSteamWishlist(
 async function fetchSteamFollowedGames(
   steamId: string,
   signal: AbortSignal,
-): Promise<ZeroSteamPlayerResponse["followedGames"]> {
+): Promise<SteamPlayerResponse["followedGames"]> {
   const [followedGames, followedGameCount] = await Promise.all([
     fetchSteamJson(
       "/IStoreService/GetGamesFollowed/v1/",
@@ -381,7 +381,7 @@ export const steamPlayerData$ = command(
     { get },
     args: { readonly orgId: string; readonly userId: string },
     signal: AbortSignal,
-  ): Promise<ZeroSteamPlayerResponse | null> => {
+  ): Promise<SteamPlayerResponse | null> => {
     const db = get(db$);
     const snapshot = await loadConnectorRuntimeSnapshot(db);
     signal.throwIfAborted();

--- a/turbo/packages/api-contracts/src/contracts/steam-player.ts
+++ b/turbo/packages/api-contracts/src/contracts/steam-player.ts
@@ -64,7 +64,7 @@ export const steamPlayerFollowedGamesSchema = z.object({
   appIds: z.array(z.number().int()),
 });
 
-export const zeroSteamPlayerResponseSchema = z.object({
+export const steamPlayerResponseSchema = z.object({
   steamId: z.string(),
   profile: steamPlayerProfileSchema.nullable(),
   ownedGames: steamPlayerOwnedGamesSchema.nullable(),
@@ -75,17 +75,15 @@ export const zeroSteamPlayerResponseSchema = z.object({
   followedGames: steamPlayerFollowedGamesSchema.nullable(),
 });
 
-export type ZeroSteamPlayerResponse = z.infer<
-  typeof zeroSteamPlayerResponseSchema
->;
+export type SteamPlayerResponse = z.infer<typeof steamPlayerResponseSchema>;
 
-export const zeroSteamPlayerContract = c.router({
+export const steamPlayerContract = c.router({
   getPlayer: {
     method: "GET",
     path: "/api/okou/connectors/steam/player",
     headers: authHeadersSchema,
     responses: {
-      200: zeroSteamPlayerResponseSchema,
+      200: steamPlayerResponseSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,


### PR DESCRIPTION
## Summary

- Rename the internal Steam Player contract and route modules to their canonical neutral names.
- Rename the response schema, response type, contract, route collection, and every live caller.
- Preserve the public Steam player API, authorization, error behavior, credentials, upstream requests, conversions, and runtime behavior exactly; add no compatibility aliases or forwarding modules.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/connectors-openid.bdd.test.ts -t 'Steam OpenID connector'` (8 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts -t 'executes an external OpenID grant with catalog-owned storage|reconciles configuration changes and retains rolling-build evaluations|reports a known provider contract mismatch without private details'` (3 passed, 104 skipped)
- Final live-code search found no `zero-steam-player`, `zeroSteamPlayer`, or `ZeroSteamPlayer`; the public route remains `GET /api/okou/connectors/steam/player`.

Closes #26934