### PR TITLE
fix(e2e): synchronize runner organization bootstrap

### DIFF
--- a/e2e/playwright/lib/onboarding.test.ts
+++ b/e2e/playwright/lib/onboarding.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { test } from "node:test";
+
+import { ensureRunnerOrganizationReady } from "./onboarding";
+
+test("synchronizes runner organization onboarding through the public status route", async () => {
+  const requests: Array<{
+    readonly authorization: string | null;
+    readonly bypass: string | null;
+    readonly method: string | undefined;
+    readonly url: string | undefined;
+  }> = [];
+  const server = createServer((request, response) => {
+    requests.push({
+      authorization: request.headers.authorization ?? null,
+      bypass: headerValue(request.headers["x-vercel-protection-bypass"]),
+      method: request.method,
+      url: request.url,
+    });
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(
+      JSON.stringify({
+        needsOnboarding: true,
+        onboardingComplete: false,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: "agent_default",
+        defaultAgentMetadata: null,
+      }),
+    );
+  });
+
+  await listen(server);
+  try {
+    const address = server.address();
+    assert(address && typeof address === "object");
+
+    await ensureRunnerOrganizationReady({
+      apiUrl: `http://127.0.0.1:${address.port}`,
+      clerkSessionToken: "clerk-session-token",
+      vercelAutomationBypassSecret: "preview-bypass",
+    });
+
+    assert.deepEqual(requests, [
+      {
+        authorization: "Bearer clerk-session-token",
+        bypass: "preview-bypass",
+        method: "GET",
+        url: "/api/okou/onboarding/status",
+      },
+    ]);
+  } finally {
+    await close(server);
+  }
+});
+
+test("rejects a runner organization that remains uninitialized", async () => {
+  let requestCount = 0;
+  const server = createServer((_request, response) => {
+    requestCount += 1;
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(
+      JSON.stringify({
+        needsOnboarding: true,
+        onboardingComplete: false,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: false,
+        defaultAgentId: null,
+        defaultAgentMetadata: null,
+      }),
+    );
+  });
+
+  await listen(server);
+  try {
+    const address = server.address();
+    assert(address && typeof address === "object");
+
+    await assert.rejects(
+      ensureRunnerOrganizationReady({
+        apiUrl: `http://127.0.0.1:${address.port}`,
+        clerkSessionToken: "clerk-session-token",
+      }),
+      /did not return a ready admin organization/u,
+    );
+    assert.equal(requestCount, 1);
+  } finally {
+    await close(server);
+  }
+});
+
+async function listen(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+async function close(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function headerValue(
+  value: string | readonly string[] | undefined,
+): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  return value?.[0] ?? null;
+}

--- a/e2e/playwright/lib/onboarding.ts
+++ b/e2e/playwright/lib/onboarding.ts
@@ -9,14 +9,64 @@ interface OnboardingFlowOptions {
   readonly appUrl: string;
 }
 
-export function authHeadersForToken(token: string): AuthHeaders {
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+interface RunnerOrganizationReadinessOptions {
+  readonly apiUrl: string;
+  readonly clerkSessionToken: string;
+  readonly vercelAutomationBypassSecret?: string;
+}
+
+export function authHeadersForToken(
+  token: string,
+  bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+): AuthHeaders {
   return {
     Authorization: `Bearer ${token}`,
     ...(bypassSecret
       ? { "x-vercel-protection-bypass": bypassSecret }
       : undefined),
   };
+}
+
+/**
+ * The onboarding status route synchronously creates the fresh organization's
+ * default agent, limited-free entitlement, and onboarding credit grant.
+ */
+export async function ensureRunnerOrganizationReady(
+  options: RunnerOrganizationReadinessOptions,
+): Promise<void> {
+  const response = await fetch(
+    new URL("/api/okou/onboarding/status", options.apiUrl),
+    {
+      headers: authHeadersForToken(
+        options.clerkSessionToken,
+        options.vercelAutomationBypassSecret,
+      ),
+    },
+  );
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new Error(
+      `Runner organization onboarding status failed with HTTP ${response.status}`,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = (await response.json()) as unknown;
+  } catch (cause) {
+    throw new Error(
+      "Runner organization onboarding status returned invalid JSON",
+      {
+        cause,
+      },
+    );
+  }
+
+  if (!isReadyRunnerOrganization(body)) {
+    throw new Error(
+      "Runner organization onboarding status did not return a ready admin organization",
+    );
+  }
 }
 
 export async function completeExploreOnboarding(
@@ -138,4 +188,20 @@ function isChatUrl(url: URL): boolean {
 
 function isPromptOrChatUrl(url: URL): boolean {
   return url.pathname === "/prompt" || isChatUrl(url);
+}
+
+function isReadyRunnerOrganization(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "hasOrg" in value &&
+    value.hasOrg === true &&
+    "isAdmin" in value &&
+    value.isAdmin === true &&
+    "hasDefaultAgent" in value &&
+    value.hasDefaultAgent === true &&
+    "defaultAgentId" in value &&
+    typeof value.defaultAgentId === "string" &&
+    value.defaultAgentId.length > 0
+  );
 }

--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -11,6 +11,7 @@ import {
 import { issueCliToken } from "./lib/cli-token";
 import { runnerTestAccounts } from "./lib/clerk-api";
 import {
+  ensureRunnerOrganizationReady,
   startVideoOnboardingCheckout,
   waitForPaidOnboardingCompletion,
 } from "./lib/onboarding";
@@ -94,6 +95,11 @@ async function main(): Promise<void> {
           appUrl,
           { activeOrganizationId: target.organizationId },
         );
+        await ensureRunnerOrganizationReady({
+          apiUrl,
+          clerkSessionToken,
+          vercelAutomationBypassSecret,
+        });
         if (target.upgradeToPro) {
           await completePaidOnboarding(page, target, appUrl, outputDirectory);
           clerkSessionToken = await refreshClerkSessionToken(page, {


### PR DESCRIPTION
## Summary

- synchronize every fresh runner E2E organization through the public onboarding status route before issuing its CLI credential
- fail account preparation immediately if the route does not return an admin organization with a committed default agent
- cover both the one-request synchronization contract and the not-ready failure path without polling, sleeps, or chat retries

## Root cause evidence

[Turbo run 31691430484](https://github.com/vm0-ai/vm0/actions/runs/31691430484) was not ten independent test failures. All ten ordinary runner shards shared one fresh limited-free organization and received `201` chat responses with `runId: null`; the separate paid Codex/Claude organizations passed.

The first failed chat request at `2026-08-13T10:36:54.672Z` (trace `62d397eb6ab0087abd5a196accef2a36`) persisted `input.rejected` and `output.error` with the `insufficient_credits` marker. It had no usage-pack credit read, agent-run insert, or runner notification. That request preceded the affected fresh organization's delayed plan-entitlement bootstrap. In contrast, the same PR head's green [Turbo run 31690038921](https://github.com/vm0-ai/vm0/actions/runs/31690038921) read the plan entitlement and usage-pack grant before persisting and dispatching the run (trace `c442cbf77154619085ea286184d1c0e0`).

Runner account preparation previously issued the ordinary CLI token immediately after Clerk organization activation. Clerk webhook delivery initializes the API-local default agent, limited-free entitlement, and onboarding credits asynchronously. Paid runner accounts incidentally waited through the checkout lifecycle, explaining why only their shards escaped the race. `GET /api/okou/onboarding/status` is the existing synchronous lifecycle boundary: it awaits `ensureOrgLimitedFreeBootstrap$`, whose final transaction commits the default agent, entitlement, and credit grant.

The represented PR #26917 is excluded as a deterministic integration regression: its exact merge-group diff only neutralized TypeScript workflow facade names, and its identical head SHA completed all runner shards successfully before this merge-group attempt.

## Verification

- `cd e2e && pnpm exec tsx --test playwright/lib/onboarding.test.ts` — 5 consecutive passes (2/2 each)
- `cd e2e && pnpm check-types`
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- repository Prettier, Turbo lint, Knip, and staged Turbo/App/API type checks
- Turbo PR pipeline will exercise the real fresh-account runner blast; UI preview is not applicable to this account-preparation-only change

<!-- turbo-flaky-repair -->
TURBO_FLAKY_KEY: cli-e2e-03-runner:parallel-chat-create:immediate-run-id-null-after-runner-ready
