### PR TITLE
refactor(logs): neutralize the logs api modules

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -98,7 +98,7 @@ import { zeroHostRoutes } from "./routes/zero-host";
 import { zeroBuiltInGenerationRoutes } from "./routes/zero-built-in-generation";
 import { zeroImageIoGenerateRoutes } from "./routes/zero-image-io-generate";
 import { imageShareXRoutes } from "./routes/image-share-x";
-import { zeroLogsRoutes } from "./routes/zero-logs";
+import { logsRoutes } from "./routes/logs";
 import { zeroMailRoutes } from "./routes/zero-mail";
 import { mapsRoutes } from "./routes/maps";
 import { zeroMcpConnectorsRoutes } from "./routes/zero-mcp-connectors";
@@ -291,7 +291,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...imageShareXRoutes,
   ...zeroAvatarVideoRoutes,
   ...zeroVideoIoGenerateRoutes,
-  ...zeroLogsRoutes,
+  ...logsRoutes,
   ...zeroMailRoutes,
   ...mapsRoutes,
   ...zeroMcpConnectorsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
@@ -29,7 +29,7 @@ import { createZeroRouteMocks } from "./zero-route-test";
 import { zeroIntegrationsPhoneUploadCompleteRoutes } from "../../zero-integrations-phone-upload-complete";
 import { zeroIntegrationsPhoneUploadInitRoutes } from "../../zero-integrations-phone-upload-init";
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "../../zero-integrations-phone-download-file";
-import { zeroLogsRoutes } from "../../zero-logs";
+import { logsRoutes } from "../../logs";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
 
@@ -37,7 +37,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...zeroIntegrationsPhoneDownloadFileRoutes,
   ...zeroIntegrationsPhoneUploadCompleteRoutes,
   ...zeroIntegrationsPhoneUploadInitRoutes,
-  ...zeroLogsRoutes,
+  ...logsRoutes,
   ...zeroModelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
 ]);
@@ -333,11 +333,11 @@ export function createAgentPhoneBddApi(context: TestContext) {
 
     /**
      * Read a run's agent session id through the public activity-detail API
-     * (GET /api/zero/logs/:id) — the only session projection visible without
+     * (GET /api/okou/logs/:id) — the only session projection visible without
      * checkpoints.
      */
     async readRunSessionId(actor: ApiTestUser, runId: string): Promise<string> {
-      const client = setupApp({ context, routes: zeroLogsRoutes })(
+      const client = setupApp({ context, routes: logsRoutes })(
         logsByIdContract,
       );
       const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -36,7 +36,7 @@ import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 import { emailUnsubscribeRoutes } from "../../email-unsubscribe";
 import { userExportRoutes } from "../../user-export";
-import { zeroLogsRoutes } from "../../zero-logs";
+import { logsRoutes } from "../../logs";
 import { zeroMeModelProvidersDeleteRoutes } from "../../zero-me-model-providers-delete";
 import { zeroMeModelProvidersListRoutes } from "../../zero-me-model-providers-list";
 import { zeroMeModelProvidersResetSubscriptionRoutes } from "../../zero-me-model-providers-reset-subscription";
@@ -66,7 +66,7 @@ type UpdateUserPreferencesInput = z.input<
   typeof updateUserPreferencesRequestSchema
 >;
 
-type ZeroLogsListQuery = z.input<(typeof logsListContract.list)["query"]>;
+type LogsListQuery = z.input<(typeof logsListContract.list)["query"]>;
 
 interface ClerkOrg {
   readonly imageUrl: string | null;
@@ -140,14 +140,14 @@ function asyncIterableOf(buffer: Buffer): AsyncIterable<Uint8Array> {
   };
 }
 
-async function requestZeroLogsList<TStatus extends 200 | 400 | 401 | 403>(
+async function requestLogsList<TStatus extends 200 | 400 | 401 | 403>(
   context: TestContext,
   actor: ApiTestUser | null,
-  query: ZeroLogsListQuery,
+  query: LogsListQuery,
   statuses: readonly TStatus[],
 ) {
   return await accept(
-    setupApp({ context, routes: zeroLogsRoutes })(logsListContract).list({
+    setupApp({ context, routes: logsRoutes })(logsListContract).list({
       headers: authenticate(context, actor),
       query,
     }),
@@ -595,15 +595,15 @@ export function createMiscRoutesApi(context: TestContext) {
     },
 
     async listLogs(actor: ApiTestUser) {
-      return await requestZeroLogsList(context, actor, {}, [200]);
+      return await requestLogsList(context, actor, {}, [200]);
     },
 
     async requestListLogs<TStatus extends 200 | 400 | 401 | 403>(
       actor: ApiTestUser | null,
-      query: ZeroLogsListQuery,
+      query: LogsListQuery,
       statuses: readonly TStatus[],
     ) {
-      return await requestZeroLogsList(context, actor, query, statuses);
+      return await requestLogsList(context, actor, query, statuses);
     },
 
     async readLog(
@@ -612,12 +612,10 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroLogsRoutes })(logsByIdContract).getById(
-          {
-            headers: authenticate(context, actor),
-            params: { id },
-          },
-        ),
+        setupApp({ context, routes: logsRoutes })(logsByIdContract).getById({
+          headers: authenticate(context, actor),
+          params: { id },
+        }),
         statuses,
       );
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-reads.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-reads.ts
@@ -16,12 +16,12 @@ import {
 } from "../../../../test-fixtures/agent-runs";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
-import { zeroLogsRoutes } from "../../zero-logs";
+import { logsRoutes } from "../../logs";
 import { zeroQueuePositionRoutes } from "../../zero-queue-position";
 import { zeroRunDetailRoutes } from "../../zero-run-detail";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...zeroLogsRoutes,
+  ...logsRoutes,
   ...zeroQueuePositionRoutes,
   ...zeroRunDetailRoutes,
 ]);
@@ -188,7 +188,7 @@ export function createRunReadsApi(context: TestContext) {
       statuses: readonly TStatus[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroLogsRoutes })(logsListContract).list({
+        setupApp({ context, routes: logsRoutes })(logsListContract).list({
           headers: authenticate(context, actor),
           query,
         }),
@@ -201,7 +201,7 @@ export function createRunReadsApi(context: TestContext) {
       actor: ApiTestUser | null,
     ) {
       return await accept(
-        setupApp({ context, routes: zeroLogsRoutes })(logsListContract).list({
+        setupApp({ context, routes: logsRoutes })(logsListContract).list({
           headers: authenticate(context, actor),
           query: { triggerSource: "automation" } as unknown as LogsListQuery,
         }),
@@ -216,7 +216,7 @@ export function createRunReadsApi(context: TestContext) {
       statuses: readonly TStatus[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroLogsRoutes })(logsListContract).list({
+        setupApp({ context, routes: logsRoutes })(logsListContract).list({
           headers: { authorization },
           query,
         }),
@@ -230,12 +230,10 @@ export function createRunReadsApi(context: TestContext) {
       statuses: readonly TStatus[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroLogsRoutes })(logsByIdContract).getById(
-          {
-            headers: authenticate(context, actor),
-            params: { id: runId },
-          },
-        ),
+        setupApp({ context, routes: logsRoutes })(logsByIdContract).getById({
+          headers: authenticate(context, actor),
+          params: { id: runId },
+        }),
         statuses,
       );
     },
@@ -247,12 +245,10 @@ export function createRunReadsApi(context: TestContext) {
       statuses: readonly TStatus[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroLogsRoutes })(logsByIdContract).getById(
-          {
-            headers: { authorization },
-            params: { id: runId },
-          },
-        ),
+        setupApp({ context, routes: logsRoutes })(logsByIdContract).getById({
+          headers: { authorization },
+          params: { id: runId },
+        }),
         statuses,
       );
     },

--- a/turbo/apps/api/src/signals/routes/logs.ts
+++ b/turbo/apps/api/src/signals/routes/logs.ts
@@ -8,7 +8,7 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf, queryOf } from "../context/request";
 import { notFound } from "../../lib/error";
-import { zeroLogDetail, zeroLogsList } from "../services/zero-logs.service";
+import { logDetail, logsList } from "../services/logs.service";
 import type { RouteEntry } from "../route-entry";
 
 const runReadAuth = {
@@ -23,7 +23,7 @@ const getLogsListInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const query = get(queryOf(logsListContract.list));
   const result = await get(
-    zeroLogsList({
+    logsList({
       userId: auth.userId,
       orgId: auth.orgId,
       cursor: query.cursor,
@@ -43,7 +43,7 @@ const getLogByIdInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(logsByIdContract.getById));
   const detail = await get(
-    zeroLogDetail({
+    logDetail({
       runId: params.id,
       userId: auth.userId,
       orgId: auth.orgId,
@@ -55,7 +55,7 @@ const getLogByIdInner$ = computed(async (get) => {
   return { status: 200 as const, body: detail };
 });
 
-export const zeroLogsRoutes: readonly RouteEntry[] = [
+export const logsRoutes: readonly RouteEntry[] = [
   {
     route: logsListContract.list,
     handler: authRoute(runReadAuth, getLogsListInner$),

--- a/turbo/apps/api/src/signals/services/logs.service.ts
+++ b/turbo/apps/api/src/signals/services/logs.service.ts
@@ -134,7 +134,7 @@ interface LogsListData {
   filters: LogsFilters;
 }
 
-export function zeroLogsList(
+export function logsList(
   params: LogsListParams,
 ): Computed<Promise<LogsListData>> {
   return computed(async (get): Promise<LogsListData> => {
@@ -363,7 +363,7 @@ function extractArtifact(runResult: RunResult | null): {
   return { name, version };
 }
 
-export function zeroLogDetail(
+export function logDetail(
   params: LogDetailParams,
 ): Computed<Promise<LogDetail | null>> {
   return computed(async (get): Promise<LogDetail | null> => {

--- a/turbo/packages/api-contracts/src/contracts/logs.ts
+++ b/turbo/packages/api-contracts/src/contracts/logs.ts
@@ -82,7 +82,7 @@ const logEntrySchema = z.object({
 
 /**
  * Available filter values returned by the list endpoint.
- * agents contains canonical Zero agent IDs.
+ * agents contains canonical agent IDs.
  */
 const logsFiltersSchema = z.object({
   statuses: z.array(logStatusSchema),


### PR DESCRIPTION
## Summary

- rename the internal Logs route and service modules from `zero-logs` to `logs`
- rename the approved internal route, service, query, and request-helper symbols and update their direct callers
- correct the stale Logs contract and AgentPhone helper comments

## Compatibility

- public endpoints remain `GET /api/okou/logs` and `GET /api/okou/logs/:id`
- protocol contracts, schemas, `agent-run:read` authorization, token semantics (including run-scoped Zero tokens), DB facade names (`zeroAgents` and `zeroRuns`), and serialized values are unchanged
- persistence, filtering, ordering, pagination, status/source/artifact handling, not-found behavior, and all other runtime behavior are unchanged

## Verification

- Prettier on all changed files
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- package and API boundary-aware TypeScript checks
- `pnpm exec vitest run src/signals/routes/__tests__/misc-routes.bdd.test.ts src/signals/routes/__tests__/run-reads.bdd.test.ts src/signals/routes/__tests__/agentphone.bdd.test.ts` (45 tests)

Closes #26981

Parent: #26873
