### PR TITLE
refactor(chat): remove historical model recovery

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -3966,6 +3966,128 @@ describe("CHAT-02: model-first provider policies", () => {
     await cancelChatRun(actor, recovered.runId);
   }, 90_000);
 
+  it("resolves a NULL legacy thread from current defaults without replaying its first run", async () => {
+    const { actor, agentId, runnerGroup, providerId } =
+      await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-5",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+      {
+        model: "claude-opus-4-8",
+        isDefault: false,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: "establish the historical thread model",
+      model: "claude-sonnet-5",
+    });
+    const queuedEventId = randomUUID();
+    const queued = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: first.threadId,
+        prompt: "continue after canonical default resolution",
+        clientEventId: queuedEventId,
+      },
+      [201],
+    );
+    if (queued.status !== 201) {
+      throw new Error("Expected the legacy-thread follow-up to queue");
+    }
+    expect(queued.body.runId).toBeNull();
+
+    const historicalMessages = await chat.listThreadEvents(
+      actor,
+      first.threadId,
+    );
+    expect(userMessages(historicalMessages.events)).toContainEqual(
+      expect.objectContaining({ runId: first.runId }),
+    );
+
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-opus-4-8",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+      {
+        model: "claude-sonnet-5",
+        isDefault: false,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+    ]);
+    await chat.updateUserModelPreference(actor, "claude-opus-4-8");
+    await chat.updateThreadModelSelection(actor, first.threadId, null);
+    expect(
+      (await chat.readThreadMetadata(actor, first.threadId)).selectedModel,
+    ).toBeNull();
+
+    const firstClaim = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(first.runId, firstClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
+
+    const promotedMessages = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (messages) => {
+        return userMessages(messages).some((message) => {
+          return (
+            message.revokesEventId === queuedEventId &&
+            typeof message.runId === "string"
+          );
+        });
+      },
+    );
+    const promotedRunId = userMessages(promotedMessages.events).find(
+      (message) => {
+        return message.revokesEventId === queuedEventId;
+      },
+    )?.runId;
+    if (!promotedRunId) {
+      throw new Error("Expected the queued legacy-thread message to run");
+    }
+
+    const promotedClaim = await claimChatRun(runnerGroup, promotedRunId);
+    expect(promotedClaim.claim.cliAgentType).toBe("claude-code");
+    expect(claimEnvironment(promotedClaim.claim).ANTHROPIC_MODEL).toBe(
+      "claude-opus-4-8",
+    );
+    expect(
+      (await chat.readThreadMetadata(actor, first.threadId)).selectedModel,
+    ).toBe("claude-opus-4-8");
+
+    const threadEvents = await chat.requestThreadEvents(actor, {}, [200]);
+    if (threadEvents.status !== 200) {
+      throw new Error("Expected chat thread events to load");
+    }
+    expect(threadEvents.body.events).toContainEqual(
+      expect.objectContaining({
+        kind: "model_selection_updated",
+        chatThreadId: first.threadId,
+        selectedModel: "claude-opus-4-8",
+      }),
+    );
+
+    await cancelChatRun(actor, promotedRunId, promotedClaim.sandboxHeaders);
+  }, 90_000);
+
   it("does not overwrite a concurrent explicit thread model selection", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -9,6 +9,7 @@ import {
   chatThreadEventsContract,
   chatThreadMarkAgentReadContract,
   chatThreadMarkReadContract,
+  chatThreadMetadataContract,
   chatThreadModelSelectionContract,
   chatThreadPinContract,
   chatThreadRenameContract,
@@ -19,6 +20,7 @@ import {
   type ChatThreadArtifactRun,
   type ChatThreadDetail,
   type ChatThreadDraft,
+  type ChatThreadMetadata,
   type ChatThreadSnapshotProjection,
   type ChatRunOptionsRequest,
   type CodexServiceTier,
@@ -27,6 +29,7 @@ import {
   type UserMessageInputDocument,
   type ZeroIndicators,
 } from "@okouai/api-contracts/contracts/chat-threads";
+import { zeroUserModelPreferenceContract } from "@okouai/api-contracts/contracts/zero-user-model-preference";
 import {
   artifactCatalogContract,
   type ArtifactCatalogKind,
@@ -76,6 +79,7 @@ import { zeroHostRoutes } from "../../zero-host";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { zeroUploadsCompleteRoutes } from "../../zero-uploads-complete";
 import { zeroUploadsPrepareRoutes } from "../../zero-uploads-prepare";
+import { zeroUserModelPreferenceRoutes } from "../../zero-user-model-preference";
 import type { ApiTestUser } from "./api-bdd";
 import {
   projectChatEventRows,
@@ -188,6 +192,7 @@ const chatFilesRoutes = [
   ...zeroUploadsCompleteRoutes,
   ...zeroHostRoutes,
   ...zeroModelPoliciesRoutes,
+  ...zeroUserModelPreferenceRoutes,
 ] as const;
 
 function chatFilesApp(context: TestContext) {
@@ -265,6 +270,10 @@ export function createChatFilesBddApi(context: TestContext) {
     return chatFilesApp(context)(chatThreadByIdContract);
   }
 
+  function threadMetadataClient() {
+    return chatFilesApp(context)(chatThreadMetadataContract);
+  }
+
   function threadDraftClient() {
     return chatFilesApp(context)(chatThreadDraftContract);
   }
@@ -303,6 +312,10 @@ export function createChatFilesBddApi(context: TestContext) {
 
   function threadModelSelectionClient() {
     return chatFilesApp(context)(chatThreadModelSelectionContract);
+  }
+
+  function userModelPreferenceClient() {
+    return chatFilesApp(context)(zeroUserModelPreferenceContract);
   }
 
   function threadComputerUseHostClient() {
@@ -616,6 +629,20 @@ export function createChatFilesBddApi(context: TestContext) {
       return response.body;
     },
 
+    async readThreadMetadata(
+      actor: ApiTestUser,
+      threadId: string,
+    ): Promise<ChatThreadMetadata> {
+      const response = await accept(
+        threadMetadataClient().get({
+          headers: authenticate(context, actor),
+          params: { id: threadId },
+        }),
+        [200],
+      );
+      return response.body;
+    },
+
     async requestReadThread(
       actor: ApiTestUser | null,
       threadId: string,
@@ -846,6 +873,19 @@ export function createChatFilesBddApi(context: TestContext) {
           },
         }),
         [204],
+      );
+    },
+
+    async updateUserModelPreference(
+      actor: ApiTestUser,
+      selectedModel: SupportedRunModel | null,
+    ): Promise<void> {
+      await accept(
+        userModelPreferenceClient().update({
+          headers: authenticate(context, actor),
+          body: { selectedModel, serviceTier: null },
+        }),
+        [200],
       );
     },
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -41,10 +41,7 @@ import { zeroIntegrationsSlackContract } from "@okouai/api-contracts/contracts/z
 import { zeroIntegrationsTelegramContract } from "@okouai/api-contracts/contracts/zero-integrations-telegram";
 import { zeroFeatureSwitchesContract } from "@okouai/api-contracts/contracts/zero-feature-switches";
 import { zeroModelPoliciesMainContract } from "@okouai/api-contracts/contracts/zero-model-policies";
-import {
-  zeroModelProvidersByTypeContract,
-  zeroModelProvidersMainContract,
-} from "@okouai/api-contracts/contracts/zero-model-providers";
+import { zeroModelProvidersMainContract } from "@okouai/api-contracts/contracts/zero-model-providers";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { zeroSlackChannelsContract } from "@okouai/api-contracts/contracts/zero-slack-channels";
 import { zeroSlackConnectContract } from "@okouai/api-contracts/contracts/zero-slack-connect";
@@ -1262,68 +1259,6 @@ export function createBddIntegrationApi(context: TestContext) {
           body: { switches: { [FeatureSwitchKey.ZeroDebug]: true } },
         }),
         [200],
-      );
-    },
-
-    async configureUnpinnedSlackModelRoute(actor: ApiTestUser): Promise<void> {
-      const providers = setupApp({ context, routes: zeroModelProvidersRoutes })(
-        zeroModelProvidersMainContract,
-      );
-      // openrouter-api-key is a claude-code provider whose catalog entry has
-      // no default model, so runs admitted through it keep selectedModel null.
-      await accept(
-        providers.upsert({
-          headers: authenticate(context, routeMocks, actor),
-          body: { type: "openrouter-api-key", secret: "bdd-openrouter-key" },
-        }),
-        [200, 201],
-      );
-      const openai = await accept(
-        providers.upsert({
-          headers: authenticate(context, routeMocks, actor),
-          body: { type: "openai-api-key", secret: "bdd-openai-key" },
-        }),
-        [200, 201],
-      );
-      await accept(
-        setupApp({ context, routes: zeroModelPoliciesRoutes })(
-          zeroModelPoliciesMainContract,
-        ).update({
-          headers: authenticate(context, routeMocks, actor),
-          body: {
-            policies: [
-              {
-                model: "gpt-5.6-sol",
-                isDefault: true,
-                defaultProviderType: "openai-api-key",
-                credentialScope: "org",
-                modelProviderId: openai.body.provider.id,
-              },
-            ],
-          },
-        }),
-        [200],
-      );
-      await accept(
-        setupApp({ context, routes: zeroModelProvidersRoutes })(
-          zeroModelProvidersByTypeContract,
-        ).delete({
-          headers: authenticate(context, routeMocks, actor),
-          params: { type: "openai-api-key" },
-        }),
-        [204],
-      );
-      // Onboarding seeds an org "vm0" no-secret provider pinned to a model;
-      // delete it too so unpinned runs resolve the org openrouter provider,
-      // which carries no selected model.
-      await accept(
-        setupApp({ context, routes: zeroModelProvidersRoutes })(
-          zeroModelProvidersByTypeContract,
-        ).delete({
-          headers: authenticate(context, routeMocks, actor),
-          params: { type: "vm0" },
-        }),
-        [204],
       );
     },
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -3053,6 +3053,103 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(continuationRun.result?.agentSessionId).toBe(gptSessionId);
   });
 
+  it("resolves a NULL Slack thread from canonical defaults without replaying its first run", async () => {
+    const actor = bdd.user();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    integrations.configureSlackAppMocks();
+    integrations.acceptSlackSessionHistoryDownloads();
+    const runnerGroup = runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await integrations.configureSlackRunModelPolicies(actor);
+    const slackUserId = uniqueSlackUserId();
+    const { teamId } = await integrations.installSlackWorkspace(actor, {
+      installerSlackUserId: slackUserId,
+    });
+
+    const channelId = "C_BDD_NULL_MODEL";
+    const threadTs = "3150.000100";
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUserId,
+      text: "establish the historical Slack model",
+      ts: threadTs,
+      channel: channelId,
+    });
+    const firstRunId = await pollSlackRun(runnerGroup);
+    const firstClaim = await runs.claimRunnerJob(firstRunId);
+    expect(firstClaim.cliAgentType).toBe("claude-code");
+    expect(firstClaim.environment).toMatchObject({
+      ANTHROPIC_API_KEY: expect.stringMatching(/.+/),
+      ANTHROPIC_MODEL: "claude-sonnet-5",
+    });
+    await completeSlackTriggeredRun({
+      runId: firstRunId,
+      sandboxToken: firstClaim.sandboxToken,
+      cliAgentType: firstClaim.cliAgentType,
+    });
+    await flushWaitUntilForTest();
+
+    const slackState = await integrations.readSlackTestState(teamId);
+    const chatThreadId = slackState.chat_thread_routes.find((route) => {
+      return route.channelId === channelId && route.threadTs === threadTs;
+    })?.chatThreadId;
+    if (!chatThreadId) {
+      throw new Error("Expected Slack ingress to create a canonical thread");
+    }
+    const historicalMessages = await chat.listThreadEvents(actor, chatThreadId);
+    expect(historicalMessages.events).toContainEqual(
+      expect.objectContaining({
+        eventType: "input.prompt",
+        runId: firstRunId,
+      }),
+    );
+
+    await chat.updateThreadModelSelection(actor, chatThreadId, null);
+    await integrations.updateUserModelPreference(actor, "gpt-5.6-sol");
+    expect(
+      (await chat.readThreadMetadata(actor, chatThreadId)).selectedModel,
+    ).toBeNull();
+
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUserId,
+      text: "resolve the current canonical Slack model",
+      ts: "3150.000200",
+      thread_ts: threadTs,
+      channel: channelId,
+    });
+    const resolvedRunId = await pollSlackRun(runnerGroup);
+    const resolvedClaim = await runs.claimRunnerJob(resolvedRunId);
+    expect(resolvedClaim.cliAgentType).toBe("codex");
+    expect(resolvedClaim.environment).toMatchObject({
+      OPENAI_API_KEY: expect.stringMatching(/.+/),
+      OPENAI_MODEL: "gpt-5.6-sol",
+    });
+    expect(resolvedClaim.environment).not.toHaveProperty("ANTHROPIC_API_KEY");
+    expect(
+      (await chat.readThreadMetadata(actor, chatThreadId)).selectedModel,
+    ).toBe("gpt-5.6-sol");
+
+    const threadEvents = await chat.requestThreadEvents(actor, {}, [200]);
+    if (threadEvents.status !== 200) {
+      throw new Error("Expected canonical Slack thread events to load");
+    }
+    expect(threadEvents.body.events).toContainEqual(
+      expect.objectContaining({
+        kind: "model_selection_updated",
+        chatThreadId,
+        selectedModel: "gpt-5.6-sol",
+      }),
+    );
+
+    await completeSlackTriggeredRun({
+      runId: resolvedRunId,
+      sandboxToken: resolvedClaim.sandboxToken,
+      cliAgentType: resolvedClaim.cliAgentType,
+    });
+  }, 90_000);
+
   it("prompts disconnected Slack users and filters non-actionable messages", async () => {
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
@@ -4380,7 +4477,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(run6.status).toBe("completed");
   }, 90_000);
 
-  it("keeps canonical Slack callbacks visible when model routes unpin and installs vanish", async () => {
+  it("keeps canonical Slack callbacks visible when status updates fail and installs vanish", async () => {
     const actor = bdd.user();
     runs.acceptStorageDownloads();
     runs.acceptTelemetryIngest();
@@ -4389,19 +4486,19 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const runnerGroup = runs.configureRunnerGroup();
     await runs.grantProEntitlement(actor);
     await bdd.readOnboardingStatus(actor);
-    await integrations.configureUnpinnedSlackModelRoute(actor);
+    await integrations.configureSlackRunModelPolicies(actor);
     const slackUserId = uniqueSlackUserId();
     const { teamId } = await integrations.installSlackWorkspace(actor, {
       installerSlackUserId: slackUserId,
     });
     integrations.clearSlackCallHistory();
 
-    const channelId = "C_BDD_UNPINNED";
+    const channelId = "C_BDD_CALLBACK_RESILIENCE";
     const threadU1 = "5100.000100";
     await integrations.postSlackEvent(teamId, {
       type: "app_mention",
       user: slackUserId,
-      text: "run without a pinned model",
+      text: "run while Slack status updates fail",
       ts: threadU1,
       channel: channelId,
     });
@@ -4409,8 +4506,8 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const claim1 = await runs.claimRunnerJob(run1Id);
     expect(claim1.cliAgentType).toBe("claude-code");
     expect(claim1.environment).toMatchObject({
-      ANTHROPIC_AUTH_TOKEN: expect.stringMatching(/.+/),
-      ANTHROPIC_BASE_URL: "https://openrouter.ai/api",
+      ANTHROPIC_API_KEY: expect.stringMatching(/.+/),
+      ANTHROPIC_MODEL: "claude-sonnet-5",
     });
 
     context.mocks.slack.assistant.threads.setStatus.mockRejectedValueOnce(
@@ -4435,22 +4532,17 @@ describe("INT-01: Slack app deep webhook flows", () => {
       runId: run1Id,
       sandboxToken: claim1.sandboxToken,
       cliAgentType: "claude-code",
-      resultText: "NO_MODEL_FOOTER_OUTPUT",
+      resultText: "CALLBACK_RESILIENCE_OUTPUT",
     });
     await flushWaitUntilAndAssert(() => {
       expect(context.mocks.slack.chat.postMessage).toHaveBeenLastCalledWith(
         expect.objectContaining({
           channel: channelId,
           thread_ts: threadU1,
-          text: "NO_MODEL_FOOTER_OUTPUT",
+          text: "CALLBACK_RESILIENCE_OUTPUT",
         }),
       );
     });
-    const unpinnedBlocks = slackPostMessageCallsJson();
-    expect(unpinnedBlocks).not.toContain("Audit");
-    expect(unpinnedBlocks).not.toContain("Responded by");
-    expect(unpinnedBlocks).not.toContain("Reply to");
-    expect(unpinnedBlocks).not.toContain("Claude");
     const run1 = await runs.readRun(actor, run1Id);
     expect(run1.status).toBe("completed");
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -10,7 +10,6 @@ import {
   serializeChatFollowupsContent,
   type ChatRecommendedFollowup,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { modelProviderCredentialScopeSchema } from "@okouai/api-contracts/contracts/model-providers";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
@@ -171,10 +170,7 @@ import { resolveChatThreadSession } from "./chat-session-continuity.service";
 import { loadComputerUseHostGrantForAutoSend } from "./zero-chat-computer-use-host.service";
 import { resolveRunChatThreadModelContext } from "./zero-chat-run-event.service";
 import { releaseThreadBrowsersForRun$ } from "./zero-browser.service";
-import {
-  resolveModelFirstProviderAdmission,
-  type ModelFirstPin,
-} from "./zero-model-selection.service";
+import type { ModelFirstPin } from "./zero-model-selection.service";
 import {
   chatEventTextCondition,
   chatEventTypeIn,
@@ -2537,85 +2533,6 @@ type QueuedMessageModelRouteResolution =
   | { readonly route: QueuedMessageModelRoute }
   | { readonly error: QueuedMessageModelRouteError };
 
-function persistedModelProviderCredentialScope(
-  value: string | null,
-): ModelFirstPin["modelProviderCredentialScope"] {
-  if (value === null) {
-    return null;
-  }
-  const parsed = modelProviderCredentialScopeSchema.safeParse(value);
-  return parsed.success ? parsed.data : null;
-}
-
-async function resolveUnpinnedSlackQueuedMessageModelRoute(args: {
-  readonly db: Db;
-  readonly threadId: string;
-  readonly userId: string;
-  readonly orgId: string;
-}): Promise<QueuedMessageModelRouteResolution | null> {
-  const [thread] = await args.db
-    .select({ selectedModel: chatThreads.selectedModel })
-    .from(chatThreads)
-    .where(eq(chatThreads.id, args.threadId))
-    .limit(1);
-  if (!thread || thread.selectedModel !== null) {
-    return null;
-  }
-
-  const [firstRun] = await args.db
-    .select({
-      modelProviderId: zeroRuns.modelProviderId,
-      modelProviderType: zeroRuns.modelProvider,
-      modelProviderCredentialScope: zeroRuns.modelProviderCredentialScope,
-      selectedModel: zeroRuns.selectedModel,
-    })
-    .from(chatEvents)
-    .innerJoin(zeroRuns, eq(zeroRuns.id, chatEvents.runId))
-    .where(
-      and(
-        eq(chatEvents.chatThreadId, args.threadId),
-        chatEventTypeIn(["input.prompt"]),
-        isNotNull(chatEvents.runId),
-        eq(zeroRuns.triggerSource, "slack"),
-      ),
-    )
-    .orderBy(asc(chatEvents.seqId))
-    .limit(1);
-  const modelPin: ModelFirstPin = firstRun
-    ? {
-        modelProviderId: firstRun.modelProviderId,
-        modelProviderType: firstRun.modelProviderType,
-        modelProviderCredentialScope: persistedModelProviderCredentialScope(
-          firstRun.modelProviderCredentialScope,
-        ),
-        selectedModel: firstRun.selectedModel,
-      }
-    : {
-        modelProviderId: null,
-        modelProviderType: null,
-        modelProviderCredentialScope: null,
-        selectedModel: null,
-      };
-  const providerAdmission = await resolveModelFirstProviderAdmission({
-    db: args.db,
-    orgId: args.orgId,
-    userId: args.userId,
-    modelPin,
-    requestedModelProvider: undefined,
-  });
-  if (providerAdmission.error) {
-    return { error: providerAdmission.error.body.error };
-  }
-  return {
-    route: {
-      modelPin,
-      effectiveModelProvider: providerAdmission.effectiveModelProvider,
-      cliAgentType: providerAdmission.cliAgentType,
-      codexServiceTier: undefined,
-    },
-  };
-}
-
 async function resolveQueuedMessageModelRoute(args: {
   readonly db: Db;
   readonly threadId: string;
@@ -2638,13 +2555,6 @@ async function resolveQueuedMessageModelRoute(args: {
     },
   );
   if ("status" in modelContext) {
-    if (args.contextType === "slack") {
-      const unpinnedRoute =
-        await resolveUnpinnedSlackQueuedMessageModelRoute(args);
-      if (unpinnedRoute) {
-        return unpinnedRoute;
-      }
-    }
     return { error: modelContext.body.error };
   }
   if (modelContext.providerAdmission.error) {

--- a/turbo/apps/api/src/signals/services/zero-chat-run-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-run-event.service.ts
@@ -1,8 +1,5 @@
-import { chatEvents } from "@okouai/db/schema/chat-event";
-import { zeroRuns } from "@okouai/db/schema/zero-run";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { and, asc, eq, isNotNull } from "drizzle-orm";
 
 import { badRequestMessage } from "../../lib/error";
 import type { Db } from "../external/db";
@@ -11,38 +8,16 @@ import {
   publishUserSignal,
 } from "../external/realtime";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
-import { chatEventTypeIn } from "./zero-chat-event-type.service";
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 import {
   resolvePersistedChatThreadModel,
   type ResolvedPersistedChatThreadModel,
 } from "./zero-chat-thread-model.service";
 
-async function getFirstRunSelectedModel(
-  db: Db,
-  threadId: string,
-): Promise<string | null> {
-  const [run] = await db
-    .select({ selectedModel: zeroRuns.selectedModel })
-    .from(chatEvents)
-    .innerJoin(zeroRuns, eq(zeroRuns.id, chatEvents.runId))
-    .where(
-      and(
-        eq(chatEvents.chatThreadId, threadId),
-        chatEventTypeIn(["input.prompt"]),
-        isNotNull(chatEvents.runId),
-        isNotNull(zeroRuns.selectedModel),
-      ),
-    )
-    .orderBy(asc(chatEvents.seqId))
-    .limit(1);
-  return run?.selectedModel ?? null;
-}
-
 /**
- * Resolve a chat-derived run against the current workspace model policy.
- * Legacy threads without a stored model may use their first run as the sticky
- * preference before normal workspace-default recovery applies.
+ * Resolve a chat-derived run against the current canonical model policy.
+ * Legacy threads without a stored model use the current canonical default and
+ * persist that selection before the run is created.
  */
 export async function resolveRunChatThreadModelContext(params: {
   readonly db: Db;
@@ -52,16 +27,16 @@ export async function resolveRunChatThreadModelContext(params: {
 }): Promise<
   ResolvedPersistedChatThreadModel | ReturnType<typeof badRequestMessage>
 > {
-  const [fallbackSelectedModel, featureSwitchContext] = await Promise.all([
-    getFirstRunSelectedModel(params.db, params.threadId),
-    loadUserFeatureSwitchContext(params.db, params.orgId, params.userId),
-  ]);
+  const featureSwitchContext = await loadUserFeatureSwitchContext(
+    params.db,
+    params.orgId,
+    params.userId,
+  );
   const resolved = await resolvePersistedChatThreadModel({
     db: params.db,
     orgId: params.orgId,
     userId: params.userId,
     threadId: params.threadId,
-    fallbackSelectedModel,
     persistRequestedCodexServiceTier: false,
     codexFastModeEnabled: isFeatureEnabled(
       FeatureSwitchKey.CodexFastMode,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread-model.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread-model.service.ts
@@ -48,7 +48,6 @@ interface ResolvePersistedChatThreadModelParams {
   readonly userId: string;
   readonly threadId: string;
   readonly threadSnapshot?: PersistedChatThreadModelSnapshot;
-  readonly fallbackSelectedModel?: string | null;
   readonly requestedCodexServiceTier?: CodexServiceTier;
   readonly persistRequestedCodexServiceTier: boolean;
   readonly codexFastModeEnabled: boolean;
@@ -287,28 +286,55 @@ async function evaluatePersistedChatThreadModel(
   params: ResolvePersistedChatThreadModelParams,
   thread: PersistedChatThreadModelSnapshot,
 ): Promise<PersistedChatThreadModelEvaluationResult> {
-  const modelResolution = await resolvePersistedModelFirstRoute({
-    db,
-    orgId: params.orgId,
-    userId: params.userId,
-    selectedModel: thread.selectedModel ?? params.fallbackSelectedModel ?? null,
-  });
-  if (!modelResolution.route) {
-    return {
-      kind: "error",
-      error: badRequestMessage(
-        "No valid model route is configured for this workspace",
-      ),
+  let pin: ModelFirstPin;
+  let selectedModelChanged: boolean;
+  if (thread.selectedModel === null) {
+    const defaultPin = await resolveDefaultModelFirstPin(
+      db,
+      params.orgId,
+      params.userId,
+    );
+    if (!defaultPin.selectedModel) {
+      return {
+        kind: "error",
+        error: badRequestMessage(
+          "No valid model route is configured for this workspace",
+        ),
+      };
+    }
+    pin = {
+      modelProviderId: defaultPin.modelProviderId,
+      modelProviderType: defaultPin.modelProviderType,
+      modelProviderCredentialScope: defaultPin.modelProviderCredentialScope,
+      selectedModel: defaultPin.selectedModel,
     };
+    selectedModelChanged = true;
+  } else {
+    const modelResolution = await resolvePersistedModelFirstRoute({
+      db,
+      orgId: params.orgId,
+      userId: params.userId,
+      selectedModel: thread.selectedModel,
+    });
+    if (!modelResolution.route) {
+      return {
+        kind: "error",
+        error: badRequestMessage(
+          "No valid model route is configured for this workspace",
+        ),
+      };
+    }
+    pin = {
+      modelProviderId: modelResolution.route.modelProviderId,
+      modelProviderType: modelResolution.route.modelProviderType,
+      modelProviderCredentialScope:
+        modelResolution.route.modelProviderCredentialScope,
+      selectedModel: modelResolution.route.selectedModel,
+    };
+    selectedModelChanged =
+      modelResolution.selectedModelChanged ||
+      thread.selectedModel !== pin.selectedModel;
   }
-
-  const pin: ModelFirstPin = {
-    modelProviderId: modelResolution.route.modelProviderId,
-    modelProviderType: modelResolution.route.modelProviderType,
-    modelProviderCredentialScope:
-      modelResolution.route.modelProviderCredentialScope,
-    selectedModel: modelResolution.route.selectedModel,
-  };
   const providerAdmission = await resolveModelFirstProviderAdmission({
     db,
     orgId: params.orgId,
@@ -316,9 +342,6 @@ async function evaluatePersistedChatThreadModel(
     modelPin: pin,
     requestedModelProvider: undefined,
   });
-  const selectedModelChanged =
-    modelResolution.selectedModelChanged ||
-    thread.selectedModel !== pin.selectedModel;
   const tier = resolveCodexTier({
     persistedTier: thread.codexServiceTier,
     requestedTier: params.requestedCodexServiceTier,


### PR DESCRIPTION
## Summary

- remove the first-run `chat_events` model recovery used by NULL-selected-model threads
- resolve NULL thread selections through the canonical user/workspace default-model path and persist the resolved model
- remove the Slack-specific event-history provider/credential/model fallback while preserving normal routing for already-selected threads
- add focused Web queue and Slack ingress regressions with historical first-run events still present

## Verification

- `pnpm format`
- `pnpm --filter api lint`
- `pnpm --filter api check-types`
- `pnpm knip`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts src/signals/routes/__tests__/integrations.bdd.test.ts -t "resolves a NULL"`
- focused existing model reconciliation, Slack model pinning, and Slack callback resilience tests

## Retained compatibility

- leaves the existing snapshot v4-to-v5 full-rebuild migration path untouched (`ARCHIVE_SCHEMA_VERSION = 5`, minimum supported version 4); no retention, snapshot, or search-projection cleanup is included
