### PR TITLE
test(python): cover identity catalog length mismatch

### DIFF
--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
@@ -235,6 +235,11 @@ async def test_set_cookie_is_not_replayed_from_cached_brotli_response(real_flow)
             id="wrong-shape",
         ),
         pytest.param(
+            catalog_response(headers={"Content-Length": str(len(CATALOG_BODY) + 1)}),
+            "response_body",
+            id="length-mismatch",
+        ),
+        pytest.param(
             catalog_response(headers={"Content-Length": str(catalog_cache.MAX_ENTRY_BYTES + 1)}),
             "response_size",
             id="oversized-declaration",


### PR DESCRIPTION
## Summary

- add an identity `Content-Length` mismatch case to the existing invalid catalog-response integration matrix
- verify the response passes through, reports `response_body`, and is not installed in the process cache
- cover the production mismatch guard with a mutation-sensitive regression test

## Exclusions

- no production behavior or runtime code changes
- no dependency, API, migration, compatibility, or rollout changes

## Validation

- `uv run --no-sync python -m pytest 'tests/test_codex_model_catalog_cache_responses.py::test_invalid_identity_responses_pass_through_without_installing[length-mismatch]' -q` — 1 passed
- mutation check with only the identity mismatch guard removed — expected failure, observed `model_catalog_cold_stored`; guard restored and targeted test passed again
- `uv run --no-sync python -m pytest tests/test_codex_model_catalog_cache_responses.py -q` — 45 passed
- `uv run --no-sync python -m pytest tests/test_codex_model_catalog_cache*.py -q` — 89 passed
- `uv run --no-sync ruff check .` — passed
- `uv run --no-sync ruff format --check .` — 324 files already formatted
- `uv run --no-sync basedpyright -p .` — 0 errors, 0 warnings, 0 notes
- `uv run --no-sync python -m pytest tests/ -q` — 5,391 passed

Closes #27058
