### PR TITLE
fix: route vm0 claude models directly through anthropic

### DIFF
--- a/turbo/apps/api/src/scripts/__tests__/dev-seed.test.ts
+++ b/turbo/apps/api/src/scripts/__tests__/dev-seed.test.ts
@@ -22,6 +22,21 @@ function buildVendorKeys(
 }
 
 describe("buildVm0ApiKeys", () => {
+  it("falls back to ANTHROPIC_API_KEY for Anthropic dev seed rows", () => {
+    const anthropicKeys = buildVendorKeys("anthropic", {
+      DEV_MODEL_ANTHROPIC_KEY: "",
+      ANTHROPIC_API_KEY: "provider-anthropic-key",
+    });
+
+    expect(anthropicKeys).toStrictEqual([
+      {
+        apiKey: "provider-anthropic-key",
+        label: "dev-seed",
+        vendor: "anthropic",
+      },
+    ]);
+  });
+
   it("builds DeepSeek dev seed rows from DEV_MODEL_DEEPSEEK_KEY", () => {
     const deepSeekKeys = buildVendorKeys("deepseek", {
       DEV_MODEL_DEEPSEEK_KEY: "dev-deepseek-key",
@@ -48,20 +63,6 @@ describe("buildVm0ApiKeys", () => {
         apiKey: "dev-openai-key",
         label: "dev-seed",
         vendor: "openai",
-      },
-    ]);
-  });
-
-  it("builds an OpenRouter dev seed row from DEV_MODEL_OPENROUTER_KEY", () => {
-    const openRouterKeys = buildVendorKeys("openrouter", {
-      DEV_MODEL_OPENROUTER_KEY: "dev-openrouter-key",
-    });
-
-    expect(openRouterKeys).toStrictEqual([
-      {
-        apiKey: "dev-openrouter-key",
-        label: "dev-seed",
-        vendor: "openrouter",
       },
     ]);
   });

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -37,9 +37,10 @@ function writeLine(message: string): void {
  * Prices are per 1M tokens, stored as integer credits per 1M tokens.
  *
  * API keys are read from environment variables per vendor:
- *   DEV_MODEL_{VENDOR_UPPER}_KEY (e.g., DEV_MODEL_OPENROUTER_KEY, DEV_MODEL_OPENAI_KEY)
- * OpenAI and DeepSeek also fall back to their provider env names because CI
- * and local dev already use them for real model smoke tests.
+ *   DEV_MODEL_{VENDOR_UPPER}_KEY (e.g., DEV_MODEL_ANTHROPIC_KEY, DEV_MODEL_OPENAI_KEY)
+ * Anthropic and OpenAI also fall back to their provider env names because
+ * CI and local dev already use them for real model smoke tests.
+ * DeepSeek also falls back to its provider env name.
  */
 
 /** 1 USD = 1000 credits */
@@ -650,6 +651,9 @@ const USAGE_PRICING: readonly (typeof usagePricing.$inferInsert)[] = [
 
 function getVendorApiKeyEnvVars(vendor: string): string[] {
   const envVar = `DEV_MODEL_${vendor.toUpperCase()}_KEY`;
+  if (vendor === "anthropic") {
+    return [envVar, "ANTHROPIC_API_KEY"];
+  }
   if (vendor === "openai") {
     return [envVar, "OPENAI_API_KEY"];
   }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4702,7 +4702,7 @@ describe("CHAT-02: model-first provider policies", () => {
     });
   }, 90_000);
 
-  it("routes vm0 managed Claude through the OpenRouter vendor", async () => {
+  it("selects a vm0 managed key by vendor", async () => {
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const keyFixtureId = randomUUID();
@@ -4720,7 +4720,7 @@ describe("CHAT-02: model-first provider policies", () => {
 
     const acquiredApiKey = await acquireBddVm0ApiKey({
       fixtureId: keyFixtureId,
-      vendor: "openrouter",
+      vendor: "anthropic",
       apiKey: requestedApiKey,
     });
     expect(acquiredApiKey === requestedApiKey).toBeFalsy();
@@ -4747,31 +4747,10 @@ describe("CHAT-02: model-first provider policies", () => {
       run.runId,
     );
     const environment = claimEnvironment(claim);
-    expect(claim.cliAgentType).toBe("claude-code");
-    expect(environment).toMatchObject({
-      ANTHROPIC_AUTH_TOKEN: modelProviderSecretPlaceholder(
-        "openrouter-api-key",
-        "OPENROUTER_API_KEY",
-      ),
-      ANTHROPIC_BASE_URL: "https://openrouter.ai/api",
-      ANTHROPIC_API_KEY: "",
-      ANTHROPIC_MODEL: "anthropic/claude-opus-4.8",
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "anthropic/claude-opus-4.8",
-      ANTHROPIC_DEFAULT_SONNET_MODEL: "anthropic/claude-opus-4.8",
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: "anthropic/claude-opus-4.8",
-      CLAUDE_CODE_SUBAGENT_MODEL: "anthropic/claude-opus-4.8",
-    });
-    expect(
-      claim.firewalls?.map((firewall) => {
-        return firewall.kind === "builtin"
-          ? firewall.name
-          : firewall.firewall.name;
-      }),
-    ).toContain("model-provider:openrouter-api-key");
-    expect(claim.billableFirewalls).toContain(
-      "model-provider:openrouter-api-key",
+    expect(environment.ANTHROPIC_API_KEY).toBe(
+      modelProviderSecretPlaceholder("anthropic-api-key", "ANTHROPIC_API_KEY"),
     );
-    expect(claim.modelUsageProvider).toBe("claude-opus-4-8");
+    expect(environment.ANTHROPIC_MODEL).toBe("claude-opus-4-8");
 
     if (!claim.encryptedSecrets) {
       throw new Error("Expected vm0 claim to carry encrypted secrets");
@@ -4781,7 +4760,7 @@ describe("CHAT-02: model-first provider policies", () => {
       {
         encryptedSecrets: claim.encryptedSecrets,
         authHeaders: {
-          Authorization: `Bearer ${secretTemplate("OPENROUTER_API_KEY")}`,
+          Authorization: `Bearer ${secretTemplate("ANTHROPIC_API_KEY")}`,
         },
       },
       [200],

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -247,8 +247,8 @@ function vm0ManagedKeyRows(composeId: string) {
       label: composeId,
     },
     {
-      vendor: getVm0Vendor("claude-opus-4-8"),
-      apiKey: `vm0-key-claude-${composeId}`,
+      vendor: "anthropic",
+      apiKey: `vm0-key-anthropic-${composeId}`,
       label: composeId,
     },
     {

--- a/turbo/apps/api/src/signals/routes/test-teams-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-state.ts
@@ -286,8 +286,8 @@ function vm0ManagedKeyRows(composeId: string) {
       label: composeId,
     },
     {
-      vendor: getVm0Vendor("claude-opus-4-8"),
-      apiKey: `vm0-key-claude-${composeId}`,
+      vendor: "anthropic",
+      apiKey: `vm0-key-anthropic-${composeId}`,
       label: composeId,
     },
     {

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -879,8 +879,8 @@ async function seedTelegramPostModelKeys(
         label: seed.composeId,
       },
       {
-        vendor: getVm0Vendor("claude-opus-4-8"),
-        apiKey: `vm0-key-claude-${seed.composeId}`,
+        vendor: "anthropic",
+        apiKey: `vm0-key-anthropic-${seed.composeId}`,
         label: seed.composeId,
       },
       {
@@ -1449,8 +1449,8 @@ async function seedModelPoliciesForAction(
   await db
     .insert(vm0ApiKeys)
     .values({
-      vendor: getVm0Vendor("claude-opus-4-8"),
-      apiKey: "vm0-key-claude",
+      vendor: "anthropic",
+      apiKey: "vm0-key-anthropic",
       label: required.compose_id!,
     })
     .onConflictDoNothing({ target: vm0ApiKeys.vendor });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -506,20 +506,17 @@ describe("model-first canonical catalog", () => {
   });
 
   it.each([
-    ["claude-fable-5", "anthropic/claude-fable-5"],
-    ["claude-opus-5", "anthropic/claude-opus-5"],
-    ["claude-opus-4-8", "anthropic/claude-opus-4.8"],
-    ["claude-sonnet-5", "anthropic/claude-sonnet-5"],
-    ["claude-sonnet-4-6", "anthropic/claude-sonnet-4.6"],
-  ] as const)(
-    "routes vm0 managed %s through OpenRouter as %s",
-    (model, apiModel) => {
-      expect(getVm0ConcreteProviderType(model)).toBe("openrouter-api-key");
-      expect(getVm0Vendor(model)).toBe("openrouter");
-      expect(getVm0ApiModel(model)).toBe(apiModel);
-      expect(getProviderRuntimeModel("vm0", model)).toBe(apiModel);
-    },
-  );
+    "claude-fable-5",
+    "claude-opus-5",
+    "claude-opus-4-8",
+    "claude-sonnet-5",
+    "claude-sonnet-4-6",
+  ] as const)("routes vm0 managed %s directly through Anthropic", (model) => {
+    expect(getVm0ConcreteProviderType(model)).toBe("anthropic-api-key");
+    expect(getVm0Vendor(model)).toBe("anthropic");
+    expect(getVm0ApiModel(model)).toBe(model);
+    expect(getProviderRuntimeModel("vm0", model)).toBe(model);
+  });
 
   it("builds the default org policy seed from the workspace defaults", () => {
     expect(DEFAULT_ORG_MODEL_POLICY_MODELS).toEqual([

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -239,29 +239,24 @@ interface Vm0ModelConfig {
 // the order models appear in the Built-in model dropdown.
 export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
   "claude-fable-5": {
-    concreteType: "openrouter-api-key",
-    vendor: "openrouter",
-    apiModel: "anthropic/claude-fable-5",
+    concreteType: "anthropic-api-key",
+    vendor: "anthropic",
   },
   "claude-opus-5": {
-    concreteType: "openrouter-api-key",
-    vendor: "openrouter",
-    apiModel: "anthropic/claude-opus-5",
+    concreteType: "anthropic-api-key",
+    vendor: "anthropic",
   },
   "claude-opus-4-8": {
-    concreteType: "openrouter-api-key",
-    vendor: "openrouter",
-    apiModel: "anthropic/claude-opus-4.8",
+    concreteType: "anthropic-api-key",
+    vendor: "anthropic",
   },
   "claude-sonnet-5": {
-    concreteType: "openrouter-api-key",
-    vendor: "openrouter",
-    apiModel: "anthropic/claude-sonnet-5",
+    concreteType: "anthropic-api-key",
+    vendor: "anthropic",
   },
   "claude-sonnet-4-6": {
-    concreteType: "openrouter-api-key",
-    vendor: "openrouter",
-    apiModel: "anthropic/claude-sonnet-4.6",
+    concreteType: "anthropic-api-key",
+    vendor: "anthropic",
   },
   "deepseek-v4-flash": {
     concreteType: "deepseek",

--- a/turbo/packages/core/src/model-display-name.ts
+++ b/turbo/packages/core/src/model-display-name.ts
@@ -5,7 +5,7 @@ import type { CodexServiceTier } from "@okouai/api-contracts/contracts/chat-thre
  * Falls back to the raw model ID if no mapping is found.
  */
 const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
-  // Canonical Claude model IDs
+  // Anthropic direct (claude-code-oauth-token, anthropic-api-key, vm0)
   "claude-fable-5": "Claude Fable 5",
   "claude-opus-5": "Claude Opus 5",
   "claude-sonnet-5": "Claude Sonnet 5",


### PR DESCRIPTION
## Summary

- route VM0-managed Claude models directly through Anthropic again
- restore Anthropic managed-key seeding and claim secret resolution
- keep the real Claude E2E flow on the builtin `vm0` provider

## Deployment compatibility

- no schema, persisted-data, API shape, queue payload, or runner protocol changes
- new claims use Anthropic after the API deployment; already claimed runs keep their existing provider environment
- builtin model IDs and the E2E policy shape remain unchanged

## Validation

- `pnpm exec prettier --check apps/api/src/scripts/__tests__/dev-seed.test.ts apps/api/src/scripts/dev-seed.ts apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts apps/api/src/signals/routes/test-slack-state.ts apps/api/src/signals/routes/test-teams-state.ts apps/api/src/signals/routes/test-telegram-state.ts packages/api-contracts/src/contracts/__tests__/model-providers.test.ts packages/api-contracts/src/contracts/model-providers.ts packages/core/src/model-display-name.ts`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/scripts/__tests__/dev-seed.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'selects a vm0 managed key by vendor'`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm knip`
