### PR TITLE
test(python): cover non-object catalog responses

### DIFF
--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_responses.py
@@ -230,6 +230,26 @@ async def test_set_cookie_is_not_replayed_from_cached_brotli_response(real_flow)
             id="deep-json",
         ),
         pytest.param(
+            catalog_response(body=b"[]"),
+            "response_shape",
+            id="top-level-array",
+        ),
+        pytest.param(
+            catalog_response(body=b"null"),
+            "response_shape",
+            id="top-level-null",
+        ),
+        pytest.param(
+            catalog_response(body=b"123"),
+            "response_shape",
+            id="top-level-number",
+        ),
+        pytest.param(
+            catalog_response(body=b'"text"'),
+            "response_shape",
+            id="top-level-string",
+        ),
+        pytest.param(
             catalog_response(body=b'{"items":[]}'),
             "response_shape",
             id="wrong-shape",


### PR DESCRIPTION
## Summary

- Add response-finalization cases for valid top-level JSON arrays, nulls, numbers, and strings.
- Reuse the existing identity-response contract to verify unchanged pass-through, `response_shape` telemetry, and absence of a cache entry.

## Scope

- Test-only change in `test_codex_model_catalog_cache_responses.py`.
- No production code, helper, dependency, lockfile, API, schema, migration, documentation, or Brotli-coverage change.

## Validation

- `uv run --frozen pytest tests/test_codex_model_catalog_cache_responses.py::test_invalid_identity_responses_pass_through_without_installing` — 23 passed.
- Four new category-specific nodes after guard restoration — 4 passed.
- `uv run --frozen pytest tests/test_codex_model_catalog_cache_responses.py` — 48 passed.
- `uv run --frozen pytest tests -k codex_model_catalog_cache` — 92 passed, 5302 deselected.
- `uv run --frozen ruff check tests/test_codex_model_catalog_cache_responses.py` — passed.
- `uv run --frozen ruff format --check tests/test_codex_model_catalog_cache_responses.py` — passed.
- `uv run --frozen basedpyright tests/test_codex_model_catalog_cache_responses.py` — 0 errors, 0 warnings, 0 notes.
- Mutation check: temporarily removing only the top-level dictionary guard made all four new nodes fail with the expected executor-future `AttributeError`; restoring the guard made all four pass and left no production diff.

Closes #27057
