### PR TITLE
fix(guest): terminate stuck codex steers after timeout

### DIFF
--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -721,6 +721,15 @@ impl ActiveInputController {
         Ok(())
     }
 
+    /// Records that the active-input sink cannot make further progress.
+    ///
+    /// Callers must first confirm that the backend consumer process exited.
+    /// This closes only the local in-flight operation; it does not record
+    /// backend acceptance or add a delivery receipt.
+    pub(crate) fn mark_sink_stopped_after_consumer_exit(&self) {
+        self.inner.sink_in_flight_tx.send_replace(false);
+    }
+
     /// Stop direct receipt delivery and return every backend-accepted ID.
     pub async fn finalize_receipts(&self) -> Result<Vec<String>, AgentError> {
         let sink_in_flight = self.sink_in_flight();

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -107,7 +107,6 @@ enum AppServerRunOutcome {
     Completed(Box<Result<CliExecutionResult, AgentError>>),
     ExecutionTimedOut { timeout_secs: u64 },
     UserCancelled,
-    ActiveInputQuiescenceFailed,
 }
 
 async fn settle_active_input_before_stop<Run>(
@@ -126,20 +125,16 @@ where
     let settle = async {
         tokio::select! {
             biased;
-            result = run.as_mut() => Ok(Some(result)),
-            idle = active_input.wait_for_sink_idle() => idle.map(|()| None),
+            _ = run.as_mut() => {}
+            _ = active_input.wait_for_sink_idle() => {}
         }
     };
-    match tokio::time::timeout(
+    let _ = tokio::time::timeout(
         Duration::from_secs(crate::constants::ACTIVE_INPUT_SINK_QUIESCENCE_TIMEOUT_SECS),
         settle,
     )
-    .await
-    {
-        Ok(Ok(Some(result))) => AppServerRunOutcome::Completed(Box::new(result)),
-        Ok(Ok(None)) => stopped,
-        Ok(Err(_)) | Err(_) => AppServerRunOutcome::ActiveInputQuiescenceFailed,
-    }
+    .await;
+    stopped
 }
 
 async fn run_with_execution_deadline(
@@ -446,20 +441,39 @@ async fn run_codex_app_server(
     )
     .await;
     active_input.close_terminal();
-    let active_input_delivery_ids = active_input_controller.finalize_receipts().await;
 
     let shutdown_result = match &run_outcome {
         AppServerRunOutcome::Completed(result) if result.is_ok() => client.shutdown().await,
         AppServerRunOutcome::Completed(_)
         | AppServerRunOutcome::ExecutionTimedOut { .. }
-        | AppServerRunOutcome::UserCancelled
-        | AppServerRunOutcome::ActiveInputQuiescenceFailed => client.terminate().await,
+        | AppServerRunOutcome::UserCancelled => client.terminate().await,
     };
+    if shutdown_result.is_ok()
+        && matches!(
+            &run_outcome,
+            AppServerRunOutcome::ExecutionTimedOut { .. } | AppServerRunOutcome::UserCancelled
+        )
+        && active_input_controller.sink_in_flight()
+    {
+        active_input_controller.mark_sink_stopped_after_consumer_exit();
+    }
+    let active_input_delivery_ids = active_input_controller.finalize_receipts().await;
     let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
     // Complete the final event-log write after the child is stopped and
     // before callers observe the finished app-server execution.
     let _ = log_file.flush().await;
-    let active_input_delivery_ids = active_input_delivery_ids?;
+    let active_input_delivery_ids = match active_input_delivery_ids {
+        Ok(delivery_ids) => delivery_ids,
+        Err(active_input_error) => {
+            if let Err(shutdown_error) = &shutdown_result {
+                return Err(AgentError::Execution(format!(
+                    "codex app-server cleanup failed before active-input quiescence: {}",
+                    masker.mask_string(&shutdown_error.to_string())
+                )));
+            }
+            return Err(active_input_error);
+        }
+    };
 
     match run_outcome {
         AppServerRunOutcome::Completed(run_result) => match (*run_result, shutdown_result) {
@@ -532,9 +546,6 @@ async fn run_codex_app_server(
                 active_input_delivery_ids,
             })
         }
-        AppServerRunOutcome::ActiveInputQuiescenceFailed => Err(AgentError::Execution(
-            "Codex active-input steer did not quiesce after terminal stop".to_string(),
-        )),
     }
 }
 

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_execution_timeout.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_execution_timeout.rs
@@ -1,0 +1,147 @@
+//! An execution deadline must terminate a Codex steer whose response never arrives.
+//!
+//! This test lives in its own binary to isolate process environment and current
+//! directory changes required by the mock Codex integration harness.
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
+use guest_agent::cli::{CliExecutionControls, execute_cli_with_controls_for_config_started_at};
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{AGENT_EXECUTION_TIMEOUT_EXIT_CODE, CliTerminationReason};
+use httpmock::prelude::*;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+const RUN_ID: &str = "codex-app-server-backend-active-input-execution-timeout-test";
+const DELIVERY_ID: &str = "2532261d-b0e1-471e-b93d-1acae383d003";
+
+#[tokio::test]
+async fn execution_timeout_terminates_a_stuck_active_input_steer()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let server = MockServer::start();
+
+    unsafe {
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: RUN_ID,
+                prompt: "drive the active-input execution timeout path",
+                scenario: Some("wait-on-turn-steer-response"),
+                resume_session_id: None,
+            },
+        )?;
+        std::env::set_var(guest_contracts::env::AGENT_EXECUTION_TIMEOUT_SECS_ENV, "1");
+    }
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let receipt = server.mock(|when, then| {
+        when.method(POST)
+            .path(format!(
+                "/api/runners/runs/{RUN_ID}/active-inputs/deliveries/{DELIVERY_ID}/receipt"
+            ))
+            .header("Authorization", "Bearer test-token")
+            .json_body(json!({}));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({ "outcome": "delivered" }));
+    });
+    let journal_path = guest_contracts::runtime_paths::active_input_receipt_journal_file(
+        runtime.paths.runtime_dir(),
+    );
+    let active_input = ActiveInputRuntime::new_with_receipts(
+        RUN_ID,
+        &runtime.config.prompt,
+        &journal_path,
+        HttpClient::with_api_config(server.base_url(), "test-token", "", RUN_ID, Duration::ZERO)?,
+    )?;
+    let active_input_controller = active_input.controller();
+    assert_eq!(
+        active_input_controller.handle_control_payload(
+            &guest_contracts::active_input::encode_active_input(
+                DELIVERY_ID,
+                "save a resumable handoff before timeout",
+            )?,
+        ),
+        ActiveInputControlOutcome::Accepted
+    );
+
+    let masker = SecretMasker::from_raw("");
+    let execution = execute_cli_with_controls_for_config_started_at(
+        &masker,
+        common::spawn_dummy_heartbeat(),
+        runtime.http.clone(),
+        CliExecutionControls::new(active_input.into_writer(), CancellationToken::new(), None),
+        &runtime.config,
+        &runtime.paths,
+        Instant::now(),
+    );
+    tokio::pin!(execution);
+    let ready_file = tmp.path().join(common::MOCK_CODEX_TURN_STEER_READY_FILE);
+    tokio::select! {
+        result = &mut execution => {
+            return Err(format!("Codex execution ended before the steer blocked: {result:?}").into());
+        }
+        ready = common::wait_for_file_contains(
+            &ready_file,
+            common::MOCK_CODEX_TURN_STEER_READY_EVENT,
+            Duration::from_secs(5),
+        ) => ready?,
+    }
+
+    let execution_timeout = runtime
+        .config
+        .agent_execution_timeout
+        .expect("test config should set an execution timeout");
+    tokio::time::pause();
+    tokio::time::advance(execution_timeout).await;
+    tokio::select! {
+        biased;
+        result = &mut execution => {
+            return Err(format!("Codex execution ended before the sink settle budget: {result:?}").into());
+        }
+        () = std::future::ready(()) => {}
+    }
+    tokio::time::advance(Duration::from_secs(10)).await;
+    tokio::time::resume();
+
+    let result = tokio::time::timeout(Duration::from_secs(10), execution)
+        .await
+        .expect("execution deadline should terminate the stuck steer")?;
+
+    assert_eq!(result.exit_code, AGENT_EXECUTION_TIMEOUT_EXIT_CODE);
+    let error = result
+        .control_error
+        .as_ref()
+        .expect("execution timeout should preserve a controlled error");
+    assert!(
+        error
+            .to_string()
+            .contains("Agent execution timed out after 1 seconds"),
+        "unexpected timeout error: {error}"
+    );
+    assert_eq!(
+        result
+            .cli_termination
+            .expect("execution timeout should attach termination diagnostics")
+            .reason,
+        CliTerminationReason::ExecutionTimeout
+    );
+    assert!(result.active_input_delivery_ids.is_empty());
+    receipt.assert_calls(0);
+    assert!(
+        guest_contracts::active_input_receipts::read_active_input_receipt_journal(
+            &journal_path,
+            RUN_ID,
+        )?
+        .is_empty()
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_execution_timeout.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_execution_timeout.rs
@@ -82,38 +82,36 @@ async fn execution_timeout_terminates_a_stuck_active_input_steer()
         &runtime.paths,
         Instant::now(),
     );
-    tokio::pin!(execution);
     let ready_file = tmp.path().join(common::MOCK_CODEX_TURN_STEER_READY_FILE);
-    tokio::select! {
-        result = &mut execution => {
-            return Err(format!("Codex execution ended before the steer blocked: {result:?}").into());
-        }
-        ready = common::wait_for_file_contains(
-            &ready_file,
-            common::MOCK_CODEX_TURN_STEER_READY_EVENT,
-            Duration::from_secs(5),
-        ) => ready?,
-    }
-
+    let ready_file = ready_file
+        .to_str()
+        .ok_or_else(|| std::io::Error::other("mock readiness path is not valid UTF-8"))?;
     let execution_timeout = runtime
         .config
         .agent_execution_timeout
         .expect("test config should set an execution timeout");
-    tokio::time::pause();
-    tokio::time::advance(execution_timeout).await;
-    tokio::select! {
-        biased;
-        result = &mut execution => {
-            return Err(format!("Codex execution ended before the sink settle budget: {result:?}").into());
-        }
-        () = std::future::ready(()) => {}
-    }
-    tokio::time::advance(Duration::from_secs(10)).await;
-    tokio::time::resume();
+    let checkpoints = [
+        common::VirtualTimeCheckpoint::new(
+            ready_file,
+            common::MOCK_CODEX_TURN_STEER_READY_EVENT,
+            execution_timeout,
+        ),
+        common::VirtualTimeCheckpoint::new(
+            ready_file,
+            common::MOCK_CODEX_TURN_STEER_READY_EVENT,
+            Duration::from_secs(10),
+        ),
+    ];
 
-    let result = tokio::time::timeout(Duration::from_secs(10), execution)
-        .await
-        .expect("execution deadline should terminate the stuck steer")?;
+    // The first jump selects the execution timeout and starts the bounded sink
+    // settle timer. The second jump exhausts that timer while the mock keeps
+    // the turn/steer response pending.
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        common::execute_with_virtual_time_checkpoints(execution, &checkpoints),
+    )
+    .await
+    .expect("execution deadline should terminate the stuck steer")??;
 
     assert_eq!(result.exit_code, AGENT_EXECUTION_TIMEOUT_EXIT_CODE);
     let error = result

--- a/docs/active-input-delivery.md
+++ b/docs/active-input-delivery.md
@@ -54,6 +54,14 @@ Cancellation is visible immediately, and heartbeat timeout records an unknown
 consumer state, but neither path releases a reservation. Cooperative Guest
 completion and Runner post-exit completion are the existing quiescence signals.
 
+Codex execution timeout and cancellation first allow an in-flight `turn/steer`
+to settle within the bounded sink window. A successful response still persists
+its receipt. If the response remains pending, Guest drops the non-reusable
+JSON-RPC request, terminates and waits for the owned app-server process, and
+only then closes the local sink operation and finalizes receipts. The
+unconfirmed delivery ID remains absent from completion, so the existing
+completion transaction releases or expires it only after consumer-stop proof.
+
 An open delivery is therefore a non-expiring thread-ordering barrier. The queue
 scheduler cannot skip its source events or launch later input on the same
 thread, even after cancellation recovery becomes stale. Once completion settles


### PR DESCRIPTION
## Summary

- keep an already-selected Codex execution timeout or cancellation authoritative after the bounded active-input settle window
- terminate and reap the owned app-server process before clearing a still-pending local steer operation and finalizing receipts
- cover the stuck `turn/steer` response path with a real mock-process integration test and document the delivery ordering

## Scope

- no API, database, queue payload, or Runner protocol changes
- no independent steer timeout; the existing execution deadline and active-input settle window remain unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent -p guest-mock-codex --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent -p guest-mock-codex --all-features --no-deps`
- `cargo test -p guest-agent --test codex_app_server_backend_active_input_execution_timeout --all-features`
- `cargo test -p guest-agent --test codex_app_server_backend_active_input_cancellation --all-features`
- `cargo test -p guest-agent --test codex_app_server_backend_active_input --all-features`
- `cargo test -p guest-agent -p guest-mock-codex --all-targets --all-features`

Closes #27009
