### PR TITLE
refactor(chat): retire legacy search projection

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
@@ -31,7 +31,6 @@ async function projectChatSearchMessages(
     client.project({ body: { chat_thread_ids: [...chatThreadIds] } }),
     [200],
   );
-  expect(response.body.durableProjectionAvailable).toBeTruthy();
   expect(response.body.convergence.durableCaughtUpThreads).toBe(
     chatThreadIds.length,
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
@@ -12,7 +12,6 @@ import {
   insertSearchablePromptFixture,
   readChatEventSearchProjectionFixture,
   rejectSearchablePromptFixture,
-  resetDurableChatEventSearchProjectionFixture,
 } from "../../../test-fixtures/chat-event-search";
 import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
 import { testChatEventSearchProjectionRoutes } from "../test-chat-event-search-projection";
@@ -39,22 +38,13 @@ async function projectChatEventSearch() {
   return response.body;
 }
 
-async function projectOwnedChatEventSearch(
-  chatThreadIds: readonly string[],
-  options: { readonly simulateDurableSchemaUnavailable?: boolean } = {},
-) {
+async function projectOwnedChatEventSearch(chatThreadIds: readonly string[]) {
   const client = setupApp({
     context,
     routes: testChatEventSearchProjectionRoutes,
   })(testChatEventSearchProjectionContract);
   const response = await accept(
-    client.project({
-      body: {
-        chat_thread_ids: [...chatThreadIds],
-        simulate_durable_schema_unavailable:
-          options.simulateDurableSchemaUnavailable,
-      },
-    }),
+    client.project({ body: { chat_thread_ids: [...chatThreadIds] } }),
     [200],
   );
   return response.body;
@@ -71,7 +61,7 @@ async function createProjectionThread(): Promise<string> {
 }
 
 describe("GET /api/cron/project-chat-event-search", () => {
-  it("dual-projects only non-empty visible user and assistant messages", async () => {
+  it("projects only non-empty visible user and assistant messages", async () => {
     const chatThreadId = await createProjectionThread();
     const promptText = `durable prompt ${randomUUID()}`;
     const assistantText = `durable assistant ${randomUUID()}`;
@@ -87,32 +77,15 @@ describe("GET /api/cron/project-chat-event-search", () => {
 
     const tick = await projectChatEventSearch();
     expect(tick.success).toBeTruthy();
-    expect(tick.durableProjectionAvailable).toBeTruthy();
-    expect(tick.durableThreads).toBeGreaterThanOrEqual(1);
-    expect(tick.durableIndexedMessages).toBeGreaterThanOrEqual(2);
-    expect(tick.convergence.eligibleThreads).toBeGreaterThanOrEqual(
-      tick.convergence.legacyCaughtUpThreads,
-    );
+    expect(tick.threads).toBeGreaterThanOrEqual(1);
+    expect(tick.indexedEvents).toBeGreaterThanOrEqual(2);
     expect(tick.convergence.eligibleThreads).toBeGreaterThanOrEqual(
       tick.convergence.durableCaughtUpThreads,
     );
-    expect(tick.convergence.legacyCaughtUpThreads).toBeGreaterThanOrEqual(1);
     expect(tick.convergence.durableCaughtUpThreads).toBeGreaterThanOrEqual(1);
 
     const projection = await readChatEventSearchProjectionFixture(chatThreadId);
-    expect(
-      projection.legacyDocs
-        .map((doc) => {
-          return [doc.role, doc.text];
-        })
-        .sort(),
-    ).toStrictEqual(
-      [
-        ["assistant", assistantText],
-        ["user", promptText],
-      ].sort(),
-    );
-    expect(projection.durableMessages).toStrictEqual([
+    expect(projection.messages).toStrictEqual([
       {
         seqId: expect.any(Number),
         runId: null,
@@ -126,49 +99,45 @@ describe("GET /api/cron/project-chat-event-search", () => {
         text: assistantText,
       },
     ]);
-    expect(projection.legacyIndexedSeqId).toBe(projection.lastChatEventSeqId);
-    expect(projection.durableIndexedSeqId).toBe(projection.lastChatEventSeqId);
+    expect(projection.indexedSeqId).toBe(projection.lastChatEventSeqId);
   });
 
-  it("backfills the durable projection from zero independently and idempotently", async () => {
+  it("serializes overlapping projection ticks idempotently", async () => {
     const chatThreadId = await createProjectionThread();
+    const assistantText = `overlap assistant ${randomUUID()}`;
     await insertChatSearchProjectionCoverageFixture({
       chatThreadId,
-      promptText: `backfill prompt ${randomUUID()}`,
-      assistantText: `backfill assistant ${randomUUID()}`,
-      errorText: `backfill error ${randomUUID()}`,
-      terminalText: `backfill terminal ${randomUUID()}`,
+      promptText: `overlap prompt ${randomUUID()}`,
+      assistantText,
+      errorText: `overlap error ${randomUUID()}`,
+      terminalText: `overlap terminal ${randomUUID()}`,
     });
-    await projectOwnedChatEventSearch([chatThreadId]);
-    const established =
-      await readChatEventSearchProjectionFixture(chatThreadId);
 
-    await resetDurableChatEventSearchProjectionFixture(chatThreadId);
-    const rolloutStart =
-      await readChatEventSearchProjectionFixture(chatThreadId);
-    expect(rolloutStart.legacyIndexedSeqId).toBe(
-      rolloutStart.lastChatEventSeqId,
-    );
-    expect(rolloutStart.durableIndexedSeqId).toBeNull();
-    expect(rolloutStart.durableMessages).toStrictEqual([]);
-
-    await Promise.all([
+    const ticks = await Promise.all([
       projectOwnedChatEventSearch([chatThreadId]),
       projectOwnedChatEventSearch([chatThreadId]),
     ]);
 
-    const backfilled = await readChatEventSearchProjectionFixture(chatThreadId);
-    expect(backfilled.legacyIndexedSeqId).toBe(established.legacyIndexedSeqId);
-    expect(backfilled.durableIndexedSeqId).toBe(backfilled.lastChatEventSeqId);
-    expect(backfilled.durableMessages).toStrictEqual(
-      established.durableMessages,
-    );
+    expect(
+      ticks.reduce((total, tick) => {
+        return total + tick.indexedEvents;
+      }, 0),
+    ).toBe(2);
+    const projection = await readChatEventSearchProjectionFixture(chatThreadId);
+    expect(projection.indexedSeqId).toBe(projection.lastChatEventSeqId);
+    expect(
+      projection.messages.filter((message) => {
+        return message.text === assistantText;
+      }),
+    ).toHaveLength(1);
   });
 
-  it("keeps bounded rollout batches focused on serving projection lag", async () => {
-    const servingThreadId = await createProjectionThread();
-    const backfillThreadId = await createProjectionThread();
-    for (const chatThreadId of [servingThreadId, backfillThreadId]) {
+  it("bounds each projection tick to the configured thread batch", async () => {
+    const threadIds = [
+      await createProjectionThread(),
+      await createProjectionThread(),
+    ];
+    for (const chatThreadId of threadIds) {
       await insertChatSearchProjectionCoverageFixture({
         chatThreadId,
         promptText: `bounded prompt ${randomUUID()}`,
@@ -177,39 +146,34 @@ describe("GET /api/cron/project-chat-event-search", () => {
         terminalText: `bounded terminal ${randomUUID()}`,
       });
     }
-    await projectOwnedChatEventSearch([servingThreadId, backfillThreadId]);
-    await resetDurableChatEventSearchProjectionFixture(backfillThreadId);
-    const tail = await insertSearchablePromptFixture({
-      chatThreadId: servingThreadId,
-      text: `serving tail ${randomUUID()}`,
-    });
+    const [selectedThreadId, deferredThreadId] = [...threadIds].sort();
+    if (!selectedThreadId || !deferredThreadId) {
+      throw new Error("Expected two bounded projection threads");
+    }
 
     mockOptionalEnv("CHAT_EVENT_SEARCH_PROJECTION_BATCH_SIZE", "1");
-    const tick = await projectOwnedChatEventSearch([
-      servingThreadId,
-      backfillThreadId,
-    ]);
+    const tick = await projectOwnedChatEventSearch(threadIds);
 
     expect(tick.threads).toBe(1);
-    expect(tick.indexedEvents).toBe(1);
-    expect(tick.durableThreads).toBe(1);
-    expect(tick.durableIndexedMessages).toBe(1);
-    const serving = await readChatEventSearchProjectionFixture(servingThreadId);
-    expect(serving.legacyIndexedSeqId).toBe(tail.seqId);
-    expect(serving.durableIndexedSeqId).toBe(tail.seqId);
-    const backfill =
-      await readChatEventSearchProjectionFixture(backfillThreadId);
-    expect(backfill.durableIndexedSeqId).toBeNull();
+    expect(tick.indexedEvents).toBe(2);
+    const selected =
+      await readChatEventSearchProjectionFixture(selectedThreadId);
+    expect(selected.indexedSeqId).toBe(selected.lastChatEventSeqId);
+    expect(selected.messages).toHaveLength(2);
+    const deferred =
+      await readChatEventSearchProjectionFixture(deferredThreadId);
+    expect(deferred.indexedSeqId).toBeNull();
+    expect(deferred.messages).toStrictEqual([]);
   });
 
-  it("deletes a later-revoked durable message by thread and sequence", async () => {
+  it("deletes a later-revoked message by thread and sequence", async () => {
     const chatThreadId = await createProjectionThread();
     const text = `revoked durable prompt ${randomUUID()}`;
     const target = await insertSearchablePromptFixture({ chatThreadId, text });
     await projectOwnedChatEventSearch([chatThreadId]);
 
     const before = await readChatEventSearchProjectionFixture(chatThreadId);
-    expect(before.durableMessages).toStrictEqual([
+    expect(before.messages).toStrictEqual([
       {
         seqId: target.seqId,
         runId: null,
@@ -225,13 +189,9 @@ describe("GET /api/cron/project-chat-event-search", () => {
     });
     const tick = await projectOwnedChatEventSearch([chatThreadId]);
     expect(tick.deletedDocs).toBeGreaterThanOrEqual(1);
-    expect(tick.durableDeletedMessages).toBeGreaterThanOrEqual(1);
 
     const after = await readChatEventSearchProjectionFixture(chatThreadId);
-    expect(after.legacyDocs).toStrictEqual([
-      { eventId: replacement.id, role: "user", text },
-    ]);
-    expect(after.durableMessages).toStrictEqual([
+    expect(after.messages).toStrictEqual([
       {
         seqId: replacement.seqId,
         runId: null,
@@ -239,42 +199,7 @@ describe("GET /api/cron/project-chat-event-search", () => {
         text,
       },
     ]);
-    expect(after.durableMessages[0]?.seqId).not.toBe(target.seqId);
-    expect(after.durableIndexedSeqId).toBe(after.lastChatEventSeqId);
-  });
-
-  it("keeps the legacy projection safe before the durable schema migration", async () => {
-    const chatThreadId = await createProjectionThread();
-    const text = `pre-migration prompt ${randomUUID()}`;
-    const prompt = await insertSearchablePromptFixture({
-      chatThreadId,
-      text,
-    });
-
-    const tick = await projectOwnedChatEventSearch([chatThreadId], {
-      simulateDurableSchemaUnavailable: true,
-    });
-
-    expect(tick).toMatchObject({
-      success: true,
-      durableProjectionAvailable: false,
-      threads: 1,
-      indexedEvents: 1,
-      durableThreads: 0,
-      durableIndexedMessages: 0,
-      durableDeletedMessages: 0,
-      convergence: {
-        eligibleThreads: 1,
-        legacyCaughtUpThreads: 1,
-        durableCaughtUpThreads: 0,
-      },
-    });
-    const projection = await readChatEventSearchProjectionFixture(chatThreadId);
-    expect(projection.legacyDocs).toStrictEqual([
-      { eventId: prompt.id, role: "user", text },
-    ]);
-    expect(projection.legacyIndexedSeqId).toBe(prompt.seqId);
-    expect(projection.durableMessages).toStrictEqual([]);
-    expect(projection.durableIndexedSeqId).toBeNull();
+    expect(after.messages[0]?.seqId).not.toBe(target.seqId);
+    expect(after.indexedSeqId).toBe(after.lastChatEventSeqId);
   });
 });

--- a/turbo/apps/api/src/signals/routes/test-chat-event-search-projection.ts
+++ b/turbo/apps/api/src/signals/routes/test-chat-event-search-projection.ts
@@ -26,11 +26,7 @@ const projectChatEventSearchTestRoute$ = command(
     }
     const result = await set(
       projectChatEventSearchTestScope$,
-      {
-        chatThreadIds: bodyResult.data.chat_thread_ids,
-        simulateDurableSchemaUnavailable:
-          bodyResult.data.simulate_durable_schema_unavailable ?? false,
-      },
+      { chatThreadIds: bodyResult.data.chat_thread_ids },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts
@@ -8,21 +8,17 @@ import {
   gt,
   gte,
   inArray,
-  or,
   sql,
 } from "drizzle-orm";
 import type { UserMessageDocument } from "@okouai/api-contracts/contracts/chat-threads";
 import { agentComposes } from "@okouai/db/schema/agent-compose";
 import {
-  chatEventSearchDocs,
   chatEventSearchMessages,
   chatEventSearchMessageWatermarks,
-  chatEventSearchWatermarks,
 } from "@okouai/db/schema/chat-event-search";
 import { chatEvents } from "@okouai/db/schema/chat-event";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { chatSearchIndexText } from "../../lib/chat-search-bigram";
-import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import type { Tx } from "../../lib/db-types";
 import { optionalEnv } from "../../lib/env";
 import { writeDb$, type Db } from "../external/db";
@@ -37,19 +33,14 @@ import {
 import { visibleChatEventCondition } from "./zero-chat-event-shared.service";
 
 interface ChatEventSearchProjectionStats {
-  readonly durableProjectionAvailable: boolean;
   readonly threads: number;
   readonly indexedEvents: number;
   readonly deletedDocs: number;
-  readonly durableThreads: number;
-  readonly durableIndexedMessages: number;
-  readonly durableDeletedMessages: number;
   readonly convergence: ChatEventSearchProjectionConvergence;
 }
 
 interface ChatEventSearchProjectionConvergence {
   readonly eligibleThreads: number;
-  readonly legacyCaughtUpThreads: number;
   readonly durableCaughtUpThreads: number;
 }
 
@@ -61,12 +52,9 @@ interface CandidateThread {
 }
 
 interface ThreadProjectionStats {
-  readonly legacyThread: number;
-  readonly legacyIndexedEvents: number;
-  readonly legacyDeletedDocs: number;
-  readonly durableThread: number;
-  readonly durableIndexedMessages: number;
-  readonly durableDeletedMessages: number;
+  readonly thread: number;
+  readonly indexedEvents: number;
+  readonly deletedDocs: number;
 }
 
 interface SearchMessageProjection {
@@ -76,38 +64,30 @@ interface SearchMessageProjection {
 }
 
 interface ThreadProjectionProgress {
-  readonly legacyLagging: boolean;
-  readonly durableLagging: boolean;
-  readonly legacyRows: readonly ProjectionRow[];
-  readonly durableRows: readonly ProjectionRow[];
+  readonly lagging: boolean;
+  readonly rows: readonly ProjectionRow[];
 }
 
 interface SearchProjectionBatch {
-  readonly legacyDocs: LegacySearchDocInsert[];
-  readonly durableMessages: DurableSearchMessageInsert[];
+  readonly messages: SearchMessageInsert[];
   readonly revokedEventIds: string[];
 }
 
 interface SearchProjectionWriteStats {
-  readonly legacyIndexedEvents: number;
-  readonly legacyDeletedDocs: number;
-  readonly durableIndexedMessages: number;
-  readonly durableDeletedMessages: number;
+  readonly indexedEvents: number;
+  readonly deletedDocs: number;
 }
 
 interface ChatEventSearchProjectionOptions {
   readonly chatThreadIds?: readonly string[];
-  readonly durableProjectionAvailable: boolean;
 }
 
 interface ChatEventSearchTestProjectionOptions {
   readonly chatThreadIds: readonly string[];
-  readonly simulateDurableSchemaUnavailable: boolean;
 }
 
 type SearchableRole = "user" | "assistant";
-type LegacySearchDocInsert = typeof chatEventSearchDocs.$inferInsert;
-type DurableSearchMessageInsert = typeof chatEventSearchMessages.$inferInsert;
+type SearchMessageInsert = typeof chatEventSearchMessages.$inferInsert;
 
 const DEFAULT_THREAD_BATCH_SIZE = 500;
 const THREAD_EVENT_LIMIT = 1000;
@@ -126,26 +106,7 @@ function chatEventSearchThreadBatchSize(): number {
   return parsed;
 }
 
-async function durableChatEventSearchSchemaAvailable(
-  db: Pick<Db, "select">,
-): Promise<boolean> {
-  // DB/API compatibility fallback (#26762): new API code can precede migration
-  // 0916 for an observed maximum of ~102 minutes. Keep legacy projection ticks
-  // working until 0916 is visible; remove after the phase-2 cutover is deployed
-  // and its API rollback window closes.
-  const [state] = await db
-    .select({
-      available: sql`
-        to_regclass('public.chat_event_search_messages') IS NOT NULL
-        AND to_regclass('public.chat_event_search_message_watermarks') IS NOT NULL
-      `.mapWith(pgBooleanDecoder),
-    })
-    .from(sql`(SELECT 1) AS schema_probe`)
-    .limit(1);
-  return state?.available ?? false;
-}
-
-function searchDocRole(eventType: string): SearchableRole | null {
+function searchMessageRole(eventType: string): SearchableRole | null {
   if (eventType === "input.prompt" || eventType === "input.rejected") {
     return "user";
   }
@@ -155,7 +116,7 @@ function searchDocRole(eventType: string): SearchableRole | null {
   return null;
 }
 
-function searchDocText(row: {
+function searchMessageText(row: {
   readonly eventType: (typeof chatEvents.$inferSelect)["eventType"];
   readonly content: string | null;
   readonly userMessage: UserMessageDocument | null;
@@ -176,11 +137,11 @@ function searchMessageProjection(row: {
   readonly content: string | null;
   readonly userMessage: UserMessageDocument | null;
 }): SearchMessageProjection | null {
-  const role = searchDocRole(row.eventType);
+  const role = searchMessageRole(row.eventType);
   if (role === null) {
     return null;
   }
-  const text = searchDocText(row);
+  const text = searchMessageText(row);
   if (text === null) {
     return null;
   }
@@ -265,101 +226,44 @@ async function loadThreadProjectionProgress(
   tx: Tx,
   chatThreadId: string,
   lastChatEventSeqId: number,
-  durableProjectionAvailable: boolean,
 ): Promise<ThreadProjectionProgress> {
-  const [legacyProgress] = await tx
-    .select({
-      legacyIndexedSeqId: chatEventSearchWatermarks.indexedSeqId,
-    })
-    .from(chatThreads)
-    .leftJoin(
-      chatEventSearchWatermarks,
-      eq(chatEventSearchWatermarks.chatThreadId, chatThreads.id),
-    )
-    .where(eq(chatThreads.id, chatThreadId))
+  const [progress] = await tx
+    .select({ indexedSeqId: chatEventSearchMessageWatermarks.indexedSeqId })
+    .from(chatEventSearchMessageWatermarks)
+    .where(eq(chatEventSearchMessageWatermarks.chatThreadId, chatThreadId))
     .limit(1);
-  if (!legacyProgress) {
-    throw new Error("Locked chat search projection thread disappeared");
-  }
-  const legacyIndexedSeqId = legacyProgress.legacyIndexedSeqId ?? 0;
-  const [durableProgress] = durableProjectionAvailable
-    ? await tx
-        .select({
-          durableIndexedSeqId: chatEventSearchMessageWatermarks.indexedSeqId,
-        })
-        .from(chatEventSearchMessageWatermarks)
-        .where(eq(chatEventSearchMessageWatermarks.chatThreadId, chatThreadId))
-        .limit(1)
+  const indexedSeqId = progress?.indexedSeqId ?? 0;
+  const lagging = lastChatEventSeqId > indexedSeqId;
+  const rows = lagging
+    ? await loadProjectionRows(tx, chatThreadId, indexedSeqId)
     : [];
-  const durableIndexedSeqId = durableProgress?.durableIndexedSeqId ?? 0;
-  const legacyLagging = lastChatEventSeqId > legacyIndexedSeqId;
-  const durableLagging =
-    durableProjectionAvailable && lastChatEventSeqId > durableIndexedSeqId;
-  const legacyRows = legacyLagging
-    ? await loadProjectionRows(tx, chatThreadId, legacyIndexedSeqId)
-    : [];
-  const durableRows = durableLagging
-    ? legacyLagging && durableIndexedSeqId === legacyIndexedSeqId
-      ? legacyRows
-      : await loadProjectionRows(tx, chatThreadId, durableIndexedSeqId)
-    : [];
-  return { legacyLagging, durableLagging, legacyRows, durableRows };
+  return { lagging, rows };
 }
 
-function collectSearchMessageProjections(
-  legacyRows: readonly ProjectionRow[],
-  durableRows: readonly ProjectionRow[],
-): {
+function collectSearchMessageProjections(rows: readonly ProjectionRow[]): {
   readonly projectionByEventId: ReadonlyMap<string, SearchMessageProjection>;
   readonly revokedEventIds: Set<string>;
 } {
   const revokedEventIds = new Set<string>();
   const projectionByEventId = new Map<string, SearchMessageProjection>();
-  for (const rows of [legacyRows, durableRows]) {
-    for (const row of rows) {
-      if (row.revokesEventId !== null) {
-        revokedEventIds.add(row.revokesEventId);
-      }
-      if (!projectionByEventId.has(row.id)) {
-        const projection = searchMessageProjection(row);
-        if (projection !== null) {
-          projectionByEventId.set(row.id, projection);
-        }
-      }
+  for (const row of rows) {
+    if (row.revokesEventId !== null) {
+      revokedEventIds.add(row.revokesEventId);
+    }
+    const projection = searchMessageProjection(row);
+    if (projection !== null) {
+      projectionByEventId.set(row.id, projection);
     }
   }
   return { projectionByEventId, revokedEventIds };
 }
 
-function legacySearchDoc(
+function searchMessage(
   row: ProjectionRow,
   thread: CandidateThread,
   projections: ReadonlyMap<string, SearchMessageProjection>,
   visibleEventIds: ReadonlySet<string>,
-): LegacySearchDocInsert | null {
-  const projection = projections.get(row.id);
-  if (!projection || !visibleEventIds.has(row.id)) {
-    return null;
-  }
-  return {
-    eventId: row.id,
-    chatThreadId: thread.chatThreadId,
-    orgId: thread.orgId,
-    userId: thread.userId,
-    agentComposeId: thread.agentComposeId,
-    role: projection.role,
-    createdAt: row.createdAt,
-    text: projection.text,
-    textBigram: projection.textBigram,
-  };
-}
-
-function durableSearchMessage(
-  row: ProjectionRow,
-  thread: CandidateThread,
-  projections: ReadonlyMap<string, SearchMessageProjection>,
-  visibleEventIds: ReadonlySet<string>,
-): DurableSearchMessageInsert | null {
+): SearchMessageInsert | null {
   const projection = projections.get(row.id);
   if (!projection || !visibleEventIds.has(row.id)) {
     return null;
@@ -386,22 +290,13 @@ async function buildSearchProjectionBatch(
   // Any event type can revoke an earlier one. Resolve every target before
   // chat_events retention can remove its stable thread/sequence coordinate.
   const { projectionByEventId, revokedEventIds } =
-    collectSearchMessageProjections(progress.legacyRows, progress.durableRows);
+    collectSearchMessageProjections(progress.rows);
   const visibleEventIds = await visibleSearchEventIds(tx, [
     ...projectionByEventId.keys(),
   ]);
   return {
-    legacyDocs: progress.legacyRows.flatMap((row) => {
-      const doc = legacySearchDoc(
-        row,
-        thread,
-        projectionByEventId,
-        visibleEventIds,
-      );
-      return doc ? [doc] : [];
-    }),
-    durableMessages: progress.durableRows.flatMap((row) => {
-      const message = durableSearchMessage(
+    messages: progress.rows.flatMap((row) => {
+      const message = searchMessage(
         row,
         thread,
         projectionByEventId,
@@ -413,24 +308,9 @@ async function buildSearchProjectionBatch(
   };
 }
 
-async function insertLegacySearchDocs(
+async function insertSearchMessages(
   tx: Tx,
-  docs: readonly LegacySearchDocInsert[],
-): Promise<number> {
-  if (docs.length === 0) {
-    return 0;
-  }
-  const indexed = await tx
-    .insert(chatEventSearchDocs)
-    .values([...docs])
-    .onConflictDoNothing({ target: chatEventSearchDocs.eventId })
-    .returning({ eventId: chatEventSearchDocs.eventId });
-  return indexed.length;
-}
-
-async function insertDurableSearchMessages(
-  tx: Tx,
-  messages: readonly DurableSearchMessageInsert[],
+  messages: readonly SearchMessageInsert[],
 ): Promise<number> {
   if (messages.length === 0) {
     return 0;
@@ -448,21 +328,7 @@ async function insertDurableSearchMessages(
   return indexed.length;
 }
 
-async function deleteLegacyRevokedDocs(
-  tx: Tx,
-  revokedEventIds: readonly string[],
-): Promise<number> {
-  if (revokedEventIds.length === 0) {
-    return 0;
-  }
-  const deleted = await tx
-    .delete(chatEventSearchDocs)
-    .where(inArray(chatEventSearchDocs.eventId, [...revokedEventIds]))
-    .returning({ eventId: chatEventSearchDocs.eventId });
-  return deleted.length;
-}
-
-async function deleteDurableRevokedMessages(
+async function deleteRevokedMessages(
   tx: Tx,
   revokedEventIds: readonly string[],
 ): Promise<number> {
@@ -495,87 +361,46 @@ async function deleteDurableRevokedMessages(
 async function writeSearchProjectionBatch(
   tx: Tx,
   batch: SearchProjectionBatch,
-  durableProjectionAvailable: boolean,
 ): Promise<SearchProjectionWriteStats> {
-  const legacyIndexedEvents = await insertLegacySearchDocs(
-    tx,
-    batch.legacyDocs,
-  );
-  const durableIndexedMessages = durableProjectionAvailable
-    ? await insertDurableSearchMessages(tx, batch.durableMessages)
-    : 0;
-  const legacyDeletedDocs = await deleteLegacyRevokedDocs(
-    tx,
-    batch.revokedEventIds,
-  );
-  const durableDeletedMessages = durableProjectionAvailable
-    ? await deleteDurableRevokedMessages(tx, batch.revokedEventIds)
-    : 0;
-  return {
-    legacyIndexedEvents,
-    legacyDeletedDocs,
-    durableIndexedMessages,
-    durableDeletedMessages,
-  };
+  const indexedEvents = await insertSearchMessages(tx, batch.messages);
+  const deletedDocs = await deleteRevokedMessages(tx, batch.revokedEventIds);
+  return { indexedEvents, deletedDocs };
 }
 
-async function advanceProjectionWatermarks(
+async function advanceProjectionWatermark(
   tx: Tx,
   chatThreadId: string,
   lastChatEventSeqId: number,
   progress: ThreadProjectionProgress,
 ): Promise<void> {
-  if (progress.legacyLagging) {
-    await tx
-      .insert(chatEventSearchWatermarks)
-      .values({
-        chatThreadId,
-        indexedSeqId: nextProjectionWatermark(
-          progress.legacyRows,
-          lastChatEventSeqId,
-        ),
-      })
-      .onConflictDoUpdate({
-        target: chatEventSearchWatermarks.chatThreadId,
-        set: {
-          indexedSeqId: sql`GREATEST(${chatEventSearchWatermarks.indexedSeqId}, EXCLUDED.indexed_seq_id)`,
-        },
-      });
+  if (!progress.lagging) {
+    return;
   }
-  if (progress.durableLagging) {
-    await tx
-      .insert(chatEventSearchMessageWatermarks)
-      .values({
-        chatThreadId,
-        indexedSeqId: nextProjectionWatermark(
-          progress.durableRows,
-          lastChatEventSeqId,
-        ),
-      })
-      .onConflictDoUpdate({
-        target: chatEventSearchMessageWatermarks.chatThreadId,
-        set: {
-          indexedSeqId: sql`GREATEST(${chatEventSearchMessageWatermarks.indexedSeqId}, EXCLUDED.indexed_seq_id)`,
-        },
-      });
-  }
+  await tx
+    .insert(chatEventSearchMessageWatermarks)
+    .values({
+      chatThreadId,
+      indexedSeqId: nextProjectionWatermark(progress.rows, lastChatEventSeqId),
+    })
+    .onConflictDoUpdate({
+      target: chatEventSearchMessageWatermarks.chatThreadId,
+      set: {
+        indexedSeqId: sql`GREATEST(${chatEventSearchMessageWatermarks.indexedSeqId}, EXCLUDED.indexed_seq_id)`,
+      },
+    });
 }
 
 function emptyThreadProjectionStats(): ThreadProjectionStats {
   return {
-    legacyThread: 0,
-    legacyIndexedEvents: 0,
-    legacyDeletedDocs: 0,
-    durableThread: 0,
-    durableIndexedMessages: 0,
-    durableDeletedMessages: 0,
+    thread: 0,
+    indexedEvents: 0,
+    deletedDocs: 0,
   };
 }
 
 async function projectThread(
   db: Db,
   thread: CandidateThread,
-  durableProjectionAvailable: boolean,
 ): Promise<ThreadProjectionStats> {
   return await db.transaction(async (tx) => {
     const lockedThread = await lockProjectionThread(tx, thread.chatThreadId);
@@ -586,16 +411,11 @@ async function projectThread(
       tx,
       thread.chatThreadId,
       lockedThread.lastChatEventSeqId,
-      durableProjectionAvailable,
     );
 
     const batch = await buildSearchProjectionBatch(tx, thread, progress);
-    const writes = await writeSearchProjectionBatch(
-      tx,
-      batch,
-      durableProjectionAvailable,
-    );
-    await advanceProjectionWatermarks(
+    const writes = await writeSearchProjectionBatch(tx, batch);
+    await advanceProjectionWatermark(
       tx,
       thread.chatThreadId,
       lockedThread.lastChatEventSeqId,
@@ -603,12 +423,9 @@ async function projectThread(
     );
 
     return {
-      legacyThread: progress.legacyLagging ? 1 : 0,
-      legacyIndexedEvents: writes.legacyIndexedEvents,
-      legacyDeletedDocs: writes.legacyDeletedDocs,
-      durableThread: progress.durableLagging ? 1 : 0,
-      durableIndexedMessages: writes.durableIndexedMessages,
-      durableDeletedMessages: writes.durableDeletedMessages,
+      thread: progress.lagging ? 1 : 0,
+      indexedEvents: writes.indexedEvents,
+      deletedDocs: writes.deletedDocs,
     };
   });
 }
@@ -624,36 +441,6 @@ async function loadCandidateThreads(
   options: ChatEventSearchProjectionOptions,
 ): Promise<readonly CandidateThread[]> {
   const threadScope = projectionThreadScope(options.chatThreadIds);
-  if (!options.durableProjectionAvailable) {
-    return await db
-      .select({
-        chatThreadId: chatThreads.id,
-        userId: chatThreads.userId,
-        orgId: agentComposes.orgId,
-        agentComposeId: chatThreads.agentComposeId,
-      })
-      .from(chatThreads)
-      .innerJoin(
-        agentComposes,
-        eq(chatThreads.agentComposeId, agentComposes.id),
-      )
-      .leftJoin(
-        chatEventSearchWatermarks,
-        eq(chatEventSearchWatermarks.chatThreadId, chatThreads.id),
-      )
-      .where(
-        and(
-          threadScope,
-          gt(
-            chatThreads.lastChatEventSeqId,
-            sql`COALESCE(${chatEventSearchWatermarks.indexedSeqId}, 0)`,
-          ),
-        ),
-      )
-      .orderBy(asc(chatThreads.id))
-      .limit(chatEventSearchThreadBatchSize());
-  }
-
   return await db
     .select({
       chatThreadId: chatThreads.id,
@@ -664,36 +451,19 @@ async function loadCandidateThreads(
     .from(chatThreads)
     .innerJoin(agentComposes, eq(chatThreads.agentComposeId, agentComposes.id))
     .leftJoin(
-      chatEventSearchWatermarks,
-      eq(chatEventSearchWatermarks.chatThreadId, chatThreads.id),
-    )
-    .leftJoin(
       chatEventSearchMessageWatermarks,
       eq(chatEventSearchMessageWatermarks.chatThreadId, chatThreads.id),
     )
     .where(
       and(
         threadScope,
-        or(
-          gt(
-            chatThreads.lastChatEventSeqId,
-            sql`COALESCE(${chatEventSearchWatermarks.indexedSeqId}, 0)`,
-          ),
-          gt(
-            chatThreads.lastChatEventSeqId,
-            sql`COALESCE(${chatEventSearchMessageWatermarks.indexedSeqId}, 0)`,
-          ),
+        gt(
+          chatThreads.lastChatEventSeqId,
+          sql`COALESCE(${chatEventSearchMessageWatermarks.indexedSeqId}, 0)`,
         ),
       ),
     )
-    // Keep the serving legacy projection fresh while the durable projection
-    // works through its zero-based backfill in the remaining bounded slots.
-    .orderBy(
-      asc(
-        sql`CASE WHEN ${chatThreads.lastChatEventSeqId} > COALESCE(${chatEventSearchWatermarks.indexedSeqId}, 0) THEN 0 ELSE 1 END`,
-      ),
-      asc(chatThreads.id),
-    )
+    .orderBy(asc(chatThreads.id))
     .limit(chatEventSearchThreadBatchSize());
 }
 
@@ -705,51 +475,14 @@ async function projectionConvergence(
     projectionThreadScope(options.chatThreadIds),
     gt(chatThreads.lastChatEventSeqId, 0),
   );
-  if (!options.durableProjectionAvailable) {
-    const [legacyStats] = await db
-      .select({
-        eligibleThreads: count(),
-        legacyCaughtUpThreads: count(chatEventSearchWatermarks.chatThreadId),
-      })
-      .from(chatThreads)
-      .leftJoin(
-        chatEventSearchWatermarks,
-        and(
-          eq(chatEventSearchWatermarks.chatThreadId, chatThreads.id),
-          gte(
-            chatEventSearchWatermarks.indexedSeqId,
-            chatThreads.lastChatEventSeqId,
-          ),
-        ),
-      )
-      .where(eligibleScope);
-    if (!legacyStats) {
-      throw new Error(
-        "Legacy chat search projection convergence query returned no row",
-      );
-    }
-    return { ...legacyStats, durableCaughtUpThreads: 0 };
-  }
-
   const [stats] = await db
     .select({
       eligibleThreads: count(),
-      legacyCaughtUpThreads: count(chatEventSearchWatermarks.chatThreadId),
       durableCaughtUpThreads: count(
         chatEventSearchMessageWatermarks.chatThreadId,
       ),
     })
     .from(chatThreads)
-    .leftJoin(
-      chatEventSearchWatermarks,
-      and(
-        eq(chatEventSearchWatermarks.chatThreadId, chatThreads.id),
-        gte(
-          chatEventSearchWatermarks.indexedSeqId,
-          chatThreads.lastChatEventSeqId,
-        ),
-      ),
-    )
     .leftJoin(
       chatEventSearchMessageWatermarks,
       and(
@@ -778,57 +511,30 @@ async function projectChatEventSearch(
   let threads = 0;
   let indexedEvents = 0;
   let deletedDocs = 0;
-  let durableThreads = 0;
-  let durableIndexedMessages = 0;
-  let durableDeletedMessages = 0;
   for (const thread of candidateThreads) {
-    const stats = await projectThread(
-      db,
-      thread,
-      options.durableProjectionAvailable,
-    );
+    const stats = await projectThread(db, thread);
     signal.throwIfAborted();
-    threads += stats.legacyThread;
-    indexedEvents += stats.legacyIndexedEvents;
-    deletedDocs += stats.legacyDeletedDocs;
-    durableThreads += stats.durableThread;
-    durableIndexedMessages += stats.durableIndexedMessages;
-    durableDeletedMessages += stats.durableDeletedMessages;
+    threads += stats.thread;
+    indexedEvents += stats.indexedEvents;
+    deletedDocs += stats.deletedDocs;
   }
   const convergence = await projectionConvergence(db, options);
   signal.throwIfAborted();
   return {
-    durableProjectionAvailable: options.durableProjectionAvailable,
     threads,
     indexedEvents,
     deletedDocs,
-    durableThreads,
-    durableIndexedMessages,
-    durableDeletedMessages,
     convergence,
   };
 }
 
-/**
- * Compatibility fallback (#26762): dual-writes the serving event-ID projection
- * and the durable thread/sequence projection while phase 2 is unavailable.
- * This bridges the DB/backend rollout and rollback window (observed maximum
- * ~102 minutes). Remove the legacy write only after the phase-2 reader and
- * snapshot watermark cut over, durable convergence is proven, and rollback
- * closes. Each projection keeps an independent watermark and bounded backfill.
- */
 export const projectChatEventSearch$ = command(
   async (
     { set },
     signal: AbortSignal,
   ): Promise<ChatEventSearchProjectionStats> => {
     const db = set(writeDb$);
-    const durableProjectionAvailable =
-      await durableChatEventSearchSchemaAvailable(db);
-    signal.throwIfAborted();
-    return await projectChatEventSearch(db, signal, {
-      durableProjectionAvailable,
-    });
+    return await projectChatEventSearch(db, signal, {});
   },
 );
 
@@ -839,13 +545,8 @@ export const projectChatEventSearchTestScope$ = command(
     signal: AbortSignal,
   ): Promise<ChatEventSearchProjectionStats> => {
     const db = set(writeDb$);
-    const durableProjectionAvailable =
-      !options.simulateDurableSchemaUnavailable &&
-      (await durableChatEventSearchSchemaAvailable(db));
-    signal.throwIfAborted();
     return await projectChatEventSearch(db, signal, {
       chatThreadIds: options.chatThreadIds,
-      durableProjectionAvailable,
     });
   },
 );

--- a/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-snapshot-chat-events.service.ts
@@ -21,7 +21,7 @@ import {
   sql,
 } from "drizzle-orm";
 import { chatEvents } from "@okouai/db/schema/chat-event";
-import { chatEventSearchWatermarks } from "@okouai/db/schema/chat-event-search";
+import { chatEventSearchMessageWatermarks } from "@okouai/db/schema/chat-event-search";
 import { chatEventSnapshots } from "@okouai/db/schema/chat-event-snapshot";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 
@@ -784,7 +784,7 @@ export const snapshotChatEvents$ = command(
     const candidates = await db
       .select({
         chatThreadId: chatThreads.id,
-        indexedSeqId: chatEventSearchWatermarks.indexedSeqId,
+        indexedSeqId: chatEventSearchMessageWatermarks.indexedSeqId,
         headId: chatEventSnapshots.id,
         headLastSeqId: chatEventSnapshots.lastSeqId,
         headObjectKey: chatEventSnapshots.objectKey,
@@ -792,8 +792,8 @@ export const snapshotChatEvents$ = command(
       })
       .from(chatThreads)
       .innerJoin(
-        chatEventSearchWatermarks,
-        eq(chatEventSearchWatermarks.chatThreadId, chatThreads.id),
+        chatEventSearchMessageWatermarks,
+        eq(chatEventSearchMessageWatermarks.chatThreadId, chatThreads.id),
       )
       .leftJoin(
         chatEventSnapshots,
@@ -820,7 +820,7 @@ export const snapshotChatEvents$ = command(
           or(
             lt(chatEventSnapshots.archiveSchemaVersion, ARCHIVE_SCHEMA_VERSION),
             gt(
-              chatEventSearchWatermarks.indexedSeqId,
+              chatEventSearchMessageWatermarks.indexedSeqId,
               sql`COALESCE(${chatEventSnapshots.lastSeqId}, 0)`,
             ),
           ),

--- a/turbo/apps/api/src/test-fixtures/chat-event-search.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-event-search.ts
@@ -3,10 +3,8 @@ import { randomUUID } from "node:crypto";
 import { agentComposes } from "@okouai/db/schema/agent-compose";
 import { chatEvents } from "@okouai/db/schema/chat-event";
 import {
-  chatEventSearchDocs,
   chatEventSearchMessages,
   chatEventSearchMessageWatermarks,
-  chatEventSearchWatermarks,
 } from "@okouai/db/schema/chat-event-search";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { asc, eq, inArray, sql } from "drizzle-orm";
@@ -20,14 +18,8 @@ import { createUserMessageDocument } from "../signals/services/zero-chat-user-me
 
 interface ChatEventSearchProjectionFixture {
   readonly lastChatEventSeqId: number;
-  readonly legacyIndexedSeqId: number | null;
-  readonly durableIndexedSeqId: number | null;
-  readonly legacyDocs: readonly {
-    readonly eventId: string;
-    readonly role: "user" | "assistant";
-    readonly text: string;
-  }[];
-  readonly durableMessages: readonly {
+  readonly indexedSeqId: number | null;
+  readonly messages: readonly {
     readonly seqId: number;
     readonly runId: string | null;
     readonly role: "user" | "assistant";
@@ -46,26 +38,12 @@ export async function readChatEventSearchProjectionFixture(
   if (!thread) {
     throw new Error("Expected chat search projection fixture thread");
   }
-  const [legacyWatermark] = await db()
-    .select({ indexedSeqId: chatEventSearchWatermarks.indexedSeqId })
-    .from(chatEventSearchWatermarks)
-    .where(eq(chatEventSearchWatermarks.chatThreadId, chatThreadId))
-    .limit(1);
-  const [durableWatermark] = await db()
+  const [watermark] = await db()
     .select({ indexedSeqId: chatEventSearchMessageWatermarks.indexedSeqId })
     .from(chatEventSearchMessageWatermarks)
     .where(eq(chatEventSearchMessageWatermarks.chatThreadId, chatThreadId))
     .limit(1);
-  const legacyDocs = await db()
-    .select({
-      eventId: chatEventSearchDocs.eventId,
-      role: chatEventSearchDocs.role,
-      text: chatEventSearchDocs.text,
-    })
-    .from(chatEventSearchDocs)
-    .where(eq(chatEventSearchDocs.chatThreadId, chatThreadId))
-    .orderBy(asc(chatEventSearchDocs.createdAt));
-  const durableMessages = await db()
+  const messages = await db()
     .select({
       seqId: chatEventSearchMessages.seqId,
       runId: chatEventSearchMessages.runId,
@@ -77,25 +55,9 @@ export async function readChatEventSearchProjectionFixture(
     .orderBy(asc(chatEventSearchMessages.seqId));
   return {
     lastChatEventSeqId: thread.lastChatEventSeqId,
-    legacyIndexedSeqId: legacyWatermark?.indexedSeqId ?? null,
-    durableIndexedSeqId: durableWatermark?.indexedSeqId ?? null,
-    legacyDocs,
-    durableMessages,
+    indexedSeqId: watermark?.indexedSeqId ?? null,
+    messages,
   };
-}
-
-/** Recreates the rollout state where only the established projection exists. */
-export async function resetDurableChatEventSearchProjectionFixture(
-  chatThreadId: string,
-): Promise<void> {
-  await db().transaction(async (tx) => {
-    await tx
-      .delete(chatEventSearchMessages)
-      .where(eq(chatEventSearchMessages.chatThreadId, chatThreadId));
-    await tx
-      .delete(chatEventSearchMessageWatermarks)
-      .where(eq(chatEventSearchMessageWatermarks.chatThreadId, chatThreadId));
-  });
 }
 
 export async function insertChatSearchProjectionCoverageFixture(args: {
@@ -154,7 +116,7 @@ export async function insertChatSearchProjectionCoverageFixture(args: {
 /**
  * Simulates retention after the durable projection has caught up. Product APIs
  * cannot delete append-only source events, so the fixture removes only rows
- * owned by the test's unique threads while preserving both search projections.
+ * owned by the test's unique threads while preserving the search projection.
  */
 export async function removeChatSearchSourceEventsFixture(
   chatThreadIds: readonly string[],

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -81,16 +81,11 @@ const cronCompactChatThreadSnapshotsResponseSchema = z.object({
 
 export const cronProjectChatEventSearchResponseSchema = z.object({
   success: z.literal(true),
-  durableProjectionAvailable: z.boolean(),
   threads: z.number(),
   indexedEvents: z.number(),
   deletedDocs: z.number(),
-  durableThreads: z.number(),
-  durableIndexedMessages: z.number(),
-  durableDeletedMessages: z.number(),
   convergence: z.object({
     eligibleThreads: z.number(),
-    legacyCaughtUpThreads: z.number(),
     durableCaughtUpThreads: z.number(),
   }),
 });
@@ -296,7 +291,7 @@ export const cronProjectChatEventSearchContract = c.router({
       200: cronProjectChatEventSearchResponseSchema,
       401: apiErrorSchema,
     },
-    summary: "Project chat events into the search docs table",
+    summary: "Project chat events into durable search messages",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/test-chat-event-search-projection.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-chat-event-search-projection.ts
@@ -7,7 +7,6 @@ const c = initContract();
 
 export const testChatEventSearchProjectionBodySchema = z.object({
   chat_thread_ids: z.array(z.uuid()).min(1).max(20),
-  simulate_durable_schema_unavailable: z.boolean().optional(),
 });
 
 export const testChatEventSearchProjectionContract = c.router({

--- a/turbo/packages/db/src/schema/chat-event-search.ts
+++ b/turbo/packages/db/src/schema/chat-event-search.ts
@@ -18,10 +18,11 @@ const tsvectorColumn = customType<{ data: string }>({
 });
 
 /**
- * Search projection over the canonical chat_events stream: one row per
- * searchable user prompt or assistant message. Rows are derived data — the
- * search projector cron rebuilds them from chat_events, so this table can be
- * dropped and replayed without data loss.
+ * Retained only to model the physical schema used by historical migrations.
+ * Runtime projection and search code must not read or write this table. Drop
+ * it in a later release after the Phase 3 API and its rollback target drain.
+ *
+ * @deprecated Use chatEventSearchMessages.
  */
 export const chatEventSearchDocs = pgTable(
   "chat_event_search_docs",
@@ -72,8 +73,11 @@ export const chatEventSearchDocs = pgTable(
 );
 
 /**
- * Per-thread projection watermark: chat_events with seq_id <=
- * indexed_seq_id are reflected in chat_event_search_docs.
+ * Retained only to model the physical schema used by historical migrations.
+ * Runtime projection and snapshot code must use the message watermark. Drop
+ * it with chat_event_search_docs in the later physical cleanup release.
+ *
+ * @deprecated Use chatEventSearchMessageWatermarks.
  */
 export const chatEventSearchWatermarks = pgTable(
   "chat_event_search_watermarks",
@@ -91,9 +95,9 @@ export const chatEventSearchWatermarks = pgTable(
 );
 
 /**
- * Durable searchable-message projection. Unlike chatEventSearchDocs, these
- * rows do not depend on a chat_events UUID and remain authoritative after the
- * canonical event row ages out of PostgreSQL.
+ * Durable searchable-message projection. These rows do not depend on a
+ * chat_events UUID and remain authoritative after the canonical event row
+ * ages out of PostgreSQL.
  */
 export const chatEventSearchMessages = pgTable(
   "chat_event_search_messages",
@@ -139,8 +143,7 @@ export const chatEventSearchMessages = pgTable(
 );
 
 /**
- * Independent durable-projection watermark. Missing rows intentionally mean
- * zero so the online backfill never inherits progress from the legacy index.
+ * Durable-projection watermark. Missing rows intentionally mean zero.
  */
 export const chatEventSearchMessageWatermarks = pgTable(
   "chat_event_search_message_watermarks",


### PR DESCRIPTION
## Summary

- retire every runtime read, write, delete, upsert, fallback, and convergence path for `chat_event_search_docs` and `chat_event_search_watermarks`
- make the projector and snapshot eligibility gate use only `chat_event_search_messages` and `chat_event_search_message_watermarks`, while preserving index-time visibility and revocation resolution
- remove rollout-only response fields, test switches, fixtures, and mutable parity tests for the legacy projection
- preserve the durable reader test that deletes the source `chat_events` rows and still proves keyword matches, user/assistant context, stable `thread:seq` identity, `seqId`, `runId`, and compatibility output fields

## Removal evidence

- Phase 2 is deployed in `api-v1.444.1`; serving keyword and context reads already use only the durable message projection
- the latest completed production projection tick reported 1,047,338 rows in both projections and 134,526 rows in both watermark tables, with only two newly active threads waiting for the next minute tick
- a production `GET /api/okou/chat/search` completed with HTTP 200 in 25.8 ms and selected `chat_event_search_messages` without related errors

## Rollout safety

This PR intentionally contains no database migration and no `DROP TABLE`. Production migrations run before the new API artifact is promoted, so a same-release drop could break the currently deployed Phase 2 projector while it is still dual-writing and would also invalidate its rollback target.

The physical legacy tables therefore remain inert under Phase 3. Their deprecated schema declarations remain only so Drizzle continues to model the physical final schema instead of generating an unsafe drop. A rollback to Phase 2 remains valid and its projector can resume catching up the legacy projection.

The narrowly scoped follow-up is: after the Phase 3 API is healthy in production and the Phase 2 rollback target has drained, use a separate migration to drop only `chat_event_search_docs` and `chat_event_search_watermarks`, then remove their deprecated schema declarations.

Catalog verification after applying current migrations shows both legacy tables have one foreign key each, both referencing `chat_threads`; neither table has a foreign key to `chat_events`, so they do not block future source-event deletion.

## Verification

Passed:

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/db db:migrate`
- `pnpm --filter @okouai/db exec vitest run src/__tests__/chat-event-search.test.ts` (2 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-project-chat-event-search.test.ts` (4 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-search-reader.test.ts` (2 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts` (8 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts` (6 tests)
- PostgreSQL catalog query confirming the two legacy-table foreign keys reference only `chat_threads`

`pnpm --filter @okouai/db test:migration-consistency` passed its migration-runner, snapshot-chain, timestamp, and preceding rollout validations, but the local PostgreSQL 18 run stopped before normalized schema comparison at an unrelated Custom Connector historical-migration assertion: it expected `exceeds canonical limit` and received `malformed header injection`. This PR does not change migrations or migration snapshots.

## Out of scope

- physical `chat_events` retention or deletion
- issue #26697, archive/snapshot v5, model fallback cleanup, or duplicate snapshot UUID normalization

Refs #26762
