### PR TITLE
fix(desktop): show app name in tray open action

### DIFF
--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -154,7 +154,7 @@ describe("desktop tray menu", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses Okou account copy for the Okou product", () => {
+  it("uses Okou copy for the Okou product", () => {
     const menu = buildDesktopTrayMenuItems(
       {
         brandName: "Okou",
@@ -165,6 +165,7 @@ describe("desktop tray menu", () => {
       trayActions(),
     );
 
+    expect(findItem(menu, "Open Okou")).toBeDefined();
     expect(findItem(menu, "Sign in to Okou")).toBeDefined();
     expect(
       findItem(submenu(findItem(menu, "Sign in to Okou")), "Sign in to Okou"),
@@ -182,14 +183,14 @@ describe("desktop tray menu", () => {
     );
 
     expect(menu.map((item) => item.label).filter((label) => label)).toEqual([
-      "Open Computer Use",
+      "Open Zero",
       "Workspace: Max & Zoe",
       "Computer Use: Online",
       "Keep Mac Awake",
       "No Recent Commands",
       "Quit",
     ]);
-    expect(findItem(menu, "Open Computer Use")).toBeDefined();
+    expect(findItem(menu, "Open Zero")).toBeDefined();
     expect(findItem(menu, "Keep Mac Awake")).toStrictEqual({
       label: "Keep Mac Awake",
       type: "checkbox",

--- a/turbo/apps/desktop/src/desktop-tray-menu.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.ts
@@ -375,7 +375,10 @@ export function buildDesktopTrayMenuItems(
   actions: DesktopTrayMenuActions,
 ): readonly DesktopTrayMenuItem[] {
   return [
-    { label: "Open Computer Use", click: actions.showMainWindow },
+    {
+      label: `Open ${desktopBrandName(state)}`,
+      click: actions.showMainWindow,
+    },
     {
       label: authStatusLabel(state),
       submenu: buildAuthSubmenu(state, actions),


### PR DESCRIPTION
## Summary

- derive the Desktop tray's main-window action from the existing product brand identity
- show `Open Okou` in Okou builds and `Open Zero` in legacy Zero builds
- cover both branded labels in the tray menu state-matrix tests

## Verification

- `corepack pnpm exec prettier --write apps/desktop/src/desktop-tray-menu.ts apps/desktop/src/desktop-tray-menu.test.ts`
- `corepack pnpm -F @okouai/desktop lint`
- `corepack pnpm -F @okouai/desktop check-types`
- `corepack pnpm -F @okouai/desktop exec vitest run src/desktop-tray-menu.test.ts --silent=passed-only` (18 tests)
