### PR TITLE
fix(e2e): isolate clerk bootstrap retries

### DIFF
--- a/e2e/playwright/lib/auth.test.ts
+++ b/e2e/playwright/lib/auth.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import { test } from "node:test";
+
+import { chromium } from "@playwright/test";
+
+import { withLoadedClerkTestingPage } from "./auth";
+
+type ClerkFixtureMode = "absent" | "incomplete" | "loaded" | "recover";
+
+interface ClerkFixture {
+  readonly appUrl: string;
+  readonly documentRequestCount: () => number;
+  readonly frontendRequestCount: () => number;
+}
+
+const FIXTURE_QUERY_SECRET = "do-not-log-capability";
+
+test("isolates runner Clerk bootstrap recovery before side effects", async (context) => {
+  const browser = await chromium.launch();
+  try {
+    await context.test(
+      "retries a stalled bootstrap in a clean context",
+      async () => {
+        await withClerkFixture("recover", async (fixture) => {
+          let callbackCount = 0;
+          const state = await withLoadedClerkTestingPage(
+            browser,
+            {
+              appUrl: fixture.appUrl,
+              bootstrapTimeoutsMs: [100, 1_000],
+              contextOptions: {},
+            },
+            async (page) => {
+              callbackCount += 1;
+              return page.evaluate(() => {
+                return {
+                  hasLoadedClerk: Boolean(window.Clerk?.loaded),
+                  poison: localStorage.getItem("clerk-bootstrap-poison"),
+                };
+              });
+            },
+          );
+
+          assert.deepEqual(state, { hasLoadedClerk: true, poison: null });
+          assert.equal(callbackCount, 1);
+          assert.equal(fixture.documentRequestCount(), 2);
+          assert.equal(fixture.frontendRequestCount(), 2);
+        });
+      },
+    );
+
+    await context.test("reports a sanitized terminal timeout", async () => {
+      await withClerkFixture("incomplete", async (fixture) => {
+        await assert.rejects(
+          withLoadedClerkTestingPage(
+            browser,
+            {
+              appUrl: fixture.appUrl,
+              bootstrapTimeoutsMs: [100, 100],
+              contextOptions: {},
+            },
+            async () => {
+              throw new Error("callback must not run");
+            },
+          ),
+          (error: unknown) => {
+            assert(error instanceof Error);
+            assert.match(
+              error.message,
+              /Clerk bootstrap timed out after 2 attempts: ClerkJS present but not loaded; last Clerk request: GET \/v1\/client -> 503/u,
+            );
+            assert.doesNotMatch(
+              error.message,
+              new RegExp(FIXTURE_QUERY_SECRET),
+            );
+            return true;
+          },
+        );
+        assert.equal(fixture.documentRequestCount(), 2);
+        assert.equal(fixture.frontendRequestCount(), 2);
+      });
+    });
+
+    await context.test("distinguishes an absent ClerkJS global", async () => {
+      await withClerkFixture("absent", async (fixture) => {
+        await assert.rejects(
+          withLoadedClerkTestingPage(
+            browser,
+            {
+              appUrl: fixture.appUrl,
+              bootstrapTimeoutsMs: [100, 100],
+              contextOptions: {},
+            },
+            async () => {
+              throw new Error("callback must not run");
+            },
+          ),
+          (error: unknown) => {
+            assert(error instanceof Error);
+            assert.match(
+              error.message,
+              /Clerk bootstrap timed out after 2 attempts: ClerkJS absent; last Clerk request: GET \/v1\/client -> 200/u,
+            );
+            return true;
+          },
+        );
+        assert.equal(fixture.documentRequestCount(), 2);
+      });
+    });
+
+    await context.test("does not retry errors after bootstrap", async () => {
+      await withClerkFixture("loaded", async (fixture) => {
+        const callbackError = new Error("post-bootstrap side effect failed");
+        await assert.rejects(
+          withLoadedClerkTestingPage(
+            browser,
+            {
+              appUrl: fixture.appUrl,
+              bootstrapTimeoutsMs: [100, 1_000],
+              contextOptions: {},
+            },
+            async () => {
+              throw callbackError;
+            },
+          ),
+          (error: unknown) => error === callbackError,
+        );
+        assert.equal(fixture.documentRequestCount(), 1);
+        assert.equal(fixture.frontendRequestCount(), 0);
+      });
+    });
+  } finally {
+    await browser.close();
+  }
+});
+
+async function withClerkFixture<Result>(
+  mode: ClerkFixtureMode,
+  use: (fixture: ClerkFixture) => Promise<Result>,
+): Promise<Result> {
+  let documentRequests = 0;
+  let frontendRequests = 0;
+  const server = createServer((request, response) => {
+    const requestUrl = request.url;
+    if (!requestUrl) {
+      throw new Error("Clerk fixture request URL is required");
+    }
+    const pathname = new URL(requestUrl, "http://clerk.fixture").pathname;
+    if (pathname === "/_/skeleton") {
+      documentRequests += 1;
+      response.writeHead(200, { "Content-Type": "text/html" });
+      response.end(clerkFixtureDocument(mode, documentRequests));
+      return;
+    }
+    if (pathname === "/v1/client") {
+      frontendRequests += 1;
+      if (mode === "recover" && frontendRequests === 1) {
+        return;
+      }
+      response.writeHead(mode === "incomplete" ? 503 : 200, {
+        "Content-Type": "application/json",
+      });
+      response.end("{}");
+      return;
+    }
+    response.writeHead(404);
+    response.end();
+  });
+
+  await listen(server);
+  const address = server.address();
+  assert(address && typeof address === "object");
+  const previousFrontendApi = process.env.CLERK_FAPI;
+  const previousTestingToken = process.env.CLERK_TESTING_TOKEN;
+  process.env.CLERK_FAPI = `127.0.0.1:${address.port}`;
+  process.env.CLERK_TESTING_TOKEN = "fixture-testing-token";
+  try {
+    return await use({
+      appUrl: `http://127.0.0.1:${address.port}`,
+      documentRequestCount: () => documentRequests,
+      frontendRequestCount: () => frontendRequests,
+    });
+  } finally {
+    restoreEnvironmentVariable("CLERK_FAPI", previousFrontendApi);
+    restoreEnvironmentVariable("CLERK_TESTING_TOKEN", previousTestingToken);
+    await close(server);
+  }
+}
+
+function clerkFixtureDocument(
+  mode: ClerkFixtureMode,
+  documentRequest: number,
+): string {
+  if (mode === "loaded") {
+    return `<!doctype html><script>window.Clerk = { loaded: true };</script>`;
+  }
+  if (mode === "absent") {
+    return `<!doctype html><script>fetch("/v1/client?__clerk_testing_token=${FIXTURE_QUERY_SECRET}");</script>`;
+  }
+  const poisonFirstContext =
+    mode === "recover" && documentRequest === 1
+      ? `localStorage.setItem("clerk-bootstrap-poison", "true");`
+      : "";
+  const finishBootstrap =
+    mode === "recover"
+      ? `if (!localStorage.getItem("clerk-bootstrap-poison")) { window.Clerk.loaded = true; }`
+      : "";
+  return `<!doctype html>
+<script>
+  window.Clerk = { loaded: false };
+  ${poisonFirstContext}
+  fetch("/v1/client?__clerk_testing_token=${FIXTURE_QUERY_SECRET}").then(() => {
+    ${finishBootstrap}
+  });
+</script>`;
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+    server.closeAllConnections();
+  });
+}
+
+function restoreEnvironmentVariable(
+  name: "CLERK_FAPI" | "CLERK_TESTING_TOKEN",
+  value: string | undefined,
+): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/e2e/playwright/lib/auth.test.ts
+++ b/e2e/playwright/lib/auth.test.ts
@@ -28,7 +28,7 @@ test("isolates runner Clerk bootstrap recovery before side effects", async (cont
             browser,
             {
               appUrl: fixture.appUrl,
-              bootstrapTimeoutsMs: [100, 1_000],
+              bootstrapTimeoutsMs: [250, 1_000],
               contextOptions: {},
             },
             async (page) => {
@@ -57,7 +57,7 @@ test("isolates runner Clerk bootstrap recovery before side effects", async (cont
             browser,
             {
               appUrl: fixture.appUrl,
-              bootstrapTimeoutsMs: [100, 100],
+              bootstrapTimeoutsMs: [250, 250],
               contextOptions: {},
             },
             async () => {
@@ -89,7 +89,7 @@ test("isolates runner Clerk bootstrap recovery before side effects", async (cont
             browser,
             {
               appUrl: fixture.appUrl,
-              bootstrapTimeoutsMs: [100, 100],
+              bootstrapTimeoutsMs: [250, 250],
               contextOptions: {},
             },
             async () => {
@@ -117,7 +117,7 @@ test("isolates runner Clerk bootstrap recovery before side effects", async (cont
             browser,
             {
               appUrl: fixture.appUrl,
-              bootstrapTimeoutsMs: [100, 1_000],
+              bootstrapTimeoutsMs: [250, 1_000],
               contextOptions: {},
             },
             async () => {

--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -209,17 +209,17 @@ async function loadClerkInContext(
   if (!frontendApi) {
     throw new Error("CLERK_FAPI environment variable is required");
   }
-  const frontendApiHostname = new URL(`https://${frontendApi}`).hostname;
+  const frontendApiHost = new URL(`https://${frontendApi}`).host;
   let lastRequest: ClerkBootstrapRequest | undefined;
   const recordRequest = (request: Request): void => {
-    const path = clerkFrontendApiPath(request, frontendApiHostname);
+    const path = clerkFrontendApiPath(request, frontendApiHost);
     if (path) {
       lastRequest = { method: request.method(), path, status: "pending" };
     }
   };
   const recordResponse = (response: Response): void => {
     const request = response.request();
-    const path = clerkFrontendApiPath(request, frontendApiHostname);
+    const path = clerkFrontendApiPath(request, frontendApiHost);
     if (path) {
       lastRequest = {
         method: request.method(),
@@ -229,7 +229,7 @@ async function loadClerkInContext(
     }
   };
   const recordFailedRequest = (request: Request): void => {
-    const path = clerkFrontendApiPath(request, frontendApiHostname);
+    const path = clerkFrontendApiPath(request, frontendApiHost);
     if (path) {
       lastRequest = { method: request.method(), path, status: "failed" };
     }
@@ -274,10 +274,10 @@ async function loadClerkInContext(
 
 function clerkFrontendApiPath(
   request: Request,
-  frontendApiHostname: string,
+  frontendApiHost: string,
 ): string | undefined {
   const url = new URL(request.url());
-  if (url.hostname === frontendApiHostname && url.pathname.startsWith("/v1/")) {
+  if (url.host === frontendApiHost && url.pathname.startsWith("/v1/")) {
     return url.pathname;
   }
   return undefined;

--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -1,10 +1,69 @@
-import { clerk } from "@clerk/testing/playwright";
-import { errors, type Page, type Route } from "@playwright/test";
+import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
+import {
+  errors,
+  type Browser,
+  type BrowserContext,
+  type BrowserContextOptions,
+  type Page,
+  type Request,
+  type Response,
+  type Route,
+} from "@playwright/test";
 
 const CLERK_BOOTSTRAP_TIMEOUTS_MS = [15_000, 30_000] as const;
 
+type ClerkBootstrapTimeouts = readonly [number, number];
+
+interface ClerkBootstrapRequest {
+  readonly method: string;
+  readonly path: string;
+  readonly status: number | "failed" | "pending";
+}
+
+interface ClerkBootstrapState {
+  readonly hasClerk: boolean;
+  readonly hasLoadedClerk: boolean;
+}
+
+interface LoadedClerkAttempt {
+  readonly loaded: true;
+  readonly page: Page;
+}
+
+interface TimedOutClerkAttempt {
+  readonly cause: Error;
+  readonly diagnostic: string;
+  readonly loaded: false;
+}
+
+type ClerkBootstrapAttempt = LoadedClerkAttempt | TimedOutClerkAttempt;
+
+interface LoadedClerkContext {
+  readonly context: BrowserContext;
+  readonly page: Page;
+}
+
 export interface ClerkTestingSignInOptions {
   readonly activeOrganizationId?: string;
+}
+
+export interface LoadedClerkTestingPageOptions {
+  readonly appUrl: string;
+  readonly bootstrapTimeoutsMs?: ClerkBootstrapTimeouts;
+  readonly contextOptions: BrowserContextOptions;
+}
+
+export async function withLoadedClerkTestingPage<Result>(
+  browser: Browser,
+  options: LoadedClerkTestingPageOptions,
+  use: (page: Page) => Promise<Result>,
+): Promise<Result> {
+  const { context, page } = await createLoadedClerkContext(browser, options);
+  try {
+    return await use(page);
+  } finally {
+    await context.close();
+  }
 }
 
 export async function refreshClerkSessionToken(
@@ -38,6 +97,16 @@ export async function signInWithClerkTestingHelper(
 ): Promise<string> {
   const helperUrl = new URL("/_/skeleton", appUrl);
   await navigateToLoadedClerk(page, helperUrl);
+  return signInWithLoadedClerkTestingHelper(page, email, appUrl, options);
+}
+
+export async function signInWithLoadedClerkTestingHelper(
+  page: Page,
+  email: string,
+  appUrl: string,
+  options: ClerkTestingSignInOptions,
+): Promise<string> {
+  const helperUrl = new URL("/_/skeleton", appUrl);
   const clerkStateBefore = await page.evaluate(() => {
     return {
       hasLoadedClerk: Boolean(window.Clerk?.loaded),
@@ -93,6 +162,140 @@ export async function signInWithClerkTestingHelper(
 
   await gotoAboutBlankAfterClerkNavigation(page);
   return token;
+}
+
+async function createLoadedClerkContext(
+  browser: Browser,
+  options: LoadedClerkTestingPageOptions,
+): Promise<LoadedClerkContext> {
+  const timeouts = options.bootstrapTimeoutsMs ?? CLERK_BOOTSTRAP_TIMEOUTS_MS;
+
+  for (const [attempt, timeout] of timeouts.entries()) {
+    const context = await browser.newContext(options.contextOptions);
+    let result: ClerkBootstrapAttempt;
+    try {
+      result = await loadClerkInContext(context, options.appUrl, timeout);
+    } catch (error) {
+      await context.close();
+      throw error;
+    }
+
+    if (result.loaded) {
+      return { context, page: result.page };
+    }
+
+    await context.close();
+    if (attempt === timeouts.length - 1) {
+      throw new Error(
+        `Clerk bootstrap timed out after ${timeouts.length} attempts: ${result.diagnostic}`,
+        { cause: result.cause },
+      );
+    }
+    console.warn(
+      `[e2e] Clerk bootstrap stalled; recreating context: ${result.diagnostic}`,
+    );
+  }
+
+  throw new Error("Clerk bootstrap attempts exhausted");
+}
+
+async function loadClerkInContext(
+  context: BrowserContext,
+  appUrl: string,
+  timeout: number,
+): Promise<ClerkBootstrapAttempt> {
+  await setupClerkTestingToken({ context });
+  const frontendApi = process.env.CLERK_FAPI;
+  if (!frontendApi) {
+    throw new Error("CLERK_FAPI environment variable is required");
+  }
+  const frontendApiHostname = new URL(`https://${frontendApi}`).hostname;
+  let lastRequest: ClerkBootstrapRequest | undefined;
+  const recordRequest = (request: Request): void => {
+    const path = clerkFrontendApiPath(request, frontendApiHostname);
+    if (path) {
+      lastRequest = { method: request.method(), path, status: "pending" };
+    }
+  };
+  const recordResponse = (response: Response): void => {
+    const request = response.request();
+    const path = clerkFrontendApiPath(request, frontendApiHostname);
+    if (path) {
+      lastRequest = {
+        method: request.method(),
+        path,
+        status: response.status(),
+      };
+    }
+  };
+  const recordFailedRequest = (request: Request): void => {
+    const path = clerkFrontendApiPath(request, frontendApiHostname);
+    if (path) {
+      lastRequest = { method: request.method(), path, status: "failed" };
+    }
+  };
+
+  context.on("request", recordRequest);
+  context.on("response", recordResponse);
+  context.on("requestfailed", recordFailedRequest);
+  try {
+    const page = await context.newPage();
+    const helperUrl = new URL("/_/skeleton", appUrl);
+    await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
+    try {
+      await page.waitForFunction(
+        () => Boolean(window.Clerk?.loaded),
+        undefined,
+        { timeout },
+      );
+      return { loaded: true, page };
+    } catch (error) {
+      if (!(error instanceof errors.TimeoutError)) {
+        throw error;
+      }
+      const state = await page.evaluate<ClerkBootstrapState>(() => {
+        return {
+          hasClerk: window.Clerk !== undefined,
+          hasLoadedClerk: Boolean(window.Clerk?.loaded),
+        };
+      });
+      return {
+        cause: error,
+        diagnostic: formatClerkBootstrapDiagnostic(state, lastRequest),
+        loaded: false,
+      };
+    }
+  } finally {
+    context.off("request", recordRequest);
+    context.off("response", recordResponse);
+    context.off("requestfailed", recordFailedRequest);
+  }
+}
+
+function clerkFrontendApiPath(
+  request: Request,
+  frontendApiHostname: string,
+): string | undefined {
+  const url = new URL(request.url());
+  if (url.hostname === frontendApiHostname && url.pathname.startsWith("/v1/")) {
+    return url.pathname;
+  }
+  return undefined;
+}
+
+function formatClerkBootstrapDiagnostic(
+  state: ClerkBootstrapState,
+  lastRequest: ClerkBootstrapRequest | undefined,
+): string {
+  const clerkState = state.hasLoadedClerk
+    ? "ClerkJS loaded after wait timeout"
+    : state.hasClerk
+      ? "ClerkJS present but not loaded"
+      : "ClerkJS absent";
+  if (!lastRequest) {
+    return clerkState;
+  }
+  return `${clerkState}; last Clerk request: ${lastRequest.method} ${lastRequest.path} -> ${lastRequest.status}`;
 }
 
 async function activateClerkOrganization(

--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -1,12 +1,13 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
+import { clerkSetup } from "@clerk/testing/playwright";
 import { chromium, type Page } from "@playwright/test";
 
 import {
   refreshClerkSessionToken,
-  signInWithClerkTestingHelper,
+  signInWithLoadedClerkTestingHelper,
+  withLoadedClerkTestingPage,
 } from "./lib/auth";
 import { issueCliToken } from "./lib/cli-token";
 import { runnerTestAccounts } from "./lib/clerk-api";
@@ -78,52 +79,54 @@ async function main(): Promise<void> {
   const browser = await chromium.launch();
   try {
     for (const target of targets) {
-      const context = await browser.newContext({
-        ignoreHTTPSErrors: true,
-        extraHTTPHeaders: vercelAutomationBypassSecret
-          ? {
-              "x-vercel-protection-bypass": vercelAutomationBypassSecret,
-            }
-          : undefined,
-      });
-      try {
-        await setupClerkTestingToken({ context });
-        const page = await context.newPage();
-        let clerkSessionToken = await signInWithClerkTestingHelper(
-          page,
-          target.email,
+      await withLoadedClerkTestingPage(
+        browser,
+        {
           appUrl,
-          { activeOrganizationId: target.organizationId },
-        );
-        await ensureRunnerOrganizationReady({
-          apiUrl,
-          clerkSessionToken,
-          vercelAutomationBypassSecret,
-        });
-        if (target.upgradeToPro) {
-          await completePaidOnboarding(page, target, appUrl, outputDirectory);
-          clerkSessionToken = await refreshClerkSessionToken(page, {
-            activeOrganizationId: target.organizationId,
+          contextOptions: {
+            ignoreHTTPSErrors: true,
+            extraHTTPHeaders: vercelAutomationBypassSecret
+              ? {
+                  "x-vercel-protection-bypass": vercelAutomationBypassSecret,
+                }
+              : undefined,
+          },
+        },
+        async (page) => {
+          let clerkSessionToken = await signInWithLoadedClerkTestingHelper(
+            page,
+            target.email,
+            appUrl,
+            { activeOrganizationId: target.organizationId },
+          );
+          await ensureRunnerOrganizationReady({
+            apiUrl,
+            clerkSessionToken,
+            vercelAutomationBypassSecret,
           });
-        }
-        const token = await issueCliToken({
-          apiUrl,
-          clerkSessionToken,
-          vercelAutomationBypassSecret,
-        });
-        const outputFile = join(outputDirectory, target.fileName);
-        await writeFile(
-          outputFile,
-          `${JSON.stringify({ token, apiUrl }, null, 2)}\n`,
-          { encoding: "utf8", mode: 0o600 },
-        );
-        console.log("Generated runner E2E API credential", {
-          email: target.email,
-          outputFile,
-        });
-      } finally {
-        await context.close();
-      }
+          if (target.upgradeToPro) {
+            await completePaidOnboarding(page, target, appUrl, outputDirectory);
+            clerkSessionToken = await refreshClerkSessionToken(page, {
+              activeOrganizationId: target.organizationId,
+            });
+          }
+          const token = await issueCliToken({
+            apiUrl,
+            clerkSessionToken,
+            vercelAutomationBypassSecret,
+          });
+          const outputFile = join(outputDirectory, target.fileName);
+          await writeFile(
+            outputFile,
+            `${JSON.stringify({ token, apiUrl }, null, 2)}\n`,
+            { encoding: "utf8", mode: 0o600 },
+          );
+          console.log("Generated runner E2E API credential", {
+            email: target.email,
+            outputFile,
+          });
+        },
+      );
     }
   } finally {
     await browser.close();


### PR DESCRIPTION
## Summary

- recreate the Playwright `BrowserContext` before the existing final Clerk bootstrap attempt, isolating context routes, storage, pages, and service workers
- keep sign-in, onboarding, Stripe, token issuance, and file output outside the retry boundary
- add sanitized terminal state and Clerk FAPI method/path/status diagnostics without query strings, headers, bodies, or session data
- cover clean-context recovery, both terminal ClerkJS states, diagnostic redaction, and post-bootstrap error propagation with real Chromium and a local external-boundary server

## Scope

- preserves the existing 15-second plus 30-second bootstrap budget and four credential outputs
- changes the isolation unit of the existing two-attempt recovery; it adds no retry, sleep, skip, workflow timeout, or cross-version compatibility fallback
- leaves fixture-owned Playwright authentication and production Clerk authentication unchanged

## Testing

- `cd turbo && pnpm exec prettier --check ../e2e/playwright/lib/auth.ts ../e2e/playwright/lib/auth.test.ts ../e2e/playwright/runner-token.ts`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` (35 tests passed; complete suite about 3.1 seconds)
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`

Closes #27016
