### PR TITLE
test(api): enforce external behavior test boundary

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { zeroWorkflowAutomationsContract } from "@okouai/api-contracts/contracts/zero-workflows";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { mockOptionalEnv } from "../../../lib/env";
@@ -18,6 +19,8 @@ import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
+import { chatEventDisplayText } from "./helpers/chat-event";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
 
 /**
@@ -45,7 +48,7 @@ function authHeaders() {
 }
 
 interface ChatAutomationFixture {
-  readonly actor: ApiTestUser;
+  readonly actor: ApiTestUser & { readonly orgId: string };
   readonly agentId: string;
   readonly workflowId: string;
   readonly runnerGroup: string;
@@ -53,6 +56,9 @@ interface ChatAutomationFixture {
 
 async function setupChatAutomationFixture(): Promise<ChatAutomationFixture> {
   const actor = bdd.user();
+  if (!actor.orgId) {
+    throw new Error("Expected an org-scoped workflow actor");
+  }
   chatCallbacks.acceptChatObjectStorage();
   api.acceptStorageDownloads();
   api.acceptTelemetryIngest();
@@ -71,7 +77,12 @@ async function setupChatAutomationFixture(): Promise<ChatAutomationFixture> {
     name: "chat-run-finished-workflow",
   });
   context.mocks.s3.send.mockResolvedValue({});
-  return { actor, agentId: agent.agentId, workflowId, runnerGroup };
+  return {
+    actor: { ...actor, orgId: actor.orgId },
+    agentId: agent.agentId,
+    workflowId,
+    runnerGroup,
+  };
 }
 
 /**
@@ -240,6 +251,7 @@ async function expectAutomationSourceAnnotation(
   fixture: ChatAutomationFixture,
   automationId: string,
   sourceRun: { readonly runId: string; readonly threadId: string },
+  expectedDisplayMessage?: string,
 ): Promise<void> {
   const automation = await accept(
     automationsClient().get({
@@ -270,6 +282,9 @@ async function expectAutomationSourceAnnotation(
   });
   if (!automationInput || automationInput.eventType !== "input.prompt") {
     throw new Error("Expected the triggered automation input");
+  }
+  if (expectedDisplayMessage) {
+    expect(chatEventDisplayText(automationInput)).toBe(expectedDisplayMessage);
   }
   expect(
     automationInput.userMessage.parts.filter((part) => {
@@ -386,6 +401,9 @@ describe("chat-run-finished workflow automations", () => {
     { timeout: 30_000 },
     async () => {
       const fixture = await setupChatAutomationFixture();
+      await updateFeatureSwitchesForUser(context, fixture.actor, {
+        [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+      });
       const run = await startWatchedChatRun(fixture, "watched completed run");
       await setRunAutonomyBudgetFixture(context, run.runId, 2);
 
@@ -448,7 +466,12 @@ describe("chat-run-finished workflow automations", () => {
         readLatestWorkflowAutomationRunFixture(context, patternMatch),
       ).resolves.toMatchObject({ autonomyBudget: 1 });
 
-      await expectAutomationSourceAnnotation(fixture, fireAlways, run);
+      await expectAutomationSourceAnnotation(
+        fixture,
+        fireAlways,
+        run,
+        "A run in the watched chat thread completed.",
+      );
 
       const automationRuns = await api.listAgentRuns(fixture.actor, {
         status: "pending",

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -489,6 +489,9 @@ describe("Stripe automation event webhook", () => {
     const scenario = await setupScenario({
       billingReasons: ["subscription_cycle"],
     });
+    await connectors.updateFeatureSwitches(scenario.actor, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
     expect((await readStripeAutomation(scenario)).health).toStrictEqual({
       lastMatchingEventReceivedAt: null,
       lastDeliveryStatus: null,
@@ -556,8 +559,8 @@ describe("Stripe automation event webhook", () => {
     if (!input) {
       throw new Error("Expected one Stripe automation input event");
     }
-    expect(chatEventDisplayText(input)).toContain(
-      "Stripe event evt_workflow_once paid invoice in_workflow_once",
+    expect(chatEventDisplayText(input)).toBe(
+      'Stripe invoice "in_workflow_once" was paid.',
     );
     expect(context.mocks.stripe.invoices.list).not.toHaveBeenCalled();
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -4,6 +4,7 @@ import {
   zeroWorkflowAutomationsContract,
   type ZeroWorkflowAutomationCreateRequest,
 } from "@okouai/api-contracts/contracts/zero-workflows";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -19,6 +20,7 @@ import {
   chatEventAutomationPart,
   chatEventDisplayText,
 } from "./helpers/chat-event";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
 import { webhooksGithubRoutes } from "../webhooks-github";
@@ -219,6 +221,7 @@ type GithubWebhookAutomationCase = {
   readonly payload: (installationId: string) => string;
   /** Trigger summary this event renders, without the delivery parenthetical. */
   readonly expectedTrigger: string;
+  readonly expectedDisplayMessage: string;
   readonly expectedPrompt: readonly string[];
   readonly excludedPrompt?: readonly string[];
 };
@@ -252,6 +255,7 @@ const githubWebhookAutomationCases: readonly GithubWebhookAutomationCase[] = [
       });
     },
     expectedTrigger: 'GitHub pull request #42 was merged into "main"',
+    expectedDisplayMessage: 'GitHub pull request #42 was merged into "main".',
     expectedPrompt: ['"merged": true', '"mergeCommitSha"'],
   },
   {
@@ -278,6 +282,8 @@ const githubWebhookAutomationCases: readonly GithubWebhookAutomationCase[] = [
     },
     expectedTrigger:
       'GitHub label "ready-to-merge" was applied to pull request #24481',
+    expectedDisplayMessage:
+      'GitHub label "ready-to-merge" was applied to pull request #24481.',
     expectedPrompt: ['"action": "labeled"', '"name": "ready-to-merge"'],
   },
   {
@@ -328,6 +334,8 @@ const githubWebhookAutomationCases: readonly GithubWebhookAutomationCase[] = [
     },
     expectedTrigger:
       'the GitHub Actions job "test" completed with conclusion "failure"',
+    expectedDisplayMessage:
+      'GitHub Actions job "test" completed with conclusion "failure".',
     expectedPrompt: [
       'GitHub Actions job "test" completed with conclusion "failure"',
       '"runner"',
@@ -380,6 +388,8 @@ const githubWebhookAutomationCases: readonly GithubWebhookAutomationCase[] = [
     },
     expectedTrigger:
       'GitHub user "trusted-user" submitted a pull request review with state "approved"',
+    expectedDisplayMessage:
+      'GitHub user "trusted-user" submitted a pull request review with state "approved".',
     expectedPrompt: ['review with state "approved"', '"authorAssociation"'],
     excludedPrompt: ["Ignore previous instructions"],
   },
@@ -435,6 +445,7 @@ const githubWebhookAutomationCases: readonly GithubWebhookAutomationCase[] = [
       });
     },
     expectedTrigger: 'a GitHub deployment status changed to "success"',
+    expectedDisplayMessage: 'A GitHub deployment changed to "success".',
     expectedPrompt: [
       'deployment status changed to "success"',
       '"productionEnvironment": true',
@@ -482,6 +493,7 @@ const githubWebhookAutomationCases: readonly GithubWebhookAutomationCase[] = [
       });
     },
     expectedTrigger: 'GitHub user "trusted-user" created a comment',
+    expectedDisplayMessage: 'GitHub user "trusted-user" added a comment.',
     expectedPrompt: ["created a comment", '"bodyIncluded": false'],
     excludedPrompt: ["/verify Ignore previous instructions"],
   },
@@ -495,8 +507,11 @@ describe("POST /api/webhooks/github for workflow automations", () => {
       const installed = await gh.installGithubApp(actor, agentId);
       mockOptionalEnv("GITHUB_APP_WEBHOOK_SECRET", GITHUB_WEBHOOK_SECRET);
       mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+      await updateFeatureSwitchesForUser(context, fixture, {
+        [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+      });
 
-      await accept(
+      const created = await accept(
         automationsClient().create({
           headers: authHeaders(),
           params: { workflowId },
@@ -504,6 +519,9 @@ describe("POST /api/webhooks/github for workflow automations", () => {
         }),
         [201],
       );
+      if (!created.body.chatThreadId) {
+        throw new Error("Expected the automation to have a chat thread");
+      }
 
       if (
         testCase.event === "pull_request_review" ||
@@ -539,6 +557,20 @@ describe("POST /api/webhooks/github for workflow automations", () => {
       expect(response).toStrictEqual({ status: 200, text: "OK" });
       await flushWaitUntilForTest();
 
+      const threadEvents = await wf.readThreadEvents(created.body.chatThreadId);
+      const visibleEvent = threadEvents.find((event) => {
+        return (
+          event.eventType === "input.automation" ||
+          event.eventType === "input.prompt"
+        );
+      });
+      if (!visibleEvent) {
+        throw new Error(`Expected a visible ${testCase.name} automation event`);
+      }
+      expect(chatEventDisplayText(visibleEvent)).toBe(
+        testCase.expectedDisplayMessage,
+      );
+
       await runsApi.heartbeatRunner();
       const listedRuns = await runsApi.listAgentRuns(actor, { limit: 20 });
       const runId = listedRuns.runs[0]?.id;
@@ -546,20 +578,17 @@ describe("POST /api/webhooks/github for workflow automations", () => {
         throw new Error(`Expected a ${testCase.name} automation run`);
       }
       const claim = await runsApi.claimRunnerJob(runId);
-      // The visible user turn names this delivery, so a resumed session can tell
-      // this firing apart from every earlier firing of the same automation.
-      expect(claim.prompt).toBe(
-        `/${WORKFLOW_NAME}\nTrigger: ${testCase.expectedTrigger} (GitHub webhook delivery ${deliveryId}).`,
+      expect(claim.prompt).toContain(
+        `Summary: ${testCase.expectedTrigger} (GitHub webhook delivery ${deliveryId}).`,
       );
       for (const expected of testCase.expectedPrompt) {
-        expect(claim.appendSystemPrompt).toContain(expected);
+        expect(claim.prompt).toContain(expected);
       }
-      expect(claim.appendSystemPrompt).toContain(
-        `Trigger: ${testCase.expectedTrigger} (GitHub webhook delivery ${deliveryId}).`,
-      );
       for (const excluded of testCase.excludedPrompt ?? []) {
-        expect(claim.appendSystemPrompt).not.toContain(excluded);
+        expect(claim.prompt).not.toContain(excluded);
       }
+      expect(claim.appendSystemPrompt).toContain("# Agent Identity");
+      expect(claim.appendSystemPrompt).not.toContain("# Current context");
     },
   );
 
@@ -724,6 +753,9 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     const installed = await gh.installGithubApp(actor, agentId);
     mockOptionalEnv("GITHUB_APP_WEBHOOK_SECRET", GITHUB_WEBHOOK_SECRET);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
 
     const created = await accept(
       automationsClient().create({
@@ -783,7 +815,8 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     if (!runId || listedRuns.runs.length !== 1) {
       throw new Error("Expected a GitHub workflow run automation");
     }
-    const displayPrompt = `/${WORKFLOW_NAME}\nTrigger: GitHub Actions workflow "Turbo" completed with conclusion "failure" (run 555 attempt 2, GitHub webhook delivery ${deliveryId}).`;
+    const displayMessage =
+      'GitHub Actions workflow "Turbo" completed with conclusion "failure".';
     const events = await wf.readThreadEvents(created.body.chatThreadId);
     const admittedEvent = events.find((event) => {
       return event.eventType === "input.automation";
@@ -801,7 +834,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     expect(
       chatEventAutomationPart(admittedEvent)?.automationBrief,
     ).toBeUndefined();
-    expect(chatEventDisplayText(admittedEvent)).toBe(displayPrompt);
+    expect(chatEventDisplayText(admittedEvent)).toBe(displayMessage);
     expect(claimedEvent.userMessage).toStrictEqual({
       version: 1,
       parts: [
@@ -809,7 +842,7 @@ describe("POST /api/webhooks/github for workflow automations", () => {
         { type: "model", selectedModel: "claude-sonnet-5" },
       ],
     });
-    expect(chatEventDisplayText(claimedEvent)).toBe(displayPrompt);
+    expect(chatEventDisplayText(claimedEvent)).toBe(displayMessage);
     const claim = await runsApi.claimRunnerJob(runId);
     const okouToken = claim.environment?.OKOU_TOKEN;
     if (!okouToken) {
@@ -818,12 +851,13 @@ describe("POST /api/webhooks/github for workflow automations", () => {
     expect(verifyZeroToken(okouToken)?.capabilities).toContain(
       "goal:user-control:write",
     );
-    expect(claim.prompt).toBe(displayPrompt);
-    expect(claim.appendSystemPrompt).toContain(
+    expect(claim.prompt).toContain(
       'GitHub Actions workflow "Turbo" completed with conclusion "failure"',
     );
-    expect(claim.appendSystemPrompt).toContain('"attempt": 2');
-    expect(claim.appendSystemPrompt).toContain('"triggeringEvent": "push"');
+    expect(claim.prompt).toContain('"attempt": 2');
+    expect(claim.prompt).toContain('"triggeringEvent": "push"');
+    expect(claim.appendSystemPrompt).toContain("# Agent Identity");
+    expect(claim.appendSystemPrompt).not.toContain("# Current context");
   });
 
   it("accepts startup failures with GitHub's documented nullable run fields", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -10,6 +10,7 @@ import {
   zeroWorkflowAutomationsContract,
   type ZeroWorkflowAutomationSummary,
 } from "@okouai/api-contracts/contracts/zero-workflows";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -31,8 +32,12 @@ import {
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsApi } from "./helpers/api-bdd-runs";
-import { chatEventAutomationPart } from "./helpers/chat-event";
+import {
+  chatEventAutomationPart,
+  chatEventDisplayText,
+} from "./helpers/chat-event";
 import { seedVm0ManagedModelKey } from "./helpers/runtime-state";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
 import { webhooksGmailRoutes } from "../webhooks-gmail";
@@ -98,12 +103,10 @@ function sandboxOperationEvents(): readonly Record<string, unknown>[] {
 }
 
 function expectGmailEventContextInPrompt(
-  appendSystemPrompt: string,
+  prompt: string,
   expected: Record<string, unknown>,
 ): void {
-  expect(appendSystemPrompt).toContain(
-    `# This run's event\n${JSON.stringify(expected, null, 2)}`,
-  );
+  expect(prompt).toContain(JSON.stringify(expected, null, 2));
 }
 
 function encodeJwtPart(value: unknown): string {
@@ -565,10 +568,10 @@ function requireAutomationChatThreadId(
   return automation.chatThreadId;
 }
 
-async function workflowAutomationBriefs(
+async function workflowAutomationDisplayTexts(
   actor: ApiTestUser,
   chatThreadId: string,
-): Promise<readonly (string | null | undefined)[]> {
+): Promise<readonly (string | null)[]> {
   const { events } = await chatApi.listThreadEvents(actor, chatThreadId, {
     limit: 20,
   });
@@ -577,7 +580,7 @@ async function workflowAutomationBriefs(
       return event.eventType === "input.prompt";
     })
     .map((event) => {
-      return chatEventAutomationPart(event)?.automationBrief;
+      return chatEventDisplayText(event);
     });
 }
 
@@ -877,6 +880,9 @@ describe("POST /api/webhooks/gmail", () => {
     const { actor, workflowId } = await setupFixture();
     await connectGmail(actor, gmailEmail);
     await configureWorkspaceModelProvider(actor);
+    await updateFeatureSwitchesForUser(context, actor, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
 
     const created = await accept(
       automationsClient().create({
@@ -929,15 +935,12 @@ describe("POST /api/webhooks/gmail", () => {
       dispatched: 1,
       duplicates: 0,
     });
-    const expectedAutomationBrief = [
-      "Gmail new message",
-      "From: Customer Example <customer@example.com>",
-      "Subject: Invoice needs a reply",
-    ].join("\n");
+    const expectedDisplayMessage =
+      'A new email arrived from Customer Example <customer@example.com> with subject "Invoice needs a reply".';
 
     await expect(
-      workflowAutomationBriefs(actor, chatThreadId),
-    ).resolves.toContain(expectedAutomationBrief);
+      workflowAutomationDisplayTexts(actor, chatThreadId),
+    ).resolves.toContain(expectedDisplayMessage);
     await expect(readAutomation(actor, created.body.id)).resolves.toMatchObject(
       {
         lastRunAt: expect.any(String),
@@ -954,13 +957,9 @@ describe("POST /api/webhooks/gmail", () => {
     }
     await runsApi.heartbeatRunner(runnerGroup);
     const claim = await runsApi.claimRunnerJob(runId);
-    const appendSystemPrompt = claim.appendSystemPrompt;
-    if (typeof appendSystemPrompt !== "string") {
-      throw new Error("Expected appendSystemPrompt on the claimed run");
-    }
-    expect(appendSystemPrompt).toContain("Not included below: the email body.");
-    expect(appendSystemPrompt).not.toContain("Please draft a helpful reply.");
-    expectGmailEventContextInPrompt(appendSystemPrompt, {
+    expect(claim.prompt).toContain("Not included below: the email body.");
+    expect(claim.prompt).not.toContain("Please draft a helpful reply.");
+    expectGmailEventContextInPrompt(claim.prompt, {
       automationId: created.body.id,
       event: "new_message",
       emailAddress: gmailEmail,
@@ -971,6 +970,8 @@ describe("POST /api/webhooks/gmail", () => {
       cc: [],
       subject: "Invoice needs a reply",
     });
+    expect(claim.appendSystemPrompt).toContain("# Agent Identity");
+    expect(claim.appendSystemPrompt).not.toContain("# Current context");
     const timingEvents = sandboxOperationEvents().filter((event) => {
       return event.automation_event_source === "gmail";
     });
@@ -1029,13 +1030,13 @@ describe("POST /api/webhooks/gmail", () => {
       dispatched: 0,
       duplicates: 1,
     });
-    const triggerBriefsAfterDuplicate = await workflowAutomationBriefs(
+    const displayMessagesAfterDuplicate = await workflowAutomationDisplayTexts(
       actor,
       chatThreadId,
     );
     expect(
-      triggerBriefsAfterDuplicate.filter((brief) => {
-        return brief === expectedAutomationBrief;
+      displayMessagesAfterDuplicate.filter((message) => {
+        return message === expectedDisplayMessage;
       }),
     ).toHaveLength(1);
   });
@@ -1053,6 +1054,9 @@ describe("POST /api/webhooks/gmail", () => {
     const { actor, workflowId } = await setupFixture();
     await connectGmail(actor, gmailEmail);
     await configureWorkspaceModelProvider(actor);
+    await updateFeatureSwitchesForUser(context, actor, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
 
     const created = await accept(
       automationsClient().create({
@@ -1097,13 +1101,9 @@ describe("POST /api/webhooks/gmail", () => {
       duplicates: 0,
     });
     await expect(
-      workflowAutomationBriefs(actor, chatThreadId),
+      workflowAutomationDisplayTexts(actor, chatThreadId),
     ).resolves.toContain(
-      [
-        "Gmail label applied: Support",
-        "From: Support Team <support@example.com>",
-        "Subject: Support request",
-      ].join("\n"),
+      'Gmail label "Support" was added to an email from Support Team <support@example.com> with subject "Support request".',
     );
     await expect(readAutomation(actor, created.body.id)).resolves.toMatchObject(
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { zeroWorkflowAutomationsContract } from "@okouai/api-contracts/contracts/zero-workflows";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { expect } from "vitest";
 
@@ -18,6 +19,8 @@ import {
   createWorkflowsBddApi,
   mockGoogleCalendarConnectorOAuth,
 } from "./helpers/api-bdd-workflows";
+import { chatEventDisplayText } from "./helpers/chat-event";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
 import { webhooksGoogleCalendarRoutes } from "../webhooks-google-calendar";
@@ -198,7 +201,7 @@ function configureGoogleCalendarApiMock(args: {
 }
 
 interface CalendarScenario {
-  readonly actor: ApiTestUser;
+  readonly actor: ApiTestUser & { readonly orgId: string };
   readonly runnerGroup: string;
   readonly workflowId: string;
 }
@@ -220,7 +223,28 @@ async function setupFixture(): Promise<CalendarScenario> {
   });
   mocks.clerk.session(actor.userId, actor.orgId, "org:member");
   context.mocks.s3.send.mockResolvedValue({});
-  return { actor, runnerGroup, workflowId };
+  return {
+    actor: { ...actor, orgId: actor.orgId },
+    runnerGroup,
+    workflowId,
+  };
+}
+
+async function expectAutomationDisplayMessage(
+  threadId: string,
+  expectedMessage: string,
+): Promise<void> {
+  const events = await wf.readThreadEvents(threadId);
+  const visibleEvent = events.find((event) => {
+    return (
+      event.eventType === "input.automation" ||
+      event.eventType === "input.prompt"
+    );
+  });
+  if (!visibleEvent) {
+    throw new Error("Expected a visible calendar automation event");
+  }
+  expect(chatEventDisplayText(visibleEvent)).toBe(expectedMessage);
 }
 
 async function connectGoogleCalendar(
@@ -352,6 +376,9 @@ describe("POST /api/webhooks/google-calendar", () => {
     const scenario = await setupFixture();
     const { runnerGroup, workflowId } = scenario;
     await connectGoogleCalendar(scenario);
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
 
     const created = await accept(
       automationsClient().create({
@@ -379,6 +406,13 @@ describe("POST /api/webhooks/google-calendar", () => {
       dispatched: 1,
       duplicates: 0,
     });
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected the automation to have a chat thread");
+    }
+    await expectAutomationDisplayMessage(
+      created.body.chatThreadId,
+      'Google Calendar event "Planning" was created.',
+    );
     await runsApi.heartbeatRunner(runnerGroup);
     const firstJob = await runsApi.pollRunner(runnerGroup);
     expect(firstJob.body.job?.runId).toStrictEqual(expect.any(String));
@@ -563,8 +597,11 @@ describe("POST /api/webhooks/google-calendar", () => {
     const scenario = await setupFixture();
     const { runnerGroup, workflowId } = scenario;
     await connectGoogleCalendar(scenario);
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
 
-    await accept(
+    const created = await accept(
       automationsClient().create({
         headers: authHeaders(),
         params: { workflowId },
@@ -590,6 +627,13 @@ describe("POST /api/webhooks/google-calendar", () => {
       dispatched: 1,
       duplicates: 0,
     });
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected the automation to have a chat thread");
+    }
+    await expectAutomationDisplayMessage(
+      created.body.chatThreadId,
+      'Google Calendar event "Existing updated" was updated.',
+    );
     await runsApi.heartbeatRunner(runnerGroup);
     const firstJob = await runsApi.pollRunner(runnerGroup);
     expect(firstJob.body.job?.runId).toStrictEqual(expect.any(String));
@@ -669,8 +713,11 @@ describe("POST /api/webhooks/google-calendar", () => {
     const scenario = await setupFixture();
     const { runnerGroup, workflowId } = scenario;
     await connectGoogleCalendar(scenario);
+    await updateFeatureSwitchesForUser(context, scenario.actor, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
 
-    await accept(
+    const cancelled = await accept(
       automationsClient().create({
         headers: authHeaders(),
         params: { workflowId },
@@ -707,6 +754,13 @@ describe("POST /api/webhooks/google-calendar", () => {
       dispatched: 1,
       duplicates: 0,
     });
+    if (!cancelled.body.chatThreadId) {
+      throw new Error("Expected the automation to have a chat thread");
+    }
+    await expectAutomationDisplayMessage(
+      cancelled.body.chatThreadId,
+      "A Google Calendar event was cancelled.",
+    );
     // Only the cancelled automation dispatched a run; the minimal deleted
     // payload never reaches the updated automation.
     await runsApi.heartbeatRunner(runnerGroup);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
+import { chatEventDisplayText } from "./helpers/chat-event";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
@@ -233,16 +234,14 @@ async function postWebhook(rawBody: string): Promise<{
   return { status: response.status, body: await response.json() };
 }
 
-function eventContextFromPrompt(
-  appendSystemPrompt: string,
-): Record<string, unknown> {
-  const marker = "# This run's event\n";
-  const markerIndex = appendSystemPrompt.indexOf(marker);
+function eventContextFromAgentPrompt(prompt: string): Record<string, unknown> {
+  const marker = "\nEvent data:\n";
+  const markerIndex = prompt.indexOf(marker);
   if (markerIndex === -1) {
-    throw new Error("Expected automation event payload in appendSystemPrompt");
+    throw new Error("Expected automation event payload in the agent prompt");
   }
   const parsed = JSON.parse(
-    appendSystemPrompt.slice(markerIndex + marker.length),
+    prompt.slice(markerIndex + marker.length),
   ) as unknown;
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Error("Expected automation event payload object");
@@ -269,7 +268,10 @@ describe("Google Forms Pub/Sub webhook", () => {
     await updateFeatureSwitchesForUser(
       context,
       { orgId: actor.orgId, userId: actor.userId },
-      { [FeatureSwitchKey.GoogleFormsWorkflowAutomations]: true },
+      {
+        [FeatureSwitchKey.GoogleFormsWorkflowAutomations]: true,
+        [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+      },
     );
     mockGoogleFormsConnectorOAuth();
     await workflows.connectConnector(actor, "google-forms");
@@ -326,6 +328,18 @@ describe("Google Forms Pub/Sub webhook", () => {
     );
 
     const events = await workflows.readThreadEvents(created.body.chatThreadId);
+    const visibleEvent = events.find((event) => {
+      return (
+        event.eventType === "input.automation" ||
+        event.eventType === "input.prompt"
+      );
+    });
+    if (!visibleEvent) {
+      throw new Error("Expected a visible Google Forms automation event");
+    }
+    expect(chatEventDisplayText(visibleEvent)).toBe(
+      `A new response from respondent@example.test was submitted to Google Form "${FORM_TITLE}".`,
+    );
     const runId = events.find((event) => {
       return event.eventType === "input.prompt" && event.runId;
     })?.runId;
@@ -334,10 +348,7 @@ describe("Google Forms Pub/Sub webhook", () => {
     }
     await runs.heartbeatRunner(RUNNER_GROUP);
     const claim = await runs.claimRunnerJob(runId);
-    if (typeof claim.appendSystemPrompt !== "string") {
-      throw new Error("Expected appendSystemPrompt on the claimed run");
-    }
-    const eventContext = eventContextFromPrompt(claim.appendSystemPrompt);
+    const eventContext = eventContextFromAgentPrompt(claim.prompt);
     expect(eventContext).toStrictEqual({
       automationId: created.body.id,
       formId: FORM_ID,
@@ -351,6 +362,8 @@ describe("Google Forms Pub/Sub webhook", () => {
       previouslyDelivered: false,
     });
     expect(eventContext).not.toHaveProperty("answers");
+    expect(claim.appendSystemPrompt).toContain("# Agent Identity");
+    expect(claim.appendSystemPrompt).not.toContain("# Current context");
 
     const retry = await postWebhook(push);
     expect(retry).toStrictEqual({

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
@@ -1,0 +1,250 @@
+import { Buffer } from "node:buffer";
+import { generateKeyPairSync, sign as signData } from "node:crypto";
+
+import { zeroWorkflowAutomationsContract } from "@okouai/api-contracts/contracts/zero-workflows";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { HttpResponse, http } from "msw";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { createApp } from "../../../app-factory";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { server } from "../../../mocks/server";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
+import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
+import { chatEventDisplayText } from "./helpers/chat-event";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { webhooksGoogleWorkspaceEventsRoutes } from "../webhooks-google-workspace-events";
+import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+
+const context = testContext();
+const connectors = createConnectorBddApi(context);
+const mocks = createZeroRouteMocks(context);
+const workflows = createWorkflowsBddApi(context);
+
+const TOPIC_NAME = "projects/vm0-ai-488909/topics/google-workspace-events";
+const PUSH_AUDIENCE = "https://api.vm0.ai/api/webhooks/google-workspace-events";
+const PUSH_SERVICE_ACCOUNT =
+  "google-workspace-events-push@vm0-ai-488909.iam.gserviceaccount.com";
+const OIDC_CERT_KID = "google-workspace-events-test-key";
+const SUBSCRIPTION_NAME = "subscriptions/google-meet-test";
+const TRANSCRIPT_NAME = "conferenceRecords/123/transcripts/456";
+const oidcKeyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const oidcPublicKeyPem = oidcKeyPair.publicKey.export({
+  type: "spki",
+  format: "pem",
+});
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function automationsClient() {
+  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+    zeroWorkflowAutomationsContract,
+  );
+}
+
+function encodeJwtPart(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+function signedGoogleIdToken(): string {
+  const issuedAt = Math.floor(now() / 1000);
+  const header = { alg: "RS256", kid: OIDC_CERT_KID, typ: "JWT" };
+  const payload = {
+    aud: PUSH_AUDIENCE,
+    email: PUSH_SERVICE_ACCOUNT,
+    email_verified: true,
+    exp: issuedAt + 600,
+    iat: issuedAt,
+    iss: "https://accounts.google.com",
+    sub: "google-workspace-events-test-subject",
+  };
+  const signedContent = `${encodeJwtPart(header)}.${encodeJwtPart(payload)}`;
+  const signature = signData(
+    "RSA-SHA256",
+    Buffer.from(signedContent, "utf8"),
+    oidcKeyPair.privateKey,
+  );
+  return `${signedContent}.${signature.toString("base64url")}`;
+}
+
+function configureGoogleMeetBoundaries(): void {
+  mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
+  mockOptionalEnv("GOOGLE_OAUTH_CLIENT_ID", "google-client-id");
+  mockOptionalEnv("GOOGLE_OAUTH_CLIENT_SECRET", "google-client-secret");
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/google-workspace-events-test");
+  mockOptionalEnv("GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME", TOPIC_NAME);
+  mockOptionalEnv(
+    "GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_AUDIENCE",
+    PUSH_AUDIENCE,
+  );
+  mockOptionalEnv(
+    "GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL",
+    PUSH_SERVICE_ACCOUNT,
+  );
+
+  server.use(
+    http.post("https://oauth2.googleapis.com/token", () => {
+      return HttpResponse.json({
+        access_token: "google-meet-access-token",
+        refresh_token: "google-meet-refresh-token",
+        expires_in: 3600,
+        token_type: "Bearer",
+        scope:
+          "https://www.googleapis.com/auth/meetings.space.readonly https://www.googleapis.com/auth/userinfo.email",
+      });
+    }),
+    http.get("https://www.googleapis.com/oauth2/v2/userinfo", () => {
+      return HttpResponse.json({
+        id: "google-meet-user-id",
+        email: "meet-user@example.test",
+        name: "Google Meet User",
+      });
+    }),
+    http.post(
+      "https://workspaceevents.googleapis.com/v1/subscriptions",
+      async ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer google-meet-access-token",
+        );
+        await expect(request.json()).resolves.toStrictEqual({
+          targetResource:
+            "//cloudidentity.googleapis.com/users/google-meet-user-id",
+          eventTypes: ["google.workspace.meet.transcript.v2.fileGenerated"],
+          notificationEndpoint: { pubsubTopic: TOPIC_NAME },
+          ttl: "604800s",
+        });
+        return HttpResponse.json({
+          response: {
+            name: SUBSCRIPTION_NAME,
+            targetResource:
+              "//cloudidentity.googleapis.com/users/google-meet-user-id",
+            eventTypes: ["google.workspace.meet.transcript.v2.fileGenerated"],
+            notificationEndpoint: { pubsubTopic: TOPIC_NAME },
+            state: "ACTIVE",
+            expireTime: "2099-08-14T00:00:00.000Z",
+          },
+        });
+      },
+    ),
+    http.get("https://www.googleapis.com/oauth2/v1/certs", () => {
+      return HttpResponse.json(
+        { [OIDC_CERT_KID]: oidcPublicKeyPem },
+        { headers: { "cache-control": "no-cache" } },
+      );
+    }),
+  );
+}
+
+async function connectGoogleMeet(
+  actor: Parameters<typeof connectors.startOauth>[0],
+): Promise<void> {
+  const started = await connectors.startOauth(actor, "google-meet", "oauth");
+  const state = new URL(started.authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected Google Meet OAuth state");
+  }
+  await connectors.completeOauthCallback("google-meet", {
+    code: "google-meet-code",
+    state,
+  });
+}
+
+function pubSubPushBody(): string {
+  const cloudEvent = {
+    id: "google-meet-cloud-event",
+    source: `//workspaceevents.googleapis.com/${SUBSCRIPTION_NAME}`,
+    subject: "//meet.googleapis.com/conferenceRecords/123",
+    type: "google.workspace.meet.transcript.v2.fileGenerated",
+    time: "2026-08-14T01:00:00.000Z",
+    specversion: "1.0",
+    data: { transcript: { name: TRANSCRIPT_NAME } },
+  };
+  return JSON.stringify({
+    message: {
+      messageId: "google-meet-pubsub-message",
+      data: Buffer.from(JSON.stringify(cloudEvent), "utf8").toString("base64"),
+    },
+    subscription:
+      "projects/vm0-ai-488909/subscriptions/google-workspace-events-push",
+  });
+}
+
+describe("POST /api/webhooks/google-workspace-events", () => {
+  it("dispatches a visible Google Meet transcript message", async () => {
+    configureGoogleMeetBoundaries();
+    const { actor } = await workflows.setupWorkflowOrg();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped workflow actor");
+    }
+    const featureSwitchActor = {
+      userId: actor.userId,
+      orgId: actor.orgId,
+    };
+    const agent = await workflows.createAgent(actor, {
+      displayName: "Google Meet automation agent",
+    });
+    const workflowId = await workflows.createWorkflow(actor, {
+      agentId: agent.agentId,
+      name: "google-meet-transcript-workflow",
+    });
+    await connectGoogleMeet(actor);
+    mocks.clerk.session(actor.userId, actor.orgId, "org:member");
+    context.mocks.s3.send.mockResolvedValue({});
+    await updateFeatureSwitchesForUser(context, featureSwitchActor, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
+
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-meet-transcript-generated",
+        },
+      }),
+      [201],
+    );
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected the automation to bind a chat thread");
+    }
+
+    const response = await createApp({
+      signal: context.signal,
+      routes: webhooksGoogleWorkspaceEventsRoutes,
+    }).request("/api/webhooks/google-workspace-events", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${signedGoogleIdToken()}`,
+        "content-type": "application/json",
+      },
+      body: pubSubPushBody(),
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({
+      success: true,
+      watchStates: 1,
+      dispatched: 1,
+      duplicates: 0,
+    });
+
+    const events = await workflows.readThreadEvents(created.body.chatThreadId);
+    const visibleEvent = events.find((event) => {
+      return (
+        event.eventType === "input.automation" ||
+        event.eventType === "input.prompt"
+      );
+    });
+    if (!visibleEvent) {
+      throw new Error("Expected a visible Google Meet automation event");
+    }
+    expect(chatEventDisplayText(visibleEvent)).toBe(
+      "A Google Meet transcript is ready.",
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
@@ -18,7 +18,10 @@ import {
   createWorkflowsBddApi,
   mockNotionConnectorOAuth,
 } from "./helpers/api-bdd-workflows";
-import { chatEventAutomationPart } from "./helpers/chat-event";
+import {
+  chatEventAutomationPart,
+  chatEventDisplayText,
+} from "./helpers/chat-event";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
@@ -105,6 +108,7 @@ async function enableNotionWorkflowAutomations(
 ): Promise<void> {
   await updateFeatureSwitchesForUser(context, fixture, {
     [FeatureSwitchKey.NotionWorkflowAutomations]: true,
+    [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
   });
 }
 
@@ -386,15 +390,11 @@ function record(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function notionEventContextFromPrompt(
-  appendSystemPrompt: string,
-): Record<string, unknown> {
-  const marker = "# This run's event\n";
-  const markerIndex = appendSystemPrompt.indexOf(marker);
+function notionEventContextFromPrompt(prompt: string): Record<string, unknown> {
+  const marker = "\nEvent data:\n";
+  const markerIndex = prompt.indexOf(marker);
   expect(markerIndex).toBeGreaterThanOrEqual(0);
-  const parsed: unknown = JSON.parse(
-    appendSystemPrompt.slice(markerIndex + marker.length),
-  );
+  const parsed: unknown = JSON.parse(prompt.slice(markerIndex + marker.length));
   return record(parsed, "Notion event context");
 }
 
@@ -510,6 +510,7 @@ describe("POST /api/webhooks/notion", () => {
   });
 
   it("verifies, signs, de-duplicates, and refreshes pending child page events", async () => {
+    const runnerGroup = runsApi.configureRunnerGroup();
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
     await enableNotionWorkflowAutomations(fixture);
@@ -605,9 +606,34 @@ describe("POST /api/webhooks/notion", () => {
         duplicates: 1,
       },
     });
+
+    configureNotionChildPageMock(entities);
+    mockNow(new Date("2026-07-06T12:20:00.000Z"));
+    const executed = await executeDueWorkflowAutomations(created.body.id);
+    expect(executed.body).toStrictEqual({
+      success: true,
+      executed: 1,
+      skipped: 0,
+    });
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected the Notion automation to bind a chat thread");
+    }
+    const messages = await wf.readThreadEvents(created.body.chatThreadId);
+    const workflowMessage = messages.find((message) => {
+      return message.eventType === "input.prompt";
+    });
+    if (!workflowMessage?.runId) {
+      throw new Error("Expected a dispatched Notion child page event");
+    }
+    expect(chatEventDisplayText(workflowMessage)).toBe(
+      'Notion page "Launch notes" was created under the configured parent page.',
+    );
+    await runsApi.heartbeatRunner(runnerGroup);
+    await runsApi.claimRunnerJob(workflowMessage.runId);
   });
 
   it("enqueues and refreshes pending database item events", async () => {
+    const runnerGroup = runsApi.configureRunnerGroup();
     const scenario = await setupFixture();
     const { fixture, workflowId, entities } = scenario;
     await enableNotionWorkflowAutomations(fixture);
@@ -686,6 +712,38 @@ describe("POST /api/webhooks/notion", () => {
         duplicates: 0,
       },
     });
+
+    configureNotionChildPageMock(
+      entities,
+      {
+        type: "data_source_id",
+        data_source_id: entities.dataSourceId,
+        database_id: entities.databaseId,
+      },
+      { title: "Bug Bash item" },
+    );
+    mockNow(new Date("2026-07-06T12:20:00.000Z"));
+    const executed = await executeDueWorkflowAutomations(created.body.id);
+    expect(executed.body).toStrictEqual({
+      success: true,
+      executed: 1,
+      skipped: 0,
+    });
+    if (!created.body.chatThreadId) {
+      throw new Error("Expected the Notion automation to bind a chat thread");
+    }
+    const messages = await wf.readThreadEvents(created.body.chatThreadId);
+    const workflowMessage = messages.find((message) => {
+      return message.eventType === "input.prompt";
+    });
+    if (!workflowMessage?.runId) {
+      throw new Error("Expected a dispatched Notion database item event");
+    }
+    expect(chatEventDisplayText(workflowMessage)).toBe(
+      'Notion item "Bug Bash item" was created in the configured database.',
+    );
+    await runsApi.heartbeatRunner(runnerGroup);
+    await runsApi.claimRunnerJob(workflowMessage.runId);
   });
 
   it("enqueues and debounces page content updated events for a page scope", async () => {
@@ -862,8 +920,8 @@ describe("POST /api/webhooks/notion", () => {
       skipped: 0,
     });
 
-    // The run landed in the automation's bound chat thread with the friendly
-    // Notion brief, linked to the created run.
+    // The run landed in the automation's bound chat thread with the public
+    // user-facing message, linked to the created run.
     const messages = await wf.readThreadEvents(threadId);
     const workflowMessage = messages.find((message) => {
       return (
@@ -874,19 +932,15 @@ describe("POST /api/webhooks/notion", () => {
     if (!workflowMessage?.runId) {
       throw new Error("Expected a dispatched Notion workflow run message");
     }
-    expect(chatEventAutomationPart(workflowMessage)?.automationBrief).toBe(
-      'Notion page content updated "Launch notes v2" in Launch notes v2',
+    expect(chatEventDisplayText(workflowMessage)).toBe(
+      'Notion page "Launch notes v2" was updated.',
     );
 
     // The runner claim exposes the persisted event context: latest page
     // title, properties, and no page body/content.
     await runsApi.heartbeatRunner(runnerGroup);
     const claim = await runsApi.claimRunnerJob(workflowMessage.runId);
-    const appendSystemPrompt = claim.appendSystemPrompt;
-    if (typeof appendSystemPrompt !== "string") {
-      throw new Error("Expected appendSystemPrompt on the claimed run");
-    }
-    const eventContext = notionEventContextFromPrompt(appendSystemPrompt);
+    const eventContext = notionEventContextFromPrompt(claim.prompt);
     const page = record(eventContext.page, "Notion page");
     const properties = record(page.properties, "Notion page properties");
     expect(eventContext).toMatchObject({
@@ -910,6 +964,8 @@ describe("POST /api/webhooks/notion", () => {
     expect(eventContext).not.toHaveProperty("content");
     expect(page).not.toHaveProperty("body");
     expect(page).not.toHaveProperty("content");
+    expect(claim.appendSystemPrompt).toContain("# Agent Identity");
+    expect(claim.appendSystemPrompt).not.toContain("# Current context");
   });
 
   it("enqueues page content updated events for a database scope", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts
@@ -7,6 +7,7 @@ import {
   zeroAgentsMainContract,
 } from "@okouai/api-contracts/contracts/zero-agents";
 import { zeroUserConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { createStore } from "ccstate";
 
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -24,7 +25,11 @@ import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
-import { chatEventAutomationPart } from "./helpers/chat-event";
+import {
+  chatEventAutomationPart,
+  chatEventDisplayText,
+} from "./helpers/chat-event";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
@@ -219,11 +224,18 @@ async function onlyWorkflowRunMessage(
   return messages[0]!;
 }
 
-function friendlyTriggeredAtPattern(timezone: string): string {
-  return String.raw`Triggered at \d{1,2}:\d{2} [AP]M, [A-Z][a-z]{2} \d{1,2}, \d{4} \(${timezone.replace(
-    /\//gu,
-    String.raw`\/`,
-  )}\)`;
+async function onlyWorkflowDisplayText(
+  threadId: string,
+): Promise<string | null> {
+  const messages = await wf.readThreadEvents(threadId);
+  const workflowMessages = messages.filter((message) => {
+    return (
+      message.eventType === "input.prompt" &&
+      chatEventAutomationPart(message)?.workflowName === WORKFLOW_NAME
+    );
+  });
+  expect(workflowMessages).toHaveLength(1);
+  return chatEventDisplayText(workflowMessages[0]!);
 }
 
 async function completeRunThroughSandbox(
@@ -401,6 +413,9 @@ describe("okou workflow automation scheduler", () => {
 
   it("fires a due cron automation: creates a run, posts to the thread, sets last run state", async () => {
     const scenario = await setup({ timezone: "Asia/Shanghai" });
+    await updateFeatureSwitchesForUser(context, scenario, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
     const created = await accept(
       automationsClient().create({
         headers: authHeaders(),
@@ -434,13 +449,8 @@ describe("okou workflow automation scheduler", () => {
         triggerSource: "automation-schedule",
       }),
     );
-    expect(run.triggerBrief).toMatch(
-      new RegExp(
-        `^${friendlyTriggeredAtPattern(
-          "Asia/Shanghai",
-        )}\\nSchedule: Every day at 5:00 PM$`,
-        "u",
-      ),
+    await expect(onlyWorkflowDisplayText(threadId)).resolves.toBe(
+      "This workflow started on schedule.",
     );
 
     const automation = await wf.readAutomation(created.body.id);
@@ -450,6 +460,9 @@ describe("okou workflow automation scheduler", () => {
 
   it("disables a one-time automation when it fires", async () => {
     const scenario = await setup({ timezone: "Asia/Shanghai" });
+    await updateFeatureSwitchesForUser(context, scenario, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
     const created = await accept(
       automationsClient().create({
         headers: authHeaders(),
@@ -500,27 +513,22 @@ describe("okou workflow automation scheduler", () => {
     expect(automation.enabled).toBeFalsy();
     expect(automation.nextRunAt).toBeNull();
 
-    const run = await onlyWorkflowRunMessage(threadId);
-    expect(run.triggerBrief).toMatch(
-      new RegExp(
-        `^Once at \\d{1,2}:\\d{2} [AP]M, [A-Z][a-z]{2} \\d{1,2}, \\d{4} \\(Asia\\/Shanghai\\)$`,
-        "u",
-      ),
+    await expect(onlyWorkflowDisplayText(threadId)).resolves.toBe(
+      "The one-time scheduled run started.",
     );
   });
 
-  it("fires a due loop automation with a persisted friendly automation brief", async () => {
+  it("fires a due loop automation with a user-facing message", async () => {
     const scenario = await setup({ timezone: "Asia/Shanghai" });
+    await updateFeatureSwitchesForUser(context, scenario, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
     const automation = await createDueLoopAutomation(scenario, 3600);
 
     await executeDueWorkflowAutomations(automation.automationId);
 
-    const run = await onlyWorkflowRunMessage(automation.threadId);
-    expect(run.triggerBrief).toMatch(
-      new RegExp(
-        `^${friendlyTriggeredAtPattern("Asia/Shanghai")}\\nEvery 1 hour$`,
-        "u",
-      ),
+    await expect(onlyWorkflowDisplayText(automation.threadId)).resolves.toBe(
+      "The next recurring run started.",
     );
     await disableAutomation(automation.automationId);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-automations.test.ts
@@ -40,7 +40,10 @@ import {
   mockGoogleCalendarConnectorOAuth,
   mockNotionConnectorOAuth,
 } from "./helpers/api-bdd-workflows";
-import { chatEventAutomationPart } from "./helpers/chat-event";
+import {
+  chatEventAutomationPart,
+  chatEventDisplayText,
+} from "./helpers/chat-event";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { cronRenewGmailWatchesRoutes } from "../cron-renew-gmail-watches";
@@ -3997,7 +4000,10 @@ describe("okou workflow automations", () => {
     const requestedAt = Date.UTC(2026, 7, 1, 12, 34, 56);
     mockNow(requestedAt);
     const runnerGroup = runs.configureRunnerGroup();
-    const { workflowId } = await setupFixture();
+    const { fixture, workflowId } = await setupFixture();
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UserFriendlyAutomationMessage]: true,
+    });
     const created = await accept(
       automationsClient().create({
         headers: authHeaders(),
@@ -4072,29 +4078,22 @@ describe("okou workflow automations", () => {
     await runs.heartbeatRunner(runnerGroup);
     const claim = await runs.claimRunnerJob(run.body.runId);
     const requestedAtIso = new Date(requestedAt).toISOString();
-    expect(claim.prompt).toBe(
-      `/${WORKFLOW_NAME}\nTrigger: manual run requested at ${requestedAtIso}.`,
+    expect(claim.prompt).toContain(
+      `/${WORKFLOW_NAME}\n\nAutomation event\nType: manual\nSummary: manual run requested at ${requestedAtIso}.`,
     );
-    expect(claim.appendSystemPrompt).toContain(
-      [
-        "# Current context",
-        `Run created by workflow automation "${WORKFLOW_NAME}".`,
-        `Trigger: manual run requested at ${requestedAtIso}.`,
-        `Procedure: skill "${WORKFLOW_NAME}".`,
-        "Output destination: this web chat thread, read by the user.",
-        "",
-        "# This run's event",
-        JSON.stringify(
-          {
-            automationId: created.body.id,
-            trigger: "manual",
-            requestedAt: requestedAtIso,
-          },
-          null,
-          2,
-        ),
-      ].join("\n"),
+    expect(claim.prompt).toContain(
+      JSON.stringify(
+        {
+          automationId: created.body.id,
+          trigger: "manual",
+          requestedAt: requestedAtIso,
+        },
+        null,
+        2,
+      ),
     );
+    expect(claim.appendSystemPrompt).toContain("# Agent Identity");
+    expect(claim.appendSystemPrompt).not.toContain("# Current context");
 
     const automation = await wf.readAutomation(created.body.id);
     expect(typeof automation.lastRunAt).toBe("string");
@@ -4111,8 +4110,8 @@ describe("okou workflow automations", () => {
     });
     expect(workflowMessage).toBeDefined();
     expect(workflowMessage?.runId).toBe(run.body.runId);
-    expect(chatEventAutomationPart(workflowMessage!)?.automationBrief).toMatch(
-      /^Once at \d{1,2}:\d{2} [AP]M, [A-Z][a-z]{2} \d{1,2}, \d{4} \(Asia\/Shanghai\)$/u,
+    expect(chatEventDisplayText(workflowMessage!)).toBe(
+      "A manual run of this workflow was requested.",
     );
   });
 

--- a/turbo/apps/api/src/signals/services/__tests__/workflow-automation-context.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/workflow-automation-context.test.ts
@@ -7,9 +7,7 @@ import {
   persistedWorkflowAutomationEventPayload,
   restoredWorkflowAutomationEventPayload,
   storedWorkflowAutomationContext,
-  workflowAutomationAgentPrompt,
   workflowAutomationAppendSystemPrompt,
-  workflowAutomationDisplayMessage,
   workflowAutomationEventUsesUserFriendlyMessage,
   workflowAutomationPrompt,
   workflowAutomationTrigger,
@@ -352,38 +350,6 @@ const cases: readonly WorkflowAutomationContextCase[] = [
   },
 ];
 
-const displayMessages: Readonly<Record<WorkflowAutomationEventType, string>> = {
-  "chat-run-finished": "A run in the watched chat thread completed.",
-  "gmail-new-message": "A new email arrived.",
-  "gmail-label-applied": 'Gmail label "Follow up" was added to an email.',
-  "github-pull-request": 'GitHub pull request #24480 was merged into "main".',
-  "github-deployment-status-created":
-    'A GitHub deployment changed to "success".',
-  "github-issue-comment-created": 'GitHub user "octocat" added a comment.',
-  "github-pull-request-review-submitted":
-    'GitHub user "octocat" submitted a pull request review with state "approved".',
-  "github-workflow-job-completed":
-    'GitHub Actions job "test" completed with conclusion "success".',
-  "github-workflow-run-completed":
-    'GitHub Actions workflow ".github/workflows/ci.yml" completed with conclusion "failure".',
-  "google-calendar-event-created": "A Google Calendar event was created.",
-  "google-calendar-event-updated": "A Google Calendar event was updated.",
-  "google-calendar-event-cancelled": "A Google Calendar event was cancelled.",
-  "google-forms-response-submitted":
-    'A new response was submitted to Google Form "Customer feedback".',
-  "google-meet-transcript-generated": "A Google Meet transcript is ready.",
-  "notion-child-page-created":
-    "A Notion child page was created under the configured parent page.",
-  "notion-database-item-created": "A Notion database item was created.",
-  "notion-page-content-updated": "A Notion page was updated.",
-  "strapi-entry-published":
-    'Strapi entry "article-123" was published in Publishing.',
-  "stripe-invoice-paid": 'Stripe invoice "in_stripe" was paid.',
-  "webhook-received": "A signed webhook request was received.",
-  schedule: "This workflow started on schedule.",
-  manual: "A manual run of this workflow was requested.",
-};
-
 describe("workflow automation context lookup contracts", () => {
   it("covers every trigger renderer exactly once", () => {
     expect(
@@ -448,18 +414,6 @@ describe("workflow automation context lookup contracts", () => {
       const restoredUserFriendlyPayload =
         restoredWorkflowAutomationEventPayload(userFriendlyPayload);
       expect(restoredUserFriendlyPayload).toStrictEqual(payload);
-
-      expect(workflowAutomationDisplayMessage(restoredContext)).toBe(
-        displayMessages[eventType],
-      );
-      const agentPrompt = workflowAutomationAgentPrompt(restoredContext);
-      expect(agentPrompt).toContain(
-        `/workflow-context-test\n\nAutomation event\nType: ${eventType}\nSummary: ${trigger}`,
-      );
-      expect(agentPrompt).toContain(
-        `\n\nEvent data:\n${JSON.stringify(payload, null, 2)}`,
-      );
-      expect(agentPrompt).not.toContain("# Current context");
     },
   );
 
@@ -473,7 +427,6 @@ describe("workflow automation context lookup contracts", () => {
         firedAt: "2026-08-01T13:00:00.000Z",
       },
       trigger: "schedule fired at 2026-08-01T13:00:00.000Z (every 300s).",
-      displayMessage: "The next recurring run started.",
     },
     {
       payload: {
@@ -485,23 +438,13 @@ describe("workflow automation context lookup contracts", () => {
       },
       trigger:
         "schedule fired at 2026-08-01T14:00:00.000Z (once in America/Los_Angeles).",
-      displayMessage: "The one-time scheduled run started.",
     },
-  ])(
-    "reconstructs the legacy and user-friendly schedule variants",
-    ({ payload, trigger, displayMessage }) => {
-      expect(
-        workflowAutomationTrigger({
-          eventType: "schedule",
-          eventPayload: payload,
-        }),
-      ).toBe(trigger);
-      const context = storedWorkflowAutomationContext({
-        workflowName: "workflow-context-test",
+  ])("reconstructs the legacy schedule variants", ({ payload, trigger }) => {
+    expect(
+      workflowAutomationTrigger({
         eventType: "schedule",
         eventPayload: payload,
-      });
-      expect(workflowAutomationDisplayMessage(context)).toBe(displayMessage);
-    },
-  );
+      }),
+    ).toBe(trigger);
+  });
 });

--- a/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog-artifact.ts
@@ -1004,6 +1004,20 @@ const connectors = [
     ),
   }),
   connector({
+    connectorSlug: "google-meet",
+    label: "Google Meet",
+    authMethods: [
+      standardOauthMethod({
+        connectorSlug: "google-meet",
+        prefix: "GOOGLE_MEET",
+        tokenEnvironmentNames: ["GOOGLE_MEET_TOKEN"],
+      }),
+    ],
+    firewall: generatedFirewall([
+      bearerApi("https://meet.googleapis.com", "GOOGLE_MEET_TOKEN"),
+    ]),
+  }),
+  connector({
     connectorSlug: "google-maps",
     label: "Google Maps",
     authMethods: [


### PR DESCRIPTION
## Scan

- Timestamp: `2026-08-14T05:36:43+08:00`
- Base commit: `d4b03177f4d02de47a17072af70c02dcc0cf9a1e`
- Scope: API package test files covered by the external-behavior boundary policy
- Found: one exempted service test directly asserted the user-visible display message and agent prompt across the workflow-automation event matrix.
- Fixed: moved those observable assertions to production API/webhook/scheduler/manual route tests. Remaining external-behavior violations: **0**.

## Changes

- `chat-run-finished-automations.bdd.test.ts`: observes the friendly completion message through the public chat-thread event API after a watched run finishes.
- `stripe-automation-events.test.ts`: posts a signed Stripe webhook and observes the friendly invoice message through the chat API.
- `webhooks-github-workflow.test.ts`: sends signed GitHub webhook variants, then verifies public chat messages and runner claim output.
- `webhooks-gmail.test.ts`: sends authenticated Gmail Pub/Sub pushes, then verifies public chat messages and runner claim output.
- `webhooks-google-calendar.test.ts`: sends authenticated Calendar webhook notifications and verifies created, updated, and cancelled messages through the chat API.
- `webhooks-google-forms.test.ts`: sends a signed Forms Pub/Sub push and verifies the public chat message and runner claim output.
- `webhooks-google-workspace-events.test.ts`: adds end-to-end Google Meet coverage through OAuth start/callback, the Workspace Events subscription HTTP boundary, a signed Pub/Sub push, and the public chat API.
- `connector-catalog-artifact.ts`: adds the minimal Google Meet connector catalog fixture required to exercise that public OAuth flow.
- `webhooks-notion.test.ts`: admits signed Notion webhooks through the production route and verifies child-page, database-item, and page-update messages through the public chat/runner APIs.
- `zero-workflow-automation-scheduler.test.ts`: verifies cron, once, and loop messages through automation create/read and chat APIs.
- `zero-workflow-automations.test.ts`: verifies a manual run through the production manual-run endpoint, public chat API, and runner claim API.
- `workflow-automation-context.test.ts`: removes direct assertions of friendly display rendering and agent prompt composition; it retains only the finite internal compatibility matrix described below.

Existing production-boundary tests already cover Strapi publication and signed generic webhooks; those equivalents were also run locally.

## Intentional exceptions

- `workflow-automation-context.test.ts` still imports its service to validate compatibility with already-persisted legacy payload shapes, reversed JSON key order, trigger metadata, and policy selection. Production APIs only create the current payload format, so they cannot construct these historical records.
- Notion debounce expiry and scheduled worker ticks use the existing scoped `test-workflow-automation-execution` route because there is no production client endpoint for advancing the background worker. Event admission/setup still goes through production APIs, and results are asserted through public chat and runner APIs.

## Verification

- Prettier on all changed files
- `git diff --check`
- Full API ESLint scan: 1,065 files, 0 messages, 0 `no-restricted-imports` findings
- Secondary boundary scan: no direct DB access; only the documented compatibility service import remains
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run check-types`
- Targeted Vitest coverage for every migrated behavior across the changed tests, backed by local PostgreSQL in UTC
- Existing Strapi and signed generic-webhook endpoint equivalents
