### PR TITLE
fix(platform): stabilize billing dialogs and pending changes

### DIFF
--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -86,6 +86,7 @@ export interface StripeSubscriptionPreviousAttributes {
 export interface StripeSchedulePhase {
   readonly start_date: number;
   readonly end_date: number;
+  readonly add_invoice_items?: readonly unknown[];
   readonly items?: readonly {
     readonly price: StripeRef;
     readonly quantity?: number;

--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -90,6 +90,11 @@ export interface StripeSchedulePhase {
     readonly price: StripeRef;
     readonly quantity?: number;
   }[];
+  readonly discounts?: readonly {
+    readonly coupon: StripeRef;
+    readonly discount: StripeRef;
+    readonly promotion_code: StripeRef;
+  }[];
 }
 
 export interface StripeSubscriptionSchedule {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -4842,6 +4842,18 @@ describe("usage pack allocation management", () => {
       },
     );
 
+    await postManagedUsagePackEvent(
+      "customer.subscription.updated",
+      upgradedSubscription,
+    );
+    const reflected = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(reflected.changes).toContainEqual(
+      expect.objectContaining({ kind: "upgrade", status: "applied" }),
+    );
+
     await postManagedUsagePackEvent("invoice.paid", paidInvoice);
     const state = await readUsagePackState(
       fixture.orgId,
@@ -4866,6 +4878,9 @@ describe("usage pack allocation management", () => {
       ]),
     );
     expect(state.grants).toHaveLength(4);
+    expect(state.changes).toContainEqual(
+      expect.objectContaining({ kind: "upgrade", status: "completed" }),
+    );
   });
 
   it("adds an active member package to the existing subscription", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -4349,6 +4349,16 @@ describe("usage pack allocation management", () => {
       }),
       [200],
     );
+    expect(context.mocks.stripe.invoices.createPreview).toHaveBeenCalledWith({
+      customer: fixture.customerId,
+      preview_mode: "recurring",
+      subscription_details: {
+        items: [
+          { price: TEST_PRICE_USAGE_PACK_PLAN_TEAM, quantity: 1 },
+          { price: TEST_PRICE_USAGE_PACK_20, quantity: 1 },
+        ],
+      },
+    });
     const prorationTimestamp = Math.floor(
       new Date(preview.body.prorationDate).getTime() / 1000,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -4198,6 +4198,197 @@ describe("usage pack allocation management", () => {
     }
   });
 
+  it("reopens the same pending subscription change without creating another preview", async () => {
+    const userId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
+    const sourceSubscription = managedUsagePackSubscription(
+      fixture,
+      new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+    );
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      sourceSubscription,
+    );
+    mockUsagePackSubscriptionChangePreviews(8000, 16_000);
+    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      zeroBillingUsagePackManagementContract,
+    );
+    const body = {
+      targetTier: "team" as const,
+      memberUsagePacks: [{ memberId: userId, usagePackUsd: 20 as const }],
+    };
+    const preview = await accept(
+      client.previewSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body,
+      }),
+      [200],
+    );
+    const prorationTimestamp = Math.floor(
+      new Date(preview.body.prorationDate).getTime() / 1000,
+    );
+    const invoice = {
+      ...managedUsagePackUpgradeInvoice(fixture, {
+        invoiceId: `in_${randomUUID()}`,
+        sourcePriceId: TEST_PRICE_USAGE_PACK_PLAN_PRO,
+        targetPriceId: TEST_PRICE_USAGE_PACK_PLAN_TEAM,
+        prorationTimestamp,
+      }),
+      status: "open" as const,
+      paid: false,
+    };
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({
+      ...sourceSubscription,
+      pending_update: { expires_at: prorationTimestamp + 300 },
+      latest_invoice: invoice,
+    });
+    context.mocks.stripe.invoices.retrieve.mockResolvedValue(invoice);
+
+    const confirmed = await accept(
+      client.confirmSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { changeId: preview.body.changeId },
+      }),
+      [200],
+    );
+    expect(confirmed.body.status).toBe("pending_payment");
+
+    const reopened = await accept(
+      client.previewSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body,
+      }),
+      [200],
+    );
+    expect(reopened.body).toStrictEqual(
+      expect.objectContaining({
+        changeId: preview.body.changeId,
+        sourceTier: "pro",
+        targetTier: "team",
+        immediateAmountCents: 8000,
+        nextRecurringAmountCents: 18_000,
+      }),
+    );
+    expect(context.mocks.stripe.invoices.createPreview).toHaveBeenCalledTimes(
+      2,
+    );
+    const differentChange = await accept(
+      client.previewSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          targetTier: "pro",
+          memberUsagePacks: [{ memberId: userId, usagePackUsd: 50 }],
+        },
+      }),
+      [409],
+    );
+    expect(differentChange.body.error.message).toBe(
+      "Another usage pack billing change is in progress",
+    );
+
+    const reconfirmed = await accept(
+      client.confirmSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { changeId: reopened.body.changeId },
+      }),
+      [200],
+    );
+    expect(reconfirmed.body.status).toBe("pending_payment");
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledOnce();
+  });
+
+  it("continues through a Stripe schedule with no future billing changes", async () => {
+    const userId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
+    const scheduleId = `sub_sched_${randomUUID()}`;
+    const sourceSubscription = managedUsagePackSubscription(
+      fixture,
+      new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      fixture.billingPeriod,
+      { scheduleId },
+    );
+    const scheduleItems = sourceSubscription.items.data.map((item) => {
+      return { price: item.price.id, quantity: item.quantity };
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      sourceSubscription,
+    );
+    context.mocks.stripe.subscriptionSchedules.retrieve.mockResolvedValue({
+      id: scheduleId,
+      end_behavior: "release",
+      current_phase: {
+        start_date: fixture.billingPeriod.start,
+        end_date: fixture.billingPeriod.end,
+      },
+      phases: [
+        {
+          start_date: fixture.billingPeriod.start,
+          end_date: fixture.billingPeriod.end,
+          items: scheduleItems,
+        },
+        {
+          start_date: fixture.billingPeriod.end,
+          end_date: fixture.billingPeriod.end + 30 * 86_400,
+          items: scheduleItems,
+        },
+      ],
+    });
+    context.mocks.stripe.subscriptionSchedules.release.mockResolvedValue({
+      id: scheduleId,
+    });
+    mockUsagePackSubscriptionChangePreviews(8000, 16_000);
+    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      zeroBillingUsagePackManagementContract,
+    );
+    const preview = await accept(
+      client.previewSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          targetTier: "team",
+          memberUsagePacks: [{ memberId: userId, usagePackUsd: 20 }],
+        },
+      }),
+      [200],
+    );
+    const prorationTimestamp = Math.floor(
+      new Date(preview.body.prorationDate).getTime() / 1000,
+    );
+    const invoice = managedUsagePackUpgradeInvoice(fixture, {
+      invoiceId: `in_${randomUUID()}`,
+      sourcePriceId: TEST_PRICE_USAGE_PACK_PLAN_PRO,
+      targetPriceId: TEST_PRICE_USAGE_PACK_PLAN_TEAM,
+      prorationTimestamp,
+    });
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({
+      ...sourceSubscription,
+      schedule: null,
+      latest_invoice: invoice,
+      items: {
+        data: sourceSubscription.items.data.map((item) => {
+          return item.price.id === TEST_PRICE_USAGE_PACK_PLAN_PRO
+            ? {
+                ...item,
+                price: { ...item.price, id: TEST_PRICE_USAGE_PACK_PLAN_TEAM },
+              }
+            : item;
+        }),
+      },
+    });
+
+    const confirmed = await accept(
+      client.confirmSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { changeId: preview.body.changeId },
+      }),
+      [200],
+    );
+
+    expect(confirmed.body.status).toBe("processing");
+    expect(
+      context.mocks.stripe.subscriptionSchedules.release,
+    ).toHaveBeenCalledWith(scheduleId);
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledOnce();
+  });
+
   it("replaces an unconfirmed package change preview", async () => {
     mockNow(new Date("2035-01-16T00:00:00.000Z"));
     onTestFinished(() => {
@@ -5481,9 +5672,17 @@ describe("usage pack allocation management", () => {
       [200],
     );
     expect(confirmed.body.status).toBe("pending_payment");
+    const reopened = await accept(
+      client.previewChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { memberId: sourceUserId, targetUsagePackUsd: 50 },
+      }),
+      [200],
+    );
+    expect(reopened.body.changeId).toBe(preview.body.changeId);
     const duplicateConfirmation = await accept(
       client.confirmChange({
-        params: { changeId: preview.body.changeId },
+        params: { changeId: reopened.body.changeId },
         headers: { authorization: "Bearer clerk-session" },
         body: {},
       }),
@@ -8072,6 +8271,23 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     context.mocks.stripe.subscriptions.update.mockClear();
     context.mocks.stripe.invoices.createPreview.mockClear();
     context.mocks.stripe.subscriptionSchedules.retrieve.mockClear();
+    context.mocks.stripe.subscriptionSchedules.retrieve.mockResolvedValue({
+      id: scheduleId,
+      end_behavior: "release",
+      current_phase: { start_date: 1, end_date: 2 },
+      phases: [
+        {
+          start_date: 1,
+          end_date: 2,
+          items: [{ price: TEST_PRICE_TEAM, quantity: 1 }],
+        },
+        {
+          start_date: 2,
+          end_date: 3,
+          items: [{ price: TEST_PRICE_PRO, quantity: 1 }],
+        },
+      ],
+    });
     context.mocks.stripe.subscriptionSchedules.update.mockClear();
 
     const client = setupApp({
@@ -8108,21 +8324,26 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     expect(context.mocks.stripe.invoices.createPreview).not.toHaveBeenCalled();
     expect(
       context.mocks.stripe.subscriptionSchedules.retrieve,
-    ).not.toHaveBeenCalled();
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      context.mocks.stripe.subscriptionSchedules.retrieve,
+    ).toHaveBeenCalledWith(scheduleId);
     expect(
       context.mocks.stripe.subscriptionSchedules.update,
     ).not.toHaveBeenCalled();
   });
 
-  it("adds concurrency to the Plan subscription", async () => {
+  it("adds concurrency to the Plan subscription through a neutral schedule", async () => {
     const fixture = await createSubscriptionOrg({ tier: "team" });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const periodEndUnix = 4_102_444_800;
     const concurrencyItemId = `si_${TEST_PRICE_CONCURRENCY}`;
+    const scheduleId = `sub_sched_${randomUUID()}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValueOnce({
       id: fixture.subscriptionId,
       latest_invoice: null,
       pending_update: null,
+      schedule: scheduleId,
       items: {
         data: [
           {
@@ -8132,6 +8353,26 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
           },
         ],
       },
+    });
+    context.mocks.stripe.subscriptionSchedules.retrieve.mockResolvedValueOnce({
+      id: scheduleId,
+      end_behavior: "release",
+      current_phase: { start_date: 1, end_date: 2 },
+      phases: [
+        {
+          start_date: 1,
+          end_date: 2,
+          items: [{ price: TEST_PRICE_TEAM, quantity: 1 }],
+        },
+        {
+          start_date: 2,
+          end_date: 3,
+          items: [{ price: TEST_PRICE_TEAM, quantity: 1 }],
+        },
+      ],
+    });
+    context.mocks.stripe.subscriptionSchedules.release.mockResolvedValueOnce({
+      id: scheduleId,
     });
     context.mocks.stripe.subscriptions.update.mockResolvedValueOnce({
       id: fixture.subscriptionId,
@@ -8179,6 +8420,9 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       fixture.subscriptionId,
       { expand: ["latest_invoice"] },
     );
+    expect(
+      context.mocks.stripe.subscriptionSchedules.release,
+    ).toHaveBeenCalledWith(scheduleId);
     expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
       fixture.subscriptionId,
       {
@@ -9072,6 +9316,123 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     expect(context.mocks.stripe.subscriptions.update).not.toHaveBeenCalled();
   });
 
+  it("reuses a concurrency schedule with no future billing changes", async () => {
+    const subscriptionId = `sub_${randomUUID()}`;
+    const subscriptionItemId = `si_${randomUUID()}`;
+    const scheduleId = `sub_sched_${randomUUID()}`;
+    const periodStartUnix = 4_075_660_800;
+    const periodEndUnix = 4_078_252_800;
+    const fixture = await createConcurrencySubscriptionOrg({
+      subscriptionId,
+      slots: 5,
+      periodEnd: new Date(periodEndUnix * 1000),
+      tier: "team",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const subscription = {
+      id: subscriptionId,
+      customer: `cus_${randomUUID()}`,
+      status: "active",
+      cancel_at_period_end: false,
+      latest_invoice: null,
+      pending_update: null,
+      schedule: scheduleId,
+      items: {
+        data: [
+          {
+            id: subscriptionItemId,
+            price: {
+              id: TEST_PRICE_CONCURRENCY,
+              recurring: { interval: "month" as const, interval_count: 1 },
+            },
+            quantity: 5,
+            current_period_start: periodStartUnix,
+            current_period_end: periodEndUnix,
+          },
+        ],
+      },
+    };
+    const schedule = {
+      id: scheduleId,
+      end_behavior: "release",
+      current_phase: {
+        start_date: periodStartUnix,
+        end_date: periodEndUnix,
+      },
+      phases: [
+        {
+          start_date: periodStartUnix,
+          end_date: periodEndUnix,
+          items: [{ price: TEST_PRICE_CONCURRENCY, quantity: 5 }],
+        },
+        {
+          start_date: periodEndUnix,
+          end_date: periodEndUnix + 30 * 86_400,
+          items: [{ price: TEST_PRICE_CONCURRENCY, quantity: 5 }],
+        },
+      ],
+    };
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(subscription);
+    context.mocks.stripe.subscriptionSchedules.retrieve.mockResolvedValue(
+      schedule,
+    );
+    context.mocks.stripe.invoices.createPreview.mockResolvedValueOnce(
+      recurringConcurrencyPreviewInvoice(3),
+    );
+    context.mocks.stripe.subscriptionSchedules.update.mockResolvedValue({
+      id: scheduleId,
+    });
+
+    const client = setupApp({
+      context,
+      routes: zeroBillingConcurrencySubscriptionRoutes,
+    })(zeroBillingConcurrencySubscriptionContract);
+    const preview = await accept(
+      client.previewChange({
+        params: { subscriptionId },
+        body: { quantity: 3 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(preview.body.targetQuantity).toBe(3);
+    expect(context.mocks.stripe.invoices.createPreview).toHaveBeenCalledWith({
+      subscription: subscriptionId,
+      preview_mode: "recurring",
+      subscription_details: {
+        items: [{ id: subscriptionItemId, quantity: 3 }],
+      },
+    });
+
+    const confirmed = await accept(
+      client.confirmChange({
+        params: { subscriptionId },
+        body: { quantity: 3 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(confirmed.body).toStrictEqual({
+      status: "completed",
+      hostedInvoiceUrl: null,
+      effectiveAt: new Date(periodEndUnix * 1000).toISOString(),
+    });
+    expect(
+      context.mocks.stripe.subscriptionSchedules.update,
+    ).toHaveBeenCalledWith(
+      scheduleId,
+      expect.objectContaining({
+        phases: expect.arrayContaining([
+          expect.objectContaining({
+            start_date: periodEndUnix,
+            items: [{ price: TEST_PRICE_CONCURRENCY, quantity: 3 }],
+          }),
+        ]),
+      }),
+      { idempotencyKey: expect.any(String) },
+    );
+  });
+
   it("rejects concurrency changes owned by another Plan schedule", async () => {
     const periodEnd = new Date("2099-05-20T00:00:00Z");
     const fixture = await createMergedConcurrencySubscriptionOrg({
@@ -9103,6 +9464,29 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     context.mocks.stripe.subscriptions.update.mockClear();
     context.mocks.stripe.invoices.createPreview.mockClear();
     context.mocks.stripe.subscriptionSchedules.retrieve.mockClear();
+    context.mocks.stripe.subscriptionSchedules.retrieve.mockResolvedValue({
+      id: scheduleId,
+      end_behavior: "release",
+      current_phase: { start_date: 1, end_date: 2 },
+      phases: [
+        {
+          start_date: 1,
+          end_date: 2,
+          items: [
+            { price: TEST_PRICE_TEAM, quantity: 1 },
+            { price: TEST_PRICE_CONCURRENCY, quantity: 5 },
+          ],
+        },
+        {
+          start_date: 2,
+          end_date: 3,
+          items: [
+            { price: TEST_PRICE_PRO, quantity: 1 },
+            { price: TEST_PRICE_CONCURRENCY, quantity: 5 },
+          ],
+        },
+      ],
+    });
     context.mocks.stripe.subscriptionSchedules.release.mockClear();
     context.mocks.stripe.subscriptionSchedules.update.mockClear();
 
@@ -9153,7 +9537,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     expect(context.mocks.stripe.invoices.createPreview).not.toHaveBeenCalled();
     expect(
       context.mocks.stripe.subscriptionSchedules.retrieve,
-    ).not.toHaveBeenCalled();
+    ).toHaveBeenCalledWith(scheduleId);
     expect(
       context.mocks.stripe.subscriptionSchedules.release,
     ).not.toHaveBeenCalled();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -9458,6 +9458,93 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     );
   });
 
+  it("rejects a schedule that repeats invoice items in a future phase", async () => {
+    const subscriptionId = `sub_${randomUUID()}`;
+    const subscriptionItemId = `si_${randomUUID()}`;
+    const scheduleId = `sub_sched_${randomUUID()}`;
+    const periodStartUnix = 4_075_660_800;
+    const periodEndUnix = 4_078_252_800;
+    const fixture = await createConcurrencySubscriptionOrg({
+      subscriptionId,
+      slots: 5,
+      periodEnd: new Date(periodEndUnix * 1000),
+      tier: "team",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const subscription = {
+      id: subscriptionId,
+      customer: `cus_${randomUUID()}`,
+      status: "active",
+      cancel_at_period_end: false,
+      latest_invoice: null,
+      pending_update: null,
+      schedule: scheduleId,
+      items: {
+        data: [
+          {
+            id: subscriptionItemId,
+            price: {
+              id: TEST_PRICE_CONCURRENCY,
+              recurring: { interval: "month" as const, interval_count: 1 },
+            },
+            quantity: 5,
+            current_period_start: periodStartUnix,
+            current_period_end: periodEndUnix,
+          },
+        ],
+      },
+    };
+    const repeatedInvoiceItems = [
+      { price: `price_${randomUUID()}`, quantity: 1 },
+    ];
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(subscription);
+    context.mocks.stripe.subscriptionSchedules.retrieve.mockResolvedValue({
+      id: scheduleId,
+      end_behavior: "release",
+      current_phase: {
+        start_date: periodStartUnix,
+        end_date: periodEndUnix,
+      },
+      phases: [
+        {
+          start_date: periodStartUnix,
+          end_date: periodEndUnix,
+          add_invoice_items: repeatedInvoiceItems,
+          items: [{ price: TEST_PRICE_CONCURRENCY, quantity: 5 }],
+        },
+        {
+          start_date: periodEndUnix,
+          end_date: periodEndUnix + 30 * 86_400,
+          add_invoice_items: repeatedInvoiceItems,
+          items: [{ price: TEST_PRICE_CONCURRENCY, quantity: 5 }],
+        },
+      ],
+    });
+
+    const response = await accept(
+      setupApp({
+        context,
+        routes: zeroBillingConcurrencySubscriptionRoutes,
+      })(zeroBillingConcurrencySubscriptionContract).previewChange({
+        params: { subscriptionId },
+        body: { quantity: 3 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Complete the pending concurrency update before changing slots",
+    );
+    expect(context.mocks.stripe.invoices.createPreview).not.toHaveBeenCalled();
+    expect(
+      context.mocks.stripe.subscriptionSchedules.release,
+    ).not.toHaveBeenCalled();
+    expect(
+      context.mocks.stripe.subscriptionSchedules.update,
+    ).not.toHaveBeenCalled();
+  });
+
   it("rejects concurrency changes owned by another Plan schedule", async () => {
     const periodEnd = new Date("2099-05-20T00:00:00Z");
     const fixture = await createMergedConcurrencySubscriptionOrg({

--- a/turbo/apps/api/src/signals/services/stripe-subscription-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-subscription-schedules.service.ts
@@ -1,5 +1,10 @@
+import { isDeepStrictEqual } from "node:util";
+
 import {
   getStripeClient,
+  type StripeRef,
+  type StripeSchedulePhase,
+  type StripeSubscription,
   type StripeSubscriptionSchedule,
 } from "../external/stripe-client";
 
@@ -25,6 +30,184 @@ export function subscriptionScheduleFinalEnd(
   }, schedule.current_phase?.end_date ?? null);
 
   return finalEnd === null ? null : new Date(finalEnd * 1000);
+}
+
+function stripeRefId(ref: StripeRef): string | null {
+  return typeof ref === "string" ? ref : (ref?.id ?? null);
+}
+
+function schedulePhaseSettings(
+  phase: StripeSchedulePhase,
+): Readonly<Record<string, unknown>> {
+  return Object.fromEntries(
+    Object.entries(phase).filter(([key]) => {
+      return !["start_date", "end_date", "items", "discounts"].includes(key);
+    }),
+  );
+}
+
+function normalizedScheduleItems(
+  items: StripeSchedulePhase["items"],
+): readonly { readonly price: string; readonly quantity: number }[] | null {
+  if (!items) {
+    return null;
+  }
+  const normalized = items.flatMap((item) => {
+    const price = stripeRefId(item.price);
+    const quantity = item.quantity ?? 1;
+    return price && Number.isSafeInteger(quantity) && quantity > 0
+      ? [{ price, quantity }]
+      : [];
+  });
+  if (normalized.length !== items.length) {
+    return null;
+  }
+  return normalized.sort((left, right) => {
+    return left.price.localeCompare(right.price);
+  });
+}
+
+function normalizedScheduleItemConfigurations(
+  items: StripeSchedulePhase["items"],
+):
+  | readonly {
+      readonly price: string;
+      readonly quantity: number;
+      readonly settings: Readonly<Record<string, unknown>>;
+    }[]
+  | null {
+  if (!items) {
+    return null;
+  }
+  const normalized = items.flatMap((item) => {
+    const price = stripeRefId(item.price);
+    const quantity = item.quantity ?? 1;
+    if (!price || !Number.isSafeInteger(quantity) || quantity <= 0) {
+      return [];
+    }
+    return [
+      {
+        price,
+        quantity,
+        settings: Object.fromEntries(
+          Object.entries(item).filter(([key]) => {
+            return key !== "price" && key !== "quantity";
+          }),
+        ),
+      },
+    ];
+  });
+  if (normalized.length !== items.length) {
+    return null;
+  }
+  return normalized.sort((left, right) => {
+    return left.price.localeCompare(right.price);
+  });
+}
+
+function normalizedSubscriptionItems(
+  subscription: StripeSubscription,
+): readonly { readonly price: string; readonly quantity: number }[] | null {
+  const normalized = subscription.items.data.flatMap((item) => {
+    const quantity = item.quantity ?? 1;
+    return Number.isSafeInteger(quantity) && quantity > 0
+      ? [{ price: item.price.id, quantity }]
+      : [];
+  });
+  if (normalized.length !== subscription.items.data.length) {
+    return null;
+  }
+  return normalized.sort((left, right) => {
+    return left.price.localeCompare(right.price);
+  });
+}
+
+function normalizedScheduleDiscounts(
+  discounts: StripeSchedulePhase["discounts"],
+): readonly string[] | null {
+  const normalized = (discounts ?? []).flatMap((discount) => {
+    const id = stripeRefId(discount.discount);
+    return id ? [id] : [];
+  });
+  if (normalized.length !== (discounts?.length ?? 0)) {
+    return null;
+  }
+  return normalized.sort();
+}
+
+function normalizedSubscriptionDiscounts(
+  discounts: readonly StripeRef[] | undefined,
+): readonly string[] | null {
+  const normalized = (discounts ?? []).flatMap((discount) => {
+    const id = stripeRefId(discount);
+    return id ? [id] : [];
+  });
+  if (normalized.length !== (discounts?.length ?? 0)) {
+    return null;
+  }
+  return normalized.sort();
+}
+
+/**
+ * Returns true only when an attached schedule preserves the subscription's
+ * current billing configuration in every remaining phase.
+ */
+export function subscriptionScheduleHasNoFutureChanges(
+  subscription: StripeSubscription,
+  schedule: StripeSubscriptionSchedule,
+): boolean {
+  const currentPhaseRef = schedule.current_phase;
+  if (schedule.end_behavior !== "release" || !currentPhaseRef) {
+    return false;
+  }
+  const currentPhase = schedule.phases.find((phase) => {
+    return (
+      phase.start_date === currentPhaseRef.start_date &&
+      phase.end_date === currentPhaseRef.end_date
+    );
+  });
+  if (!currentPhase) {
+    return false;
+  }
+  const currentItems = normalizedScheduleItems(currentPhase.items);
+  const currentItemConfigurations = normalizedScheduleItemConfigurations(
+    currentPhase.items,
+  );
+  const subscriptionItems = normalizedSubscriptionItems(subscription);
+  const currentDiscounts = normalizedScheduleDiscounts(currentPhase.discounts);
+  const subscriptionDiscounts = normalizedSubscriptionDiscounts(
+    subscription.discounts,
+  );
+  if (
+    !currentItems ||
+    !currentItemConfigurations ||
+    !subscriptionItems ||
+    !currentDiscounts ||
+    !subscriptionDiscounts ||
+    !isDeepStrictEqual(currentItems, subscriptionItems) ||
+    !isDeepStrictEqual(currentDiscounts, subscriptionDiscounts)
+  ) {
+    return false;
+  }
+  const currentSettings = schedulePhaseSettings(currentPhase);
+  return schedule.phases
+    .filter((phase) => {
+      return phase.start_date >= currentPhase.start_date;
+    })
+    .every((phase) => {
+      return (
+        isDeepStrictEqual(normalizedScheduleItems(phase.items), currentItems) &&
+        isDeepStrictEqual(
+          normalizedScheduleItemConfigurations(phase.items),
+          currentItemConfigurations,
+        ) &&
+        isDeepStrictEqual(
+          normalizedScheduleDiscounts(phase.discounts),
+          currentDiscounts,
+        ) &&
+        isDeepStrictEqual(schedulePhaseSettings(phase), currentSettings)
+      );
+    });
 }
 
 export async function subscriptionScheduleCancellationEnd(

--- a/turbo/apps/api/src/signals/services/stripe-subscription-schedules.service.ts
+++ b/turbo/apps/api/src/signals/services/stripe-subscription-schedules.service.ts
@@ -196,6 +196,8 @@ export function subscriptionScheduleHasNoFutureChanges(
     })
     .every((phase) => {
       return (
+        (phase.start_date === currentPhase.start_date ||
+          (phase.add_invoice_items?.length ?? 0) === 0) &&
         isDeepStrictEqual(normalizedScheduleItems(phase.items), currentItems) &&
         isDeepStrictEqual(
           normalizedScheduleItemConfigurations(phase.items),

--- a/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
@@ -841,6 +841,38 @@ async function persistUsagePackChangePreview(
   return change;
 }
 
+function storedUsagePackChangePreview(
+  change: UsagePackAllocationChangeRow,
+): UsagePackChangePreviewResponse {
+  if (
+    (change.kind !== "upgrade" && change.kind !== "downgrade") ||
+    change.sourceUsagePackUsd === null ||
+    change.targetUsagePackUsd === null ||
+    change.immediateAmountCents === null ||
+    change.nextRecurringAmountCents === null ||
+    change.currency === null ||
+    change.effectiveAt === null ||
+    change.prorationTimestamp === null ||
+    change.previewExpiresAt === null
+  ) {
+    throw new Error(`Usage pack change ${change.id} has no preview snapshot`);
+  }
+  return {
+    changeId: change.id,
+    kind: change.kind,
+    sourceUsagePackUsd: usagePackUsd(change.sourceUsagePackUsd),
+    targetUsagePackUsd: usagePackUsd(change.targetUsagePackUsd),
+    immediateAmountCents: change.immediateAmountCents,
+    nextRecurringAmountCents: change.nextRecurringAmountCents,
+    currency: change.currency,
+    effectiveAt: change.effectiveAt.toISOString(),
+    prorationDate: new Date(change.prorationTimestamp * 1000).toISOString(),
+    expiresAt: (
+      change.stripePendingUpdateExpiresAt ?? change.previewExpiresAt
+    ).toISOString(),
+  };
+}
+
 export async function previewUsagePackAllocationChange(
   db: Db,
   args: UsagePackChangePreviewArgs,
@@ -867,6 +899,21 @@ export async function previewUsagePackAllocationChange(
   const stripeSubscriptionId = context?.subscription.stripeSubscriptionId;
   if (!context || !stripeSubscriptionId) {
     return { status: "not_found" };
+  }
+  const existing = context.changes.find((change) => {
+    return (
+      change.subscriptionChangeId === null && change.userId === args.userId
+    );
+  });
+  if (
+    existing &&
+    (existing.status !== "previewed" ||
+      (existing.previewExpiresAt !== null &&
+        existing.previewExpiresAt > nowDate()))
+  ) {
+    return existing.targetUsagePackUsd === args.targetUsagePackUsd
+      ? { status: "ready", preview: storedUsagePackChangePreview(existing) }
+      : { status: "conflict" };
   }
   if (context.subscription.cancelAtPeriodEnd) {
     return { status: "conflict" };

--- a/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
@@ -2248,7 +2248,11 @@ async function commitReflectedUsagePackChanges(
         .where(eq(usagePackAllocationChanges.id, expectedChange.id))
         .for("update")
         .limit(1);
-      if (!change || change.status === "completed") {
+      if (
+        !change ||
+        change.status === "applied" ||
+        change.status === "completed"
+      ) {
         continue;
       }
       if (change.status === "failed" || change.replacementAllocationId) {

--- a/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
@@ -129,6 +129,7 @@ interface PreparedSubscriptionChange {
   readonly hasImmediateChanges: boolean;
   readonly hasScheduledChanges: boolean;
   readonly existingScheduleId: string | null;
+  readonly hasAttachedSchedule: boolean;
 }
 
 interface PersistSubscriptionChangePreviewArgs {
@@ -901,6 +902,7 @@ async function prepareSubscriptionChange(
           return change.kind === "downgrade";
         }),
       existingScheduleId,
+      hasAttachedSchedule: stripeScheduleId !== null,
     },
   };
 }
@@ -1308,7 +1310,7 @@ export async function previewUsagePackSubscriptionChange(
   const [recurringPreview, immediatePreview, immediateCreditGrant] =
     await Promise.all([
       stripe.invoices.createPreview(
-        prepared.existingScheduleId
+        prepared.hasAttachedSchedule
           ? scheduledSubscriptionRecurringPreviewParams(
               prepared.subscription,
               finalScheduleItems(

--- a/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
@@ -48,6 +48,7 @@ import {
   type UsagePackChangeInvoiceInput,
 } from "./usage-pack-allocation-change.service";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
+import { subscriptionScheduleHasNoFutureChanges } from "./stripe-subscription-schedules.service";
 import {
   activeUsagePackPlanPriceId,
   activeUsagePackPriceId,
@@ -719,6 +720,20 @@ type ExistingSchedulePreparation =
   | { readonly status: "ready"; readonly scheduleId: string | null }
   | { readonly status: "same_configuration" | "conflict" };
 
+type SubscriptionChangePreparation =
+  | { readonly status: "ready"; readonly prepared: PreparedSubscriptionChange }
+  | {
+      readonly status: "resumed";
+      readonly preview: UsagePackSubscriptionChangePreviewResponse;
+    }
+  | {
+      readonly status:
+        | "not_found"
+        | "same_configuration"
+        | "invalid_members"
+        | "conflict";
+    };
+
 function prepareExistingSchedule(args: {
   readonly allocationChanges: readonly PreparedAllocationChange[];
   readonly hasImmediateChanges: boolean;
@@ -748,6 +763,36 @@ function prepareExistingSchedule(args: {
     : { status: "conflict" };
 }
 
+async function resumeOpenSubscriptionChange(
+  db: Db,
+  context: UsagePackSubscriptionChangeContext,
+  args: {
+    readonly targetTier: UsagePackTier;
+    readonly memberUsagePacks: readonly MemberUsagePack[];
+  },
+  signal: AbortSignal,
+): Promise<SubscriptionChangePreparation | null> {
+  const resumableChange = context.openSubscriptionChanges.find((change) => {
+    return change.status !== "previewed";
+  });
+  if (!resumableChange) {
+    return null;
+  }
+  const stored = await loadStoredSubscriptionChange(db, resumableChange.id);
+  signal.throwIfAborted();
+  if (!stored) {
+    throw new Error(
+      `Open usage pack subscription change ${resumableChange.id} disappeared`,
+    );
+  }
+  return storedSubscriptionChangeMatchesRequest(stored, args)
+    ? {
+        status: "resumed",
+        preview: storedSubscriptionChangePreview(stored.root),
+      }
+    : { status: "conflict" };
+}
+
 async function prepareSubscriptionChange(
   args: {
     readonly db: Db;
@@ -756,16 +801,7 @@ async function prepareSubscriptionChange(
     readonly memberUsagePacks: readonly MemberUsagePack[];
   },
   signal: AbortSignal,
-): Promise<
-  | { readonly status: "ready"; readonly prepared: PreparedSubscriptionChange }
-  | {
-      readonly status:
-        | "not_found"
-        | "same_configuration"
-        | "invalid_members"
-        | "conflict";
-    }
-> {
+): Promise<SubscriptionChangePreparation> {
   const context = await loadUsagePackSubscriptionChangeContext(
     args.db,
     args.orgId,
@@ -773,12 +809,16 @@ async function prepareSubscriptionChange(
   if (!context || !context.subscription.stripeSubscriptionId) {
     return { status: "not_found" };
   }
-  if (
-    context.subscription.cancelAtPeriodEnd ||
-    context.openSubscriptionChanges.some((change) => {
-      return change.status !== "previewed";
-    })
-  ) {
+  const resumed = await resumeOpenSubscriptionChange(
+    args.db,
+    context,
+    args,
+    signal,
+  );
+  if (resumed) {
+    return resumed;
+  }
+  if (context.subscription.cancelAtPeriodEnd) {
     return { status: "conflict" };
   }
   const allocationChanges = prepareAllocationChanges(
@@ -815,19 +855,27 @@ async function prepareSubscriptionChange(
       `${args.targetTier} usage pack plan Price is not configured`,
     );
   }
-  const subscription = await getStripeClient().subscriptions.retrieve(
+  const stripe = getStripeClient();
+  const subscription = await stripe.subscriptions.retrieve(
     context.subscription.stripeSubscriptionId,
     { expand: ["latest_invoice"] },
   );
   signal.throwIfAborted();
   const stripeScheduleId = stripeObjectId(subscription.schedule);
-  if (
-    subscription.pending_update ||
-    (existingScheduleId
-      ? stripeScheduleId !== existingScheduleId
-      : stripeScheduleId !== null)
-  ) {
+  if (subscription.pending_update) {
     return { status: "conflict" };
+  }
+  if (existingScheduleId) {
+    if (stripeScheduleId !== existingScheduleId) {
+      return { status: "conflict" };
+    }
+  } else if (stripeScheduleId) {
+    const schedule =
+      await stripe.subscriptionSchedules.retrieve(stripeScheduleId);
+    signal.throwIfAborted();
+    if (!subscriptionScheduleHasNoFutureChanges(subscription, schedule)) {
+      return { status: "conflict" };
+    }
   }
   const planItem = validateStripeSubscription(context, subscription);
   const period = usagePackPeriod(subscription);
@@ -1195,6 +1243,18 @@ async function immediateUsagePackUpgradeCreditGrant(
   };
 }
 
+function subscriptionChangeEffectiveAt(
+  prepared: PreparedSubscriptionChange,
+  targetTier: UsagePackTier,
+): Date {
+  const timestamp =
+    planIsDowngrade(prepared.context.subscription.tier, targetTier) ||
+    (!prepared.hasImmediateChanges && prepared.hasScheduledChanges)
+      ? prepared.period.end
+      : prepared.prorationTimestamp;
+  return new Date(timestamp * 1000);
+}
+
 export async function previewUsagePackSubscriptionChange(
   db: Db,
   args: {
@@ -1205,6 +1265,9 @@ export async function previewUsagePackSubscriptionChange(
   signal: AbortSignal,
 ): Promise<UsagePackSubscriptionChangePreviewResult> {
   const result = await prepareSubscriptionChange({ db, ...args }, signal);
+  if (result.status === "resumed") {
+    return { status: "ready", preview: result.preview };
+  }
   if (result.status !== "ready") {
     return result;
   }
@@ -1284,12 +1347,7 @@ export async function previewUsagePackSubscriptionChange(
   }
   const createdAt = nowDate();
   const expiresAt = new Date(createdAt.getTime() + PREVIEW_TTL_MS);
-  const effectiveAt = new Date(
-    (planIsDowngrade(prepared.context.subscription.tier, args.targetTier) ||
-    (!prepared.hasImmediateChanges && prepared.hasScheduledChanges)
-      ? prepared.period.end
-      : prepared.prorationTimestamp) * 1000,
-  );
+  const effectiveAt = subscriptionChangeEffectiveAt(prepared, args.targetTier);
   const immediateAmountCents = immediatePreview
     ? immediateProrationAmount(immediatePreview, prepared.prorationTimestamp)
     : 0;
@@ -1466,6 +1524,63 @@ async function loadStoredSubscriptionChange(
     throw new Error(`Subscription change ${root.id} lost its subscription`);
   }
   return { root, allocationChanges, subscription, allocations };
+}
+
+function storedSubscriptionChangeMatchesRequest(
+  stored: NonNullable<Awaited<ReturnType<typeof loadStoredSubscriptionChange>>>,
+  args: {
+    readonly targetTier: UsagePackTier;
+    readonly memberUsagePacks: readonly MemberUsagePack[];
+  },
+): boolean {
+  if (stored.root.targetTier !== args.targetTier) {
+    return false;
+  }
+  const targetUsagePackByMember = new Map(
+    activeMemberAllocations(stored.allocations).map((allocation) => {
+      if (!allocation.userId) {
+        throw new Error("Active usage pack allocation has no member");
+      }
+      return [allocation.userId, allocation.usagePackUsd] as const;
+    }),
+  );
+  for (const change of stored.allocationChanges) {
+    if (change.kind === "removal") {
+      targetUsagePackByMember.delete(change.userId);
+      continue;
+    }
+    if (change.targetUsagePackUsd === null) {
+      throw new Error(`Subscription change ${change.id} has no target package`);
+    }
+    targetUsagePackByMember.set(change.userId, change.targetUsagePackUsd);
+  }
+  return (
+    targetUsagePackByMember.size === args.memberUsagePacks.length &&
+    args.memberUsagePacks.every((selection) => {
+      return (
+        targetUsagePackByMember.get(selection.memberId) ===
+        selection.usagePackUsd
+      );
+    })
+  );
+}
+
+function storedSubscriptionChangePreview(
+  root: UsagePackSubscriptionChangeRow,
+): UsagePackSubscriptionChangePreviewResponse {
+  return {
+    changeId: root.id,
+    sourceTier: root.sourceTier,
+    targetTier: root.targetTier,
+    immediateAmountCents: root.immediateAmountCents,
+    nextRecurringAmountCents: root.nextRecurringAmountCents,
+    currency: root.currency,
+    effectiveAt: root.effectiveAt.toISOString(),
+    prorationDate: new Date(root.prorationTimestamp * 1000).toISOString(),
+    expiresAt: (
+      root.stripePendingUpdateExpiresAt ?? root.previewExpiresAt
+    ).toISOString(),
+  };
 }
 
 async function persistDeferredSubscriptionChangeSchedule(
@@ -2094,6 +2209,46 @@ async function restoreScheduledSubscriptionChange(
   };
 }
 
+async function prepareApplicableSubscription(
+  args: {
+    readonly db: Db;
+    readonly stored: StoredSubscriptionChange;
+    readonly subscription: StripeSubscription;
+    readonly supersededScheduleId: string | null;
+    readonly hasImmediateChanges: boolean;
+  },
+  signal: AbortSignal,
+): Promise<
+  | { readonly status: "ready"; readonly subscription: StripeSubscription }
+  | { readonly status: "conflict" }
+> {
+  const attachedScheduleId = stripeObjectId(args.subscription.schedule);
+  if (args.supersededScheduleId || !attachedScheduleId) {
+    return { status: "ready", subscription: args.subscription };
+  }
+  const stripe = getStripeClient();
+  const schedule =
+    await stripe.subscriptionSchedules.retrieve(attachedScheduleId);
+  signal.throwIfAborted();
+  if (!subscriptionScheduleHasNoFutureChanges(args.subscription, schedule)) {
+    await failApplyingSubscriptionChange(
+      args.db,
+      args.stored.root,
+      "unexpected_schedule_conflict",
+    );
+    return { status: "conflict" };
+  }
+  if (!args.hasImmediateChanges) {
+    return { status: "ready", subscription: args.subscription };
+  }
+  await stripe.subscriptionSchedules.release(attachedScheduleId);
+  signal.throwIfAborted();
+  return {
+    status: "ready",
+    subscription: { ...args.subscription, schedule: null },
+  };
+}
+
 async function applyStoredSubscriptionChange(
   db: Db,
   stored: StoredSubscriptionChange,
@@ -2103,10 +2258,10 @@ async function applyStoredSubscriptionChange(
   if (!subscriptionId) {
     throw new Error("Usage pack subscription has no Stripe subscription ID");
   }
-  const subscription = await getStripeClient().subscriptions.retrieve(
-    subscriptionId,
-    { expand: ["latest_invoice"] },
-  );
+  const stripe = getStripeClient();
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId, {
+    expand: ["latest_invoice"],
+  });
   signal.throwIfAborted();
   if (subscription.pending_update) {
     await failApplyingSubscriptionChange(
@@ -2172,6 +2327,20 @@ async function applyStoredSubscriptionChange(
     stored.allocationChanges.some((change) => {
       return change.kind === "downgrade";
     });
+  const applicable = await prepareApplicableSubscription(
+    {
+      db,
+      stored,
+      subscription,
+      supersededScheduleId,
+      hasImmediateChanges,
+    },
+    signal,
+  );
+  if (applicable.status === "conflict") {
+    return applicable;
+  }
+  const applicableSubscription = applicable.subscription;
   if (!hasImmediateChanges) {
     if (!hasScheduledChanges) {
       throw new Error("Stored usage pack subscription change has no changes");
@@ -2179,7 +2348,7 @@ async function applyStoredSubscriptionChange(
     const effectiveAt = await scheduleDeferredSubscriptionChange(
       db,
       stored,
-      subscription,
+      applicableSubscription,
       signal,
     );
     return {
@@ -2195,7 +2364,7 @@ async function applyStoredSubscriptionChange(
     db,
     {
       stored,
-      subscription,
+      subscription: applicableSubscription,
       planItem,
       hasPlanUpgrade,
       immediatePackageChanges,

--- a/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
@@ -32,6 +32,7 @@ import {
   activeConcurrencySubscriptions,
   isConcurrencyPriceId,
 } from "./org-concurrency-entitlements.service";
+import { subscriptionScheduleHasNoFutureChanges } from "./stripe-subscription-schedules.service";
 
 const CONCURRENCY_SUBSCRIPTION_QUANTITY_MAX = 1000;
 const STRIPE_INVOICE_LINE_PAGE_SIZE = 100;
@@ -474,8 +475,15 @@ export const addStripeConcurrencySubscriptionItem$ = command(
         subscription,
       };
     }
-    if (stripeObjectId(subscription.schedule) !== null) {
-      return { ok: false, reason: "pending_update" };
+    const scheduleId = stripeObjectId(subscription.schedule);
+    if (scheduleId) {
+      const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
+      signal.throwIfAborted();
+      if (!subscriptionScheduleHasNoFutureChanges(subscription, schedule)) {
+        return { ok: false, reason: "pending_update" };
+      }
+      await stripe.subscriptionSchedules.release(scheduleId);
+      signal.throwIfAborted();
     }
 
     const updatedSubscription = await stripe.subscriptions.update(
@@ -701,6 +709,33 @@ function concurrencyRecurringPreviewParams(
   };
 }
 
+async function prepareConcurrencyPreviewSchedule(
+  stripe: StripeClient,
+  subscription: StripeSubscription,
+  hasScheduledConcurrencyChange: boolean,
+  signal: AbortSignal,
+): Promise<
+  | {
+      readonly ok: true;
+      readonly scheduleId: string | null;
+      readonly schedule: StripeSubscriptionSchedule | null;
+    }
+  | { readonly ok: false }
+> {
+  const scheduleId = stripeObjectId(subscription.schedule);
+  if (!scheduleId) {
+    return { ok: true, scheduleId: null, schedule: null };
+  }
+  const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
+  signal.throwIfAborted();
+  if (hasScheduledConcurrencyChange) {
+    return { ok: true, scheduleId, schedule };
+  }
+  return subscriptionScheduleHasNoFutureChanges(subscription, schedule)
+    ? { ok: true, scheduleId: null, schedule: null }
+    : { ok: false };
+}
+
 export const previewStripeConcurrencySubscriptionChange$ = command(
   async (
     _,
@@ -730,11 +765,16 @@ export const previewStripeConcurrencySubscriptionChange$ = command(
     ) {
       return { ok: false, reason: "invalid_quantity" };
     }
-    const scheduleId = stripeObjectId(subscription.schedule);
-    if (scheduleId !== null && !args.hasScheduledConcurrencyChange) {
+    const schedulePreparation = await prepareConcurrencyPreviewSchedule(
+      stripe,
+      subscription,
+      args.hasScheduledConcurrencyChange,
+      signal,
+    );
+    if (!schedulePreparation.ok) {
       return { ok: false, reason: "pending_update" };
     }
-    const scheduledChange = scheduleId !== null;
+    const scheduledChange = schedulePreparation.scheduleId !== null;
     if (targetQuantity === currentQuantity && !scheduledChange) {
       return { ok: false, reason: "no_change" };
     }
@@ -746,14 +786,13 @@ export const previewStripeConcurrencySubscriptionChange$ = command(
         : { price: args.priceId, quantity: targetQuantity },
     ];
     const scheduledPreview =
-      scheduleId && item
+      scheduledChange && item && schedulePreparation.schedule
         ? {
-            id: scheduleId,
+            id: schedulePreparation.scheduleId,
             item,
-            schedule: await stripe.subscriptionSchedules.retrieve(scheduleId),
+            schedule: schedulePreparation.schedule,
           }
         : null;
-    signal.throwIfAborted();
     const recurringPreviewParams = concurrencyRecurringPreviewParams(
       subscription,
       items,
@@ -870,7 +909,11 @@ export const applyStripeConcurrencySubscriptionChange$ = command(
     }
     const scheduleId = stripeObjectId(subscription.schedule);
     if (scheduleId !== null && !args.hasScheduledConcurrencyChange) {
-      return { ok: false, reason: "pending_update" };
+      const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
+      signal.throwIfAborted();
+      if (!subscriptionScheduleHasNoFutureChanges(subscription, schedule)) {
+        return { ok: false, reason: "pending_update" };
+      }
     }
     if (targetQuantity === item.quantity && scheduleId === null) {
       return {
@@ -1026,7 +1069,18 @@ export const cancelConcurrencySubscription$ = command(
         subscription.scheduledQuantity === null &&
         !subscription.cancelAtPeriodEnd
       ) {
-        return { ok: false, reason: "pending_update" };
+        const scheduleId = stripeObjectId(stripeSubscription.schedule);
+        if (!scheduleId) {
+          throw new Error("Stripe subscription schedule disappeared");
+        }
+        const schedule =
+          await stripe.subscriptionSchedules.retrieve(scheduleId);
+        signal.throwIfAborted();
+        if (
+          !subscriptionScheduleHasNoFutureChanges(stripeSubscription, schedule)
+        ) {
+          return { ok: false, reason: "pending_update" };
+        }
       }
       await scheduleConcurrencyChange(stripeSubscription, 0, signal);
     } else {

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -245,7 +245,12 @@ const internalWorkflowAutomationCreateDialog$ =
 const internalCreatedWorkflowWebhookAutomation$ =
   state<WorkflowWebhookAutomationSummary | null>(null);
 const internalWorkflowAutomationPickerOpen$ = state(false);
-const internalWorkflowWebhookUpgradeDialogOpen$ = state(false);
+type WorkflowWebhookUpgradeDialogSource =
+  | { readonly action: "create"; readonly workflowId: string }
+  | { readonly action: "enable"; readonly automationId: string }
+  | { readonly action: "menu" };
+const internalWorkflowWebhookUpgradeDialogSource$ =
+  state<WorkflowWebhookUpgradeDialogSource | null>(null);
 const internalCreateStrapiIntegrationId$ = state<string | null>(null);
 const internalWorkflowAutomationPickerCategory$ =
   state<WorkflowAutomationCategoryKey>("schedule");
@@ -568,12 +573,19 @@ export const setWorkflowAutomationPickerOpen$ = command(
 );
 
 export const workflowWebhookUpgradeDialogOpen$ = computed((get) => {
-  return get(internalWorkflowWebhookUpgradeDialogOpen$);
+  return get(internalWorkflowWebhookUpgradeDialogSource$) !== null;
+});
+
+export const workflowWebhookUpgradeDialogSource$ = computed((get) => {
+  return get(internalWorkflowWebhookUpgradeDialogSource$);
 });
 
 export const setWorkflowWebhookUpgradeDialogOpen$ = command(
   ({ set }, open: boolean) => {
-    set(internalWorkflowWebhookUpgradeDialogOpen$, open);
+    set(
+      internalWorkflowWebhookUpgradeDialogSource$,
+      open ? { action: "menu" } : null,
+    );
   },
 );
 
@@ -1418,7 +1430,10 @@ export const createWorkflowWebhookAutomation$ = command(
     signal.throwIfAborted();
     if (result.status === 402) {
       if (result.body.error.code === "TEAM_REQUIRED") {
-        set(internalWorkflowWebhookUpgradeDialogOpen$, true);
+        set(internalWorkflowWebhookUpgradeDialogSource$, {
+          action: "create",
+          workflowId: input.workflowId,
+        });
         return null;
       }
       throw new Error(result.body.error.message);
@@ -1593,7 +1608,10 @@ export const setWorkflowAutomationEnabled$ = command(
     signal.throwIfAborted();
     if (result.status === 402) {
       if (result.body.error.code === "TEAM_REQUIRED") {
-        set(internalWorkflowWebhookUpgradeDialogOpen$, true);
+        set(internalWorkflowWebhookUpgradeDialogSource$, {
+          action: "enable",
+          automationId: input.automationId,
+        });
         return;
       }
       throw new Error(result.body.error.message);

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -67,6 +67,8 @@ type DowngradeTargetTier = "limited-free-1" | "pro-suspend" | "pro";
 export type CreditCheckoutSelection =
   | { readonly credits: number; readonly customAmount?: false }
   | { readonly credits: number; readonly customAmount: true };
+type CreditPurchaseOrigin = "billing" | "chat";
+type ConcurrencyPurchaseOrigin = "billing" | "queue";
 export type ConcurrencyChangeMode = "quantity" | "cancel";
 
 const RESTORE_PAYMENT_PENDING_KEY = "vm0:billing:restore-payment-pending";
@@ -258,6 +260,7 @@ interface ConcurrencySubscriptionConfirmDialogState {
 interface ConcurrencyPurchaseConfirmDialogState {
   readonly action: "purchase";
   readonly newTab: boolean;
+  readonly origin: ConcurrencyPurchaseOrigin;
   readonly quantity: number;
   readonly preview: ConcurrencySubscriptionChangePreviewResponse;
 }
@@ -266,10 +269,16 @@ export type ConcurrencyConfirmDialogState =
   | ConcurrencyPurchaseConfirmDialogState
   | ConcurrencySubscriptionConfirmDialogState;
 
+interface CreditPurchasePreviewState {
+  readonly origin: CreditPurchaseOrigin;
+  readonly preview: CreditPurchasePreviewResponse;
+}
+
 const internalConcurrencyConfirmDialog$ =
   state<ConcurrencyConfirmDialogState | null>(null);
-const internalCreditPurchasePreview$ =
-  state<CreditPurchasePreviewResponse | null>(null);
+const internalCreditPurchasePreview$ = state<CreditPurchasePreviewState | null>(
+  null,
+);
 
 // ---------------------------------------------------------------------------
 // Selectors
@@ -294,7 +303,10 @@ export const concurrencyConfirmDialog$ = computed((get) => {
   return get(internalConcurrencyConfirmDialog$);
 });
 export const creditPurchasePreview$ = computed((get) => {
-  return get(internalCreditPurchasePreview$);
+  return get(internalCreditPurchasePreview$)?.preview ?? null;
+});
+export const creditPurchaseOrigin$ = computed((get) => {
+  return get(internalCreditPurchasePreview$)?.origin ?? null;
 });
 export const setPendingEnabled$ = command(({ set }, value: boolean | null) => {
   set(internalPendingEnabled$, value);
@@ -1022,6 +1034,7 @@ export const startCreditCheckout$ = command(
     { get, set },
     selection: CreditCheckoutSelection,
     newTab: boolean,
+    origin: CreditPurchaseOrigin,
     signal: AbortSignal,
   ) => {
     const successUrl = checkoutReturnUrl();
@@ -1060,7 +1073,10 @@ export const startCreditCheckout$ = command(
     );
     signal.throwIfAborted();
     if (!("url" in result.body)) {
-      set(internalCreditPurchasePreview$, result.body);
+      set(internalCreditPurchasePreview$, {
+        origin,
+        preview: result.body,
+      });
       return;
     }
     // Hosted Checkout is the canonical response when saved billing is absent.
@@ -1077,10 +1093,11 @@ export const startCreditCheckout$ = command(
 
 export const confirmCreditPurchase$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const preview = get(internalCreditPurchasePreview$);
-    if (!preview) {
+    const previewState = get(internalCreditPurchasePreview$);
+    if (!previewState) {
       throw new Error("Credit purchase preview is not available");
     }
+    const { preview } = previewState;
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingCreditCheckoutContract);
     const result = await accept(
@@ -1157,6 +1174,7 @@ export const openConcurrencyPurchaseReview$ = command(
     { get, set },
     quantity: number,
     newTab: boolean,
+    origin: ConcurrencyPurchaseOrigin,
     signal: AbortSignal,
   ): Promise<void> => {
     const createClient = get(zeroClient$);
@@ -1173,6 +1191,7 @@ export const openConcurrencyPurchaseReview$ = command(
     set(internalConcurrencyConfirmDialog$, {
       action: "purchase",
       newTab,
+      origin,
       quantity,
       preview: result.body,
     });

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -492,12 +492,15 @@ describe("queue drawer", () => {
       expect(screen.getByText("Buy $500/month")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Buy $500/month"));
+    const buyButton = getButtonByText("Buy $500/month");
+    click(buyButton);
 
     await screen.findByText("$70.00");
     const reviewDialog = screen.getByRole("dialog", {
       name: "Buy concurrency",
     });
+    expect(buyButton).toHaveTextContent("Updating...");
+    expect(buyButton).toBeDisabled();
     expect(previewQuantity).toBe(5);
     expect(within(reviewDialog).getByText("5")).toBeInTheDocument();
     expect(within(reviewDialog).getByText("$220.00/month")).toBeInTheDocument();
@@ -610,11 +613,14 @@ describe("queue drawer", () => {
       expect(screen.getByText("Buy $200/month")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Buy $200/month"));
+    const buyButton = getButtonByText("Buy $200/month");
+    click(buyButton);
 
     const reviewDialog = await screen.findByRole("dialog", {
       name: "Review concurrency change",
     });
+    expect(buyButton).toHaveTextContent("Updating...");
+    expect(buyButton).toBeDisabled();
     expect(checkoutQuantity).toBeNull();
     expect(previewedSubscriptionId).toBe("sub_concurrency_active");
     expect(previewedQuantity).toBe(4);

--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -30,6 +30,8 @@ import { queueData$ } from "../../signals/queue-page/queue-signals.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
   billingStatusAsync$,
+  concurrencyConfirmDialog$,
+  type ConcurrencyConfirmDialogState,
   openConcurrencyChangeReview$,
   openConcurrencyPurchaseReview$,
   startCheckout$,
@@ -583,6 +585,27 @@ function ConcurrencyPurchaseCard({
   );
 }
 
+function isQueueConcurrencyReviewOpen({
+  activeChangeReviewAvailable,
+  activeSubscriptionId,
+  confirmDialog,
+  purchaseReviewAvailable,
+}: {
+  readonly activeChangeReviewAvailable: boolean;
+  readonly activeSubscriptionId: string | undefined;
+  readonly confirmDialog: ConcurrencyConfirmDialogState | null;
+  readonly purchaseReviewAvailable: boolean;
+}): boolean {
+  if (confirmDialog?.action === "purchase") {
+    return purchaseReviewAvailable && confirmDialog.origin === "queue";
+  }
+  return (
+    activeChangeReviewAvailable &&
+    confirmDialog?.action === "change" &&
+    confirmDialog.subscriptionId === activeSubscriptionId
+  );
+}
+
 function ConcurrencyPurchaseCardMount({
   canManageBilling,
   tierColor,
@@ -601,6 +624,7 @@ function ConcurrencyPurchaseCardMount({
     openConcurrencyPurchaseReview$,
   );
   const quantity = useGet(concurrencyQuantity$);
+  const confirmDialog = useGet(concurrencyConfirmDialog$);
   const setQuantity = useSet(setConcurrencyQuantity$);
   const billingStatus = useLastResolved(billingStatusAsync$);
   const capabilities = billingStatus
@@ -620,10 +644,17 @@ function ConcurrencyPurchaseCardMount({
     !activeSubscription &&
     billingStatus?.concurrencyPurchaseReviewAvailable === true;
   const reviewingInApp = activeChangeReviewAvailable || purchaseReviewAvailable;
+  const reviewDialogOpen = isQueueConcurrencyReviewOpen({
+    activeChangeReviewAvailable,
+    activeSubscriptionId: activeSubscription?.id,
+    confirmDialog,
+    purchaseReviewAvailable,
+  });
   const loading =
     checkoutLoadable.state === "loading" ||
     reviewLoadable.state === "loading" ||
-    purchaseReviewLoadable.state === "loading";
+    purchaseReviewLoadable.state === "loading" ||
+    reviewDialogOpen;
 
   if (!canManageBilling || capabilities?.canBuyConcurrency !== true) {
     return null;
@@ -653,7 +684,7 @@ function ConcurrencyPurchaseCardMount({
         }
         if (purchaseReviewAvailable) {
           detach(
-            openPurchaseReview(quantity, newTab, pageSignal),
+            openPurchaseReview(quantity, newTab, "queue", pageSignal),
             Reason.DomCallback,
           );
           return;

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -3471,6 +3471,44 @@ describe("workflow detail page", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps webhook creation stable while the Team upgrade dialog opens", async () => {
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Test Org",
+      role: "admin",
+    });
+    mockWorkflowApis([salesResearch()]);
+    context.mocks.api(zeroWorkflowAutomationsContract.create, ({ respond }) => {
+      return respond(402, {
+        error: {
+          code: "TEAM_REQUIRED",
+          message: "Webhook automations require a Team or Custom workspace",
+        },
+      });
+    });
+    detachedSetupWorkflowDetailPage(
+      workflowDetailPath("automations"),
+      {},
+      "pro",
+      { workflowWebhookAutomationAllowed: true },
+    );
+
+    click(await screen.findByText("Add automation"));
+    const picker = await screen.findByRole("dialog");
+    click(buttonByText("Integrations", picker));
+    click(buttonByText(/^Webhook/u, picker));
+    await waitFor(() => {
+      expect(buttonByText("Create webhook")).toBeInTheDocument();
+    });
+    const createButton = buttonByText("Create webhook");
+    click(createButton);
+
+    await expect(
+      screen.findByText("Upgrade for webhook automations"),
+    ).resolves.toBeInTheDocument();
+    expect(createButton).toBeDisabled();
+  });
+
   it("asks non-admins to contact an admin for webhook access", async () => {
     context.mocks.data.org({
       id: "org_1",
@@ -3505,6 +3543,7 @@ describe("workflow detail page", () => {
     const workflow = {
       ...salesResearch(),
       automations: [
+        weekdayWorkflowAutomation(),
         {
           ...webhookWorkflowAutomation(),
           enabled: false,
@@ -3527,11 +3566,19 @@ describe("workflow detail page", () => {
       "pro",
     );
 
-    click(await screen.findByRole("switch", { name: "Enable Webhook" }));
+    const enableSwitch = await screen.findByRole("switch", {
+      name: "Enable Webhook",
+    });
+    const unrelatedSwitch = screen.getByRole("switch", {
+      name: "Disable Every weekday at 9:00 AM",
+    });
+    click(enableSwitch);
     const upgradeTitle = await screen.findByText(
       "Upgrade for webhook automations",
     );
     expect(upgradeTitle).toBeInTheDocument();
+    expect(enableSwitch).toHaveAttribute("aria-disabled", "true");
+    expect(unrelatedSwitch).not.toHaveAttribute("aria-disabled", "true");
     expect(
       screen.getByText("Disabled — paid plan required"),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -178,6 +178,7 @@ import {
   setWorkflowAutomationPickerCategory$,
   setWorkflowAutomationPickerOpen$,
   setWorkflowWebhookUpgradeDialogOpen$,
+  workflowWebhookUpgradeDialogSource$,
   workflowCopyForm$,
   workflowDetailActiveTab$,
   workflowAutomationCreateDialog$,
@@ -9044,7 +9045,11 @@ function CreateWebhookAutomationDialog({
   const [createLoadable, createWebhookAutomation] = useLoadableSet(
     createWorkflowWebhookAutomation$,
   );
-  const creating = createLoadable.state === "loading";
+  const upgradeDialogSource = useGet(workflowWebhookUpgradeDialogSource$);
+  const creating =
+    createLoadable.state === "loading" ||
+    (upgradeDialogSource?.action === "create" &&
+      upgradeDialogSource.workflowId === workflowId);
 
   return (
     <Dialog
@@ -9720,7 +9725,11 @@ function AutomationStatusSwitch({
   const [enabledLoadable, setEnabled] = useLoadableSet(
     setWorkflowAutomationEnabled$,
   );
-  const toggling = enabledLoadable.state === "loading";
+  const upgradeDialogSource = useGet(workflowWebhookUpgradeDialogSource$);
+  const toggling =
+    enabledLoadable.state === "loading" ||
+    (upgradeDialogSource?.action === "enable" &&
+      upgradeDialogSource.automationId === automation.id);
 
   return (
     <div className="flex items-center justify-start sm:justify-center">

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
@@ -11,6 +11,7 @@ import {
   zeroBillingCreditCheckoutContract,
   zeroBillingStatusContract,
 } from "@okouai/api-contracts/contracts/zero-billing";
+import { FeatureSwitchKey } from "@okouai/core";
 import { logsByIdContract } from "@okouai/api-contracts/contracts/logs";
 import { zeroRunsByIdContract } from "@okouai/api-contracts/contracts/zero-runs";
 import { zeroQueuePositionContract } from "@okouai/api-contracts/contracts/zero-queue-position";
@@ -294,6 +295,79 @@ describe("chat lifecycle", () => {
         "https://checkout.stripe.com/credits?credits=25000",
       );
     });
+  });
+
+  it("keeps a paid credit trigger stable while its review dialog opens", async () => {
+    const checkoutReady = createDeferredPromise<void>(context.signal);
+    const threadId = "e1000000-0000-4000-a000-000000000009";
+    mockFailedAssistantThread({ threadId, error: "insufficient_credits" });
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Test Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, {
+        tier: "pro",
+        credits: 0,
+        onboardingPaymentPending: false,
+        subscriptionStatus: "active",
+        currentPeriodEnd: "2026-04-01T00:00:00Z",
+        cancelAtPeriodEnd: false,
+        scheduledChange: null,
+        hasSubscription: true,
+        autoRecharge: { enabled: false, threshold: null, amount: null },
+        creditExpiry: {
+          expiringNextCycle: 0,
+          nextExpiryDate: null,
+        },
+        creditBreakdown: [],
+        creditGrants: [],
+        concurrencyLimit: 0,
+        concurrencySubscriptions: [],
+      });
+    });
+    context.mocks.api(
+      zeroBillingCreditCheckoutContract.create,
+      async ({ respond }) => {
+        await checkoutReady.promise;
+        return respond(200, {
+          status: "preview",
+          credits: 25_000,
+          amountCents: 2500,
+          currency: "usd",
+          expiresAt: "2026-08-13T12:15:00.000Z",
+          previewToken: "chat-credit-preview-token",
+        });
+      },
+    );
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(buttonByText("$100")).toBeInTheDocument();
+    });
+    click(buttonByText("Custom"));
+    await fill(screen.getByLabelText("Custom dollar amount"), "25");
+    const buyButton = buttonByText("Buy");
+    click(buyButton);
+
+    await waitFor(() => {
+      expect(buyButton).toHaveTextContent("Preparing...");
+      expect(buyButton).toBeDisabled();
+    });
+    checkoutReady.resolve(undefined);
+
+    await expect(
+      screen.findByRole("dialog", { name: "Review credit purchase" }),
+    ).resolves.toBeInTheDocument();
+    expect(buyButton).toHaveTextContent("Preparing...");
+    expect(buyButton).toBeDisabled();
   });
 
   it("uses the plan capability when a paid tier cannot buy credits", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -2745,6 +2745,38 @@ describe("organization billing settings", () => {
     });
   });
 
+  it("keeps the concurrency trigger stable while opening the change dialog", async () => {
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Team Concurrency Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, {
+        ...activeTeamBillingStatus(),
+        concurrencySubscriptions: [
+          {
+            id: "sub_concurrency_12345678",
+            quantity: 2,
+            currentPeriodEnd: "2026-06-01T00:00:00Z",
+            cancelAtPeriodEnd: false,
+            canReduce: true,
+            canChangeInApp: true,
+          },
+        ],
+      });
+    });
+
+    await openBillingTab();
+
+    const changeButton = buttonByText("Change");
+    click(changeButton);
+    await screen.findByRole("dialog", { name: "Change concurrency" });
+
+    expect(changeButton).toHaveTextContent("Change");
+    expect(changeButton).toBeEnabled();
+  });
+
   it("manages an active concurrency subscription through Change", async () => {
     let previewedQuantity: number | null = null;
     let confirmedQuantity: number | null = null;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -796,10 +796,14 @@ describe("organization billing settings", () => {
     const orderSummary = screen.getByRole("region", {
       name: "Order summary",
     });
-    click(buttonByText("Confirm", orderSummary));
-    await expect(
-      screen.findByRole("dialog", { name: "Review package change" }),
-    ).resolves.toBeInTheDocument();
+    const confirmButton = buttonByText("Confirm", orderSummary);
+    click(confirmButton);
+    const reviewDialog = await screen.findByRole("dialog", {
+      name: "Review package change",
+    });
+    expect(reviewDialog).toBeInTheDocument();
+    expect(confirmButton).toHaveTextContent("Updating...");
+    expect(confirmButton).toBeDisabled();
   });
 
   it("does not probe legacy migrations while usage packs are disabled", async () => {
@@ -1325,10 +1329,16 @@ describe("organization billing settings", () => {
       within(orderSummary).getByText("Scheduled for Sep 1, 2026"),
     ).toBeInTheDocument();
 
-    click(buttonByText("Review conversion", orderSummary));
+    const reviewConversionButton = buttonByText(
+      "Review conversion",
+      orderSummary,
+    );
+    click(reviewConversionButton);
     const reviewDialog = await screen.findByRole("dialog", {
       name: "Review plan conversion",
     });
+    expect(reviewConversionButton).toHaveTextContent("Review conversion");
+    expect(reviewConversionButton).toBeDisabled();
     expect(
       within(reviewDialog).queryByRole("table", {
         name: "Current and new subscription comparison",
@@ -1378,10 +1388,13 @@ describe("organization billing settings", () => {
     await screen.findByRole("heading", {
       name: "Configure member packages",
     });
-    click(buttonByText("Review conversion"));
+    const reviewRevisionButton = buttonByText("Review conversion");
+    click(reviewRevisionButton);
     const revisionDialog = await screen.findByRole("dialog", {
       name: "Review package change",
     });
+    expect(reviewRevisionButton).toHaveTextContent("Review conversion");
+    expect(reviewRevisionButton).toBeDisabled();
     click(buttonByText("Confirm", revisionDialog));
     await waitFor(() => {
       expect(buttonByText("Current plan")).toBeDisabled();
@@ -3403,7 +3416,8 @@ describe("organization billing settings", () => {
       [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
     });
     const locationBeforePurchase = window.location.href;
-    click(screen.getByText("Quick buy $20.00"));
+    const quickBuyButton = buttonByText("Quick buy $20.00");
+    click(quickBuyButton);
 
     await waitFor(() => {
       expect(buttonByText("Preparing...")).toBeDisabled();
@@ -3414,6 +3428,8 @@ describe("organization billing settings", () => {
     const reviewDialog = await screen.findByRole("dialog", {
       name: "Review credit purchase",
     });
+    expect(quickBuyButton).toHaveTextContent("Preparing...");
+    expect(quickBuyButton).toBeDisabled();
     expect(
       within(reviewDialog).getByText(
         "Confirm this one-time charge with your saved payment method.",

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/buy-credits-section.tsx
@@ -8,6 +8,7 @@ import { detach, Reason } from "../../../../signals/utils.ts";
 import {
   buyCreditsCustomDollars$,
   buyCreditsSelection$,
+  creditPurchaseOrigin$,
   setBuyCreditsCustomDollars$,
   setBuyCreditsSelection$,
   startCreditCheckout$,
@@ -203,12 +204,14 @@ export function BuyCreditsSection() {
   const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
   const [checkoutLoadable, checkout] = useLoadableSet(startCreditCheckout$);
+  const purchaseOrigin = useGet(creditPurchaseOrigin$);
   const selection = useGet(buyCreditsSelection$);
   const customDollars = useGet(buyCreditsCustomDollars$);
   const setSelection = useSet(setBuyCreditsSelection$);
   const setCustomDollars = useSet(setBuyCreditsCustomDollars$);
 
-  const preparing = checkoutLoadable.state === "loading";
+  const preparing =
+    checkoutLoadable.state === "loading" || purchaseOrigin === "billing";
   const buyDollars = resolveBuyDollars(selection, customDollars);
   const buyInvalid = buyDollars === null;
   const buyLabel = preparing
@@ -245,7 +248,10 @@ export function BuyCreditsSection() {
     const payload: CreditCheckoutSelection =
       selection === "custom" ? { credits, customAmount: true } : { credits };
     const newTab = e.metaKey || e.ctrlKey;
-    detach(checkout(payload, newTab, pageSignal), Reason.DomCallback);
+    detach(
+      checkout(payload, newTab, "billing", pageSignal),
+      Reason.DomCallback,
+    );
   };
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -1422,12 +1422,10 @@ function ConcurrencyQuantityControl({
 }
 
 function ConcurrencySubscriptionRow({
-  changing,
   canceled,
   onAction,
   subscription,
 }: {
-  changing: boolean;
   canceled: boolean;
   onAction: (args: {
     readonly action: "change" | "restore";
@@ -1474,7 +1472,6 @@ function ConcurrencySubscriptionRow({
         variant={canceled ? "default" : "outline"}
         size="sm"
         className="h-8 shrink-0 text-xs"
-        disabled={changing}
         onClick={() => {
           onAction({
             action,
@@ -1488,17 +1485,13 @@ function ConcurrencySubscriptionRow({
           });
         }}
       >
-        {changing
+        {canceled
           ? i18n.t(($) => {
-              return $.billing.common.updating;
+              return $.billing.common.restore;
             })
-          : canceled
-            ? i18n.t(($) => {
-                return $.billing.common.restore;
-              })
-            : i18n.t(($) => {
-                return $.billing.concurrency.changeButton;
-              })}
+          : i18n.t(($) => {
+              return $.billing.concurrency.changeButton;
+            })}
       </Button>
     </div>
   );
@@ -2195,7 +2188,6 @@ function ConcurrencyBillingSection({
 }) {
   const openPurchaseDialog = useSet(openConcurrencyPurchaseDialog$);
   const openConfirmDialog = useSet(openConcurrencyConfirmDialog$);
-  const dialog = useGet(concurrencyConfirmDialog$);
   const subscriptions = status?.concurrencySubscriptions ?? [];
   const concurrencyLimit = status?.concurrencyLimit ?? 0;
   const purchaseReviewAvailable =
@@ -2242,10 +2234,6 @@ function ConcurrencyBillingSection({
               <div key={subscription.id}>
                 {index > 0 && <div className="h-0 zero-border-t mx-5" />}
                 <ConcurrencySubscriptionRow
-                  changing={
-                    dialog?.action !== "purchase" &&
-                    dialog?.subscriptionId === subscription.id
-                  }
                   canceled={canceled}
                   onAction={openConfirmDialog}
                   subscription={subscription}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -2099,8 +2099,12 @@ function ConcurrencyPurchaseDialog({
   const [reviewLoadable, review] = useLoadableSet(
     openConcurrencyPurchaseReview$,
   );
+  const confirmDialog = useGet(concurrencyConfirmDialog$);
   const checkoutLoading =
-    checkoutLoadable.state === "loading" || reviewLoadable.state === "loading";
+    checkoutLoadable.state === "loading" ||
+    reviewLoadable.state === "loading" ||
+    (confirmDialog?.action === "purchase" &&
+      confirmDialog.origin === "billing");
   const quantity = quantityOverride ?? CONCURRENCY_SUBSCRIPTION_QUANTITY_MIN;
   const actionLabel = checkoutLoading
     ? i18n.t(($) => {
@@ -2167,7 +2171,12 @@ function ConcurrencyPurchaseDialog({
             onClick={(e) => {
               detach(
                 reviewAvailable
-                  ? review(quantity, e.metaKey || e.ctrlKey, pageSignal)
+                  ? review(
+                      quantity,
+                      e.metaKey || e.ctrlKey,
+                      "billing",
+                      pageSignal,
+                    )
                   : checkout(quantity, e.metaKey || e.ctrlKey, pageSignal),
                 Reason.DomCallback,
               );

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -2043,7 +2043,7 @@ function ManagedSubscriptionOrderSummary({
   const [confirmationLoadable, confirmChange] = useLoadableSet(
     confirmUsagePackSubscriptionChange$,
   );
-  const previewing = previewLoadable.state === "loading";
+  const previewing = previewLoadable.state === "loading" || preview !== null;
   const confirming = confirmationLoadable.state === "loading";
   const error =
     previewLoadable.state === "hasError" ||
@@ -2230,7 +2230,8 @@ function MigrationOrderSummary({
   const [previewLoadable, previewMigration] = useLoadableSet(
     previewUsagePackMigration$,
   );
-  const previewing = previewLoadable.state === "loading";
+  const preview = useGet(usagePackMigrationPreview$);
+  const previewing = previewLoadable.state === "loading" || preview !== null;
   const previewError = previewLoadable.state === "hasError";
   const monthlyTotal = plan.basePriceUsd + totals.totalUsd;
   const currentMonthlyTotal = sourceTier === "pro" ? 20 : 200;
@@ -2317,7 +2318,8 @@ function MigrationRevisionOrderSummary({
   const [previewLoadable, previewRevision] = useLoadableSet(
     previewUsagePackMigrationRevision$,
   );
-  const previewing = previewLoadable.state === "loading";
+  const preview = useGet(usagePackMigrationRevisionPreview$);
+  const previewing = previewLoadable.state === "loading" || preview !== null;
   const previewError = previewLoadable.state === "hasError";
   const currentPlan = usagePackPlan(configuration.tier);
   const currentTotals = migrationConfigurationTotals(configuration, catalog);

--- a/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-automations-page.tsx
@@ -52,6 +52,7 @@ import { ROUTES } from "../../signals/route-paths.ts";
 import {
   allVisibleWorkflows$,
   setWorkflowAutomationEnabled$,
+  workflowWebhookUpgradeDialogSource$,
   type WorkflowAutomationEntry,
 } from "../../signals/workflows-page/workflows-signals.ts";
 import {
@@ -724,8 +725,12 @@ export function WorkflowAutomationEnabledSwitch({
   const [enabledLoadable, setEnabled] = useLoadableSet(
     setWorkflowAutomationEnabled$,
   );
+  const upgradeDialogSource = useGet(workflowWebhookUpgradeDialogSource$);
   const { t } = useTranslation();
-  const busy = enabledLoadable.state === "loading";
+  const busy =
+    enabledLoadable.state === "loading" ||
+    (upgradeDialogSource?.action === "enable" &&
+      upgradeDialogSource.automationId === entry.automation.id);
   const title = workflowTitle(entry.workflow);
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -284,6 +284,7 @@ import { openSettingsDialogAt$ } from "../../signals/zero-page/settings/settings
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
   billingStatusAsync$,
+  creditPurchaseOrigin$,
   type CreditCheckoutSelection,
   startCheckout$,
   startCreditCheckout$,
@@ -5673,6 +5674,7 @@ function InsufficientCreditsCard() {
   const openSettings = useSet(openSettingsDialogAt$);
   const setSubPage = useSet(setBillingSubPage$);
   const pageSignal = useGet(pageSignal$);
+  const creditPurchaseOrigin = useGet(creditPurchaseOrigin$);
 
   const billingResolved = billingLoadable.state === "hasData";
   const credits = billingResolved ? billingLoadable.data.credits : null;
@@ -5686,7 +5688,9 @@ function InsufficientCreditsCard() {
   const shouldStartProCheckout = !canBuyCredits;
   const canShowBillingAction = billingResolved && canManageBilling;
   const checkoutRedirecting = checkoutLoadable.state === "loading";
-  const creditCheckoutPreparing = creditCheckoutLoadable.state === "loading";
+  const creditCheckoutPreparing =
+    creditCheckoutLoadable.state === "loading" ||
+    creditPurchaseOrigin === "chat";
 
   if (hasAvailableCredits) {
     return <CreditsAvailableMessage />;
@@ -5720,7 +5724,10 @@ function InsufficientCreditsCard() {
     event: ReactMouseEvent<HTMLButtonElement>,
   ) => {
     const newTab = event.metaKey || event.ctrlKey;
-    detach(creditCheckout(selection, newTab, pageSignal), Reason.DomCallback);
+    detach(
+      creditCheckout(selection, newTab, "chat", pageSignal),
+      Reason.DomCallback,
+    );
   };
 
   return (

--- a/turbo/packages/ui/src/styles/__tests__/globals.test.ts
+++ b/turbo/packages/ui/src/styles/__tests__/globals.test.ts
@@ -105,6 +105,29 @@ describe("global Lucide defaults", () => {
   });
 });
 
+describe("dialog transitions", () => {
+  it("does not apply exit styles while a remounted dialog is open", () => {
+    expect(
+      readRuleBody(
+        globalCss,
+        ".zero-dialog-overlay[data-ending-style]:not([data-open])",
+      ),
+    ).toMatch(/animation:\s*zero-dialog-overlay-out/);
+    expect(
+      readRuleBody(
+        globalCss,
+        ".zero-dialog-overlay[data-ending-style]:not([data-open])::after",
+      ),
+    ).toMatch(/visibility:\s*hidden/);
+    expect(
+      readRuleBody(
+        globalCss,
+        ".zero-dialog-content[data-ending-style]:not([data-open])",
+      ),
+    ).toMatch(/animation:\s*zero-dialog-content-out/);
+  });
+});
+
 describe("interaction state ladder", () => {
   it.each(THEMES)(
     "gives $name a layer colour and every alpha",

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -529,7 +529,11 @@
     animation: zero-dialog-overlay-in 180ms ease;
   }
 
-  .zero-dialog-overlay[data-ending-style] {
+  /* Base UI can briefly retain the previous ending style while a controlled
+     dialog mounts open again. Only let the ending style win after the dialog
+     is no longer open, otherwise the first frame flashes fully visible before
+     the enter animation starts. */
+  .zero-dialog-overlay[data-ending-style]:not([data-open]) {
     animation: zero-dialog-overlay-out 180ms ease;
   }
 
@@ -550,7 +554,7 @@
     animation: zero-dialog-blur-in 180ms step-end;
   }
 
-  .zero-dialog-overlay[data-ending-style]::after {
+  .zero-dialog-overlay[data-ending-style]:not([data-open])::after {
     visibility: hidden;
   }
 
@@ -576,7 +580,7 @@
     animation: zero-dialog-content-in 180ms ease;
   }
 
-  .zero-dialog-content[data-ending-style] {
+  .zero-dialog-content[data-ending-style]:not([data-open]) {
     animation: zero-dialog-content-out 180ms ease;
   }
 


### PR DESCRIPTION
## Summary

- keep async billing dialog triggers stable across repeated opens and prevent exit styles from flashing on reopen
- make repeated usage-pack and concurrency requests idempotent by returning the matching pending change instead of reporting a conflict or repeating the Stripe mutation
- distinguish neutral Stripe schedules from genuine future billing changes, safely releasing or reusing neutral schedules while continuing to block real cross-feature changes
- detach recurring invoice previews from attached schedules to satisfy Stripe's recurring-estimate restrictions
- make usage-pack reconciliation idempotent when `customer.subscription.updated` and `invoice.paid` race

## Root cause and scope

- The recurring-preview 500 was a regression in this PR's neutral-schedule support. The new flow allowed a subscription with a neutral attached schedule to continue, but initially still requested a subscription-based recurring estimate, which Stripe rejects for scheduled subscriptions.
- The allocation change stuck in `applying` was a pre-existing webhook race from #25510, not introduced by this PR. If `customer.subscription.updated` reflected the allocation before `invoice.paid` ran, the invoice handler treated the already-`applied` change as a reconciliation conflict. This PR exposed that latent race while exercising repeated changes through the expanded schedule flow, so it now also fixes the reconciliation path to treat `applied` changes idempotently and finish invoice fulfillment.
- Previous tests covered the invoice-first ordering only. The regression coverage now sends `customer.subscription.updated` before `invoice.paid` and verifies the change reaches `completed` without duplicate allocations or credit grants.

## Testing

- `pnpm -F @okouai/ui test`
- `pnpm vitest run apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx --maxWorkers=4 --silent=passed-only`
- `pnpm -F @okouai/ui lint`
- `pnpm -F @okouai/ui check-types`
- `pnpm knip --workspace @okouai/ui`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-checkout.test.ts` (132 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hooks: full Knip and monorepo typecheck
- local browser: three consecutive opens each for Concurrency Change and Buy Credits
- local Stripe dev reconciliation: recovered the stuck 100→200 change through the production scoped reconciliation path and verified the root change, allocation change, invoice fulfillment, and credit grants
