### PR TITLE
test(api): isolate claim-setup heartbeats from mocked clocks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -51,7 +51,7 @@ import { createAppWithRoutes } from "../../../../app-factory-core";
 import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { mockEnv, mockOptionalEnv } from "../../../../lib/env";
-import { now } from "../../../../lib/time";
+import { now, withNowScopeForTest } from "../../../../lib/time";
 import { createAgentComposeFixture } from "../../../../test-fixtures/agent-composes";
 import {
   createDirectRunFixture,
@@ -1107,13 +1107,17 @@ export function createRunsApi(context: TestContext) {
     },
 
     async heartbeatRunner(group?: string) {
-      return await accept(
-        runApp(context)(runnersHeartbeatContract).heartbeat({
-          headers: runnerHeaders(true),
-          body: runnerHeartbeatBody({ group }),
-        }),
-        [200],
-      );
+      // Claim setup must not let a feature-specific mocked clock prune runner
+      // rows owned by parallel files in the shared test database.
+      return await withNowScopeForTest(async () => {
+        return await accept(
+          runApp(context)(runnersHeartbeatContract).heartbeat({
+            headers: runnerHeaders(true),
+            body: runnerHeartbeatBody({ group }),
+          }),
+          [200],
+        );
+      });
     },
 
     async requestHeartbeatRunner(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -4916,6 +4916,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       sequence: 1,
       resource: undefined,
     });
+    // An unrelated runner's heartbeat must not drop this runner's retained
+    // snapshot. Parallel test files share one database and perform incidental
+    // claim setup under their own mocked clocks, so this heartbeat is issued
+    // far ahead of `baseTime` to pin the stale-runner pruning boundary.
+    mockNow(baseTime + 9 * 60 * 60 * 1000);
+    await api.heartbeatRunner(runnerGroup);
+    mockNow(baseTime + 5000);
     await expectReusePreference("reusableSandbox");
 
     mockNow(baseTime + 20_000);


### PR DESCRIPTION
## Problem

`test-api (7)` failed in the merge group with a dropped runner reuse preference:

```
AssertionError: expected { kind: 'noPreference', … } to match object { kind: 'preference', … }
 ❯ expectReusePreference run-lifecycle.bdd.test.ts:4887
```

Failing run: https://github.com/vm0-ai/vm0/actions/runs/31708700324 (job [`test-api (7)`](https://github.com/vm0-ai/vm0/actions/runs/31708700324/job/94475866423), SHA `855846baaf436d92988d843cb39abe74a55750c9`).

The represented PR (#26993) only touched `zero-browser.test.ts`; the exact PR head and the exact main parent each passed this test. The assertion immediately before the failure (`poll.body.job?.runId === followUp.runId`) passed, so the correct follow-up job was selected and only its **preference projection** diverged.

## Root cause

`turbo/apps/api/src/signals/routes/runners.ts:522-529` prunes stale runners with a single **unscoped** delete, evaluated against the API process clock:

```ts
await db.delete(runnerState).where(
  lt(runnerState.lastSeenAt, new Date(currentDate.getTime() - STALE_RUNNER_THRESHOLD_MS)),
);
```

`currentDate` comes from `nowDate()`, which honours `mockNow()`. This is the only `runnerState` GC in the codebase, and parallel API test files share one database per shard. So any file that heartbeats under a **future** mocked clock deletes every runner row in the shard.

`cron-execute-morning-briefs.test.ts:92-96` anchors on the next 07:00 Asia/Shanghai *strictly after the real clock*, then calls the shared `heartbeatRunner()` helper while that clock is active:

```ts
const SEVEN_LOCAL = new Cron("0 7 * * *", { timezone: TIMEZONE })
  .nextRun(new Date(now() + 60 * 1000))!.getTime();
const BEFORE_SEVEN_LOCAL = SEVEN_LOCAL - 10 * 60 * 1000;
```

At the failing run (2026-08-13T14:09:53Z) that clock sat **8.67 hours ahead** of real time, so its prune deleted every row with `last_seen_at < 2026-08-13T22:45:00Z` — including the ordered snapshot holder that `run-lifecycle.bdd.test.ts` had just written at real time.

With the holder gone, the following out-of-order heartbeat no longer hit a conflict, so `onConflictDoUpdate`'s `setWhere` ordering guard was bypassed and the row was re-inserted with empty `heldSandboxStates` → `noPreference`. `runner_job_queue` is untouched by the delete, which is exactly why job selection still succeeded.

It is intermittent because it needs the morning-briefs heartbeat to land inside the narrow window between the ordered heartbeat and its poll — pure parallel-fork scheduling. #26993's edit to `zero-browser.test.ts` perturbed shard 7's file interleaving; it did not introduce the defect.

## Fix

Run the shared claim-setup heartbeat under `withNowScopeForTest()` so it uses the real clock and can only prune genuinely stale rows. This helper is incidental setup — it exists so a runner exists to claim a job — and no test asserts on its timestamp. Feature-specific heartbeats that deliberately assert ordering, expiry, or protection-window semantics keep their mocked clocks.

Scoping the product delete by runner group was rejected: it is the only `runner_state` GC, so group-scoping would leak rows for groups that stop heartbeating.

A guard in the ordered-heartbeat test pins the invariant that an unrelated runner's heartbeat must not drop this runner's retained snapshot.

## Verification

- **A/B reproduction** against a local UTC Postgres: with a simulated parallel future-clock heartbeat and the fix reverted, the test fails with the *exact* CI assertion at the *exact* line (`run-lifecycle.bdd.test.ts:4887`). With the fix applied, it passes.
- Target test repeated **5×** — all pass.
- All **38 test files** that use the changed shared helper run together against one shared database: **981 passed**.
- `prettier --check` clean; `oxlint` warning count unchanged (7 before, 7 after — all pre-existing).
- `tsc --noEmit` for `apps/api` did not complete locally (stalled past 29 min; this project is known-heavy). Left to the PR pipeline. The change adds no new type surface.

## Follow-up worth tracking separately

The same unscoped delete is a latent production risk: an API instance whose clock runs >5 minutes fast would evict **all** healthy runner rows globally. Out of scope for this flaky fix.
