### PR TITLE
test(e2e): preserve clerk auth page ownership

### DIFF
--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -41,8 +41,56 @@ for required_state in \
   fi
 done
 
+browser_page_call_log="$(mktemp)"
 otp_call_log="$(mktemp)"
-trap 'rm -f "$otp_call_log"' EXIT
+trap 'rm -f "$browser_page_call_log" "$otp_call_log"' EXIT
+VM0_API_BACKEND_URL="https://api.example.com" \
+  BROWSER_PAGE_CALL_LOG="$browser_page_call_log" \
+  bash -c '
+    source "$1"
+    active_page="blank"
+    tab_listing="initial"
+    agent-browser() {
+      printf "%s\n" "$*" >> "$BROWSER_PAGE_CALL_LOG"
+      case "$*" in
+        "--json tab")
+          case "$tab_listing" in
+            initial)
+              printf "%s\n" '\''{"success":true,"data":{"tabs":[{"active":true,"index":7,"url":"about:blank"}]}}'\''
+              ;;
+            stolen)
+              printf "%s\n" '\''{"success":true,"data":{"tabs":[{"active":false,"index":7,"url":"https://app.example.com/sign-up"},{"active":true,"index":8,"url":"about:blank"}]}}'\''
+              ;;
+            missing)
+              printf "%s\n" '\''{"success":true,"data":{"tabs":[{"active":true,"index":8,"url":"about:blank"}]}}'\''
+              ;;
+          esac
+          ;;
+        "tab 7")
+          active_page="owned"
+          ;;
+        "eval "*)
+          [[ "$active_page" == "owned" ]] && printf "true\n" || printf "false\n"
+          ;;
+      esac
+    }
+    browser_setup
+    BROWSER_PAGE_URL="https://app.example.com/sign-up"
+    active_page="blank"
+    tab_listing="stolen"
+    wait_for_browser_target --timeout-seconds 1 --fn "window.__ready"
+    tab_listing="missing"
+    if agent_browser_on_page eval "window.__ready" 2>/dev/null; then
+      echo "browser helper accepted a missing owned page" >&2
+      exit 1
+    fi
+  ' _ "$browser_helper"
+expected_browser_page_calls=$'set viewport 1920 1080\n--json tab\n--json tab\ntab 7\neval Boolean(window.__ready)\n--json tab'
+if [[ "$(<"$browser_page_call_log")" != "$expected_browser_page_calls" ]]; then
+  echo "browser helper must restore its captured page before inspection" >&2
+  exit 1
+fi
+
 OTP_CALL_LOG="$otp_call_log" bash -c '
   source "$1"
   wait_for_browser_target() {
@@ -50,13 +98,17 @@ OTP_CALL_LOG="$otp_call_log" bash -c '
   }
   agent-browser() {
     printf "%s\n" "$*" >> "$OTP_CALL_LOG"
+    if [[ "$1" == "tab" ]]; then
+      return 0
+    fi
     if [[ "$1" == "get" && "$2" == "count" ]]; then
       printf "1\n"
     fi
   }
+  BROWSER_PAGE_INDEX=0
   enter_otp "424242"
 ' _ "$browser_helper"
-expected_otp_calls=$'get count input[autocomplete="one-time-code"], input[name="code"], input[inputmode="numeric"]\nfill input[autocomplete="one-time-code"], input[name="code"], input[inputmode="numeric"] 424242'
+expected_otp_calls=$'tab 0\nget count input[autocomplete="one-time-code"], input[name="code"], input[inputmode="numeric"]\ntab 0\nfill input[autocomplete="one-time-code"], input[name="code"], input[inputmode="numeric"] 424242'
 if [[ "$(<"$otp_call_log")" != "$expected_otp_calls" ]]; then
   echo "browser helper must leave OTP submission to Clerk" >&2
   exit 1

--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -28,6 +28,83 @@ url_is_on_app() {
 }
 
 # ---------------------------------------------------------------------------
+# capture_browser_page / focus_browser_page / agent_browser_on_page
+# Keep every page operation bound to the tab that browser_setup launched.
+# agent-browser 0.22 automatically activates event-discovered targets, so an
+# auxiliary about:blank target must not take ownership from the E2E page.
+# ---------------------------------------------------------------------------
+capture_browser_page() {
+  local tabs_json
+  tabs_json="$(agent-browser --json tab)" || return
+
+  BROWSER_PAGE_INDEX="$(
+    jq -e -r '.data.tabs[] | select(.active == true) | .index' \
+      <<<"$tabs_json"
+  )" || return
+  if [[ ! "$BROWSER_PAGE_INDEX" =~ ^[0-9]+$ ]]; then
+    echo "Failed to capture the active browser page" >&2
+    return 1
+  fi
+  export BROWSER_PAGE_INDEX
+}
+
+focus_browser_page() {
+  if [[ ! "${BROWSER_PAGE_INDEX:-}" =~ ^[0-9]+$ ]]; then
+    echo "Browser page ownership is not initialized" >&2
+    return 1
+  fi
+
+  local target_index="$BROWSER_PAGE_INDEX"
+  if [[ -n "${BROWSER_PAGE_URL:-}" ]]; then
+    local tabs_json
+    tabs_json="$(agent-browser --json tab)" || return
+
+    local -a matching_indexes=()
+    local index candidate_url
+    local tab_records
+    tab_records="$(jq -r '.data.tabs[] | [.index, .url] | @tsv' <<<"$tabs_json")" || return
+    while IFS=$'\t' read -r index candidate_url; do
+      if browser_page_url_matches "$candidate_url" "$BROWSER_PAGE_URL"; then
+        matching_indexes+=("$index")
+      fi
+    done <<<"$tab_records"
+
+    if (( ${#matching_indexes[@]} != 1 )); then
+      echo "Expected one owned browser page, found ${#matching_indexes[@]}" >&2
+      return 1
+    fi
+    target_index="${matching_indexes[0]}"
+    BROWSER_PAGE_INDEX="$target_index"
+    export BROWSER_PAGE_INDEX
+  fi
+
+  agent-browser tab "$target_index" >/dev/null
+}
+
+browser_page_url_matches() {
+  local candidate_url="$1"
+  local expected_url="$2"
+  if [[ "$expected_url" == http://* || "$expected_url" == https://* ]]; then
+    url_is_on_app "$candidate_url" "$expected_url"
+  else
+    [[ "$candidate_url" == "$expected_url" ]]
+  fi
+}
+
+agent_browser_on_page() {
+  focus_browser_page || return
+  agent-browser "$@"
+}
+
+open_browser_page() {
+  local url="$1"
+  focus_browser_page || return
+  agent-browser open "$url" || return
+  BROWSER_PAGE_URL="$url"
+  export BROWSER_PAGE_URL
+}
+
+# ---------------------------------------------------------------------------
 # browser_setup — Validate environment, initialize shared state
 # Call this in setup_file() before any browser interactions.
 # ---------------------------------------------------------------------------
@@ -44,6 +121,7 @@ browser_setup() {
 
   export NODE_TLS_REJECT_UNAUTHORIZED=0
   export AGENT_BROWSER_SESSION="${AGENT_BROWSER_SESSION:-${JOB_REF:-local}-sign-up}"
+  unset BROWSER_PAGE_URL
 
   export OTP="424242"
 
@@ -55,6 +133,7 @@ browser_setup() {
   AGENT_BROWSER_IGNORE_HTTPS_ERRORS=true \
     agent-browser set viewport 1920 1080 || return
 
+  capture_browser_page || return
   seed_preview_bypass_cookies || return
 }
 
@@ -97,6 +176,8 @@ seed_preview_bypass_cookies() {
 # Keeps normal runs quiet and avoids screenshots/snapshots.
 # ---------------------------------------------------------------------------
 report_auth_page_failure() {
+  focus_browser_page >/dev/null 2>&1 || true
+
   echo "# Auth page state:" >&3
   agent-browser eval \
     '({
@@ -220,7 +301,7 @@ wait_for_browser_target() {
   local wait_started="$SECONDS"
   local wait_output
   while (( SECONDS - wait_started < wait_timeout_seconds )); do
-    if wait_output=$(agent-browser eval "$condition" 2>&1); then
+    if wait_output=$(agent_browser_on_page eval "$condition" 2>&1); then
       if [[ "$wait_output" == "true" ]]; then
         return 0
       fi
@@ -256,7 +337,7 @@ wait_for_javascript_target() {
   local wait_started="$SECONDS"
   while (( SECONDS - wait_started < wait_timeout_seconds )); do
     local target_ready
-    target_ready="$(agent-browser eval \
+    target_ready="$(agent_browser_on_page eval \
       "(async () => {
         try {
           const response = await fetch(${url_json}, { cache: 'reload' });
@@ -295,9 +376,9 @@ wait_for_auth_next_step() {
         || text.includes('forgot password');
     })()"
 
-  if [[ "$(agent-browser eval "window.location.pathname.includes('/${auth_path}')")" != "true" ]]; then
+  if [[ "$(agent_browser_on_page eval "window.location.pathname.includes('/${auth_path}')")" != "true" ]]; then
     echo "complete"
-  elif [[ "$(agent-browser get count "$otp_selector")" -gt 0 ]]; then
+  elif [[ "$(agent_browser_on_page get count "$otp_selector")" -gt 0 ]]; then
     echo "otp"
   else
     echo "password"
@@ -325,8 +406,8 @@ wait_for_sign_in_email_code_ready() {
 # Clerk renders this when legal_consent_enabled is on. Safe to call always.
 # ---------------------------------------------------------------------------
 accept_legal_consent() {
-  if [[ "$(agent-browser get count 'input[name="legalAccepted"]')" -gt 0 ]]; then
-    agent-browser check 'input[name="legalAccepted"]'
+  if [[ "$(agent_browser_on_page get count 'input[name="legalAccepted"]')" -gt 0 ]]; then
+    agent_browser_on_page check 'input[name="legalAccepted"]'
   fi
 }
 
@@ -334,18 +415,18 @@ accept_legal_consent() {
 # click_continue — Click form "Continue" button (not "Continue with Google")
 # ---------------------------------------------------------------------------
 click_continue() {
-  agent-browser find role button click --name "Continue" --exact
+  agent_browser_on_page find role button click --name "Continue" --exact
 }
 
 # ---------------------------------------------------------------------------
 # dismiss_cookie_banner — Dismiss cookie consent banner if present
 # ---------------------------------------------------------------------------
 dismiss_cookie_banner() {
-  if [[ "$(agent-browser eval \
+  if [[ "$(agent_browser_on_page eval \
     "Array.from(document.querySelectorAll('button')).some(
       (button) => button.textContent?.trim() === 'Accept'
     )")" == "true" ]]; then
-    agent-browser find role button click --name "Accept" --exact
+    agent_browser_on_page find role button click --name "Accept" --exact
   fi
 }
 
@@ -357,13 +438,13 @@ enter_otp() {
   local otp_selector='input[autocomplete="one-time-code"], input[name="code"], input[inputmode="numeric"]'
 
   wait_for_browser_target "$otp_selector"
-  if [[ "$(agent-browser get count "$otp_selector")" -eq 1 ]]; then
-    agent-browser fill "$otp_selector" "$code"
+  if [[ "$(agent_browser_on_page get count "$otp_selector")" -eq 1 ]]; then
+    agent_browser_on_page fill "$otp_selector" "$code"
   else
-    agent-browser find first "$otp_selector" click
+    agent_browser_on_page find first "$otp_selector" click
     local digit
     for digit in $(echo "$code" | grep -o .); do
-      agent-browser press "$digit"
+      agent_browser_on_page press "$digit"
     done
   fi
 }
@@ -524,13 +605,13 @@ derive_app_url() {
 # ---------------------------------------------------------------------------
 sign_in_via_token() {
   local base_url="${1:-$(derive_app_url)}"
-  agent-browser open "${base_url}/sign-in-token?token=${SIGN_IN_TOKEN}"
+  open_browser_page "${base_url}/sign-in-token?token=${SIGN_IN_TOKEN}"
 
   wait_for_browser_target --fn \
     "!window.location.pathname.includes('/sign-in-token')"
 
   local current_url
-  current_url=$(agent-browser get url 2>/dev/null || true)
+  current_url=$(agent_browser_on_page get url 2>/dev/null || true)
   if ! url_is_on_app "$current_url" "$base_url"; then
     echo "Failed to redirect after sign-in-token" >&2
     return 1
@@ -559,7 +640,7 @@ navigate_to_app_page() {
   local path="$1"
   local app_url
   app_url="$(derive_app_url)"
-  agent-browser open "${app_url}${path}"
+  open_browser_page "${app_url}${path}"
 }
 
 # ---------------------------------------------------------------------------

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -110,16 +110,16 @@ open_auth_form() {
     }
   )"
 
-  agent-browser open "$url"
+  open_browser_page "$url"
   if wait_for_browser_target --timeout-seconds 30 --fn \
     "Boolean(${target_expression}) || Boolean(${failed_script_expression})"; then
-    if [[ "$(agent-browser eval "Boolean(${target_expression})")" == "true" ]]; then
+    if [[ "$(agent_browser_on_page eval "Boolean(${target_expression})")" == "true" ]]; then
       return
     fi
 
     report_auth_page_failure
     local failed_script_urls_json
-    failed_script_urls_json="$(agent-browser eval \
+    failed_script_urls_json="$(agent_browser_on_page eval \
       "Array.from(new Set(
         performance.getEntriesByType('resource')
           .filter((entry) => {
@@ -147,7 +147,7 @@ open_auth_form() {
     done
 
     echo "# Failed app scripts are available; reloading once" >&3
-    agent-browser reload
+    agent_browser_on_page reload
     if ! wait_for_browser_target --timeout-seconds 30 --fn "$target_expression"; then
       report_auth_page_failure
       return 1
@@ -161,7 +161,7 @@ open_auth_form() {
   # A failed app module request leaves the static HTML bootstrap skeleton in
   # place before Clerk exists. Recover that transport failure once without
   # masking a Clerk form stall after the application has started.
-  if [[ "$(agent-browser eval \
+  if [[ "$(agent_browser_on_page eval \
     "Boolean(
       document.getElementById('app-bootstrap-skeleton')
       && typeof window.Clerk === 'undefined'
@@ -170,7 +170,7 @@ open_auth_form() {
   fi
 
   echo "# App bootstrap did not complete; reloading once" >&3
-  agent-browser reload
+  agent_browser_on_page reload
   if ! wait_for_browser_target --timeout-seconds 30 --fn "$target_expression"; then
     report_auth_page_failure
     return 1
@@ -195,8 +195,8 @@ open_auth_form() {
 
   # Fill sign-up form
   echo "# Filling sign-up form with $E2E_ACCOUNT" >&3
-  agent-browser fill 'input[name="emailAddress"]' "$E2E_ACCOUNT"
-  agent-browser fill 'input[name="password"]' "$SIGNUP_PASSWORD"
+  agent_browser_on_page fill 'input[name="emailAddress"]' "$E2E_ACCOUNT"
+  agent_browser_on_page fill 'input[name="password"]' "$SIGNUP_PASSWORD"
   accept_legal_consent
   click_continue
 
@@ -235,7 +235,7 @@ open_auth_form() {
 
   # Check if already signed in (redirected away from /sign-in)
   local current_url
-  current_url=$(agent-browser get url 2>/dev/null || true)
+  current_url=$(agent_browser_on_page get url 2>/dev/null || true)
   if [[ -n "$current_url" && ! "$current_url" =~ sign-in ]]; then
     echo "# Already signed in (redirected to $current_url)" >&3
     return 0
@@ -245,7 +245,7 @@ open_auth_form() {
 
   # Enter email and click Continue
   echo "# Entering email: $E2E_ACCOUNT" >&3
-  agent-browser fill 'input[name="identifier"]' "$E2E_ACCOUNT"
+  agent_browser_on_page fill 'input[name="identifier"]' "$E2E_ACCOUNT"
   click_continue
 
   local sign_in_state
@@ -260,9 +260,9 @@ open_auth_form() {
     # finish mounting. Wait for the control this test actually consumes so a
     # partial password form cannot send the flow down a transient branch.
     wait_for_browser_target --text "Use another method"
-    agent-browser find text "Use another method" click
+    agent_browser_on_page find text "Use another method" click
     wait_for_browser_target --text "Email code"
-    agent-browser find text "Email code" click
+    agent_browser_on_page find text "Email code" click
   fi
 
   wait_for_sign_in_email_code_ready


### PR DESCRIPTION
## Summary

- retain explicit ownership of the browser E2E page across Clerk navigation
- recover from an event-discovered auxiliary `about:blank` target without retrying the auth operation
- fail when the owned app page is missing or ambiguous instead of accepting a blank or unrelated tab

## Root cause

Turbo run [31773597308](https://github.com/vm0-ai/vm0/actions/runs/31773597308) failed in [cli-e2e-02-browser](https://github.com/vm0-ai/vm0/actions/runs/31773597308/job/94685043656) after the sign-up submit. The pinned `agent-browser@0.22.0` registers every event-discovered `Target.targetCreated` page and unconditionally makes the newest target active. A transient auxiliary `about:blank` target therefore stole the active-page pointer before `wait_for_auth_completion`, so the test polled `about:blank` (`location.origin + location.pathname === "nullblank"`) rather than the Clerk/app page.

The same boundary reproduces without any service: opening an auxiliary `about:blank` target on `agent-browser@0.22.0` switches the next page command to `nullblank` while the original page remains open.

## Fix

`browser_setup` now captures the launched page. After navigation, every browser page operation resolves exactly one tab on the owned app host and switches to its current index before interacting. This handles an auxiliary target stealing the active pointer while preserving the auth invariant: zero or multiple owned-page candidates fail immediately, and a closed page cannot be replaced by an index-shifted blank tab.

## Validation

- 5/5 real `agent-browser@0.22.0` regressions with an injected auxiliary `about:blank` target; every run stayed on the owned page
- 5/5 real missing-page regressions after closing the owned page; every run rejected the remaining blank target
- 5/5 focused `clerk-test-resource-workflow-test.sh` runs
- `bash -n` and `shellcheck` for the three changed shell/BATS files
- focused workflow shell compatibility check for `turbo.yml`
- `actionlint` for `turbo.yml` and `security.yml`
- diff and file-size checks
- PR [Turbo run 31775267488](https://github.com/vm0-ai/vm0/actions/runs/31775267488) passed, including [cli-e2e-02-browser](https://github.com/vm0-ai/vm0/actions/runs/31775267488/job/94689729190): sign-up and subsequent sign-in both passed on the deployed preview

## Preview

PASS on head `7813d9632148438b8500e9b3dfac44f36f5cd8fe` using the actual deployment outputs:

- App: `https://pr-27099-app.omby.ai`
- API: `https://pr-27099-api.vm6.ai`
- 5/5 independent fresh Clerk test-account sign-ups completed at the authenticated app state `/_/skeleton`
- each final checkpoint had one active app tab, zero `about:blank`/`nullblank` tabs, a loaded Clerk user/session, and non-empty page scripts/resources
- [sign-up form screenshot](https://cdn.vm0.io/artifacts/6t4t69zfa5.png)
- [authenticated preview screenshot](https://cdn.vm0.io/artifacts/d2ex1h52a3.png)