### PR TITLE
fix(platform): fit presentation artifact previews

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/presentation-artifact-viewport.ts
+++ b/turbo/apps/platform/src/signals/zero-page/presentation-artifact-viewport.ts
@@ -1,0 +1,61 @@
+import { command } from "ccstate";
+import { onRef } from "../utils.ts";
+
+export const PRESENTATION_ARTIFACT_VIEWPORT_WIDTH = 1920;
+export const PRESENTATION_ARTIFACT_VIEWPORT_HEIGHT = 1080;
+
+function presentationArtifactCanvas(container: HTMLDivElement): HTMLDivElement {
+  const canvas = container.querySelector<HTMLDivElement>(
+    "[data-presentation-artifact-canvas]",
+  );
+  if (!canvas) {
+    throw new Error("Presentation artifact viewport has no canvas");
+  }
+  return canvas;
+}
+
+function fitPresentationArtifactCanvas(
+  container: HTMLDivElement,
+  canvas: HTMLDivElement,
+): void {
+  const { clientHeight, clientWidth } = container;
+  if (clientHeight === 0 || clientWidth === 0) {
+    canvas.style.visibility = "hidden";
+    return;
+  }
+
+  const scale = Math.min(
+    clientWidth / PRESENTATION_ARTIFACT_VIEWPORT_WIDTH,
+    clientHeight / PRESENTATION_ARTIFACT_VIEWPORT_HEIGHT,
+  );
+  const left = (clientWidth - PRESENTATION_ARTIFACT_VIEWPORT_WIDTH * scale) / 2;
+  const top =
+    (clientHeight - PRESENTATION_ARTIFACT_VIEWPORT_HEIGHT * scale) / 2;
+
+  canvas.style.transform = `translate(${String(left)}px, ${String(top)}px) scale(${String(scale)})`;
+  canvas.style.visibility = "visible";
+}
+
+const attachPresentationArtifactViewport$ = command(
+  (_, container: HTMLDivElement, signal: AbortSignal): void => {
+    const canvas = presentationArtifactCanvas(container);
+    const fit = () => {
+      fitPresentationArtifactCanvas(container, canvas);
+    };
+    const observer = new ResizeObserver(fit);
+
+    observer.observe(container);
+    signal.addEventListener(
+      "abort",
+      () => {
+        observer.disconnect();
+      },
+      { once: true },
+    );
+    fit();
+  },
+);
+
+export const presentationArtifactViewportRef$ = onRef(
+  attachPresentationArtifactViewport$,
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2477,16 +2477,21 @@ describe("zero attachment chips", () => {
     expect(screen.queryByLabelText("Enter fullscreen")).toBeNull();
   });
 
-  it("opens presentation HTML preview controls from chat message links", async () => {
+  it("opens presentation HTML preview controls from hosted alias links", async () => {
     const resizeObserver = mockResizeObserver();
-    const presentationUrl =
-      "https://cdn.vm7.io/artifacts/test/body-presentation/quarterly-roadmap.html";
+    const presentationUrl = "https://quarterly-roadmap.sites.vm7.io";
+    const presentationDeploymentUrl =
+      "https://dpl-quarterly-roadmap.sites.vm7.io";
     context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
       return respond(200, {
         runs: [
           {
             runId: "run-presentation",
-            files: [artifactFile(presentationUrl)],
+            files: [
+              artifactFile(presentationDeploymentUrl, {
+                aliasUrl: presentationUrl,
+              }),
+            ],
           },
         ],
       });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -20,6 +20,7 @@ import { click, detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { canonicalUserMessageFileUrl } from "../../../signals/chat-page/user-message-files.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 import { mockChatEventRows } from "./chat-event-test-helpers.ts";
+import { mockResizeObserver } from "./chat-lifecycle-test-helpers.ts";
 
 const context = testContext();
 const PLACEHOLDER = "Ask me to automate workflows, manage tasks...";
@@ -1782,6 +1783,9 @@ describe("zero attachment chips", () => {
         presignedFileUrl("attachment-html"),
       );
     });
+    expect(
+      screen.queryByTestId("presentation-artifact-viewport"),
+    ).not.toBeInTheDocument();
 
     click(screen.getByLabelText("Open in split view"));
 
@@ -1791,6 +1795,9 @@ describe("zero attachment chips", () => {
         presignedFileUrl("attachment-html"),
       );
     });
+    expect(
+      screen.queryByTestId("presentation-artifact-viewport"),
+    ).not.toBeInTheDocument();
   });
 
   it("navigates modal image artifacts within the current run", async () => {
@@ -2471,6 +2478,7 @@ describe("zero attachment chips", () => {
   });
 
   it("opens presentation HTML preview controls from chat message links", async () => {
+    const resizeObserver = mockResizeObserver();
     const presentationUrl =
       "https://cdn.vm7.io/artifacts/test/body-presentation/quarterly-roadmap.html";
     context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
@@ -2520,6 +2528,22 @@ describe("zero attachment chips", () => {
       "tabindex",
       "-1",
     );
+    const dialog = screen.getByTestId("attachment-lightbox");
+    const dialogViewport = within(dialog).getByTestId(
+      "presentation-artifact-viewport",
+    );
+    mockElementBox(dialogViewport, { height: 600, width: 960 });
+    act(() => {
+      resizeObserver.automationAll();
+    });
+    expect(
+      within(dialog).getByTestId("presentation-artifact-canvas"),
+    ).toHaveStyle({
+      height: "1080px",
+      transform: "translate(0px, 30px) scale(0.5)",
+      visibility: "visible",
+      width: "1920px",
+    });
 
     click(screen.getByLabelText("Enter fullscreen"));
 
@@ -2551,6 +2575,22 @@ describe("zero attachment chips", () => {
       "tabindex",
       "-1",
     );
+    const sidebar = screen.getByTestId("artifact-sidebar");
+    const sidebarViewport = within(sidebar).getByTestId(
+      "presentation-artifact-viewport",
+    );
+    mockElementBox(sidebarViewport, { height: 600, width: 480 });
+    act(() => {
+      resizeObserver.automationAll();
+    });
+    expect(
+      within(sidebar).getByTestId("presentation-artifact-canvas"),
+    ).toHaveStyle({
+      height: "1080px",
+      transform: "translate(0px, 165px) scale(0.25)",
+      visibility: "visible",
+      width: "1920px",
+    });
 
     click(screen.getByLabelText("Close artifact"));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -13,6 +13,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { logsListContract } from "@okouai/api-contracts/contracts/logs";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -2477,6 +2478,66 @@ describe("zero attachment chips", () => {
     expect(screen.queryByLabelText("Enter fullscreen")).toBeNull();
   });
 
+  it("keeps hosted presentation aliases on the legacy preview when disabled", async () => {
+    const presentationUrl = "https://legacy-roadmap.sites.vm7.io";
+    const presentationDeploymentUrl = "https://dpl-legacy-roadmap.sites.vm7.io";
+    context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
+      return respond(200, {
+        runs: [
+          {
+            runId: "run-legacy-presentation",
+            files: [
+              artifactFile(presentationDeploymentUrl, {
+                aliasUrl: presentationUrl,
+              }),
+            ],
+          },
+        ],
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatEvents: [
+        {
+          id: "msg-legacy-presentation-artifact",
+          role: "assistant",
+          content: `[Legacy roadmap](${presentationUrl})`,
+          runId: "run-legacy-presentation",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.PresentationArtifactViewport]: false,
+      },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(await screen.findByLabelText("Open html preview for Legacy roadmap"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("artifact-dialog-body-html"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("presentation-artifact-viewport"),
+    ).not.toBeInTheDocument();
+
+    click(screen.getByLabelText("Open in split view"));
+
+    const sidebar = await screen.findByTestId("artifact-sidebar");
+    expect(
+      within(sidebar).queryByTestId("presentation-artifact-viewport"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(sidebar).getByTestId("artifact-sidebar-body-html"),
+    ).not.toHaveAttribute("tabindex", "-1");
+  });
+
   it("opens presentation HTML preview controls from hosted alias links", async () => {
     const resizeObserver = mockResizeObserver();
     const presentationUrl = "https://quarterly-roadmap.sites.vm7.io";
@@ -2511,6 +2572,9 @@ describe("zero attachment chips", () => {
 
     detachedSetupPage({
       context,
+      featureSwitches: {
+        [FeatureSwitchKey.PresentationArtifactViewport]: true,
+      },
       path: `/chats/${THREAD_ID}`,
     });
 

--- a/turbo/apps/platform/src/views/zero-page/presentation-artifact-viewport.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-artifact-viewport.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { useSet } from "ccstate-react";
+import {
+  PRESENTATION_ARTIFACT_VIEWPORT_HEIGHT,
+  PRESENTATION_ARTIFACT_VIEWPORT_WIDTH,
+  presentationArtifactViewportRef$,
+} from "../../signals/zero-page/presentation-artifact-viewport.ts";
+
+export function PresentationArtifactViewport({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  const viewportRef = useSet(presentationArtifactViewportRef$);
+
+  return (
+    <div
+      ref={viewportRef}
+      className="relative h-full w-full overflow-hidden bg-background"
+      data-testid="presentation-artifact-viewport"
+    >
+      <div
+        data-presentation-artifact-canvas
+        data-testid="presentation-artifact-canvas"
+        className="absolute left-0 top-0"
+        style={{
+          height: PRESENTATION_ARTIFACT_VIEWPORT_HEIGHT,
+          transformOrigin: "top left",
+          visibility: "hidden",
+          width: PRESENTATION_ARTIFACT_VIEWPORT_WIDTH,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -49,6 +49,7 @@ import {
 } from "./zero-zoomable-image-canvas.tsx";
 import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signals.ts";
 import type { ChatThreadArtifactFile } from "@okouai/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   ArtifactActionSeparator,
   ArtifactActionTooltip,
@@ -68,6 +69,7 @@ import {
 } from "./zero-artifact-image-navigation.ts";
 import { AutoFocusedArtifactIframe } from "./auto-focused-artifact-iframe.tsx";
 import { PresentationArtifactViewport } from "./presentation-artifact-viewport.tsx";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 
 // ---------------------------------------------------------------------------
 // ArtifactSidebar — thread-owned pane for rendering kind-specific artifact
@@ -159,11 +161,18 @@ function ArtifactSidebarWithThreadContext({
     equalityFn: equalEventImageGroups,
   });
   const reloadArtifacts = useSet(thread.reloadArtifacts$);
+  const presentationArtifactViewportEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.PresentationArtifactViewport] ??
+    false;
   const text$ = providedText$ ?? artifactRef.text$;
   const markdownTree$ = providedMarkdownTree$ ?? artifactRef.markdownTree$;
   const item =
     loadable.state === "hasData"
-      ? findArtifactItemForUrl(loadable.data, artifactRef.url)
+      ? findArtifactItemForUrl(
+          loadable.data,
+          artifactRef.url,
+          presentationArtifactViewportEnabled,
+        )
       : undefined;
   const imageNavigation =
     loadable.state === "hasData"
@@ -486,12 +495,14 @@ type ArtifactKindForBody =
 function findArtifactItemForUrl(
   runs: { runId: string; files: ChatThreadArtifactFile[] }[],
   url: string,
+  includeAliasUrl: boolean,
 ): ArtifactSidebarItem | undefined {
   for (const run of runs) {
     const file = run.files.find((candidate) => {
       return (
         artifactPreviewUrlsMatch(candidate.url, url) ||
-        (candidate.aliasUrl !== undefined &&
+        (includeAliasUrl &&
+          candidate.aliasUrl !== undefined &&
           artifactPreviewUrlsMatch(candidate.aliasUrl, url))
       );
     });
@@ -1416,6 +1427,9 @@ function ArtifactIframeBody({
   fullscreen: boolean;
 }) {
   const { t } = useTranslation();
+  const presentationArtifactViewportEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.PresentationArtifactViewport] ??
+    false;
   const resourceUrl = useResolvedAttachmentUrl(url);
   // PDF Open Parameters: #navpanes=0 hides Chromium's built-in left rail
   // (thumbnails / bookmarks) so the embedded preview shows just the page
@@ -1425,7 +1439,9 @@ function ArtifactIframeBody({
       ? `${resourceUrl}#navpanes=0`
       : resourceUrl;
   const isPresentationHtml =
-    kind === "html" && artifactKind === "presentation-html";
+    presentationArtifactViewportEnabled &&
+    kind === "html" &&
+    artifactKind === "presentation-html";
   if (resourceUrl === null || src === null) {
     return <ArtifactSpinner />;
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -67,6 +67,7 @@ import {
   shouldIgnoreImageArtifactNavigationKey,
 } from "./zero-artifact-image-navigation.ts";
 import { AutoFocusedArtifactIframe } from "./auto-focused-artifact-iframe.tsx";
+import { PresentationArtifactViewport } from "./presentation-artifact-viewport.tsx";
 
 // ---------------------------------------------------------------------------
 // ArtifactSidebar — thread-owned pane for rendering kind-specific artifact
@@ -1425,23 +1426,31 @@ function ArtifactIframeBody({
     return <ArtifactSpinner />;
   }
   if (kind === "html") {
+    const frame = (
+      <AutoFocusedArtifactIframe
+        focusKey={`${resourceUrl}:${fullscreen ? "fullscreen" : "sidebar"}`}
+        focusOnMount={fullscreen && !isPresentationHtml}
+        src={resourceUrl}
+        title={t(
+          ($) => {
+            return $.artifacts.preview.dialogLabel;
+          },
+          { filename },
+        )}
+        sandbox="allow-same-origin allow-scripts"
+        tabIndex={isPresentationHtml ? -1 : undefined}
+        className="h-full w-full border-0 bg-background"
+        data-testid={`artifact-sidebar-body-${kind}`}
+      />
+    );
+
     return (
       <div className="h-full w-full">
-        <AutoFocusedArtifactIframe
-          focusKey={`${resourceUrl}:${fullscreen ? "fullscreen" : "sidebar"}`}
-          focusOnMount={fullscreen && !isPresentationHtml}
-          src={resourceUrl}
-          title={t(
-            ($) => {
-              return $.artifacts.preview.dialogLabel;
-            },
-            { filename },
-          )}
-          sandbox="allow-same-origin allow-scripts"
-          tabIndex={isPresentationHtml ? -1 : undefined}
-          className="h-full w-full border-0 bg-background"
-          data-testid={`artifact-sidebar-body-${kind}`}
-        />
+        {isPresentationHtml ? (
+          <PresentationArtifactViewport>{frame}</PresentationArtifactViewport>
+        ) : (
+          frame
+        )}
       </div>
     );
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -489,7 +489,11 @@ function findArtifactItemForUrl(
 ): ArtifactSidebarItem | undefined {
   for (const run of runs) {
     const file = run.files.find((candidate) => {
-      return artifactPreviewUrlsMatch(candidate.url, url);
+      return (
+        artifactPreviewUrlsMatch(candidate.url, url) ||
+        (candidate.aliasUrl !== undefined &&
+          artifactPreviewUrlsMatch(candidate.aliasUrl, url))
+      );
     });
     if (file) {
       return { runId: run.runId, file };

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -335,7 +335,11 @@ function findArtifactDialogItemForUrl(
 ): ArtifactDialogItem | undefined {
   for (const run of runs) {
     const file = run.files.find((candidate) => {
-      return artifactPreviewUrlsMatch(candidate.url, url);
+      return (
+        artifactPreviewUrlsMatch(candidate.url, url) ||
+        (candidate.aliasUrl !== undefined &&
+          artifactPreviewUrlsMatch(candidate.aliasUrl, url))
+      );
     });
     if (file) {
       return { runId: run.runId, file };

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -24,6 +24,7 @@ import type {
   ChatThreadArtifactFile,
   ChatThreadArtifactRun,
 } from "@okouai/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type { ZeroChatAttachment } from "../../signals/zero-page/chat-draft";
 import type { ChatPanelSignals } from "../../signals/chat-page/chat-panel-signals.ts";
 import { downloadAttachment$ } from "../../signals/attachment-download.ts";
@@ -84,6 +85,7 @@ import {
 } from "./zero-zoomable-image-canvas.tsx";
 import { AutoFocusedArtifactIframe } from "./auto-focused-artifact-iframe.tsx";
 import { PresentationArtifactViewport } from "./presentation-artifact-viewport.tsx";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 
 type TextPreviewLoadState = {
   readonly status: "loading" | "loaded" | "error";
@@ -332,12 +334,14 @@ function artifactDialogSyncTarget(
 function findArtifactDialogItemForUrl(
   runs: ChatThreadArtifactRun[],
   url: string,
+  includeAliasUrl: boolean,
 ): ArtifactDialogItem | undefined {
   for (const run of runs) {
     const file = run.files.find((candidate) => {
       return (
         artifactPreviewUrlsMatch(candidate.url, url) ||
-        (candidate.aliasUrl !== undefined &&
+        (includeAliasUrl &&
+          candidate.aliasUrl !== undefined &&
           artifactPreviewUrlsMatch(candidate.aliasUrl, url))
       );
     });
@@ -979,8 +983,13 @@ function ArtifactDialogHtmlBody({
 }) {
   const { t } = useTranslation();
   const fullscreen = useGet(lightboxDialogFullscreen$);
+  const presentationArtifactViewportEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.PresentationArtifactViewport] ??
+    false;
   const src = useResolvedAttachmentUrl(preview.url);
-  const isPresentationHtml = artifact?.artifactKind === "presentation-html";
+  const isPresentationHtml =
+    presentationArtifactViewportEnabled &&
+    artifact?.artifactKind === "presentation-html";
 
   if (src === null) {
     return (
@@ -1104,11 +1113,18 @@ function ArtifactPreviewDialogThreadResolver({
   const eventGroups = useLastResolved(thread.eventImageGroups$, {
     equalityFn: equalEventImageGroups,
   });
+  const presentationArtifactViewportEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.PresentationArtifactViewport] ??
+    false;
   const navigateImageLightbox = useSet(navigateImageLightbox$);
   const reloadArtifacts = useSet(thread.reloadArtifacts$);
   const item =
     loadable.state === "hasData"
-      ? findArtifactDialogItemForUrl(loadable.data, preview.url)
+      ? findArtifactDialogItemForUrl(
+          loadable.data,
+          preview.url,
+          presentationArtifactViewportEnabled,
+        )
       : undefined;
   const resolvedImageNavigation =
     preview.kind === "image"

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -83,6 +83,7 @@ import {
   zoomableArtifactImageKey,
 } from "./zero-zoomable-image-canvas.tsx";
 import { AutoFocusedArtifactIframe } from "./auto-focused-artifact-iframe.tsx";
+import { PresentationArtifactViewport } from "./presentation-artifact-viewport.tsx";
 
 type TextPreviewLoadState = {
   readonly status: "loading" | "loaded" | "error";
@@ -909,9 +910,11 @@ function ArtifactDialogDocumentFrameBody({
 }
 
 function ArtifactDialogBody({
+  artifact,
   imageNavigation,
   preview,
 }: {
+  artifact: AttachmentArtifactMetadata | undefined;
   imageNavigation?: ArtifactImageNavigationActions;
   preview: AttachmentLightboxState;
 }) {
@@ -947,7 +950,13 @@ function ArtifactDialogBody({
   }
 
   if (preview.kind === "html") {
-    return <ArtifactDialogHtmlBody filename={filename} preview={preview} />;
+    return (
+      <ArtifactDialogHtmlBody
+        artifact={artifact}
+        filename={filename}
+        preview={preview}
+      />
+    );
   }
 
   return (
@@ -956,17 +965,18 @@ function ArtifactDialogBody({
 }
 
 function ArtifactDialogHtmlBody({
+  artifact,
   filename,
   preview,
 }: {
+  artifact: AttachmentArtifactMetadata | undefined;
   filename: string;
   preview: AttachmentLightboxState;
 }) {
   const { t } = useTranslation();
   const fullscreen = useGet(lightboxDialogFullscreen$);
   const src = useResolvedAttachmentUrl(preview.url);
-  const isPresentationHtml =
-    preview.artifact?.artifactKind === "presentation-html";
+  const isPresentationHtml = artifact?.artifactKind === "presentation-html";
 
   if (src === null) {
     return (
@@ -977,27 +987,35 @@ function ArtifactDialogHtmlBody({
     );
   }
 
+  const frame = (
+    <AutoFocusedArtifactIframe
+      focusKey={`${preview.url}:${fullscreen ? "fullscreen" : "dialog"}`}
+      focusOnMount={!isPresentationHtml}
+      src={src}
+      title={t(
+        ($) => {
+          return $.artifacts.preview.dialogLabel;
+        },
+        { filename },
+      )}
+      sandbox="allow-same-origin allow-scripts"
+      tabIndex={isPresentationHtml ? -1 : undefined}
+      scrolling="yes"
+      className="block h-full w-full border-0 bg-background"
+      data-testid="artifact-dialog-body-html"
+    />
+  );
+
   return (
     <div
       className="h-full w-full bg-background"
       data-testid="artifact-dialog-site-frame"
     >
-      <AutoFocusedArtifactIframe
-        focusKey={`${preview.url}:${fullscreen ? "fullscreen" : "dialog"}`}
-        focusOnMount={!isPresentationHtml}
-        src={src}
-        title={t(
-          ($) => {
-            return $.artifacts.preview.dialogLabel;
-          },
-          { filename },
-        )}
-        sandbox="allow-same-origin allow-scripts"
-        tabIndex={isPresentationHtml ? -1 : undefined}
-        scrolling="yes"
-        className="block h-full w-full border-0 bg-background"
-        data-testid="artifact-dialog-body-html"
-      />
+      {isPresentationHtml ? (
+        <PresentationArtifactViewport>{frame}</PresentationArtifactViewport>
+      ) : (
+        frame
+      )}
     </div>
   );
 }
@@ -1365,6 +1383,7 @@ function ArtifactPreviewDialogContent({
           </div>
           <div className="min-h-0 flex-1 bg-background">
             <ArtifactDialogBody
+              artifact={artifact}
               imageNavigation={imageNavigation}
               preview={preview}
             />

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -120,6 +120,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.PersonalModelProviderAccounts]).toBe(
       true,
     );
+    expect(staffOrgStates[FeatureSwitchKey.PresentationArtifactViewport]).toBe(
+      true,
+    );
     expect(staffOrgStates[FeatureSwitchKey.LatestWebsiteTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.SavedBillingCreditPurchase]).toBe(
@@ -153,6 +156,9 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ConnectorDiscovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ConnectorCatalogCount]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PersonalModelProviderAccounts]).toBe(
+      false,
+    );
+    expect(otherOrgStates[FeatureSwitchKey.PresentationArtifactViewport]).toBe(
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.LatestWebsiteTemplates]).toBe(false);

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -78,6 +78,7 @@ export enum FeatureSwitchKey {
   VideoTemplateOptions = "videoTemplateOptions",
   EmojiPickerCategoryRail = "emojiPickerCategoryRail",
   PresentationTemplates = "presentationTemplates",
+  PresentationArtifactViewport = "presentationArtifactViewport",
   LatestWebsiteTemplates = "latestWebsiteTemplates",
   ChatConversationLocator = "chatConversationLocator",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -314,6 +314,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable owner-scoped presentation template imports and catalog APIs.",
     enabled: false,
   },
+  [FeatureSwitchKey.PresentationArtifactViewport]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Fit presentation HTML artifacts into dialog, sidebar, and fullscreen previews and resolve their hosted aliases.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.LatestWebsiteTemplates]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- render `presentation-html` artifacts in a fixed 1920x1080 iframe viewport, then scale and center that viewport in direct chat dialogs, fullscreen, and sidebar previews
- resolve hosted `aliasUrl` links back to their artifact metadata so presentation previews use the same path in every surface
- gate the behavior behind `presentationArtifactViewport`; it is disabled globally and enabled only for `STAFF_ORG_ID_HASHES`, with the legacy iframe path preserved when disabled

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (24 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx` (47 passed)
- `pnpm exec prettier --check <changed files>`