### PR TITLE
test(python): cover non-object builtin catalog cache payloads

### DIFF
--- a/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_catalog_validation.py
@@ -235,6 +235,27 @@ class TestRegistryBuiltinCatalogValidation:
             == "https://acme.uspacy.com/v1/hooks/{hookKey}"
         )
 
+    @pytest.mark.parametrize(
+        "raw_json",
+        [
+            pytest.param("[]", id="array"),
+            pytest.param("null", id="null"),
+            pytest.param("123", id="number"),
+            pytest.param('"text"', id="string"),
+        ],
+    )
+    def test_non_object_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx, raw_json):
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        write_trusted_catalog_cache_text(cache_path, raw_json)
+
+        with mitm_ctx():
+            snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+
+        assert snapshot.dependency_file_key is not None
+        assert snapshot.catalog is None
+        assert snapshot.cache_path == str(cache_path.absolute())
+        assert snapshot.unavailable_reason == "cache_invalid"
+
     def test_malformed_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"


### PR DESCRIPTION
## Summary

- cover array, null, numeric, and string roots in the trusted builtin catalog cache
- assert each invalid document retains its dependency identity and fails closed as `cache_invalid`
- give every root class an explicit pytest case ID for focused regression output

## Scope

- test-only change in `test_registry_builtin_catalog_validation.py`
- no production loader, cache schema, shared helper, dependency, or lockfile changes
- complete repository and addon suites are left to the PR pipeline per repository guidance

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest 'tests/test_registry_builtin_catalog_validation.py::TestRegistryBuiltinCatalogValidation::test_non_object_runner_catalog_cache_fails_closed' -v` (4 passed)
- `uv run --no-sync python -m pytest tests/test_registry_builtin_catalog_validation.py -v` (35 passed)
- mutation check with the top-level object guard temporarily removed: all 4 new cases failed with the expected escaping `AttributeError`; after restoring the guard, all 4 passed
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`

Closes #27059
