### PR TITLE
test(api): settle browser cleanup between thread deletes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-browser.test.ts
@@ -1102,14 +1102,16 @@ describe("okou browser route", () => {
     });
     expect(providerStopAttempts).toStrictEqual([providerIds[0]]);
 
+    // Each deletion can promote a queued run and revoke its marker on another
+    // fixture thread. Settle that route-owned work before deleting the next one.
     for (const threadId of [
       first.threadId,
       other.threadId,
       candidate.threadId,
     ]) {
       await chat.deleteThread(actor, threadId);
+      await flushWaitUntilForTest();
     }
-    await flushWaitUntilForTest();
     expect(providerStopAttempts).toStrictEqual([
       providerIds[0],
       providerIds[1],


### PR DESCRIPTION
## Summary

- settle each chat-thread deletion's route-owned `waitUntil` work before deleting the next related browser fixture thread
- preserve the assertions that the earliest idle lease is reclaimed before a new provider session starts
- keep the existing provider-stop cleanup assertions intact

## Root cause evidence

- Trigger: Turbo run [31704531149](https://github.com/vm0-ai/vm0/actions/runs/31704531149), `test-api (4)` job [94461715102](https://github.com/vm0-ai/vm0/actions/runs/31704531149/job/94461715102), exact SHA `917fe5141289c0b844062952b4b36fcd505ecd41`.
- Recurrence: merge-group run [31703544445](https://github.com/vm0-ai/vm0/actions/runs/31703544445), job [94458400085](https://github.com/vm0-ai/vm0/actions/runs/31703544445/job/94458400085), failed the same test with the same PostgreSQL `40P01` cycle.
- A same-SHA comparison run [31703878156](https://github.com/vm0-ai/vm0/actions/runs/31703878156) passed the test, but its logs contain the same deadlock with the opposite victim: the event-sequence UPDATE was aborted and logged by `ChatThreadDelete`, so a green rerun did not mean the race was gone.
- That passing-run stack identifies the late UPDATE owner as `dispatchCancelSideEffects -> drainOrgQueue$ -> promoteQueuedCandidate -> revokeQueuedRunAssistantMarkers -> revokeChatEvent -> reserveChatEventSeqIds`, not the earlier Browser Use stop or screenshot tasks. Those browser tasks are settled by the existing pre-assertion flush.
- The teardown deleted three related fixture threads back-to-back. A previous DELETE could therefore retain an organization-queue lock on `agent_runs` while revoking a marker on a later fixture thread. The next DELETE held that chat thread and reached `agent_runs` through the temporary `zero_runs -> agent_runs` compatibility trigger, forming the observed reverse lock order.

## Fix

`flushWaitUntilForTest()` is the route's deterministic ownership barrier for post-delete cancellation and queue work. Move that barrier inside the fixture deletion loop so each DELETE fully settles before cleanup begins deleting another thread that its side effects may update.

This does not add retries, sleeps, timeouts, skipped assertions, or swallowed failures.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run lint` on the rebased latest `origin/main`
- `pnpm --filter api run check-types` on the rebased latest `origin/main`
- `git diff --check`

The targeted API test requires a PostgreSQL service. It was intentionally not run locally because this repair must not start local services; PR CI is the service-backed validation path.

Preview validation is not applicable: this is a test-only synchronization change with no deployable runtime or UI behavior.

Turbo flaky fingerprint: `test-api-zero-browser-reclaims-earliest-idle-lease-chat-thread-delete-deadlock`
