### PR TITLE
fix(api): drain orphaned workflow automation events

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -1543,12 +1543,22 @@ describe("workflow queue", () => {
       runId: null,
       chatThreadId: webhookAutomation.threadId,
     });
-    await expect(
-      pendingWorkflowAutomationIds(webhookAutomation.threadId),
-    ).resolves.toStrictEqual([
-      webhookAutomation.automationId,
-      scheduleAutomation.automationId,
-    ]);
+    const pendingAfterManual = await pendingAutomationEvents(
+      webhookAutomation.threadId,
+    );
+    expect(pendingAfterManual).toHaveLength(2);
+    expect(pendingAfterManual[0]?.id).toBe(orphanedEvent.id);
+    const scheduleEvent = pendingAfterManual[1];
+    if (!scheduleEvent) {
+      throw new Error("Expected the manual schedule event to remain queued");
+    }
+    const schedulePrompt = chatEventDisplayText(scheduleEvent);
+    if (schedulePrompt === null) {
+      throw new Error("Expected the manual schedule event display prompt");
+    }
+    expect(schedulePrompt).toMatch(
+      /^\/workflow-queue-workflow\nTrigger: manual run requested at .+\.$/,
+    );
 
     await accept(
       automationsClient().delete({
@@ -1582,9 +1592,20 @@ describe("workflow queue", () => {
     if (!scheduleRunId) {
       throw new Error("Expected the next automation event to create a run");
     }
+    const claimedScheduleEvent = events.find((event) => {
+      return (
+        event.eventType === "input.prompt" &&
+        event.revokesEventId === scheduleEvent.id
+      );
+    });
+    if (claimedScheduleEvent?.eventType !== "input.prompt") {
+      throw new Error("Expected the queued schedule event to be claimed");
+    }
+    expect(claimedScheduleEvent.runId).toBe(scheduleRunId);
+    expect(chatEventDisplayText(claimedScheduleEvent)).toBe(schedulePrompt);
     await expect(
-      readWorkflowRunTriggerSourceFixture(scheduleRunId),
-    ).resolves.toBe("automation-schedule");
+      runsApi.readRun(scenario.actor, scheduleRunId),
+    ).resolves.toMatchObject({ prompt: schedulePrompt });
     await runsApi.requestCancelRun(scenario.actor, scheduleRunId, [200]);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue.test.ts
@@ -1513,6 +1513,81 @@ describe("workflow queue", () => {
     await runsApi.requestCancelRun(scenario.actor, runId, [200]);
   });
 
+  it("rejects a deleted automation's queued event and drains the next automation", async () => {
+    const scenario = await setup();
+    const webhookAutomation = await createWebhookAutomation(scenario);
+    const runningRunId = await expectAcceptedRunId(
+      await postWorkflowWebhook(webhookAutomation, "running before deletion"),
+      webhookAutomation.threadId,
+    );
+    expectAcceptedWithoutRun(
+      await postWorkflowWebhook(webhookAutomation, "orphaned after deletion"),
+    );
+    const orphanedEvent = (
+      await pendingAutomationEvents(webhookAutomation.threadId)
+    )[0];
+    if (!orphanedEvent) {
+      throw new Error("Expected the webhook event to remain queued");
+    }
+
+    const scheduleAutomation = await createScheduleAutomation(scenario);
+    expect(scheduleAutomation.threadId).toBe(webhookAutomation.threadId);
+    const manual = await accept(
+      automationsClient().run({
+        headers: authHeaders(),
+        params: { id: scheduleAutomation.automationId },
+      }),
+      [201],
+    );
+    expect(manual.body).toStrictEqual({
+      runId: null,
+      chatThreadId: webhookAutomation.threadId,
+    });
+    await expect(
+      pendingWorkflowAutomationIds(webhookAutomation.threadId),
+    ).resolves.toStrictEqual([
+      webhookAutomation.automationId,
+      scheduleAutomation.automationId,
+    ]);
+
+    await accept(
+      automationsClient().delete({
+        headers: authHeaders(),
+        params: { id: webhookAutomation.automationId },
+      }),
+      [204],
+    );
+
+    await completeRunThroughSandbox(scenario, runningRunId);
+
+    const events = await readProjectedChatEvents(context, {
+      threadId: webhookAutomation.threadId,
+      headers: authHeaders(),
+    });
+    const rejectedEvent = events.find((event) => {
+      return (
+        event.eventType === "input.rejected" &&
+        event.revokesEventId === orphanedEvent.id
+      );
+    });
+    if (rejectedEvent?.eventType !== "input.rejected") {
+      throw new Error("Expected the orphaned automation event to be rejected");
+    }
+    expect(rejectedEvent.error).toBe("Workflow automation no longer exists");
+    expect(rejectedEvent.userMessage).toStrictEqual(orphanedEvent.userMessage);
+
+    const runIds = await workflowRunIds(webhookAutomation.threadId);
+    expect(runIds).toHaveLength(2);
+    const scheduleRunId = runIds[1];
+    if (!scheduleRunId) {
+      throw new Error("Expected the next automation event to create a run");
+    }
+    await expect(
+      readWorkflowRunTriggerSourceFixture(scheduleRunId),
+    ).resolves.toBe("automation-schedule");
+    await runsApi.requestCancelRun(scenario.actor, scheduleRunId, [200]);
+  });
+
   it("rejects only the failed webhook trigger and accepts the next event", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);

--- a/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-chat-event-queue.service.ts
@@ -185,9 +185,9 @@ export async function admitWorkflowAutomationEvent(
 export interface PendingWorkflowQueueEvent {
   readonly id: string;
   readonly userId: string;
-  readonly automationId: string;
+  readonly automationId: string | null;
   readonly chatThreadId: string;
-  readonly triggerSource: TriggerSource;
+  readonly triggerSource: TriggerSource | null;
   readonly triggerBrief: string | null;
   readonly workflowName: string | null;
   readonly workflowAutomationEventType: string | null;
@@ -195,8 +195,10 @@ export interface PendingWorkflowQueueEvent {
 }
 
 /**
- * Load the runnable automation head. Pending user events always win and any
- * active run blocks the whole thread.
+ * Load the automation queue head. Pending user events always win and any
+ * active run blocks the whole thread. Missing automation context is returned
+ * with null launch fields so the drain can reject the persisted input and
+ * continue instead of leaving the thread stuck.
  *
  * A concurrently deleted thread can remove the selected event before this
  * lookup; that canonical deletion race returns null rather than failing.
@@ -254,15 +256,12 @@ export async function loadNextWorkflowQueueEvent(
     if (!event) {
       return null;
     }
-    if (!event.automationId || !event.automationKind) {
-      throw new Error(
-        `Workflow queue event ${event.id} is missing its typed payload`,
-      );
-    }
     return {
       ...event,
-      automationId: event.automationId,
-      triggerSource: manualTriggerSource({ kind: event.automationKind }),
+      triggerSource:
+        event.automationKind === null
+          ? null
+          : manualTriggerSource({ kind: event.automationKind }),
     };
   });
 }
@@ -274,7 +273,6 @@ async function loadAutomationRejectionPayload(
   const [event] = await db
     .select({
       automationId: chatAutomationContext.automationId,
-      automationKind: workflowAutomations.kind,
       triggerBrief: chatAutomationContext.triggerBrief,
       userMessage: canonicalChatEventUserMessage(),
       workflowId: workflows.id,
@@ -329,7 +327,7 @@ export async function rejectWorkflowQueueEvent(
       return false;
     }
     const payload = await loadAutomationRejectionPayload(tx, args.eventId);
-    if (!payload?.automationId || !payload.automationKind) {
+    if (!payload) {
       return false;
     }
     const userMessage =
@@ -358,7 +356,9 @@ export async function rejectWorkflowQueueEvent(
       userMessage,
       runId: null,
       error: args.reason,
-      automationId: payload.automationId,
+      ...(payload.automationId === null
+        ? {}
+        : { automationId: payload.automationId }),
       triggerBrief: payload.triggerBrief,
     });
     return rejected !== null;

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -36,7 +36,7 @@ interface DequeueTarget {
 
 async function loadDequeueTarget(
   db: Db,
-  event: PendingWorkflowQueueEvent,
+  automationId: string,
 ): Promise<DequeueTarget | null> {
   const [row] = await db
     .select({
@@ -45,7 +45,7 @@ async function loadDequeueTarget(
     })
     .from(workflowAutomations)
     .innerJoin(workflows, eq(workflows.id, workflowAutomations.workflowId))
-    .where(eq(workflowAutomations.id, event.automationId))
+    .where(eq(workflowAutomations.id, automationId))
     .limit(1);
   return row ?? null;
 }
@@ -159,6 +159,29 @@ async function consumeInvalidAutomationEvent(
   };
 }
 
+function consumeUnavailableAutomationEvent(
+  db: Db,
+  event: PendingWorkflowQueueEvent,
+  launchHint: AutomationEventLaunch | undefined,
+  signal: AbortSignal,
+): Promise<WorkflowQueueDrainStep> {
+  const conflictMessage =
+    event.automationId === null
+      ? "Workflow queue event payload is unreadable"
+      : "Workflow automation no longer exists";
+  log.debug("Consuming workflow queue event without automation", {
+    eventId: event.id,
+    automationId: event.automationId,
+  });
+  return consumeInvalidAutomationEvent(
+    db,
+    event,
+    conflictMessage,
+    launchHint,
+    signal,
+  );
+}
+
 async function handleWorkflowLaunchResult(
   args: {
     readonly db: Db;
@@ -236,17 +259,25 @@ export const drainWorkflowQueueForThread$ = command(
         return null;
       }
 
-      const target = await loadDequeueTarget(db, event);
-      signal.throwIfAborted();
-      if (!target) {
-        log.debug("Consuming workflow queue event without automation", {
-          eventId: event.id,
-          automationId: event.automationId,
-        });
-        const step = await consumeInvalidAutomationEvent(
+      if (!event.automationId || !event.triggerSource) {
+        const step = await consumeUnavailableAutomationEvent(
           db,
           event,
-          "Workflow automation no longer exists",
+          args.automationEventLaunch,
+          signal,
+        );
+        if (step !== CONTINUE_DRAIN) {
+          return step;
+        }
+        continue;
+      }
+
+      const target = await loadDequeueTarget(db, event.automationId);
+      signal.throwIfAborted();
+      if (!target) {
+        const step = await consumeUnavailableAutomationEvent(
+          db,
+          event,
           args.automationEventLaunch,
           signal,
         );


### PR DESCRIPTION
## Summary

- let the workflow queue loader return persisted automation inputs whose live automation or typed context is missing
- replace those unfireable inputs with immutable `input.rejected` events while preserving the canonical user message
- continue the same drain pass so a later valid automation event can start immediately

## Root cause

`loadNextWorkflowQueueEvent` required both the persisted automation context and a live `zero_workflow_automations` row. Deleting an automation while one of its events was queued made the loader throw before the existing invalid-event consumption path could run, leaving the thread head permanently pending.

## Test plan

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- bounded non-API, app, and API type checks
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts -t "rejects a deleted automation's queued event and drains the next automation"`
