### PR TITLE
refactor(model-provider): neutralize device auth modules

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -78,11 +78,11 @@ import { zeroBankingRoutes } from "./routes/zero-banking";
 import { zeroChatThreadRoutes } from "./routes/zero-chat-threads";
 import { zeroChatEventsRoutes } from "./routes/zero-chat-events";
 import { zeroSharedThreadRoutes } from "./routes/zero-shared-threads";
-import { zeroClaudeCodeDeviceAuthRoutes } from "./routes/zero-claude-code-device-auth";
+import { claudeCodeDeviceAuthRoutes } from "./routes/claude-code-device-auth";
 import { zeroComposesRoutes } from "./routes/zero-composes";
 import { zeroComputerUseAuthorizationRoutes } from "./routes/zero-computer-use-authorization";
 import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
-import { zeroCodexDeviceAuthRoutes } from "./routes/zero-codex-device-auth";
+import { codexDeviceAuthRoutes } from "./routes/codex-device-auth";
 import { zeroConnectorCatalogRoutes } from "./routes/zero-connector-catalog";
 import { zeroConnectorCheckRoutes } from "./routes/zero-connector-check";
 import { zeroConnectorsExternalCodeRoutes } from "./routes/zero-connectors-external-code";
@@ -269,11 +269,11 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroChatThreadRoutes,
   ...zeroChatEventsRoutes,
   ...zeroSharedThreadRoutes,
-  ...zeroClaudeCodeDeviceAuthRoutes,
+  ...claudeCodeDeviceAuthRoutes,
   ...zeroComposesRoutes,
   ...zeroComputerUseAuthorizationRoutes,
   ...zeroComputerUseRoutes,
-  ...zeroCodexDeviceAuthRoutes,
+  ...codexDeviceAuthRoutes,
   ...zeroConnectorCatalogRoutes,
   ...zeroConnectorCheckRoutes,
   ...zeroConnectorsExternalCodeRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
@@ -24,12 +24,12 @@ import {
 import { platformRealtimeTokenContract } from "@okouai/api-contracts/contracts/realtime";
 import {
   type ClaudeCodeDeviceAuthScope,
-  zeroClaudeCodeDeviceAuthContract,
-} from "@okouai/api-contracts/contracts/zero-claude-code-device-auth";
+  claudeCodeDeviceAuthContract,
+} from "@okouai/api-contracts/contracts/claude-code-device-auth";
 import {
   type CodexDeviceAuthScope,
-  zeroCodexDeviceAuthContract,
-} from "@okouai/api-contracts/contracts/zero-codex-device-auth";
+  codexDeviceAuthContract,
+} from "@okouai/api-contracts/contracts/codex-device-auth";
 import { zeroModelProvidersByTypeContract } from "@okouai/api-contracts/contracts/zero-model-providers";
 import { http, HttpResponse } from "msw";
 
@@ -46,8 +46,8 @@ import { cliAuthTestRoutes } from "../../cli-auth-test";
 import { desktopAuthRoutes } from "../../desktop-auth";
 import { zeroAgentsRoutes } from "../../zero-agents";
 import { zeroBillingStatusRoutes } from "../../zero-billing-status";
-import { zeroClaudeCodeDeviceAuthRoutes } from "../../zero-claude-code-device-auth";
-import { zeroCodexDeviceAuthRoutes } from "../../zero-codex-device-auth";
+import { claudeCodeDeviceAuthRoutes } from "../../claude-code-device-auth";
+import { codexDeviceAuthRoutes } from "../../codex-device-auth";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
 import { zeroRealtimeTokenRoutes } from "../../zero-realtime-token";
 import type { ApiTestUser } from "./api-bdd";
@@ -84,8 +84,8 @@ const authDeviceRoutes: readonly RouteEntry[] = [
   ...desktopAuthRoutes,
   ...zeroAgentsRoutes,
   ...zeroBillingStatusRoutes,
-  ...zeroClaudeCodeDeviceAuthRoutes,
-  ...zeroCodexDeviceAuthRoutes,
+  ...claudeCodeDeviceAuthRoutes,
+  ...codexDeviceAuthRoutes,
   ...zeroModelProvidersRoutes,
   ...zeroRealtimeTokenRoutes,
 ];
@@ -693,7 +693,7 @@ export function createAuthDeviceApiActions(context: TestContext) {
         readonly modelProviderId?: string;
       },
     ) {
-      const client = authDeviceApp(context)(zeroCodexDeviceAuthContract);
+      const client = authDeviceApp(context)(codexDeviceAuthContract);
       return await accept(
         client.start({
           headers: authenticate(actor),
@@ -708,7 +708,7 @@ export function createAuthDeviceApiActions(context: TestContext) {
       sessionToken: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 503)[],
     ) {
-      const client = authDeviceApp(context)(zeroCodexDeviceAuthContract);
+      const client = authDeviceApp(context)(codexDeviceAuthContract);
       return await accept(
         client.complete({
           headers: authenticate(actor),
@@ -723,7 +723,7 @@ export function createAuthDeviceApiActions(context: TestContext) {
       sessionToken: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404)[],
     ) {
-      const client = authDeviceApp(context)(zeroCodexDeviceAuthContract);
+      const client = authDeviceApp(context)(codexDeviceAuthContract);
       return await accept(
         client.cancel({
           headers: authenticate(actor),
@@ -742,7 +742,7 @@ export function createAuthDeviceApiActions(context: TestContext) {
         readonly modelProviderId?: string;
       },
     ) {
-      const client = authDeviceApp(context)(zeroClaudeCodeDeviceAuthContract);
+      const client = authDeviceApp(context)(claudeCodeDeviceAuthContract);
       return await accept(
         client.start({
           headers: authenticate(actor),
@@ -758,7 +758,7 @@ export function createAuthDeviceApiActions(context: TestContext) {
       authorizationCode: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 503)[],
     ) {
-      const client = authDeviceApp(context)(zeroClaudeCodeDeviceAuthContract);
+      const client = authDeviceApp(context)(claudeCodeDeviceAuthContract);
       return await accept(
         client.complete({
           headers: authenticate(actor),
@@ -773,7 +773,7 @@ export function createAuthDeviceApiActions(context: TestContext) {
       sessionToken: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404)[],
     ) {
-      const client = authDeviceApp(context)(zeroClaudeCodeDeviceAuthContract);
+      const client = authDeviceApp(context)(claudeCodeDeviceAuthContract);
       return await accept(
         client.cancel({
           headers: authenticate(actor),

--- a/turbo/apps/api/src/signals/routes/claude-code-device-auth.ts
+++ b/turbo/apps/api/src/signals/routes/claude-code-device-auth.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { zeroCodexDeviceAuthContract } from "@okouai/api-contracts/contracts/zero-codex-device-auth";
+import { claudeCodeDeviceAuthContract } from "@okouai/api-contracts/contracts/claude-code-device-auth";
 
 import { badRequestMessage, notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -7,11 +7,11 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { writeDb$ } from "../external/db";
 import {
-  cancelCodexDeviceAuth$,
-  codexDeviceAuthUnavailable,
-  completeCodexDeviceAuth$,
-  startCodexDeviceAuth,
-} from "../services/codex-device-auth.service";
+  cancelClaudeCodeDeviceAuth$,
+  claudeCodeDeviceAuthUnavailable,
+  completeClaudeCodeDeviceAuth$,
+  startClaudeCodeDeviceAuth,
+} from "../services/claude-code-device-auth.service";
 import type { RouteEntry } from "../route-entry";
 
 const modelProviderWriteAuth = {
@@ -29,20 +29,20 @@ const adminRequired = Object.freeze({
   }),
 });
 
-const startCodexDeviceAuthBody$ = bodyResultOf(
-  zeroCodexDeviceAuthContract.start,
+const startClaudeCodeDeviceAuthBody$ = bodyResultOf(
+  claudeCodeDeviceAuthContract.start,
 );
-const completeCodexDeviceAuthBody$ = bodyResultOf(
-  zeroCodexDeviceAuthContract.complete,
+const completeClaudeCodeDeviceAuthBody$ = bodyResultOf(
+  claudeCodeDeviceAuthContract.complete,
 );
-const cancelCodexDeviceAuthBody$ = bodyResultOf(
-  zeroCodexDeviceAuthContract.cancel,
+const cancelClaudeCodeDeviceAuthBody$ = bodyResultOf(
+  claudeCodeDeviceAuthContract.cancel,
 );
 
-const startCodexDeviceAuthInner$ = command(
+const startClaudeCodeDeviceAuthInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const body = await get(startCodexDeviceAuthBody$);
+    const body = await get(startClaudeCodeDeviceAuthBody$);
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
@@ -58,7 +58,7 @@ const startCodexDeviceAuthInner$ = command(
       return badRequestMessage("modelProviderId is required for reconnect");
     }
 
-    const result = await startCodexDeviceAuth(
+    const result = await startClaudeCodeDeviceAuth(
       {
         writeDb: set(writeDb$),
         orgId: auth.orgId,
@@ -72,56 +72,46 @@ const startCodexDeviceAuthInner$ = command(
     signal.throwIfAborted();
 
     if (!result.ok) {
-      return codexDeviceAuthUnavailable(result.message);
+      return claudeCodeDeviceAuthUnavailable(result.message);
     }
 
     return {
       status: 200 as const,
       body: {
         sessionToken: result.sessionToken,
-        type: "codex" as const,
+        type: "claude-code" as const,
         status: "pending" as const,
         scope: result.scope,
         browserUrl: result.browserUrl,
-        verificationCode: result.verificationCode,
         expiresIn: result.expiresIn,
-        interval: result.interval,
       },
     };
   },
 );
 
-const completeCodexDeviceAuthInner$ = command(
+const completeClaudeCodeDeviceAuthInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const body = await get(completeCodexDeviceAuthBody$);
+    const body = await get(completeClaudeCodeDeviceAuthBody$);
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
     }
 
     const result = await set(
-      completeCodexDeviceAuth$,
+      completeClaudeCodeDeviceAuth$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
         orgRole: auth.orgRole,
         sessionToken: body.data.sessionToken,
+        authorizationCode: body.data.authorizationCode,
       },
       signal,
     );
     signal.throwIfAborted();
 
     switch (result.status) {
-      case "pending": {
-        return {
-          status: 200 as const,
-          body: {
-            status: "pending" as const,
-            errorMessage: result.errorMessage,
-          },
-        };
-      }
       case "complete": {
         return {
           status: 200 as const,
@@ -142,23 +132,23 @@ const completeCodexDeviceAuthInner$ = command(
         return result.response;
       }
       case "error": {
-        return codexDeviceAuthUnavailable(result.message);
+        return claudeCodeDeviceAuthUnavailable(result.message);
       }
     }
   },
 );
 
-const cancelCodexDeviceAuthInner$ = command(
+const cancelClaudeCodeDeviceAuthInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const body = await get(cancelCodexDeviceAuthBody$);
+    const body = await get(cancelClaudeCodeDeviceAuthBody$);
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
     }
 
     const result = await set(
-      cancelCodexDeviceAuth$,
+      cancelClaudeCodeDeviceAuth$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
@@ -185,17 +175,23 @@ const cancelCodexDeviceAuthInner$ = command(
   },
 );
 
-export const zeroCodexDeviceAuthRoutes: readonly RouteEntry[] = [
+export const claudeCodeDeviceAuthRoutes: readonly RouteEntry[] = [
   {
-    route: zeroCodexDeviceAuthContract.start,
-    handler: authRoute(modelProviderWriteAuth, startCodexDeviceAuthInner$),
+    route: claudeCodeDeviceAuthContract.start,
+    handler: authRoute(modelProviderWriteAuth, startClaudeCodeDeviceAuthInner$),
   },
   {
-    route: zeroCodexDeviceAuthContract.complete,
-    handler: authRoute(modelProviderWriteAuth, completeCodexDeviceAuthInner$),
+    route: claudeCodeDeviceAuthContract.complete,
+    handler: authRoute(
+      modelProviderWriteAuth,
+      completeClaudeCodeDeviceAuthInner$,
+    ),
   },
   {
-    route: zeroCodexDeviceAuthContract.cancel,
-    handler: authRoute(modelProviderWriteAuth, cancelCodexDeviceAuthInner$),
+    route: claudeCodeDeviceAuthContract.cancel,
+    handler: authRoute(
+      modelProviderWriteAuth,
+      cancelClaudeCodeDeviceAuthInner$,
+    ),
   },
 ];

--- a/turbo/apps/api/src/signals/routes/codex-device-auth.ts
+++ b/turbo/apps/api/src/signals/routes/codex-device-auth.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { zeroClaudeCodeDeviceAuthContract } from "@okouai/api-contracts/contracts/zero-claude-code-device-auth";
+import { codexDeviceAuthContract } from "@okouai/api-contracts/contracts/codex-device-auth";
 
 import { badRequestMessage, notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -7,11 +7,11 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { writeDb$ } from "../external/db";
 import {
-  cancelClaudeCodeDeviceAuth$,
-  claudeCodeDeviceAuthUnavailable,
-  completeClaudeCodeDeviceAuth$,
-  startClaudeCodeDeviceAuth,
-} from "../services/claude-code-device-auth.service";
+  cancelCodexDeviceAuth$,
+  codexDeviceAuthUnavailable,
+  completeCodexDeviceAuth$,
+  startCodexDeviceAuth,
+} from "../services/codex-device-auth.service";
 import type { RouteEntry } from "../route-entry";
 
 const modelProviderWriteAuth = {
@@ -29,20 +29,16 @@ const adminRequired = Object.freeze({
   }),
 });
 
-const startClaudeCodeDeviceAuthBody$ = bodyResultOf(
-  zeroClaudeCodeDeviceAuthContract.start,
+const startCodexDeviceAuthBody$ = bodyResultOf(codexDeviceAuthContract.start);
+const completeCodexDeviceAuthBody$ = bodyResultOf(
+  codexDeviceAuthContract.complete,
 );
-const completeClaudeCodeDeviceAuthBody$ = bodyResultOf(
-  zeroClaudeCodeDeviceAuthContract.complete,
-);
-const cancelClaudeCodeDeviceAuthBody$ = bodyResultOf(
-  zeroClaudeCodeDeviceAuthContract.cancel,
-);
+const cancelCodexDeviceAuthBody$ = bodyResultOf(codexDeviceAuthContract.cancel);
 
-const startClaudeCodeDeviceAuthInner$ = command(
+const startCodexDeviceAuthInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const body = await get(startClaudeCodeDeviceAuthBody$);
+    const body = await get(startCodexDeviceAuthBody$);
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
@@ -58,7 +54,7 @@ const startClaudeCodeDeviceAuthInner$ = command(
       return badRequestMessage("modelProviderId is required for reconnect");
     }
 
-    const result = await startClaudeCodeDeviceAuth(
+    const result = await startCodexDeviceAuth(
       {
         writeDb: set(writeDb$),
         orgId: auth.orgId,
@@ -72,46 +68,56 @@ const startClaudeCodeDeviceAuthInner$ = command(
     signal.throwIfAborted();
 
     if (!result.ok) {
-      return claudeCodeDeviceAuthUnavailable(result.message);
+      return codexDeviceAuthUnavailable(result.message);
     }
 
     return {
       status: 200 as const,
       body: {
         sessionToken: result.sessionToken,
-        type: "claude-code" as const,
+        type: "codex" as const,
         status: "pending" as const,
         scope: result.scope,
         browserUrl: result.browserUrl,
+        verificationCode: result.verificationCode,
         expiresIn: result.expiresIn,
+        interval: result.interval,
       },
     };
   },
 );
 
-const completeClaudeCodeDeviceAuthInner$ = command(
+const completeCodexDeviceAuthInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const body = await get(completeClaudeCodeDeviceAuthBody$);
+    const body = await get(completeCodexDeviceAuthBody$);
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
     }
 
     const result = await set(
-      completeClaudeCodeDeviceAuth$,
+      completeCodexDeviceAuth$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
         orgRole: auth.orgRole,
         sessionToken: body.data.sessionToken,
-        authorizationCode: body.data.authorizationCode,
       },
       signal,
     );
     signal.throwIfAborted();
 
     switch (result.status) {
+      case "pending": {
+        return {
+          status: 200 as const,
+          body: {
+            status: "pending" as const,
+            errorMessage: result.errorMessage,
+          },
+        };
+      }
       case "complete": {
         return {
           status: 200 as const,
@@ -132,23 +138,23 @@ const completeClaudeCodeDeviceAuthInner$ = command(
         return result.response;
       }
       case "error": {
-        return claudeCodeDeviceAuthUnavailable(result.message);
+        return codexDeviceAuthUnavailable(result.message);
       }
     }
   },
 );
 
-const cancelClaudeCodeDeviceAuthInner$ = command(
+const cancelCodexDeviceAuthInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const body = await get(cancelClaudeCodeDeviceAuthBody$);
+    const body = await get(cancelCodexDeviceAuthBody$);
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
     }
 
     const result = await set(
-      cancelClaudeCodeDeviceAuth$,
+      cancelCodexDeviceAuth$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
@@ -175,23 +181,17 @@ const cancelClaudeCodeDeviceAuthInner$ = command(
   },
 );
 
-export const zeroClaudeCodeDeviceAuthRoutes: readonly RouteEntry[] = [
+export const codexDeviceAuthRoutes: readonly RouteEntry[] = [
   {
-    route: zeroClaudeCodeDeviceAuthContract.start,
-    handler: authRoute(modelProviderWriteAuth, startClaudeCodeDeviceAuthInner$),
+    route: codexDeviceAuthContract.start,
+    handler: authRoute(modelProviderWriteAuth, startCodexDeviceAuthInner$),
   },
   {
-    route: zeroClaudeCodeDeviceAuthContract.complete,
-    handler: authRoute(
-      modelProviderWriteAuth,
-      completeClaudeCodeDeviceAuthInner$,
-    ),
+    route: codexDeviceAuthContract.complete,
+    handler: authRoute(modelProviderWriteAuth, completeCodexDeviceAuthInner$),
   },
   {
-    route: zeroClaudeCodeDeviceAuthContract.cancel,
-    handler: authRoute(
-      modelProviderWriteAuth,
-      cancelClaudeCodeDeviceAuthInner$,
-    ),
+    route: codexDeviceAuthContract.cancel,
+    handler: authRoute(modelProviderWriteAuth, cancelCodexDeviceAuthInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/claude-code-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/claude-code-device-auth.service.ts
@@ -4,7 +4,7 @@ import { command } from "ccstate";
 import type {
   ClaudeCodeDeviceAuthMode,
   ClaudeCodeDeviceAuthScope,
-} from "@okouai/api-contracts/contracts/zero-claude-code-device-auth";
+} from "@okouai/api-contracts/contracts/claude-code-device-auth";
 import type { ModelProviderResponse } from "@okouai/api-contracts/contracts/model-providers";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";

--- a/turbo/apps/api/src/signals/services/codex-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/codex-device-auth.service.ts
@@ -2,7 +2,7 @@ import { command } from "ccstate";
 import type {
   CodexDeviceAuthMode,
   CodexDeviceAuthScope,
-} from "@okouai/api-contracts/contracts/zero-codex-device-auth";
+} from "@okouai/api-contracts/contracts/codex-device-auth";
 import type { ModelProviderResponse } from "@okouai/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -1,10 +1,10 @@
 import { command, computed, state, type Command, type State } from "ccstate";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import {
-  zeroClaudeCodeDeviceAuthContract,
+  claudeCodeDeviceAuthContract,
   type ClaudeCodeDeviceAuthMode,
   type ClaudeCodeDeviceAuthScope,
-} from "@okouai/api-contracts/contracts/zero-claude-code-device-auth";
+} from "@okouai/api-contracts/contracts/claude-code-device-auth";
 
 import { accept } from "../../../lib/accept.ts";
 import { i18n } from "../../../i18n/index.ts";
@@ -106,7 +106,7 @@ const startClaudeCodeDeviceAuth$ = command(
     },
     signal: AbortSignal,
   ) => {
-    const client = get(zeroClient$)(zeroClaudeCodeDeviceAuthContract, {
+    const client = get(zeroClient$)(claudeCodeDeviceAuthContract, {
       apiBase: "api",
     });
     const result = await accept(
@@ -128,7 +128,7 @@ const completeClaudeCodeDeviceAuth$ = command(
     authorizationCode: string,
     signal: AbortSignal,
   ) => {
-    const client = get(zeroClient$)(zeroClaudeCodeDeviceAuthContract, {
+    const client = get(zeroClient$)(claudeCodeDeviceAuthContract, {
       apiBase: "api",
     });
     const result = await accept(
@@ -148,7 +148,7 @@ const completeClaudeCodeDeviceAuth$ = command(
 
 const cancelClaudeCodeDeviceAuth$ = command(
   async ({ get }, sessionToken: string, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroClaudeCodeDeviceAuthContract, {
+    const client = get(zeroClient$)(claudeCodeDeviceAuthContract, {
       apiBase: "api",
     });
     const result = await accept(

--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -2,10 +2,10 @@ import { command, computed, state, type Command, type State } from "ccstate";
 import { delay } from "signal-timers";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import {
-  zeroCodexDeviceAuthContract,
+  codexDeviceAuthContract,
   type CodexDeviceAuthMode,
   type CodexDeviceAuthScope,
-} from "@okouai/api-contracts/contracts/zero-codex-device-auth";
+} from "@okouai/api-contracts/contracts/codex-device-auth";
 
 import { accept } from "../../../lib/accept.ts";
 import { i18n } from "../../../i18n/index.ts";
@@ -180,7 +180,7 @@ const startCodexDeviceAuth$ = command(
     },
     signal: AbortSignal,
   ) => {
-    const client = get(zeroClient$)(zeroCodexDeviceAuthContract, {
+    const client = get(zeroClient$)(codexDeviceAuthContract, {
       apiBase: "api",
     });
     const result = await accept(
@@ -197,7 +197,7 @@ const startCodexDeviceAuth$ = command(
 
 const completeCodexDeviceAuth$ = command(
   async ({ get }, sessionToken: string, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroCodexDeviceAuthContract, {
+    const client = get(zeroClient$)(codexDeviceAuthContract, {
       apiBase: "api",
     });
     const result = await accept(
@@ -214,7 +214,7 @@ const completeCodexDeviceAuth$ = command(
 
 const cancelCodexDeviceAuth$ = command(
   async ({ get }, sessionToken: string, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroCodexDeviceAuthContract, {
+    const client = get(zeroClient$)(codexDeviceAuthContract, {
       apiBase: "api",
     });
     const result = await accept(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -20,8 +20,8 @@ import {
   type PublicConnectorCatalogStatusItem,
 } from "@okouai/api-contracts/contracts/zero-connector-catalog";
 import { zeroUserPermissionGrantsContract } from "@okouai/api-contracts/contracts/zero-user-permission-grants";
-import { zeroClaudeCodeDeviceAuthContract } from "@okouai/api-contracts/contracts/zero-claude-code-device-auth";
-import { zeroCodexDeviceAuthContract } from "@okouai/api-contracts/contracts/zero-codex-device-auth";
+import { claudeCodeDeviceAuthContract } from "@okouai/api-contracts/contracts/claude-code-device-auth";
+import { codexDeviceAuthContract } from "@okouai/api-contracts/contracts/codex-device-auth";
 import { zeroPersonalModelProvidersMainContract } from "@okouai/api-contracts/contracts/zero-personal-model-providers";
 import { zeroModelPoliciesMainContract } from "@okouai/api-contracts/contracts/zero-model-policies";
 import { zeroBillingStatusContract } from "@okouai/api-contracts/contracts/zero-billing";
@@ -2341,7 +2341,7 @@ describe("chat composer models", () => {
     ]);
     context.mocks.data.personalModelProviders([]);
     mockAgent();
-    context.mocks.api(zeroCodexDeviceAuthContract.start, ({ respond }) => {
+    context.mocks.api(codexDeviceAuthContract.start, ({ respond }) => {
       return respond(200, {
         sessionToken: "mock-codex-device-session",
         type: "codex",
@@ -2353,18 +2353,15 @@ describe("chat composer models", () => {
         interval: 1,
       });
     });
-    context.mocks.api(
-      zeroCodexDeviceAuthContract.complete,
-      async ({ respond }) => {
-        await codexApproval.promise;
-        context.mocks.data.personalModelProviders([codexProvider]);
-        return respond(200, {
-          status: "complete",
-          provider: codexProvider,
-          created: true,
-        });
-      },
-    );
+    context.mocks.api(codexDeviceAuthContract.complete, async ({ respond }) => {
+      await codexApproval.promise;
+      context.mocks.data.personalModelProviders([codexProvider]);
+      return respond(200, {
+        status: "complete",
+        provider: codexProvider,
+        created: true,
+      });
+    });
 
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
     await expectComposerModel("GPT 5.5");
@@ -2431,7 +2428,7 @@ describe("chat composer models", () => {
       }),
     ]);
     mockAgent();
-    context.mocks.api(zeroCodexDeviceAuthContract.start, ({ respond }) => {
+    context.mocks.api(codexDeviceAuthContract.start, ({ respond }) => {
       return respond(200, {
         sessionToken: "mock-stale-codex-device-session",
         type: "codex",
@@ -2443,7 +2440,7 @@ describe("chat composer models", () => {
         interval: 1,
       });
     });
-    context.mocks.api(zeroCodexDeviceAuthContract.complete, ({ respond }) => {
+    context.mocks.api(codexDeviceAuthContract.complete, ({ respond }) => {
       return respond(200, { status: "pending", errorMessage: null });
     });
 
@@ -2483,7 +2480,7 @@ describe("chat composer models", () => {
     ]);
     context.mocks.data.personalModelProviders([]);
     mockAgent();
-    context.mocks.api(zeroClaudeCodeDeviceAuthContract.start, ({ respond }) => {
+    context.mocks.api(claudeCodeDeviceAuthContract.start, ({ respond }) => {
       return respond(200, {
         sessionToken: "mock-claude-code-device-session",
         type: "claude-code",
@@ -2493,20 +2490,17 @@ describe("chat composer models", () => {
         expiresIn: 30,
       });
     });
-    context.mocks.api(
-      zeroClaudeCodeDeviceAuthContract.complete,
-      ({ respond }) => {
-        return respond(200, {
-          status: "complete",
-          provider: buildProvider({
-            id: "00000000-0000-4000-a000-000000000401",
-            type: "claude-code-oauth-token",
-            secretName: "CLAUDE_CODE_OAUTH_TOKEN",
-          }),
-          created: true,
-        });
-      },
-    );
+    context.mocks.api(claudeCodeDeviceAuthContract.complete, ({ respond }) => {
+      return respond(200, {
+        status: "complete",
+        provider: buildProvider({
+          id: "00000000-0000-4000-a000-000000000401",
+          type: "claude-code-oauth-token",
+          secretName: "CLAUDE_CODE_OAUTH_TOKEN",
+        }),
+        created: true,
+      });
+    });
 
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
     await expectComposerModel("Claude Opus 4.8");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
@@ -1,5 +1,5 @@
-import { zeroCodexDeviceAuthContract } from "@okouai/api-contracts/contracts/zero-codex-device-auth";
-import { zeroClaudeCodeDeviceAuthContract } from "@okouai/api-contracts/contracts/zero-claude-code-device-auth";
+import { codexDeviceAuthContract } from "@okouai/api-contracts/contracts/codex-device-auth";
+import { claudeCodeDeviceAuthContract } from "@okouai/api-contracts/contracts/claude-code-device-auth";
 import {
   zeroBillingCheckoutContract,
   zeroBillingStatusContract,
@@ -137,7 +137,7 @@ function missingOpenAiPolicy(): OrgModelPolicy {
 function mockStaleProviderStory(): void {
   mockAdminOrg();
   context.mocks.data.orgModelProviders([staleCodexProvider()]);
-  context.mocks.api(zeroCodexDeviceAuthContract.start, ({ respond }) => {
+  context.mocks.api(codexDeviceAuthContract.start, ({ respond }) => {
     return respond(200, {
       sessionToken: "mock-codex-device-session",
       type: "codex",
@@ -149,7 +149,7 @@ function mockStaleProviderStory(): void {
       interval: 1,
     });
   });
-  context.mocks.api(zeroCodexDeviceAuthContract.complete, ({ respond }) => {
+  context.mocks.api(codexDeviceAuthContract.complete, ({ respond }) => {
     return respond(200, { status: "pending", errorMessage: null });
   });
 }
@@ -1077,7 +1077,7 @@ describe("organization model providers settings", () => {
   it("reconnects a stale workspace Claude Code provider", async () => {
     mockAdminOrg();
     context.mocks.data.orgModelProviders([staleClaudeCodeProvider()]);
-    context.mocks.api(zeroClaudeCodeDeviceAuthContract.start, ({ respond }) => {
+    context.mocks.api(claudeCodeDeviceAuthContract.start, ({ respond }) => {
       return respond(200, {
         sessionToken: "mock-workspace-claude-code-session",
         type: "claude-code",
@@ -1087,20 +1087,17 @@ describe("organization model providers settings", () => {
         expiresIn: 30,
       });
     });
-    context.mocks.api(
-      zeroClaudeCodeDeviceAuthContract.complete,
-      ({ respond }) => {
-        return respond(200, {
-          status: "complete",
-          provider: {
-            ...staleClaudeCodeProvider(),
-            needsReconnect: false,
-            lastRefreshErrorCode: null,
-          },
-          created: false,
-        });
-      },
-    );
+    context.mocks.api(claudeCodeDeviceAuthContract.complete, ({ respond }) => {
+      return respond(200, {
+        status: "complete",
+        provider: {
+          ...staleClaudeCodeProvider(),
+          needsReconnect: false,
+          lastRefreshErrorCode: null,
+        },
+        created: false,
+      });
+    });
 
     await openProvidersTab();
 
@@ -1141,7 +1138,7 @@ describe("organization model providers settings", () => {
     mockStaleProviderStory();
     context.mocks.browser.open(context.mocks.browser.authWindow());
     context.mocks.browser.clipboardWriteText();
-    context.mocks.api(zeroCodexDeviceAuthContract.complete, ({ respond }) => {
+    context.mocks.api(codexDeviceAuthContract.complete, ({ respond }) => {
       return respond(200, {
         status: "complete",
         provider: {
@@ -1167,13 +1164,10 @@ describe("organization model providers settings", () => {
   it("cancels workspace Codex reconnect when the dialog closes", async () => {
     mockStaleProviderStory();
     let cancelledSessionToken: string | null = null;
-    context.mocks.api(
-      zeroCodexDeviceAuthContract.cancel,
-      ({ body, respond }) => {
-        cancelledSessionToken = body.sessionToken;
-        return respond(200, { status: "cancelled" });
-      },
-    );
+    context.mocks.api(codexDeviceAuthContract.cancel, ({ body, respond }) => {
+      cancelledSessionToken = body.sessionToken;
+      return respond(200, { status: "cancelled" });
+    });
     await openProvidersTab();
 
     const alert = await screen.findByRole("alert");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -1,5 +1,5 @@
-import { zeroClaudeCodeDeviceAuthContract } from "@okouai/api-contracts/contracts/zero-claude-code-device-auth";
-import { zeroCodexDeviceAuthContract } from "@okouai/api-contracts/contracts/zero-codex-device-auth";
+import { claudeCodeDeviceAuthContract } from "@okouai/api-contracts/contracts/claude-code-device-auth";
+import { codexDeviceAuthContract } from "@okouai/api-contracts/contracts/codex-device-auth";
 import {
   zeroBillingStatusContract,
   type BillingStatusResponse,
@@ -126,7 +126,7 @@ function mockPersonalProvidersStory(role: "admin" | "member" = "member"): void {
     role,
   });
   context.mocks.data.personalModelProviders([stalePersonalCodexProvider()]);
-  context.mocks.api(zeroCodexDeviceAuthContract.start, ({ respond }) => {
+  context.mocks.api(codexDeviceAuthContract.start, ({ respond }) => {
     return respond(200, {
       sessionToken: "mock-personal-codex-device-session",
       type: "codex",
@@ -138,7 +138,7 @@ function mockPersonalProvidersStory(role: "admin" | "member" = "member"): void {
       interval: 1,
     });
   });
-  context.mocks.api(zeroCodexDeviceAuthContract.complete, ({ respond }) => {
+  context.mocks.api(codexDeviceAuthContract.complete, ({ respond }) => {
     return respond(200, { status: "pending", errorMessage: null });
   });
 }
@@ -410,7 +410,7 @@ describe("personal model providers settings", () => {
       role: "member",
     });
     context.mocks.data.personalModelProviders([]);
-    context.mocks.api(zeroClaudeCodeDeviceAuthContract.start, ({ respond }) => {
+    context.mocks.api(claudeCodeDeviceAuthContract.start, ({ respond }) => {
       return respond(200, {
         sessionToken: "mock-personal-claude-code-session",
         type: "claude-code",
@@ -455,7 +455,7 @@ describe("personal model providers settings", () => {
       role: "member",
     });
     context.mocks.data.personalModelProviders([]);
-    context.mocks.api(zeroClaudeCodeDeviceAuthContract.start, ({ respond }) => {
+    context.mocks.api(claudeCodeDeviceAuthContract.start, ({ respond }) => {
       return respond(200, {
         sessionToken: "mock-personal-claude-code-session",
         type: "claude-code",
@@ -465,18 +465,15 @@ describe("personal model providers settings", () => {
         expiresIn: 30,
       });
     });
-    context.mocks.api(
-      zeroClaudeCodeDeviceAuthContract.complete,
-      ({ respond }) => {
-        const provider = connectedPersonalClaudeCodeProvider();
-        context.mocks.data.personalModelProviders([provider]);
-        return respond(200, {
-          status: "complete",
-          provider,
-          created: true,
-        });
-      },
-    );
+    context.mocks.api(claudeCodeDeviceAuthContract.complete, ({ respond }) => {
+      const provider = connectedPersonalClaudeCodeProvider();
+      context.mocks.data.personalModelProviders([provider]);
+      return respond(200, {
+        status: "complete",
+        provider,
+        created: true,
+      });
+    });
 
     await openModelSettings();
 
@@ -519,7 +516,7 @@ describe("personal model providers settings", () => {
       role: "member",
     });
     context.mocks.data.personalModelProviders([]);
-    context.mocks.api(zeroClaudeCodeDeviceAuthContract.start, ({ respond }) => {
+    context.mocks.api(claudeCodeDeviceAuthContract.start, ({ respond }) => {
       return respond(200, {
         sessionToken: "mock-personal-claude-code-session",
         type: "claude-code",
@@ -530,26 +527,23 @@ describe("personal model providers settings", () => {
       });
     });
     let completeCount = 0;
-    context.mocks.api(
-      zeroClaudeCodeDeviceAuthContract.complete,
-      ({ respond }) => {
-        completeCount += 1;
-        if (completeCount === 1) {
-          return respond(400, {
-            error: {
-              message: "Invalid Claude authorization code",
-              code: "BAD_REQUEST",
-            },
-          });
-        }
-        return respond(503, {
+    context.mocks.api(claudeCodeDeviceAuthContract.complete, ({ respond }) => {
+      completeCount += 1;
+      if (completeCount === 1) {
+        return respond(400, {
           error: {
-            message: "Claude authorization is unavailable",
-            code: "UNAVAILABLE",
+            message: "Invalid Claude authorization code",
+            code: "BAD_REQUEST",
           },
         });
-      },
-    );
+      }
+      return respond(503, {
+        error: {
+          message: "Claude authorization is unavailable",
+          code: "UNAVAILABLE",
+        },
+      });
+    });
 
     await openModelSettings();
 

--- a/turbo/packages/api-contracts/src/contracts/claude-code-device-auth.ts
+++ b/turbo/packages/api-contracts/src/contracts/claude-code-device-auth.ts
@@ -29,11 +29,11 @@ const claudeCodeDeviceAuthCancelResponseSchema = z.object({
 });
 
 /**
- * Zero contract for Claude Code device-style OAuth.
+ * Contract for Claude Code device-style OAuth.
  * Runs the same PKCE OAuth path as `claude setup-token` and imports the
  * resulting long-lived Claude Code token.
  */
-export const zeroClaudeCodeDeviceAuthContract = c.router({
+export const claudeCodeDeviceAuthContract = c.router({
   start: {
     method: "POST",
     path: "/api/okou/model-providers/claude-code/device-auth/sessions",
@@ -92,5 +92,4 @@ export type ClaudeCodeDeviceAuthScope = z.infer<
 export type ClaudeCodeDeviceAuthMode = z.infer<
   typeof claudeCodeDeviceAuthModeSchema
 >;
-export type ZeroClaudeCodeDeviceAuthContract =
-  typeof zeroClaudeCodeDeviceAuthContract;
+export type ClaudeCodeDeviceAuthContract = typeof claudeCodeDeviceAuthContract;

--- a/turbo/packages/api-contracts/src/contracts/codex-device-auth.ts
+++ b/turbo/packages/api-contracts/src/contracts/codex-device-auth.ts
@@ -37,11 +37,11 @@ const codexDeviceAuthCancelResponseSchema = z.object({
 });
 
 /**
- * Zero contract for Codex device auth.
+ * Contract for Codex device auth.
  * Runs the official Codex device authorization flow through OpenAI auth and
  * imports the resulting ChatGPT tokens.
  */
-export const zeroCodexDeviceAuthContract = c.router({
+export const codexDeviceAuthContract = c.router({
   start: {
     method: "POST",
     path: "/api/okou/model-providers/codex/device-auth/sessions",
@@ -93,4 +93,4 @@ export const zeroCodexDeviceAuthContract = c.router({
 
 export type CodexDeviceAuthScope = z.infer<typeof codexDeviceAuthScopeSchema>;
 export type CodexDeviceAuthMode = z.infer<typeof codexDeviceAuthModeSchema>;
-export type ZeroCodexDeviceAuthContract = typeof zeroCodexDeviceAuthContract;
+export type CodexDeviceAuthContract = typeof codexDeviceAuthContract;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1042,16 +1042,16 @@ export {
 } from "./connector-identity";
 export {
   codexDeviceAuthScopeSchema,
-  zeroCodexDeviceAuthContract,
+  codexDeviceAuthContract,
   type CodexDeviceAuthScope,
-  type ZeroCodexDeviceAuthContract,
-} from "./zero-codex-device-auth";
+  type CodexDeviceAuthContract,
+} from "./codex-device-auth";
 export {
   claudeCodeDeviceAuthScopeSchema,
-  zeroClaudeCodeDeviceAuthContract,
+  claudeCodeDeviceAuthContract,
   type ClaudeCodeDeviceAuthScope,
-  type ZeroClaudeCodeDeviceAuthContract,
-} from "./zero-claude-code-device-auth";
+  type ClaudeCodeDeviceAuthContract,
+} from "./claude-code-device-auth";
 export {
   zeroOrgContract,
   zeroOrgLeaveContract,


### PR DESCRIPTION
## Summary

- rename the Claude Code and Codex device-auth contract and route modules to provider-neutral internal names
- update all API, Platform, and focused test callers without deprecated exports, forwarding modules, or internal compatibility aliases
- preserve the two independent provider-specific contracts, routes, services, authorization flows, and all wire behavior

## Compatibility

- canonical `/api/okou/model-providers/{claude-code|codex}/device-auth/**` paths are unchanged
- generated `/api/zero/**` namespace aliases retain the same handlers and schemas
- Claude Code authorization-code/PKCE behavior and Codex verification-code/polling behavior remain separate
- no database, persistence, broader model-provider contract, feature-switch, UI, copy, or changelog changes

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- API-contract, Platform, API, and remaining workspace type checks
- API model-provider Device Auth: 11 focused cases
- chat composer Device Auth: 3 focused cases
- organization providers Device Auth: 4 focused cases
- personal providers Device Auth: 5 focused cases
- API namespace compatibility: symmetric Okou and Zero alias case
- final Claude Code and Codex stale module-path/symbol searches: no matches

Closes #26942
Parent: #26873