### PR TITLE
refactor(org): neutralize the organization logo vertical slice

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -110,7 +110,7 @@ import { zeroOnboardingCompleteRoutes } from "./routes/zero-onboarding-complete"
 import { zeroOnboardingStatusRoutes } from "./routes/zero-onboarding-status";
 import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
 import { zeroOrgDeleteRoutes } from "./routes/zero-org-delete";
-import { zeroOrgLogoRoutes } from "./routes/zero-org-logo";
+import { orgLogoRoutes } from "./routes/org-logo";
 import { zeroOrgMembersRoutes } from "./routes/zero-org-members";
 import { zeroOrgMembershipRequestsRoutes } from "./routes/zero-org-membership-requests";
 import { zeroOrgReadRoutes } from "./routes/zero-org-read";
@@ -325,7 +325,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroOnboardingStatusRoutes,
   ...zeroOrgInviteRoutes,
   ...zeroOrgDeleteRoutes,
-  ...zeroOrgLogoRoutes,
+  ...orgLogoRoutes,
   ...zeroOrgMembersRoutes,
   ...zeroOrgMembershipRequestsRoutes,
   ...zeroOrgReadRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -53,7 +53,7 @@ import {
   zeroOrgDeleteContract,
   zeroOrgLeaveContract,
 } from "@okouai/api-contracts/contracts/zero-org";
-import { zeroOrgLogoContract } from "@okouai/api-contracts/contracts/zero-org-logo";
+import { orgLogoContract } from "@okouai/api-contracts/contracts/org-logo";
 import {
   zeroOrgInviteContract,
   zeroOrgMembersContract,
@@ -96,7 +96,7 @@ import { zeroOnboardingCompleteRoutes } from "../../zero-onboarding-complete";
 import { zeroOnboardingStatusRoutes } from "../../zero-onboarding-status";
 import { zeroOrgDeleteRoutes } from "../../zero-org-delete";
 import { zeroOrgInviteRoutes } from "../../zero-org-invite";
-import { zeroOrgLogoRoutes } from "../../zero-org-logo";
+import { orgLogoRoutes } from "../../org-logo";
 import { zeroOrgMembersRoutes } from "../../zero-org-members";
 import { zeroOrgMembershipRequestsRoutes } from "../../zero-org-membership-requests";
 import { zeroOrgReadRoutes } from "../../zero-org-read";
@@ -216,7 +216,7 @@ const authOrgRoutes = [
   ...zeroOrgMembersRoutes,
   ...zeroOrgInviteRoutes,
   ...zeroOrgMembershipRequestsRoutes,
-  ...zeroOrgLogoRoutes,
+  ...orgLogoRoutes,
   ...zeroTeamRoutes,
   ...zeroAgentsRoutes,
   ...zeroComposesRoutes,
@@ -630,7 +630,7 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
       const client = setupAppWithRoutes({ context, routes: authOrgRoutes })(
-        zeroOrgLogoContract,
+        orgLogoContract,
       );
       return await accept(
         client.get({ headers: authenticate(actor) }),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -25,7 +25,7 @@ import {
   zeroPersonalModelProvidersByTypeContract,
   zeroPersonalModelProvidersMainContract,
 } from "@okouai/api-contracts/contracts/zero-personal-model-providers";
-import { zeroOrgLogoContract } from "@okouai/api-contracts/contracts/zero-org-logo";
+import { orgLogoContract } from "@okouai/api-contracts/contracts/org-logo";
 import {
   zeroUserPreferencesContract,
   updateUserPreferencesRequestSchema,
@@ -43,7 +43,7 @@ import { zeroMeModelProvidersResetSubscriptionRoutes } from "../../zero-me-model
 import { zeroMeModelProvidersUpsertRoutes } from "../../zero-me-model-providers-upsert";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
-import { zeroOrgLogoRoutes } from "../../zero-org-logo";
+import { orgLogoRoutes } from "../../org-logo";
 import { zeroPushSubscriptionsRoutes } from "../../zero-push-subscriptions";
 import { zeroUserPreferencesRoutes } from "../../zero-user-preferences";
 import { zeroWorkflowsRoutes } from "../../zero-workflows";
@@ -197,9 +197,7 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroOrgLogoRoutes })(
-          zeroOrgLogoContract,
-        ).get({
+        setupApp({ context, routes: orgLogoRoutes })(orgLogoContract).get({
           headers: authenticate(context, actor),
         }),
         statuses,
@@ -216,9 +214,7 @@ export function createMiscRoutesApi(context: TestContext) {
         body.append("file", file);
       }
       return await accept(
-        setupApp({ context, routes: zeroOrgLogoRoutes })(
-          zeroOrgLogoContract,
-        ).post({
+        setupApp({ context, routes: orgLogoRoutes })(orgLogoContract).post({
           headers: authenticate(context, actor),
           body,
         }),

--- a/turbo/apps/api/src/signals/routes/org-logo.ts
+++ b/turbo/apps/api/src/signals/routes/org-logo.ts
@@ -1,5 +1,5 @@
 import { command, computed } from "ccstate";
-import { zeroOrgLogoContract } from "@okouai/api-contracts/contracts/zero-org-logo";
+import { orgLogoContract } from "@okouai/api-contracts/contracts/org-logo";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -141,13 +141,13 @@ const postOrgLogoInner$ = command(async ({ get }, signal: AbortSignal) => {
   };
 });
 
-export const zeroOrgLogoRoutes: readonly RouteEntry[] = [
+export const orgLogoRoutes: readonly RouteEntry[] = [
   {
-    route: zeroOrgLogoContract.get,
+    route: orgLogoContract.get,
     handler: authRoute({}, getOrgLogoInner$),
   },
   {
-    route: zeroOrgLogoContract.post,
+    route: orgLogoContract.post,
     handler: authRoute({}, postOrgLogoInner$),
   },
 ];

--- a/turbo/apps/platform/src/signals/zero-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/workspace-settings-state.ts
@@ -6,7 +6,7 @@ import {
   zeroOrgDeleteContract,
   zeroOrgLeaveContract,
 } from "@okouai/api-contracts/contracts/zero-org";
-import { zeroOrgLogoContract } from "@okouai/api-contracts/contracts/zero-org-logo";
+import { orgLogoContract } from "@okouai/api-contracts/contracts/org-logo";
 import {
   zeroOrgInviteContract,
   zeroOrgMembersContract,
@@ -432,7 +432,7 @@ const uploadOrgLogo$ = command(
   ): Promise<{ readonly logoUrl: string | null }> => {
     const formData = new FormData();
     formData.append("file", file);
-    const client = get(zeroClient$)(zeroOrgLogoContract);
+    const client = get(zeroClient$)(orgLogoContract);
     const result = await accept(
       client.post({
         body: formData,
@@ -447,7 +447,7 @@ const uploadOrgLogo$ = command(
 
 export const loadOrgLogo$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    const client = get(zeroClient$)(zeroOrgLogoContract);
+    const client = get(zeroClient$)(orgLogoContract);
     const result = await accept(
       client.get({
         fetchOptions: { signal },

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1061,11 +1061,11 @@ export {
   type ZeroOrgDeleteContract,
 } from "./zero-org";
 export {
-  zeroOrgLogoContract,
-  zeroOrgLogoResponseSchema,
-  type ZeroOrgLogoContract,
-  type ZeroOrgLogoResponse,
-} from "./zero-org-logo";
+  orgLogoContract,
+  orgLogoResponseSchema,
+  type OrgLogoContract,
+  type OrgLogoResponse,
+} from "./org-logo";
 export {
   zeroOrgMembersContract,
   zeroOrgInviteContract,

--- a/turbo/packages/api-contracts/src/contracts/org-logo.ts
+++ b/turbo/packages/api-contracts/src/contracts/org-logo.ts
@@ -4,23 +4,20 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
-export const zeroOrgLogoResponseSchema = z.object({
+export const orgLogoResponseSchema = z.object({
   logoUrl: z.string().nullable(),
   hasImage: z.boolean(),
 });
 
-export type ZeroOrgLogoResponse = z.infer<typeof zeroOrgLogoResponseSchema>;
+export type OrgLogoResponse = z.infer<typeof orgLogoResponseSchema>;
 
-/**
- * Zero contract for /api/okou/org/logo
- */
-export const zeroOrgLogoContract = c.router({
+export const orgLogoContract = c.router({
   get: {
     method: "GET",
     path: "/api/okou/org/logo",
     headers: authHeadersSchema,
     responses: {
-      200: zeroOrgLogoResponseSchema,
+      200: orgLogoResponseSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
@@ -34,7 +31,7 @@ export const zeroOrgLogoContract = c.router({
     contentType: "multipart/form-data",
     body: c.type<FormData>(),
     responses: {
-      200: zeroOrgLogoResponseSchema,
+      200: orgLogoResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
@@ -45,4 +42,4 @@ export const zeroOrgLogoContract = c.router({
   },
 });
 
-export type ZeroOrgLogoContract = typeof zeroOrgLogoContract;
+export type OrgLogoContract = typeof orgLogoContract;


### PR DESCRIPTION
## Summary

- rename the internal Organization Logo contract and route modules to neutral `org-logo` names
- update every live API-contract, API, test-helper, and Platform caller and remove the old module paths directly
- preserve canonical and compatibility API namespaces and all runtime behavior

## Verification

- `pnpm format`
- `pnpm --filter @okouai/api-contracts run lint`
- `pnpm --filter api run lint`
- `pnpm --filter @okouai/app run lint`
- `pnpm --filter @okouai/api-contracts run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app run check-types`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/org-team.bdd.test.ts -t "ORG-01: org logo lifecycle through the Clerk boundary"` (1 passed, 6 skipped by filter)
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/org-general-tab.test.tsx` (6 passed)
- final live-code search: no `zero-org-logo`, `zeroOrgLogo`, or `ZeroOrgLogo` references
- verified canonical `/api/okou/org/logo` GET/POST coverage and unchanged raw `/api/zero/org/logo` compatibility coverage

## Acceptance criteria

- [x] canonical contract module is `@okouai/api-contracts/contracts/org-logo` with only `orgLogo*` / `OrgLogo*` exports
- [x] canonical API route module is `routes/org-logo` and exports `orgLogoRoutes`
- [x] every live caller uses canonical module paths and declarations
- [x] no deprecated internal alias or forwarding module remains
- [x] API paths, authorization, multipart `file` validation, 2 MiB limit, MIME support, Clerk behavior, schemas, errors, aborts, and runtime behavior are unchanged
- [x] focused local tests and relevant package format, lint, and type checks pass

Closes #26939