### PR TITLE
fix(billing): unblock scheduled subscription transitions

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -77,6 +77,10 @@ export default defineConfig({
       testMatch: "paid-onboarding.spec.ts",
     },
     {
+      name: "billing-transitions",
+      testMatch: "billing-transitions.spec.ts",
+    },
+    {
       name: "features",
       testMatch: [
         "agents.spec.ts",

--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -1,0 +1,1031 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../fixtures";
+import {
+  refreshClerkSessionToken,
+  signInWithClerkTestingHelper,
+} from "../lib/auth";
+import {
+  createOrganization,
+  createUser,
+  deleteClerkTestOwnerResources,
+  generateTestEmail,
+} from "../lib/clerk-api";
+import {
+  authHeadersForToken,
+  completeExploreOnboarding,
+} from "../lib/onboarding";
+import { fillStripeCheckout } from "../lib/stripe-checkout";
+import { deriveAppUrl } from "../playwright.config";
+
+type PaidTier = "pro" | "team";
+type UsagePackUsd = 20 | 50 | 100 | 200;
+
+interface BillingOwner {
+  readonly organizationId: string;
+  readonly userId: string;
+}
+
+interface ScheduledPlanChangeSummary {
+  readonly targetTier: string | null;
+  readonly type: string;
+}
+
+interface ConcurrencySubscriptionSummary {
+  readonly cancelAtPeriodEnd: boolean;
+  readonly quantity: number;
+  readonly scheduledQuantity: number | null;
+}
+
+interface BillingSummary {
+  readonly cancelAtPeriodEnd: boolean;
+  readonly canBuyConcurrency: boolean;
+  readonly concurrencyLimit: number;
+  readonly concurrencyPurchaseReviewAvailable: boolean;
+  readonly concurrencySubscriptions: readonly ConcurrencySubscriptionSummary[];
+  readonly hasSubscription: boolean;
+  readonly scheduledChange: ScheduledPlanChangeSummary | null;
+  readonly tier: string;
+}
+
+interface UsagePackPendingChangeSummary {
+  readonly kind: string;
+  readonly status: string;
+  readonly targetUsagePackUsd: number | null;
+}
+
+interface UsagePackSummary {
+  readonly pendingChange: UsagePackPendingChangeSummary | null;
+  readonly tier: string;
+  readonly usagePackUsd: number;
+}
+
+const apiUrl = process.env.VM0_API_BACKEND_URL!;
+const appUrl = deriveAppUrl(apiUrl);
+const appOrigin = new URL(appUrl).origin;
+const STATE_TIMEOUT_MS = 60_000;
+const POLL_INTERVALS_MS = [500, 1_000, 2_000];
+
+test.describe.configure({ mode: "parallel" });
+
+test("usage-pack and Plan transitions preserve scheduled intent", async ({
+  page,
+}) => {
+  test.setTimeout(360_000);
+
+  await withBillingOwner(page, "E2E Usage Pack Transitions", async (owner) => {
+    let token = await buyUsagePackPlan(page, owner, "pro");
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: false,
+      hasSubscription: true,
+      scheduledChange: null,
+      tier: "pro",
+    });
+    await expectUsagePackState(page, token, owner.userId, {
+      pendingChange: null,
+      tier: "pro",
+      usagePackUsd: 20,
+    });
+
+    token = await changeUsagePack(page, owner, "pro", 200, "Confirm", true);
+    await expectUsagePackState(page, token, owner.userId, {
+      pendingChange: null,
+      tier: "pro",
+      usagePackUsd: 200,
+    });
+
+    token = await changeUsagePack(page, owner, "pro", 20, "Confirm");
+    await expectUsagePackState(page, token, owner.userId, {
+      pendingChange: {
+        kind: "downgrade",
+        status: "scheduled",
+        targetUsagePackUsd: 20,
+      },
+      tier: "pro",
+      usagePackUsd: 200,
+    });
+
+    token = await changeUsagePack(page, owner, "pro", 100, "Confirm");
+    await expectUsagePackState(page, token, owner.userId, {
+      pendingChange: {
+        kind: "downgrade",
+        status: "scheduled",
+        targetUsagePackUsd: 100,
+      },
+      tier: "pro",
+      usagePackUsd: 200,
+    });
+
+    token = await changeUsagePack(page, owner, "pro", 200, "Restore");
+    await expectUsagePackState(page, token, owner.userId, {
+      pendingChange: null,
+      tier: "pro",
+      usagePackUsd: 200,
+    });
+
+    token = await cancelPlan(page, owner, "pro");
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: true,
+      hasSubscription: true,
+      scheduledChange: {
+        targetTier: "limited-free-1",
+        type: "cancel",
+      },
+      tier: "pro",
+    });
+
+    token = await restorePlan(page, owner, "pro");
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: false,
+      hasSubscription: true,
+      scheduledChange: null,
+      tier: "pro",
+    });
+
+    token = await upgradeProToTeam(page, owner);
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: false,
+      hasSubscription: true,
+      scheduledChange: null,
+      tier: "team",
+    });
+    await expectUsagePackState(page, token, owner.userId, {
+      pendingChange: null,
+      tier: "team",
+      usagePackUsd: 200,
+    });
+
+    token = await cancelPlan(page, owner, "team");
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: true,
+      hasSubscription: true,
+      scheduledChange: {
+        targetTier: "limited-free-1",
+        type: "cancel",
+      },
+      tier: "team",
+    });
+
+    token = await restorePlan(page, owner, "team");
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: false,
+      hasSubscription: true,
+      scheduledChange: null,
+      tier: "team",
+    });
+
+    token = await downgradeTeamToPro(page, owner);
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: false,
+      hasSubscription: true,
+      scheduledChange: { targetTier: "pro", type: "downgrade" },
+      tier: "team",
+    });
+
+    token = await restorePlan(page, owner, "team");
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: false,
+      hasSubscription: true,
+      scheduledChange: null,
+      tier: "team",
+    });
+
+    token = await cancelPlan(page, owner, "team");
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: true,
+      hasSubscription: true,
+      scheduledChange: {
+        targetTier: "limited-free-1",
+        type: "cancel",
+      },
+      tier: "team",
+    });
+
+    token = await replaceTeamCancellationWithPro(page, owner);
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: false,
+      hasSubscription: true,
+      scheduledChange: { targetTier: "pro", type: "downgrade" },
+      tier: "team",
+    });
+
+    token = await restorePlan(page, owner, "team");
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: false,
+      hasSubscription: true,
+      scheduledChange: null,
+      tier: "team",
+    });
+    await expectUsagePackState(page, token, owner.userId, {
+      pendingChange: null,
+      tier: "team",
+      usagePackUsd: 200,
+    });
+  });
+});
+
+test("concurrency transitions handle schedules, cancellation, and restoration", async ({
+  page,
+}) => {
+  test.setTimeout(360_000);
+
+  await withBillingOwner(page, "E2E Concurrency Transitions", async (owner) => {
+    let token = await buyUsagePackPlan(page, owner, "team");
+    await expectPlanState(page, token, {
+      cancelAtPeriodEnd: false,
+      hasSubscription: true,
+      scheduledChange: null,
+      tier: "team",
+    });
+    await expectConcurrencyState(page, token, {
+      cancelAtPeriodEnd: null,
+      concurrencyLimit: 10,
+      quantity: null,
+      scheduledQuantity: null,
+      subscriptionCount: 0,
+    });
+
+    token = await buyConcurrency(page, owner, 5);
+    await expectConcurrencyState(page, token, {
+      cancelAtPeriodEnd: false,
+      concurrencyLimit: 15,
+      quantity: 5,
+      scheduledQuantity: null,
+      subscriptionCount: 1,
+    });
+
+    token = await changeConcurrency(page, owner, 1);
+    await expectConcurrencyState(page, token, {
+      cancelAtPeriodEnd: false,
+      concurrencyLimit: 15,
+      quantity: 5,
+      scheduledQuantity: 1,
+      subscriptionCount: 1,
+    });
+
+    token = await changeConcurrency(page, owner, 3);
+    await expectConcurrencyState(page, token, {
+      cancelAtPeriodEnd: false,
+      concurrencyLimit: 15,
+      quantity: 5,
+      scheduledQuantity: 3,
+      subscriptionCount: 1,
+    });
+
+    token = await changeConcurrency(page, owner, 6);
+    await expectConcurrencyState(page, token, {
+      cancelAtPeriodEnd: false,
+      concurrencyLimit: 16,
+      quantity: 6,
+      scheduledQuantity: null,
+      subscriptionCount: 1,
+    });
+
+    token = await cancelConcurrency(page, owner);
+    await expectConcurrencyState(page, token, {
+      cancelAtPeriodEnd: true,
+      concurrencyLimit: 16,
+      quantity: 6,
+      scheduledQuantity: null,
+      subscriptionCount: 1,
+    });
+
+    token = await restoreConcurrency(page, owner);
+    await expectConcurrencyState(page, token, {
+      cancelAtPeriodEnd: false,
+      concurrencyLimit: 16,
+      quantity: 6,
+      scheduledQuantity: null,
+      subscriptionCount: 1,
+    });
+
+    token = await changeConcurrency(page, owner, 10);
+    await expectConcurrencyState(page, token, {
+      cancelAtPeriodEnd: false,
+      concurrencyLimit: 20,
+      quantity: 10,
+      scheduledQuantity: null,
+      subscriptionCount: 1,
+    });
+  });
+});
+
+async function withBillingOwner(
+  page: Page,
+  organizationName: string,
+  run: (owner: BillingOwner) => Promise<void>,
+): Promise<void> {
+  const email = generateTestEmail("paid-onboarding");
+  let organizationId: string | undefined;
+
+  try {
+    const userId = await createUser(email);
+    organizationId = await createOrganization(
+      organizationName,
+      userId,
+      "paid-onboarding",
+    );
+    await signInWithClerkTestingHelper(page, email, appUrl, {
+      activeOrganizationId: organizationId,
+    });
+    await completeExploreOnboarding(page, { appUrl });
+    const token = await currentToken(page, organizationId);
+    await enableUsagePackPlans(page, token);
+    await run({ organizationId, userId });
+  } finally {
+    await deleteClerkTestOwnerResources(
+      email,
+      organizationId,
+      "paid-onboarding",
+    );
+  }
+}
+
+async function enableUsagePackPlans(page: Page, token: string): Promise<void> {
+  const response = await page.request.post(
+    `${apiUrl}/api/okou/feature-switches`,
+    {
+      data: { switches: { usagePackPlans: true } },
+      headers: authHeadersForToken(token),
+    },
+  );
+  if (response.status() !== 200) {
+    throw new Error(
+      `feature switch update failed with ${response.status()}: ${await response.text()}`,
+    );
+  }
+  const body: unknown = await response.json();
+  const responseBody = requireRecord(body, "feature switch response");
+  const effectiveSwitches = requireRecord(
+    responseBody.effectiveSwitches,
+    "effective feature switches",
+  );
+  if (effectiveSwitches.usagePackPlans !== true) {
+    throw new Error("usagePackPlans was not enabled for the billing E2E owner");
+  }
+}
+
+async function buyUsagePackPlan(
+  page: Page,
+  owner: BillingOwner,
+  tier: PaidTier,
+): Promise<string> {
+  const planLabel = tier === "pro" ? "Pro" : "Team";
+  const settings = await openBillingSettings(page);
+  await expect(
+    settings.getByText("No active plan", { exact: true }),
+  ).toBeVisible();
+  await settings.getByRole("button", { name: "Upgrade", exact: true }).click();
+
+  const choosePlan = page.getByRole("dialog", { name: "Choose a plan" });
+  await expect(choosePlan).toBeVisible();
+  const plan = choosePlan.getByRole("article", { name: `${planLabel} plan` });
+  await plan
+    .getByRole("button", { name: `Start with ${planLabel}`, exact: true })
+    .click();
+
+  const packages = page.getByRole("dialog", {
+    name: "Configure member packages",
+  });
+  await expect(packages).toBeVisible();
+  await expect(
+    packages.getByRole("combobox", { name: /^Usage for /u }),
+  ).toBeVisible();
+  const summary = packages.getByRole("region", { name: "Order summary" });
+  await summary
+    .getByRole("button", { name: `Upgrade to ${planLabel}`, exact: true })
+    .click();
+
+  await fillStripeCheckout(page);
+  await page.waitForURL((url) => url.origin === appOrigin, {
+    timeout: 120_000,
+    waitUntil: "domcontentloaded",
+  });
+  return await currentToken(page, owner.organizationId);
+}
+
+async function changeUsagePack(
+  page: Page,
+  owner: BillingOwner,
+  tier: PaidTier,
+  target: UsagePackUsd,
+  action: "Confirm" | "Restore",
+  cancelReviewOnce = false,
+): Promise<string> {
+  const packages = await openUsagePackManagement(page, tier);
+  await selectUsagePack(page, packages, target);
+  return await submitUsagePackConfiguration(
+    page,
+    owner,
+    packages,
+    action,
+    cancelReviewOnce,
+  );
+}
+
+async function openUsagePackManagement(
+  page: Page,
+  tier: PaidTier,
+): Promise<Locator> {
+  const planLabel = tier === "pro" ? "Pro" : "Team";
+  const settings = await openBillingSettings(page);
+  await expect(
+    settings.getByText(`${planLabel} plan`, { exact: true }).first(),
+  ).toBeVisible();
+  await settings
+    .getByRole("button", { name: "Compare all plans", exact: true })
+    .click();
+  const choosePlan = page.getByRole("dialog", { name: "Choose a plan" });
+  const plan = choosePlan.getByRole("article", { name: `${planLabel} plan` });
+  await plan.getByRole("button", { name: "Manage", exact: true }).click();
+  const packages = page.getByRole("dialog", {
+    name: "Configure member packages",
+  });
+  await expect(packages).toBeVisible();
+  return packages;
+}
+
+async function selectUsagePack(
+  page: Page,
+  packages: Locator,
+  target: UsagePackUsd,
+): Promise<void> {
+  const select = packages.getByRole("combobox", { name: /^Usage for /u });
+  await select.click();
+  await page
+    .getByRole("option", { name: new RegExp(`^\\$${target}(?:\\s|·)`, "u") })
+    .click();
+}
+
+async function submitUsagePackConfiguration(
+  page: Page,
+  owner: BillingOwner,
+  packages: Locator,
+  action: "Confirm" | "Restore",
+  cancelReviewOnce = false,
+): Promise<string> {
+  const summary = packages.getByRole("region", { name: "Order summary" });
+  const actionButton = summary.getByRole("button", {
+    name: action,
+    exact: true,
+  });
+  await expect(actionButton).toBeEnabled();
+  await actionButton.click();
+
+  let review = page.getByRole("dialog", { name: "Review package change" });
+  await expect(review).toBeVisible();
+  if (cancelReviewOnce) {
+    await review.getByRole("button", { name: "Cancel", exact: true }).click();
+    await expect(review).toBeHidden();
+    await expect(actionButton).toBeEnabled();
+    await actionButton.click();
+    review = page.getByRole("dialog", { name: "Review package change" });
+    await expect(review).toBeVisible();
+  }
+
+  const token = await currentToken(page, owner.organizationId);
+  await review.getByRole("button", { name: "Confirm", exact: true }).click();
+  await expect(review).toBeHidden({ timeout: 30_000 });
+  return token;
+}
+
+async function cancelPlan(
+  page: Page,
+  owner: BillingOwner,
+  tier: PaidTier,
+): Promise<string> {
+  const settings = await openBillingSettings(page);
+  const planLabel = tier === "pro" ? "Pro" : "Team";
+  await expect(
+    settings.getByText(`${planLabel} plan`, { exact: true }).first(),
+  ).toBeVisible();
+  await settings
+    .getByRole("button", { name: "Downgrade", exact: true })
+    .click();
+  const dialog = page.getByRole("dialog", { name: "Downgrade plan" });
+  await expect(dialog).toBeVisible();
+  if (tier === "team") {
+    await dialog.getByText("Free", { exact: true }).click();
+  }
+  const token = await currentToken(page, owner.organizationId);
+  await dialog
+    .getByRole("button", { name: "Cancel subscription", exact: true })
+    .click();
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  return token;
+}
+
+async function restorePlan(
+  page: Page,
+  owner: BillingOwner,
+  tier: PaidTier,
+): Promise<string> {
+  const settings = await openBillingSettings(page);
+  const restore = settings.getByRole("button", {
+    name: "Restore plan",
+    exact: true,
+  });
+  await expect(restore).toBeVisible();
+  await expect(
+    settings.getByRole("button", { name: "Upgrade", exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    settings.getByRole("button", { name: "Downgrade", exact: true }),
+  ).toHaveCount(0);
+  await restore.click();
+
+  const planLabel = tier === "pro" ? "Pro" : "Team";
+  const dialog = page.getByRole("dialog", {
+    name: `Restore ${planLabel} plan?`,
+  });
+  const token = await currentToken(page, owner.organizationId);
+  await dialog
+    .getByRole("button", { name: "Restore plan", exact: true })
+    .click();
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  return token;
+}
+
+async function upgradeProToTeam(
+  page: Page,
+  owner: BillingOwner,
+): Promise<string> {
+  const settings = await openBillingSettings(page);
+  await settings.getByRole("button", { name: "Upgrade", exact: true }).click();
+  const packages = page.getByRole("dialog", {
+    name: "Configure member packages",
+  });
+  await expect(packages).toBeVisible();
+  return await submitUsagePackConfiguration(page, owner, packages, "Confirm");
+}
+
+async function downgradeTeamToPro(
+  page: Page,
+  owner: BillingOwner,
+): Promise<string> {
+  const settings = await openBillingSettings(page);
+  await settings
+    .getByRole("button", { name: "Compare all plans", exact: true })
+    .click();
+  const choosePlan = page.getByRole("dialog", { name: "Choose a plan" });
+  const pro = choosePlan.getByRole("article", { name: "Pro plan" });
+  await pro.getByRole("button", { name: "Downgrade", exact: true }).click();
+  const packages = page.getByRole("dialog", {
+    name: "Configure member packages",
+  });
+  await expect(packages).toBeVisible();
+  return await submitUsagePackConfiguration(page, owner, packages, "Confirm");
+}
+
+async function replaceTeamCancellationWithPro(
+  page: Page,
+  owner: BillingOwner,
+): Promise<string> {
+  const settings = await openBillingSettings(page);
+  await settings
+    .getByRole("button", { name: "Compare all plans", exact: true })
+    .click();
+  const choosePlan = page.getByRole("dialog", { name: "Choose a plan" });
+  const pro = choosePlan.getByRole("article", { name: "Pro plan" });
+  await pro
+    .getByRole("button", { name: "Downgrade to Pro", exact: true })
+    .click();
+  const dialog = page.getByRole("dialog", { name: "Downgrade plan" });
+  const token = await currentToken(page, owner.organizationId);
+  await dialog
+    .getByRole("button", { name: "Downgrade to Pro", exact: true })
+    .click();
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  return token;
+}
+
+async function buyConcurrency(
+  page: Page,
+  owner: BillingOwner,
+  quantity: number,
+): Promise<string> {
+  const token = await currentToken(page, owner.organizationId);
+  const initial = await readBillingSummary(page, token);
+  expect(initial.canBuyConcurrency).toBe(true);
+  expect(initial.concurrencyPurchaseReviewAvailable).toBe(true);
+
+  const settings = await openBillingSettings(page);
+  await settings
+    .getByRole("button", { name: "Buy concurrency", exact: true })
+    .click();
+  const dialog = page.getByRole("dialog", { name: "Buy concurrency" });
+  const increase = dialog.getByRole("button", {
+    name: "Increase additional concurrency quantity",
+  });
+  for (let current = 1; current < quantity; current += 1) {
+    await increase.click();
+  }
+  await dialog
+    .getByRole("button", {
+      name: `Buy $${quantity * 100}/month`,
+      exact: true,
+    })
+    .click();
+  await expect(
+    dialog.getByRole("button", { name: "Confirm", exact: true }),
+  ).toBeVisible({ timeout: 30_000 });
+  const confirmationToken = await currentToken(page, owner.organizationId);
+  await dialog.getByRole("button", { name: "Confirm", exact: true }).click();
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  return confirmationToken;
+}
+
+async function changeConcurrency(
+  page: Page,
+  owner: BillingOwner,
+  targetQuantity: number,
+): Promise<string> {
+  const settings = await openBillingSettings(page);
+  await settings.getByRole("button", { name: "Change", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "Change concurrency" });
+  const input = dialog.getByLabel("New total slot quantity");
+  const reviewButton = dialog.getByRole("button", {
+    name: "Review change",
+    exact: true,
+  });
+  await expect(reviewButton).toBeDisabled();
+  await input.fill(String(targetQuantity));
+  await expect(reviewButton).toBeEnabled();
+  await reviewButton.click();
+
+  const review = page.getByRole("dialog", {
+    name: "Review concurrency change",
+  });
+  await expect(review).toBeVisible();
+  const token = await currentToken(page, owner.organizationId);
+  await review.getByRole("button", { name: "Confirm", exact: true }).click();
+  await expect(review).toBeHidden({ timeout: 30_000 });
+  return token;
+}
+
+async function cancelConcurrency(
+  page: Page,
+  owner: BillingOwner,
+): Promise<string> {
+  const settings = await openBillingSettings(page);
+  await settings.getByRole("button", { name: "Change", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "Change concurrency" });
+  await dialog
+    .getByRole("radio", { name: /Cancel entire subscription/u })
+    .click();
+  const token = await currentToken(page, owner.organizationId);
+  await dialog
+    .getByRole("button", { name: "Cancel subscription", exact: true })
+    .click();
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  return token;
+}
+
+async function restoreConcurrency(
+  page: Page,
+  owner: BillingOwner,
+): Promise<string> {
+  const settings = await openBillingSettings(page);
+  await expect(
+    settings.getByRole("button", { name: "Change", exact: true }),
+  ).toHaveCount(0);
+  const restore = settings.getByRole("button", {
+    name: "Restore",
+    exact: true,
+  });
+  await expect(restore).toBeVisible();
+  await restore.click();
+  const dialog = page.getByRole("dialog", {
+    name: "Restore concurrency subscription?",
+  });
+  const token = await currentToken(page, owner.organizationId);
+  await dialog
+    .getByRole("button", { name: "Restore subscription", exact: true })
+    .click();
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  return token;
+}
+
+async function openBillingSettings(page: Page): Promise<Locator> {
+  await page.goto(new URL("/?settings=billing", appUrl).toString(), {
+    waitUntil: "domcontentloaded",
+  });
+  const settings = page.getByRole("dialog", { name: "Settings" });
+  await expect(settings).toBeVisible({ timeout: 30_000 });
+  return settings;
+}
+
+async function currentToken(
+  page: Page,
+  organizationId: string,
+): Promise<string> {
+  return await refreshClerkSessionToken(page, {
+    activeOrganizationId: organizationId,
+  });
+}
+
+async function expectPlanState(
+  page: Page,
+  token: string,
+  expected: {
+    readonly cancelAtPeriodEnd: boolean;
+    readonly hasSubscription: boolean;
+    readonly scheduledChange: ScheduledPlanChangeSummary | null;
+    readonly tier: string;
+  },
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const state = await pollSafely(async () => {
+          return await readBillingSummary(page, token);
+        });
+        if ("pollingError" in state) {
+          return state;
+        }
+        return {
+          cancelAtPeriodEnd: state.cancelAtPeriodEnd,
+          hasSubscription: state.hasSubscription,
+          scheduledChange: state.scheduledChange,
+          tier: state.tier,
+        };
+      },
+      {
+        intervals: POLL_INTERVALS_MS,
+        message: `billing Plan state should become ${JSON.stringify(expected)}`,
+        timeout: STATE_TIMEOUT_MS,
+      },
+    )
+    .toEqual(expected);
+}
+
+async function expectUsagePackState(
+  page: Page,
+  token: string,
+  memberId: string,
+  expected: UsagePackSummary,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        return await pollSafely(async () => {
+          return await readUsagePackSummary(page, token, memberId);
+        });
+      },
+      {
+        intervals: POLL_INTERVALS_MS,
+        message: `usage-pack state should become ${JSON.stringify(expected)}`,
+        timeout: STATE_TIMEOUT_MS,
+      },
+    )
+    .toEqual(expected);
+}
+
+async function expectConcurrencyState(
+  page: Page,
+  token: string,
+  expected: {
+    readonly cancelAtPeriodEnd: boolean | null;
+    readonly concurrencyLimit: number;
+    readonly quantity: number | null;
+    readonly scheduledQuantity: number | null;
+    readonly subscriptionCount: number;
+  },
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const state = await pollSafely(async () => {
+          return await readBillingSummary(page, token);
+        });
+        if ("pollingError" in state) {
+          return state;
+        }
+        const subscription = state.concurrencySubscriptions[0] ?? null;
+        return {
+          cancelAtPeriodEnd: subscription?.cancelAtPeriodEnd ?? null,
+          concurrencyLimit: state.concurrencyLimit,
+          quantity: subscription?.quantity ?? null,
+          scheduledQuantity: subscription?.scheduledQuantity ?? null,
+          subscriptionCount: state.concurrencySubscriptions.length,
+        };
+      },
+      {
+        intervals: POLL_INTERVALS_MS,
+        message: `concurrency state should become ${JSON.stringify(expected)}`,
+        timeout: STATE_TIMEOUT_MS,
+      },
+    )
+    .toEqual(expected);
+}
+
+async function pollSafely<T>(
+  read: () => Promise<T>,
+): Promise<T | { readonly pollingError: string }> {
+  try {
+    return await read();
+  } catch (error) {
+    return {
+      pollingError: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function readBillingSummary(
+  page: Page,
+  token: string,
+): Promise<BillingSummary> {
+  const body = requireRecord(
+    await getApiJson(page, "/api/okou/billing/status", token),
+    "billing status",
+  );
+  const scheduledChange = parseScheduledPlanChange(body.scheduledChange);
+  const subscriptions = requireArray(
+    body.concurrencySubscriptions,
+    "billing concurrency subscriptions",
+  ).map((value, index) => {
+    const subscription = requireRecord(
+      value,
+      `billing concurrency subscription ${index}`,
+    );
+    return {
+      cancelAtPeriodEnd: requireBoolean(
+        subscription.cancelAtPeriodEnd,
+        "concurrency cancelAtPeriodEnd",
+      ),
+      quantity: requireNumber(subscription.quantity, "concurrency quantity"),
+      scheduledQuantity: optionalNullableNumber(
+        subscription.scheduledQuantity,
+        "concurrency scheduledQuantity",
+      ),
+    };
+  });
+
+  return {
+    cancelAtPeriodEnd: requireBoolean(
+      body.cancelAtPeriodEnd,
+      "billing cancelAtPeriodEnd",
+    ),
+    canBuyConcurrency: optionalBoolean(
+      body.canBuyConcurrency,
+      "billing canBuyConcurrency",
+    ),
+    concurrencyLimit: requireNumber(
+      body.concurrencyLimit,
+      "billing concurrencyLimit",
+    ),
+    concurrencyPurchaseReviewAvailable: optionalBoolean(
+      body.concurrencyPurchaseReviewAvailable,
+      "billing concurrencyPurchaseReviewAvailable",
+    ),
+    concurrencySubscriptions: subscriptions,
+    hasSubscription: requireBoolean(
+      body.hasSubscription,
+      "billing hasSubscription",
+    ),
+    scheduledChange,
+    tier: requireString(body.tier, "billing tier"),
+  };
+}
+
+async function readUsagePackSummary(
+  page: Page,
+  token: string,
+  memberId: string,
+): Promise<UsagePackSummary> {
+  const body = requireRecord(
+    await getApiJson(page, "/api/okou/billing/usage-pack-subscription", token),
+    "usage-pack management",
+  );
+  const allocation = requireArray(body.allocations, "usage-pack allocations")
+    .map((value, index) => {
+      return requireRecord(value, `usage-pack allocation ${index}`);
+    })
+    .find((value) => value.memberId === memberId);
+  if (!allocation) {
+    throw new Error(`usage-pack allocation for member ${memberId} not found`);
+  }
+
+  return {
+    pendingChange: parseUsagePackPendingChange(allocation.pendingChange),
+    tier: requireString(body.tier, "usage-pack tier"),
+    usagePackUsd: requireNumber(
+      allocation.usagePackUsd,
+      "usage-pack allocation amount",
+    ),
+  };
+}
+
+async function getApiJson(
+  page: Page,
+  path: string,
+  token: string,
+): Promise<unknown> {
+  const response = await page.request.get(new URL(path, apiUrl).toString(), {
+    headers: authHeadersForToken(token),
+  });
+  if (response.status() !== 200) {
+    throw new Error(
+      `${path} failed with ${response.status()}: ${await response.text()}`,
+    );
+  }
+  const body: unknown = await response.json();
+  return body;
+}
+
+function parseScheduledPlanChange(
+  value: unknown,
+): ScheduledPlanChangeSummary | null {
+  if (value === null) {
+    return null;
+  }
+  const change = requireRecord(value, "scheduled Plan change");
+  return {
+    targetTier: optionalNullableString(
+      change.targetTier,
+      "scheduled Plan targetTier",
+    ),
+    type: requireString(change.type, "scheduled Plan change type"),
+  };
+}
+
+function parseUsagePackPendingChange(
+  value: unknown,
+): UsagePackPendingChangeSummary | null {
+  if (value === null) {
+    return null;
+  }
+  const change = requireRecord(value, "usage-pack pending change");
+  return {
+    kind: requireString(change.kind, "usage-pack pending change kind"),
+    status: requireString(change.status, "usage-pack pending change status"),
+    targetUsagePackUsd: optionalNullableNumber(
+      change.targetUsagePackUsd,
+      "usage-pack pending target",
+    ),
+  };
+}
+
+function requireRecord(
+  value: unknown,
+  description: string,
+): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${description} is not an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireArray(value: unknown, description: string): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${description} is not an array`);
+  }
+  return value;
+}
+
+function requireBoolean(value: unknown, description: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`${description} is not a boolean`);
+  }
+  return value;
+}
+
+function optionalBoolean(value: unknown, description: string): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  return requireBoolean(value, description);
+}
+
+function requireNumber(value: unknown, description: string): number {
+  if (typeof value !== "number") {
+    throw new Error(`${description} is not a number`);
+  }
+  return value;
+}
+
+function optionalNullableNumber(
+  value: unknown,
+  description: string,
+): number | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  return requireNumber(value, description);
+}
+
+function requireString(value: unknown, description: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${description} is not a string`);
+  }
+  return value;
+}
+
+function optionalNullableString(
+  value: unknown,
+  description: string,
+): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  return requireString(value, description);
+}

--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -22,7 +22,13 @@ type UsagePackUsd = 20 | 50 | 100 | 200;
 
 interface BillingOwner {
   readonly organizationId: string;
+  readonly session: BillingSession;
   readonly userId: string;
+}
+
+interface BillingSession {
+  refreshedAt: number;
+  token: string;
 }
 
 interface ScheduledPlanChangeSummary {
@@ -63,6 +69,7 @@ const apiUrl = process.env.VM0_API_BACKEND_URL!;
 const appUrl = deriveAppUrl(apiUrl);
 const appOrigin = new URL(appUrl).origin;
 const STATE_TIMEOUT_MS = 60_000;
+const TOKEN_REUSE_MS = 30_000;
 const POLL_INTERVALS_MS = [500, 1_000, 2_000];
 const USAGE_PACK_OPTION_PATTERNS: Readonly<Record<UsagePackUsd, RegExp>> = {
   20: /^\$20(?:\s|·)/u,
@@ -330,13 +337,16 @@ async function withBillingOwner(
       userId,
       "paid-onboarding",
     );
-    await signInWithClerkTestingHelper(page, email, appUrl, {
+    const token = await signInWithClerkTestingHelper(page, email, appUrl, {
       activeOrganizationId: organizationId,
     });
     await completeExploreOnboarding(page, { appUrl });
-    const token = await currentToken(page, organizationId);
     await enableUsagePackPlans(page, token);
-    await run({ organizationId, userId });
+    await run({
+      organizationId,
+      session: { refreshedAt: Date.now(), token },
+      userId,
+    });
   } finally {
     await deleteClerkTestOwnerResources(
       email,
@@ -406,7 +416,7 @@ async function buyUsagePackPlan(
     timeout: 120_000,
     waitUntil: "domcontentloaded",
   });
-  return await currentToken(page, owner.organizationId);
+  return await currentToken(page, owner);
 }
 
 async function changeUsagePack(
@@ -417,13 +427,14 @@ async function changeUsagePack(
   action: "Confirm" | "Restore",
   cancelReviewOnce = false,
 ): Promise<string> {
+  const token = await currentToken(page, owner);
   const packages = await openUsagePackManagement(page, tier);
   await selectUsagePack(page, packages, target);
   return await submitUsagePackConfiguration(
     page,
-    owner,
     packages,
     action,
+    token,
     cancelReviewOnce,
   );
 }
@@ -464,9 +475,9 @@ async function selectUsagePack(
 
 async function submitUsagePackConfiguration(
   page: Page,
-  owner: BillingOwner,
   packages: Locator,
   action: "Confirm" | "Restore",
+  token: string,
   cancelReviewOnce = false,
 ): Promise<string> {
   const summary = packages.getByRole("region", { name: "Order summary" });
@@ -488,7 +499,6 @@ async function submitUsagePackConfiguration(
     await expect(review).toBeVisible();
   }
 
-  const token = await currentToken(page, owner.organizationId);
   await review.getByRole("button", { name: "Confirm", exact: true }).click();
   await expect(review).toBeHidden({ timeout: 30_000 });
   return token;
@@ -499,6 +509,7 @@ async function cancelPlan(
   owner: BillingOwner,
   tier: PaidTier,
 ): Promise<string> {
+  const token = await currentToken(page, owner);
   const settings = await openBillingSettings(page);
   const planLabel = tier === "pro" ? "Pro" : "Team";
   await expect(
@@ -512,7 +523,6 @@ async function cancelPlan(
   if (tier === "team") {
     await dialog.getByRole("button", { name: /^No plan/u }).click();
   }
-  const token = await currentToken(page, owner.organizationId);
   await dialog
     .getByRole("button", { name: "Cancel subscription", exact: true })
     .click();
@@ -525,6 +535,7 @@ async function restorePlan(
   owner: BillingOwner,
   tier: PaidTier,
 ): Promise<string> {
+  const token = await currentToken(page, owner);
   const settings = await openBillingSettings(page);
   const restore = settings.getByRole("button", {
     name: "Restore plan",
@@ -543,7 +554,6 @@ async function restorePlan(
   const dialog = page.getByRole("dialog", {
     name: `Restore ${planLabel} plan?`,
   });
-  const token = await currentToken(page, owner.organizationId);
   await dialog
     .getByRole("button", { name: "Restore plan", exact: true })
     .click();
@@ -555,19 +565,21 @@ async function upgradeProToTeam(
   page: Page,
   owner: BillingOwner,
 ): Promise<string> {
+  const token = await currentToken(page, owner);
   const settings = await openBillingSettings(page);
   await settings.getByRole("button", { name: "Upgrade", exact: true }).click();
   const packages = page.getByRole("dialog", {
     name: "Configure member packages",
   });
   await expect(packages).toBeVisible();
-  return await submitUsagePackConfiguration(page, owner, packages, "Confirm");
+  return await submitUsagePackConfiguration(page, packages, "Confirm", token);
 }
 
 async function downgradeTeamToPro(
   page: Page,
   owner: BillingOwner,
 ): Promise<string> {
+  const token = await currentToken(page, owner);
   const settings = await openBillingSettings(page);
   await settings
     .getByRole("button", { name: "Compare all plans", exact: true })
@@ -579,13 +591,14 @@ async function downgradeTeamToPro(
     name: "Configure member packages",
   });
   await expect(packages).toBeVisible();
-  return await submitUsagePackConfiguration(page, owner, packages, "Confirm");
+  return await submitUsagePackConfiguration(page, packages, "Confirm", token);
 }
 
 async function replaceTeamCancellationWithPro(
   page: Page,
   owner: BillingOwner,
 ): Promise<string> {
+  const token = await currentToken(page, owner);
   const settings = await openBillingSettings(page);
   await settings
     .getByRole("button", { name: "Compare all plans", exact: true })
@@ -595,7 +608,6 @@ async function replaceTeamCancellationWithPro(
   await pro.getByRole("button", { name: "Downgrade", exact: true }).click();
   const dialog = page.getByRole("dialog", { name: "Downgrade plan" });
   await expect(dialog).toBeVisible();
-  const token = await currentToken(page, owner.organizationId);
   await dialog
     .getByRole("button", { name: "Downgrade to Pro", exact: true })
     .click();
@@ -608,7 +620,7 @@ async function buyConcurrency(
   owner: BillingOwner,
   quantity: number,
 ): Promise<string> {
-  const token = await currentToken(page, owner.organizationId);
+  const token = await currentToken(page, owner);
   const initial = await readBillingSummary(page, token);
   expect(initial.canBuyConcurrency).toBe(true);
   expect(initial.concurrencyPurchaseReviewAvailable).toBe(true);
@@ -625,18 +637,17 @@ async function buyConcurrency(
     await increase.click();
   }
   await dialog
-    .getByRole("button", {
-      name: `Buy $${quantity * 100}/month`,
-      exact: true,
-    })
+    .getByRole("button", { name: "Review purchase", exact: true })
     .click();
-  await expect(
-    dialog.getByRole("button", { name: "Confirm", exact: true }),
-  ).toBeVisible({ timeout: 30_000 });
-  const confirmationToken = await currentToken(page, owner.organizationId);
-  await dialog.getByRole("button", { name: "Confirm", exact: true }).click();
-  await expect(dialog).toBeHidden({ timeout: 30_000 });
-  return confirmationToken;
+  const review = page.getByRole("dialog", {
+    name: "Review concurrency purchase",
+  });
+  await expect(review).toBeVisible({ timeout: 30_000 });
+  await review
+    .getByRole("button", { name: "Pay and add slots", exact: true })
+    .click();
+  await expect(review).toBeHidden({ timeout: 30_000 });
+  return token;
 }
 
 async function changeConcurrency(
@@ -644,10 +655,11 @@ async function changeConcurrency(
   owner: BillingOwner,
   targetQuantity: number,
 ): Promise<string> {
+  const token = await currentToken(page, owner);
   const settings = await openBillingSettings(page);
   await settings.getByRole("button", { name: "Change", exact: true }).click();
   const dialog = page.getByRole("dialog", { name: "Change concurrency" });
-  const input = dialog.getByLabel("New total slot quantity");
+  const input = dialog.getByRole("textbox", { name: "Slots" });
   const reviewButton = dialog.getByRole("button", {
     name: "Review change",
     exact: true,
@@ -661,8 +673,11 @@ async function changeConcurrency(
     name: "Review concurrency change",
   });
   await expect(review).toBeVisible({ timeout: 30_000 });
-  const token = await currentToken(page, owner.organizationId);
-  await review.getByRole("button", { name: "Confirm", exact: true }).click();
+  await review
+    .getByRole("button", {
+      name: /^(?:Pay and update|Schedule change|Update slots)$/u,
+    })
+    .click();
   await expect(review).toBeHidden({ timeout: 30_000 });
   return token;
 }
@@ -671,17 +686,22 @@ async function cancelConcurrency(
   page: Page,
   owner: BillingOwner,
 ): Promise<string> {
+  const token = await currentToken(page, owner);
   const settings = await openBillingSettings(page);
   await settings.getByRole("button", { name: "Change", exact: true }).click();
-  const dialog = page.getByRole("dialog", { name: "Change concurrency" });
-  await dialog
-    .getByRole("radio", { name: /Cancel entire subscription/u })
+  const changeDialog = page.getByRole("dialog", {
+    name: "Change concurrency",
+  });
+  await changeDialog
+    .getByRole("button", { name: "Cancel entire subscription", exact: true })
     .click();
-  const token = await currentToken(page, owner.organizationId);
-  await dialog
+  const cancelDialog = page.getByRole("dialog", {
+    name: "Cancel entire subscription",
+  });
+  await cancelDialog
     .getByRole("button", { name: "Cancel subscription", exact: true })
     .click();
-  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  await expect(cancelDialog).toBeHidden({ timeout: 30_000 });
   return token;
 }
 
@@ -689,6 +709,7 @@ async function restoreConcurrency(
   page: Page,
   owner: BillingOwner,
 ): Promise<string> {
+  const token = await currentToken(page, owner);
   const settings = await openBillingSettings(page);
   await expect(
     settings.getByRole("button", { name: "Change", exact: true }),
@@ -702,7 +723,6 @@ async function restoreConcurrency(
   const dialog = page.getByRole("dialog", {
     name: "Restore concurrency subscription?",
   });
-  const token = await currentToken(page, owner.organizationId);
   await dialog
     .getByRole("button", { name: "Restore subscription", exact: true })
     .click();
@@ -719,13 +739,16 @@ async function openBillingSettings(page: Page): Promise<Locator> {
   return settings;
 }
 
-async function currentToken(
-  page: Page,
-  organizationId: string,
-): Promise<string> {
-  return await refreshClerkSessionToken(page, {
-    activeOrganizationId: organizationId,
+async function currentToken(page: Page, owner: BillingOwner): Promise<string> {
+  if (Date.now() - owner.session.refreshedAt < TOKEN_REUSE_MS) {
+    return owner.session.token;
+  }
+  const token = await refreshClerkSessionToken(page, {
+    activeOrganizationId: owner.organizationId,
   });
+  owner.session.refreshedAt = Date.now();
+  owner.session.token = token;
+  return token;
 }
 
 async function expectPlanState(

--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -586,22 +586,7 @@ async function replaceTeamCancellationWithPro(
   page: Page,
   owner: BillingOwner,
 ): Promise<string> {
-  const settings = await openBillingSettings(page);
-  await settings
-    .getByRole("button", { name: "Compare all plans", exact: true })
-    .click();
-  const choosePlan = page.getByRole("dialog", { name: "Choose a plan" });
-  const pro = choosePlan.getByRole("article", { name: "Pro plan" });
-  await pro
-    .getByRole("button", { name: "Downgrade to Pro", exact: true })
-    .click();
-  const dialog = page.getByRole("dialog", { name: "Downgrade plan" });
-  const token = await currentToken(page, owner.organizationId);
-  await dialog
-    .getByRole("button", { name: "Downgrade to Pro", exact: true })
-    .click();
-  await expect(dialog).toBeHidden({ timeout: 30_000 });
-  return token;
+  return await downgradeTeamToPro(page, owner);
 }
 
 async function buyConcurrency(

--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -425,7 +425,7 @@ async function changeUsagePack(
   tier: PaidTier,
   target: UsagePackUsd,
   action: "Confirm" | "Restore",
-  cancelReviewOnce = false,
+  backFromReviewOnce = false,
 ): Promise<string> {
   const token = await currentToken(page, owner);
   const packages = await openUsagePackManagement(page, tier);
@@ -435,7 +435,7 @@ async function changeUsagePack(
     packages,
     action,
     token,
-    cancelReviewOnce,
+    backFromReviewOnce,
   );
 }
 
@@ -478,7 +478,7 @@ async function submitUsagePackConfiguration(
   packages: Locator,
   action: "Confirm" | "Restore",
   token: string,
-  cancelReviewOnce = false,
+  backFromReviewOnce = false,
 ): Promise<string> {
   const summary = packages.getByRole("region", { name: "Order summary" });
   const actionButton = summary.getByRole("button", {
@@ -490,8 +490,8 @@ async function submitUsagePackConfiguration(
 
   let review = page.getByRole("dialog", { name: "Review package change" });
   await expect(review).toBeVisible();
-  if (cancelReviewOnce) {
-    await review.getByRole("button", { name: "Cancel", exact: true }).click();
+  if (backFromReviewOnce) {
+    await review.getByRole("button", { name: "Back", exact: true }).click();
     await expect(review).toBeHidden();
     await expect(actionButton).toBeEnabled();
     await actionButton.click();

--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -586,7 +586,21 @@ async function replaceTeamCancellationWithPro(
   page: Page,
   owner: BillingOwner,
 ): Promise<string> {
-  return await downgradeTeamToPro(page, owner);
+  const settings = await openBillingSettings(page);
+  await settings
+    .getByRole("button", { name: "Compare all plans", exact: true })
+    .click();
+  const choosePlan = page.getByRole("dialog", { name: "Choose a plan" });
+  const pro = choosePlan.getByRole("article", { name: "Pro plan" });
+  await pro.getByRole("button", { name: "Downgrade", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "Downgrade plan" });
+  await expect(dialog).toBeVisible();
+  const token = await currentToken(page, owner.organizationId);
+  await dialog
+    .getByRole("button", { name: "Downgrade to Pro", exact: true })
+    .click();
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  return token;
 }
 
 async function buyConcurrency(

--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -64,6 +64,12 @@ const appUrl = deriveAppUrl(apiUrl);
 const appOrigin = new URL(appUrl).origin;
 const STATE_TIMEOUT_MS = 60_000;
 const POLL_INTERVALS_MS = [500, 1_000, 2_000];
+const USAGE_PACK_OPTION_PATTERNS: Readonly<Record<UsagePackUsd, RegExp>> = {
+  20: /^\$20(?:\s|·)/u,
+  50: /^\$50(?:\s|·)/u,
+  100: /^\$100(?:\s|·)/u,
+  200: /^\$200(?:\s|·)/u,
+};
 
 test.describe.configure({ mode: "parallel" });
 
@@ -452,7 +458,7 @@ async function selectUsagePack(
   const select = packages.getByRole("combobox", { name: /^Usage for /u });
   await select.click();
   await page
-    .getByRole("option", { name: new RegExp(`^\\$${target}(?:\\s|·)`, "u") })
+    .getByRole("option", { name: USAGE_PACK_OPTION_PATTERNS[target] })
     .click();
 }
 
@@ -504,7 +510,7 @@ async function cancelPlan(
   const dialog = page.getByRole("dialog", { name: "Downgrade plan" });
   await expect(dialog).toBeVisible();
   if (tier === "team") {
-    await dialog.getByText("Free", { exact: true }).click();
+    await dialog.getByRole("button", { name: /^No plan/u }).click();
   }
   const token = await currentToken(page, owner.organizationId);
   await dialog
@@ -655,7 +661,7 @@ async function changeConcurrency(
   const review = page.getByRole("dialog", {
     name: "Review concurrency change",
   });
-  await expect(review).toBeVisible();
+  await expect(review).toBeVisible({ timeout: 30_000 });
   const token = await currentToken(page, owner.organizationId);
   await review.getByRole("button", { name: "Confirm", exact: true }).click();
   await expect(review).toBeHidden({ timeout: 30_000 });

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -5823,6 +5823,202 @@ describe("usage pack allocation management", () => {
     ]);
   });
 
+  it("revises a pending Team to Pro schedule when the package total increases from $20 to $40", async () => {
+    const actor = createOrgFixture();
+    const addedUserId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack(
+      [{ userId: actor.userId, usagePackUsd: 20 }],
+      "team",
+      actor,
+    );
+    const scheduleId = `sub_sched_${randomUUID()}`;
+    const sourceSubscription = managedUsagePackSubscription(
+      fixture,
+      new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+    );
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      sourceSubscription,
+    );
+    mockUsagePackSubscriptionChangePreviews(0, 0);
+    context.mocks.stripe.subscriptionSchedules.create.mockResolvedValue({
+      id: scheduleId,
+    });
+    context.mocks.stripe.subscriptionSchedules.update.mockResolvedValue({
+      id: scheduleId,
+    });
+    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      zeroBillingUsagePackManagementContract,
+    );
+
+    const downgradePreview = await accept(
+      client.previewSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          targetTier: "pro",
+          memberUsagePacks: [{ memberId: actor.userId, usagePackUsd: 20 }],
+        },
+      }),
+      [200],
+    );
+    await accept(
+      client.confirmSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { changeId: downgradePreview.body.changeId },
+      }),
+      [200],
+    );
+
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [
+          {
+            role: "org:admin",
+            publicUserData: { userId: actor.userId },
+            createdAt: now(),
+          },
+          {
+            role: "org:member",
+            publicUserData: { userId: addedUserId },
+            createdAt: now(),
+          },
+        ],
+      },
+    );
+    const scheduledSubscription = managedUsagePackSubscription(
+      fixture,
+      new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      fixture.billingPeriod,
+      { scheduleId },
+    );
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      scheduledSubscription,
+    );
+    mockUsagePackSubscriptionAdditionPreviews({
+      immediateAmountCents: 2500,
+      nextRecurringAmountCents: 4000,
+      targetPriceId: TEST_PRICE_USAGE_PACK_20,
+    });
+
+    const packagePreview = await accept(
+      client.previewSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          targetTier: "pro",
+          memberUsagePacks: [
+            { memberId: actor.userId, usagePackUsd: 20 },
+            { memberId: addedUserId, usagePackUsd: 20 },
+          ],
+        },
+      }),
+      [200],
+    );
+    expect(packagePreview.body).toStrictEqual(
+      expect.objectContaining({
+        sourceTier: "team",
+        targetTier: "pro",
+        immediateAmountCents: 2500,
+        nextRecurringAmountCents: 4000,
+        effectiveAt: new Date(fixture.billingPeriod.end * 1000).toISOString(),
+      }),
+    );
+    const prorationTimestamp = Math.floor(
+      new Date(packagePreview.body.prorationDate).getTime() / 1000,
+    );
+    const paidInvoice = managedUsagePackAdditionInvoice(fixture, {
+      invoiceId: `in_${randomUUID()}`,
+      targetPriceId: TEST_PRICE_USAGE_PACK_20,
+      prorationTimestamp,
+    });
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({
+      ...scheduledSubscription,
+      pending_update: { expires_at: prorationTimestamp + 300 },
+      latest_invoice: { ...paidInvoice, status: "open" },
+    });
+
+    const confirmed = await accept(
+      client.confirmSubscriptionChange({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { changeId: packagePreview.body.changeId },
+      }),
+      [200],
+    );
+    expect(confirmed.body.status).toBe("pending_payment");
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      fixture.subscriptionId,
+      expect.objectContaining({
+        items: [{ id: `si_${TEST_PRICE_USAGE_PACK_20}`, quantity: 2 }],
+      }),
+      {
+        idempotencyKey: `usage-pack-subscription-change:${packagePreview.body.changeId}:apply`,
+      },
+    );
+
+    const updatedSubscription = managedUsagePackSubscription(
+      fixture,
+      new Map([[TEST_PRICE_USAGE_PACK_20, 2]]),
+      fixture.billingPeriod,
+      { scheduleId },
+    );
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      updatedSubscription,
+    );
+    await postManagedUsagePackEvent("invoice.paid", paidInvoice);
+
+    expect(
+      context.mocks.stripe.subscriptionSchedules.update,
+    ).toHaveBeenLastCalledWith(
+      scheduleId,
+      expect.objectContaining({
+        phases: [
+          expect.objectContaining({
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                price: TEST_PRICE_USAGE_PACK_PLAN_TEAM,
+              }),
+              { price: TEST_PRICE_USAGE_PACK_20, quantity: 2 },
+            ]),
+          }),
+          expect.objectContaining({
+            items: expect.arrayContaining([
+              { price: TEST_PRICE_USAGE_PACK_PLAN_PRO, quantity: 1 },
+              { price: TEST_PRICE_USAGE_PACK_20, quantity: 2 },
+            ]),
+          }),
+        ],
+      }),
+      {
+        idempotencyKey: `usage-pack-subscription-change:${packagePreview.body.changeId}:schedule-update`,
+      },
+    );
+    const state = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(state.org?.tier).toBe("team");
+    expect(state.allocations).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId: actor.userId,
+          usagePackUsd: 20,
+          status: "active",
+        }),
+        expect.objectContaining({
+          userId: addedUserId,
+          usagePackUsd: 20,
+          status: "active",
+        }),
+      ]),
+    );
+    expect(state.changes).toContainEqual(
+      expect.objectContaining({
+        userId: addedUserId,
+        kind: "addition",
+        status: "completed",
+        targetUsagePackUsd: 20,
+      }),
+    );
+  });
+
   it("serializes concurrent package previews across an organization", async () => {
     const firstUserId = `user_${randomUUID()}`;
     const secondUserId = `user_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -5846,7 +5846,7 @@ describe("usage pack allocation management", () => {
     context.mocks.stripe.subscriptionSchedules.update.mockResolvedValue({
       id: scheduleId,
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -10823,7 +10823,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     );
   });
 
-  it("cancels and restores a shared concurrency item without canceling the Plan", async () => {
+  it("cancels and restores a shared concurrency item without blocking later changes", async () => {
     const periodStartUnix = 4_075_660_800;
     const periodEndUnix = 4_078_252_800;
     const scheduleId = `sub_sched_${randomUUID()}`;
@@ -10867,19 +10867,6 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       context,
       routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
-    context.mocks.stripe.subscriptionSchedules.retrieve.mockResolvedValue({
-      id: scheduleId,
-      end_behavior: "release",
-      phases: [
-        { start_date: periodStartUnix, end_date: periodEndUnix },
-        {
-          start_date: periodEndUnix,
-          end_date: periodEndUnix + 2_592_000,
-          items: [{ price: TEST_PRICE_TEAM, quantity: 1 }],
-        },
-      ],
-    });
-
     await accept(
       client.cancel({
         params: { subscriptionId: fixture.subscriptionId },
@@ -10999,16 +10986,8 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
         ],
       },
     });
-    context.mocks.stripe.subscriptionSchedules.retrieve.mockResolvedValueOnce({
+    context.mocks.stripe.subscriptionSchedules.release.mockResolvedValueOnce({
       id: scheduleId,
-      phases: [
-        { start_date: periodStartUnix, end_date: periodEndUnix },
-        {
-          start_date: periodEndUnix,
-          end_date: periodEndUnix + 2_592_000,
-          items: [{ price: TEST_PRICE_TEAM, quantity: 1 }],
-        },
-      ],
     });
     await accept(
       client.restore({
@@ -11020,39 +10999,58 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     );
 
     expect(
+      context.mocks.stripe.subscriptionSchedules.release,
+    ).toHaveBeenCalledWith(scheduleId);
+    expect(
       context.mocks.stripe.subscriptionSchedules.update,
-    ).toHaveBeenLastCalledWith(
-      scheduleId,
-      {
-        end_behavior: "release",
-        proration_behavior: "none",
-        phases: [
-          {
-            start_date: periodStartUnix,
-            end_date: periodEndUnix,
-            items: [
-              { price: TEST_PRICE_TEAM, quantity: 1 },
-              { price: TEST_PRICE_CONCURRENCY, quantity: 2 },
-            ],
-            proration_behavior: "none",
-          },
-          {
-            start_date: periodEndUnix,
-            duration: { interval: "month", interval_count: 1 },
-            items: [
-              { price: TEST_PRICE_TEAM, quantity: 1 },
-              { price: TEST_PRICE_CONCURRENCY, quantity: 2 },
-            ],
-            proration_behavior: "none",
-          },
-        ],
-      },
-      { idempotencyKey: expect.any(String) },
-    );
+    ).toHaveBeenCalledOnce();
+    expect(
+      context.mocks.stripe.subscriptionSchedules.retrieve,
+    ).not.toHaveBeenCalled();
     expect(context.mocks.stripe.subscriptions.update).not.toHaveBeenCalled();
     status = await readBillingStatus(fixture);
     expect(status.cancelAtPeriodEnd).toBeFalsy();
     expect(status.concurrencySubscriptions[0]?.cancelAtPeriodEnd).toBeFalsy();
+
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValueOnce({
+      id: fixture.subscriptionId,
+      pending_update: null,
+      schedule: null,
+      items: {
+        data: [
+          {
+            id: fixture.concurrencyItemId,
+            price: {
+              id: TEST_PRICE_CONCURRENCY,
+              recurring: { interval: "month", interval_count: 1 },
+            },
+            quantity: 2,
+            current_period_start: periodStartUnix,
+            current_period_end: periodEndUnix,
+          },
+        ],
+      },
+    });
+    context.mocks.stripe.invoices.createPreview.mockResolvedValueOnce(
+      recurringConcurrencyPreviewInvoice(1),
+    );
+
+    const nextChange = await accept(
+      client.previewChange({
+        params: { subscriptionId: fixture.subscriptionId },
+        body: { quantity: 1 },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(nextChange.body).toStrictEqual({
+      currentQuantity: 2,
+      targetQuantity: 1,
+      immediateAmountCents: 0,
+      nextRecurringAmountCents: 10_000,
+      currency: "usd",
+      effectiveAt: new Date(periodEndUnix * 1000).toISOString(),
+    });
   });
 
   it("cancels Custom concurrency without canceling its usage allowance", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -10944,6 +10944,18 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
         previous_attributes: {},
       },
     };
+    context.mocks.stripe.subscriptionSchedules.retrieve.mockResolvedValueOnce({
+      id: scheduleId,
+      end_behavior: "release",
+      phases: [
+        { start_date: periodStartUnix, end_date: periodEndUnix },
+        {
+          start_date: periodEndUnix,
+          end_date: periodEndUnix + 2_592_000,
+          items: [{ price: TEST_PRICE_TEAM, quantity: 1 }],
+        },
+      ],
+    });
     context.mocks.stripe.webhooks.constructEvent.mockReturnValueOnce(
       scheduledItemEvent,
     );
@@ -11006,7 +11018,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     ).toHaveBeenCalledOnce();
     expect(
       context.mocks.stripe.subscriptionSchedules.retrieve,
-    ).not.toHaveBeenCalled();
+    ).toHaveBeenCalledOnce();
     expect(context.mocks.stripe.subscriptions.update).not.toHaveBeenCalled();
     status = await readBillingStatus(fixture);
     expect(status.cancelAtPeriodEnd).toBeFalsy();

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -5990,32 +5990,24 @@ describe("usage pack allocation management", () => {
         idempotencyKey: `usage-pack-subscription-change:${packagePreview.body.changeId}:schedule-update`,
       },
     );
-    const state = await readUsagePackState(
-      fixture.orgId,
-      fixture.usagePackSubscriptionId,
+    const management = await accept(
+      client.get({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
     );
-    expect(state.org?.tier).toBe("team");
-    expect(state.allocations).toStrictEqual(
+    expect(management.body.tier).toBe("team");
+    expect(management.body.allocations).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          userId: actor.userId,
+          memberId: actor.userId,
+          pendingChange: null,
           usagePackUsd: 20,
-          status: "active",
         }),
         expect.objectContaining({
-          userId: addedUserId,
+          memberId: addedUserId,
+          pendingChange: null,
           usagePackUsd: 20,
-          status: "active",
         }),
       ]),
-    );
-    expect(state.changes).toContainEqual(
-      expect.objectContaining({
-        userId: addedUserId,
-        kind: "addition",
-        status: "completed",
-        targetUsagePackUsd: 20,
-      }),
     );
   });
 
@@ -11017,6 +11009,38 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
         }),
       ]),
     );
+  });
+
+  it("does not release a Plan schedule when shared concurrency is not canceling", async () => {
+    const fixture = await createMergedConcurrencySubscriptionOrg({
+      slots: 2,
+      periodEnd: new Date("2099-05-20T00:00:00Z"),
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const scheduleId = `sub_sched_plan_${randomUUID()}`;
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: fixture.subscriptionId,
+      schedule: scheduleId,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockClear();
+    const client = setupApp({
+      context,
+      routes: billingConcurrencySubscriptionRoutes,
+    })(zeroBillingConcurrencySubscriptionContract);
+
+    await accept(
+      client.restore({
+        params: { subscriptionId: fixture.subscriptionId },
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(context.mocks.stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+    expect(
+      context.mocks.stripe.subscriptionSchedules.release,
+    ).not.toHaveBeenCalled();
   });
 
   it("cancels and restores a shared concurrency item without blocking later changes", async () => {

--- a/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
@@ -102,6 +102,8 @@ interface UsagePackSubscriptionChangeContext {
     readonly id: string;
     readonly status: UsagePackSubscriptionChangeRow["status"];
   }[];
+  readonly pendingPlanScheduleId: string | null;
+  readonly pendingPlanTargetTier: string | null;
 }
 
 type PreparedAllocationChange =
@@ -226,7 +228,7 @@ async function loadUsagePackSubscriptionChangeContext(
   if (!subscription) {
     return null;
   }
-  const [allocations, openAllocationChanges, openSubscriptionChanges] =
+  const [allocations, openAllocationChanges, openSubscriptionChanges, orgs] =
     await Promise.all([
       db
         .select()
@@ -270,12 +272,26 @@ async function loadUsagePackSubscriptionChangeContext(
           ),
         )
         .limit(1),
+      db
+        .select({
+          pendingPlanScheduleId: orgMetadata.pendingSubscriptionScheduleId,
+          pendingPlanTargetTier: orgMetadata.pendingSubscriptionTargetTier,
+        })
+        .from(orgMetadata)
+        .where(eq(orgMetadata.orgId, orgId))
+        .limit(1),
     ]);
+  const org = orgs[0];
+  if (!org) {
+    throw new Error("Usage pack subscription lost its organization");
+  }
   return {
     subscription,
     allocations,
     openAllocationChanges,
     openSubscriptionChanges,
+    pendingPlanScheduleId: org.pendingPlanScheduleId,
+    pendingPlanTargetTier: org.pendingPlanTargetTier,
   };
 }
 
@@ -690,6 +706,7 @@ function restorableScheduleId(
 }
 
 function replacementScheduleId(
+  root: UsagePackSubscriptionChangeRow,
   changes: readonly UsagePackAllocationChangeRow[],
 ): string | null {
   const scheduleId = changes[0]?.stripeScheduleId;
@@ -705,16 +722,45 @@ function replacementScheduleId(
     }
     return null;
   }
+  const replacesPlanDowngrade = planIsDowngrade(
+    root.sourceTier,
+    root.targetTier,
+  );
   if (
     !changes.every((change) => {
       return (
-        change.kind === "downgrade" && change.stripeScheduleId === scheduleId
+        change.stripeScheduleId === scheduleId &&
+        (replacesPlanDowngrade || change.kind === "downgrade")
       );
     })
   ) {
     throw new Error("Usage pack replacement has inconsistent Stripe schedules");
   }
   return scheduleId;
+}
+
+async function pendingPlanReplacementScheduleId(
+  db: Pick<Db, "select">,
+  root: UsagePackSubscriptionChangeRow,
+): Promise<string | null> {
+  if (!planIsDowngrade(root.sourceTier, root.targetTier)) {
+    return null;
+  }
+  const [org] = await db
+    .select({
+      tier: orgMetadata.tier,
+      scheduleId: orgMetadata.pendingSubscriptionScheduleId,
+      targetTier: orgMetadata.pendingSubscriptionTargetTier,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, root.orgId))
+    .limit(1);
+  if (!org) {
+    throw new Error("Usage pack subscription lost its organization");
+  }
+  return org.tier === root.sourceTier && org.targetTier === root.targetTier
+    ? org.scheduleId
+    : null;
 }
 
 type ExistingSchedulePreparation =
@@ -739,8 +785,20 @@ function prepareExistingSchedule(args: {
   readonly allocationChanges: readonly PreparedAllocationChange[];
   readonly hasImmediateChanges: boolean;
   readonly openAllocationChanges: readonly UsagePackAllocationChangeRow[];
+  readonly ownedPlanScheduleId: string | null;
   readonly sameConfiguration: boolean;
 }): ExistingSchedulePreparation {
+  if (args.ownedPlanScheduleId) {
+    const ownsOpenChanges = args.openAllocationChanges.every((change) => {
+      return (
+        change.status === "scheduled" &&
+        change.stripeScheduleId === args.ownedPlanScheduleId
+      );
+    });
+    return ownsOpenChanges
+      ? { status: "ready", scheduleId: args.ownedPlanScheduleId }
+      : { status: "conflict" };
+  }
   if (args.openAllocationChanges.length === 0) {
     return args.sameConfiguration
       ? { status: "same_configuration" }
@@ -837,10 +895,16 @@ async function prepareSubscriptionChange(
     allocationChanges.some((change) => {
       return change.kind === "addition" || change.kind === "upgrade";
     });
+  const ownedPlanScheduleId =
+    planIsDowngrade(context.subscription.tier, args.targetTier) &&
+    context.pendingPlanTargetTier === args.targetTier
+      ? context.pendingPlanScheduleId
+      : null;
   const existingSchedule = prepareExistingSchedule({
     allocationChanges,
     hasImmediateChanges,
     openAllocationChanges: context.openAllocationChanges,
+    ownedPlanScheduleId,
     sameConfiguration,
   });
   if (existingSchedule.status !== "ready") {
@@ -1033,7 +1097,7 @@ async function subscriptionChangeSnapshotMatches(
   ) {
     return false;
   }
-  const [openAllocation, openSubscription] = await Promise.all([
+  const [openAllocation, openSubscription, orgs] = await Promise.all([
     tx
       .select()
       .from(usagePackAllocationChanges)
@@ -1063,7 +1127,26 @@ async function subscriptionChangeSnapshotMatches(
         ),
       )
       .limit(1),
+    tx
+      .select({
+        tier: orgMetadata.tier,
+        pendingPlanScheduleId: orgMetadata.pendingSubscriptionScheduleId,
+        pendingPlanTargetTier: orgMetadata.pendingSubscriptionTargetTier,
+      })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, context.subscription.orgId))
+      .for("update")
+      .limit(1),
   ]);
+  const org = orgs[0];
+  if (
+    !org ||
+    org.tier !== context.subscription.tier ||
+    org.pendingPlanScheduleId !== context.pendingPlanScheduleId ||
+    org.pendingPlanTargetTier !== context.pendingPlanTargetTier
+  ) {
+    return false;
+  }
   const expectedOpenAllocationIds = new Set(
     context.openAllocationChanges.map((change) => {
       return change.id;
@@ -1592,9 +1675,27 @@ async function persistDeferredSubscriptionChangeSchedule(
   effectiveAt: Date,
 ): Promise<void> {
   const updatedAt = nowDate();
-  const supersededScheduleId = replacementScheduleId(stored.allocationChanges);
+  const allocationReplacementScheduleId = replacementScheduleId(
+    stored.root,
+    stored.allocationChanges,
+  );
   await db.transaction(async (tx) => {
     await lockUsagePackBillingOrg(tx, stored.root.orgId);
+    const planReplacementScheduleId = await pendingPlanReplacementScheduleId(
+      tx,
+      stored.root,
+    );
+    if (
+      allocationReplacementScheduleId &&
+      planReplacementScheduleId &&
+      allocationReplacementScheduleId !== planReplacementScheduleId
+    ) {
+      throw new Error(
+        "Usage pack replacement has inconsistent Stripe schedules",
+      );
+    }
+    const supersededScheduleId =
+      allocationReplacementScheduleId ?? planReplacementScheduleId;
     if (supersededScheduleId) {
       const superseded = await tx
         .update(usagePackAllocationChanges)
@@ -1618,7 +1719,10 @@ async function persistDeferredSubscriptionChangeSchedule(
           ),
         )
         .returning({ id: usagePackAllocationChanges.id });
-      if (superseded.length === 0) {
+      if (
+        superseded.length === 0 &&
+        planReplacementScheduleId !== supersededScheduleId
+      ) {
         throw new Error("Scheduled usage pack replacement lost its source");
       }
     }
@@ -2278,6 +2382,8 @@ async function applyStoredSubscriptionChange(
     allocations: stored.allocations,
     openAllocationChanges: [],
     openSubscriptionChanges: [],
+    pendingPlanScheduleId: null,
+    pendingPlanTargetTier: null,
   };
   const planItem = validateStripeSubscription(context, subscription);
   if (isScheduledSubscriptionRestore(stored)) {
@@ -2288,7 +2394,29 @@ async function applyStoredSubscriptionChange(
       signal,
     );
   }
-  const supersededScheduleId = replacementScheduleId(stored.allocationChanges);
+  const allocationReplacementScheduleId = replacementScheduleId(
+    stored.root,
+    stored.allocationChanges,
+  );
+  const planReplacementScheduleId = await pendingPlanReplacementScheduleId(
+    db,
+    stored.root,
+  );
+  signal.throwIfAborted();
+  if (
+    allocationReplacementScheduleId &&
+    planReplacementScheduleId &&
+    allocationReplacementScheduleId !== planReplacementScheduleId
+  ) {
+    await failApplyingSubscriptionChange(
+      db,
+      stored.root,
+      "scheduled_replacement_conflict",
+    );
+    return { status: "conflict" };
+  }
+  const supersededScheduleId =
+    allocationReplacementScheduleId ?? planReplacementScheduleId;
   if (supersededScheduleId) {
     const scheduledChanges = await db
       .select()
@@ -2303,9 +2431,12 @@ async function applyStoredSubscriptionChange(
         ),
       );
     signal.throwIfAborted();
+    const ownsPlanSchedule = planReplacementScheduleId === supersededScheduleId;
+    const ownsPackageSchedule =
+      restorableScheduleId(scheduledChanges) === supersededScheduleId;
     if (
       stripeObjectId(subscription.schedule) !== supersededScheduleId ||
-      restorableScheduleId(scheduledChanges) !== supersededScheduleId
+      (!ownsPlanSchedule && !ownsPackageSchedule)
     ) {
       await failApplyingSubscriptionChange(
         db,

--- a/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
@@ -2355,6 +2355,71 @@ async function prepareApplicableSubscription(
   };
 }
 
+type ReplacementScheduleResolution =
+  | { readonly status: "ready"; readonly scheduleId: string | null }
+  | { readonly status: "conflict" };
+
+async function resolveReplacementSchedule(
+  db: Db,
+  stored: StoredSubscriptionChange,
+  subscription: StripeSubscription,
+  signal: AbortSignal,
+): Promise<ReplacementScheduleResolution> {
+  const allocationScheduleId = replacementScheduleId(
+    stored.root,
+    stored.allocationChanges,
+  );
+  const planScheduleId = await pendingPlanReplacementScheduleId(
+    db,
+    stored.root,
+  );
+  signal.throwIfAborted();
+  if (
+    allocationScheduleId &&
+    planScheduleId &&
+    allocationScheduleId !== planScheduleId
+  ) {
+    await failApplyingSubscriptionChange(
+      db,
+      stored.root,
+      "scheduled_replacement_conflict",
+    );
+    return { status: "conflict" };
+  }
+  const scheduleId = allocationScheduleId ?? planScheduleId;
+  if (!scheduleId) {
+    return { status: "ready", scheduleId: null };
+  }
+  const scheduledChanges = await db
+    .select()
+    .from(usagePackAllocationChanges)
+    .where(
+      and(
+        eq(
+          usagePackAllocationChanges.usagePackSubscriptionId,
+          stored.subscription.id,
+        ),
+        eq(usagePackAllocationChanges.status, "scheduled"),
+      ),
+    );
+  signal.throwIfAborted();
+  const ownsPlanSchedule = planScheduleId === scheduleId;
+  const ownsPackageSchedule =
+    restorableScheduleId(scheduledChanges) === scheduleId;
+  if (
+    stripeObjectId(subscription.schedule) !== scheduleId ||
+    (!ownsPlanSchedule && !ownsPackageSchedule)
+  ) {
+    await failApplyingSubscriptionChange(
+      db,
+      stored.root,
+      "scheduled_replacement_conflict",
+    );
+    return { status: "conflict" };
+  }
+  return { status: "ready", scheduleId };
+}
+
 async function applyStoredSubscriptionChange(
   db: Db,
   stored: StoredSubscriptionChange,
@@ -2394,58 +2459,16 @@ async function applyStoredSubscriptionChange(
       signal,
     );
   }
-  const allocationReplacementScheduleId = replacementScheduleId(
-    stored.root,
-    stored.allocationChanges,
-  );
-  const planReplacementScheduleId = await pendingPlanReplacementScheduleId(
+  const replacementSchedule = await resolveReplacementSchedule(
     db,
-    stored.root,
+    stored,
+    subscription,
+    signal,
   );
-  signal.throwIfAborted();
-  if (
-    allocationReplacementScheduleId &&
-    planReplacementScheduleId &&
-    allocationReplacementScheduleId !== planReplacementScheduleId
-  ) {
-    await failApplyingSubscriptionChange(
-      db,
-      stored.root,
-      "scheduled_replacement_conflict",
-    );
-    return { status: "conflict" };
+  if (replacementSchedule.status === "conflict") {
+    return replacementSchedule;
   }
-  const supersededScheduleId =
-    allocationReplacementScheduleId ?? planReplacementScheduleId;
-  if (supersededScheduleId) {
-    const scheduledChanges = await db
-      .select()
-      .from(usagePackAllocationChanges)
-      .where(
-        and(
-          eq(
-            usagePackAllocationChanges.usagePackSubscriptionId,
-            stored.subscription.id,
-          ),
-          eq(usagePackAllocationChanges.status, "scheduled"),
-        ),
-      );
-    signal.throwIfAborted();
-    const ownsPlanSchedule = planReplacementScheduleId === supersededScheduleId;
-    const ownsPackageSchedule =
-      restorableScheduleId(scheduledChanges) === supersededScheduleId;
-    if (
-      stripeObjectId(subscription.schedule) !== supersededScheduleId ||
-      (!ownsPlanSchedule && !ownsPackageSchedule)
-    ) {
-      await failApplyingSubscriptionChange(
-        db,
-        stored.root,
-        "scheduled_replacement_conflict",
-      );
-      return { status: "conflict" };
-    }
-  }
+  const supersededScheduleId = replacementSchedule.scheduleId;
   const hasPlanUpgrade = planIsUpgrade(
     stored.root.sourceTier,
     stored.root.targetTier,

--- a/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
@@ -1197,11 +1197,16 @@ export const restoreConcurrencySubscription$ = command(
         args.subscriptionId,
       );
       signal.throwIfAborted();
-      await scheduleConcurrencyChange(
-        stripeSubscription,
-        subscription.quantity,
-        signal,
-      );
+      const scheduleId = stripeObjectId(stripeSubscription.schedule);
+      if (!scheduleId) {
+        throw new Error(
+          "Canceling shared concurrency subscription has no schedule",
+        );
+      }
+      // Cancellation can create this schedule only when no other subscription
+      // update is pending. Releasing it restores the current items and keeps
+      // later concurrency changes from treating the canceled change as foreign.
+      await stripe.subscriptionSchedules.release(scheduleId);
     } else {
       await stripe.subscriptions.update(args.subscriptionId, {
         cancel_at_period_end: false,

--- a/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
@@ -1187,7 +1187,7 @@ export const restoreConcurrencySubscription$ = command(
       args,
     );
     signal.throwIfAborted();
-    if (!subscription) {
+    if (!subscription || !subscription.cancelAtPeriodEnd) {
       return { ok: false, reason: "not_found" };
     }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -2587,6 +2587,112 @@ describe("organization billing settings", () => {
     });
   });
 
+  it("replaces a managed Team cancellation without previewing packages", async () => {
+    let requestedTargetTier: string | null = null;
+    let packagePreviewCalls = 0;
+    let billingStatus: BillingStatusResponse = {
+      ...activeTeamBillingStatus(),
+      cancelAtPeriodEnd: true,
+      scheduledChange: {
+        type: "cancel",
+        targetTier: "limited-free-1",
+        effectiveDate: "2026-05-01T00:00:00Z",
+      },
+    };
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Managed Team Cancel Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, billingStatus);
+    });
+    context.mocks.api(
+      zeroBillingUsagePackCatalogContract.get,
+      ({ respond }) => {
+        return respond(200, usagePackCatalogResponse());
+      },
+    );
+    context.mocks.api(
+      zeroBillingUsagePackManagementContract.get,
+      ({ respond }) => {
+        return respond(200, {
+          tier: "team",
+          currentPeriodEnd: "2026-05-01T00:00:00Z",
+          allocations: [
+            {
+              id: "3a9138ff-bb8c-4476-95c2-64775cc50ceb",
+              memberId: "user_1",
+              usagePackUsd: 20,
+              currentPeriodEnd: "2026-05-01T00:00:00Z",
+              pendingChange: null,
+            },
+          ],
+        });
+      },
+    );
+    context.mocks.api(
+      zeroBillingUsagePackManagementContract.previewSubscriptionChange,
+      () => {
+        packagePreviewCalls += 1;
+        throw new Error("Package preview must not replace a Plan cancellation");
+      },
+    );
+    context.mocks.api(
+      zeroBillingDowngradeContract.create,
+      ({ body, respond }) => {
+        requestedTargetTier = body.targetTier;
+        billingStatus = {
+          ...billingStatus,
+          cancelAtPeriodEnd: false,
+          scheduledChange: {
+            type: "downgrade",
+            targetTier: "pro",
+            effectiveDate: "2026-05-01T00:00:00Z",
+          },
+        };
+        return respond(200, {
+          success: true,
+          effectiveDate: "2026-05-01T00:00:00Z",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/?settings=billing",
+      user: {
+        id: "user_1",
+        fullName: "Alex Chen",
+        email: "alex@example.com",
+      },
+      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Restore plan")).toBeInTheDocument();
+    });
+    click(buttonByText("Compare all plans"));
+    const proPlan = await screen.findByRole("article", { name: "Pro plan" });
+    click(buttonByText("Downgrade", proPlan));
+
+    const downgradeDialog = await screen.findByRole("dialog", {
+      name: "Downgrade plan",
+    });
+    expect(
+      within(downgradeDialog).getByText("Downgrade to Pro?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Configure member packages" }),
+    ).not.toBeInTheDocument();
+    click(buttonByText("Downgrade to Pro", downgradeDialog));
+
+    await waitFor(() => {
+      expect(requestedTargetTier).toBe("pro");
+    });
+    expect(packagePreviewCalls).toBe(0);
+  });
+
   it("scrolls to buy credits from the credits billing deep link", async () => {
     const scrollIntoView = installScrollIntoViewMock();
     context.mocks.data.org({

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -2571,6 +2571,16 @@ function scheduledMigrationPlanActions(
   };
 }
 
+function cancellationReplacementAction(
+  currentTier: BillingTier,
+  scheduledChange: ScheduledBillingChange,
+  action: () => void,
+): (() => void) | undefined {
+  return currentTier === "team" && scheduledChange?.type === "cancel"
+    ? action
+    : undefined;
+}
+
 function CurrentPlanTitle({
   label,
   legacy,
@@ -2600,6 +2610,7 @@ function UsagePackPricingFlowDialogs({
   migrationTargetTier,
   onMigrationBack,
   onClose,
+  onReplaceCancellationWithPro,
   onSelectMigration,
 }: {
   readonly checkoutAllowed: boolean;
@@ -2609,6 +2620,7 @@ function UsagePackPricingFlowDialogs({
   readonly migrationTargetTier: "pro" | "team" | null;
   readonly onMigrationBack: () => void;
   readonly onClose: () => void;
+  readonly onReplaceCancellationWithPro?: () => void;
   readonly onSelectMigration: (tier: "pro" | "team") => void;
 }) {
   if (migration) {
@@ -2628,6 +2640,7 @@ function UsagePackPricingFlowDialogs({
       checkoutAllowed={checkoutAllowed}
       currentTier={currentTier}
       onClose={onClose}
+      onReplaceCancellationWithPro={onReplaceCancellationWithPro}
     />
   );
 }
@@ -2700,6 +2713,16 @@ export function OrgBillingTab() {
   const handleRestore = () => {
     openRestore();
   };
+  const handleReplaceCancellationWithPro = () => {
+    closeBillingSubPage();
+    setLockedTarget("pro");
+    openDowngrade();
+  };
+  const replaceCancellationWithPro = cancellationReplacementAction(
+    currentTier,
+    scheduledChange,
+    handleReplaceCancellationWithPro,
+  );
   const handleUpgrade = () => {
     if (!usagePackPlansEnabled || currentTier !== "pro") {
       openPricingPage();
@@ -2925,6 +2948,7 @@ export function OrgBillingTab() {
           migrationTargetTier={migrationTargetTier}
           onMigrationBack={closeMigrationSubPage}
           onClose={closeBillingSubPage}
+          onReplaceCancellationWithPro={replaceCancellationWithPro}
           onSelectMigration={openMigrationPage}
         />
       )}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -3391,10 +3391,12 @@ export function UsagePackPricingDialogs({
   checkoutAllowed,
   currentTier,
   onClose,
+  onReplaceCancellationWithPro,
 }: {
   readonly checkoutAllowed: boolean;
   readonly currentTier: BillingTier;
   readonly onClose: () => void;
+  readonly onReplaceCancellationWithPro?: () => void;
 }) {
   const selectedPlanTier = useGet(selectedUsagePackPlan$);
   const setSelectedPlan = useSet(setSelectedUsagePackPlan$);
@@ -3459,6 +3461,14 @@ export function UsagePackPricingDialogs({
           catalog={catalog}
           onAction={(plan, action) => {
             if (action === "disabled") {
+              return;
+            }
+            if (
+              plan === "pro" &&
+              action === "downgrade" &&
+              onReplaceCancellationWithPro
+            ) {
+              onReplaceCancellationWithPro();
               return;
             }
             setMemberUsageSelections(


### PR DESCRIPTION
## Summary

- add an isolated Playwright project with independent Clerk organizations for billing transition coverage
- cover usage-pack upgrades, downgrade replacement, restore, Pro and Team cancel-to-restore, and transitions between paid plans
- cover concurrency purchase, reduction replacement, cancel-to-restore, and a post-restore increase
- release the shared Stripe cancellation schedule during concurrency restore so later quantity changes are not rejected as a foreign pending update
- route a canceled managed Team plan through the Plan downgrade endpoint when switching to Pro, replacing its cancellation schedule while preserving member packages
- drive E2E mutations through the rendered product UI and Stripe Checkout while polling public billing APIs for webhook state

## Coverage notes

- usage-pack values exercise the lower and upper boundaries plus the $100 interior tier
- both self-serve paid plans, Pro and Team, include cancel-to-restore coverage
- the API integration suite verifies that a shared concurrency subscription accepts another preview after cancel-to-restore
- the UI suite verifies that managed Team cancellation replacement does not invoke the conflicting package preview
- rejection paths remain in the existing API integration suite, matching the repository E2E success-path policy

## Verification

- `npx --yes prettier@3.8.1 --check` on all changed files
- `cd e2e && corepack pnpm check-types`
- `cd e2e && corepack pnpm test` (35 passed)
- `npx --yes pnpm@10.33.4 -F api check-types`
- `npx --yes pnpm@10.33.4 -F @okouai/app check-types`
- targeted platform test for managed Team cancellation replacement
- ESLint and Oxlint on changed API and platform files
- Playwright collection succeeds with both billing transition tests

The deployed Stripe-backed browser flows and database-backed API integration test run in the PR pipeline.