### PR TITLE
refactor(api): dual-write run metadata

### DIFF
--- a/turbo/apps/api/src/scripts/__tests__/dev-bench-seed.test.ts
+++ b/turbo/apps/api/src/scripts/__tests__/dev-bench-seed.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { chatEventCompatibilityRole } from "@okouai/api-contracts/contracts/chat-events";
 import { resolveChatEventRecommendedFollowups } from "@okouai/api-contracts/contracts/chat-threads";
 
-import { buildProfileRows, DEV_BENCH_THREAD_PROFILES } from "../dev-bench-seed";
+import {
+  buildProfileRows,
+  DEV_BENCH_THREAD_PROFILES,
+  type BuiltProfileRows,
+} from "../dev-bench-seed";
 
 const EXPECTED_PROFILE_SHAPES = {
   "feature-switch-digest": {
@@ -42,6 +46,30 @@ function countWhere<T>(
   return rows.filter(predicate).length;
 }
 
+type ProfileRunMetadataRow =
+  | BuiltProfileRows["runRows"][number]
+  | BuiltProfileRows["zeroRunRows"][number];
+
+function runMetadata(row: ProfileRunMetadataRow) {
+  return {
+    triggerSource: row.triggerSource,
+    autonomyBudget: row.autonomyBudget,
+    workflowAutomationId: row.workflowAutomationId,
+    goalId: row.goalId,
+    modelProvider: row.modelProvider,
+    modelProviderId: row.modelProviderId,
+    modelProviderCredentialScope: row.modelProviderCredentialScope,
+    selectedModel: row.selectedModel,
+    codexServiceTier: row.codexServiceTier,
+    selectedVideoModel: row.selectedVideoModel,
+    chatThreadId: row.chatThreadId,
+    apiStartedAt: row.apiStartedAt,
+    firstAssistantEventAcknowledgedAt: row.firstAssistantEventAcknowledgedAt,
+    summary: row.summary,
+    triggerBrief: row.triggerBrief,
+  };
+}
+
 describe("dev bench seed profile rows", () => {
   it("preserves the production-shaped profile invariants", () => {
     for (const profile of DEV_BENCH_THREAD_PROFILES) {
@@ -63,6 +91,16 @@ describe("dev bench seed profile rows", () => {
 
       expect(rows.runRows).toHaveLength(expected.runs);
       expect(rows.zeroRunRows).toHaveLength(expected.runs);
+      const runRowsById = new Map(
+        rows.runRows.map((row) => {
+          return [row.id, row] as const;
+        }),
+      );
+      for (const zeroRunRow of rows.zeroRunRows) {
+        const runRow = runRowsById.get(zeroRunRow.id);
+        expect(runRow).toBeDefined();
+        expect(runMetadata(runRow!)).toStrictEqual(runMetadata(zeroRunRow));
+      }
       expect(rows.eventRows).toHaveLength(expected.events);
       expect(
         rows.eventRows.some((row) => {

--- a/turbo/apps/api/src/scripts/dev-bench-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-bench-seed.ts
@@ -24,6 +24,7 @@ import { zeroRuns } from "@okouai/db/schema/zero-run";
 
 import { closeDbPool, db } from "../lib/db";
 import { optionalEnv } from "../lib/env";
+import { normalizeRunMetadata } from "../signals/services/agent-run-metadata-write.service";
 import { onRejection } from "../signals/utils";
 
 const BULK_INSERT_CHUNK = 500;
@@ -668,6 +669,13 @@ function appendRunEvents(
 
   args.runUserMessageRows.push(userMessageRow);
   args.rows.eventRows.push(userMessageRow);
+  const metadata = normalizeRunMetadata({
+    triggerSource: args.workflowAutomationBrief ? "automation-schedule" : "web",
+    selectedModel: args.profile.selectedModel,
+    chatThreadId: args.threadId,
+    summary: `Synthetic ${args.profile.slug} run ${String(args.runIndex)}`,
+    triggerBrief: args.workflowAutomationBrief,
+  });
   args.rows.runRows.push({
     id: runId,
     userId: args.userId,
@@ -686,14 +694,11 @@ function appendRunEvents(
     createdAt: baseCreatedAt,
     startedAt: addMs(baseCreatedAt, 1000),
     completedAt: addMs(baseCreatedAt, 45_000 + eventCount * 100),
+    ...metadata,
   });
   args.rows.zeroRunRows.push({
     id: runId,
-    triggerSource: args.workflowAutomationBrief ? "automation-schedule" : "web",
-    selectedModel: args.profile.selectedModel,
-    chatThreadId: args.threadId,
-    summary: `Synthetic ${args.profile.slug} run ${String(args.runIndex)}`,
-    triggerBrief: args.workflowAutomationBrief,
+    ...metadata,
   });
 
   appendAssistantEvents({

--- a/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/zero-chat-threads.bench.ts
@@ -51,6 +51,7 @@ import {
 import { encodeConnectorCatalogSnapshot } from "../../services/connector-catalog-artifacts/loader";
 import { connectorCatalogSource } from "../../services/connector-catalog-source";
 import { currentConnectorCatalogValidatorIdentity } from "../../services/connector-catalog-validator-authority";
+import { normalizeRunMetadata } from "../../services/agent-run-metadata-write.service";
 import { seedUserModelProvider$ } from "./helpers/zero-model-providers";
 import { seedOrgMembership$ } from "../__tests__/helpers/zero-org-membership";
 import { createZeroRouteMocks } from "../__tests__/helpers/zero-route-test";
@@ -504,23 +505,15 @@ async function seedBackgroundLoad(): Promise<void> {
     },
   );
 
-  const runRows: {
-    id: string;
-    userId: string;
-    orgId: string;
-    agentComposeVersionId: string;
-    sessionId: string;
-    status: string;
-    prompt: string;
-  }[] = [];
-  const zRunRows: {
-    id: string;
-    triggerSource: string;
-    chatThreadId: string;
-  }[] = [];
+  const runRows: (typeof agentRuns.$inferInsert)[] = [];
+  const zRunRows: (typeof zeroRuns.$inferInsert)[] = [];
   for (let t = 0; t < BACKGROUND_THREAD_COUNT; t++) {
     for (let r = 0; r < BACKGROUND_RUNS_PER_THREAD; r++) {
       const runId = randomUUID();
+      const metadata = normalizeRunMetadata({
+        triggerSource: "test",
+        chatThreadId: threadIds[t]!,
+      });
       runRows.push({
         id: runId,
         userId: bgUserId,
@@ -529,11 +522,11 @@ async function seedBackgroundLoad(): Promise<void> {
         sessionId: sessionIds[t]!,
         status: STATUSES[r % STATUSES.length]!,
         prompt: "bg",
+        ...metadata,
       });
       zRunRows.push({
         id: runId,
-        triggerSource: "test",
-        chatThreadId: threadIds[t]!,
+        ...metadata,
       });
     }
   }
@@ -609,20 +602,8 @@ async function seedTargetThreadRuns(
     throw new Error("target session insert returned no row");
   }
 
-  const runRows: {
-    id: string;
-    userId: string;
-    orgId: string;
-    agentComposeVersionId: string;
-    sessionId: string;
-    status: string;
-    prompt: string;
-  }[] = [];
-  const zRunRows: {
-    id: string;
-    triggerSource: string;
-    chatThreadId: string;
-  }[] = [];
+  const runRows: (typeof agentRuns.$inferInsert)[] = [];
+  const zRunRows: (typeof zeroRuns.$inferInsert)[] = [];
   const eventRows: {
     chatThreadId: string;
     runId: string;
@@ -636,6 +617,10 @@ async function seedTargetThreadRuns(
   const now = nowDate().getTime();
   for (let i = 0; i < TARGET_RUN_COUNT; i++) {
     const runId = randomUUID();
+    const metadata = normalizeRunMetadata({
+      triggerSource: "test",
+      chatThreadId: fixture.threadId,
+    });
     runRows.push({
       id: runId,
       userId: fixture.userId,
@@ -644,11 +629,11 @@ async function seedTargetThreadRuns(
       sessionId: session.id,
       status: STATUSES[i % STATUSES.length]!,
       prompt: `bench prompt ${String(i)}`,
+      ...metadata,
     });
     zRunRows.push({
       id: runId,
-      triggerSource: "test",
-      chatThreadId: fixture.threadId,
+      ...metadata,
     });
     for (let m = 0; m < TARGET_MESSAGES_PER_RUN; m++) {
       const latestAttachmentStart = TARGET_RUN_COUNT - TARGET_ATTACHMENT_COUNT;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -44,6 +44,7 @@ import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { chatEventDisplayText } from "./helpers/chat-event";
+import { readRunMetadataPair } from "./helpers/runtime-state";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import {
   generateDataKeyOutput,
@@ -1197,6 +1198,16 @@ describe("CHAT-02: completed chat callback", () => {
         );
       })
       .toBe(true);
+    const completedMetadata = await readRunMetadataPair(context, first.runId);
+    expect(completedMetadata.agent_run).toStrictEqual(
+      completedMetadata.zero_run,
+    );
+    expect(completedMetadata.zero_run).toStrictEqual(
+      expect.objectContaining({
+        first_assistant_event_acknowledged_at: expect.any(String),
+        summary: "Generated summary",
+      }),
+    );
 
     const afterAutoSend = await waitForThreadMessages(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -45,6 +45,7 @@ import {
 import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import { readRunMetadataPair } from "./helpers/runtime-state";
 import { runnersRoutes } from "../runners";
 
 const context = testContext();
@@ -540,6 +541,30 @@ describe("sandbox cleanup", () => {
     });
   });
 
+  it("keeps lifecycle-only cleanup fixtures one-sided", async () => {
+    const fixture = await trackRun(insertRunFixture({ status: "pending" }));
+
+    const metadata = await readRunMetadataPair(context, fixture.runId);
+    expect(metadata.agent_run).toStrictEqual({
+      trigger_source: null,
+      autonomy_budget: null,
+      workflow_automation_id: null,
+      goal_id: null,
+      model_provider: null,
+      model_provider_id: null,
+      model_provider_credential_scope: null,
+      selected_model: null,
+      codex_service_tier: null,
+      selected_video_model: null,
+      chat_thread_id: null,
+      api_started_at: null,
+      first_assistant_event_acknowledged_at: null,
+      summary: null,
+      trigger_brief: null,
+    });
+    expect(metadata.zero_run).toBeNull();
+  });
+
   it("leaves the audited pre-forward threadless cohort discoverable", async () => {
     mockNow(THREADLESS_TEST_NOW_MS);
     const fixture = await trackRun(
@@ -552,6 +577,8 @@ describe("sandbox cleanup", () => {
         threadless: true,
       }),
     );
+    const metadata = await readRunMetadataPair(context, fixture.runId);
+    expect(metadata.agent_run).toStrictEqual(metadata.zero_run);
 
     const response = await cleanupRegisteredFixtures();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -167,12 +167,37 @@ export async function setRunAutonomyBudgetFixture(
   context: TestContext,
   runId: string,
   autonomyBudget: number,
+  options?: { readonly disableBridge?: boolean },
 ): Promise<void> {
   await postAction(context, {
     action: "set-run-autonomy-budget",
     run_id: runId,
     autonomy_budget: autonomyBudget,
+    ...(options?.disableBridge === true ? { disable_bridge: true } : {}),
   });
+}
+
+export async function readPairedRunAutonomyBudgets(
+  context: TestContext,
+  runId: string,
+): Promise<{
+  readonly zeroRun: number | null;
+  readonly agentRun: number | null;
+}> {
+  const response = await postAction(context, {
+    action: "read-run-autonomy-budget",
+    run_id: runId,
+  });
+  if (
+    !("autonomy_budget" in response) ||
+    !("agent_autonomy_budget" in response)
+  ) {
+    throw new Error("readPairedRunAutonomyBudgets missing paired budgets");
+  }
+  return {
+    zeroRun: response.autonomy_budget ?? null,
+    agentRun: response.agent_autonomy_budget ?? null,
+  };
 }
 
 export async function readWorkflowAutomationAutonomyFixture(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -11,6 +11,9 @@ import type { TestContext } from "../../../../__tests__/test-context";
 import { testRuntimeStateRoutes } from "../../test-runtime-state";
 
 const RUNTIME_STATE_ROUTE = "/api/test/runtime-state";
+type RunMetadataPair = NonNullable<
+  TestRuntimeStateActionResponse["run_metadata_pair"]
+>;
 
 function requestRuntimeState(
   context: TestContext,
@@ -198,6 +201,38 @@ export async function readPairedRunAutonomyBudgets(
     zeroRun: response.autonomy_budget ?? null,
     agentRun: response.agent_autonomy_budget ?? null,
   };
+}
+
+export async function readRunMetadataPair(
+  context: TestContext,
+  runId: string,
+): Promise<RunMetadataPair> {
+  const response = await postAction(context, {
+    action: "read-run-metadata-pair",
+    run_id: runId,
+  });
+  if (!response.run_metadata_pair) {
+    throw new Error("readRunMetadataPair missing metadata pair");
+  }
+  return response.run_metadata_pair;
+}
+
+export async function saveRunSummaryFixture(
+  context: TestContext,
+  args: {
+    readonly runId: string;
+    readonly triggerSource: string;
+    readonly prompt: string;
+    readonly resultText: string;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "save-run-summary",
+    run_id: args.runId,
+    trigger_source: args.triggerSource,
+    prompt: args.prompt,
+    result_text: args.resultText,
+  });
 }
 
 export async function measureRunMetadataBridgeTargetUpdates(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -200,6 +200,57 @@ export async function readPairedRunAutonomyBudgets(
   };
 }
 
+export async function measureRunMetadataBridgeTargetUpdates(
+  context: TestContext,
+  runId: string,
+  autonomyBudget: number,
+): Promise<number> {
+  const response = await postAction(context, {
+    action: "measure-run-metadata-bridge-target-updates",
+    run_id: runId,
+    autonomy_budget: autonomyBudget,
+  });
+  if (response.agent_run_update_count === undefined) {
+    throw new Error(
+      "measureRunMetadataBridgeTargetUpdates missing update count",
+    );
+  }
+  return response.agent_run_update_count;
+}
+
+export async function verifyRunMetadataTargetFailureRollback(
+  context: TestContext,
+  runId: string,
+  autonomyBudget: number,
+): Promise<{
+  readonly targetWriteFailed: boolean;
+  readonly errorCode: string | null;
+  readonly zeroRun: number | null;
+  readonly agentRun: number | null;
+}> {
+  const response = await postAction(context, {
+    action: "verify-run-metadata-target-failure-rollback",
+    run_id: runId,
+    autonomy_budget: autonomyBudget,
+  });
+  if (
+    response.target_write_failed === undefined ||
+    !("target_write_error_code" in response) ||
+    !("autonomy_budget" in response) ||
+    !("agent_autonomy_budget" in response)
+  ) {
+    throw new Error(
+      "verifyRunMetadataTargetFailureRollback missing rollback evidence",
+    );
+  }
+  return {
+    targetWriteFailed: response.target_write_failed,
+    errorCode: response.target_write_error_code ?? null,
+    zeroRun: response.autonomy_budget ?? null,
+    agentRun: response.agent_autonomy_budget ?? null,
+  };
+}
+
 export async function readWorkflowAutomationAutonomyFixture(
   context: TestContext,
   automationId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -110,6 +110,7 @@ import {
   readOrgAdmissionLockState,
   readRunApiStart,
   readRunClaimOwner,
+  readRunMetadataPair,
   readRunnerJobStorageState,
   readStoragePersistenceState,
   releaseOrgAdmissionLock,
@@ -5750,6 +5751,16 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     );
     const stored = await api.readRun(actor, failed.runId);
     expect(stored.status).toBe("failed");
+    const failedMetadata = await readRunMetadataPair(context, failed.runId);
+    expect(failedMetadata.agent_run).toStrictEqual(failedMetadata.zero_run);
+    expect(failedMetadata.zero_run).toStrictEqual(
+      expect.objectContaining({
+        autonomy_budget: 10,
+        api_started_at: expect.any(String),
+        first_assistant_event_acknowledged_at: null,
+        summary: null,
+      }),
+    );
     const queue = await api.readRunQueue(actor);
     expect(queue.body.queue).not.toContainEqual(
       expect.objectContaining({ runId: failed.runId }),
@@ -12849,6 +12860,16 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       modelProvider: "anthropic-api-key",
     });
     expect(queued.status).toBe("queued");
+    const queuedMetadata = await readRunMetadataPair(context, queued.runId);
+    expect(queuedMetadata.agent_run).toStrictEqual(queuedMetadata.zero_run);
+    expect(queuedMetadata.zero_run).toStrictEqual(
+      expect.objectContaining({
+        autonomy_budget: 10,
+        api_started_at: null,
+        first_assistant_event_acknowledged_at: null,
+        summary: null,
+      }),
+    );
     const queueState = await api.readRunQueue(actor);
     expect(queueState.body.queue[0]?.runId).toBe(queued.runId);
 
@@ -12864,6 +12885,11 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       "pending",
     );
     expect(promoted.status).toBe("pending");
+    const promotedMetadata = await readRunMetadataPair(context, queued.runId);
+    expect(promotedMetadata.agent_run).toStrictEqual(promotedMetadata.zero_run);
+    expect(promotedMetadata.zero_run?.api_started_at).toBe(
+      new Date(promotedAt).toISOString(),
+    );
 
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(queued.runId);
@@ -14532,6 +14558,14 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
         run_id: runId,
       }),
     ]);
+    const acknowledgedMetadata = await readRunMetadataPair(context, runId);
+    expect(acknowledgedMetadata.agent_run).toStrictEqual(
+      acknowledgedMetadata.zero_run,
+    );
+    expect(
+      acknowledgedMetadata.zero_run?.first_assistant_event_acknowledged_at,
+    ).toBe(new Date(acknowledgedAt).toISOString());
+    expect(acknowledgedMetadata.zero_run?.api_started_at).toBe(apiStartedAtIso);
 
     await api.requestCancelRun(actor, runId, [200]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from "node:crypto";
+
+import { expect, test } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
+import { createBddApi } from "./helpers/api-bdd";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import {
+  readPairedRunAutonomyBudgets,
+  setRunAutonomyBudgetFixture,
+} from "./helpers/runtime-state";
+
+const context = testContext();
+const bdd = createBddApi(context);
+const api = createRunsApi(context);
+
+test("normalizes the run autonomy default and writes it without the database bridge", async () => {
+  const actor = bdd.user();
+  await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 20_000 });
+  bdd.acceptAgentStorageWrites();
+  api.acceptStorageDownloads();
+  api.acceptTelemetryIngest();
+
+  const agentName = `metadata-writer-${randomUUID().slice(0, 8)}`;
+  const compose = await api.createCompose(actor, {
+    version: "1.0",
+    agents: {
+      [agentName]: {
+        framework: "claude-code",
+        environment: { ANTHROPIC_API_KEY: "metadata-writer-test-key" },
+      },
+    },
+  });
+  const run = await api.createDirectRun(actor, {
+    agentComposeId: compose.composeId,
+    prompt: "verify paired metadata writes",
+  });
+
+  await expect(
+    readPairedRunAutonomyBudgets(context, run.runId),
+  ).resolves.toStrictEqual({ zeroRun: 10, agentRun: 10 });
+
+  await setRunAutonomyBudgetFixture(context, run.runId, 4, {
+    disableBridge: true,
+  });
+
+  await expect(
+    readPairedRunAutonomyBudgets(context, run.runId),
+  ).resolves.toStrictEqual({ zeroRun: 4, agentRun: 4 });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts
@@ -1,14 +1,19 @@
 import { randomUUID } from "node:crypto";
 
+import { HttpResponse, http } from "msw";
 import { expect, test } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
+import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { createBddApi } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import {
   measureRunMetadataBridgeTargetUpdates,
   readPairedRunAutonomyBudgets,
+  readRunMetadataPair,
+  saveRunSummaryFixture,
   setRunAutonomyBudgetFixture,
   verifyRunMetadataTargetFailureRollback,
 } from "./helpers/runtime-state";
@@ -42,6 +47,26 @@ test("normalizes metadata and preserves compatibility-writer transaction semanti
     prompt: "verify paired metadata writes",
   });
 
+  const initialMetadata = await readRunMetadataPair(context, run.runId);
+  expect(initialMetadata.agent_run).toStrictEqual(initialMetadata.zero_run);
+  expect(initialMetadata.zero_run).toStrictEqual({
+    trigger_source: "test",
+    autonomy_budget: 10,
+    workflow_automation_id: null,
+    goal_id: null,
+    model_provider: null,
+    model_provider_id: null,
+    model_provider_credential_scope: null,
+    selected_model: null,
+    codex_service_tier: null,
+    selected_video_model: null,
+    chat_thread_id: null,
+    api_started_at: expect.any(String),
+    first_assistant_event_acknowledged_at: null,
+    summary: null,
+    trigger_brief: null,
+  });
+
   await expect(
     readPairedRunAutonomyBudgets(context, run.runId),
   ).resolves.toStrictEqual({ zeroRun: 10, agentRun: 10 });
@@ -69,4 +94,38 @@ test("normalizes metadata and preserves compatibility-writer transaction semanti
     zeroRun: 5,
     agentRun: 5,
   });
+
+  mockOptionalEnv("OPENROUTER_API_KEY", "metadata-summary-key");
+  let generatedSummary = "Initial metadata summary";
+  server.use(
+    http.post("https://openrouter.ai/api/v1/chat/completions", () => {
+      return HttpResponse.json({
+        choices: [{ message: { content: generatedSummary } }],
+      });
+    }),
+  );
+  await saveRunSummaryFixture(context, {
+    runId: run.runId,
+    triggerSource: "test",
+    prompt: "summarize the metadata writer",
+    resultText: "the metadata writer completed",
+  });
+  let summarizedMetadata = await readRunMetadataPair(context, run.runId);
+  expect(summarizedMetadata.agent_run).toStrictEqual(
+    summarizedMetadata.zero_run,
+  );
+  expect(summarizedMetadata.zero_run?.summary).toBe(generatedSummary);
+
+  generatedSummary = "Replacement metadata summary";
+  await saveRunSummaryFixture(context, {
+    runId: run.runId,
+    triggerSource: "test",
+    prompt: "replace the metadata summary",
+    resultText: "the replacement completed",
+  });
+  summarizedMetadata = await readRunMetadataPair(context, run.runId);
+  expect(summarizedMetadata.agent_run).toStrictEqual(
+    summarizedMetadata.zero_run,
+  );
+  expect(summarizedMetadata.zero_run?.summary).toBe(generatedSummary);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { DEFAULT_VIDEO_MODEL } from "@okouai/core/video-model-catalog";
 import { HttpResponse, http } from "msw";
 import { expect, test } from "vitest";
 
@@ -59,7 +60,7 @@ test("normalizes metadata and preserves compatibility-writer transaction semanti
     model_provider_credential_scope: null,
     selected_model: null,
     codex_service_tier: null,
-    selected_video_model: null,
+    selected_video_model: DEFAULT_VIDEO_MODEL,
     chat_thread_id: null,
     api_started_at: expect.any(String),
     first_assistant_event_acknowledged_at: null,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts
@@ -7,16 +7,21 @@ import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { createBddApi } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import {
+  measureRunMetadataBridgeTargetUpdates,
   readPairedRunAutonomyBudgets,
   setRunAutonomyBudgetFixture,
+  verifyRunMetadataTargetFailureRollback,
 } from "./helpers/runtime-state";
 
 const context = testContext();
 const bdd = createBddApi(context);
 const api = createRunsApi(context);
 
-test("normalizes the run autonomy default and writes it without the database bridge", async () => {
+test("normalizes metadata and preserves compatibility-writer transaction semantics", async () => {
   const actor = bdd.user();
+  if (!actor.orgId) {
+    throw new Error("Expected the metadata writer actor to have an org");
+  }
   await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 20_000 });
   bdd.acceptAgentStorageWrites();
   api.acceptStorageDownloads();
@@ -48,4 +53,20 @@ test("normalizes the run autonomy default and writes it without the database bri
   await expect(
     readPairedRunAutonomyBudgets(context, run.runId),
   ).resolves.toStrictEqual({ zeroRun: 4, agentRun: 4 });
+
+  await expect(
+    measureRunMetadataBridgeTargetUpdates(context, run.runId, 5),
+  ).resolves.toBe(1);
+  await expect(
+    readPairedRunAutonomyBudgets(context, run.runId),
+  ).resolves.toStrictEqual({ zeroRun: 5, agentRun: 5 });
+
+  await expect(
+    verifyRunMetadataTargetFailureRollback(context, run.runId, 6),
+  ).resolves.toStrictEqual({
+    targetWriteFailed: true,
+    errorCode: "55P03",
+    zeroRun: 5,
+    agentRun: 5,
+  });
 });

--- a/turbo/apps/api/src/signals/routes/test-computer-use-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-computer-use-state.ts
@@ -13,6 +13,7 @@ import { bodyResultOf, queryOf } from "../context/request";
 import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
+import { normalizeRunMetadata } from "../services/agent-run-metadata-write.service";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -85,6 +86,10 @@ async function seedBaseComputerUseRun(args: {
   const runId = randomUUID();
   const threadId =
     args.triggerSource === "web" || args.canonicalThread ? randomUUID() : null;
+  const metadata = normalizeRunMetadata({
+    triggerSource: args.triggerSource,
+    chatThreadId: threadId,
+  });
 
   await args.db.insert(agentComposes).values({
     id: composeId,
@@ -119,13 +124,13 @@ async function seedBaseComputerUseRun(args: {
     sessionId,
     status: "running",
     prompt: "Need Computer Use",
+    ...metadata,
   });
   args.signal.throwIfAborted();
 
   await args.db.insert(zeroRuns).values({
     id: runId,
-    triggerSource: args.triggerSource,
-    chatThreadId: threadId,
+    ...metadata,
   });
   args.signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -37,6 +37,10 @@ import {
   encryptQueuedRunnerJobPayload,
   queuedRunnerJobPayload,
 } from "../services/agent-run-queue-payload.service";
+import {
+  normalizeRunMetadata,
+  writeRunMetadata,
+} from "../services/agent-run-metadata-write.service";
 import { cleanupSandboxes$ } from "../services/cron-cleanup-sandboxes.service";
 import { insertChatEvent } from "../services/zero-chat-event.service";
 import {
@@ -175,6 +179,10 @@ async function seedRunForAction(
     return actionBadRequest("failed to seed session");
   }
 
+  const threadless = readOptionalBoolean(body, "threadless") === true;
+  const pairedMetadata = threadless
+    ? normalizeRunMetadata({ triggerSource: triggerSource.data })
+    : null;
   const [run] = await db
     .insert(agentRuns)
     .values({
@@ -193,6 +201,7 @@ async function seedRunForAction(
         body,
         "cancellation_recovery_completed",
       ),
+      ...pairedMetadata,
     })
     .returning({ id: agentRuns.id, sandboxId: agentRuns.sandboxId });
   signal.throwIfAborted();
@@ -200,10 +209,8 @@ async function seedRunForAction(
     return actionBadRequest("failed to seed run");
   }
 
-  if (readOptionalBoolean(body, "threadless") === true) {
-    await db
-      .insert(zeroRuns)
-      .values({ id: run.id, triggerSource: triggerSource.data });
+  if (pairedMetadata) {
+    await db.insert(zeroRuns).values({ id: run.id, ...pairedMetadata });
     signal.throwIfAborted();
   }
 
@@ -779,10 +786,10 @@ async function attachRunThreadForAction(
   if (!thread) {
     return actionBadRequest("failed to seed chat thread");
   }
-  await db
-    .update(zeroRuns)
-    .set({ chatThreadId: thread.id })
-    .where(eq(zeroRuns.id, runId));
+  await writeRunMetadata(db, {
+    patch: { chatThreadId: thread.id },
+    where: eq(zeroRuns.id, runId),
+  });
   signal.throwIfAborted();
   return actionOk({ thread_id: thread.id });
 }

--- a/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-monitor-chat-event-queue-state.ts
@@ -23,6 +23,7 @@ import {
   insertChatEvent,
   replaceChatEvent,
 } from "../services/zero-chat-event.service";
+import { normalizeRunMetadata } from "../services/agent-run-metadata-write.service";
 import { createUserMessageDocument } from "../services/zero-chat-user-message.service";
 import { monitorChatEventQueueForEvents$ } from "../services/cron-monitor-chat-event-queue.service";
 import {
@@ -121,6 +122,10 @@ async function seedActiveRun(
     throw new Error("Failed to seed orphan monitor session");
   }
 
+  const metadata = normalizeRunMetadata({
+    triggerSource: "web",
+    chatThreadId: fixture.threadId,
+  });
   const [run] = await db
     .insert(agentRuns)
     .values({
@@ -129,6 +134,7 @@ async function seedActiveRun(
       sessionId: session.id,
       status: "pending",
       prompt: "orphan monitor active run fixture",
+      ...metadata,
     })
     .returning({ id: agentRuns.id });
   signal.throwIfAborted();
@@ -138,8 +144,7 @@ async function seedActiveRun(
 
   await db.insert(zeroRuns).values({
     id: run.id,
-    triggerSource: "web",
-    chatThreadId: fixture.threadId,
+    ...metadata,
   });
   signal.throwIfAborted();
 }

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -28,6 +28,7 @@ import { and, count, desc, eq, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 import { closeDbPool } from "../../lib/db";
 import { executeRawRows } from "../../lib/db-raw-rows";
+import type { Tx } from "../../lib/db-types";
 import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
@@ -37,6 +38,7 @@ import type { RouteEntry } from "../route-entry";
 import {
   createDeferredPromise,
   onRejection,
+  settle,
   settleIncludingAbort,
 } from "../utils";
 import {
@@ -75,6 +77,39 @@ const orgAdmissionLockStateRowSchema = z.object({
   held: z.boolean(),
   waiting: z.boolean(),
 });
+const transactionUpdateCountRowSchema = z.object({
+  updatedRows: z.int().nonnegative(),
+});
+
+async function transactionAgentRunUpdateCount(tx: Tx): Promise<number> {
+  const [row] = await executeRawRows(
+    tx,
+    sql`
+      SELECT n_tup_upd::integer AS "updatedRows"
+      FROM pg_stat_xact_user_tables
+      WHERE relname = 'agent_runs'
+    `,
+    transactionUpdateCountRowSchema,
+  );
+  return row?.updatedRows ?? 0;
+}
+
+function postgresErrorCode(error: unknown): string | null {
+  let current = error;
+  for (let depth = 0; depth < 4; depth += 1) {
+    if (typeof current !== "object" || current === null) {
+      return null;
+    }
+    if ("code" in current && typeof current.code === "string") {
+      return current.code;
+    }
+    if (!("cause" in current)) {
+      return null;
+    }
+    current = current.cause;
+  }
+  return null;
+}
 
 function createOrgAdmissionLockGate(signal: AbortSignal): OrgAdmissionLockGate {
   const released = createDeferredPromise<void>(signal);
@@ -280,11 +315,10 @@ async function clearRunApiStart(
   runId: string,
   signal: AbortSignal,
 ): Promise<void> {
-  const [cleared] = await db
-    .update(zeroRuns)
-    .set({ apiStartedAt: null })
-    .where(eq(zeroRuns.id, runId))
-    .returning({ id: zeroRuns.id });
+  const [cleared] = await writeRunMetadata(db, {
+    patch: { apiStartedAt: null },
+    where: eq(zeroRuns.id, runId),
+  });
   signal.throwIfAborted();
   if (!cleared) {
     throw new Error("Expected a Zero run timing row");
@@ -352,6 +386,97 @@ async function clearThreadSessionBinding(
   if (!thread) {
     throw new Error("Expected a chat thread session binding row");
   }
+}
+
+type RunMetadataWriterFixtureAction = Extract<
+  TestRuntimeStateActionBody,
+  {
+    action:
+      | "measure-run-metadata-bridge-target-updates"
+      | "verify-run-metadata-target-failure-rollback";
+  }
+>;
+
+function isRunMetadataWriterFixtureAction(
+  body: TestRuntimeStateActionBody,
+): body is RunMetadataWriterFixtureAction {
+  return (
+    body.action === "measure-run-metadata-bridge-target-updates" ||
+    body.action === "verify-run-metadata-target-failure-rollback"
+  );
+}
+
+async function runMetadataWriterFixtureActionResponse(
+  db: Db,
+  body: RunMetadataWriterFixtureAction,
+  signal: AbortSignal,
+) {
+  if (body.action === "measure-run-metadata-bridge-target-updates") {
+    return await db.transaction(async (tx) => {
+      const before = await transactionAgentRunUpdateCount(tx);
+      const rows = await writeRunMetadataInTransaction(tx, {
+        patch: { autonomyBudget: body.autonomy_budget },
+        where: eq(zeroRuns.id, body.run_id),
+      });
+      signal.throwIfAborted();
+      if (rows.length === 0) {
+        throw new Error("Expected the bridge target-update run fixture");
+      }
+      const after = await transactionAgentRunUpdateCount(tx);
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          agent_run_update_count: after - before,
+        },
+      };
+    });
+  }
+
+  const outcome = await db.transaction(async (lockingTx) => {
+    await lockingTx.execute(sql`
+      SELECT ${agentRuns.id}
+      FROM ${agentRuns}
+      WHERE ${agentRuns.id} = ${body.run_id}
+      FOR UPDATE
+    `);
+    signal.throwIfAborted();
+    return await settle(
+      db.transaction(async (writerTx) => {
+        await writerTx.execute(
+          sql`SET LOCAL session_replication_role = replica`,
+        );
+        await writerTx.execute(sql`SET LOCAL lock_timeout = '100ms'`);
+        return await writeRunMetadataInTransaction(writerTx, {
+          patch: { autonomyBudget: body.autonomy_budget },
+          where: eq(zeroRuns.id, body.run_id),
+        });
+      }),
+      signal,
+    );
+  });
+  signal.throwIfAborted();
+  const [run] = await db
+    .select({
+      autonomyBudget: zeroRuns.autonomyBudget,
+      agentAutonomyBudget: agentRuns.autonomyBudget,
+    })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+    .where(eq(zeroRuns.id, body.run_id))
+    .limit(1);
+  return {
+    status: 200 as const,
+    body: {
+      ok: true as const,
+      target_write_failed: !outcome.ok,
+      target_write_error_code: outcome.ok
+        ? null
+        : postgresErrorCode(outcome.error),
+      autonomy_budget: run?.autonomyBudget ?? null,
+      agent_autonomy_budget: run?.agentAutonomyBudget ?? null,
+    },
+  };
 }
 
 type AutonomyBudgetFixtureAction = Extract<
@@ -1195,6 +1320,7 @@ async function setRunnerJobContextProfileAsPreviousApi(
 }
 
 type CompatibilityFixtureAction =
+  | RunMetadataWriterFixtureAction
   | AutonomyBudgetFixtureAction
   | LegacyArtifactCatalogFileAction
   | PreviousApiHostedSiteAction
@@ -1348,6 +1474,8 @@ function isCompatibilityFixtureAction(
   return [
     "set-run-autonomy-budget",
     "read-run-autonomy-budget",
+    "measure-run-metadata-bridge-target-updates",
+    "verify-run-metadata-target-failure-rollback",
     "set-workflow-automation-autonomy-budget",
     "read-workflow-automation-autonomy-state",
     "read-latest-workflow-automation-run",
@@ -1367,6 +1495,9 @@ async function compatibilityFixtureActionResponse(
   body: CompatibilityFixtureAction,
   signal: AbortSignal,
 ) {
+  if (isRunMetadataWriterFixtureAction(body)) {
+    return await runMetadataWriterFixtureActionResponse(db, body, signal);
+  }
   if (isAutonomyBudgetFixtureAction(body)) {
     return await autonomyBudgetFixtureActionResponse(db, body, signal);
   }

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -49,9 +49,11 @@ import { browserScreenshotSchemaAvailable } from "../services/browser-screenshot
 import { usagePackInvitationPurchaseSchemaAvailable } from "../services/usage-pack-invitation-purchase.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
 import {
+  type RunMetadataValues,
   writeRunMetadata,
   writeRunMetadataInTransaction,
 } from "../services/agent-run-metadata-write.service";
+import { saveRunSummary } from "../services/run-summary.service";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -109,6 +111,97 @@ function postgresErrorCode(error: unknown): string | null {
     current = current.cause;
   }
   return null;
+}
+
+type StoredRunMetadata = Pick<
+  typeof agentRuns.$inferSelect,
+  keyof RunMetadataValues
+>;
+
+function serializeRunMetadata(row: StoredRunMetadata) {
+  return {
+    trigger_source: row.triggerSource,
+    autonomy_budget: row.autonomyBudget,
+    workflow_automation_id: row.workflowAutomationId,
+    goal_id: row.goalId,
+    model_provider: row.modelProvider,
+    model_provider_id: row.modelProviderId,
+    model_provider_credential_scope: row.modelProviderCredentialScope,
+    selected_model: row.selectedModel,
+    codex_service_tier: row.codexServiceTier,
+    selected_video_model: row.selectedVideoModel,
+    chat_thread_id: row.chatThreadId,
+    api_started_at: row.apiStartedAt?.toISOString() ?? null,
+    first_assistant_event_acknowledged_at:
+      row.firstAssistantEventAcknowledgedAt?.toISOString() ?? null,
+    summary: row.summary,
+    trigger_brief: row.triggerBrief,
+  };
+}
+
+type RunMetadataReadFixtureAction = Extract<
+  TestRuntimeStateActionBody,
+  { action: "read-run-metadata-pair" }
+>;
+
+function isRunMetadataReadFixtureAction(
+  body: TestRuntimeStateActionBody,
+): body is RunMetadataReadFixtureAction {
+  return body.action === "read-run-metadata-pair";
+}
+
+async function runMetadataReadFixtureActionResponse(
+  db: Db,
+  body: RunMetadataReadFixtureAction,
+  signal: AbortSignal,
+) {
+  const [agentRows, zeroRows] = await Promise.all([
+    db.select().from(agentRuns).where(eq(agentRuns.id, body.run_id)).limit(1),
+    db.select().from(zeroRuns).where(eq(zeroRuns.id, body.run_id)).limit(1),
+  ]);
+  signal.throwIfAborted();
+  const agentRun = agentRows[0];
+  const zeroRun = zeroRows[0];
+  return {
+    status: 200 as const,
+    body: {
+      ok: true as const,
+      run_metadata_pair: {
+        agent_run: agentRun ? serializeRunMetadata(agentRun) : null,
+        zero_run: zeroRun ? serializeRunMetadata(zeroRun) : null,
+      },
+    },
+  };
+}
+
+type RunSummaryFixtureAction = Extract<
+  TestRuntimeStateActionBody,
+  { action: "save-run-summary" }
+>;
+
+function isRunSummaryFixtureAction(
+  body: TestRuntimeStateActionBody,
+): body is RunSummaryFixtureAction {
+  return body.action === "save-run-summary";
+}
+
+async function runSummaryFixtureActionResponse(
+  db: Db,
+  body: RunSummaryFixtureAction,
+  signal: AbortSignal,
+) {
+  await saveRunSummary(
+    db,
+    {
+      runId: body.run_id,
+      triggerSource: body.trigger_source,
+      prompt: body.prompt,
+      resultText: body.result_text,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+  return { status: 200 as const, body: { ok: true as const } };
 }
 
 function createOrgAdmissionLockGate(signal: AbortSignal): OrgAdmissionLockGate {
@@ -1552,6 +1645,12 @@ const postRuntimeStateAction$ = command(
     }
     if (isChatEventFixtureAction(body)) {
       return await chatEventFixtureActionResponse(db, body, signal);
+    }
+    if (isRunMetadataReadFixtureAction(body)) {
+      return await runMetadataReadFixtureActionResponse(db, body, signal);
+    }
+    if (isRunSummaryFixtureAction(body)) {
+      return await runSummaryFixtureActionResponse(db, body, signal);
     }
     if (isCompatibilityFixtureAction(body)) {
       return await compatibilityFixtureActionResponse(db, body, signal);

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -47,6 +47,10 @@ import { browserScreenshotSchemaAvailable } from "../services/browser-screenshot
 import { usagePackInvitationPurchaseSchemaAvailable } from "../services/usage-pack-invitation-purchase.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
 import {
+  writeRunMetadata,
+  writeRunMetadataInTransaction,
+} from "../services/agent-run-metadata-write.service";
+import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
 } from "./test-endpoint-helpers";
@@ -383,21 +387,30 @@ async function autonomyBudgetFixtureActionResponse(
 ) {
   switch (body.action) {
     case "set-run-autonomy-budget": {
-      const [run] = await db
-        .update(zeroRuns)
-        .set({ autonomyBudget: body.autonomy_budget })
-        .where(eq(zeroRuns.id, body.run_id))
-        .returning({ id: zeroRuns.id });
+      const writeArgs = {
+        patch: { autonomyBudget: body.autonomy_budget },
+        where: eq(zeroRuns.id, body.run_id),
+      };
+      const rows = body.disable_bridge
+        ? await db.transaction(async (tx) => {
+            await tx.execute(sql`SET LOCAL session_replication_role = replica`);
+            return await writeRunMetadataInTransaction(tx, writeArgs);
+          })
+        : await writeRunMetadata(db, writeArgs);
       signal.throwIfAborted();
-      if (!run) {
+      if (rows.length === 0) {
         throw new Error("Expected the autonomy-budget run fixture");
       }
       return { status: 200 as const, body: { ok: true as const } };
     }
     case "read-run-autonomy-budget": {
       const [run] = await db
-        .select({ autonomyBudget: zeroRuns.autonomyBudget })
+        .select({
+          autonomyBudget: zeroRuns.autonomyBudget,
+          agentAutonomyBudget: agentRuns.autonomyBudget,
+        })
         .from(zeroRuns)
+        .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
         .where(eq(zeroRuns.id, body.run_id))
         .limit(1);
       signal.throwIfAborted();
@@ -406,6 +419,7 @@ async function autonomyBudgetFixtureActionResponse(
         body: {
           ok: true as const,
           autonomy_budget: run?.autonomyBudget ?? null,
+          agent_autonomy_budget: run?.agentAutonomyBudget ?? null,
         },
       };
     }

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -40,6 +40,10 @@ import { nowDate } from "../../lib/time";
 import type { RouteEntry } from "../route-entry";
 import { resolveTestOrgId$, testUserId$ } from "../services/cli-auth.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
+import {
+  normalizeRunMetadata,
+  writeRunMetadata,
+} from "../services/agent-run-metadata-write.service";
 import { tapError } from "../utils";
 import {
   isTestEndpointAllowed,
@@ -696,10 +700,12 @@ async function updateRunForAction(
   if (!runId) {
     return actionBadRequest("run_id is required");
   }
-  await db
-    .update(zeroRuns)
-    .set({ selectedModel: readActionNullableString(body, "selected_model") })
-    .where(eq(zeroRuns.id, runId));
+  await writeRunMetadata(db, {
+    patch: {
+      selectedModel: readActionNullableString(body, "selected_model") ?? null,
+    },
+    where: eq(zeroRuns.id, runId),
+  });
   signal.throwIfAborted();
   return actionOk();
 }
@@ -1367,6 +1373,11 @@ async function seedCompletedRunForAction(
   if (!sessionId) {
     return actionBadRequest("failed to seed agent session");
   }
+  const metadata = normalizeRunMetadata({
+    triggerSource: "telegram",
+    modelProvider: readActionNullableString(body, "model_provider"),
+    selectedModel: required.selected_model!,
+  });
   const [run] = await db
     .insert(agentRuns)
     .values({
@@ -1379,6 +1390,7 @@ async function seedCompletedRunForAction(
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       startedAt: new Date("2026-01-01T00:00:00.000Z"),
       completedAt: new Date("2026-01-01T00:01:00.000Z"),
+      ...metadata,
     })
     .returning({ id: agentRuns.id });
   signal.throwIfAborted();
@@ -1387,9 +1399,7 @@ async function seedCompletedRunForAction(
   }
   await db.insert(zeroRuns).values({
     id: run.id,
-    triggerSource: "telegram",
-    modelProvider: readActionNullableString(body, "model_provider") ?? null,
-    selectedModel: required.selected_model!,
+    ...metadata,
   });
   signal.throwIfAborted();
   return actionOk({ agent_session_id: sessionId, run_id: run.id });

--- a/turbo/apps/api/src/signals/routes/test-usage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-usage-state.ts
@@ -44,6 +44,7 @@ import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
+import { normalizeRunMetadata } from "../services/agent-run-metadata-write.service";
 import {
   deleteOrgUsageData,
   deleteUserUsageData,
@@ -380,6 +381,11 @@ async function seedRun(
   if (!session) {
     throw new Error("seedRun: session insert returned no row");
   }
+  const metadata = normalizeRunMetadata({
+    triggerSource: args.triggerSource ?? "test",
+    chatThreadId: args.chatThreadId,
+    selectedModel: args.selectedModel,
+  });
   const [run] = await db
     .insert(agentRuns)
     .values({
@@ -398,6 +404,7 @@ async function seedRun(
       result: args.result ?? null,
       error: args.error ?? null,
       lastEventSequence: args.lastEventSequence ?? null,
+      ...metadata,
     })
     .returning({ id: agentRuns.id });
   signal.throwIfAborted();
@@ -406,9 +413,7 @@ async function seedRun(
   }
   await db.insert(zeroRuns).values({
     id: run.id,
-    triggerSource: args.triggerSource ?? "test",
-    chatThreadId: args.chatThreadId ?? null,
-    selectedModel: args.selectedModel ?? null,
+    ...metadata,
   });
   signal.throwIfAborted();
   return { runId: run.id };

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -20,6 +20,7 @@ import {
   recordFirstAssistantEventAcknowledgementMetric,
 } from "./zero-chat-first-assistant-event-metric.service";
 import { chatThreadForRunFromDb } from "./zero-chat-thread.service";
+import { writeRunMetadataInTransaction } from "./agent-run-metadata-write.service";
 
 const INITIAL_PROCESSED_THROUGH_SEQUENCE = -1;
 const RUN_OUTPUT_PROJECTION_LOCK_TIMEOUT = "1s";
@@ -339,19 +340,20 @@ async function materializeRunOutputEvents(
     }
 
     const acknowledgedAt = nowDate();
+    const firstAssistantClaimWhere = and(
+      eq(zeroRuns.id, payload.runId),
+      isNotNull(zeroRuns.apiStartedAt),
+      isNull(zeroRuns.firstAssistantEventAcknowledgedAt),
+    );
+    if (!firstAssistantClaimWhere) {
+      throw new Error("First assistant acknowledgement predicate is empty");
+    }
     const [firstAssistantClaim] =
       insertedRowCount > 0 && shouldAttemptFirstAssistantEventClaim
-        ? await tx
-            .update(zeroRuns)
-            .set({ firstAssistantEventAcknowledgedAt: acknowledgedAt })
-            .where(
-              and(
-                eq(zeroRuns.id, payload.runId),
-                isNotNull(zeroRuns.apiStartedAt),
-                isNull(zeroRuns.firstAssistantEventAcknowledgedAt),
-              ),
-            )
-            .returning({ apiStartedAt: zeroRuns.apiStartedAt })
+        ? await writeRunMetadataInTransaction(tx, {
+            patch: { firstAssistantEventAcknowledgedAt: acknowledgedAt },
+            where: firstAssistantClaimWhere,
+          })
         : [];
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -303,6 +303,10 @@ import {
   activatePendingRun$,
   type PendingRunActivation,
 } from "./agent-run-activation.service";
+import {
+  normalizeRunMetadata,
+  type RunMetadataValues,
+} from "./agent-run-metadata-write.service";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const AUTO_MEMORY_ARTIFACT_NAME = MEMORY_ARTIFACT_NAME;
@@ -5606,19 +5610,24 @@ function initialRunBody(args: CreateAgentRunArgs): CreateRunBody {
 function zeroRunModelProviderValues(
   modelProvider: ResolvedModelProviderEnvironment | null,
 ): Pick<
-  typeof zeroRuns.$inferInsert,
-  "modelProvider" | "modelProviderId" | "selectedModel"
+  RunMetadataValues,
+  | "modelProvider"
+  | "modelProviderId"
+  | "modelProviderCredentialScope"
+  | "selectedModel"
 > {
   if (!modelProvider) {
     return {
       modelProvider: null,
       modelProviderId: null,
+      modelProviderCredentialScope: null,
       selectedModel: null,
     };
   }
   return {
     modelProvider: modelProvider.type,
     modelProviderId: modelProvider.id,
+    modelProviderCredentialScope: null,
     selectedModel: modelProvider.selectedModel,
   };
 }
@@ -5736,6 +5745,7 @@ function launchSessionValues(
 function launchRunValues(
   args: LaunchRunRowsArgs,
   createdAt: Date,
+  metadata: RunMetadataValues,
 ): typeof agentRuns.$inferInsert {
   return {
     id: args.identity.runId,
@@ -5755,30 +5765,31 @@ function launchRunValues(
     runnerGroup: args.runnerGroup ?? null,
     completedAt: args.status === "failed" ? createdAt : null,
     error: args.error ?? null,
+    ...metadata,
   };
 }
 
-function launchZeroRunValues(
-  args: LaunchRunRowsArgs,
-): typeof zeroRuns.$inferInsert {
+function launchRunMetadataValues(args: LaunchRunRowsArgs): RunMetadataValues {
   const metadata: ZeroRunMetadata = args.zeroRunMetadata ?? {};
-  return {
-    id: args.identity.runId,
+  const modelPin =
+    args.zeroRunModelPin ?? zeroRunModelProviderValues(args.modelProvider);
+  return normalizeRunMetadata({
     triggerSource: args.body.triggerSource,
+    autonomyBudget: metadata.autonomyBudget,
     workflowAutomationId: metadata.workflowAutomationId ?? null,
-    triggerBrief: metadata.triggerBrief ?? null,
     goalId: metadata.goalId ?? null,
-    ...(metadata.autonomyBudget === undefined
-      ? {}
-      : { autonomyBudget: metadata.autonomyBudget }),
-    ...(args.zeroRunModelPin ?? zeroRunModelProviderValues(args.modelProvider)),
-    ...(metadata.codexServiceTier === undefined
-      ? {}
-      : { codexServiceTier: metadata.codexServiceTier }),
+    modelProvider: modelPin.modelProvider,
+    modelProviderId: modelPin.modelProviderId,
+    modelProviderCredentialScope: modelPin.modelProviderCredentialScope,
+    selectedModel: modelPin.selectedModel,
+    codexServiceTier: metadata.codexServiceTier ?? null,
     selectedVideoModel: args.selectedVideoModel,
     chatThreadId: args.chatThreadId ?? null,
     apiStartedAt: args.status === "queued" ? null : new Date(args.apiStartTime),
-  };
+    firstAssistantEventAcknowledgedAt: null,
+    summary: null,
+    triggerBrief: metadata.triggerBrief ?? null,
+  });
 }
 
 async function insertLaunchRunRows(
@@ -5790,8 +5801,9 @@ async function insertLaunchRunRows(
   }
 
   const createdAt = nowDate();
-  await tx.insert(agentRuns).values(launchRunValues(args, createdAt));
-  await tx.insert(zeroRuns).values(launchZeroRunValues(args));
+  const metadata = launchRunMetadataValues(args);
+  await tx.insert(agentRuns).values(launchRunValues(args, createdAt, metadata));
+  await tx.insert(zeroRuns).values({ id: args.identity.runId, ...metadata });
 
   if (args.callbackRows.length > 0) {
     await tx.insert(agentRunCallbacks).values([...args.callbackRows]);
@@ -6716,11 +6728,12 @@ function buildAtomicLaunchCteContext(args: PersistAtomicLaunchRowsArgs) {
     ctes.push(insertedSession);
   }
 
+  const metadata = launchRunMetadataValues(rowsArgs);
   const insertedRun = args.tx.$with("inserted_launch_run").as(
     args.tx
       .insert(agentRuns)
       .values({
-        ...launchRunValues(rowsArgs, createdAt),
+        ...launchRunValues(rowsArgs, createdAt, metadata),
         sessionId: insertedSession
           ? returnedCteId(insertedSession)
           : rowsArgs.identity.sessionId,
@@ -6730,7 +6743,7 @@ function buildAtomicLaunchCteContext(args: PersistAtomicLaunchRowsArgs) {
   ctes.push(insertedRun);
 
   const zeroRunValues = {
-    ...launchZeroRunValues(rowsArgs),
+    ...metadata,
     id: returnedCteId(insertedRun),
   };
   const insertedZeroRun = args.tx

--- a/turbo/apps/api/src/signals/services/agent-run-metadata-write.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-metadata-write.service.ts
@@ -24,7 +24,7 @@ export type RunMetadataValues = Pick<
   | "triggerBrief"
 >;
 
-export type RunMetadataInput = Readonly<
+type RunMetadataInput = Readonly<
   Pick<RunMetadataValues, "triggerSource"> &
     Partial<Omit<RunMetadataValues, "triggerSource">>
 >;
@@ -40,7 +40,7 @@ interface RunMetadataWriteArgs {
   readonly where: SQL;
 }
 
-export interface RunMetadataSourceRow {
+interface RunMetadataSourceRow {
   readonly id: string;
   readonly apiStartedAt: Date | null;
 }
@@ -152,6 +152,9 @@ function targetMetadataDiffPredicate(patch: RunMetadataPatch): SQL {
   return predicate;
 }
 
+// DB/API compatibility for mixed Stage 3/4 rollout (observed up to ~102 minutes).
+// Remove via #26924 only after Stage 4 read cutover and bridge removal, once old
+// API revisions and deferred callbacks have drained through production gates.
 export async function writeRunMetadataInTransaction(
   tx: Tx,
   args: RunMetadataWriteArgs,

--- a/turbo/apps/api/src/signals/services/agent-run-metadata-write.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-metadata-write.service.ts
@@ -1,0 +1,194 @@
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { zeroRuns } from "@okouai/db/schema/zero-run";
+import { and, inArray, or, sql, type SQL } from "drizzle-orm";
+
+import type { Tx } from "../../lib/db-types";
+import type { Db } from "../external/db";
+
+export type RunMetadataValues = Pick<
+  typeof zeroRuns.$inferSelect,
+  | "triggerSource"
+  | "autonomyBudget"
+  | "workflowAutomationId"
+  | "goalId"
+  | "modelProvider"
+  | "modelProviderId"
+  | "modelProviderCredentialScope"
+  | "selectedModel"
+  | "codexServiceTier"
+  | "selectedVideoModel"
+  | "chatThreadId"
+  | "apiStartedAt"
+  | "firstAssistantEventAcknowledgedAt"
+  | "summary"
+  | "triggerBrief"
+>;
+
+export type RunMetadataInput = Readonly<
+  Pick<RunMetadataValues, "triggerSource"> &
+    Partial<Omit<RunMetadataValues, "triggerSource">>
+>;
+
+type RunMetadataPatch = {
+  [Key in keyof RunMetadataValues]: Readonly<
+    Pick<RunMetadataValues, Key> & Partial<RunMetadataValues>
+  >;
+}[keyof RunMetadataValues];
+
+interface RunMetadataWriteArgs {
+  readonly patch: RunMetadataPatch;
+  readonly where: SQL;
+}
+
+export interface RunMetadataSourceRow {
+  readonly id: string;
+  readonly apiStartedAt: Date | null;
+}
+
+export function normalizeRunMetadata(
+  input: RunMetadataInput,
+): RunMetadataValues {
+  return {
+    triggerSource: input.triggerSource,
+    autonomyBudget: input.autonomyBudget ?? 10,
+    workflowAutomationId: input.workflowAutomationId ?? null,
+    goalId: input.goalId ?? null,
+    modelProvider: input.modelProvider ?? null,
+    modelProviderId: input.modelProviderId ?? null,
+    modelProviderCredentialScope: input.modelProviderCredentialScope ?? null,
+    selectedModel: input.selectedModel ?? null,
+    codexServiceTier: input.codexServiceTier ?? null,
+    selectedVideoModel: input.selectedVideoModel ?? null,
+    chatThreadId: input.chatThreadId ?? null,
+    apiStartedAt: input.apiStartedAt ?? null,
+    firstAssistantEventAcknowledgedAt:
+      input.firstAssistantEventAcknowledgedAt ?? null,
+    summary: input.summary ?? null,
+    triggerBrief: input.triggerBrief ?? null,
+  };
+}
+
+function targetMetadataDiffPredicate(patch: RunMetadataPatch): SQL {
+  const predicates: SQL[] = [];
+
+  if (patch.triggerSource !== undefined) {
+    predicates.push(
+      sql`${agentRuns.triggerSource} IS DISTINCT FROM ${patch.triggerSource}`,
+    );
+  }
+  if (patch.autonomyBudget !== undefined) {
+    predicates.push(
+      sql`${agentRuns.autonomyBudget} IS DISTINCT FROM ${patch.autonomyBudget}`,
+    );
+  }
+  if (patch.workflowAutomationId !== undefined) {
+    predicates.push(
+      sql`${agentRuns.workflowAutomationId} IS DISTINCT FROM ${patch.workflowAutomationId}`,
+    );
+  }
+  if (patch.goalId !== undefined) {
+    predicates.push(sql`${agentRuns.goalId} IS DISTINCT FROM ${patch.goalId}`);
+  }
+  if (patch.modelProvider !== undefined) {
+    predicates.push(
+      sql`${agentRuns.modelProvider} IS DISTINCT FROM ${patch.modelProvider}`,
+    );
+  }
+  if (patch.modelProviderId !== undefined) {
+    predicates.push(
+      sql`${agentRuns.modelProviderId} IS DISTINCT FROM ${patch.modelProviderId}`,
+    );
+  }
+  if (patch.modelProviderCredentialScope !== undefined) {
+    predicates.push(
+      sql`${agentRuns.modelProviderCredentialScope} IS DISTINCT FROM ${patch.modelProviderCredentialScope}`,
+    );
+  }
+  if (patch.selectedModel !== undefined) {
+    predicates.push(
+      sql`${agentRuns.selectedModel} IS DISTINCT FROM ${patch.selectedModel}`,
+    );
+  }
+  if (patch.codexServiceTier !== undefined) {
+    predicates.push(
+      sql`${agentRuns.codexServiceTier} IS DISTINCT FROM ${patch.codexServiceTier}`,
+    );
+  }
+  if (patch.selectedVideoModel !== undefined) {
+    predicates.push(
+      sql`${agentRuns.selectedVideoModel} IS DISTINCT FROM ${patch.selectedVideoModel}`,
+    );
+  }
+  if (patch.chatThreadId !== undefined) {
+    predicates.push(
+      sql`${agentRuns.chatThreadId} IS DISTINCT FROM ${patch.chatThreadId}`,
+    );
+  }
+  if (patch.apiStartedAt !== undefined) {
+    predicates.push(
+      sql`${agentRuns.apiStartedAt} IS DISTINCT FROM ${patch.apiStartedAt}`,
+    );
+  }
+  if (patch.firstAssistantEventAcknowledgedAt !== undefined) {
+    predicates.push(
+      sql`${agentRuns.firstAssistantEventAcknowledgedAt} IS DISTINCT FROM ${patch.firstAssistantEventAcknowledgedAt}`,
+    );
+  }
+  if (patch.summary !== undefined) {
+    predicates.push(
+      sql`${agentRuns.summary} IS DISTINCT FROM ${patch.summary}`,
+    );
+  }
+  if (patch.triggerBrief !== undefined) {
+    predicates.push(
+      sql`${agentRuns.triggerBrief} IS DISTINCT FROM ${patch.triggerBrief}`,
+    );
+  }
+
+  const predicate = or(...predicates);
+  if (!predicate) {
+    throw new Error("Run metadata patch must contain at least one field");
+  }
+  return predicate;
+}
+
+export async function writeRunMetadataInTransaction(
+  tx: Tx,
+  args: RunMetadataWriteArgs,
+): Promise<readonly RunMetadataSourceRow[]> {
+  const sourceRows = await tx
+    .update(zeroRuns)
+    .set(args.patch)
+    .where(args.where)
+    .returning({ id: zeroRuns.id, apiStartedAt: zeroRuns.apiStartedAt });
+
+  if (sourceRows.length === 0) {
+    return sourceRows;
+  }
+
+  await tx
+    .update(agentRuns)
+    .set(args.patch)
+    .where(
+      and(
+        inArray(
+          agentRuns.id,
+          sourceRows.map((row) => {
+            return row.id;
+          }),
+        ),
+        targetMetadataDiffPredicate(args.patch),
+      ),
+    );
+
+  return sourceRows;
+}
+
+export function writeRunMetadata(
+  db: Db,
+  args: RunMetadataWriteArgs,
+): Promise<readonly RunMetadataSourceRow[]> {
+  return db.transaction(async (tx) => {
+    return await writeRunMetadataInTransaction(tx, args);
+  });
+}

--- a/turbo/apps/api/src/signals/services/run-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/run-summary.service.ts
@@ -6,6 +6,7 @@ import { logger } from "../../lib/log";
 import { optionalEnv } from "../../lib/env";
 import { writeDb$, type Db } from "../external/db";
 import { tapError } from "../utils";
+import { writeRunMetadata } from "./agent-run-metadata-write.service";
 
 const log = logger("run-summary");
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
@@ -138,10 +139,10 @@ export async function saveRunSummary(
         return;
       }
 
-      await db
-        .update(zeroRuns)
-        .set({ summary })
-        .where(eq(zeroRuns.id, args.runId));
+      await writeRunMetadata(db, {
+        patch: { summary },
+        where: eq(zeroRuns.id, args.runId),
+      });
       signal?.throwIfAborted();
     })(),
     (error) => {

--- a/turbo/apps/api/src/signals/services/zero-chat-first-assistant-event-metric.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-first-assistant-event-metric.service.ts
@@ -9,6 +9,7 @@ import { publishUserSignal } from "../external/realtime";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
 import { now } from "../../lib/time";
 import { tapError } from "../utils";
+import { writeRunMetadata } from "./agent-run-metadata-write.service";
 
 const L = logger("api:zero:chat-first-assistant-message-metric");
 
@@ -31,21 +32,20 @@ async function recordFirstAssistantEventAcknowledgement(args: {
   readonly runId: string;
   readonly acknowledgedAt: number;
 }): Promise<void> {
-  const [claimed] = await args.db
-    .update(zeroRuns)
-    .set({
+  const firstAssistantClaimWhere = and(
+    eq(zeroRuns.id, args.runId),
+    isNotNull(zeroRuns.apiStartedAt),
+    isNull(zeroRuns.firstAssistantEventAcknowledgedAt),
+  );
+  if (!firstAssistantClaimWhere) {
+    throw new Error("First assistant acknowledgement predicate is empty");
+  }
+  const [claimed] = await writeRunMetadata(args.db, {
+    patch: {
       firstAssistantEventAcknowledgedAt: new Date(args.acknowledgedAt),
-    })
-    .where(
-      and(
-        eq(zeroRuns.id, args.runId),
-        isNotNull(zeroRuns.apiStartedAt),
-        isNull(zeroRuns.firstAssistantEventAcknowledgedAt),
-      ),
-    )
-    .returning({
-      apiStartedAt: zeroRuns.apiStartedAt,
-    });
+    },
+    where: firstAssistantClaimWhere,
+  });
   if (!claimed?.apiStartedAt) {
     return;
   }

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -41,6 +41,7 @@ import {
   activatePendingRun$,
   type PendingRunActivation,
 } from "./agent-run-activation.service";
+import { writeRunMetadataInTransaction } from "./agent-run-metadata-write.service";
 
 const L = logger("ZeroRunQueue");
 
@@ -184,10 +185,10 @@ async function insertPromotedRunnerJob(
     },
   });
 
-  await tx
-    .update(zeroRuns)
-    .set({ apiStartedAt: new Date(promotedAt) })
-    .where(eq(zeroRuns.id, args.runId));
+  await writeRunMetadataInTransaction(tx, {
+    patch: { apiStartedAt: new Date(promotedAt) },
+    where: eq(zeroRuns.id, args.runId),
+  });
 
   const timestamps = runnerJobQueueTimestamps();
   const profile = args.payload.profile;

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -3,6 +3,24 @@ import { initContract } from "./base";
 
 const c = initContract();
 
+const testRunMetadataSchema = z.object({
+  trigger_source: z.string().nullable(),
+  autonomy_budget: z.int().min(0).max(10).nullable(),
+  workflow_automation_id: z.string().nullable(),
+  goal_id: z.string().nullable(),
+  model_provider: z.string().nullable(),
+  model_provider_id: z.string().nullable(),
+  model_provider_credential_scope: z.string().nullable(),
+  selected_model: z.string().nullable(),
+  codex_service_tier: z.string().nullable(),
+  selected_video_model: z.string().nullable(),
+  chat_thread_id: z.string().nullable(),
+  api_started_at: z.string().nullable(),
+  first_assistant_event_acknowledged_at: z.string().nullable(),
+  summary: z.string().nullable(),
+  trigger_brief: z.string().nullable(),
+});
+
 // Test-only support actions for infrastructure fixtures used by API suites.
 export const testRuntimeStateErrorSchema = z.object({
   error: z.string(),
@@ -37,6 +55,17 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("read-run-autonomy-budget"),
     run_id: z.uuid(),
+  }),
+  z.object({
+    action: z.literal("read-run-metadata-pair"),
+    run_id: z.uuid(),
+  }),
+  z.object({
+    action: z.literal("save-run-summary"),
+    run_id: z.uuid(),
+    trigger_source: z.string(),
+    prompt: z.string(),
+    result_text: z.string(),
   }),
   z.object({
     action: z.literal("measure-run-metadata-bridge-target-updates"),
@@ -203,6 +232,12 @@ export const testRuntimeStateActionResponseSchema = z.object({
   agent_run_update_count: z.int().nonnegative().optional(),
   target_write_failed: z.boolean().optional(),
   target_write_error_code: z.string().nullable().optional(),
+  run_metadata_pair: z
+    .object({
+      agent_run: testRunMetadataSchema.nullable(),
+      zero_run: testRunMetadataSchema.nullable(),
+    })
+    .optional(),
   workflow_automation_state: z
     .object({
       autonomy_budget: z.int().min(0).max(10),

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -32,6 +32,7 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     action: z.literal("set-run-autonomy-budget"),
     run_id: z.uuid(),
     autonomy_budget: z.int().min(0).max(10),
+    disable_bridge: z.boolean().optional(),
   }),
   z.object({
     action: z.literal("read-run-autonomy-budget"),
@@ -188,6 +189,7 @@ export const testRuntimeStateActionResponseSchema = z.object({
   browser_screenshot_schema_available: z.boolean().optional(),
   usage_pack_invitation_schema_available: z.boolean().optional(),
   autonomy_budget: z.int().min(0).max(10).nullable().optional(),
+  agent_autonomy_budget: z.int().min(0).max(10).nullable().optional(),
   workflow_automation_state: z
     .object({
       autonomy_budget: z.int().min(0).max(10),

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -39,6 +39,16 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     run_id: z.uuid(),
   }),
   z.object({
+    action: z.literal("measure-run-metadata-bridge-target-updates"),
+    run_id: z.uuid(),
+    autonomy_budget: z.int().min(0).max(10),
+  }),
+  z.object({
+    action: z.literal("verify-run-metadata-target-failure-rollback"),
+    run_id: z.uuid(),
+    autonomy_budget: z.int().min(0).max(10),
+  }),
+  z.object({
     action: z.literal("set-workflow-automation-autonomy-budget"),
     automation_id: z.uuid(),
     autonomy_budget: z.int().min(0).max(10),
@@ -190,6 +200,9 @@ export const testRuntimeStateActionResponseSchema = z.object({
   usage_pack_invitation_schema_available: z.boolean().optional(),
   autonomy_budget: z.int().min(0).max(10).nullable().optional(),
   agent_autonomy_budget: z.int().min(0).max(10).nullable().optional(),
+  agent_run_update_count: z.int().nonnegative().optional(),
+  target_write_failed: z.boolean().optional(),
+  target_write_error_code: z.string().nullable().optional(),
   workflow_automation_state: z
     .object({
       autonomy_budget: z.int().min(0).max(10),


### PR DESCRIPTION
## Summary

- define one canonical 15-field run-metadata tuple with an explicit autonomy default of 10 and reuse it for ordinary and atomic creation in both tables
- add a source-first transactional compatibility writer that updates `zero_runs`, no-ops when the source CAS misses, and skips a redundant explicit `agent_runs` update when the Stage 1 bridge already produced the target value
- route queue promotion, both first-assistant CAS paths, summary writes, test metadata mutations, and classified paired seed/benchmark writers through the migration-safe shape
- preserve intentional lifecycle-only `agent_runs` fixtures without broadening product metadata

## Local evidence

| Classification | Command / evidence | Result |
| --- | --- | --- |
| Passed | `git diff --check origin/main...HEAD` | clean on final head |
| Passed | Prettier check over every changed Turbo file | all files match |
| Passed | `pnpm --filter @okouai/api-contracts check-types` | exit 0 on final head |
| Passed | `pnpm --filter api check-types` | ordered deps/boundaries/gateways/core/bootstrap/tests/bootstrap-wiring exit 0 after the #27038 rebase |
| Passed | `pnpm --filter api check-types:core && pnpm --filter api check-types:tests` | exit 0 after the final #27040 rebase |
| Passed | `pnpm --filter api lint` | exit 0; repository-existing warnings only |
| Passed | ESLint over every changed API file | exit 0 on final head |
| Passed | `DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts` | 1/1; exact creation tuple, bridge-disabled dual write, bridge no-op, target-lock rollback, and summary replacement |
| Passed | `DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'records a failed queued launch when queue payload encryption fails'` | 1/1 selected; failed creation parity |
| Passed | `DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts -t 'keeps lifecycle-only cleanup fixtures one-sided|leaves the audited pre-forward threadless cohort discoverable'` | 2/2 selected; all-null agent-only fixture and paired threadless fixture |
| Passed | `DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm --filter api exec vitest run src/scripts/__tests__/dev-bench-seed.test.ts` | 1/1; all 15 benchmark metadata fields paired |
| Baseline-reproduced / CI-required | filtered promotion and concurrent-CAS lifecycle cases | both branch and dispatch baseline reach the same pre-existing runner-claim `404`; promotion parity assertions execute before that boundary; normal PR orchestration is authoritative |
| CI-required | deferred callback case | filtered run reaches the same pre-existing runner-claim boundary before its new parity assertion; assertion is retained for normal PR orchestration |

## Final inventory and scope

- multiline typed scan leaves exactly one mutable `update(zeroRuns)`, in `agent-run-metadata-write.service.ts`
- no raw-SQL `zero_runs` application writer remains
- two production creation sites and eight classified paired fixture/benchmark insert sites use the canonical tuple
- Telegram-running, non-threadless-cleanup, and canonical-interrupt lifecycle fixtures remain intentionally `agent_runs`-only
- no product reader, schema, migration, Stage 1 bridge/validator, MaskDB, permanent DB function, queue/lifecycle behavior, or external product contract changed

## Fallbacks

- `agent-run-metadata-write.service.ts:writeRunMetadataInTransaction` — the source-first dual-write bridge protects mixed Stage 3/Stage 4 application and database rollout while old revisions and deferred callbacks still write `zero_runs`. Surface: DB/API mixed versions, up to the observed ~102-minute window. Remove only in the staged write-retirement child after reads cut over, bridge removal, and production gates; follow-up #26924.

Refs #27033
