### PR TITLE
refactor(morning-brief): neutralize manual trigger shell

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -28,7 +28,7 @@ import { cronTelegramCleanupRoutes } from "./routes/cron-telegram-cleanup";
 import { desktopAuthRoutes } from "./routes/desktop-auth";
 import { desktopUpdateRoutes } from "./routes/desktop-updates";
 import { emailMorningBriefUnsubscribeRoutes } from "./routes/email-morning-brief-unsubscribe";
-import { zeroMorningBriefRoutes } from "./routes/zero-morning-brief";
+import { morningBriefRoutes } from "./routes/morning-brief";
 import { emailUnsubscribeRoutes } from "./routes/email-unsubscribe";
 import { healthRoutes } from "./routes/health";
 import { buildInfoRoutes } from "./routes/build-info";
@@ -245,7 +245,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...cronSyncSkillsRoutes,
   ...cronTelegramCleanupRoutes,
   ...emailMorningBriefUnsubscribeRoutes,
-  ...zeroMorningBriefRoutes,
+  ...morningBriefRoutes,
   ...emailUnsubscribeRoutes,
   ...agentDraftRoutes,
   ...zeroAgentInstructionsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -9,7 +9,7 @@ import {
   type GenerationTemplateRequest,
   type UserMessageInputDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { zeroMorningBriefContract } from "@okouai/api-contracts/contracts/zero-morning-brief";
+import { morningBriefContract } from "@okouai/api-contracts/contracts/morning-brief";
 import { zeroModelProvidersByTypeContract } from "@okouai/api-contracts/contracts/zero-model-providers";
 import { zeroUserPreferencesContract } from "@okouai/api-contracts/contracts/zero-user-preferences";
 import { ILLUSTRATION_TEMPLATE_ITEMS } from "@okouai/core";
@@ -54,7 +54,7 @@ import { cronExecuteMorningBriefsRoutes } from "../cron-execute-morning-briefs";
 import { emailMorningBriefUnsubscribeRoutes } from "../email-morning-brief-unsubscribe";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
 import { zeroModelProvidersRoutes } from "../zero-model-providers";
-import { zeroMorningBriefRoutes } from "../zero-morning-brief";
+import { morningBriefRoutes } from "../morning-brief";
 import { zeroUserPreferencesRoutes } from "../zero-user-preferences";
 
 const TEST_APP_ROUTES = Object.freeze([
@@ -62,7 +62,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...emailMorningBriefUnsubscribeRoutes,
   ...zeroChatThreadRoutes,
   ...zeroModelProvidersRoutes,
-  ...zeroMorningBriefRoutes,
+  ...morningBriefRoutes,
   ...zeroUserPreferencesRoutes,
 ]);
 
@@ -237,8 +237,8 @@ function preferencesClient() {
 }
 
 function morningBriefTriggerClient() {
-  return setupApp({ context, routes: zeroMorningBriefRoutes })(
-    zeroMorningBriefContract,
+  return setupApp({ context, routes: morningBriefRoutes })(
+    morningBriefContract,
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/morning-brief.ts
+++ b/turbo/apps/api/src/signals/routes/morning-brief.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { zeroMorningBriefContract } from "@okouai/api-contracts/contracts/zero-morning-brief";
+import { morningBriefContract } from "@okouai/api-contracts/contracts/morning-brief";
 
 import { badRequestMessage } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -42,9 +42,9 @@ const triggerMorningBriefInner$ = command(
   },
 );
 
-export const zeroMorningBriefRoutes: readonly RouteEntry[] = [
+export const morningBriefRoutes: readonly RouteEntry[] = [
   {
-    route: zeroMorningBriefContract.trigger,
+    route: morningBriefContract.trigger,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       triggerMorningBriefInner$,

--- a/turbo/apps/platform/src/signals/zero-page/settings/user-preferences.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/user-preferences.ts
@@ -3,7 +3,7 @@ import {
   zeroUserPreferencesContract,
   type UpdateUserPreferencesRequest,
 } from "@okouai/api-contracts/contracts/zero-user-preferences";
-import { zeroMorningBriefContract } from "@okouai/api-contracts/contracts/zero-morning-brief";
+import { morningBriefContract } from "@okouai/api-contracts/contracts/morning-brief";
 import { zeroClient$ } from "../../api-client.ts";
 import { clerk$ } from "../../auth.ts";
 import { accept } from "../../../lib/accept.ts";
@@ -66,7 +66,7 @@ export const triggerMorningBrief$ = command(
     _signal: AbortSignal,
   ): Promise<{ runId: string | null; queued: boolean }> => {
     const createClient = get(zeroClient$);
-    const client = createClient(zeroMorningBriefContract);
+    const client = createClient(morningBriefContract);
     const result = await accept(
       client.trigger({ body: {}, fetchOptions: { signal: _signal } }),
       [200],

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -296,9 +296,9 @@ export {
   type EmailUnsubscribeResponse,
 } from "./email-unsubscribe";
 export {
-  zeroMorningBriefContract,
-  type ZeroMorningBriefContract,
-} from "./zero-morning-brief";
+  morningBriefContract,
+  type MorningBriefContract,
+} from "./morning-brief";
 export {
   emailMorningBriefUnsubscribeContract,
   type EmailMorningBriefUnsubscribeContract,

--- a/turbo/packages/api-contracts/src/contracts/morning-brief.ts
+++ b/turbo/packages/api-contracts/src/contracts/morning-brief.ts
@@ -17,7 +17,7 @@ const triggerMorningBriefResponseSchema = z.object({
  * Testing entry point gated by the manualMorningBrief feature switch:
  * immediately runs the collect → agent-run → email pipeline for the caller.
  */
-export const zeroMorningBriefContract = c.router({
+export const morningBriefContract = c.router({
   trigger: {
     method: "POST",
     path: "/api/okou/morning-brief/trigger",
@@ -34,4 +34,4 @@ export const zeroMorningBriefContract = c.router({
   },
 });
 
-export type ZeroMorningBriefContract = typeof zeroMorningBriefContract;
+export type MorningBriefContract = typeof morningBriefContract;


### PR DESCRIPTION
## summary

- rename `turbo/packages/api-contracts/src/contracts/zero-morning-brief.ts` to `turbo/packages/api-contracts/src/contracts/morning-brief.ts`
- rename `zeroMorningBriefContract` to `morningBriefContract` and `ZeroMorningBriefContract` to `MorningBriefContract`
- rename `turbo/apps/api/src/signals/routes/zero-morning-brief.ts` to `turbo/apps/api/src/signals/routes/morning-brief.ts` and `zeroMorningBriefRoutes` to `morningBriefRoutes`
- move the contract barrel, API route registry, focused API integration test, and Platform settings caller to the neutral declarations atomically, without a compatibility alias

## behavior preserved

- protocol is unchanged: the endpoint remains `POST /api/okou/morning-brief/trigger` with the same request and response schemas and the same authentication/status behavior
- feature gating is unchanged: the existing `manualMorningBrief` switch still controls the manual trigger
- pipeline behavior is unchanged: collection, queueing, agent-run creation, email delivery, daily deduplication, active/queued handling, and retry behavior still delegate to the existing `triggerMorningBriefNow$` implementation
- persistence is unchanged: no service, schedule, delivery, database schema, migration, or persisted-value code changed

## verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts` (10 tests passed)
- repository-wide residual search confirms no active old module path or declaration remains

Closes #27024

Parent EPIC: #26873
