### PR TITLE
fix(chat): preserve unread agent actions during active runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1648,7 +1648,7 @@ describe("CHAT-01 chat thread read state", () => {
     );
   }, 120_000);
 
-  it("lists active chat thread ids for the current user and org", async () => {
+  it("lists active thread ids without hiding the agent's unread state", async () => {
     const {
       actor: owner,
       agentId: ownerAgent,
@@ -1701,7 +1701,7 @@ describe("CHAT-01 chat thread read state", () => {
       new Set([runningRun.threadId, queuedRun.threadId]),
     );
     await expect(chat.listIndicators(owner)).resolves.toStrictEqual({
-      agents: { [ownerAgent]: "active" },
+      agents: { [ownerAgent]: "unread" },
       threads: {
         [completedRun.threadId]: "unread",
         [runningRun.threadId]: "active",
@@ -1724,7 +1724,7 @@ describe("CHAT-01 chat thread read state", () => {
       new Set([queuedRun.threadId]),
     );
     await expect(chat.listIndicators(owner)).resolves.toStrictEqual({
-      agents: { [ownerAgent]: "active" },
+      agents: { [ownerAgent]: "unread" },
       threads: {
         [completedRun.threadId]: "unread",
         [runningRun.threadId]: "unread",
@@ -1763,7 +1763,7 @@ describe("CHAT-01 chat thread read state", () => {
         new Set([expiredRun.threadId, recentRun.threadId]),
       );
       await expect(chat.listIndicators(actor)).resolves.toStrictEqual({
-        agents: { [agentId]: "active" },
+        agents: { [agentId]: "unread" },
         threads: {
           [recentRun.threadId]: "unread",
           [activeRun.threadId]: "active",
@@ -1862,7 +1862,7 @@ describe("CHAT-01 chat thread read state", () => {
       ),
     ).toStrictEqual(new Set([completedRun.threadId, completeGoalRun.threadId]));
     await expect(chat.listIndicators(owner)).resolves.toStrictEqual({
-      agents: { [agentId]: "active" },
+      agents: { [agentId]: "unread" },
       threads: {
         [runningRun.threadId]: "active",
         [completedRun.threadId]: "unread",

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -411,8 +411,9 @@ export function zeroChatThreadUnreadThreadIds(args: {
  * Active and unread indicators for the user's agents and threads in the
  * current organization. Active threads are complete; unread threads are the
  * latest 50 terminal markers from the last seven days. Active threads are
- * computed once and reused to keep unread classification and indicator
- * precedence within one database snapshot.
+ * computed once and reused to keep unread classification within one database
+ * snapshot. Unread agent aggregates take precedence so unread actions remain
+ * available while another thread for the same agent is active.
  */
 export function zeroChatIndicators(args: {
   readonly userId: string;
@@ -502,7 +503,7 @@ export function zeroChatIndicators(args: {
     const threads: Record<string, ZeroIndicator> = {};
     for (const row of rows) {
       threads[row.threadId] = row.indicator;
-      if (row.indicator === "active" || agents[row.agentId] === undefined) {
+      if (row.indicator === "unread" || agents[row.agentId] === undefined) {
         agents[row.agentId] = row.indicator;
       }
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2536,18 +2536,22 @@ describe("zero sidebar", () => {
   it("marks all default agent chats read from the default agent menu", async () => {
     prepareAgentTeam();
 
-    let unreadAgentIds = [AGENT_ID, SUPPORT_AGENT_ID];
+    let hasUnread = true;
     const markedAgentIds: string[] = [];
-    context.mocks.api(chatThreadsContract.unreadAgents, ({ respond }) => {
-      return respond(200, { agentIds: unreadAgentIds });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, {
+        agents: { [AGENT_ID]: hasUnread ? "unread" : "active" },
+        threads: {
+          [INCIDENT_THREAD_ID]: "active",
+          ...(hasUnread ? { [EXISTING_THREAD_ID]: "unread" as const } : {}),
+        },
+      });
     });
     context.mocks.api(
       chatThreadMarkAgentReadContract.markAgentRead,
       ({ body, respond }) => {
         markedAgentIds.push(body.agentId);
-        unreadAgentIds = unreadAgentIds.filter((id) => {
-          return id !== body.agentId;
-        });
+        hasUnread = false;
         return respond(204);
       },
     );
@@ -2555,6 +2559,7 @@ describe("zero sidebar", () => {
     setupSidebarPage({
       context,
       path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.UnifiedIndicatorApi]: true },
     });
 
     const nav = await waitFor(() => {
@@ -2581,6 +2586,9 @@ describe("zero sidebar", () => {
       expect(queryMenuItemByText("Mark all read")).not.toBeInTheDocument();
       expect(
         within(defaultSidebarRow).queryByLabelText("Unread"),
+      ).not.toBeInTheDocument();
+      expect(
+        within(defaultSidebarRow).queryByLabelText("Open agent menu"),
       ).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary

- prioritize unread state in unified agent aggregates so agent-level actions remain reachable while another thread is active
- preserve per-thread active indicators and the unified endpoint's existing request, query, and retention behavior
- exercise the default agent's `Mark all read` menu through the rendered unified-indicator path, including concurrent active and unread threads

## Scope

- no API schema, database migration, or new endpoint
- no change to the seven-day lookback or 50-thread unread limit
- no change to the legacy indicator path or non-default pin/unpin actions

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t 'marks all default agent chats read from the default agent menu'` (1 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'lists active thread ids without hiding|limits unified unread indicators|excludes unread chat threads'` (3 passed)

Closes #26968
