### PR TITLE
fix(platform): refine forward composer modal layout

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -9,6 +9,8 @@ const modelChangeThreadId = "b0000000-0000-4000-a000-000000000735";
 const imageLayoutThreadId = "b0000000-0000-4000-a000-000000000736";
 const cardSpacingThreadId = "b0000000-0000-4000-a000-000000000737";
 const forwardLayoutThreadId = "b0000000-0000-4000-a000-000000000738";
+const forwardLayoutThreadTitle =
+  "Forward composer layout with a very long thread title";
 // Card slots carry the same block margins as the paragraphs around them, and
 // adjacent margins collapse into one gap.
 const cardSlotGapPx = 8;
@@ -522,7 +524,7 @@ async function mockForwardLayoutThread(
     createdAt,
     selectedModel: null,
     threadId: forwardLayoutThreadId,
-    title: "Forward composer layout",
+    title: forwardLayoutThreadTitle,
     events: [
       {
         id: "msg-forward-layout-assistant",
@@ -1185,13 +1187,35 @@ test("forward composer stays inside the modal on narrow screens", async ({
   await page.getByRole("button", { name: /^Forward\b/ }).click();
 
   const dialog = page.getByRole("dialog", { name: "Forward to" });
-  await dialog.getByRole("option").first().click();
-  const composerDialog = page.getByRole("dialog");
+  await dialog
+    .getByRole("option", { name: forwardLayoutThreadTitle })
+    .click();
+  const composerDialog = page.getByRole("dialog", {
+    name: forwardLayoutThreadTitle,
+  });
+  const title = composerDialog.getByRole("heading", {
+    name: forwardLayoutThreadTitle,
+  });
+  const composerSurface = composerDialog.locator("[data-chat-composer]");
   const composer = composerDialog.locator(".zero-composer");
 
   for (const width of [360, 320]) {
     await page.setViewportSize({ width, height: 780 });
+    await expectInside(title, composerDialog);
     await expectInside(composer, composerDialog);
+    await expect
+      .poll(async () => {
+        return await composerSurface.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return [
+            style.paddingTop,
+            style.paddingRight,
+            style.paddingBottom,
+            style.paddingLeft,
+          ];
+        });
+      })
+      .toEqual(["20px", "20px", "20px", "20px"]);
   }
 });
 

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1186,11 +1186,12 @@ test("forward composer stays inside the modal on narrow screens", async ({
 
   const dialog = page.getByRole("dialog", { name: "Forward to" });
   await dialog.getByRole("option").first().click();
-  const composer = dialog.locator(".zero-composer");
+  const composerDialog = page.getByRole("dialog");
+  const composer = composerDialog.locator(".zero-composer");
 
   for (const width of [360, 320]) {
     await page.setViewportSize({ width, height: 780 });
-    await expectInside(composer, dialog);
+    await expectInside(composer, composerDialog);
   }
 });
 

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -92,9 +92,6 @@ describe("platform entrypoint safe area behavior", () => {
       /@media\s*\(display-mode:\s*standalone\)\s*{[\s\S]*\[data-chat-composer\]\s+\.zero-composer\s*{\s*scroll-margin-block-end:\s*16px;\s*}/,
     );
     expect(globalCss).toMatch(
-      /\[data-chat-composer\]\s*{\s*padding-bottom:\s*max\(0\.5rem\s*-\s*var\(--sab\),\s*0px\);\s*}/,
-    );
-    expect(globalCss).toMatch(
       /#root::after\s*{[\s\S]*height:\s*var\(--zero-keyboard-scroll-reserve,\s*0px\);[\s\S]*pointer-events:\s*none;/,
     );
     expect(globalCss).not.toContain("data-keyboard-inset-page");

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -154,15 +154,6 @@ body {
   }
 }
 
-/* The chat composer footer keeps 8px of breathing room below the card but
-   overlaps it with the root-owned bottom inset instead of stacking on top of
-   it, so the gap to the screen edge is max(0.5rem, inset) rather than
-   0.5rem + inset. While the keyboard is open --sab is 0px and the full 8px
-   returns above the keyboard. */
-[data-chat-composer] {
-  padding-bottom: max(0.5rem - var(--sab), 0px);
-}
-
 .zero-sidebar-header {
   padding-top: 0.375rem;
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -356,7 +356,7 @@ describe("chat inline feedback", () => {
     await user.keyboard("{ArrowDown}{Enter}");
 
     const feedbackNote = await findForwardFeedbackNote(dialog);
-    expect(within(dialog).getByText("Zero")).toBeInTheDocument();
+    expect(dialog).toHaveAccessibleName("Zero");
     expect(within(dialog).queryByText("Content")).toBeNull();
     expect(within(dialog).getAllByText(selectedContent)).toHaveLength(1);
     pastePlainText(feedbackNote, additionalContext);
@@ -364,7 +364,7 @@ describe("chat inline feedback", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("dialog", { name: "Forward to" }),
+        screen.queryByRole("dialog", { name: "Zero" }),
       ).not.toBeInTheDocument();
       expect(sentRequests).toHaveLength(1);
     });
@@ -460,8 +460,7 @@ describe("chat inline feedback", () => {
     await user.keyboard("{ArrowDown}{Enter}");
 
     const feedbackNote = await findForwardFeedbackNote(dialog);
-    expect(within(dialog).getAllByText("Forward to")).toHaveLength(1);
-    expect(within(dialog).getByText("Launch ownership")).toBeInTheDocument();
+    expect(dialog).toHaveAccessibleName("Launch ownership");
     expect(within(dialog).queryByText("Content")).toBeNull();
     expect(within(dialog).getAllByText(selectedContent)).toHaveLength(1);
     pastePlainText(feedbackNote, additionalContext);
@@ -469,7 +468,7 @@ describe("chat inline feedback", () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("dialog", { name: "Forward to" }),
+        screen.queryByRole("dialog", { name: "Launch ownership" }),
       ).not.toBeInTheDocument();
       expect(sentRequests).toHaveLength(1);
     });
@@ -596,6 +595,7 @@ describe("chat inline feedback", () => {
     await findForwardFeedbackNote(dialog);
     await waitForDeferredSelectionCapture();
 
+    expect(dialog).toHaveAccessibleName("Rollout review");
     expect(within(dialog).queryByText(queuedContent)).not.toBeInTheDocument();
     expect(
       within(dialog).queryByText(automationContent),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -382,7 +382,11 @@ describe("chat lifecycle", () => {
     });
     const composerCard = composer.closest(".zero-composer");
     expect(composerCard).not.toBeNull();
-    expect(composerCard?.closest("[data-chat-composer]")).not.toBeNull();
+    const composerFooter = composerCard?.closest("[data-chat-composer]");
+    expect(composerFooter).not.toBeNull();
+    expect(composerFooter).toHaveStyle({
+      paddingBottom: "max(0.5rem - var(--sab), 0px)",
+    });
 
     await sendMessageInUI(user, composer, "Continue working");
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-forward-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-forward-dialog.tsx
@@ -67,7 +67,7 @@ function ForwardTargetContent({
         alt=""
         className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
       />
-      <span className="truncate text-sm text-foreground">{target.title}</span>
+      <span className="truncate text-foreground">{target.title}</span>
     </span>
   );
 }
@@ -192,7 +192,7 @@ function ForwardComposerSurface({
   readonly composer: ComposerSignals;
 }) {
   return (
-    <div className="w-full min-w-0 px-5 pb-5 pt-4" data-chat-composer>
+    <div className="w-full min-w-0 p-5" data-chat-composer>
       <ZeroChatComposer signals={composer} showPendingItems={false} />
     </div>
   );
@@ -267,7 +267,7 @@ export function ChatForwardDialog({
     >
       <DialogContent className="zero-app w-[calc(100vw-2rem)] gap-0 overflow-hidden p-0 sm:max-w-xl">
         <DialogHeader className="px-5 pb-3 pt-5">
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2 pr-8">
             {target ? (
               <button
                 type="button"
@@ -282,10 +282,14 @@ export function ChatForwardDialog({
                 <ArrowLeft size={16} />
               </button>
             ) : null}
-            <DialogTitle className="text-base font-semibold">
-              {t(($) => {
-                return $.chat.forward.title;
-              })}
+            <DialogTitle className="min-w-0 text-base font-semibold">
+              {target ? (
+                <ForwardTargetContent target={target} />
+              ) : (
+                t(($) => {
+                  return $.chat.forward.title;
+                })
+              )}
             </DialogTitle>
           </div>
           <DialogDescription className="sr-only">
@@ -296,12 +300,7 @@ export function ChatForwardDialog({
         </DialogHeader>
         {target ? null : <ForwardContent text={selection.quote} />}
         {target && composerState ? (
-          <>
-            <div className="px-5 pt-4">
-              <ForwardTargetContent target={target} />
-            </div>
-            <ForwardComposer state={composerState} />
-          </>
+          <ForwardComposer state={composerState} />
         ) : (
           <ForwardTargetPicker onSelect={handleTargetSelect} />
         )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-forward-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-forward-dialog.tsx
@@ -265,8 +265,8 @@ export function ChatForwardDialog({
         }
       }}
     >
-      <DialogContent className="zero-app w-[calc(100vw-2rem)] gap-0 overflow-hidden p-0 sm:max-w-xl">
-        <DialogHeader className="px-5 pb-3 pt-5">
+      <DialogContent className="zero-app w-[calc(100vw-2rem)] grid-cols-[minmax(0,1fr)] gap-0 overflow-hidden p-0 sm:max-w-xl">
+        <DialogHeader className="min-w-0 px-5 pb-3 pt-5">
           <div className="flex min-w-0 items-center gap-2 pr-8">
             {target ? (
               <button
@@ -282,7 +282,7 @@ export function ChatForwardDialog({
                 <ArrowLeft size={16} />
               </button>
             ) : null}
-            <DialogTitle className="min-w-0 text-base font-semibold">
+            <DialogTitle className="min-w-0 flex-1 overflow-hidden text-base font-semibold">
               {target ? (
                 <ForwardTargetContent target={target} />
               ) : (

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4931,6 +4931,11 @@ function ChatThreadComposer({ thread }: { thread: ChatPanelSignals }) {
     <footer
       data-chat-composer
       className="relative shrink-0 bg-[hsl(var(--background))]"
+      style={{
+        // Overlap the footer's breathing room with the root-owned safe area;
+        // --sab is zero while the software keyboard is open.
+        paddingBottom: "max(0.5rem - var(--sab), 0px)",
+      }}
     >
       <div className="pointer-events-none absolute inset-x-0 -top-5 h-[21px] bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
       <div


### PR DESCRIPTION
## Summary

- Move the selected agent or thread title into the second-step forward dialog title.
- Keep the second-step body limited to the composer, with equal outer padding on every side.
- Scope the iOS safe-area compensation to the actual chat-thread footer instead of every `[data-chat-composer]` consumer.
- Constrain long thread titles so the title and composer remain inside the modal at narrow widths.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `cd e2e && pnpm check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`

Playwright was not run locally because repository guidance disallows starting a local dev server; the PR pipeline will run it.
