### PR TITLE
refactor(api): rename platform realtime token route shell

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -116,7 +116,7 @@ import { zeroOrgMembershipRequestsRoutes } from "./routes/zero-org-membership-re
 import { zeroOrgReadRoutes } from "./routes/zero-org-read";
 import { zeroPushSubscriptionsRoutes } from "./routes/zero-push-subscriptions";
 import { zeroQueuePositionRoutes } from "./routes/zero-queue-position";
-import { zeroRealtimeTokenRoutes } from "./routes/zero-realtime-token";
+import { realtimeTokenRoutes } from "./routes/realtime-token";
 import { imageRecognitionRoutes } from "./routes/image-recognition";
 import { translationRoutes } from "./routes/translation";
 import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
@@ -315,7 +315,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroWebDownloadRoutes,
   ...zeroWebFileUrlRoutes,
   ...zeroQueuePositionRoutes,
-  ...zeroRealtimeTokenRoutes,
+  ...realtimeTokenRoutes,
   ...imageRecognitionRoutes,
   ...translationRoutes,
   ...zeroRunDetailRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
@@ -49,7 +49,7 @@ import { zeroBillingStatusRoutes } from "../../zero-billing-status";
 import { claudeCodeDeviceAuthRoutes } from "../../claude-code-device-auth";
 import { codexDeviceAuthRoutes } from "../../codex-device-auth";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
-import { zeroRealtimeTokenRoutes } from "../../zero-realtime-token";
+import { realtimeTokenRoutes } from "../../realtime-token";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 
@@ -87,7 +87,7 @@ const authDeviceRoutes: readonly RouteEntry[] = [
   ...claudeCodeDeviceAuthRoutes,
   ...codexDeviceAuthRoutes,
   ...zeroModelProvidersRoutes,
-  ...zeroRealtimeTokenRoutes,
+  ...realtimeTokenRoutes,
 ];
 
 function authDeviceApp(context: TestContext) {

--- a/turbo/apps/api/src/signals/routes/realtime-token.ts
+++ b/turbo/apps/api/src/signals/routes/realtime-token.ts
@@ -30,7 +30,7 @@ const createInner$ = command(async ({ set }, signal: AbortSignal) => {
   return { status: 200 as const, body: tokenRequest };
 });
 
-export const zeroRealtimeTokenRoutes: readonly RouteEntry[] = [
+export const realtimeTokenRoutes: readonly RouteEntry[] = [
   {
     route: platformRealtimeTokenContract.create,
     handler: createInner$,


### PR DESCRIPTION
## summary

- rename `turbo/apps/api/src/signals/routes/zero-realtime-token.ts` to `turbo/apps/api/src/signals/routes/realtime-token.ts`
- rename the exported route registry symbol from `zeroRealtimeTokenRoutes` to `realtimeTokenRoutes`
- update the production route registry and focused BDD helper registrations without changing their ordering or other upstream registrations

## behavior preservation

- protocol and `POST /api/okou/realtime/token` remain unchanged
- authentication and the exact 401 response remain unchanged
- the request/response contract and 200/401/500 schema remain unchanged
- Ably channel capability (`user:<userId>` with `subscribe` only), one-hour TTL, and `clientId: userId` remain unchanged
- Platform subscriptions, reconnection, diagnostics, push signals, and all runtime behavior remain unchanged

## verification

- `pnpm exec prettier --write apps/api/src/signals/route.ts apps/api/src/signals/routes/realtime-token.ts apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts` (Prettier 3.8.1)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/auth-device.bdd.test.ts -t "AUTH-02: platform realtime token"`
- `pnpm knip --workspace api`
- confirmed no active `routes/zero-realtime-token` import or `zeroRealtimeTokenRoutes` reference remains

Closes #27021

Parent EPIC: #26873
