### PR TITLE
fix(platform): align avatar template toolbar to the default control scale

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-template-picker.tsx
@@ -193,13 +193,8 @@ function CatalogFiltersPopover({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-9 gap-2 rounded-full bg-background px-3 shadow-none"
-        >
-          <SlidersHorizontal size={15} />
+        <Button type="button" variant="outline">
+          <SlidersHorizontal />
           {t(($) => {
             return $.artifacts.templates.filters.title;
           })}
@@ -245,12 +240,7 @@ function AvatarAspectRatioPicker({
     return $.artifacts.templates.filters.aspectRatio;
   });
   return (
-    <SegmentControl
-      aria-label={label}
-      size="sm"
-      value={value}
-      onValueChange={onChange}
-    >
+    <SegmentControl aria-label={label} value={value} onValueChange={onChange}>
       <SegmentControlItem value="portrait" aria-label={`${label}: 9:16`}>
         <span className="h-4 w-2.5 rounded-[2px] border-2 border-current" />
         9:16


### PR DESCRIPTION
## What

The avatar template picker toolbar carried two different control heights, and the filters trigger used a pill shape that the button component does not offer.

- `SegmentControl` (aspect ratio) ran at `size="sm"` → **h-8 (32px)**
- The filters `Button` ran at `size="sm"` with a `className="h-9 … rounded-full …"` override → **h-9 (36px)**, pill radius

`segment-control.tsx` documents that its sizes mirror `buttonVariants` one for one, with `default` = h-9 matching `Input` and `SelectTrigger`. The filter `Select`s inside this very popover are h-9, and the equivalent filter trigger on the connectors page is h-9 `rounded-lg`. The segment control was the only element off that step.

`buttonVariants` has no shape axis — its base radius is `rounded-lg`, and the only other `rounded-full` buttons in the platform are circular icon-only controls. The pill here was a one-off.

## Change

Both controls now take the component defaults: h-9, `rounded-lg`. The redundant `gap-2`, `bg-background`, and `shadow-none` classes are dropped (all already supplied by the base and the `outline` variant), as is the dead `size={15}` on the icon (the base `[&_svg]:size-4` wins over the attribute).

## Verification

Rendered both states against the real `globals.css` tokens in dark mode and measured:

| | segment | filters |
|---|---|---|
| before | 32px | 36px, radius 3.4e7px |
| after | **36px** | **36px, radius 8px** |

No test asserts on these classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
