### PR TITLE
fix(connectors): isolate unavailable stored runtimes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
@@ -44,7 +44,7 @@ const store = createStore();
 
 interface ConnectedFixture {
   readonly actor: ApiTestUser;
-  readonly connectorSlug: "github" | "reap";
+  readonly connectorSlug: "github" | "reap" | "removed-connector";
 }
 
 const trackConnectedFixture = createFixtureTracker<ConnectedFixture>(
@@ -368,6 +368,31 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
       connector: {
         connectorSlug: "github",
       },
+    });
+  });
+
+  it("ignores stale stored connectors that are absent from the catalog", async () => {
+    const actor = bdd.user();
+    await seedConnectorStorageRow(context, {
+      authMethod: "api",
+      connectorSlug: "removed-connector",
+      orgId: requireOrgId(actor),
+      storageVersion: 1,
+      userId: actor.userId,
+    });
+    await trackConnectedFixture(
+      Promise.resolve({ actor, connectorSlug: "removed-connector" }),
+    );
+
+    const response = await checkWithSession(actor, {
+      mode: "url",
+      method: "GET",
+      url: "https://api.github.com/repos/vm0-ai/vm0",
+    });
+
+    expect(response.body).toMatchObject({
+      outcome: "resolved",
+      connector: { connectorSlug: "github" },
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -691,6 +691,40 @@ describe("CONN-02: OAuth device authorization", () => {
     });
   });
 
+  it("returns 403 when a device-auth runtime becomes unavailable before polling", async () => {
+    mockTestOAuthDeviceConnectorProvider({ deviceCode: "pending" });
+    const actor = createBddApi(context).user();
+    const session = await connectorsApi.startDeviceAuth(
+      actor,
+      "test-oauth-device",
+      "oauth",
+    );
+    await installCatalogWithUnavailableMethods({
+      capabilityIdentityEnvName: "DEEL_OAUTH_CLIENT_ID",
+      filteredAuthMethods: [
+        {
+          connectorSlug: "test-oauth-device",
+          authMethodId: "oauth",
+          reasons: ["missing-grant-provider"],
+        },
+      ],
+    });
+
+    const response = await connectorsApi.requestDeviceAuthPoll(
+      actor,
+      "test-oauth-device",
+      session.sessionId,
+      session.sessionToken,
+      [403],
+    );
+
+    expectApiError(response.body);
+    expect(response.body.error).toStrictEqual({
+      message: "test-oauth-device connector is not available",
+      code: "FORBIDDEN",
+    });
+  });
+
   it("starts and completes a device authorization session, with state visible through connector APIs", async () => {
     mockTestOAuthDeviceConnectorProvider();
 
@@ -1593,6 +1627,38 @@ describe("CONN-02: external-code authorization", () => {
       actor,
       "aws",
       "cli",
+      [403],
+    );
+
+    expectApiError(response.body);
+    expect(response.body.error).toStrictEqual({
+      message: "aws connector is not available",
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("returns 403 when an external-code runtime becomes unavailable before completion", async () => {
+    const actor = createBddApi(context).user();
+    const session = await connectorsApi.startExternalCode(actor, "aws", "cli");
+    await installCatalogWithUnavailableMethods({
+      capabilityIdentityEnvName: "DOCUSIGN_OAUTH_CLIENT_ID",
+      filteredAuthMethods: [
+        {
+          connectorSlug: "aws",
+          authMethodId: "cli",
+          reasons: ["missing-grant-provider"],
+        },
+      ],
+    });
+
+    const response = await connectorsApi.requestExternalCodeComplete(
+      actor,
+      "aws",
+      {
+        sessionId: session.sessionId,
+        sessionToken: session.sessionToken,
+        code: "bdd-code",
+      },
       [403],
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -21,9 +21,13 @@ import { describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { mockEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { extractFileFromTarGz } from "../../../lib/tar";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
+import {
+  installApiTestConnectorCatalog,
+  replaceApiTestConnectorCatalogFilteredAuthMethods,
+} from "../../../test-fixtures/connector-catalog";
 import { generateSandboxToken, generateZeroToken } from "../../auth/tokens";
 import { createDeferredPromise } from "../../utils";
 import {
@@ -65,6 +69,19 @@ const context = testContext();
 const connectorsApi = createConnectorBddApi(context);
 const authOrgApi = createAuthOrgAgentsBddApi(context);
 const storagesApi = createStoragesBddApi(context);
+
+async function installCatalogWithUnavailableMethods(args: {
+  readonly capabilityIdentityEnvName: string;
+  readonly filteredAuthMethods: Parameters<
+    typeof replaceApiTestConnectorCatalogFilteredAuthMethods
+  >[0];
+}): Promise<void> {
+  mockOptionalEnv(args.capabilityIdentityEnvName, undefined);
+  await installApiTestConnectorCatalog();
+  await replaceApiTestConnectorCatalogFilteredAuthMethods(
+    args.filteredAuthMethods,
+  );
+}
 
 function mockAuthoritativeOrganizationMembers(
   actors: readonly ApiTestUser[],
@@ -646,6 +663,34 @@ describe("CONN-02: OAuth start and callback", () => {
 });
 
 describe("CONN-02: OAuth device authorization", () => {
+  it("returns 403 when the selected device-auth runtime method is unavailable", async () => {
+    await installCatalogWithUnavailableMethods({
+      capabilityIdentityEnvName: "CALCOM_OAUTH_CLIENT_ID",
+      filteredAuthMethods: [
+        {
+          connectorSlug: "test-oauth-device",
+          authMethodId: "oauth",
+          reasons: ["missing-grant-provider"],
+        },
+      ],
+    });
+    const actor = createBddApi(context).user();
+
+    const response = await connectorsApi.requestDeviceAuthStart(
+      actor,
+      "test-oauth-device",
+      "oauth",
+      undefined,
+      [403],
+    );
+
+    expectApiError(response.body);
+    expect(response.body.error).toStrictEqual({
+      message: "test-oauth-device connector is not available",
+      code: "FORBIDDEN",
+    });
+  });
+
   it("starts and completes a device authorization session, with state visible through connector APIs", async () => {
     mockTestOAuthDeviceConnectorProvider();
 
@@ -1531,6 +1576,33 @@ describe("CONN-02: OAuth device authorization", () => {
 });
 
 describe("CONN-02: external-code authorization", () => {
+  it("returns 403 when the external-code runtime method is unavailable", async () => {
+    await installCatalogWithUnavailableMethods({
+      capabilityIdentityEnvName: "CANVA_OAUTH_CLIENT_ID",
+      filteredAuthMethods: [
+        {
+          connectorSlug: "aws",
+          authMethodId: "cli",
+          reasons: ["missing-grant-provider"],
+        },
+      ],
+    });
+    const actor = createBddApi(context).user();
+
+    const response = await connectorsApi.requestExternalCodeStart(
+      actor,
+      "aws",
+      "cli",
+      [403],
+    );
+
+    expectApiError(response.body);
+    expect(response.body.error).toStrictEqual({
+      message: "aws connector is not available",
+      code: "FORBIDDEN",
+    });
+  });
+
   it("validates external-code auth, grant, and session boundaries without using rollout as authorization", async () => {
     const bdd = createBddApi(context);
     const actor = bdd.user();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-delete.test.ts
@@ -8,6 +8,10 @@ import {
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import {
+  readConnectorCredentialStorageState,
+  seedConnectorStorageRow,
+} from "./helpers/connector-credential-storage-state";
+import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
@@ -21,11 +25,12 @@ interface AuthenticatedFixture {
   readonly userId: string;
 }
 
-type ConnectorSlugToCleanUp = "openai" | "gitlab";
+type ConnectorSlugToCleanUp = "openai" | "gitlab" | "removed-connector";
 
 const CONNECTOR_SLUGS_TO_CLEAN_UP: readonly ConnectorSlugToCleanUp[] = [
   "openai",
   "gitlab",
+  "removed-connector",
 ];
 
 function authHeaders() {
@@ -200,6 +205,27 @@ describe("DELETE /api/zero/connectors/:connectorSlug", () => {
     expect(response.body).toBeUndefined();
     const readAfterDelete = await readMissingConnector(fixture, "gitlab");
     expect(readAfterDelete.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("deletes local state when the connector runtime method is unavailable", async () => {
+    const fixture = await track(seedFixture());
+    await seedConnectorStorageRow(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "removed-connector",
+      authMethod: "unavailable-method",
+      storageVersion: 1,
+    });
+
+    const response = await deleteConnector(fixture, "removed-connector", [204]);
+
+    expect(response.body).toBeUndefined();
+    const storageState = await readConnectorCredentialStorageState(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "removed-connector",
+    });
+    expect(storageState.connector).toBeNull();
   });
 
   it("deletes only the requested connector slug", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-delete.test.ts
@@ -7,6 +7,11 @@ import {
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import {
+  deleteApiTestConnectorCatalogCompatibility,
+  installApiTestConnectorCatalog,
+} from "../../../test-fixtures/connector-catalog";
 import {
   readConnectorCredentialStorageState,
   seedConnectorStorageRow,
@@ -224,6 +229,24 @@ describe("DELETE /api/zero/connectors/:connectorSlug", () => {
       orgId: fixture.orgId,
       userId: fixture.userId,
       connectorSlug: "removed-connector",
+    });
+    expect(storageState.connector).toBeNull();
+  });
+
+  it("deletes local state when the external catalog is unavailable", async () => {
+    const fixture = await track(seedFixture());
+    await connectOpenai(fixture);
+    mockOptionalEnv("CLOSE_OAUTH_CLIENT_ID", undefined);
+    await installApiTestConnectorCatalog();
+    await deleteApiTestConnectorCatalogCompatibility();
+
+    const response = await deleteConnector(fixture, "openai", [204]);
+
+    expect(response.body).toBeUndefined();
+    const storageState = await readConnectorCredentialStorageState(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "openai",
     });
     expect(storageState.connector).toBeNull();
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-get.test.ts
@@ -9,7 +9,12 @@ import { afterEach } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
+import {
+  deleteApiTestConnectorCatalogCompatibility,
+  installApiTestConnectorCatalog,
+} from "../../../test-fixtures/connector-catalog";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { seedConnectorStorageRow } from "./helpers/connector-credential-storage-state";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
@@ -175,6 +180,29 @@ describe("GET /api/zero/connectors/:connectorSlug", () => {
       authMethod: "unavailable-method",
       storageVersion: 1,
     });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context, routes: zeroConnectorsRoutes })(
+      zeroConnectorsBySlugContract,
+    );
+    const response = await accept(
+      client.get({
+        params: { connectorSlug: "openai" },
+        headers: authHeaders(),
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 404 when the external catalog is unavailable", async () => {
+    const fixture = seedAuthenticatedFixture();
+    seededFixtures.push(fixture);
+    await connectOpenai(fixture);
+    mockOptionalEnv("DROPBOX_OAUTH_CLIENT_ID", undefined);
+    await installApiTestConnectorCatalog();
+    await deleteApiTestConnectorCatalogCompatibility();
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context, routes: zeroConnectorsRoutes })(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-by-slug-get.test.ts
@@ -11,6 +11,7 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
+import { seedConnectorStorageRow } from "./helpers/connector-credential-storage-state";
 import { seedOrgMembership$ } from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { zeroConnectorsRoutes } from "../zero-connectors";
@@ -162,6 +163,32 @@ describe("GET /api/zero/connectors/:connectorSlug", () => {
       authMethod: "api-token",
       connectionStatus: "connected",
     });
+  });
+
+  it("returns 404 when the stored connector runtime method is unavailable", async () => {
+    const fixture = seedAuthenticatedFixture();
+    seededFixtures.push(fixture);
+    await seedConnectorStorageRow(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "openai",
+      authMethod: "unavailable-method",
+      storageVersion: 1,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context, routes: zeroConnectorsRoutes })(
+      zeroConnectorsBySlugContract,
+    );
+    const response = await accept(
+      client.get({
+        params: { connectorSlug: "openai" },
+        headers: authHeaders(),
+      }),
+      [404],
+    );
+
+    expect(response.body.error.code).toBe("NOT_FOUND");
   });
 
   it("allows access with a sandbox JWT carrying connector:read capability", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -9,6 +9,11 @@ import { afterEach } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { mockOptionalEnv } from "../../../lib/env";
+import {
+  deleteApiTestConnectorCatalogCompatibility,
+  installApiTestConnectorCatalog,
+} from "../../../test-fixtures/connector-catalog";
 import { seedConnectorStorageRow } from "./helpers/connector-credential-storage-state";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { zeroConnectorsRoutes } from "../zero-connectors";
@@ -155,6 +160,29 @@ describe("GET /api/zero/connectors", () => {
     expect(response.body.connectorProvidedBindings).not.toContainEqual(
       expect.objectContaining({ connectorSlug: "openai" }),
     );
+  });
+
+  it("skips stored connectors when the external catalog is unavailable", async () => {
+    const fixture = seedAuthenticatedFixture();
+    seededFixtures.push(fixture);
+    await connectGitlab(fixture);
+    mockOptionalEnv("BOX_OAUTH_CLIENT_ID", undefined);
+    await installApiTestConnectorCatalog();
+    await deleteApiTestConnectorCatalogCompatibility();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context, routes: zeroConnectorsRoutes })(
+      zeroConnectorsMainContract,
+    );
+    const response = await accept(
+      client.list({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      connectors: [],
+      connectorProvidedBindings: [],
+    });
   });
 
   it("returns 401 when not authenticated", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-list.test.ts
@@ -9,6 +9,7 @@ import { afterEach } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { seedConnectorStorageRow } from "./helpers/connector-credential-storage-state";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { zeroConnectorsRoutes } from "../zero-connectors";
 
@@ -53,13 +54,16 @@ async function connectGitlab(fixture: AuthenticatedFixture): Promise<void> {
   );
 }
 
-async function deleteGitlab(fixture: AuthenticatedFixture): Promise<void> {
+async function deleteConnector(
+  fixture: AuthenticatedFixture,
+  connectorSlug: "gitlab" | "openai",
+): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
   await accept(
     setupApp({ context, routes: zeroConnectorsRoutes })(
       zeroConnectorsBySlugContract,
     ).delete({
-      params: { connectorSlug: "gitlab" },
+      params: { connectorSlug },
       headers: authHeaders(),
     }),
     [204, 404],
@@ -73,7 +77,8 @@ describe("GET /api/zero/connectors", () => {
     while (seededFixtures.length > 0) {
       const fixture = seededFixtures.pop();
       if (fixture) {
-        await deleteGitlab(fixture);
+        await deleteConnector(fixture, "gitlab");
+        await deleteConnector(fixture, "openai");
       }
     }
   });
@@ -121,6 +126,34 @@ describe("GET /api/zero/connectors", () => {
         namespace: "secrets",
         name: "GITLAB_TOKEN",
       }),
+    );
+  });
+
+  it("skips stored connectors whose runtime method is unavailable", async () => {
+    const fixture = seedAuthenticatedFixture();
+    seededFixtures.push(fixture);
+    await connectGitlab(fixture);
+    await seedConnectorStorageRow(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "openai",
+      authMethod: "unavailable-method",
+      storageVersion: 1,
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    const client = setupApp({ context, routes: zeroConnectorsRoutes })(
+      zeroConnectorsMainContract,
+    );
+    const response = await accept(
+      client.list({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body.connectors).toHaveLength(1);
+    expect(response.body.connectors[0]).toMatchObject({ slug: "gitlab" });
+    expect(response.body.connectorProvidedBindings).not.toContainEqual(
+      expect.objectContaining({ connectorSlug: "openai" }),
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-oauth-start.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "../../../app-factory";
 import { testContext } from "../../../__tests__/test-context";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
-import { clearMockNow, mockNow } from "../../../lib/time";
+import { clearMockNow } from "../../../lib/time";
 import {
   API_TEST_CONNECTOR_CATALOG,
   installApiTestConnectorCatalog,
@@ -476,7 +476,7 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
     });
   });
 
-  it("returns 500 when the auth method lacks executable platform configuration", async () => {
+  it("returns 403 when the auth method lacks executable platform configuration", async () => {
     mockOptionalEnv("GH_OAUTH_CLIENT_ID", undefined);
     await installApiTestConnectorCatalog();
     mockAuthenticatedSession();
@@ -485,11 +485,11 @@ describe("POST /api/zero/connectors/:connectorSlug/oauth/start", () => {
       headers: authHeaders(),
     });
 
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(403);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message: "Connector execution is not configured",
-        code: "INTERNAL_SERVER_ERROR",
+        message: "github connector is not available",
+        code: "FORBIDDEN",
       },
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connectors-scope-diff.test.ts
@@ -15,6 +15,7 @@ import {
   createConnectorBddApi,
   mockGitHubConnectorOAuth,
 } from "./helpers/api-bdd-connectors";
+import { seedConnectorStorageRow } from "./helpers/connector-credential-storage-state";
 import { zeroConnectorsRoutes } from "../zero-connectors";
 
 const context = testContext();
@@ -111,6 +112,30 @@ describe("GET /api/zero/connectors/:connectorSlug/scope-diff", () => {
     );
     expectApiError(response.body);
     expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("returns 404 when the stored connector runtime method is unavailable", async () => {
+    const actor = bdd.user();
+    if (actor.orgId === null) {
+      throw new Error("Expected test actor organization");
+    }
+    await seedConnectorStorageRow(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      connectorSlug: "openai",
+      authMethod: "unavailable-method",
+      storageVersion: 1,
+    });
+
+    const response = await connectorsApi.requestScopeDiff(
+      actor,
+      "openai",
+      [404],
+    );
+
+    expectApiError(response.body);
+    expect(response.body.error.code).toBe("NOT_FOUND");
+    await connectorsApi.deleteConnectorBySlug(actor, "openai");
   });
 
   it("returns an empty diff when stored scopes match current scopes exactly", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connectors.ts
@@ -40,7 +40,6 @@ import {
 import {
   connectorActionResolver,
   type ConnectorActionMethodResolution,
-  type ConnectorSlugResolution,
 } from "../services/connector-action-resolver.service";
 import { isConnectorCatalogUnavailableError } from "../services/connector-catalog-reader.service";
 import type { RouteEntry } from "../route-entry";
@@ -148,20 +147,7 @@ function connectorMethodResolutionError(
       return connectorUnavailable(args.connectorSlug);
     }
     case "missing_executable_capability": {
-      return internalServerError("Connector execution is not configured");
-    }
-  }
-}
-
-function connectorSlugResolutionError(
-  resolution: Exclude<ConnectorSlugResolution, { readonly ok: true }>,
-) {
-  switch (resolution.reason) {
-    case "unknown_connector": {
-      return notFound("Connector not found");
-    }
-    case "missing_executable_capability": {
-      return internalServerError("Connector execution is not configured");
+      return connectorUnavailable(args.connectorSlug);
     }
   }
 }
@@ -177,20 +163,11 @@ const getConnectorListInner$ = computed(async (get) => {
 const getConnectorBySlugInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroConnectorsBySlugContract.get));
-  const resolver = await get(connectorActionResolver());
-  const resolved = await resolver.resolveSlug({
-    connectorSlug: params.connectorSlug,
-    requireExecutable: false,
-  });
-  if (!resolved.ok) {
-    return connectorSlugResolutionError(resolved);
-  }
   const connector = await get(
     zeroConnectorBySlug({
       orgId: auth.orgId,
       userId: auth.userId,
-      connectorSlug: resolved.connectorSlug,
-      snapshot: resolved.snapshot,
+      connectorSlug: params.connectorSlug,
     }),
   );
   if (!connector) {
@@ -204,23 +181,12 @@ const deleteConnectorBySlugInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(zeroConnectorsBySlugContract.delete));
-    const resolver = await get(connectorActionResolver());
-    signal.throwIfAborted();
-    const resolved = await resolver.resolveSlug({
-      connectorSlug: params.connectorSlug,
-      requireExecutable: false,
-    });
-    signal.throwIfAborted();
-    if (!resolved.ok) {
-      return connectorSlugResolutionError(resolved);
-    }
     const deleted = await set(
       deleteZeroConnectorLocalState$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        connectorSlug: resolved.connectorSlug,
-        snapshot: resolved.snapshot,
+        connectorSlug: params.connectorSlug,
       },
       signal,
     );
@@ -237,20 +203,11 @@ const deleteConnectorBySlugInner$ = command(
 const getScopeDiffInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroConnectorScopeDiffContract.getScopeDiff));
-  const resolver = await get(connectorActionResolver());
-  const resolved = await resolver.resolveSlug({
-    connectorSlug: params.connectorSlug,
-    requireExecutable: false,
-  });
-  if (!resolved.ok) {
-    return connectorSlugResolutionError(resolved);
-  }
   const diff = await get(
     zeroConnectorScopeDiff({
       orgId: auth.orgId,
       userId: auth.userId,
-      connectorSlug: resolved.connectorSlug,
-      snapshot: resolved.snapshot,
+      connectorSlug: params.connectorSlug,
     }),
   );
   if (!diff) {

--- a/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
@@ -9,6 +9,7 @@ import type {
 } from "@okouai/api-contracts/contracts/zero-connector-catalog";
 import type { ConnectorAuthMethodRuntimeConfig } from "@okouai/connectors/connector-config";
 
+import { logger } from "../../lib/log";
 import { db$ } from "../external/db";
 import {
   getConnectorRuntimeConnector,
@@ -19,10 +20,12 @@ import {
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
 
+const log = logger("api:connector-action-resolver");
+
 type ConnectorCatalogGrantKind =
   PublicConnectorCatalogAuthMethodDetail["grantKind"];
 
-export type ConnectorSlugResolutionFailure =
+type ConnectorSlugResolutionFailure =
   | { readonly ok: false; readonly reason: "unknown_connector" }
   | {
       readonly ok: false;
@@ -120,6 +123,9 @@ function resolvedSlug(args: {
       return method.executable;
     })
   ) {
+    log.warn("Connector runtime capability is unavailable", {
+      connectorSlug: args.connectorSlug,
+    });
     return { ok: false, reason: "missing_executable_capability" };
   }
   return {
@@ -146,6 +152,10 @@ function executableMethod(args: {
     runtimeMethod === undefined ||
     runtimeMethod.method.grant.kind !== args.catalogMethod.grantKind
   ) {
+    log.warn("Connector auth method runtime capability is unavailable", {
+      connectorSlug: args.resolvedSlug.connectorSlug,
+      authMethodId: args.authMethodId,
+    });
     return { ok: false, reason: "missing_executable_capability" };
   }
   return {

--- a/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
@@ -170,7 +170,7 @@ function executableMethod(args: {
 function createConnectorActionResolver(
   snapshot: ConnectorRuntimeSnapshot,
 ): ConnectorActionResolver {
-  const resolveSlug: ConnectorActionResolver["resolveSlug"] = (input) => {
+  const resolveSlugCore: ConnectorActionResolver["resolveSlug"] = (input) => {
     const runtimeConnector = getConnectorRuntimeConnector(
       snapshot,
       input.connectorSlug,
@@ -186,7 +186,20 @@ function createConnectorActionResolver(
     });
   };
 
-  const resolveMethod: ConnectorActionResolver["resolveMethod"] = (input) => {
+  const resolveSlug: ConnectorActionResolver["resolveSlug"] = (input) => {
+    const resolution = resolveSlugCore(input);
+    if (!resolution.ok && resolution.reason === "unknown_connector") {
+      log.warn("Connector runtime is unavailable", {
+        connectorSlug: input.connectorSlug,
+        reason: resolution.reason,
+      });
+    }
+    return resolution;
+  };
+
+  const resolveMethodCore: ConnectorActionResolver["resolveMethod"] = (
+    input,
+  ) => {
     const runtimeConnector = getConnectorRuntimeConnector(
       snapshot,
       input.connectorSlug,
@@ -230,6 +243,21 @@ function createConnectorActionResolver(
     });
   };
 
+  const resolveMethod: ConnectorActionResolver["resolveMethod"] = (input) => {
+    const resolution = resolveMethodCore(input);
+    if (
+      !resolution.ok &&
+      resolution.reason !== "missing_executable_capability"
+    ) {
+      log.warn("Connector action runtime method is unavailable", {
+        connectorSlug: input.connectorSlug,
+        authMethodId: input.authMethodId,
+        reason: resolution.reason,
+      });
+    }
+    return resolution;
+  };
+
   return {
     resolveSlug,
     resolveMethod,
@@ -252,13 +280,13 @@ function createConnectorActionResolver(
         }
       }
 
-      return resolveMethod(input);
+      return resolveMethodCore(input);
     },
 
     resolveSlugs(input) {
       const connectors: ResolvedConnectorSlug[] = [];
       for (const connectorSlug of input.connectorSlugs) {
-        const resolved = resolveSlug({
+        const resolved = resolveSlugCore({
           connectorSlug,
           requireExecutable: input.requireExecutable,
         });

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -191,6 +191,11 @@ function pendingStoredConnectorRuntimes(
   >();
 
   for (const row of rows) {
+    if (pending.has(row.connectorSlug)) {
+      throw new Error(
+        `Duplicate stored connector state for ${row.connectorSlug}`,
+      );
+    }
     const accessResult = resolveConnectorCredentialAccess({
       snapshot: args.snapshot,
       stored: {
@@ -204,11 +209,6 @@ function pendingStoredConnectorRuntimes(
     });
     if (!isConnectorSlug(args.snapshot, row.connectorSlug)) {
       continue;
-    }
-    if (pending.has(row.connectorSlug)) {
-      throw new Error(
-        `Duplicate stored connector state for ${row.connectorSlug}`,
-      );
     }
     if (accessResult.kind !== "ok") {
       pending.set(row.connectorSlug, null);

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -191,14 +191,6 @@ function pendingStoredConnectorRuntimes(
   >();
 
   for (const row of rows) {
-    if (!isConnectorSlug(args.snapshot, row.connectorSlug)) {
-      continue;
-    }
-    if (pending.has(row.connectorSlug)) {
-      throw new Error(
-        `Duplicate stored connector state for ${row.connectorSlug}`,
-      );
-    }
     const accessResult = resolveConnectorCredentialAccess({
       snapshot: args.snapshot,
       stored: {
@@ -210,6 +202,14 @@ function pendingStoredConnectorRuntimes(
         userId: args.userId,
       },
     });
+    if (!isConnectorSlug(args.snapshot, row.connectorSlug)) {
+      continue;
+    }
+    if (pending.has(row.connectorSlug)) {
+      throw new Error(
+        `Duplicate stored connector state for ${row.connectorSlug}`,
+      );
+    }
     if (accessResult.kind !== "ok") {
       pending.set(row.connectorSlug, null);
       continue;

--- a/turbo/apps/api/src/signals/services/connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-access.service.ts
@@ -17,12 +17,15 @@ import {
 } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
+import { logger } from "../../lib/log";
 import type { ReadonlyDb } from "../external/db";
 import {
   getConnectorRuntimeMethod,
   type ConnectorRuntimeMethod,
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
+
+const log = logger("api:connector-credential-access");
 
 /**
  * One executable stored connection, resolved against one immutable catalog
@@ -76,15 +79,37 @@ export function connectorCredentialStorageIsCompatible(args: {
   return args.storageVersion === args.runtimeMethod.method.storage.version;
 }
 
-export function resolveConnectorCredentialAccess(args: {
+export function resolveStoredConnectorRuntimeMethod(args: {
   readonly snapshot: ConnectorRuntimeSnapshot;
-  readonly stored: ConnectorCredentialStoredIdentity;
-}): ConnectorCredentialAccessResult {
+  readonly stored: {
+    readonly authMethodId: string;
+    readonly connectorId: string;
+    readonly connectorSlug: string;
+  };
+}): ConnectorRuntimeMethod | undefined {
   const runtimeMethod = getConnectorRuntimeMethod({
     snapshot: args.snapshot,
     connectorSlug: args.stored.connectorSlug,
     authMethodId: args.stored.authMethodId,
     requireExecutable: true,
+  });
+  if (runtimeMethod === undefined) {
+    log.warn("Stored connector runtime method is unavailable", {
+      connectorId: args.stored.connectorId,
+      connectorSlug: args.stored.connectorSlug,
+      authMethodId: args.stored.authMethodId,
+    });
+  }
+  return runtimeMethod;
+}
+
+export function resolveConnectorCredentialAccess(args: {
+  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly stored: ConnectorCredentialStoredIdentity;
+}): ConnectorCredentialAccessResult {
+  const runtimeMethod = resolveStoredConnectorRuntimeMethod({
+    snapshot: args.snapshot,
+    stored: args.stored,
   });
   if (!runtimeMethod) {
     return { kind: "unavailable" };

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -225,7 +225,7 @@ async function resolveStoredExternalCodeMethod(args: {
     expectedGrantKind: "external-code",
   });
   if (!resolved.ok) {
-    return internalServerError("Invalid external-code authorization session");
+    return connectorExternalCodeUnavailable(args.connectorSlug);
   }
   return resolved;
 }

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -110,6 +110,18 @@ const connectorExternalCodeDisabled = Object.freeze({
   }),
 });
 
+function connectorExternalCodeUnavailable(connectorSlug: ConnectorSlug) {
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: `${connectorSlug} connector is not available`,
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
+
 function externalCodeResolutionError(
   resolution: Exclude<ConnectorActionMethodResolution, { readonly ok: true }>,
   args: {
@@ -144,7 +156,7 @@ function externalCodeResolutionError(
       return connectorExternalCodeDisabled;
     }
     case "missing_executable_capability": {
-      return internalServerError("Connector execution is not configured");
+      return connectorExternalCodeUnavailable(args.connectorSlug);
     }
   }
 }

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -182,6 +182,18 @@ const connectorOauthDeviceAuthDisabled = Object.freeze({
   }),
 });
 
+function connectorOauthDeviceAuthUnavailable(connectorSlug: ConnectorSlug) {
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: `${connectorSlug} connector is not available`,
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
+
 function deviceAuthResolutionError(
   resolution: Exclude<ConnectorActionMethodResolution, { readonly ok: true }>,
   args: {
@@ -227,7 +239,7 @@ function deviceAuthResolutionError(
       return connectorOauthDeviceAuthDisabled;
     }
     case "missing_executable_capability": {
-      return internalServerError("Connector execution is not configured");
+      return connectorOauthDeviceAuthUnavailable(args.connectorSlug);
     }
   }
 }

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -369,7 +369,7 @@ async function resolveStoredDeviceAuthMethod(args: {
     expectedGrantKind: "device-auth",
   });
   if (!resolved.ok) {
-    return internalServerError("Invalid OAuth device authorization session");
+    return connectorOauthDeviceAuthUnavailable(args.connectorSlug);
   }
   return resolved;
 }

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -64,8 +64,10 @@ import {
   deleteOrgUsageData,
   deleteUserUsageData,
 } from "./usage-event-cleanup.service";
-import { deleteZeroConnectorLocalState$ } from "./zero-connector-data.service";
-import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+import {
+  deleteZeroConnectorLocalState$,
+  loadStoredConnectorRuntimeSnapshot,
+} from "./zero-connector-data.service";
 import { deleteConnectorOwnerState } from "./connector-owner-cleanup.service";
 
 const L = logger("WebhookClerkCleanup");
@@ -379,7 +381,7 @@ const revokeOrgConnectorTokens$ = command(
     orgId: string,
     signal: AbortSignal,
   ): Promise<void> => {
-    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    const snapshot = await loadStoredConnectorRuntimeSnapshot(db);
     signal.throwIfAborted();
     const rows = await db
       .select({
@@ -423,7 +425,7 @@ const revokeUserConnectorTokens$ = command(
     userId: string,
     signal: AbortSignal,
   ): Promise<void> => {
-    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    const snapshot = await loadStoredConnectorRuntimeSnapshot(db);
     signal.throwIfAborted();
     const rows = await db
       .select({

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -1,4 +1,3 @@
-import { connectorSlugSchema } from "@okouai/api-contracts/contracts/connector-identity";
 import {
   agentComposes,
   agentComposeVersions,
@@ -38,6 +37,7 @@ import { command, computed, type Computed } from "ccstate";
 import { and, count, eq, inArray, isNotNull, like, sql } from "drizzle-orm";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
+import { pgTextDecoder } from "../../lib/db-structured-result";
 import {
   sharedThreadArtifactAuthorUserId,
   SHARED_THREAD_ARTIFACT_LOGICAL_KEY_PREFIX,
@@ -386,7 +386,9 @@ const revokeOrgConnectorTokens$ = command(
     const rows = await db
       .select({
         userId: connectors.userId,
-        connectorSlug: connectors.connectorSlug,
+        connectorSlug: sql`${connectors.connectorSlug}`
+          .mapWith(pgTextDecoder)
+          .as("connector_slug"),
       })
       .from(connectors)
       .where(
@@ -395,21 +397,12 @@ const revokeOrgConnectorTokens$ = command(
     signal.throwIfAborted();
 
     for (const row of rows) {
-      const parsed = connectorSlugSchema.safeParse(row.connectorSlug);
-      if (!parsed.success) {
-        L.warn("unknown connector slug, skipping revocation", {
-          orgId,
-          connectorSlug: row.connectorSlug,
-        });
-        continue;
-      }
-
       await set(
         deleteZeroConnectorLocalState$,
         {
           orgId,
           userId: row.userId,
-          connectorSlug: parsed.data,
+          connectorSlug: row.connectorSlug,
           snapshot,
         },
         signal,
@@ -430,7 +423,9 @@ const revokeUserConnectorTokens$ = command(
     const rows = await db
       .select({
         orgId: connectors.orgId,
-        connectorSlug: connectors.connectorSlug,
+        connectorSlug: sql`${connectors.connectorSlug}`
+          .mapWith(pgTextDecoder)
+          .as("connector_slug"),
       })
       .from(connectors)
       .where(
@@ -439,21 +434,12 @@ const revokeUserConnectorTokens$ = command(
     signal.throwIfAborted();
 
     for (const row of rows) {
-      const parsed = connectorSlugSchema.safeParse(row.connectorSlug);
-      if (!parsed.success) {
-        L.warn("unknown connector slug, skipping revocation", {
-          userId,
-          connectorSlug: row.connectorSlug,
-        });
-        continue;
-      }
-
       await set(
         deleteZeroConnectorLocalState$,
         {
           orgId: row.orgId,
           userId,
-          connectorSlug: parsed.data,
+          connectorSlug: row.connectorSlug,
           snapshot,
         },
         signal,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -34,10 +34,11 @@ import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
 import { pgTextDecoder } from "../../lib/db-structured-result";
+import { logger } from "../../lib/log";
 import type { Tx } from "../../lib/db-types";
 import { nowDate } from "../../lib/time";
 import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
-import { bestEffort } from "../utils";
+import { bestEffort, settle } from "../utils";
 import {
   decryptStoredSecretValue,
   encryptStoredSecretValue,
@@ -55,6 +56,7 @@ import {
   connectorCredentialSecretReadCondition,
   connectorCredentialStorageIsCompatible,
   resolveConnectorCredentialAccess,
+  resolveStoredConnectorRuntimeMethod,
   type ConnectorCredentialAccess,
 } from "./connector-credential-access.service";
 import { publishBuiltinConnectorInvalidationAfterCommit } from "./connector-client-invalidation.service";
@@ -64,9 +66,11 @@ import {
   upsertConnectorOwnedVariable,
 } from "./connector-credential-storage-write.service";
 import { normalizeManualGrantSubmittedValuesWithMethod } from "./connector-catalog-form-fields.service";
-import { searchConnectorCatalog } from "./connector-catalog-reader.service";
 import {
-  getConnectorRuntimeMethod,
+  isConnectorCatalogUnavailableError,
+  searchConnectorCatalog,
+} from "./connector-catalog-reader.service";
+import {
   loadConnectorRuntimeSnapshot,
   type ConnectorRuntimeMethod,
   type ConnectorRuntimeSnapshot,
@@ -80,6 +84,7 @@ import {
   type StoredConnectorConnectionRow as StoredConnectorRow,
 } from "./connector-connection-write.service";
 
+const log = logger("api:zero-connector-data");
 const oauthScopesSchema = z.array(z.string());
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
 interface ExternalUserInfo {
@@ -161,6 +166,27 @@ type PendingConnectorTokenRevoke = {
   readonly featureSwitchContext: FeatureSwitchContext;
 };
 
+/**
+ * External catalog availability must not turn persisted connector reads or
+ * local cleanup into server failures. Callers use a missing snapshot to skip
+ * runtime-dependent presentation and provider revocation only.
+ */
+export async function loadStoredConnectorRuntimeSnapshot(
+  db: ReadonlyDb,
+): Promise<ConnectorRuntimeSnapshot | null> {
+  const result = await settle(loadConnectorRuntimeSnapshot(db));
+  if (result.ok) {
+    return result.value;
+  }
+  if (!isConnectorCatalogUnavailableError(result.error)) {
+    throw result.error;
+  }
+  log.warn("Connector catalog unavailable while resolving stored connectors", {
+    error: result.error,
+  });
+  return null;
+}
+
 function parseOauthScopes(value: string | null): string[] | null {
   return value ? oauthScopesSchema.parse(JSON.parse(value)) : null;
 }
@@ -217,6 +243,29 @@ function storedConnectorRowToResponse(
     tokenExpiresAt: row.tokenExpiresAt?.toISOString() ?? null,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function storedConnectorRowWithRuntimeMethod(args: {
+  readonly connectorSlug: string;
+  readonly now: Date;
+  readonly row: StoredConnectorRow;
+  readonly snapshot: ConnectorRuntimeSnapshot;
+}): ConnectorWithRuntimeMethod | null {
+  const runtimeMethod = resolveStoredConnectorRuntimeMethod({
+    snapshot: args.snapshot,
+    stored: {
+      connectorId: args.row.id,
+      connectorSlug: args.connectorSlug,
+      authMethodId: args.row.authMethod,
+    },
+  });
+  if (runtimeMethod === undefined) {
+    return null;
+  }
+  return {
+    response: storedConnectorRowToResponse(args.row, runtimeMethod, args.now),
+    runtimeMethod,
   };
 }
 
@@ -431,28 +480,21 @@ export function zeroConnectorList(args: {
       );
     const [storedRows, snapshot] = await Promise.all([
       storedRowsPromise,
-      loadConnectorRuntimeSnapshot(db),
+      loadStoredConnectorRuntimeSnapshot(db),
     ]);
     const now = nowDate();
-    const connectorList: ConnectorWithRuntimeMethod[] = storedRows.map(
-      (row) => {
-        const runtimeMethod = getConnectorRuntimeMethod({
-          snapshot,
-          connectorSlug: row.connectorSlug,
-          authMethodId: row.authMethod,
-          requireExecutable: true,
-        });
-        if (runtimeMethod === undefined) {
-          throw new Error(
-            `Stored connector ${row.connectorSlug}:${row.authMethod} has no executable runtime method`,
-          );
-        }
-        return {
-          response: storedConnectorRowToResponse(row, runtimeMethod, now),
-          runtimeMethod,
-        };
-      },
-    );
+    const connectorList: ConnectorWithRuntimeMethod[] =
+      snapshot === null
+        ? []
+        : storedRows.flatMap((row) => {
+            const connector = storedConnectorRowWithRuntimeMethod({
+              connectorSlug: row.connectorSlug,
+              now,
+              row,
+              snapshot,
+            });
+            return connector === null ? [] : [connector];
+          });
     const connectorProvidedBindings =
       connectorProvidedBindingsForStoredConnectors(connectorList);
 
@@ -514,8 +556,8 @@ function storedConnectorBySlug(args: {
   readonly userId: string;
   readonly connectorSlug: string;
   readonly snapshot: ConnectorRuntimeSnapshot;
-}): Computed<Promise<ConnectorResponse | null>> {
-  return computed(async (get): Promise<ConnectorResponse | null> => {
+}): Computed<Promise<ConnectorWithRuntimeMethod | null>> {
+  return computed(async (get): Promise<ConnectorWithRuntimeMethod | null> => {
     const db = get(db$);
     const oauthRows = await db
       .select({
@@ -544,18 +586,12 @@ function storedConnectorBySlug(args: {
 
     const oauthRow = oauthRows[0];
     if (oauthRow) {
-      const runtimeMethod = getConnectorRuntimeMethod({
-        snapshot: args.snapshot,
+      return storedConnectorRowWithRuntimeMethod({
         connectorSlug: args.connectorSlug,
-        authMethodId: oauthRow.authMethod,
-        requireExecutable: true,
+        now: nowDate(),
+        row: oauthRow,
+        snapshot: args.snapshot,
       });
-      if (runtimeMethod === undefined) {
-        throw new Error(
-          `Stored connector ${args.connectorSlug}:${oauthRow.authMethod} has no executable runtime method`,
-        );
-      }
-      return storedConnectorRowToResponse(oauthRow, runtimeMethod, nowDate());
     }
 
     return null;
@@ -570,8 +606,12 @@ export function zeroConnectorBySlug(args: {
 }): Computed<Promise<ConnectorResponse | null>> {
   return computed(async (get): Promise<ConnectorResponse | null> => {
     const snapshot =
-      args.snapshot ?? (await loadConnectorRuntimeSnapshot(get(db$)));
-    return await get(storedConnectorBySlug({ ...args, snapshot }));
+      args.snapshot ?? (await loadStoredConnectorRuntimeSnapshot(get(db$)));
+    if (snapshot === null) {
+      return null;
+    }
+    const connector = await get(storedConnectorBySlug({ ...args, snapshot }));
+    return connector?.response ?? null;
   });
 }
 
@@ -697,22 +737,28 @@ export const deleteZeroConnectorLocalState$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly connectorSlug: string;
-      readonly snapshot?: ConnectorRuntimeSnapshot;
+      readonly snapshot?: ConnectorRuntimeSnapshot | null;
     },
     signal: AbortSignal,
   ): Promise<boolean> => {
     const writeDb = set(writeDb$);
     const snapshot =
-      args.snapshot ?? (await loadConnectorRuntimeSnapshot(get(db$)));
-    const featureSwitchOverrides = await get(
-      userFeatureSwitchOverrides(args.orgId, args.userId),
-    );
+      args.snapshot === undefined
+        ? await loadStoredConnectorRuntimeSnapshot(get(db$))
+        : args.snapshot;
+    const featureSwitchOverrides =
+      snapshot === null
+        ? null
+        : await get(userFeatureSwitchOverrides(args.orgId, args.userId));
     signal.throwIfAborted();
-    const featureSwitchContext = {
-      orgId: args.orgId,
-      userId: args.userId,
-      overrides: featureSwitchOverrides,
-    } satisfies FeatureSwitchContext;
+    const featureSwitchContext =
+      featureSwitchOverrides === null
+        ? null
+        : ({
+            orgId: args.orgId,
+            userId: args.userId,
+            overrides: featureSwitchOverrides,
+          } satisfies FeatureSwitchContext);
 
     let postCommitAbort: unknown = null;
     const deleteResult = await writeDb.transaction(async (tx) => {
@@ -745,31 +791,33 @@ export const deleteZeroConnectorLocalState$ = command(
         return { deleted: false, pendingTokenRevoke: null };
       }
 
-      const accessResult = resolveConnectorCredentialAccess({
-        snapshot,
-        stored: {
-          authMethodId: existing.authMethod,
-          connectorId: existing.id,
-          connectorSlug: args.connectorSlug,
-          orgId: args.orgId,
-          storageVersion: existing.storageVersion,
-          userId: args.userId,
-        },
-      });
-
       let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
-      if (
-        accessResult.kind === "ok" &&
-        accessResult.access.runtimeMethod.method.revoke.kind === "token-revoke"
-      ) {
-        pendingTokenRevoke = await loadPendingConnectorTokenRevoke(
-          {
-            access: accessResult.access,
-            db: tx,
-            featureSwitchContext,
+      if (snapshot !== null && featureSwitchContext !== null) {
+        const accessResult = resolveConnectorCredentialAccess({
+          snapshot,
+          stored: {
+            authMethodId: existing.authMethod,
+            connectorId: existing.id,
+            connectorSlug: args.connectorSlug,
+            orgId: args.orgId,
+            storageVersion: existing.storageVersion,
+            userId: args.userId,
           },
-          signal,
-        );
+        });
+        if (
+          accessResult.kind === "ok" &&
+          accessResult.access.runtimeMethod.method.revoke.kind ===
+            "token-revoke"
+        ) {
+          pendingTokenRevoke = await loadPendingConnectorTokenRevoke(
+            {
+              access: accessResult.access,
+              db: tx,
+              featureSwitchContext,
+            },
+            signal,
+          );
+        }
       }
       signal.throwIfAborted();
 
@@ -1847,22 +1895,16 @@ export function zeroConnectorScopeDiff(args: {
 }): Computed<Promise<ScopeDiffResponse | null>> {
   return computed(async (get): Promise<ScopeDiffResponse | null> => {
     const snapshot =
-      args.snapshot ?? (await loadConnectorRuntimeSnapshot(get(db$)));
-    const connector = await get(zeroConnectorBySlug({ ...args, snapshot }));
-    if (!connector) {
+      args.snapshot ?? (await loadStoredConnectorRuntimeSnapshot(get(db$)));
+    if (snapshot === null) {
       return null;
     }
-    const runtimeMethod = getConnectorRuntimeMethod({
-      snapshot,
-      connectorSlug: args.connectorSlug,
-      authMethodId: connector.authMethod,
-      requireExecutable: true,
-    });
-    return runtimeMethod === undefined
+    const connector = await get(storedConnectorBySlug({ ...args, snapshot }));
+    return connector === null
       ? null
       : connectorAuthMethodScopeDiff(
-          runtimeMethod.method,
-          connector.oauthScopes,
+          connector.runtimeMethod.method,
+          connector.response.oauthScopes,
         );
   });
 }

--- a/turbo/apps/api/src/test-fixtures/connector-catalog.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog.ts
@@ -7,6 +7,7 @@ import {
   connectorCatalogCompatibilityEvaluation,
   connectorCatalogSyncState,
 } from "@okouai/db/schema/connector-catalog";
+import type { ConnectorCatalogCompatibilityEvaluationPayload } from "@okouai/db/jsonb-contracts/connector-catalog";
 import { and, asc, eq } from "drizzle-orm";
 
 import { mockOptionalEnv } from "../lib/env";
@@ -23,6 +24,7 @@ import {
 } from "../signals/services/connector-catalog-artifacts/relationships";
 import {
   connectorCatalogExecutableCapabilityState,
+  connectorCatalogCompatibilityEvaluationSchema,
   persistConnectorCatalogCompatibility,
 } from "../signals/services/connector-catalog-compatibility.service";
 import { connectorCatalogSource } from "../signals/services/connector-catalog-source";
@@ -417,6 +419,22 @@ export async function invalidateApiTestConnectorCatalogCompatibility(): Promise<
     .where(currentApiTestConnectorCatalogCompatibilityWhere(identity))
     .returning({ sourceId: connectorCatalogCompatibilityEvaluation.sourceId });
   requireSingleCatalogMutation(updated, "compatibility corruption");
+}
+
+export async function replaceApiTestConnectorCatalogFilteredAuthMethods(
+  filteredAuthMethods: ConnectorCatalogCompatibilityEvaluationPayload["filteredAuthMethods"],
+): Promise<void> {
+  const identity = await currentApiTestConnectorCatalogIdentity();
+  const payload = connectorCatalogCompatibilityEvaluationSchema.parse({
+    filteredAuthMethods,
+  });
+  const db = store.set(writeDb$);
+  const updated = await db
+    .update(connectorCatalogCompatibilityEvaluation)
+    .set({ filteredAuthMethods: payload })
+    .where(currentApiTestConnectorCatalogCompatibilityWhere(identity))
+    .returning({ sourceId: connectorCatalogCompatibilityEvaluation.sourceId });
+  requireSingleCatalogMutation(updated, "compatibility filter replacement");
 }
 
 export async function deleteApiTestConnectorCatalogCompatibility(): Promise<void> {


### PR DESCRIPTION
## Summary

- treat unavailable external connector runtime methods as warning-level unavailability
- omit unavailable stored connectors from list, detail, binding, scope-diff, diagnostic, and agent-configuration projections
- keep local disconnect and Clerk cleanup independent of catalog availability or slug membership
- return the existing connector-unavailable response for new and in-flight actions without executable runtime support

## Problem

The accepted external connector catalog can temporarily lag the API's provider/storage contract. A stored connector whose auth method is filtered from the executable runtime snapshot then caused connector reads to throw, for example `Stored connector playstation:api has no executable runtime method`.

External catalog drift must not turn unrelated connector reads, in-flight authorization continuations, or local cleanup into server failures. Credential reads, firewall materialization, and runtime authorization must still fail closed.

## Behavior

- Stored runtime lookup emits structured warnings without logging credentials.
- Collection reads skip only unavailable rows; retained rows continue producing runtime bindings.
- Singular reads and scope diff treat an unavailable stored connector as not found.
- Diagnostics and persisted agent connector projections warn and omit unavailable connector identities.
- Disconnect deletes local credentials, watches, and connector state even when the connector or catalog is unavailable.
- Organization and user cleanup delete persisted connector state without requiring the slug to remain in the catalog.
- Manual, no-auth, OAuth, OpenID, external-code, and device-auth starts return connector unavailable when the selected catalog method has no executable runtime capability.
- Device-auth polling and external-code completion also return connector unavailable if their runtime disappears after the session starts.
- Database, decryption, provider, malformed persisted-state, and internal invariant errors continue to propagate normally.

## Fallbacks

- **Per-row stored connector omission:** When an accepted catalog exists but a stored connector or auth method has no executable runtime, list/detail/scope/diagnostic projections omit that connector and emit a warning. This is a permanent compatibility fallback while the connector catalog is independently published.
- **Catalog-independent local deletion:** When the accepted external catalog is unavailable, disconnect and Clerk cleanup skip runtime-dependent provider revocation but still remove local state. Provider revocation was already best-effort; this fallback is permanent and has no rollout expiry.
- **In-flight action unavailability:** If a valid persisted authorization session no longer resolves against the accepted catalog, completion stops before provider execution and returns the existing unavailable response.

## Risks

- A transient full catalog outage can make stored connector reads appear empty or not found until the catalog recovers.
- Disconnect during a catalog outage cannot attempt provider-side token revocation, although local credentials are still deleted.
- A catalog rollout that removes or changes a method can interrupt an already-started external-code or device-auth session; clients now receive 403 instead of an internal error.
- Warnings can repeat while stale persisted references remain in active use.

## Out of scope

- relaxing connector contract compatibility checks
- making connector execution proceed without an executable runtime method
- fabricating an empty catalog for discovery, firewall, permission, or execution paths
- changing provider-specific connector contracts or external catalog publication
- adding retries, sleeps, timeout increases, or skipped tests

## Validation

- `pnpm -F api exec vitest run <8 affected API test files> --maxWorkers=4 --silent=passed-only` (126 tests, 10.75 seconds total; 5.06 seconds test execution)
- focused device-auth polling and external-code completion regressions (2 tests, 162 ms test execution)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- targeted Prettier and `git diff --check`
- pre-commit hooks: repository-wide Prettier, Knip, Turbo type checks across 16 workspaces, file-size check, and commitlint

Closes #27042
