### PR TITLE
fix(nbd-cow): remove benchmark dependency on which executable

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "which",
 ]
 
 [[package]]

--- a/crates/nbd-cow/Cargo.toml
+++ b/crates/nbd-cow/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/bin/bench/main.rs"
 required-features = ["bench"]
 
 [features]
-bench = ["dep:serde_json", "dep:tempfile"]
+bench = ["dep:serde_json", "dep:tempfile", "dep:which"]
 
 [dependencies]
 bitvec = { workspace = true }
@@ -21,6 +21,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+which = { workspace = true, optional = true }
 
 [dev-dependencies]
 nix = { workspace = true, features = ["user"] }

--- a/crates/nbd-cow/src/bin/bench/devices/mod.rs
+++ b/crates/nbd-cow/src/bin/bench/devices/mod.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -51,9 +52,47 @@ pub(crate) fn is_root() -> bool {
 }
 
 pub(crate) fn tool_exists(name: &str) -> bool {
-    Command::new("which")
-        .arg(name)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    let Ok(cwd) = std::env::current_dir() else {
+        return false;
+    };
+    tool_exists_in(name, &paths, &cwd)
+}
+
+fn tool_exists_in(name: &str, paths: &OsStr, cwd: &Path) -> bool {
+    which::which_in(name, Some(paths), cwd).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    #[test]
+    fn tool_exists_in_finds_only_executable_files() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let executable = temp_dir.path().join("available-tool");
+        std::fs::write(&executable, "#!/bin/sh\n").unwrap();
+        let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions).unwrap();
+
+        let non_executable = temp_dir.path().join("non-executable-tool");
+        std::fs::write(&non_executable, "not executable\n").unwrap();
+        let mut permissions = std::fs::metadata(&non_executable).unwrap().permissions();
+        permissions.set_mode(0o644);
+        std::fs::set_permissions(&non_executable, permissions).unwrap();
+
+        let paths = std::env::join_paths([temp_dir.path()]).unwrap();
+        assert!(tool_exists_in("available-tool", &paths, temp_dir.path()));
+        assert!(!tool_exists_in("missing-tool", &paths, temp_dir.path()));
+        assert!(!tool_exists_in(
+            "non-executable-tool",
+            &paths,
+            temp_dir.path()
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

- replace the NBD COW benchmark's external `which` subprocess with the workspace `which` crate
- keep executable lookup behind the existing `bench` feature and preserve the default library dependency surface
- cover executable, missing, and non-executable lookup cases with deterministic path-explicit fixtures

## Scope

- preserves the benchmark's arguments and tool-specific missing-executable diagnostics
- does not change the production NBD COW library API or privileged benchmark device flow

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nbd-cow --features bench --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p nbd-cow --features bench --no-deps`
- `cargo test -p nbd-cow --features bench`

Closes #27086
