### PR TITLE
refactor(api): remove queued chat events endpoint

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts
@@ -349,56 +349,6 @@ describe("chat event snapshot read endpoints", () => {
     });
   }, 60_000);
 
-  it("lists the authoritative queue without requiring a snapshot", async () => {
-    const orgId = `org_${randomUUID()}`;
-    const owner = bdd.user({ orgId });
-    await api.grantProEntitlement(owner);
-    await api.ensureOrgModelProvider(owner);
-    api.configureRunnerGroup();
-    const agent = await bdd.createAgent(owner, {
-      displayName: "Authoritative queue agent",
-    });
-    const active = await chat.requestSendEvent(
-      owner,
-      {
-        agentId: agent.agentId,
-        prompt: `authoritative-queue-blocker-${randomUUID()}`,
-      },
-      [201],
-    );
-    if (active.status !== 201 || active.body.runId === null) {
-      throw new Error("Expected an active blocker run");
-    }
-    const queuedEventId = randomUUID();
-    const queued = await chat.requestSendEvent(
-      owner,
-      {
-        agentId: agent.agentId,
-        threadId: active.body.threadId,
-        clientEventId: queuedEventId,
-        prompt: `authoritative-queue-pending-${randomUUID()}`,
-      },
-      [201],
-    );
-    if (queued.status !== 201) {
-      throw new Error("Expected the second message to be queued");
-    }
-    expect(queued.body.runId).toBeNull();
-    const threadId = active.body.threadId;
-
-    const response = await accept(
-      eventsClient().queued({
-        headers: authenticate(owner),
-        params: { threadId },
-      }),
-      [200],
-    );
-    expect(response.body.events).toStrictEqual([
-      { eventId: queuedEventId, seqId: expect.any(Number) },
-    ]);
-    await api.requestCancelRun(owner, active.body.runId, [200]);
-  }, 60_000);
-
   it("immediately retires snapshot versions below the supported minimum", async () => {
     const owner = bdd.user({ orgId: `org_${randomUUID()}` });
     const agent = await bdd.createAgent(owner, {

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -22,7 +22,6 @@ import {
   zeroChatThreadActiveRunThreadIds,
   zeroChatThreadArtifacts,
   zeroChatThreadDetail,
-  zeroChatThreadQueuedEvents,
   zeroChatThreadDraftIds,
   zeroChatThreadUnreadAgentIds,
   zeroChatThreadUnreadThreadIds,
@@ -221,24 +220,6 @@ const listChatEventRowsInner$ = computed(async (get) => {
   };
 });
 
-const listQueuedChatEventsInner$ = computed(async (get) => {
-  const auth = get(organizationAuthContext$);
-  const params = get(pathParamsOf(chatThreadEventsContract.queued));
-  const events = await get(
-    zeroChatThreadQueuedEvents({
-      threadId: params.threadId,
-      userId: auth.userId,
-    }),
-  );
-  if (!events) {
-    return chatThreadNotFound();
-  }
-  return {
-    status: 200 as const,
-    body: { events: [...events] },
-  };
-});
-
 const listChatThreadDraftsInner$ = computed(async (get) => {
   const auth = get(authContext$);
 
@@ -421,17 +402,6 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
     handler: authRoute(
       { requiredCapability: "chat-event:read" },
       listChatEventRowsInner$,
-    ),
-  },
-  {
-    route: chatThreadEventsContract.queued,
-    handler: authRoute(
-      {
-        requireOrganization: true,
-        missingOrganizationStatus: 401,
-        requiredCapability: "chat-event:read",
-      },
-      listQueuedChatEventsInner$,
     ),
   },
   {

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -61,7 +61,6 @@ import {
 import { cancelRun$, type CancelRunResult } from "./zero-run-cancel.service";
 import { runOwnedChatEventForRunCondition } from "./zero-chat-event-type.service";
 import { cancellationRecoveryPendingForThread } from "./zero-chat-active-run.service";
-import { listPendingChatQueueEvents } from "./chat-event-queue.service";
 
 type ChatThreadRow = {
   readonly id: string;
@@ -717,27 +716,6 @@ export function zeroChatThreadArtifacts(args: {
       });
     },
   );
-}
-
-export function zeroChatThreadQueuedEvents(args: {
-  readonly threadId: string;
-  readonly userId: string;
-}): Computed<
-  Promise<
-    readonly { readonly eventId: string; readonly seqId: number }[] | null
-  >
-> {
-  return computed(async (get) => {
-    const owned = await get(ownedChatThread(args.threadId, args.userId));
-    if (!owned) {
-      return null;
-    }
-
-    const events = await listPendingChatQueueEvents(get(db$), args.threadId);
-    return events.map((event) => {
-      return { eventId: event.id, seqId: event.seqId };
-    });
-  });
 }
 
 export const createChatThread$ = command(

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1613,26 +1613,6 @@ export const chatThreadEventsContract = c.router({
     },
     summary: "Get raw chat event rows after a seq cursor",
   },
-  queued: {
-    method: "GET",
-    path: "/api/okou/chat-threads/:threadId/queued-events",
-    headers: authHeadersSchema,
-    pathParams: chatThreadThreadIdPathParamsSchema,
-    responses: {
-      200: z.object({
-        events: z.array(
-          z.object({
-            eventId: z.string(),
-            seqId: z.number().int().positive(),
-          }),
-        ),
-      }),
-      401: apiErrorSchema,
-      403: apiErrorSchema,
-      404: apiErrorSchema,
-    },
-    summary: "List authoritative queued chat events for a thread",
-  },
 });
 
 export const chatThreadArtifactsContract = c.router({


### PR DESCRIPTION
## Summary

- remove the `GET /api/okou/chat-threads/:threadId/queued-events` contract and route after the old commit-addressed CLI contexts have drained
- delete the now-unused queued-event service adapter and API integration coverage
- leave the internal chat queue claim, drain, promotion, and cancellation paths unchanged

## Context

This is the server-side compatibility cleanup deferred by #26925.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts` (6 tests passed)
