### PR TITLE
fix: route vm0 claude models through openrouter

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -336,7 +336,6 @@ end
 raise "missing real Claude account bootstrap" unless claude_step
 claude_script = claude_step.fetch("run")
 %w[
-  /api/okou/model-providers
   /api/okou/model-policies
   /api/okou/feature-switches
   claude-sonnet-4-6
@@ -346,9 +345,9 @@ claude_script = claude_step.fetch("run")
     raise "real Claude bootstrap must include #{required_fragment}"
   end
 end
-unless claude_step.dig("env", "ANTHROPIC_API_KEY") ==
-    "${{ secrets.CI_ANTHROPIC_API_KEY }}"
-  raise "real Claude bootstrap must receive the Anthropic credential"
+unless claude_script.include?('defaultProviderType: "vm0"') &&
+    claude_script.include?("modelProviderId: null")
+  raise "real Claude bootstrap must use the VM0-managed provider"
 end
 
 shard_step = runner.fetch("steps").find do |step|

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2605,18 +2605,8 @@ jobs:
             headers+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
           fi
 
-          provider_payload=$(jq -nc \
-            --arg secret "$ANTHROPIC_API_KEY" \
-            '{type: "anthropic-api-key", secret: $secret}')
-          provider_response=$(curl -fsS "${headers[@]}" \
-            -X POST \
-            -d "$provider_payload" \
-            "${api_url}/api/okou/model-providers")
-          provider_id=$(jq -er '.provider.id | select(type == "string" and length > 0)' \
-            <<< "$provider_response")
-
           policies=$(curl -fsS "${headers[@]}" "${api_url}/api/okou/model-policies")
-          policy_payload=$(jq -c --arg providerId "$provider_id" '
+          policy_payload=$(jq -c '
             {
               policies: (
                 [.policies[] |
@@ -2632,9 +2622,9 @@ jobs:
                   {
                     model: "claude-sonnet-4-6",
                     isDefault: false,
-                    defaultProviderType: "anthropic-api-key",
+                    defaultProviderType: "vm0",
                     credentialScope: "org",
-                    modelProviderId: $providerId
+                    modelProviderId: null
                   }
                 ]
               )
@@ -2653,7 +2643,6 @@ jobs:
             | jq -e '.effectiveSwitches.realAgentInPreview == true' \
             >/dev/null
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
   cli-e2e-03-runner:

--- a/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Real Claude BYOK smoke test through supported model, agent, chat, and usage APIs.
+# Real VM0-managed Claude smoke test through supported model, agent, and chat APIs.
 
 load '../../helpers/setup'
 load '../../helpers/runner-chat'
@@ -115,7 +115,19 @@ run_real_claude_steer() {
     printf '%s\n%s\n' "$steer_output" "$successor_output"
 }
 
-@test "real claude returns a successful answer" {
+@test "vm0-managed real claude returns a successful answer" {
+    run runner_api_curl "/api/okou/model-policies"
+    assert_success
+    run jq -e '
+        any(.policies[]?;
+            .model == "claude-sonnet-4-6" and
+            .defaultProviderType == "vm0" and
+            .credentialScope == "org" and
+            .modelProviderId == null
+        )
+    ' <<<"$output"
+    assert_success
+
     run run_real_claude_chat \
         "123+456. Reply only RESULT=<answer>." \
         "RESULT=579"
@@ -123,19 +135,12 @@ run_real_claude_steer() {
     assert_success
     assert_output --partial '"status":"completed"'
     assert_output --partial "RESULT=579"
-    local run_id thread_id
-    run_id="$(runner_chat_field "$output" '.runId')"
-    thread_id="$(runner_chat_field "$output" '.threadId')"
-    [[ -n "$run_id" ]]
+    [[ -n "$(runner_chat_field "$output" '.runId')" ]]
+    [[ -n "$(runner_chat_field "$output" '.threadId')" ]]
     [[ -n "$(runner_chat_field "$output" '.sessionId')" ]]
-
-    run runner_e2e_assert_no_usage_for_thread "$thread_id" "$run_id"
-    echo "$output"
-    assert_success
-    assert_output --partial '"vm0UsageCredits":0'
 }
 
-@test "real claude steers an active run then starts a successor" {
+@test "vm0-managed real claude steers an active run then starts a successor" {
     local steer_nonce steer_prompt after_complete_nonce after_complete_prompt
     steer_nonce="$(_runner_uuid)"
     steer_prompt="claude-steer-${steer_nonce%%-*}"

--- a/turbo/apps/api/src/scripts/__tests__/dev-seed.test.ts
+++ b/turbo/apps/api/src/scripts/__tests__/dev-seed.test.ts
@@ -22,21 +22,6 @@ function buildVendorKeys(
 }
 
 describe("buildVm0ApiKeys", () => {
-  it("falls back to ANTHROPIC_API_KEY for Anthropic dev seed rows", () => {
-    const anthropicKeys = buildVendorKeys("anthropic", {
-      DEV_MODEL_ANTHROPIC_KEY: "",
-      ANTHROPIC_API_KEY: "provider-anthropic-key",
-    });
-
-    expect(anthropicKeys).toStrictEqual([
-      {
-        apiKey: "provider-anthropic-key",
-        label: "dev-seed",
-        vendor: "anthropic",
-      },
-    ]);
-  });
-
   it("builds DeepSeek dev seed rows from DEV_MODEL_DEEPSEEK_KEY", () => {
     const deepSeekKeys = buildVendorKeys("deepseek", {
       DEV_MODEL_DEEPSEEK_KEY: "dev-deepseek-key",
@@ -63,6 +48,20 @@ describe("buildVm0ApiKeys", () => {
         apiKey: "dev-openai-key",
         label: "dev-seed",
         vendor: "openai",
+      },
+    ]);
+  });
+
+  it("builds an OpenRouter dev seed row from DEV_MODEL_OPENROUTER_KEY", () => {
+    const openRouterKeys = buildVendorKeys("openrouter", {
+      DEV_MODEL_OPENROUTER_KEY: "dev-openrouter-key",
+    });
+
+    expect(openRouterKeys).toStrictEqual([
+      {
+        apiKey: "dev-openrouter-key",
+        label: "dev-seed",
+        vendor: "openrouter",
       },
     ]);
   });

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -37,10 +37,9 @@ function writeLine(message: string): void {
  * Prices are per 1M tokens, stored as integer credits per 1M tokens.
  *
  * API keys are read from environment variables per vendor:
- *   DEV_MODEL_{VENDOR_UPPER}_KEY (e.g., DEV_MODEL_ANTHROPIC_KEY, DEV_MODEL_OPENAI_KEY)
- * Anthropic and OpenAI also fall back to their provider env names because
- * CI and local dev already use them for real model smoke tests.
- * DeepSeek also falls back to its provider env name.
+ *   DEV_MODEL_{VENDOR_UPPER}_KEY (e.g., DEV_MODEL_OPENROUTER_KEY, DEV_MODEL_OPENAI_KEY)
+ * OpenAI and DeepSeek also fall back to their provider env names because CI
+ * and local dev already use them for real model smoke tests.
  */
 
 /** 1 USD = 1000 credits */
@@ -651,9 +650,6 @@ const USAGE_PRICING: readonly (typeof usagePricing.$inferInsert)[] = [
 
 function getVendorApiKeyEnvVars(vendor: string): string[] {
   const envVar = `DEV_MODEL_${vendor.toUpperCase()}_KEY`;
-  if (vendor === "anthropic") {
-    return [envVar, "ANTHROPIC_API_KEY"];
-  }
   if (vendor === "openai") {
     return [envVar, "OPENAI_API_KEY"];
   }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4693,7 +4693,7 @@ describe("CHAT-02: model-first provider policies", () => {
     });
   }, 90_000);
 
-  it("selects a vm0 managed key by vendor", async () => {
+  it("routes vm0 managed Claude through the OpenRouter vendor", async () => {
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const keyFixtureId = randomUUID();
@@ -4711,7 +4711,7 @@ describe("CHAT-02: model-first provider policies", () => {
 
     const acquiredApiKey = await acquireBddVm0ApiKey({
       fixtureId: keyFixtureId,
-      vendor: "anthropic",
+      vendor: "openrouter",
       apiKey: requestedApiKey,
     });
     expect(acquiredApiKey === requestedApiKey).toBeFalsy();
@@ -4738,10 +4738,31 @@ describe("CHAT-02: model-first provider policies", () => {
       run.runId,
     );
     const environment = claimEnvironment(claim);
-    expect(environment.ANTHROPIC_API_KEY).toBe(
-      modelProviderSecretPlaceholder("anthropic-api-key", "ANTHROPIC_API_KEY"),
+    expect(claim.cliAgentType).toBe("claude-code");
+    expect(environment).toMatchObject({
+      ANTHROPIC_AUTH_TOKEN: modelProviderSecretPlaceholder(
+        "openrouter-api-key",
+        "OPENROUTER_API_KEY",
+      ),
+      ANTHROPIC_BASE_URL: "https://openrouter.ai/api",
+      ANTHROPIC_API_KEY: "",
+      ANTHROPIC_MODEL: "anthropic/claude-opus-4.8",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "anthropic/claude-opus-4.8",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "anthropic/claude-opus-4.8",
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "anthropic/claude-opus-4.8",
+      CLAUDE_CODE_SUBAGENT_MODEL: "anthropic/claude-opus-4.8",
+    });
+    expect(
+      claim.firewalls?.map((firewall) => {
+        return firewall.kind === "builtin"
+          ? firewall.name
+          : firewall.firewall.name;
+      }),
+    ).toContain("model-provider:openrouter-api-key");
+    expect(claim.billableFirewalls).toContain(
+      "model-provider:openrouter-api-key",
     );
-    expect(environment.ANTHROPIC_MODEL).toBe("claude-opus-4-8");
+    expect(claim.modelUsageProvider).toBe("claude-opus-4-8");
 
     if (!claim.encryptedSecrets) {
       throw new Error("Expected vm0 claim to carry encrypted secrets");
@@ -4751,7 +4772,7 @@ describe("CHAT-02: model-first provider policies", () => {
       {
         encryptedSecrets: claim.encryptedSecrets,
         authHeaders: {
-          Authorization: `Bearer ${secretTemplate("ANTHROPIC_API_KEY")}`,
+          Authorization: `Bearer ${secretTemplate("OPENROUTER_API_KEY")}`,
         },
       },
       [200],

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -247,8 +247,8 @@ function vm0ManagedKeyRows(composeId: string) {
       label: composeId,
     },
     {
-      vendor: "anthropic",
-      apiKey: `vm0-key-anthropic-${composeId}`,
+      vendor: getVm0Vendor("claude-opus-4-8"),
+      apiKey: `vm0-key-claude-${composeId}`,
       label: composeId,
     },
     {

--- a/turbo/apps/api/src/signals/routes/test-teams-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-state.ts
@@ -286,8 +286,8 @@ function vm0ManagedKeyRows(composeId: string) {
       label: composeId,
     },
     {
-      vendor: "anthropic",
-      apiKey: `vm0-key-anthropic-${composeId}`,
+      vendor: getVm0Vendor("claude-opus-4-8"),
+      apiKey: `vm0-key-claude-${composeId}`,
       label: composeId,
     },
     {

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -873,8 +873,8 @@ async function seedTelegramPostModelKeys(
         label: seed.composeId,
       },
       {
-        vendor: "anthropic",
-        apiKey: `vm0-key-anthropic-${seed.composeId}`,
+        vendor: getVm0Vendor("claude-opus-4-8"),
+        apiKey: `vm0-key-claude-${seed.composeId}`,
         label: seed.composeId,
       },
       {
@@ -1439,8 +1439,8 @@ async function seedModelPoliciesForAction(
   await db
     .insert(vm0ApiKeys)
     .values({
-      vendor: "anthropic",
-      apiKey: "vm0-key-anthropic",
+      vendor: getVm0Vendor("claude-opus-4-8"),
+      apiKey: "vm0-key-claude",
       label: required.compose_id!,
     })
     .onConflictDoNothing({ target: vm0ApiKeys.vendor });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -17,6 +17,7 @@ import {
   getDefaultOrgModelPolicySeed,
   getProviderRuntimeModel,
   getProvidersForModel,
+  getVm0ApiModel,
   getVm0ConcreteProviderType,
   getVm0Vendor,
   getVm0ModelPriceTier,
@@ -503,6 +504,22 @@ describe("model-first canonical catalog", () => {
       "custom/model",
     );
   });
+
+  it.each([
+    ["claude-fable-5", "anthropic/claude-fable-5"],
+    ["claude-opus-5", "anthropic/claude-opus-5"],
+    ["claude-opus-4-8", "anthropic/claude-opus-4.8"],
+    ["claude-sonnet-5", "anthropic/claude-sonnet-5"],
+    ["claude-sonnet-4-6", "anthropic/claude-sonnet-4.6"],
+  ] as const)(
+    "routes vm0 managed %s through OpenRouter as %s",
+    (model, apiModel) => {
+      expect(getVm0ConcreteProviderType(model)).toBe("openrouter-api-key");
+      expect(getVm0Vendor(model)).toBe("openrouter");
+      expect(getVm0ApiModel(model)).toBe(apiModel);
+      expect(getProviderRuntimeModel("vm0", model)).toBe(apiModel);
+    },
+  );
 
   it("builds the default org policy seed from the workspace defaults", () => {
     expect(DEFAULT_ORG_MODEL_POLICY_MODELS).toEqual([

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -239,24 +239,29 @@ interface Vm0ModelConfig {
 // the order models appear in the Built-in model dropdown.
 export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
   "claude-fable-5": {
-    concreteType: "anthropic-api-key",
-    vendor: "anthropic",
+    concreteType: "openrouter-api-key",
+    vendor: "openrouter",
+    apiModel: "anthropic/claude-fable-5",
   },
   "claude-opus-5": {
-    concreteType: "anthropic-api-key",
-    vendor: "anthropic",
+    concreteType: "openrouter-api-key",
+    vendor: "openrouter",
+    apiModel: "anthropic/claude-opus-5",
   },
   "claude-opus-4-8": {
-    concreteType: "anthropic-api-key",
-    vendor: "anthropic",
+    concreteType: "openrouter-api-key",
+    vendor: "openrouter",
+    apiModel: "anthropic/claude-opus-4.8",
   },
   "claude-sonnet-5": {
-    concreteType: "anthropic-api-key",
-    vendor: "anthropic",
+    concreteType: "openrouter-api-key",
+    vendor: "openrouter",
+    apiModel: "anthropic/claude-sonnet-5",
   },
   "claude-sonnet-4-6": {
-    concreteType: "anthropic-api-key",
-    vendor: "anthropic",
+    concreteType: "openrouter-api-key",
+    vendor: "openrouter",
+    apiModel: "anthropic/claude-sonnet-4.6",
   },
   "deepseek-v4-flash": {
     concreteType: "deepseek",

--- a/turbo/packages/core/src/model-display-name.ts
+++ b/turbo/packages/core/src/model-display-name.ts
@@ -5,7 +5,7 @@ import type { CodexServiceTier } from "@okouai/api-contracts/contracts/chat-thre
  * Falls back to the raw model ID if no mapping is found.
  */
 const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
-  // Anthropic direct (claude-code-oauth-token, anthropic-api-key, vm0)
+  // Canonical Claude model IDs
   "claude-fable-5": "Claude Fable 5",
   "claude-opus-5": "Claude Opus 5",
   "claude-sonnet-5": "Claude Sonnet 5",


### PR DESCRIPTION
## Summary

- route all five VM0-managed Claude models through the existing OpenRouter provider and managed credential vendor
- send exact OpenRouter-qualified model IDs while preserving canonical VM0 usage attribution
- update development and integration fixtures to seed the active OpenRouter vendor and remove the unreachable Anthropic VM0 seed fallback
- cover mapping, runtime environment, firewall authentication, billable firewall selection, and usage attribution
- run the real Claude E2E smoke through the VM0-managed route so preview CI verifies OpenRouter without depending on the exhausted Anthropic BYOK credential

## Explicit exclusions

- user-configured Anthropic API key, Claude Code OAuth, OpenRouter, and Vercel AI Gateway routes are unchanged
- this does not add automatic provider failover or repair claims already constructed for active runs
- production still requires a valid funded `openrouter` managed-key row and a post-deploy completed smoke run

## Validation

- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts`
- `pnpm -F api exec vitest run src/scripts/__tests__/dev-seed.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "routes vm0 managed Claude through the OpenRouter vendor"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-slack-state.test.ts src/signals/routes/__tests__/test-telegram-state.test.ts src/signals/routes/__tests__/test-teams-state.test.ts`
- `pnpm turbo run lint --filter=@okouai/api-contracts --filter=@okouai/core --filter=api --concurrency=1`
- `pnpm check-types`
- `pnpm knip`
- Prettier check for the changed workflow and E2E files
- YAML parse and focused VM0 real-Claude bootstrap assertions
- Bash syntax check for the changed workflow test and Bats file

Closes #27063
