### PR TITLE
refactor(platform): remove activity event route rollout fallback

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -71,7 +71,7 @@ async function fetchAgentEventPage(
     readonly cursor?: string;
   },
   signal: AbortSignal,
-): Promise<AgentEventsResponse | null> {
+): Promise<AgentEventsResponse> {
   const result = await accept(
     client.getAgentEvents({
       params: { id: runId },
@@ -85,14 +85,10 @@ async function fetchAgentEventPage(
       },
       fetchOptions: { signal },
     }),
-    // A newly promoted app can briefly reach an API version from before this
-    // additive Activity route existed. Surface: app/API rollout and rollback,
-    // ~2 days. Remove after that API is outside the production rollback
-    // window; tracked by #27010.
-    [200, 404],
+    [200],
     signal,
   );
-  return result.status === 200 ? result.body : null;
+  return result.body;
 }
 
 async function fetchAgentEventBatch(
@@ -103,17 +99,13 @@ async function fetchAgentEventBatch(
     readonly expectedSequence?: number;
   },
   signal: AbortSignal,
-): Promise<Omit<ZeroActivityEvents, "runId"> | null> {
+): Promise<Omit<ZeroActivityEvents, "runId">> {
   const firstPage = await fetchAgentEventPage(
     client,
     runId,
     request.since === undefined ? {} : { since: request.since },
     signal,
   );
-  if (!firstPage) {
-    return null;
-  }
-
   const events = [...firstPage.events];
   let page = firstPage;
 
@@ -147,9 +139,6 @@ async function fetchAgentEventBatch(
       { cursor: nextCursor },
       signal,
     );
-    if (!nextPage) {
-      return null;
-    }
     events.push(...nextPage.events);
     page = nextPage;
   }
@@ -260,10 +249,6 @@ export const setupActivityEvents$ = command(
       },
     );
     signal.throwIfAborted();
-    if (!initial) {
-      set(internalActivityEventsState$, { phase: "unavailable", runId });
-      return;
-    }
 
     let current = {
       runId,
@@ -302,9 +287,6 @@ export const setupActivityEvents$ = command(
           loopSignal,
         );
         loopSignal.throwIfAborted();
-        if (!batch) {
-          return true;
-        }
 
         const previous = current;
         current = {

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx
@@ -362,36 +362,6 @@ describe("activity paged events", () => {
     ).toBeTruthy();
   });
 
-  it("keeps activity details visible while the event route rolls out", async () => {
-    context.mocks.data.composesList([]);
-    context.mocks.api(logsByIdContract.getById, ({ respond }) => {
-      return respond(200, makeLogDetail({ status: "completed" }));
-    });
-    context.mocks.api(
-      zeroRunAgentEventsContract.getAgentEvents,
-      ({ respond }) => {
-        return respond(404, {
-          error: { code: "NOT_FOUND", message: "Route not found" },
-        });
-      },
-    );
-
-    await setupPage({
-      context,
-      path: "/activities/a0000000-0000-4000-a000-000000000099",
-      featureSwitches: { [FeatureSwitchKey.ZeroDebug]: true },
-    });
-
-    expect(
-      screen.getByRole("heading", { name: "Test Agent" }),
-    ).toBeInTheDocument();
-    expect(
-      queryAllByRoleFast("tab").map((tab) => {
-        return tab.textContent?.trim();
-      }),
-    ).toStrictEqual(["Steps", "Context", "Runner", "Network"]);
-  });
-
   it("keeps activity details visible when event loading fails", async () => {
     context.mocks.data.composesList([]);
     context.mocks.api(logsByIdContract.getById, ({ respond }) => {


### PR DESCRIPTION
## Summary

- require successful Activity agent-event responses instead of accepting the temporary route-level `404`
- make event page and batch results non-nullable and remove rollout-only control flow
- delete the rollout compatibility test while retaining genuine event-loading failure coverage

## Compatibility

- API versions predating #27004 are not supported rollback targets for this change
- the shared agent-events API contract keeps its legitimate missing or inaccessible run `404`
- Activity detail not-found behavior, event pagination, polling, and rendering are unchanged

## Validation

- `pnpm exec prettier --write apps/platform/src/signals/activity-page/activity-signals.ts apps/platform/src/views/activity-page/__tests__/activity-paged-events.test.tsx`
- `pnpm -F @okouai/app exec vitest run src/views/activity-page/__tests__/activity-paged-events.test.tsx` (8 tests passed)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit hook: staged Prettier, repository Knip, repository type checks, file-size check, and commitlint

Closes #27010
