### PR TITLE
perf(api): attribute runner notification latency

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -4661,6 +4661,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "runner_notification_queue_to_entry",
       "runner_notification_affinity_lookup",
       "runner_notification_queue_to_publish_start",
+      "runner_notification_realtime_publish",
     ]) {
       const events = sandboxOperationEventsForRunByAction(
         protectedFollowUp.runId,
@@ -4677,12 +4678,50 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           runner_group: runnerGroup,
           profile: "vm0/default",
           notification_target: "broadcast",
+          activation_origin: "direct",
+          same_thread_markers: "recorded",
           runner_preference_resolution: "exact_history_generation",
           reuse_key_kind: "thread",
           history_generation_run_id: first.runId,
         }),
       );
     }
+    for (const actionType of [
+      "runner_notification_queue_to_commit_return",
+      "runner_notification_queue_to_run_context_registered",
+      "runner_notification_queue_to_dispatch_timings_registered",
+      "runner_notification_queue_to_activation_scheduled",
+      "runner_notification_queue_to_activation_entry",
+      "runner_notification_queue_to_same_thread_markers_complete",
+      "runner_notification_queue_to_database_ready",
+    ]) {
+      const events = sandboxOperationEventsForRunByAction(
+        protectedFollowUp.runId,
+        actionType,
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0]).toStrictEqual(
+        expect.objectContaining({
+          source: "api",
+          op_type: actionType,
+          sandbox_type: "runner",
+          duration_ms: 0,
+          success: true,
+          runner_group: runnerGroup,
+          profile: "vm0/default",
+          notification_target: "broadcast",
+          activation_origin: "direct",
+          same_thread_markers: "recorded",
+        }),
+      );
+      expect(events[0]).not.toHaveProperty("history_generation_run_id");
+    }
+    expect(
+      sandboxOperationEventsForRunByAction(
+        protectedFollowUp.runId,
+        "runner_notification_queue_to_promotion_side_effects_registered",
+      ),
+    ).toHaveLength(0);
     expect(
       sandboxOperationEventsForRunByAction(
         protectedFollowUp.runId,
@@ -5495,6 +5534,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
       "runner_notification_queue_to_entry",
       "runner_notification_affinity_lookup",
       "runner_notification_queue_to_publish_start",
+      "runner_notification_realtime_publish",
     ]) {
       const events = sandboxOperationEventsForRunByAction(
         third.runId,
@@ -5511,6 +5551,8 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
           runner_group: runnerGroup,
           profile: "vm0/default",
           notification_target: "broadcast",
+          activation_origin: "promotion",
+          same_thread_markers: "not_applicable",
           runner_preference_resolution: "no_reuse_key",
           runner_preference_decision_kind: "noPreference",
           runner_preference_no_preference_reason: "noReuseKey",
@@ -5518,6 +5560,43 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
         }),
       );
       expect(events[0]).not.toHaveProperty("history_generation_run_id");
+    }
+    for (const actionType of [
+      "runner_notification_queue_to_commit_return",
+      "runner_notification_queue_to_promotion_side_effects_registered",
+      "runner_notification_queue_to_activation_scheduled",
+      "runner_notification_queue_to_activation_entry",
+      "runner_notification_queue_to_same_thread_markers_complete",
+      "runner_notification_queue_to_database_ready",
+    ]) {
+      const events = sandboxOperationEventsForRunByAction(
+        third.runId,
+        actionType,
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0]).toStrictEqual(
+        expect.objectContaining({
+          source: "api",
+          op_type: actionType,
+          sandbox_type: "runner",
+          duration_ms: 0,
+          success: true,
+          runner_group: runnerGroup,
+          profile: "vm0/default",
+          notification_target: "broadcast",
+          activation_origin: "promotion",
+          same_thread_markers: "not_applicable",
+        }),
+      );
+      expect(events[0]).not.toHaveProperty("history_generation_run_id");
+    }
+    for (const actionType of [
+      "runner_notification_queue_to_run_context_registered",
+      "runner_notification_queue_to_dispatch_timings_registered",
+    ]) {
+      expect(
+        sandboxOperationEventsForRunByAction(third.runId, actionType),
+      ).toHaveLength(0);
     }
     expect(
       sandboxOperationEventsForRunByAction(

--- a/turbo/apps/api/src/signals/services/agent-run-activation.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-activation.service.ts
@@ -1,8 +1,10 @@
 import { command } from "ccstate";
 
+import { now } from "../../lib/time";
 import { writeDb$ } from "../external/db";
 import {
   notifyRunnerJob,
+  type RunnerJobPreActivationTiming,
   type RunnerJobNotification,
 } from "./runner-dispatch.service";
 import { recordSameThreadRunnerJobPersisted } from "./runner-job-queue-lifecycle.service";
@@ -12,25 +14,43 @@ export interface PendingRunActivation {
   readonly apiStartTime: number;
   readonly chatThreadId: string | undefined;
   readonly runnerNotification: RunnerJobNotification;
+  readonly timing: RunnerJobPreActivationTiming;
+}
+
+interface PendingRunActivationRequest {
+  readonly activation: PendingRunActivation;
+  readonly activationScheduledAt: number;
 }
 
 /** Common post-commit activation for direct and promoted pending runs. */
 export const activatePendingRun$ = command(
-  async ({ set }, input: PendingRunActivation): Promise<void> => {
+  async ({ set }, input: PendingRunActivationRequest): Promise<void> => {
+    const activationEnteredAt = now();
+    const activation = input.activation;
     // Activation follows a durable run/job commit and therefore must finish
     // independently from the request that initiated that commit.
-    if (input.chatThreadId !== undefined) {
+    if (activation.chatThreadId !== undefined) {
       recordSameThreadRunnerJobPersisted({
-        runId: input.runnerNotification.runId,
-        createdAt: input.runnerNotification.createdAt,
+        runId: activation.runnerNotification.runId,
+        createdAt: activation.runnerNotification.createdAt,
       });
       recordFirstAssistantEventEligibility({
-        runId: input.runnerNotification.runId,
-        apiStartedAt: input.apiStartTime,
+        runId: activation.runnerNotification.runId,
+        apiStartedAt: activation.apiStartTime,
       });
     }
+    const sameThreadMarkersCompletedAt = now();
 
     const db = set(writeDb$);
-    await notifyRunnerJob(db, input.runnerNotification);
+    const databaseReadyAt = now();
+    await notifyRunnerJob(db, activation.runnerNotification, {
+      preActivation: activation.timing,
+      activationScheduledAt: input.activationScheduledAt,
+      activationEnteredAt,
+      sameThreadMarkersCompletedAt,
+      databaseReadyAt,
+      sameThreadMarkers:
+        activation.chatThreadId === undefined ? "not_applicable" : "recorded",
+    });
   },
 );

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -657,9 +657,13 @@ type QueuePayloadRequiredResult = Extract<
 type AtomicLaunchCommitAttempt =
   | AtomicLaunchCommitResult
   | CreateRunErrorResult;
+interface AtomicLaunchCommitCompletion {
+  readonly result: AtomicLaunchCommitAttempt;
+  readonly transactionReturnedAt: number;
+}
 type CommitAtomicLaunch = (
   encryptedQueuedParams: string | undefined,
-) => Promise<AtomicLaunchCommitAttempt>;
+) => Promise<AtomicLaunchCommitCompletion>;
 type CommittedAtomicLaunchResult = Exclude<
   AtomicLaunchCommitResult,
   | { readonly kind: "queue-payload-required" }
@@ -7496,7 +7500,7 @@ async function commitPreparedLaunchUnderLock(
 
 async function commitPreparedLaunch(
   args: CommitPreparedLaunchArgs,
-): Promise<AtomicLaunchCommitResult | CreateRunErrorResult> {
+): Promise<AtomicLaunchCommitCompletion> {
   const committed = await args.db.transaction(async (tx) => {
     const payload = queuedRunnerJobPayload({
       ...args.launch.runnerJobPayload,
@@ -7521,12 +7525,16 @@ async function commitPreparedLaunch(
       admissionLockHeldStartedAt,
     };
   });
+  const transactionReturnedAt = now();
   args.timing.recordElapsed(
     "api_dispatch_admission_lock_held",
     "nested",
     committed.admissionLockHeldStartedAt,
   );
-  return committed.result;
+  return {
+    result: committed.result,
+    transactionReturnedAt,
+  };
 }
 
 function buildAtomicLaunchPayload(
@@ -8678,6 +8686,7 @@ function prepareRunContext(
 function committedAtomicLaunchResponse(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly committed: CommittedAtomicLaunchResult;
+  readonly transactionReturnedAt: number;
   readonly timing: ApiDispatchTimingCollector;
   readonly launch: PreparedRunnerLaunch;
 }): Extract<CreateRunRouteResult, { readonly status: 201 }> {
@@ -8715,7 +8724,21 @@ function committedAtomicLaunchResponse(args: {
   }
 
   ingestRunContextSnapshot(args.committed.runContextSnapshot);
+  const runContextRegisteredAt = now();
   const dispatchedProfile = args.committed.runnerJobPayload.profile;
+  args.timing.flush({
+    runId: args.committed.run.id,
+    runnerGroup: args.committed.runnerJobPayload.runnerGroup,
+    profile: dispatchedProfile,
+    dispatchPath: "direct",
+    ...(args.createArgs.timingDimensions
+      ? { dimensions: args.createArgs.timingDimensions }
+      : {}),
+    ...(args.createArgs.body.triggerSource
+      ? { triggerSource: args.createArgs.body.triggerSource }
+      : {}),
+  });
+  const dispatchTimingsRegisteredAt = now();
   const pendingActivation: PendingRunActivation = {
     apiStartTime: args.createArgs.apiStartTime,
     chatThreadId: args.createArgs.chatThreadId,
@@ -8729,19 +8752,13 @@ function committedAtomicLaunchResponse(args: {
         args.committed.runnerJobPayload.historyGenerationRunId,
       createdAt: args.committed.runnerJobCreatedAt,
     },
+    timing: {
+      activationOrigin: "direct",
+      commitReturnedAt: args.transactionReturnedAt,
+      runContextRegisteredAt,
+      dispatchTimingsRegisteredAt,
+    },
   };
-  args.timing.flush({
-    runId: args.committed.run.id,
-    runnerGroup: args.committed.runnerJobPayload.runnerGroup,
-    profile: dispatchedProfile,
-    dispatchPath: "direct",
-    ...(args.createArgs.timingDimensions
-      ? { dimensions: args.createArgs.timingDimensions }
-      : {}),
-    ...(args.createArgs.body.triggerSource
-      ? { triggerSource: args.createArgs.body.triggerSource }
-      : {}),
-  });
   const response = createdRunResponse(args.committed.run, {
     status: "pending",
   });
@@ -8798,31 +8815,33 @@ function finalizeAtomicLaunchCommit(
     readonly input: AtomicLaunchRunInput;
     readonly identity: LaunchRunIdentity;
     readonly launch: PreparedRunnerLaunch;
-    readonly committed: AtomicLaunchCommitAttempt;
+    readonly committed: AtomicLaunchCommitCompletion;
   },
   signal: AbortSignal,
 ): QueueFirstAgentRunResult | QueuePayloadRequiredResult {
-  if (isReturnableRouteError(args.committed, signal)) {
-    return args.committed;
+  const committed = args.committed.result;
+  if (isReturnableRouteError(committed, signal)) {
+    return committed;
   }
-  if (args.committed.kind === "queue-first-claim-lost") {
+  if (committed.kind === "queue-first-claim-lost") {
     flushQueueFirstClaimLostTiming({
       createArgs: args.input.args,
       identity: args.identity,
       launch: args.launch,
       timing: args.input.timing,
     });
-    return args.committed;
+    return committed;
   }
-  if (args.committed.kind === "thread-session-snapshot-stale") {
-    return args.committed;
+  if (committed.kind === "thread-session-snapshot-stale") {
+    return committed;
   }
-  if (args.committed.kind === "queue-payload-required") {
-    return args.committed;
+  if (committed.kind === "queue-payload-required") {
+    return committed;
   }
   return committedAtomicLaunchResponse({
     createArgs: args.input.args,
-    committed: args.committed,
+    committed,
+    transactionReturnedAt: args.committed.transactionReturnedAt,
     timing: args.input.timing,
     launch: args.launch,
   });
@@ -9181,7 +9200,11 @@ export const completeAgentRun$ = command(
       return result;
     }
 
-    await set(activatePendingRun$, result.pendingActivation);
+    const activationScheduledAt = now();
+    await set(activatePendingRun$, {
+      activation: result.pendingActivation,
+      activationScheduledAt,
+    });
     if (signal.aborted) {
       L.debug("Request remained aborted after run activation", {
         runId: result.pendingActivation.runnerNotification.runId,

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -23,9 +23,113 @@ export interface RunnerJobNotification {
   readonly createdAt: Date;
 }
 
+export type RunnerJobPreActivationTiming =
+  | {
+      readonly activationOrigin: "direct";
+      readonly commitReturnedAt: number;
+      readonly runContextRegisteredAt: number;
+      readonly dispatchTimingsRegisteredAt: number;
+    }
+  | {
+      readonly activationOrigin: "promotion";
+      readonly commitReturnedAt: number;
+      readonly promotionSideEffectsRegisteredAt: number;
+    };
+
+interface RunnerJobNotificationTiming {
+  readonly preActivation: RunnerJobPreActivationTiming;
+  readonly activationScheduledAt: number;
+  readonly activationEnteredAt: number;
+  readonly sameThreadMarkersCompletedAt: number;
+  readonly databaseReadyAt: number;
+  readonly sameThreadMarkers: "recorded" | "not_applicable";
+}
+
+interface RunnerNotificationAttributionMilestone {
+  readonly actionType: string;
+  readonly completedAt: number;
+}
+
+interface RunnerNotificationAttributionEvent {
+  readonly sandboxType: "runner";
+  readonly actionType: string;
+  readonly durationMs: number;
+  readonly success: true;
+  readonly runId: string;
+  readonly dimensions: Record<string, string>;
+}
+
+function runnerNotificationAttributionEvents(
+  notification: RunnerJobNotification,
+  timing: RunnerJobNotificationTiming,
+  dimensions: Record<string, string>,
+): readonly RunnerNotificationAttributionEvent[] {
+  const preActivationMilestones: readonly RunnerNotificationAttributionMilestone[] =
+    timing.preActivation.activationOrigin === "direct"
+      ? [
+          {
+            actionType: "runner_notification_queue_to_commit_return",
+            completedAt: timing.preActivation.commitReturnedAt,
+          },
+          {
+            actionType: "runner_notification_queue_to_run_context_registered",
+            completedAt: timing.preActivation.runContextRegisteredAt,
+          },
+          {
+            actionType:
+              "runner_notification_queue_to_dispatch_timings_registered",
+            completedAt: timing.preActivation.dispatchTimingsRegisteredAt,
+          },
+        ]
+      : [
+          {
+            actionType: "runner_notification_queue_to_commit_return",
+            completedAt: timing.preActivation.commitReturnedAt,
+          },
+          {
+            actionType:
+              "runner_notification_queue_to_promotion_side_effects_registered",
+            completedAt: timing.preActivation.promotionSideEffectsRegisteredAt,
+          },
+        ];
+  const milestones: readonly RunnerNotificationAttributionMilestone[] = [
+    ...preActivationMilestones,
+    {
+      actionType: "runner_notification_queue_to_activation_scheduled",
+      completedAt: timing.activationScheduledAt,
+    },
+    {
+      actionType: "runner_notification_queue_to_activation_entry",
+      completedAt: timing.activationEnteredAt,
+    },
+    {
+      actionType: "runner_notification_queue_to_same_thread_markers_complete",
+      completedAt: timing.sameThreadMarkersCompletedAt,
+    },
+    {
+      actionType: "runner_notification_queue_to_database_ready",
+      completedAt: timing.databaseReadyAt,
+    },
+  ];
+  return milestones.map((milestone): RunnerNotificationAttributionEvent => {
+    return {
+      sandboxType: "runner",
+      actionType: milestone.actionType,
+      durationMs: Math.max(
+        0,
+        milestone.completedAt - notification.createdAt.getTime(),
+      ),
+      success: true,
+      runId: notification.runId,
+      dimensions,
+    };
+  });
+}
+
 export async function notifyRunnerJob(
   db: Pick<Db, "select">,
   args: RunnerJobNotification,
+  timing: RunnerJobNotificationTiming,
 ): Promise<boolean> {
   const notificationEnteredAt = now();
   const currentDate = new Date(notificationEnteredAt);
@@ -69,10 +173,15 @@ export async function notifyRunnerJob(
   });
   const publishFinishedAt = now();
 
-  const dimensions: Record<string, string> = {
+  const attributionDimensions: Record<string, string> = {
     runner_group: args.runnerGroup,
     profile: args.profile,
     notification_target: "broadcast",
+    activation_origin: timing.preActivation.activationOrigin,
+    same_thread_markers: timing.sameThreadMarkers,
+  };
+  const dimensions: Record<string, string> = {
+    ...attributionDimensions,
     reuse_key_kind: runnerReuseKeyTelemetryKind(args.reuseKey),
     ...runnerPreferenceTelemetryDimensions(runnerPreference),
   };
@@ -82,6 +191,7 @@ export async function notifyRunnerJob(
   // Queue-relative actions are cumulative boundaries. Preference lookup and
   // publish durations are nested children and must not be added to them.
   recordSandboxOperations([
+    ...runnerNotificationAttributionEvents(args, timing, attributionDimensions),
     {
       sandboxType: "runner",
       actionType: "runner_notification_queue_to_entry",

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -86,15 +86,31 @@ interface PromotedRunnerJob {
   readonly profile: string;
 }
 
-type PromoteQueuedCandidateResult =
-  | {
-      readonly status: "promoted";
-      readonly pendingActivation: PendingRunActivation;
-      readonly queueMarkerNotification: QueueMarkerRevokeNotification | null;
-    }
+type PreparedPendingRunActivation = Omit<PendingRunActivation, "timing">;
+
+type PromoteQueuedCandidateNonPromotedResult =
   | { readonly status: "full" }
   | { readonly status: "removed-stale" }
   | { readonly status: "lost" };
+
+interface PromotedQueuedCandidateTransactionResult {
+  readonly status: "promoted";
+  readonly pendingActivation: PreparedPendingRunActivation;
+  readonly queueMarkerNotification: QueueMarkerRevokeNotification | null;
+}
+
+type PromotionResult =
+  | PromotedQueuedCandidateTransactionResult
+  | PromoteQueuedCandidateNonPromotedResult;
+
+type PromoteQueuedCandidateResult =
+  | {
+      readonly status: "promoted";
+      readonly pendingActivation: PreparedPendingRunActivation;
+      readonly queueMarkerNotification: QueueMarkerRevokeNotification | null;
+      readonly transactionReturnedAt: number;
+    }
+  | PromoteQueuedCandidateNonPromotedResult;
 
 type PromoteQueuedCandidateSideEffectResult =
   | {
@@ -237,7 +253,7 @@ async function promoteQueuedCandidate(
     readonly payload: QueuedRunnerJobPayload | null;
   },
 ): Promise<PromoteQueuedCandidateResult> {
-  return await db.transaction(async (tx) => {
+  const result = await db.transaction(async (tx): Promise<PromotionResult> => {
     await tx.execute(
       sql`SELECT pg_advisory_xact_lock(hashtext(${args.orgId}))`,
     );
@@ -337,6 +353,14 @@ async function promoteQueuedCandidate(
       },
     };
   });
+  const transactionReturnedAt = now();
+  if (result.status !== "promoted") {
+    return result;
+  }
+  return {
+    ...result,
+    transactionReturnedAt,
+  };
 }
 
 async function publishPromotedQueueSideEffects(args: {
@@ -376,9 +400,17 @@ async function promoteQueuedCandidateWithSideEffects(
   await publishPromotedQueueSideEffects({
     queueMarkerNotification: result.queueMarkerNotification,
   });
+  const promotionSideEffectsRegisteredAt = now();
   return {
     status: "drained",
-    pendingActivation: result.pendingActivation,
+    pendingActivation: {
+      ...result.pendingActivation,
+      timing: {
+        activationOrigin: "promotion",
+        commitReturnedAt: result.transactionReturnedAt,
+        promotionSideEffectsRegisteredAt,
+      },
+    },
   };
 }
 
@@ -434,8 +466,12 @@ export const drainOrgQueue$ = command(
       if (result.status === "skipped") {
         continue;
       }
+      const activationScheduledAt = now();
       await tapError(
-        set(activatePendingRun$, result.pendingActivation),
+        set(activatePendingRun$, {
+          activation: result.pendingActivation,
+          activationScheduledAt,
+        }),
         (error) => {
           L.error("Failed to activate promoted queued run", {
             runId: row.runId,


### PR DESCRIPTION
## Summary

- carry typed direct-versus-promotion timing milestones from runner-job commit through shared
  activation
- emit cumulative queue-relative attribution events in the existing post-publish telemetry batch
- distinguish activation origin and marker applicability while keeping new events free of
  history-generation IDs
- extend API route integration coverage for direct same-thread notification and organization-queue
  promotion

## Behavior and compatibility

The runner job still commits before notification, and direct run-context registration, API timing
flush, promotion side effects, commit-owned activation, preference lookup, realtime publication,
polling, claiming, and cancellation keep their existing order and ownership.

This PR adds only API-internal timestamps and telemetry. It does not add a schema migration, public
API or runner/guest protocol field, persisted queue-payload field, feature switch, scheduler, relay,
or behavioral latency optimization.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `DATABASE_URL="$task_database_url" pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` (159 passed)
- `pnpm -F api build`
- `pnpm knip --workspace api`
- pre-commit full-workspace Knip and type checks

Closes #26985

Parent context: #24203
