### PR TITLE
refactor(chat): remove unified indicator api fallback

### DIFF
--- a/e2e/playwright/tests/agents.spec.ts
+++ b/e2e/playwright/tests/agents.spec.ts
@@ -22,9 +22,6 @@ test("reveal the default agent unread action from the whole row", async ({
     throw new Error("Could not resolve the default agent from the sidebar");
   }
 
-  await page.route("**/api/okou/chat-thread-unread-agents", async (route) => {
-    await route.fulfill({ json: { agentIds: [defaultAgentId] } });
-  });
   await page.route("**/api/okou/indicators", async (route) => {
     await route.fulfill({
       json: {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1490,7 +1490,7 @@ describe("CHAT-01 chat thread read state", () => {
     });
   }, 120_000);
 
-  it("lists unread agent and thread ids", async () => {
+  it("lists unread agent and thread indicators", async () => {
     const {
       actor: owner,
       agentId: agentA,
@@ -1503,13 +1503,10 @@ describe("CHAT-01 chat thread read state", () => {
       })
     ).agentId;
 
-    const unauthenticated = await chat.requestListUnreadChatThreadIds(
-      null,
-      [401],
-    );
+    const unauthenticated = await chat.requestIndicators(null, [401]);
     expectApiError(unauthenticated.body);
     expect(unauthenticated.body.error.code).toBe("UNAUTHORIZED");
-    const orgless = await chat.requestListUnreadChatThreadIds(
+    const orgless = await chat.requestIndicators(
       bdd.user({ orgId: null }),
       [401],
     );
@@ -1741,7 +1738,7 @@ describe("CHAT-01 chat thread read state", () => {
 
     await withMockNowForTest(currentTime, async () => {
       mockNow(currentTime - 7 * DAY_MS - 1);
-      const expiredRun = await completeChatRunInThread(actor, runnerGroup, {
+      await completeChatRunInThread(actor, runnerGroup, {
         agentId,
         prompt: "expired unread indicator",
       });
@@ -1759,9 +1756,6 @@ describe("CHAT-01 chat thread read state", () => {
       });
 
       mockNow(currentTime);
-      expect(new Set(await chat.listUnreadChatThreadIds(actor))).toStrictEqual(
-        new Set([expiredRun.threadId, recentRun.threadId]),
-      );
       await expect(chat.listIndicators(actor)).resolves.toStrictEqual({
         agents: { [agentId]: "unread" },
         threads: {
@@ -1799,14 +1793,6 @@ describe("CHAT-01 chat thread read state", () => {
       }
 
       mockNow(firstCompletedAt + 60_000);
-      expect(new Set(await chat.listUnreadChatThreadIds(actor))).toStrictEqual(
-        new Set(
-          runs.map((run) => {
-            return run.threadId;
-          }),
-        ),
-      );
-
       const indicators = await chat.listIndicators(actor);
       expect(indicators.agents).toStrictEqual({
         [agentA]: "unread",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -524,12 +524,16 @@ export function createChatFilesBddApi(context: TestContext) {
       actor: ApiTestUser,
     ): Promise<readonly string[]> {
       const response = await accept(
-        threadsClient().activeIds({
+        threadsClient().indicators({
           headers: authenticate(context, actor),
         }),
         [200],
       );
-      return response.body.threadIds;
+      return Object.entries(response.body.threads).flatMap(
+        ([threadId, indicator]) => {
+          return indicator === "active" ? [threadId] : [];
+        },
+      );
     },
 
     async listIndicators(actor: ApiTestUser): Promise<ZeroIndicators> {
@@ -546,32 +550,24 @@ export function createChatFilesBddApi(context: TestContext) {
       actor: ApiTestUser,
     ): Promise<readonly string[]> {
       const response = await accept(
-        threadsClient().unreadIds({
+        threadsClient().indicators({
           headers: authenticate(context, actor),
         }),
         [200],
       );
-      return response.body.threadIds;
+      return Object.entries(response.body.threads).flatMap(
+        ([threadId, indicator]) => {
+          return indicator === "unread" ? [threadId] : [];
+        },
+      );
     },
 
-    async requestListUnreadChatThreadIds(
+    async requestIndicators(
       actor: ApiTestUser | null,
       statuses: readonly (200 | 401)[],
     ) {
       return await accept(
-        threadsClient().unreadIds({
-          headers: authenticate(context, actor),
-        }),
-        statuses,
-      );
-    },
-
-    async requestListUnreadAgents(
-      actor: ApiTestUser | null,
-      statuses: readonly (200 | 401 | 403)[],
-    ) {
-      return await accept(
-        threadsClient().unreadAgents({
+        threadsClient().indicators({
           headers: authenticate(context, actor),
         }),
         statuses,
@@ -580,12 +576,16 @@ export function createChatFilesBddApi(context: TestContext) {
 
     async listUnreadAgents(actor: ApiTestUser): Promise<readonly string[]> {
       const response = await accept(
-        threadsClient().unreadAgents({
+        threadsClient().indicators({
           headers: authenticate(context, actor),
         }),
         [200],
       );
-      return response.body.agentIds;
+      return Object.entries(response.body.agents).flatMap(
+        ([agentId, indicator]) => {
+          return indicator === "unread" ? [agentId] : [];
+        },
+      );
     },
 
     async markAgentThreadsRead(

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -19,12 +19,9 @@ import {
 } from "../services/google-drive-artifact-sync.service";
 import {
   zeroChatIndicators,
-  zeroChatThreadActiveRunThreadIds,
   zeroChatThreadArtifacts,
   zeroChatThreadDetail,
   zeroChatThreadDraftIds,
-  zeroChatThreadUnreadAgentIds,
-  zeroChatThreadUnreadThreadIds,
   zeroChatThreadUnreads,
 } from "../services/zero-chat-thread.service";
 import { zeroChatSearch } from "../services/zero-chat-search.service";
@@ -127,18 +124,6 @@ const listChatThreadLifecycleEventsInner$ = computed(async (get) => {
       hasMore: result.hasMore,
     },
   };
-});
-
-const listChatThreadActiveIdsInner$ = computed(async (get) => {
-  const auth = get(organizationAuthContext$);
-  const threadIds = await get(
-    zeroChatThreadActiveRunThreadIds({
-      userId: auth.userId,
-      orgId: auth.orgId,
-    }),
-  );
-
-  return { status: 200 as const, body: { threadIds: [...threadIds] } };
 });
 
 const listZeroIndicatorsInner$ = computed(async (get) => {
@@ -249,30 +234,6 @@ const listChatThreadUnreadsInner$ = computed(async (get) => {
   return { status: 200 as const, body: { unreads: [...unreads] } };
 });
 
-const listChatThreadUnreadAgentsInner$ = computed(async (get) => {
-  const auth = get(organizationAuthContext$);
-  const agentIds = await get(
-    zeroChatThreadUnreadAgentIds({
-      userId: auth.userId,
-      orgId: auth.orgId,
-    }),
-  );
-
-  return { status: 200 as const, body: { agentIds: [...agentIds] } };
-});
-
-const listChatThreadUnreadIdsInner$ = computed(async (get) => {
-  const auth = get(organizationAuthContext$);
-  const threadIds = await get(
-    zeroChatThreadUnreadThreadIds({
-      userId: auth.userId,
-      orgId: auth.orgId,
-    }),
-  );
-
-  return { status: 200 as const, body: { threadIds: [...threadIds] } };
-});
-
 const listChatThreadArtifactsInner$ = computed(async (get) => {
   const auth = get(authContext$);
   const params = get(pathParamsOf(chatThreadArtifactsContract.list));
@@ -354,33 +315,12 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
     ),
   },
   {
-    route: chatThreadsContract.activeIds,
-    handler: authRoute(
-      { requireOrganization: true, missingOrganizationStatus: 401 },
-      listChatThreadActiveIdsInner$,
-    ),
-  },
-  {
-    route: chatThreadsContract.unreadIds,
-    handler: authRoute(
-      { requireOrganization: true, missingOrganizationStatus: 401 },
-      listChatThreadUnreadIdsInner$,
-    ),
-  },
-  {
     route: chatThreadsContract.drafts,
     handler: authRoute({}, listChatThreadDraftsInner$),
   },
   {
     route: chatThreadsContract.unreads,
     handler: authRoute({}, listChatThreadUnreadsInner$),
-  },
-  {
-    route: chatThreadsContract.unreadAgents,
-    handler: authRoute(
-      { requireOrganization: true, missingOrganizationStatus: 401 },
-      listChatThreadUnreadAgentsInner$,
-    ),
   },
   {
     route: chatThreadByIdContract.get,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -343,71 +343,6 @@ export function zeroChatThreadUnreads(args: {
 }
 
 /**
- * Agents that currently have at least one unread thread for the user. Uses
- * the same timestamp watermark comparison as `zeroChatThreadUnreads`.
- */
-export function zeroChatThreadUnreadAgentIds(args: {
-  readonly userId: string;
-  readonly orgId: string;
-}): Computed<Promise<readonly string[]>> {
-  return computed(async (get) => {
-    const db = get(db$);
-    const lastRunFinish = latestRunFinishEventSubquery(db, chatThreads.id);
-    const rows = await db
-      .selectDistinct({ agentId: chatThreads.agentComposeId })
-      .from(chatThreads)
-      .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
-      .crossJoinLateral(lastRunFinish)
-      .where(
-        and(
-          eq(chatThreads.userId, args.userId),
-          eq(zeroAgents.orgId, args.orgId),
-          or(
-            isNull(chatThreads.lastReadAt),
-            gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
-          ),
-          noActiveRunsForCurrentThreadCondition(db),
-          noActiveGoalsForCurrentThreadCondition(db),
-        ),
-      );
-    return rows.map((row) => {
-      return row.agentId;
-    });
-  });
-}
-
-/** The user's unread thread ids in the current organization. */
-export function zeroChatThreadUnreadThreadIds(args: {
-  readonly userId: string;
-  readonly orgId: string;
-}): Computed<Promise<readonly string[]>> {
-  return computed(async (get) => {
-    const db = get(db$);
-    const lastRunFinish = latestRunFinishEventSubquery(db, chatThreads.id);
-    const rows = await db
-      .select({ threadId: chatThreads.id })
-      .from(chatThreads)
-      .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
-      .crossJoinLateral(lastRunFinish)
-      .where(
-        and(
-          eq(chatThreads.userId, args.userId),
-          eq(zeroAgents.orgId, args.orgId),
-          or(
-            isNull(chatThreads.lastReadAt),
-            gt(lastRunFinish.createdAt, chatThreads.lastReadAt),
-          ),
-          noActiveRunsForCurrentThreadCondition(db),
-          noActiveGoalsForCurrentThreadCondition(db),
-        ),
-      );
-    return rows.map((row) => {
-      return row.threadId;
-    });
-  });
-}
-
-/**
  * Active and unread indicators for the user's agents and threads in the
  * current organization. Active threads are complete; unread threads are the
  * latest 50 terminal markers from the last seven days. Active threads are
@@ -508,38 +443,6 @@ export function zeroChatIndicators(args: {
       }
     }
     return { agents, threads };
-  });
-}
-
-/**
- * Chat threads owned by the user in the current org that currently have at
- * least one non-terminal run. Used by local-first thread lists to hydrate the
- * transient sidebar running indicator outside lifecycle event replay.
- */
-export function zeroChatThreadActiveRunThreadIds(args: {
-  readonly userId: string;
-  readonly orgId: string;
-}): Computed<Promise<readonly string[]>> {
-  return computed(async (get) => {
-    const db = get(db$);
-    const rows = await db
-      .selectDistinct({ threadId: zeroRuns.chatThreadId })
-      .from(zeroRuns)
-      .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
-      .innerJoin(chatThreads, eq(chatThreads.id, zeroRuns.chatThreadId))
-      .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
-      .where(
-        and(
-          eq(chatThreads.userId, args.userId),
-          eq(zeroAgents.orgId, args.orgId),
-          isNotNull(zeroRuns.chatThreadId),
-          inArray(agentRuns.status, [...ACTIVE_RUN_STATUSES]),
-        ),
-      );
-
-    return rows.flatMap((row) => {
-      return row.threadId ? [row.threadId] : [];
-    });
   });
 }
 

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -244,16 +244,6 @@ export const apiAgentsHandlers = [
     return respond(200, { agents: {}, threads: {} });
   }),
 
-  // GET /api/okou/chat-threads/active-ids
-  mockApi(chatThreadsContract.activeIds, ({ respond }) => {
-    return respond(200, { threadIds: [] });
-  }),
-
-  // GET /api/okou/chat-threads/unread-ids
-  mockApi(chatThreadsContract.unreadIds, ({ respond }) => {
-    return respond(200, { threadIds: [] });
-  }),
-
   // GET /api/okou/chat-thread-drafts
   mockApi(chatThreadsContract.drafts, ({ respond }) => {
     return respond(200, { draftThreadIds: [] });
@@ -324,11 +314,6 @@ export const apiAgentsHandlers = [
   // GET /api/okou/chat-thread-unreads
   mockApi(chatThreadsContract.unreads, ({ respond }) => {
     return respond(200, { unreads: [] });
-  }),
-
-  // GET /api/okou/chat-thread-unread-agents
-  mockApi(chatThreadsContract.unreadAgents, ({ respond }) => {
-    return respond(200, { agentIds: [] });
   }),
 
   // POST /api/okou/chat-thread-unreads/mark-read

--- a/turbo/apps/platform/src/mocks/msw-contract.ts
+++ b/turbo/apps/platform/src/mocks/msw-contract.ts
@@ -121,7 +121,7 @@ function routePattern(route: AppRoute): string | RegExp {
   if (route.path === "/api/okou/chat-threads/:id") {
     // Keep thread detail mocks from swallowing static sibling routes while
     // still accepting the descriptive non-UUID thread ids used by UI tests.
-    return /\/api\/okou\/chat-threads\/(?!snapshot$|events$|active-ids$|unread-ids$)([^/]+)$/;
+    return /\/api\/okou\/chat-threads\/(?!snapshot$|events$)([^/]+)$/;
   }
   return `*${route.path}`;
 }

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-event-background-sync.test.ts
@@ -4,7 +4,6 @@ import {
   chatThreadEventsContract,
   chatThreadsContract,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -135,7 +134,6 @@ async function setupAuthenticatedBackgroundSync(): Promise<void> {
       activeOrg: { id: orgId(), name: "Background Sync Org" },
       memberships: [{ id: orgId() }],
     },
-    featureSwitches: { [FeatureSwitchKey.UnifiedIndicatorApi]: true },
   });
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
@@ -106,11 +106,11 @@ function expectCallback(callback: (() => void) | null): () => void {
 
 describe("chat thread event sourcing local-first list", () => {
   it("does not start remote event sync on signed-out pages", async () => {
-    let activeIdsRequests = 0;
+    let indicatorRequests = 0;
     let eventsRequests = 0;
-    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-      activeIdsRequests += 1;
-      return respond(200, { threadIds: [] });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      indicatorRequests += 1;
+      return respond(200, { agents: {}, threads: {} });
     });
     context.mocks.api(chatThreadsContract.events, ({ respond }) => {
       eventsRequests += 1;
@@ -126,7 +126,7 @@ describe("chat thread event sourcing local-first list", () => {
       org: { activeOrg: null, memberships: [] },
     });
 
-    expect(activeIdsRequests).toBe(0);
+    expect(indicatorRequests).toBe(0);
     expect(eventsRequests).toBe(0);
     expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
   });
@@ -356,8 +356,8 @@ describe("chat thread event sourcing local-first list", () => {
     context.mocks.api(chatThreadsContract.events, ({ respond }) => {
       return respond(200, { events: [], hasMore: false });
     });
-    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-      return respond(200, { threadIds: [] });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, { agents: {}, threads: {} });
     });
     context.mocks.api(chatThreadsContract.unreads, ({ respond }) => {
       unreadsRequests += 1;
@@ -425,8 +425,8 @@ describe("chat thread event sourcing local-first list", () => {
     context.mocks.api(chatThreadsContract.events, ({ respond }) => {
       return respond(200, { events: [], hasMore: false });
     });
-    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-      return respond(200, { threadIds: [] });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, { agents: {}, threads: {} });
     });
     await setupPage({
       context,
@@ -482,8 +482,8 @@ describe("chat thread event sourcing local-first list", () => {
     context.mocks.api(chatThreadsContract.events, ({ respond }) => {
       return respond(200, { events: [], hasMore: false });
     });
-    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-      return respond(200, { threadIds: [] });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, { agents: {}, threads: {} });
     });
     await setupPage({
       context,
@@ -564,8 +564,8 @@ describe("chat thread event sourcing local-first list", () => {
     context.mocks.api(chatThreadsContract.events, ({ respond }) => {
       return respond(200, { events: [], hasMore: false });
     });
-    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-      return respond(200, { threadIds: [] });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, { agents: {}, threads: {} });
     });
     await setupPage({
       context,
@@ -615,8 +615,8 @@ describe("chat thread event sourcing local-first list", () => {
     context.mocks.api(chatThreadsContract.events, ({ respond }) => {
       return respond(200, { events: [], hasMore: false });
     });
-    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-      return respond(200, { threadIds: [] });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, { agents: {}, threads: {} });
     });
     await setupPage({
       context,
@@ -743,8 +743,8 @@ describe("chat thread event sourcing local-first list", () => {
         hasMore: false,
       });
     });
-    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-      return respond(200, { threadIds: [] });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, { agents: {}, threads: {} });
     });
     await setupPage({
       context,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-indicators.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-indicators.ts
@@ -1,18 +1,11 @@
 import { computed } from "ccstate";
 import { chatThreadsContract } from "@okouai/api-contracts/contracts/chat-threads";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { reloadChatIndicatorsCounter$ } from "../chat-thread-list-reload.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
-
-const unifiedIndicatorApiEnabled$ = computed((get): boolean => {
-  return get(featureSwitch$)[FeatureSwitchKey.UnifiedIndicatorApi] ?? false;
-});
 
 const chatThreadIndicators$ = computed(async (get) => {
-  get(unifiedIndicatorApiEnabled$);
   get(reloadChatIndicatorsCounter$);
   const client = get(zeroClient$)(chatThreadsContract);
   const result = await accept(client.indicators(), [200]);
@@ -21,54 +14,33 @@ const chatThreadIndicators$ = computed(async (get) => {
 
 export const unreadAgentIds$ = computed(
   async (get): Promise<ReadonlySet<string>> => {
-    if (get(unifiedIndicatorApiEnabled$)) {
-      const indicators = await get(chatThreadIndicators$);
-      return new Set(
-        Object.entries(indicators.agents).flatMap(([agentId, indicator]) => {
-          return indicator === "unread" ? [agentId] : [];
-        }),
-      );
-    }
-
-    get(reloadChatIndicatorsCounter$);
-    const client = get(zeroClient$)(chatThreadsContract);
-    const result = await accept(client.unreadAgents(), [200]);
-    return new Set(result.body.agentIds);
+    const indicators = await get(chatThreadIndicators$);
+    return new Set(
+      Object.entries(indicators.agents).flatMap(([agentId, indicator]) => {
+        return indicator === "unread" ? [agentId] : [];
+      }),
+    );
   },
 );
 
 export const allUnreadThreadIds$ = computed(
   async (get): Promise<ReadonlySet<string>> => {
-    if (get(unifiedIndicatorApiEnabled$)) {
-      const indicators = await get(chatThreadIndicators$);
-      return new Set(
-        Object.entries(indicators.threads).flatMap(([threadId, indicator]) => {
-          return indicator === "unread" ? [threadId] : [];
-        }),
-      );
-    }
-
-    get(reloadChatIndicatorsCounter$);
-    const client = get(zeroClient$)(chatThreadsContract);
-    const result = await accept(client.unreadIds(), [200]);
-    return new Set(result.body.threadIds);
+    const indicators = await get(chatThreadIndicators$);
+    return new Set(
+      Object.entries(indicators.threads).flatMap(([threadId, indicator]) => {
+        return indicator === "unread" ? [threadId] : [];
+      }),
+    );
   },
 );
 
 export const sidebarActiveThreadIds$ = computed(
   async (get): Promise<ReadonlySet<string>> => {
-    if (get(unifiedIndicatorApiEnabled$)) {
-      const indicators = await get(chatThreadIndicators$);
-      return new Set(
-        Object.entries(indicators.threads).flatMap(([threadId, indicator]) => {
-          return indicator === "active" ? [threadId] : [];
-        }),
-      );
-    }
-
-    get(reloadChatIndicatorsCounter$);
-    const client = get(zeroClient$)(chatThreadsContract);
-    const result = await accept(client.activeIds(), [200]);
-    return new Set(result.body.threadIds);
+    const indicators = await get(chatThreadIndicators$);
+    return new Set(
+      Object.entries(indicators.threads).flatMap(([threadId, indicator]) => {
+        return indicator === "active" ? [threadId] : [];
+      }),
+    );
   },
 );

--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page-tabs.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page-tabs.test.tsx
@@ -2,7 +2,6 @@ import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { chatThreadsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import type { TeamComposeItem } from "@okouai/api-contracts/contracts/zero-team";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -175,7 +174,6 @@ describe("agents page (redesign)", () => {
     detachedSetupPage({
       context,
       path: "/agents",
-      featureSwitches: { [FeatureSwitchKey.UnifiedIndicatorApi]: true },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -489,8 +489,8 @@ function mockTeamAPIs({
   context.mocks.api(chatThreadsContract.events, ({ respond }) => {
     return respond(200, { events: [], hasMore: false });
   });
-  context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-    return respond(200, { threadIds: [] });
+  context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+    return respond(200, { agents: {}, threads: {} });
   });
   context.mocks.api(zeroAgentsByIdContract.get, ({ params, respond }) => {
     const agent = params.id === zeroAgentId ? "Zero" : "Research Agent";
@@ -1004,8 +1004,8 @@ describe("team page navigation", () => {
     context.mocks.api(chatThreadsContract.events, ({ respond }) => {
       return respond(200, { events: [], hasMore: false });
     });
-    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-      return respond(200, { threadIds: [] });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, { agents: {}, threads: {} });
     });
     context.mocks.api(chatThreadByIdContract.get, ({ respond }) => {
       return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-test-helpers.ts
@@ -356,12 +356,13 @@ export function mockThread(options?: {
   context.mocks.api(chatThreadsContract.events, ({ respond }) => {
     return respond(200, { events: [], hasMore: false });
   });
-  context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
+  context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
     return respond(200, {
-      threadIds:
+      agents: {},
+      threads:
         options?.activeRunIds && options.activeRunIds.length > 0
-          ? [THREAD_ID]
-          : [],
+          ? { [THREAD_ID]: "active" }
+          : {},
     });
   });
   context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle-test-helpers.ts
@@ -372,8 +372,8 @@ export function mockKeyboardNavigationThreads({
   context.mocks.api(chatThreadsContract.events, ({ respond }) => {
     return respond(200, { events: [], hasMore: false });
   });
-  context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-    return respond(200, { threadIds: [] });
+  context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+    return respond(200, { agents: {}, threads: {} });
   });
   context.mocks.api(chatThreadByIdContract.get, ({ params, respond }) => {
     const thread = byId.get(params.id);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -1174,9 +1174,6 @@ describe("chat scroll position", () => {
       initialEvents,
       appendedEvents,
     });
-    context.mocks.api(chatThreadsContract.unreadIds, ({ respond }) => {
-      return respond(200, { threadIds: [threadId] });
-    });
     context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
       return respond(200, {
         agents: {},

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -739,7 +739,7 @@ export function mockChatLifecycle(
   context.mocks.api(chatThreadsContract.events, ({ respond }) => {
     return respond(200, { events: [], hasMore: false });
   });
-  context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
+  context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
     const activeThreadIds = new Set<string>();
     if (
       optionActiveRunIds.length > 0 ||
@@ -748,9 +748,16 @@ export function mockChatLifecycle(
       activeThreadIds.add(threadId);
     }
     return respond(200, {
-      threadIds: [...activeThreadIds].filter((id) => {
-        return UUID_PATTERN.test(id);
-      }),
+      agents: {},
+      threads: Object.fromEntries(
+        [...activeThreadIds]
+          .filter((id) => {
+            return UUID_PATTERN.test(id);
+          })
+          .map((id) => {
+            return [id, "active" as const];
+          }),
+      ),
     });
   });
   context.mocks.api(chatThreadsContract.create, ({ body, respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx
@@ -85,8 +85,8 @@ function mockSidebarThreadStory(threads: readonly SidebarThread[]): void {
   context.mocks.api(chatThreadsContract.events, ({ respond }) => {
     return respond(200, { events: [], hasMore: false });
   });
-  context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-    return respond(200, { threadIds: [] });
+  context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+    return respond(200, { agents: {}, threads: {} });
   });
   context.mocks.api(chatThreadByIdContract.get, ({ respond }) => {
     return respond(200, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -197,9 +197,6 @@ function mockChatThreadSnapshot(
   context.mocks.api(chatThreadsContract.events, ({ respond }) => {
     return respond(200, { events: [], hasMore: false });
   });
-  context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
-    return respond(200, { threadIds: [...activeThreadIds()] });
-  });
   context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
     return respond(200, {
       agents: {},
@@ -216,10 +213,6 @@ function mockUnreadAgents(
   unreadAgentIds: () => readonly string[],
   onRequest: () => void = () => {},
 ): void {
-  context.mocks.api(chatThreadsContract.unreadAgents, ({ respond }) => {
-    onRequest();
-    return respond(200, { agentIds: [...unreadAgentIds()] });
-  });
   context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
     onRequest();
     return respond(200, {
@@ -503,9 +496,6 @@ describe("zero sidebar", () => {
     });
     context.mocks.api(chatThreadsContract.events, ({ respond }) => {
       return respond(200, { events: [], hasMore: false });
-    });
-    context.mocks.api(chatThreadsContract.activeIds, ({ never }) => {
-      return never();
     });
     context.mocks.api(chatThreadsContract.indicators, ({ never }) => {
       indicatorRequests += 1;
@@ -2597,7 +2587,6 @@ describe("zero sidebar", () => {
     setupSidebarPage({
       context,
       path: `/agents/${AGENT_ID}/chat`,
-      featureSwitches: { [FeatureSwitchKey.UnifiedIndicatorApi]: true },
     });
 
     const nav = await waitFor(() => {

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -122,10 +122,6 @@ const chatThreadUnreadsSchema = z.object({
   ),
 });
 
-const chatThreadUnreadAgentsSchema = z.object({
-  agentIds: z.array(z.string()),
-});
-
 export const zeroIndicatorSchema = z.enum(["active", "unread"]);
 
 const zeroIndicatorsSchema = z.object({
@@ -1006,32 +1002,6 @@ export const chatThreadsContract = c.router({
     },
     summary: "List chat thread lifecycle events after an optional cursor.",
   },
-  activeIds: {
-    method: "GET",
-    path: "/api/okou/chat-threads/active-ids",
-    headers: authHeadersSchema,
-    responses: {
-      200: z.object({
-        threadIds: z.array(z.string().uuid()),
-      }),
-      401: apiErrorSchema,
-    },
-    summary:
-      "List chat thread ids that currently have queued, pending, or running runs.",
-  },
-  unreadIds: {
-    method: "GET",
-    path: "/api/okou/chat-threads/unread-ids",
-    headers: authHeadersSchema,
-    responses: {
-      200: z.object({
-        threadIds: z.array(z.string().uuid()),
-      }),
-      401: apiErrorSchema,
-    },
-    summary:
-      "List unread chat thread ids for the caller in the current organization.",
-  },
   create: {
     method: "POST",
     path: "/api/okou/chat-threads",
@@ -1087,18 +1057,6 @@ export const chatThreadsContract = c.router({
     },
     summary:
       "List the caller's unread chat threads under an agent, each with the timestamp of the message that made it unread.",
-  },
-  unreadAgents: {
-    method: "GET",
-    path: "/api/okou/chat-thread-unread-agents",
-    headers: authHeadersSchema,
-    responses: {
-      200: chatThreadUnreadAgentsSchema,
-      401: apiErrorSchema,
-      403: apiErrorSchema,
-    },
-    summary:
-      "List agent IDs with at least one unread chat thread for the caller.",
   },
 });
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -14,9 +14,6 @@ describe("isFeatureEnabled", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.TeamsIntegration, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.JoggAiBuiltIn, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.MetaAdsConnector, {})).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.UnifiedIndicatorApi, {})).toBe(
-      true,
-    );
   });
 
   it("should return true for globally enabled switch even with context", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -76,7 +76,6 @@ export enum FeatureSwitchKey {
   SharedThreadSharing = "sharedThreadSharing",
   PiLoop = "piLoop",
   VideoTemplateOptions = "videoTemplateOptions",
-  UnifiedIndicatorApi = "unifiedIndicatorApi",
   EmojiPickerCategoryRail = "emojiPickerCategoryRail",
   PresentationTemplates = "presentationTemplates",
   LatestWebsiteTemplates = "latestWebsiteTemplates",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -308,12 +308,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.UnifiedIndicatorApi]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Load global agent and chat thread indicators from the unified API.",
-    enabled: true,
-  },
   [FeatureSwitchKey.PresentationTemplates]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- treat `UnifiedIndicatorApi` / `unifiedIndicatorApi` as terminal `fully-rolled-out`, based on the user's explicit production rollout confirmation
- make `chatThreadsContract.indicators` the unconditional platform data source and remove the feature-switch rollback branch
- retire the three legacy global indicator endpoints and their route/service implementations while preserving the unified endpoint and positive behavior coverage
- preserve `chatThreadsContract.unreads` at `/api/okou/chat-thread-unreads`; it remains the per-agent unread-detail API

## Terminal-state and production gate

- source rollout: #26960, merged as `169409de2f824947ff3077e44b98e26d647f24b8` at `2026-08-13T14:03:54Z`
- terminal decision: the user explicitly confirmed production is fully rolled out and authorized immediate cleanup, overriding the workflow's former 12-hour elapsed-time wait and allowing observed stale-bundle legacy traffic to be reported rather than treated as a blocker
- latest `main` at implementation start: `3a15a8bb568093a3323ebb606bfb0786e26b996a`; `git merge-base --is-ancestor 169409de... origin/main` passed
- current successful GitHub deployment for `app/production`: deployment `5890470537`, SHA `cc2db861dbbb832336f7a6486c166fbdba2e618d`, successful at `2026-08-13T15:01:25Z`, environment URL `https://app.vm0.ai`
- `git merge-base --is-ancestor 169409de... cc2db861...` passed, proving the deployed app contains #26960

### Bounded Axiom evidence

Dataset: `vm0-request-log-prod`. Every APL request used explicit finite UTC `startTime`/`endTime` bounds, with the in-query `_time` predicate before exact `method`, `path_template`, and `status` filters. Results were complete (`isPartial: false`).

| UTC window | Exact route/status evidence |
| --- | --- |
| `2026-08-13T15:01:25Z <= _time < 2026-08-13T15:22:00Z` (successful deployment through gate time) | `GET /api/okou/indicators`: 229 x 200, 0 x 5xx. `GET /api/okou/chat-thread-unread-agents`: 97 x 200. `GET /api/okou/chat-threads/active-ids` and `GET /api/okou/chat-threads/unread-ids`: 0 observed. |
| `2026-08-13T13:22:00Z <= _time < 2026-08-13T15:22:00Z` (focused trailing two hours) | `GET /api/okou/indicators`: 1,296 x 200, 1 x 401, 0 x 5xx. `GET /api/okou/chat-thread-unread-agents`: 1,916 x 200 and 5 x 426. The other two legacy routes: 0 observed. |

The observed successful `chat-thread-unread-agents` traffic is intentionally disclosed. Per the user's explicit decision, already-loaded old web/app bundles do not delay this cleanup; the unified route's successful traffic and zero 5xx satisfy the health gate.

## Archaeology and retained behavior

- `ccd1f4f044` / #26568 introduced the unified contract, `zeroChatIndicators`, and the new gated `chat-thread-indicators.ts`; its parent had no consolidated indicator signal file
- `b036c02de5` / #26816 bounded unified unread results to the newest 50 terminal markers from the last seven days while leaving active indicators complete; this behavior remains unchanged
- `08bef36763` / #26975 made unread agent aggregation take precedence over active state so unread actions remain available during another active run; this behavior remains unchanged
- #26960 changed the registry entry to globally enabled after its bounded production comparison reported average latency -49.2%, P50 -56.5%, P95 -40.3%, P99 -19.6%, 67.5% more requests, and no 5xx
- the retired legacy helpers originated separately: `zeroChatThreadActiveRunThreadIds` in `40a3f06a57` / #20031, `zeroChatThreadUnreadThreadIds` in `23af2422c1` / #25563, and `zeroChatThreadUnreadAgentIds` in `d04cfbc55e` / #19374; fresh whole-repository references showed each was only retained by its legacy route

## Removed scope

- `FeatureSwitchKey.UnifiedIndicatorApi` and its `FEATURE_SWITCHES` registry entry/test assertion
- `unifiedIndicatorApiEnabled$`, feature-switch reads, and all three switch-off client branches
- contract members/routes `activeIds`, `unreadIds`, and `unreadAgents`
- route handlers and service functions `zeroChatThreadActiveRunThreadIds`, `zeroChatThreadUnreadThreadIds`, and `zeroChatThreadUnreadAgentIds`
- legacy MSW/Playwright mocks, feature-switch overrides, route-pattern exclusions, and dual-path test fixtures

Valuable API and platform tests now exercise `chatThreadsContract.indicators` directly. `chatThreadsContract.indicators`, `zeroChatIndicators`, the 7-day/50-result bound, unread-over-active agent precedence, and `/api/okou/chat-thread-unreads` remain.

## Keyword and orphan sweep

- runtime/source hits after cleanup: 0 for the exact switch key and naming variants, all three legacy endpoint strings, all three removed service symbols, and removed contract member calls
- intentionally retained history: the #26960 release entries in package changelogs and the historical `unreadIds` rollout example in `docs/fallback.md`; neither is executable production fallback code
- no negative absence tests were added
- Knip baseline: exit 0, 45 existing configuration hints, no unused code diagnostics
- Knip after cleanup (including Lefthook rerun): exit 0, the same 45 configuration hints, no new unused file/export/dependency diagnostics

## Verification

- `git diff --check`
- Prettier on all 22 changed files
- `pnpm knip` before and after cleanup
- `pnpm --filter @okouai/core run lint`
- `pnpm --filter @okouai/api-contracts run lint`
- `pnpm --filter @okouai/app run lint`
- `pnpm --filter api run lint`
- `pnpm --filter @okouai/core run check-types`
- `pnpm --filter @okouai/api-contracts run check-types`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `cd e2e && pnpm run check-types`
- Lefthook pre-commit: Prettier, Knip, full serial `pnpm check-types` (14/14 tasks), and file-size check passed
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (24/24 passed)
- targeted platform Vitest across seven affected files (120/120 passed)

The targeted API command `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts` was attempted as a single process, but this checkout has no local PostgreSQL listener: collection failed with `ECONNREFUSED ::1:5432` / `127.0.0.1:5432`, so all 35 tests were skipped. API lint, API production/test type-checks, and the full Lefthook type-check passed; the PR pipeline will run the database-backed API lane. No full local Vitest or local dev server was run.

## Fallbacks

No version-migration fallback is retained by this change. The separate per-agent unread-detail API is permanent product behavior, not rollout compatibility.
