### PR TITLE
refactor(artifacts): rename artifact catalog route shell

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -59,7 +59,7 @@ import { webhooksStripeAutomationEventsRoutes } from "./routes/webhooks-stripe-a
 import { agentDraftRoutes } from "./routes/agent-draft";
 import { zeroAgentInstructionsRoutes } from "./routes/zero-agent-instructions";
 import { zeroAgentsRoutes } from "./routes/zero-agents";
-import { zeroArtifactCatalogRoutes } from "./routes/zero-artifact-catalog";
+import { artifactCatalogRoutes } from "./routes/artifact-catalog";
 import { zeroAttributionRoutes } from "./routes/zero-attribution";
 import { zeroBillingAutoRechargeRoutes } from "./routes/zero-billing-auto-recharge";
 import { zeroBillingCheckoutRoutes } from "./routes/zero-billing-checkout";
@@ -250,7 +250,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...agentDraftRoutes,
   ...zeroAgentInstructionsRoutes,
   ...zeroAgentsRoutes,
-  ...zeroArtifactCatalogRoutes,
+  ...artifactCatalogRoutes,
   ...zeroAttributionRoutes,
   ...zeroBillingAutoRechargeRoutes,
   ...zeroBillingCheckoutRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
@@ -9,7 +9,7 @@ import { testContext } from "../../../__tests__/test-context";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import type { RouteEntry } from "../../route-entry";
-import { zeroArtifactCatalogRoutes } from "../zero-artifact-catalog";
+import { artifactCatalogRoutes } from "../artifact-catalog";
 import { zeroSharedThreadRoutes } from "../zero-shared-threads";
 import {
   createBddApi,
@@ -38,7 +38,7 @@ const host = createHostMapsBddApi(context);
 const webhooks = createWebhookCallbackApi(context);
 const routeMocks = createZeroRouteMocks(context);
 const sharedThreadTestRoutes: readonly RouteEntry[] = [
-  ...zeroArtifactCatalogRoutes,
+  ...artifactCatalogRoutes,
   ...zeroSharedThreadRoutes,
 ];
 type RunnerClaim = Awaited<ReturnType<typeof api.claimRunnerJob>>;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -63,7 +63,7 @@ import {
 } from "../../../../lib/file-url";
 import { createAgentComposeFixture } from "../../../../test-fixtures/agent-composes";
 import { zeroChatEventsRoutes } from "../../zero-chat-events";
-import { zeroArtifactCatalogRoutes } from "../../zero-artifact-catalog";
+import { artifactCatalogRoutes } from "../../artifact-catalog";
 import { zeroChatThreadComputerUseHostRoutes } from "../../zero-chat-threads-computer-use-host";
 import { zeroChatThreadCreateRoutes } from "../../zero-chat-threads-create";
 import { zeroChatThreadDeleteRoutes } from "../../zero-chat-threads-delete";
@@ -175,7 +175,7 @@ function mockObjectStorageObjectsExist(context: TestContext): void {
 }
 
 const chatFilesRoutes = [
-  ...zeroArtifactCatalogRoutes,
+  ...artifactCatalogRoutes,
   ...zeroChatThreadRoutes,
   ...zeroChatThreadCreateRoutes,
   ...zeroChatThreadDeleteRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts
@@ -22,7 +22,7 @@ import {
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
 import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generations";
-import { zeroArtifactCatalogRoutes } from "../zero-artifact-catalog";
+import { artifactCatalogRoutes } from "../artifact-catalog";
 import { zeroAvatarVideoRoutes } from "../zero-avatar-video";
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
 import { zeroBuiltInGenerationRoutes } from "../zero-built-in-generation";
@@ -68,7 +68,7 @@ function createAvatarVideoTestApp(
     signal: context.signal,
     routes: [
       ...zeroAvatarVideoRoutes,
-      ...zeroArtifactCatalogRoutes,
+      ...artifactCatalogRoutes,
       ...zeroBuiltInGenerationRoutes,
       ...webhooksBuiltInGenerationRoutes,
       ...zeroBillingStatusRoutes,

--- a/turbo/apps/api/src/signals/routes/artifact-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/artifact-catalog.ts
@@ -61,7 +61,7 @@ const getArtifactCatalogEntryInner$ = command(
   },
 );
 
-export const zeroArtifactCatalogRoutes: readonly RouteEntry[] = [
+export const artifactCatalogRoutes: readonly RouteEntry[] = [
   {
     route: artifactCatalogContract.list,
     handler: authRoute(


### PR DESCRIPTION
## summary

- rename `turbo/apps/api/src/signals/routes/zero-artifact-catalog.ts` to `turbo/apps/api/src/signals/routes/artifact-catalog.ts`
- rename the exported route registry from `zeroArtifactCatalogRoutes` to `artifactCatalogRoutes` and update every production and test registration
- retain the upstream `logsRoutes` import and registration from #26996 while keeping #26947 independent

## compatibility

- protocol is unchanged: the public endpoints remain `GET /api/okou/artifacts/catalog` and `GET /api/okou/artifacts/catalog/:artifactId`, with the same request and response contracts
- persistence is unchanged: database facade names and persisted identities including `zeroRuns`, `zero-official-image`, `zero-official-video`, and `zero-joggai-avatar-video` remain intact
- authorization is unchanged: organization authentication, `chat-event:read` capability enforcement, and existing 401/403/404 behavior are preserved
- behavior is unchanged: schemas, filtering, cursor pagination, ordering, projections, ownership, and not-found semantics are untouched
- `artifact-catalog.ts` remains wired to the existing neutral contract and `artifact-catalog.service.ts`; neither module was changed

## verification

- `pnpm exec prettier --write apps/api/src/signals/route.ts apps/api/src/signals/routes/artifact-catalog.ts apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts apps/api/src/signals/routes/__tests__/zero-avatar-video.test.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/artifact-catalog.bdd.test.ts` (18 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-files.bdd.test.ts` (10 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-avatar-video.test.ts` (6 passed)
- confirmed no active `routes/zero-artifact-catalog` import or `zeroArtifactCatalogRoutes` reference remains

Closes #26997
Parent EPIC: #26873
