### PR TITLE
refactor(shared-threads): neutralize api route shell

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -77,7 +77,7 @@ import { zeroBillingUsagePackCreditsRoutes } from "./routes/zero-billing-usage-p
 import { zeroBankingRoutes } from "./routes/zero-banking";
 import { zeroChatThreadRoutes } from "./routes/zero-chat-threads";
 import { zeroChatEventsRoutes } from "./routes/zero-chat-events";
-import { zeroSharedThreadRoutes } from "./routes/zero-shared-threads";
+import { sharedThreadRoutes } from "./routes/shared-threads";
 import { claudeCodeDeviceAuthRoutes } from "./routes/claude-code-device-auth";
 import { zeroComposesRoutes } from "./routes/zero-composes";
 import { zeroComputerUseAuthorizationRoutes } from "./routes/zero-computer-use-authorization";
@@ -268,7 +268,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroBankingRoutes,
   ...zeroChatThreadRoutes,
   ...zeroChatEventsRoutes,
-  ...zeroSharedThreadRoutes,
+  ...sharedThreadRoutes,
   ...claudeCodeDeviceAuthRoutes,
   ...zeroComposesRoutes,
   ...zeroComputerUseAuthorizationRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
@@ -10,7 +10,7 @@ import { signSandboxJwtForTests } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import type { RouteEntry } from "../../route-entry";
 import { artifactCatalogRoutes } from "../artifact-catalog";
-import { zeroSharedThreadRoutes } from "../zero-shared-threads";
+import { sharedThreadRoutes } from "../shared-threads";
 import {
   createBddApi,
   expectApiError,
@@ -39,7 +39,7 @@ const webhooks = createWebhookCallbackApi(context);
 const routeMocks = createZeroRouteMocks(context);
 const sharedThreadTestRoutes: readonly RouteEntry[] = [
   ...artifactCatalogRoutes,
-  ...zeroSharedThreadRoutes,
+  ...sharedThreadRoutes,
 ];
 type RunnerClaim = Awaited<ReturnType<typeof api.claimRunnerJob>>;
 interface CatalogActor {

--- a/turbo/apps/api/src/signals/routes/shared-threads.ts
+++ b/turbo/apps/api/src/signals/routes/shared-threads.ts
@@ -98,7 +98,7 @@ const getSharedThreadMeta$ = command(
   },
 );
 
-export const zeroSharedThreadRoutes: readonly RouteEntry[] = [
+export const sharedThreadRoutes: readonly RouteEntry[] = [
   {
     route: sharedThreadsContract.create,
     handler: authRoute(


### PR DESCRIPTION
## Summary

- rename the Shared Threads API route shell to `shared-threads.ts` and its route-array export to `sharedThreadRoutes`
- update the API route registry and artifact-catalog BDD integration caller atomically
- preserve every endpoint, compatibility alias, handler, response, cache policy, and persistence boundary

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged Turbo type checks for non-API, Platform, and API workspaces
- `DATABASE_URL=... pnpm --filter api run check-types` after rebasing onto current main
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/artifact-catalog.bdd.test.ts` (18 passed)
- non-historical source search confirms `zero-shared-threads` and `zeroSharedThreadRoutes` are absent
- compatibility audit confirms all four intentional raw `/api/zero/**` Shared Threads requests are unchanged

Closes #27039