### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -112,8 +112,8 @@ ROOTFS_DIR=""
 CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
-GO_VERSION="1.26.5"
-CLAUDE_CODE_VERSION="2.1.229"
+GO_VERSION="1.26.6"
+CLAUDE_CODE_VERSION="2.1.232"
 CODEX_CLI_VERSION="0.147.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
@@ -121,8 +121,8 @@ AGENT_BROWSER_VERSION="0.33.0-vm0.1"
 AGENT_BROWSER_LINUX_X64_SHA256="a9e3fbe24c537960b9ac0d1f358224a10eb70d87a619aec7bcb1175222a46a18"
 AGENT_BROWSER_LINUX_ARM64_SHA256="6a74dba04c299a69d564eae5aff67adc2ffc6fda5ddf672994ff75b73d64a9fe"
 PNPM_VERSION="11.21.0"
-CHROMIUM_VERSION="151.0.7922.108-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260808T215433Z"
+CHROMIUM_VERSION="151.0.7922.137-1~deb12u1"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260813T095557Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

- Update Go from 1.26.5 to 1.26.6.
- Update Claude Code from 2.1.229 to 2.1.232.
- Update Chromium from 151.0.7922.108-1~deb12u1 to 151.0.7922.137-1~deb12u1.
- Update the Debian security snapshot from 20260808T215433Z to 20260813T095557Z.

## Validation

- Confirmed Go and Claude Code release artifacts for amd64 and arm64.
- Confirmed chromium, chromium-common, and chromium-sandbox at the new version for amd64 and arm64 in the pinned snapshot.
- `git diff --check`
- `bash -n crates/runner/scripts/build-template.sh`