### PR TITLE
fix(auth): preserve okou brand through primary clerk handoff

### DIFF
--- a/turbo/apps/platform/src/signals/auth-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-page-setup.ts
@@ -2,12 +2,13 @@ import { command } from "ccstate";
 import { createElement } from "react";
 import { i18n } from "../i18n/index.ts";
 import { AuthPage, type AuthPageMode } from "../views/auth/auth-page.tsx";
-import { clerk$ } from "./auth.ts";
+import { clerk$, resolveAuthBrandContext } from "./auth.ts";
 import { updateDocumentTitle$ } from "./document-title.ts";
 import { updatePage$ } from "./react-router.ts";
 
 function setupAuthPage(mode: AuthPageMode) {
   return command(async ({ get, set }, signal: AbortSignal) => {
+    const authBrand = resolveAuthBrandContext();
     set(updatePage$, createElement(AuthPage, { mode }));
     set(
       updateDocumentTitle$,
@@ -18,6 +19,7 @@ function setupAuthPage(mode: AuthPageMode) {
         : i18n.t(($) => {
             return $.auth.documentTitles.signUp;
           }),
+      authBrand.brandName,
     );
     await get(clerk$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -16,6 +16,7 @@ import {
   resolvePlatformEnvironment,
   resolvePlatformRuntimeConfig,
 } from "../lib/platform-host.ts";
+import { resolveBrandNameForHostname, type BrandName } from "./branding.ts";
 import { bestEffort, onDomEventFn } from "./utils.ts";
 import { createAuthRecovery, setupAuthCatchUp$ } from "./auth-retry.ts";
 import { writeConnectionDiagnostic$ } from "./connection-diagnostics.ts";
@@ -38,6 +39,11 @@ interface ClerkSatelliteConfig {
   readonly domain: typeof PRODUCTION_SATELLITE_HOSTNAME;
   readonly isSatellite: true;
   readonly satelliteAutoSync: true;
+}
+
+export interface AuthBrandContext {
+  readonly brandName: BrandName;
+  readonly homeUrl: string;
 }
 
 const AD_ATTRIBUTION_PARAMS = [
@@ -260,7 +266,7 @@ function isAllowedRedirectOrigin(
 function readAllowedRedirectUrl(
   params: URLSearchParams,
   allowedRedirectOrigins: readonly AllowedAuthRedirectOrigin[],
-): string | null {
+): URL | null {
   const rawRedirectUrl = params.get("redirect_url");
   if (!rawRedirectUrl) {
     return null;
@@ -271,19 +277,59 @@ function readAllowedRedirectUrl(
     return null;
   }
   return isAllowedRedirectOrigin(redirectUrl, allowedRedirectOrigins)
-    ? redirectUrl.toString()
+    ? redirectUrl
     : null;
+}
+
+function readAuthRedirectParams(
+  authSearch: string,
+  authHash: string,
+): URLSearchParams {
+  const searchParams = new URLSearchParams(authSearch);
+  if (searchParams.has("redirect_url")) {
+    return searchParams;
+  }
+
+  const hashQueryIndex = authHash.indexOf("?");
+  return hashQueryIndex === -1
+    ? searchParams
+    : new URLSearchParams(authHash.slice(hashQueryIndex + 1));
+}
+
+export function resolveAuthBrandContext(
+  authSearch: string = location.search,
+  authHash: string = location.hash,
+  allowedRedirectOrigins: readonly AllowedAuthRedirectOrigin[] = getAllowedAuthRedirectOriginsForCurrentPage(),
+): AuthBrandContext {
+  const currentBrandName = resolveBrandNameForHostname(location.hostname);
+  if (currentBrandName === "Okou") {
+    return { brandName: currentBrandName, homeUrl: "/" };
+  }
+
+  const redirectUrl = readAllowedRedirectUrl(
+    readAuthRedirectParams(authSearch, authHash),
+    allowedRedirectOrigins,
+  );
+  if (
+    redirectUrl &&
+    resolveBrandNameForHostname(redirectUrl.hostname) === "Okou"
+  ) {
+    return { brandName: "Okou", homeUrl: redirectUrl.origin };
+  }
+
+  return { brandName: currentBrandName, homeUrl: "/" };
 }
 
 export function buildSignupRedirectUrl(
   signUpSearch: string,
   allowedRedirectOrigins: readonly AllowedAuthRedirectOrigin[] = getAllowedAuthRedirectOriginsForCurrentPage(),
+  signUpHash = "",
 ): string {
   const appUrl = resolveAppUrl();
-  const params = new URLSearchParams(signUpSearch);
+  const params = readAuthRedirectParams(signUpSearch, signUpHash);
   const redirectUrl = readAllowedRedirectUrl(params, allowedRedirectOrigins);
   if (redirectUrl) {
-    return redirectUrl;
+    return redirectUrl.toString();
   }
 
   if (!hasAdTraffic(params)) {
@@ -291,18 +337,19 @@ export function buildSignupRedirectUrl(
   }
 
   const redirectParams = new URLSearchParams();
-  appendHomepageAttributionParams(redirectParams, signUpSearch);
+  appendHomepageAttributionParams(redirectParams, params.toString());
   return buildVm0OnboardingEntryUrl(redirectParams);
 }
 
 export function buildSignInRedirectUrl(
   signInSearch: string,
   allowedRedirectOrigins: readonly AllowedAuthRedirectOrigin[] = getAllowedAuthRedirectOriginsForCurrentPage(),
+  signInHash = "",
 ): string {
-  const params = new URLSearchParams(signInSearch);
+  const params = readAuthRedirectParams(signInSearch, signInHash);
   const redirectUrl = readAllowedRedirectUrl(params, allowedRedirectOrigins);
 
-  return redirectUrl ?? resolveAppUrl();
+  return redirectUrl?.toString() ?? resolveAppUrl();
 }
 
 export const clerkUi$ = computed(() => {

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -291,9 +291,16 @@ function readAuthRedirectParams(
   }
 
   const hashQueryIndex = authHash.indexOf("?");
-  return hashQueryIndex === -1
-    ? searchParams
-    : new URLSearchParams(authHash.slice(hashQueryIndex + 1));
+  if (hashQueryIndex === -1) {
+    return searchParams;
+  }
+
+  const hashParams = new URLSearchParams(authHash.slice(hashQueryIndex + 1));
+  const hashRedirectUrl = hashParams.get("redirect_url");
+  if (hashRedirectUrl) {
+    searchParams.set("redirect_url", hashRedirectUrl);
+  }
+  return searchParams;
 }
 
 export function resolveAuthBrandContext(

--- a/turbo/apps/platform/src/signals/branding.ts
+++ b/turbo/apps/platform/src/signals/branding.ts
@@ -6,13 +6,19 @@ type ComputerUseProductName = "Zero" | "Okou";
 
 const OKOU_ROOT_DOMAINS = ["okou.ai", "omby.ai", "okou-app.pages.dev"] as const;
 
-const branding$ = computed<Branding>(() => {
-  const hostname = location.host.toLowerCase().replace(/:\d+$/u, "");
+export function resolveBrandNameForHostname(hostname: string): BrandName {
+  const normalizedHostname = hostname.toLowerCase().replace(/:\d+$/u, "");
   const isOkou = OKOU_ROOT_DOMAINS.some((domain) => {
-    return hostname === domain || hostname.endsWith(`.${domain}`);
+    return (
+      normalizedHostname === domain || normalizedHostname.endsWith(`.${domain}`)
+    );
   });
 
-  return isOkou ? "okou" : "vm0";
+  return isOkou ? "Okou" : "VM0";
+}
+
+const branding$ = computed<Branding>(() => {
+  return resolveBrandNameForHostname(location.host) === "Okou" ? "okou" : "vm0";
 });
 
 export const brandName$ = computed<BrandName>((get) => {

--- a/turbo/apps/platform/src/signals/document-title.ts
+++ b/turbo/apps/platform/src/signals/document-title.ts
@@ -1,11 +1,13 @@
 import { command } from "ccstate";
-import { brandName$ } from "./branding.ts";
+import { brandName$, type BrandName } from "./branding.ts";
 
-export const updateDocumentTitle$ = command(({ get }, pageName: string) => {
-  const brandName = get(brandName$);
-  const brandSuffix = ` | ${brandName}`;
-  document.title =
-    pageName === brandName || pageName.endsWith(brandSuffix)
-      ? pageName
-      : `${pageName}${brandSuffix}`;
-});
+export const updateDocumentTitle$ = command(
+  ({ get }, pageName: string, brandNameOverride?: BrandName) => {
+    const brandName = brandNameOverride ?? get(brandName$);
+    const brandSuffix = ` | ${brandName}`;
+    document.title =
+      pageName === brandName || pageName.endsWith(brandSuffix)
+        ? pageName
+        : `${pageName}${brandSuffix}`;
+  },
+);

--- a/turbo/apps/platform/src/test/mocks/clerk-react.ts
+++ b/turbo/apps/platform/src/test/mocks/clerk-react.ts
@@ -40,18 +40,40 @@ function subscribeToClerkAuthComponent(listener: () => void): () => void {
 interface ClerkProviderProps {
   children: ReactNode;
   allowedRedirectOrigins?: readonly (string | RegExp)[];
-  localization?: unknown;
+  localization?: {
+    signIn?: {
+      emailCode?: { subtitle?: string };
+      start?: { title?: string };
+    };
+  };
   signInFallbackRedirectUrl?: string;
   signInUrl?: string;
   signUpFallbackRedirectUrl?: string;
   signUpUrl?: string;
 }
 
-export function ClerkProvider({ children }: ClerkProviderProps) {
-  return children;
+export function ClerkProvider({ children, localization }: ClerkProviderProps) {
+  return createElement(
+    Fragment,
+    null,
+    createElement("span", {
+      "data-clerk-sign-in-email-code-subtitle":
+        localization?.signIn?.emailCode?.subtitle,
+      "data-clerk-sign-in-start-title": localization?.signIn?.start?.title,
+      "data-testid": "clerk-provider-config",
+      hidden: true,
+    }),
+    children,
+  );
 }
 
 interface ClerkAuthComponentProps {
+  appearance?: {
+    options?: {
+      logoImageUrl?: string;
+      logoPlacement?: string;
+    };
+  };
   fallback?: ReactNode;
   fallbackRedirectUrl?: string;
   forceRedirectUrl?: string;
@@ -61,6 +83,7 @@ interface ClerkAuthComponentProps {
 
 function ClerkAuthComponent({
   componentName,
+  appearance,
   fallback,
   fallbackRedirectUrl,
   forceRedirectUrl,
@@ -86,6 +109,8 @@ function ClerkAuthComponent({
         "data-clerk-component": componentName,
         "data-clerk-fallback-redirect-url": fallbackRedirectUrl,
         "data-clerk-force-redirect-url": forceRedirectUrl,
+        "data-clerk-logo-image-url": appearance?.options?.logoImageUrl,
+        "data-clerk-logo-placement": appearance?.options?.logoPlacement,
         "data-clerk-routing": routing,
         "data-testid": testId,
       },

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -1,7 +1,10 @@
 import { act, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 import { PRESENTATION_ONBOARDING_URL } from "../../../__tests__/presentation-onboarding-fixture.ts";
 import type { SupportedLocale } from "../../../i18n/resources.ts";
@@ -9,12 +12,23 @@ import { platformVm0LogoDarkImg } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { i18n } from "../../../i18n/index.ts";
+import { getClerkAppearance } from "../auth-clerk-appearance.ts";
 import { getClerkLocalization } from "../clerk-localization.ts";
 
 const context = testContext();
 
 function setBrowserUrl(url: string): void {
   context.mocks.browser.url(url);
+}
+
+function okouBrandLink(): HTMLElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.textContent?.trim() === "Okou";
+  });
+  if (!link) {
+    throw new Error("Okou brand link not found");
+  }
+  return link;
 }
 
 function disableUrlCanParse(): void {
@@ -366,7 +380,7 @@ describe("app auth pages", () => {
   });
 
   it("allows sign-in redirects to okou.ai subdomains", async () => {
-    const redirectUrl = "https://console.okou.ai/_/skeleton";
+    const redirectUrl = "https://app.okou.ai/_/skeleton";
     const path = `/sign-in?redirect_url=${encodeURIComponent(redirectUrl)}`;
     setBrowserUrl(`https://app.vm0.ai${path}`);
 
@@ -380,6 +394,68 @@ describe("app auth pages", () => {
       "data-clerk-force-redirect-url",
       redirectUrl,
     );
+    expect(document.title).toBe("Sign in | Okou");
+    expect(screen.queryByAltText("VM0")).not.toBeInTheDocument();
+    expect(okouBrandLink()).toHaveAttribute("href", "https://app.okou.ai");
+    expect(screen.getByTestId("clerk-google-one-tap")).toHaveAttribute(
+      "data-sign-in-force-redirect-url",
+      redirectUrl,
+    );
+    expect(screen.getByTestId("clerk-google-one-tap")).toHaveAttribute(
+      "data-sign-up-force-redirect-url",
+      redirectUrl,
+    );
+
+    const appearance = getClerkAppearance("light", "Okou");
+    expect(appearance.options).toStrictEqual({ logoPlacement: "none" });
+
+    const localization = getClerkLocalization("Okou", "en-US", i18n.t);
+    expect(localization.signIn?.start?.title).toBe("Sign in to Okou");
+    expect(localization.signIn?.emailCode?.subtitle).toBe(
+      "to continue to Okou",
+    );
+  });
+
+  it("preserves Okou auth intent when Clerk moves the redirect into the hash", async () => {
+    const redirectUrl = "https://app.okou.ai/onboarding?source=auth-switch";
+    const hash = `#/?redirect_url=${encodeURIComponent(redirectUrl)}`;
+    setBrowserUrl(`https://app.vm0.ai/sign-up${hash}`);
+
+    detachedSetupPage({ context, path: "/sign-up" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("clerk-sign-up")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("clerk-sign-up")).toHaveAttribute(
+      "data-clerk-force-redirect-url",
+      redirectUrl,
+    );
+    expect(document.title).toBe("Sign up | Okou");
+    expect(okouBrandLink()).toHaveAttribute("href", "https://app.okou.ai");
+  });
+
+  it("does not let an untrusted redirect URL control the auth brand", async () => {
+    const redirectUrl = "https://app.okou.ai.evil.example/sign-in";
+    const path = `/sign-in?redirect_url=${encodeURIComponent(redirectUrl)}`;
+    setBrowserUrl(`https://app.vm0.ai${path}`);
+
+    detachedSetupPage({ context, path });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("clerk-sign-in")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("clerk-sign-in")).toHaveAttribute(
+      "data-clerk-force-redirect-url",
+      "https://app.vm0.ai",
+    );
+    expect(document.title).toBe("Sign in | VM0");
+    expect(screen.getByAltText("VM0")).toHaveAttribute(
+      "src",
+      platformVm0LogoDarkImg,
+    );
+    expect(screen.queryByText("Okou")).not.toBeInTheDocument();
   });
 
   it("renders the app-hosted sign-in route when URL.canParse is unavailable", async () => {

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -12,7 +12,6 @@ import { platformVm0LogoDarkImg } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { i18n } from "../../../i18n/index.ts";
-import { getClerkAppearance } from "../auth-clerk-appearance.ts";
 import { getClerkLocalization } from "../clerk-localization.ts";
 
 const context = testContext();
@@ -406,12 +405,19 @@ describe("app auth pages", () => {
       redirectUrl,
     );
 
-    const appearance = getClerkAppearance("light", "Okou");
-    expect(appearance.options).toStrictEqual({ logoPlacement: "none" });
-
-    const localization = getClerkLocalization("Okou", "en-US", i18n.t);
-    expect(localization.signIn?.start?.title).toBe("Sign in to Okou");
-    expect(localization.signIn?.emailCode?.subtitle).toBe(
+    expect(screen.getByTestId("clerk-sign-in")).toHaveAttribute(
+      "data-clerk-logo-placement",
+      "none",
+    );
+    expect(screen.getByTestId("clerk-sign-in")).not.toHaveAttribute(
+      "data-clerk-logo-image-url",
+    );
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-sign-in-start-title",
+      "Sign in to Okou",
+    );
+    expect(screen.getByTestId("clerk-provider-config")).toHaveAttribute(
+      "data-clerk-sign-in-email-code-subtitle",
       "to continue to Okou",
     );
   });
@@ -561,6 +567,26 @@ describe("app auth pages", () => {
   it("routes ad-attributed sign-up visits through onboarding", async () => {
     const path = "/sign-up?gclid=click-123&utm_campaign=summer";
     setBrowserUrl(`https://app.vm0.ai${path}`);
+
+    detachedSetupPage({ context, path });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("clerk-sign-up")).toBeInTheDocument();
+    });
+
+    const redirectUrl = new URL(
+      screen.getByTestId("clerk-sign-up").dataset.clerkForceRedirectUrl ?? "",
+    );
+    expect(redirectUrl.origin).toBe("https://app.vm0.ai");
+    expect(redirectUrl.pathname).toBe("/onboarding");
+    expect(redirectUrl.searchParams.get("gclid")).toBe("click-123");
+    expect(redirectUrl.searchParams.get("utm_campaign")).toBe("summer");
+    expect(redirectUrl.searchParams.get("vm0_source")).toBe("homepage");
+  });
+
+  it("keeps sign-up attribution when the Clerk hash has no redirect", async () => {
+    const path = "/sign-up?gclid=click-123&utm_campaign=summer";
+    setBrowserUrl(`https://app.vm0.ai${path}#/verify?step=code`);
 
     detachedSetupPage({ context, path });
 

--- a/turbo/apps/platform/src/views/auth/auth-clerk-appearance.ts
+++ b/turbo/apps/platform/src/views/auth/auth-clerk-appearance.ts
@@ -1,5 +1,6 @@
 import type { SignIn } from "@clerk/react";
 import type { ComponentProps } from "react";
+import type { BrandName } from "../../signals/branding.ts";
 import {
   platformVm0LogoDarkImg,
   platformVm0LogoImg,
@@ -7,13 +8,19 @@ import {
 
 type ClerkAppearance = NonNullable<ComponentProps<typeof SignIn>["appearance"]>;
 
-export function getClerkAppearance(theme: "light" | "dark"): ClerkAppearance {
+export function getClerkAppearance(
+  theme: "light" | "dark",
+  brandName: BrandName,
+): ClerkAppearance {
   return {
-    options: {
-      logoImageUrl:
-        theme === "dark" ? platformVm0LogoImg : platformVm0LogoDarkImg,
-      logoPlacement: "inside",
-    },
+    options:
+      brandName === "Okou"
+        ? { logoPlacement: "none" }
+        : {
+            logoImageUrl:
+              theme === "dark" ? platformVm0LogoImg : platformVm0LogoDarkImg,
+            logoPlacement: "inside",
+          },
     variables: {
       colorBackground: "hsl(var(--card))",
       colorForeground: "hsl(var(--card-foreground))",

--- a/turbo/apps/platform/src/views/auth/auth-layout.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-layout.tsx
@@ -6,6 +6,7 @@ import {
   platformVm0LogoDarkImg,
   platformVm0LogoImg,
 } from "../../lib/static-assets.ts";
+import type { AuthBrandContext } from "../../signals/auth.ts";
 import { setTheme$, theme$ } from "../../signals/theme.ts";
 
 const CLERK_CSS = `
@@ -343,10 +344,11 @@ a[class*="resendCode"] {
 `;
 
 interface AuthLayoutProps {
+  authBrand: AuthBrandContext;
   children: ReactNode;
 }
 
-export function AuthLayout({ children }: AuthLayoutProps) {
+export function AuthLayout({ authBrand, children }: AuthLayoutProps) {
   const { t } = useTranslation();
   const theme = useGet(theme$);
   const setTheme = useSet(setTheme$);
@@ -387,16 +389,27 @@ export function AuthLayout({ children }: AuthLayoutProps) {
         </button>
 
         {/* Logo Header */}
-        <a href="/" className="absolute left-6 top-6 flex items-center gap-2">
-          <img
-            src={theme === "dark" ? platformVm0LogoImg : platformVm0LogoDarkImg}
-            alt={t(($) => {
-              return $.appShell.logoAlt;
-            })}
-            crossOrigin="anonymous"
-            width={82}
-            height={20}
-          />
+        <a
+          href={authBrand.homeUrl}
+          className="absolute left-6 top-6 flex items-center gap-2"
+        >
+          {authBrand.brandName === "Okou" ? (
+            <span className="text-xl font-semibold tracking-tight">
+              {authBrand.brandName}
+            </span>
+          ) : (
+            <img
+              src={
+                theme === "dark" ? platformVm0LogoImg : platformVm0LogoDarkImg
+              }
+              alt={t(($) => {
+                return $.appShell.logoAlt;
+              })}
+              crossOrigin="anonymous"
+              width={82}
+              height={20}
+            />
+          )}
         </a>
 
         <div className="relative z-10 m-auto flex w-full min-w-0 justify-center">

--- a/turbo/apps/platform/src/views/auth/auth-page.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-page.tsx
@@ -6,7 +6,7 @@ import { activeRoute$ } from "../../signals/active-route.ts";
 import {
   buildSignInRedirectUrl,
   buildSignupRedirectUrl,
-  resolveAppUrl,
+  resolveAuthBrandContext,
 } from "../../signals/auth.ts";
 import { authPageMountRef$ } from "../../signals/auth-page-mount.ts";
 import { theme$ } from "../../signals/theme.ts";
@@ -41,27 +41,31 @@ export function AuthPage({ mode }: AuthPageProps) {
   const authPageMountRef = useSet(authPageMountRef$);
   const activeRoute = useGet(activeRoute$);
   const theme = useGet(theme$);
+  const authBrand = resolveAuthBrandContext();
 
   if (mode === "sign-in") {
-    const appUrl = resolveAppUrl();
-    const redirectUrl = buildSignInRedirectUrl(location.search);
+    const redirectUrl = buildSignInRedirectUrl(
+      location.search,
+      undefined,
+      location.hash,
+    );
 
     return (
       <>
         {activeRoute === "signIn" && (
           <GoogleOneTap
-            signInForceRedirectUrl={appUrl}
-            signUpForceRedirectUrl={appUrl}
+            signInForceRedirectUrl={redirectUrl}
+            signUpForceRedirectUrl={redirectUrl}
           />
         )}
-        <AuthLayout>
+        <AuthLayout authBrand={authBrand}>
           <div
             className="relative z-10 flex w-full max-w-md flex-col gap-3"
             data-testid="app-sign-in"
             ref={authPageMountRef}
           >
             <SignIn
-              appearance={getClerkAppearance(theme)}
+              appearance={getClerkAppearance(theme, authBrand.brandName)}
               fallback={<AuthLoadingFallback />}
               fallbackRedirectUrl={redirectUrl}
               forceRedirectUrl={redirectUrl}
@@ -74,13 +78,17 @@ export function AuthPage({ mode }: AuthPageProps) {
     );
   }
 
-  const redirectUrl = buildSignupRedirectUrl(location.search);
+  const redirectUrl = buildSignupRedirectUrl(
+    location.search,
+    undefined,
+    location.hash,
+  );
 
   return (
-    <AuthLayout>
+    <AuthLayout authBrand={authBrand}>
       <div data-testid="app-sign-up" ref={authPageMountRef}>
         <SignUp
-          appearance={getClerkAppearance(theme)}
+          appearance={getClerkAppearance(theme, authBrand.brandName)}
           fallback={<AuthLoadingFallback />}
           fallbackRedirectUrl={redirectUrl}
           forceRedirectUrl={redirectUrl}

--- a/turbo/apps/platform/src/views/auth/clerk-localization.ts
+++ b/turbo/apps/platform/src/views/auth/clerk-localization.ts
@@ -14,6 +14,27 @@ import type { TFunction } from "i18next";
 import type { SupportedLocale } from "../../i18n/resources.ts";
 import type { BrandName } from "../../signals/branding.ts";
 
+const CLERK_APPLICATION_NAME = "{{applicationName}}";
+
+function replaceClerkApplicationName<T>(value: T, brandName: BrandName): T {
+  if (typeof value === "string") {
+    return value.replaceAll(CLERK_APPLICATION_NAME, brandName) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      return replaceClerkApplicationName(item, brandName);
+    }) as T;
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => {
+        return [key, replaceClerkApplicationName(item, brandName)];
+      }),
+    ) as T;
+  }
+  return value;
+}
+
 export function getClerkLocalization(
   brandName: BrandName,
   locale: SupportedLocale,
@@ -39,10 +60,14 @@ export function getClerkLocalization(
                     : locale === "hi-IN"
                       ? hiIN
                       : enUS;
+  const brandedLocalization =
+    brandName === "Okou"
+      ? replaceClerkApplicationName(localization, brandName)
+      : localization;
   return {
-    ...localization,
+    ...brandedLocalization,
     unstable__errors: {
-      ...localization.unstable__errors,
+      ...brandedLocalization.unstable__errors,
       not_allowed_access: t(($) => {
         return $.auth.clerk.accessNotAllowed;
       }),

--- a/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
+++ b/turbo/apps/platform/src/views/clerk/clerk-provider.tsx
@@ -12,6 +12,7 @@ import {
   clerkInstance$,
   clerkUi$,
   getAllowedAuthRedirectOriginsForCurrentPage,
+  resolveAuthBrandContext,
   resolveAppAuthUrl,
   resolveAppUrl,
   resolveClerkSatelliteConfig,
@@ -27,8 +28,16 @@ export function VM0ClerkProvider({ children }: ClerkProviderProps) {
   const { t } = useTranslation();
   const clerkInstance = useGet(clerkInstance$);
   const clerkUi = useGet(clerkUi$);
-  const brandName = useGet(brandName$);
+  const domainBrandName = useGet(brandName$);
   const locale = useGet(locale$);
+  const isAuthPage =
+    location.pathname === "/sign-in" ||
+    location.pathname.startsWith("/sign-in/") ||
+    location.pathname === "/sign-up" ||
+    location.pathname.startsWith("/sign-up/");
+  const clerkBrandName = isAuthPage
+    ? resolveAuthBrandContext().brandName
+    : domainBrandName;
 
   const publishableKey = resolvePlatformRuntimeConfig().clerkPublishableKey;
   const appUrl = resolveAppUrl();
@@ -40,7 +49,7 @@ export function VM0ClerkProvider({ children }: ClerkProviderProps) {
     afterSignOutUrl: resolveAppAuthUrl("/sign-in"),
     allowedRedirectOrigins,
     appearance: getClerkAppearance(),
-    localization: getClerkLocalization(brandName, locale, t),
+    localization: getClerkLocalization(clerkBrandName, locale, t),
     publishableKey,
     signInFallbackRedirectUrl: appUrl,
     signInUrl: resolveAppAuthUrl("/sign-in"),


### PR DESCRIPTION
## Summary

- preserve Okou brand intent when the production satellite hands authentication to the primary Clerk host
- trust only the existing allowlisted redirect target, including Clerk's hash-based sign-in/sign-up navigation
- render Okou auth titles, wordmark, and Clerk copy without changing direct VM0 authentication
- carry the validated return URL through Google One Tap and reject lookalike redirect origins

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/auth/__tests__/auth-page.test.tsx src/signals/__tests__/auth-url.test.ts --maxWorkers=1`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app lint`
- `pnpm knip --workspace @okouai/app`

## Deployment notes

- Clerk remains canonical on `app.vm0.ai`; this PR changes the branded handoff, not the primary-domain topology
- direct `app.vm0.ai/sign-in` and VM0 logo behavior remain unchanged
