### PR TITLE
fix(runner): disable workload memory.high reclaim

### DIFF
--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -117,7 +117,7 @@ test "$(cat "$base/memory.min")" = "$expected_control_memory_min"
 test "$(cat "$parent/memory.min")" = "$expected_control_memory_min"
 test "$(cat "$parent/control/memory.min")" = "$expected_control_memory_min"
 grep -Eq '^[0-9]+ [0-9]+$' "$parent/workload/cpu.max"
-grep -Eq '^[0-9]+$' "$parent/workload/memory.high"
+test "$(cat "$parent/workload/memory.high")" = max
 grep -Eq '^[0-9]+$' "$parent/workload/memory.max"
 test "$(cat "$parent/workload/pids.max")" = max
 test -z "${VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT:-}"
@@ -505,9 +505,6 @@ relative = next(
     if line.startswith("0::")
 )
 workload = pathlib.Path(f"/sys/fs/cgroup{relative}")
-# Disable soft-limit throttling for this smoke so reclaim cannot postpone the
-# workload-local OOM. The production memory.high policy is covered above.
-(workload / "memory.high").write_text("max")
 (workload / "memory.max").write_text(str(256 * 1024 * 1024))
 chunk_size = 16 * 1024 * 1024
 chunks = []

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -479,7 +479,7 @@ fn verify_workload_policy(workload_path: &Path) -> io::Result<()> {
             CPU_MAX_FILE,
             format!("{} {}", policy.cpu_quota_us, policy.cpu_period_us),
         ),
-        (MEMORY_HIGH_FILE, policy.memory_high_bytes.to_string()),
+        (MEMORY_HIGH_FILE, policy.memory_high.to_string()),
         (MEMORY_MAX_FILE, policy.memory_max_bytes.to_string()),
         (MEMORY_OOM_GROUP_FILE, "1".to_string()),
         (PIDS_MAX_FILE, policy.pids_max.to_string()),

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -414,6 +414,33 @@ fn prepare_for_reuse_rejects_stale_workload_pid_limit() -> TestResult {
 }
 
 #[test]
+fn prepare_for_reuse_rejects_stale_workload_memory_high() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    let policy =
+        guest_contracts::process_containment::WorkloadResourcePolicy::for_current_guest_capacity()
+            .map_err(std::io::Error::other)?;
+    let legacy_memory_high = policy
+        .memory_max_bytes
+        .checked_sub(256 * 1024 * 1024)
+        .ok_or_else(|| {
+            std::io::Error::other("test Guest is below the retired memory.high policy")
+        })?;
+    std::fs::write(
+        containment.base.join("exec-current/workload/memory.high"),
+        legacy_memory_high.to_string(),
+    )?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
 fn prepare_for_reuse_rejects_helper_in_control_leaf() -> TestResult {
     let (request, _runtime) = reusable_request()?;
     let containment = ContainmentFixture::new()?;
@@ -491,7 +518,7 @@ impl ContainmentFixture {
                 "cpu.max",
                 format!("{} {}", policy.cpu_quota_us, policy.cpu_period_us),
             ),
-            ("memory.high", policy.memory_high_bytes.to_string()),
+            ("memory.high", policy.memory_high.to_string()),
             ("memory.max", policy.memory_max_bytes.to_string()),
             ("memory.oom.group", "1".to_string()),
             ("pids.max", policy.pids_max.to_string()),

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -60,8 +60,8 @@ pub const MATERIAL_CPU_THROTTLED_USEC: u64 = 1_000_000;
 /// this value so concurrent operation siblings cannot reclaim the reservation.
 pub const CONTROL_MEMORY_RESERVE_BYTES: u64 = 384 * 1024 * 1024;
 
-/// Additional distance between workload `memory.high` and `memory.max`.
-pub const WORKLOAD_MEMORY_HIGH_HEADROOM_BYTES: u64 = 256 * 1024 * 1024;
+/// Value written to workload `memory.high` to avoid unmonitored soft-limit reclaim.
+pub const WORKLOAD_MEMORY_HIGH: &str = "max";
 
 /// Value written to workload `pids.max` while no production ceiling is calibrated.
 ///
@@ -81,8 +81,8 @@ pub struct WorkloadResourcePolicy {
     pub cpu_quota_us: u64,
     /// Workload CPU bandwidth period in microseconds.
     pub cpu_period_us: u64,
-    /// Workload memory throttling threshold in bytes.
-    pub memory_high_bytes: u64,
+    /// Value written to the workload `memory.high` cgroup file.
+    pub memory_high: &'static str,
     /// Workload hard memory limit in bytes.
     pub memory_max_bytes: u64,
     /// Protected Guest Agent memory in bytes.
@@ -119,7 +119,7 @@ impl WorkloadResourcePolicy {
     ///
     /// `vcpu` is the number of online processors and `memory_bytes` is physical
     /// memory visible to the Guest. The calculation fails when the Guest cannot
-    /// preserve the fixed control reserve and workload high-limit headroom.
+    /// preserve the fixed control reserve.
     pub fn for_guest_capacity(vcpu: u32, memory_bytes: u64) -> Result<Self, &'static str> {
         let total_cpu_us = u64::from(vcpu)
             .checked_mul(WORKLOAD_CPU_PERIOD_US)
@@ -133,15 +133,10 @@ impl WorkloadResourcePolicy {
             .checked_sub(CONTROL_MEMORY_RESERVE_BYTES)
             .filter(|limit| *limit > 0)
             .ok_or("guest memory capacity cannot preserve control headroom")?;
-        let memory_high_bytes = memory_max_bytes
-            .checked_sub(WORKLOAD_MEMORY_HIGH_HEADROOM_BYTES)
-            .filter(|limit| *limit > 0)
-            .ok_or("guest memory capacity cannot provide a workload high threshold")?;
-
         Ok(Self {
             cpu_quota_us,
             cpu_period_us: WORKLOAD_CPU_PERIOD_US,
-            memory_high_bytes,
+            memory_high: WORKLOAD_MEMORY_HIGH,
             memory_max_bytes,
             control_memory_min_bytes: CONTROL_MEMORY_RESERVE_BYTES,
             pids_max: WORKLOAD_PIDS_MAX,
@@ -161,8 +156,8 @@ mod tests {
 
         assert_eq!(policy.cpu_quota_us, 190_000);
         assert_eq!(policy.cpu_period_us, 100_000);
+        assert_eq!(policy.memory_high, "max");
         assert_eq!(policy.memory_max_bytes, 3712 * 1024 * 1024);
-        assert_eq!(policy.memory_high_bytes, 3456 * 1024 * 1024);
         assert_eq!(policy.control_memory_min_bytes, 384 * 1024 * 1024);
         assert_eq!(policy.pids_max, "max");
     }
@@ -185,8 +180,8 @@ mod tests {
                 .unwrap();
 
         assert_eq!(policy.cpu_quota_us, 90_000);
+        assert_eq!(policy.memory_high, "max");
         assert_eq!(policy.memory_max_bytes, 640 * 1024 * 1024);
-        assert_eq!(policy.memory_high_bytes, 384 * 1024 * 1024);
     }
 
     #[test]
@@ -196,7 +191,7 @@ mod tests {
         let policy = WorkloadResourcePolicy::for_guest_capacity(1, 1_033_928_704).unwrap();
 
         assert_eq!(policy.cpu_quota_us, 90_000);
+        assert_eq!(policy.memory_high, "max");
         assert_eq!(policy.memory_max_bytes, 631_275_520);
-        assert_eq!(policy.memory_high_bytes, 362_840_064);
     }
 }

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -495,7 +495,7 @@ fn configure_resource_policy(
     write_cgroup_value(
         workload_path,
         MEMORY_HIGH_FILE,
-        &policy.memory_high_bytes.to_string(),
+        policy.memory_high,
         "configure workload memory.high",
     )?;
     write_cgroup_value(


### PR DESCRIPTION
## Summary

- configure workload cgroups with `memory.high=max` so supported memory-intensive tools do not livelock in unmonitored soft-limit reclaim
- retain numeric `memory.max`, the 384-MiB Guest Agent protection chain, CPU isolation, cleanup, and structured hard-limit diagnostics
- make Guest installation and reuse verification consume the same literal policy, with integration coverage rejecting sandboxes carrying the retired numeric value
- exercise the installed production policy in the existing real-Guest containment smoke instead of overriding `memory.high` inside the OOM scenario

## Evidence

Production run `4c015c70-7f7a-44b4-b9d7-1bcae0e879fc` remained heartbeat-healthy until its two-hour timeout while recording about 46.2 million `memory.high` events, no `memory.max` or OOM event, and sustained kernel-heavy CPU use.

On a production-equivalent 2-vCPU / 4-GiB `local-1` workload with a resident 1-GiB agent baseline:

| Policy | Result | Kernel CPU | Memory events |
| --- | --- | --- | --- |
| numeric `memory.high`, existing numeric `memory.max` | timed out at 600 seconds | about 789 seconds | `high=436340`, `max=0`, OOM 0 |
| `memory.high=max`, existing numeric `memory.max` | completed in 141 seconds | about 19.5 seconds | `high=0`, `max=391`, OOM 0 |

## Compatibility and risk

- No API, database, heartbeat, terminal-state, or durable-data contract changes.
- Exact reuse validation intentionally rejects old sandboxes with numeric `memory.high`, causing the existing safe cold fallback and a possible temporary reuse-rate dip during rollout.
- Workloads can use the final 256 MiB inside the existing hard allowance. A workload that cannot reclaim below numeric `memory.max` can still fail through the existing workload-local OOM path without consuming Guest Agent control memory.
- This PR does not increase profile memory or timeouts, reduce control protection, remove `memory.max`, add an adaptive pressure controller, or add a multi-gigabyte synthetic CI workload.

## Validation

- `cargo fmt --all --check`
- `cargo test -p guest-contracts -p vsock-guest -p guest-agent --all-targets --all-features`
- `cargo clippy -p guest-contracts -p vsock-guest -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-contracts -p vsock-guest -p guest-agent --all-features --no-deps`
- `cargo test -p runner --bin runner config::tests --all-features`
- `cargo test -p guest-agent --test reuse_preparation_helper prepare_for_reuse_rejects_stale_workload_memory_high --all-features`
- `cargo clippy -p guest-agent --test reuse_preparation_helper --all-features -- -D warnings`
- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- repository pre-commit hooks, including workspace Rust formatting, Clippy, and rustdoc

Closes #27110
