### PR TITLE
refactor(onboarding): neutralize api route shell

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -106,8 +106,8 @@ import { weatherRoutes } from "./routes/weather";
 import { zeroModelPoliciesRoutes } from "./routes/zero-model-policies";
 import { zeroModelProviderGatewayRoutes } from "./routes/zero-model-provider-gateways";
 import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
-import { zeroOnboardingCompleteRoutes } from "./routes/zero-onboarding-complete";
-import { zeroOnboardingStatusRoutes } from "./routes/zero-onboarding-status";
+import { onboardingCompleteRoutes } from "./routes/onboarding-complete";
+import { onboardingStatusRoutes } from "./routes/onboarding-status";
 import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
 import { zeroOrgDeleteRoutes } from "./routes/zero-org-delete";
 import { orgLogoRoutes } from "./routes/org-logo";
@@ -321,8 +321,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroRunDetailRoutes,
   ...zeroRunsRoutes,
   ...zeroRunsCancelRoutes,
-  ...zeroOnboardingCompleteRoutes,
-  ...zeroOnboardingStatusRoutes,
+  ...onboardingCompleteRoutes,
+  ...onboardingStatusRoutes,
   ...zeroOrgInviteRoutes,
   ...zeroOrgDeleteRoutes,
   ...orgLogoRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -92,8 +92,8 @@ import { zeroCustomConnectorsDeleteRoutes } from "../../zero-custom-connectors-d
 import { zeroCustomConnectorsGetRoutes } from "../../zero-custom-connectors-get";
 import { zeroCustomConnectorDisconnectRoutes } from "../../zero-custom-connectors-disconnect";
 import { zeroCustomConnectorsValuesSetRoutes } from "../../zero-custom-connectors-values-set";
-import { zeroOnboardingCompleteRoutes } from "../../zero-onboarding-complete";
-import { zeroOnboardingStatusRoutes } from "../../zero-onboarding-status";
+import { onboardingCompleteRoutes } from "../../onboarding-complete";
+import { onboardingStatusRoutes } from "../../onboarding-status";
 import { zeroOrgDeleteRoutes } from "../../zero-org-delete";
 import { zeroOrgInviteRoutes } from "../../zero-org-invite";
 import { orgLogoRoutes } from "../../org-logo";
@@ -208,8 +208,8 @@ interface RawJsonResponse {
 const authOrgRoutes = [
   ...authMeRoutes,
   ...cliAuthRoutes,
-  ...zeroOnboardingStatusRoutes,
-  ...zeroOnboardingCompleteRoutes,
+  ...onboardingStatusRoutes,
+  ...onboardingCompleteRoutes,
   ...zeroUserPreferencesRoutes,
   ...zeroOrgReadRoutes,
   ...zeroOrgDeleteRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
@@ -25,8 +25,8 @@ import { signSandboxJwtForTests } from "../../../auth/tokens";
 import { authMeRoutes } from "../../auth-me";
 import { zeroAgentsRoutes } from "../../zero-agents";
 import { zeroAgentInstructionsRoutes } from "../../zero-agent-instructions";
-import { zeroOnboardingCompleteRoutes } from "../../zero-onboarding-complete";
-import { zeroOnboardingStatusRoutes } from "../../zero-onboarding-status";
+import { onboardingCompleteRoutes } from "../../onboarding-complete";
+import { onboardingStatusRoutes } from "../../onboarding-status";
 import { zeroOrgReadRoutes } from "../../zero-org-read";
 import { zeroUserPreferencesRoutes } from "../../zero-user-preferences";
 import { createZeroRouteMocks } from "./zero-route-test";
@@ -122,14 +122,14 @@ export function createBddApi(context: TestContext) {
   function onboardingStatusClient() {
     return setupAppWithRoutes({
       context,
-      routes: zeroOnboardingStatusRoutes,
+      routes: onboardingStatusRoutes,
     })(onboardingStatusContract);
   }
 
   function onboardingCompleteClient() {
     return setupAppWithRoutes({
       context,
-      routes: zeroOnboardingCompleteRoutes,
+      routes: onboardingCompleteRoutes,
     })(onboardingCompleteContract);
   }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-onboarding.test.ts
@@ -8,8 +8,8 @@ import {
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroOnboardingCompleteRoutes } from "../zero-onboarding-complete";
-import { zeroOnboardingStatusRoutes } from "../zero-onboarding-status";
+import { onboardingCompleteRoutes } from "../onboarding-complete";
+import { onboardingStatusRoutes } from "../onboarding-status";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -19,13 +19,13 @@ function authHeaders() {
 }
 
 function onboardingStatusClient() {
-  return setupApp({ context, routes: zeroOnboardingStatusRoutes })(
+  return setupApp({ context, routes: onboardingStatusRoutes })(
     onboardingStatusContract,
   );
 }
 
 function onboardingCompleteClient() {
-  return setupApp({ context, routes: zeroOnboardingCompleteRoutes })(
+  return setupApp({ context, routes: onboardingCompleteRoutes })(
     onboardingCompleteContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/onboarding-complete.ts
+++ b/turbo/apps/api/src/signals/routes/onboarding-complete.ts
@@ -35,7 +35,7 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return await set(completeOnboarding$, { orgId: auth.orgId }, signal);
 });
 
-export const zeroOnboardingCompleteRoutes: readonly RouteEntry[] = [
+export const onboardingCompleteRoutes: readonly RouteEntry[] = [
   {
     route: onboardingCompleteContract.complete,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/onboarding-status.ts
+++ b/turbo/apps/api/src/signals/routes/onboarding-status.ts
@@ -9,7 +9,7 @@ import { ensureOrgLimitedFreeBootstrap$ } from "../services/org-limited-free-boo
 import { onboardingStatus } from "../services/onboarding.service";
 import { tapError } from "../utils";
 
-const L = logger("zero-onboarding-status.route");
+const L = logger("onboarding-status.route");
 
 const getOnboardingStatusInner$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
@@ -50,7 +50,7 @@ const getOnboardingStatusInner$ = command(
   },
 );
 
-export const zeroOnboardingStatusRoutes: readonly RouteEntry[] = [
+export const onboardingStatusRoutes: readonly RouteEntry[] = [
   {
     route: onboardingStatusContract.getStatus,
     handler: authRoute({}, getOnboardingStatusInner$),


### PR DESCRIPTION
## Summary

- rename the onboarding status and completion route modules to domain-neutral filenames
- rename their exported route arrays and the onboarding status logger label
- update the production route registry, focused route test, and both BDD route registries atomically

## Compatibility and scope

- preserve authentication, status codes, response schemas, admin-only completion, persisted onboarding state, lazy default-agent bootstrap, limited-free credits, and post-bootstrap rereads
- retain both `/api/okou/onboarding/**` and `/api/zero/onboarding/**` through the unchanged shared namespace alias layer
- retain `zero-onboarding.test.ts`, its `/api/zero/onboarding/**` labels, and `createZeroRouteMocks`
- add no old-name bridge modules or exports and make no contract, service, database, credit, Platform, historical documentation, or handler-control-flow changes

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace type checks, followed by `pnpm --filter @okouai/app run check-types` and `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-onboarding.test.ts` (4 passed)
- post-rebase focused Prettier, API type, and onboarding route test reruns
- residual source search for both old module paths, both old exports, and the old logger label

Closes #27037
Refs #26873
