### PR TITLE
feat(billing): move usage pack plan steps into a dialog

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -430,6 +430,9 @@ describe("organization billing settings", () => {
       name: "Choose a plan",
     });
     expect(choosePlanHeading).toBeInTheDocument();
+    // The plan steps are a dialog over the billing tab, not a page that
+    // replaces it, so the plan the workspace is deciding against stays visible.
+    expect(screen.getByText("No active plan")).toBeInTheDocument();
     const proPlan = await screen.findByRole("article", { name: "Pro plan" });
     const teamPlan = screen.getByRole("article", { name: "Team plan" });
     expect(proPlan).toHaveTextContent("Plan$0/month");
@@ -592,6 +595,9 @@ describe("organization billing settings", () => {
         screen.queryByRole("dialog", { name: "Configure member packages" }),
       ).not.toBeInTheDocument();
     });
+    // Closing the flow lands back on the billing overview it was opened from.
+    expect(screen.getByText("No active plan")).toBeInTheDocument();
+    expect(buttonByText("Upgrade")).toBeInTheDocument();
 
     const settingsDialog = screen.getByRole("dialog", { name: "Settings" });
     click(within(settingsDialog).getByLabelText("Close"));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -581,6 +581,18 @@ describe("organization billing settings", () => {
       name: "Configure member packages",
     });
 
+    // The plan steps are modal, so the settings dialog underneath is inert
+    // until the step dialog closes.
+    const packagesDialog = screen.getByRole("dialog", {
+      name: "Configure member packages",
+    });
+    click(within(packagesDialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Configure member packages" }),
+      ).not.toBeInTheDocument();
+    });
+
     const settingsDialog = screen.getByRole("dialog", { name: "Settings" });
     click(within(settingsDialog).getByLabelText("Close"));
     await waitFor(() => {
@@ -591,6 +603,10 @@ describe("organization billing settings", () => {
 
     const reopenedDialog = await openSettingsFromAccountMenu("Alex Chen");
     click(buttonByText("Billing", reopenedDialog));
+    await waitFor(() => {
+      expect(screen.getByText("No active plan")).toBeInTheDocument();
+    });
+    click(buttonByText("Upgrade"));
     await expect(
       screen.findByRole("heading", { name: "Choose a plan" }),
     ).resolves.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -2836,11 +2836,13 @@ export function OrgBillingTab() {
 
       {showConcurrency && <ConcurrencyBillingSection status={status} />}
 
-      {usagePackPlanDialogs && (
+      {/* Past the early return above, an open billing sub-page can only be the
+          usage pack plan flow. Mount it only while it is open so its catalog
+          and subscription load with the flow, not with every tab visit. */}
+      {pricingOpen && (
         <UsagePackPricingDialogs
           checkoutAllowed={canStartUsagePackCheckout(status)}
           currentTier={currentTier}
-          open={pricingOpen}
           onClose={closeBillingSubPage}
         />
       )}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -100,7 +100,7 @@ import { openSettingsUsagePackUpgrade$ } from "../../../../signals/zero-page/set
 import {
   UsagePackMigrationPage,
   UsagePackMigrationPlanSelectionPage,
-  UsagePackPricingPage,
+  UsagePackPricingDialogs,
 } from "./usage-pack-pricing-page.tsx";
 
 const PLANS = [
@@ -2402,7 +2402,6 @@ function BillingPricingPage({
   onRestore,
   periodEnd,
   scheduledChange,
-  usagePackCheckoutAllowed,
 }: {
   readonly currentTier: BillingTier;
   readonly migration: UsagePackMigrationStateResponse | null;
@@ -2415,11 +2414,7 @@ function BillingPricingPage({
   readonly onRestore: () => void;
   readonly periodEnd: string | null | undefined;
   readonly scheduledChange: ScheduledBillingChange;
-  readonly usagePackCheckoutAllowed: boolean;
 }) {
-  const featureSwitches = useGet(featureSwitch$);
-  const usagePackPlansEnabled =
-    featureSwitches[FeatureSwitchKey.UsagePackPlans];
   const migrationInProgress = usagePackMigrationInProgress(migration);
   const scheduledMigrationMissingConfiguration =
     migration?.status === "scheduled" && !migration.configuration;
@@ -2450,12 +2445,6 @@ function BillingPricingPage({
           configuration={migration.configuration ?? null}
           onBack={onBack}
           onSelect={onSelectMigration}
-        />
-      ) : usagePackPlansEnabled ? (
-        <UsagePackPricingPage
-          checkoutAllowed={usagePackCheckoutAllowed}
-          currentTier={currentTier}
-          onBack={onBack}
         />
       ) : (
         <PricingPage
@@ -2492,6 +2481,17 @@ function usagePackMigrationInProgress(
   migration: UsagePackMigrationStateResponse | null,
 ): boolean {
   return migration?.status === "applying";
+}
+
+/* The usage pack plans live in their own dialog over the billing tab.
+   Everything else -- the legacy pricing page and the legacy plan conversion --
+   still takes the tab over, so those keep the sub-page. */
+function showsUsagePackPlanDialogs(
+  enabled: boolean,
+  migrationLoading: boolean,
+  migration: UsagePackMigrationStateResponse | null,
+): boolean {
+  return enabled && !migrationLoading && migration === null;
 }
 
 function usagePackMigrationConfigurable(
@@ -2654,7 +2654,13 @@ export function OrgBillingTab() {
     );
   };
 
-  if (pricingOpen) {
+  const usagePackPlanDialogs = showsUsagePackPlanDialogs(
+    usagePackPlansEnabled,
+    migrationLoading,
+    migration,
+  );
+
+  if (pricingOpen && !usagePackPlanDialogs) {
     return (
       <BillingPricingPage
         currentTier={currentTier}
@@ -2666,7 +2672,6 @@ export function OrgBillingTab() {
         onSelectMigration={openMigrationPage}
         scheduledChange={scheduledChange}
         periodEnd={periodEnd}
-        usagePackCheckoutAllowed={canStartUsagePackCheckout(status)}
         onBack={closeBillingSubPage}
         onRestore={handleRestore}
       />
@@ -2830,6 +2835,15 @@ export function OrgBillingTab() {
       )}
 
       {showConcurrency && <ConcurrencyBillingSection status={status} />}
+
+      {usagePackPlanDialogs && (
+        <UsagePackPricingDialogs
+          checkoutAllowed={canStartUsagePackCheckout(status)}
+          currentTier={currentTier}
+          open={pricingOpen}
+          onClose={closeBillingSubPage}
+        />
+      )}
 
       <DowngradeConfirmDialog currentTier={currentTier} />
       <RestorePlanConfirmDialog

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -407,9 +407,11 @@ function MemberIdentity({ member }: { readonly member: MemberDisplay }) {
 }
 
 /* Every ledger row lands on the same three columns: who or what the line is,
-   the control, and the money. */
+   the control, and the money. The money column is wide enough for the total
+   row's 30px figure at five digits -- it is the one number that has to fit,
+   and a shared width is what keeps every amount on one right edge. */
 const LEDGER_ROW =
-  "grid grid-cols-[minmax(0,1fr)_minmax(15rem,17rem)_4.5rem] items-center gap-3 py-2.5";
+  "grid grid-cols-[minmax(0,1fr)_minmax(15rem,17rem)_9.5rem] items-center gap-3 py-2.5";
 const LEDGER_RULE = "border-t-[0.7px] border-[hsl(var(--gray-100))]";
 
 function LedgerPrice({
@@ -950,6 +952,36 @@ function PlanSelectionCard({
   );
 }
 
+function PricingBackButton({ onBack }: { readonly onBack: () => void }) {
+  const { t } = useTranslation();
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            onClick={onBack}
+            variant="quiet"
+            size="icon-xs"
+            aria-label={t(($) => {
+              return $.billing.common.back;
+            })}
+          >
+            <ArrowLeft size={16} />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p className="text-xs">
+            {t(($) => {
+              return $.billing.common.back;
+            })}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function UsagePackPageHeader({
   description,
   onBack,
@@ -961,33 +993,9 @@ function UsagePackPageHeader({
   readonly title: string;
   readonly trailing?: ReactNode;
 }) {
-  const { t } = useTranslation();
   return (
     <div className="flex items-center gap-3">
-      <TooltipProvider delayDuration={200}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              onClick={onBack}
-              variant="quiet"
-              size="icon-xs"
-              aria-label={t(($) => {
-                return $.billing.common.back;
-              })}
-            >
-              <ArrowLeft size={16} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <p className="text-xs">
-              {t(($) => {
-                return $.billing.common.back;
-              })}
-            </p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <PricingBackButton onBack={onBack} />
       <div className="min-w-0 flex-1">
         <h3 className="text-sm font-medium text-foreground">{title}</h3>
         {description && (
@@ -1034,6 +1042,67 @@ function PricingPageHeader({
       }
       trailing={<PricingStepIndicator current={step} />}
     />
+  );
+}
+
+function pricingStepTitle(step: 1 | 2): string {
+  return step === 1
+    ? i18n.t(($) => {
+        return $.billing.plans.usagePacks.choosePlan;
+      })
+    : i18n.t(($) => {
+        return $.billing.plans.usagePacks.configurePackages;
+      });
+}
+
+/* Both pricing steps are their own modal rather than a page inside Settings:
+   picking a plan is a decision the workspace makes in one sitting, and a
+   dialog keeps the billing overview it is decided against in place behind it.
+   The two steps share one dialog frame at one width, so moving between them
+   only changes the body -- the header band, the step counter and the outer
+   edges hold still. */
+function PricingStepDialog({
+  children,
+  onBack,
+  onClose,
+  open,
+  step,
+}: {
+  readonly children: ReactNode;
+  readonly onBack?: () => void;
+  readonly onClose: () => void;
+  readonly open: boolean;
+  readonly step: 1 | 2;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent
+        aria-describedby={undefined}
+        closeLabel={t(($) => {
+          return $.settings.shared.close;
+        })}
+        className="flex max-h-[min(46rem,calc(100dvh-4rem))] w-[calc(100vw-2rem)] max-w-[860px] flex-col gap-0 overflow-hidden p-0"
+      >
+        <DialogHeader className="flex-row shrink-0 items-center gap-3 space-y-0 border-b-[0.7px] border-[hsl(var(--gray-200))] px-5 py-4 pr-16 text-left">
+          {onBack && <PricingBackButton onBack={onBack} />}
+          <DialogTitle className="min-w-0 flex-1 text-base font-medium leading-none">
+            {pricingStepTitle(step)}
+          </DialogTitle>
+          <PricingStepIndicator current={step} />
+        </DialogHeader>
+        <div className="dialog-scrollable min-h-0 flex-1 overflow-y-auto">
+          {children}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -1126,19 +1195,13 @@ function PlanSelectionStep({
   catalog,
   checkoutAllowed,
   currentTier,
-  error,
-  loading,
   managedTier,
-  onBack,
   onAction,
 }: {
   readonly catalog: readonly UsagePackCatalogItem[];
   readonly checkoutAllowed: boolean;
   readonly currentTier: BillingTier;
-  readonly error: string | null;
-  readonly loading: boolean;
   readonly managedTier: UsagePackPlanTier | null;
-  readonly onBack: () => void;
   readonly onAction: (
     plan: UsagePackPlanTier,
     action: PlanSelectionAction,
@@ -1146,34 +1209,32 @@ function PlanSelectionStep({
 }) {
   const minimumPackage = usagePackCatalogItem(catalog, MINIMUM_USAGE_PACK_USD);
   return (
-    <>
-      <PricingPageHeader onBack={onBack} step={1} />
-      <PlanSelectionPanel>
-        {USAGE_PACK_PLANS.map((plan, index) => {
-          const action = usagePackPlanAction(
-            checkoutAllowed,
-            currentTier,
-            managedTier,
-            plan.tier,
-          );
-          return (
-            <PlanSelectionCard
-              key={plan.tier}
-              action={action}
-              busy={loading}
-              divided={index > 0}
-              keepsMemberPackages={managedTier !== null}
-              minimumPackage={minimumPackage}
-              plan={plan}
-              onAction={() => {
-                onAction(plan.tier, action);
-              }}
-            />
-          );
-        })}
-      </PlanSelectionPanel>
-      {error && <p className="text-sm text-destructive">{error}</p>}
-    </>
+    /* The dialog is the panel, so the columns meet its edges and only the
+       hairline between them separates the two plans. */
+    <div className="grid grid-cols-1 sm:grid-cols-2">
+      {USAGE_PACK_PLANS.map((plan, index) => {
+        const action = usagePackPlanAction(
+          checkoutAllowed,
+          currentTier,
+          managedTier,
+          plan.tier,
+        );
+        return (
+          <PlanSelectionCard
+            key={plan.tier}
+            action={action}
+            busy={false}
+            divided={index > 0}
+            keepsMemberPackages={managedTier !== null}
+            minimumPackage={minimumPackage}
+            plan={plan}
+            onAction={() => {
+              onAction(plan.tier, action);
+            }}
+          />
+        );
+      })}
+    </div>
   );
 }
 
@@ -2145,12 +2206,10 @@ function ManagedSubscriptionOrderSummary({
 function PackageConfigurationStep({
   catalog,
   management,
-  onBack,
   plan,
 }: {
   readonly catalog: readonly UsagePackCatalogItem[];
   readonly management: UsagePackManagementResponse | null;
-  readonly onBack: () => void;
   readonly plan: UsagePackPlan;
 }) {
   const selections = useGet(memberUsageSelections$);
@@ -2180,8 +2239,7 @@ function PackageConfigurationStep({
   const totals = memberUsageTotals(members ?? [], selections, catalog);
 
   return (
-    <>
-      <PricingPageHeader onBack={onBack} step={2} />
+    <div className="flex flex-col gap-5 px-5 py-5">
       <MemberUsageConfiguration
         catalog={catalog}
         management={management}
@@ -2207,7 +2265,7 @@ function PackageConfigurationStep({
           selections={selections}
         />
       )}
-    </>
+    </div>
   );
 }
 
@@ -2849,19 +2907,20 @@ export function UsagePackMigrationPage({
   );
 }
 
-export function UsagePackPricingPage({
+export function UsagePackPricingDialogs({
   checkoutAllowed,
   currentTier,
-  onBack,
+  onClose,
+  open,
 }: {
   readonly checkoutAllowed: boolean;
   readonly currentTier: BillingTier;
-  readonly onBack: () => void;
+  readonly onClose: () => void;
+  readonly open: boolean;
 }) {
   const selectedPlanTier = useGet(selectedUsagePackPlan$);
   const setSelectedPlan = useSet(setSelectedUsagePackPlan$);
   const setMemberUsageSelections = useSet(setMemberUsageSelections$);
-  const usagePackPricingPageRef = useSet(usagePackPricingPageRef$);
   const catalogLoadable = useLoadable(usagePackCatalogAsync$);
   const managementLoadable = useLoadable(usagePackManagementAsync$);
   const catalog =
@@ -2879,35 +2938,35 @@ export function UsagePackPricingPage({
     );
   });
   return (
-    <div
-      className="flex flex-col gap-5 outline-none"
-      ref={usagePackPricingPageRef}
-      role="group"
-      tabIndex={-1}
+    <PricingStepDialog
+      open={open}
+      step={selectedPlan ? 2 : 1}
+      onBack={
+        selectedPlan
+          ? () => {
+              setSelectedPlan(null);
+            }
+          : undefined
+      }
+      onClose={() => {
+        setSelectedPlan(null);
+        onClose();
+      }}
     >
       {!catalog || !managementLoaded ? (
-        <div className="h-80 animate-pulse rounded-xl bg-muted/40" />
+        <div className="m-5 h-80 animate-pulse rounded-xl bg-muted/40" />
       ) : selectedPlan ? (
         <PackageConfigurationStep
           catalog={catalog}
           management={management}
           plan={selectedPlan}
-          onBack={() => {
-            setSelectedPlan(null);
-          }}
         />
       ) : (
         <PlanSelectionStep
           catalog={catalog}
           checkoutAllowed={checkoutAllowed}
           currentTier={currentTier}
-          error={null}
-          loading={false}
           managedTier={management?.tier ?? null}
-          onBack={() => {
-            setSelectedPlan(null);
-            onBack();
-          }}
           onAction={(plan, action) => {
             if (action === "disabled") {
               return;
@@ -2928,6 +2987,6 @@ export function UsagePackPricingPage({
           }}
         />
       )}
-    </div>
+    </PricingStepDialog>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1062,24 +1062,26 @@ function pricingStepTitle(step: 1 | 2): string {
    moving between them only changes the body -- the header band, the step
    counter and the outer edges hold still. The height is the taller step's
    (plan selection), and the body insets its content so no rule, tint or column
-   runs into the frame. */
+   runs into the frame.
+
+   The dialog is mounted only while the flow is open, so the plan catalog and
+   the subscription it loads stay owned by the flow rather than by every visit
+   to the billing tab. */
 function PricingStepDialog({
   children,
   onBack,
   onClose,
-  open,
   step,
 }: {
   readonly children: ReactNode;
   readonly onBack?: () => void;
   readonly onClose: () => void;
-  readonly open: boolean;
   readonly step: 1 | 2;
 }) {
   const { t } = useTranslation();
   return (
     <Dialog
-      open={open}
+      open
       onOpenChange={(next) => {
         if (!next) {
           onClose();
@@ -2923,12 +2925,10 @@ export function UsagePackPricingDialogs({
   checkoutAllowed,
   currentTier,
   onClose,
-  open,
 }: {
   readonly checkoutAllowed: boolean;
   readonly currentTier: BillingTier;
   readonly onClose: () => void;
-  readonly open: boolean;
 }) {
   const selectedPlanTier = useGet(selectedUsagePackPlan$);
   const setSelectedPlan = useSet(setSelectedUsagePackPlan$);
@@ -2951,7 +2951,6 @@ export function UsagePackPricingDialogs({
   });
   return (
     <PricingStepDialog
-      open={open}
       step={selectedPlan ? 2 : 1}
       onBack={
         selectedPlan

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1058,9 +1058,11 @@ function pricingStepTitle(step: 1 | 2): string {
 /* Both pricing steps are their own modal rather than a page inside Settings:
    picking a plan is a decision the workspace makes in one sitting, and a
    dialog keeps the billing overview it is decided against in place behind it.
-   The two steps share one dialog frame at one width, so moving between them
-   only changes the body -- the header band, the step counter and the outer
-   edges hold still. */
+   The two steps share one dialog frame at one fixed width and height, so
+   moving between them only changes the body -- the header band, the step
+   counter and the outer edges hold still. The height is the taller step's
+   (plan selection), and the body insets its content so no rule, tint or column
+   runs into the frame. */
 function PricingStepDialog({
   children,
   onBack,
@@ -1089,7 +1091,7 @@ function PricingStepDialog({
         closeLabel={t(($) => {
           return $.settings.shared.close;
         })}
-        className="flex max-h-[min(46rem,calc(100dvh-4rem))] w-[calc(100vw-2rem)] max-w-[860px] flex-col gap-0 overflow-hidden p-0"
+        className="flex h-[min(43rem,calc(100dvh-4rem))] w-[calc(100vw-2rem)] max-w-[860px] flex-col gap-0 overflow-hidden p-0"
       >
         <DialogHeader className="flex-row shrink-0 items-center gap-3 space-y-0 border-b-[0.7px] border-[hsl(var(--gray-200))] px-5 py-4 pr-16 text-left">
           {onBack && <PricingBackButton onBack={onBack} />}
@@ -1098,7 +1100,7 @@ function PricingStepDialog({
           </DialogTitle>
           <PricingStepIndicator current={step} />
         </DialogHeader>
-        <div className="dialog-scrollable min-h-0 flex-1 overflow-y-auto">
+        <div className="dialog-scrollable flex min-h-0 flex-1 flex-col overflow-y-auto p-5">
           {children}
         </div>
       </DialogContent>
@@ -1209,9 +1211,10 @@ function PlanSelectionStep({
 }) {
   const minimumPackage = usagePackCatalogItem(catalog, MINIMUM_USAGE_PACK_USD);
   return (
-    /* The dialog is the panel, so the columns meet its edges and only the
-       hairline between them separates the two plans. */
-    <div className="grid grid-cols-1 sm:grid-cols-2">
+    /* No panel border inside the dialog frame -- the only rule between the two
+       plans is the hairline the second column carries, and it runs the full
+       height of the body so the frame reads as two columns, not two cards. */
+    <div className="grid flex-1 grid-cols-1 sm:grid-cols-2">
       {USAGE_PACK_PLANS.map((plan, index) => {
         const action = usagePackPlanAction(
           checkoutAllowed,
@@ -2239,7 +2242,7 @@ function PackageConfigurationStep({
   const totals = memberUsageTotals(members ?? [], selections, catalog);
 
   return (
-    <div className="flex flex-col gap-5 px-5 py-5">
+    <div className="flex flex-1 flex-col gap-5">
       <MemberUsageConfiguration
         catalog={catalog}
         management={management}
@@ -2248,23 +2251,32 @@ function PackageConfigurationStep({
         plan={plan}
         totals={totals}
       />
-      <MemberUsageFooter />
-      {management ? (
-        <ManagedSubscriptionOrderSummary
-          currentTotals={managedMemberUsageTotals(management, members, catalog)}
-          management={management}
-          members={members}
-          plan={plan}
-          selections={selections}
-          totals={totals}
-        />
-      ) : (
-        <CheckoutOrderSummary
-          members={members}
-          plan={plan}
-          selections={selections}
-        />
-      )}
+      {/* The frame keeps step 1's height, so a short member list leaves slack
+          below the ledger. Spend it above the fine print and the action, which
+          stay together at the foot of the dialog. */}
+      <div className="mt-auto flex flex-col gap-5">
+        <MemberUsageFooter />
+        {management ? (
+          <ManagedSubscriptionOrderSummary
+            currentTotals={managedMemberUsageTotals(
+              management,
+              members,
+              catalog,
+            )}
+            management={management}
+            members={members}
+            plan={plan}
+            selections={selections}
+            totals={totals}
+          />
+        ) : (
+          <CheckoutOrderSummary
+            members={members}
+            plan={plan}
+            selections={selections}
+          />
+        )}
+      </div>
     </div>
   );
 }
@@ -2954,7 +2966,7 @@ export function UsagePackPricingDialogs({
       }}
     >
       {!catalog || !managementLoaded ? (
-        <div className="m-5 h-80 animate-pulse rounded-xl bg-muted/40" />
+        <div className="flex-1 animate-pulse rounded-xl bg-muted/40" />
       ) : selectedPlan ? (
         <PackageConfigurationStep
           catalog={catalog}


### PR DESCRIPTION
## What

Behind `usagePackPlans`, "Choose a plan" and "Configure member packages" replaced the entire Billing tab. Both steps now open as a modal over the tab instead.

- One dialog frame at one width (860px) carries both steps, so moving between them only changes the body — the header band, step counter and outer edges hold still.
- Step 1: the dialog *is* the panel — the two plan columns meet its edges, split by a single hairline.
- Step 2: back arrow in the header returns to step 1; the close button ends the flow and returns to the billing overview.
- The legacy pricing page and the legacy plan conversion still take the tab over — they keep the sub-page.
- Ledger price column widened from `4.5rem` to `9.5rem`: the monthly total renders at 30px and needs 152px at five digits, so it used to bleed past its column (invisible inside the page's padding, clipped inside a dialog).

## Verification

- `pnpm -F @okouai/app check-types`, `lint`, `knip`
- `vitest run org-billing-tab.test.tsx org-members-tab.test.tsx zero-sidebar-account-menu.test.tsx org-usage-tab.test.tsx personal-usage-tab.test.tsx` — 88 passed
- Rendered both steps with the app's own tokens and Tailwind build to check the frame, column hairline and the amount rail

One test changed: the settings dialog is inert while a step dialog is open, so the "closing settings resets the flow" case now closes the step dialog first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)