### PR TITLE
perf(api): avoid duplicate goal run preparation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -26,6 +26,7 @@ import {
   holdChatEventInsertTransactionFixture,
   holdGoalThreadLockFixture,
   holdModelPolicyReadsFixture,
+  invalidateChatCallbackPayloadFixture,
   insertQueuedSlackMissingContextFixture,
   readChatEventContextFixture,
   removeAcknowledgedCancellationLifecycleFixture,
@@ -1758,6 +1759,7 @@ ${noisySeparator}
 
 Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-42](https://acme.example.com/treasury) before marking done.`;
     await createGoalForRun(actor, first.runId, goalObjective);
+    const kms = useSecretKmsProbe();
     chatCallbacks.mockChatOutputEvents([
       assistantEvent(0, "completed before goal continuation"),
     ]);
@@ -1766,7 +1768,6 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await completeChatRunOk(first.runId, sandboxHeaders, {
       lastEventSequence: 0,
     });
-
     const messages = await waitForThreadMessages(
       actor,
       first.threadId,
@@ -1796,6 +1797,7 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       throw new Error("Expected goal continuation run id");
     }
     await flushWaitUntilForTest();
+    expect(kms.generateDataKeyCalls).toBe(1);
     await expectGoalDrainPreCreateTiming({
       runId: goalContinuation.runId,
       forbiddenValues: [
@@ -1845,6 +1847,51 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       eventType: "goal.close",
       content: null,
     });
+  }, 90_000);
+
+  it("falls back to the terminal scheduler when the chat callback fails", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before the chat callback fallback",
+    });
+    const goalBrief = "Continue through the terminal fallback";
+    await createGoalForRun(actor, first.runId, goalBrief);
+    await invalidateChatCallbackPayloadFixture(first.runId);
+    const kms = useSecretKmsProbe();
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    const messages = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return isGoalContinuationUserMessage(message, goalBrief);
+        });
+      },
+    );
+    const continuation = userMessages(messages.events).find((message) => {
+      return isGoalContinuationUserMessage(message, goalBrief);
+    });
+    if (!continuation?.runId) {
+      throw new Error("Expected a fallback goal continuation run");
+    }
+    await flushWaitUntilForTest();
+    expect(kms.generateDataKeyCalls).toBe(1);
+    await expect(goalRunIds(first.threadId)).resolves.toStrictEqual([
+      continuation.runId,
+    ]);
+
+    await api.requestCancelRun(actor, continuation.runId, [200]);
+    await waitForRunStatus(actor, continuation.runId, "cancelled");
+    await flushWaitUntilForTest();
   }, 90_000);
 
   it("rebuilds a preparing goal run from the latest row despite its UI marker", async () => {
@@ -1941,9 +1988,8 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     const runPreparationStarted = createDeferredPromise<void>(context.signal);
     const releaseRunPreparation = deferredGate();
     useSecretKmsProbe((request) => {
-      // The terminal callback drain and the goal enqueue drain may both prepare
-      // this queued run. Hold every preparation so neither can win the final
-      // claim before the goal is deleted.
+      // Hold the terminal callback's single retained preparation so the goal
+      // can be deleted before its final queue-first claim.
       if (!runPreparationStarted.settled()) {
         runPreparationStarted.resolve(undefined);
       }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -331,6 +331,7 @@ describe("zero goals", () => {
       prompt: "create a goal outside chat",
       modelProvider: "anthropic-api-key",
     });
+    const kms = useSecretKmsProbe();
 
     const created = await accept(
       goalsClient().create({
@@ -440,6 +441,7 @@ describe("zero goals", () => {
       id: goalRunId,
       goalId: goal.goalId,
     });
+    expect(kms.generateDataKeyCalls).toBe(1);
 
     await api.requestCancelRun(actor, goalRunId, [200]);
     await api.requestCancelRun(actor, origin.runId, [200]);

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -132,7 +132,8 @@ const dispatchInternalCallback$ = command(
         };
       }
       case "chat": {
-        const result = await set(
+        const db = set(writeDb$);
+        return await set(
           handleChatInternalCallback$,
           {
             callback: input.envelope,
@@ -153,7 +154,7 @@ const dispatchInternalCallback$ = command(
                     set(
                       handleTerminalGoalContinuation$,
                       {
-                        db: set(writeDb$),
+                        db,
                         runId,
                       },
                       inputSignal,
@@ -170,7 +171,6 @@ const dispatchInternalCallback$ = command(
           },
           signal,
         );
-        return result;
       }
       case "github:chat": {
         return {
@@ -449,13 +449,13 @@ export const dispatchRunCallbacks$ = command(
     signal.throwIfAborted();
 
     const results: DispatchResult[] = [];
-    let terminalGoalHandledByChatCallback = false;
+    let terminalGoalOwnedByChatCallback = false;
     for (const callback of callbacks) {
       const internalKind = internalRunCallbackKindForRecord(callback);
       const handleTerminalGoal: boolean =
         redriveChatCallbackId === undefined &&
         internalKind === "chat" &&
-        !terminalGoalHandledByChatCallback;
+        !terminalGoalOwnedByChatCallback;
       const dispatchResult: DispatchResult = internalKind
         ? await set(
             dispatchSingleInternalCallback$,
@@ -482,12 +482,12 @@ export const dispatchRunCallbacks$ = command(
           });
       signal.throwIfAborted();
       results.push(dispatchResult);
-      terminalGoalHandledByChatCallback ||=
+      terminalGoalOwnedByChatCallback ||=
         handleTerminalGoal && dispatchResult.success;
     }
     if (
       redriveChatCallbackId === undefined &&
-      !terminalGoalHandledByChatCallback
+      !terminalGoalOwnedByChatCallback
     ) {
       await tapError(
         set(

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -6,7 +6,7 @@ import { and, eq, inArray, isNull, notInArray, or } from "drizzle-orm";
 import { env, optionalEnv } from "../../lib/env";
 import { computeHmacSignature } from "../../lib/event-consumer/hmac";
 import { logger } from "../../lib/log";
-import type { Db } from "../external/db";
+import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../../lib/time";
 import { settle, tapError } from "../utils";
 import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
@@ -34,7 +34,7 @@ import {
   handleWorkflowAutomationInternalCallback,
   handleWorkflowAutomationInternalCallback$,
 } from "./zero-workflow-automation-run-callback.service";
-import { continueGoalIfIdle$ } from "./zero-goal-continuation.service";
+import { handleTerminalGoalContinuation$ } from "./zero-goal-continuation.service";
 
 const L = logger("AgentRunCallback");
 
@@ -109,11 +109,13 @@ interface DispatchInternalRunCallbackInput {
   readonly result?: Record<string, unknown>;
   readonly error?: string;
   readonly kind: InternalRunCallbackKind;
+  readonly handleTerminalGoal: boolean;
 }
 
 interface DispatchInternalCallbackInput {
   readonly kind: InternalRunCallbackKind;
   readonly envelope: InternalRunCallbackEnvelope;
+  readonly handleTerminalGoal: boolean;
 }
 
 const dispatchInternalCallback$ = command(
@@ -130,7 +132,7 @@ const dispatchInternalCallback$ = command(
         };
       }
       case "chat": {
-        return await set(
+        const result = await set(
           handleChatInternalCallback$,
           {
             callback: input.envelope,
@@ -145,9 +147,30 @@ const dispatchInternalCallback$ = command(
                 inputSignal,
               );
             },
+            handleTerminalGoal: input.handleTerminalGoal
+              ? async (runId, inputSignal) => {
+                  await tapError(
+                    set(
+                      handleTerminalGoalContinuation$,
+                      {
+                        db: set(writeDb$),
+                        runId,
+                      },
+                      inputSignal,
+                    ),
+                    (error) => {
+                      L.error("Goal continuation dispatch failed", {
+                        runId,
+                        error,
+                      });
+                    },
+                  );
+                }
+              : undefined,
           },
           signal,
         );
+        return result;
       }
       case "github:chat": {
         return {
@@ -226,6 +249,7 @@ const dispatchSingleInternalCallback$ = command(
         {
           kind: input.kind,
           envelope: callbackEnvelope(input),
+          handleTerminalGoal: input.handleTerminalGoal,
         },
         signal,
       ),
@@ -425,9 +449,14 @@ export const dispatchRunCallbacks$ = command(
     signal.throwIfAborted();
 
     const results: DispatchResult[] = [];
+    let terminalGoalHandledByChatCallback = false;
     for (const callback of callbacks) {
       const internalKind = internalRunCallbackKindForRecord(callback);
-      const dispatchResult = internalKind
+      const handleTerminalGoal: boolean =
+        redriveChatCallbackId === undefined &&
+        internalKind === "chat" &&
+        !terminalGoalHandledByChatCallback;
+      const dispatchResult: DispatchResult = internalKind
         ? await set(
             dispatchSingleInternalCallback$,
             {
@@ -438,6 +467,7 @@ export const dispatchRunCallbacks$ = command(
               result,
               error,
               kind: internalKind,
+              handleTerminalGoal,
             },
             signal,
           )
@@ -452,15 +482,19 @@ export const dispatchRunCallbacks$ = command(
           });
       signal.throwIfAborted();
       results.push(dispatchResult);
+      terminalGoalHandledByChatCallback ||=
+        handleTerminalGoal && dispatchResult.success;
     }
-    if (redriveChatCallbackId === undefined) {
+    if (
+      redriveChatCallbackId === undefined &&
+      !terminalGoalHandledByChatCallback
+    ) {
       await tapError(
         set(
-          continueGoalIfIdle$,
+          handleTerminalGoalContinuation$,
           {
             db,
             runId,
-            dispatchFailedCallbacks: dispatchFailedRunCallbacks,
           },
           signal,
         ),

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -616,6 +616,10 @@ interface ChatCallbackDependencies {
     signal: AbortSignal,
     timing?: ChatCallbackPreCreateTimingCollector,
   ) => Promise<void>;
+  readonly handleTerminalGoal?: (
+    runId: string,
+    signal: AbortSignal,
+  ) => Promise<void>;
 }
 
 interface ChatThreadForRunRow {
@@ -4866,6 +4870,8 @@ async function handleChatInternalCallback(
     args.callback.runId,
   );
   signal.throwIfAborted();
+  await args.dependencies.handleTerminalGoal?.(args.callback.runId, signal);
+  signal.throwIfAborted();
 
   // The webhook sender (dispatchRunCallbacks) awaits this response only to
   // record delivery; it does not retry and nothing downstream reads the body.
@@ -5096,6 +5102,7 @@ const buildChatCallbackDependencies$ = command(
     input: {
       readonly db: Db;
       readonly drainThreadQueue?: ChatCallbackDependencies["drainThreadQueue"];
+      readonly handleTerminalGoal?: ChatCallbackDependencies["handleTerminalGoal"];
     },
   ): ChatCallbackDependencies => {
     const { db } = input;
@@ -5150,6 +5157,7 @@ const buildChatCallbackDependencies$ = command(
       ...agentPhoneChatDeliveryDependencies(db),
       ...githubChatDeliveryDependencies(db),
       drainThreadQueue: input.drainThreadQueue,
+      handleTerminalGoal: input.handleTerminalGoal,
     };
     const dependencies: ChatCallbackDependencies = {
       ...baseDependencies,
@@ -5317,6 +5325,7 @@ export const handleChatInternalCallback$ = command(
     input: {
       readonly callback: InternalRunCallbackEnvelope;
       readonly drainThreadQueue?: ChatCallbackDependencies["drainThreadQueue"];
+      readonly handleTerminalGoal?: ChatCallbackDependencies["handleTerminalGoal"];
     },
     signal: AbortSignal,
   ): Promise<
@@ -5327,6 +5336,7 @@ export const handleChatInternalCallback$ = command(
     const dependencies = set(buildChatCallbackDependencies$, {
       db,
       drainThreadQueue: input.drainThreadQueue,
+      handleTerminalGoal: input.handleTerminalGoal,
     });
     return await handleChatInternalCallback(
       {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -4862,9 +4862,9 @@ async function handleChatInternalCallback(
     return { success: true };
   }
 
-  // Goal continuation runs after this callback is acknowledged and may pause a
-  // failed goal before the background notification step starts. Snapshot the
-  // goal state here so the Push decision reflects the moment the run ended.
+  // Terminal goal handling below may pause a failed goal before background
+  // notifications start. Snapshot first so the Push decision reflects the
+  // moment the run ended.
   const suppressWebPushForActiveGoal = await runHasActiveGoal(
     args.db,
     args.callback.runId,
@@ -4876,11 +4876,11 @@ async function handleChatInternalCallback(
   // The webhook sender (dispatchRunCallbacks) awaits this response only to
   // record delivery; it does not retry and nothing downstream reads the body.
   // The frontend learns about new messages through Ably realtime signals, not
-  // this HTTP response. So acknowledge immediately and run the heavy terminal
-  // processing (message persistence, LLM generation, and push delivery) in the
-  // background, mirroring webhooks-agent-complete. Use a
-  // detached signal so request cancellation cannot interrupt the idempotency
-  // marker -> queued auto-send sequence after the callback is acknowledged.
+  // this HTTP response. After the durable goal action above, acknowledge before
+  // running heavy terminal processing (message persistence, LLM generation,
+  // and push delivery) in the background, mirroring webhooks-agent-complete.
+  // Use a detached signal so request cancellation cannot interrupt the
+  // idempotency marker -> queued auto-send sequence after acknowledgement.
   const backgroundSignal = new AbortController().signal;
   waitUntil(
     tapError(

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -78,13 +78,12 @@ async function loadTerminatingRun(
   return row ?? null;
 }
 
-const enqueueGoalContinuation$ = command(
+const admitGoalContinuation$ = command(
   async (
-    { set },
+    _context,
     args: {
       readonly db: Db;
       readonly goal: GoalBootstrap;
-      readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
     },
     signal: AbortSignal,
   ): Promise<GoalEnqueueResult> => {
@@ -116,16 +115,6 @@ const enqueueGoalContinuation$ = command(
       };
     }
 
-    await set(
-      drainChatThreadQueueForThread$,
-      {
-        chatThreadId: args.goal.threadId,
-        dispatchFailedCallbacks: args.dispatchFailedCallbacks,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-
     return admission.value.kind === "inserted"
       ? {
           kind: "enqueued",
@@ -136,13 +125,12 @@ const enqueueGoalContinuation$ = command(
   },
 );
 
-export const continueGoalIfIdle$ = command(
+export const handleTerminalGoalContinuation$ = command(
   async (
     { set },
     args: {
       readonly db: Db;
       readonly runId: string;
-      readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
     },
     signal: AbortSignal,
   ): Promise<GoalContinuationResult> => {
@@ -181,7 +169,7 @@ export const continueGoalIfIdle$ = command(
     }
 
     return await set(
-      enqueueGoalContinuation$,
+      admitGoalContinuation$,
       {
         db: args.db,
         goal: {
@@ -191,7 +179,6 @@ export const continueGoalIfIdle$ = command(
           threadId: goal.chatThreadId,
           objectiveBrief: goal.objectiveBrief,
         },
-        dispatchFailedCallbacks: args.dispatchFailedCallbacks,
       },
       signal,
     );
@@ -208,6 +195,20 @@ export const bootstrapGoalRun$ = command(
     },
     signal: AbortSignal,
   ): Promise<GoalEnqueueResult> => {
-    return await set(enqueueGoalContinuation$, args, signal);
+    const result = await set(admitGoalContinuation$, args, signal);
+    signal.throwIfAborted();
+    if (result.kind === "failed-to-enqueue") {
+      return result;
+    }
+    await set(
+      drainChatThreadQueueForThread$,
+      {
+        chatThreadId: args.goal.threadId,
+        dispatchFailedCallbacks: args.dispatchFailedCallbacks,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    return result;
   },
 );

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -1093,6 +1093,26 @@ export async function removeAcknowledgedCancellationLifecycleFixture(args: {
   });
 }
 
+/** Make the canonical chat callback fail validation before terminal processing. */
+export async function invalidateChatCallbackPayloadFixture(
+  runId: string,
+): Promise<void> {
+  const callbacks = await db()
+    .update(agentRunCallbacks)
+    .set({ payload: {} })
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, runId),
+        eq(agentRunCallbacks.internalKind, "chat"),
+        eq(agentRunCallbacks.status, "pending"),
+      ),
+    )
+    .returning({ id: agentRunCallbacks.id });
+  if (callbacks.length !== 1) {
+    throw new Error("Expected one pending canonical chat callback");
+  }
+}
+
 async function transitiveBlockedWaiterCount(
   holderPid: number,
 ): Promise<number> {


### PR DESCRIPTION
## Summary

- make the canonical terminal chat callback the normal single owner of the shared thread scheduler
- separate durable goal-event admission from draining, while retaining explicit bootstrap and failed-callback fallback drains
- prove the completed-run path prepares one goal run instead of two and preserve callback-failure liveness

## Behavior

Terminal goal handling now admits or pauses the active goal before the successful chat callback detaches its existing terminal processing. The detached callback then performs the one normal shared-thread drain. If no canonical chat callback succeeds, the existing outer terminal fallback still drains the admitted event. Goal bootstrap continues to admit and drain explicitly.

The final queue-first claim remains authoritative for unrelated concurrent schedulers and mixed API revisions.

## Scope exclusions

- no schema, migration, persisted queue shape, public API, feature switch, frontend, runner, or guest-protocol change
- no distributed preparation lease or process-local single-flight
- no change to user-message, goal, or workflow queue priority and FIFO behavior

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api build`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts src/signals/routes/__tests__/zero-goals.test.ts src/signals/routes/__tests__/zero-workflow-queue.test.ts --maxWorkers=1 --silent=passed-only` (93 passed)
- pre-commit full-repository Knip and workspace type checks
- baseline proof on pre-fix main: the same completed-goal integration assertion observed 2 KMS data-key calls; this head observes exactly 1

## Rollout risk

During a mixed-version API rollout, old instances may still enter the duplicate path. Existing goal-event coalescing and the final queue-first claim preserve correctness; the expected difference is temporary extra preparation work until old instances drain.

Closes #26983

Parent context: #24203
