### PR TITLE
refactor(rust): share active-input control payload contract

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1302,6 +1302,7 @@ name = "guest-contracts"
 version = "0.11.1"
 dependencies = [
  "libc",
+ "process-control-ipc",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use serde::Deserialize;
+use guest_contracts::active_input::{ActiveInputDecodeError, decode_active_input};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use tokio::sync::{mpsc, watch};
@@ -15,7 +15,6 @@ use crate::active_input_receipts::ActiveInputReceiptRuntime;
 use crate::error::AgentError;
 use crate::http::HttpClient;
 
-const ACTIVE_INPUT_TYPE: &str = "active-input";
 const ACTIVE_INPUT_QUEUE_CAPACITY: usize = 8;
 const ACTIVE_INPUT_DELIVERY_ID_CAPACITY: usize =
     guest_contracts::active_input_receipts::MAX_ACTIVE_INPUT_RECEIPT_IDS;
@@ -289,15 +288,6 @@ pub struct ActiveInputRuntime {
     writer: ActiveInputWriter,
 }
 
-#[derive(Deserialize)]
-struct ActiveInputPayload {
-    #[serde(rename = "type")]
-    payload_type: String,
-    #[serde(rename = "deliveryId")]
-    delivery_id: String,
-    text: String,
-}
-
 /// Derives the deterministic Claude user-frame UUID for the run's initial prompt.
 ///
 /// Claude stream-JSON stdin writers use this UUID when sending the initial
@@ -311,6 +301,19 @@ pub fn claude_initial_prompt_uuid(run_id: &str) -> String {
         format!("vm0:{run_id}:claude-initial-prompt").as_bytes(),
     )
     .to_string()
+}
+
+fn active_input_decode_rejection(error: ActiveInputDecodeError) -> ActiveInputControlOutcome {
+    let diagnostic = match error {
+        ActiveInputDecodeError::InvalidPayload => "active input payload is invalid",
+        ActiveInputDecodeError::UnsupportedType => "active input payload type is unsupported",
+        ActiveInputDecodeError::EmptyText => "active input text is empty",
+        ActiveInputDecodeError::InvalidDeliveryId => "active input delivery id is invalid",
+        ActiveInputDecodeError::NonCanonicalDeliveryId => {
+            "active input delivery id is not canonical"
+        }
+    };
+    ActiveInputControlOutcome::Rejected { diagnostic }
 }
 
 fn active_input_text_digest(text: &str) -> [u8; 32] {
@@ -513,38 +516,11 @@ impl ActiveInputController {
                 diagnostic: "active input is not supported for this agent",
             };
         };
-        let payload = match serde_json::from_slice::<ActiveInputPayload>(payload) {
+        let payload = match decode_active_input(payload) {
             Ok(payload) => payload,
-            Err(_) => {
-                return ActiveInputControlOutcome::Rejected {
-                    diagnostic: "active input payload is invalid",
-                };
-            }
+            Err(error) => return active_input_decode_rejection(error),
         };
-        if payload.payload_type != ACTIVE_INPUT_TYPE {
-            return ActiveInputControlOutcome::Rejected {
-                diagnostic: "active input payload type is unsupported",
-            };
-        }
-        if payload.text.is_empty() {
-            return ActiveInputControlOutcome::Rejected {
-                diagnostic: "active input text is empty",
-            };
-        }
-
-        let text = payload.text;
-        let delivery_id = payload.delivery_id;
-        let Ok(parsed) = Uuid::parse_str(&delivery_id) else {
-            return ActiveInputControlOutcome::Rejected {
-                diagnostic: "active input delivery id is invalid",
-            };
-        };
-        let canonical_delivery_id = parsed.hyphenated().to_string();
-        if canonical_delivery_id != delivery_id {
-            return ActiveInputControlOutcome::Rejected {
-                diagnostic: "active input delivery id is not canonical",
-            };
-        }
+        let (delivery_id, text) = payload.into_parts();
         let text_digest = active_input_text_digest(&text);
 
         let mut state = self

--- a/crates/guest-agent/src/active_input/tests.rs
+++ b/crates/guest-agent/src/active_input/tests.rs
@@ -21,12 +21,8 @@ fn active_input_uuid(sequence: u64) -> String {
 }
 
 fn active_input_payload(sequence: u64, text: &str) -> Vec<u8> {
-    serde_json::to_vec(&json!({
-        "type": ACTIVE_INPUT_TYPE,
-        "deliveryId": active_input_uuid(sequence),
-        "text": text,
-    }))
-    .expect("active input payload should serialize")
+    guest_contracts::active_input::encode_active_input(&active_input_uuid(sequence), text)
+        .expect("active input payload should serialize")
 }
 
 fn accept_active_input(controller: &ActiveInputController, sequence: u64, text: &str) -> String {
@@ -112,19 +108,48 @@ fn active_input_rejects_invalid_payloads() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();
 
-    for (case, payload) in [
-        ("bad-json", br#"{"type":"active-input""#.as_slice()),
-        ("bad-type", br#"{"type":"other","text":"hello"}"#.as_slice()),
-        ("empty", br#"{"type":"active-input","text":""}"#.as_slice()),
-        ("missing-delivery-id", br#"{"type":"active-input","text":"hello"}"#.as_slice()),
-        ("null-delivery-id", br#"{"type":"active-input","deliveryId":null,"text":"hello"}"#.as_slice()),
-        ("malformed-delivery-id", br#"{"type":"active-input","deliveryId":"invalid","text":"hello"}"#.as_slice()),
-        ("noncanonical-delivery-id", br#"{"type":"active-input","deliveryId":"223F8797-A456-4EEA-98F7-F7AB88C43C00","text":"hello"}"#.as_slice()),
+    for (case, payload, expected_diagnostic) in [
+        (
+            "bad-json",
+            br#"{"type":"active-input""#.as_slice(),
+            "active input payload is invalid",
+        ),
+        (
+            "bad-type",
+            br#"{"type":"other","deliveryId":"223f8797-a456-4eea-98f7-f7ab88c43c00","text":"hello"}"#.as_slice(),
+            "active input payload type is unsupported",
+        ),
+        (
+            "empty",
+            br#"{"type":"active-input","deliveryId":"223f8797-a456-4eea-98f7-f7ab88c43c00","text":""}"#.as_slice(),
+            "active input text is empty",
+        ),
+        (
+            "missing-delivery-id",
+            br#"{"type":"active-input","text":"hello"}"#.as_slice(),
+            "active input payload is invalid",
+        ),
+        (
+            "null-delivery-id",
+            br#"{"type":"active-input","deliveryId":null,"text":"hello"}"#.as_slice(),
+            "active input payload is invalid",
+        ),
+        (
+            "malformed-delivery-id",
+            br#"{"type":"active-input","deliveryId":"invalid","text":"hello"}"#.as_slice(),
+            "active input delivery id is invalid",
+        ),
+        (
+            "noncanonical-delivery-id",
+            br#"{"type":"active-input","deliveryId":"223F8797-A456-4EEA-98F7-F7AB88C43C00","text":"hello"}"#.as_slice(),
+            "active input delivery id is not canonical",
+        ),
     ] {
         assert!(
             matches!(
                 controller.handle_control_payload(payload),
-                ActiveInputControlOutcome::Rejected { .. }
+                ActiveInputControlOutcome::Rejected { diagnostic }
+                    if diagnostic == expected_diagnostic
             ),
             "payload should reject: {case}"
         );

--- a/crates/guest-agent/src/control.rs
+++ b/crates/guest-agent/src/control.rs
@@ -288,12 +288,8 @@ mod tests {
             &uuid::Uuid::NAMESPACE_OID,
             format!("vm0:control-test:active-input:{sequence}").as_bytes(),
         );
-        serde_json::to_vec(&serde_json::json!({
-            "type": "active-input",
-            "deliveryId": delivery_id.to_string(),
-            "text": "hello",
-        }))
-        .expect("active-input control payload should serialize")
+        guest_contracts::active_input::encode_active_input(&delivery_id.to_string(), "hello")
+            .expect("active-input control payload should serialize")
     }
 
     fn accept_control_stream_and_read_hello(

--- a/crates/guest-agent/tests/active_input_receipts.rs
+++ b/crates/guest-agent/tests/active_input_receipts.rs
@@ -16,11 +16,7 @@ fn receipt_http(base_url: &str) -> Result<HttpClient, guest_agent::error::AgentE
 }
 
 fn payload(text: &str) -> Result<Vec<u8>, serde_json::Error> {
-    serde_json::to_vec(&json!({
-        "type": "active-input",
-        "deliveryId": DELIVERY_ID,
-        "text": text,
-    }))
+    guest_contracts::active_input::encode_active_input(DELIVERY_ID, text)
 }
 
 #[tokio::test]
@@ -110,11 +106,10 @@ async fn accepted_input_is_deduplicated_reported_and_compacted()
     );
     assert!(matches!(
         controller.handle_control_payload(
-            &serde_json::to_vec(&json!({
-                "type": "active-input",
-                "deliveryId": "8736a7bd-8ddc-46b4-a159-af71d09f65e4",
-                "text": "new after close",
-            }))?
+            &guest_contracts::active_input::encode_active_input(
+                "8736a7bd-8ddc-46b4-a159-af71d09f65e4",
+                "new after close",
+            )?
         ),
         ActiveInputControlOutcome::Rejected { diagnostic }
             if diagnostic == "active input is closed"

--- a/crates/guest-agent/tests/claude_active_input_receipt.rs
+++ b/crates/guest-agent/tests/claude_active_input_receipt.rs
@@ -51,11 +51,8 @@ async fn claude_receipts_delivery_only_after_follow_up_reaches_stdin()
         receipt_http,
     )?;
     let controller = active_input.controller();
-    let payload = serde_json::to_vec(&json!({
-        "type": "active-input",
-        "deliveryId": DELIVERY_ID,
-        "text": "follow-up prompt",
-    }))?;
+    let payload =
+        guest_contracts::active_input::encode_active_input(DELIVERY_ID, "follow-up prompt")?;
     assert_eq!(
         controller.handle_control_payload(&payload),
         ActiveInputControlOutcome::Accepted

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
@@ -58,11 +58,8 @@ async fn codex_app_server_backend_steers_active_input_into_active_turn()
         HttpClient::with_api_config(server.base_url(), "test-token", "", RUN_ID, Duration::ZERO)?,
     )?;
     let controller = active_input.controller();
-    let payload = serde_json::to_vec(&json!({
-        "type": "active-input",
-        "deliveryId": DELIVERY_ID,
-        "text": "follow-up prompt",
-    }))?;
+    let payload =
+        guest_contracts::active_input::encode_active_input(DELIVERY_ID, "follow-up prompt")?;
     assert_eq!(
         controller.handle_control_payload(&payload),
         ActiveInputControlOutcome::Accepted

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_cancellation.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_cancellation.rs
@@ -64,11 +64,12 @@ async fn cancellation_preserves_a_steer_response_already_in_flight()
     )?;
     let active_input_controller = active_input.controller();
     assert_eq!(
-        active_input_controller.handle_control_payload(&serde_json::to_vec(&json!({
-            "type": "active-input",
-            "deliveryId": DELIVERY_ID,
-            "text": "settle this steer before stopping",
-        }))?),
+        active_input_controller.handle_control_payload(
+            &guest_contracts::active_input::encode_active_input(
+                DELIVERY_ID,
+                "settle this steer before stopping",
+            )?,
+        ),
         ActiveInputControlOutcome::Accepted
     );
 
@@ -105,11 +106,12 @@ async fn cancellation_preserves_a_steer_response_already_in_flight()
         () = std::future::ready(()) => {}
     }
     assert_eq!(
-        active_input_controller.handle_control_payload(&serde_json::to_vec(&json!({
-            "type": "active-input",
-            "deliveryId": LATE_DELIVERY_ID,
-            "text": "do not admit this after cancellation",
-        }))?),
+        active_input_controller.handle_control_payload(
+            &guest_contracts::active_input::encode_active_input(
+                LATE_DELIVERY_ID,
+                "do not admit this after cancellation",
+            )?,
+        ),
         ActiveInputControlOutcome::Rejected {
             diagnostic: "active input is closed",
         }

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
@@ -54,11 +54,10 @@ async fn codex_app_server_backend_fails_visible_when_no_active_turn()
         &journal_path,
         HttpClient::with_api_config(server.base_url(), "test-token", "", RUN_ID, Duration::ZERO)?,
     )?;
-    let payload = serde_json::to_vec(&json!({
-        "type": "active-input",
-        "deliveryId": DELIVERY_ID,
-        "text": "no-active-turn follow-up prompt",
-    }))?;
+    let payload = guest_contracts::active_input::encode_active_input(
+        DELIVERY_ID,
+        "no-active-turn follow-up prompt",
+    )?;
     assert_eq!(
         active_input.controller().handle_control_payload(&payload),
         ActiveInputControlOutcome::Accepted

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod process_session;
 mod system_log;
 
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
-use serde_json::{Value, json};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::future::Future;
@@ -978,11 +978,7 @@ pub unsafe fn setup_codex_app_server_env(
 }
 
 pub fn active_input_payload(text: &str) -> Result<Vec<u8>, serde_json::Error> {
-    serde_json::to_vec(&json!({
-        "type": "active-input",
-        "deliveryId": "223f8797-a456-4eea-98f7-f7ab88c43c00",
-        "text": text,
-    }))
+    guest_contracts::active_input::encode_active_input("223f8797-a456-4eea-98f7-f7ab88c43c00", text)
 }
 
 pub fn active_input_runtime(

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -118,11 +118,9 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
     let active_input_controller = active_input.controller();
     let mut active_input_writer = active_input.into_writer();
     assert_eq!(
-        active_input_controller.handle_control_payload(&serde_json::to_vec(&json!({
-            "type": "active-input",
-            "deliveryId": delivery_id,
-            "text": "local follow-up",
-        }))?),
+        active_input_controller.handle_control_payload(
+            &guest_contracts::active_input::encode_active_input(delivery_id, "local follow-up")?,
+        ),
         ActiveInputControlOutcome::Accepted,
     );
     let active_input_frame = active_input_writer

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -187,10 +187,14 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         .take_stream_receiver()
         .ok_or("supervised exec should expose stdout stream")?;
 
+    let pre_ready_payload = guest_contracts::active_input::encode_active_input(
+        "1e208848-53bc-440a-85d8-adcd048e167c",
+        "before-ready",
+    )?;
     let pre_ready_ack = handle
         .control(
             PRE_READY_CONTROL_MESSAGE_ID,
-            br#"{"type":"active-input","deliveryId":"1e208848-53bc-440a-85d8-adcd048e167c","text":"before-ready"}"#,
+            &pre_ready_payload,
             Duration::from_secs(10),
         )
         .await?;
@@ -203,10 +207,14 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     )
     .await?;
 
+    let ready_payload = guest_contracts::active_input::encode_active_input(
+        "e6c121e3-9a6f-4835-87c0-a31b042f3008",
+        "after-ready",
+    )?;
     let ack = handle
         .control(
             READY_CONTROL_MESSAGE_ID,
-            br#"{"type":"active-input","deliveryId":"e6c121e3-9a6f-4835-87c0-a31b042f3008","text":"after-ready"}"#,
+            &ready_payload,
             Duration::from_secs(10),
         )
         .await?;

--- a/crates/guest-contracts/Cargo.toml
+++ b/crates/guest-contracts/Cargo.toml
@@ -11,6 +11,7 @@ serde_json.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
+process-control-ipc.workspace = true
 tempfile.workspace = true
 
 [lints]

--- a/crates/guest-contracts/src/active_input.rs
+++ b/crates/guest-contracts/src/active_input.rs
@@ -1,0 +1,142 @@
+//! Runner-to-guest active-input process-control payload contract.
+//!
+//! Runner encodes borrowed delivery IDs and text through this module before
+//! process-control transport. Guest-agent decodes the bytes into owned,
+//! validated values before applying run-scoped queue and receipt policy.
+
+use std::fmt;
+use std::io::{self, Write};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const ACTIVE_INPUT_TYPE: &str = "active-input";
+
+#[derive(Serialize)]
+struct ActiveInputEncodeWire<'a> {
+    #[serde(rename = "type")]
+    payload_type: &'static str,
+    #[serde(rename = "deliveryId")]
+    delivery_id: &'a str,
+    text: &'a str,
+}
+
+impl<'a> ActiveInputEncodeWire<'a> {
+    fn new(delivery_id: &'a str, text: &'a str) -> Self {
+        Self {
+            payload_type: ACTIVE_INPUT_TYPE,
+            delivery_id,
+            text,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ActiveInputDecodeWire {
+    #[serde(rename = "type")]
+    payload_type: String,
+    #[serde(rename = "deliveryId")]
+    delivery_id: String,
+    text: String,
+}
+
+/// Owned active-input fields after shared wire validation.
+#[derive(Debug, PartialEq, Eq)]
+pub struct DecodedActiveInput {
+    delivery_id: String,
+    text: String,
+}
+
+impl DecodedActiveInput {
+    /// Consume the decoded payload and return its delivery ID and text.
+    pub fn into_parts(self) -> (String, String) {
+        (self.delivery_id, self.text)
+    }
+}
+
+/// Classification of an invalid active-input control payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActiveInputDecodeError {
+    /// The bytes are not JSON with all required string fields.
+    InvalidPayload,
+    /// The payload discriminant is not `active-input`.
+    UnsupportedType,
+    /// The follow-up text is empty.
+    EmptyText,
+    /// The delivery ID is not a UUID.
+    InvalidDeliveryId,
+    /// The delivery ID is a UUID but not in lowercase hyphenated form.
+    NonCanonicalDeliveryId,
+}
+
+impl fmt::Display for ActiveInputDecodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidPayload => "active-input payload is invalid",
+            Self::UnsupportedType => "active-input payload type is unsupported",
+            Self::EmptyText => "active-input text is empty",
+            Self::InvalidDeliveryId => "active-input delivery ID is invalid",
+            Self::NonCanonicalDeliveryId => "active-input delivery ID is not canonical",
+        })
+    }
+}
+
+impl std::error::Error for ActiveInputDecodeError {}
+
+/// Encode an active-input payload from borrowed producer fields.
+///
+/// The producer remains responsible for supplying valid field values. Use
+/// [`decode_active_input`] at the consumer trust boundary to validate them.
+pub fn encode_active_input(delivery_id: &str, text: &str) -> Result<Vec<u8>, serde_json::Error> {
+    serde_json::to_vec(&ActiveInputEncodeWire::new(delivery_id, text))
+}
+
+#[derive(Default)]
+struct CountingWriter {
+    len: usize,
+}
+
+impl Write for CountingWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.len = self
+            .len
+            .checked_add(buffer.len())
+            .ok_or_else(|| io::Error::other("serialized active-input payload length overflow"))?;
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Calculate the exact encoded byte length without allocating the payload.
+pub fn encoded_active_input_len(delivery_id: &str, text: &str) -> Result<usize, serde_json::Error> {
+    let mut counter = CountingWriter::default();
+    serde_json::to_writer(&mut counter, &ActiveInputEncodeWire::new(delivery_id, text))?;
+    Ok(counter.len)
+}
+
+/// Decode and validate one active-input process-control payload.
+///
+/// Unknown JSON fields are accepted so a newer producer can add optional
+/// metadata without breaking an older guest consumer.
+pub fn decode_active_input(bytes: &[u8]) -> Result<DecodedActiveInput, ActiveInputDecodeError> {
+    let wire = serde_json::from_slice::<ActiveInputDecodeWire>(bytes)
+        .map_err(|_| ActiveInputDecodeError::InvalidPayload)?;
+    if wire.payload_type != ACTIVE_INPUT_TYPE {
+        return Err(ActiveInputDecodeError::UnsupportedType);
+    }
+    if wire.text.is_empty() {
+        return Err(ActiveInputDecodeError::EmptyText);
+    }
+    let parsed = Uuid::parse_str(&wire.delivery_id)
+        .map_err(|_| ActiveInputDecodeError::InvalidDeliveryId)?;
+    if parsed.hyphenated().to_string() != wire.delivery_id {
+        return Err(ActiveInputDecodeError::NonCanonicalDeliveryId);
+    }
+    Ok(DecodedActiveInput {
+        delivery_id: wire.delivery_id,
+        text: wire.text,
+    })
+}

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -5,6 +5,7 @@
 //! Keep guest-only runtime helpers in `guest-common`. This crate is for names,
 //! values, and filesystem layout helpers both sides must keep in lockstep.
 
+pub mod active_input;
 pub mod active_input_receipts;
 pub mod cli_agent_session_id;
 pub mod codex_thread_id;

--- a/crates/guest-contracts/tests/active_input.rs
+++ b/crates/guest-contracts/tests/active_input.rs
@@ -1,0 +1,104 @@
+use guest_contracts::active_input::{
+    ActiveInputDecodeError, decode_active_input, encode_active_input, encoded_active_input_len,
+};
+use process_control_ipc::MAX_CONTROL_PAYLOAD_BYTES;
+
+const DELIVERY_ID: &str = "b1e2ad6d-930a-4d51-aa40-7952d54f978b";
+
+#[test]
+fn producer_bytes_round_trip_through_consumer() {
+    for text in [
+        "plain ascii",
+        "quotes \" backslash \\ newline \n tab \t carriage \r",
+        "unicode café 你好 🚀",
+    ] {
+        let bytes = encode_active_input(DELIVERY_ID, text).unwrap();
+        assert_eq!(
+            encoded_active_input_len(DELIVERY_ID, text).unwrap(),
+            bytes.len()
+        );
+        assert_eq!(
+            decode_active_input(&bytes).unwrap().into_parts(),
+            (DELIVERY_ID.to_owned(), text.to_owned())
+        );
+    }
+
+    assert_eq!(
+        encode_active_input(DELIVERY_ID, "follow-up prompt").unwrap(),
+        br#"{"type":"active-input","deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b","text":"follow-up prompt"}"#
+    );
+}
+
+#[test]
+fn consumer_rejects_invalid_shapes() {
+    for bytes in [
+        br#"{"type":"active-input""#.as_slice(),
+        br#"{}"#.as_slice(),
+        br#"{"deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b","text":"hello"}"#.as_slice(),
+        br#"{"type":"active-input","text":"hello"}"#.as_slice(),
+        br#"{"type":"active-input","deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b"}"#.as_slice(),
+        br#"{"type":null,"deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b","text":"hello"}"#.as_slice(),
+        br#"{"type":"active-input","deliveryId":null,"text":"hello"}"#.as_slice(),
+        br#"{"type":"active-input","deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b","text":null}"#.as_slice(),
+        br#"{"type":1,"deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b","text":"hello"}"#.as_slice(),
+        br#"{"type":"active-input","deliveryId":1,"text":"hello"}"#.as_slice(),
+        br#"{"type":"active-input","deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b","text":1}"#.as_slice(),
+    ] {
+        assert_eq!(
+            decode_active_input(bytes),
+            Err(ActiveInputDecodeError::InvalidPayload)
+        );
+    }
+}
+
+#[test]
+fn consumer_rejects_invalid_field_values() {
+    for (bytes, expected) in [
+        (
+            br#"{"type":"other","deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b","text":"hello"}"#.as_slice(),
+            ActiveInputDecodeError::UnsupportedType,
+        ),
+        (
+            br#"{"type":"active-input","deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b","text":""}"#.as_slice(),
+            ActiveInputDecodeError::EmptyText,
+        ),
+        (
+            br#"{"type":"active-input","deliveryId":"invalid","text":"hello"}"#.as_slice(),
+            ActiveInputDecodeError::InvalidDeliveryId,
+        ),
+        (
+            br#"{"type":"active-input","deliveryId":"B1E2AD6D-930A-4D51-AA40-7952D54F978B","text":"hello"}"#.as_slice(),
+            ActiveInputDecodeError::NonCanonicalDeliveryId,
+        ),
+    ] {
+        assert_eq!(decode_active_input(bytes), Err(expected));
+    }
+}
+
+#[test]
+fn consumer_accepts_unknown_fields() {
+    let decoded = decode_active_input(
+        br#"{"type":"active-input","deliveryId":"b1e2ad6d-930a-4d51-aa40-7952d54f978b","text":"hello","futureMetadata":{"version":2}}"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        decoded.into_parts(),
+        (DELIVERY_ID.to_owned(), "hello".to_owned())
+    );
+}
+
+#[test]
+fn encoded_payloads_cover_the_transport_size_boundary() {
+    let empty_len = encoded_active_input_len(DELIVERY_ID, "").unwrap();
+    let exact_text = "x".repeat(MAX_CONTROL_PAYLOAD_BYTES - empty_len);
+    let exact = encode_active_input(DELIVERY_ID, &exact_text).unwrap();
+    assert_eq!(exact.len(), MAX_CONTROL_PAYLOAD_BYTES);
+    assert_eq!(
+        decode_active_input(&exact).unwrap().into_parts(),
+        (DELIVERY_ID.to_owned(), exact_text.clone())
+    );
+
+    let over = encode_active_input(DELIVERY_ID, &format!("{exact_text}x")).unwrap();
+    assert_eq!(over.len(), MAX_CONTROL_PAYLOAD_BYTES + 1);
+}

--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -1,6 +1,6 @@
-use std::io::{self, Write};
 use std::time::Duration;
 
+use guest_contracts::active_input::encoded_active_input_len;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
@@ -24,66 +24,9 @@ const _: () = assert!(
     ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES == process_control_ipc::MAX_CONTROL_PAYLOAD_BYTES
 );
 
-#[derive(serde::Serialize)]
-pub(crate) struct ActiveInputPayload<'a> {
-    #[serde(rename = "type")]
-    payload_type: &'static str,
-    #[serde(rename = "deliveryId")]
-    delivery_id: &'a str,
-    text: &'a str,
-}
-
-impl<'a> ActiveInputPayload<'a> {
-    pub(crate) fn new(delivery_id: &'a str, text: &'a str) -> Self {
-        Self {
-            payload_type: "active-input",
-            delivery_id,
-            text,
-        }
-    }
-
-    pub(crate) fn to_vec(&self) -> Result<Vec<u8>, serde_json::Error> {
-        serde_json::to_vec(self)
-    }
-}
-
-#[derive(Default)]
-struct CountingWriter {
-    len: usize,
-}
-
-impl CountingWriter {
-    fn len(&self) -> usize {
-        self.len
-    }
-}
-
-impl Write for CountingWriter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.len = self
-            .len
-            .checked_add(buf.len())
-            .ok_or_else(|| io::Error::other("serialized active-input payload length overflow"))?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-pub(crate) fn active_input_payload_len(
-    delivery_id: &str,
-    text: &str,
-) -> Result<usize, serde_json::Error> {
-    let mut counter = CountingWriter::default();
-    serde_json::to_writer(&mut counter, &ActiveInputPayload::new(delivery_id, text))?;
-    Ok(counter.len())
-}
-
 pub(crate) fn identified_active_input_payload_len(text: &str) -> Result<usize, serde_json::Error> {
     let delivery_id = Uuid::nil().hyphenated().to_string();
-    active_input_payload_len(&delivery_id, text)
+    encoded_active_input_len(&delivery_id, text)
 }
 
 pub(crate) fn local_active_input_delivery_id(run_id: RunId, sequence: u64) -> String {
@@ -252,28 +195,4 @@ async fn read_api_active_input(source: &ApiActiveInputSource) -> RunnerResult<Ac
         .reserve_active_inputs(source.run_id, &source.sandbox_token)
         .await?;
     Ok(ActiveInputBatch::Api(response))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn active_input_payload_len_matches_serialized_payload_len() {
-        let texts = [
-            "plain ascii".to_string(),
-            "quotes \" backslash \\ newline \n tab \t carriage \r".to_string(),
-            "unicode café 你好 🚀".to_string(),
-            "x".repeat(ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES - 128),
-        ];
-        let delivery_id = Uuid::new_v4().hyphenated().to_string();
-
-        for text in texts {
-            let counted = active_input_payload_len(&delivery_id, &text).unwrap();
-            let serialized = ActiveInputPayload::new(&delivery_id, &text)
-                .to_vec()
-                .unwrap();
-            assert_eq!(counted, serialized.len(), "text len={}", text.len());
-        }
-    }
 }

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -6,6 +6,7 @@ use api_contracts::generated::types::runners::runs::active_inputs::{
     receipt::Response as ActiveInputReceiptResponse,
     reserve::{Response as ActiveInputReserveResponse, ResponseRejectedReason},
 };
+use guest_contracts::active_input::encode_active_input;
 use sandbox::{
     GuestProcessControlHandle, ProcessControlFailureKind, ProcessControlGuestStatus,
     ProcessControlOutcome, ProcessControlWriteState, Sandbox,
@@ -14,8 +15,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use crate::active_input::{
-    ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, ActiveInputBatch, ActiveInputPayload,
-    ActiveInputSource, ApiActiveInputRecovery, local_active_input_delivery_id,
+    ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, ActiveInputBatch, ActiveInputSource,
+    ApiActiveInputRecovery, local_active_input_delivery_id,
 };
 use crate::ids::RunId;
 
@@ -258,7 +259,7 @@ async fn forward_once(
     control: &GuestProcessControlHandle,
     warn_retryable_failure: bool,
 ) -> ForwardDisposition {
-    let bytes = match ActiveInputPayload::new(delivery_id, text).to_vec() {
+    let bytes = match encode_active_input(delivery_id, text) {
         Ok(bytes) if bytes.len() <= ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES => bytes,
         Ok(_) => {
             warn!(


### PR DESCRIPTION
## Summary

- centralize the runner-to-guest active-input JSON contract in `guest-contracts`
- reuse the shared codec in runner and guest-agent production paths and valid test fixtures
- preserve guest validation diagnostics and forward-compatible unknown-field handling
- cover exact serialization, decoding failures, UUID canonicalization, and the 1 MiB transport boundary

## Scope

This refactor does not change queueing, retry, receipt, or process-control behavior. Transport size enforcement remains owned by runner/process-control; the shared contract only provides exact encoded length and payload encoding/decoding.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `cd crates && cargo test -p guest-contracts`
- `cd crates && cargo test -p runner`
- `cd crates && cargo test -p guest-agent`

Closes #26893
