### PR TITLE
refactor(web-files): neutralize private web file modules

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -189,8 +189,8 @@ import { zeroVoiceIoQuotaRoutes } from "./routes/zero-voice-io-quota";
 import { zeroVoiceIoSpeechRoutes } from "./routes/zero-voice-io-speech";
 import { zeroVoiceIoSttRoutes } from "./routes/zero-voice-io-stt";
 import { zeroVideoIoGenerateRoutes } from "./routes/zero-video-io-generate";
-import { zeroWebDownloadRoutes } from "./routes/zero-web-download";
-import { zeroWebFileUrlRoutes } from "./routes/zero-web-file-url";
+import { webDownloadRoutes } from "./routes/web-download";
+import { webFileUrlRoutes } from "./routes/web-file-url";
 
 export const ROUTES: readonly RouteEntry[] = [
   ...healthRoutes,
@@ -312,8 +312,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroVoiceIoQuotaRoutes,
   ...zeroVoiceIoSpeechRoutes,
   ...zeroVoiceIoSttRoutes,
-  ...zeroWebDownloadRoutes,
-  ...zeroWebFileUrlRoutes,
+  ...webDownloadRoutes,
+  ...webFileUrlRoutes,
   ...zeroQueuePositionRoutes,
   ...realtimeTokenRoutes,
   ...imageRecognitionRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-web-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-web-download.test.ts
@@ -8,7 +8,7 @@ import { mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
 import { signSandboxJwtForTests } from "../../auth/tokens";
-import { zeroWebDownloadRoutes } from "../zero-web-download";
+import { webDownloadRoutes } from "../web-download";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 
 const context = testContext();
@@ -131,7 +131,7 @@ function requestDownload(args: {
     : {};
   const app = createAppWithRoutes({
     signal: context.signal,
-    routes: zeroWebDownloadRoutes,
+    routes: webDownloadRoutes,
   });
   return Promise.resolve(
     app.request(`${ROUTE}${search}`, { method: "GET", headers }),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-web-file-url.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-web-file-url.test.ts
@@ -2,14 +2,14 @@ import { randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
 import { describe, expect, it } from "vitest";
 import type { ZeroCapability } from "@okouai/api-contracts/contracts/composes";
-import { zeroWebFilesContract } from "@okouai/api-contracts/contracts/zero-web-files";
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
-import { zeroWebFileUrlRoutes } from "../zero-web-file-url";
+import { webFileUrlRoutes } from "../web-file-url";
 import { expectApiError } from "./helpers/api-bdd";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 
@@ -19,9 +19,7 @@ const BUCKET = "test-user-artifacts";
 const PRESIGNED_URL = "https://r2.example.com/artifacts/photo.png?sig=test";
 
 function client() {
-  return setupApp({ context, routes: zeroWebFileUrlRoutes })(
-    zeroWebFilesContract,
-  );
+  return setupApp({ context, routes: webFileUrlRoutes })(webFilesContract);
 }
 
 function currentSecond(): number {

--- a/turbo/apps/api/src/signals/routes/web-download.ts
+++ b/turbo/apps/api/src/signals/routes/web-download.ts
@@ -1,23 +1,23 @@
 import { computed } from "ccstate";
-import { zeroWebFilesContract } from "@okouai/api-contracts/contracts/zero-web-files";
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
 import { notFound, badRequestMessage } from "../../lib/error";
-import { zeroWebDownloadFile } from "../services/zero-web-download.service";
+import { webDownloadFile } from "../services/web-download.service";
 import type { RouteEntry } from "../route-entry";
 
 const downloadFileInner$ = computed(async (get) => {
   const auth = get(authContext$);
-  const params = get(queryOf(zeroWebFilesContract.download));
+  const params = get(queryOf(webFilesContract.download));
 
   const fileId = params.file_id;
   if (!fileId) {
     return badRequestMessage("file_id query parameter is required");
   }
 
-  const result = await get(zeroWebDownloadFile(fileId, auth.userId));
+  const result = await get(webDownloadFile(fileId, auth.userId));
   if (!result) {
     return notFound("File not found");
   }
@@ -35,9 +35,9 @@ const downloadFileInner$ = computed(async (get) => {
   });
 });
 
-export const zeroWebDownloadRoutes: readonly RouteEntry[] = [
+export const webDownloadRoutes: readonly RouteEntry[] = [
   {
-    route: zeroWebFilesContract.download,
+    route: webFilesContract.download,
     handler: authRoute(
       {
         requireOrganization: false,

--- a/turbo/apps/api/src/signals/routes/web-file-url.ts
+++ b/turbo/apps/api/src/signals/routes/web-file-url.ts
@@ -1,5 +1,5 @@
 import { computed } from "ccstate";
-import { zeroWebFilesContract } from "@okouai/api-contracts/contracts/zero-web-files";
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
 
 import { env } from "../../lib/env";
 import { notFound } from "../../lib/error";
@@ -16,7 +16,7 @@ const FILE_URL_TTL_SECONDS = 2 * 60 * 60;
 
 const fileUrlInner$ = computed(async (get) => {
   const auth = get(authContext$);
-  const params = get(queryOf(zeroWebFilesContract.fileUrl));
+  const params = get(queryOf(webFilesContract.fileUrl));
 
   const object = await get(resolvedArtifactObject(auth.userId, params.file_id));
   if (!object) {
@@ -38,9 +38,9 @@ const fileUrlInner$ = computed(async (get) => {
   return { status: 200 as const, body: { url } };
 });
 
-export const zeroWebFileUrlRoutes: readonly RouteEntry[] = [
+export const webFileUrlRoutes: readonly RouteEntry[] = [
   {
-    route: zeroWebFilesContract.fileUrl,
+    route: webFilesContract.fileUrl,
     handler: authRoute(
       {
         requireOrganization: false,

--- a/turbo/apps/api/src/signals/services/web-download.service.ts
+++ b/turbo/apps/api/src/signals/services/web-download.service.ts
@@ -14,7 +14,7 @@ interface DownloadFileResult {
  * Locate and download a user-owned file by its file ID and owning user.
  * Returns null when no matching S3 object exists.
  */
-export function zeroWebDownloadFile(
+export function webDownloadFile(
   fileId: string,
   userId: string,
 ): Computed<Promise<DownloadFileResult | null>> {

--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -1,5 +1,5 @@
 import { computed, type Computed } from "ccstate";
-import { zeroWebFilesContract } from "@okouai/api-contracts/contracts/zero-web-files";
+import { webFilesContract } from "@okouai/api-contracts/contracts/web-files";
 import { accept } from "../lib/accept.ts";
 import { pageSignal$ } from "./page-signal.ts";
 import { resolveApiBase } from "./api-base.ts";
@@ -37,7 +37,7 @@ function createAttachmentResourceUrl$(url: string): Computed<Promise<string>> {
       throw new Error("Authenticated attachment URL is missing file_id");
     }
     const signal = get(pageSignal$);
-    const client = get(zeroClient$)(zeroWebFilesContract);
+    const client = get(zeroClient$)(webFilesContract);
     const response = await accept(
       client.fileUrl({
         query: { file_id: fileId },

--- a/turbo/packages/api-contracts/src/contracts/web-files.ts
+++ b/turbo/packages/api-contracts/src/contracts/web-files.ts
@@ -5,7 +5,7 @@ import { initContract } from "./trpc-contract";
 
 const c = initContract();
 
-export const zeroWebFilesContract = c.router({
+export const webFilesContract = c.router({
   download: {
     method: "GET",
     path: "/api/okou/web/download-file",


### PR DESCRIPTION
## summary

- rename `turbo/packages/api-contracts/src/contracts/zero-web-files.ts` to `turbo/packages/api-contracts/src/contracts/web-files.ts` and `zeroWebFilesContract` to `webFilesContract`
- rename `turbo/apps/api/src/signals/routes/zero-web-download.ts` to `turbo/apps/api/src/signals/routes/web-download.ts` and `zeroWebDownloadRoutes` to `webDownloadRoutes`
- rename `turbo/apps/api/src/signals/routes/zero-web-file-url.ts` to `turbo/apps/api/src/signals/routes/web-file-url.ts` and `zeroWebFileUrlRoutes` to `webFileUrlRoutes`
- rename `turbo/apps/api/src/signals/services/zero-web-download.service.ts` to `turbo/apps/api/src/signals/services/web-download.service.ts` and `zeroWebDownloadFile` to `webDownloadFile`
- move every in-repository consumer atomically, with no old-path bridge or TypeScript compatibility alias

## compatibility and behavior

Protocol compatibility is unchanged: the canonical `GET /api/okou/web/download-file` and `GET /api/okou/web/file-url` contracts still receive symmetric `/api/zero/**` registrations through the untouched shared namespace alias layer. Both `zero-web-*.test.ts` filenames and their `ZeroCapability`, `mintZeroToken`, `scope: "zero"`, legacy route literals, and `file:read` evidence remain intact.

Security behavior is unchanged, including authentication, capability enforcement, user ownership isolation, and 404 anti-enumeration. Storage identity and behavior are unchanged, including the R2 bucket, artifact object-key resolution, MIME inference, download bytes and headers, inline disposition, and the two-hour presigned URL. CLI behavior, Platform attachment preview behavior, request and response schemas, status codes, and all other runtime behavior are unchanged.

## verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-web-download.test.ts`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-web-file-url.test.ts`
- `pnpm --filter api exec vitest run src/__tests__/api-namespace-compatibility.test.ts`
- focused Platform attachment URL exchange scenarios in `zero-attachment-chips.test.tsx`
- full residual-reference audit plus reverse-rename blob comparison for all eight changed files
- refreshed and rebased onto current `main`; retained all upstream route registrations

Closes #27026

Parent: #26873