### PR TITLE
fix(vsock-host): prevent sequence collisions after wrap

### DIFF
--- a/crates/vsock-host/src/connection/listener.rs
+++ b/crates/vsock-host/src/connection/listener.rs
@@ -96,8 +96,10 @@ impl VsockHost {
             frame_builder: tokio::sync::Mutex::new(()),
             file_write_gate: tokio::sync::Mutex::new(()),
             fd,
-            seq: AtomicU32::new(2),
+            temp_seq: AtomicU32::new(2),
             state: std::sync::Mutex::new(ConnectionState::Connected {
+                next_route_id: 2,
+                route_reservations: HashMap::new(),
                 pending: HashMap::new(),
                 operations: exec_operation::Operations::new(),
             }),

--- a/crates/vsock-host/src/connection/mod.rs
+++ b/crates/vsock-host/src/connection/mod.rs
@@ -30,9 +30,9 @@ const READ_BUF_SIZE: usize = 64 * 1024;
 
 /// Connection lifecycle, expressed as data rather than a separate atomic flag.
 ///
-/// Pending requests, active exec operations, and connected process state
-/// live inside the `Connected` variant so registrations are structurally
-/// unreachable once the reader task has exited.
+/// Pending requests, active exec operations, queued-frame route reservations,
+/// and connected process state live inside the `Connected` variant so new
+/// registrations are structurally unreachable once the reader task has exited.
 ///
 /// The invariant "connection is closed ⇔ registrations are impossible" is
 /// enforced by the type: every code path that cares about liveness must
@@ -40,6 +40,10 @@ const READ_BUF_SIZE: usize = 64 * 1024;
 /// without taking the corresponding lock.
 pub(super) enum ConnectionState {
     Connected {
+        /// Next logical route identity. Its low 32 bits are used on the wire.
+        next_route_id: u64,
+        /// Routes held by frames admitted for a future write.
+        route_reservations: HashMap<u32, RouteReservationEntry>,
         /// Pending request responses: seq → response route.
         pending: HashMap<u32, PendingResponse>,
         /// Active exec-operation state owned by the exec_operation module.
@@ -60,10 +64,8 @@ pub(super) struct Shared {
     pub(super) file_write_gate: tokio::sync::Mutex<()>,
     /// Raw fd of the underlying socket, used to poison a corrupted stream.
     pub(super) fd: RawFd,
-    /// Monotonically increasing sequence number (starts at 2, skips 0).
-    /// Handshake uses seq=1 before Shared is created, so post-handshake
-    /// sequences start at 2 to avoid collisions.
-    pub(super) seq: AtomicU32,
+    /// Counter used only to distinguish temporary file names.
+    pub(super) temp_seq: AtomicU32,
     /// Single source of truth for connection liveness plus all per-connection
     /// registration tables. See [`ConnectionState`].
     pub(super) state: std::sync::Mutex<ConnectionState>,
@@ -81,9 +83,20 @@ pub(super) struct Shared {
 }
 
 pub(super) struct PendingResponse {
+    route_id: RouteId,
     response_tx: oneshot::Sender<RawMessage>,
     normal_operation: Option<PendingNormalOperation>,
     normal_terminal_msg_types: &'static [u8],
+}
+
+pub(super) struct RouteReservationEntry {
+    route_id: RouteId,
+    holders: usize,
+}
+
+pub(super) struct RouteReservation {
+    shared: Arc<Shared>,
+    route_id: RouteId,
 }
 
 enum PendingNormalOperation {
@@ -91,15 +104,122 @@ enum PendingNormalOperation {
     Composite(NormalOperationTransitionHandle),
 }
 
+/// Connection-local registration identity.
+///
+/// The guest protocol carries only [`Self::wire_seq`]. The complete value
+/// distinguishes owners after that wire sequence wraps and is reused.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct RouteId(u64);
+
+impl RouteId {
+    pub(super) fn wire_seq(self) -> u32 {
+        self.0 as u32
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+}
+
 impl Shared {
-    /// Get next sequence number, skipping 0 (reserved for unsolicited messages).
-    pub(super) fn next_seq(&self) -> u32 {
+    /// Register one response route while holding the connection-state lock.
+    ///
+    /// Candidate selection spans ordinary requests, exec operations, and exec
+    /// controls so a wire sequence has exactly one live owner. The callback
+    /// must insert that owner before returning.
+    pub(super) fn register_route<T>(
+        &self,
+        register: impl FnOnce(RouteId, &mut ConnectionState) -> io::Result<T>,
+    ) -> io::Result<(RouteId, T)> {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let route_id = match &mut *guard {
+            ConnectionState::Connected {
+                next_route_id,
+                route_reservations,
+                pending,
+                operations,
+            } => loop {
+                let route_id = RouteId(*next_route_id);
+                *next_route_id = next_route_id
+                    .checked_add(1)
+                    .ok_or_else(|| io::Error::other("vsock route identity exhausted"))?;
+                let seq = route_id.wire_seq();
+                if seq != 0
+                    && !route_reservations.contains_key(&seq)
+                    && !pending.contains_key(&seq)
+                    && !operations.contains_route_seq(seq)
+                {
+                    break route_id;
+                }
+            },
+            ConnectionState::Closed => {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "connection closed",
+                ));
+            }
+        };
+        let value = register(route_id, &mut guard)?;
+        Ok((route_id, value))
+    }
+
+    /// Reserve a route while a frame waits to acquire the writer lock.
+    ///
+    /// A free route may be reserved for an earlier owner whose frame is still
+    /// queued. A route owned by a newer generation cannot be reserved.
+    pub(super) fn reserve_exec_route_for_frame(
+        self: &Arc<Self>,
+        route_id: RouteId,
+    ) -> io::Result<Option<RouteReservation>> {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let ConnectionState::Connected {
+            route_reservations,
+            pending,
+            operations,
+            ..
+        } = &mut *guard
+        else {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "connection closed",
+            ));
+        };
+        let seq = route_id.wire_seq();
+        if route_reservations
+            .get(&seq)
+            .is_some_and(|reservation| reservation.route_id != route_id)
+        {
+            return Ok(None);
+        }
+        let owns_exec_route = operations.contains_route(route_id);
+        if !owns_exec_route && (pending.contains_key(&seq) || operations.contains_route_seq(seq)) {
+            return Ok(None);
+        }
+        match route_reservations.entry(seq) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                entry.get_mut().holders += 1;
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(RouteReservationEntry {
+                    route_id,
+                    holders: 1,
+                });
+            }
+        }
+        Ok(Some(RouteReservation {
+            shared: Arc::clone(self),
+            route_id,
+        }))
+    }
+
+    /// Get the next temporary-file suffix, skipping zero.
+    pub(super) fn next_temp_seq(&self) -> u32 {
         loop {
-            let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+            let seq = self.temp_seq.fetch_add(1, Ordering::Relaxed);
             if seq != 0 {
                 return seq;
             }
-            // Wrapped to 0 — skip it.
         }
     }
 
@@ -123,6 +243,7 @@ impl Shared {
                 ConnectionState::Connected {
                     pending,
                     operations,
+                    ..
                 } => {
                     // Serialize tracker close/poison with terminal dispatch,
                     // which completes tracker tokens under this same state lock.
@@ -155,17 +276,44 @@ impl Shared {
         let _ = nix::sys::socket::shutdown(self.fd, nix::sys::socket::Shutdown::Both);
     }
 
-    fn remove_pending(&self, seq: u32) {
+    fn remove_pending(&self, route_id: RouteId) {
         let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
         if let ConnectionState::Connected { pending, .. } = &mut *guard {
-            pending.remove(&seq);
+            let seq = route_id.wire_seq();
+            if pending
+                .get(&seq)
+                .is_some_and(|pending| pending.route_id == route_id)
+            {
+                pending.remove(&seq);
+            }
         }
     }
 
-    pub(super) fn remove_operation(&self, seq: u32) {
+    pub(super) fn remove_operation(&self, route_id: RouteId) {
         let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
         if let ConnectionState::Connected { operations, .. } = &mut *guard {
-            operations.remove(seq);
+            operations.remove(route_id);
+        }
+    }
+
+    fn release_route_reservation(&self, route_id: RouteId) {
+        let mut guard = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let ConnectionState::Connected {
+            route_reservations, ..
+        } = &mut *guard
+        else {
+            return;
+        };
+        let seq = route_id.wire_seq();
+        let Some(reservation) = route_reservations.get_mut(&seq) else {
+            return;
+        };
+        if reservation.route_id != route_id {
+            return;
+        }
+        reservation.holders -= 1;
+        if reservation.holders == 0 {
+            route_reservations.remove(&seq);
         }
     }
 
@@ -173,6 +321,12 @@ impl Shared {
         self.normal_operations
             .reserve()
             .map_err(request::normal_operation_rejection_error)
+    }
+}
+
+impl Drop for RouteReservation {
+    fn drop(&mut self) {
+        self.shared.release_route_reservation(self.route_id);
     }
 }
 

--- a/crates/vsock-host/src/connection/request.rs
+++ b/crates/vsock-host/src/connection/request.rs
@@ -17,11 +17,11 @@ use crate::operation_tracker::{
 };
 use crate::{FrameWriteObserver, VsockHost};
 
-use super::{ConnectionState, PendingNormalOperation, PendingResponse, Shared};
+use super::{ConnectionState, PendingNormalOperation, PendingResponse, RouteId, Shared};
 
 struct PendingRequestGuard {
     shared: Arc<Shared>,
-    seq: u32,
+    route_id: RouteId,
 }
 
 pub(crate) struct RequestWriteGuard {
@@ -31,14 +31,14 @@ pub(crate) struct RequestWriteGuard {
 }
 
 impl PendingRequestGuard {
-    fn new(shared: Arc<Shared>, seq: u32) -> Self {
-        Self { shared, seq }
+    fn new(shared: Arc<Shared>, route_id: RouteId) -> Self {
+        Self { shared, route_id }
     }
 }
 
 impl Drop for PendingRequestGuard {
     fn drop(&mut self) {
-        self.shared.remove_pending(self.seq);
+        self.shared.remove_pending(self.route_id);
     }
 }
 
@@ -122,8 +122,7 @@ async fn request_on_shared(
         return Err(request_timeout_error());
     }
     let deadline = deadline_after(timeout, "request timeout overflowed")?;
-    let seq = shared.next_seq();
-    request_raw_on_shared(shared, msg_type, seq, payload, deadline).await
+    request_raw_on_shared(shared, msg_type, payload, deadline).await
 }
 
 async fn write_request_frame(
@@ -180,38 +179,40 @@ fn encode_request_frame(msg_type: u8, seq: u32, payload: &[u8]) -> io::Result<Ve
 
 fn register_pending_response(
     shared: &Arc<Shared>,
-    seq: u32,
-    build_pending: impl FnOnce(oneshot::Sender<RawMessage>) -> io::Result<PendingResponse>,
-) -> io::Result<oneshot::Receiver<RawMessage>> {
+    build_pending: impl FnOnce(RouteId, oneshot::Sender<RawMessage>) -> io::Result<PendingResponse>,
+) -> io::Result<(RouteId, oneshot::Receiver<RawMessage>)> {
     // Register under the state lock: `Closed` short-circuits to an
     // immediate error, and insertion into `pending` is serialised with
     // the `Connected -> Closed` transition in `close()`. There is no
     // post-write `is_closed` check because close is observed via the
     // oneshot receiver becoming `Closed` when `close()` drops the map.
     let (tx, rx) = oneshot::channel();
-    let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-    if let ConnectionState::Connected { pending, .. } = &mut *guard {
-        let pending_response = build_pending(tx)?;
-        pending.insert(seq, pending_response);
-        Ok(rx)
-    } else {
-        Err(io::Error::new(
-            io::ErrorKind::ConnectionReset,
-            "connection closed",
-        ))
-    }
+    let (route_id, ()) = shared.register_route(|route_id, state| {
+        let ConnectionState::Connected { pending, .. } = state else {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "connection closed",
+            ));
+        };
+        let pending_response = build_pending(route_id, tx)?;
+        assert!(
+            pending
+                .insert(route_id.wire_seq(), pending_response)
+                .is_none(),
+            "pending response route must be vacant"
+        );
+        Ok(())
+    })?;
+    Ok((route_id, rx))
 }
 
 async fn write_registered_request_and_wait(
     shared: &Arc<Shared>,
-    seq: u32,
     data: &[u8],
     deadline: Instant,
     before_write: impl FnOnce() -> io::Result<()>,
     rx: oneshot::Receiver<RawMessage>,
 ) -> io::Result<RawMessage> {
-    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
-
     // The pending guard removes the pending entry on write failure, timeout,
     // or cancellation before reader_loop dispatches a response. The write
     // helper separately poisons the connection if cancellation interrupts an
@@ -231,8 +232,6 @@ async fn write_registered_request_and_wait_with_frame_builder(
     before_write: impl FnOnce() -> io::Result<()>,
     rx: oneshot::Receiver<RawMessage>,
 ) -> io::Result<RawMessage> {
-    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
-
     time::timeout_at(
         deadline,
         write_request_frame_with_builder(shared, seq, build_frame, before_write),
@@ -268,24 +267,25 @@ fn request_timeout_error() -> io::Error {
     io::Error::new(io::ErrorKind::TimedOut, "request timeout")
 }
 
-/// Send a request with a pre-allocated sequence number.
 async fn request_raw_on_shared(
     shared: &Arc<Shared>,
     msg_type: u8,
-    seq: u32,
     payload: &[u8],
     deadline: Instant,
 ) -> io::Result<RawMessage> {
-    let data = encode_request_frame(msg_type, seq, payload)?;
-    let rx = register_pending_response(shared, seq, |tx| {
+    let (route_id, rx) = register_pending_response(shared, |route_id, tx| {
         Ok(PendingResponse {
+            route_id,
             response_tx: tx,
             normal_operation: None,
             normal_terminal_msg_types: &[],
         })
     })?;
+    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), route_id);
+    let seq = route_id.wire_seq();
+    let data = encode_request_frame(msg_type, seq, payload)?;
 
-    write_registered_request_and_wait(shared, seq, &data, deadline, || Ok(()), rx).await
+    write_registered_request_and_wait(shared, &data, deadline, || Ok(()), rx).await
 }
 
 pub(crate) async fn normal_request_on_shared_with_write_observer_frame_builder(
@@ -299,15 +299,17 @@ pub(crate) async fn normal_request_on_shared_with_write_observer_frame_builder(
         return Err(request_timeout_error());
     }
     let deadline = deadline_after(timeout, "request timeout overflowed")?;
-    let seq = shared.next_seq();
     let normal_operation = shared.reserve_normal_operation()?;
-    let rx = register_pending_response(shared, seq, |tx| {
+    let (route_id, rx) = register_pending_response(shared, |route_id, tx| {
         Ok(PendingResponse {
+            route_id,
             response_tx: tx,
             normal_operation: Some(PendingNormalOperation::Owned(normal_operation)),
             normal_terminal_msg_types: terminal_msg_types,
         })
     })?;
+    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), route_id);
+    let seq = route_id.wire_seq();
 
     write_registered_request_and_wait_with_frame_builder(
         shared,
@@ -315,7 +317,7 @@ pub(crate) async fn normal_request_on_shared_with_write_observer_frame_builder(
         build_frame,
         deadline,
         || {
-            mark_pending_normal_operation_possible_guest_write(shared, seq, |_| Ok(()))?;
+            mark_pending_normal_operation_possible_guest_write(shared, route_id, |_| Ok(()))?;
             write_observer.record_write_start()
         },
         rx,
@@ -335,9 +337,9 @@ pub(crate) async fn request_on_shared_with_composite_operation_and_observer_fram
         return Err(request_timeout_error());
     }
     let deadline = deadline_after(timeout, "request timeout overflowed")?;
-    let seq = shared.next_seq();
-    let rx = register_pending_response(shared, seq, |tx| {
+    let (route_id, rx) = register_pending_response(shared, |route_id, tx| {
         Ok(PendingResponse {
+            route_id,
             response_tx: tx,
             normal_operation: Some(PendingNormalOperation::Composite(
                 normal_operation.transition_handle()?,
@@ -345,6 +347,8 @@ pub(crate) async fn request_on_shared_with_composite_operation_and_observer_fram
             normal_terminal_msg_types: terminal_msg_types,
         })
     })?;
+    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), route_id);
+    let seq = route_id.wire_seq();
 
     write_registered_request_and_wait_with_frame_builder(
         shared,
@@ -352,7 +356,7 @@ pub(crate) async fn request_on_shared_with_composite_operation_and_observer_fram
         build_frame,
         deadline,
         || {
-            mark_pending_normal_operation_possible_guest_write(shared, seq, |_| Ok(()))?;
+            mark_pending_normal_operation_possible_guest_write(shared, route_id, |_| Ok(()))?;
             write_observer.record_write_start()
         },
         rx,
@@ -362,19 +366,26 @@ pub(crate) async fn request_on_shared_with_composite_operation_and_observer_fram
 
 fn mark_pending_normal_operation_possible_guest_write(
     shared: &Arc<Shared>,
-    seq: u32,
+    route_id: RouteId,
     pre_write: impl FnOnce(&mut ConnectionState) -> io::Result<()>,
 ) -> io::Result<()> {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     pre_write(&mut guard)?;
     match &mut *guard {
         ConnectionState::Connected { pending, .. } => {
+            let seq = route_id.wire_seq();
             let Some(pending_response) = pending.get_mut(&seq) else {
                 return Err(io::Error::new(
                     io::ErrorKind::ConnectionReset,
                     "normal request closed before frame write",
                 ));
             };
+            if pending_response.route_id != route_id {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "normal request route was replaced before frame write",
+                ));
+            }
             let Some(normal_operation) = pending_response.normal_operation.as_mut() else {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/crates/vsock-host/src/exec_operation/dispatch.rs
+++ b/crates/vsock-host/src/exec_operation/dispatch.rs
@@ -173,7 +173,7 @@ fn dispatch_output(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Res
     let prepared_output = {
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         if let ConnectionState::Connected { operations, .. } = &mut *guard
-            && let Some(operation) = operations.get_mut(msg.seq)
+            && let Some(operation) = operations.get_mut_by_seq(msg.seq)
         {
             let decoded = vsock_proto::decode_exec_output(msg.payload)
                 .map_err(exec_operation_protocol_error)?;
@@ -218,7 +218,7 @@ fn dispatch_output(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Res
             // Channel identity rejects a replacement operation after sequence
             // wrap; holding state makes the check and delivery atomic with teardown.
             let sender_matches = if let ConnectionState::Connected { operations, .. } = &mut *guard
-                && let Some(operation) = operations.get_mut(msg.seq)
+                && let Some(operation) = operations.get_mut_by_seq(msg.seq)
                 && let Some(tx) = operation.stream_tx.as_ref()
             {
                 permit.same_channel_as_sender(tx)
@@ -253,7 +253,7 @@ fn dispatch_started(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Re
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
             ConnectionState::Connected { operations, .. } => {
-                let Some(operation) = operations.get_mut(msg.seq) else {
+                let Some(operation) = operations.get_mut_by_seq(msg.seq) else {
                     return Ok(());
                 };
                 let decoded = vsock_proto::decode_exec_started(msg.payload)
@@ -303,10 +303,10 @@ pub(in crate::exec_operation) fn dispatch_result(
     let Some((terminal, decoded)) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
-            ConnectionState::Connected { operations, .. } if operations.contains(msg.seq) => {
+            ConnectionState::Connected { operations, .. } if operations.contains_seq(msg.seq) => {
                 let decoded = vsock_proto::decode_exec_result(msg.payload)
                     .map_err(exec_operation_protocol_error)?;
-                let Some(operation) = operations.get_mut(msg.seq) else {
+                let Some(operation) = operations.get_mut_by_seq(msg.seq) else {
                     return Ok(());
                 };
                 operation.validates_result_before_start(&decoded)?;
@@ -361,10 +361,11 @@ fn dispatch_control_result(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) ->
             "exec_control_result nonce mismatch",
         ));
     }
-    if decoded.target_seq != pending.target_seq {
+    if decoded.target_seq != pending.target_route_id.wire_seq() {
         return Err(exec_operation_protocol_error(format!(
             "exec_control_result target seq mismatch: expected {}, got {}",
-            pending.target_seq, decoded.target_seq
+            pending.target_route_id.wire_seq(),
+            decoded.target_seq
         )));
     }
     if decoded.message_id != pending.message_id {
@@ -395,7 +396,7 @@ fn dispatch_error(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Resu
     let Some((terminal, err)) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
-            ConnectionState::Connected { operations, .. } if operations.contains(msg.seq) => {
+            ConnectionState::Connected { operations, .. } if operations.contains_seq(msg.seq) => {
                 let err = vsock_proto::decode_error(msg.payload)
                     .map(|message| exec_operation_guest_error(message.to_string()))
                     .map_err(exec_operation_protocol_error)?;

--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -7,7 +7,10 @@ use tokio::sync::oneshot;
 use tokio::time::Instant;
 use vsock_proto::{ExecControlStatus, MSG_EXEC_CANCEL, MSG_EXEC_START};
 
-use crate::{ConnectionState, FrameWriteObserver, Shared, normal_operation_transition_error};
+use crate::{
+    ConnectionState, FrameWriteObserver, RouteId, RouteReservation, Shared,
+    normal_operation_transition_error,
+};
 
 use super::diagnostics::{ExecOperationDiagnostic, ExecOperationFrameDiagnostic};
 use super::types::exec_control_status_error;
@@ -47,32 +50,46 @@ impl Drop for ExecOperationFrameWriteGuard {
     }
 }
 
-pub(in crate::exec_operation) fn exec_cancel_write_observer(
+pub(in crate::exec_operation) fn admit_exec_cancel_frame(
     shared: &Arc<Shared>,
-    seq: u32,
-) -> FrameWriteObserver {
-    let shared = Arc::clone(shared);
-    FrameWriteObserver::new(move || {
-        mark_exec_operation_host_cancel_requested(&shared, seq);
-        Ok(())
-    })
+    route_id: RouteId,
+) -> io::Result<Option<RouteReservation>> {
+    shared.reserve_exec_route_for_frame(route_id)
 }
 
-fn mark_exec_operation_host_cancel_requested(shared: &Arc<Shared>, seq: u32) {
+pub(in crate::exec_operation) fn exec_cancel_write_observer(
+    shared: &Arc<Shared>,
+    route_id: RouteId,
+) -> FrameWriteObserver {
+    let shared = Arc::clone(shared);
+    FrameWriteObserver::new(move || mark_exec_operation_host_cancel_requested(&shared, route_id))
+}
+
+fn mark_exec_operation_host_cancel_requested(
+    shared: &Arc<Shared>,
+    route_id: RouteId,
+) -> io::Result<()> {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-    if let ConnectionState::Connected { operations, .. } = &mut *guard {
-        operations.mark_host_cancel_requested(seq);
+    match &mut *guard {
+        ConnectionState::Connected { operations, .. } => {
+            operations.mark_host_cancel_requested(route_id);
+            Ok(())
+        }
+        ConnectionState::Closed => Err(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection closed",
+        )),
     }
 }
 
 fn mark_exec_operation_host_cancel_requested_for_wait(
     shared: &Arc<Shared>,
-    seq: u32,
+    route_id: RouteId,
 ) -> io::Result<ExecCancelFrameWriteOutcome> {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     match &mut *guard {
         ConnectionState::Connected { operations, .. } => {
-            if operations.mark_host_cancel_requested(seq) {
+            if operations.mark_host_cancel_requested(route_id) {
                 Ok(ExecCancelFrameWriteOutcome::Sent)
             } else {
                 Ok(ExecCancelFrameWriteOutcome::AlreadyTerminal)
@@ -87,19 +104,23 @@ fn mark_exec_operation_host_cancel_requested_for_wait(
 
 pub(in crate::exec_operation) async fn send_exec_cancel_frame_for_wait_with_write_start(
     shared: &Arc<Shared>,
-    seq: u32,
+    route_id: RouteId,
     diagnostic: &ExecOperationDiagnostic,
     write_started_tx: Option<oneshot::Sender<()>>,
 ) -> io::Result<ExecCancelFrameWriteOutcome> {
+    let Some(_reservation) = shared.reserve_exec_route_for_frame(route_id)? else {
+        return Ok(ExecCancelFrameWriteOutcome::AlreadyTerminal);
+    };
     let payload = vsock_proto::encode_exec_cancel();
     let mut write_started_tx = write_started_tx;
+    let seq = route_id.wire_seq();
     let decision = write_frame_with_pre_write_decision(
         shared,
         MSG_EXEC_CANCEL,
         seq,
         &payload,
         Some(diagnostic.frame("cancel")),
-        || match mark_exec_operation_host_cancel_requested_for_wait(shared, seq)? {
+        || match mark_exec_operation_host_cancel_requested_for_wait(shared, route_id)? {
             ExecCancelFrameWriteOutcome::Sent => {
                 if let Some(write_started_tx) = write_started_tx.take() {
                     let _ = write_started_tx.send(());
@@ -117,11 +138,14 @@ pub(in crate::exec_operation) async fn send_exec_cancel_frame_for_wait_with_writ
     })
 }
 
-fn mark_exec_operation_possible_guest_write(shared: &Arc<Shared>, seq: u32) -> io::Result<()> {
+fn mark_exec_operation_possible_guest_write(
+    shared: &Arc<Shared>,
+    route_id: RouteId,
+) -> io::Result<()> {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     match &mut *guard {
         ConnectionState::Connected { operations, .. } => {
-            let Some(operation) = operations.get_mut(seq) else {
+            let Some(operation) = operations.get_mut(route_id) else {
                 return Err(io::Error::new(
                     io::ErrorKind::ConnectionReset,
                     "exec operation closed before frame write",
@@ -142,11 +166,11 @@ fn mark_exec_operation_possible_guest_write(shared: &Arc<Shared>, seq: u32) -> i
 
 pub(in crate::exec_operation) fn clear_exec_operation_stream_sender(
     shared: &Arc<Shared>,
-    seq: u32,
+    route_id: RouteId,
 ) {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { operations, .. } = &mut *guard
-        && let Some(operation) = operations.get_mut(seq)
+        && let Some(operation) = operations.get_mut(route_id)
     {
         operation.stream_tx = None;
     }
@@ -154,34 +178,41 @@ pub(in crate::exec_operation) fn clear_exec_operation_stream_sender(
 
 pub(in crate::exec_operation) fn remove_pending_exec_control(
     shared: &Arc<Shared>,
-    request_seq: u32,
+    request_route_id: RouteId,
 ) {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     if let ConnectionState::Connected { operations, .. } = &mut *guard {
-        operations.remove_pending_control(request_seq);
+        operations.remove_pending_control(request_route_id);
     }
 }
 
 pub(in crate::exec_operation) fn mark_pending_exec_control_possible_guest_write(
     shared: &Arc<Shared>,
-    target_seq: u32,
-    request_seq: u32,
+    target_route_id: RouteId,
+    request_route_id: RouteId,
 ) -> io::Result<()> {
     let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
     match &mut *guard {
         ConnectionState::Connected { operations, .. } => {
-            let Some(operation) = operations.get_mut(target_seq) else {
+            let Some(operation) = operations.get_mut(target_route_id) else {
                 return Err(exec_control_status_error(
                     ExecControlStatus::Inactive,
                     "exec operation is not active",
                 ));
             };
+            let request_seq = request_route_id.wire_seq();
             let Some(pending) = operation.pending_controls.get_mut(&request_seq) else {
                 return Err(io::Error::new(
                     io::ErrorKind::ConnectionReset,
                     "exec control request closed before frame write",
                 ));
             };
+            if pending.route_id != request_route_id {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "exec control route was replaced before frame write",
+                ));
+            }
             pending
                 .normal_operation
                 .mark_possible_guest_write_started()
@@ -200,12 +231,12 @@ pub(in crate::exec_operation) async fn write_frame(
     seq: u32,
     payload: &[u8],
     diagnostic: Option<ExecOperationFrameDiagnostic>,
-    normal_operation_seq: Option<u32>,
+    normal_operation_route_id: Option<RouteId>,
     write_observer: FrameWriteObserver,
 ) -> io::Result<()> {
     write_frame_with_pre_write(shared, msg_type, seq, payload, diagnostic, || {
-        if let Some(normal_operation_seq) = normal_operation_seq {
-            mark_exec_operation_possible_guest_write(shared, normal_operation_seq)?;
+        if let Some(normal_operation_route_id) = normal_operation_route_id {
+            mark_exec_operation_possible_guest_write(shared, normal_operation_route_id)?;
         }
         write_observer.record_write_start()
     })
@@ -214,13 +245,14 @@ pub(in crate::exec_operation) async fn write_frame(
 
 pub(in crate::exec_operation) async fn write_exec_start_frame(
     shared: &Arc<Shared>,
-    seq: u32,
+    route_id: RouteId,
     payload: &[u8],
     diagnostic: &ExecOperationDiagnostic,
     tracks_normal_operation: bool,
     write_admission: FrameWriteObserver,
     write_observer: FrameWriteObserver,
 ) -> io::Result<()> {
+    let seq = route_id.wire_seq();
     write_frame_with_pre_write(
         shared,
         MSG_EXEC_START,
@@ -230,7 +262,7 @@ pub(in crate::exec_operation) async fn write_exec_start_frame(
         || {
             write_admission.record_write_start()?;
             if tracks_normal_operation {
-                mark_exec_operation_possible_guest_write(shared, seq)?;
+                mark_exec_operation_possible_guest_write(shared, route_id)?;
             }
             write_observer.record_write_start()
         },

--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -7,13 +7,13 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, Instant};
 use vsock_proto::{ExecControlNonce, ExecControlStatus, ExecTermination, MSG_EXEC_CANCEL};
 
-use crate::{ConnectionState, FrameWriteObserver, Shared};
+use crate::{ConnectionState, FrameWriteObserver, RouteId, Shared};
 
 use super::EXEC_OPERATION_DROP_CANCEL_WRITE_TIMEOUT;
 use super::diagnostics::ExecOperationDiagnostic;
 use super::frame::{
-    ExecCancelFrameWriteOutcome, clear_exec_operation_stream_sender, exec_cancel_write_observer,
-    mark_pending_exec_control_possible_guest_write,
+    ExecCancelFrameWriteOutcome, admit_exec_cancel_frame, clear_exec_operation_stream_sender,
+    exec_cancel_write_observer, mark_pending_exec_control_possible_guest_write,
     send_exec_cancel_frame_for_wait_with_write_start, write_encoded_frame_with_pre_write,
     write_frame,
 };
@@ -37,7 +37,7 @@ pub struct ExecOperationHandle {
 
 pub(in crate::exec_operation) struct ExecWaitCore {
     pub(in crate::exec_operation) shared: Arc<Shared>,
-    pub(in crate::exec_operation) seq: Option<u32>,
+    pub(in crate::exec_operation) route_id: Option<RouteId>,
     pub(in crate::exec_operation) diagnostic: ExecOperationDiagnostic,
     pub(in crate::exec_operation) result_rx:
         Option<oneshot::Receiver<io::Result<ExecOperationResult>>>,
@@ -100,7 +100,10 @@ pub(in crate::exec_operation) struct ExecCancelWaitResult {
 
 enum ExecCancelWriteOutcome {
     Terminal(io::Result<ExecOperationResult>),
-    CancelSent { seq: u32, remaining: Duration },
+    CancelSent {
+        route_id: RouteId,
+        remaining: Duration,
+    },
 }
 
 impl ExecWaitLifecycle {
@@ -195,11 +198,15 @@ impl ExecCancelWaitResult {
 
 pub(in crate::exec_operation) async fn send_exec_cancel_frame(
     shared: &Arc<Shared>,
-    seq: u32,
+    route_id: RouteId,
     diagnostic: &ExecOperationDiagnostic,
     lifecycle: ExecWaitLifecycle,
 ) -> io::Result<()> {
+    let Some(_reservation) = admit_exec_cancel_frame(shared, route_id)? else {
+        return Ok(());
+    };
     let payload = vsock_proto::encode_exec_cancel();
+    let seq = route_id.wire_seq();
     write_frame(
         shared,
         MSG_EXEC_CANCEL,
@@ -207,7 +214,7 @@ pub(in crate::exec_operation) async fn send_exec_cancel_frame(
         &payload,
         Some(diagnostic.frame("cancel")),
         None,
-        exec_cancel_write_observer(shared, seq),
+        exec_cancel_write_observer(shared, route_id),
     )
     .await?;
     lifecycle.log_cancel_sent(seq, diagnostic);
@@ -258,7 +265,7 @@ impl ExecWaitCore {
         &mut self,
         result: Result<io::Result<ExecOperationResult>, oneshot::error::RecvError>,
     ) -> ExecOperationWaitOutcome<ExecOperationResult> {
-        self.seq = None;
+        self.route_id = None;
         self.result_rx = None;
         match result {
             Ok(result) => ExecOperationWaitOutcome::terminal(result),
@@ -271,14 +278,14 @@ impl ExecWaitCore {
 
     fn abandon_timed_out_operation(
         &mut self,
-        seq: u32,
+        route_id: RouteId,
         poison_on_timeout: bool,
         lifecycle: ExecWaitLifecycle,
     ) -> io::Error {
-        self.shared.remove_operation(seq);
-        self.seq = None;
+        self.shared.remove_operation(route_id);
+        self.route_id = None;
         self.result_rx = None;
-        self.log_timeout(seq, poison_on_timeout, lifecycle);
+        self.log_timeout(route_id.wire_seq(), poison_on_timeout, lifecycle);
         if poison_on_timeout {
             self.shared.poison_connection();
         }
@@ -287,13 +294,13 @@ impl ExecWaitCore {
 
     pub(in crate::exec_operation) fn new(
         shared: Arc<Shared>,
-        seq: u32,
+        route_id: RouteId,
         diagnostic: ExecOperationDiagnostic,
         result_rx: oneshot::Receiver<io::Result<ExecOperationResult>>,
     ) -> Self {
         Self {
             shared,
-            seq: Some(seq),
+            route_id: Some(route_id),
             diagnostic,
             result_rx: Some(result_rx),
         }
@@ -307,21 +314,21 @@ impl ExecWaitCore {
         &self.diagnostic
     }
 
-    pub(in crate::exec_operation) fn active_seq(&self) -> Option<u32> {
-        self.seq
+    pub(in crate::exec_operation) fn active_route_id(&self) -> Option<RouteId> {
+        self.route_id
     }
 
-    pub(in crate::exec_operation) fn active_seq_or_closed(
+    pub(in crate::exec_operation) fn active_route_id_or_closed(
         &self,
         message: &'static str,
-    ) -> io::Result<u32> {
-        self.seq
+    ) -> io::Result<RouteId> {
+        self.route_id
             .ok_or_else(|| io::Error::new(io::ErrorKind::ConnectionReset, message))
     }
 
     pub(in crate::exec_operation) fn remove_operation_if_active(&mut self) {
-        if let Some(seq) = self.seq.take() {
-            self.shared.remove_operation(seq);
+        if let Some(route_id) = self.route_id.take() {
+            self.shared.remove_operation(route_id);
         }
     }
 
@@ -334,13 +341,13 @@ impl ExecWaitCore {
 
         match rx.try_recv() {
             Ok(result) => {
-                self.seq = None;
+                self.route_id = None;
                 self.result_rx = None;
                 Ok(Some(result))
             }
             Err(oneshot::error::TryRecvError::Empty) => Ok(None),
             Err(oneshot::error::TryRecvError::Closed) => {
-                self.seq = None;
+                self.route_id = None;
                 self.result_rx = None;
                 Err(io::Error::new(
                     io::ErrorKind::ConnectionReset,
@@ -357,8 +364,8 @@ impl ExecWaitCore {
         lifecycle: ExecWaitLifecycle,
     ) -> ExecOperationWaitOutcome<ExecOperationResult> {
         tokio::pin!(timeout);
-        let seq = match self.active_seq_or_closed(lifecycle.operation_closed_message()) {
-            Ok(seq) => seq,
+        let route_id = match self.active_route_id_or_closed(lifecycle.operation_closed_message()) {
+            Ok(route_id) => route_id,
             Err(error) => return ExecOperationWaitOutcome::unproven(error),
         };
         let Some(rx) = self.result_rx.as_mut() else {
@@ -371,7 +378,7 @@ impl ExecWaitCore {
         tokio::select! {
             biased;
             result = rx => {
-                self.seq = None;
+                self.route_id = None;
                 self.result_rx = None;
                 match result {
                     Ok(result) => ExecOperationWaitOutcome::terminal(result),
@@ -383,7 +390,7 @@ impl ExecWaitCore {
             }
             _ = &mut timeout => {
                 ExecOperationWaitOutcome::unproven(
-                    self.abandon_timed_out_operation(seq, poison_on_timeout, lifecycle),
+                    self.abandon_timed_out_operation(route_id, poison_on_timeout, lifecycle),
                 )
             }
         }
@@ -422,13 +429,14 @@ impl ExecWaitCore {
             return Ok(ExecCancelWriteOutcome::Terminal(result));
         }
 
-        let seq = self.active_seq_or_closed(lifecycle.operation_closed_message())?;
+        let route_id = self.active_route_id_or_closed(lifecycle.operation_closed_message())?;
+        let seq = route_id.wire_seq();
         if timeout.is_zero() {
-            return Err(self.abandon_timed_out_operation(seq, false, lifecycle));
+            return Err(self.abandon_timed_out_operation(route_id, false, lifecycle));
         }
         let Some(deadline) = Instant::now().checked_add(timeout) else {
-            self.shared.remove_operation(seq);
-            self.seq = None;
+            self.shared.remove_operation(route_id);
+            self.route_id = None;
             self.result_rx = None;
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -441,7 +449,7 @@ impl ExecWaitCore {
         let (write_started_tx, mut write_started_rx) = oneshot::channel();
         let mut cancel_write = Box::pin(send_exec_cancel_frame_for_wait_with_write_start(
             &shared,
-            seq,
+            route_id,
             &diagnostic,
             Some(write_started_tx),
         ));
@@ -464,7 +472,7 @@ impl ExecWaitCore {
                                 }
                             }
                         );
-                        Err(self.abandon_timed_out_operation(seq, true, lifecycle))
+                        Err(self.abandon_timed_out_operation(route_id, true, lifecycle))
                     })
             }
             result = &mut result_rx => {
@@ -476,7 +484,7 @@ impl ExecWaitCore {
                 };
             }
             _ = time::sleep_until(deadline) => {
-                return Err(self.abandon_timed_out_operation(seq, false, lifecycle));
+                return Err(self.abandon_timed_out_operation(route_id, false, lifecycle));
             }
             result = &mut cancel_write => {
                 result
@@ -497,7 +505,7 @@ impl ExecWaitCore {
                 self.result_rx = Some(result_rx);
                 lifecycle.log_cancel_sent(seq, &diagnostic);
                 Ok(ExecCancelWriteOutcome::CancelSent {
-                    seq,
+                    route_id,
                     remaining: deadline.saturating_duration_since(Instant::now()),
                 })
             }
@@ -506,7 +514,7 @@ impl ExecWaitCore {
 
     async fn wait_for_terminal_after_cancel_sent(
         &mut self,
-        seq: u32,
+        route_id: RouteId,
         remaining: Duration,
         lifecycle: ExecWaitLifecycle,
     ) -> ExecOperationWaitOutcome<ExecCancelWaitResult> {
@@ -514,7 +522,7 @@ impl ExecWaitCore {
             .await
             .map(|result| ExecCancelWaitResult {
                 result,
-                cancel_seq: Some(seq),
+                cancel_seq: Some(route_id.wire_seq()),
             })
     }
 }
@@ -592,7 +600,7 @@ impl ExecOperationHandle {
         mut self,
         timeout: Duration,
     ) -> ExecOperationWaitOutcome<ExecCancelWaitResult> {
-        let (seq, remaining) = match self
+        let (route_id, remaining) = match self
             .wait_core
             .send_cancel_before_terminal_with_deadline(timeout, ExecWaitLifecycle::OneShot)
             .await
@@ -605,12 +613,15 @@ impl ExecOperationHandle {
                     }
                 });
             }
-            Ok(ExecCancelWriteOutcome::CancelSent { seq, remaining }) => (seq, remaining),
+            Ok(ExecCancelWriteOutcome::CancelSent {
+                route_id,
+                remaining,
+            }) => (route_id, remaining),
             Err(error) => return ExecOperationWaitOutcome::unproven(error),
         };
 
         self.wait_core
-            .wait_for_terminal_after_cancel_sent(seq, remaining, ExecWaitLifecycle::OneShot)
+            .wait_for_terminal_after_cancel_sent(route_id, remaining, ExecWaitLifecycle::OneShot)
             .await
     }
 }
@@ -646,7 +657,7 @@ pub struct SupervisedExecHandle {
 #[must_use = "dropping this cancel handle does not send MSG_EXEC_CANCEL"]
 pub struct SupervisedExecCancelHandle {
     shared: Arc<Shared>,
-    seq: u32,
+    route_id: RouteId,
     diagnostic: ExecOperationDiagnostic,
 }
 
@@ -656,13 +667,15 @@ impl SupervisedExecCancelHandle {
     /// The paired [`SupervisedExecHandle`] still owns the result receiver and must
     /// be waited or abandoned by its caller. If this times out before the
     /// cancel frame write starts, the paired handle can still observe the
-    /// terminal result.
+    /// terminal result. If the original operation is already terminal and its
+    /// wire sequence belongs to a newer operation, this returns successfully
+    /// without sending a stale cancel frame.
     pub async fn cancel(self, timeout: Duration) -> io::Result<()> {
         tokio::time::timeout(
             timeout,
             send_exec_cancel_frame(
                 &self.shared,
-                self.seq,
+                self.route_id,
                 &self.diagnostic,
                 ExecWaitLifecycle::Supervised,
             ),
@@ -670,7 +683,7 @@ impl SupervisedExecCancelHandle {
         .await
         .unwrap_or_else(|_| {
             tracing::warn!(
-                seq = self.seq,
+                seq = self.route_id.wire_seq(),
                 label = %self.diagnostic.label_log,
                 elapsed_ms = self.diagnostic.elapsed_ms(),
                 "supervised exec operation cancel write timed out"
@@ -700,11 +713,11 @@ impl SupervisedExecHandle {
         if self.cancel_handle_taken {
             return None;
         }
-        let seq = self.wait_core.active_seq()?;
+        let route_id = self.wait_core.active_route_id()?;
         self.cancel_handle_taken = true;
         Some(SupervisedExecCancelHandle {
             shared: Arc::clone(self.wait_core.shared()),
-            seq,
+            route_id,
             diagnostic: self.wait_core.diagnostic().clone(),
         })
     }
@@ -737,11 +750,11 @@ impl SupervisedExecHandle {
     }
 
     fn clear_unclaimed_stream_sender(&mut self) {
-        let Some(seq) = self.wait_core.active_seq() else {
+        let Some(route_id) = self.wait_core.active_route_id() else {
             return;
         };
         if self.stream_rx.take().is_some() {
-            clear_exec_operation_stream_sender(self.wait_core.shared(), seq);
+            clear_exec_operation_stream_sender(self.wait_core.shared(), route_id);
         }
     }
 
@@ -789,7 +802,7 @@ impl SupervisedExecHandle {
         mut self,
         timeout: Duration,
     ) -> ExecOperationWaitOutcome<ExecCancelWaitResult> {
-        let (seq, remaining) = match self
+        let (route_id, remaining) = match self
             .wait_core
             .send_cancel_before_terminal_with_deadline(timeout, ExecWaitLifecycle::Supervised)
             .await
@@ -802,13 +815,16 @@ impl SupervisedExecHandle {
                     }
                 });
             }
-            Ok(ExecCancelWriteOutcome::CancelSent { seq, remaining }) => (seq, remaining),
+            Ok(ExecCancelWriteOutcome::CancelSent {
+                route_id,
+                remaining,
+            }) => (route_id, remaining),
             Err(error) => return ExecOperationWaitOutcome::unproven(error),
         };
 
         self.clear_unclaimed_stream_sender();
         self.wait_core
-            .wait_for_terminal_after_cancel_sent(seq, remaining, ExecWaitLifecycle::Supervised)
+            .wait_for_terminal_after_cancel_sent(route_id, remaining, ExecWaitLifecycle::Supervised)
             .await
     }
 }
@@ -823,7 +839,7 @@ impl Drop for SupervisedExecHandle {
 #[derive(Clone)]
 pub struct ExecControlHandle {
     pub(in crate::exec_operation) shared: Arc<Shared>,
-    pub(in crate::exec_operation) target_seq: u32,
+    pub(in crate::exec_operation) target_route_id: RouteId,
     pub(in crate::exec_operation) control_nonce: ExecControlNonce,
 }
 
@@ -910,7 +926,7 @@ impl ExecControlHandle {
     ) -> io::Result<ExecControlOutcome> {
         let request_timeout_ms = duration_to_request_timeout_ms(timeout);
         vsock_proto::validate_exec_control(
-            self.target_seq,
+            self.target_route_id.wire_seq(),
             self.control_nonce,
             message_id,
             payload,
@@ -939,7 +955,7 @@ impl ExecControlHandle {
     ) -> io::Result<ExecControlOutcome> {
         exec_control_on_shared(
             &self.shared,
-            self.target_seq,
+            self.target_route_id,
             self.control_nonce,
             message_id,
             payload,
@@ -952,19 +968,19 @@ impl ExecControlHandle {
 
 pub(crate) struct ExecOperationCancelOnDropGuard {
     pub(in crate::exec_operation) shared: Option<Arc<Shared>>,
-    pub(in crate::exec_operation) seq: u32,
+    pub(in crate::exec_operation) route_id: RouteId,
     pub(in crate::exec_operation) diagnostic: ExecOperationDiagnostic,
 }
 
 impl ExecOperationCancelOnDropGuard {
-    pub(in crate::exec_operation) fn new_for_seq(
+    pub(in crate::exec_operation) fn new_for_route(
         shared: Arc<Shared>,
-        seq: u32,
+        route_id: RouteId,
         diagnostic: ExecOperationDiagnostic,
     ) -> Self {
         Self {
             shared: Some(shared),
-            seq,
+            route_id,
             diagnostic,
         }
     }
@@ -972,7 +988,7 @@ impl ExecOperationCancelOnDropGuard {
     pub(crate) fn new(handle: &ExecOperationHandle) -> Option<Self> {
         Some(Self {
             shared: Some(Arc::clone(handle.wait_core.shared())),
-            seq: handle.wait_core.active_seq()?,
+            route_id: handle.wait_core.active_route_id()?,
             diagnostic: handle.wait_core.diagnostic().clone(),
         })
     }
@@ -981,7 +997,7 @@ impl ExecOperationCancelOnDropGuard {
     pub(crate) fn new_supervised(handle: &SupervisedExecHandle) -> Option<Self> {
         Some(Self {
             shared: Some(Arc::clone(handle.wait_core.shared())),
-            seq: handle.wait_core.active_seq()?,
+            route_id: handle.wait_core.active_route_id()?,
             diagnostic: handle.wait_core.diagnostic().clone(),
         })
     }
@@ -996,13 +1012,29 @@ impl Drop for ExecOperationCancelOnDropGuard {
         let Some(shared) = self.shared.take() else {
             return;
         };
-        let seq = self.seq;
+        let route_id = self.route_id;
+        let seq = route_id.wire_seq();
         let diagnostic = self.diagnostic.clone();
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             return;
         };
+        let reservation = match admit_exec_cancel_frame(&shared, route_id) {
+            Ok(Some(reservation)) => reservation,
+            Ok(None) => return,
+            Err(err) => {
+                tracing::warn!(
+                    seq = seq,
+                    label = %diagnostic.label_log,
+                    elapsed_ms = diagnostic.elapsed_ms(),
+                    error = %err,
+                    "exec operation cancel on drop admission failed"
+                );
+                return;
+            }
+        };
 
         handle.spawn(async move {
+            let _reservation = reservation;
             let payload = vsock_proto::encode_exec_cancel();
             let result = tokio::time::timeout(
                 EXEC_OPERATION_DROP_CANCEL_WRITE_TIMEOUT,
@@ -1013,7 +1045,7 @@ impl Drop for ExecOperationCancelOnDropGuard {
                     &payload,
                     Some(diagnostic.frame("drop-cancel")),
                     None,
-                    exec_cancel_write_observer(&shared, seq),
+                    exec_cancel_write_observer(&shared, route_id),
                 ),
             )
             .await;
@@ -1060,7 +1092,7 @@ pub(in crate::exec_operation) fn duration_to_request_timeout_ms(timeout: Duratio
 
 pub(in crate::exec_operation) async fn exec_control_on_shared(
     shared: &Arc<Shared>,
-    target_seq: u32,
+    target_route_id: RouteId,
     control_nonce: ExecControlNonce,
     message_id: String,
     control_payload: Vec<u8>,
@@ -1068,6 +1100,7 @@ pub(in crate::exec_operation) async fn exec_control_on_shared(
     write_observer: FrameWriteObserver,
 ) -> io::Result<ExecControlOutcome> {
     let request_timeout_ms = duration_to_request_timeout_ms(timeout);
+    let target_seq = target_route_id.wire_seq();
     vsock_proto::validate_exec_control(
         target_seq,
         control_nonce,
@@ -1076,34 +1109,30 @@ pub(in crate::exec_operation) async fn exec_control_on_shared(
         request_timeout_ms,
     )
     .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
-    let request_seq = shared.next_seq();
     let normal_operation = shared.reserve_normal_operation()?;
     let (response_tx, response_rx) = oneshot::channel();
-    {
-        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        match &mut *guard {
-            ConnectionState::Closed => {
-                return Err(io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "connection closed",
-                ));
-            }
-            ConnectionState::Connected { operations, .. } => {
-                operations.insert_pending_control(
-                    target_seq,
-                    request_seq,
-                    PendingExecControl {
-                        target_seq,
-                        message_id: message_id.clone(),
-                        control_nonce,
-                        response_tx,
-                        normal_operation,
-                    },
-                )?;
-            }
-        }
-    }
-    let _pending_guard = PendingExecControlGuard::new(Arc::clone(shared), request_seq);
+    let (request_route_id, ()) = shared.register_route(|request_route_id, state| {
+        let ConnectionState::Connected { operations, .. } = state else {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "connection closed",
+            ));
+        };
+        operations.insert_pending_control(
+            target_route_id,
+            request_route_id,
+            PendingExecControl {
+                route_id: request_route_id,
+                target_route_id,
+                message_id: message_id.clone(),
+                control_nonce,
+                response_tx,
+                normal_operation,
+            },
+        )
+    })?;
+    let _pending_guard = PendingExecControlGuard::new(Arc::clone(shared), request_route_id);
+    let request_seq = request_route_id.wire_seq();
     let mut frame = Vec::new();
     vsock_proto::encode_exec_control_frame_into(
         &mut frame,
@@ -1118,7 +1147,7 @@ pub(in crate::exec_operation) async fn exec_control_on_shared(
     drop(control_payload);
     drop(message_id);
     write_encoded_frame_with_pre_write(shared, &frame, None, || {
-        mark_pending_exec_control_possible_guest_write(shared, target_seq, request_seq)?;
+        mark_pending_exec_control_possible_guest_write(shared, target_route_id, request_route_id)?;
         write_observer.record_write_start()
     })
     .await?;

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -11,7 +11,7 @@ use vsock_proto::{
 
 use crate::{CompositeNormalOperation, FrameWriteObserver, Shared};
 
-use super::frame::{write_exec_start_frame, write_frame};
+use super::frame::{admit_exec_cancel_frame, write_exec_start_frame, write_frame};
 use super::handle::{
     ExecControlHandle, ExecOperationCancelOnDropGuard, ExecOperationHandle,
     ExecOperationWaitOutcome, ExecWaitCore, SupervisedExecHandle,
@@ -123,7 +123,7 @@ async fn start_exec_operation_on_shared_with_tracking_and_admission(
     let deadline = exec_start_deadline(request.start_write_timeout)?;
 
     let ExecOperationRegistration {
-        seq,
+        route_id,
         diagnostic,
         result_rx,
         stream_rx,
@@ -144,7 +144,7 @@ async fn start_exec_operation_on_shared_with_tracking_and_admission(
         deadline,
         write_exec_start_frame(
             shared,
-            seq,
+            route_id,
             &payload,
             &diagnostic,
             tracks_normal_operation,
@@ -158,7 +158,7 @@ async fn start_exec_operation_on_shared_with_tracking_and_admission(
 
     Ok((
         ExecOperationHandle {
-            wait_core: ExecWaitCore::new(Arc::clone(shared), seq, diagnostic, result_rx),
+            wait_core: ExecWaitCore::new(Arc::clone(shared), route_id, diagnostic, result_rx),
             stream_rx,
         },
         deadline,
@@ -238,7 +238,7 @@ where
 
     let (start_tx, start_rx) = oneshot::channel();
     let ExecOperationRegistration {
-        seq,
+        route_id,
         diagnostic,
         result_rx,
         stream_rx,
@@ -258,13 +258,16 @@ where
             tracking: ExecOperationTracking::Tracked,
         },
     )?;
-    let mut start_cancel_on_drop =
-        ExecOperationCancelOnDropGuard::new_for_seq(Arc::clone(shared), seq, diagnostic.clone());
+    let mut start_cancel_on_drop = ExecOperationCancelOnDropGuard::new_for_route(
+        Arc::clone(shared),
+        route_id,
+        diagnostic.clone(),
+    );
     let start_write_result = time::timeout_at(
         deadline,
         write_exec_start_frame(
             shared,
-            seq,
+            route_id,
             &payload,
             &diagnostic,
             tracks_normal_operation,
@@ -300,9 +303,16 @@ where
             }
         }
         _ = time::sleep_until(deadline) => {
-            let payload = vsock_proto::encode_exec_cancel();
-            shared.remove_operation(seq);
+            let Some(_reservation) = admit_exec_cancel_frame(shared, route_id)? else {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "supervised exec route was replaced before start-timeout cancel",
+                ));
+            };
+            shared.remove_operation(route_id);
             registration_guard.disarm();
+            let seq = route_id.wire_seq();
+            let payload = vsock_proto::encode_exec_cancel();
             let cancel_result = tokio::time::timeout(
                 start_timeout_cancel_write_timeout,
                 write_frame(
@@ -341,13 +351,13 @@ where
     registration_guard.disarm();
 
     Ok(SupervisedExecHandle {
-        wait_core: ExecWaitCore::new(Arc::clone(shared), seq, diagnostic, result_rx),
+        wait_core: ExecWaitCore::new(Arc::clone(shared), route_id, diagnostic, result_rx),
         pid,
         cancel_handle_taken: false,
         stream_rx,
         control: control_nonce.map(|control_nonce| ExecControlHandle {
             shared: Arc::clone(shared),
-            target_seq: seq,
+            target_route_id: route_id,
             control_nonce,
         }),
     })

--- a/crates/vsock-host/src/exec_operation/state.rs
+++ b/crates/vsock-host/src/exec_operation/state.rs
@@ -6,7 +6,7 @@ use tokio::sync::{mpsc, oneshot};
 use vsock_proto::{ExecControlNonce, ExecControlStatus, ExecOutputPolicy, ExecTermination};
 
 use crate::{
-    CompositeNormalOperation, ConnectionState, Shared, normal_operation_transition_error,
+    CompositeNormalOperation, ConnectionState, RouteId, Shared, normal_operation_transition_error,
     operation_tracker::{NormalOperationToken, NormalOperationTransitionHandle},
 };
 
@@ -25,7 +25,7 @@ use super::{
 
 pub(crate) struct Operations {
     operations: HashMap<u32, ExecOperation>,
-    control_targets: HashMap<u32, u32>,
+    control_targets: HashMap<u32, RouteId>,
 }
 
 impl Operations {
@@ -41,19 +41,46 @@ impl Operations {
         self.operations.len()
     }
 
-    pub(in crate::exec_operation) fn insert(&mut self, seq: u32, operation: ExecOperation) {
-        self.operations.insert(seq, operation);
+    #[cfg(test)]
+    pub(crate) fn pending_control_count(&self) -> usize {
+        self.control_targets.len()
     }
 
-    pub(crate) fn remove(&mut self, seq: u32) {
-        if let Some(operation) = self.operations.remove(&seq) {
-            for request_seq in operation.pending_controls.keys() {
-                self.control_targets.remove(request_seq);
-            }
+    pub(crate) fn contains_route_seq(&self, seq: u32) -> bool {
+        self.operations.contains_key(&seq) || self.control_targets.contains_key(&seq)
+    }
+
+    pub(crate) fn contains_route(&self, route_id: RouteId) -> bool {
+        self.operations
+            .get(&route_id.wire_seq())
+            .is_some_and(|operation| operation.route_id == route_id)
+    }
+
+    pub(in crate::exec_operation) fn insert(
+        &mut self,
+        route_id: RouteId,
+        operation: ExecOperation,
+    ) {
+        assert!(
+            self.operations
+                .insert(route_id.wire_seq(), operation)
+                .is_none(),
+            "exec operation route must be vacant"
+        );
+    }
+
+    pub(crate) fn remove(&mut self, route_id: RouteId) {
+        let seq = route_id.wire_seq();
+        if self
+            .operations
+            .get(&seq)
+            .is_some_and(|operation| operation.route_id == route_id)
+        {
+            self.take_by_seq(seq);
         }
     }
 
-    pub(in crate::exec_operation) fn take(&mut self, seq: u32) -> Option<ExecOperation> {
+    pub(in crate::exec_operation) fn take_by_seq(&mut self, seq: u32) -> Option<ExecOperation> {
         let operation = self.operations.remove(&seq)?;
         for request_seq in operation.pending_controls.keys() {
             self.control_targets.remove(request_seq);
@@ -61,23 +88,45 @@ impl Operations {
         Some(operation)
     }
 
+    #[cfg(test)]
+    pub(crate) fn remove_by_seq(&mut self, seq: u32) -> bool {
+        self.take_by_seq(seq).is_some()
+    }
+
     pub(in crate::exec_operation) fn take_terminal_exec_operation(
         &mut self,
         seq: u32,
     ) -> io::Result<Option<TerminalExecOperation>> {
-        self.take(seq).map(ExecOperation::into_terminal).transpose()
+        self.take_by_seq(seq)
+            .map(ExecOperation::into_terminal)
+            .transpose()
     }
 
-    pub(in crate::exec_operation) fn contains(&self, seq: u32) -> bool {
+    pub(in crate::exec_operation) fn contains_seq(&self, seq: u32) -> bool {
         self.operations.contains_key(&seq)
     }
 
-    pub(in crate::exec_operation) fn get_mut(&mut self, seq: u32) -> Option<&mut ExecOperation> {
+    pub(in crate::exec_operation) fn get_mut_by_seq(
+        &mut self,
+        seq: u32,
+    ) -> Option<&mut ExecOperation> {
         self.operations.get_mut(&seq)
     }
 
-    pub(in crate::exec_operation) fn mark_host_cancel_requested(&mut self, seq: u32) -> bool {
-        if let Some(operation) = self.operations.get_mut(&seq) {
+    pub(in crate::exec_operation) fn get_mut(
+        &mut self,
+        route_id: RouteId,
+    ) -> Option<&mut ExecOperation> {
+        self.operations
+            .get_mut(&route_id.wire_seq())
+            .filter(|operation| operation.route_id == route_id)
+    }
+
+    pub(in crate::exec_operation) fn mark_host_cancel_requested(
+        &mut self,
+        route_id: RouteId,
+    ) -> bool {
+        if let Some(operation) = self.get_mut(route_id) {
             operation.host_cancel_requested = true;
             true
         } else {
@@ -87,28 +136,48 @@ impl Operations {
 
     pub(in crate::exec_operation) fn insert_pending_control(
         &mut self,
-        target_seq: u32,
-        request_seq: u32,
+        target_route_id: RouteId,
+        request_route_id: RouteId,
         pending: PendingExecControl,
     ) -> io::Result<()> {
-        let Some(operation) = self.operations.get_mut(&target_seq) else {
+        let Some(operation) = self.get_mut(target_route_id) else {
             return Err(exec_control_status_error(
                 ExecControlStatus::Inactive,
                 "exec operation is not active",
             ));
         };
         operation.validate_control_nonce(pending.control_nonce)?;
-        operation.pending_controls.insert(request_seq, pending);
-        self.control_targets.insert(request_seq, target_seq);
+        let request_seq = request_route_id.wire_seq();
+        assert!(
+            operation
+                .pending_controls
+                .insert(request_seq, pending)
+                .is_none(),
+            "exec control route must be vacant"
+        );
+        assert!(
+            self.control_targets
+                .insert(request_seq, target_route_id)
+                .is_none(),
+            "exec control target route must be vacant"
+        );
         Ok(())
     }
 
-    pub(in crate::exec_operation) fn remove_pending_control(&mut self, request_seq: u32) {
-        let Some(target_seq) = self.control_targets.remove(&request_seq) else {
+    pub(in crate::exec_operation) fn remove_pending_control(&mut self, request_route_id: RouteId) {
+        let request_seq = request_route_id.wire_seq();
+        let Some(target_route_id) = self.control_targets.get(&request_seq).copied() else {
             return;
         };
-        if let Some(operation) = self.operations.get_mut(&target_seq) {
-            operation.pending_controls.remove(&request_seq);
+        let request_matches = self
+            .get_mut(target_route_id)
+            .and_then(|operation| operation.pending_controls.get(&request_seq))
+            .is_some_and(|pending| pending.route_id == request_route_id);
+        if request_matches {
+            self.control_targets.remove(&request_seq);
+            if let Some(operation) = self.get_mut(target_route_id) {
+                operation.pending_controls.remove(&request_seq);
+            }
         }
     }
 
@@ -116,9 +185,8 @@ impl Operations {
         &mut self,
         request_seq: u32,
     ) -> Option<PendingExecControl> {
-        let target_seq = self.control_targets.remove(&request_seq)?;
-        self.operations
-            .get_mut(&target_seq)?
+        let target_route_id = self.control_targets.remove(&request_seq)?;
+        self.get_mut(target_route_id)?
             .pending_controls
             .remove(&request_seq)
     }
@@ -145,6 +213,7 @@ impl Default for Operations {
 }
 
 pub(in crate::exec_operation) struct ExecOperation {
+    pub(in crate::exec_operation) route_id: RouteId,
     pub(in crate::exec_operation) normal_operation: Option<ExecOperationNormalTracking>,
     pub(in crate::exec_operation) lifecycle: ExecOperationLifecycle,
     pub(in crate::exec_operation) diagnostic: ExecOperationDiagnostic,
@@ -173,7 +242,8 @@ pub(in crate::exec_operation) enum ExecOperationLifecycle {
 }
 
 pub(in crate::exec_operation) struct PendingExecControl {
-    pub(in crate::exec_operation) target_seq: u32,
+    pub(in crate::exec_operation) route_id: RouteId,
+    pub(in crate::exec_operation) target_route_id: RouteId,
     pub(in crate::exec_operation) message_id: String,
     pub(in crate::exec_operation) control_nonce: ExecControlNonce,
     pub(in crate::exec_operation) response_tx: oneshot::Sender<io::Result<ExecControlOutcome>>,
@@ -324,7 +394,7 @@ pub(in crate::exec_operation) struct ExecOperationRegistrationInput<'a> {
 }
 
 pub(in crate::exec_operation) struct ExecOperationRegistration {
-    pub(in crate::exec_operation) seq: u32,
+    pub(in crate::exec_operation) route_id: RouteId,
     pub(in crate::exec_operation) diagnostic: ExecOperationDiagnostic,
     pub(in crate::exec_operation) result_rx: oneshot::Receiver<io::Result<ExecOperationResult>>,
     pub(in crate::exec_operation) stream_rx: Option<mpsc::Receiver<ExecOutputEvent>>,
@@ -346,20 +416,20 @@ pub(in crate::exec_operation) struct ExecStreamState {
 
 pub(in crate::exec_operation) struct ExecOperationRegistrationGuard {
     pub(in crate::exec_operation) shared: Arc<Shared>,
-    pub(in crate::exec_operation) seq: u32,
+    pub(in crate::exec_operation) route_id: RouteId,
     pub(in crate::exec_operation) disarmed: bool,
 }
 
 pub(in crate::exec_operation) struct PendingExecControlGuard {
     pub(in crate::exec_operation) shared: Arc<Shared>,
-    pub(in crate::exec_operation) request_seq: u32,
+    pub(in crate::exec_operation) request_route_id: RouteId,
 }
 
 impl ExecOperationRegistrationGuard {
-    pub(in crate::exec_operation) fn new(shared: Arc<Shared>, seq: u32) -> Self {
+    pub(in crate::exec_operation) fn new(shared: Arc<Shared>, route_id: RouteId) -> Self {
         Self {
             shared,
-            seq,
+            route_id,
             disarmed: false,
         }
     }
@@ -372,23 +442,23 @@ impl ExecOperationRegistrationGuard {
 impl Drop for ExecOperationRegistrationGuard {
     fn drop(&mut self) {
         if !self.disarmed {
-            self.shared.remove_operation(self.seq);
+            self.shared.remove_operation(self.route_id);
         }
     }
 }
 
 impl PendingExecControlGuard {
-    pub(in crate::exec_operation) fn new(shared: Arc<Shared>, request_seq: u32) -> Self {
+    pub(in crate::exec_operation) fn new(shared: Arc<Shared>, request_route_id: RouteId) -> Self {
         Self {
             shared,
-            request_seq,
+            request_route_id,
         }
     }
 }
 
 impl Drop for PendingExecControlGuard {
     fn drop(&mut self) {
-        remove_pending_exec_control(&self.shared, self.request_seq);
+        remove_pending_exec_control(&self.shared, self.request_route_id);
     }
 }
 
@@ -485,8 +555,6 @@ pub(in crate::exec_operation) fn register_exec_operation_start(
         None => (None, None),
     };
     let (result_tx, result_rx) = oneshot::channel();
-    let seq = shared.next_seq();
-    let diagnostic = ExecOperationDiagnostic::new(seq, label);
     let normal_operation = match tracking {
         ExecOperationTracking::Tracked => Some(ExecOperationNormalTracking::Owned(
             shared.reserve_normal_operation()?,
@@ -497,43 +565,40 @@ pub(in crate::exec_operation) fn register_exec_operation_start(
         ExecOperationTracking::Untracked => None,
     };
     let tracks_normal_operation = normal_operation.is_some();
-    let operation = ExecOperation {
-        normal_operation,
-        lifecycle,
-        diagnostic: diagnostic.clone(),
-        result_tx,
-        stream_tx,
-        stdout_capture: capture_state(stdout),
-        stderr_capture: capture_state(stderr),
-        stdout_stream: stream_state(stdout),
-        stderr_stream: stream_state(stderr),
-        expected_output_seq: 0,
-        stream_overflowed: false,
-        host_cancel_requested: false,
-        pending_controls: HashMap::new(),
-    };
-
-    {
-        let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
-        match &mut *guard {
-            ConnectionState::Closed => {
-                return Err(io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "connection closed",
-                ));
-            }
-            ConnectionState::Connected { operations, .. } => {
-                operations.insert(seq, operation);
-            }
-        }
-    }
+    let (route_id, diagnostic) = shared.register_route(|route_id, state| {
+        let diagnostic = ExecOperationDiagnostic::new(route_id.wire_seq(), label);
+        let operation = ExecOperation {
+            route_id,
+            normal_operation,
+            lifecycle,
+            diagnostic: diagnostic.clone(),
+            result_tx,
+            stream_tx,
+            stdout_capture: capture_state(stdout),
+            stderr_capture: capture_state(stderr),
+            stdout_stream: stream_state(stdout),
+            stderr_stream: stream_state(stderr),
+            expected_output_seq: 0,
+            stream_overflowed: false,
+            host_cancel_requested: false,
+            pending_controls: HashMap::new(),
+        };
+        let ConnectionState::Connected { operations, .. } = state else {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "connection closed",
+            ));
+        };
+        operations.insert(route_id, operation);
+        Ok(diagnostic)
+    })?;
 
     Ok(ExecOperationRegistration {
-        seq,
+        route_id,
         diagnostic,
         result_rx,
         stream_rx,
-        registration_guard: ExecOperationRegistrationGuard::new(Arc::clone(shared), seq),
+        registration_guard: ExecOperationRegistrationGuard::new(Arc::clone(shared), route_id),
         tracks_normal_operation,
     })
 }

--- a/crates/vsock-host/src/exec_operation/tests.rs
+++ b/crates/vsock-host/src/exec_operation/tests.rs
@@ -15,7 +15,7 @@ use vsock_proto::{
 };
 
 use crate::tests::support::read_guest_message;
-use crate::{ConnectionState, Shared};
+use crate::{ConnectionState, RouteId, Shared};
 
 use super::diagnostics::*;
 use super::dispatch::dispatch_result;
@@ -31,6 +31,7 @@ fn exec_operation_for_snapshot(seq: u32, label: &str) -> ExecOperation {
     let (result_tx, _result_rx) = oneshot::channel();
     let normal_operations = crate::operation_tracker::NormalOperationTracker::new();
     ExecOperation {
+        route_id: RouteId::from_raw(u64::from(seq)),
         normal_operation: Some(ExecOperationNormalTracking::Owned(
             normal_operations.reserve().unwrap(),
         )),
@@ -415,8 +416,10 @@ fn shared_with_logged_operation(
         frame_builder: tokio::sync::Mutex::new(()),
         file_write_gate: tokio::sync::Mutex::new(()),
         fd,
-        seq: AtomicU32::new(2),
+        temp_seq: AtomicU32::new(2),
         state: std::sync::Mutex::new(ConnectionState::Connected {
+            next_route_id: 2,
+            route_reservations: HashMap::new(),
             pending: HashMap::new(),
             operations: Operations::new(),
         }),
@@ -432,9 +435,11 @@ fn shared_with_logged_operation(
         let ConnectionState::Connected { operations, .. } = &mut *guard else {
             panic!("test shared state must be connected");
         };
+        let route_id = RouteId::from_raw(7);
         operations.insert(
-            7,
+            route_id,
             ExecOperation {
+                route_id,
                 normal_operation: None,
                 lifecycle,
                 diagnostic: diagnostic.clone(),
@@ -540,9 +545,14 @@ async fn supervised_cancel_frame_marks_terminal_result_as_host_requested_cancel(
         false,
     );
 
-    send_exec_cancel_frame(&shared, 7, &diagnostic, ExecWaitLifecycle::Supervised)
-        .await
-        .unwrap();
+    send_exec_cancel_frame(
+        &shared,
+        RouteId::from_raw(7),
+        &diagnostic,
+        ExecWaitLifecycle::Supervised,
+    )
+    .await
+    .unwrap();
 
     let payload = vsock_proto::encode_exec_result(
         ExecTermination::Cancelled,
@@ -586,7 +596,12 @@ async fn one_shot_cancel_handle_marks_terminal_result_as_host_requested_cancel()
         false,
     );
     let handle = ExecOperationHandle {
-        wait_core: ExecWaitCore::new(Arc::clone(&shared), 7, diagnostic, result_rx),
+        wait_core: ExecWaitCore::new(
+            Arc::clone(&shared),
+            RouteId::from_raw(7),
+            diagnostic,
+            result_rx,
+        ),
         stream_rx: None,
     };
 
@@ -1052,7 +1067,7 @@ fn exec_operation_close_snapshot_limits_logged_operations() {
     let mut operations = Operations::new();
     for seq in 0..active_count {
         operations.insert(
-            seq as u32,
+            RouteId::from_raw(seq as u64),
             exec_operation_for_snapshot(seq as u32, &format!("operation-{seq}")),
         );
     }
@@ -1068,7 +1083,7 @@ fn exec_operation_close_snapshot_limits_logged_operations() {
         active_count - EXEC_OPERATION_CLOSE_ACTIVE_LOG_LIMIT
     );
     for operation in snapshot.operations {
-        assert!(operations.contains(operation.seq));
+        assert!(operations.contains_seq(operation.seq));
         assert!(operation.label_log.starts_with("operation-"));
     }
 }

--- a/crates/vsock-host/src/file/copy.rs
+++ b/crates/vsock-host/src/file/copy.rs
@@ -439,7 +439,7 @@ impl VsockHost {
         }
 
         let (mut temp_guard, temp_file) =
-            create_copy_temp_file(host_path, self.shared.next_seq()).await?;
+            create_copy_temp_file(host_path, self.shared.next_temp_seq()).await?;
         let mut normal_operation = CompositeNormalOperation::reserve(&self.shared)?;
         let copy_result = self
             .copy_file_to_temp(

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -562,7 +562,7 @@ impl VsockHost {
         // Write chunks to a per-call temp file, then atomic rename. The
         // suffix prevents concurrent large writes to the same destination
         // from appending to or cleaning up each other's staging file.
-        let tmp = format!("{path}.vm0tmp-{}", self.shared.next_seq());
+        let tmp = format!("{path}.vm0tmp-{}", self.shared.next_temp_seq());
         let quoted_tmp = quote_shell_arg(&tmp);
         let rm_tmp = format!("rm -f -- {quoted_tmp}");
         let cleanup_armed = Arc::new(AtomicBool::new(false));

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -82,8 +82,8 @@ use std::time::Duration;
 use tokio::task::JoinHandle;
 
 use connection::{
-    CompositeNormalOperation, ConnectionState, Shared, normal_operation_transition_error,
-    normal_request_on_shared_with_write_observer_frame_builder,
+    CompositeNormalOperation, ConnectionState, RouteId, RouteReservation, Shared,
+    normal_operation_transition_error, normal_request_on_shared_with_write_observer_frame_builder,
     request_on_shared_with_composite_operation_and_observer_frame_builder,
 };
 #[cfg(test)]

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -12,7 +12,8 @@ use super::support::{
     MockGuest, await_mock_guest, captured_output_bytes, drop_idle_request_write_guard,
     drop_started_request_write_guard, exec_capture_default, fence_normal_operations,
     host_from_stream, is_connected, make_pair, normal_operation_readiness, pending_request_count,
-    poison_connection, setup_host_and_mock_guest,
+    poison_connection, set_next_route_id, setup_host_and_mock_guest,
+    wait_for_pending_request_count,
 };
 use crate::{
     NormalOperationFenceRejection, VsockHost, operation_tracker::NormalOperationReadiness,
@@ -393,6 +394,48 @@ async fn memory_snapshot_timeout_removes_pending_and_ignores_late_response() {
         )
         .await;
     assert_eq!(second_task.await.unwrap().unwrap(), memory_snapshot());
+}
+
+#[tokio::test]
+async fn stale_request_cleanup_does_not_remove_reused_wire_sequence() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    let expected = memory_snapshot();
+    let wire_seq = 17;
+    set_next_route_id(&host, wire_seq.into());
+
+    let mut first = Box::pin(host.memory_snapshot(Duration::from_secs(5)));
+    let first_request = tokio::select! {
+        result = &mut first => panic!("first request completed before guest response: {result:?}"),
+        request = guest.expect_message(MSG_MEMORY_SNAPSHOT) => request,
+    };
+    assert_eq!(first_request.seq, wire_seq);
+    guest
+        .send_response(
+            MSG_MEMORY_SNAPSHOT_RESULT,
+            first_request.seq,
+            &expected.encode_payload(),
+        )
+        .await;
+    wait_for_pending_request_count(&host, 0).await;
+
+    set_next_route_id(&host, (1_u64 << 32) + u64::from(wire_seq));
+    let mut second = Box::pin(host.memory_snapshot(Duration::from_secs(5)));
+    let second_request = tokio::select! {
+        result = &mut second => panic!("second request completed before guest response: {result:?}"),
+        request = guest.expect_message(MSG_MEMORY_SNAPSHOT) => request,
+    };
+    assert_eq!(second_request.seq, first_request.seq);
+
+    drop(first);
+    assert_eq!(pending_request_count(&host), 1);
+    guest
+        .send_response(
+            MSG_MEMORY_SNAPSHOT_RESULT,
+            second_request.seq,
+            &expected.encode_payload(),
+        )
+        .await;
+    assert_eq!(second.await.unwrap(), expected);
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/exec.rs
+++ b/crates/vsock-host/src/tests/exec_operation/exec.rs
@@ -1,13 +1,14 @@
 use std::io;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
 use vsock_proto::{ExecTermination, MSG_ERROR, MSG_EXEC_START};
 
 use super::super::support::{
     MockGuest, await_mock_guest, captured_output_bytes, exec_capture_default, host_from_stream,
-    make_pair, normal_operation_readiness, read_guest_message, send_exec_result,
-    setup_host_and_guest, wait_for_operation_count,
+    make_pair, normal_operation_readiness, operation_count, read_guest_message, send_exec_result,
+    set_next_route_id, setup_host_and_guest, wait_for_operation_count,
 };
 use super::start_capture_operation;
 use crate::operation_tracker::NormalOperationReadiness;
@@ -87,6 +88,46 @@ async fn exec_operation_tracks_until_terminal_result() {
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle
     );
+}
+
+#[tokio::test]
+async fn stale_exec_handle_cleanup_does_not_remove_reused_wire_sequence() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let wire_seq = 23;
+    set_next_route_id(&host, wire_seq.into());
+
+    let first_handle = start_capture_operation(&host, "first generation").await;
+    let first_start = read_guest_message(&mut guest).await;
+    assert_eq!(first_start.msg_type, MSG_EXEC_START);
+    assert_eq!(first_start.seq, wire_seq);
+    send_exec_result(
+        &mut guest,
+        first_start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"first",
+        b"",
+    )
+    .await;
+    wait_for_operation_count(&host, 0).await;
+
+    set_next_route_id(&host, (1_u64 << 32) + u64::from(wire_seq));
+    let second_handle = start_capture_operation(&host, "second generation").await;
+    let second_start = read_guest_message(&mut guest).await;
+    assert_eq!(second_start.msg_type, MSG_EXEC_START);
+    assert_eq!(second_start.seq, first_start.seq);
+
+    drop(first_handle);
+    assert_eq!(operation_count(&host), 1);
+    send_exec_result(
+        &mut guest,
+        second_start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"second",
+        b"",
+    )
+    .await;
+    let result = second_handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(captured_output_bytes(&result.stdout), b"second");
 }
 
 /// `host.exec` with `timeout_ms == 0` must reject at the boundary rather

--- a/crates/vsock-host/src/tests/exec_operation/stream.rs
+++ b/crates/vsock-host/src/tests/exec_operation/stream.rs
@@ -557,8 +557,7 @@ async fn exec_output_teardown_before_copy_discards_reserved_event() {
             let ConnectionState::Connected { operations, .. } = &mut *guard else {
                 return false;
             };
-            operations.remove(seq);
-            true
+            operations.remove_by_seq(seq)
         })
         .join()
         .expect("operation teardown thread should not panic");

--- a/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
@@ -1,12 +1,15 @@
 use std::io;
+use std::sync::Arc;
 use std::time::Duration;
 
-use vsock_proto::{ExecTermination, MSG_EXEC_CANCEL};
+use vsock_proto::{ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_START};
 
 use super::super::super::support::{
     assert_connection_accepts_exec_operation, is_connected, normal_operation_readiness,
-    operation_count, read_guest_message, send_exec_result, wait_for_operation_count,
+    operation_count, read_guest_message, route_reservation_count, send_exec_result,
+    set_next_route_id, wait_for_operation_count, wait_for_route_reservation_count,
 };
+use super::super::start_capture_operation;
 use super::support::{
     StartedSupervisedExec, assert_no_guest_frame, send_guest_error, start_supervised_exec_fixture,
     supervised_request,
@@ -36,6 +39,62 @@ async fn supervised_exec_cancel_on_drop_sends_exec_cancel() {
     send_exec_result(&mut guest, start_seq, ExecTermination::Cancelled, b"", b"").await;
     let result = handle.wait(Duration::from_secs(5)).await.unwrap();
     assert_eq!(result.termination, ExecTermination::Cancelled);
+}
+
+#[tokio::test]
+async fn queued_cancel_reservation_prevents_wire_sequence_reuse() {
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        mut handle,
+    } = start_supervised_exec_fixture(supervised_request("queued-cancel-route")).await;
+    let start_seq = start.seq();
+    let cancel_handle = handle
+        .take_cancel_handle()
+        .expect("supervised handle should expose a cancel handle");
+    let writer_guard = host.shared.writer.lock().await;
+    let cancel_task =
+        tokio::spawn(async move { cancel_handle.cancel(Duration::from_secs(5)).await });
+    wait_for_route_reservation_count(&host, 1).await;
+
+    send_exec_result(
+        &mut guest,
+        start_seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    wait_for_operation_count(&host, 0).await;
+    set_next_route_id(&host, (1_u64 << 32) + u64::from(start_seq));
+    let replacement_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { start_capture_operation(&host, "replacement").await })
+    };
+    wait_for_operation_count(&host, 1).await;
+
+    drop(writer_guard);
+    let cancel = read_guest_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start_seq);
+    let replacement_start = read_guest_message(&mut guest).await;
+    assert_eq!(replacement_start.msg_type, MSG_EXEC_START);
+    assert_eq!(replacement_start.seq, start_seq + 1);
+    cancel_task.await.unwrap().unwrap();
+    assert_eq!(route_reservation_count(&host), 0);
+
+    let replacement = replacement_task.await.unwrap();
+    send_exec_result(
+        &mut guest,
+        replacement_start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    replacement.wait(Duration::from_secs(5)).await.unwrap();
+    handle.wait(Duration::from_secs(5)).await.unwrap();
 }
 
 #[tokio::test]
@@ -291,6 +350,49 @@ async fn supervised_exec_cancel_handle_after_terminal_result_preserves_wait_and_
     assert_eq!(operation_count(&host), 0);
 
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn stale_cancel_handle_does_not_cancel_reused_wire_sequence() {
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        mut handle,
+    } = start_supervised_exec_fixture(supervised_request("stale-cancel-handle")).await;
+    let start_seq = start.seq();
+    let cancel_handle = handle
+        .take_cancel_handle()
+        .expect("supervised handle should expose a cancel handle");
+    send_exec_result(
+        &mut guest,
+        start_seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    wait_for_operation_count(&host, 0).await;
+
+    set_next_route_id(&host, (1_u64 << 32) + u64::from(start_seq));
+    let replacement = start_capture_operation(&host, "replacement cancel target").await;
+    let replacement_start = read_guest_message(&mut guest).await;
+    assert_eq!(replacement_start.msg_type, MSG_EXEC_START);
+    assert_eq!(replacement_start.seq, start_seq);
+
+    cancel_handle.cancel(Duration::from_secs(5)).await.unwrap();
+    assert_no_guest_frame(&mut guest, "stale cancel must not target replacement");
+    assert_eq!(operation_count(&host), 1);
+    handle.wait(Duration::from_secs(5)).await.unwrap();
+    send_exec_result(
+        &mut guest,
+        replacement_start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    replacement.wait(Duration::from_secs(5)).await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
@@ -1,15 +1,19 @@
 use std::io;
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
 use vsock_proto::{
     ExecControlStatus, ExecTermination, MSG_ERROR, MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT,
+    MSG_EXEC_START, MSG_OPERATIONS_RESUMED, MSG_RESUME_OPERATIONS,
 };
 
 use super::super::super::support::{
     assert_connection_accepts_exec_operation, normal_operation_readiness, operation_count,
-    read_guest_message, send_exec_control_result, send_exec_result,
+    pending_control_count, read_guest_message, send_exec_control_result, send_exec_result,
+    set_next_route_id, wait_for_pending_control_count,
 };
+use super::super::start_capture_operation;
 use super::support::{
     StartedControlSupervisedExec, StartedSupervisedExec, assert_no_guest_frame,
     finish_supervised_exec_success, send_guest_error, start_control_supervised_exec_fixture,
@@ -64,6 +68,150 @@ async fn supervised_exec_control_uses_exec_control_messages() {
     assert_eq!(ack.message_id, "message-1");
 
     finish_supervised_exec_success(&mut guest, start_seq, handle)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn stale_control_cleanup_does_not_remove_reused_wire_sequence() {
+    let StartedControlSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        control_nonce,
+    } = start_control_supervised_exec_fixture("control-route-generation").await;
+    let wire_seq = 29;
+    set_next_route_id(&host, wire_seq.into());
+
+    let mut first =
+        Box::pin(control_handle.control("first-generation", b"first", Duration::from_secs(5)));
+    let first_control = tokio::select! {
+        result = &mut first => panic!("first control completed before guest response: {result:?}"),
+        message = read_guest_message(&mut guest) => message,
+    };
+    assert_eq!(first_control.msg_type, MSG_EXEC_CONTROL);
+    assert_eq!(first_control.seq, wire_seq);
+    send_exec_control_result(
+        &mut guest,
+        first_control.seq,
+        start.seq(),
+        control_nonce,
+        "first-generation",
+        ExecControlStatus::Delivered,
+        "",
+    )
+    .await;
+    wait_for_pending_control_count(&host, 0).await;
+
+    set_next_route_id(&host, (1_u64 << 32) + u64::from(wire_seq));
+    let mut second =
+        Box::pin(control_handle.control("second-generation", b"second", Duration::from_secs(5)));
+    let second_control = tokio::select! {
+        result = &mut second => panic!("second control completed before guest response: {result:?}"),
+        message = read_guest_message(&mut guest) => message,
+    };
+    assert_eq!(second_control.msg_type, MSG_EXEC_CONTROL);
+    assert_eq!(second_control.seq, first_control.seq);
+
+    drop(first);
+    assert_eq!(pending_control_count(&host), 1);
+    send_exec_control_result(
+        &mut guest,
+        second_control.seq,
+        start.seq(),
+        control_nonce,
+        "second-generation",
+        ExecControlStatus::Delivered,
+        "",
+    )
+    .await;
+    assert_eq!(second.await.unwrap().message_id, "second-generation");
+
+    finish_supervised_exec_success(&mut guest, start.seq(), handle)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn route_wrap_skips_every_live_request_class() {
+    let StartedControlSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        control_nonce,
+    } = start_control_supervised_exec_fixture("route-wrap").await;
+    assert_eq!(start.seq(), 2);
+
+    set_next_route_id(&host, u64::from(u32::MAX));
+    let wrapped_exec = start_capture_operation(&host, "wrapped exec").await;
+    let wrapped_start = read_guest_message(&mut guest).await;
+    assert_eq!(wrapped_start.msg_type, MSG_EXEC_START);
+    assert_eq!(wrapped_start.seq, u32::MAX);
+
+    let control_task = tokio::spawn({
+        let control_handle = control_handle.clone();
+        async move {
+            control_handle
+                .control("wrapped-control", b"control", Duration::from_secs(5))
+                .await
+        }
+    });
+    let control = read_guest_message(&mut guest).await;
+    assert_eq!(control.msg_type, MSG_EXEC_CONTROL);
+    assert_eq!(control.seq, 1);
+
+    let resume_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.resume_operations(Duration::from_secs(5)).await })
+    };
+    let resume = read_guest_message(&mut guest).await;
+    assert_eq!(resume.msg_type, MSG_RESUME_OPERATIONS);
+    assert_eq!(resume.seq, 3);
+
+    set_next_route_id(&host, (1_u64 << 32) + u64::from(u32::MAX));
+    let next_exec = start_capture_operation(&host, "next generation").await;
+    let next_start = read_guest_message(&mut guest).await;
+    assert_eq!(next_start.msg_type, MSG_EXEC_START);
+    assert_eq!(next_start.seq, 4);
+
+    send_exec_control_result(
+        &mut guest,
+        control.seq,
+        start.seq(),
+        control_nonce,
+        "wrapped-control",
+        ExecControlStatus::Delivered,
+        "",
+    )
+    .await;
+    let resumed = vsock_proto::encode(MSG_OPERATIONS_RESUMED, resume.seq, &[]).unwrap();
+    guest.write_all(&resumed).await.unwrap();
+    assert_eq!(control_task.await.unwrap().unwrap().target_seq, start.seq());
+    resume_task.await.unwrap().unwrap();
+
+    send_exec_result(
+        &mut guest,
+        wrapped_start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    send_exec_result(
+        &mut guest,
+        next_start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    wrapped_exec.wait(Duration::from_secs(5)).await.unwrap();
+    next_exec.wait(Duration::from_secs(5)).await.unwrap();
+    finish_supervised_exec_success(&mut guest, start.seq(), handle)
         .await
         .unwrap();
 }
@@ -653,7 +801,7 @@ async fn supervised_exec_control_message_id_mismatch_poisons_connection() {
 #[tokio::test]
 async fn supervised_exec_control_inactive_target_returns_not_found_without_frame() {
     let StartedControlSupervisedExec {
-        host: _host,
+        host,
         mut guest,
         start,
         handle,
@@ -671,10 +819,26 @@ async fn supervised_exec_control_inactive_target_returns_not_found_without_frame
     .await;
     handle.wait(Duration::from_secs(5)).await.unwrap();
 
+    set_next_route_id(&host, (1_u64 << 32) + u64::from(start_seq));
+    let replacement = start_capture_operation(&host, "replacement target").await;
+    let replacement_start = read_guest_message(&mut guest).await;
+    assert_eq!(replacement_start.msg_type, MSG_EXEC_START);
+    assert_eq!(replacement_start.seq, start_seq);
+
     let err = control_handle
         .control("after-exit", b"payload", Duration::from_secs(5))
         .await
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::NotFound);
     assert_no_guest_frame(&mut guest, "inactive control must not send a frame");
+    assert_eq!(operation_count(&host), 1);
+    send_exec_result(
+        &mut guest,
+        replacement_start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    replacement.wait(Duration::from_secs(5)).await.unwrap();
 }

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -187,6 +187,36 @@ pub(crate) fn pending_request_count(host: &VsockHost) -> usize {
     }
 }
 
+pub(crate) fn pending_control_count(host: &VsockHost) -> usize {
+    let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    match &*guard {
+        ConnectionState::Connected { operations, .. } => operations.pending_control_count(),
+        ConnectionState::Closed => 0,
+    }
+}
+
+pub(crate) fn set_next_route_id(host: &VsockHost, next_route_id: u64) {
+    let mut guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    let ConnectionState::Connected {
+        next_route_id: current,
+        ..
+    } = &mut *guard
+    else {
+        panic!("connection should be open");
+    };
+    *current = next_route_id;
+}
+
+pub(crate) fn route_reservation_count(host: &VsockHost) -> usize {
+    let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
+    match &*guard {
+        ConnectionState::Connected {
+            route_reservations, ..
+        } => route_reservations.len(),
+        ConnectionState::Closed => 0,
+    }
+}
+
 pub(crate) fn is_connected(host: &VsockHost) -> bool {
     let guard = host.shared.state.lock().unwrap_or_else(|e| e.into_inner());
     matches!(&*guard, ConnectionState::Connected { .. })
@@ -443,6 +473,36 @@ pub(crate) async fn send_exec_output(
 pub(crate) async fn wait_for_operation_count(host: &VsockHost, expected: usize) {
     tokio::time::timeout(Duration::from_secs(5), async {
         while operation_count(host) != expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+pub(crate) async fn wait_for_pending_request_count(host: &VsockHost, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while pending_request_count(host) != expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+pub(crate) async fn wait_for_pending_control_count(host: &VsockHost, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while pending_control_count(host) != expected {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+pub(crate) async fn wait_for_route_reservation_count(host: &VsockHost, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while route_reservation_count(host) != expected {
             tokio::task::yield_now().await;
         }
     })


### PR DESCRIPTION
## Summary

- allocate and register ordinary requests, exec operations, and exec controls atomically from one connection-local route namespace
- retain a full logical route generation for owner-side cleanup and actions while preserving the existing `u32` wire sequence
- reserve admitted queued cancel frames until their write completes so stale cancellation cannot target a replacement route
- separate temporary-file suffix generation from protocol route allocation

## Compatibility

- no guest or wire-format changes
- no public API, database, or migration changes
- handshake sequence `1`, first post-handshake route `2`, and temporary filename formats remain unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p vsock-host --all-targets --all-features`
- `cargo clippy -p vsock-host --all-targets --all-features -- -D warnings`
- `cargo doc -p vsock-host --all-features --no-deps`
- `cargo test -p vsock-host --quiet`
- six wrap and stale-owner integration tests repeated 20 times each
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-targets --all-features`

Closes #26891
