### PR TITLE
refactor(integrations): neutralize upload-init route shells

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -141,10 +141,10 @@ import { zeroIntegrationsAgentPhoneRoutes } from "./routes/zero-integrations-age
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "./routes/zero-integrations-phone-download-file";
 import { zeroIntegrationsPhoneMessageRoutes } from "./routes/zero-integrations-phone-message";
 import { zeroIntegrationsPhoneUploadCompleteRoutes } from "./routes/zero-integrations-phone-upload-complete";
-import { zeroIntegrationsPhoneUploadInitRoutes } from "./routes/zero-integrations-phone-upload-init";
+import { integrationsPhoneUploadInitRoutes } from "./routes/integrations-phone-upload-init";
 import { zeroIntegrationsGithubDownloadFileRoutes } from "./routes/zero-integrations-github-download-file";
 import { zeroIntegrationsGithubUploadCompleteRoutes } from "./routes/zero-integrations-github-upload-complete";
-import { zeroIntegrationsGithubUploadInitRoutes } from "./routes/zero-integrations-github-upload-init";
+import { integrationsGithubUploadInitRoutes } from "./routes/integrations-github-upload-init";
 import { zeroIntegrationsFeishuFileRoutes } from "./routes/zero-integrations-feishu-files";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
 import { zeroIntegrationsSlackMessageRoutes } from "./routes/zero-integrations-slack-message";
@@ -155,11 +155,11 @@ import { zeroIntegrationsSlackUploadMaterializeRoutes } from "./routes/zero-inte
 import { zeroIntegrationsTeamsDownloadFileRoutes } from "./routes/zero-integrations-teams-download-file";
 import { zeroIntegrationsTeamsMessageRoutes } from "./routes/zero-integrations-teams-message";
 import { zeroIntegrationsTeamsUploadCompleteRoutes } from "./routes/zero-integrations-teams-upload-complete";
-import { zeroIntegrationsTeamsUploadInitRoutes } from "./routes/zero-integrations-teams-upload-init";
+import { integrationsTeamsUploadInitRoutes } from "./routes/integrations-teams-upload-init";
 import { zeroIntegrationsTelegramRoutes } from "./routes/zero-integrations-telegram";
 import { zeroIntegrationsTelegramMessageRoutes } from "./routes/zero-integrations-telegram-message";
 import { zeroIntegrationsTelegramUploadCompleteRoutes } from "./routes/zero-integrations-telegram-upload-complete";
-import { zeroIntegrationsTelegramUploadInitRoutes } from "./routes/zero-integrations-telegram-upload-init";
+import { integrationsTelegramUploadInitRoutes } from "./routes/integrations-telegram-upload-init";
 import { zeroSlackChannelsRoutes } from "./routes/zero-slack-channels";
 import { zeroSlackCommandsRoutes } from "./routes/zero-slack-commands";
 import { zeroSlackConnectRoutes } from "./routes/zero-slack-connect";
@@ -354,10 +354,10 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroIntegrationsPhoneDownloadFileRoutes,
   ...zeroIntegrationsPhoneMessageRoutes,
   ...zeroIntegrationsPhoneUploadCompleteRoutes,
-  ...zeroIntegrationsPhoneUploadInitRoutes,
+  ...integrationsPhoneUploadInitRoutes,
   ...zeroIntegrationsGithubDownloadFileRoutes,
   ...zeroIntegrationsGithubUploadCompleteRoutes,
-  ...zeroIntegrationsGithubUploadInitRoutes,
+  ...integrationsGithubUploadInitRoutes,
   ...zeroIntegrationsFeishuFileRoutes,
   ...zeroIntegrationsSlackRoutes,
   ...zeroIntegrationsSlackMessageRoutes,
@@ -368,13 +368,13 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroIntegrationsTeamsDownloadFileRoutes,
   ...zeroIntegrationsTeamsMessageRoutes,
   ...zeroIntegrationsTeamsUploadCompleteRoutes,
-  ...zeroIntegrationsTeamsUploadInitRoutes,
+  ...integrationsTeamsUploadInitRoutes,
   ...zeroSlackChannelsRoutes,
   ...steamPlayerRoutes,
   ...zeroIntegrationsTelegramRoutes,
   ...zeroIntegrationsTelegramMessageRoutes,
   ...zeroIntegrationsTelegramUploadCompleteRoutes,
-  ...zeroIntegrationsTelegramUploadInitRoutes,
+  ...integrationsTelegramUploadInitRoutes,
   ...zeroTeamRoutes,
   ...zeroUploadsCompleteRoutes,
   ...zeroUploadsMultipartRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
@@ -27,7 +27,7 @@ import {
 import { sessionHistoryBlobBodyForKey } from "./api-bdd-session-history";
 import { createZeroRouteMocks } from "./zero-route-test";
 import { zeroIntegrationsPhoneUploadCompleteRoutes } from "../../zero-integrations-phone-upload-complete";
-import { zeroIntegrationsPhoneUploadInitRoutes } from "../../zero-integrations-phone-upload-init";
+import { integrationsPhoneUploadInitRoutes } from "../../integrations-phone-upload-init";
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "../../zero-integrations-phone-download-file";
 import { logsRoutes } from "../../logs";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
@@ -36,7 +36,7 @@ import { zeroModelProvidersRoutes } from "../../zero-model-providers";
 const TEST_APP_ROUTES = Object.freeze([
   ...zeroIntegrationsPhoneDownloadFileRoutes,
   ...zeroIntegrationsPhoneUploadCompleteRoutes,
-  ...zeroIntegrationsPhoneUploadInitRoutes,
+  ...integrationsPhoneUploadInitRoutes,
   ...logsRoutes,
   ...zeroModelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
@@ -300,7 +300,7 @@ export function createAgentPhoneBddApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsPhoneUploadInitRoutes,
+        routes: integrationsPhoneUploadInitRoutes,
       })(integrationsPhoneUploadInitContract);
       return await accept(
         client.init({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -63,11 +63,11 @@ import { testSlackStateRoutes } from "../../test-slack-state";
 import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
 import { zeroIntegrationsAgentPhoneRoutes } from "../../zero-integrations-agentphone";
 import { zeroIntegrationsGithubUploadCompleteRoutes } from "../../zero-integrations-github-upload-complete";
-import { zeroIntegrationsGithubUploadInitRoutes } from "../../zero-integrations-github-upload-init";
+import { integrationsGithubUploadInitRoutes } from "../../integrations-github-upload-init";
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "../../zero-integrations-phone-download-file";
 import { zeroIntegrationsPhoneMessageRoutes } from "../../zero-integrations-phone-message";
 import { zeroIntegrationsPhoneUploadCompleteRoutes } from "../../zero-integrations-phone-upload-complete";
-import { zeroIntegrationsPhoneUploadInitRoutes } from "../../zero-integrations-phone-upload-init";
+import { integrationsPhoneUploadInitRoutes } from "../../integrations-phone-upload-init";
 import { zeroIntegrationsSlackRoutes } from "../../zero-integrations-slack";
 import { zeroIntegrationsSlackMessageRoutes } from "../../zero-integrations-slack-message";
 import { zeroIntegrationsSlackUploadCompleteRoutes } from "../../zero-integrations-slack-upload-complete";
@@ -75,7 +75,7 @@ import { zeroIntegrationsSlackUploadInitRoutes } from "../../zero-integrations-s
 import { zeroIntegrationsTelegramRoutes } from "../../zero-integrations-telegram";
 import { zeroIntegrationsTelegramMessageRoutes } from "../../zero-integrations-telegram-message";
 import { zeroIntegrationsTelegramUploadCompleteRoutes } from "../../zero-integrations-telegram-upload-complete";
-import { zeroIntegrationsTelegramUploadInitRoutes } from "../../zero-integrations-telegram-upload-init";
+import { integrationsTelegramUploadInitRoutes } from "../../integrations-telegram-upload-init";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
 import { zeroSlackChannelsRoutes } from "../../zero-slack-channels";
@@ -93,18 +93,18 @@ const TEST_APP_ROUTES = Object.freeze([
   ...zeroFeatureSwitchesRoutes,
   ...zeroIntegrationsAgentPhoneRoutes,
   ...zeroIntegrationsGithubUploadCompleteRoutes,
-  ...zeroIntegrationsGithubUploadInitRoutes,
+  ...integrationsGithubUploadInitRoutes,
   ...zeroIntegrationsPhoneDownloadFileRoutes,
   ...zeroIntegrationsPhoneMessageRoutes,
   ...zeroIntegrationsPhoneUploadCompleteRoutes,
-  ...zeroIntegrationsPhoneUploadInitRoutes,
+  ...integrationsPhoneUploadInitRoutes,
   ...zeroIntegrationsSlackMessageRoutes,
   ...zeroIntegrationsSlackUploadCompleteRoutes,
   ...zeroIntegrationsSlackUploadInitRoutes,
   ...zeroIntegrationsSlackRoutes,
   ...zeroIntegrationsTelegramMessageRoutes,
   ...zeroIntegrationsTelegramUploadCompleteRoutes,
-  ...zeroIntegrationsTelegramUploadInitRoutes,
+  ...integrationsTelegramUploadInitRoutes,
   ...zeroIntegrationsTelegramRoutes,
   ...zeroModelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
@@ -1543,7 +1543,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramUploadInitRoutes,
+        routes: integrationsTelegramUploadInitRoutes,
       })(integrationsTelegramUploadInitContract);
       return await accept(
         client.init({
@@ -1627,7 +1627,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsGithubUploadInitRoutes,
+        routes: integrationsGithubUploadInitRoutes,
       })(integrationsGithubUploadInitContract);
       return await accept(
         client.init({
@@ -1763,7 +1763,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsPhoneUploadInitRoutes,
+        routes: integrationsPhoneUploadInitRoutes,
       })(integrationsPhoneUploadInitContract);
       return await accept(
         client.init({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-github-files.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-github-files.test.ts
@@ -21,13 +21,13 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createComposesBddApi } from "./helpers/api-bdd-composes";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { zeroIntegrationsGithubUploadCompleteRoutes } from "../zero-integrations-github-upload-complete";
-import { zeroIntegrationsGithubUploadInitRoutes } from "../zero-integrations-github-upload-init";
+import { integrationsGithubUploadInitRoutes } from "../integrations-github-upload-init";
 import { zeroIntegrationsGithubDownloadFileRoutes } from "../zero-integrations-github-download-file";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...zeroIntegrationsGithubDownloadFileRoutes,
   ...zeroIntegrationsGithubUploadCompleteRoutes,
-  ...zeroIntegrationsGithubUploadInitRoutes,
+  ...integrationsGithubUploadInitRoutes,
 ]);
 
 const context = testContext();
@@ -283,7 +283,7 @@ describe("GitHub zero file integration routes", () => {
     const fixture = await seedFixture();
     const client = setupApp({
       context,
-      routes: zeroIntegrationsGithubUploadInitRoutes,
+      routes: integrationsGithubUploadInitRoutes,
     })(integrationsGithubUploadInitContract);
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/integrations-github-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-github-upload-init.ts
@@ -65,7 +65,7 @@ const githubWriteAuth = {
   requiredCapability: "github:write",
 } as const;
 
-export const zeroIntegrationsGithubUploadInitRoutes: readonly RouteEntry[] = [
+export const integrationsGithubUploadInitRoutes: readonly RouteEntry[] = [
   {
     route: integrationsGithubUploadInitContract.init,
     handler: authRoute(githubWriteAuth, init$),

--- a/turbo/apps/api/src/signals/routes/integrations-phone-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-phone-upload-init.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { integrationsTelegramUploadInitContract } from "@okouai/api-contracts/contracts/integrations";
+import { integrationsPhoneUploadInitContract } from "@okouai/api-contracts/contracts/integrations";
 
 import { env } from "../../lib/env";
 import { sanitizeArtifactFilename } from "../../lib/file-url";
@@ -12,24 +12,23 @@ import type { RouteEntry } from "../route-entry";
 
 const PUT_URL_TTL_SECONDS = 3600;
 
-const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+const init$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
-
   const bodyResult = await get(
-    bodyResultOf(integrationsTelegramUploadInitContract.init),
+    bodyResultOf(integrationsPhoneUploadInitContract.init),
   );
   signal.throwIfAborted();
   if (!bodyResult.ok) {
     return bodyResult.response;
   }
 
-  const { filename, contentType, length } = bodyResult.data;
-  const sanitized = sanitizeArtifactFilename(filename);
+  const body = bodyResult.data;
+  const filename = sanitizeArtifactFilename(body.filename);
   const artifact = await set(
     allocateArtifactObject$,
     {
       userId: auth.userId,
-      filename,
+      filename: body.filename,
     },
     signal,
   );
@@ -39,7 +38,7 @@ const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     generatePresignedPutUrl(
       bucket,
       artifact.key,
-      contentType,
+      body.contentType,
       PUT_URL_TTL_SECONDS,
       { usePublicEndpoint: true, metadata: artifact.metadata },
     ),
@@ -52,17 +51,17 @@ const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       uploadId: artifact.id,
       uploadUrl,
       fileUrl: artifact.url,
-      filename: sanitized,
-      contentType,
-      size: length,
+      filename,
+      contentType: body.contentType,
+      size: body.length,
       ...(uploadHeaders ? { uploadHeaders } : {}),
     },
   };
 });
 
-export const zeroIntegrationsTelegramUploadInitRoutes: readonly RouteEntry[] = [
+export const integrationsPhoneUploadInitRoutes: readonly RouteEntry[] = [
   {
-    route: integrationsTelegramUploadInitContract.init,
-    handler: authRoute({ requiredCapability: "telegram:write" }, initInner$),
+    route: integrationsPhoneUploadInitContract.init,
+    handler: authRoute({ requiredCapability: "phone:write" }, init$),
   },
 ];

--- a/turbo/apps/api/src/signals/routes/integrations-teams-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-teams-upload-init.ts
@@ -59,7 +59,7 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-export const zeroIntegrationsTeamsUploadInitRoutes: readonly RouteEntry[] = [
+export const integrationsTeamsUploadInitRoutes: readonly RouteEntry[] = [
   {
     route: integrationsTeamsUploadInitContract.init,
     handler: authRoute({ requiredCapability: "teams:write" }, init$),

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-upload-init.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { integrationsPhoneUploadInitContract } from "@okouai/api-contracts/contracts/integrations";
+import { integrationsTelegramUploadInitContract } from "@okouai/api-contracts/contracts/integrations";
 
 import { env } from "../../lib/env";
 import { sanitizeArtifactFilename } from "../../lib/file-url";
@@ -12,23 +12,24 @@ import type { RouteEntry } from "../route-entry";
 
 const PUT_URL_TTL_SECONDS = 3600;
 
-const init$ = command(async ({ get, set }, signal: AbortSignal) => {
+const initInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
+
   const bodyResult = await get(
-    bodyResultOf(integrationsPhoneUploadInitContract.init),
+    bodyResultOf(integrationsTelegramUploadInitContract.init),
   );
   signal.throwIfAborted();
   if (!bodyResult.ok) {
     return bodyResult.response;
   }
 
-  const body = bodyResult.data;
-  const filename = sanitizeArtifactFilename(body.filename);
+  const { filename, contentType, length } = bodyResult.data;
+  const sanitized = sanitizeArtifactFilename(filename);
   const artifact = await set(
     allocateArtifactObject$,
     {
       userId: auth.userId,
-      filename: body.filename,
+      filename,
     },
     signal,
   );
@@ -38,7 +39,7 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
     generatePresignedPutUrl(
       bucket,
       artifact.key,
-      body.contentType,
+      contentType,
       PUT_URL_TTL_SECONDS,
       { usePublicEndpoint: true, metadata: artifact.metadata },
     ),
@@ -51,17 +52,17 @@ const init$ = command(async ({ get, set }, signal: AbortSignal) => {
       uploadId: artifact.id,
       uploadUrl,
       fileUrl: artifact.url,
-      filename,
-      contentType: body.contentType,
-      size: body.length,
+      filename: sanitized,
+      contentType,
+      size: length,
       ...(uploadHeaders ? { uploadHeaders } : {}),
     },
   };
 });
 
-export const zeroIntegrationsPhoneUploadInitRoutes: readonly RouteEntry[] = [
+export const integrationsTelegramUploadInitRoutes: readonly RouteEntry[] = [
   {
-    route: integrationsPhoneUploadInitContract.init,
-    handler: authRoute({ requiredCapability: "phone:write" }, init$),
+    route: integrationsTelegramUploadInitContract.init,
+    handler: authRoute({ requiredCapability: "telegram:write" }, initInner$),
   },
 ];


### PR DESCRIPTION
## Summary

- rename the Phone, Teams, Telegram, and GitHub upload-init route shells and route arrays to domain-neutral names
- update the API registry, BDD helpers, and focused GitHub test callers atomically
- preserve every handler, endpoint alias, response behavior, and provider-specific authorization boundary

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts` (42 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/agentphone.bdd.test.ts -t 'uploads and streams phone media with a real run-scoped zero token'` (1 passed, 14 skipped)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-integrations-github-files.test.ts` (6 passed)
- searched the non-historical source tree for all four old route paths and route-array symbols (no matches)

Closes #27045
