### PR TITLE
refactor: remove the payment method capability flag

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-status.test.ts
@@ -133,7 +133,6 @@ describe("GET /api/zero/billing/status", () => {
     expect(response.body.supportByok).toBeFalsy();
     expect(response.body.restrictedVm0Models).toBeTruthy();
     expect(response.body.videoGenerationAllowed).toBeFalsy();
-    expect(response.body.paymentMethodManagementAvailable).toBeTruthy();
     expect(response.body.credits).toBe(100_000);
     expect(response.body.onboardingPaymentPending).toBeFalsy();
     expect(response.body.hasSubscription).toBeFalsy();

--- a/turbo/apps/api/src/signals/routes/zero-billing-status.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-status.ts
@@ -9,10 +9,7 @@ import type { RouteEntry } from "../route-entry";
 const getBillingStatusInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const body = await get(zeroBillingStatus(auth.orgId));
-  return {
-    status: 200 as const,
-    body: { ...body, paymentMethodManagementAvailable: true },
-  };
+  return { status: 200 as const, body };
 });
 
 export const zeroBillingStatusRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/platform/src/mocks/handlers/api-billing.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-billing.ts
@@ -40,7 +40,6 @@ function defaultBillingStatus(): BillingStatusResponse {
     creditGrants: [],
     concurrencyLimit: 0,
     concurrencySubscriptions: [],
-    paymentMethodManagementAvailable: true,
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -96,7 +96,6 @@ function activeProBillingStatus(): BillingStatusResponse {
     creditGrants: [],
     concurrencyLimit: 2,
     concurrencySubscriptions: [],
-    paymentMethodManagementAvailable: true,
   };
 }
 
@@ -155,7 +154,6 @@ function noActiveBillingStatus(): BillingStatusResponse {
     creditGrants: [],
     concurrencyLimit: 0,
     concurrencySubscriptions: [],
-    paymentMethodManagementAvailable: true,
   };
 }
 

--- a/turbo/packages/api-contracts/src/contracts/zero-billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-billing.ts
@@ -80,13 +80,6 @@ const usageAllowanceSchema = z.object({
 
 const billingStatusResponseSchema = z.object({
   tier: z.string(),
-  /**
-   * Always `true` since #25716 retired the payment-method portal rollout
-   * switch. It stays optional like every other capability flag so a new app
-   * reaching a draining older API keeps the shared
-   * `org-plan-capabilities.ts` default instead of failing response parsing.
-   */
-  paymentMethodManagementAvailable: z.boolean().optional(),
   canBuyConcurrency: z.boolean().optional(),
   concurrencyPurchaseReviewAvailable: z.boolean().optional(),
   canBuyCredits: z.boolean().optional(),


### PR DESCRIPTION
Completes the cleanup started in #26424 and closes the last item of #25716.

#26424 retired the payment-method portal rollout compatibility but deliberately kept one field alive: `paymentMethodManagementAvailable` stayed `.optional()` in `billingStatusResponseSchema` and the API kept returning the constant `true`, because already-loaded app builds still read it before falling back to the legacy subscriber UI. That was sized to the ~2-day stale web/app client window. The window has closed, so the field goes.

## Removal evidence

**Rollout.** The first `app/production` deployment containing #26424's merge commit `dad4358adcb9fa179bad39d26fc6e0612234d7a0` is deployment `5897…`/`1d68b310db74f43cd71d1fb2fc386fcc23780b1d`, app **v0.730.1**, `state: success` at **2026-08-12T00:41:13Z** (`https://app.vm0.ai`). Verified with `git merge-base --is-ancestor dad4358… 1d68b310…`. The immediately preceding production deployment, `8321a3025ee74241c0650fc4c163074fabe6ae24` at 2026-08-11T20:10:14Z, does **not** contain it, which confirms `1d68b310…` is the first build that stopped reading the field. At this run (**2026-08-14T01:00:55Z**) that is **2 days 0h 19m**, past the ~2-day window.

**Client floor.** `minimumSupportedVersion` is now **0.738.1**, eight minors above the 0.730.1 that stopped reading the field. App traffic in `vm0-request-log-prod` over the last 3.5 hours (2026-08-13T21:30:55Z → 2026-08-14T01:00:55Z), after the current floor was in place:

| minor | requests | served (not 426) |
|---|---|---|
| 714 | 18 | 0 |
| 715 | 20 | 0 |
| 727 | 1 | 0 |
| 728 | 12 | 0 |
| 730 | 565 | 0 |
| 731 | 627 | 0 |
| 734 | 146 | 0 |
| 735 | 6 | 0 |
| 738 | 70 | 70 |
| 739 | 299 | 299 |
| 740 | 11 | 11 |
| 741 | 102 | 102 |
| 742 | 2 899 | 2 899 |
| 743 | 22 | 22 |
| 744 | 318 | 318 |
| 745 | 3 475 | 3 475 |
| 746 | 1 148 | 1 148 |
| 747 | 8 990 | 8 990 |

Every bundle below the floor is rejected with `426` and served **zero** times. No live app client predates 0.738.1, so none can read the field. The same query over the full window since the app deployment shows served sub-0.738 traffic only from the earlier part of the window, when the floor was still lower; that is the floor doing its job, not a live reader.

**Readers.** A repo-wide grep for `paymentMethodManagementAvailable` before this change returned only the API handler, the contract, the API test assertion, and two platform test fixtures plus one MSW mock. No production client reads it. After this change the grep returns nothing.

## Removed

- `billingStatusResponseSchema.paymentMethodManagementAvailable` and its comment in `turbo/packages/api-contracts/src/contracts/zero-billing.ts`
- the hardcoded `paymentMethodManagementAvailable: true` in `getBillingStatusInner$`, `turbo/apps/api/src/signals/routes/zero-billing-status.ts`, which now returns the service body directly
- the `paymentMethodManagementAvailable` assertion in `zero-billing-status.test.ts`
- the stale fixture entries in `turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx` (two fixtures) and the MSW default in `turbo/apps/platform/src/mocks/handlers/api-billing.ts`

No replacement default, `??` chain, or tolerance branch is introduced, and no negative test asserting the field is gone is left behind (`docs/fallback.md` §1).

## Checks

Run against this diff with a local PostgreSQL 18 cluster whose session `timezone` is `UTC`, migrations applied:

- `pnpm format` — no changes
- lint, 0 errors: `@okouai/api-contracts` and `@okouai/app` via `pnpm -F <pkg> lint`; `api` via its four constituent steps (`oxlint`, `oxlint src --type-aware`, `oxlint <__tests__ dirs> --type-aware`, `eslint . --max-warnings 0`), each exiting 0. The single aggregate `pnpm turbo run lint` command exceeded this environment's 10-minute per-command cap, so it was run as those steps rather than skipped.
- `check-types`: `@okouai/api-contracts` and `@okouai/app` clean; `api` clean across `deps`, `boundaries`, `gateways`, `core`, `bootstrap`, `tests`, `bootstrap-wiring`
- `pnpm knip` — exit 0
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-status.test.ts` — 33 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/billing-usage-media.bdd.test.ts` — 8 passed
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx` — 34 passed
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx` — 19 passed (covers the shared billing MSW default)

Per repo guidance the full local Vitest suite was not run and no dev server was started.

Closes #25716
