### PR TITLE
perf(api): reduce tsgolint memory pressure

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -11,7 +11,7 @@
     "db:dev-bench-seed": "dotenv -e .env.local -- tsx src/scripts/dev-bench-seed.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "oxlint && oxlint src --type-aware -c ../../.oxlintrc.typeaware.json --ignore-pattern '**/__tests__/**' && oxlint $(find src -type d -name __tests__) --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
+    "lint": "oxlint && GOMAXPROCS=1 oxlint src --type-aware -c ../../.oxlintrc.typeaware.json --ignore-pattern '**/__tests__/**' && GOMAXPROCS=1 oxlint $(find src -type d -name __tests__) --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
     "check-types": "pnpm run check-types:deps && pnpm run check-types:boundaries && pnpm run check-types:gateways && pnpm run check-types:core && pnpm run check-types:bootstrap && pnpm run check-types:tests && pnpm run check-types:bootstrap-wiring",
     "check-types:deps": "pnpm --filter @okouai/pi-agent-runtime run build",
     "check-types:boundaries": "node scripts/check-typecheck-boundaries.mjs",


### PR DESCRIPTION
## Summary

- limit the tsgolint Go worker pool to one worker for both API type-aware lint passes
- preserve the existing rules, production/test file coverage, and final ESLint pass
- avoid crossing the workload memory.high threshold during allocation-heavy TypeScript module resolution

## Evidence

A same-command local A/B reduced the workload peak from 2725 MiB to 2529 MiB and wall time from 35 seconds to 24 seconds. Direct page scans fell from 33,534 to 127.

The Go backend derives its worker-pool size from GOMAXPROCS, so this changes scheduling only; it does not change which files or rules execute.

## Verification

- `pnpm exec prettier --check apps/api/package.json`
- `pnpm --filter api lint`

Vitest was not run because this PR only changes the lint command environment.