### PR TITLE
fix(ci): use direct neon urls for migrations

### DIFF
--- a/.github/actions/neon-branch/action.yml
+++ b/.github/actions/neon-branch/action.yml
@@ -30,7 +30,7 @@ inputs:
 
 outputs:
   database-url:
-    description: "Database connection URL for the branch"
+    description: "Pooled database connection URL for branch runtime traffic"
     value: ${{ steps.branch.outputs.database-url }}
   console-url:
     description: "Neon console URL for the branch"
@@ -97,14 +97,28 @@ runs:
           exit 1
         fi
 
-        DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME" --pooled)
-        if [ -z "$DATABASE_URL" ]; then
-          echo "Error: Failed to get database URL from neonctl"
-          echo "Attempting without --pooled flag..."
-          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME")
+        if ! RUNTIME_DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME" --pooled); then
+          echo "::error::Failed to resolve pooled branch database URL"
+          exit 1
         fi
-        echo "DATABASE_URL value: $DATABASE_URL"
-        echo "database-url=$DATABASE_URL" >> $GITHUB_OUTPUT
+        if [ -z "$RUNTIME_DATABASE_URL" ]; then
+          echo "::error::Pooled branch database URL is empty"
+          exit 1
+        fi
+
+        if ! MIGRATION_DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME"); then
+          echo "::error::Failed to resolve direct branch migration database URL"
+          exit 1
+        fi
+        if [ -z "$MIGRATION_DATABASE_URL" ]; then
+          echo "::error::Direct branch migration database URL is empty"
+          exit 1
+        fi
+
+        echo "::add-mask::$RUNTIME_DATABASE_URL"
+        echo "::add-mask::$MIGRATION_DATABASE_URL"
+        echo "database-url=$RUNTIME_DATABASE_URL" >> "$GITHUB_OUTPUT"
+        echo "migration-database-url=$MIGRATION_DATABASE_URL" >> "$GITHUB_OUTPUT"
         echo "Neon branch ready: $BRANCH_NAME"
 
         # Get branch ID for console URL
@@ -117,16 +131,11 @@ runs:
       if: inputs.action == 'create'
       shell: bash
       env:
-        DATABASE_URL: ${{ steps.branch.outputs.database-url }}
+        DATABASE_URL: ${{ steps.branch.outputs.migration-database-url }}
       run: |
-        if [ -n "$DATABASE_URL" ]; then
-          echo "Running database migrations..."
-          echo "Migration output:"
-          cd turbo && pnpm -F @okouai/db db:migrate 2>&1
-          echo "Migration complete"
-        else
-          echo "No database URL provided, skipping migrations"
-        fi
+        echo "Running database migrations..."
+        cd turbo && pnpm -F @okouai/db db:migrate
+        echo "Migration complete"
 
     - name: Delete Neon Branch
       if: inputs.action == 'cleanup'

--- a/.github/actions/production-migration-smoke/action.yml
+++ b/.github/actions/production-migration-smoke/action.yml
@@ -58,15 +58,22 @@ runs:
           exit 1
         fi
 
-        DATABASE_URL=$(neonctl connection-string "$BRANCH_ID" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
-        echo "::add-mask::$DATABASE_URL"
-        echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
+        if ! MIGRATION_DATABASE_URL=$(neonctl connection-string "$BRANCH_ID" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner); then
+          echo "::error::Failed to resolve direct migration smoke database URL"
+          exit 1
+        fi
+        if [ -z "$MIGRATION_DATABASE_URL" ]; then
+          echo "::error::Direct migration smoke database URL is empty"
+          exit 1
+        fi
+        echo "::add-mask::$MIGRATION_DATABASE_URL"
+        echo "migration-database-url=$MIGRATION_DATABASE_URL" >> "$GITHUB_OUTPUT"
 
     - name: Run Production Migration Smoke Test
       shell: bash
       working-directory: turbo
       env:
-        DATABASE_URL: ${{ steps.create-migration-smoke-branch.outputs.database-url }}
+        DATABASE_URL: ${{ steps.create-migration-smoke-branch.outputs.migration-database-url }}
       run: pnpm -F @okouai/db db:migrate
 
     - name: Delete Production Migration Smoke Branch

--- a/.github/scripts/tests/neon-migration-routing-workflow-test.sh
+++ b/.github/scripts/tests/neon-migration-routing-workflow-test.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+ruby -ryaml - \
+  "${repo_root}/.github/workflows/release-please.yml" \
+  "${repo_root}/.github/actions/production-migration-smoke/action.yml" \
+  "${repo_root}/.github/actions/neon-branch/action.yml" \
+  "${repo_root}/.github/workflows/turbo.yml" <<'RUBY'
+def named_step(container, name)
+  Array(container.fetch("steps")).find { |step| step["name"] == name } ||
+    raise("missing step: #{name}")
+end
+
+def guarded_block(source, prefix)
+  lines = source.lines.map(&:strip)
+  start_index = lines.index { |line| line.start_with?(prefix) }
+  raise "missing fail-closed guard: #{prefix}" unless start_index
+
+  end_index = ((start_index + 1)...lines.length).find do |index|
+    lines.fetch(index) == "fi"
+  end
+  raise "unterminated fail-closed guard: #{prefix}" unless end_index
+
+  lines[start_index..end_index]
+end
+
+def assert_connection_resolution(source, variable, pooled:)
+  prefix = "if ! #{variable}=$(neonctl connection-string"
+  assignments = source.lines.map(&:strip).select do |line|
+    line.match?(/(?:^|\s)#{Regexp.escape(variable)}=\$\(neonctl connection-string/)
+  end
+  unless assignments.length == 1
+    raise "#{variable} must have exactly one Neon connection-string assignment"
+  end
+  unless assignments.fetch(0).start_with?(prefix)
+    raise "#{variable} retrieval must be guarded"
+  end
+
+  has_pooled_flag = assignments.fetch(0).match?(/(?:^|\s)--pooled(?:\s|\))/)
+  unless has_pooled_flag == pooled
+    connection_class = pooled ? "pooled" : "direct"
+    raise "#{variable} must resolve a #{connection_class} Neon URL"
+  end
+
+  command_guard = guarded_block(source, prefix)
+  unless command_guard.include?("exit 1")
+    raise "#{variable} retrieval failure must abort"
+  end
+
+  empty_guard = guarded_block(source, %(if [ -z "$#{variable}" ]; then))
+  unless empty_guard.include?("exit 1")
+    raise "empty #{variable} must abort"
+  end
+  if empty_guard.any? { |line| line.include?("neonctl connection-string") }
+    raise "empty #{variable} must not fall back to another connection class"
+  end
+end
+
+def assert_masked_before(source, variable, sink)
+  mask_index = source.index(%(echo "::add-mask::$#{variable}"))
+  sink_index = source.index(sink)
+  raise "missing mask for #{variable}" unless mask_index
+  raise "missing protected sink for #{variable}: #{sink}" unless sink_index
+  unless mask_index < sink_index
+    raise "#{variable} must be masked before it is used or written to outputs"
+  end
+end
+
+def assert_no_url_logging(source, *variables)
+  raise "shell tracing could expose database URLs" if source.include?("set -x")
+
+  variables.each do |variable|
+    source.lines.each do |line|
+      stripped = line.strip
+      next unless stripped.start_with?("echo ") && stripped.include?("$#{variable}")
+      next if stripped == %(echo "::add-mask::$#{variable}")
+      next if stripped.end_with?('>> "$GITHUB_OUTPUT"')
+
+      raise "#{variable} must not be printed"
+    end
+  end
+end
+
+def database_variable_from_command(command)
+  match = command.match(
+    /\bDATABASE_URL=(?:"?\$\{?)([A-Z][A-Z0-9_]*)(?:\}?"?)/,
+  )
+  match&.captures&.fetch(0)
+end
+
+def output_assignment(source, output_name)
+  matches = source.lines.map(&:strip).filter_map do |line|
+    match = line.match(
+      /(?:^|["'])#{Regexp.escape(output_name)}=\$([A-Z][A-Z0-9_]*)/,
+    )
+    [match.captures.fetch(0), line] if match
+  end
+  unless matches.length == 1
+    raise "#{output_name} must have exactly one variable-backed output assignment"
+  end
+  matches.fetch(0)
+end
+
+def assert_companion_runtime_routes(source, migration_variable)
+  runtime_sinks = source.lines.map(&:strip).filter_map do |line|
+    if line.match?(/\bpnpm\b.*\bdb:dev-seed\b/)
+      variable = database_variable_from_command(line)
+      raise "preview seed must receive an explicit database variable" unless variable
+      [variable, line]
+    else
+      match = line.match(
+        /(?:^|["'])((?:runtime-)?database-url)=\$([A-Z][A-Z0-9_]*)/,
+      )
+      [match.captures.fetch(1), line] if match
+    end
+  end
+
+  runtime_sinks.each do |variable, sink|
+    if variable == migration_variable
+      raise "runtime and seed traffic must not share the direct migration URL"
+    end
+    assert_connection_resolution(source, variable, pooled: true)
+    assert_masked_before(source, variable, sink)
+    assert_no_url_logging(source, variable)
+  end
+end
+
+def assert_direct_migration_route(source, variable, sink)
+  unless variable.include?("MIGRATION_DATABASE_URL")
+    raise "db:migrate must receive an explicitly named migration database URL"
+  end
+  assert_connection_resolution(source, variable, pooled: false)
+  assert_masked_before(source, variable, sink)
+  assert_no_url_logging(source, variable)
+  assert_companion_runtime_routes(source, variable)
+end
+
+def resolve_step_output(steps, expression)
+  match = expression.match(
+    /\A\$\{\{\s*steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)\s*\}\}\z/,
+  )
+  raise "db:migrate DATABASE_URL must resolve from a step output" unless match
+
+  step_id, output_name = match.captures
+  producer = steps.find { |step| step["id"] == step_id }
+  raise "missing database URL producer step: #{step_id}" unless producer
+  producer_source = producer.fetch("run")
+  variable, sink = output_assignment(producer_source, output_name)
+  [producer_source, variable, sink]
+end
+
+def audit_migration_routes(repo_root)
+  paths = Dir[File.join(repo_root, ".github/workflows/*.{yml,yaml}")] +
+    Dir[File.join(repo_root, ".github/actions/**/action.{yml,yaml}")]
+  neon_route_count = 0
+
+  paths.sort.each do |path|
+    document = YAML.load_file(path)
+    containers = if document.key?("jobs")
+      document.fetch("jobs").map do |name, job|
+        ["#{path}:#{name}", job]
+      end
+    elsif document.key?("runs")
+      [[path, document.fetch("runs")]]
+    else
+      []
+    end
+
+    containers.each do |context, container|
+      steps = Array(container["steps"])
+      steps.each do |step|
+        source = step["run"].to_s
+        migration_commands = source.lines.map(&:strip).select do |line|
+          !line.start_with?("#") && line.match?(/\bpnpm\b.*\bdb:migrate\b/)
+        end
+        migration_commands.each do |command|
+          database_env = step.dig("env", "DATABASE_URL")
+          migration_variable = database_variable_from_command(command)
+          if !migration_variable &&
+              database_env&.start_with?("postgresql://postgres@postgres:")
+            next
+          end
+
+          migration_source = source
+          sink = command
+          unless migration_variable
+            unless database_env.is_a?(String)
+              raise "#{context}: db:migrate has no auditable DATABASE_URL route"
+            end
+            migration_source, migration_variable, sink = resolve_step_output(
+              steps,
+              database_env,
+            )
+          end
+
+          begin
+            assert_direct_migration_route(
+              migration_source,
+              migration_variable,
+              sink,
+            )
+          rescue RuntimeError => error
+            raise "#{context}: #{error.message}"
+          end
+          neon_route_count += 1
+        end
+      end
+    end
+  end
+
+  unless neon_route_count >= 5
+    raise "expected all five current Neon-backed db:migrate routes to be audited"
+  end
+end
+
+release = YAML.load_file(ARGV.fetch(0))
+release_job = release.fetch("jobs").fetch("promote-api-production")
+release_urls = named_step(release_job, "Get Production Database URLs")
+raise "production URL step id changed" unless release_urls["id"] == "get-db-urls"
+release_source = release_urls.fetch("run")
+assert_connection_resolution(release_source, "RUNTIME_DATABASE_URL", pooled: true)
+assert_connection_resolution(release_source, "MIGRATION_DATABASE_URL", pooled: false)
+assert_masked_before(
+  release_source,
+  "RUNTIME_DATABASE_URL",
+  'echo "runtime-database-url=$RUNTIME_DATABASE_URL" >> "$GITHUB_OUTPUT"',
+)
+assert_masked_before(
+  release_source,
+  "MIGRATION_DATABASE_URL",
+  'echo "migration-database-url=$MIGRATION_DATABASE_URL" >> "$GITHUB_OUTPUT"',
+)
+assert_no_url_logging(
+  release_source,
+  "RUNTIME_DATABASE_URL",
+  "MIGRATION_DATABASE_URL",
+)
+
+production_environment = named_step(
+  release_job,
+  "Resolve API production environment",
+)
+unless production_environment.dig("with", "database-url") ==
+    "${{ steps.get-db-urls.outputs.runtime-database-url }}"
+  raise "production API must keep the pooled runtime URL"
+end
+production_migration = named_step(release_job, "Run Production Migrations")
+unless production_migration.dig("env", "DATABASE_URL") ==
+    "${{ steps.get-db-urls.outputs.migration-database-url }}"
+  raise "production db:migrate must use the direct migration URL"
+end
+unless production_migration.fetch("run").scan("db:migrate").length == 1
+  raise "production migration route changed"
+end
+
+smoke = YAML.load_file(ARGV.fetch(1)).fetch("runs")
+smoke_branch = named_step(smoke, "Create Production Migration Smoke Branch")
+smoke_source = smoke_branch.fetch("run")
+assert_connection_resolution(smoke_source, "MIGRATION_DATABASE_URL", pooled: false)
+assert_masked_before(
+  smoke_source,
+  "MIGRATION_DATABASE_URL",
+  'echo "migration-database-url=$MIGRATION_DATABASE_URL" >> "$GITHUB_OUTPUT"',
+)
+assert_no_url_logging(smoke_source, "MIGRATION_DATABASE_URL")
+raise "production smoke must not resolve pooled URLs" if smoke_source.include?("--pooled")
+
+smoke_migration = named_step(smoke, "Run Production Migration Smoke Test")
+unless smoke_migration.dig("env", "DATABASE_URL") ==
+    "${{ steps.create-migration-smoke-branch.outputs.migration-database-url }}"
+  raise "production smoke db:migrate must use its direct URL"
+end
+unless smoke_migration.fetch("run").scan("db:migrate").length == 1
+  raise "production smoke migration route changed"
+end
+
+branch_action = YAML.load_file(ARGV.fetch(2))
+unless branch_action.dig("outputs", "database-url", "value") ==
+    "${{ steps.branch.outputs.database-url }}"
+  raise "Neon branch public database-url output must remain the runtime URL"
+end
+if branch_action.fetch("outputs").key?("migration-database-url")
+  raise "Neon branch direct migration URL must remain internal"
+end
+
+branch_runs = branch_action.fetch("runs")
+branch = named_step(branch_runs, "Create or Update Neon Branch")
+branch_source = branch.fetch("run")
+assert_connection_resolution(branch_source, "RUNTIME_DATABASE_URL", pooled: true)
+assert_connection_resolution(branch_source, "MIGRATION_DATABASE_URL", pooled: false)
+assert_masked_before(
+  branch_source,
+  "RUNTIME_DATABASE_URL",
+  'echo "database-url=$RUNTIME_DATABASE_URL" >> "$GITHUB_OUTPUT"',
+)
+assert_masked_before(
+  branch_source,
+  "MIGRATION_DATABASE_URL",
+  'echo "migration-database-url=$MIGRATION_DATABASE_URL" >> "$GITHUB_OUTPUT"',
+)
+assert_no_url_logging(
+  branch_source,
+  "RUNTIME_DATABASE_URL",
+  "MIGRATION_DATABASE_URL",
+)
+
+branch_migration = named_step(branch_runs, "Run Database Migrations")
+unless branch_migration.dig("env", "DATABASE_URL") ==
+    "${{ steps.branch.outputs.migration-database-url }}"
+  raise "reusable Neon branch db:migrate must use the direct URL"
+end
+unless branch_migration.fetch("run").scan("db:migrate").length == 1
+  raise "reusable Neon branch migration route changed"
+end
+if branch_migration.fetch("run").include?("skipping migrations")
+  raise "reusable Neon branch migrations must fail closed instead of skipping"
+end
+
+turbo = YAML.load_file(ARGV.fetch(3))
+deploy_api = turbo.fetch("jobs").fetch("deploy-api")
+preview_branch = named_step(deploy_api, "Create Neon Branch")
+preview_source = preview_branch.fetch("run")
+assert_connection_resolution(
+  preview_source,
+  "PARENT_MIGRATION_DATABASE_URL",
+  pooled: false,
+)
+assert_connection_resolution(preview_source, "RUNTIME_DATABASE_URL", pooled: true)
+assert_connection_resolution(preview_source, "MIGRATION_DATABASE_URL", pooled: false)
+assert_masked_before(
+  preview_source,
+  "PARENT_MIGRATION_DATABASE_URL",
+  'DATABASE_URL="$PARENT_MIGRATION_DATABASE_URL" pnpm -F @okouai/db db:migrate',
+)
+assert_masked_before(
+  preview_source,
+  "RUNTIME_DATABASE_URL",
+  'ENV=preview DATABASE_URL="$RUNTIME_DATABASE_URL" pnpm -F api db:dev-seed',
+)
+assert_masked_before(
+  preview_source,
+  "RUNTIME_DATABASE_URL",
+  'echo "database-url=$RUNTIME_DATABASE_URL" >> "$GITHUB_OUTPUT"',
+)
+assert_masked_before(
+  preview_source,
+  "MIGRATION_DATABASE_URL",
+  'DATABASE_URL="$MIGRATION_DATABASE_URL" pnpm -F @okouai/db db:migrate',
+)
+assert_no_url_logging(
+  preview_source,
+  "PARENT_MIGRATION_DATABASE_URL",
+  "RUNTIME_DATABASE_URL",
+  "MIGRATION_DATABASE_URL",
+)
+preview_migration_count = preview_source.lines.count do |line|
+  line.include?("pnpm -F @okouai/db db:migrate")
+end
+unless preview_migration_count == 2
+  raise "Turbo must retain exactly the test-parent and preview migration routes"
+end
+if preview_source.include?(
+  'ENV=preview DATABASE_URL="$MIGRATION_DATABASE_URL" pnpm -F api db:dev-seed',
+)
+  raise "preview seed traffic must not use the direct migration URL"
+end
+
+preview_environment = named_step(deploy_api, "Resolve API deploy environment")
+unless preview_environment.dig("with", "database-url") ==
+    "${{ steps.neon.outputs.database-url }}"
+  raise "deployed preview API must keep the pooled runtime URL"
+end
+
+repo_root = File.expand_path("../..", File.dirname(ARGV.fetch(0)))
+audit_migration_routes(repo_root)
+RUBY
+
+echo "neon-migration-routing-workflow-test: ok"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1055,13 +1055,34 @@ jobs:
           vercel-org-id: ${{ vars.VERCEL_TEAM_ID }}
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_API }}
 
-      - name: Get Production Database URL
-        id: get-db-url
+      - name: Get Production Database URLs
+        id: get-db-urls
         run: |
-          DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --role-name neondb_owner --pooled)
-          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
+          if ! RUNTIME_DATABASE_URL=$(neonctl connection-string production --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled); then
+            echo "::error::Failed to resolve pooled production database URL"
+            exit 1
+          fi
+          if [ -z "$RUNTIME_DATABASE_URL" ]; then
+            echo "::error::Pooled production database URL is empty"
+            exit 1
+          fi
+
+          if ! MIGRATION_DATABASE_URL=$(neonctl connection-string production --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner); then
+            echo "::error::Failed to resolve direct production migration database URL"
+            exit 1
+          fi
+          if [ -z "$MIGRATION_DATABASE_URL" ]; then
+            echo "::error::Direct production migration database URL is empty"
+            exit 1
+          fi
+
+          echo "::add-mask::$RUNTIME_DATABASE_URL"
+          echo "::add-mask::$MIGRATION_DATABASE_URL"
+          echo "runtime-database-url=$RUNTIME_DATABASE_URL" >> "$GITHUB_OUTPUT"
+          echo "migration-database-url=$MIGRATION_DATABASE_URL" >> "$GITHUB_OUTPUT"
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
 
       - name: Fetch production Doppler OAuth config
         id: doppler-oauth
@@ -1121,7 +1142,7 @@ jobs:
         with:
           app: api
           environment: production
-          database-url: ${{ steps.get-db-url.outputs.database-url }}
+          database-url: ${{ steps.get-db-urls.outputs.runtime-database-url }}
           web-url: https://www.vm0.ai
           app-url: https://app.vm0.ai
           api-backend-url: ${{ vars.VM0_API_BACKEND_URL }}
@@ -1167,7 +1188,7 @@ jobs:
           echo "Running production migrations on production"
           cd turbo && pnpm -F @okouai/db db:migrate
         env:
-          DATABASE_URL: ${{ steps.get-db-url.outputs.database-url }}
+          DATABASE_URL: ${{ steps.get-db-urls.outputs.migration-database-url }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -988,11 +988,16 @@ jobs:
           # NEON_PROJECT_ID resolves to the Neon TEST project, never production.
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "main push: pre-migrating test project default (parent) branch"
-            PARENT_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
-            if [ -z "$PARENT_DATABASE_URL" ]; then
-              PARENT_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner)
+            if ! PARENT_MIGRATION_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner); then
+              echo "::error::Failed to resolve direct test parent migration database URL"
+              exit 1
             fi
-            (cd turbo && DATABASE_URL="$PARENT_DATABASE_URL" pnpm -F @okouai/db db:migrate)
+            if [ -z "$PARENT_MIGRATION_DATABASE_URL" ]; then
+              echo "::error::Direct test parent migration database URL is empty"
+              exit 1
+            fi
+            echo "::add-mask::$PARENT_MIGRATION_DATABASE_URL"
+            (cd turbo && DATABASE_URL="$PARENT_MIGRATION_DATABASE_URL" pnpm -F @okouai/db db:migrate)
           fi
 
           BRANCH_NAME="preview/${{ needs.prepare.outputs.job-ref }}"
@@ -1010,16 +1015,32 @@ jobs:
             neonctl branches create --name "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID"
           fi
 
-          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
-          if [ -z "$DATABASE_URL" ]; then
-            DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner)
+          if ! RUNTIME_DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled); then
+            echo "::error::Failed to resolve pooled preview database URL"
+            exit 1
+          fi
+          if [ -z "$RUNTIME_DATABASE_URL" ]; then
+            echo "::error::Pooled preview database URL is empty"
+            exit 1
           fi
 
-          cd turbo
-          DATABASE_URL="$DATABASE_URL" pnpm -F @okouai/db db:migrate
-          ENV=preview DATABASE_URL="$DATABASE_URL" pnpm -F api db:dev-seed
+          if ! MIGRATION_DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner); then
+            echo "::error::Failed to resolve direct preview migration database URL"
+            exit 1
+          fi
+          if [ -z "$MIGRATION_DATABASE_URL" ]; then
+            echo "::error::Direct preview migration database URL is empty"
+            exit 1
+          fi
 
-          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$RUNTIME_DATABASE_URL"
+          echo "::add-mask::$MIGRATION_DATABASE_URL"
+
+          cd turbo
+          DATABASE_URL="$MIGRATION_DATABASE_URL" pnpm -F @okouai/db db:migrate
+          ENV=preview DATABASE_URL="$RUNTIME_DATABASE_URL" pnpm -F api db:dev-seed
+
+          echo "database-url=$RUNTIME_DATABASE_URL" >> "$GITHUB_OUTPUT"
 
       - name: Resolve API deploy environment
         id: api-deploy-env


### PR DESCRIPTION
## Summary

- resolve separate pooled runtime and direct migration Neon URLs for production, migration smoke, the reusable Neon branch action, and Turbo preview branches
- fail closed on direct URL resolution, mask URLs before outputs, and keep deployed API and seed traffic pooled
- add a structural workflow contract test that audits every Neon-backed `db:migrate` route and rejects pooled or fallback migration routing

## Tests

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `.github/scripts/tests/neon-migration-routing-workflow-test.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release-please.yml .github/workflows/turbo.yml`
- `bash -n .github/scripts/tests/neon-migration-routing-workflow-test.sh`
- `git diff --check`

## Fallbacks

- None. Migration URL resolution fails closed and never falls back to `--pooled`; application and seed routes remain intentionally pooled.

Closes #26999
