### PR TITLE
refactor(rust): preserve exec terminal-proof outcomes

### DIFF
--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -43,6 +43,50 @@ pub(in crate::exec_operation) struct ExecWaitCore {
         Option<oneshot::Receiver<io::Result<ExecOperationResult>>>,
 }
 
+#[must_use = "exec operation wait outcomes contain terminal-proof state that must be handled"]
+pub(crate) enum ExecOperationWaitOutcome<T> {
+    Terminal(io::Result<T>),
+    Unproven(io::Error),
+}
+
+impl<T> ExecOperationWaitOutcome<T> {
+    pub(crate) fn terminal(result: io::Result<T>) -> Self {
+        Self::Terminal(result)
+    }
+
+    pub(crate) fn unproven(error: io::Error) -> Self {
+        Self::Unproven(error)
+    }
+
+    pub(crate) fn terminal_observed(&self) -> bool {
+        matches!(self, Self::Terminal(_))
+    }
+
+    pub(crate) fn map<U>(self, map: impl FnOnce(T) -> U) -> ExecOperationWaitOutcome<U> {
+        match self {
+            Self::Terminal(result) => ExecOperationWaitOutcome::Terminal(result.map(map)),
+            Self::Unproven(error) => ExecOperationWaitOutcome::Unproven(error),
+        }
+    }
+
+    pub(crate) fn and_then<U>(
+        self,
+        map: impl FnOnce(T) -> io::Result<U>,
+    ) -> ExecOperationWaitOutcome<U> {
+        match self {
+            Self::Terminal(result) => ExecOperationWaitOutcome::Terminal(result.and_then(map)),
+            Self::Unproven(error) => ExecOperationWaitOutcome::Unproven(error),
+        }
+    }
+
+    pub(crate) fn into_result(self) -> io::Result<T> {
+        match self {
+            Self::Terminal(result) => result,
+            Self::Unproven(error) => Err(error),
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(in crate::exec_operation) enum ExecWaitLifecycle {
     OneShot,
@@ -55,7 +99,7 @@ pub(in crate::exec_operation) struct ExecCancelWaitResult {
 }
 
 enum ExecCancelWriteOutcome {
-    Terminal(ExecOperationResult),
+    Terminal(io::Result<ExecOperationResult>),
     CancelSent { seq: u32, remaining: Duration },
 }
 
@@ -213,10 +257,16 @@ impl ExecWaitCore {
     fn complete_taken_result(
         &mut self,
         result: Result<io::Result<ExecOperationResult>, oneshot::error::RecvError>,
-    ) -> io::Result<ExecOperationResult> {
+    ) -> ExecOperationWaitOutcome<ExecOperationResult> {
         self.seq = None;
         self.result_rx = None;
-        result.map_err(|_| io::Error::new(io::ErrorKind::ConnectionReset, "connection closed"))?
+        match result {
+            Ok(result) => ExecOperationWaitOutcome::terminal(result),
+            Err(_) => ExecOperationWaitOutcome::unproven(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "connection closed",
+            )),
+        }
     }
 
     fn abandon_timed_out_operation(
@@ -277,7 +327,7 @@ impl ExecWaitCore {
 
     pub(in crate::exec_operation) fn try_take_ready_result(
         &mut self,
-    ) -> io::Result<Option<ExecOperationResult>> {
+    ) -> io::Result<Option<io::Result<ExecOperationResult>>> {
         let Some(rx) = self.result_rx.as_mut() else {
             return Ok(None);
         };
@@ -286,7 +336,7 @@ impl ExecWaitCore {
             Ok(result) => {
                 self.seq = None;
                 self.result_rx = None;
-                result.map(Some)
+                Ok(Some(result))
             }
             Err(oneshot::error::TryRecvError::Empty) => Ok(None),
             Err(oneshot::error::TryRecvError::Closed) => {
@@ -305,28 +355,36 @@ impl ExecWaitCore {
         timeout: impl Future<Output = ()>,
         poison_on_timeout: bool,
         lifecycle: ExecWaitLifecycle,
-    ) -> io::Result<ExecOperationResult> {
+    ) -> ExecOperationWaitOutcome<ExecOperationResult> {
         tokio::pin!(timeout);
-        let seq = self.active_seq_or_closed(lifecycle.operation_closed_message())?;
-        let rx = self.result_rx.as_mut().ok_or_else(|| {
-            io::Error::new(
+        let seq = match self.active_seq_or_closed(lifecycle.operation_closed_message()) {
+            Ok(seq) => seq,
+            Err(error) => return ExecOperationWaitOutcome::unproven(error),
+        };
+        let Some(rx) = self.result_rx.as_mut() else {
+            return ExecOperationWaitOutcome::unproven(io::Error::new(
                 io::ErrorKind::ConnectionReset,
                 lifecycle.operation_closed_message(),
-            )
-        })?;
+            ));
+        };
 
         tokio::select! {
             biased;
             result = rx => {
                 self.seq = None;
                 self.result_rx = None;
-                result.map_err(|_| io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "connection closed",
-                ))?
+                match result {
+                    Ok(result) => ExecOperationWaitOutcome::terminal(result),
+                    Err(_) => ExecOperationWaitOutcome::unproven(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "connection closed",
+                    )),
+                }
             }
             _ = &mut timeout => {
-                Err(self.abandon_timed_out_operation(seq, poison_on_timeout, lifecycle))
+                ExecOperationWaitOutcome::unproven(
+                    self.abandon_timed_out_operation(seq, poison_on_timeout, lifecycle),
+                )
             }
         }
     }
@@ -336,7 +394,7 @@ impl ExecWaitCore {
         timeout: Duration,
         poison_on_timeout: bool,
         lifecycle: ExecWaitLifecycle,
-    ) -> io::Result<ExecOperationResult> {
+    ) -> ExecOperationWaitOutcome<ExecOperationResult> {
         self.wait_with_timeout_future(tokio::time::sleep(timeout), poison_on_timeout, lifecycle)
             .await
     }
@@ -346,7 +404,7 @@ impl ExecWaitCore {
         deadline: Instant,
         poison_on_timeout: bool,
         lifecycle: ExecWaitLifecycle,
-    ) -> io::Result<ExecOperationResult> {
+    ) -> ExecOperationWaitOutcome<ExecOperationResult> {
         self.wait_with_timeout_future(
             tokio::time::sleep_until(deadline),
             poison_on_timeout,
@@ -410,9 +468,12 @@ impl ExecWaitCore {
                     })
             }
             result = &mut result_rx => {
-                return self
-                    .complete_taken_result(result)
-                    .map(ExecCancelWriteOutcome::Terminal);
+                return match self.complete_taken_result(result) {
+                    ExecOperationWaitOutcome::Terminal(result) => {
+                        Ok(ExecCancelWriteOutcome::Terminal(result))
+                    }
+                    ExecOperationWaitOutcome::Unproven(error) => Err(error),
+                };
             }
             _ = time::sleep_until(deadline) => {
                 return Err(self.abandon_timed_out_operation(seq, false, lifecycle));
@@ -425,8 +486,12 @@ impl ExecWaitCore {
         match write_outcome? {
             ExecCancelFrameWriteOutcome::AlreadyTerminal => {
                 let result = result_rx.await;
-                self.complete_taken_result(result)
-                    .map(ExecCancelWriteOutcome::Terminal)
+                match self.complete_taken_result(result) {
+                    ExecOperationWaitOutcome::Terminal(result) => {
+                        Ok(ExecCancelWriteOutcome::Terminal(result))
+                    }
+                    ExecOperationWaitOutcome::Unproven(error) => Err(error),
+                }
             }
             ExecCancelFrameWriteOutcome::Sent => {
                 self.result_rx = Some(result_rx);
@@ -444,12 +509,13 @@ impl ExecWaitCore {
         seq: u32,
         remaining: Duration,
         lifecycle: ExecWaitLifecycle,
-    ) -> io::Result<ExecCancelWaitResult> {
-        let result = self.wait_with_timeout(remaining, true, lifecycle).await?;
-        Ok(ExecCancelWaitResult {
-            result,
-            cancel_seq: Some(seq),
-        })
+    ) -> ExecOperationWaitOutcome<ExecCancelWaitResult> {
+        self.wait_with_timeout(remaining, true, lifecycle)
+            .await
+            .map(|result| ExecCancelWaitResult {
+                result,
+                cancel_seq: Some(seq),
+            })
     }
 }
 
@@ -465,16 +531,23 @@ impl ExecOperationHandle {
     /// not cancel the guest-side exec operation. If the request may have
     /// reached the guest, normal operations can become unavailable on this
     /// connection even though the connection itself may still be open.
-    pub async fn wait(mut self, timeout: Duration) -> io::Result<ExecOperationResult> {
+    pub async fn wait(self, timeout: Duration) -> io::Result<ExecOperationResult> {
+        self.wait_for_outcome(timeout).await.into_result()
+    }
+
+    pub(crate) async fn wait_for_outcome(
+        mut self,
+        timeout: Duration,
+    ) -> ExecOperationWaitOutcome<ExecOperationResult> {
         self.wait_core
             .wait_with_timeout(timeout, false, ExecWaitLifecycle::OneShot)
             .await
     }
 
-    pub(in crate::exec_operation) async fn wait_until(
+    pub(in crate::exec_operation) async fn wait_until_outcome(
         mut self,
         deadline: Instant,
-    ) -> io::Result<ExecOperationResult> {
+    ) -> ExecOperationWaitOutcome<ExecOperationResult> {
         self.wait_core
             .wait_with_deadline(deadline, false, ExecWaitLifecycle::OneShot)
             .await
@@ -495,18 +568,21 @@ impl ExecOperationHandle {
         let cancel_label_log = self.wait_core.diagnostic().label_log.clone();
         let registered_at = self.wait_core.diagnostic().registered_at;
         self.cancel_and_wait_for_terminal_status(timeout)
-            .await?
-            .into_expected_cancel_result(
-                ExecWaitLifecycle::OneShot,
-                &cancel_label_log,
-                registered_at,
-            )
+            .await
+            .and_then(|wait_result| {
+                wait_result.into_expected_cancel_result(
+                    ExecWaitLifecycle::OneShot,
+                    &cancel_label_log,
+                    registered_at,
+                )
+            })
+            .into_result()
     }
 
     pub(crate) async fn cancel_and_wait_for_terminal(
         self,
         timeout: Duration,
-    ) -> io::Result<ExecOperationResult> {
+    ) -> ExecOperationWaitOutcome<ExecOperationResult> {
         self.cancel_and_wait_for_terminal_status(timeout)
             .await
             .map(|wait_result| wait_result.result)
@@ -515,19 +591,22 @@ impl ExecOperationHandle {
     pub(in crate::exec_operation) async fn cancel_and_wait_for_terminal_status(
         mut self,
         timeout: Duration,
-    ) -> io::Result<ExecCancelWaitResult> {
+    ) -> ExecOperationWaitOutcome<ExecCancelWaitResult> {
         let (seq, remaining) = match self
             .wait_core
             .send_cancel_before_terminal_with_deadline(timeout, ExecWaitLifecycle::OneShot)
-            .await?
+            .await
         {
-            ExecCancelWriteOutcome::Terminal(result) => {
-                return Ok(ExecCancelWaitResult {
-                    result,
-                    cancel_seq: None,
+            Ok(ExecCancelWriteOutcome::Terminal(result)) => {
+                return ExecOperationWaitOutcome::terminal(result).map(|result| {
+                    ExecCancelWaitResult {
+                        result,
+                        cancel_seq: None,
+                    }
                 });
             }
-            ExecCancelWriteOutcome::CancelSent { seq, remaining } => (seq, remaining),
+            Ok(ExecCancelWriteOutcome::CancelSent { seq, remaining }) => (seq, remaining),
+            Err(error) => return ExecOperationWaitOutcome::unproven(error),
         };
 
         self.wait_core
@@ -677,6 +756,7 @@ impl SupervisedExecHandle {
         self.wait_core
             .wait_with_timeout(timeout, false, ExecWaitLifecycle::Supervised)
             .await
+            .into_result()
     }
 
     /// Send `MSG_EXEC_CANCEL` and wait for the terminal exec result.
@@ -694,30 +774,36 @@ impl SupervisedExecHandle {
         let cancel_label_log = self.wait_core.diagnostic().label_log.clone();
         let registered_at = self.wait_core.diagnostic().registered_at;
         self.cancel_and_wait_for_terminal_status(timeout)
-            .await?
-            .into_expected_cancel_result(
-                ExecWaitLifecycle::Supervised,
-                &cancel_label_log,
-                registered_at,
-            )
+            .await
+            .and_then(|wait_result| {
+                wait_result.into_expected_cancel_result(
+                    ExecWaitLifecycle::Supervised,
+                    &cancel_label_log,
+                    registered_at,
+                )
+            })
+            .into_result()
     }
 
     pub(in crate::exec_operation) async fn cancel_and_wait_for_terminal_status(
         mut self,
         timeout: Duration,
-    ) -> io::Result<ExecCancelWaitResult> {
+    ) -> ExecOperationWaitOutcome<ExecCancelWaitResult> {
         let (seq, remaining) = match self
             .wait_core
             .send_cancel_before_terminal_with_deadline(timeout, ExecWaitLifecycle::Supervised)
-            .await?
+            .await
         {
-            ExecCancelWriteOutcome::Terminal(result) => {
-                return Ok(ExecCancelWaitResult {
-                    result,
-                    cancel_seq: None,
+            Ok(ExecCancelWriteOutcome::Terminal(result)) => {
+                return ExecOperationWaitOutcome::terminal(result).map(|result| {
+                    ExecCancelWaitResult {
+                        result,
+                        cancel_seq: None,
+                    }
                 });
             }
-            ExecCancelWriteOutcome::CancelSent { seq, remaining } => (seq, remaining),
+            Ok(ExecCancelWriteOutcome::CancelSent { seq, remaining }) => (seq, remaining),
+            Err(error) => return ExecOperationWaitOutcome::unproven(error),
         };
 
         self.clear_unclaimed_stream_sender();

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -1,5 +1,5 @@
+use std::io;
 use std::time::Duration;
-use std::{fmt, io};
 
 mod diagnostics;
 mod dispatch;
@@ -20,7 +20,7 @@ pub use types::{
 
 pub(crate) use diagnostics::log_operations_closed;
 pub(crate) use dispatch::dispatch_incoming_frame;
-pub(crate) use handle::ExecOperationCancelOnDropGuard;
+pub(crate) use handle::{ExecOperationCancelOnDropGuard, ExecOperationWaitOutcome};
 pub(crate) use start::{
     append_diagnostic, exec_operation_capture_on_shared,
     exec_operation_capture_on_shared_with_write_admission,
@@ -50,25 +50,8 @@ const EXEC_OPERATION_FRAME_WRITE_NOT_STARTED: u8 = 0;
 const EXEC_OPERATION_FRAME_WRITE_STARTED: u8 = 1;
 const EXEC_OPERATION_FRAME_WRITE_COMPLETED: u8 = 2;
 
-#[derive(Debug)]
-struct ExecOperationGuestError(String);
-
-impl fmt::Display for ExecOperationGuestError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl std::error::Error for ExecOperationGuestError {}
-
 fn exec_operation_guest_error(message: String) -> io::Error {
-    io::Error::other(ExecOperationGuestError(message))
-}
-
-pub(crate) fn error_is_exec_operation_guest_error(error: &io::Error) -> bool {
-    error
-        .get_ref()
-        .is_some_and(|error| error.is::<ExecOperationGuestError>())
+    io::Error::other(message)
 }
 
 fn exec_operation_protocol_error(error: impl ToString) -> io::Error {

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -13,8 +13,8 @@ use crate::{CompositeNormalOperation, FrameWriteObserver, Shared};
 
 use super::frame::{write_exec_start_frame, write_frame};
 use super::handle::{
-    ExecControlHandle, ExecOperationCancelOnDropGuard, ExecOperationHandle, ExecWaitCore,
-    SupervisedExecHandle,
+    ExecControlHandle, ExecOperationCancelOnDropGuard, ExecOperationHandle,
+    ExecOperationWaitOutcome, ExecWaitCore, SupervisedExecHandle,
 };
 use super::state::{
     ExecOperationLifecycle, ExecOperationRegistration, ExecOperationRegistrationInput,
@@ -418,7 +418,25 @@ async fn exec_operation_capture_on_shared_with_tracking_and_admission(
     write_admission: FrameWriteObserver,
     write_observer: FrameWriteObserver,
 ) -> io::Result<ExecOperationResult> {
-    let (handle, deadline) = start_exec_operation_on_shared_with_tracking_and_admission(
+    exec_operation_capture_on_shared_with_tracking_and_admission_outcome(
+        shared,
+        request,
+        tracking,
+        write_admission,
+        write_observer,
+    )
+    .await
+    .into_result()
+}
+
+async fn exec_operation_capture_on_shared_with_tracking_and_admission_outcome(
+    shared: &Arc<Shared>,
+    request: ExecCaptureRequest<'_>,
+    tracking: ExecOperationTracking<'_>,
+    write_admission: FrameWriteObserver,
+    write_observer: FrameWriteObserver,
+) -> ExecOperationWaitOutcome<ExecOperationResult> {
+    let start_result = start_exec_operation_on_shared_with_tracking_and_admission(
         shared,
         ExecOperationRequest {
             timeout_ms: request.timeout_ms,
@@ -441,8 +459,12 @@ async fn exec_operation_capture_on_shared_with_tracking_and_admission(
         write_admission,
         write_observer,
     )
-    .await?;
-    handle.wait_until(deadline).await
+    .await;
+    let (handle, deadline) = match start_result {
+        Ok(started) => started,
+        Err(error) => return ExecOperationWaitOutcome::unproven(error),
+    };
+    handle.wait_until_outcome(deadline).await
 }
 
 pub(crate) async fn exec_operation_stream_on_shared(
@@ -537,7 +559,29 @@ async fn exec_operation_cleanup_on_shared_with_tracking(
     tracking: ExecOperationTracking<'_>,
     write_observer: FrameWriteObserver,
 ) -> io::Result<ExecOperationResult> {
-    exec_operation_capture_on_shared_with_tracking(
+    exec_operation_cleanup_on_shared_with_tracking_outcome(
+        shared,
+        command,
+        timeout_ms,
+        env,
+        sudo,
+        tracking,
+        write_observer,
+    )
+    .await
+    .into_result()
+}
+
+async fn exec_operation_cleanup_on_shared_with_tracking_outcome(
+    shared: &Arc<Shared>,
+    command: &str,
+    timeout_ms: u32,
+    env: &[(&str, &str)],
+    sudo: bool,
+    tracking: ExecOperationTracking<'_>,
+    write_observer: FrameWriteObserver,
+) -> ExecOperationWaitOutcome<ExecOperationResult> {
+    exec_operation_capture_on_shared_with_tracking_and_admission_outcome(
         shared,
         ExecCaptureRequest {
             timeout_ms,
@@ -552,6 +596,7 @@ async fn exec_operation_cleanup_on_shared_with_tracking(
             wait_timeout: Duration::from_millis(timeout_ms as u64),
         },
         tracking,
+        FrameWriteObserver::default(),
         write_observer,
     )
     .await
@@ -565,8 +610,8 @@ pub(crate) async fn exec_operation_cleanup_with_composite_on_shared_and_observer
     sudo: bool,
     normal_operation: &mut CompositeNormalOperation,
     write_observer: FrameWriteObserver,
-) -> io::Result<ExecOperationResult> {
-    exec_operation_cleanup_on_shared_with_tracking(
+) -> ExecOperationWaitOutcome<ExecOperationResult> {
+    exec_operation_cleanup_on_shared_with_tracking_outcome(
         shared,
         command,
         timeout_ms,
@@ -583,11 +628,12 @@ pub(crate) async fn exec_operation_capture_with_composite_on_shared_and_observer
     request: ExecCaptureRequest<'_>,
     normal_operation: &mut CompositeNormalOperation,
     write_observer: FrameWriteObserver,
-) -> io::Result<ExecOperationResult> {
-    exec_operation_capture_on_shared_with_tracking(
+) -> ExecOperationWaitOutcome<ExecOperationResult> {
+    exec_operation_capture_on_shared_with_tracking_and_admission_outcome(
         shared,
         request,
         ExecOperationTracking::Composite(normal_operation),
+        FrameWriteObserver::default(),
         write_observer,
     )
     .await

--- a/crates/vsock-host/src/exec_operation/tests.rs
+++ b/crates/vsock-host/src/exec_operation/tests.rs
@@ -626,7 +626,7 @@ async fn one_shot_cancel_handle_marks_terminal_result_as_host_requested_cancel()
     };
 
     let (wait_result, ()) = tokio::join!(cancel_future, peer);
-    let wait_result = wait_result.unwrap();
+    let wait_result = wait_result.into_result().unwrap();
     assert_eq!(wait_result.cancel_seq, Some(7));
     assert_eq!(wait_result.result.termination, ExecTermination::Cancelled);
 }

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -12,11 +12,12 @@ use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTermination};
 use crate::{
     CompositeNormalOperation, ExecOperationResult, ExecOutputEvent, ExecOwnedCapturedOutput,
     ExecStreamRequest, FrameWriteObserver, VsockHost, exec_operation,
+    exec_operation::ExecOperationWaitOutcome,
 };
 
 use super::{
-    MISSING_FILE_EXIT_CODE, file_operation_error_is_terminal, normalize_file_exec_stderr,
-    read_regular_file_command, validate_guest_file_path,
+    MISSING_FILE_EXIT_CODE, normalize_file_exec_stderr, read_regular_file_command,
+    validate_guest_file_path,
 };
 
 const COPY_TEMP_CREATE_ATTEMPTS: usize = 16;
@@ -74,48 +75,12 @@ enum CopyFileOutcome {
     Missing,
 }
 
-struct CopyFileToTempError {
-    error: io::Error,
-    terminal_proven: bool,
-}
-
 struct CopyFileToTempRequest<'a> {
     path: &'a str,
     stream_limit_bytes: u32,
     timeout_ms: u32,
     missing_ok: bool,
     write_observer: FrameWriteObserver,
-}
-
-impl CopyFileToTempError {
-    fn unproven(error: io::Error) -> Self {
-        Self {
-            error,
-            terminal_proven: false,
-        }
-    }
-
-    fn terminal(error: io::Error) -> Self {
-        Self {
-            error,
-            terminal_proven: true,
-        }
-    }
-
-    fn from_exec_wait(error: io::Error) -> Self {
-        if file_operation_error_is_terminal(&error) {
-            Self::terminal(error)
-        } else {
-            Self::unproven(error)
-        }
-    }
-
-    fn after_cancel(error: io::Error, cancel_result: io::Result<ExecOperationResult>) -> Self {
-        Self {
-            error,
-            terminal_proven: cancel_result.is_ok(),
-        }
-    }
 }
 
 struct HostTempFileGuard {
@@ -490,7 +455,7 @@ impl VsockHost {
             )
             .await;
         match copy_result {
-            Ok(CopyFileOutcome::Copied { bytes_copied }) => {
+            ExecOperationWaitOutcome::Terminal(Ok(CopyFileOutcome::Copied { bytes_copied })) => {
                 match tokio::fs::rename(temp_guard.path(), host_path).await {
                     Ok(()) => {
                         temp_guard.disarm();
@@ -504,17 +469,19 @@ impl VsockHost {
                     }
                 }
             }
-            Ok(CopyFileOutcome::Missing) => {
+            ExecOperationWaitOutcome::Terminal(Ok(CopyFileOutcome::Missing)) => {
                 temp_guard.remove_now().await;
                 normal_operation.complete()?;
                 Ok(CopyFileResult { bytes_copied: 0 })
             }
-            Err(err) => {
+            ExecOperationWaitOutcome::Terminal(Err(error)) => {
                 temp_guard.remove_now().await;
-                if err.terminal_proven {
-                    normal_operation.complete()?;
-                }
-                Err(err.error)
+                normal_operation.complete()?;
+                Err(error)
+            }
+            ExecOperationWaitOutcome::Unproven(error) => {
+                temp_guard.remove_now().await;
+                Err(error)
             }
         }
     }
@@ -524,7 +491,7 @@ impl VsockHost {
         request: CopyFileToTempRequest<'_>,
         mut temp_file: tokio::fs::File,
         normal_operation: &mut CompositeNormalOperation,
-    ) -> Result<CopyFileOutcome, CopyFileToTempError> {
+    ) -> ExecOperationWaitOutcome<CopyFileOutcome> {
         let CopyFileToTempRequest {
             path,
             stream_limit_bytes,
@@ -539,7 +506,7 @@ impl VsockHost {
             &[]
         };
         let wait_timeout = Duration::from_millis(timeout_ms as u64 + 5000);
-        let mut handle =
+        let start_result =
             exec_operation::exec_operation_stream_with_composite_on_shared_and_observer(
                 &self.shared,
                 ExecStreamRequest {
@@ -563,15 +530,18 @@ impl VsockHost {
                 normal_operation,
                 write_observer,
             )
-            .await
-            .map_err(CopyFileToTempError::unproven)?;
+            .await;
+        let mut handle = match start_result {
+            Ok(handle) => handle,
+            Err(error) => return ExecOperationWaitOutcome::unproven(error),
+        };
         let mut cancel_on_drop = exec_operation::ExecOperationCancelOnDropGuard::new(&handle);
-        let mut stream_rx = handle.take_stream_receiver().ok_or_else(|| {
-            CopyFileToTempError::unproven(io::Error::new(
+        let Some(mut stream_rx) = handle.take_stream_receiver() else {
+            return ExecOperationWaitOutcome::unproven(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "copy_file exec operation did not create a stream receiver",
-            ))
-        })?;
+            ));
+        };
         let mut bytes_copied = 0u64;
 
         let drain_result = tokio::time::timeout(wait_timeout, async {
@@ -596,7 +566,11 @@ impl VsockHost {
                 if let Some(cancel_on_drop) = &mut cancel_on_drop {
                     cancel_on_drop.disarm();
                 }
-                return Err(CopyFileToTempError::after_cancel(err, cancel_result));
+                return if cancel_result.terminal_observed() {
+                    ExecOperationWaitOutcome::terminal(Err(err))
+                } else {
+                    ExecOperationWaitOutcome::unproven(err)
+                };
             }
             Err(_) => {
                 let cancel_result = handle
@@ -605,28 +579,42 @@ impl VsockHost {
                 if let Some(cancel_on_drop) = &mut cancel_on_drop {
                     cancel_on_drop.disarm();
                 }
-                return Err(CopyFileToTempError::after_cancel(
-                    io::Error::new(
-                        io::ErrorKind::TimedOut,
-                        format!("copy_file stream drain timed out for {path}"),
-                    ),
-                    cancel_result,
-                ));
+                let error = io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("copy_file stream drain timed out for {path}"),
+                );
+                return if cancel_result.terminal_observed() {
+                    ExecOperationWaitOutcome::terminal(Err(error))
+                } else {
+                    ExecOperationWaitOutcome::unproven(error)
+                };
             }
         };
 
-        let result = handle
-            .wait(Duration::from_secs(5))
-            .await
-            .map_err(CopyFileToTempError::from_exec_wait)?;
-        if let Some(cancel_on_drop) = &mut cancel_on_drop {
+        let wait_outcome = handle.wait_for_outcome(Duration::from_secs(5)).await;
+        if wait_outcome.terminal_observed()
+            && let Some(cancel_on_drop) = &mut cancel_on_drop
+        {
             cancel_on_drop.disarm();
         }
-        match validate_copy_exec_result(path, result).map_err(CopyFileToTempError::terminal)? {
+        let result = match wait_outcome {
+            ExecOperationWaitOutcome::Terminal(Ok(result)) => result,
+            ExecOperationWaitOutcome::Terminal(Err(error)) => {
+                return ExecOperationWaitOutcome::terminal(Err(error));
+            }
+            ExecOperationWaitOutcome::Unproven(error) => {
+                return ExecOperationWaitOutcome::unproven(error);
+            }
+        };
+        let status = match validate_copy_exec_result(path, result) {
+            Ok(status) => status,
+            Err(error) => return ExecOperationWaitOutcome::terminal(Err(error)),
+        };
+        match status {
             CopyFileExecStatus::Present => {}
             CopyFileExecStatus::Missing => {
                 if bytes_copied != 0 {
-                    return Err(CopyFileToTempError::terminal(io::Error::new(
+                    return ExecOperationWaitOutcome::terminal(Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!(
                             "copy_file missing result for {path} streamed {bytes_copied} bytes"
@@ -634,20 +622,19 @@ impl VsockHost {
                     )));
                 }
                 if missing_ok {
-                    return Ok(CopyFileOutcome::Missing);
+                    return ExecOperationWaitOutcome::terminal(Ok(CopyFileOutcome::Missing));
                 }
-                return Err(CopyFileToTempError::terminal(io::Error::new(
+                return ExecOperationWaitOutcome::terminal(Err(io::Error::new(
                     io::ErrorKind::NotFound,
                     format!("guest file not found: {path}"),
                 )));
             }
         }
-        temp_file
-            .flush()
-            .await
-            .map_err(CopyFileToTempError::terminal)?;
+        if let Err(error) = temp_file.flush().await {
+            return ExecOperationWaitOutcome::terminal(Err(error));
+        }
 
-        Ok(CopyFileOutcome::Copied { bytes_copied })
+        ExecOperationWaitOutcome::terminal(Ok(CopyFileOutcome::Copied { bytes_copied }))
     }
 }
 

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -181,17 +181,6 @@ fn normalize_file_exec_stderr(mut stderr: Vec<u8>, stderr_truncated: bool) -> Ve
     stderr
 }
 
-fn file_operation_error_is_terminal(error: &io::Error) -> bool {
-    !matches!(
-        error.kind(),
-        io::ErrorKind::TimedOut
-            | io::ErrorKind::ConnectionReset
-            | io::ErrorKind::BrokenPipe
-            | io::ErrorKind::UnexpectedEof
-            | io::ErrorKind::InvalidData
-    )
-}
-
 #[cfg(test)]
 pub(crate) mod test_support {
     use std::io;

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -10,6 +10,7 @@ use vsock_proto::{ExecTermination, MSG_ERROR, MSG_WRITE_FILE_RESULT, MSG_WRITE_F
 use crate::{
     CompositeNormalOperation, ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutput,
     FrameWriteObserver, Shared, VsockHost, exec_operation,
+    exec_operation::ExecOperationWaitOutcome,
     normal_request_on_shared_with_write_observer_frame_builder,
     request_on_shared_with_composite_operation_and_observer_frame_builder,
 };
@@ -144,7 +145,7 @@ impl ChunkedWriteCleanupGuard {
         }
 
         let result = if let Some(shared) = self.shared.as_ref() {
-            cleanup_timeout(
+            cleanup_outcome_timeout(
                 exec_operation::exec_operation_cleanup_with_composite_on_shared_and_observer(
                     shared,
                     &self.command,
@@ -157,7 +158,8 @@ impl ChunkedWriteCleanupGuard {
                 CLEANUP_EXEC_TIMEOUT_MS,
             )
             .await
-            .and_then(|result| validate_cleanup_result(result).map_err(|err| err.error))
+            .and_then(validate_cleanup_result)
+            .into_result()
         } else {
             Ok(())
         };
@@ -165,6 +167,22 @@ impl ChunkedWriteCleanupGuard {
             self.disarm();
         }
         result
+    }
+}
+
+async fn cleanup_outcome_timeout<F>(
+    cleanup: F,
+    timeout_ms: u32,
+) -> ExecOperationWaitOutcome<ExecOperationResult>
+where
+    F: Future<Output = ExecOperationWaitOutcome<ExecOperationResult>>,
+{
+    match tokio::time::timeout(Duration::from_millis(timeout_ms as u64), cleanup).await {
+        Ok(outcome) => outcome,
+        Err(_) => ExecOperationWaitOutcome::unproven(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "cleanup command timed out",
+        )),
     }
 }
 
@@ -177,44 +195,15 @@ where
         .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "cleanup command timed out"))?
 }
 
-struct WriteHelperExecError {
-    error: io::Error,
-    terminal_proven: bool,
-}
-
-impl WriteHelperExecError {
-    fn terminal(error: io::Error) -> Self {
-        Self {
-            error,
-            terminal_proven: true,
-        }
-    }
-
-    fn unproven(error: io::Error) -> Self {
-        Self {
-            error,
-            terminal_proven: false,
-        }
-    }
-
-    fn from_exec_wait(error: io::Error) -> Self {
-        if exec_operation::error_is_exec_operation_guest_error(&error) {
-            Self::terminal(error)
-        } else {
-            Self::unproven(error)
-        }
-    }
-}
-
 fn write_helper_exec_output(
     context: &str,
     result: ExecOperationResult,
-) -> Result<(ExecTermination, Vec<u8>, String), WriteHelperExecError> {
+) -> io::Result<(ExecTermination, Vec<u8>, String)> {
     if result.stream_overflowed {
-        return Err(WriteHelperExecError::unproven(io::Error::new(
+        return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("{context} exec operation unexpectedly overflowed a stream queue"),
-        )));
+        ));
     }
 
     let ExecOperationResult {
@@ -238,13 +227,13 @@ fn write_helper_exec_captured_output(
     context: &str,
     name: &str,
     output: ExecOwnedCapturedOutput,
-) -> Result<(Vec<u8>, bool), WriteHelperExecError> {
+) -> io::Result<(Vec<u8>, bool)> {
     match output {
         ExecOwnedCapturedOutput::Captured { bytes, truncated } => Ok((bytes, truncated)),
-        ExecOwnedCapturedOutput::Discarded => Err(WriteHelperExecError::unproven(io::Error::new(
+        ExecOwnedCapturedOutput::Discarded => Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("{context} exec result discarded {name} for capture request"),
-        ))),
+        )),
     }
 }
 
@@ -263,89 +252,70 @@ fn write_helper_terminal_message(prefix: String, stderr: &[u8], diagnostic: &str
     }
 }
 
-fn validate_cleanup_result(result: ExecOperationResult) -> Result<(), WriteHelperExecError> {
+fn validate_cleanup_result(result: ExecOperationResult) -> io::Result<()> {
     let (termination, stderr, diagnostic) = write_helper_exec_output("cleanup command", result)?;
     match termination {
         ExecTermination::Exited { exit_code: 0 } => Ok(()),
-        ExecTermination::Exited { exit_code } => {
-            Err(WriteHelperExecError::terminal(io::Error::other(format!(
-                "cleanup command failed with exit code {exit_code}: {}",
-                String::from_utf8_lossy(&stderr)
-            ))))
-        }
-        ExecTermination::TimedOut => Err(WriteHelperExecError::terminal(io::Error::new(
+        ExecTermination::Exited { exit_code } => Err(io::Error::other(format!(
+            "cleanup command failed with exit code {exit_code}: {}",
+            String::from_utf8_lossy(&stderr)
+        ))),
+        ExecTermination::TimedOut => Err(io::Error::new(
             io::ErrorKind::TimedOut,
             write_helper_terminal_message(
                 "cleanup command timed out".to_string(),
                 &stderr,
                 &diagnostic,
             ),
+        )),
+        ExecTermination::Cancelled => Err(io::Error::other(write_helper_terminal_message(
+            "cleanup command was cancelled".to_string(),
+            &stderr,
+            &diagnostic,
         ))),
-        ExecTermination::Cancelled => Err(WriteHelperExecError::terminal(io::Error::other(
-            write_helper_terminal_message(
-                "cleanup command was cancelled".to_string(),
-                &stderr,
-                &diagnostic,
-            ),
+        ExecTermination::StartFailed => Err(io::Error::other(write_helper_terminal_message(
+            "cleanup command exec start failed".to_string(),
+            &stderr,
+            &diagnostic,
         ))),
-        ExecTermination::StartFailed => Err(WriteHelperExecError::terminal(io::Error::other(
-            write_helper_terminal_message(
-                "cleanup command exec start failed".to_string(),
-                &stderr,
-                &diagnostic,
-            ),
-        ))),
-        ExecTermination::WaitFailed => Err(WriteHelperExecError::terminal(io::Error::other(
-            write_helper_terminal_message(
-                "cleanup command exec wait failed".to_string(),
-                &stderr,
-                &diagnostic,
-            ),
+        ExecTermination::WaitFailed => Err(io::Error::other(write_helper_terminal_message(
+            "cleanup command exec wait failed".to_string(),
+            &stderr,
+            &diagnostic,
         ))),
     }
 }
 
-fn validate_rename_result(
-    path: &str,
-    result: ExecOperationResult,
-) -> Result<(), WriteHelperExecError> {
+fn validate_rename_result(path: &str, result: ExecOperationResult) -> io::Result<()> {
     let (termination, stderr, diagnostic) = write_helper_exec_output("rename command", result)?;
     match termination {
         ExecTermination::Exited { exit_code: 0 } => Ok(()),
-        ExecTermination::Exited { exit_code } => {
-            Err(WriteHelperExecError::terminal(io::Error::other(format!(
-                "failed to rename temp file to {path} with exit code {exit_code}: {}",
-                String::from_utf8_lossy(&stderr)
-            ))))
-        }
-        ExecTermination::TimedOut => Err(WriteHelperExecError::terminal(io::Error::new(
+        ExecTermination::Exited { exit_code } => Err(io::Error::other(format!(
+            "failed to rename temp file to {path} with exit code {exit_code}: {}",
+            String::from_utf8_lossy(&stderr)
+        ))),
+        ExecTermination::TimedOut => Err(io::Error::new(
             io::ErrorKind::TimedOut,
             write_helper_terminal_message(
                 format!("rename command timed out while moving temp file to {path}"),
                 &stderr,
                 &diagnostic,
             ),
+        )),
+        ExecTermination::Cancelled => Err(io::Error::other(write_helper_terminal_message(
+            format!("rename command was cancelled while moving temp file to {path}"),
+            &stderr,
+            &diagnostic,
         ))),
-        ExecTermination::Cancelled => Err(WriteHelperExecError::terminal(io::Error::other(
-            write_helper_terminal_message(
-                format!("rename command was cancelled while moving temp file to {path}"),
-                &stderr,
-                &diagnostic,
-            ),
+        ExecTermination::StartFailed => Err(io::Error::other(write_helper_terminal_message(
+            format!("rename command exec start failed while moving temp file to {path}"),
+            &stderr,
+            &diagnostic,
         ))),
-        ExecTermination::StartFailed => Err(WriteHelperExecError::terminal(io::Error::other(
-            write_helper_terminal_message(
-                format!("rename command exec start failed while moving temp file to {path}"),
-                &stderr,
-                &diagnostic,
-            ),
-        ))),
-        ExecTermination::WaitFailed => Err(WriteHelperExecError::terminal(io::Error::other(
-            write_helper_terminal_message(
-                format!("rename command exec wait failed while moving temp file to {path}"),
-                &stderr,
-                &diagnostic,
-            ),
+        ExecTermination::WaitFailed => Err(io::Error::other(write_helper_terminal_message(
+            format!("rename command exec wait failed while moving temp file to {path}"),
+            &stderr,
+            &diagnostic,
         ))),
     }
 }
@@ -650,22 +620,25 @@ impl VsockHost {
                 write_observer,
             )
             .await
-            .map_err(WriteHelperExecError::from_exec_wait)
             .and_then(|result| validate_rename_result(path, result));
         match rename_result {
-            Ok(()) => {
+            ExecOperationWaitOutcome::Terminal(Ok(())) => {
                 cleanup_guard.disarm();
                 normal_operation.complete()?;
                 Ok(())
             }
-            Err(err) => {
+            ExecOperationWaitOutcome::Terminal(Err(error)) => {
                 // Terminal proof only releases the tracker after cleanup also
                 // succeeds; unproven helper failures remain fail-closed.
                 let cleanup_result = cleanup_guard.cleanup_now(&mut normal_operation).await;
-                if err.terminal_proven && cleanup_result.is_ok() {
+                if cleanup_result.is_ok() {
                     normal_operation.complete()?;
                 }
-                Err(err.error)
+                Err(error)
+            }
+            ExecOperationWaitOutcome::Unproven(error) => {
+                let _ = cleanup_guard.cleanup_now(&mut normal_operation).await;
+                Err(error)
             }
         }
     }

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -407,6 +407,7 @@ impl VsockHost {
             FrameWriteObserver::default(),
         )
         .await
+        .into_result()
         .map_err(FencedExecError::Operation)?;
         let fence = guard.complete().map_err(FencedExecError::Operation)?;
         Ok((result, fence))

--- a/crates/vsock-host/src/tests/file/copy.rs
+++ b/crates/vsock-host/src/tests/file/copy.rs
@@ -4,10 +4,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 use tokio::task::JoinHandle;
 use vsock_proto::{
-    ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_START,
+    ExecOutputPolicy, ExecOutputStream, ExecTermination, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_START,
 };
 
 use super::super::support::{
@@ -418,6 +419,92 @@ async fn copy_file_stream_error_releases_tracker_when_cancel_sees_terminal_resul
     let err = copy_task.await.unwrap().unwrap_err();
     assert!(err.to_string().contains("truncated"));
     fixture.assert_readiness(NormalOperationReadiness::Idle);
+    fixture.assert_host_bytes(b"old host log");
+    fixture.assert_no_temp_files();
+}
+
+#[tokio::test]
+async fn copy_file_stream_error_releases_tracker_when_cancel_sees_guest_error() {
+    let mut fixture =
+        CopyFileFixture::new("vsock-host-copy-cancel-guest-error", "system.log").await;
+    fixture.write_host_bytes(b"old host log");
+    let copy_task = fixture.spawn_copy("/tmp/vm0-system-run.log", default_copy_options());
+
+    let start = fixture.expect_start().await;
+    fixture.assert_readiness(NormalOperationReadiness::Busy);
+    send_exec_output(
+        &mut fixture.guest,
+        start.seq(),
+        0,
+        ExecOutputStream::Stdout,
+        b"partial",
+        true,
+    )
+    .await;
+
+    let cancel = read_guest_message(&mut fixture.guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq());
+    send_guest_error(
+        &mut fixture.guest,
+        start.seq(),
+        "guest rejected cancellation",
+    )
+    .await;
+
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("truncated"));
+    fixture.assert_readiness(NormalOperationReadiness::Idle);
+    fixture.assert_host_bytes(b"old host log");
+    fixture.assert_no_temp_files();
+}
+
+#[tokio::test]
+async fn copy_file_stream_error_keeps_tracker_fail_closed_when_cancel_loses_connection() {
+    let mut fixture =
+        CopyFileFixture::new("vsock-host-copy-cancel-connection-close", "system.log").await;
+    fixture.write_host_bytes(b"old host log");
+    let copy_task = fixture.spawn_copy("/tmp/vm0-system-run.log", default_copy_options());
+
+    let start = fixture.expect_start().await;
+    send_exec_output(
+        &mut fixture.guest,
+        start.seq(),
+        0,
+        ExecOutputStream::Stdout,
+        b"partial",
+        true,
+    )
+    .await;
+    let cancel = read_guest_message(&mut fixture.guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq());
+
+    fixture.guest.shutdown().await.unwrap();
+
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("truncated"));
+    fixture.assert_readiness(NormalOperationReadiness::NotParkable);
+    fixture.assert_host_bytes(b"old host log");
+    fixture.assert_no_temp_files();
+}
+
+#[tokio::test]
+async fn copy_file_malformed_error_removes_temp_and_keeps_tracker_fail_closed() {
+    let mut fixture = CopyFileFixture::new("vsock-host-copy-malformed-error", "system.log").await;
+    fixture.write_host_bytes(b"old host log");
+    let copy_task = fixture.spawn_copy("/tmp/vm0-system-run.log", default_copy_options());
+
+    let start = fixture.expect_start().await;
+    fixture
+        .guest
+        .write_all(&vsock_proto::encode(MSG_ERROR, start.seq(), &[0]).unwrap())
+        .await
+        .unwrap();
+
+    let err = copy_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    fixture.assert_readiness(NormalOperationReadiness::NotParkable);
     fixture.assert_host_bytes(b"old host log");
     fixture.assert_no_temp_files();
 }

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -1559,6 +1559,32 @@ async fn write_file_chunked_rename_guest_timeout_cleans_up_and_releases_tracker(
 }
 
 #[tokio::test]
+async fn write_file_chunked_rename_wait_timeout_cleans_up_and_keeps_tracker_fail_closed() {
+    let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
+    tokio::time::pause();
+    let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
+
+    let _rename = drive_two_chunk_write_to_rename(&mut fixture).await;
+    fixture.assert_readiness(NormalOperationReadiness::Busy);
+
+    tokio::time::advance(Duration::from_secs(11)).await;
+    let cleanup = fixture.expect_cleanup().await;
+    send_exec_result(
+        &mut fixture.guest,
+        cleanup.seq(),
+        ExecTermination::Exited { exit_code: 0 },
+        &[],
+        &[],
+    )
+    .await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert!(err.to_string().contains("exec operation timeout"));
+    fixture.assert_readiness(NormalOperationReadiness::NotParkable);
+}
+
+#[tokio::test]
 async fn write_file_chunked_rename_observer_error_keeps_tracker_fail_closed() {
     let mut fixture = ChunkedWriteFixture::new("/tmp/big.bin").await;
     let write_start_count = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## Summary

- preserve terminal observation in a typed exec wait/cancel outcome
- make copy and chunked-write cleanup consume authoritative lifecycle evidence
- remove duplicated error-kind/tag inference and add fast tracker-readiness regressions

## Scope

- no wire protocol or public Rust API changes
- retains copy host-temp and chunked-write guest-temp cleanup policies

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-host --all-targets -- -D warnings`
- `cargo doc -p vsock-host --no-deps`
- `cargo test -p vsock-host` (350 passed)
- `git diff --check origin/main...HEAD`

Closes #26894
