### PR TITLE
fix(platform): restore legal consent checkbox checkmark

### DIFF
--- a/turbo/apps/platform/src/lib/static-assets.ts
+++ b/turbo/apps/platform/src/lib/static-assets.ts
@@ -4,9 +4,6 @@ export function platformStaticAssetUrl(path: string) {
   return `${STATIC_ASSETS_BASE_URL}/platform/${path.replace(/^\/+/u, "")}`;
 }
 
-export const platformCheckmarkPrimaryImg = platformStaticAssetUrl(
-  "checkmark-primary-52b8c1164a7c.svg",
-);
 export const platformEmptyPrivateAgentsImg = platformStaticAssetUrl(
   "views/agents-page/assets/empty-private-agents-9a8d7e3750b6.png",
 );

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -3,7 +3,6 @@ import { useGet, useSet } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  platformCheckmarkPrimaryImg,
   platformVm0LogoDarkImg,
   platformVm0LogoImg,
 } from "../../lib/static-assets.ts";
@@ -315,7 +314,7 @@ a[class*="resendCode"] {
   color: hsl(var(--primary)) !important;
 }
 
-/* Legal consent checkbox - clear visual distinction between checked/unchecked states */
+/* Legal consent checkbox - preserve Clerk's checkmark on the platform checked surface */
 .cl-card input[type="checkbox"],
 .cl-formFieldCheckboxInput input[type="checkbox"] {
   -webkit-appearance: none;
@@ -333,12 +332,8 @@ a[class*="resendCode"] {
 
 .cl-card input[type="checkbox"]:checked,
 .cl-formFieldCheckboxInput input[type="checkbox"]:checked {
-  background-color: transparent !important;
+  background-color: hsl(var(--primary)) !important;
   border-color: hsl(var(--primary)) !important;
-  background-image: url("${platformCheckmarkPrimaryImg}") !important;
-  background-repeat: no-repeat !important;
-  background-position: center !important;
-  background-size: 70% !important;
 }
 
 .cl-card input[type="checkbox"]:hover,


### PR DESCRIPTION
Closes #25528

Supersedes #25530 with a focused change based on the current `main` branch.

## Root cause

The auth stylesheet replaced Clerk's built-in, centered white checkbox mark with a custom primary-colored CDN SVG while keeping the checked surface transparent. On the 16 px Legal consent checkbox at DPR 1, the SVG rendered as a faint partial mark, so the checked state was difficult to distinguish.

## Fix

- Preserve Clerk's built-in 8 px white checkmark.
- Fill the checked surface with `--primary`, matching the platform Checkbox checked state.
- Remove the now-unused checkmark static asset export.

## Verification

- Reproduced on `https://app.vm0.ai/sign-up` at DPR 1 and confirmed the failing computed styles (`background-size: 70%`, transparent background, custom CDN SVG).
- Verified the candidate styles against the same live Clerk DOM: the checked surface is primary-filled and the built-in mark is complete and centered.
- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (12/12 tasks)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/auth/__tests__/auth-page.test.tsx` (20/20 tests)

## PR Preview browser verification

- Target PR: #27079
- Head SHA: `00c3c05d845a57a13eb23ca55591e4e6c22f0de9`
- Deployed app merge SHA: `6509d41c8099daea73257bf502605f9470196d2e` (second parent is the head SHA above)
- App: `https://pr-27079-app.omby.ai/sign-up`
- API: `https://pr-27079-api.vm6.ai`
- Fixture: unauthenticated sign-up page; no onboarding bypass; no feature switches

PASS on desktop Chromium 151 at 1280 x 900, DPR 1 and on the iPhone 14 profile at 390 x 844, DPR 3:

- Clicking the checkbox changes its native checked state to `true`.
- The 16 x 16 checked surface is `--primary` (`rgb(239, 80, 1)`).
- Clerk's 8 x 8 white SVG checkmark is centered at `50% 50%` and fully visible.
- Uncheck and re-check both work; hover retains the checked-state colors.
- The mobile viewport has no horizontal overflow.
- No browser page errors were reported. The console only contains Clerk's expected development-key warning.

| Desktop close-up | iPhone 14 close-up |
| --- | --- |
| ![Desktop legal consent checkbox](https://cdn.vm0.io/artifacts/oln2ph3t7f.png) | ![Mobile legal consent checkbox](https://cdn.vm0.io/artifacts/hevyb6ymbx.png) |

Full-page screenshots: [desktop](https://cdn.vm0.io/artifacts/0a2x1twkps.png) and [iPhone 14](https://cdn.vm0.io/artifacts/gpi7dltbuv.png).
