### PR TITLE
fix(api): record chat event snapshot completion

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -43,6 +43,8 @@ const PREVIOUS_ARCHIVE_SCHEMA_VERSION = 4;
 const DUPLICATE_EVENT_ID_NAMESPACE = "46842b1d-a596-47fb-86b3-4f51962751c7";
 const DUPLICATE_EVENT_ID_WARNING =
   "Normalized duplicate chat event IDs in snapshot";
+const SNAPSHOT_COMPLETED_MESSAGE = "Completed chat event snapshot";
+const SNAPSHOT_COMPLETED_TYPE = "chat_event_snapshot_completed";
 const OBJECT_KEY_PATTERN =
   /^chat-events\/([0-9a-f-]{36})\/(\d+)-([0-9a-f]{64})\.ndjson\.gz$/;
 
@@ -72,6 +74,50 @@ async function runSnapshotCron(
     [200],
   );
   return response.body;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function snapshotCompletionEvents(): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.ingest.mock.calls.flatMap(([dataset, events]) => {
+    if (dataset !== "web-logs" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return isRecord(event) && event.type === SNAPSHOT_COMPLETED_TYPE;
+    });
+  });
+}
+
+function expectSnapshotCompletion(expected: {
+  readonly duplicateEventIdConflictThreads: number;
+  readonly duplicateEventIdConflicts: number;
+  readonly duplicateEventIdsRemapped: number;
+  readonly duplicateEventReferencesRemapped: number;
+}): void {
+  const events = snapshotCompletionEvents();
+  expect(events).toHaveLength(1);
+  const event = events[0];
+  expect({
+    level: event?.level,
+    message: event?.message,
+    source: event?.source,
+    type: event?.type,
+    context: event?.context,
+    duplicateEventIdConflictThreads: event?.duplicateEventIdConflictThreads,
+    duplicateEventIdConflicts: event?.duplicateEventIdConflicts,
+    duplicateEventIdsRemapped: event?.duplicateEventIdsRemapped,
+    duplicateEventReferencesRemapped: event?.duplicateEventReferencesRemapped,
+  }).toStrictEqual({
+    level: "info",
+    message: SNAPSHOT_COMPLETED_MESSAGE,
+    source: "api",
+    type: SNAPSHOT_COMPLETED_TYPE,
+    context: "api:cron:snapshot-chat-events",
+    ...expected,
+  });
 }
 
 async function projectChatEventSearch(...chatThreadIds: readonly string[]) {
@@ -380,9 +426,16 @@ describe("cron snapshot chat events", () => {
       ]),
     );
     context.mocks.axiomLogging.warn.mockClear();
+    context.mocks.axiom.ingest.mockClear();
 
     const result = await runSnapshotCron([threadId]);
     expect(result).toMatchObject({
+      duplicateEventIdConflictThreads: 0,
+      duplicateEventIdConflicts: 0,
+      duplicateEventIdsRemapped: 0,
+      duplicateEventReferencesRemapped: 0,
+    });
+    expectSnapshotCompletion({
       duplicateEventIdConflictThreads: 0,
       duplicateEventIdConflicts: 0,
       duplicateEventIdsRemapped: 0,
@@ -398,6 +451,29 @@ describe("cron snapshot chat events", () => {
         return call[0] === DUPLICATE_EVENT_ID_WARNING;
       }),
     ).toBeFalsy();
+  }, 60_000);
+
+  it("does not log completion when snapshotting fails", async () => {
+    const owner = bdd.user({ orgId: `org_${randomUUID()}` });
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Failing snapshot agent",
+    });
+    const threadId = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: `failing-snapshot-${randomUUID()}`,
+    });
+    await projectChatEventSearch(threadId);
+
+    const snapshotFailure = new Error("Forced snapshot R2 write failure");
+    installFakeChatEventR2(context, recordedPuts, () => {
+      return Promise.reject(snapshotFailure);
+    });
+    context.mocks.axiom.ingest.mockClear();
+
+    await expect(runSnapshotCron([threadId])).rejects.toThrow(
+      "Unknown response status 500",
+    );
+    expect(snapshotCompletionEvents()).toHaveLength(0);
   }, 60_000);
 
   it("normalizes duplicate IDs and their resolved historical references deterministically", async () => {
@@ -565,6 +641,7 @@ describe("cron snapshot chat events", () => {
     ).toBeTruthy();
 
     installFakeChatEventR2(context, recordedPuts);
+    context.mocks.axiom.ingest.mockClear();
     const secondResult = await runSnapshotCron([secondThreadId]);
     expect(secondResult).toMatchObject({
       duplicateEventIdConflictThreads: 1,
@@ -572,6 +649,12 @@ describe("cron snapshot chat events", () => {
       duplicateEventIdsRemapped: 2,
       duplicateEventReferencesRemapped: 2,
       nonV4SnapshotHeads: 0,
+    });
+    expectSnapshotCompletion({
+      duplicateEventIdConflictThreads: 1,
+      duplicateEventIdConflicts: 1,
+      duplicateEventIdsRemapped: 2,
+      duplicateEventReferencesRemapped: 2,
     });
     const secondPut = putsForThread(secondThreadId)[1];
     if (secondPut === undefined) {

--- a/turbo/apps/api/src/signals/routes/cron-snapshot-chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/cron-snapshot-chat-events.ts
@@ -1,9 +1,44 @@
 import { cronSnapshotChatEventsContract } from "@okouai/api-contracts/contracts/cron";
+import { trace } from "@opentelemetry/api";
 import { command } from "ccstate";
 
+import { nowDate } from "../../lib/time";
+import { getDatasetName, ingestToAxiom } from "../external/axiom";
 import type { RouteEntry } from "../route-entry";
 import { snapshotChatEvents$ } from "../services/cron-snapshot-chat-events.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
+
+const CHAT_EVENT_SNAPSHOT_COMPLETION_DATASET = "web-logs";
+const CHAT_EVENT_SNAPSHOT_COMPLETION_CONTEXT = "api:cron:snapshot-chat-events";
+
+interface ChatEventSnapshotCompletionCounters {
+  readonly duplicateEventIdConflictThreads: number;
+  readonly duplicateEventIdConflicts: number;
+  readonly duplicateEventIdsRemapped: number;
+  readonly duplicateEventReferencesRemapped: number;
+}
+
+export function recordChatEventSnapshotCompleted(
+  counters: ChatEventSnapshotCompletionCounters,
+): void {
+  const traceId = trace.getActiveSpan()?.spanContext().traceId;
+  ingestToAxiom(getDatasetName(CHAT_EVENT_SNAPSHOT_COMPLETION_DATASET), [
+    {
+      _time: nowDate().toISOString(),
+      level: "info",
+      message: "Completed chat event snapshot",
+      source: "api",
+      type: "chat_event_snapshot_completed",
+      context: CHAT_EVENT_SNAPSHOT_COMPLETION_CONTEXT,
+      ...(traceId ? { trace_id: traceId } : {}),
+      duplicateEventIdConflictThreads: counters.duplicateEventIdConflictThreads,
+      duplicateEventIdConflicts: counters.duplicateEventIdConflicts,
+      duplicateEventIdsRemapped: counters.duplicateEventIdsRemapped,
+      duplicateEventReferencesRemapped:
+        counters.duplicateEventReferencesRemapped,
+    },
+  ]);
+}
 
 const snapshotChatEventsRoute$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -13,6 +48,7 @@ const snapshotChatEventsRoute$ = command(
 
     const result = await set(snapshotChatEvents$, { kind: "global" }, signal);
     signal.throwIfAborted();
+    recordChatEventSnapshotCompleted(result);
     return {
       status: 200 as const,
       body: { success: true as const, ...result },

--- a/turbo/apps/api/src/signals/routes/test-chat-event-snapshot.ts
+++ b/turbo/apps/api/src/signals/routes/test-chat-event-snapshot.ts
@@ -5,6 +5,7 @@ import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import { snapshotChatEvents$ } from "../services/cron-snapshot-chat-events.service";
+import { recordChatEventSnapshotCompleted } from "./cron-snapshot-chat-events";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -32,6 +33,7 @@ const snapshotChatEventFixturesRoute$ = command(
       signal,
     );
     signal.throwIfAborted();
+    recordChatEventSnapshotCompleted(result);
     return {
       status: 200 as const,
       body: { success: true as const, ...result },


### PR DESCRIPTION
## Summary

- Record exactly one info-level chat_event_snapshot_completed event after snapshotChatEvents$ succeeds and before the HTTP success response.
- Persist all four duplicate-normalization aggregate counters on every event, including zero values, and correlate the event with the active server trace_id.
- Cover no-conflict, conflict, and failure behavior in the focused cron snapshot tests.

## Event schema

- _time
- level: info
- message: Completed chat event snapshot
- source: api
- type: chat_event_snapshot_completed
- context: api:cron:snapshot-chat-events
- trace_id when an active server span is present
- duplicateEventIdConflictThreads
- duplicateEventIdConflicts
- duplicateEventIdsRemapped
- duplicateEventReferencesRemapped

## Verification

- pnpm exec prettier --check on the three changed files
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts (11 passed)

Broad checks are left to the PR pipeline.