### PR TITLE
feat: unify saved billing purchase routing

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,3 +35,21 @@ self-harm. It excludes non-graphic news, medical, educational, historical,
 safety, moderation, and ordinary fictional discussion.
 
 _Avoid_: 18+ content, adult content
+
+# Billing Context
+
+The billing context decides whether a purchase can be reviewed and confirmed inside vm0 or must continue on a Stripe-hosted page.
+
+## Language
+
+**Saved payment method**:
+A Stripe payment method available to an organization through, in priority order, the subscription default, customer invoice default, an attached card, or a legacy default source.
+_Avoid_: Bound card, default card
+
+**Operation invoice**:
+The invoice produced by confirming the current purchase or subscription change. Unpaid invoices from earlier operations are not part of this decision.
+_Avoid_: Customer balance, historical invoice
+
+**Hosted invoice payment**:
+The Stripe-hosted invoice page used when an operation invoice remains unpaid after an in-app confirmation attempt.
+_Avoid_: Checkout

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -197,6 +197,7 @@ export interface ApiTestMocks {
       readonly update: AsyncMock;
     };
     readonly subscriptions: {
+      readonly create: AsyncMock;
       readonly list: AsyncMock;
       readonly retrieve: AsyncMock;
       readonly update: AsyncMock;
@@ -375,6 +376,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       update: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     subscriptions: {
+      create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       update: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
@@ -939,6 +941,7 @@ vi.mock("stripe", async (importOriginal) => {
           update: apiTestMocks.stripe.customers.update,
         },
         subscriptions: {
+          create: apiTestMocks.stripe.subscriptions.create,
           list: apiTestMocks.stripe.subscriptions.list,
           retrieve: apiTestMocks.stripe.subscriptions.retrieve,
           update: apiTestMocks.stripe.subscriptions.update,
@@ -1217,6 +1220,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.stripe.customers.create.mockReset();
   apiTestMocks.stripe.customers.update.mockReset();
   apiTestMocks.stripe.paymentMethods.retrieve.mockReset();
+  apiTestMocks.stripe.subscriptions.create.mockReset();
   apiTestMocks.stripe.subscriptions.list.mockReset();
   apiTestMocks.stripe.subscriptions.list.mockResolvedValue({ data: [] });
   apiTestMocks.stripe.subscriptions.retrieve.mockReset();

--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -68,6 +68,7 @@ export interface StripeSubscription {
   readonly schedule?: StripeRef;
   readonly discounts?: readonly StripeRef[];
   readonly default_payment_method?: StripeRef;
+  readonly default_source?: StripeRef;
   readonly latest_invoice: string | StripeInvoice | null;
   readonly pending_update?: {
     readonly expires_at: number;
@@ -145,6 +146,7 @@ export interface StripeSubscriptionUpdateParams {
   readonly cancel_at?: number | null;
   readonly cancel_at_period_end?: boolean;
   readonly metadata?: StripeMetadataParam;
+  readonly default_payment_method?: string;
   readonly items?: StripeSubscriptionUpdateItemParam[];
   readonly payment_behavior?:
     | "allow_incomplete"
@@ -152,6 +154,20 @@ export interface StripeSubscriptionUpdateParams {
     | "pending_if_incomplete";
   readonly proration_behavior?: "always_invoice" | "create_prorations" | "none";
   readonly proration_date?: number;
+  readonly expand?: string[];
+}
+
+export interface StripeSubscriptionCreateParams {
+  readonly customer: string;
+  readonly items: {
+    readonly price: string;
+    readonly quantity?: number;
+  }[];
+  readonly default_payment_method?: string;
+  readonly default_source?: string;
+  readonly metadata: StripeMetadataParam;
+  readonly payment_behavior: "default_incomplete";
+  readonly trial_period_days?: number;
   readonly expand?: string[];
 }
 
@@ -169,6 +185,7 @@ export interface StripeCustomer {
   readonly invoice_settings?: {
     readonly default_payment_method?: StripeRef;
   } | null;
+  readonly default_source?: StripeRef;
 }
 
 export interface StripeDeletedCustomer {
@@ -379,6 +396,10 @@ export type StripeSubscriptionListStatus =
   | "unpaid";
 
 export interface StripeSubscriptionsApi {
+  create(
+    params: StripeSubscriptionCreateParams,
+    options?: StripeRequestOptions,
+  ): Promise<StripeSubscription>;
   retrieve(
     id: string,
     params?: { expand?: string[] },
@@ -458,6 +479,7 @@ export interface StripeInvoicesApi {
       customer: string;
       auto_advance?: boolean;
       default_payment_method?: string;
+      default_source?: string;
       discounts?: "" | { readonly coupon: string }[];
       metadata?: StripeMetadataParam;
     },

--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -147,6 +147,7 @@ export interface StripeSubscriptionUpdateParams {
   readonly cancel_at_period_end?: boolean;
   readonly metadata?: StripeMetadataParam;
   readonly default_payment_method?: string;
+  readonly default_source?: string;
   readonly items?: StripeSubscriptionUpdateItemParam[];
   readonly payment_behavior?:
     | "allow_incomplete"

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -1004,6 +1004,9 @@ describe("POST /api/zero/billing/checkout", () => {
     await enableSavedBillingPurchasePreview(fixture);
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const paymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
+    const subscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const periodStart = currentSecond();
+    const periodEnd = periodStart + 30 * 86_400;
     const hostedInvoiceUrl =
       "https://invoice.stripe.com/plan-purchase-authentication";
     context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
@@ -1034,15 +1037,48 @@ describe("POST /api/zero/billing/checkout", () => {
       amount_due: 2000,
       currency: "usd",
       status: "open",
-      lines: { has_more: false, data: [] },
-      parent: null,
+      lines: {
+        has_more: false,
+        data: [
+          {
+            amount: 2000,
+            price: { id: TEST_PRICE_PRO },
+            parent: { type: "subscription_item_details" as const },
+            period: { start: periodStart, end: periodEnd },
+          },
+        ],
+      },
+      parent: {
+        subscription_details: {
+          subscription: subscriptionId,
+          metadata: {},
+        },
+      },
     };
     context.mocks.stripe.subscriptions.create.mockResolvedValue({
-      id: `sub_${randomUUID().slice(0, 8)}`,
+      id: subscriptionId,
       customer: customerId,
       status: "incomplete",
       metadata: {},
       latest_invoice: operationInvoice,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: subscriptionId,
+      customer: customerId,
+      status: "active",
+      metadata: {},
+      cancel_at_period_end: false,
+      cancel_at: null,
+      schedule: null,
+      trial_end: null,
+      items: {
+        data: [
+          {
+            price: { id: TEST_PRICE_PRO },
+            current_period_end: periodEnd,
+          },
+        ],
+      },
     });
     context.mocks.stripe.invoices.pay.mockResolvedValue({
       ...operationInvoice,
@@ -1114,6 +1150,191 @@ describe("POST /api/zero/billing/checkout", () => {
         idempotencyKey: expect.stringContaining("billing-operation:plan:"),
       }),
     );
+    const billing = await readBillingStatus(fixture);
+    expect(billing.tier).toBe("pro");
+    expect(billing.subscriptionStatus).toBe("active");
+    expect(billing.hasSubscription).toBeTruthy();
+  });
+
+  it("resumes a pending Team purchase and applies it before returning", async () => {
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const pendingTeamSubscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const activeProSubscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const fixture = await trackedBillingSeed({
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: pendingTeamSubscriptionId,
+      subscriptionStatus: "incomplete",
+      tier: "pro",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await enableSavedBillingPurchasePreview(fixture);
+
+    const paymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
+    const periodStart = currentSecond();
+    const periodEnd = periodStart + 30 * 86_400;
+    const invoiceId = `in_${randomUUID().slice(0, 8)}`;
+    const pendingPurchaseMetadata = {
+      orgId: fixture.orgId,
+      tier: "team",
+      priceId: TEST_PRICE_TEAM,
+      billingPurchaseId: `purchase_${randomUUID().slice(0, 8)}`,
+    };
+    let teamPaid = false;
+
+    const teamInvoice = () => {
+      return {
+        id: invoiceId,
+        hosted_invoice_url: teamPaid
+          ? null
+          : "https://invoice.stripe.com/pending-team",
+        customer: customerId,
+        metadata: {},
+        amount_due: 20_000,
+        currency: "usd",
+        status: teamPaid ? ("paid" as const) : ("open" as const),
+        lines: {
+          has_more: false,
+          data: [
+            {
+              amount: 20_000,
+              price: { id: TEST_PRICE_TEAM },
+              parent: { type: "subscription_item_details" as const },
+              period: { start: periodStart, end: periodEnd },
+            },
+          ],
+        },
+        parent: {
+          subscription_details: {
+            subscription: pendingTeamSubscriptionId,
+            metadata: pendingPurchaseMetadata,
+          },
+        },
+      };
+    };
+    const pendingTeamSubscription = () => {
+      return {
+        id: pendingTeamSubscriptionId,
+        customer: customerId,
+        status: teamPaid ? "active" : "incomplete",
+        metadata: pendingPurchaseMetadata,
+        default_payment_method: paymentMethodId,
+        cancel_at_period_end: false,
+        cancel_at: null,
+        schedule: null,
+        trial_end: null,
+        items: {
+          data: [
+            {
+              price: { id: TEST_PRICE_TEAM },
+              current_period_end: periodEnd,
+            },
+          ],
+        },
+        latest_invoice: teamInvoice(),
+      };
+    };
+    const activeProSubscription = {
+      id: activeProSubscriptionId,
+      customer: customerId,
+      status: "active",
+      metadata: { orgId: fixture.orgId },
+      default_payment_method: paymentMethodId,
+      cancel_at_period_end: false,
+      cancel_at: null,
+      schedule: null,
+      trial_end: null,
+      items: {
+        data: [
+          {
+            price: { id: TEST_PRICE_PRO },
+            current_period_end: periodEnd,
+          },
+        ],
+      },
+    };
+    context.mocks.stripe.subscriptions.retrieve.mockImplementation(
+      (subscriptionId) => {
+        if (subscriptionId === pendingTeamSubscriptionId) {
+          return Promise.resolve(pendingTeamSubscription());
+        }
+        if (subscriptionId === activeProSubscriptionId) {
+          return Promise.resolve(activeProSubscription);
+        }
+        throw new Error(`Unexpected Stripe subscription ${subscriptionId}`);
+      },
+    );
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [pendingTeamSubscription(), activeProSubscription],
+      has_more: false,
+    });
+    context.mocks.stripe.invoices.createPreview.mockResolvedValue({
+      id: `in_preview_${randomUUID().slice(0, 8)}`,
+      hosted_invoice_url: null,
+      customer: customerId,
+      metadata: {},
+      amount_due: 20_000,
+      currency: "usd",
+      status: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+    context.mocks.stripe.invoices.pay.mockImplementation(() => {
+      teamPaid = true;
+      return Promise.resolve(teamInvoice());
+    });
+    context.mocks.stripe.subscriptions.cancel.mockResolvedValue({
+      id: activeProSubscriptionId,
+      status: "canceled",
+    });
+
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      zeroBillingCheckoutContract,
+    );
+    const purchaseBody = {
+      tier: "team" as const,
+      supportsInAppPreview: true,
+      successUrl: `${APP_ORIGIN}/billing?billing=success`,
+      cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+    };
+    const start = await accept(
+      client.create({
+        body: purchaseBody,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    if (!("previewToken" in start.body)) {
+      throw new Error("Expected a Team purchase preview");
+    }
+
+    const confirmation = await accept(
+      client.create({
+        body: { ...purchaseBody, previewToken: start.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(confirmation.body).toStrictEqual({
+      status: "completed",
+      hostedInvoiceUrl: null,
+    });
+    expect(context.mocks.stripe.subscriptions.create).not.toHaveBeenCalled();
+    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledWith(
+      invoiceId,
+      {},
+      expect.objectContaining({
+        idempotencyKey: expect.stringContaining("billing-operation:plan:"),
+      }),
+    );
+    expect(context.mocks.stripe.subscriptions.cancel).toHaveBeenCalledWith(
+      activeProSubscriptionId,
+      { invoice_now: false, prorate: false },
+    );
+    const billing = await readBillingStatus(fixture);
+    expect(billing.tier).toBe("team");
+    expect(billing.subscriptionStatus).toBe("active");
+    expect(billing.hasSubscription).toBeTruthy();
   });
 
   it("refreshes an invalid Plan preview through the rollout-safe checkout route", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -741,7 +741,9 @@ async function seedMemberRole(args: {
 
 describe("POST /api/zero/billing/checkout", () => {
   beforeEach(() => {
+    mockStripeClient(context.mocks.stripe as unknown as StripeSDK);
     setZeroPrice();
+    mockEnv("SECRETS_ENCRYPTION_KEY", "a".repeat(64));
   });
 
   function trackedSeed(): { orgId: string; userId: string } {
@@ -965,6 +967,147 @@ describe("POST /api/zero/billing/checkout", () => {
         },
       },
     });
+  });
+
+  it("previews a saved-card plan purchase and routes its unpaid invoice", async () => {
+    const fixture = await trackedSeed();
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const paymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
+    const hostedInvoiceUrl =
+      "https://invoice.stripe.com/plan-purchase-authentication";
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: customerId,
+      invoice_settings: { default_payment_method: paymentMethodId },
+    });
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [],
+      has_more: false,
+    });
+    context.mocks.stripe.invoices.createPreview.mockResolvedValue({
+      id: `in_preview_${randomUUID().slice(0, 8)}`,
+      hosted_invoice_url: null,
+      customer: customerId,
+      metadata: {},
+      amount_due: 2000,
+      currency: "usd",
+      status: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+    const operationInvoice = {
+      id: `in_${randomUUID().slice(0, 8)}`,
+      hosted_invoice_url: hostedInvoiceUrl,
+      customer: customerId,
+      metadata: {},
+      amount_due: 2000,
+      currency: "usd",
+      status: "open",
+      lines: { has_more: false, data: [] },
+      parent: null,
+    };
+    context.mocks.stripe.subscriptions.create.mockResolvedValue({
+      id: `sub_${randomUUID().slice(0, 8)}`,
+      customer: customerId,
+      status: "incomplete",
+      metadata: {},
+      latest_invoice: operationInvoice,
+    });
+    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      zeroBillingCheckoutContract,
+    );
+    const start = await accept(
+      client.create({
+        body: {
+          tier: "pro",
+          supportsInAppPreview: true,
+          successUrl: `${APP_ORIGIN}/billing?billing=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(start.body).toMatchObject({
+      status: "preview",
+      purchaseType: "plan",
+      tier: "pro",
+      immediateAmountCents: 2000,
+      nextRecurringAmountCents: 2000,
+      currency: "usd",
+      previewToken: expect.any(String),
+    });
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).not.toHaveBeenCalled();
+    if (!("previewToken" in start.body)) {
+      throw new Error("Expected a Plan purchase preview");
+    }
+
+    const confirmation = await accept(
+      client.confirm({
+        body: { previewToken: start.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(confirmation.body).toStrictEqual({
+      status: "pending_payment",
+      hostedInvoiceUrl,
+    });
+    expect(context.mocks.stripe.invoices.createPreview).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(context.mocks.stripe.subscriptions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: customerId,
+        default_payment_method: paymentMethodId,
+        payment_behavior: "default_incomplete",
+      }),
+      expect.objectContaining({
+        idempotencyKey: expect.stringContaining("plan-purchase:"),
+      }),
+    );
+    expect(context.mocks.stripe.invoices.pay).not.toHaveBeenCalled();
+  });
+
+  it("uses hosted Checkout when an opted-in plan purchase has no saved card", async () => {
+    const fixture = await trackedSeed();
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: customerId,
+      invoice_settings: { default_payment_method: null },
+      default_source: null,
+    });
+    context.mocks.stripe.paymentMethods.list.mockResolvedValue({ data: [] });
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
+      url: "https://checkout.stripe.com/session/plan-no-card",
+    });
+
+    const response = await accept(
+      setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+        zeroBillingCheckoutContract,
+      ).create({
+        body: {
+          tier: "pro",
+          supportsInAppPreview: true,
+          successUrl: `${APP_ORIGIN}/billing?billing=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      url: "https://checkout.stripe.com/session/plan-no-card",
+    });
+    expect(context.mocks.stripe.invoices.createPreview).not.toHaveBeenCalled();
   });
 
   it("tags preview Stripe checkout objects with the current job ref", async () => {
@@ -1720,22 +1863,25 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
       purpose: "usage_pack_subscription",
       usagePackSubscriptionId: createdSnapshotId,
     };
-    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith({
-      mode: "subscription",
-      customer: expect.any(String),
-      line_items: [
-        { price: TEST_PRICE_USAGE_PACK_PLAN_TEAM, quantity: 1 },
-        { price: TEST_PRICE_USAGE_PACK_20, quantity: 99 },
-        { price: TEST_PRICE_USAGE_PACK_50, quantity: 1 },
-        { price: TEST_PRICE_USAGE_PACK_100, quantity: 1 },
-        { price: TEST_PRICE_USAGE_PACK_200, quantity: 1 },
-      ],
-      allow_promotion_codes: true,
-      success_url: `${APP_ORIGIN}/billing?billing=success`,
-      cancel_url: `${APP_ORIGIN}/billing?billing=canceled`,
-      metadata,
-      subscription_data: { metadata },
-    });
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      {
+        mode: "subscription",
+        customer: expect.any(String),
+        line_items: [
+          { price: TEST_PRICE_USAGE_PACK_PLAN_TEAM, quantity: 1 },
+          { price: TEST_PRICE_USAGE_PACK_20, quantity: 99 },
+          { price: TEST_PRICE_USAGE_PACK_50, quantity: 1 },
+          { price: TEST_PRICE_USAGE_PACK_100, quantity: 1 },
+          { price: TEST_PRICE_USAGE_PACK_200, quantity: 1 },
+        ],
+        allow_promotion_codes: true,
+        success_url: `${APP_ORIGIN}/billing?billing=success`,
+        cancel_url: `${APP_ORIGIN}/billing?billing=canceled`,
+        metadata,
+        subscription_data: { metadata },
+      },
+      { idempotencyKey: `usage-pack-checkout:${createdSnapshotId}` },
+    );
     expect(
       context.mocks.clerk.organizations.getOrganizationMembershipList,
     ).toHaveBeenNthCalledWith(1, {
@@ -4451,6 +4597,52 @@ describe("usage pack allocation management", () => {
     mockOptionalEnv("STRIPE_WEBHOOK_SECRET", STRIPE_WEBHOOK_SECRET);
   });
 
+  it("records a card collected for a usage pack purchase setup", async () => {
+    const actor = createOrgFixture();
+    const fixture = await seedManagedUsagePack(
+      [{ userId: actor.userId, usagePackUsd: 20 }],
+      "pro",
+      actor,
+    );
+    const paymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
+    const event = {
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: `cs_setup_${randomUUID().slice(0, 8)}`,
+          mode: "setup",
+          customer: fixture.customerId,
+          subscription: null,
+          metadata: {
+            purpose: "billing_purchase",
+            orgId: fixture.orgId,
+            subscriptionId: fixture.subscriptionId,
+          },
+          setup_intent: {
+            id: `seti_${randomUUID().slice(0, 8)}`,
+            payment_method: paymentMethodId,
+          },
+        },
+      },
+    };
+    context.mocks.stripe.webhooks.constructEvent.mockReturnValueOnce(event);
+
+    await accept(
+      setupApp({ context, routes: webhooksStripeRoutes })(
+        webhookStripeContract,
+      ).post({
+        body: JSON.stringify(event),
+        extraHeaders: { "stripe-signature": "t=1,v1=purchase-setup" },
+      }),
+      [200],
+    );
+
+    expect(context.mocks.stripe.customers.update).toHaveBeenCalledWith(
+      fixture.customerId,
+      { invoice_settings: { default_payment_method: paymentMethodId } },
+    );
+  });
+
   it("routes a concurrency-only invoice on the Plan subscription", async () => {
     const actor = createOrgFixture();
     const fixture = await seedManagedUsagePack(
@@ -5115,7 +5307,7 @@ describe("usage pack allocation management", () => {
     expect(confirmed.body).toStrictEqual({
       status: "pending_payment",
       effectiveAt: preview.body.prorationDate,
-      hostedInvoiceUrl: null,
+      hostedInvoiceUrl: paidInvoice.hosted_invoice_url,
     });
     await postManagedUsagePackEvent(
       "customer.subscription.updated",
@@ -5954,7 +6146,7 @@ describe("usage pack allocation management", () => {
     expect(confirmed.body).toStrictEqual({
       status: "pending_payment",
       effectiveAt: preview.body.prorationDate,
-      hostedInvoiceUrl: null,
+      hostedInvoiceUrl: openInvoice.hosted_invoice_url,
     });
 
     mockNow(new Date(initialNow.getTime() + 25 * 60 * 60 * 1000));
@@ -6572,10 +6764,15 @@ describe("usage pack allocation management", () => {
     const prorationTimestamp = Math.floor(
       new Date(preview.body.prorationDate).getTime() / 1000,
     );
+    const pendingInvoiceId = `in_${randomUUID()}`;
     context.mocks.stripe.subscriptions.update.mockResolvedValue({
       ...subscription,
       pending_update: { expires_at: prorationTimestamp + 60 },
-      latest_invoice: `in_${randomUUID()}`,
+      latest_invoice: {
+        id: pendingInvoiceId,
+        status: "open",
+        hosted_invoice_url: `https://invoice.stripe.test/${pendingInvoiceId}`,
+      },
     });
     await accept(
       client.confirmChange({
@@ -7438,12 +7635,16 @@ describe("usage pack allocation management", () => {
     context.mocks.stripe.invoices.create.mockResolvedValue({
       id: invoiceId,
       metadata,
+      status: "draft",
+      hosted_invoice_url: null,
     });
     context.mocks.stripe.invoiceItems.create.mockResolvedValue({
       id: `ii_invite_${randomUUID()}`,
     });
     context.mocks.stripe.invoices.finalizeInvoice.mockResolvedValue({
       id: invoiceId,
+      status: "open",
+      hosted_invoice_url: `https://invoice.stripe.test/${invoiceId}`,
     });
     context.mocks.stripe.invoices.pay.mockResolvedValue({
       id: invoiceId,
@@ -7470,14 +7671,7 @@ describe("usage pack allocation management", () => {
         ],
       },
     };
-    context.mocks.stripe.invoices.retrieve
-      .mockResolvedValueOnce({
-        ...paidInvoice,
-        status: "draft",
-        paid: false,
-        payments: { data: [] },
-      })
-      .mockResolvedValue(paidInvoice);
+    context.mocks.stripe.invoices.retrieve.mockResolvedValue(paidInvoice);
 
     const confirmed = await accept(
       client.confirmPurchase({
@@ -7514,8 +7708,18 @@ describe("usage pack allocation management", () => {
     );
     expect(context.mocks.stripe.invoices.finalizeInvoice).toHaveBeenCalledWith(
       invoiceId,
+      {},
+      {
+        idempotencyKey: `billing-operation:usage-pack-invitation:${activePurchaseId}:finalize`,
+      },
     );
-    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledWith(invoiceId);
+    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledWith(
+      invoiceId,
+      {},
+      {
+        idempotencyKey: `billing-operation:usage-pack-invitation:${activePurchaseId}:pay`,
+      },
+    );
     await postManagedUsagePackEvent("invoice.paid", {
       id: invoiceId,
       customer: fixture.customerId,
@@ -9168,6 +9372,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       id: fixture.subscriptionId,
       latest_invoice: {
         id: `in_${randomUUID()}`,
+        status: "open",
         hosted_invoice_url: hostedInvoiceUrl,
       },
       pending_update: {
@@ -9476,6 +9681,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       id: subscriptionId,
       latest_invoice: {
         id: `in_${randomUUID()}`,
+        status: "open",
         hosted_invoice_url: hostedInvoiceUrl,
       },
       pending_update: {
@@ -9810,6 +10016,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       id: subscriptionId,
       latest_invoice: {
         id: `in_${randomUUID()}`,
+        status: "open",
         hosted_invoice_url: hostedInvoiceUrl,
       },
       pending_update: {
@@ -10832,6 +11039,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       id: subscriptionId,
       latest_invoice: {
         id: `in_${randomUUID()}`,
+        status: "open",
         hosted_invoice_url: hostedInvoiceUrl,
       },
       pending_update: {
@@ -12105,6 +12313,116 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     );
   });
 
+  it("uses a legacy subscription source when no higher-priority card exists", async () => {
+    const fixture = await createSubscriptionOrg({ tier: "pro" });
+    const subscriptionSourceId = `card_${randomUUID().slice(0, 8)}`;
+    const customerSourceId = `card_${randomUUID().slice(0, 8)}`;
+    const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: fixture.subscriptionId,
+      customer: fixture.customerId,
+      default_payment_method: null,
+      default_source: subscriptionSourceId,
+    });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: fixture.customerId,
+      discount: null,
+      invoice_settings: { default_payment_method: null },
+      default_source: customerSourceId,
+    });
+    context.mocks.stripe.paymentMethods.list.mockResolvedValue({ data: [] });
+    mockCreditPurchasePreview(fixture.customerId);
+
+    const client = setupApp({
+      context,
+      routes: zeroBillingCreditCheckoutRoutes,
+    })(zeroBillingCreditCheckoutContract);
+    const preview = await accept(
+      client.create({
+        body: {
+          credits: 20_000,
+          supportsInAppPreview: true,
+          successUrl: `${APP_ORIGIN}/billing?credit=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?credit=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    if (!("previewToken" in preview.body)) {
+      throw new Error("Expected a credit purchase preview");
+    }
+
+    const draftInvoice = {
+      id: invoiceId,
+      hosted_invoice_url: null,
+      customer: fixture.customerId,
+      metadata: { purpose: "credit_purchase" },
+      amount_due: 2000,
+      currency: "usd",
+      status: "draft",
+      lines: { has_more: false, data: [] },
+      parent: null,
+    };
+    context.mocks.stripe.invoices.create.mockResolvedValue(draftInvoice);
+    let purchaseId: string | null = null;
+    context.mocks.stripe.invoiceItems.create.mockImplementation((rawParams) => {
+      const params = rawParams as {
+        readonly metadata?: Readonly<Record<string, string>>;
+      };
+      purchaseId = params.metadata?.credit_purchase_preview_id ?? null;
+      return Promise.resolve({ id: `ii_${randomUUID().slice(0, 8)}` });
+    });
+    context.mocks.stripe.invoices.retrieve.mockImplementation(() => {
+      if (!purchaseId) {
+        throw new Error("Expected a confirmed credit purchase ID");
+      }
+      return Promise.resolve({
+        ...draftInvoice,
+        status: "paid",
+        lines: {
+          has_more: false,
+          data: [
+            {
+              id: `il_${randomUUID().slice(0, 8)}`,
+              amount: 2000,
+              subtotal: 2000,
+              metadata: { credit_purchase_preview_id: purchaseId },
+              period: { start: currentSecond(), end: currentSecond() },
+              parent: null,
+            },
+          ],
+        },
+      });
+    });
+
+    const confirmation = await accept(
+      client.confirm({
+        body: { previewToken: preview.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(confirmation.body).toStrictEqual({
+      status: "completed",
+      hostedInvoiceUrl: null,
+    });
+    expect(context.mocks.stripe.invoices.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: fixture.customerId,
+        default_source: subscriptionSourceId,
+      }),
+      expect.any(Object),
+    );
+    expect(context.mocks.stripe.invoices.create).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        default_payment_method: expect.anything(),
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("rejects payment when the finalized invoice amount differs from the preview", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
@@ -12421,7 +12739,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
       invoiceId,
       {},
       expect.objectContaining({
-        idempotencyKey: expect.stringContaining("credit-purchase:"),
+        idempotencyKey: expect.stringContaining("billing-operation:credit:"),
       }),
     );
     expect(context.mocks.stripe.invoices.retrieve).toHaveBeenCalledTimes(2);
@@ -12461,6 +12779,71 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     expect(response.body).toStrictEqual({
       url: "https://checkout.stripe.com/session/credit-fallback",
     });
+  });
+
+  it("returns Checkout when all saved cards are removed after preview", async () => {
+    const fixture = await createSubscriptionOrg({ tier: "pro" });
+    const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: fixture.subscriptionId,
+      customer: fixture.customerId,
+      default_payment_method: paymentMethodId,
+    });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: fixture.customerId,
+      discount: null,
+    });
+    mockCreditPurchasePreview(fixture.customerId);
+    const client = setupApp({
+      context,
+      routes: zeroBillingCreditCheckoutRoutes,
+    })(zeroBillingCreditCheckoutContract);
+    const preview = await accept(
+      client.create({
+        body: {
+          credits: 20_000,
+          supportsInAppPreview: true,
+          successUrl: `${APP_ORIGIN}/billing?credit=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?credit=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    if (!("previewToken" in preview.body)) {
+      throw new Error("Expected a credit purchase preview");
+    }
+
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: fixture.subscriptionId,
+      customer: fixture.customerId,
+      default_payment_method: null,
+      default_source: null,
+    });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: fixture.customerId,
+      discount: null,
+      invoice_settings: { default_payment_method: null },
+      default_source: null,
+    });
+    context.mocks.stripe.paymentMethods.list.mockResolvedValue({ data: [] });
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
+      url: "https://checkout.stripe.com/session/cards-removed",
+    });
+
+    const confirmation = await accept(
+      client.confirm({
+        body: { previewToken: preview.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(confirmation.body).toStrictEqual({
+      status: "checkout_required",
+      checkoutUrl: "https://checkout.stripe.com/session/cards-removed",
+    });
+    expect(context.mocks.stripe.invoices.create).not.toHaveBeenCalled();
   });
 
   it("rejects credit checkout when the plan capability is disabled", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -2148,6 +2148,9 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
         [200],
       );
 
+      if (!("url" in response.body)) {
+        throw new Error("Expected hosted usage pack checkout response");
+      }
       expect(response.body.url).toBe(checkoutSessions[0].url);
       expect(
         context.mocks.stripe.checkout.sessions.create,
@@ -2163,6 +2166,9 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
             },
             { price: TEST_PRICE_USAGE_PACK_20, quantity: 1 },
           ],
+        }),
+        expect.objectContaining({
+          idempotencyKey: expect.stringContaining("usage-pack-checkout:"),
         }),
       );
       context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValueOnce({
@@ -2187,6 +2193,9 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
         [200],
       );
 
+      if (!("url" in retried.body)) {
+        throw new Error("Expected hosted usage pack checkout response");
+      }
       expect(retried.body.url).toBe(checkoutSessions[0].url);
       expect(
         context.mocks.stripe.checkout.sessions.retrieve,
@@ -2221,6 +2230,9 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
         [200],
       );
 
+      if (!("url" in replaced.body)) {
+        throw new Error("Expected hosted usage pack checkout response");
+      }
       expect(replaced.body.url).toBe(checkoutSessions[1].url);
       expect(
         context.mocks.stripe.checkout.sessions.expire,
@@ -2240,6 +2252,9 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
             },
             { price: TEST_PRICE_USAGE_PACK_50, quantity: 1 },
           ],
+        }),
+        expect.objectContaining({
+          idempotencyKey: expect.stringContaining("usage-pack-checkout:"),
         }),
       );
       const [firstUsagePackSubscriptionId, replacementSubscriptionId] =
@@ -2264,7 +2279,7 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
     },
   );
 
-  it("allows only one of two usage pack previews to create a subscription", async () => {
+  it("reuses a pending usage pack preview and creates one subscription", async () => {
     const fixture = createOrgFixture();
     const customerId = `cus_${randomUUID()}`;
     const paymentMethodId = `pm_${randomUUID()}`;
@@ -2341,6 +2356,17 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
         latest_invoice: null,
       });
     });
+    context.mocks.stripe.subscriptions.retrieve.mockImplementation(
+      (subscriptionId) => {
+        if (!createdSubscription || subscriptionId !== createdSubscription.id) {
+          throw new Error("Expected the created usage pack subscription");
+        }
+        return Promise.resolve({
+          ...createdSubscription,
+          latest_invoice: null,
+        });
+      },
+    );
 
     const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackCheckoutContract,
@@ -2392,7 +2418,7 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
           return status;
         })
         .sort(),
-    ).toStrictEqual([200, 409]);
+    ).toStrictEqual([200, 200]);
     expect(context.mocks.stripe.subscriptions.create).toHaveBeenCalledTimes(1);
     expect(context.mocks.stripe.subscriptions.create).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -1337,6 +1337,139 @@ describe("POST /api/zero/billing/checkout", () => {
     expect(billing.hasSubscription).toBeTruthy();
   });
 
+  it("rejects a resumable Plan purchase after its saved card changes", async () => {
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const pendingSubscriptionId = `sub_${randomUUID().slice(0, 8)}`;
+    const fixture = await trackedBillingSeed({
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: pendingSubscriptionId,
+      subscriptionStatus: "incomplete",
+      tier: "pro",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await enableSavedBillingPurchasePreview(fixture);
+
+    const previewPaymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
+    const replacementPaymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
+    const periodStart = currentSecond();
+    const periodEnd = periodStart + 30 * 86_400;
+    const invoiceId = `in_${randomUUID().slice(0, 8)}`;
+    let currentPaymentMethodId = previewPaymentMethodId;
+    const metadata = {
+      orgId: fixture.orgId,
+      tier: "team",
+      priceId: TEST_PRICE_TEAM,
+      billingPurchaseId: `purchase_${randomUUID().slice(0, 8)}`,
+    };
+    const invoice = {
+      id: invoiceId,
+      hosted_invoice_url: "https://invoice.stripe.com/pending-team",
+      customer: customerId,
+      metadata: {},
+      amount_due: 20_000,
+      currency: "usd",
+      status: "open" as const,
+      lines: {
+        has_more: false,
+        data: [
+          {
+            amount: 20_000,
+            price: { id: TEST_PRICE_TEAM },
+            parent: { type: "subscription_item_details" as const },
+            period: { start: periodStart, end: periodEnd },
+          },
+        ],
+      },
+      parent: {
+        subscription_details: {
+          subscription: pendingSubscriptionId,
+          metadata,
+        },
+      },
+    };
+    const pendingSubscription = () => {
+      return {
+        id: pendingSubscriptionId,
+        customer: customerId,
+        status: "incomplete",
+        metadata,
+        default_payment_method: currentPaymentMethodId,
+        cancel_at_period_end: false,
+        cancel_at: null,
+        schedule: null,
+        trial_end: null,
+        items: {
+          data: [
+            {
+              price: { id: TEST_PRICE_TEAM },
+              current_period_end: periodEnd,
+            },
+          ],
+        },
+        latest_invoice: invoice,
+      };
+    };
+    context.mocks.stripe.subscriptions.retrieve.mockImplementation(
+      (subscriptionId) => {
+        if (subscriptionId !== pendingSubscriptionId) {
+          throw new Error(`Unexpected Stripe subscription ${subscriptionId}`);
+        }
+        return Promise.resolve(pendingSubscription());
+      },
+    );
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [pendingSubscription()],
+      has_more: false,
+    });
+    context.mocks.stripe.invoices.createPreview.mockResolvedValue({
+      id: `in_preview_${randomUUID().slice(0, 8)}`,
+      hosted_invoice_url: null,
+      customer: customerId,
+      metadata: {},
+      amount_due: 20_000,
+      currency: "usd",
+      status: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      zeroBillingCheckoutContract,
+    );
+    const start = await accept(
+      client.create({
+        body: {
+          tier: "team",
+          supportsInAppPreview: true,
+          successUrl: `${APP_ORIGIN}/billing?billing=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    if (!("previewToken" in start.body)) {
+      throw new Error("Expected a Team purchase preview");
+    }
+    currentPaymentMethodId = replacementPaymentMethodId;
+
+    const confirmation = await accept(
+      client.confirm({
+        body: { previewToken: start.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+
+    expect(confirmation.body).toStrictEqual({
+      error: {
+        message: "Plan purchase preview is no longer valid",
+        code: "CONFLICT",
+      },
+    });
+    expect(context.mocks.stripe.invoices.pay).not.toHaveBeenCalled();
+  });
+
   it("refreshes an invalid Plan preview through the rollout-safe checkout route", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
@@ -2554,6 +2687,212 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
       });
     },
   );
+
+  it("rejects a usage pack preview after a replacement retires its snapshot", async () => {
+    const fixture = createOrgFixture();
+    const customerId = `cus_${randomUUID()}`;
+    const paymentMethodId = `pm_${randomUUID()}`;
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UsagePackPlans]: true,
+      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
+    });
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [
+          {
+            role: "org:admin",
+            publicUserData: { userId: fixture.userId },
+            createdAt: now(),
+          },
+        ],
+      },
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: customerId,
+      invoice_settings: { default_payment_method: paymentMethodId },
+    });
+    context.mocks.stripe.invoices.createPreview.mockResolvedValue({
+      id: `in_preview_${randomUUID()}`,
+      customer: customerId,
+      amount_due: 4000,
+      currency: "usd",
+      status: null,
+      metadata: {},
+      hosted_invoice_url: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      zeroBillingUsagePackCheckoutContract,
+    );
+    const purchaseBody = {
+      tier: "pro" as const,
+      supportsInAppPreview: true,
+      memberUsagePacks: [
+        { memberId: fixture.userId, usagePackUsd: 20 as const },
+      ],
+      successUrl: `${APP_ORIGIN}/billing?billing=success`,
+      cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+    };
+    const firstPreview = await accept(
+      client.create({
+        body: purchaseBody,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    await accept(
+      client.create({
+        body: {
+          ...purchaseBody,
+          memberUsagePacks: [{ memberId: fixture.userId, usagePackUsd: 50 }],
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    if (!("previewToken" in firstPreview.body)) {
+      throw new Error("Expected a usage pack purchase preview");
+    }
+
+    const confirmation = await accept(
+      client.confirm({
+        body: { previewToken: firstPreview.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [409],
+    );
+
+    expect(confirmation.body).toStrictEqual({
+      error: {
+        message: "Usage pack purchase preview is no longer valid",
+        code: "CONFLICT",
+      },
+    });
+    expect(context.mocks.stripe.subscriptions.create).not.toHaveBeenCalled();
+  });
+
+  it("attempts the saved card for an open usage pack invoice", async () => {
+    const fixture = createOrgFixture();
+    const customerId = `cus_${randomUUID()}`;
+    const paymentMethodId = `pm_${randomUUID()}`;
+    const subscriptionId = `sub_${randomUUID()}`;
+    const hostedInvoiceUrl =
+      "https://invoice.stripe.com/usage-pack-authentication";
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UsagePackPlans]: true,
+      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
+    });
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [
+          {
+            role: "org:admin",
+            publicUserData: { userId: fixture.userId },
+            createdAt: now(),
+          },
+        ],
+      },
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: customerId,
+      invoice_settings: { default_payment_method: paymentMethodId },
+    });
+    context.mocks.stripe.invoices.createPreview.mockResolvedValue({
+      id: `in_preview_${randomUUID()}`,
+      customer: customerId,
+      amount_due: 4000,
+      currency: "usd",
+      status: null,
+      metadata: {},
+      hosted_invoice_url: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+    const operationInvoice = {
+      id: `in_${randomUUID()}`,
+      customer: customerId,
+      amount_due: 4000,
+      currency: "usd",
+      status: "open" as const,
+      metadata: {},
+      hosted_invoice_url: hostedInvoiceUrl,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    };
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [],
+      has_more: false,
+    });
+    context.mocks.stripe.subscriptions.create.mockResolvedValue({
+      id: subscriptionId,
+      customer: customerId,
+      status: "incomplete",
+      metadata: {},
+      items: {
+        data: [
+          { price: { id: TEST_PRICE_USAGE_PACK_PLAN_PRO } },
+          { price: { id: TEST_PRICE_USAGE_PACK_20 } },
+        ],
+      },
+      latest_invoice: operationInvoice,
+    });
+    context.mocks.stripe.invoices.pay.mockRejectedValue(
+      new Error("Payment requires customer authentication"),
+    );
+    context.mocks.stripe.invoices.retrieve.mockResolvedValue(operationInvoice);
+
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      zeroBillingUsagePackCheckoutContract,
+    );
+    const start = await accept(
+      client.create({
+        body: {
+          tier: "pro",
+          supportsInAppPreview: true,
+          memberUsagePacks: [{ memberId: fixture.userId, usagePackUsd: 20 }],
+          successUrl: `${APP_ORIGIN}/billing?billing=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    if (!("previewToken" in start.body)) {
+      throw new Error("Expected a usage pack purchase preview");
+    }
+
+    const confirmation = await accept(
+      client.confirm({
+        body: { previewToken: start.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(confirmation.body).toStrictEqual({
+      status: "pending_payment",
+      hostedInvoiceUrl,
+    });
+    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledWith(
+      operationInvoice.id,
+      {},
+      expect.objectContaining({
+        idempotencyKey: expect.stringContaining(
+          "billing-operation:usage-pack:",
+        ),
+      }),
+    );
+  });
 
   it("reuses a pending usage pack preview and creates one subscription", async () => {
     const fixture = createOrgFixture();

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -998,43 +998,7 @@ describe("POST /api/zero/billing/checkout", () => {
     });
   });
 
-  it("keeps saved-card Plan preview behind the server feature switch", async () => {
-    const fixture = await trackedSeed();
-    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const customerId = `cus_${randomUUID().slice(0, 8)}`;
-    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
-    context.mocks.stripe.customers.retrieve.mockResolvedValue({
-      id: customerId,
-      invoice_settings: {
-        default_payment_method: `pm_${randomUUID().slice(0, 8)}`,
-      },
-    });
-    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
-      url: "https://checkout.stripe.com/session/server-gated-preview",
-    });
-
-    const response = await accept(
-      setupApp({ context, routes: billingCheckoutRoutes })(
-        zeroBillingCheckoutContract,
-      ).create({
-        body: {
-          tier: "pro",
-          supportsInAppPreview: true,
-          successUrl: `${APP_ORIGIN}/billing?billing=success`,
-          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
-        },
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    expect(response.body).toStrictEqual({
-      url: "https://checkout.stripe.com/session/server-gated-preview",
-    });
-    expect(context.mocks.stripe.invoices.createPreview).not.toHaveBeenCalled();
-  });
-
-  it("previews a saved-card plan purchase and routes its unpaid invoice", async () => {
+  it("pays a saved-card Plan preview through the rollout-safe checkout route", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     await enableSavedBillingPurchasePreview(fixture);
@@ -1080,17 +1044,23 @@ describe("POST /api/zero/billing/checkout", () => {
       metadata: {},
       latest_invoice: operationInvoice,
     });
+    context.mocks.stripe.invoices.pay.mockResolvedValue({
+      ...operationInvoice,
+      hosted_invoice_url: null,
+      status: "paid",
+    });
     const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
+    const purchaseBody = {
+      tier: "pro" as const,
+      supportsInAppPreview: true,
+      successUrl: `${APP_ORIGIN}/billing?billing=success`,
+      cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+    };
     const start = await accept(
       client.create({
-        body: {
-          tier: "pro",
-          supportsInAppPreview: true,
-          successUrl: `${APP_ORIGIN}/billing?billing=success`,
-          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
-        },
+        body: purchaseBody,
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -1113,16 +1083,16 @@ describe("POST /api/zero/billing/checkout", () => {
     }
 
     const confirmation = await accept(
-      client.confirm({
-        body: { previewToken: start.body.previewToken },
+      client.create({
+        body: { ...purchaseBody, previewToken: start.body.previewToken },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
     );
 
     expect(confirmation.body).toStrictEqual({
-      status: "pending_payment",
-      hostedInvoiceUrl,
+      status: "completed",
+      hostedInvoiceUrl: null,
     });
     expect(context.mocks.stripe.invoices.createPreview).toHaveBeenCalledTimes(
       2,
@@ -1137,7 +1107,92 @@ describe("POST /api/zero/billing/checkout", () => {
         idempotencyKey: expect.stringContaining("plan-purchase:"),
       }),
     );
-    expect(context.mocks.stripe.invoices.pay).not.toHaveBeenCalled();
+    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledWith(
+      operationInvoice.id,
+      {},
+      expect.objectContaining({
+        idempotencyKey: expect.stringContaining("billing-operation:plan:"),
+      }),
+    );
+  });
+
+  it("refreshes an invalid Plan preview through the rollout-safe checkout route", async () => {
+    const fixture = await trackedSeed();
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await enableSavedBillingPurchasePreview(fixture);
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const initialPaymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
+    const currentPaymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.customers.retrieve
+      .mockResolvedValueOnce({
+        id: customerId,
+        invoice_settings: {
+          default_payment_method: initialPaymentMethodId,
+        },
+      })
+      .mockResolvedValue({
+        id: customerId,
+        invoice_settings: { default_payment_method: currentPaymentMethodId },
+      });
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [],
+      has_more: false,
+    });
+    context.mocks.stripe.invoices.createPreview.mockResolvedValue({
+      id: `in_preview_${randomUUID().slice(0, 8)}`,
+      hosted_invoice_url: null,
+      customer: customerId,
+      metadata: {},
+      amount_due: 2000,
+      currency: "usd",
+      status: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      zeroBillingCheckoutContract,
+    );
+    const purchaseBody = {
+      tier: "pro" as const,
+      supportsInAppPreview: true,
+      successUrl: `${APP_ORIGIN}/billing?billing=success`,
+      cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+    };
+    const start = await accept(
+      client.create({
+        body: purchaseBody,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    if (!("previewToken" in start.body)) {
+      throw new Error("Expected a Plan purchase preview");
+    }
+
+    const refreshed = await accept(
+      client.create({
+        body: { ...purchaseBody, previewToken: start.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(refreshed.body).toMatchObject({
+      status: "preview",
+      purchaseType: "plan",
+      tier: "pro",
+      immediateAmountCents: 2000,
+      nextRecurringAmountCents: 2000,
+      currency: "usd",
+      previewToken: expect.any(String),
+    });
+    if (!("previewToken" in refreshed.body)) {
+      throw new Error("Expected a refreshed Plan purchase preview");
+    }
+    expect(refreshed.body.previewToken).not.toBe(start.body.previewToken);
+    expect(context.mocks.stripe.customers.retrieve).toHaveBeenCalledTimes(3);
+    expect(context.mocks.stripe.subscriptions.create).not.toHaveBeenCalled();
   });
 
   it("allows only one of two Plan previews to create a subscription", async () => {
@@ -2427,6 +2482,152 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
       }),
       expect.any(Object),
     );
+  });
+
+  it("reuses an open Checkout when repeated usage pack previews lose their saved card", async () => {
+    const fixture = createOrgFixture();
+    const customerId = `cus_${randomUUID()}`;
+    const paymentMethodId = `pm_${randomUUID()}`;
+    const checkoutSessionId = `cs_${randomUUID()}`;
+    const checkoutUrl = "https://checkout.stripe.com/session/usage-pack-retry";
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UsagePackPlans]: true,
+      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
+    });
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [
+          {
+            role: "org:admin",
+            publicUserData: { userId: fixture.userId },
+            createdAt: now(),
+          },
+        ],
+      },
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    let customerRetrievalCount = 0;
+    context.mocks.stripe.customers.retrieve.mockImplementation(() => {
+      customerRetrievalCount += 1;
+      return Promise.resolve({
+        id: customerId,
+        invoice_settings: {
+          default_payment_method:
+            customerRetrievalCount <= 2 ? paymentMethodId : null,
+        },
+        default_source: null,
+      });
+    });
+    context.mocks.stripe.paymentMethods.list.mockResolvedValue({ data: [] });
+    context.mocks.stripe.invoices.createPreview.mockResolvedValue({
+      id: `in_preview_${randomUUID()}`,
+      customer: customerId,
+      amount_due: 4000,
+      currency: "usd",
+      status: null,
+      metadata: {},
+      hosted_invoice_url: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [],
+      has_more: false,
+    });
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
+      id: checkoutSessionId,
+      url: checkoutUrl,
+    });
+    context.mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      id: checkoutSessionId,
+      status: "open",
+      url: checkoutUrl,
+    });
+
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      zeroBillingUsagePackCheckoutContract,
+    );
+    const firstBody = {
+      tier: "pro" as const,
+      supportsInAppPreview: true,
+      memberUsagePacks: [
+        { memberId: fixture.userId, usagePackUsd: 20 as const },
+      ],
+      successUrl: `${APP_ORIGIN}/billing?billing=first-success`,
+      cancelUrl: `${APP_ORIGIN}/billing?billing=first-canceled`,
+    };
+    const secondBody = {
+      ...firstBody,
+      successUrl: `${APP_ORIGIN}/settings?billing=second-success`,
+      cancelUrl: `${APP_ORIGIN}/settings?billing=second-canceled`,
+    };
+    const firstPreview = await accept(
+      client.create({
+        body: firstBody,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const secondPreview = await accept(
+      client.create({
+        body: secondBody,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    if (
+      !("previewToken" in firstPreview.body) ||
+      !("previewToken" in secondPreview.body)
+    ) {
+      throw new Error("Expected two usage pack purchase previews");
+    }
+
+    const firstConfirmation = await accept(
+      client.create({
+        body: {
+          ...firstBody,
+          previewToken: firstPreview.body.previewToken,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const secondConfirmation = await accept(
+      client.create({
+        body: {
+          ...secondBody,
+          previewToken: secondPreview.body.previewToken,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const repeatedPurchase = await accept(
+      client.create({
+        body: secondBody,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(firstConfirmation.body).toStrictEqual({
+      status: "checkout_required",
+      checkoutUrl,
+    });
+    expect(secondConfirmation.body).toStrictEqual(firstConfirmation.body);
+    expect(repeatedPurchase.body).toStrictEqual({ url: checkoutUrl });
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(
+      context.mocks.stripe.checkout.sessions.retrieve,
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      context.mocks.stripe.checkout.sessions.retrieve,
+    ).toHaveBeenCalledWith(checkoutSessionId);
   });
 
   it("rejects stale member selections before creating checkout", async () => {
@@ -7898,6 +8099,109 @@ describe("usage pack allocation management", () => {
     expect(response.body.error.code).toBe("NOT_FOUND");
   });
 
+  it("creates fresh Setup Checkouts when an invitation preview return URL changes", async () => {
+    const existingMemberUserId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([
+      { userId: existingMemberUserId, usagePackUsd: 20 },
+    ]);
+    await enableSavedBillingPurchasePreview(fixture);
+    const email = `setup-invite-${randomUUID()}@example.test`;
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [
+          {
+            publicUserData: {
+              userId: existingMemberUserId,
+              identifier: `${existingMemberUserId}@example.test`,
+            },
+            createdAt: now(),
+          },
+        ],
+      },
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      ...managedUsagePackSubscription(
+        fixture,
+        new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      ),
+      default_payment_method: null,
+      default_source: null,
+    });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: fixture.customerId,
+      invoice_settings: { default_payment_method: null },
+      default_source: null,
+    });
+    context.mocks.stripe.paymentMethods.list.mockResolvedValue({ data: [] });
+    mockUsagePackChangePreviews(1000, 2000);
+    context.mocks.stripe.checkout.sessions.create
+      .mockResolvedValueOnce({
+        id: `cs_${randomUUID()}`,
+        url: "https://checkout.stripe.com/session/invitation-setup-first",
+      })
+      .mockResolvedValueOnce({
+        id: `cs_${randomUUID()}`,
+        url: "https://checkout.stripe.com/session/invitation-setup-second",
+      });
+
+    const client = setupApp({ context, routes: orgInviteRoutes })(
+      zeroOrgInviteContract,
+    );
+    const firstReturnUrl = `${APP_ORIGIN}/billing?invite=first`;
+    const secondReturnUrl = `${APP_ORIGIN}/settings?invite=second`;
+    const previewBody = {
+      email,
+      role: "member" as const,
+      usagePackUsd: 20 as const,
+      supportsInAppPreview: true,
+    };
+    const first = await accept(
+      client.previewPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { ...previewBody, returnUrl: firstReturnUrl },
+      }),
+      [200],
+    );
+    const second = await accept(
+      client.previewPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { ...previewBody, returnUrl: secondReturnUrl },
+      }),
+      [200],
+    );
+
+    expect(first.body.purchaseId).toBe(second.body.purchaseId);
+    expect(first.body.checkoutUrl).toBe(
+      "https://checkout.stripe.com/session/invitation-setup-first",
+    );
+    expect(second.body.checkoutUrl).toBe(
+      "https://checkout.stripe.com/session/invitation-setup-second",
+    );
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        mode: "setup",
+        success_url: firstReturnUrl,
+        cancel_url: firstReturnUrl,
+      }),
+    );
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        mode: "setup",
+        success_url: secondReturnUrl,
+        cancel_url: secondReturnUrl,
+      }),
+    );
+  });
+
   it("previews and confirms an invitation with the saved payment method", async () => {
     const existingMemberUserId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([
@@ -8172,6 +8476,66 @@ describe("usage pack allocation management", () => {
         usagePackUsd: 20,
       }),
     ]);
+  });
+
+  it("does not report a pending invitation payment as sent to an older client", async () => {
+    const purchase = await beginInvitationPurchase();
+    const paymentMethodId = `pm_invite_${randomUUID()}`;
+    const invoiceId = `in_invite_${randomUUID()}`;
+    const hostedInvoiceUrl = `https://invoice.stripe.test/${invoiceId}`;
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      ...managedUsagePackSubscription(
+        purchase.fixture,
+        new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      ),
+      default_payment_method: paymentMethodId,
+    });
+    const metadata = {
+      purpose: "usage_pack_invitation_purchase",
+      usagePackInvitationPurchaseId: purchase.purchaseId,
+    };
+    context.mocks.stripe.invoices.create.mockResolvedValue({
+      id: invoiceId,
+      metadata,
+      status: "draft",
+      hosted_invoice_url: null,
+    });
+    context.mocks.stripe.invoiceItems.create.mockResolvedValue({
+      id: `ii_invite_${randomUUID()}`,
+    });
+    context.mocks.stripe.invoices.finalizeInvoice.mockResolvedValue({
+      id: invoiceId,
+      metadata,
+      status: "open",
+      hosted_invoice_url: hostedInvoiceUrl,
+    });
+    context.mocks.stripe.invoices.pay.mockResolvedValue({
+      id: invoiceId,
+      metadata,
+      status: "open",
+      hosted_invoice_url: hostedInvoiceUrl,
+    });
+
+    const response = await accept(
+      setupApp({ context, routes: orgInviteRoutes })(
+        zeroOrgInviteContract,
+      ).confirmPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { purchaseId: purchase.purchaseId },
+        body: {},
+      }),
+      [409],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        code: "CONFLICT",
+        message: "Payment confirmation is required",
+      },
+    });
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).not.toHaveBeenCalled();
   });
 
   it("ignores invitation PaymentIntents from another preview job", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -6282,7 +6282,15 @@ describe("usage pack allocation management", () => {
       [200],
     );
     expect(confirmed.body.status).toBe("pending_payment");
-    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenNthCalledWith(
+      1,
+      fixture.subscriptionId,
+      {
+        default_payment_method: paymentMethodId,
+      },
+    );
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenNthCalledWith(
+      2,
       fixture.subscriptionId,
       expect.objectContaining({
         items: expect.arrayContaining([
@@ -6292,7 +6300,6 @@ describe("usage pack allocation management", () => {
         payment_behavior: "pending_if_incomplete",
         proration_behavior: "always_invoice",
         proration_date: prorationTimestamp,
-        default_payment_method: paymentMethodId,
       }),
       {
         idempotencyKey: `usage-pack-subscription-change:${preview.body.changeId}:apply`,
@@ -7519,12 +7526,22 @@ describe("usage pack allocation management", () => {
       [200],
     );
     expect(confirmed.body.status).toBe("completed");
-    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenNthCalledWith(
+      1,
+      fixture.subscriptionId,
+      {
+        default_payment_method: paymentMethodId,
+      },
+    );
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenNthCalledWith(
+      2,
       fixture.subscriptionId,
       expect.objectContaining({
-        default_payment_method: paymentMethodId,
+        payment_behavior: "pending_if_incomplete",
+        proration_behavior: "always_invoice",
+        proration_date: prorationTimestamp,
       }),
-      expect.any(Object),
+      { idempotencyKey: `usage-pack-change:${preview.body.changeId}:apply` },
     );
     const state = await readUsagePackState(
       fixture.orgId,
@@ -9916,7 +9933,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
           data: [allowanceLine, ...recurringInvoice.lines.data],
         },
       });
-    context.mocks.stripe.subscriptions.update.mockResolvedValueOnce({
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({
       id: subscriptionId,
       latest_invoice: null,
       pending_update: null,
@@ -9990,7 +10007,15 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
         items: [{ price: TEST_PRICE_CONCURRENCY, quantity: 3 }],
       },
     });
-    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenNthCalledWith(
+      1,
+      subscriptionId,
+      {
+        default_payment_method: paymentMethodId,
+      },
+    );
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenNthCalledWith(
+      2,
       subscriptionId,
       {
         items: [{ price: TEST_PRICE_CONCURRENCY, quantity: 3 }],
@@ -9998,7 +10023,6 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
         proration_behavior: "always_invoice",
         proration_date: expect.any(Number),
         expand: ["latest_invoice"],
-        default_payment_method: paymentMethodId,
       },
     );
     expect(
@@ -10989,7 +11013,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
         });
       })
       .mockResolvedValueOnce(recurringConcurrencyPreviewInvoice(4));
-    context.mocks.stripe.subscriptions.update.mockResolvedValueOnce({
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({
       id: subscriptionId,
       latest_invoice: {
         id: `in_${randomUUID()}`,
@@ -11068,7 +11092,15 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       status: "pending_payment",
       hostedInvoiceUrl,
     });
-    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenNthCalledWith(
+      1,
+      subscriptionId,
+      {
+        default_payment_method: paymentMethodId,
+      },
+    );
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenNthCalledWith(
+      2,
       subscriptionId,
       {
         items: [{ id: subscriptionItemId, quantity: 4 }],
@@ -11076,7 +11108,6 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
         proration_behavior: "always_invoice",
         proration_date: expect.any(Number),
         expand: ["latest_invoice"],
-        default_payment_method: paymentMethodId,
       },
     );
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -210,6 +210,27 @@ function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
 
+function stripeInputMetadata(input: unknown): Readonly<Record<string, string>> {
+  if (
+    typeof input !== "object" ||
+    input === null ||
+    !("metadata" in input) ||
+    typeof input.metadata !== "object" ||
+    input.metadata === null
+  ) {
+    throw new Error("Expected Stripe metadata");
+  }
+  const metadata = Object.entries(input.metadata);
+  if (
+    metadata.some(([, value]) => {
+      return typeof value !== "string";
+    })
+  ) {
+    throw new Error("Expected string Stripe metadata values");
+  }
+  return Object.fromEntries(metadata) as Readonly<Record<string, string>>;
+}
+
 function zeroToken(args: {
   readonly userId: string;
   readonly orgId: string;
@@ -239,6 +260,14 @@ function authenticateOrg(
   role: "org:admin" | "org:member" = "org:admin",
 ): void {
   mocks.clerk.session(fixture.userId, fixture.orgId, role);
+}
+
+async function enableSavedBillingPurchasePreview(
+  fixture: BillingOrgFixture,
+): Promise<void> {
+  await updateFeatureSwitchesForUser(context, fixture, {
+    [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
+  });
 }
 
 function mockClerkOrganization(fixture: BillingOrgFixture): void {
@@ -969,9 +998,46 @@ describe("POST /api/zero/billing/checkout", () => {
     });
   });
 
+  it("keeps saved-card Plan preview behind the server feature switch", async () => {
+    const fixture = await trackedSeed();
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: customerId,
+      invoice_settings: {
+        default_payment_method: `pm_${randomUUID().slice(0, 8)}`,
+      },
+    });
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValue({
+      url: "https://checkout.stripe.com/session/server-gated-preview",
+    });
+
+    const response = await accept(
+      setupApp({ context, routes: billingCheckoutRoutes })(
+        zeroBillingCheckoutContract,
+      ).create({
+        body: {
+          tier: "pro",
+          supportsInAppPreview: true,
+          successUrl: `${APP_ORIGIN}/billing?billing=success`,
+          cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      url: "https://checkout.stripe.com/session/server-gated-preview",
+    });
+    expect(context.mocks.stripe.invoices.createPreview).not.toHaveBeenCalled();
+  });
+
   it("previews a saved-card plan purchase and routes its unpaid invoice", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await enableSavedBillingPurchasePreview(fixture);
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     const paymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
     const hostedInvoiceUrl =
@@ -1014,7 +1080,7 @@ describe("POST /api/zero/billing/checkout", () => {
       metadata: {},
       latest_invoice: operationInvoice,
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
     const start = await accept(
@@ -1074,9 +1140,118 @@ describe("POST /api/zero/billing/checkout", () => {
     expect(context.mocks.stripe.invoices.pay).not.toHaveBeenCalled();
   });
 
+  it("allows only one of two Plan previews to create a subscription", async () => {
+    const fixture = await trackedSeed();
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await enableSavedBillingPurchasePreview(fixture);
+    const customerId = `cus_${randomUUID().slice(0, 8)}`;
+    const paymentMethodId = `pm_${randomUUID().slice(0, 8)}`;
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: customerId,
+      invoice_settings: { default_payment_method: paymentMethodId },
+    });
+    context.mocks.stripe.invoices.createPreview.mockResolvedValue({
+      id: `in_preview_${randomUUID().slice(0, 8)}`,
+      hosted_invoice_url: null,
+      customer: customerId,
+      metadata: {},
+      amount_due: 2000,
+      currency: "usd",
+      status: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+    let createdSubscription:
+      | {
+          readonly id: string;
+          readonly customer: string;
+          readonly status: string;
+          readonly metadata: Readonly<Record<string, string>>;
+          readonly items: {
+            readonly data: readonly {
+              readonly price: { readonly id: string };
+            }[];
+          };
+        }
+      | undefined;
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [],
+      has_more: false,
+    });
+    context.mocks.stripe.subscriptions.create.mockImplementation((input) => {
+      createdSubscription = {
+        id: `sub_${randomUUID().slice(0, 8)}`,
+        customer: customerId,
+        status: "active",
+        metadata: stripeInputMetadata(input),
+        items: { data: [{ price: { id: TEST_PRICE_PRO } }] },
+      };
+      context.mocks.stripe.subscriptions.list.mockResolvedValue({
+        data: [createdSubscription],
+        has_more: false,
+      });
+      return Promise.resolve({
+        ...createdSubscription,
+        latest_invoice: null,
+      });
+    });
+
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      zeroBillingCheckoutContract,
+    );
+    const purchaseBody = {
+      tier: "pro" as const,
+      supportsInAppPreview: true,
+      successUrl: `${APP_ORIGIN}/billing?billing=success`,
+      cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+    };
+    const firstPreview = await accept(
+      client.create({
+        body: purchaseBody,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const secondPreview = await accept(
+      client.create({
+        body: purchaseBody,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    if (
+      !("previewToken" in firstPreview.body) ||
+      !("previewToken" in secondPreview.body)
+    ) {
+      throw new Error("Expected two Plan purchase previews");
+    }
+
+    const confirmations = await Promise.all([
+      client.confirm({
+        body: { previewToken: firstPreview.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      client.confirm({
+        body: { previewToken: secondPreview.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+    ]);
+
+    expect(
+      confirmations
+        .map(({ status }) => {
+          return status;
+        })
+        .sort(),
+    ).toStrictEqual([200, 409]);
+    expect(context.mocks.stripe.subscriptions.create).toHaveBeenCalledTimes(1);
+  });
+
   it("uses hosted Checkout when an opted-in plan purchase has no saved card", async () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await enableSavedBillingPurchasePreview(fixture);
     const customerId = `cus_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
     context.mocks.stripe.customers.retrieve.mockResolvedValue({
@@ -1090,7 +1265,7 @@ describe("POST /api/zero/billing/checkout", () => {
     });
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingCheckoutContract,
       ).create({
         body: {
@@ -2088,6 +2263,145 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
       });
     },
   );
+
+  it("allows only one of two usage pack previews to create a subscription", async () => {
+    const fixture = createOrgFixture();
+    const customerId = `cus_${randomUUID()}`;
+    const paymentMethodId = `pm_${randomUUID()}`;
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UsagePackPlans]: true,
+      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
+    });
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [
+          {
+            role: "org:admin",
+            publicUserData: { userId: fixture.userId },
+            createdAt: now(),
+          },
+        ],
+      },
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    context.mocks.stripe.customers.create.mockResolvedValue({ id: customerId });
+    context.mocks.stripe.customers.retrieve.mockResolvedValue({
+      id: customerId,
+      invoice_settings: { default_payment_method: paymentMethodId },
+    });
+    context.mocks.stripe.invoices.createPreview.mockResolvedValue({
+      id: `in_preview_${randomUUID()}`,
+      customer: customerId,
+      amount_due: 4000,
+      currency: "usd",
+      status: null,
+      metadata: {},
+      hosted_invoice_url: null,
+      lines: { has_more: false, data: [] },
+      parent: null,
+    });
+    let createdSubscription:
+      | {
+          readonly id: string;
+          readonly customer: string;
+          readonly status: string;
+          readonly metadata: Readonly<Record<string, string>>;
+          readonly items: {
+            readonly data: readonly {
+              readonly price: { readonly id: string };
+            }[];
+          };
+        }
+      | undefined;
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [],
+      has_more: false,
+    });
+    context.mocks.stripe.subscriptions.create.mockImplementation((input) => {
+      createdSubscription = {
+        id: `sub_${randomUUID()}`,
+        customer: customerId,
+        status: "active",
+        metadata: stripeInputMetadata(input),
+        items: {
+          data: [
+            { price: { id: TEST_PRICE_USAGE_PACK_PLAN_PRO } },
+            { price: { id: TEST_PRICE_USAGE_PACK_20 } },
+          ],
+        },
+      };
+      context.mocks.stripe.subscriptions.list.mockResolvedValue({
+        data: [createdSubscription],
+        has_more: false,
+      });
+      return Promise.resolve({
+        ...createdSubscription,
+        latest_invoice: null,
+      });
+    });
+
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
+      zeroBillingUsagePackCheckoutContract,
+    );
+    const purchaseBody = {
+      tier: "pro" as const,
+      supportsInAppPreview: true,
+      memberUsagePacks: [
+        { memberId: fixture.userId, usagePackUsd: 20 as const },
+      ],
+      successUrl: `${APP_ORIGIN}/billing?billing=success`,
+      cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
+    };
+    const firstPreview = await accept(
+      client.create({
+        body: purchaseBody,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const secondPreview = await accept(
+      client.create({
+        body: purchaseBody,
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    if (
+      !("previewToken" in firstPreview.body) ||
+      !("previewToken" in secondPreview.body)
+    ) {
+      throw new Error("Expected two usage pack purchase previews");
+    }
+
+    const confirmations = await Promise.all([
+      client.confirm({
+        body: { previewToken: firstPreview.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      client.confirm({
+        body: { previewToken: secondPreview.body.previewToken },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+    ]);
+
+    expect(
+      confirmations
+        .map(({ status }) => {
+          return status;
+        })
+        .sort(),
+    ).toStrictEqual([200, 409]);
+    expect(context.mocks.stripe.subscriptions.create).toHaveBeenCalledTimes(1);
+    expect(context.mocks.stripe.subscriptions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: customerId,
+        default_payment_method: paymentMethodId,
+      }),
+      expect.any(Object),
+    );
+  });
 
   it("rejects stale member selections before creating checkout", async () => {
     const fixture = createOrgFixture();
@@ -5439,10 +5753,15 @@ describe("usage pack allocation management", () => {
     });
     const userId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
-    const oldSubscription = managedUsagePackSubscription(
-      fixture,
-      new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
-    );
+    await enableSavedBillingPurchasePreview(fixture);
+    const paymentMethodId = `pm_${randomUUID()}`;
+    const oldSubscription = {
+      ...managedUsagePackSubscription(
+        fixture,
+        new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      ),
+      default_payment_method: paymentMethodId,
+    };
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
       oldSubscription,
     );
@@ -5461,6 +5780,8 @@ describe("usage pack allocation management", () => {
         body: {
           targetTier: "pro",
           memberUsagePacks: [{ memberId: userId, usagePackUsd: 50 }],
+          supportsInAppPreview: true,
+          returnUrl: `${APP_ORIGIN}/billing`,
         },
       }),
       [200],
@@ -5471,8 +5792,13 @@ describe("usage pack allocation management", () => {
         targetTier: "pro",
         immediateAmountCents: 1500,
         nextRecurringAmountCents: 5000,
+        paymentMethodPreviewToken: expect.any(String),
       }),
     );
+    const paymentMethodPreviewToken = preview.body.paymentMethodPreviewToken;
+    if (!paymentMethodPreviewToken) {
+      throw new Error("Expected a saved-payment-method preview token");
+    }
     const prorationTimestamp = Math.floor(
       new Date(preview.body.prorationDate).getTime() / 1000,
     );
@@ -5489,6 +5815,7 @@ describe("usage pack allocation management", () => {
     );
     context.mocks.stripe.subscriptions.retrieve
       .mockResolvedValueOnce(oldSubscription)
+      .mockResolvedValueOnce(oldSubscription)
       .mockResolvedValue(upgradedSubscription);
     context.mocks.stripe.subscriptions.update.mockResolvedValue({
       ...oldSubscription,
@@ -5499,7 +5826,10 @@ describe("usage pack allocation management", () => {
     const confirmed = await accept(
       client.confirmSubscriptionChange({
         headers: { authorization: "Bearer clerk-session" },
-        body: { changeId: preview.body.changeId },
+        body: {
+          changeId: preview.body.changeId,
+          paymentMethodPreviewToken,
+        },
       }),
       [200],
     );
@@ -5514,6 +5844,7 @@ describe("usage pack allocation management", () => {
         payment_behavior: "pending_if_incomplete",
         proration_behavior: "always_invoice",
         proration_date: prorationTimestamp,
+        default_payment_method: paymentMethodId,
       }),
       {
         idempotencyKey: `usage-pack-subscription-change:${preview.body.changeId}:apply`,
@@ -6676,10 +7007,15 @@ describe("usage pack allocation management", () => {
     });
     const userId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
-    const oldSubscription = managedUsagePackSubscription(
-      fixture,
-      new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
-    );
+    await enableSavedBillingPurchasePreview(fixture);
+    const paymentMethodId = `pm_${randomUUID()}`;
+    const oldSubscription = {
+      ...managedUsagePackSubscription(
+        fixture,
+        new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      ),
+      default_payment_method: paymentMethodId,
+    };
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
       oldSubscription,
     );
@@ -6690,10 +7026,19 @@ describe("usage pack allocation management", () => {
     const preview = await accept(
       client.previewChange({
         headers: { authorization: "Bearer clerk-session" },
-        body: { memberId: userId, targetUsagePackUsd: 50 },
+        body: {
+          memberId: userId,
+          targetUsagePackUsd: 50,
+          supportsInAppPreview: true,
+          returnUrl: `${APP_ORIGIN}/billing`,
+        },
       }),
       [200],
     );
+    const paymentMethodPreviewToken = preview.body.paymentMethodPreviewToken;
+    if (!paymentMethodPreviewToken) {
+      throw new Error("Expected a saved-payment-method preview token");
+    }
     const prorationTimestamp = Math.floor(
       new Date(preview.body.prorationDate).getTime() / 1000,
     );
@@ -6711,6 +7056,7 @@ describe("usage pack allocation management", () => {
     );
     context.mocks.stripe.subscriptions.retrieve
       .mockResolvedValueOnce(oldSubscription)
+      .mockResolvedValueOnce(oldSubscription)
       .mockResolvedValue(upgradedSubscription);
     context.mocks.stripe.subscriptions.update.mockResolvedValue(
       upgradedSubscription,
@@ -6720,11 +7066,18 @@ describe("usage pack allocation management", () => {
       client.confirmChange({
         params: { changeId: preview.body.changeId },
         headers: { authorization: "Bearer clerk-session" },
-        body: {},
+        body: { paymentMethodPreviewToken },
       }),
       [200],
     );
     expect(confirmed.body.status).toBe("completed");
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      fixture.subscriptionId,
+      expect.objectContaining({
+        default_payment_method: paymentMethodId,
+      }),
+      expect.any(Object),
+    );
     const state = await readUsagePackState(
       fixture.orgId,
       fixture.usagePackSubscriptionId,
@@ -8886,23 +9239,21 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       expiresAt: periodEnd,
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await enableSavedBillingPurchasePreview(fixture);
+    const paymentMethodId = `pm_${randomUUID()}`;
     const allowanceItem = {
       id: `si_${TEST_PRICE_USAGE_ALLOWANCE}`,
       price: { id: TEST_PRICE_USAGE_ALLOWANCE },
       quantity: 1,
     };
-    context.mocks.stripe.subscriptions.retrieve
-      .mockResolvedValueOnce({
-        id: subscriptionId,
-        pending_update: null,
-        items: { data: [allowanceItem] },
-      })
-      .mockResolvedValueOnce({
-        id: subscriptionId,
-        latest_invoice: null,
-        pending_update: null,
-        items: { data: [allowanceItem] },
-      });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: subscriptionId,
+      customer: customerId,
+      default_payment_method: paymentMethodId,
+      latest_invoice: null,
+      pending_update: null,
+      items: { data: [allowanceItem] },
+    });
     const recurringInvoice = recurringConcurrencyPreviewInvoice(3);
     const allowanceLine = {
       ...recurringInvoice.lines.data[0],
@@ -8976,16 +9327,25 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     })(zeroBillingConcurrencyCheckoutContract);
     const preview = await accept(
       client.preview({
-        body: { quantity: 3 },
+        body: {
+          quantity: 3,
+          supportsInAppPreview: true,
+          returnUrl: `${APP_ORIGIN}/billing`,
+        },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
     );
+    const paymentMethodPreviewToken = preview.body.paymentMethodPreviewToken;
+    if (!paymentMethodPreviewToken) {
+      throw new Error("Expected a saved-payment-method preview token");
+    }
     const successUrl = `${APP_ORIGIN}/billing?concurrency=success`;
     const purchase = await accept(
       client.create({
         body: {
           quantity: 3,
+          paymentMethodPreviewToken,
           successUrl,
           cancelUrl: `${APP_ORIGIN}/billing?concurrency=canceled`,
         },
@@ -9000,6 +9360,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       immediateAmountCents: 5500,
       nextRecurringAmountCents: 30_000,
       currency: "usd",
+      paymentMethodPreviewToken: expect.any(String),
     });
     expect(purchase.body).toStrictEqual({ url: successUrl });
     expect(context.mocks.stripe.invoices.createPreview).toHaveBeenCalledWith({
@@ -9026,6 +9387,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
         proration_behavior: "always_invoice",
         proration_date: expect.any(Number),
         expand: ["latest_invoice"],
+        default_payment_method: paymentMethodId,
       },
     );
     expect(
@@ -9950,8 +10312,12 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       tier: "team",
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await enableSavedBillingPurchasePreview(fixture);
+    const paymentMethodId = `pm_${randomUUID()}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       id: subscriptionId,
+      customer: fixture.customerId,
+      default_payment_method: paymentMethodId,
       pending_update: null,
       items: {
         data: [
@@ -10039,7 +10405,11 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const preview = await accept(
       client.previewChange({
         params: { subscriptionId },
-        body: { quantity: 4 },
+        body: {
+          quantity: 4,
+          supportsInAppPreview: true,
+          returnUrl: `${APP_ORIGIN}/billing`,
+        },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -10051,6 +10421,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       immediateAmountCents: 15_000,
       nextRecurringAmountCents: 40_000,
       currency: "usd",
+      paymentMethodPreviewToken: expect.any(String),
     });
     expect(context.mocks.stripe.invoices.createPreview).toHaveBeenCalledWith({
       subscription: subscriptionId,
@@ -10069,10 +10440,14 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
       },
     });
 
+    const paymentMethodPreviewToken = preview.body.paymentMethodPreviewToken;
+    if (!paymentMethodPreviewToken) {
+      throw new Error("Expected a saved-payment-method preview token");
+    }
     const confirmed = await accept(
       client.confirmChange({
         params: { subscriptionId },
-        body: { quantity: 4 },
+        body: { quantity: 4, paymentMethodPreviewToken },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -10090,6 +10465,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
         proration_behavior: "always_invoice",
         proration_date: expect.any(Number),
         expand: ["latest_invoice"],
+        default_payment_method: paymentMethodId,
       },
     );
     expect(
@@ -12151,6 +12527,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
   it("applies a customer coupon without including subscription renewal", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
+    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
     const couponId = `coupon_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
@@ -12315,6 +12692,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
   it("uses a legacy subscription source when no higher-priority card exists", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
+    await enableSavedBillingPurchasePreview(fixture);
     const subscriptionSourceId = `card_${randomUUID().slice(0, 8)}`;
     const customerSourceId = `card_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
@@ -12335,7 +12713,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
     const preview = await accept(
       client.create({
@@ -12425,6 +12803,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
   it("rejects payment when the finalized invoice amount differs from the preview", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
+    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
@@ -12532,6 +12911,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
   it("returns completed when customer balance pays the invoice during finalization", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
+    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
@@ -12630,6 +13010,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
   it("returns the hosted invoice when saved-billing payment requires authentication", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
+    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
     const invoiceId = `in_credit_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
@@ -12747,6 +13128,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
   it("falls back to Stripe checkout when saved billing is unavailable", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
+    await enableSavedBillingPurchasePreview(fixture);
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       id: fixture.subscriptionId,
       default_payment_method: null,
@@ -12783,6 +13165,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
   it("returns Checkout when all saved cards are removed after preview", async () => {
     const fixture = await createSubscriptionOrg({ tier: "pro" });
+    await enableSavedBillingPurchasePreview(fixture);
     const paymentMethodId = `pm_credit_${randomUUID().slice(0, 8)}`;
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       id: fixture.subscriptionId,
@@ -12796,7 +13179,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     mockCreditPurchasePreview(fixture.customerId);
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
     const preview = await accept(
       client.create({

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -4356,7 +4356,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     expect(bound.tier).toBe("limited-free-1");
     expect(bound.currentPeriodEnd).toBeNull();
 
-    // An incomplete dashboard subscription is recorded without a paid tier.
+    // An incomplete dashboard subscription cannot replace the active one.
     await api.postStripeEvent(
       stripeEvent({
         type: "customer.subscription.created",
@@ -4372,7 +4372,7 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
       [200],
     );
     const incomplete = await billing.readBillingStatus(actor);
-    expect(incomplete.subscriptionStatus).toBe("incomplete");
+    expect(incomplete.subscriptionStatus).toBe("active");
     expect(incomplete.tier).toBe("limited-free-1");
 
     // A subscription checkout completion binds its subscription.

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -45,6 +45,7 @@ import {
   checkoutTierConflictMessage,
   checkoutWouldReplaceWithSameOrLowerTier,
   startPlanPurchase$,
+  type SubscriptionCheckoutTier,
 } from "../services/zero-billing-checkout.service";
 import {
   confirmUsagePackPurchase$,
@@ -424,6 +425,27 @@ function hasActiveLegacyPlanSubscription(
   );
 }
 
+function usagePackCheckoutTierConflicts(
+  metadata:
+    | {
+        readonly tier: string | null;
+        readonly subscriptionStatus: string | null;
+      }
+    | undefined,
+  targetTier: SubscriptionCheckoutTier,
+): boolean {
+  const configuresGrantedPlan =
+    metadata?.subscriptionStatus === "atom_grant" &&
+    metadata.tier === targetTier;
+  return (
+    !configuresGrantedPlan &&
+    checkoutWouldReplaceWithSameOrLowerTier({
+      currentTier: metadata?.tier,
+      targetTier,
+    })
+  );
+}
+
 const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   if (auth.orgRole !== "admin") {
@@ -690,15 +712,7 @@ const usagePackCheckoutAuthed$ = command(
       );
     }
 
-    const configuresGrantedPlan =
-      metadata?.subscriptionStatus === "atom_grant" && metadata.tier === tier;
-    if (
-      !configuresGrantedPlan &&
-      checkoutWouldReplaceWithSameOrLowerTier({
-        currentTier: metadata?.tier,
-        targetTier: tier,
-      })
-    ) {
+    if (usagePackCheckoutTierConflicts(metadata, tier)) {
       return badRequestMessage(
         checkoutTierConflictMessage({
           currentTier: metadata?.tier,

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -446,6 +446,17 @@ function usagePackCheckoutTierConflicts(
   );
 }
 
+const confirmPlanPurchaseForOrg$ = command(
+  async ({ set }, orgId: string, previewToken: string, signal: AbortSignal) => {
+    const result = await set(confirmPlanPurchase$, orgId, previewToken, signal);
+    signal.throwIfAborted();
+    if (result.status === "invalid_preview") {
+      return conflict("Plan purchase preview is no longer valid");
+    }
+    return { status: 200 as const, body: result.response };
+  },
+);
+
 const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   if (auth.orgRole !== "admin") {
@@ -459,6 +470,18 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
   signal.throwIfAborted();
   if (!bodyResult.ok) {
     return bodyResult.response;
+  }
+  if (bodyResult.data.previewToken) {
+    const confirmation = await set(
+      confirmPlanPurchase$,
+      auth.orgId,
+      bodyResult.data.previewToken,
+      signal,
+    );
+    signal.throwIfAborted();
+    if (confirmation.status !== "invalid_preview") {
+      return { status: 200 as const, body: confirmation.response };
+    }
   }
   const {
     tier,
@@ -582,17 +605,12 @@ const checkoutConfirmAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
-    const result = await set(
-      confirmPlanPurchase$,
+    return await set(
+      confirmPlanPurchaseForOrg$,
       auth.orgId,
       bodyResult.data.previewToken,
       signal,
     );
-    signal.throwIfAborted();
-    if (result.status === "invalid_preview") {
-      return conflict("Plan purchase preview is no longer valid");
-    }
-    return { status: 200 as const, body: result.response };
   },
 );
 
@@ -609,11 +627,43 @@ const checkoutConfirm$ = command(async ({ set }, signal: AbortSignal) => {
   );
 });
 
+const confirmUsagePackPurchaseForOrg$ = command(
+  async ({ set }, orgId: string, previewToken: string, signal: AbortSignal) => {
+    const result = await set(
+      confirmUsagePackPurchase$,
+      orgId,
+      previewToken,
+      signal,
+    );
+    signal.throwIfAborted();
+    if (result.status === "invalid_preview") {
+      return conflict("Usage pack purchase preview is no longer valid");
+    }
+    return { status: 200 as const, body: result.response };
+  },
+);
+
 const usagePackCheckoutAuthed$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     if (auth.orgRole !== "admin") {
       return adminRequired;
+    }
+
+    const bodyResult = await get(
+      bodyResultOf(zeroBillingUsagePackCheckoutContract.create),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    if (bodyResult.data.previewToken) {
+      return await set(
+        confirmUsagePackPurchaseForOrg$,
+        auth.orgId,
+        bodyResult.data.previewToken,
+        signal,
+      );
     }
 
     const overrides = await get(
@@ -637,27 +687,13 @@ const usagePackCheckoutAuthed$ = command(
     }
     signal.throwIfAborted();
 
-    const bodyResult = await get(
-      bodyResultOf(zeroBillingUsagePackCheckoutContract.create),
-    );
-    signal.throwIfAborted();
-    if (!bodyResult.ok) {
-      return bodyResult.response;
-    }
-    const {
-      tier,
-      supportsInAppPreview,
-      memberUsagePacks,
-      successUrl,
-      cancelUrl,
-      adAttribution,
-    } = bodyResult.data;
+    const body = bodyResult.data;
     const previewEnabled = await set(
       billingPurchasePreviewEnabled$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        requested: supportsInAppPreview === true,
+        requested: body.supportsInAppPreview === true,
       },
       signal,
     );
@@ -665,20 +701,20 @@ const usagePackCheckoutAuthed$ = command(
     const resolvedAttribution = await checkoutAttribution(
       clerk,
       auth.userId,
-      adAttribution,
+      body.adAttribution,
       signal,
     );
 
-    if (!checkoutRedirectsAllowed(successUrl, cancelUrl)) {
+    if (!checkoutRedirectsAllowed(body.successUrl, body.cancelUrl)) {
       return badRequestMessage(
         "successUrl and cancelUrl must match the platform origin",
       );
     }
 
-    const planPriceId = activeUsagePackPlanPriceId(tier);
+    const planPriceId = activeUsagePackPlanPriceId(body.tier);
     if (!planPriceId) {
       return badRequestMessage(
-        `Usage pack plan price not configured for ${tier} tier`,
+        `Usage pack plan price not configured for ${body.tier} tier`,
       );
     }
 
@@ -702,7 +738,7 @@ const usagePackCheckoutAuthed$ = command(
       {
         clerk,
         orgId: auth.orgId,
-        selections: memberUsagePacks,
+        selections: body.memberUsagePacks,
       },
       signal,
     );
@@ -712,11 +748,11 @@ const usagePackCheckoutAuthed$ = command(
       );
     }
 
-    if (usagePackCheckoutTierConflicts(metadata, tier)) {
+    if (usagePackCheckoutTierConflicts(metadata, body.tier)) {
       return badRequestMessage(
         checkoutTierConflictMessage({
           currentTier: metadata?.tier,
-          targetTier: tier,
+          targetTier: body.tier,
         }),
       );
     }
@@ -725,11 +761,11 @@ const usagePackCheckoutAuthed$ = command(
       startUsagePackPurchase$,
       {
         orgId: auth.orgId,
-        tier,
+        tier: body.tier,
         planPriceId,
         allocations,
-        successUrl,
-        cancelUrl,
+        successUrl: body.successUrl,
+        cancelUrl: body.cancelUrl,
         adAttribution: resolvedAttribution,
         supportsInAppPreview: previewEnabled,
         sourceSubscriptionId: metadata?.stripeSubscriptionId ?? null,
@@ -757,17 +793,12 @@ const usagePackCheckoutConfirmAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
-    const result = await set(
-      confirmUsagePackPurchase$,
+    return await set(
+      confirmUsagePackPurchaseForOrg$,
       auth.orgId,
       bodyResult.data.previewToken,
       signal,
     );
-    signal.throwIfAborted();
-    if (result.status === "invalid_preview") {
-      return conflict("Usage pack purchase preview is no longer valid");
-    }
-    return { status: 200 as const, body: result.response };
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -56,9 +56,11 @@ import {
 } from "../services/usage-pack-subscription.service";
 import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
 import {
+  billingPurchasePreviewEnabled$,
   revalidateBillingPurchase,
   routeBillingPurchasePreview,
-} from "../services/zero-billing-payment-method.service";
+  type BillingPurchasePaymentMethod,
+} from "../services/billing-payment-method.service";
 import {
   confirmUsagePackAllocationChange,
   discardUsagePackAllocationChangePreviewForPaymentSetup,
@@ -383,6 +385,45 @@ function usagePackCheckoutAllocations(
   });
 }
 
+async function loadUsagePackCheckoutAllocations(
+  args: {
+    readonly clerk: ClerkClient;
+    readonly orgId: string;
+    readonly selections: readonly MemberUsagePack[];
+  },
+  signal: AbortSignal,
+): Promise<readonly UsagePackCheckoutAllocation[] | null> {
+  const catalog = await loadUsagePackCatalog();
+  signal.throwIfAborted();
+  const [memberships, invitations] = await Promise.all([
+    listAllOrganizationMemberships(args.clerk.organizations, args.orgId),
+    listAllPendingOrganizationInvitations(args.clerk.organizations, args.orgId),
+  ]);
+  signal.throwIfAborted();
+  return usagePackCheckoutAllocations(
+    args.selections,
+    memberships,
+    invitations,
+    catalog,
+  );
+}
+
+function hasActiveLegacyPlanSubscription(
+  metadata:
+    | {
+        readonly tier: string | null;
+        readonly stripeSubscriptionId: string | null;
+        readonly subscriptionStatus: string | null;
+      }
+    | undefined,
+): boolean {
+  return Boolean(
+    metadata?.stripeSubscriptionId &&
+    metadata.subscriptionStatus === "active" &&
+    (metadata.tier === "pro" || metadata.tier === "team"),
+  );
+}
+
 const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   if (auth.orgRole !== "admin") {
@@ -405,6 +446,15 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
     trialDays,
     adAttribution,
   } = bodyResult.data;
+  const previewEnabled = await set(
+    billingPurchasePreviewEnabled$,
+    {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      requested: supportsInAppPreview === true,
+    },
+    signal,
+  );
   const clerk = get(clerk$);
   const resolvedAttribution = await checkoutAttribution(
     clerk,
@@ -471,7 +521,7 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
       successUrl,
       cancelUrl,
       adAttribution: resolvedAttribution,
-      supportsInAppPreview: supportsInAppPreview === true,
+      supportsInAppPreview: previewEnabled,
       subscriptionId: metadata?.stripeSubscriptionId ?? null,
     },
     signal,
@@ -580,6 +630,15 @@ const usagePackCheckoutAuthed$ = command(
       cancelUrl,
       adAttribution,
     } = bodyResult.data;
+    const previewEnabled = await set(
+      billingPurchasePreviewEnabled$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        requested: supportsInAppPreview === true,
+      },
+      signal,
+    );
     const clerk = get(clerk$);
     const resolvedAttribution = await checkoutAttribution(
       clerk,
@@ -611,29 +670,19 @@ const usagePackCheckoutAuthed$ = command(
       .where(eq(orgMetadata.orgId, auth.orgId))
       .limit(1);
     signal.throwIfAborted();
-    if (
-      metadata?.stripeSubscriptionId &&
-      metadata.subscriptionStatus === "active" &&
-      (metadata.tier === "pro" || metadata.tier === "team")
-    ) {
+    if (hasActiveLegacyPlanSubscription(metadata)) {
       return badRequestMessage(
         "Existing subscriptions must migrate before starting usage pack checkout",
       );
     }
 
-    const catalog = await loadUsagePackCatalog();
-    signal.throwIfAborted();
-
-    const [memberships, invitations] = await Promise.all([
-      listAllOrganizationMemberships(clerk.organizations, auth.orgId),
-      listAllPendingOrganizationInvitations(clerk.organizations, auth.orgId),
-    ]);
-    signal.throwIfAborted();
-    const allocations = usagePackCheckoutAllocations(
-      memberUsagePacks,
-      memberships,
-      invitations,
-      catalog,
+    const allocations = await loadUsagePackCheckoutAllocations(
+      {
+        clerk,
+        orgId: auth.orgId,
+        selections: memberUsagePacks,
+      },
+      signal,
     );
     if (!allocations) {
       return badRequestMessage(
@@ -668,7 +717,7 @@ const usagePackCheckoutAuthed$ = command(
         successUrl,
         cancelUrl,
         adAttribution: resolvedAttribution,
-        supportsInAppPreview: supportsInAppPreview === true,
+        supportsInAppPreview: previewEnabled,
         sourceSubscriptionId: metadata?.stripeSubscriptionId ?? null,
       },
       signal,
@@ -846,8 +895,17 @@ const usagePackChangePreviewAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
+    const previewEnabled = await set(
+      billingPurchasePreviewEnabled$,
+      {
+        orgId: access.auth.orgId,
+        userId: access.auth.userId,
+        requested: bodyResult.data.supportsInAppPreview === true,
+      },
+      signal,
+    );
     if (
-      bodyResult.data.supportsInAppPreview === true &&
+      previewEnabled &&
       (!bodyResult.data.returnUrl ||
         !billingRedirectAllowed(bodyResult.data.returnUrl))
     ) {
@@ -884,7 +942,7 @@ const usagePackChangePreviewAuthed$ = command(
     }
     if (
       result.preview.immediateAmountCents > 0 &&
-      bodyResult.data.supportsInAppPreview === true &&
+      previewEnabled &&
       bodyResult.data.returnUrl
     ) {
       const billing = await activeUsagePackBillingContext(
@@ -955,6 +1013,7 @@ const usagePackChangeConfirmAuthed$ = command(
     if (!subscriptionSchema || !changeSchema) {
       return providerUnavailable("Usage pack billing is not ready");
     }
+    let paymentMethod: BillingPurchasePaymentMethod | undefined;
     if (bodyResult.data.paymentMethodPreviewToken) {
       const preview = parseBillingPaymentMethodPreviewToken(
         bodyResult.data.paymentMethodPreviewToken,
@@ -1006,12 +1065,14 @@ const usagePackChangeConfirmAuthed$ = command(
           },
         };
       }
+      paymentMethod = revalidated;
     }
     const result = await confirmUsagePackAllocationChange(
       db,
       {
         orgId: access.auth.orgId,
         changeId,
+        paymentMethod,
       },
       signal,
     );
@@ -1366,8 +1427,17 @@ const usagePackSubscriptionChangePreviewAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
+    const previewEnabled = await set(
+      billingPurchasePreviewEnabled$,
+      {
+        orgId: access.auth.orgId,
+        userId: access.auth.userId,
+        requested: bodyResult.data.supportsInAppPreview === true,
+      },
+      signal,
+    );
     if (
-      bodyResult.data.supportsInAppPreview === true &&
+      previewEnabled &&
       (!bodyResult.data.returnUrl ||
         !billingRedirectAllowed(bodyResult.data.returnUrl))
     ) {
@@ -1441,7 +1511,7 @@ const usagePackSubscriptionChangePreviewAuthed$ = command(
     }
     if (
       result.preview.immediateAmountCents > 0 &&
-      bodyResult.data.supportsInAppPreview === true &&
+      previewEnabled &&
       bodyResult.data.returnUrl
     ) {
       const paymentRoute = await routeUsagePackSubscriptionChangePayment(
@@ -1488,6 +1558,7 @@ const usagePackSubscriptionChangeConfirmAuthed$ = command(
     if (!subscriptionSchema || !changeSchema || !subscriptionChangeSchema) {
       return providerUnavailable("Usage pack billing is not ready");
     }
+    let paymentMethod: BillingPurchasePaymentMethod | undefined;
     if (bodyResult.data.paymentMethodPreviewToken) {
       const preview = parseBillingPaymentMethodPreviewToken(
         bodyResult.data.paymentMethodPreviewToken,
@@ -1539,12 +1610,14 @@ const usagePackSubscriptionChangeConfirmAuthed$ = command(
           },
         };
       }
+      paymentMethod = revalidated;
     }
     const result = await confirmUsagePackSubscriptionChange(
       db,
       {
         orgId: access.auth.orgId,
         changeId: bodyResult.data.changeId,
+        paymentMethod,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -86,6 +86,7 @@ import {
 } from "../services/usage-pack-subscription-migration.service";
 import { usagePackInvitationPurchaseSchemaAvailable } from "../services/usage-pack-invitation-purchase.service";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import { reconcilePaidStripeInvoice$ } from "../services/webhooks-stripe.service";
 import {
   mergeFirstTouchAttribution,
   parseStoredSignupAttribution,
@@ -453,6 +454,19 @@ const confirmPlanPurchaseForOrg$ = command(
     if (result.status === "invalid_preview") {
       return conflict("Plan purchase preview is no longer valid");
     }
+    if (result.paidInvoice) {
+      const reconciledOrgId = await set(
+        reconcilePaidStripeInvoice$,
+        result.paidInvoice,
+        signal,
+      );
+      signal.throwIfAborted();
+      if (reconciledOrgId !== orgId) {
+        throw new Error(
+          `Paid Plan purchase invoice ${result.paidInvoice.id} did not reconcile to org ${orgId}`,
+        );
+      }
+    }
     return { status: 200 as const, body: result.response };
   },
 );
@@ -473,14 +487,14 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   if (bodyResult.data.previewToken) {
     const confirmation = await set(
-      confirmPlanPurchase$,
+      confirmPlanPurchaseForOrg$,
       auth.orgId,
       bodyResult.data.previewToken,
       signal,
     );
     signal.throwIfAborted();
-    if (confirmation.status !== "invalid_preview") {
-      return { status: 200 as const, body: confirmation.response };
+    if (confirmation.status !== 409) {
+      return confirmation;
     }
   }
   const {
@@ -638,6 +652,19 @@ const confirmUsagePackPurchaseForOrg$ = command(
     signal.throwIfAborted();
     if (result.status === "invalid_preview") {
       return conflict("Usage pack purchase preview is no longer valid");
+    }
+    if (result.paidInvoice) {
+      const reconciledOrgId = await set(
+        reconcilePaidStripeInvoice$,
+        result.paidInvoice,
+        signal,
+      );
+      signal.throwIfAborted();
+      if (reconciledOrgId !== orgId) {
+        throw new Error(
+          `Paid usage pack purchase invoice ${result.paidInvoice.id} did not reconcile to org ${orgId}`,
+        );
+      }
     }
     return { status: 200 as const, body: result.response };
   },

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -7,6 +7,7 @@ import {
   zeroBillingUsagePackMigrationContract,
   type MemberUsagePack,
   type UsagePackCatalogItem,
+  type UsagePackSubscriptionChangePreviewResponse,
 } from "@okouai/api-contracts/contracts/zero-billing";
 import { adAttributionMetadataSchema } from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
@@ -17,6 +18,7 @@ import { eq } from "drizzle-orm";
 import { optionalEnv } from "../../lib/env";
 import { billingRedirectAllowed } from "../../lib/billing-redirect";
 import { logger } from "../../lib/log";
+import { nowDate } from "../../lib/time";
 import { settle } from "../utils";
 import {
   badRequestMessage,
@@ -32,30 +34,41 @@ import {
   listAllOrganizationMemberships,
   listAllPendingOrganizationInvitations,
 } from "../external/clerk-organization-lists";
-import { db$, writeDb$ } from "../external/db";
+import { db$, writeDb$, type Db } from "../external/db";
+import { getStripeClient } from "../external/stripe-client";
 import {
   activePriceId,
   activeUsagePackPlanPriceId,
   activeUsagePackPriceId,
   completeCheckoutSession$,
+  confirmPlanPurchase$,
   checkoutTierConflictMessage,
   checkoutWouldReplaceWithSameOrLowerTier,
-  createCheckoutSession$,
+  startPlanPurchase$,
 } from "../services/zero-billing-checkout.service";
 import {
-  createUsagePackCheckoutSession$,
+  confirmUsagePackPurchase$,
+  activeUsagePackBillingContext,
   loadUsagePackCatalog,
+  startUsagePackPurchase$,
   usagePackSubscriptionSchemaAvailable,
   type UsagePackCheckoutAllocation,
 } from "../services/usage-pack-subscription.service";
+import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
+import {
+  revalidateBillingPurchase,
+  routeBillingPurchasePreview,
+} from "../services/zero-billing-payment-method.service";
 import {
   confirmUsagePackAllocationChange,
+  discardUsagePackAllocationChangePreviewForPaymentSetup,
   getUsagePackManagement,
   previewUsagePackAllocationChange,
   usagePackAllocationChangeSchemaAvailable,
 } from "../services/usage-pack-allocation-change.service";
 import {
   confirmUsagePackSubscriptionChange,
+  discardUsagePackSubscriptionChangePreviewForPaymentSetup,
   previewUsagePackSubscriptionChange,
   usagePackMemberAdditionSchemaAvailable,
   usagePackSubscriptionChangeSchemaAvailable,
@@ -141,6 +154,20 @@ async function signupAttributionForUser(
     : undefined;
 }
 
+async function checkoutAttribution(
+  clerk: ClerkClient,
+  userId: string,
+  adAttribution: Parameters<typeof mergeFirstTouchAttribution>[0],
+  signal: AbortSignal,
+): Promise<ReturnType<typeof mergeFirstTouchAttribution>> {
+  const storedAttribution = await signupAttributionForUser(
+    clerk,
+    userId,
+    signal,
+  );
+  return mergeFirstTouchAttribution(adAttribution, storedAttribution);
+}
+
 function memberUsagePackIdsMatch(
   selections: readonly MemberUsagePack[],
   expectedMemberIds: readonly string[],
@@ -157,6 +184,104 @@ function memberUsagePackIdsMatch(
       return selectedMemberIds.has(memberId);
     })
   );
+}
+
+function checkoutRedirectsAllowed(
+  successUrl: string,
+  cancelUrl: string,
+): boolean {
+  return (
+    billingRedirectAllowed(successUrl) && billingRedirectAllowed(cancelUrl)
+  );
+}
+
+async function validateUsagePackSubscriptionMembers(
+  args: {
+    readonly clerk: ClerkClient;
+    readonly orgId: string;
+    readonly memberUsagePacks: readonly MemberUsagePack[];
+    readonly allocatedMemberIds: readonly string[];
+    readonly memberAdditionSchemaAvailable: boolean;
+  },
+  signal: AbortSignal,
+): Promise<"valid" | "member_additions_unavailable" | "members_changed"> {
+  const allocatedMemberIds = new Set(args.allocatedMemberIds);
+  const addsMember = args.memberUsagePacks.some((selection) => {
+    return !allocatedMemberIds.has(selection.memberId);
+  });
+  if (!addsMember) {
+    return "valid";
+  }
+  if (!args.memberAdditionSchemaAvailable) {
+    return "member_additions_unavailable";
+  }
+  const memberships = await listAllOrganizationMemberships(
+    args.clerk.organizations,
+    args.orgId,
+  );
+  signal.throwIfAborted();
+  const activeMemberIds = memberships.map((membership) => {
+    const memberId = membership.publicUserData?.userId;
+    if (!memberId) {
+      throw new Error("Clerk organization membership is missing its user ID");
+    }
+    return memberId;
+  });
+  return memberUsagePackIdsMatch(args.memberUsagePacks, activeMemberIds)
+    ? "valid"
+    : "members_changed";
+}
+
+async function routeUsagePackSubscriptionChangePayment(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly preview: UsagePackSubscriptionChangePreviewResponse;
+    readonly returnUrl: string;
+  },
+  signal: AbortSignal,
+): Promise<
+  | { readonly kind: "not_found" }
+  | {
+      readonly kind: "response";
+      readonly body: UsagePackSubscriptionChangePreviewResponse;
+    }
+> {
+  const billing = await activeUsagePackBillingContext(args.db, args.orgId);
+  signal.throwIfAborted();
+  if (!billing) {
+    return { kind: "not_found" };
+  }
+  const route = await routeBillingPurchasePreview(
+    {
+      stripe: getStripeClient(),
+      orgId: args.orgId,
+      customerId: billing.stripeCustomerId,
+      subscriptionId: billing.stripeSubscriptionId,
+      operation: "usage_pack_subscription",
+      operationId: args.preview.changeId,
+      returnUrl: args.returnUrl,
+    },
+    signal,
+  );
+  if (route.kind === "checkout") {
+    await discardUsagePackSubscriptionChangePreviewForPaymentSetup(args.db, {
+      orgId: args.orgId,
+      changeId: args.preview.changeId,
+    });
+    signal.throwIfAborted();
+    return {
+      kind: "response",
+      body: { ...args.preview, checkoutUrl: route.url },
+    };
+  }
+  return {
+    kind: "response",
+    body: {
+      ...args.preview,
+      paymentMethodPreviewToken: route.paymentMethodPreviewToken,
+    },
+  };
 }
 
 interface UsagePackMembership {
@@ -272,23 +397,23 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!bodyResult.ok) {
     return bodyResult.response;
   }
-  const { tier, successUrl, cancelUrl, trialDays, adAttribution } =
-    bodyResult.data;
+  const {
+    tier,
+    supportsInAppPreview,
+    successUrl,
+    cancelUrl,
+    trialDays,
+    adAttribution,
+  } = bodyResult.data;
   const clerk = get(clerk$);
-  const storedAttribution = await signupAttributionForUser(
+  const resolvedAttribution = await checkoutAttribution(
     clerk,
     auth.userId,
+    adAttribution,
     signal,
   );
-  const resolvedAttribution = mergeFirstTouchAttribution(
-    adAttribution,
-    storedAttribution,
-  );
 
-  if (
-    !billingRedirectAllowed(successUrl) ||
-    !billingRedirectAllowed(cancelUrl)
-  ) {
+  if (!checkoutRedirectsAllowed(successUrl, cancelUrl)) {
     return badRequestMessage(
       "successUrl and cancelUrl must match the platform origin",
     );
@@ -303,6 +428,7 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
   const [metadata] = await db
     .select({
       onboardingPaymentPending: orgMetadata.onboardingPaymentPending,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
       tier: orgMetadata.tier,
     })
     .from(orgMetadata)
@@ -335,8 +461,8 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
     }
   }
 
-  const url = await set(
-    createCheckoutSession$,
+  const result = await set(
+    startPlanPurchase$,
     {
       orgId: auth.orgId,
       tier,
@@ -345,11 +471,16 @@ const checkoutAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
       successUrl,
       cancelUrl,
       adAttribution: resolvedAttribution,
+      supportsInAppPreview: supportsInAppPreview === true,
+      subscriptionId: metadata?.stripeSubscriptionId ?? null,
     },
     signal,
   );
   signal.throwIfAborted();
-  return { status: 200 as const, body: { url } };
+  return {
+    status: 200 as const,
+    body: result.status === "preview" ? result.preview : { url: result.url },
+  };
 });
 
 const checkout$ = command(async ({ set }, signal: AbortSignal) => {
@@ -361,6 +492,46 @@ const checkout$ = command(async ({ set }, signal: AbortSignal) => {
     authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       checkoutAuthed$,
+    ),
+    signal,
+  );
+});
+
+const checkoutConfirmAuthed$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return adminRequired;
+    }
+    const bodyResult = await get(
+      bodyResultOf(zeroBillingCheckoutContract.confirm),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    const result = await set(
+      confirmPlanPurchase$,
+      auth.orgId,
+      bodyResult.data.previewToken,
+      signal,
+    );
+    signal.throwIfAborted();
+    if (result.status === "invalid_preview") {
+      return conflict("Plan purchase preview is no longer valid");
+    }
+    return { status: 200 as const, body: result.response };
+  },
+);
+
+const checkoutConfirm$ = command(async ({ set }, signal: AbortSignal) => {
+  if (!optionalEnv("STRIPE_SECRET_KEY")) {
+    return providerUnavailable("Billing not configured");
+  }
+  return await set(
+    authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      checkoutConfirmAuthed$,
     ),
     signal,
   );
@@ -401,23 +572,23 @@ const usagePackCheckoutAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
-    const { tier, memberUsagePacks, successUrl, cancelUrl, adAttribution } =
-      bodyResult.data;
+    const {
+      tier,
+      supportsInAppPreview,
+      memberUsagePacks,
+      successUrl,
+      cancelUrl,
+      adAttribution,
+    } = bodyResult.data;
     const clerk = get(clerk$);
-    const storedAttribution = await signupAttributionForUser(
+    const resolvedAttribution = await checkoutAttribution(
       clerk,
       auth.userId,
+      adAttribution,
       signal,
     );
-    const resolvedAttribution = mergeFirstTouchAttribution(
-      adAttribution,
-      storedAttribution,
-    );
 
-    if (
-      !billingRedirectAllowed(successUrl) ||
-      !billingRedirectAllowed(cancelUrl)
-    ) {
+    if (!checkoutRedirectsAllowed(successUrl, cancelUrl)) {
       return badRequestMessage(
         "successUrl and cancelUrl must match the platform origin",
       );
@@ -487,8 +658,8 @@ const usagePackCheckoutAuthed$ = command(
       );
     }
 
-    const url = await set(
-      createUsagePackCheckoutSession$,
+    const result = await set(
+      startUsagePackPurchase$,
       {
         orgId: auth.orgId,
         tier,
@@ -497,11 +668,43 @@ const usagePackCheckoutAuthed$ = command(
         successUrl,
         cancelUrl,
         adAttribution: resolvedAttribution,
+        supportsInAppPreview: supportsInAppPreview === true,
+        sourceSubscriptionId: metadata?.stripeSubscriptionId ?? null,
       },
       signal,
     );
     signal.throwIfAborted();
-    return { status: 200 as const, body: { url } };
+    return {
+      status: 200 as const,
+      body: result.status === "preview" ? result.preview : { url: result.url },
+    };
+  },
+);
+
+const usagePackCheckoutConfirmAuthed$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.orgRole !== "admin") {
+      return adminRequired;
+    }
+    const bodyResult = await get(
+      bodyResultOf(zeroBillingUsagePackCheckoutContract.confirm),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    const result = await set(
+      confirmUsagePackPurchase$,
+      auth.orgId,
+      bodyResult.data.previewToken,
+      signal,
+    );
+    signal.throwIfAborted();
+    if (result.status === "invalid_preview") {
+      return conflict("Usage pack purchase preview is no longer valid");
+    }
+    return { status: 200 as const, body: result.response };
   },
 );
 
@@ -558,6 +761,21 @@ const usagePackCheckout$ = command(async ({ set }, signal: AbortSignal) => {
     signal,
   );
 });
+
+const usagePackCheckoutConfirm$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    if (!optionalEnv("STRIPE_SECRET_KEY")) {
+      return providerUnavailable("Billing not configured");
+    }
+    return await set(
+      authRoute(
+        { requireOrganization: true, missingOrganizationStatus: 401 },
+        usagePackCheckoutConfirmAuthed$,
+      ),
+      signal,
+    );
+  },
+);
 
 const usagePackManagementAccess$ = command(
   async ({ get }, signal: AbortSignal) => {
@@ -628,6 +846,15 @@ const usagePackChangePreviewAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
+    if (
+      bodyResult.data.supportsInAppPreview === true &&
+      (!bodyResult.data.returnUrl ||
+        !billingRedirectAllowed(bodyResult.data.returnUrl))
+    ) {
+      return badRequestMessage(
+        "returnUrl must match the platform origin for in-app billing",
+      );
+    }
     const db = set(writeDb$);
     const [subscriptionSchema, changeSchema] = await Promise.all([
       usagePackSubscriptionSchemaAvailable(db),
@@ -654,6 +881,50 @@ const usagePackChangePreviewAuthed$ = command(
     }
     if (result.status === "conflict") {
       return conflict("Another usage pack billing change is in progress");
+    }
+    if (
+      result.preview.immediateAmountCents > 0 &&
+      bodyResult.data.supportsInAppPreview === true &&
+      bodyResult.data.returnUrl
+    ) {
+      const billing = await activeUsagePackBillingContext(
+        db,
+        access.auth.orgId,
+      );
+      signal.throwIfAborted();
+      if (!billing) {
+        return notFound("Usage pack subscription not found");
+      }
+      const route = await routeBillingPurchasePreview(
+        {
+          stripe: getStripeClient(),
+          orgId: access.auth.orgId,
+          customerId: billing.stripeCustomerId,
+          subscriptionId: billing.stripeSubscriptionId,
+          operation: "usage_pack_allocation",
+          operationId: result.preview.changeId,
+          returnUrl: bodyResult.data.returnUrl,
+        },
+        signal,
+      );
+      if (route.kind === "checkout") {
+        await discardUsagePackAllocationChangePreviewForPaymentSetup(db, {
+          orgId: access.auth.orgId,
+          changeId: result.preview.changeId,
+        });
+        signal.throwIfAborted();
+        return {
+          status: 200 as const,
+          body: { ...result.preview, checkoutUrl: route.url },
+        };
+      }
+      return {
+        status: 200 as const,
+        body: {
+          ...result.preview,
+          paymentMethodPreviewToken: route.paymentMethodPreviewToken,
+        },
+      };
     }
     return { status: 200 as const, body: result.preview };
   },
@@ -683,6 +954,58 @@ const usagePackChangeConfirmAuthed$ = command(
     signal.throwIfAborted();
     if (!subscriptionSchema || !changeSchema) {
       return providerUnavailable("Usage pack billing is not ready");
+    }
+    if (bodyResult.data.paymentMethodPreviewToken) {
+      const preview = parseBillingPaymentMethodPreviewToken(
+        bodyResult.data.paymentMethodPreviewToken,
+      );
+      const billing = await activeUsagePackBillingContext(
+        db,
+        access.auth.orgId,
+      );
+      signal.throwIfAborted();
+      if (
+        !preview ||
+        !billing ||
+        preview.operation !== "usage_pack_allocation" ||
+        preview.operationId !== changeId ||
+        preview.orgId !== access.auth.orgId ||
+        preview.customerId !== billing.stripeCustomerId ||
+        preview.subscriptionId !== billing.stripeSubscriptionId ||
+        new Date(preview.expiresAt) <= nowDate()
+      ) {
+        return conflict("Usage pack change preview is no longer valid");
+      }
+      const revalidated = await revalidateBillingPurchase(
+        {
+          stripe: getStripeClient(),
+          orgId: access.auth.orgId,
+          customerId: preview.customerId,
+          subscriptionId: preview.subscriptionId,
+          paymentMethodId: preview.paymentMethodId,
+          operation: preview.operation,
+          operationId: preview.operationId,
+          returnUrl: preview.returnUrl,
+        },
+        signal,
+      );
+      if (revalidated.kind === "invalid_preview") {
+        return conflict("Usage pack change preview is no longer valid");
+      }
+      if (revalidated.kind === "checkout") {
+        await discardUsagePackAllocationChangePreviewForPaymentSetup(db, {
+          orgId: access.auth.orgId,
+          changeId,
+        });
+        signal.throwIfAborted();
+        return {
+          status: 200 as const,
+          body: {
+            status: "checkout_required" as const,
+            checkoutUrl: revalidated.url,
+          },
+        };
+      }
     }
     const result = await confirmUsagePackAllocationChange(
       db,
@@ -1043,6 +1366,15 @@ const usagePackSubscriptionChangePreviewAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
+    if (
+      bodyResult.data.supportsInAppPreview === true &&
+      (!bodyResult.data.returnUrl ||
+        !billingRedirectAllowed(bodyResult.data.returnUrl))
+    ) {
+      return badRequestMessage(
+        "returnUrl must match the platform origin for in-app billing",
+      );
+    }
     const db = set(writeDb$);
     const [
       subscriptionSchema,
@@ -1064,43 +1396,25 @@ const usagePackSubscriptionChangePreviewAuthed$ = command(
     if (!management) {
       return notFound("Usage pack subscription not found");
     }
-    const allocatedMemberIds = new Set(
-      management.allocations.map((allocation) => {
-        return allocation.memberId;
-      }),
+    const memberValidation = await validateUsagePackSubscriptionMembers(
+      {
+        clerk: get(clerk$),
+        orgId: access.auth.orgId,
+        memberUsagePacks: bodyResult.data.memberUsagePacks,
+        allocatedMemberIds: management.allocations.map((allocation) => {
+          return allocation.memberId;
+        }),
+        memberAdditionSchemaAvailable: memberAdditionSchema,
+      },
+      signal,
     );
-    const addsMember = bodyResult.data.memberUsagePacks.some((selection) => {
-      return !allocatedMemberIds.has(selection.memberId);
-    });
-    if (addsMember) {
-      if (!memberAdditionSchema) {
-        return providerUnavailable("Usage pack member additions are not ready");
-      }
-      const clerk = get(clerk$);
-      const memberships = await listAllOrganizationMemberships(
-        clerk.organizations,
-        access.auth.orgId,
+    if (memberValidation === "member_additions_unavailable") {
+      return providerUnavailable("Usage pack member additions are not ready");
+    }
+    if (memberValidation === "members_changed") {
+      return badRequestMessage(
+        "Organization members changed; refresh billing and try again",
       );
-      signal.throwIfAborted();
-      const activeMemberIds = memberships.map((membership) => {
-        const memberId = membership.publicUserData?.userId;
-        if (!memberId) {
-          throw new Error(
-            "Clerk organization membership is missing its user ID",
-          );
-        }
-        return memberId;
-      });
-      if (
-        !memberUsagePackIdsMatch(
-          bodyResult.data.memberUsagePacks,
-          activeMemberIds,
-        )
-      ) {
-        return badRequestMessage(
-          "Organization members changed; refresh billing and try again",
-        );
-      }
     }
     const result = await previewUsagePackSubscriptionChange(
       db,
@@ -1124,6 +1438,25 @@ const usagePackSubscriptionChangePreviewAuthed$ = command(
     }
     if (result.status === "conflict") {
       return conflict("Another usage pack billing change is in progress");
+    }
+    if (
+      result.preview.immediateAmountCents > 0 &&
+      bodyResult.data.supportsInAppPreview === true &&
+      bodyResult.data.returnUrl
+    ) {
+      const paymentRoute = await routeUsagePackSubscriptionChangePayment(
+        {
+          db,
+          orgId: access.auth.orgId,
+          preview: result.preview,
+          returnUrl: bodyResult.data.returnUrl,
+        },
+        signal,
+      );
+      if (paymentRoute.kind === "not_found") {
+        return notFound("Usage pack subscription not found");
+      }
+      return { status: 200 as const, body: paymentRoute.body };
     }
     return { status: 200 as const, body: result.preview };
   },
@@ -1154,6 +1487,58 @@ const usagePackSubscriptionChangeConfirmAuthed$ = command(
     signal.throwIfAborted();
     if (!subscriptionSchema || !changeSchema || !subscriptionChangeSchema) {
       return providerUnavailable("Usage pack billing is not ready");
+    }
+    if (bodyResult.data.paymentMethodPreviewToken) {
+      const preview = parseBillingPaymentMethodPreviewToken(
+        bodyResult.data.paymentMethodPreviewToken,
+      );
+      const billing = await activeUsagePackBillingContext(
+        db,
+        access.auth.orgId,
+      );
+      signal.throwIfAborted();
+      if (
+        !preview ||
+        !billing ||
+        preview.operation !== "usage_pack_subscription" ||
+        preview.operationId !== bodyResult.data.changeId ||
+        preview.orgId !== access.auth.orgId ||
+        preview.customerId !== billing.stripeCustomerId ||
+        preview.subscriptionId !== billing.stripeSubscriptionId ||
+        new Date(preview.expiresAt) <= nowDate()
+      ) {
+        return conflict("Usage pack subscription preview is no longer valid");
+      }
+      const revalidated = await revalidateBillingPurchase(
+        {
+          stripe: getStripeClient(),
+          orgId: access.auth.orgId,
+          customerId: preview.customerId,
+          subscriptionId: preview.subscriptionId,
+          paymentMethodId: preview.paymentMethodId,
+          operation: preview.operation,
+          operationId: preview.operationId,
+          returnUrl: preview.returnUrl,
+        },
+        signal,
+      );
+      if (revalidated.kind === "invalid_preview") {
+        return conflict("Usage pack subscription preview is no longer valid");
+      }
+      if (revalidated.kind === "checkout") {
+        await discardUsagePackSubscriptionChangePreviewForPaymentSetup(db, {
+          orgId: access.auth.orgId,
+          changeId: bodyResult.data.changeId,
+        });
+        signal.throwIfAborted();
+        return {
+          status: 200 as const,
+          body: {
+            status: "checkout_required" as const,
+            checkoutUrl: revalidated.url,
+          },
+        };
+      }
     }
     const result = await confirmUsagePackSubscriptionChange(
       db,
@@ -1343,12 +1728,20 @@ export const billingCheckoutRoutes: readonly RouteEntry[] = [
     handler: checkout$,
   },
   {
+    route: zeroBillingCheckoutContract.confirm,
+    handler: checkoutConfirm$,
+  },
+  {
     route: zeroBillingCheckoutContract.complete,
     handler: checkoutComplete$,
   },
   {
     route: zeroBillingUsagePackCheckoutContract.create,
     handler: usagePackCheckout$,
+  },
+  {
+    route: zeroBillingUsagePackCheckoutContract.confirm,
+    handler: usagePackCheckoutConfirm$,
   },
   {
     route: zeroBillingUsagePackCatalogContract.get,

--- a/turbo/apps/api/src/signals/routes/billing-concurrency-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-concurrency-checkout.ts
@@ -3,6 +3,7 @@ import { zeroBillingConcurrencyCheckoutContract } from "@okouai/api-contracts/co
 
 import { optionalEnv } from "../../lib/env";
 import { billingRedirectAllowed } from "../../lib/billing-redirect";
+import { nowDate } from "../../lib/time";
 import {
   badRequestMessage,
   conflict,
@@ -19,9 +20,16 @@ import {
 } from "../services/org-concurrency-entitlements.service";
 import {
   previewInitialConcurrencyPurchase$,
+  orgPlanSubscriptionId,
   startConcurrencyPurchase$,
 } from "../services/zero-billing-checkout.service";
 import { previewConcurrencySubscriptionChange$ } from "../services/zero-billing-concurrency-subscription.service";
+import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
+import {
+  revalidateBillingPurchase,
+  routeBillingPurchasePreview,
+} from "../services/zero-billing-payment-method.service";
+import { getStripeClient } from "../external/stripe-client";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
 import type { RouteEntry } from "../route-entry";
 
@@ -83,6 +91,118 @@ async function loadConcurrencyPurchaseTarget(
   };
 }
 
+type ReadyConcurrencyPurchaseTarget = Extract<
+  ConcurrencyPurchaseTarget,
+  { readonly ok: true }
+>;
+
+async function loadConcurrencyPaymentPreview(
+  args: {
+    readonly db: ReadonlyDb;
+    readonly orgId: string;
+    readonly target: ReadyConcurrencyPurchaseTarget;
+    readonly quantity: number;
+    readonly supportsInAppPreview: boolean;
+    readonly returnUrl: string | undefined;
+  },
+  signal: AbortSignal,
+): Promise<
+  | { readonly kind: "missing_subscription" }
+  | {
+      readonly kind: "ready";
+      readonly paymentMethodPreviewToken?: string;
+      readonly checkoutUrl?: string;
+    }
+> {
+  const subscriptionId =
+    args.target.existingSubscription?.id ??
+    (await orgPlanSubscriptionId(args.db, args.orgId));
+  signal.throwIfAborted();
+  if (!subscriptionId) {
+    return { kind: "missing_subscription" };
+  }
+  if (!args.supportsInAppPreview || !args.returnUrl) {
+    return { kind: "ready" };
+  }
+  const targetQuantity = args.target.existingSubscription
+    ? args.target.existingSubscription.quantity + args.quantity
+    : args.quantity;
+  const route = await routeBillingPurchasePreview(
+    {
+      stripe: getStripeClient(),
+      orgId: args.orgId,
+      customerId: null,
+      subscriptionId,
+      operation: "concurrency",
+      operationId: `${subscriptionId}:${targetQuantity}`,
+      returnUrl: args.returnUrl,
+    },
+    signal,
+  );
+  return route.kind === "checkout"
+    ? { kind: "ready", checkoutUrl: route.url }
+    : {
+        kind: "ready",
+        paymentMethodPreviewToken: route.paymentMethodPreviewToken,
+      };
+}
+
+async function revalidateConcurrencyPaymentPreview(
+  args: {
+    readonly db: ReadonlyDb;
+    readonly orgId: string;
+    readonly target: ReadyConcurrencyPurchaseTarget;
+    readonly quantity: number;
+    readonly paymentMethodPreviewToken: string;
+  },
+  signal: AbortSignal,
+): Promise<
+  | { readonly kind: "continue" }
+  | { readonly kind: "invalid_preview" }
+  | { readonly kind: "checkout"; readonly url: string }
+> {
+  const subscriptionId =
+    args.target.existingSubscription?.id ??
+    (await orgPlanSubscriptionId(args.db, args.orgId));
+  signal.throwIfAborted();
+  const targetQuantity = args.target.existingSubscription
+    ? args.target.existingSubscription.quantity + args.quantity
+    : args.quantity;
+  const preview = parseBillingPaymentMethodPreviewToken(
+    args.paymentMethodPreviewToken,
+  );
+  if (
+    !subscriptionId ||
+    !preview ||
+    preview.operation !== "concurrency" ||
+    preview.operationId !== `${subscriptionId}:${targetQuantity}` ||
+    preview.orgId !== args.orgId ||
+    preview.subscriptionId !== subscriptionId ||
+    new Date(preview.expiresAt) <= nowDate()
+  ) {
+    return { kind: "invalid_preview" };
+  }
+  const revalidated = await revalidateBillingPurchase(
+    {
+      stripe: getStripeClient(),
+      orgId: args.orgId,
+      customerId: preview.customerId,
+      subscriptionId,
+      paymentMethodId: preview.paymentMethodId,
+      operation: preview.operation,
+      operationId: preview.operationId,
+      returnUrl: preview.returnUrl,
+    },
+    signal,
+  );
+  if (revalidated.kind === "invalid_preview") {
+    return { kind: "invalid_preview" };
+  }
+  return revalidated.kind === "checkout"
+    ? { kind: "checkout", url: revalidated.url }
+    : { kind: "continue" };
+}
+
 const concurrencyCheckoutPreviewAuthed$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
@@ -98,6 +218,15 @@ const concurrencyCheckoutPreviewAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
+    const { supportsInAppPreview, returnUrl } = bodyResult.data;
+    if (
+      supportsInAppPreview === true &&
+      (!returnUrl || !billingRedirectAllowed(returnUrl))
+    ) {
+      return badRequestMessage(
+        "returnUrl must match the platform origin for in-app billing",
+      );
+    }
 
     const target = await loadConcurrencyPurchaseTarget(
       get(db$),
@@ -106,6 +235,23 @@ const concurrencyCheckoutPreviewAuthed$ = command(
     );
     if (!target.ok) {
       return badRequestMessage(target.message);
+    }
+
+    const paymentPreview = await loadConcurrencyPaymentPreview(
+      {
+        db: get(db$),
+        orgId: auth.orgId,
+        target,
+        quantity: bodyResult.data.quantity,
+        supportsInAppPreview: supportsInAppPreview === true,
+        returnUrl,
+      },
+      signal,
+    );
+    if (paymentPreview.kind === "missing_subscription") {
+      return badRequestMessage(
+        "An active Plan subscription is required to buy concurrency",
+      );
     }
 
     const result = target.existingSubscription
@@ -158,7 +304,21 @@ const concurrencyCheckoutPreviewAuthed$ = command(
       }
     }
 
-    return { status: 200 as const, body: result.preview };
+    return {
+      status: 200 as const,
+      body: {
+        ...result.preview,
+        ...(paymentPreview.paymentMethodPreviewToken
+          ? {
+              paymentMethodPreviewToken:
+                paymentPreview.paymentMethodPreviewToken,
+            }
+          : {}),
+        ...(paymentPreview.checkoutUrl
+          ? { checkoutUrl: paymentPreview.checkoutUrl }
+          : {}),
+      },
+    };
   },
 );
 
@@ -196,7 +356,8 @@ const concurrencyCheckoutAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
-    const { quantity, successUrl, cancelUrl } = bodyResult.data;
+    const { quantity, paymentMethodPreviewToken, successUrl, cancelUrl } =
+      bodyResult.data;
 
     const db = get(db$);
     if (
@@ -211,6 +372,25 @@ const concurrencyCheckoutAuthed$ = command(
     const target = await loadConcurrencyPurchaseTarget(db, auth.orgId, signal);
     if (!target.ok) {
       return badRequestMessage(target.message);
+    }
+
+    if (paymentMethodPreviewToken) {
+      const revalidated = await revalidateConcurrencyPaymentPreview(
+        {
+          db,
+          orgId: auth.orgId,
+          target,
+          quantity,
+          paymentMethodPreviewToken,
+        },
+        signal,
+      );
+      if (revalidated.kind === "invalid_preview") {
+        return conflict("Concurrency purchase preview is no longer valid");
+      }
+      if (revalidated.kind === "checkout") {
+        return { status: 200 as const, body: { url: revalidated.url } };
+      }
     }
 
     const purchase = await set(

--- a/turbo/apps/api/src/signals/routes/billing-concurrency-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-concurrency-checkout.ts
@@ -26,9 +26,11 @@ import {
 import { previewConcurrencySubscriptionChange$ } from "../services/zero-billing-concurrency-subscription.service";
 import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
 import {
+  billingPurchasePreviewEnabled$,
   revalidateBillingPurchase,
   routeBillingPurchasePreview,
-} from "../services/zero-billing-payment-method.service";
+  type BillingPurchasePaymentMethod,
+} from "../services/billing-payment-method.service";
 import { getStripeClient } from "../external/stripe-client";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
 import type { RouteEntry } from "../route-entry";
@@ -157,7 +159,10 @@ async function revalidateConcurrencyPaymentPreview(
   },
   signal: AbortSignal,
 ): Promise<
-  | { readonly kind: "continue" }
+  | {
+      readonly kind: "continue";
+      readonly paymentMethod: BillingPurchasePaymentMethod;
+    }
   | { readonly kind: "invalid_preview" }
   | { readonly kind: "checkout"; readonly url: string }
 > {
@@ -200,7 +205,7 @@ async function revalidateConcurrencyPaymentPreview(
   }
   return revalidated.kind === "checkout"
     ? { kind: "checkout", url: revalidated.url }
-    : { kind: "continue" };
+    : { kind: "continue", paymentMethod: revalidated };
 }
 
 const concurrencyCheckoutPreviewAuthed$ = command(
@@ -219,10 +224,16 @@ const concurrencyCheckoutPreviewAuthed$ = command(
       return bodyResult.response;
     }
     const { supportsInAppPreview, returnUrl } = bodyResult.data;
-    if (
-      supportsInAppPreview === true &&
-      (!returnUrl || !billingRedirectAllowed(returnUrl))
-    ) {
+    const previewEnabled = await set(
+      billingPurchasePreviewEnabled$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        requested: supportsInAppPreview === true,
+      },
+      signal,
+    );
+    if (previewEnabled && (!returnUrl || !billingRedirectAllowed(returnUrl))) {
       return badRequestMessage(
         "returnUrl must match the platform origin for in-app billing",
       );
@@ -243,7 +254,7 @@ const concurrencyCheckoutPreviewAuthed$ = command(
         orgId: auth.orgId,
         target,
         quantity: bodyResult.data.quantity,
-        supportsInAppPreview: supportsInAppPreview === true,
+        supportsInAppPreview: previewEnabled,
         returnUrl,
       },
       signal,
@@ -374,6 +385,7 @@ const concurrencyCheckoutAuthed$ = command(
       return badRequestMessage(target.message);
     }
 
+    let paymentMethod: BillingPurchasePaymentMethod | undefined;
     if (paymentMethodPreviewToken) {
       const revalidated = await revalidateConcurrencyPaymentPreview(
         {
@@ -391,6 +403,7 @@ const concurrencyCheckoutAuthed$ = command(
       if (revalidated.kind === "checkout") {
         return { status: 200 as const, body: { url: revalidated.url } };
       }
+      paymentMethod = revalidated.paymentMethod;
     }
 
     const purchase = await set(
@@ -404,6 +417,7 @@ const concurrencyCheckoutAuthed$ = command(
           target.existingSubscription?.scheduledQuantity !== null &&
           target.existingSubscription?.scheduledQuantity !== undefined,
         successUrl,
+        paymentMethod,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/billing-concurrency-subscriptions.ts
+++ b/turbo/apps/api/src/signals/routes/billing-concurrency-subscriptions.ts
@@ -3,6 +3,7 @@ import { zeroBillingConcurrencySubscriptionContract } from "@okouai/api-contract
 
 import { billingRedirectAllowed } from "../../lib/billing-redirect";
 import { optionalEnv } from "../../lib/env";
+import { nowDate } from "../../lib/time";
 import {
   badRequestMessage,
   conflict,
@@ -19,6 +20,12 @@ import {
   reduceConcurrencySubscription$,
   restoreConcurrencySubscription$,
 } from "../services/zero-billing-concurrency-subscription.service";
+import { getStripeClient } from "../external/stripe-client";
+import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
+import {
+  revalidateBillingPurchase,
+  routeBillingPurchasePreview,
+} from "../services/zero-billing-payment-method.service";
 import type { RouteEntry } from "../route-entry";
 
 const adminRequired = Object.freeze({
@@ -45,6 +52,15 @@ const previewConcurrencySubscriptionChangeAuthed$ = command(
     signal.throwIfAborted();
     if (!bodyResult.ok) {
       return bodyResult.response;
+    }
+    if (
+      bodyResult.data.supportsInAppPreview === true &&
+      (!bodyResult.data.returnUrl ||
+        !billingRedirectAllowed(bodyResult.data.returnUrl))
+    ) {
+      return badRequestMessage(
+        "returnUrl must match the platform origin for in-app billing",
+      );
     }
     const { subscriptionId } = get(
       pathParamsOf(zeroBillingConcurrencySubscriptionContract.previewChange),
@@ -88,6 +104,36 @@ const previewConcurrencySubscriptionChangeAuthed$ = command(
       }
     }
 
+    if (
+      bodyResult.data.supportsInAppPreview === true &&
+      bodyResult.data.returnUrl
+    ) {
+      const route = await routeBillingPurchasePreview(
+        {
+          stripe: getStripeClient(),
+          orgId: auth.orgId,
+          customerId: null,
+          subscriptionId,
+          operation: "concurrency",
+          operationId: `${subscriptionId}:${bodyResult.data.quantity}`,
+          returnUrl: bodyResult.data.returnUrl,
+        },
+        signal,
+      );
+      if (route.kind === "checkout") {
+        return {
+          status: 200 as const,
+          body: { ...result.preview, checkoutUrl: route.url },
+        };
+      }
+      return {
+        status: 200 as const,
+        body: {
+          ...result.preview,
+          paymentMethodPreviewToken: route.paymentMethodPreviewToken,
+        },
+      };
+    }
     return { status: 200 as const, body: result.preview };
   },
 );
@@ -130,6 +176,47 @@ const confirmConcurrencySubscriptionChangeAuthed$ = command(
     const { subscriptionId } = get(
       pathParamsOf(zeroBillingConcurrencySubscriptionContract.confirmChange),
     );
+    if (bodyResult.data.paymentMethodPreviewToken) {
+      const preview = parseBillingPaymentMethodPreviewToken(
+        bodyResult.data.paymentMethodPreviewToken,
+      );
+      if (
+        !preview ||
+        preview.operation !== "concurrency" ||
+        preview.operationId !==
+          `${subscriptionId}:${bodyResult.data.quantity}` ||
+        preview.orgId !== auth.orgId ||
+        preview.subscriptionId !== subscriptionId ||
+        new Date(preview.expiresAt) <= nowDate()
+      ) {
+        return conflict("Concurrency change preview is no longer valid");
+      }
+      const revalidated = await revalidateBillingPurchase(
+        {
+          stripe: getStripeClient(),
+          orgId: auth.orgId,
+          customerId: preview.customerId,
+          subscriptionId,
+          paymentMethodId: preview.paymentMethodId,
+          operation: preview.operation,
+          operationId: preview.operationId,
+          returnUrl: preview.returnUrl,
+        },
+        signal,
+      );
+      if (revalidated.kind === "invalid_preview") {
+        return conflict("Concurrency change preview is no longer valid");
+      }
+      if (revalidated.kind === "checkout") {
+        return {
+          status: 200 as const,
+          body: {
+            status: "checkout_required" as const,
+            checkoutUrl: revalidated.url,
+          },
+        };
+      }
+    }
     const result = await set(
       changeConcurrencySubscription$,
       {

--- a/turbo/apps/api/src/signals/routes/billing-concurrency-subscriptions.ts
+++ b/turbo/apps/api/src/signals/routes/billing-concurrency-subscriptions.ts
@@ -23,9 +23,11 @@ import {
 import { getStripeClient } from "../external/stripe-client";
 import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
 import {
+  billingPurchasePreviewEnabled$,
   revalidateBillingPurchase,
   routeBillingPurchasePreview,
-} from "../services/zero-billing-payment-method.service";
+  type BillingPurchasePaymentMethod,
+} from "../services/billing-payment-method.service";
 import type { RouteEntry } from "../route-entry";
 
 const adminRequired = Object.freeze({
@@ -53,8 +55,17 @@ const previewConcurrencySubscriptionChangeAuthed$ = command(
     if (!bodyResult.ok) {
       return bodyResult.response;
     }
+    const previewEnabled = await set(
+      billingPurchasePreviewEnabled$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        requested: bodyResult.data.supportsInAppPreview === true,
+      },
+      signal,
+    );
     if (
-      bodyResult.data.supportsInAppPreview === true &&
+      previewEnabled &&
       (!bodyResult.data.returnUrl ||
         !billingRedirectAllowed(bodyResult.data.returnUrl))
     ) {
@@ -104,10 +115,7 @@ const previewConcurrencySubscriptionChangeAuthed$ = command(
       }
     }
 
-    if (
-      bodyResult.data.supportsInAppPreview === true &&
-      bodyResult.data.returnUrl
-    ) {
+    if (previewEnabled && bodyResult.data.returnUrl) {
       const route = await routeBillingPurchasePreview(
         {
           stripe: getStripeClient(),
@@ -176,6 +184,7 @@ const confirmConcurrencySubscriptionChangeAuthed$ = command(
     const { subscriptionId } = get(
       pathParamsOf(zeroBillingConcurrencySubscriptionContract.confirmChange),
     );
+    let paymentMethod: BillingPurchasePaymentMethod | undefined;
     if (bodyResult.data.paymentMethodPreviewToken) {
       const preview = parseBillingPaymentMethodPreviewToken(
         bodyResult.data.paymentMethodPreviewToken,
@@ -216,6 +225,7 @@ const confirmConcurrencySubscriptionChangeAuthed$ = command(
           },
         };
       }
+      paymentMethod = revalidated;
     }
     const result = await set(
       changeConcurrencySubscription$,
@@ -223,6 +233,7 @@ const confirmConcurrencySubscriptionChangeAuthed$ = command(
         orgId: auth.orgId,
         subscriptionId,
         quantity: bodyResult.data.quantity,
+        paymentMethod,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/billing-credit-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-credit-checkout.ts
@@ -55,6 +55,7 @@ const creditCheckoutAuthed$ = command(
       cancelUrl,
       autoRecharge,
       previewExistingBilling,
+      supportsInAppPreview,
     } = bodyResult.data;
 
     const capabilities = await loadOrgPlanCapabilities(get(db$), auth.orgId);
@@ -112,10 +113,10 @@ const creditCheckoutAuthed$ = command(
     // hosted Checkout, while old app builds can omit this opt-in for about two
     // days during rollout. Remove the rollout compatibility after #26842; keep
     // an explicit hosted-checkout contract for CLI before narrowing this field.
-    if (previewExistingBilling === true) {
+    if (supportsInAppPreview === true || previewExistingBilling === true) {
       const preview = await set(
         previewExistingBillingCreditPurchase$,
-        { orgId: auth.orgId, credits },
+        { orgId: auth.orgId, credits, successUrl, cancelUrl },
         signal,
       );
       if (preview) {

--- a/turbo/apps/api/src/signals/routes/billing-credit-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-credit-checkout.ts
@@ -22,6 +22,7 @@ import {
 } from "../services/zero-billing-checkout.service";
 import { updateAutoRechargeConfig$ } from "../services/billing.service";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
+import { billingPurchasePreviewEnabled$ } from "../services/billing-payment-method.service";
 import type { RouteEntry } from "../route-entry";
 
 const adminRequired = Object.freeze({
@@ -113,7 +114,17 @@ const creditCheckoutAuthed$ = command(
     // hosted Checkout, while old app builds can omit this opt-in for about two
     // days during rollout. Remove the rollout compatibility after #26842; keep
     // an explicit hosted-checkout contract for CLI before narrowing this field.
-    if (supportsInAppPreview === true || previewExistingBilling === true) {
+    const previewEnabled = await set(
+      billingPurchasePreviewEnabled$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        requested:
+          supportsInAppPreview === true || previewExistingBilling === true,
+      },
+      signal,
+    );
+    if (previewEnabled) {
       const preview = await set(
         previewExistingBillingCreditPurchase$,
         { orgId: auth.orgId, credits, successUrl, cancelUrl },

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -29,9 +29,11 @@ import {
 } from "../services/usage-pack-invitation-purchase.service";
 import { activeUsagePackBillingContext } from "../services/usage-pack-subscription.service";
 import {
+  billingPurchasePreviewEnabled$,
   revalidateBillingPurchase,
   routeBillingPurchasePreview,
-} from "../services/zero-billing-payment-method.service";
+  type BillingPurchasePaymentMethod,
+} from "../services/billing-payment-method.service";
 import type { RouteEntry } from "../route-entry";
 
 const adminRequired = Object.freeze({
@@ -208,8 +210,17 @@ const purchasePreviewInner$ = command(
     if (!body.ok) {
       return body.response;
     }
+    const previewEnabled = await set(
+      billingPurchasePreviewEnabled$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        requested: body.data.supportsInAppPreview === true,
+      },
+      signal,
+    );
     if (
-      body.data.supportsInAppPreview === true &&
+      previewEnabled &&
       (!body.data.returnUrl || !billingRedirectAllowed(body.data.returnUrl))
     ) {
       return badRequestMessage(
@@ -236,7 +247,7 @@ const purchasePreviewInner$ = command(
         "This invitation cannot be purchased in the current billing state",
       );
     }
-    if (body.data.supportsInAppPreview === true && body.data.returnUrl) {
+    if (previewEnabled && body.data.returnUrl) {
       const billing = await activeUsagePackBillingContext(db, auth.orgId);
       signal.throwIfAborted();
       if (!billing) {
@@ -281,7 +292,10 @@ async function revalidateInvitationPurchasePreview(
   },
   signal: AbortSignal,
 ): Promise<
-  | { readonly kind: "continue" }
+  | {
+      readonly kind: "continue";
+      readonly paymentMethod: BillingPurchasePaymentMethod;
+    }
   | { readonly kind: "invalid_preview" }
   | { readonly kind: "checkout"; readonly url: string }
 > {
@@ -320,7 +334,7 @@ async function revalidateInvitationPurchasePreview(
   }
   return revalidated.kind === "checkout"
     ? { kind: "checkout", url: revalidated.url }
-    : { kind: "continue" };
+    : { kind: "continue", paymentMethod: revalidated };
 }
 
 const purchaseConfirmInner$ = command(
@@ -361,6 +375,7 @@ const purchaseConfirmInner$ = command(
     const { purchaseId } = get(
       pathParamsOf(zeroOrgInviteContract.confirmPurchase),
     );
+    let paymentMethod: BillingPurchasePaymentMethod | undefined;
     if (body.data.paymentMethodPreviewToken) {
       const revalidated = await revalidateInvitationPurchasePreview(
         {
@@ -383,11 +398,12 @@ const purchaseConfirmInner$ = command(
           },
         };
       }
+      paymentMethod = revalidated.paymentMethod;
     }
     const result = await confirmUsagePackInvitationPurchase(
       set(writeDb$),
       get(clerk$),
-      { orgId: auth.orgId, purchaseId },
+      { orgId: auth.orgId, purchaseId, paymentMethod },
       signal,
     );
     if (result.status === "not_found") {

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -418,6 +418,9 @@ const purchaseConfirmInner$ = command(
       );
     }
     if (result.status === "pending_payment") {
+      if (!body.data.paymentMethodPreviewToken) {
+        return conflict("Payment confirmation is required");
+      }
       return {
         status: 200 as const,
         body: {

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -4,6 +4,8 @@ import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { env, optionalEnv } from "../../lib/env";
+import { billingRedirectAllowed } from "../../lib/billing-redirect";
+import { nowDate } from "../../lib/time";
 import {
   badRequestMessage,
   conflict,
@@ -14,7 +16,9 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { clerk$ } from "../external/clerk";
-import { db$, writeDb$ } from "../external/db";
+import { db$, writeDb$, type ReadonlyDb } from "../external/db";
+import { getStripeClient } from "../external/stripe-client";
+import { parseBillingPaymentMethodPreviewToken } from "../services/billing-purchase-preview-token.service";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { loadOrgPlanCapabilities } from "../services/org-plan-entitlement-read.service";
 import {
@@ -23,6 +27,11 @@ import {
   revokeUsagePackInvitationPurchase,
   usagePackInvitationPurchaseSchemaAvailable,
 } from "../services/usage-pack-invitation-purchase.service";
+import { activeUsagePackBillingContext } from "../services/usage-pack-subscription.service";
+import {
+  revalidateBillingPurchase,
+  routeBillingPurchasePreview,
+} from "../services/zero-billing-payment-method.service";
 import type { RouteEntry } from "../route-entry";
 
 const adminRequired = Object.freeze({
@@ -199,6 +208,14 @@ const purchasePreviewInner$ = command(
     if (!body.ok) {
       return body.response;
     }
+    if (
+      body.data.supportsInAppPreview === true &&
+      (!body.data.returnUrl || !billingRedirectAllowed(body.data.returnUrl))
+    ) {
+      return badRequestMessage(
+        "returnUrl must match the platform origin for in-app billing",
+      );
+    }
     const result = await createUsagePackInvitationPreview(
       set(writeDb$),
       get(clerk$),
@@ -219,9 +236,92 @@ const purchasePreviewInner$ = command(
         "This invitation cannot be purchased in the current billing state",
       );
     }
+    if (body.data.supportsInAppPreview === true && body.data.returnUrl) {
+      const billing = await activeUsagePackBillingContext(db, auth.orgId);
+      signal.throwIfAborted();
+      if (!billing) {
+        return notFound("Usage pack subscription not found");
+      }
+      const route = await routeBillingPurchasePreview(
+        {
+          stripe: getStripeClient(),
+          orgId: auth.orgId,
+          customerId: billing.stripeCustomerId,
+          subscriptionId: billing.stripeSubscriptionId,
+          operation: "usage_pack_invitation",
+          operationId: result.preview.purchaseId,
+          returnUrl: body.data.returnUrl,
+        },
+        signal,
+      );
+      if (route.kind === "checkout") {
+        return {
+          status: 200 as const,
+          body: { ...result.preview, checkoutUrl: route.url },
+        };
+      }
+      return {
+        status: 200 as const,
+        body: {
+          ...result.preview,
+          paymentMethodPreviewToken: route.paymentMethodPreviewToken,
+        },
+      };
+    }
     return { status: 200 as const, body: result.preview };
   },
 );
+
+async function revalidateInvitationPurchasePreview(
+  args: {
+    readonly db: ReadonlyDb;
+    readonly orgId: string;
+    readonly purchaseId: string;
+    readonly paymentMethodPreviewToken: string;
+  },
+  signal: AbortSignal,
+): Promise<
+  | { readonly kind: "continue" }
+  | { readonly kind: "invalid_preview" }
+  | { readonly kind: "checkout"; readonly url: string }
+> {
+  const preview = parseBillingPaymentMethodPreviewToken(
+    args.paymentMethodPreviewToken,
+  );
+  const billing = await activeUsagePackBillingContext(args.db, args.orgId);
+  signal.throwIfAborted();
+  if (
+    !preview ||
+    !billing ||
+    preview.operation !== "usage_pack_invitation" ||
+    preview.operationId !== args.purchaseId ||
+    preview.orgId !== args.orgId ||
+    preview.customerId !== billing.stripeCustomerId ||
+    preview.subscriptionId !== billing.stripeSubscriptionId ||
+    new Date(preview.expiresAt) <= nowDate()
+  ) {
+    return { kind: "invalid_preview" };
+  }
+  const revalidated = await revalidateBillingPurchase(
+    {
+      stripe: getStripeClient(),
+      orgId: args.orgId,
+      customerId: preview.customerId,
+      subscriptionId: preview.subscriptionId,
+      paymentMethodId: preview.paymentMethodId,
+      operation: preview.operation,
+      operationId: preview.operationId,
+      returnUrl: preview.returnUrl,
+    },
+    signal,
+  );
+  if (revalidated.kind === "invalid_preview") {
+    return { kind: "invalid_preview" };
+  }
+  return revalidated.kind === "checkout"
+    ? { kind: "checkout", url: revalidated.url }
+    : { kind: "continue" };
+}
 
 const purchaseConfirmInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -253,9 +353,37 @@ const purchaseConfirmInner$ = command(
     if (!(await usagePackInvitationPurchaseSchemaAvailable(db))) {
       return providerUnavailable("Usage pack invitations are not ready");
     }
+    const body = await get(bodyResultOf(zeroOrgInviteContract.confirmPurchase));
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
     const { purchaseId } = get(
       pathParamsOf(zeroOrgInviteContract.confirmPurchase),
     );
+    if (body.data.paymentMethodPreviewToken) {
+      const revalidated = await revalidateInvitationPurchasePreview(
+        {
+          db,
+          orgId: auth.orgId,
+          purchaseId,
+          paymentMethodPreviewToken: body.data.paymentMethodPreviewToken,
+        },
+        signal,
+      );
+      if (revalidated.kind === "invalid_preview") {
+        return conflict("Invitation purchase preview is no longer valid");
+      }
+      if (revalidated.kind === "checkout") {
+        return {
+          status: 200 as const,
+          body: {
+            status: "checkout_required" as const,
+            checkoutUrl: revalidated.url,
+          },
+        };
+      }
+    }
     const result = await confirmUsagePackInvitationPurchase(
       set(writeDb$),
       get(clerk$),
@@ -272,6 +400,15 @@ const purchaseConfirmInner$ = command(
       return conflict(
         "This invitation cannot be purchased in the current billing state",
       );
+    }
+    if (result.status === "pending_payment") {
+      return {
+        status: 200 as const,
+        body: {
+          status: "pending_payment" as const,
+          hostedInvoiceUrl: result.hostedInvoiceUrl,
+        },
+      };
     }
     return {
       status: 200 as const,

--- a/turbo/apps/api/src/signals/services/billing-operation-invoice.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-operation-invoice.service.ts
@@ -1,0 +1,74 @@
+import type { StripeClient, StripeInvoice } from "../external/stripe-client";
+import { settle } from "../utils";
+
+type BillingOperationInvoiceResult =
+  | { readonly status: "completed"; readonly hostedInvoiceUrl: null }
+  | {
+      readonly status: "pending_payment";
+      readonly hostedInvoiceUrl: string;
+    };
+
+async function finalizeOperationInvoice(
+  stripe: StripeClient,
+  invoice: StripeInvoice,
+  operationId: string,
+  signal: AbortSignal,
+): Promise<StripeInvoice> {
+  if (invoice.status !== "draft") {
+    return invoice;
+  }
+  const finalized = await stripe.invoices.finalizeInvoice(
+    invoice.id,
+    {},
+    { idempotencyKey: `billing-operation:${operationId}:finalize` },
+  );
+  signal.throwIfAborted();
+  return finalized;
+}
+
+export async function completeBillingOperationInvoice(
+  stripe: StripeClient,
+  invoice: StripeInvoice | null,
+  operationId: string,
+  signal: AbortSignal,
+  options?: { readonly payOpenInvoice?: boolean },
+): Promise<BillingOperationInvoiceResult> {
+  if (!invoice) {
+    return { status: "completed", hostedInvoiceUrl: null };
+  }
+
+  const shouldPay = invoice.status === "draft" || options?.payOpenInvoice;
+  let current = await finalizeOperationInvoice(
+    stripe,
+    invoice,
+    operationId,
+    signal,
+  );
+  if (shouldPay && current.status === "open") {
+    const payment = await settle(
+      stripe.invoices.pay(
+        current.id,
+        {},
+        { idempotencyKey: `billing-operation:${operationId}:pay` },
+      ),
+      signal,
+    );
+    current = payment.ok
+      ? payment.value
+      : await stripe.invoices.retrieve(current.id);
+    signal.throwIfAborted();
+  }
+
+  if (current.status === "paid") {
+    return { status: "completed", hostedInvoiceUrl: null };
+  }
+  if (current.status === "open" && current.hosted_invoice_url) {
+    return {
+      status: "pending_payment",
+      hostedInvoiceUrl: current.hosted_invoice_url,
+    };
+  }
+  throw new Error(
+    `Stripe operation invoice ${current.id} is ${current.status ?? "missing a status"} without a hosted payment URL`,
+  );
+}

--- a/turbo/apps/api/src/signals/services/billing-operation-invoice.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-operation-invoice.service.ts
@@ -8,6 +8,11 @@ type BillingOperationInvoiceResult =
       readonly hostedInvoiceUrl: string;
     };
 
+interface BillingOperationInvoiceCompletion {
+  readonly response: BillingOperationInvoiceResult;
+  readonly paidInvoice: StripeInvoice | null;
+}
+
 async function finalizeOperationInvoice(
   stripe: StripeClient,
   invoice: StripeInvoice,
@@ -26,15 +31,18 @@ async function finalizeOperationInvoice(
   return finalized;
 }
 
-export async function completeBillingOperationInvoice(
+export async function completeBillingOperationInvoiceWithInvoice(
   stripe: StripeClient,
   invoice: StripeInvoice | null,
   operationId: string,
   signal: AbortSignal,
   options?: { readonly payOpenInvoice?: boolean },
-): Promise<BillingOperationInvoiceResult> {
+): Promise<BillingOperationInvoiceCompletion> {
   if (!invoice) {
-    return { status: "completed", hostedInvoiceUrl: null };
+    return {
+      response: { status: "completed", hostedInvoiceUrl: null },
+      paidInvoice: null,
+    };
   }
 
   const shouldPay = invoice.status === "draft" || options?.payOpenInvoice;
@@ -60,15 +68,38 @@ export async function completeBillingOperationInvoice(
   }
 
   if (current.status === "paid") {
-    return { status: "completed", hostedInvoiceUrl: null };
+    return {
+      response: { status: "completed", hostedInvoiceUrl: null },
+      paidInvoice: current,
+    };
   }
   if (current.status === "open" && current.hosted_invoice_url) {
     return {
-      status: "pending_payment",
-      hostedInvoiceUrl: current.hosted_invoice_url,
+      response: {
+        status: "pending_payment",
+        hostedInvoiceUrl: current.hosted_invoice_url,
+      },
+      paidInvoice: null,
     };
   }
   throw new Error(
     `Stripe operation invoice ${current.id} is ${current.status ?? "missing a status"} without a hosted payment URL`,
   );
+}
+
+export async function completeBillingOperationInvoice(
+  stripe: StripeClient,
+  invoice: StripeInvoice | null,
+  operationId: string,
+  signal: AbortSignal,
+  options?: { readonly payOpenInvoice?: boolean },
+): Promise<BillingOperationInvoiceResult> {
+  const completion = await completeBillingOperationInvoiceWithInvoice(
+    stripe,
+    invoice,
+    operationId,
+    signal,
+    options,
+  );
+  return completion.response;
 }

--- a/turbo/apps/api/src/signals/services/billing-payment-method.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-payment-method.service.ts
@@ -1,7 +1,13 @@
 import { getStripeClient } from "../external/stripe-client";
+import {
+  billingPreviewExpiresAt,
+  createBillingPaymentMethodPreviewToken,
+  type BillingPaymentMethodPreviewToken,
+} from "./billing-purchase-preview-token.service";
 
 export const BILLING_RESTORE_PURPOSE = "billing_restore";
 export const BILLING_DOWNGRADE_PURPOSE = "billing_downgrade";
+export const BILLING_PURCHASE_PURPOSE = "billing_purchase";
 
 interface BillingSubscriptionOrg {
   readonly stripeCustomerId: string | null;
@@ -20,28 +26,32 @@ function stripeObjectId(value: unknown): string | null {
   return typeof record.id === "string" ? record.id : null;
 }
 
-function subscriptionDefaultPaymentMethodId(
-  subscription: unknown,
-): string | null {
+function subscriptionPaymentMethods(subscription: unknown): {
+  readonly defaultPaymentMethodId: string | null;
+  readonly defaultSourceId: string | null;
+} {
   if (typeof subscription !== "object" || subscription === null) {
-    return null;
+    return { defaultPaymentMethodId: null, defaultSourceId: null };
   }
   const record = subscription as {
     readonly default_payment_method?: unknown;
     readonly default_source?: unknown;
   };
-  return (
-    stripeObjectId(record.default_payment_method) ??
-    stripeObjectId(record.default_source)
-  );
+  return {
+    defaultPaymentMethodId: stripeObjectId(record.default_payment_method),
+    defaultSourceId: stripeObjectId(record.default_source),
+  };
 }
 
-function customerDefaultPaymentMethodId(customer: unknown): string | null {
+function customerPaymentMethods(customer: unknown): {
+  readonly defaultPaymentMethodId: string | null;
+  readonly defaultSourceId: string | null;
+} {
   if (typeof customer !== "object" || customer === null) {
-    return null;
+    return { defaultPaymentMethodId: null, defaultSourceId: null };
   }
   if ("deleted" in customer && customer.deleted === true) {
-    return null;
+    return { defaultPaymentMethodId: null, defaultSourceId: null };
   }
 
   const record = customer as {
@@ -50,10 +60,12 @@ function customerDefaultPaymentMethodId(customer: unknown): string | null {
     } | null;
     readonly default_source?: unknown;
   };
-  return (
-    stripeObjectId(record.invoice_settings?.default_payment_method) ??
-    stripeObjectId(record.default_source)
-  );
+  return {
+    defaultPaymentMethodId: stripeObjectId(
+      record.invoice_settings?.default_payment_method,
+    ),
+    defaultSourceId: stripeObjectId(record.default_source),
+  };
 }
 
 function subscriptionCustomerId(
@@ -75,42 +87,242 @@ export async function billingDefaultPaymentMethodStatus(args: {
   readonly org: BillingSubscriptionOrg;
   readonly subscription?: unknown;
 }): Promise<{ readonly ready: boolean; readonly customerId: string | null }> {
-  if (!args.org.stripeSubscriptionId) {
-    return { ready: false, customerId: args.org.stripeCustomerId };
+  const route = await resolveBillingPurchaseRoute({
+    stripe: args.stripe,
+    supportsInAppPreview: true,
+    customerId: args.org.stripeCustomerId,
+    subscriptionId: args.org.stripeSubscriptionId,
+    subscription: args.subscription,
+  });
+  return {
+    ready: route.kind === "preview",
+    customerId: route.customerId,
+  };
+}
+
+type BillingPurchaseRoute =
+  | {
+      readonly kind: "checkout";
+      readonly customerId: string | null;
+    }
+  | {
+      readonly kind: "preview";
+      readonly customerId: string;
+      readonly paymentMethodId: string;
+      readonly paymentMethodType: "payment_method" | "source";
+    };
+
+export function stripeBillingPurchasePaymentParams(
+  route: Extract<BillingPurchaseRoute, { readonly kind: "preview" }>,
+):
+  | { readonly default_payment_method: string }
+  | { readonly default_source: string } {
+  return route.paymentMethodType === "payment_method"
+    ? { default_payment_method: route.paymentMethodId }
+    : { default_source: route.paymentMethodId };
+}
+
+type BillingPurchasePreviewRoute =
+  | { readonly kind: "checkout"; readonly url: string }
+  | { readonly kind: "preview"; readonly paymentMethodPreviewToken: string };
+
+export async function resolveBillingPurchaseRoute(
+  args: {
+    readonly stripe: ReturnType<typeof getStripeClient>;
+    readonly supportsInAppPreview: boolean;
+    readonly customerId: string | null;
+    readonly subscriptionId?: string | null;
+    readonly subscription?: unknown;
+  },
+  signal?: AbortSignal,
+): Promise<BillingPurchaseRoute> {
+  if (!args.supportsInAppPreview) {
+    return { kind: "checkout", customerId: args.customerId };
   }
 
-  const subscription =
-    args.subscription ??
-    (await args.stripe.subscriptions.retrieve(args.org.stripeSubscriptionId));
-  if (subscriptionDefaultPaymentMethodId(subscription)) {
+  const subscription = args.subscriptionId
+    ? (args.subscription ??
+      (await args.stripe.subscriptions.retrieve(args.subscriptionId)))
+    : undefined;
+  signal?.throwIfAborted();
+  const subscriptionMethods = subscriptionPaymentMethods(subscription);
+  const customerId = subscription
+    ? subscriptionCustomerId(
+        {
+          stripeCustomerId: args.customerId,
+          stripeSubscriptionId: args.subscriptionId ?? null,
+        },
+        subscription,
+      )
+    : args.customerId;
+  if (subscriptionMethods.defaultPaymentMethodId && customerId) {
     return {
-      ready: true,
-      customerId: subscriptionCustomerId(args.org, subscription),
+      kind: "preview",
+      customerId,
+      paymentMethodId: subscriptionMethods.defaultPaymentMethodId,
+      paymentMethodType: "payment_method",
     };
   }
 
-  const customerId = subscriptionCustomerId(args.org, subscription);
   if (!customerId) {
-    return { ready: false, customerId: null };
+    return { kind: "checkout", customerId: null };
   }
 
   const customer = await args.stripe.customers.retrieve(customerId);
+  signal?.throwIfAborted();
+  const customerMethods = customerPaymentMethods(customer);
+  if (customerMethods.defaultPaymentMethodId) {
+    return {
+      kind: "preview",
+      customerId,
+      paymentMethodId: customerMethods.defaultPaymentMethodId,
+      paymentMethodType: "payment_method",
+    };
+  }
+
+  const paymentMethods = await args.stripe.paymentMethods.list({
+    customer: customerId,
+    type: "card",
+    limit: 1,
+  });
+  signal?.throwIfAborted();
+  const attachedCardId = paymentMethods.data[0]?.id;
+  if (attachedCardId) {
+    return {
+      kind: "preview",
+      customerId,
+      paymentMethodId: attachedCardId,
+      paymentMethodType: "payment_method",
+    };
+  }
+
+  const legacySourceId =
+    subscriptionMethods.defaultSourceId ?? customerMethods.defaultSourceId;
+  return legacySourceId
+    ? {
+        kind: "preview",
+        customerId,
+        paymentMethodId: legacySourceId,
+        paymentMethodType: "source",
+      }
+    : { kind: "checkout", customerId };
+}
+
+export async function routeBillingPurchasePreview(
+  args: {
+    readonly stripe: ReturnType<typeof getStripeClient>;
+    readonly orgId: string;
+    readonly customerId: string | null;
+    readonly subscriptionId: string;
+    readonly operation: BillingPaymentMethodPreviewToken["operation"];
+    readonly operationId: string;
+    readonly returnUrl: string;
+  },
+  signal: AbortSignal,
+): Promise<BillingPurchasePreviewRoute> {
+  const route = await resolveBillingPurchaseRoute(
+    {
+      stripe: args.stripe,
+      supportsInAppPreview: true,
+      customerId: args.customerId,
+      subscriptionId: args.subscriptionId,
+    },
+    signal,
+  );
+  if (route.kind === "checkout") {
+    if (!route.customerId) {
+      throw new Error("Stripe billing purchase has no customer");
+    }
+    return {
+      kind: "checkout",
+      url: await createBillingSetupCheckout({
+        stripe: args.stripe,
+        purpose: BILLING_PURCHASE_PURPOSE,
+        orgId: args.orgId,
+        customerId: route.customerId,
+        subscriptionId: args.subscriptionId,
+        returnUrl: args.returnUrl,
+        idempotencyKey: `billing-purchase-setup:${args.operation}:${args.operationId}`,
+      }),
+    };
+  }
   return {
-    ready: customerDefaultPaymentMethodId(customer) !== null,
-    customerId,
+    kind: "preview",
+    paymentMethodPreviewToken: createBillingPaymentMethodPreviewToken({
+      version: 1,
+      operation: args.operation,
+      operationId: args.operationId,
+      orgId: args.orgId,
+      customerId: route.customerId,
+      subscriptionId: args.subscriptionId,
+      paymentMethodId: route.paymentMethodId,
+      returnUrl: args.returnUrl,
+      expiresAt: billingPreviewExpiresAt(),
+    }),
   };
+}
+
+type RevalidatedBillingPurchase =
+  | { readonly kind: "preview"; readonly paymentMethodId: string }
+  | { readonly kind: "checkout"; readonly url: string }
+  | { readonly kind: "invalid_preview" };
+
+export async function revalidateBillingPurchase(
+  args: {
+    readonly stripe: ReturnType<typeof getStripeClient>;
+    readonly orgId: string;
+    readonly customerId: string;
+    readonly subscriptionId: string;
+    readonly paymentMethodId: string;
+    readonly operation: BillingPaymentMethodPreviewToken["operation"];
+    readonly operationId: string;
+    readonly returnUrl: string;
+  },
+  signal: AbortSignal,
+): Promise<RevalidatedBillingPurchase> {
+  const route = await resolveBillingPurchaseRoute(
+    {
+      stripe: args.stripe,
+      supportsInAppPreview: true,
+      customerId: args.customerId,
+      subscriptionId: args.subscriptionId,
+    },
+    signal,
+  );
+  if (route.customerId !== args.customerId) {
+    return { kind: "invalid_preview" };
+  }
+  if (route.kind === "checkout") {
+    return {
+      kind: "checkout",
+      url: await createBillingSetupCheckout({
+        stripe: args.stripe,
+        purpose: BILLING_PURCHASE_PURPOSE,
+        orgId: args.orgId,
+        customerId: args.customerId,
+        subscriptionId: args.subscriptionId,
+        returnUrl: args.returnUrl,
+        idempotencyKey: `billing-purchase-setup:${args.operation}:${args.operationId}`,
+      }),
+    };
+  }
+  return route.paymentMethodId === args.paymentMethodId
+    ? { kind: "preview", paymentMethodId: route.paymentMethodId }
+    : { kind: "invalid_preview" };
 }
 
 export async function createBillingSetupCheckout(args: {
   readonly stripe: ReturnType<typeof getStripeClient>;
   readonly purpose:
     | typeof BILLING_RESTORE_PURPOSE
-    | typeof BILLING_DOWNGRADE_PURPOSE;
+    | typeof BILLING_DOWNGRADE_PURPOSE
+    | typeof BILLING_PURCHASE_PURPOSE;
   readonly orgId: string;
   readonly customerId: string;
   readonly subscriptionId: string;
   readonly returnUrl: string;
   readonly metadata?: Readonly<Record<string, string>>;
+  readonly idempotencyKey?: string;
 }): Promise<string> {
   const metadata = {
     purpose: args.purpose,
@@ -118,7 +330,7 @@ export async function createBillingSetupCheckout(args: {
     subscriptionId: args.subscriptionId,
     ...args.metadata,
   };
-  const session = await args.stripe.checkout.sessions.create({
+  const params = {
     mode: "setup",
     customer: args.customerId,
     currency: "usd",
@@ -126,7 +338,12 @@ export async function createBillingSetupCheckout(args: {
     cancel_url: args.returnUrl,
     metadata,
     setup_intent_data: { metadata },
-  });
+  } as const;
+  const session = args.idempotencyKey
+    ? await args.stripe.checkout.sessions.create(params, {
+        idempotencyKey: args.idempotencyKey,
+      })
+    : await args.stripe.checkout.sessions.create(params);
 
   if (!session.url) {
     throw new Error("Stripe checkout session did not return a URL");

--- a/turbo/apps/api/src/signals/services/billing-payment-method.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-payment-method.service.ts
@@ -130,6 +130,19 @@ export function stripeBillingPurchasePaymentParams(
     : { default_source: paymentMethod.paymentMethodId };
 }
 
+export async function setStripeSubscriptionPaymentMethod(
+  stripe: ReturnType<typeof getStripeClient>,
+  subscriptionId: string,
+  paymentMethod: BillingPurchasePaymentMethod,
+  signal: AbortSignal,
+): Promise<void> {
+  await stripe.subscriptions.update(
+    subscriptionId,
+    stripeBillingPurchasePaymentParams(paymentMethod),
+  );
+  signal.throwIfAborted();
+}
+
 export const billingPurchasePreviewEnabled$ = command(
   async (
     { get },

--- a/turbo/apps/api/src/signals/services/billing-payment-method.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-payment-method.service.ts
@@ -275,7 +275,6 @@ export async function routeBillingPurchasePreview(
         customerId: route.customerId,
         subscriptionId: args.subscriptionId,
         returnUrl: args.returnUrl,
-        idempotencyKey: `billing-purchase-setup:${args.operation}:${args.operationId}`,
       }),
     };
   }
@@ -335,7 +334,6 @@ export async function revalidateBillingPurchase(
         customerId: args.customerId,
         subscriptionId: args.subscriptionId,
         returnUrl: args.returnUrl,
-        idempotencyKey: `billing-purchase-setup:${args.operation}:${args.operationId}`,
       }),
     };
   }

--- a/turbo/apps/api/src/signals/services/billing-payment-method.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-payment-method.service.ts
@@ -1,4 +1,9 @@
+import { command } from "ccstate";
+import { isFeatureEnabled } from "@okouai/core/feature-switch";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+
 import { getStripeClient } from "../external/stripe-client";
+import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import {
   billingPreviewExpiresAt,
   createBillingPaymentMethodPreviewToken,
@@ -100,27 +105,55 @@ export async function billingDefaultPaymentMethodStatus(args: {
   };
 }
 
+export interface BillingPurchasePaymentMethod {
+  readonly paymentMethodId: string;
+  readonly paymentMethodType: "payment_method" | "source";
+}
+
 type BillingPurchaseRoute =
   | {
       readonly kind: "checkout";
       readonly customerId: string | null;
     }
-  | {
+  | (BillingPurchasePaymentMethod & {
       readonly kind: "preview";
       readonly customerId: string;
-      readonly paymentMethodId: string;
-      readonly paymentMethodType: "payment_method" | "source";
-    };
+    });
 
 export function stripeBillingPurchasePaymentParams(
-  route: Extract<BillingPurchaseRoute, { readonly kind: "preview" }>,
+  paymentMethod: BillingPurchasePaymentMethod,
 ):
   | { readonly default_payment_method: string }
   | { readonly default_source: string } {
-  return route.paymentMethodType === "payment_method"
-    ? { default_payment_method: route.paymentMethodId }
-    : { default_source: route.paymentMethodId };
+  return paymentMethod.paymentMethodType === "payment_method"
+    ? { default_payment_method: paymentMethod.paymentMethodId }
+    : { default_source: paymentMethod.paymentMethodId };
 }
+
+export const billingPurchasePreviewEnabled$ = command(
+  async (
+    { get },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly requested: boolean;
+    },
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    if (!args.requested) {
+      return false;
+    }
+    const overrides = await get(
+      userFeatureSwitchOverrides(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+    return isFeatureEnabled(FeatureSwitchKey.SavedBillingCreditPurchase, {
+      orgId: args.orgId,
+      userId: args.userId,
+      overrides,
+    });
+  },
+);
 
 type BillingPurchasePreviewRoute =
   | { readonly kind: "checkout"; readonly url: string }
@@ -263,7 +296,7 @@ export async function routeBillingPurchasePreview(
 }
 
 type RevalidatedBillingPurchase =
-  | { readonly kind: "preview"; readonly paymentMethodId: string }
+  | ({ readonly kind: "preview" } & BillingPurchasePaymentMethod)
   | { readonly kind: "checkout"; readonly url: string }
   | { readonly kind: "invalid_preview" };
 
@@ -307,7 +340,11 @@ export async function revalidateBillingPurchase(
     };
   }
   return route.paymentMethodId === args.paymentMethodId
-    ? { kind: "preview", paymentMethodId: route.paymentMethodId }
+    ? {
+        kind: "preview",
+        paymentMethodId: route.paymentMethodId,
+        paymentMethodType: route.paymentMethodType,
+      }
     : { kind: "invalid_preview" };
 }
 

--- a/turbo/apps/api/src/signals/services/billing-purchase-lock.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-purchase-lock.service.ts
@@ -1,0 +1,15 @@
+import { sql } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+/** Serializes initial Plan and usage-pack subscription creation per org. */
+export async function lockBillingPurchaseOrg(
+  tx: Pick<WriteTx, "execute">,
+  orgId: string,
+): Promise<void> {
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtextextended(${`billing_purchase:${orgId}`}, 0))`,
+  );
+}

--- a/turbo/apps/api/src/signals/services/billing-purchase-preview-token.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-purchase-preview-token.service.ts
@@ -1,0 +1,89 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { z } from "zod";
+
+import { env } from "../../lib/env";
+import { nowDate } from "../../lib/time";
+import { safeJsonParse } from "../utils";
+
+const BILLING_PURCHASE_PREVIEW_TTL_MS = 15 * 60 * 1000;
+
+const billingPaymentMethodPreviewTokenSchema = z.object({
+  version: z.literal(1),
+  operation: z.enum([
+    "concurrency",
+    "usage_pack_allocation",
+    "usage_pack_invitation",
+    "usage_pack_subscription",
+  ]),
+  operationId: z.string().min(1),
+  orgId: z.string().min(1),
+  customerId: z.string().min(1),
+  subscriptionId: z.string().min(1),
+  paymentMethodId: z.string().min(1),
+  returnUrl: z.string().url(),
+  expiresAt: z.iso.datetime(),
+});
+
+export type BillingPaymentMethodPreviewToken = z.infer<
+  typeof billingPaymentMethodPreviewTokenSchema
+>;
+
+function billingPreviewSignature(encodedPayload: string): Buffer {
+  return createHmac("sha256", env("SECRETS_ENCRYPTION_KEY"))
+    .update(encodedPayload)
+    .digest();
+}
+
+export function createBillingPreviewToken(payload: unknown): string {
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+    "base64url",
+  );
+  const encodedSignature =
+    billingPreviewSignature(encodedPayload).toString("base64url");
+  return `${encodedPayload}.${encodedSignature}`;
+}
+
+export function parseBillingPreviewToken<T>(
+  token: string,
+  schema: z.ZodType<T>,
+): T | null {
+  const [encodedPayload, encodedSignature, extra] = token.split(".");
+  if (!encodedPayload || !encodedSignature || extra !== undefined) {
+    return null;
+  }
+  const providedSignature = Buffer.from(encodedSignature, "base64url");
+  const expectedSignature = billingPreviewSignature(encodedPayload);
+  if (
+    providedSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(providedSignature, expectedSignature)
+  ) {
+    return null;
+  }
+  const parsed = safeJsonParse(
+    Buffer.from(encodedPayload, "base64url").toString("utf8"),
+  );
+  const result = schema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
+export function billingPreviewExpiresAt(): string {
+  return new Date(
+    nowDate().getTime() + BILLING_PURCHASE_PREVIEW_TTL_MS,
+  ).toISOString();
+}
+
+export function createBillingPaymentMethodPreviewToken(
+  payload: BillingPaymentMethodPreviewToken,
+): string {
+  return createBillingPreviewToken(payload);
+}
+
+export function parseBillingPaymentMethodPreviewToken(
+  token: string,
+): BillingPaymentMethodPreviewToken | null {
+  return parseBillingPreviewToken(
+    token,
+    billingPaymentMethodPreviewTokenSchema,
+  );
+}

--- a/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
@@ -48,6 +48,10 @@ import {
 } from "./usage-pack-credit-refund.service";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
 import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
+import {
+  stripeBillingPurchasePaymentParams,
+  type BillingPurchasePaymentMethod,
+} from "./billing-payment-method.service";
 import { downgradeSubscriptionForOrg } from "./zero-billing-downgrade.service";
 import {
   activeUsagePackPriceId,
@@ -3623,11 +3627,14 @@ async function confirmUsagePackDowngrade(
 
 async function confirmUsagePackUpgrade(
   db: Db,
-  context: UsagePackChangeContext,
-  change: UsagePackAllocationChangeRow,
-  subscription: StripeSubscription,
+  args: {
+    readonly change: UsagePackAllocationChangeRow;
+    readonly subscription: StripeSubscription;
+    readonly paymentMethod: BillingPurchasePaymentMethod | undefined;
+  },
   signal: AbortSignal,
 ): Promise<UsagePackChangeConfirmResult> {
+  const { change, subscription, paymentMethod } = args;
   if (
     !change.sourceStripePriceId ||
     !change.targetStripePriceId ||
@@ -3650,6 +3657,9 @@ async function confirmUsagePackUpgrade(
     subscription.id,
     {
       items,
+      ...(paymentMethod
+        ? stripeBillingPurchasePaymentParams(paymentMethod)
+        : {}),
       payment_behavior: "pending_if_incomplete",
       proration_behavior: "always_invoice",
       proration_date: change.prorationTimestamp,
@@ -3802,6 +3812,7 @@ export async function confirmUsagePackAllocationChange(
   args: {
     readonly orgId: string;
     readonly changeId: string;
+    readonly paymentMethod?: BillingPurchasePaymentMethod;
   },
   signal: AbortSignal,
 ): Promise<UsagePackChangeConfirmResult> {
@@ -3867,9 +3878,11 @@ export async function confirmUsagePackAllocationChange(
   }
   return await confirmUsagePackUpgrade(
     db,
-    context,
-    change,
-    subscription,
+    {
+      change,
+      subscription,
+      paymentMethod: args.paymentMethod,
+    },
     signal,
   );
 }

--- a/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
@@ -47,6 +47,7 @@ import {
   prepareUsagePackMemberCreditRefunds,
 } from "./usage-pack-credit-refund.service";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
+import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
 import { downgradeSubscriptionForOrg } from "./zero-billing-downgrade.service";
 import {
   activeUsagePackPriceId,
@@ -960,6 +961,28 @@ export async function previewUsagePackAllocationChange(
       expiresAt: preview.expiresAt.toISOString(),
     },
   };
+}
+
+export async function discardUsagePackAllocationChangePreviewForPaymentSetup(
+  db: Db,
+  args: { readonly orgId: string; readonly changeId: string },
+): Promise<void> {
+  const discardedAt = nowDate();
+  await db
+    .update(usagePackAllocationChanges)
+    .set({
+      status: "failed",
+      failureReason: "payment_method_setup_required",
+      completedAt: discardedAt,
+      updatedAt: discardedAt,
+    })
+    .where(
+      and(
+        eq(usagePackAllocationChanges.id, args.changeId),
+        eq(usagePackAllocationChanges.orgId, args.orgId),
+        eq(usagePackAllocationChanges.status, "previewed"),
+      ),
+    );
 }
 
 function subscriptionPhaseItems(
@@ -3636,14 +3659,23 @@ async function confirmUsagePackUpgrade(
   );
   signal.throwIfAborted();
   const invoice = latestInvoice(updatedSubscription);
+  if (!invoice) {
+    throw new Error("Stripe did not create a usage pack change invoice");
+  }
+  const payment = await completeBillingOperationInvoice(
+    getStripeClient(),
+    invoice,
+    `usage-pack-allocation:${change.id}`,
+    signal,
+  );
   const pendingExpiry = pendingUpdateExpiry(updatedSubscription);
-  const pending = Boolean(updatedSubscription.pending_update);
+  const pending = payment.status === "pending_payment";
   const updatedAt = nowDate();
   await db
     .update(usagePackAllocationChanges)
     .set({
       status: pending ? "pending_payment" : "applying",
-      stripeInvoiceId: invoice?.id ?? null,
+      stripeInvoiceId: invoice.id,
       stripePendingUpdateExpiresAt: pendingExpiry,
       effectiveAt:
         change.effectiveAt ?? new Date(change.prorationTimestamp * 1000),
@@ -3663,7 +3695,7 @@ async function confirmUsagePackUpgrade(
       updatedSubscription,
     );
     signal.throwIfAborted();
-    if (invoice?.status === "paid") {
+    if (invoice.status === "paid") {
       await handleUsagePackAllocationChangeInvoicePaid(
         db,
         invoice as UsagePackChangeInvoiceInput,
@@ -3688,7 +3720,8 @@ async function confirmUsagePackUpgrade(
       effectiveAt:
         change.effectiveAt?.toISOString() ??
         new Date(change.prorationTimestamp * 1000).toISOString(),
-      hostedInvoiceUrl: invoice?.hosted_invoice_url ?? null,
+      hostedInvoiceUrl:
+        payment.status === "pending_payment" ? payment.hostedInvoiceUrl : null,
     },
   };
 }

--- a/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
@@ -49,7 +49,7 @@ import {
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
 import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
 import {
-  stripeBillingPurchasePaymentParams,
+  setStripeSubscriptionPaymentMethod,
   type BillingPurchasePaymentMethod,
 } from "./billing-payment-method.service";
 import { downgradeSubscriptionForOrg } from "./zero-billing-downgrade.service";
@@ -3653,13 +3653,19 @@ async function confirmUsagePackUpgrade(
     change.sourceStripePriceId,
     change.targetStripePriceId,
   );
-  const updatedSubscription = await getStripeClient().subscriptions.update(
+  const stripe = getStripeClient();
+  if (paymentMethod) {
+    await setStripeSubscriptionPaymentMethod(
+      stripe,
+      subscription.id,
+      paymentMethod,
+      signal,
+    );
+  }
+  const updatedSubscription = await stripe.subscriptions.update(
     subscription.id,
     {
       items,
-      ...(paymentMethod
-        ? stripeBillingPurchasePaymentParams(paymentMethod)
-        : {}),
       payment_behavior: "pending_if_incomplete",
       proration_behavior: "always_invoice",
       proration_date: change.prorationTimestamp,
@@ -3673,7 +3679,7 @@ async function confirmUsagePackUpgrade(
     throw new Error("Stripe did not create a usage pack change invoice");
   }
   const payment = await completeBillingOperationInvoice(
-    getStripeClient(),
+    stripe,
     invoice,
     `usage-pack-allocation:${change.id}`,
     signal,

--- a/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
@@ -57,7 +57,8 @@ import { activeUsagePackPriceId } from "./zero-billing-checkout.service";
 import {
   resolveBillingPurchaseRoute,
   stripeBillingPurchasePaymentParams,
-} from "./zero-billing-payment-method.service";
+  type BillingPurchasePaymentMethod,
+} from "./billing-payment-method.service";
 
 const PURPOSE = "usage_pack_invitation_purchase";
 const PURCHASE_ID_METADATA_KEY = "usagePackInvitationPurchaseId";
@@ -1257,15 +1258,20 @@ export async function handleUsagePackInvitationInvoicePaid(
   return { handled: true, orgId: purchase.orgId };
 }
 
-export async function confirmUsagePackInvitationPurchase(
-  db: Db,
-  clerk: ClerkClient,
-  args: { readonly orgId: string; readonly purchaseId: string },
-  signal: AbortSignal,
-): Promise<ConfirmUsagePackInvitationPurchaseResult> {
-  const purchase = await loadPurchase(db, args.purchaseId);
-  if (!purchase || purchase.orgId !== args.orgId) {
-    return { status: "not_found" };
+function invitationPurchaseConfirmState(
+  purchase: UsagePackInvitationPurchaseRow | null,
+  orgId: string,
+):
+  | {
+      readonly status: "ready";
+      readonly purchase: UsagePackInvitationPurchaseRow;
+    }
+  | {
+      readonly status: "complete";
+      readonly result: ConfirmUsagePackInvitationPurchaseResult;
+    } {
+  if (!purchase || purchase.orgId !== orgId) {
+    return { status: "complete", result: { status: "not_found" } };
   }
   if (
     purchase.status === "payment_succeeded" ||
@@ -1273,14 +1279,35 @@ export async function confirmUsagePackInvitationPurchase(
     purchase.status === "invitation_pending" ||
     ACCEPTED_PURCHASE_STATUSES.has(purchase.status)
   ) {
-    return { status: "confirmed" };
+    return { status: "complete", result: { status: "confirmed" } };
   }
   if (
     purchase.status !== "checkout_pending" ||
     purchase.stripeCheckoutSessionId
   ) {
-    return { status: "conflict" };
+    return { status: "complete", result: { status: "conflict" } };
   }
+  return { status: "ready", purchase };
+}
+
+export async function confirmUsagePackInvitationPurchase(
+  db: Db,
+  clerk: ClerkClient,
+  args: {
+    readonly orgId: string;
+    readonly purchaseId: string;
+    readonly paymentMethod?: BillingPurchasePaymentMethod;
+  },
+  signal: AbortSignal,
+): Promise<ConfirmUsagePackInvitationPurchaseResult> {
+  const purchaseState = invitationPurchaseConfirmState(
+    await loadPurchase(db, args.purchaseId),
+    args.orgId,
+  );
+  if (purchaseState.status === "complete") {
+    return purchaseState.result;
+  }
+  const { purchase } = purchaseState;
   const expiresAt = purchase.stripeCheckoutExpiresAt;
   if (!expiresAt || expiresAt <= nowDate()) {
     await db
@@ -1332,12 +1359,20 @@ export async function confirmUsagePackInvitationPurchase(
   if (route.kind === "checkout") {
     return { status: "conflict" };
   }
+  if (
+    args.paymentMethod &&
+    (args.paymentMethod.paymentMethodId !== route.paymentMethodId ||
+      args.paymentMethod.paymentMethodType !== route.paymentMethodType)
+  ) {
+    return { status: "conflict" };
+  }
+  const paymentMethod = args.paymentMethod ?? route;
   const metadata = checkoutMetadata(purchase.id);
   const invoice = await stripe.invoices.create(
     {
       customer: subscription.stripeCustomerId,
       auto_advance: false,
-      ...stripeBillingPurchasePaymentParams(route),
+      ...stripeBillingPurchasePaymentParams(paymentMethod),
       metadata,
     },
     { idempotencyKey: `usage-pack-invitation:${purchase.id}:invoice` },

--- a/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
@@ -34,7 +34,6 @@ import type { ClerkClient } from "../external/clerk";
 import type { Db } from "../external/db";
 import {
   getStripeClient,
-  type StripeClient,
   type StripeInvoice,
   type StripePaymentIntent,
   type StripeRefund,
@@ -48,12 +47,17 @@ import {
 } from "./usage-pack-allocation-change.service";
 import { createUsagePackCreditGrant } from "./usage-pack-credit.service";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
+import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
 import { loadUsagePackCatalog } from "./usage-pack-subscription.service";
 import {
   isCurrentStripePreviewMetadata,
   stripePreviewMetadata,
 } from "./stripe-preview-metadata.service";
 import { activeUsagePackPriceId } from "./zero-billing-checkout.service";
+import {
+  resolveBillingPurchaseRoute,
+  stripeBillingPurchasePaymentParams,
+} from "./zero-billing-payment-method.service";
 
 const PURPOSE = "usage_pack_invitation_purchase";
 const PURCHASE_ID_METADATA_KEY = "usagePackInvitationPurchaseId";
@@ -137,6 +141,7 @@ type CreateUsagePackInvitationPreviewResult =
 
 type ConfirmUsagePackInvitationPurchaseResult =
   | { readonly status: "confirmed" }
+  | { readonly status: "pending_payment"; readonly hostedInvoiceUrl: string }
   | { readonly status: "not_found" }
   | { readonly status: "expired" }
   | { readonly status: "conflict" };
@@ -1252,62 +1257,6 @@ export async function handleUsagePackInvitationInvoicePaid(
   return { handled: true, orgId: purchase.orgId };
 }
 
-async function invitationPaymentMethodId(
-  stripe: StripeClient,
-  subscription: UsagePackSubscriptionRow,
-): Promise<string | null> {
-  if (!subscription.stripeSubscriptionId) {
-    return null;
-  }
-  const stripeSubscription = await stripe.subscriptions.retrieve(
-    subscription.stripeSubscriptionId,
-  );
-  const subscriptionPaymentMethod = stripeObjectId(
-    stripeSubscription.default_payment_method,
-  );
-  if (subscriptionPaymentMethod) {
-    return subscriptionPaymentMethod;
-  }
-  const customer = await stripe.customers.retrieve(
-    subscription.stripeCustomerId,
-  );
-  if (!("deleted" in customer) || !customer.deleted) {
-    const customerPaymentMethod = stripeObjectId(
-      customer.invoice_settings?.default_payment_method,
-    );
-    if (customerPaymentMethod) {
-      return customerPaymentMethod;
-    }
-  }
-  const paymentMethods = await stripe.paymentMethods.list({
-    customer: subscription.stripeCustomerId,
-    type: "card",
-    limit: 1,
-  });
-  return paymentMethods.data[0]?.id ?? null;
-}
-
-async function payInvitationInvoice(
-  stripe: StripeClient,
-  invoiceId: string,
-  signal: AbortSignal,
-): Promise<boolean> {
-  const invoice = await stripe.invoices.retrieve(invoiceId);
-  if (invoice.status === "draft") {
-    await stripe.invoices.finalizeInvoice(invoiceId);
-    signal.throwIfAborted();
-    await stripe.invoices.pay(invoiceId);
-    signal.throwIfAborted();
-    return true;
-  }
-  if (invoice.status === "open") {
-    await stripe.invoices.pay(invoiceId);
-    signal.throwIfAborted();
-    return true;
-  }
-  return invoice.status === "paid";
-}
-
 export async function confirmUsagePackInvitationPurchase(
   db: Db,
   clerk: ClerkClient,
@@ -1371,9 +1320,16 @@ export async function confirmUsagePackInvitationPurchase(
     return { status: "conflict" };
   }
   const stripe = getStripeClient();
-  const paymentMethodId = await invitationPaymentMethodId(stripe, subscription);
-  signal.throwIfAborted();
-  if (!paymentMethodId) {
+  const route = await resolveBillingPurchaseRoute(
+    {
+      stripe,
+      supportsInAppPreview: true,
+      customerId: subscription.stripeCustomerId,
+      subscriptionId: subscription.stripeSubscriptionId,
+    },
+    signal,
+  );
+  if (route.kind === "checkout") {
     return { status: "conflict" };
   }
   const metadata = checkoutMetadata(purchase.id);
@@ -1381,7 +1337,7 @@ export async function confirmUsagePackInvitationPurchase(
     {
       customer: subscription.stripeCustomerId,
       auto_advance: false,
-      default_payment_method: paymentMethodId,
+      ...stripeBillingPurchasePaymentParams(route),
       metadata,
     },
     { idempotencyKey: `usage-pack-invitation:${purchase.id}:invoice` },
@@ -1398,8 +1354,15 @@ export async function confirmUsagePackInvitationPurchase(
     { idempotencyKey: `usage-pack-invitation:${purchase.id}:invoice-item` },
   );
   signal.throwIfAborted();
-  if (!(await payInvitationInvoice(stripe, invoice.id, signal))) {
-    return { status: "conflict" };
+  const payment = await completeBillingOperationInvoice(
+    stripe,
+    invoice,
+    `usage-pack-invitation:${purchase.id}`,
+    signal,
+    { payOpenInvoice: true },
+  );
+  if (payment.status === "pending_payment") {
+    return payment;
   }
   const handled = await handleUsagePackInvitationInvoicePaid(db, clerk, {
     id: invoice.id,

--- a/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
@@ -50,7 +50,7 @@ import {
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
 import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
 import {
-  stripeBillingPurchasePaymentParams,
+  setStripeSubscriptionPaymentMethod,
   type BillingPurchasePaymentMethod,
 } from "./billing-payment-method.service";
 import { subscriptionScheduleHasNoFutureChanges } from "./stripe-subscription-schedules.service";
@@ -2215,7 +2215,16 @@ async function applyImmediateSubscriptionChange(
   if (!targetPlanPriceId) {
     throw new Error("Team usage pack plan Price is not configured");
   }
-  const updatedSubscription = await getStripeClient().subscriptions.update(
+  const stripe = getStripeClient();
+  if (args.paymentMethod) {
+    await setStripeSubscriptionPaymentMethod(
+      stripe,
+      args.subscription.id,
+      args.paymentMethod,
+      signal,
+    );
+  }
+  const updatedSubscription = await stripe.subscriptions.update(
     args.subscription.id,
     {
       items: subscriptionUpdateItems(
@@ -2224,9 +2233,6 @@ async function applyImmediateSubscriptionChange(
         targetPlanPriceId,
         packageQuantities,
       ),
-      ...(args.paymentMethod
-        ? stripeBillingPurchasePaymentParams(args.paymentMethod)
-        : {}),
       payment_behavior: "pending_if_incomplete",
       proration_behavior: "always_invoice",
       proration_date: args.stored.root.prorationTimestamp,
@@ -2244,7 +2250,7 @@ async function applyImmediateSubscriptionChange(
   const pendingUpdateExpiresAt =
     subscriptionPendingUpdateExpiresAt(updatedSubscription);
   const payment = await completeBillingOperationInvoice(
-    getStripeClient(),
+    stripe,
     invoice,
     `usage-pack-subscription:${args.stored.root.id}`,
     signal,

--- a/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
@@ -49,6 +49,10 @@ import {
 } from "./usage-pack-allocation-change.service";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
 import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
+import {
+  stripeBillingPurchasePaymentParams,
+  type BillingPurchasePaymentMethod,
+} from "./billing-payment-method.service";
 import { subscriptionScheduleHasNoFutureChanges } from "./stripe-subscription-schedules.service";
 import {
   activeUsagePackPlanPriceId,
@@ -2197,6 +2201,7 @@ async function applyImmediateSubscriptionChange(
     readonly planItem: StripeSubscriptionItem;
     readonly hasPlanUpgrade: boolean;
     readonly immediatePackageChanges: readonly UsagePackAllocationChangeRow[];
+    readonly paymentMethod?: BillingPurchasePaymentMethod;
   },
   signal: AbortSignal,
 ): Promise<UsagePackSubscriptionChangeConfirmResult> {
@@ -2219,6 +2224,9 @@ async function applyImmediateSubscriptionChange(
         targetPlanPriceId,
         packageQuantities,
       ),
+      ...(args.paymentMethod
+        ? stripeBillingPurchasePaymentParams(args.paymentMethod)
+        : {}),
       payment_behavior: "pending_if_incomplete",
       proration_behavior: "always_invoice",
       proration_date: args.stored.root.prorationTimestamp,
@@ -2474,6 +2482,7 @@ async function resolveReplacementSchedule(
 async function applyStoredSubscriptionChange(
   db: Db,
   stored: StoredSubscriptionChange,
+  paymentMethod: BillingPurchasePaymentMethod | undefined,
   signal: AbortSignal,
 ): Promise<UsagePackSubscriptionChangeConfirmResult> {
   const subscriptionId = stored.subscription.stripeSubscriptionId;
@@ -2575,6 +2584,7 @@ async function applyStoredSubscriptionChange(
       planItem,
       hasPlanUpgrade,
       immediatePackageChanges,
+      paymentMethod,
     },
     signal,
   );
@@ -2585,6 +2595,7 @@ export async function confirmUsagePackSubscriptionChange(
   args: {
     readonly orgId: string;
     readonly changeId: string;
+    readonly paymentMethod?: BillingPurchasePaymentMethod;
   },
   signal: AbortSignal,
 ): Promise<UsagePackSubscriptionChangeConfirmResult> {
@@ -2596,7 +2607,12 @@ export async function confirmUsagePackSubscriptionChange(
   if (!preparation.ready) {
     return preparation.result;
   }
-  return await applyStoredSubscriptionChange(db, preparation.stored, signal);
+  return await applyStoredSubscriptionChange(
+    db,
+    preparation.stored,
+    args.paymentMethod,
+    signal,
+  );
 }
 
 function invoiceSubscriptionId(

--- a/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
@@ -48,6 +48,7 @@ import {
   type UsagePackChangeInvoiceInput,
 } from "./usage-pack-allocation-change.service";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
+import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
 import { subscriptionScheduleHasNoFutureChanges } from "./stripe-subscription-schedules.service";
 import {
   activeUsagePackPlanPriceId,
@@ -1467,6 +1468,48 @@ export async function previewUsagePackSubscriptionChange(
   };
 }
 
+export async function discardUsagePackSubscriptionChangePreviewForPaymentSetup(
+  db: Db,
+  args: { readonly orgId: string; readonly changeId: string },
+): Promise<void> {
+  const discardedAt = nowDate();
+  await db.transaction(async (tx) => {
+    const discarded = await tx
+      .update(usagePackSubscriptionChanges)
+      .set({
+        status: "failed",
+        failureReason: "payment_method_setup_required",
+        completedAt: discardedAt,
+        updatedAt: discardedAt,
+      })
+      .where(
+        and(
+          eq(usagePackSubscriptionChanges.id, args.changeId),
+          eq(usagePackSubscriptionChanges.orgId, args.orgId),
+          eq(usagePackSubscriptionChanges.status, "previewed"),
+        ),
+      )
+      .returning({ id: usagePackSubscriptionChanges.id });
+    if (discarded.length === 0) {
+      return;
+    }
+    await tx
+      .update(usagePackAllocationChanges)
+      .set({
+        status: "failed",
+        failureReason: "payment_method_setup_required",
+        completedAt: discardedAt,
+        updatedAt: discardedAt,
+      })
+      .where(
+        and(
+          eq(usagePackAllocationChanges.subscriptionChangeId, args.changeId),
+          eq(usagePackAllocationChanges.status, "previewed"),
+        ),
+      );
+  });
+}
+
 function subscriptionPhaseItems(
   subscription: StripeSubscription,
 ): StripeSchedulePhaseItemParam[] {
@@ -2107,14 +2150,14 @@ async function recordImmediateSubscriptionChangeInvoice(
   stored: StoredSubscriptionChange,
   invoice: StripeInvoice,
   pendingUpdateExpiresAt: Date | null,
+  pendingPayment: boolean,
 ): Promise<void> {
-  const pending = pendingUpdateExpiresAt !== null;
   const updatedAt = nowDate();
   await db.transaction(async (tx) => {
     await tx
       .update(usagePackSubscriptionChanges)
       .set({
-        status: pending ? "pending_payment" : "applying",
+        status: pendingPayment ? "pending_payment" : "applying",
         stripeInvoiceId: invoice.id,
         stripePendingUpdateExpiresAt: pendingUpdateExpiresAt,
         updatedAt,
@@ -2123,7 +2166,7 @@ async function recordImmediateSubscriptionChangeInvoice(
     await tx
       .update(usagePackAllocationChanges)
       .set({
-        status: pending ? "pending_payment" : "applying",
+        status: pendingPayment ? "pending_payment" : "applying",
         stripePendingUpdateExpiresAt: pendingUpdateExpiresAt,
         updatedAt,
       })
@@ -2192,19 +2235,27 @@ async function applyImmediateSubscriptionChange(
   }
   const pendingUpdateExpiresAt =
     subscriptionPendingUpdateExpiresAt(updatedSubscription);
-  const pending = pendingUpdateExpiresAt !== null;
+  const payment = await completeBillingOperationInvoice(
+    getStripeClient(),
+    invoice,
+    `usage-pack-subscription:${args.stored.root.id}`,
+    signal,
+  );
+  const pending = payment.status === "pending_payment";
   await recordImmediateSubscriptionChangeInvoice(
     db,
     args.stored,
     invoice,
     pendingUpdateExpiresAt,
+    pending,
   );
   return {
     status: "confirmed",
     response: {
       status: pending ? "pending_payment" : "processing",
       effectiveAt: args.stored.root.effectiveAt.toISOString(),
-      hostedInvoiceUrl: null,
+      hostedInvoiceUrl:
+        payment.status === "pending_payment" ? payment.hostedInvoiceUrl : null,
     },
   };
 }

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -695,12 +695,103 @@ function definedAttribution(
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
+function usagePackAllocationKeys(
+  allocations: readonly UsagePackCheckoutAllocation[],
+): readonly string[] {
+  return allocations
+    .map((allocation) => {
+      const owner =
+        "userId" in allocation
+          ? (["user", allocation.userId] as const)
+          : (["invitation", allocation.invitationId] as const);
+      return JSON.stringify([
+        ...owner,
+        allocation.usagePackUsd,
+        allocation.stripePriceId,
+      ]);
+    })
+    .sort();
+}
+
+function usagePackAllocationsMatch(
+  stored: readonly UsagePackCheckoutAllocation[],
+  requested: readonly UsagePackCheckoutAllocation[],
+): boolean {
+  const storedKeys = usagePackAllocationKeys(stored);
+  const requestedKeys = usagePackAllocationKeys(requested);
+  return (
+    storedKeys.length === requestedKeys.length &&
+    storedKeys.every((key, index) => {
+      return key === requestedKeys[index];
+    })
+  );
+}
+
+async function reusableUsagePackPurchaseSnapshot(
+  tx: WriteTx,
+  args: CreateUsagePackCheckoutSessionArgs,
+  customerId: string,
+): Promise<string | null> {
+  const candidates = await tx
+    .select({ id: usagePackSubscriptions.id })
+    .from(usagePackSubscriptions)
+    .where(
+      and(
+        eq(usagePackSubscriptions.orgId, args.orgId),
+        eq(usagePackSubscriptions.tier, args.tier),
+        eq(usagePackSubscriptions.stripePlanPriceId, args.planPriceId),
+        eq(usagePackSubscriptions.stripeCustomerId, customerId),
+        eq(usagePackSubscriptions.subscriptionStatus, "checkout_pending"),
+        isNull(usagePackSubscriptions.stripeCheckoutSessionId),
+        isNull(usagePackSubscriptions.stripeSubscriptionId),
+      ),
+    )
+    .orderBy(desc(usagePackSubscriptions.createdAt));
+  for (const candidate of candidates) {
+    const allocationRows = await tx
+      .select({
+        usagePackUsd: usagePackAllocations.usagePackUsd,
+        stripePriceId: usagePackAllocations.stripePriceId,
+        userId: usagePackAllocations.userId,
+        invitationId: usagePackAllocations.invitationId,
+        status: usagePackAllocations.status,
+      })
+      .from(usagePackAllocations)
+      .where(eq(usagePackAllocations.usagePackSubscriptionId, candidate.id));
+    if (
+      allocationRows.length === 0 ||
+      allocationRows.some((allocation) => {
+        return allocation.status !== "pending_payment";
+      })
+    ) {
+      continue;
+    }
+    const storedAllocations = checkoutAllocationsFromRows(allocationRows);
+    if (
+      storedAllocations &&
+      usagePackAllocationsMatch(storedAllocations, args.allocations)
+    ) {
+      return candidate.id;
+    }
+  }
+  return null;
+}
+
 async function createUsagePackPurchaseSnapshot(
   db: Db,
   args: CreateUsagePackCheckoutSessionArgs,
   customerId: string,
 ): Promise<string> {
   return await db.transaction(async (tx) => {
+    await lockBillingPurchaseOrg(tx, args.orgId);
+    const reusableSnapshotId = await reusableUsagePackPurchaseSnapshot(
+      tx,
+      args,
+      customerId,
+    );
+    if (reusableSnapshotId) {
+      return reusableSnapshotId;
+    }
     const [subscription] = await tx
       .insert(usagePackSubscriptions)
       .values({

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -1,6 +1,8 @@
 import {
+  type BillingPurchaseConfirmResponse,
   USAGE_PACKS_USD,
   type UsagePackCatalogItem,
+  type UsagePackPurchasePreviewResponse,
   type UsagePackUsd,
 } from "@okouai/api-contracts/contracts/zero-billing";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
@@ -11,6 +13,7 @@ import {
   usagePackSubscriptions,
 } from "@okouai/db/schema/usage-pack-subscription";
 import { command } from "ccstate";
+import { z } from "zod";
 import {
   and,
   desc,
@@ -31,8 +34,10 @@ import { writeDb$, type Db } from "../external/db";
 import {
   getStripeClient,
   type StripeClient,
+  type StripeInvoice,
   type StripeMetadataParam,
   type StripePrice,
+  type StripeSubscription,
 } from "../external/stripe-client";
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 import { persistOrgAcquisitionAttribution$ } from "./acquisition-attribution.service";
@@ -50,13 +55,24 @@ import {
   reconcileUsagePackSubscriptionChanges,
 } from "./usage-pack-plan-change.service";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
+import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
 import {
+  billingPreviewExpiresAt,
+  createBillingPreviewToken,
+  parseBillingPreviewToken,
+} from "./billing-purchase-preview-token.service";
+import {
+  activeUsagePackPlanPriceId,
   activeUsagePackPriceId,
   isUsagePackPlanPriceId,
   tierForKnownPriceId,
   type SubscriptionCheckoutTier,
   usagePackUsdForKnownPriceId,
 } from "./zero-billing-checkout.service";
+import {
+  resolveBillingPurchaseRoute,
+  stripeBillingPurchasePaymentParams,
+} from "./zero-billing-payment-method.service";
 
 export const USAGE_PACK_SUBSCRIPTION_PURPOSE = "usage_pack_subscription";
 const USAGE_PACK_SUBSCRIPTION_ID_METADATA_KEY = "usagePackSubscriptionId";
@@ -111,6 +127,47 @@ interface CreateUsagePackCheckoutSessionArgs {
   readonly cancelUrl: string;
   readonly adAttribution?: Readonly<Record<string, string | undefined>>;
 }
+
+interface StartUsagePackPurchaseArgs extends CreateUsagePackCheckoutSessionArgs {
+  readonly supportsInAppPreview: boolean;
+  readonly sourceSubscriptionId: string | null;
+}
+
+type StartUsagePackPurchaseResult =
+  | { readonly status: "checkout"; readonly url: string }
+  | {
+      readonly status: "preview";
+      readonly preview: UsagePackPurchasePreviewResponse;
+    };
+
+type ConfirmUsagePackPurchaseResult =
+  | {
+      readonly status: "confirmed";
+      readonly response: BillingPurchaseConfirmResponse;
+    }
+  | { readonly status: "invalid_preview" };
+
+const usagePackPurchasePreviewTokenSchema = z.object({
+  version: z.literal(1),
+  usagePackSubscriptionId: z.uuid(),
+  orgId: z.string().min(1),
+  customerId: z.string().min(1),
+  sourceSubscriptionId: z.string().min(1).nullable(),
+  paymentMethodId: z.string().min(1),
+  tier: z.enum(["pro", "team"]),
+  planPriceId: z.string().min(1),
+  immediateAmountCents: z.number().int().nonnegative(),
+  nextRecurringAmountCents: z.number().int().nonnegative(),
+  currency: z.string().length(3),
+  successUrl: z.string().url(),
+  cancelUrl: z.string().url(),
+  adAttribution: z.record(z.string(), z.string()).optional(),
+  expiresAt: z.iso.datetime(),
+});
+
+type UsagePackPurchasePreviewToken = z.infer<
+  typeof usagePackPurchasePreviewTokenSchema
+>;
 
 type StripeObjectReference = string | { readonly id: string };
 
@@ -390,6 +447,41 @@ export async function usagePackSubscriptionSchemaAvailable(
   return state?.available ?? false;
 }
 
+export async function activeUsagePackBillingContext(
+  db: Pick<Db, "select">,
+  orgId: string,
+): Promise<{
+  readonly usagePackSubscriptionId: string;
+  readonly stripeCustomerId: string;
+  readonly stripeSubscriptionId: string;
+} | null> {
+  const [subscription] = await db
+    .select({
+      usagePackSubscriptionId: usagePackSubscriptions.id,
+      stripeCustomerId: usagePackSubscriptions.stripeCustomerId,
+      stripeSubscriptionId: usagePackSubscriptions.stripeSubscriptionId,
+    })
+    .from(usagePackSubscriptions)
+    .where(
+      and(
+        eq(usagePackSubscriptions.orgId, orgId),
+        isNotNull(usagePackSubscriptions.stripeSubscriptionId),
+        notInArray(usagePackSubscriptions.subscriptionStatus, [
+          ...TERMINAL_USAGE_PACK_SUBSCRIPTION_STATUSES,
+        ]),
+      ),
+    )
+    .orderBy(desc(usagePackSubscriptions.updatedAt))
+    .limit(1);
+  return subscription?.stripeSubscriptionId
+    ? {
+        usagePackSubscriptionId: subscription.usagePackSubscriptionId,
+        stripeCustomerId: subscription.stripeCustomerId,
+        stripeSubscriptionId: subscription.stripeSubscriptionId,
+      }
+    : null;
+}
+
 export function usagePackSubscriptionMetadata(args: {
   readonly orgId: string;
   readonly tier: SubscriptionCheckoutTier;
@@ -590,7 +682,100 @@ async function resolvePendingUsagePackCheckout(
   return { kind: "create" };
 }
 
-export const createUsagePackCheckoutSession$ = command(
+function definedAttribution(
+  attribution: Readonly<Record<string, string | undefined>> | undefined,
+): Record<string, string> | undefined {
+  const entries = Object.entries(attribution ?? {}).filter(
+    (entry): entry is [string, string] => {
+      return entry[1] !== undefined;
+    },
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+async function createUsagePackPurchaseSnapshot(
+  db: Db,
+  args: CreateUsagePackCheckoutSessionArgs,
+  customerId: string,
+): Promise<string> {
+  return await db.transaction(async (tx) => {
+    const [subscription] = await tx
+      .insert(usagePackSubscriptions)
+      .values({
+        orgId: args.orgId,
+        tier: args.tier,
+        stripePlanPriceId: args.planPriceId,
+        stripeCustomerId: customerId,
+      })
+      .returning({ id: usagePackSubscriptions.id });
+    if (!subscription) {
+      throw new Error("Failed to create usage pack subscription snapshot");
+    }
+    await tx.insert(usagePackAllocations).values(
+      args.allocations.map((allocation) => {
+        return {
+          usagePackSubscriptionId: subscription.id,
+          orgId: args.orgId,
+          usagePackUsd: allocation.usagePackUsd,
+          stripePriceId: allocation.stripePriceId,
+          ...("userId" in allocation
+            ? { userId: allocation.userId }
+            : { invitationId: allocation.invitationId }),
+        };
+      }),
+    );
+    return subscription.id;
+  });
+}
+
+async function createUsagePackCheckoutForSnapshot(
+  args: {
+    readonly db: Db;
+    readonly stripe: StripeClient;
+    readonly purchase: CreateUsagePackCheckoutSessionArgs;
+    readonly customerId: string;
+    readonly usagePackSubscriptionId: string;
+  },
+  signal: AbortSignal,
+): Promise<string> {
+  const metadata = usagePackCheckoutMetadata({
+    orgId: args.purchase.orgId,
+    tier: args.purchase.tier,
+    planPriceId: args.purchase.planPriceId,
+    usagePackSubscriptionId: args.usagePackSubscriptionId,
+    adAttribution: args.purchase.adAttribution,
+  });
+  const session = await args.stripe.checkout.sessions.create(
+    {
+      mode: "subscription",
+      customer: args.customerId,
+      line_items: [
+        { price: args.purchase.planPriceId, quantity: 1 },
+        ...usagePackLineItems(args.purchase.allocations),
+      ],
+      allow_promotion_codes: true,
+      success_url: args.purchase.successUrl,
+      cancel_url: args.purchase.cancelUrl,
+      metadata,
+      subscription_data: { metadata },
+    },
+    {
+      idempotencyKey: `usage-pack-checkout:${args.usagePackSubscriptionId}`,
+    },
+  );
+  signal.throwIfAborted();
+  await args.db
+    .update(usagePackSubscriptions)
+    .set({ stripeCheckoutSessionId: session.id, updatedAt: nowDate() })
+    .where(eq(usagePackSubscriptions.id, args.usagePackSubscriptionId));
+  signal.throwIfAborted();
+  if (!session.url) {
+    throw new Error("Stripe checkout session did not return a URL");
+  }
+  return session.url;
+}
+
+const createUsagePackCheckoutSession$ = command(
   async (
     { set },
     args: CreateUsagePackCheckoutSessionArgs,
@@ -599,21 +784,17 @@ export const createUsagePackCheckoutSession$ = command(
     if (args.allocations.length === 0) {
       throw new Error("Usage pack checkout requires at least one allocation");
     }
-
     await set(
       persistOrgAcquisitionAttribution$,
       { orgId: args.orgId, attribution: args.adAttribution },
       signal,
     );
-    signal.throwIfAborted();
-
     const customerId = await set(
       getOrCreateStripeCustomer$,
       { orgId: args.orgId, metadata: args.adAttribution },
       signal,
     );
     signal.throwIfAborted();
-
     const db = set(writeDb$);
     const pending = await resolvePendingUsagePackCheckout(
       db,
@@ -627,75 +808,377 @@ export const createUsagePackCheckoutSession$ = command(
     const usagePackSubscriptionId =
       pending.kind === "reuse"
         ? pending.usagePackSubscriptionId
-        : await db.transaction(async (tx) => {
-            const [subscription] = await tx
-              .insert(usagePackSubscriptions)
-              .values({
-                orgId: args.orgId,
-                tier: args.tier,
-                stripePlanPriceId: args.planPriceId,
-                stripeCustomerId: customerId,
-              })
-              .returning({ id: usagePackSubscriptions.id });
-            if (!subscription) {
-              throw new Error(
-                "Failed to create usage pack subscription snapshot",
-              );
-            }
-
-            await tx.insert(usagePackAllocations).values(
-              args.allocations.map((allocation) => {
-                return {
-                  usagePackSubscriptionId: subscription.id,
-                  orgId: args.orgId,
-                  usagePackUsd: allocation.usagePackUsd,
-                  stripePriceId: allocation.stripePriceId,
-                  ...("userId" in allocation
-                    ? { userId: allocation.userId }
-                    : { invitationId: allocation.invitationId }),
-                };
-              }),
-            );
-            return subscription.id;
-          });
+        : await createUsagePackPurchaseSnapshot(db, args, customerId);
     signal.throwIfAborted();
+    return await createUsagePackCheckoutForSnapshot(
+      {
+        db,
+        stripe: getStripeClient(),
+        purchase: args,
+        customerId,
+        usagePackSubscriptionId,
+      },
+      signal,
+    );
+  },
+);
 
-    const metadata = usagePackCheckoutMetadata({
+export const startUsagePackPurchase$ = command(
+  async (
+    { set },
+    args: StartUsagePackPurchaseArgs,
+    signal: AbortSignal,
+  ): Promise<StartUsagePackPurchaseResult> => {
+    if (!args.supportsInAppPreview) {
+      return {
+        status: "checkout",
+        url: await set(createUsagePackCheckoutSession$, args, signal),
+      };
+    }
+    if (args.allocations.length === 0) {
+      throw new Error("Usage pack checkout requires at least one allocation");
+    }
+    await set(
+      persistOrgAcquisitionAttribution$,
+      { orgId: args.orgId, attribution: args.adAttribution },
+      signal,
+    );
+    const customerId = await set(
+      getOrCreateStripeCustomer$,
+      { orgId: args.orgId, metadata: args.adAttribution },
+      signal,
+    );
+    signal.throwIfAborted();
+    const db = set(writeDb$);
+    const usagePackSubscriptionId = await createUsagePackPurchaseSnapshot(
+      db,
+      args,
+      customerId,
+    );
+    signal.throwIfAborted();
+    const stripe = getStripeClient();
+    const route = await resolveBillingPurchaseRoute(
+      {
+        stripe,
+        supportsInAppPreview: true,
+        customerId,
+        subscriptionId: args.sourceSubscriptionId,
+      },
+      signal,
+    );
+    if (route.kind === "checkout") {
+      return {
+        status: "checkout",
+        url: await createUsagePackCheckoutForSnapshot(
+          {
+            db,
+            stripe,
+            purchase: args,
+            customerId,
+            usagePackSubscriptionId,
+          },
+          signal,
+        ),
+      };
+    }
+    const items = [
+      { price: args.planPriceId, quantity: 1 },
+      ...usagePackLineItems(args.allocations),
+    ];
+    const invoice = await stripe.invoices.createPreview({
+      customer: route.customerId,
+      preview_mode: "next",
+      subscription_details: { items },
+    });
+    signal.throwIfAborted();
+    if (
+      !Number.isSafeInteger(invoice.amount_due) ||
+      invoice.amount_due < 0 ||
+      invoice.currency.length !== 3
+    ) {
+      throw new Error("Stripe usage pack purchase preview is invalid");
+    }
+    const expiresAt = billingPreviewExpiresAt();
+    const attribution = definedAttribution(args.adAttribution);
+    const payload: UsagePackPurchasePreviewToken = {
+      version: 1,
+      usagePackSubscriptionId,
       orgId: args.orgId,
+      customerId: route.customerId,
+      sourceSubscriptionId: args.sourceSubscriptionId,
+      paymentMethodId: route.paymentMethodId,
       tier: args.tier,
       planPriceId: args.planPriceId,
-      usagePackSubscriptionId,
-      adAttribution: args.adAttribution,
-    });
-    const stripe = getStripeClient();
-    const session = await stripe.checkout.sessions.create({
-      mode: "subscription",
-      customer: customerId,
-      line_items: [
-        { price: args.planPriceId, quantity: 1 },
-        ...usagePackLineItems(args.allocations),
-      ],
-      allow_promotion_codes: true,
-      success_url: args.successUrl,
-      cancel_url: args.cancelUrl,
-      metadata,
-      subscription_data: { metadata },
-    });
-    signal.throwIfAborted();
+      immediateAmountCents: invoice.amount_due,
+      nextRecurringAmountCents: invoice.amount_due,
+      currency: invoice.currency,
+      successUrl: args.successUrl,
+      cancelUrl: args.cancelUrl,
+      ...(attribution ? { adAttribution: attribution } : {}),
+      expiresAt,
+    };
+    return {
+      status: "preview",
+      preview: {
+        status: "preview",
+        purchaseType: "usage_pack",
+        tier: args.tier,
+        immediateAmountCents: invoice.amount_due,
+        nextRecurringAmountCents: invoice.amount_due,
+        currency: invoice.currency,
+        expiresAt,
+        previewToken: createBillingPreviewToken(payload),
+      },
+    };
+  },
+);
 
-    await db
-      .update(usagePackSubscriptions)
-      .set({
-        stripeCheckoutSessionId: session.id,
-        updatedAt: nowDate(),
-      })
-      .where(eq(usagePackSubscriptions.id, usagePackSubscriptionId));
-    signal.throwIfAborted();
+function expandedLatestInvoice(
+  subscription: StripeSubscription,
+): StripeInvoice | null {
+  return subscription.latest_invoice &&
+    typeof subscription.latest_invoice !== "string"
+    ? subscription.latest_invoice
+    : null;
+}
 
-    if (!session.url) {
-      throw new Error("Stripe checkout session did not return a URL");
+function checkoutAllocationsFromRows(
+  rows: readonly {
+    readonly usagePackUsd: number;
+    readonly stripePriceId: string;
+    readonly userId: string | null;
+    readonly invitationId: string | null;
+  }[],
+): readonly UsagePackCheckoutAllocation[] | null {
+  const allocations: UsagePackCheckoutAllocation[] = [];
+  for (const row of rows) {
+    if (!USAGE_PACKS_USD.includes(row.usagePackUsd as UsagePackUsd)) {
+      return null;
     }
-    return session.url;
+    const common = {
+      usagePackUsd: row.usagePackUsd as UsagePackUsd,
+      stripePriceId: row.stripePriceId,
+    };
+    if (row.userId && !row.invitationId) {
+      allocations.push({ ...common, userId: row.userId });
+      continue;
+    }
+    if (row.invitationId && !row.userId) {
+      allocations.push({ ...common, invitationId: row.invitationId });
+      continue;
+    }
+    return null;
+  }
+  return allocations;
+}
+
+async function loadUsagePackPurchaseSnapshot(
+  db: Db,
+  orgId: string,
+  preview: UsagePackPurchasePreviewToken,
+  signal: AbortSignal,
+): Promise<{
+  readonly subscription: UsagePackSubscriptionRow;
+  readonly allocations: readonly UsagePackCheckoutAllocation[];
+} | null> {
+  const [subscription] = await db
+    .select()
+    .from(usagePackSubscriptions)
+    .where(eq(usagePackSubscriptions.id, preview.usagePackSubscriptionId))
+    .limit(1);
+  const allocationRows = await db
+    .select({
+      usagePackUsd: usagePackAllocations.usagePackUsd,
+      stripePriceId: usagePackAllocations.stripePriceId,
+      userId: usagePackAllocations.userId,
+      invitationId: usagePackAllocations.invitationId,
+    })
+    .from(usagePackAllocations)
+    .where(
+      eq(
+        usagePackAllocations.usagePackSubscriptionId,
+        preview.usagePackSubscriptionId,
+      ),
+    );
+  signal.throwIfAborted();
+  const allocations = checkoutAllocationsFromRows(allocationRows);
+  if (
+    !subscription ||
+    subscription.orgId !== orgId ||
+    subscription.stripeCustomerId !== preview.customerId ||
+    subscription.tier !== preview.tier ||
+    subscription.stripePlanPriceId !== preview.planPriceId ||
+    !allocations ||
+    allocations.length === 0
+  ) {
+    return null;
+  }
+  return { subscription, allocations };
+}
+
+async function confirmUsagePackPurchaseSnapshot(
+  db: Db,
+  orgId: string,
+  preview: UsagePackPurchasePreviewToken,
+  snapshot: {
+    readonly subscription: UsagePackSubscriptionRow;
+    readonly allocations: readonly UsagePackCheckoutAllocation[];
+  },
+  signal: AbortSignal,
+): Promise<ConfirmUsagePackPurchaseResult> {
+  const { subscription, allocations } = snapshot;
+  const stripe = getStripeClient();
+  if (subscription.stripeSubscriptionId) {
+    const existing = await stripe.subscriptions.retrieve(
+      subscription.stripeSubscriptionId,
+      { expand: ["latest_invoice"] },
+    );
+    signal.throwIfAborted();
+    return {
+      status: "confirmed",
+      response: await completeBillingOperationInvoice(
+        stripe,
+        expandedLatestInvoice(existing),
+        `usage-pack:${preview.usagePackSubscriptionId}`,
+        signal,
+      ),
+    };
+  }
+  const purchase: CreateUsagePackCheckoutSessionArgs = {
+    orgId,
+    tier: preview.tier,
+    planPriceId: preview.planPriceId,
+    allocations,
+    successUrl: preview.successUrl,
+    cancelUrl: preview.cancelUrl,
+    adAttribution: preview.adAttribution,
+  };
+  const route = await resolveBillingPurchaseRoute(
+    {
+      stripe,
+      supportsInAppPreview: true,
+      customerId: preview.customerId,
+      subscriptionId: preview.sourceSubscriptionId,
+    },
+    signal,
+  );
+  if (route.kind === "checkout") {
+    return {
+      status: "confirmed",
+      response: {
+        status: "checkout_required",
+        checkoutUrl: await createUsagePackCheckoutForSnapshot(
+          {
+            db,
+            stripe,
+            purchase,
+            customerId: preview.customerId,
+            usagePackSubscriptionId: preview.usagePackSubscriptionId,
+          },
+          signal,
+        ),
+      },
+    };
+  }
+  if (
+    route.customerId !== preview.customerId ||
+    route.paymentMethodId !== preview.paymentMethodId
+  ) {
+    return { status: "invalid_preview" };
+  }
+  const items = [
+    { price: preview.planPriceId, quantity: 1 },
+    ...usagePackLineItems(allocations),
+  ];
+  const currentPreview = await stripe.invoices.createPreview({
+    customer: preview.customerId,
+    preview_mode: "next",
+    subscription_details: { items },
+  });
+  signal.throwIfAborted();
+  if (
+    currentPreview.amount_due !== preview.immediateAmountCents ||
+    currentPreview.currency !== preview.currency
+  ) {
+    return { status: "invalid_preview" };
+  }
+  const metadata = usagePackCheckoutMetadata({
+    orgId,
+    tier: preview.tier,
+    planPriceId: preview.planPriceId,
+    usagePackSubscriptionId: preview.usagePackSubscriptionId,
+    adAttribution: preview.adAttribution,
+  });
+  const created = await stripe.subscriptions.create(
+    {
+      customer: preview.customerId,
+      items,
+      ...stripeBillingPurchasePaymentParams(route),
+      metadata,
+      payment_behavior: "default_incomplete",
+      expand: ["latest_invoice"],
+    },
+    {
+      idempotencyKey: `usage-pack:${preview.usagePackSubscriptionId}:subscription`,
+    },
+  );
+  signal.throwIfAborted();
+  await db
+    .update(usagePackSubscriptions)
+    .set({
+      stripeSubscriptionId: created.id,
+      subscriptionStatus: created.status,
+      updatedAt: nowDate(),
+    })
+    .where(eq(usagePackSubscriptions.id, preview.usagePackSubscriptionId));
+  signal.throwIfAborted();
+  return {
+    status: "confirmed",
+    response: await completeBillingOperationInvoice(
+      stripe,
+      expandedLatestInvoice(created),
+      `usage-pack:${preview.usagePackSubscriptionId}`,
+      signal,
+    ),
+  };
+}
+
+export const confirmUsagePackPurchase$ = command(
+  async (
+    { set },
+    orgId: string,
+    previewToken: string,
+    signal: AbortSignal,
+  ): Promise<ConfirmUsagePackPurchaseResult> => {
+    const preview = parseBillingPreviewToken(
+      previewToken,
+      usagePackPurchasePreviewTokenSchema,
+    );
+    if (
+      !preview ||
+      preview.orgId !== orgId ||
+      preview.planPriceId !== activeUsagePackPlanPriceId(preview.tier) ||
+      new Date(preview.expiresAt) <= nowDate()
+    ) {
+      return { status: "invalid_preview" };
+    }
+    const db = set(writeDb$);
+    const snapshot = await loadUsagePackPurchaseSnapshot(
+      db,
+      orgId,
+      preview,
+      signal,
+    );
+    if (!snapshot) {
+      return { status: "invalid_preview" };
+    }
+    return await confirmUsagePackPurchaseSnapshot(
+      db,
+      orgId,
+      preview,
+      snapshot,
+      signal,
+    );
   },
 );
 

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -56,6 +56,7 @@ import {
 } from "./usage-pack-plan-change.service";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
 import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
+import { lockBillingPurchaseOrg } from "./billing-purchase-lock.service";
 import {
   billingPreviewExpiresAt,
   createBillingPreviewToken,
@@ -72,7 +73,7 @@ import {
 import {
   resolveBillingPurchaseRoute,
   stripeBillingPurchasePaymentParams,
-} from "./zero-billing-payment-method.service";
+} from "./billing-payment-method.service";
 
 export const USAGE_PACK_SUBSCRIPTION_PURPOSE = "usage_pack_subscription";
 const USAGE_PACK_SUBSCRIPTION_ID_METADATA_KEY = "usagePackSubscriptionId";
@@ -100,6 +101,7 @@ const L = logger("UsagePackSubscription");
 type UsagePackSubscriptionRow = typeof usagePackSubscriptions.$inferSelect;
 type UsagePackAllocationRow = typeof usagePackAllocations.$inferSelect;
 type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+type UsagePackPurchaseDb = Pick<Db, "select" | "update">;
 
 interface ValidatedUsagePackPrice extends UsagePackCatalogItem {
   readonly stripePriceId: string;
@@ -730,7 +732,7 @@ async function createUsagePackPurchaseSnapshot(
 
 async function createUsagePackCheckoutForSnapshot(
   args: {
-    readonly db: Db;
+    readonly db: Pick<Db, "update">;
     readonly stripe: StripeClient;
     readonly purchase: CreateUsagePackCheckoutSessionArgs;
     readonly customerId: string;
@@ -972,19 +974,22 @@ function checkoutAllocationsFromRows(
   return allocations;
 }
 
+interface UsagePackPurchaseSnapshot {
+  readonly subscription: UsagePackSubscriptionRow;
+  readonly allocations: readonly UsagePackCheckoutAllocation[];
+}
+
 async function loadUsagePackPurchaseSnapshot(
-  db: Db,
+  db: Pick<Db, "select">,
   orgId: string,
   preview: UsagePackPurchasePreviewToken,
   signal: AbortSignal,
-): Promise<{
-  readonly subscription: UsagePackSubscriptionRow;
-  readonly allocations: readonly UsagePackCheckoutAllocation[];
-} | null> {
+): Promise<UsagePackPurchaseSnapshot | null> {
   const [subscription] = await db
     .select()
     .from(usagePackSubscriptions)
     .where(eq(usagePackSubscriptions.id, preview.usagePackSubscriptionId))
+    .for("update")
     .limit(1);
   const allocationRows = await db
     .select({
@@ -1016,21 +1021,20 @@ async function loadUsagePackPurchaseSnapshot(
   return { subscription, allocations };
 }
 
-async function confirmUsagePackPurchaseSnapshot(
-  db: Db,
-  orgId: string,
-  preview: UsagePackPurchasePreviewToken,
-  snapshot: {
-    readonly subscription: UsagePackSubscriptionRow;
-    readonly allocations: readonly UsagePackCheckoutAllocation[];
+async function existingUsagePackPurchaseResult(
+  args: {
+    readonly db: UsagePackPurchaseDb;
+    readonly orgId: string;
+    readonly preview: UsagePackPurchasePreviewToken;
+    readonly snapshot: UsagePackPurchaseSnapshot;
   },
   signal: AbortSignal,
-): Promise<ConfirmUsagePackPurchaseResult> {
-  const { subscription, allocations } = snapshot;
+): Promise<ConfirmUsagePackPurchaseResult | null> {
+  const { db, orgId, preview, snapshot } = args;
   const stripe = getStripeClient();
-  if (subscription.stripeSubscriptionId) {
+  if (snapshot.subscription.stripeSubscriptionId) {
     const existing = await stripe.subscriptions.retrieve(
-      subscription.stripeSubscriptionId,
+      snapshot.subscription.stripeSubscriptionId,
       { expand: ["latest_invoice"] },
     );
     signal.throwIfAborted();
@@ -1044,6 +1048,89 @@ async function confirmUsagePackPurchaseSnapshot(
       ),
     };
   }
+  const active = await activeUsagePackBillingContext(db, orgId);
+  signal.throwIfAborted();
+  if (
+    active &&
+    active.usagePackSubscriptionId !== preview.usagePackSubscriptionId
+  ) {
+    return { status: "invalid_preview" };
+  }
+  const subscriptions = await stripe.subscriptions.list({
+    customer: preview.customerId,
+    status: "all",
+    limit: 100,
+  });
+  signal.throwIfAborted();
+  const existingSummary = subscriptions.data.find((candidate) => {
+    return (
+      candidate.metadata?.[USAGE_PACK_SUBSCRIPTION_ID_METADATA_KEY] ===
+      preview.usagePackSubscriptionId
+    );
+  });
+  const competing = subscriptions.data.some((candidate) => {
+    return (
+      candidate.id !== preview.sourceSubscriptionId &&
+      candidate.metadata?.orgId === orgId &&
+      candidate.id !== existingSummary?.id &&
+      candidate.items.data.some((item) => {
+        return tierForKnownPriceId(item.price.id) !== null;
+      }) &&
+      candidate.status !== "canceled" &&
+      candidate.status !== "incomplete_expired"
+    );
+  });
+  if (competing) {
+    return { status: "invalid_preview" };
+  }
+  if (!existingSummary) {
+    return null;
+  }
+  const existing = await stripe.subscriptions.retrieve(existingSummary.id, {
+    expand: ["latest_invoice"],
+  });
+  signal.throwIfAborted();
+  await db
+    .update(usagePackSubscriptions)
+    .set({
+      stripeSubscriptionId: existing.id,
+      subscriptionStatus: existing.status,
+      updatedAt: nowDate(),
+    })
+    .where(eq(usagePackSubscriptions.id, preview.usagePackSubscriptionId));
+  signal.throwIfAborted();
+  return {
+    status: "confirmed",
+    response: await completeBillingOperationInvoice(
+      stripe,
+      expandedLatestInvoice(existing),
+      `usage-pack:${preview.usagePackSubscriptionId}`,
+      signal,
+    ),
+  };
+}
+
+async function confirmUsagePackPurchaseSnapshot(
+  db: UsagePackPurchaseDb,
+  orgId: string,
+  preview: UsagePackPurchasePreviewToken,
+  snapshot: UsagePackPurchaseSnapshot,
+  signal: AbortSignal,
+): Promise<ConfirmUsagePackPurchaseResult> {
+  const existingResult = await existingUsagePackPurchaseResult(
+    {
+      db,
+      orgId,
+      preview,
+      snapshot,
+    },
+    signal,
+  );
+  if (existingResult) {
+    return existingResult;
+  }
+  const { allocations } = snapshot;
+  const stripe = getStripeClient();
   const purchase: CreateUsagePackCheckoutSessionArgs = {
     orgId,
     tier: preview.tier,
@@ -1163,22 +1250,26 @@ export const confirmUsagePackPurchase$ = command(
       return { status: "invalid_preview" };
     }
     const db = set(writeDb$);
-    const snapshot = await loadUsagePackPurchaseSnapshot(
-      db,
-      orgId,
-      preview,
-      signal,
-    );
-    if (!snapshot) {
-      return { status: "invalid_preview" };
-    }
-    return await confirmUsagePackPurchaseSnapshot(
-      db,
-      orgId,
-      preview,
-      snapshot,
-      signal,
-    );
+    return await db.transaction(async (tx) => {
+      await lockBillingPurchaseOrg(tx, orgId);
+      signal.throwIfAborted();
+      const snapshot = await loadUsagePackPurchaseSnapshot(
+        tx,
+        orgId,
+        preview,
+        signal,
+      );
+      if (!snapshot) {
+        return { status: "invalid_preview" as const };
+      }
+      return await confirmUsagePackPurchaseSnapshot(
+        tx,
+        orgId,
+        preview,
+        snapshot,
+        signal,
+      );
+    });
   },
 );
 

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -1109,6 +1109,7 @@ async function loadUsagePackPurchaseSnapshot(
   const allocations = checkoutAllocationsFromRows(allocationRows);
   if (
     !subscription ||
+    subscription.subscriptionStatus === "checkout_expired" ||
     subscription.orgId !== orgId ||
     subscription.stripeCustomerId !== preview.customerId ||
     subscription.tier !== preview.tier ||
@@ -1173,6 +1174,7 @@ async function existingUsagePackPurchaseResult(
       expandedLatestInvoice(existing),
       `usage-pack:${preview.usagePackSubscriptionId}`,
       signal,
+      { payOpenInvoice: true },
     );
     return {
       status: "confirmed",
@@ -1235,6 +1237,7 @@ async function existingUsagePackPurchaseResult(
     expandedLatestInvoice(existing),
     `usage-pack:${preview.usagePackSubscriptionId}`,
     signal,
+    { payOpenInvoice: true },
   );
   return {
     status: "confirmed",
@@ -1357,6 +1360,7 @@ async function confirmUsagePackPurchaseSnapshot(
     expandedLatestInvoice(created),
     `usage-pack:${preview.usagePackSubscriptionId}`,
     signal,
+    { payOpenInvoice: true },
   );
   return {
     status: "confirmed",

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -943,11 +943,19 @@ export const startUsagePackPurchase$ = command(
     );
     signal.throwIfAborted();
     const db = set(writeDb$);
-    const usagePackSubscriptionId = await createUsagePackPurchaseSnapshot(
+    const pending = await resolvePendingUsagePackCheckout(
       db,
       args,
       customerId,
+      signal,
     );
+    if (pending.kind === "redirect") {
+      return { status: "checkout", url: pending.url };
+    }
+    const usagePackSubscriptionId =
+      pending.kind === "reuse"
+        ? pending.usagePackSubscriptionId
+        : await createUsagePackPurchaseSnapshot(db, args, customerId);
     signal.throwIfAborted();
     const stripe = getStripeClient();
     const route = await resolveBillingPurchaseRoute(
@@ -1123,6 +1131,34 @@ async function existingUsagePackPurchaseResult(
 ): Promise<ConfirmUsagePackPurchaseResult | null> {
   const { db, orgId, preview, snapshot } = args;
   const stripe = getStripeClient();
+  if (snapshot.subscription.stripeCheckoutSessionId) {
+    const session = (await stripe.checkout.sessions.retrieve(
+      snapshot.subscription.stripeCheckoutSessionId,
+    )) as UsagePackCheckoutSessionInput;
+    signal.throwIfAborted();
+    if (session.status === "complete") {
+      return {
+        status: "confirmed",
+        response: {
+          status: "checkout_required",
+          checkoutUrl: preview.successUrl.replace(
+            "{CHECKOUT_SESSION_ID}",
+            session.id,
+          ),
+        },
+      };
+    }
+    if (session.status === "open" && session.url) {
+      return {
+        status: "confirmed",
+        response: {
+          status: "checkout_required",
+          checkoutUrl: session.url,
+        },
+      };
+    }
+    return { status: "invalid_preview" };
+  }
   if (snapshot.subscription.stripeSubscriptionId) {
     const existing = await stripe.subscriptions.retrieve(
       snapshot.subscription.stripeSubscriptionId,

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -55,7 +55,7 @@ import {
   reconcileUsagePackSubscriptionChanges,
 } from "./usage-pack-plan-change.service";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
-import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
+import { completeBillingOperationInvoiceWithInvoice } from "./billing-operation-invoice.service";
 import { lockBillingPurchaseOrg } from "./billing-purchase-lock.service";
 import {
   billingPreviewExpiresAt,
@@ -146,6 +146,7 @@ type ConfirmUsagePackPurchaseResult =
   | {
       readonly status: "confirmed";
       readonly response: BillingPurchaseConfirmResponse;
+      readonly paidInvoice: StripeInvoice | null;
     }
   | { readonly status: "invalid_preview" };
 
@@ -1146,6 +1147,7 @@ async function existingUsagePackPurchaseResult(
             session.id,
           ),
         },
+        paidInvoice: null,
       };
     }
     if (session.status === "open" && session.url) {
@@ -1155,6 +1157,7 @@ async function existingUsagePackPurchaseResult(
           status: "checkout_required",
           checkoutUrl: session.url,
         },
+        paidInvoice: null,
       };
     }
     return { status: "invalid_preview" };
@@ -1165,14 +1168,15 @@ async function existingUsagePackPurchaseResult(
       { expand: ["latest_invoice"] },
     );
     signal.throwIfAborted();
+    const completion = await completeBillingOperationInvoiceWithInvoice(
+      stripe,
+      expandedLatestInvoice(existing),
+      `usage-pack:${preview.usagePackSubscriptionId}`,
+      signal,
+    );
     return {
       status: "confirmed",
-      response: await completeBillingOperationInvoice(
-        stripe,
-        expandedLatestInvoice(existing),
-        `usage-pack:${preview.usagePackSubscriptionId}`,
-        signal,
-      ),
+      ...completion,
     };
   }
   const active = await activeUsagePackBillingContext(db, orgId);
@@ -1226,14 +1230,15 @@ async function existingUsagePackPurchaseResult(
     })
     .where(eq(usagePackSubscriptions.id, preview.usagePackSubscriptionId));
   signal.throwIfAborted();
+  const completion = await completeBillingOperationInvoiceWithInvoice(
+    stripe,
+    expandedLatestInvoice(existing),
+    `usage-pack:${preview.usagePackSubscriptionId}`,
+    signal,
+  );
   return {
     status: "confirmed",
-    response: await completeBillingOperationInvoice(
-      stripe,
-      expandedLatestInvoice(existing),
-      `usage-pack:${preview.usagePackSubscriptionId}`,
-      signal,
-    ),
+    ...completion,
   };
 }
 
@@ -1292,6 +1297,7 @@ async function confirmUsagePackPurchaseSnapshot(
           signal,
         ),
       },
+      paidInvoice: null,
     };
   }
   if (
@@ -1346,14 +1352,15 @@ async function confirmUsagePackPurchaseSnapshot(
     })
     .where(eq(usagePackSubscriptions.id, preview.usagePackSubscriptionId));
   signal.throwIfAborted();
+  const completion = await completeBillingOperationInvoiceWithInvoice(
+    stripe,
+    expandedLatestInvoice(created),
+    `usage-pack:${preview.usagePackSubscriptionId}`,
+    signal,
+  );
   return {
     status: "confirmed",
-    response: await completeBillingOperationInvoice(
-      stripe,
-      expandedLatestInvoice(created),
-      `usage-pack:${preview.usagePackSubscriptionId}`,
-      signal,
-    ),
+    ...completion,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -20,6 +20,7 @@ import { writeDb$, type Db } from "../external/db";
 import {
   getStripeClient,
   isStripeResourceMissingError,
+  type StripeInvoice,
   type StripePaymentIntent,
   type StripeSubscription,
   type StripeWebhookEvent,
@@ -2415,12 +2416,14 @@ async function shouldSkipSubscriptionBinding(
   args: {
     readonly customerId: string;
     readonly subscriptionId: string;
+    readonly subscriptionStatus: string;
     readonly tier: SubscriptionCheckoutTier;
   },
 ): Promise<boolean> {
   const [existing] = await db
     .select({
       stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      subscriptionStatus: orgMetadata.subscriptionStatus,
       tier: orgMetadata.tier,
     })
     .from(orgMetadata)
@@ -2430,6 +2433,19 @@ async function shouldSkipSubscriptionBinding(
   if (existing?.stripeSubscriptionId === args.subscriptionId) {
     L.debug("subscription binding already processed", {
       subscriptionId: args.subscriptionId,
+    });
+    return true;
+  }
+  if (
+    args.subscriptionStatus === "incomplete" &&
+    (existing?.subscriptionStatus === "active" ||
+      existing?.subscriptionStatus === "trialing")
+  ) {
+    L.debug("provisional subscription cannot replace an active subscription", {
+      customerId: args.customerId,
+      subscriptionId: args.subscriptionId,
+      currentSubscriptionId: existing.stripeSubscriptionId,
+      currentSubscriptionStatus: existing.subscriptionStatus,
     });
     return true;
   }
@@ -2915,6 +2931,7 @@ async function bindSubscriptionToCustomerOrg(
     await shouldSkipSubscriptionBinding(db, {
       customerId: args.customerId,
       subscriptionId: args.subscription.id,
+      subscriptionStatus: args.subscription.status,
       tier: tierFromPriceId(priceId),
     })
   ) {
@@ -4489,6 +4506,29 @@ async function publishBillingChanges(
     signal.throwIfAborted();
   }
 }
+
+export const reconcilePaidStripeInvoice$ = command(
+  async (
+    { get, set },
+    invoice: StripeInvoice,
+    signal: AbortSignal,
+  ): Promise<string | null> => {
+    const db = set(writeDb$);
+    const getClerk = (): ClerkClient => {
+      return get(clerk$);
+    };
+    const orgId = await handleInvoicePaid(db, getClerk, invoice);
+    signal.throwIfAborted();
+    if (!orgId) {
+      return null;
+    }
+
+    await publishBillingChanges(db, new Set([orgId]), signal);
+    await set(drainOrgQueueToCapacity$, { orgId }, signal);
+    signal.throwIfAborted();
+    return orgId;
+  },
+);
 
 export const handleStripeWebhookEvent$ = command(
   async (

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -4,6 +4,7 @@ import { orgConcurrencyEntitlements } from "@okouai/db/schema/org-concurrency-en
 import { orgConcurrencySubscriptions } from "@okouai/db/schema/org-concurrency-subscription";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
 import { orgPlanEntitlements } from "@okouai/db/schema/org-plan-entitlement";
+import { usagePackSubscriptions } from "@okouai/db/schema/usage-pack-subscription";
 import {
   orgUsageAllowanceEntitlements,
   orgUsageAllowanceWindows,
@@ -41,6 +42,7 @@ import {
 import { downgradeSubscriptionForOrg } from "./zero-billing-downgrade.service";
 import {
   BILLING_DOWNGRADE_PURPOSE,
+  BILLING_PURCHASE_PURPOSE,
   BILLING_RESTORE_PURPOSE,
 } from "./billing-payment-method.service";
 import { restoreSubscriptionForOrg } from "./zero-billing-restore.service";
@@ -199,6 +201,11 @@ interface CheckoutSubscriptionContext {
 interface BillingRestoreCheckoutOutcome {
   readonly handled: boolean;
   readonly orgId: string | null;
+}
+
+interface CheckoutCompletedOutcome {
+  readonly drainOrgId: string | null;
+  readonly orgIds: readonly string[];
 }
 
 interface InvoicePaidOrg {
@@ -2118,6 +2125,25 @@ function billingRestoreCheckoutMetadata(
   return { orgId, subscriptionId };
 }
 
+function billingPurchaseCheckoutMetadata(
+  session: CheckoutSessionInput,
+): { readonly orgId: string; readonly subscriptionId: string } | null {
+  if (session.metadata?.purpose !== BILLING_PURCHASE_PURPOSE) {
+    return null;
+  }
+  const orgId = session.metadata.orgId;
+  const subscriptionId = session.metadata.subscriptionId;
+  if (!orgId || !subscriptionId) {
+    L.warn("billing purchase checkout missing metadata", {
+      sessionId: session.id,
+      orgId: orgId ?? null,
+      subscriptionId: subscriptionId ?? null,
+    });
+    return null;
+  }
+  return { orgId, subscriptionId };
+}
+
 function billingDowngradeTargetTier(
   value: string | undefined,
 ): BillingDowngradeCheckoutTargetTier | null {
@@ -2155,11 +2181,88 @@ function billingDowngradeCheckoutMetadata(session: CheckoutSessionInput): {
   return { orgId, subscriptionId, targetTier };
 }
 
+async function billingSetupSubscriptionState(
+  db: Db,
+  metadata: { readonly orgId: string; readonly subscriptionId: string },
+  subscriptionScope: "plan" | "purchase",
+): Promise<{
+  readonly org:
+    | {
+        readonly stripeCustomerId: string | null;
+        readonly stripeSubscriptionId: string | null;
+      }
+    | undefined;
+  readonly subscriptionMatches: boolean;
+  readonly expectedCustomerId: string | null;
+}> {
+  const [org] = await db
+    .select({
+      stripeCustomerId: orgMetadata.stripeCustomerId,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, metadata.orgId))
+    .limit(1);
+  if (subscriptionScope === "plan") {
+    return {
+      org,
+      subscriptionMatches:
+        org?.stripeSubscriptionId === metadata.subscriptionId,
+      expectedCustomerId: org?.stripeCustomerId ?? null,
+    };
+  }
+
+  const [usagePackSubscriptionsRows, concurrencySubscriptionsRows] =
+    await Promise.all([
+      db
+        .select({ stripeCustomerId: usagePackSubscriptions.stripeCustomerId })
+        .from(usagePackSubscriptions)
+        .where(
+          and(
+            eq(usagePackSubscriptions.orgId, metadata.orgId),
+            eq(
+              usagePackSubscriptions.stripeSubscriptionId,
+              metadata.subscriptionId,
+            ),
+          ),
+        )
+        .limit(1),
+      db
+        .select({
+          stripeSubscriptionId:
+            orgConcurrencySubscriptions.stripeSubscriptionId,
+        })
+        .from(orgConcurrencySubscriptions)
+        .where(
+          and(
+            eq(orgConcurrencySubscriptions.orgId, metadata.orgId),
+            eq(
+              orgConcurrencySubscriptions.stripeSubscriptionId,
+              metadata.subscriptionId,
+            ),
+          ),
+        )
+        .limit(1),
+    ]);
+  const usagePackSubscription = usagePackSubscriptionsRows[0];
+  const concurrencySubscription = concurrencySubscriptionsRows[0];
+  return {
+    org,
+    subscriptionMatches:
+      org?.stripeSubscriptionId === metadata.subscriptionId ||
+      usagePackSubscription !== undefined ||
+      concurrencySubscription !== undefined,
+    expectedCustomerId:
+      org?.stripeCustomerId ?? usagePackSubscription?.stripeCustomerId ?? null,
+  };
+}
+
 async function applyBillingSetupPaymentMethod(
   db: Db,
   session: CheckoutSessionInput,
   metadata: { readonly orgId: string; readonly subscriptionId: string },
   logContext: string,
+  subscriptionScope: "plan" | "purchase" = "plan",
 ): Promise<boolean> {
   if (session.mode !== "setup") {
     L.warn(`billing ${logContext} checkout completed with unexpected mode`, {
@@ -2178,19 +2281,13 @@ async function applyBillingSetupPaymentMethod(
     return false;
   }
 
-  const [org] = await db
-    .select({
-      stripeCustomerId: orgMetadata.stripeCustomerId,
-      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
-    })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, metadata.orgId))
-    .limit(1);
+  const { org, subscriptionMatches, expectedCustomerId } =
+    await billingSetupSubscriptionState(db, metadata, subscriptionScope);
 
   if (
     !org ||
-    org.stripeSubscriptionId !== metadata.subscriptionId ||
-    (org.stripeCustomerId !== null && org.stripeCustomerId !== customerId)
+    !subscriptionMatches ||
+    (expectedCustomerId !== null && expectedCustomerId !== customerId)
   ) {
     L.warn(
       `billing ${logContext} checkout no longer matches org billing state`,
@@ -2201,6 +2298,7 @@ async function applyBillingSetupPaymentMethod(
         metadataSubscriptionId: metadata.subscriptionId,
         orgStripeCustomerId: org?.stripeCustomerId ?? null,
         orgStripeSubscriptionId: org?.stripeSubscriptionId ?? null,
+        subscriptionScope,
       },
     );
     return false;
@@ -2254,6 +2352,27 @@ async function handleBillingRestoreCheckoutCompleted(
   }
 
   return { handled: true, orgId: metadata.orgId };
+}
+
+async function handleBillingPurchaseCheckoutCompleted(
+  db: Db,
+  session: CheckoutSessionInput,
+): Promise<BillingRestoreCheckoutOutcome> {
+  const metadata = billingPurchaseCheckoutMetadata(session);
+  if (!metadata) {
+    return { handled: false, orgId: null };
+  }
+  const paymentMethodSet = await applyBillingSetupPaymentMethod(
+    db,
+    session,
+    metadata,
+    "purchase",
+    "purchase",
+  );
+  return {
+    handled: true,
+    orgId: paymentMethodSet ? metadata.orgId : null,
+  };
 }
 
 async function handleBillingDowngradeCheckoutCompleted(
@@ -3447,15 +3566,48 @@ async function processSubscriptionInvoicePaid(
   return true;
 }
 
+function billingSetupCheckoutOutcome(
+  result: BillingRestoreCheckoutOutcome,
+): CheckoutCompletedOutcome {
+  return {
+    drainOrgId: null,
+    orgIds: result.orgId === null ? [] : [result.orgId],
+  };
+}
+
+async function handleBillingSetupCheckoutCompleted(
+  db: Db,
+  session: CheckoutSessionInput,
+): Promise<CheckoutCompletedOutcome | null> {
+  const restoreResult = await handleBillingRestoreCheckoutCompleted(
+    db,
+    session,
+  );
+  if (restoreResult.handled) {
+    return billingSetupCheckoutOutcome(restoreResult);
+  }
+  const downgradeResult = await handleBillingDowngradeCheckoutCompleted(
+    db,
+    session,
+  );
+  if (downgradeResult.handled) {
+    return billingSetupCheckoutOutcome(downgradeResult);
+  }
+  const purchaseResult = await handleBillingPurchaseCheckoutCompleted(
+    db,
+    session,
+  );
+  return purchaseResult.handled
+    ? billingSetupCheckoutOutcome(purchaseResult)
+    : null;
+}
+
 async function handleCheckoutCompleted(
   db: Db,
   getClerk: ClerkClientProvider,
   session: CheckoutSessionInput,
   paidAt: Date,
-): Promise<{
-  readonly drainOrgId: string | null;
-  readonly orgIds: readonly string[];
-}> {
+): Promise<CheckoutCompletedOutcome> {
   const usagePackInvitation = await handleUsagePackInvitationCheckoutPaid(
     db,
     getClerk(),
@@ -3469,30 +3621,12 @@ async function handleCheckoutCompleted(
     };
   }
 
-  const billingRestoreResult = await handleBillingRestoreCheckoutCompleted(
+  const billingSetupResult = await handleBillingSetupCheckoutCompleted(
     db,
     session,
   );
-  if (billingRestoreResult.handled) {
-    return {
-      drainOrgId: null,
-      orgIds:
-        billingRestoreResult.orgId === null ? [] : [billingRestoreResult.orgId],
-    };
-  }
-
-  const billingDowngradeResult = await handleBillingDowngradeCheckoutCompleted(
-    db,
-    session,
-  );
-  if (billingDowngradeResult.handled) {
-    return {
-      drainOrgId: null,
-      orgIds:
-        billingDowngradeResult.orgId === null
-          ? []
-          : [billingDowngradeResult.orgId],
-    };
+  if (billingSetupResult) {
+    return billingSetupResult;
   }
 
   if (session.metadata?.purpose === "credit_purchase") {

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -1087,6 +1087,45 @@ async function createConfirmedPlanSubscription(
   };
 }
 
+async function completeExistingPlanPurchase(
+  stripe: StripeClient,
+  preview: PlanPurchasePreviewToken,
+  subscription: StripeSubscription,
+  signal: AbortSignal,
+): Promise<ConfirmPlanPurchaseResult> {
+  const invoice = expandedLatestInvoice(subscription);
+  if (invoice && invoice.status !== "paid") {
+    const route = await resolveBillingPurchaseRoute(
+      {
+        stripe,
+        supportsInAppPreview: true,
+        customerId: preview.customerId,
+        subscriptionId: subscription.id,
+        subscription,
+      },
+      signal,
+    );
+    if (
+      route.kind === "checkout" ||
+      route.customerId !== preview.customerId ||
+      route.paymentMethodId !== preview.paymentMethodId
+    ) {
+      return { status: "invalid_preview" };
+    }
+  }
+  const completion = await completeBillingOperationInvoiceWithInvoice(
+    stripe,
+    invoice,
+    `plan:${preview.purchaseId}`,
+    signal,
+    { payOpenInvoice: true },
+  );
+  return {
+    status: "confirmed",
+    ...completion,
+  };
+}
+
 async function confirmPlanPurchaseTransaction(
   args: {
     readonly tx: WriteTx;
@@ -1114,17 +1153,12 @@ async function confirmPlanPurchaseTransaction(
     signal,
   );
   if (subscriptionState.existing) {
-    const completion = await completeBillingOperationInvoiceWithInvoice(
+    return await completeExistingPlanPurchase(
       stripe,
-      expandedLatestInvoice(subscriptionState.existing),
-      `plan:${preview.purchaseId}`,
+      preview,
+      subscriptionState.existing,
       signal,
-      { payOpenInvoice: true },
     );
-    return {
-      status: "confirmed",
-      ...completion,
-    };
   }
 
   const [org] = await tx

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -1,10 +1,12 @@
-import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
 import type {
   ConcurrencySubscriptionChangePreviewResponse,
+  BillingPurchaseConfirmResponse,
   CreditPurchaseConfirmResponse,
   CreditPurchasePreviewResponse,
+  PlanPurchasePreviewResponse,
   UsagePackUsd,
 } from "@okouai/api-contracts/contracts/zero-billing";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
@@ -18,8 +20,8 @@ import { nowDate } from "../../lib/time";
 import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import {
   getStripeClient,
-  stripeErrorInfo,
   type StripeClient,
+  type StripeCheckoutSessionCreateParams,
   type StripeInvoice,
   type StripeMetadataParam,
   type StripeSubscription,
@@ -32,7 +34,15 @@ import {
   previewStripeConcurrencySubscriptionChange$,
 } from "./zero-billing-concurrency-subscription.service";
 import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
-import { safeJsonParse, settle } from "../utils";
+import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
+import {
+  createBillingPreviewToken,
+  parseBillingPreviewToken,
+} from "./billing-purchase-preview-token.service";
+import {
+  resolveBillingPurchaseRoute,
+  stripeBillingPurchasePaymentParams,
+} from "./zero-billing-payment-method.service";
 
 interface CreateCheckoutSessionArgs {
   readonly orgId: string;
@@ -42,7 +52,27 @@ interface CreateCheckoutSessionArgs {
   readonly successUrl: string;
   readonly cancelUrl: string;
   readonly adAttribution?: Readonly<Record<string, string | undefined>>;
+  readonly checkoutIdempotencyKey?: string;
 }
+
+interface StartPlanPurchaseArgs extends CreateCheckoutSessionArgs {
+  readonly supportsInAppPreview: boolean;
+  readonly subscriptionId: string | null;
+}
+
+type StartPlanPurchaseResult =
+  | { readonly status: "checkout"; readonly url: string }
+  | {
+      readonly status: "preview";
+      readonly preview: PlanPurchasePreviewResponse;
+    };
+
+type ConfirmPlanPurchaseResult =
+  | {
+      readonly status: "confirmed";
+      readonly response: BillingPurchaseConfirmResponse;
+    }
+  | { readonly status: "invalid_preview" };
 
 interface CompleteCheckoutSessionArgs {
   readonly orgId: string;
@@ -64,11 +94,14 @@ interface CreateCreditCheckoutSessionArgs {
   readonly credits: number;
   readonly successUrl: string;
   readonly cancelUrl: string;
+  readonly checkoutIdempotencyKey?: string;
 }
 
 interface PreviewExistingBillingCreditPurchaseArgs {
   readonly orgId: string;
   readonly credits: number;
+  readonly successUrl: string;
+  readonly cancelUrl: string;
 }
 
 type ConfirmExistingBillingCreditPurchaseResult =
@@ -128,7 +161,7 @@ const ACTIVE_USAGE_ALLOWANCE_STATUSES = [
 export type SubscriptionCheckoutTier =
   (typeof STRIPE_SUBSCRIPTION_PRICE_TIERS)[number];
 
-async function orgConcurrencyBillingSubscriptionId(
+export async function orgPlanSubscriptionId(
   db: ReadonlyDb,
   orgId: string,
 ): Promise<string | null> {
@@ -185,8 +218,31 @@ const creditPurchasePreviewTokenSchema = z.object({
   credits: z.number().int().positive(),
   amountCents: z.number().int().nonnegative(),
   currency: z.string().length(3),
+  successUrl: z.string().url().optional(),
+  cancelUrl: z.string().url().optional(),
   expiresAt: z.iso.datetime(),
 });
+
+const planPurchasePreviewTokenSchema = z.object({
+  version: z.literal(1),
+  purchaseId: z.uuid(),
+  orgId: z.string().min(1),
+  customerId: z.string().min(1),
+  sourceSubscriptionId: z.string().min(1).nullable(),
+  paymentMethodId: z.string().min(1),
+  tier: z.enum(STRIPE_SUBSCRIPTION_PRICE_TIERS),
+  priceId: z.string().min(1),
+  trialDays: z.literal(7).optional(),
+  immediateAmountCents: z.number().int().nonnegative(),
+  nextRecurringAmountCents: z.number().int().nonnegative(),
+  currency: z.string().length(3),
+  successUrl: z.string().url(),
+  cancelUrl: z.string().url(),
+  adAttribution: z.record(z.string(), z.string()).optional(),
+  expiresAt: z.iso.datetime(),
+});
+
+type PlanPurchasePreviewToken = z.infer<typeof planPurchasePreviewTokenSchema>;
 
 type CreditPurchasePreviewToken = z.infer<
   typeof creditPurchasePreviewTokenSchema
@@ -375,43 +431,28 @@ export function activeCustomCreditUnitPriceId(): string | undefined {
   return env("OKOU_PRICE_CUSTOM_CREDIT_UNIT");
 }
 
-function creditPurchasePreviewTokenSignature(encodedPayload: string): Buffer {
-  return createHmac("sha256", env("SECRETS_ENCRYPTION_KEY"))
-    .update(encodedPayload)
-    .digest();
-}
-
 function createCreditPurchasePreviewToken(
   payload: CreditPurchasePreviewToken,
 ): string {
-  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
-    "base64url",
-  );
-  const signature =
-    creditPurchasePreviewTokenSignature(encodedPayload).toString("base64url");
-  return `${encodedPayload}.${signature}`;
+  return createBillingPreviewToken(payload);
 }
 
 function parseCreditPurchasePreviewToken(
   token: string,
 ): CreditPurchasePreviewToken | null {
-  const [encodedPayload, encodedSignature, extra] = token.split(".");
-  if (!encodedPayload || !encodedSignature || extra !== undefined) {
-    return null;
-  }
-  const providedSignature = Buffer.from(encodedSignature, "base64url");
-  const expectedSignature = creditPurchasePreviewTokenSignature(encodedPayload);
-  if (
-    providedSignature.length !== expectedSignature.length ||
-    !timingSafeEqual(providedSignature, expectedSignature)
-  ) {
-    return null;
-  }
-  const parsed = safeJsonParse(
-    Buffer.from(encodedPayload, "base64url").toString("utf8"),
-  );
-  const result = creditPurchasePreviewTokenSchema.safeParse(parsed);
-  return result.success ? result.data : null;
+  return parseBillingPreviewToken(token, creditPurchasePreviewTokenSchema);
+}
+
+function createPlanPurchasePreviewToken(
+  payload: PlanPurchasePreviewToken,
+): string {
+  return createBillingPreviewToken(payload);
+}
+
+function parsePlanPurchasePreviewToken(
+  token: string,
+): PlanPurchasePreviewToken | null {
+  return parseBillingPreviewToken(token, planPurchasePreviewTokenSchema);
 }
 
 interface ExistingCreditBilling {
@@ -438,44 +479,6 @@ async function existingCreditBilling(
     customerId: org.customerId,
     subscriptionId: org.subscriptionId,
   };
-}
-
-async function existingCreditPaymentMethodId(
-  stripe: StripeClient,
-  billing: ExistingCreditBilling,
-  signal: AbortSignal,
-): Promise<string | null> {
-  if (billing.subscriptionId) {
-    const subscription = await stripe.subscriptions.retrieve(
-      billing.subscriptionId,
-    );
-    signal.throwIfAborted();
-    const subscriptionPaymentMethodId = stripeObjectId(
-      subscription.default_payment_method,
-    );
-    if (subscriptionPaymentMethodId) {
-      return subscriptionPaymentMethodId;
-    }
-  }
-
-  const customer = await stripe.customers.retrieve(billing.customerId);
-  signal.throwIfAborted();
-  if (!("deleted" in customer) || !customer.deleted) {
-    const customerPaymentMethodId = stripeObjectId(
-      customer.invoice_settings?.default_payment_method,
-    );
-    if (customerPaymentMethodId) {
-      return customerPaymentMethodId;
-    }
-  }
-
-  const paymentMethods = await stripe.paymentMethods.list({
-    customer: billing.customerId,
-    type: "card",
-    limit: 1,
-  });
-  signal.throwIfAborted();
-  return paymentMethods.data[0]?.id ?? null;
 }
 
 async function existingCreditCouponId(
@@ -527,12 +530,16 @@ export const previewExistingBillingCreditPurchase$ = command(
     }
 
     const stripe = getStripeClient();
-    const paymentMethodId = await existingCreditPaymentMethodId(
-      stripe,
-      billing,
+    const route = await resolveBillingPurchaseRoute(
+      {
+        stripe,
+        supportsInAppPreview: true,
+        customerId: billing.customerId,
+        subscriptionId: billing.subscriptionId,
+      },
       signal,
     );
-    if (!paymentMethodId) {
+    if (route.kind === "checkout") {
       return null;
     }
     const couponId = await existingCreditCouponId(
@@ -577,14 +584,16 @@ export const previewExistingBillingCreditPurchase$ = command(
       version: 1,
       purchaseId,
       orgId: args.orgId,
-      customerId: billing.customerId,
-      paymentMethodId,
+      customerId: route.customerId,
+      paymentMethodId: route.paymentMethodId,
       couponId,
       priceId,
       quantity,
       credits,
       amountCents,
       currency: invoice.currency,
+      successUrl: args.successUrl,
+      cancelUrl: args.cancelUrl,
       expiresAt,
     };
     return {
@@ -597,15 +606,6 @@ export const previewExistingBillingCreditPurchase$ = command(
     };
   },
 );
-
-function isPaymentActionRequired(error: unknown): boolean {
-  const code = stripeErrorInfo(error)?.code;
-  return (
-    code === "authentication_required" ||
-    code === "invoice_payment_intent_requires_action" ||
-    code === "payment_intent_action_required"
-  );
-}
 
 async function finalizeCreditPurchaseInvoice(
   stripe: StripeClient,
@@ -623,44 +623,6 @@ async function finalizeCreditPurchaseInvoice(
   );
   signal.throwIfAborted();
   return finalized;
-}
-
-async function payCreditPurchaseInvoice(
-  stripe: StripeClient,
-  invoice: StripeInvoice,
-  purchaseId: string,
-  signal: AbortSignal,
-): Promise<CreditPurchaseConfirmResponse> {
-  let current = invoice;
-  if (current.status === "open") {
-    const paid = await settle(
-      stripe.invoices.pay(
-        current.id,
-        {},
-        { idempotencyKey: `credit-purchase:${purchaseId}:pay` },
-      ),
-      signal,
-    );
-    if (paid.ok) {
-      current = paid.value;
-    } else {
-      if (!isPaymentActionRequired(paid.error)) {
-        throw paid.error;
-      }
-      current = await stripe.invoices.retrieve(current.id);
-    }
-    signal.throwIfAborted();
-  }
-  if (current.status === "paid") {
-    return { status: "completed", hostedInvoiceUrl: null };
-  }
-  if (current.hosted_invoice_url) {
-    return {
-      status: "pending_payment",
-      hostedInvoiceUrl: current.hosted_invoice_url,
-    };
-  }
-  throw new Error("Stripe credit purchase invoice could not be paid");
 }
 
 async function discardChangedCreditPurchaseInvoice(
@@ -694,7 +656,7 @@ async function discardChangedCreditPurchaseInvoice(
 
 export const confirmExistingBillingCreditPurchase$ = command(
   async (
-    { get },
+    { get, set },
     orgId: string,
     previewToken: string,
     signal: AbortSignal,
@@ -715,12 +677,39 @@ export const confirmExistingBillingCreditPurchase$ = command(
       return { status: "billing_unavailable" };
     }
     const stripe = getStripeClient();
-    const paymentMethodId = await existingCreditPaymentMethodId(
-      stripe,
-      billing,
+    const route = await resolveBillingPurchaseRoute(
+      {
+        stripe,
+        supportsInAppPreview: true,
+        customerId: billing.customerId,
+        subscriptionId: billing.subscriptionId,
+      },
       signal,
     );
-    if (paymentMethodId !== preview.paymentMethodId) {
+    if (route.kind === "checkout") {
+      if (!preview.successUrl || !preview.cancelUrl) {
+        return { status: "billing_unavailable" };
+      }
+      const checkoutUrl = await set(
+        createCreditCheckoutSession$,
+        {
+          orgId,
+          credits: preview.credits,
+          successUrl: preview.successUrl,
+          cancelUrl: preview.cancelUrl,
+          checkoutIdempotencyKey: `credit-purchase:${preview.purchaseId}:checkout`,
+        },
+        signal,
+      );
+      return {
+        status: "confirmed",
+        response: { status: "checkout_required", checkoutUrl },
+      };
+    }
+    if (
+      route.customerId !== preview.customerId ||
+      route.paymentMethodId !== preview.paymentMethodId
+    ) {
       return { status: "invalid_preview" };
     }
 
@@ -737,7 +726,7 @@ export const confirmExistingBillingCreditPurchase$ = command(
       {
         customer: preview.customerId,
         auto_advance: false,
-        default_payment_method: preview.paymentMethodId,
+        ...stripeBillingPurchasePaymentParams(route),
         discounts: preview.couponId ? [{ coupon: preview.couponId }] : "",
         metadata,
       },
@@ -785,11 +774,12 @@ export const confirmExistingBillingCreditPurchase$ = command(
     }
     return {
       status: "confirmed",
-      response: await payCreditPurchaseInvoice(
+      response: await completeBillingOperationInvoice(
         stripe,
         confirmedInvoice,
-        preview.purchaseId,
+        `credit:${preview.purchaseId}`,
         signal,
+        { payOpenInvoice: true },
       ),
     };
   },
@@ -830,12 +820,279 @@ function subscriptionWillCancel(subscription: StripeSubscription): boolean {
   return subscription.cancel_at_period_end || subscription.cancel_at !== null;
 }
 
+function definedAttribution(
+  attribution: Readonly<Record<string, string | undefined>> | undefined,
+): Record<string, string> | undefined {
+  const entries = Object.entries(attribution ?? {}).filter(
+    (entry): entry is [string, string] => {
+      return entry[1] !== undefined;
+    },
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function expandedLatestInvoice(
+  subscription: StripeSubscription,
+): StripeInvoice | null {
+  return subscription.latest_invoice &&
+    typeof subscription.latest_invoice !== "string"
+    ? subscription.latest_invoice
+    : null;
+}
+
+async function planPurchaseSubscription(
+  stripe: StripeClient,
+  customerId: string,
+  purchaseId: string,
+  signal: AbortSignal,
+): Promise<StripeSubscription | null> {
+  const subscriptions = await stripe.subscriptions.list({
+    customer: customerId,
+    status: "all",
+    limit: 100,
+  });
+  signal.throwIfAborted();
+  const existing = subscriptions.data.find((subscription) => {
+    return subscription.metadata?.billingPurchaseId === purchaseId;
+  });
+  if (!existing) {
+    return null;
+  }
+  const subscription = await stripe.subscriptions.retrieve(existing.id, {
+    expand: ["latest_invoice"],
+  });
+  signal.throwIfAborted();
+  return subscription;
+}
+
+export const startPlanPurchase$ = command(
+  async (
+    { set },
+    args: StartPlanPurchaseArgs,
+    signal: AbortSignal,
+  ): Promise<StartPlanPurchaseResult> => {
+    if (!args.supportsInAppPreview) {
+      return {
+        status: "checkout",
+        url: await set(createCheckoutSession$, args, signal),
+      };
+    }
+
+    await set(
+      persistOrgAcquisitionAttribution$,
+      { orgId: args.orgId, attribution: args.adAttribution },
+      signal,
+    );
+    const customerId = await set(
+      getOrCreateStripeCustomer$,
+      { orgId: args.orgId, metadata: args.adAttribution },
+      signal,
+    );
+    signal.throwIfAborted();
+    const stripe = getStripeClient();
+    const route = await resolveBillingPurchaseRoute(
+      {
+        stripe,
+        supportsInAppPreview: true,
+        customerId,
+        subscriptionId: args.subscriptionId,
+      },
+      signal,
+    );
+    if (route.kind === "checkout") {
+      return {
+        status: "checkout",
+        url: await set(createCheckoutSession$, args, signal),
+      };
+    }
+
+    const invoice = await stripe.invoices.createPreview({
+      customer: route.customerId,
+      preview_mode: "next",
+      subscription_details: {
+        items: [{ price: args.priceId, quantity: 1 }],
+      },
+    });
+    signal.throwIfAborted();
+    const nextRecurringAmountCents = creditPurchasePayableAmount(invoice);
+    if (invoice.currency.length !== 3) {
+      throw new Error("Stripe Plan purchase preview has an invalid currency");
+    }
+    const purchaseId = randomUUID();
+    const expiresAt = new Date(
+      nowDate().getTime() + CREDIT_PURCHASE_PREVIEW_TTL_MS,
+    ).toISOString();
+    const token: PlanPurchasePreviewToken = {
+      version: 1,
+      purchaseId,
+      orgId: args.orgId,
+      customerId: route.customerId,
+      sourceSubscriptionId: args.subscriptionId,
+      paymentMethodId: route.paymentMethodId,
+      tier: args.tier,
+      priceId: args.priceId,
+      ...(args.trialDays === undefined ? {} : { trialDays: args.trialDays }),
+      immediateAmountCents:
+        args.trialDays === undefined ? nextRecurringAmountCents : 0,
+      nextRecurringAmountCents,
+      currency: invoice.currency,
+      successUrl: args.successUrl,
+      cancelUrl: args.cancelUrl,
+      ...(definedAttribution(args.adAttribution) === undefined
+        ? {}
+        : { adAttribution: definedAttribution(args.adAttribution) }),
+      expiresAt,
+    };
+    return {
+      status: "preview",
+      preview: {
+        status: "preview",
+        purchaseType: "plan",
+        tier: args.tier,
+        immediateAmountCents: token.immediateAmountCents,
+        nextRecurringAmountCents,
+        currency: invoice.currency,
+        expiresAt,
+        previewToken: createPlanPurchasePreviewToken(token),
+        ...(args.trialDays === undefined ? {} : { trialDays: args.trialDays }),
+      },
+    };
+  },
+);
+
+export const confirmPlanPurchase$ = command(
+  async (
+    { set },
+    orgId: string,
+    previewToken: string,
+    signal: AbortSignal,
+  ): Promise<ConfirmPlanPurchaseResult> => {
+    const preview = parsePlanPurchasePreviewToken(previewToken);
+    if (
+      !preview ||
+      preview.orgId !== orgId ||
+      new Date(preview.expiresAt) <= nowDate() ||
+      preview.priceId !== activePriceId(preview.tier)
+    ) {
+      return { status: "invalid_preview" };
+    }
+
+    const stripe = getStripeClient();
+    const existing = await planPurchaseSubscription(
+      stripe,
+      preview.customerId,
+      preview.purchaseId,
+      signal,
+    );
+    if (existing) {
+      return {
+        status: "confirmed",
+        response: await completeBillingOperationInvoice(
+          stripe,
+          expandedLatestInvoice(existing),
+          `plan:${preview.purchaseId}`,
+          signal,
+        ),
+      };
+    }
+
+    const route = await resolveBillingPurchaseRoute(
+      {
+        stripe,
+        supportsInAppPreview: true,
+        customerId: preview.customerId,
+        subscriptionId: preview.sourceSubscriptionId,
+      },
+      signal,
+    );
+    if (route.kind === "checkout") {
+      const url = await set(
+        createCheckoutSession$,
+        {
+          orgId,
+          tier: preview.tier,
+          priceId: preview.priceId,
+          trialDays: preview.trialDays,
+          successUrl: preview.successUrl,
+          cancelUrl: preview.cancelUrl,
+          adAttribution: preview.adAttribution,
+          checkoutIdempotencyKey: `plan-purchase:${preview.purchaseId}:checkout`,
+        },
+        signal,
+      );
+      return {
+        status: "confirmed",
+        response: { status: "checkout_required", checkoutUrl: url },
+      };
+    }
+    if (
+      route.customerId !== preview.customerId ||
+      route.paymentMethodId !== preview.paymentMethodId
+    ) {
+      return { status: "invalid_preview" };
+    }
+
+    const currentPreview = await stripe.invoices.createPreview({
+      customer: preview.customerId,
+      preview_mode: "next",
+      subscription_details: {
+        items: [{ price: preview.priceId, quantity: 1 }],
+      },
+    });
+    signal.throwIfAborted();
+    const nextRecurringAmountCents =
+      creditPurchasePayableAmount(currentPreview);
+    if (
+      currentPreview.currency !== preview.currency ||
+      nextRecurringAmountCents !== preview.nextRecurringAmountCents ||
+      (preview.trialDays === undefined ? nextRecurringAmountCents : 0) !==
+        preview.immediateAmountCents
+    ) {
+      return { status: "invalid_preview" };
+    }
+
+    const metadata: StripeMetadataParam = {
+      ...checkoutSessionMetadata({
+        orgId,
+        tier: preview.tier,
+        priceId: preview.priceId,
+        adAttribution: preview.adAttribution,
+      }),
+      billingPurchaseId: preview.purchaseId,
+    };
+    const subscription = await stripe.subscriptions.create(
+      {
+        customer: preview.customerId,
+        items: [{ price: preview.priceId, quantity: 1 }],
+        ...stripeBillingPurchasePaymentParams(route),
+        metadata,
+        payment_behavior: "default_incomplete",
+        ...(preview.trialDays === undefined
+          ? {}
+          : { trial_period_days: preview.trialDays }),
+        expand: ["latest_invoice"],
+      },
+      { idempotencyKey: `plan-purchase:${preview.purchaseId}:subscription` },
+    );
+    signal.throwIfAborted();
+    return {
+      status: "confirmed",
+      response: await completeBillingOperationInvoice(
+        stripe,
+        expandedLatestInvoice(subscription),
+        `plan:${preview.purchaseId}`,
+        signal,
+      ),
+    };
+  },
+);
+
 /**
  * Create a Stripe Checkout session for subscription. Returns the
  * checkout session URL. Mirrors apps/web's createCheckoutSession
  * (allow_promotion_codes + subscription metadata orgId tag).
  */
-export const createCheckoutSession$ = command(
+const createCheckoutSession$ = command(
   async (
     { set },
     args: CreateCheckoutSessionArgs,
@@ -862,7 +1119,7 @@ export const createCheckoutSession$ = command(
     signal.throwIfAborted();
 
     const stripe = getStripeClient();
-    const session = await stripe.checkout.sessions.create({
+    const params: StripeCheckoutSessionCreateParams = {
       mode: "subscription",
       customer: customerId,
       line_items: [{ price: args.priceId, quantity: 1 }],
@@ -876,7 +1133,12 @@ export const createCheckoutSession$ = command(
           ? {}
           : { trial_period_days: args.trialDays }),
       },
-    });
+    };
+    const session = args.checkoutIdempotencyKey
+      ? await stripe.checkout.sessions.create(params, {
+          idempotencyKey: args.checkoutIdempotencyKey,
+        })
+      : await stripe.checkout.sessions.create(params);
     signal.throwIfAborted();
 
     if (!session.url) {
@@ -1002,7 +1264,7 @@ export const createCreditCheckoutSession$ = command(
       creditsAmountMode: "amount_subtotal",
       requestedCreditsAmount: String(args.credits),
     };
-    const session = await stripe.checkout.sessions.create({
+    const params: StripeCheckoutSessionCreateParams = {
       mode: "payment",
       customer: customerId,
       line_items: [{ price: customCreditUnitPriceId, quantity: unitQuantity }],
@@ -1028,7 +1290,12 @@ export const createCreditCheckoutSession$ = command(
         },
       },
       metadata,
-    });
+    };
+    const session = args.checkoutIdempotencyKey
+      ? await stripe.checkout.sessions.create(params, {
+          idempotencyKey: args.checkoutIdempotencyKey,
+        })
+      : await stripe.checkout.sessions.create(params);
     signal.throwIfAborted();
 
     if (!session.url) {
@@ -1048,7 +1315,7 @@ export const previewInitialConcurrencyPurchase$ = command(
     },
     signal: AbortSignal,
   ): Promise<PreviewInitialConcurrencyPurchaseResult> => {
-    const subscriptionId = await orgConcurrencyBillingSubscriptionId(
+    const subscriptionId = await orgPlanSubscriptionId(
       set(writeDb$),
       args.orgId,
     );
@@ -1108,7 +1375,7 @@ export const startConcurrencyPurchase$ = command(
       };
     }
 
-    const subscriptionId = await orgConcurrencyBillingSubscriptionId(
+    const subscriptionId = await orgPlanSubscriptionId(
       set(writeDb$),
       args.orgId,
     );

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -34,7 +34,10 @@ import {
   previewStripeConcurrencySubscriptionChange$,
 } from "./zero-billing-concurrency-subscription.service";
 import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
-import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
+import {
+  completeBillingOperationInvoice,
+  completeBillingOperationInvoiceWithInvoice,
+} from "./billing-operation-invoice.service";
 import { lockBillingPurchaseOrg } from "./billing-purchase-lock.service";
 import {
   createBillingPreviewToken,
@@ -73,6 +76,7 @@ type ConfirmPlanPurchaseResult =
   | {
       readonly status: "confirmed";
       readonly response: BillingPurchaseConfirmResponse;
+      readonly paidInvoice: StripeInvoice | null;
     }
   | { readonly status: "invalid_preview" };
 
@@ -852,6 +856,10 @@ async function planPurchaseSubscriptionState(
     readonly customerId: string;
     readonly purchaseId: string;
     readonly sourceSubscriptionId: string | null;
+    readonly targetTier: SubscriptionCheckoutTier;
+    readonly targetPriceId: string;
+    readonly immediateAmountCents: number;
+    readonly currency: string;
   },
   signal: AbortSignal,
 ): Promise<{
@@ -864,15 +872,37 @@ async function planPurchaseSubscriptionState(
     limit: 100,
   });
   signal.throwIfAborted();
-  const existingSummary = subscriptions.data.find((subscription) => {
+  const exactPurchase = subscriptions.data.find((subscription) => {
     return subscription.metadata?.billingPurchaseId === args.purchaseId;
   });
+  const resumablePurchase = subscriptions.data.find((subscription) => {
+    return (
+      subscription.metadata?.orgId === args.orgId &&
+      subscription.metadata.billingPurchaseId !== undefined &&
+      knownPlanPriceItem(subscription.items.data)?.price.id ===
+        args.targetPriceId &&
+      subscription.status === "incomplete"
+    );
+  });
+  const existingSummary = exactPurchase ?? resumablePurchase;
   const hasCompetingPurchase = subscriptions.data.some((subscription) => {
+    const tier = tierForKnownPriceId(
+      knownPlanPriceItem(subscription.items.data)?.price.id ?? "",
+    );
+    const isReplaceableActivePlan =
+      tier !== null &&
+      (subscription.status === "active" ||
+        subscription.status === "trialing") &&
+      !checkoutWouldReplaceWithSameOrLowerTier({
+        currentTier: tier,
+        targetTier: args.targetTier,
+      });
     return (
       subscription.id !== args.sourceSubscriptionId &&
+      subscription.id !== existingSummary?.id &&
       subscription.metadata?.orgId === args.orgId &&
-      knownPlanPriceItem(subscription.items.data) !== undefined &&
-      subscription.metadata?.billingPurchaseId !== args.purchaseId &&
+      tier !== null &&
+      !isReplaceableActivePlan &&
       subscription.status !== "canceled" &&
       subscription.status !== "incomplete_expired"
     );
@@ -885,6 +915,15 @@ async function planPurchaseSubscriptionState(
     { expand: ["latest_invoice"] },
   );
   signal.throwIfAborted();
+  const invoice = expandedLatestInvoice(existing);
+  if (
+    existingSummary !== exactPurchase &&
+    (!invoice ||
+      invoice.amount_due !== args.immediateAmountCents ||
+      invoice.currency !== args.currency)
+  ) {
+    return { existing: null, hasCompetingPurchase: true };
+  }
   return { existing, hasCompetingPurchase };
 }
 
@@ -1035,15 +1074,16 @@ async function createConfirmedPlanSubscription(
     { idempotencyKey: `plan-purchase:${preview.purchaseId}:subscription` },
   );
   signal.throwIfAborted();
+  const completion = await completeBillingOperationInvoiceWithInvoice(
+    stripe,
+    expandedLatestInvoice(subscription),
+    `plan:${preview.purchaseId}`,
+    signal,
+    { payOpenInvoice: true },
+  );
   return {
     status: "confirmed",
-    response: await completeBillingOperationInvoice(
-      stripe,
-      expandedLatestInvoice(subscription),
-      `plan:${preview.purchaseId}`,
-      signal,
-      { payOpenInvoice: true },
-    ),
+    ...completion,
   };
 }
 
@@ -1066,19 +1106,24 @@ async function confirmPlanPurchaseTransaction(
       customerId: preview.customerId,
       purchaseId: preview.purchaseId,
       sourceSubscriptionId: preview.sourceSubscriptionId,
+      targetTier: preview.tier,
+      targetPriceId: preview.priceId,
+      immediateAmountCents: preview.immediateAmountCents,
+      currency: preview.currency,
     },
     signal,
   );
   if (subscriptionState.existing) {
+    const completion = await completeBillingOperationInvoiceWithInvoice(
+      stripe,
+      expandedLatestInvoice(subscriptionState.existing),
+      `plan:${preview.purchaseId}`,
+      signal,
+      { payOpenInvoice: true },
+    );
     return {
       status: "confirmed",
-      response: await completeBillingOperationInvoice(
-        stripe,
-        expandedLatestInvoice(subscriptionState.existing),
-        `plan:${preview.purchaseId}`,
-        signal,
-        { payOpenInvoice: true },
-      ),
+      ...completion,
     };
   }
 
@@ -1134,6 +1179,7 @@ async function confirmPlanPurchaseTransaction(
     return {
       status: "confirmed",
       response: { status: "checkout_required", checkoutUrl: url },
+      paidInvoice: null,
     };
   }
   if (

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -17,7 +17,7 @@ import { z } from "zod";
 
 import { env } from "../../lib/env";
 import { nowDate } from "../../lib/time";
-import { db$, writeDb$, type ReadonlyDb } from "../external/db";
+import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import {
   getStripeClient,
   type StripeClient,
@@ -35,6 +35,7 @@ import {
 } from "./zero-billing-concurrency-subscription.service";
 import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
+import { lockBillingPurchaseOrg } from "./billing-purchase-lock.service";
 import {
   createBillingPreviewToken,
   parseBillingPreviewToken,
@@ -42,7 +43,8 @@ import {
 import {
   resolveBillingPurchaseRoute,
   stripeBillingPurchasePaymentParams,
-} from "./zero-billing-payment-method.service";
+  type BillingPurchasePaymentMethod,
+} from "./billing-payment-method.service";
 
 interface CreateCheckoutSessionArgs {
   readonly orgId: string;
@@ -73,6 +75,8 @@ type ConfirmPlanPurchaseResult =
       readonly response: BillingPurchaseConfirmResponse;
     }
   | { readonly status: "invalid_preview" };
+
+type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 
 interface CompleteCheckoutSessionArgs {
   readonly orgId: string;
@@ -119,6 +123,7 @@ interface StartConcurrencyPurchaseArgs {
   readonly existingSubscriptionId?: string;
   readonly hasScheduledConcurrencyChange: boolean;
   readonly successUrl: string;
+  readonly paymentMethod?: BillingPurchasePaymentMethod;
 }
 
 type StartConcurrencyPurchaseResult =
@@ -840,29 +845,47 @@ function expandedLatestInvoice(
     : null;
 }
 
-async function planPurchaseSubscription(
-  stripe: StripeClient,
-  customerId: string,
-  purchaseId: string,
+async function planPurchaseSubscriptionState(
+  args: {
+    readonly stripe: StripeClient;
+    readonly orgId: string;
+    readonly customerId: string;
+    readonly purchaseId: string;
+    readonly sourceSubscriptionId: string | null;
+  },
   signal: AbortSignal,
-): Promise<StripeSubscription | null> {
-  const subscriptions = await stripe.subscriptions.list({
-    customer: customerId,
+): Promise<{
+  readonly existing: StripeSubscription | null;
+  readonly hasCompetingPurchase: boolean;
+}> {
+  const subscriptions = await args.stripe.subscriptions.list({
+    customer: args.customerId,
     status: "all",
     limit: 100,
   });
   signal.throwIfAborted();
-  const existing = subscriptions.data.find((subscription) => {
-    return subscription.metadata?.billingPurchaseId === purchaseId;
+  const existingSummary = subscriptions.data.find((subscription) => {
+    return subscription.metadata?.billingPurchaseId === args.purchaseId;
   });
-  if (!existing) {
-    return null;
+  const hasCompetingPurchase = subscriptions.data.some((subscription) => {
+    return (
+      subscription.id !== args.sourceSubscriptionId &&
+      subscription.metadata?.orgId === args.orgId &&
+      knownPlanPriceItem(subscription.items.data) !== undefined &&
+      subscription.metadata?.billingPurchaseId !== args.purchaseId &&
+      subscription.status !== "canceled" &&
+      subscription.status !== "incomplete_expired"
+    );
+  });
+  if (!existingSummary) {
+    return { existing: null, hasCompetingPurchase };
   }
-  const subscription = await stripe.subscriptions.retrieve(existing.id, {
-    expand: ["latest_invoice"],
-  });
+  const existing = await args.stripe.subscriptions.retrieve(
+    existingSummary.id,
+    { expand: ["latest_invoice"] },
+  );
   signal.throwIfAborted();
-  return subscription;
+  return { existing, hasCompetingPurchase };
 }
 
 export const startPlanPurchase$ = command(
@@ -960,6 +983,174 @@ export const startPlanPurchase$ = command(
   },
 );
 
+async function createConfirmedPlanSubscription(
+  args: {
+    readonly stripe: StripeClient;
+    readonly orgId: string;
+    readonly preview: PlanPurchasePreviewToken;
+    readonly paymentMethod: BillingPurchasePaymentMethod;
+  },
+  signal: AbortSignal,
+): Promise<ConfirmPlanPurchaseResult> {
+  const { stripe, orgId, preview, paymentMethod } = args;
+  const currentPreview = await stripe.invoices.createPreview({
+    customer: preview.customerId,
+    preview_mode: "next",
+    subscription_details: {
+      items: [{ price: preview.priceId, quantity: 1 }],
+    },
+  });
+  signal.throwIfAborted();
+  const nextRecurringAmountCents = creditPurchasePayableAmount(currentPreview);
+  if (
+    currentPreview.currency !== preview.currency ||
+    nextRecurringAmountCents !== preview.nextRecurringAmountCents ||
+    (preview.trialDays === undefined ? nextRecurringAmountCents : 0) !==
+      preview.immediateAmountCents
+  ) {
+    return { status: "invalid_preview" };
+  }
+
+  const metadata: StripeMetadataParam = {
+    ...checkoutSessionMetadata({
+      orgId,
+      tier: preview.tier,
+      priceId: preview.priceId,
+      adAttribution: preview.adAttribution,
+    }),
+    billingPurchaseId: preview.purchaseId,
+  };
+  const subscription = await stripe.subscriptions.create(
+    {
+      customer: preview.customerId,
+      items: [{ price: preview.priceId, quantity: 1 }],
+      ...stripeBillingPurchasePaymentParams(paymentMethod),
+      metadata,
+      payment_behavior: "default_incomplete",
+      ...(preview.trialDays === undefined
+        ? {}
+        : { trial_period_days: preview.trialDays }),
+      expand: ["latest_invoice"],
+    },
+    { idempotencyKey: `plan-purchase:${preview.purchaseId}:subscription` },
+  );
+  signal.throwIfAborted();
+  return {
+    status: "confirmed",
+    response: await completeBillingOperationInvoice(
+      stripe,
+      expandedLatestInvoice(subscription),
+      `plan:${preview.purchaseId}`,
+      signal,
+    ),
+  };
+}
+
+async function confirmPlanPurchaseTransaction(
+  args: {
+    readonly tx: WriteTx;
+    readonly orgId: string;
+    readonly preview: PlanPurchasePreviewToken;
+  },
+  signal: AbortSignal,
+): Promise<ConfirmPlanPurchaseResult> {
+  const { tx, orgId, preview } = args;
+  await lockBillingPurchaseOrg(tx, orgId);
+  signal.throwIfAborted();
+  const stripe = getStripeClient();
+  const subscriptionState = await planPurchaseSubscriptionState(
+    {
+      stripe,
+      orgId,
+      customerId: preview.customerId,
+      purchaseId: preview.purchaseId,
+      sourceSubscriptionId: preview.sourceSubscriptionId,
+    },
+    signal,
+  );
+  if (subscriptionState.existing) {
+    return {
+      status: "confirmed",
+      response: await completeBillingOperationInvoice(
+        stripe,
+        expandedLatestInvoice(subscriptionState.existing),
+        `plan:${preview.purchaseId}`,
+        signal,
+      ),
+    };
+  }
+
+  const [org] = await tx
+    .select({
+      customerId: orgMetadata.stripeCustomerId,
+      subscriptionId: orgMetadata.stripeSubscriptionId,
+      tier: orgMetadata.tier,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .for("update")
+    .limit(1);
+  signal.throwIfAborted();
+  if (
+    !org ||
+    org.customerId !== preview.customerId ||
+    org.subscriptionId !== preview.sourceSubscriptionId ||
+    checkoutWouldReplaceWithSameOrLowerTier({
+      currentTier: org.tier,
+      targetTier: preview.tier,
+    }) ||
+    subscriptionState.hasCompetingPurchase
+  ) {
+    return { status: "invalid_preview" };
+  }
+
+  const route = await resolveBillingPurchaseRoute(
+    {
+      stripe,
+      supportsInAppPreview: true,
+      customerId: preview.customerId,
+      subscriptionId: preview.sourceSubscriptionId,
+    },
+    signal,
+  );
+  if (route.kind === "checkout") {
+    const url = await createPlanCheckoutSession(
+      stripe,
+      preview.customerId,
+      {
+        orgId,
+        tier: preview.tier,
+        priceId: preview.priceId,
+        trialDays: preview.trialDays,
+        successUrl: preview.successUrl,
+        cancelUrl: preview.cancelUrl,
+        adAttribution: preview.adAttribution,
+        checkoutIdempotencyKey: `plan-purchase:${preview.purchaseId}:checkout`,
+      },
+      signal,
+    );
+    return {
+      status: "confirmed",
+      response: { status: "checkout_required", checkoutUrl: url },
+    };
+  }
+  if (
+    route.customerId !== preview.customerId ||
+    route.paymentMethodId !== preview.paymentMethodId
+  ) {
+    return { status: "invalid_preview" };
+  }
+  return await createConfirmedPlanSubscription(
+    {
+      stripe,
+      orgId,
+      preview,
+      paymentMethod: route,
+    },
+    signal,
+  );
+}
+
 export const confirmPlanPurchase$ = command(
   async (
     { set },
@@ -977,113 +1168,17 @@ export const confirmPlanPurchase$ = command(
       return { status: "invalid_preview" };
     }
 
-    const stripe = getStripeClient();
-    const existing = await planPurchaseSubscription(
-      stripe,
-      preview.customerId,
-      preview.purchaseId,
-      signal,
-    );
-    if (existing) {
-      return {
-        status: "confirmed",
-        response: await completeBillingOperationInvoice(
-          stripe,
-          expandedLatestInvoice(existing),
-          `plan:${preview.purchaseId}`,
-          signal,
-        ),
-      };
-    }
-
-    const route = await resolveBillingPurchaseRoute(
-      {
-        stripe,
-        supportsInAppPreview: true,
-        customerId: preview.customerId,
-        subscriptionId: preview.sourceSubscriptionId,
-      },
-      signal,
-    );
-    if (route.kind === "checkout") {
-      const url = await set(
-        createCheckoutSession$,
+    const db = set(writeDb$);
+    return await db.transaction(async (tx) => {
+      return await confirmPlanPurchaseTransaction(
         {
+          tx,
           orgId,
-          tier: preview.tier,
-          priceId: preview.priceId,
-          trialDays: preview.trialDays,
-          successUrl: preview.successUrl,
-          cancelUrl: preview.cancelUrl,
-          adAttribution: preview.adAttribution,
-          checkoutIdempotencyKey: `plan-purchase:${preview.purchaseId}:checkout`,
+          preview,
         },
         signal,
       );
-      return {
-        status: "confirmed",
-        response: { status: "checkout_required", checkoutUrl: url },
-      };
-    }
-    if (
-      route.customerId !== preview.customerId ||
-      route.paymentMethodId !== preview.paymentMethodId
-    ) {
-      return { status: "invalid_preview" };
-    }
-
-    const currentPreview = await stripe.invoices.createPreview({
-      customer: preview.customerId,
-      preview_mode: "next",
-      subscription_details: {
-        items: [{ price: preview.priceId, quantity: 1 }],
-      },
     });
-    signal.throwIfAborted();
-    const nextRecurringAmountCents =
-      creditPurchasePayableAmount(currentPreview);
-    if (
-      currentPreview.currency !== preview.currency ||
-      nextRecurringAmountCents !== preview.nextRecurringAmountCents ||
-      (preview.trialDays === undefined ? nextRecurringAmountCents : 0) !==
-        preview.immediateAmountCents
-    ) {
-      return { status: "invalid_preview" };
-    }
-
-    const metadata: StripeMetadataParam = {
-      ...checkoutSessionMetadata({
-        orgId,
-        tier: preview.tier,
-        priceId: preview.priceId,
-        adAttribution: preview.adAttribution,
-      }),
-      billingPurchaseId: preview.purchaseId,
-    };
-    const subscription = await stripe.subscriptions.create(
-      {
-        customer: preview.customerId,
-        items: [{ price: preview.priceId, quantity: 1 }],
-        ...stripeBillingPurchasePaymentParams(route),
-        metadata,
-        payment_behavior: "default_incomplete",
-        ...(preview.trialDays === undefined
-          ? {}
-          : { trial_period_days: preview.trialDays }),
-        expand: ["latest_invoice"],
-      },
-      { idempotencyKey: `plan-purchase:${preview.purchaseId}:subscription` },
-    );
-    signal.throwIfAborted();
-    return {
-      status: "confirmed",
-      response: await completeBillingOperationInvoice(
-        stripe,
-        expandedLatestInvoice(subscription),
-        `plan:${preview.purchaseId}`,
-        signal,
-      ),
-    };
   },
 );
 
@@ -1092,6 +1187,45 @@ export const confirmPlanPurchase$ = command(
  * checkout session URL. Mirrors apps/web's createCheckoutSession
  * (allow_promotion_codes + subscription metadata orgId tag).
  */
+async function createPlanCheckoutSession(
+  stripe: StripeClient,
+  customerId: string,
+  args: CreateCheckoutSessionArgs,
+  signal: AbortSignal,
+): Promise<string> {
+  const metadata = checkoutSessionMetadata({
+    orgId: args.orgId,
+    tier: args.tier,
+    priceId: args.priceId,
+    adAttribution: args.adAttribution,
+  });
+  const params: StripeCheckoutSessionCreateParams = {
+    mode: "subscription",
+    customer: customerId,
+    line_items: [{ price: args.priceId, quantity: 1 }],
+    allow_promotion_codes: true,
+    success_url: args.successUrl,
+    cancel_url: args.cancelUrl,
+    metadata,
+    subscription_data: {
+      metadata,
+      ...(args.trialDays === undefined
+        ? {}
+        : { trial_period_days: args.trialDays }),
+    },
+  };
+  const session = args.checkoutIdempotencyKey
+    ? await stripe.checkout.sessions.create(params, {
+        idempotencyKey: args.checkoutIdempotencyKey,
+      })
+    : await stripe.checkout.sessions.create(params);
+  signal.throwIfAborted();
+  if (!session.url) {
+    throw new Error("Stripe checkout session did not return a URL");
+  }
+  return session.url;
+}
+
 const createCheckoutSession$ = command(
   async (
     { set },
@@ -1105,12 +1239,6 @@ const createCheckoutSession$ = command(
     );
     signal.throwIfAborted();
 
-    const metadata = checkoutSessionMetadata({
-      orgId: args.orgId,
-      tier: args.tier,
-      priceId: args.priceId,
-      adAttribution: args.adAttribution,
-    });
     const customerId = await set(
       getOrCreateStripeCustomer$,
       { orgId: args.orgId, metadata: args.adAttribution },
@@ -1118,33 +1246,12 @@ const createCheckoutSession$ = command(
     );
     signal.throwIfAborted();
 
-    const stripe = getStripeClient();
-    const params: StripeCheckoutSessionCreateParams = {
-      mode: "subscription",
-      customer: customerId,
-      line_items: [{ price: args.priceId, quantity: 1 }],
-      allow_promotion_codes: true,
-      success_url: args.successUrl,
-      cancel_url: args.cancelUrl,
-      metadata,
-      subscription_data: {
-        metadata,
-        ...(args.trialDays === undefined
-          ? {}
-          : { trial_period_days: args.trialDays }),
-      },
-    };
-    const session = args.checkoutIdempotencyKey
-      ? await stripe.checkout.sessions.create(params, {
-          idempotencyKey: args.checkoutIdempotencyKey,
-        })
-      : await stripe.checkout.sessions.create(params);
-    signal.throwIfAborted();
-
-    if (!session.url) {
-      throw new Error("Stripe checkout session did not return a URL");
-    }
-    return session.url;
+    return await createPlanCheckoutSession(
+      getStripeClient(),
+      customerId,
+      args,
+      signal,
+    );
   },
 );
 
@@ -1354,6 +1461,7 @@ export const startConcurrencyPurchase$ = command(
           quantity: args.quantity,
           mode: "increase",
           hasScheduledConcurrencyChange: args.hasScheduledConcurrencyChange,
+          paymentMethod: args.paymentMethod,
         },
         signal,
       );
@@ -1390,6 +1498,7 @@ export const startConcurrencyPurchase$ = command(
         subscriptionId,
         priceId: args.priceId,
         quantity: args.quantity,
+        paymentMethod: args.paymentMethod,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-checkout.service.ts
@@ -1042,6 +1042,7 @@ async function createConfirmedPlanSubscription(
       expandedLatestInvoice(subscription),
       `plan:${preview.purchaseId}`,
       signal,
+      { payOpenInvoice: true },
     ),
   };
 }
@@ -1076,6 +1077,7 @@ async function confirmPlanPurchaseTransaction(
         expandedLatestInvoice(subscriptionState.existing),
         `plan:${preview.purchaseId}`,
         signal,
+        { payOpenInvoice: true },
       ),
     };
   }

--- a/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
@@ -33,6 +33,10 @@ import {
   isConcurrencyPriceId,
 } from "./org-concurrency-entitlements.service";
 import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
+import {
+  stripeBillingPurchasePaymentParams,
+  type BillingPurchasePaymentMethod,
+} from "./billing-payment-method.service";
 import { subscriptionScheduleHasNoFutureChanges } from "./stripe-subscription-schedules.service";
 
 const CONCURRENCY_SUBSCRIPTION_QUANTITY_MAX = 1000;
@@ -47,6 +51,10 @@ interface ConcurrencySubscriptionChangeArgs extends ConcurrencySubscriptionArgs 
   readonly quantity: number;
 }
 
+interface ConfirmedConcurrencySubscriptionChangeArgs extends ConcurrencySubscriptionChangeArgs {
+  readonly paymentMethod?: BillingPurchasePaymentMethod;
+}
+
 interface ReduceConcurrencySubscriptionArgs extends ConcurrencySubscriptionChangeArgs {
   readonly successUrl: string;
 }
@@ -56,12 +64,14 @@ interface StripeConcurrencySubscriptionChangeArgs {
   readonly quantity: number;
   readonly mode: "absolute" | "increase" | "reduce";
   readonly hasScheduledConcurrencyChange: boolean;
+  readonly paymentMethod?: BillingPurchasePaymentMethod;
 }
 
 interface AddStripeConcurrencySubscriptionItemArgs {
   readonly subscriptionId: string;
   readonly priceId: string;
   readonly quantity: number;
+  readonly paymentMethod?: BillingPurchasePaymentMethod;
 }
 
 type CancelConcurrencySubscriptionResult =
@@ -504,6 +514,9 @@ export const addStripeConcurrencySubscriptionItem$ = command(
             ? { id: currentItem.id, quantity: args.quantity }
             : { price: args.priceId, quantity: args.quantity },
         ],
+        ...(args.paymentMethod
+          ? stripeBillingPurchasePaymentParams(args.paymentMethod)
+          : {}),
         payment_behavior: "pending_if_incomplete",
         proration_behavior: "always_invoice",
         proration_date: Math.floor(nowDate().getTime() / 1000),
@@ -879,6 +892,23 @@ export const previewStripeConcurrencySubscriptionChange$ = command(
   },
 );
 
+function concurrencyChangeTargetQuantity(
+  args: Pick<StripeConcurrencySubscriptionChangeArgs, "mode" | "quantity">,
+  currentQuantity: number,
+): number | null {
+  const targetQuantity =
+    args.mode === "increase" ? currentQuantity + args.quantity : args.quantity;
+  if (
+    !Number.isSafeInteger(targetQuantity) ||
+    targetQuantity < 1 ||
+    targetQuantity > CONCURRENCY_SUBSCRIPTION_QUANTITY_MAX ||
+    (args.mode === "reduce" && targetQuantity > currentQuantity)
+  ) {
+    return null;
+  }
+  return targetQuantity;
+}
+
 export const applyStripeConcurrencySubscriptionChange$ = command(
   async (
     _,
@@ -897,16 +927,8 @@ export const applyStripeConcurrencySubscriptionChange$ = command(
         "Concurrency subscription has no active concurrency item",
       );
     }
-    const targetQuantity =
-      args.mode === "increase" ? item.quantity + args.quantity : args.quantity;
-    if (
-      !Number.isSafeInteger(targetQuantity) ||
-      targetQuantity < 1 ||
-      targetQuantity > CONCURRENCY_SUBSCRIPTION_QUANTITY_MAX
-    ) {
-      return { ok: false, reason: "invalid_quantity" };
-    }
-    if (args.mode === "reduce" && targetQuantity > item.quantity) {
+    const targetQuantity = concurrencyChangeTargetQuantity(args, item.quantity);
+    if (targetQuantity === null) {
       return { ok: false, reason: "invalid_quantity" };
     }
 
@@ -977,6 +999,9 @@ export const applyStripeConcurrencySubscriptionChange$ = command(
       subscription.id,
       {
         items: [{ id: item.id, quantity: targetQuantity }],
+        ...(args.paymentMethod
+          ? stripeBillingPurchasePaymentParams(args.paymentMethod)
+          : {}),
         payment_behavior: "pending_if_incomplete",
         proration_behavior: "always_invoice",
         proration_date: Math.floor(nowDate().getTime() / 1000),
@@ -1029,7 +1054,7 @@ export const previewConcurrencySubscriptionChange$ = command(
 export const changeConcurrencySubscription$ = command(
   async (
     { get, set },
-    args: ConcurrencySubscriptionChangeArgs,
+    args: ConfirmedConcurrencySubscriptionChangeArgs,
     signal: AbortSignal,
   ): Promise<ChangeConcurrencySubscriptionResult> => {
     const subscription = await findActiveConcurrencySubscription(
@@ -1050,6 +1075,7 @@ export const changeConcurrencySubscription$ = command(
         quantity: args.quantity,
         mode: "absolute",
         hasScheduledConcurrencyChange: subscription.scheduledQuantity !== null,
+        paymentMethod: args.paymentMethod,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
@@ -32,6 +32,7 @@ import {
   activeConcurrencySubscriptions,
   isConcurrencyPriceId,
 } from "./org-concurrency-entitlements.service";
+import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
 import { subscriptionScheduleHasNoFutureChanges } from "./stripe-subscription-schedules.service";
 
 const CONCURRENCY_SUBSCRIPTION_QUANTITY_MAX = 1000;
@@ -415,22 +416,26 @@ function expandedLatestInvoice(
     : null;
 }
 
-function appliedConcurrencyChangeResponse(
+async function appliedConcurrencyChangeResponse(
+  stripe: StripeClient,
   subscription: StripeSubscription,
-): ConcurrencySubscriptionChangeResponse {
-  if (!subscription.pending_update) {
+  targetQuantity: number,
+  signal: AbortSignal,
+): Promise<ConcurrencySubscriptionChangeResponse> {
+  const invoice = expandedLatestInvoice(subscription);
+  if (!invoice) {
     return { status: "processing", hostedInvoiceUrl: null };
   }
-  const invoice = expandedLatestInvoice(subscription);
-  if (!invoice?.hosted_invoice_url) {
-    throw new Error(
-      "Pending concurrency subscription update has no hosted invoice URL",
-    );
+  const result = await completeBillingOperationInvoice(
+    stripe,
+    invoice,
+    `concurrency:${subscription.id}:${targetQuantity}`,
+    signal,
+  );
+  if (result.status === "pending_payment") {
+    return result;
   }
-  return {
-    status: "pending_payment",
-    hostedInvoiceUrl: invoice.hosted_invoice_url,
-  };
+  return { status: "processing", hostedInvoiceUrl: null };
 }
 
 export const addStripeConcurrencySubscriptionItem$ = command(
@@ -461,7 +466,12 @@ export const addStripeConcurrencySubscriptionItem$ = command(
       return pendingItem?.quantity === args.quantity
         ? {
             ok: true,
-            response: appliedConcurrencyChangeResponse(subscription),
+            response: await appliedConcurrencyChangeResponse(
+              stripe,
+              subscription,
+              args.quantity,
+              signal,
+            ),
             subscription,
           }
         : { ok: false, reason: "pending_update" };
@@ -503,7 +513,12 @@ export const addStripeConcurrencySubscriptionItem$ = command(
     signal.throwIfAborted();
     return {
       ok: true,
-      response: appliedConcurrencyChangeResponse(updatedSubscription),
+      response: await appliedConcurrencyChangeResponse(
+        stripe,
+        updatedSubscription,
+        args.quantity,
+        signal,
+      ),
       subscription: updatedSubscription,
     };
   },
@@ -902,7 +917,12 @@ export const applyStripeConcurrencySubscriptionChange$ = command(
       return pendingItem?.quantity === targetQuantity
         ? {
             ok: true,
-            response: appliedConcurrencyChangeResponse(subscription),
+            response: await appliedConcurrencyChangeResponse(
+              stripe,
+              subscription,
+              targetQuantity,
+              signal,
+            ),
             subscription,
           }
         : { ok: false, reason: "pending_update" };
@@ -966,7 +986,12 @@ export const applyStripeConcurrencySubscriptionChange$ = command(
     signal.throwIfAborted();
     return {
       ok: true,
-      response: appliedConcurrencyChangeResponse(updatedSubscription),
+      response: await appliedConcurrencyChangeResponse(
+        stripe,
+        updatedSubscription,
+        targetQuantity,
+        signal,
+      ),
       subscription: updatedSubscription,
     };
   },
@@ -1029,6 +1054,11 @@ export const changeConcurrencySubscription$ = command(
       signal,
     );
     if (result.ok) {
+      if (result.response.status === "checkout_required") {
+        throw new Error(
+          "Stripe concurrency change unexpectedly required Checkout",
+        );
+      }
       const scheduled =
         args.quantity < subscription.quantity &&
         result.response.effectiveAt !== undefined;
@@ -1158,6 +1188,11 @@ export const reduceConcurrencySubscription$ = command(
             ? "pending_update"
             : "not_reduction",
       };
+    }
+    if (result.response.status === "checkout_required") {
+      throw new Error(
+        "Stripe concurrency reduction unexpectedly required Checkout",
+      );
     }
     await writeScheduledConcurrencyChange(set(writeDb$), {
       orgId: args.orgId,

--- a/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-concurrency-subscription.service.ts
@@ -34,7 +34,7 @@ import {
 } from "./org-concurrency-entitlements.service";
 import { completeBillingOperationInvoice } from "./billing-operation-invoice.service";
 import {
-  stripeBillingPurchasePaymentParams,
+  setStripeSubscriptionPaymentMethod,
   type BillingPurchasePaymentMethod,
 } from "./billing-payment-method.service";
 import { subscriptionScheduleHasNoFutureChanges } from "./stripe-subscription-schedules.service";
@@ -506,6 +506,15 @@ export const addStripeConcurrencySubscriptionItem$ = command(
       signal.throwIfAborted();
     }
 
+    if (args.paymentMethod) {
+      await setStripeSubscriptionPaymentMethod(
+        stripe,
+        subscription.id,
+        args.paymentMethod,
+        signal,
+      );
+    }
+
     const updatedSubscription = await stripe.subscriptions.update(
       subscription.id,
       {
@@ -514,9 +523,6 @@ export const addStripeConcurrencySubscriptionItem$ = command(
             ? { id: currentItem.id, quantity: args.quantity }
             : { price: args.priceId, quantity: args.quantity },
         ],
-        ...(args.paymentMethod
-          ? stripeBillingPurchasePaymentParams(args.paymentMethod)
-          : {}),
         payment_behavior: "pending_if_incomplete",
         proration_behavior: "always_invoice",
         proration_date: Math.floor(nowDate().getTime() / 1000),
@@ -995,13 +1001,19 @@ export const applyStripeConcurrencySubscriptionChange$ = command(
       };
     }
 
+    if (args.paymentMethod) {
+      await setStripeSubscriptionPaymentMethod(
+        stripe,
+        subscription.id,
+        args.paymentMethod,
+        signal,
+      );
+    }
+
     const updatedSubscription = await stripe.subscriptions.update(
       subscription.id,
       {
         items: [{ id: item.id, quantity: targetQuantity }],
-        ...(args.paymentMethod
-          ? stripeBillingPurchasePaymentParams(args.paymentMethod)
-          : {}),
         payment_behavior: "pending_if_incomplete",
         proration_behavior: "always_invoice",
         proration_date: Math.floor(nowDate().getTime() / 1000),

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -813,6 +813,7 @@
       "concurrentRun_other": "{{value}} gleichzeitige Ausführungen",
       "continueToStripe": "Weiter zu Stripe",
       "decreaseAria": "Verringern Sie die zusätzliche Parallelitätsmenge",
+      "dueNow": "Jetzt fällig",
       "dueToday": "Heute fällig",
       "emptyDescription": "Kaufen Sie zusätzliche gleichzeitige Ausführungen für diesen Arbeitsbereich.",
       "emptyTitle": "Keine Parallelitätsabonnements",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -813,6 +813,7 @@
       "concurrentRun_other": "{{value}} concurrent runs",
       "continueToStripe": "Continue to Stripe",
       "decreaseAria": "Decrease additional concurrency quantity",
+      "dueNow": "Due now",
       "dueToday": "Due today",
       "emptyDescription": "Buy additional concurrent runs for this workspace.",
       "emptyTitle": "No concurrency subscriptions",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -833,6 +833,7 @@
       "concurrentRun_other": "{{value}} ejecuciones simultáneas",
       "continueToStripe": "Continuar a Stripe",
       "decreaseAria": "Reducir la cantidad adicional de concurrencia",
+      "dueNow": "A pagar ahora",
       "dueToday": "A pagar hoy",
       "emptyDescription": "Compra ejecuciones concurrentes adicionales para este espacio de trabajo.",
       "emptyTitle": "No hay suscripciones de concurrencia",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -833,6 +833,7 @@
       "concurrentRun_other": "{{value}} exécutions concurrentes",
       "continueToStripe": "Continuer vers Stripe",
       "decreaseAria": "Diminuer la quantité de concurrence supplémentaire",
+      "dueNow": "À payer maintenant",
       "dueToday": "À payer aujourd’hui",
       "emptyDescription": "Acheter des exécutions concurrentes supplémentaires pour cet espace de travail.",
       "emptyTitle": "Aucun abonnement de concurrence",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -813,6 +813,7 @@
       "concurrentRun_other": "{{value}} समवर्ती चलता है",
       "continueToStripe": "Stripe पर जारी रखें",
       "decreaseAria": "अतिरिक्त समवर्ती मात्रा कम करें",
+      "dueNow": "अभी देय",
       "dueToday": "आज देय",
       "emptyDescription": "इस वर्कस्पेस के लिए अतिरिक्त समवर्ती रन खरीदें।",
       "emptyTitle": "कोई समवर्ती सदस्यता नहीं",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -813,6 +813,7 @@
       "concurrentRun_other": "{{value}} eksekusi concurrent",
       "continueToStripe": "Lanjutkan ke Stripe",
       "decreaseAria": "Kurangi jumlah concurrency tambahan",
+      "dueNow": "Jatuh tempo sekarang",
       "dueToday": "Jatuh tempo hari ini",
       "emptyDescription": "Beli eksekusi concurrent tambahan untuk ruang kerja ini.",
       "emptyTitle": "Tidak ada langganan concurrency",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -833,6 +833,7 @@
       "concurrentRun_other": "{{value}} esecuzioni simultanee",
       "continueToStripe": "Continua su Stripe",
       "decreaseAria": "Diminuire la quantità di concorrenza aggiuntiva",
+      "dueNow": "Da pagare ora",
       "dueToday": "Da pagare oggi",
       "emptyDescription": "Acquista ulteriori esecuzioni simultanee per questa area di lavoro.",
       "emptyTitle": "Nessun abbonamento simultaneo",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -813,6 +813,7 @@
       "concurrentRun_other": "{{value}} 同時実行数",
       "continueToStripe": "Stripe に進む",
       "decreaseAria": "追加の同時実行数を減らす",
+      "dueNow": "今回のお支払い",
       "dueToday": "本日のお支払い",
       "emptyDescription": "このワークスペースに対して追加の同時実行を購入します。",
       "emptyTitle": "同時実行サブスクリプションなし",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -813,6 +813,7 @@
       "concurrentRun_other": "{{value}}개의 동시 실행",
       "continueToStripe": "Stripe로 계속",
       "decreaseAria": "추가 동시 실행 수 감소",
+      "dueNow": "지금 결제",
       "dueToday": "오늘 결제",
       "emptyDescription": "이 워크스페이스에 추가 동시 실행을 구매하세요.",
       "emptyTitle": "동시 실행 구독 없음",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -833,6 +833,7 @@
       "concurrentRun_other": "{{value}} execuções simultâneas",
       "continueToStripe": "Continuar para o Stripe",
       "decreaseAria": "Diminuir a quantidade adicional de simultaneidade",
+      "dueNow": "A pagar agora",
       "dueToday": "A pagar hoje",
       "emptyDescription": "Compre execuções simultâneas adicionais para este workspace.",
       "emptyTitle": "Nenhuma assinatura de simultaneidade",

--- a/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
@@ -132,6 +132,9 @@ export const prepareOnboardingVideoRun$ = command(
         [200],
       );
       signal.throwIfAborted();
+      if (!("url" in result.body)) {
+        throw new Error("Onboarding checkout unexpectedly returned a preview");
+      }
       checkoutUrl = result.body.url;
     } else {
       const client = get(zeroClient$)(zeroBillingCheckoutContract);
@@ -148,6 +151,9 @@ export const prepareOnboardingVideoRun$ = command(
         [200],
       );
       signal.throwIfAborted();
+      if (!("url" in result.body)) {
+        throw new Error("Onboarding checkout unexpectedly returned a preview");
+      }
       checkoutUrl = result.body.url;
     }
     set(capturePaidOnboardingCheckoutCreated$, "onboarding_video");

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -16,11 +16,13 @@ import {
   zeroBillingDowngradeContract,
   zeroBillingRestoreContract,
   type BillingStatusResponse,
+  type CheckoutRequest,
   type ConcurrencySubscriptionChangePreviewResponse,
   type CreditPurchasePreviewResponse,
   type MemberUsagePack,
   type PlanPurchasePreviewResponse,
   type UsagePackCreditsResponse,
+  type UsagePackCheckoutRequest,
   type UsagePackPurchasePreviewResponse,
   type UsagePackMigrationStateResponse,
 } from "@okouai/api-contracts/contracts/zero-billing";
@@ -281,13 +283,19 @@ const internalConcurrencyConfirmDialog$ =
 const internalCreditPurchasePreview$ = state<CreditPurchasePreviewState | null>(
   null,
 );
-type SubscriptionPurchasePreview =
-  | PlanPurchasePreviewResponse
-  | UsagePackPurchasePreviewResponse;
-interface SubscriptionPurchasePreviewState {
-  readonly preview: SubscriptionPurchasePreview;
-  readonly newTab: boolean;
-}
+type SubscriptionPurchasePreviewState =
+  | {
+      readonly purchaseType: "plan";
+      readonly preview: PlanPurchasePreviewResponse;
+      readonly request: CheckoutRequest;
+      readonly newTab: boolean;
+    }
+  | {
+      readonly purchaseType: "usage_pack";
+      readonly preview: UsagePackPurchasePreviewResponse;
+      readonly request: UsagePackCheckoutRequest;
+      readonly newTab: boolean;
+    };
 const internalSubscriptionPurchasePreview$ =
   state<SubscriptionPurchasePreviewState | null>(null);
 
@@ -793,30 +801,36 @@ export const startCheckout$ = command(
 
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingCheckoutContract);
+    const request: CheckoutRequest = {
+      tier,
+      ...(supportsInAppPreview ? { supportsInAppPreview: true } : {}),
+      successUrl: stripeSuccessUrl,
+      cancelUrl: cancelUrl.toString(),
+      ...(options?.trialDays === undefined
+        ? {}
+        : { trialDays: options.trialDays }),
+      ...(adAttribution === undefined ? {} : { adAttribution }),
+    };
     const result = await accept(
       client.create({
-        body: {
-          tier,
-          ...(supportsInAppPreview ? { supportsInAppPreview: true } : {}),
-          successUrl: stripeSuccessUrl,
-          cancelUrl: cancelUrl.toString(),
-          ...(options?.trialDays === undefined
-            ? {}
-            : { trialDays: options.trialDays }),
-          ...(adAttribution === undefined ? {} : { adAttribution }),
-        },
+        body: request,
         fetchOptions: { signal },
       }),
       [200],
     );
     signal.throwIfAborted();
     set(capturePaidOnboardingCheckoutCreated$, "paywall");
-    if (!("url" in result.body)) {
+    if (!("url" in result.body) && result.body.status === "preview") {
       set(internalSubscriptionPurchasePreview$, {
+        purchaseType: "plan",
         preview: result.body,
+        request,
         newTab,
       });
       return;
+    }
+    if (!("url" in result.body)) {
+      throw new Error("Plan checkout returned an unexpected confirmation");
     }
     set(capturePaidOnboardingRedirectToStripe$, "paywall");
     if (newTab) {
@@ -858,27 +872,35 @@ export const startUsagePackCheckout$ = command(
 
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingUsagePackCheckoutContract);
+    const request: UsagePackCheckoutRequest = {
+      tier: args.tier,
+      ...(supportsInAppPreview ? { supportsInAppPreview: true } : {}),
+      memberUsagePacks: [...args.memberUsagePacks],
+      successUrl: stripeSuccessUrl,
+      cancelUrl: cancelUrl.toString(),
+      ...(adAttribution === undefined ? {} : { adAttribution }),
+    };
     const result = await accept(
       client.create({
-        body: {
-          tier: args.tier,
-          ...(supportsInAppPreview ? { supportsInAppPreview: true } : {}),
-          memberUsagePacks: [...args.memberUsagePacks],
-          successUrl: stripeSuccessUrl,
-          cancelUrl: cancelUrl.toString(),
-          ...(adAttribution === undefined ? {} : { adAttribution }),
-        },
+        body: request,
         fetchOptions: { signal },
       }),
       [200],
     );
     signal.throwIfAborted();
-    if (!("url" in result.body)) {
+    if (!("url" in result.body) && result.body.status === "preview") {
       set(internalSubscriptionPurchasePreview$, {
+        purchaseType: "usage_pack",
         preview: result.body,
+        request,
         newTab,
       });
       return;
+    }
+    if (!("url" in result.body)) {
+      throw new Error(
+        "Usage pack checkout returned an unexpected confirmation",
+      );
     }
     if (newTab) {
       window.open(result.body.url, "_blank");
@@ -896,22 +918,89 @@ export const confirmSubscriptionPurchase$ = command(
     }
     const createClient = get(zeroClient$);
     const response =
-      state.preview.purchaseType === "plan"
+      state.purchaseType === "plan"
         ? await accept(
-            createClient(zeroBillingCheckoutContract).confirm({
-              body: { previewToken: state.preview.previewToken },
+            createClient(zeroBillingCheckoutContract).create({
+              body: {
+                ...state.request,
+                previewToken: state.preview.previewToken,
+              },
               fetchOptions: { signal },
             }),
-            [200],
+            [200, 409],
           )
         : await accept(
-            createClient(zeroBillingUsagePackCheckoutContract).confirm({
-              body: { previewToken: state.preview.previewToken },
+            createClient(zeroBillingUsagePackCheckoutContract).create({
+              body: {
+                ...state.request,
+                previewToken: state.preview.previewToken,
+              },
               fetchOptions: { signal },
             }),
             [200],
           );
     signal.throwIfAborted();
+    if (response.status === 409) {
+      if (state.purchaseType !== "plan") {
+        throw new Error("Usage pack confirmation returned a conflict");
+      }
+      const refreshed = await accept(
+        createClient(zeroBillingCheckoutContract).create({
+          body: state.request,
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      if ("url" in refreshed.body) {
+        set(capturePaidOnboardingRedirectToStripe$, "paywall");
+        if (state.newTab) {
+          window.open(refreshed.body.url, "_blank");
+        } else {
+          window.location.href = refreshed.body.url;
+        }
+        return;
+      }
+      if (refreshed.body.status !== "preview") {
+        throw new Error("Plan preview refresh returned a confirmation");
+      }
+      set(internalSubscriptionPurchasePreview$, {
+        ...state,
+        preview: refreshed.body,
+      });
+      return;
+    }
+    if ("url" in response.body) {
+      if (state.newTab) {
+        window.open(response.body.url, "_blank");
+      } else {
+        window.location.href = response.body.url;
+      }
+      return;
+    }
+    if (response.body.status === "preview") {
+      if (
+        state.purchaseType === "plan" &&
+        response.body.purchaseType === "plan"
+      ) {
+        set(internalSubscriptionPurchasePreview$, {
+          ...state,
+          preview: response.body,
+        });
+        return;
+      }
+      if (
+        state.purchaseType === "usage_pack" &&
+        response.body.purchaseType === "usage_pack"
+      ) {
+        set(internalSubscriptionPurchasePreview$, {
+          ...state,
+          preview: response.body,
+        });
+        return;
+      }
+      throw new Error("Subscription preview refresh changed purchase type");
+    }
     if (response.body.status === "pending_payment") {
       if (state.newTab) {
         window.open(response.body.hostedInvoiceUrl, "_blank");

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -19,7 +19,9 @@ import {
   type ConcurrencySubscriptionChangePreviewResponse,
   type CreditPurchasePreviewResponse,
   type MemberUsagePack,
+  type PlanPurchasePreviewResponse,
   type UsagePackCreditsResponse,
+  type UsagePackPurchasePreviewResponse,
   type UsagePackMigrationStateResponse,
 } from "@okouai/api-contracts/contracts/zero-billing";
 import { FeatureSwitchKey } from "@okouai/core";
@@ -279,6 +281,15 @@ const internalConcurrencyConfirmDialog$ =
 const internalCreditPurchasePreview$ = state<CreditPurchasePreviewState | null>(
   null,
 );
+type SubscriptionPurchasePreview =
+  | PlanPurchasePreviewResponse
+  | UsagePackPurchasePreviewResponse;
+interface SubscriptionPurchasePreviewState {
+  readonly preview: SubscriptionPurchasePreview;
+  readonly newTab: boolean;
+}
+const internalSubscriptionPurchasePreview$ =
+  state<SubscriptionPurchasePreviewState | null>(null);
 
 // ---------------------------------------------------------------------------
 // Selectors
@@ -307,6 +318,9 @@ export const creditPurchasePreview$ = computed((get) => {
 });
 export const creditPurchaseOrigin$ = computed((get) => {
   return get(internalCreditPurchasePreview$)?.origin ?? null;
+});
+export const subscriptionPurchasePreview$ = computed((get) => {
+  return get(internalSubscriptionPurchasePreview$);
 });
 export const setPendingEnabled$ = command(({ set }, value: boolean | null) => {
   set(internalPendingEnabled$, value);
@@ -364,6 +378,9 @@ export const closeConcurrencyConfirmDialog$ = command(({ set }) => {
 });
 export const closeCreditPurchasePreview$ = command(({ set }) => {
   set(internalCreditPurchasePreview$, null);
+});
+export const closeSubscriptionPurchasePreview$ = command(({ set }) => {
+  set(internalSubscriptionPurchasePreview$, null);
 });
 export const setConcurrencyChangeMode$ = command(
   ({ set }, mode: ConcurrencyChangeMode) => {
@@ -771,6 +788,8 @@ export const startCheckout$ = command(
     cancelUrl.searchParams.set("billing", "canceled");
     set(applyStoredAdAttribution$, cancelUrl);
     const adAttribution = set(readStoredAdAttributionMetadata$);
+    const supportsInAppPreview =
+      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
 
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingCheckoutContract);
@@ -778,6 +797,7 @@ export const startCheckout$ = command(
       client.create({
         body: {
           tier,
+          ...(supportsInAppPreview ? { supportsInAppPreview: true } : {}),
           successUrl: stripeSuccessUrl,
           cancelUrl: cancelUrl.toString(),
           ...(options?.trialDays === undefined
@@ -791,6 +811,13 @@ export const startCheckout$ = command(
     );
     signal.throwIfAborted();
     set(capturePaidOnboardingCheckoutCreated$, "paywall");
+    if (!("url" in result.body)) {
+      set(internalSubscriptionPurchasePreview$, {
+        preview: result.body,
+        newTab,
+      });
+      return;
+    }
     set(capturePaidOnboardingRedirectToStripe$, "paywall");
     if (newTab) {
       window.open(result.body.url, "_blank");
@@ -826,6 +853,8 @@ export const startUsagePackCheckout$ = command(
     cancelUrl.searchParams.set("billing", "canceled");
     set(applyStoredAdAttribution$, cancelUrl);
     const adAttribution = set(readStoredAdAttributionMetadata$);
+    const supportsInAppPreview =
+      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
 
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingUsagePackCheckoutContract);
@@ -833,6 +862,7 @@ export const startUsagePackCheckout$ = command(
       client.create({
         body: {
           tier: args.tier,
+          ...(supportsInAppPreview ? { supportsInAppPreview: true } : {}),
           memberUsagePacks: [...args.memberUsagePacks],
           successUrl: stripeSuccessUrl,
           cancelUrl: cancelUrl.toString(),
@@ -843,11 +873,68 @@ export const startUsagePackCheckout$ = command(
       [200],
     );
     signal.throwIfAborted();
+    if (!("url" in result.body)) {
+      set(internalSubscriptionPurchasePreview$, {
+        preview: result.body,
+        newTab,
+      });
+      return;
+    }
     if (newTab) {
       window.open(result.body.url, "_blank");
     } else {
       window.location.href = result.body.url;
     }
+  },
+);
+
+export const confirmSubscriptionPurchase$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const state = get(internalSubscriptionPurchasePreview$);
+    if (!state) {
+      throw new Error("Subscription purchase preview is not available");
+    }
+    const createClient = get(zeroClient$);
+    const response =
+      state.preview.purchaseType === "plan"
+        ? await accept(
+            createClient(zeroBillingCheckoutContract).confirm({
+              body: { previewToken: state.preview.previewToken },
+              fetchOptions: { signal },
+            }),
+            [200],
+          )
+        : await accept(
+            createClient(zeroBillingUsagePackCheckoutContract).confirm({
+              body: { previewToken: state.preview.previewToken },
+              fetchOptions: { signal },
+            }),
+            [200],
+          );
+    signal.throwIfAborted();
+    if (response.body.status === "pending_payment") {
+      if (state.newTab) {
+        window.open(response.body.hostedInvoiceUrl, "_blank");
+      } else {
+        window.location.href = response.body.hostedInvoiceUrl;
+      }
+      return;
+    }
+    if (response.body.status === "checkout_required") {
+      if (state.newTab) {
+        window.open(response.body.checkoutUrl, "_blank");
+      } else {
+        window.location.href = response.body.checkoutUrl;
+      }
+      return;
+    }
+    set(internalSubscriptionPurchasePreview$, null);
+    set(reloadBillingStatus$);
+    toast.success(
+      i18n.t(($) => {
+        return $.billing.toasts.subscriptionChangeConfirmed;
+      }),
+    );
   },
 );
 
@@ -984,17 +1071,29 @@ export const previewUsagePackSubscriptionChange$ = command(
   ) => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingUsagePackManagementContract);
+    const supportsInAppPreview =
+      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
     const preview = await accept(
       client.previewSubscriptionChange({
         body: {
           targetTier: args.targetTier,
           memberUsagePacks: [...args.memberUsagePacks],
+          ...(supportsInAppPreview
+            ? {
+                supportsInAppPreview: true,
+                returnUrl: checkoutReturnUrl().toString(),
+              }
+            : {}),
         },
         fetchOptions: { signal },
       }),
       [200],
     );
     signal.throwIfAborted();
+    if (preview.body.checkoutUrl) {
+      window.location.href = preview.body.checkoutUrl;
+      return null;
+    }
     set(setUsagePackSubscriptionChangePreview$, preview.body);
     return preview.body;
   },
@@ -1014,12 +1113,30 @@ export const confirmUsagePackSubscriptionChange$ = command(
     const client = createClient(zeroBillingUsagePackManagementContract);
     const result = await accept(
       client.confirmSubscriptionChange({
-        body: { changeId: preview.changeId },
+        body: {
+          changeId: preview.changeId,
+          ...(preview.paymentMethodPreviewToken
+            ? {
+                paymentMethodPreviewToken: preview.paymentMethodPreviewToken,
+              }
+            : {}),
+        },
         fetchOptions: { signal },
       }),
       [200],
     );
     signal.throwIfAborted();
+    if (result.body.status === "pending_payment") {
+      if (result.body.hostedInvoiceUrl) {
+        window.location.href = result.body.hostedInvoiceUrl;
+        return result.body;
+      }
+      throw new Error("Pending usage pack invoice has no hosted payment URL");
+    }
+    if (result.body.status === "checkout_required") {
+      window.location.href = result.body.checkoutUrl;
+      return result.body;
+    }
     toast.success(
       i18n.t(($) => {
         return $.billing.toasts.subscriptionChangeConfirmed;
@@ -1065,7 +1182,7 @@ export const startCreditCheckout$ = command(
           credits: selection.credits,
           ...(selection.customAmount === true ? { customAmount: true } : {}),
           ...(savedBillingCreditPurchaseEnabled
-            ? { previewExistingBilling: true }
+            ? { supportsInAppPreview: true }
             : {}),
           successUrl: stripeSuccessUrl,
           cancelUrl: cancelUrl.toString(),
@@ -1115,6 +1232,10 @@ export const confirmCreditPurchase$ = command(
       window.location.href = result.body.hostedInvoiceUrl;
       return;
     }
+    if (result.body.status === "checkout_required") {
+      window.location.href = result.body.checkoutUrl;
+      return;
+    }
     set(internalCreditPurchasePreview$, null);
     set(reloadBillingStatus$);
     toast.success(
@@ -1139,10 +1260,16 @@ export const startConcurrencyCheckout$ = command(
 
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingConcurrencyCheckoutContract);
+    const dialog = get(internalConcurrencyConfirmDialog$);
+    const paymentMethodPreviewToken =
+      dialog?.action === "purchase" && dialog.quantity === quantity
+        ? dialog.preview.paymentMethodPreviewToken
+        : undefined;
     const result = await accept(
       client.create({
         body: {
           quantity,
+          ...(paymentMethodPreviewToken ? { paymentMethodPreviewToken } : {}),
           successUrl: successUrl.toString(),
           cancelUrl: cancelUrl.toString(),
         },
@@ -1182,15 +1309,31 @@ export const openConcurrencyPurchaseReview$ = command(
   ): Promise<void> => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingConcurrencyCheckoutContract);
+    const supportsInAppPreview =
+      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
+    const returnUrl = checkoutReturnUrl().toString();
     const result = await accept(
       client.preview({
-        body: { quantity },
+        body: {
+          quantity,
+          ...(supportsInAppPreview
+            ? { supportsInAppPreview: true, returnUrl }
+            : {}),
+        },
         fetchOptions: { signal },
       }),
       [200],
     );
     signal.throwIfAborted();
     set(internalConcurrencyPurchaseDialogOpen$, false);
+    if (result.body.checkoutUrl) {
+      if (newTab) {
+        window.open(result.body.checkoutUrl, "_blank");
+      } else {
+        window.location.href = result.body.checkoutUrl;
+      }
+      return;
+    }
     set(internalConcurrencyConfirmDialog$, {
       action: "purchase",
       newTab,
@@ -1211,18 +1354,32 @@ const loadConcurrencySubscriptionChangePreview$ = command(
     { get },
     args: ConcurrencySubscriptionChangePreviewArgs,
     signal: AbortSignal,
-  ) => {
+  ): Promise<ConcurrencySubscriptionChangePreviewResponse | null> => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingConcurrencySubscriptionContract);
+    const supportsInAppPreview =
+      get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ?? false;
     const result = await accept(
       client.previewChange({
         params: { subscriptionId: args.subscriptionId },
-        body: { quantity: args.quantity },
+        body: {
+          quantity: args.quantity,
+          ...(supportsInAppPreview
+            ? {
+                supportsInAppPreview: true,
+                returnUrl: checkoutReturnUrl().toString(),
+              }
+            : {}),
+        },
         fetchOptions: { signal },
       }),
       [200],
     );
     signal.throwIfAborted();
+    if (result.body.checkoutUrl) {
+      window.location.href = result.body.checkoutUrl;
+      return null;
+    }
     return result.body;
   },
 );
@@ -1239,6 +1396,9 @@ export const previewConcurrencySubscriptionChange$ = command(
       signal,
     );
     signal.throwIfAborted();
+    if (!preview) {
+      return;
+    }
     set(internalConcurrencyConfirmDialog$, (dialog) => {
       if (
         !dialog ||
@@ -1273,6 +1433,9 @@ export const openConcurrencyChangeReview$ = command(
       signal,
     );
     signal.throwIfAborted();
+    if (!preview) {
+      return;
+    }
     set(internalConcurrencyConfirmDialog$, {
       action: "change",
       subscriptionId: args.subscriptionId,
@@ -1297,7 +1460,15 @@ export const confirmConcurrencySubscriptionChange$ = command(
     const result = await accept(
       client.confirmChange({
         params: { subscriptionId: dialog.subscriptionId },
-        body: { quantity: dialog.preview.targetQuantity },
+        body: {
+          quantity: dialog.preview.targetQuantity,
+          ...(dialog.preview.paymentMethodPreviewToken
+            ? {
+                paymentMethodPreviewToken:
+                  dialog.preview.paymentMethodPreviewToken,
+              }
+            : {}),
+        },
         fetchOptions: { signal },
       }),
       [200],
@@ -1307,13 +1478,18 @@ export const confirmConcurrencySubscriptionChange$ = command(
       window.location.href = result.body.hostedInvoiceUrl;
       return;
     }
+    if (result.body.status === "checkout_required") {
+      window.location.href = result.body.checkoutUrl;
+      return;
+    }
     set(billingReload$, (x) => {
       return x + 1;
     });
     set(internalConcurrencyConfirmDialog$, null);
+    const effectiveAt = result.body.effectiveAt;
     toast.success(
       i18n.t(($) => {
-        return result.body.effectiveAt
+        return effectiveAt
           ? $.billing.toasts.concurrencyReduced
           : $.billing.toasts.concurrencyChanged;
       }),

--- a/turbo/apps/platform/src/signals/zero-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/workspace-settings-state.ts
@@ -572,18 +572,31 @@ export const inviteMember$ = command(
     const createClient = get(zeroClient$);
     const client = createClient(zeroOrgInviteContract);
     if (usagePackUsd !== null) {
+      const supportsInAppPreview =
+        get(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ??
+        false;
       const result = await accept(
         client.previewPurchase({
           body: {
             email,
             role,
             usagePackUsd,
+            ...(supportsInAppPreview
+              ? {
+                  supportsInAppPreview: true,
+                  returnUrl: window.location.href,
+                }
+              : {}),
           },
           fetchOptions: { signal },
         }),
         [200],
       );
       signal.throwIfAborted();
+      if (result.body.checkoutUrl) {
+        window.location.href = result.body.checkoutUrl;
+        return;
+      }
       set(internalInvitePurchasePreview$, {
         email,
         role,
@@ -621,15 +634,30 @@ export const confirmInvitePurchase$ = command(
     }
     const createClient = get(zeroClient$);
     const client = createClient(zeroOrgInviteContract);
-    await accept(
+    const result = await accept(
       client.confirmPurchase({
         params: { purchaseId: preview.payment.purchaseId },
-        body: {},
+        body: {
+          ...(preview.payment.paymentMethodPreviewToken
+            ? {
+                paymentMethodPreviewToken:
+                  preview.payment.paymentMethodPreviewToken,
+              }
+            : {}),
+        },
         fetchOptions: { signal },
       }),
       [200],
     );
     signal.throwIfAborted();
+    if ("status" in result.body && result.body.status === "pending_payment") {
+      window.location.href = result.body.hostedInvoiceUrl;
+      return;
+    }
+    if ("status" in result.body && result.body.status === "checkout_required") {
+      window.location.href = result.body.checkoutUrl;
+      return;
+    }
     toast.success(
       i18n.t(
         ($) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1643,7 +1643,7 @@ describe("organization billing settings", () => {
   });
 
   it("previews and confirms a current member package change inline", async () => {
-    let pendingPayment = false;
+    let changeProcessing = false;
     let paymentApplied = false;
     let previewed = false;
     let confirmationRequests = 0;
@@ -1695,11 +1695,11 @@ describe("organization billing settings", () => {
               usagePackUsd: paymentApplied ? 50 : 20,
               currentPeriodEnd: "2026-04-01T00:00:00Z",
               pendingChange:
-                pendingPayment && !paymentApplied
+                changeProcessing && !paymentApplied
                   ? {
                       id: "ad3bd64c-7237-436d-a221-61b14ed719e7",
                       kind: "upgrade",
-                      status: "pending_payment",
+                      status: "applying",
                       targetUsagePackUsd: 50,
                       effectiveAt: "2026-03-16T00:00:00Z",
                     }
@@ -1751,9 +1751,9 @@ describe("organization billing settings", () => {
         expect(body).toStrictEqual({
           changeId: "ad3bd64c-7237-436d-a221-61b14ed719e7",
         });
-        pendingPayment = true;
+        changeProcessing = true;
         return respond(200, {
-          status: "pending_payment",
+          status: "processing",
           effectiveAt: "2026-03-16T00:00:00Z",
           hostedInvoiceUrl: null,
         });
@@ -2466,7 +2466,7 @@ describe("organization billing settings", () => {
           changeId: "703d633a-fe5b-4ea7-a46d-d76078f6c802",
         });
         return respond(200, {
-          status: "pending_payment",
+          status: "processing",
           effectiveAt: "2026-03-16T00:00:00Z",
           hostedInvoiceUrl: null,
         });
@@ -3992,6 +3992,74 @@ describe("organization billing settings", () => {
     },
   );
 
+  it("reviews a saved-card plan purchase in app and opens its unpaid invoice", async () => {
+    let requestedTier: "pro" | "team" | null = null;
+    let supportsInAppPreview: boolean | undefined;
+    let confirmedPreviewToken: string | null = null;
+    const hostedInvoiceUrl =
+      "https://invoice.stripe.com/plan-purchase-authentication";
+
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Plan Preview Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, noActiveBillingStatus());
+    });
+    context.mocks.api(
+      zeroBillingCheckoutContract.create,
+      ({ body, respond }) => {
+        requestedTier = body.tier;
+        supportsInAppPreview = body.supportsInAppPreview;
+        return respond(200, {
+          status: "preview",
+          purchaseType: "plan",
+          tier: body.tier,
+          immediateAmountCents: 16_000,
+          nextRecurringAmountCents: 16_000,
+          currency: "usd",
+          expiresAt: "2026-08-13T12:15:00.000Z",
+          previewToken: "plan-preview-token",
+        });
+      },
+    );
+    context.mocks.api(
+      zeroBillingCheckoutContract.confirm,
+      ({ body, respond }) => {
+        confirmedPreviewToken = body.previewToken;
+        return respond(200, {
+          status: "pending_payment",
+          hostedInvoiceUrl,
+        });
+      },
+    );
+
+    await openBillingTab("/?settings=billing", {
+      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
+    });
+    const locationBeforePurchase = window.location.href;
+    click(screen.getByText("Upgrade"));
+    await screen.findByText("Compare plans");
+    click(screen.getByText("Start with Team"));
+
+    const reviewDialog = await screen.findByRole("dialog", {
+      name: "Order summary",
+    });
+    expect(within(reviewDialog).getByText("Team")).toBeInTheDocument();
+    expect(within(reviewDialog).getAllByText("$160.00")).toHaveLength(2);
+    expect(requestedTier).toBe("team");
+    expect(supportsInAppPreview).toBeTruthy();
+    expect(window.location.href).toBe(locationBeforePurchase);
+
+    click(buttonByText("Confirm", reviewDialog));
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(hostedInvoiceUrl);
+    });
+    expect(confirmedPreviewToken).toBe("plan-preview-token");
+  });
+
   it("previews and confirms a saved-billing credit purchase in the app", async () => {
     const checkoutReady = createDeferredPromise<void>(context.signal);
     let startRequest: CreditCheckoutRequest | null = null;
@@ -4067,7 +4135,7 @@ describe("organization billing settings", () => {
     expect(within(reviewDialog).getByText("+20,000")).toBeInTheDocument();
     expect(startRequest).toMatchObject({
       credits: 20_000,
-      previewExistingBilling: true,
+      supportsInAppPreview: true,
     });
     expect(window.location.href).toBe(locationBeforePurchase);
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -13,6 +13,7 @@ import {
   zeroBillingRestoreContract,
   zeroBillingStatusContract,
   type BillingStatusResponse,
+  type CheckoutRequest,
   type CreditCheckoutRequest,
   type UsagePackMigrationStateResponse,
 } from "@okouai/api-contracts/contracts/zero-billing";
@@ -282,6 +283,16 @@ async function openBillingTab(
       screen.getByRole("heading", { name: "Billing" }),
     ).toBeInTheDocument();
   });
+}
+
+function inAppBillingPreviewFields() {
+  return {
+    supportsInAppPreview: true as const,
+    returnUrl: new URL(
+      window.location.pathname,
+      window.location.origin,
+    ).toString(),
+  };
 }
 
 function installScrollIntoViewMock(): Mock<HTMLElement["scrollIntoView"]> {
@@ -776,6 +787,7 @@ describe("organization billing settings", () => {
             { memberId: "user_1", usagePackUsd: 20 },
             { memberId: "user_2", usagePackUsd: 50 },
           ],
+          ...inAppBillingPreviewFields(),
         });
         return respond(200, {
           changeId: "ad3bd64c-7237-436d-a221-61b14ed719e7",
@@ -1724,6 +1736,7 @@ describe("organization billing settings", () => {
         expect(body).toStrictEqual({
           targetTier: "pro",
           memberUsagePacks: [{ memberId: "user_1", usagePackUsd: 50 }],
+          ...inAppBillingPreviewFields(),
         });
         return respond(200, {
           changeId: "ad3bd64c-7237-436d-a221-61b14ed719e7",
@@ -2162,6 +2175,7 @@ describe("organization billing settings", () => {
         expect(body).toStrictEqual({
           targetTier: "pro",
           memberUsagePacks: [{ memberId: "user_1", usagePackUsd: 100 }],
+          ...inAppBillingPreviewFields(),
         });
         return respond(200, {
           changeId: "703d633a-fe5b-4ea7-a46d-d76078f6c802",
@@ -2340,6 +2354,7 @@ describe("organization billing settings", () => {
         expect(body).toStrictEqual({
           targetTier: "pro",
           memberUsagePacks: [{ memberId: "user_1", usagePackUsd: 100 }],
+          ...inAppBillingPreviewFields(),
         });
         return respond(200, {
           changeId: "703d633a-fe5b-4ea7-a46d-d76078f6c802",
@@ -2445,6 +2460,7 @@ describe("organization billing settings", () => {
         expect(body).toStrictEqual({
           targetTier: "team",
           memberUsagePacks: [{ memberId: "user_1", usagePackUsd: 20 }],
+          ...inAppBillingPreviewFields(),
         });
         return respond(200, {
           changeId: "703d633a-fe5b-4ea7-a46d-d76078f6c802",
@@ -2621,6 +2637,7 @@ describe("organization billing settings", () => {
         expect(body).toStrictEqual({
           targetTier: "pro",
           memberUsagePacks: [{ memberId: "user_1", usagePackUsd: 20 }],
+          ...inAppBillingPreviewFields(),
         });
         return respond(200, {
           changeId: "667d65ac-85df-4743-b421-b9d18a3ad89b",
@@ -3874,6 +3891,53 @@ describe("organization billing settings", () => {
     expect(screen.queryByText("Downgrade plan")).not.toBeInTheDocument();
   });
 
+  it("clears a failed downgrade before the dialog reopens", async () => {
+    let downgradeRequests = 0;
+
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Downgrade Retry Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, activeProBillingStatus());
+    });
+    context.mocks.api(zeroBillingDowngradeContract.create, ({ respond }) => {
+      downgradeRequests += 1;
+      return respond(409, {
+        error: {
+          code: "CONFLICT",
+          message: "Simulated downgrade failure",
+        },
+      });
+    });
+
+    await openBillingTab();
+    click(screen.getByText("Downgrade"));
+
+    const firstDialog = await screen.findByRole("dialog", {
+      name: "Downgrade plan",
+    });
+    click(buttonByText("Cancel subscription", firstDialog));
+    await within(firstDialog).findByText(/Simulated downgrade failure/);
+
+    click(buttonByText("Cancel", firstDialog));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Downgrade plan" }),
+      ).not.toBeInTheDocument();
+    });
+    click(screen.getByText("Downgrade"));
+
+    const reopenedDialog = await screen.findByRole("dialog", {
+      name: "Downgrade plan",
+    });
+    expect(
+      within(reopenedDialog).queryByText(/Simulated downgrade failure/),
+    ).not.toBeInTheDocument();
+    expect(downgradeRequests).toBe(1);
+  });
+
   it("redirects for restore confirmation and shows success after realtime catches up", async () => {
     const locationAssign = context.mocks.browser.locationAssign();
     const successToast = vi.spyOn(toast, "success");
@@ -3948,6 +4012,62 @@ describe("organization billing settings", () => {
     expect(successToast).toHaveBeenCalledTimes(1);
   });
 
+  it("clears a failed restore before the dialog reopens", async () => {
+    let restoreRequests = 0;
+
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Restore Retry Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, {
+        ...activeProBillingStatus(),
+        cancelAtPeriodEnd: true,
+        canRestorePlan: true,
+        scheduledChange: {
+          type: "cancel",
+          targetTier: "limited-free-1",
+          effectiveDate: "2026-04-01T00:00:00Z",
+        },
+      });
+    });
+    context.mocks.api(zeroBillingRestoreContract.create, ({ respond }) => {
+      restoreRequests += 1;
+      return respond(409, {
+        error: {
+          code: "CONFLICT",
+          message: "Simulated restore failure",
+        },
+      });
+    });
+
+    await openBillingTab();
+    click(screen.getByText("Restore plan"));
+
+    const firstDialog = await screen.findByRole("dialog", {
+      name: "Restore Pro plan?",
+    });
+    click(buttonByText("Restore plan", firstDialog));
+    await within(firstDialog).findByText(/Simulated restore failure/);
+
+    click(buttonByText("Cancel", firstDialog));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Restore Pro plan?" }),
+      ).not.toBeInTheDocument();
+    });
+    click(screen.getByText("Restore plan"));
+
+    const reopenedDialog = await screen.findByRole("dialog", {
+      name: "Restore Pro plan?",
+    });
+    expect(
+      within(reopenedDialog).queryByText(/Simulated restore failure/),
+    ).not.toBeInTheDocument();
+    expect(restoreRequests).toBe(1);
+  });
+
   it.each([
     { caseName: "not restorable", canRestorePlan: false },
     { caseName: "omitted by an older API", canRestorePlan: undefined },
@@ -3995,7 +4115,7 @@ describe("organization billing settings", () => {
   it("reviews a saved-card plan purchase in app and opens its unpaid invoice", async () => {
     let requestedTier: "pro" | "team" | null = null;
     let supportsInAppPreview: boolean | undefined;
-    let confirmedPreviewToken: string | null = null;
+    let confirmationRequest: CheckoutRequest | null = null;
     const hostedInvoiceUrl =
       "https://invoice.stripe.com/plan-purchase-authentication";
 
@@ -4005,11 +4125,18 @@ describe("organization billing settings", () => {
       role: "admin",
     });
     context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
-      return respond(200, noActiveBillingStatus());
+      return respond(200, activeProBillingStatus());
     });
     context.mocks.api(
       zeroBillingCheckoutContract.create,
       ({ body, respond }) => {
+        if (body.previewToken) {
+          confirmationRequest = body;
+          return respond(200, {
+            status: "pending_payment",
+            hostedInvoiceUrl,
+          });
+        }
         requestedTier = body.tier;
         supportsInAppPreview = body.supportsInAppPreview;
         return respond(200, {
@@ -4024,16 +4151,6 @@ describe("organization billing settings", () => {
         });
       },
     );
-    context.mocks.api(
-      zeroBillingCheckoutContract.confirm,
-      ({ body, respond }) => {
-        confirmedPreviewToken = body.previewToken;
-        return respond(200, {
-          status: "pending_payment",
-          hostedInvoiceUrl,
-        });
-      },
-    );
 
     await openBillingTab("/?settings=billing", {
       [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
@@ -4041,23 +4158,132 @@ describe("organization billing settings", () => {
     const locationBeforePurchase = window.location.href;
     click(screen.getByText("Upgrade"));
     await screen.findByText("Compare plans");
-    click(screen.getByText("Start with Team"));
+    click(buttonByText("Upgrade to Team"));
 
     const reviewDialog = await screen.findByRole("dialog", {
-      name: "Order summary",
+      name: "Upgrade to Team",
     });
+    expect(within(reviewDialog).getByText("Today")).toBeInTheDocument();
+    expect(within(reviewDialog).getByText("Due now")).toBeInTheDocument();
+    expect(within(reviewDialog).getByText("Plan")).toBeInTheDocument();
+    expect(within(reviewDialog).getByText("Every month")).toBeInTheDocument();
+    expect(within(reviewDialog).getByText("Monthly total")).toBeInTheDocument();
     expect(within(reviewDialog).getByText("Team")).toBeInTheDocument();
     expect(within(reviewDialog).getAllByText("$160.00")).toHaveLength(2);
     expect(requestedTier).toBe("team");
     expect(supportsInAppPreview).toBeTruthy();
     expect(window.location.href).toBe(locationBeforePurchase);
 
-    click(buttonByText("Confirm", reviewDialog));
+    click(buttonByText("Upgrade to Team", reviewDialog));
 
     await waitFor(() => {
       expect(window.location.href).toBe(hostedInvoiceUrl);
     });
-    expect(confirmedPreviewToken).toBe("plan-preview-token");
+    expect(confirmationRequest).toMatchObject({
+      tier: "team",
+      supportsInAppPreview: true,
+      previewToken: "plan-preview-token",
+    });
+  });
+
+  it("refreshes invalid Plan previews from current and older billing APIs", async () => {
+    let previewCount = 0;
+    let confirmationCount = 0;
+    let confirmedPreviewToken: string | null = null;
+
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Plan Retry Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, activeProBillingStatus());
+    });
+    context.mocks.api(
+      zeroBillingCheckoutContract.create,
+      ({ body, respond }) => {
+        if (body.previewToken) {
+          confirmationCount += 1;
+          confirmedPreviewToken = body.previewToken;
+          if (confirmationCount === 1) {
+            previewCount += 1;
+            return respond(200, {
+              status: "preview",
+              purchaseType: "plan",
+              tier: body.tier,
+              immediateAmountCents: 15_000 + previewCount * 1000,
+              nextRecurringAmountCents: 15_000 + previewCount * 1000,
+              currency: "usd",
+              expiresAt: "2026-08-13T12:15:00.000Z",
+              previewToken: `plan-preview-token-${previewCount}`,
+            });
+          }
+          return confirmationCount === 2
+            ? respond(409, {
+                error: {
+                  code: "CONFLICT",
+                  message: "Plan purchase preview is no longer valid",
+                },
+              })
+            : respond(200, {
+                status: "completed",
+                hostedInvoiceUrl: null,
+              });
+        }
+        previewCount += 1;
+        return respond(200, {
+          status: "preview",
+          purchaseType: "plan",
+          tier: body.tier,
+          immediateAmountCents: 15_000 + previewCount * 1000,
+          nextRecurringAmountCents: 15_000 + previewCount * 1000,
+          currency: "usd",
+          expiresAt: "2026-08-13T12:15:00.000Z",
+          previewToken: `plan-preview-token-${previewCount}`,
+        });
+      },
+    );
+
+    await openBillingTab("/?settings=billing", {
+      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
+    });
+    click(screen.getByText("Upgrade"));
+    await screen.findByText("Compare plans");
+    click(buttonByText("Upgrade to Team"));
+
+    const firstDialog = await screen.findByRole("dialog", {
+      name: "Upgrade to Team",
+    });
+    click(buttonByText("Upgrade to Team", firstDialog));
+    await screen.findAllByText("$170.00");
+    const refreshedDialog = await screen.findByRole("dialog", {
+      name: "Upgrade to Team",
+    });
+    expect(
+      within(refreshedDialog).queryByText(
+        "Could not prepare the subscription change. Try again.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(within(refreshedDialog).getAllByText("$170.00")).toHaveLength(2);
+    expect(previewCount).toBe(2);
+    expect(confirmationCount).toBe(1);
+
+    click(buttonByText("Upgrade to Team", refreshedDialog));
+    await screen.findAllByText("$180.00");
+    const legacyRefreshedDialog = await screen.findByRole("dialog", {
+      name: "Upgrade to Team",
+    });
+    expect(previewCount).toBe(3);
+    expect(confirmationCount).toBe(2);
+
+    click(buttonByText("Upgrade to Team", legacyRefreshedDialog));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Upgrade to Team" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(confirmationCount).toBe(3);
+    expect(confirmedPreviewToken).toBe("plan-preview-token-3");
   });
 
   it("previews and confirms a saved-billing credit purchase in the app", async () => {
@@ -4149,6 +4375,81 @@ describe("organization billing settings", () => {
     expect(confirmedPreviewToken).toBe("credit-preview-token");
     expect(billingStatusRequests).toBeGreaterThan(1);
     expect(window.location.href).toBe(locationBeforePurchase);
+  });
+
+  it("clears a failed credit confirmation before the purchase dialog reopens", async () => {
+    let previewCount = 0;
+    let confirmationCount = 0;
+
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Credit Retry Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, {
+        ...activeProBillingStatus(),
+        canBuyCredits: true,
+      });
+    });
+    context.mocks.api(
+      zeroBillingCreditCheckoutContract.create,
+      ({ respond }) => {
+        previewCount += 1;
+        return respond(200, {
+          status: "preview",
+          credits: 20_000,
+          amountCents: 1800,
+          currency: "usd",
+          expiresAt: "2026-08-13T12:15:00.000Z",
+          previewToken: `credit-preview-token-${previewCount}`,
+        });
+      },
+    );
+    context.mocks.api(
+      zeroBillingCreditCheckoutContract.confirm,
+      ({ respond }) => {
+        confirmationCount += 1;
+        return respond(409, {
+          error: {
+            code: "CONFLICT",
+            message: "Credit purchase preview is no longer valid",
+          },
+        });
+      },
+    );
+
+    await openBillingTab("/?settings=billing", {
+      [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
+    });
+    click(buttonByText("Quick buy $20.00"));
+
+    const firstDialog = await screen.findByRole("dialog", {
+      name: "Review credit purchase",
+    });
+    click(buttonByText("Pay and add credits", firstDialog));
+    await within(firstDialog).findByText(
+      "Could not complete this credit purchase. Review your billing details and try again.",
+    );
+
+    click(buttonByText("Cancel", firstDialog));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Review credit purchase" }),
+      ).not.toBeInTheDocument();
+    });
+    click(buttonByText("Quick buy $20.00"));
+
+    const reopenedDialog = await screen.findByRole("dialog", {
+      name: "Review credit purchase",
+    });
+    expect(
+      within(reopenedDialog).queryByText(
+        "Could not complete this credit purchase. Review your billing details and try again.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(previewCount).toBe(2);
+    expect(confirmationCount).toBe(1);
   });
 
   it("manages plan changes, credit purchases, and auto-recharge settings", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-members-tab.test.tsx
@@ -497,6 +497,11 @@ describe("organization members settings", () => {
       email: "paid.invitee@example.com",
       role: "member",
       usagePackUsd: 50,
+      supportsInAppPreview: true,
+      returnUrl: new URL(
+        window.location.pathname,
+        window.location.origin,
+      ).toString(),
     });
     expect(window.location.href).toBe(initialHref);
     click(buttonByText("Pay and invite", confirmationDialog));
@@ -512,6 +517,91 @@ describe("organization members settings", () => {
       within(rowByEmail("paid.invitee@example.com")).getByText("$50/month"),
     ).toBeInTheDocument();
     expect(window.location.href).toBe(initialHref);
+  });
+
+  it("clears a failed invitation purchase before its dialog reopens", async () => {
+    mockMembersStory();
+    mockMemberInviteEntitlement(true);
+    mockUsagePackManagement();
+    mockUsagePackCatalog();
+    let previewCount = 0;
+    context.mocks.api(
+      zeroOrgInviteContract.previewPurchase,
+      ({ body, respond }) => {
+        previewCount += 1;
+        return respond(200, {
+          purchaseId:
+            previewCount === 1
+              ? "c08a5fab-a05d-43f9-a1ee-10feaf27584c"
+              : "d19b6abc-b16e-54fa-b2ff-21afbf38695d",
+          usagePackUsd: body.usagePackUsd,
+          immediateAmountCents: 1000,
+          currency: "usd",
+          purchasedCredits: 10_000,
+          bonusCredits: 200,
+          totalCredits: 10_200,
+          currentPeriodEnd: "2026-09-01T00:00:00.000Z",
+          expiresAt: "2026-08-13T00:00:00.000Z",
+          paymentMethodPreviewToken: `invite-payment-token-${previewCount}`,
+        });
+      },
+    );
+    context.mocks.api(zeroOrgInviteContract.confirmPurchase, ({ respond }) => {
+      return respond(409, {
+        error: {
+          code: "CONFLICT",
+          message: "Invitation purchase preview is no longer valid",
+        },
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/?settings=people",
+      featureSwitches: {
+        [FeatureSwitchKey.UsagePackPlans]: true,
+        [FeatureSwitchKey.SavedBillingCreditPurchase]: true,
+      },
+    });
+    await expect(screen.findByText("Usage pack")).resolves.toBeInTheDocument();
+
+    const openPurchase = async (email: string): Promise<HTMLElement> => {
+      click(buttonByText("Add member"));
+      const inviteDialog = await screen.findByRole("dialog", {
+        name: "Invite member",
+      });
+      await fill(
+        within(inviteDialog).getByPlaceholderText("email@example.com"),
+        email,
+      );
+      await expect(
+        within(inviteDialog).findByText("Member packages"),
+      ).resolves.toBeInTheDocument();
+      click(buttonByText("Continue", inviteDialog));
+      return await screen.findByRole("dialog", {
+        name: "Review invitation",
+      });
+    };
+
+    const firstDialog = await openPurchase("first@example.com");
+    click(buttonByText("Pay and invite", firstDialog));
+    await within(firstDialog).findByText(
+      "Could not purchase this member package. Review your billing details and try again.",
+    );
+    click(buttonByText("Cancel", firstDialog));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Review invitation" }),
+      ).not.toBeInTheDocument();
+    });
+
+    const reopenedDialog = await openPurchase("second@example.com");
+    expect(
+      within(reopenedDialog).queryByText(
+        "Could not purchase this member package. Review your billing details and try again.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(previewCount).toBe(2);
   });
 
   it("opens the current plan package configuration from member actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/credit-purchase-confirm-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/credit-purchase-confirm-dialog.tsx
@@ -1,6 +1,7 @@
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
+import type { CreditPurchasePreviewResponse } from "@okouai/api-contracts/contracts/zero-billing";
 import { FeatureSwitchKey } from "@okouai/core";
 import { Button } from "@okouai/ui";
 import {
@@ -34,108 +35,120 @@ function formatCreditPurchaseAmount(
   });
 }
 
-export function CreditPurchaseConfirmDialog() {
+function CreditPurchaseConfirmDialogContent({
+  preview,
+}: {
+  readonly preview: CreditPurchasePreviewResponse;
+}) {
   const { t } = useTranslation();
-  const enabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ??
-    false;
-  const preview = useGet(creditPurchasePreview$);
   const close = useSet(closeCreditPurchasePreview$);
   const pageSignal = useGet(pageSignal$);
   const [confirmLoadable, confirm] = useLoadableSet(confirmCreditPurchase$);
   const confirming = confirmLoadable.state === "loading";
   const error = confirmLoadable.state === "hasError";
 
-  if (!enabled) {
-    return null;
-  }
-
   return (
     <Dialog
-      open={preview !== null}
+      open
       onOpenChange={(open) => {
         if (!open && !confirming) {
           close();
         }
       }}
     >
-      {preview && (
-        <DialogContent className="sm:max-w-[420px]">
-          <DialogHeader>
-            <DialogTitle>
-              {t(($) => {
-                return $.billing.credits.reviewTitle;
-              })}
-            </DialogTitle>
-            <DialogDescription>
-              {t(($) => {
-                return $.billing.credits.reviewDescription;
-              })}
-            </DialogDescription>
-          </DialogHeader>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>
+            {t(($) => {
+              return $.billing.credits.reviewTitle;
+            })}
+          </DialogTitle>
+          <DialogDescription>
+            {t(($) => {
+              return $.billing.credits.reviewDescription;
+            })}
+          </DialogDescription>
+        </DialogHeader>
 
-          <div className="mt-1">
-            <p className="pb-0.5 pt-1 text-xs font-medium text-muted-foreground">
+        <div className="mt-1">
+          <p className="pb-0.5 pt-1 text-xs font-medium text-muted-foreground">
+            {t(($) => {
+              return $.billing.credits.today;
+            })}
+          </p>
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-border py-3.5">
+            <p className="text-sm font-medium text-foreground">
               {t(($) => {
-                return $.billing.credits.today;
+                return $.billing.credits.dueNow;
               })}
             </p>
-            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-border py-3.5">
-              <p className="text-sm font-medium text-foreground">
-                {t(($) => {
-                  return $.billing.credits.dueNow;
-                })}
-              </p>
-              <p className="text-right text-3xl font-light tracking-tight tabular-nums text-foreground">
-                {formatCreditPurchaseAmount(
-                  preview.amountCents,
-                  preview.currency,
-                )}
-              </p>
-            </div>
-            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-[hsl(var(--gray-100))] py-2.5">
-              <p className="text-sm font-medium text-foreground">
-                {t(($) => {
-                  return $.billing.credits.creditsAdded;
-                })}
-              </p>
-              <p className="text-right text-sm font-medium tabular-nums text-foreground">
-                +{formatLocalizedNumber(preview.credits)}
-              </p>
-            </div>
+            <p className="text-right text-3xl font-light tracking-tight tabular-nums text-foreground">
+              {formatCreditPurchaseAmount(
+                preview.amountCents,
+                preview.currency,
+              )}
+            </p>
           </div>
-
-          {error && (
-            <p className="text-sm text-destructive">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-[hsl(var(--gray-100))] py-2.5">
+            <p className="text-sm font-medium text-foreground">
               {t(($) => {
-                return $.billing.credits.reviewError;
+                return $.billing.credits.creditsAdded;
               })}
             </p>
-          )}
+            <p className="text-right text-sm font-medium tabular-nums text-foreground">
+              +{formatLocalizedNumber(preview.credits)}
+            </p>
+          </div>
+        </div>
 
-          <DialogFooter>
-            <Button variant="outline" disabled={confirming} onClick={close}>
-              {t(($) => {
-                return $.billing.common.cancel;
-              })}
-            </Button>
-            <Button
-              disabled={confirming}
-              onClick={() => {
-                detach(confirm(pageSignal), Reason.DomCallback);
-              }}
-            >
-              {confirming
-                ? t(($) => {
-                    return $.billing.common.updating;
-                  })
-                : t(($) => {
-                    return $.billing.credits.payAndAddCredits;
-                  })}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      )}
+        {error && (
+          <p className="text-sm text-destructive">
+            {t(($) => {
+              return $.billing.credits.reviewError;
+            })}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" disabled={confirming} onClick={close}>
+            {t(($) => {
+              return $.billing.common.cancel;
+            })}
+          </Button>
+          <Button
+            disabled={confirming}
+            onClick={() => {
+              detach(confirm(pageSignal), Reason.DomCallback);
+            }}
+          >
+            {confirming
+              ? t(($) => {
+                  return $.billing.common.updating;
+                })
+              : t(($) => {
+                  return $.billing.credits.payAndAddCredits;
+                })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
     </Dialog>
+  );
+}
+
+export function CreditPurchaseConfirmDialog() {
+  const enabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ??
+    false;
+  const preview = useGet(creditPurchasePreview$);
+
+  if (!enabled || !preview) {
+    return null;
+  }
+
+  return (
+    <CreditPurchaseConfirmDialogContent
+      key={preview.previewToken}
+      preview={preview}
+    />
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -836,9 +836,12 @@ function formatTierLabel(tier: BillingTier): string {
   return planName(tier);
 }
 
-function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
+function DowngradeConfirmDialogContent({
+  currentTier,
+}: {
+  currentTier: BillingTier;
+}) {
   const pageSignal = useGet(pageSignal$);
-  const open = useGet(downgradeDialogOpen$);
   const [downgradeLoadable, confirm] = useLoadableSet(confirmDowngrade$);
   const loading = downgradeLoadable.state === "loading";
   const error =
@@ -858,23 +861,28 @@ function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
   const proPlanPrice = getPlanPrice("pro");
   const freePlanPrice = getPlanPrice("free");
 
+  const confirmAndResetTarget = async (): Promise<void> => {
+    await confirm(downgradeTarget, pageSignal);
+    setLockedTarget(null);
+  };
+
   const handleConfirm = () => {
-    detach(confirm(downgradeTarget, pageSignal), Reason.DomCallback);
+    detach(confirmAndResetTarget(), Reason.DomCallback);
+  };
+
+  const handleClose = () => {
+    close();
+    setLockedTarget(null);
   };
 
   return (
     <Dialog
-      open={open}
+      open
       onOpenChange={(v) => {
         if (v) {
           return;
         }
-        close();
-      }}
-      onOpenChangeComplete={(v) => {
-        if (!v) {
-          setLockedTarget(null);
-        }
+        handleClose();
       }}
     >
       <DialogContent className="sm:max-w-[440px]">
@@ -970,7 +978,7 @@ function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
         {error && <p className="text-sm text-destructive mt-2">{error}</p>}
 
         <div className="flex justify-end gap-2 mt-4">
-          <Button variant="outline" onClick={close} disabled={loading}>
+          <Button variant="outline" onClick={handleClose} disabled={loading}>
             {i18n.t(($) => {
               return $.billing.common.cancel;
             })}
@@ -1002,7 +1010,17 @@ function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
   );
 }
 
-function RestorePlanConfirmDialog({
+function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
+  const open = useGet(downgradeDialogOpen$);
+
+  if (!open) {
+    return null;
+  }
+
+  return <DowngradeConfirmDialogContent currentTier={currentTier} />;
+}
+
+function RestorePlanConfirmDialogContent({
   currentTier,
   periodEnd,
   scheduledChange,
@@ -1012,7 +1030,6 @@ function RestorePlanConfirmDialog({
   scheduledChange: ScheduledBillingChange;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const open = useGet(restoreDialogOpen$);
   const close = useSet(closeRestoreDialog$);
   const [restoreLoadable, restore] = useLoadableSet(restorePlan$);
   const loading = restoreLoadable.state === "loading";
@@ -1051,7 +1068,7 @@ function RestorePlanConfirmDialog({
 
   return (
     <Dialog
-      open={open}
+      open
       onOpenChange={(v) => {
         return !v && close();
       }}
@@ -1095,6 +1112,30 @@ function RestorePlanConfirmDialog({
         </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function RestorePlanConfirmDialog({
+  currentTier,
+  periodEnd,
+  scheduledChange,
+}: {
+  currentTier: BillingTier;
+  periodEnd: string | null | undefined;
+  scheduledChange: ScheduledBillingChange;
+}) {
+  const open = useGet(restoreDialogOpen$);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <RestorePlanConfirmDialogContent
+      currentTier={currentTier}
+      periodEnd={periodEnd}
+      scheduledChange={scheduledChange}
+    />
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -780,7 +780,7 @@ function InviteDialog() {
   );
 }
 
-function InvitePurchaseConfirmationDialog() {
+function InvitePurchaseConfirmationDialogContent() {
   const { t } = useTranslation();
   const preview = useGet(invitePurchasePreview$);
   const close = useSet(closeInvitePurchasePreview$);
@@ -911,6 +911,16 @@ function InvitePurchaseConfirmationDialog() {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function InvitePurchaseConfirmationDialog() {
+  const preview = useGet(invitePurchasePreview$);
+  if (!preview) {
+    return null;
+  }
+  return (
+    <InvitePurchaseConfirmationDialogContent key={preview.payment.purchaseId} />
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/subscription-purchase-confirm-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/subscription-purchase-confirm-dialog.tsx
@@ -1,4 +1,8 @@
 import { FeatureSwitchKey } from "@okouai/core";
+import type {
+  PlanPurchasePreviewResponse,
+  UsagePackPurchasePreviewResponse,
+} from "@okouai/api-contracts/contracts/zero-billing";
 import { Button } from "@okouai/ui";
 import {
   Dialog,
@@ -31,12 +35,70 @@ function formatAmount(amountCents: number, currency: string): string {
   });
 }
 
-export function SubscriptionPurchaseConfirmDialog() {
+type SubscriptionPurchasePreview =
+  | PlanPurchasePreviewResponse
+  | UsagePackPurchasePreviewResponse;
+
+function SubscriptionPurchaseSummary({
+  preview,
+  planName,
+}: {
+  readonly preview: SubscriptionPurchasePreview;
+  readonly planName: string;
+}) {
   const { t } = useTranslation();
-  const enabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ??
-    false;
-  const state = useGet(subscriptionPurchasePreview$);
+  return (
+    <div className="mt-1">
+      <p className="pb-0.5 pt-1 text-xs font-medium text-muted-foreground">
+        {t(($) => {
+          return $.billing.credits.today;
+        })}
+      </p>
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-border py-3.5">
+        <p className="text-sm font-medium text-foreground">
+          {t(($) => {
+            return $.billing.concurrency.dueNow;
+          })}
+        </p>
+        <p className="text-right text-3xl font-light tracking-tight tabular-nums text-foreground">
+          {formatAmount(preview.immediateAmountCents, preview.currency)}
+        </p>
+      </div>
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-[hsl(var(--gray-100))] py-2.5">
+        <p className="text-sm font-medium text-foreground">
+          {t(($) => {
+            return $.billing.plans.usagePacks.planStep;
+          })}
+        </p>
+        <p className="text-right text-sm font-medium text-foreground">
+          {planName}
+        </p>
+      </div>
+      <p className="pb-0.5 pt-4 text-xs font-medium text-muted-foreground">
+        {t(($) => {
+          return $.billing.plans.usagePacks.management.everyMonth;
+        })}
+      </p>
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-border py-3.5">
+        <p className="text-sm font-medium text-foreground">
+          {t(($) => {
+            return $.billing.concurrency.monthlyTotal;
+          })}
+        </p>
+        <p className="text-right text-3xl font-light tracking-tight tabular-nums text-foreground">
+          {formatAmount(preview.nextRecurringAmountCents, preview.currency)}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function SubscriptionPurchaseConfirmDialogContent({
+  preview,
+}: {
+  readonly preview: SubscriptionPurchasePreview;
+}) {
+  const { t } = useTranslation();
   const close = useSet(closeSubscriptionPurchasePreview$);
   const pageSignal = useGet(pageSignal$);
   const [confirmLoadable, confirm] = useLoadableSet(
@@ -44,111 +106,99 @@ export function SubscriptionPurchaseConfirmDialog() {
   );
   const confirming = confirmLoadable.state === "loading";
   const error = confirmLoadable.state === "hasError";
-  if (!enabled) {
-    return null;
-  }
-  const preview = state?.preview;
-  const planName = preview
-    ? preview.tier === "pro"
+  const planName =
+    preview.tier === "pro"
       ? t(($) => {
           return $.billing.plans.pro.name;
         })
       : t(($) => {
           return $.billing.plans.team.name;
-        })
-    : "";
-
+        });
+  const upgradeLabel = t(
+    ($) => {
+      return $.billing.plans.upgradeTo;
+    },
+    { plan: planName },
+  );
+  const confirmLabel =
+    preview.purchaseType === "plan"
+      ? upgradeLabel
+      : t(($) => {
+          return $.billing.common.confirm;
+        });
   return (
     <Dialog
-      open={state !== null}
+      open
       onOpenChange={(open) => {
         if (!open && !confirming) {
           close();
         }
       }}
     >
-      {preview && (
-        <DialogContent className="sm:max-w-[440px]">
-          <DialogHeader>
-            <DialogTitle>
-              {t(($) => {
-                return $.billing.plans.usagePacks.orderSummary;
-              })}
-            </DialogTitle>
-            <DialogDescription>
-              {t(($) => {
-                return $.billing.concurrency.reviewDescription;
-              })}
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="mt-1 divide-y divide-border/70 border-y border-border/70">
-            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 py-4">
-              <p className="text-sm font-semibold text-foreground">
-                {t(($) => {
-                  return $.billing.plans.selectedPlan;
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>
+            {preview.purchaseType === "plan"
+              ? upgradeLabel
+              : t(($) => {
+                  return $.billing.plans.usagePacks.orderSummary;
                 })}
-              </p>
-              <p className="text-right text-sm font-semibold text-foreground">
-                {planName}
-              </p>
-            </div>
-            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 py-4">
-              <p className="text-sm font-semibold text-foreground">
-                {t(($) => {
-                  return $.billing.concurrency.dueNow;
-                })}
-              </p>
-              <p className="text-right text-2xl font-semibold tabular-nums tracking-tight text-primary">
-                {formatAmount(preview.immediateAmountCents, preview.currency)}
-              </p>
-            </div>
-            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 py-4">
-              <p className="text-sm font-semibold text-foreground">
-                {t(($) => {
-                  return $.billing.concurrency.monthlyTotal;
-                })}
-              </p>
-              <p className="text-right text-2xl font-semibold tabular-nums tracking-tight text-primary">
-                {formatAmount(
-                  preview.nextRecurringAmountCents,
-                  preview.currency,
-                )}
-              </p>
-            </div>
-          </div>
+          </DialogTitle>
+          <DialogDescription>
+            {t(($) => {
+              return $.billing.concurrency.reviewDescription;
+            })}
+          </DialogDescription>
+        </DialogHeader>
 
-          {error && (
-            <p className="text-sm text-destructive">
-              {t(($) => {
-                return $.billing.plans.usagePacks.planChangeError;
-              })}
-            </p>
-          )}
+        <SubscriptionPurchaseSummary preview={preview} planName={planName} />
 
-          <DialogFooter>
-            <Button variant="outline" disabled={confirming} onClick={close}>
-              {t(($) => {
-                return $.billing.common.cancel;
-              })}
-            </Button>
-            <Button
-              disabled={confirming}
-              onClick={() => {
-                detach(confirm(pageSignal), Reason.DomCallback);
-              }}
-            >
-              {confirming
-                ? t(($) => {
-                    return $.billing.common.updating;
-                  })
-                : t(($) => {
-                    return $.billing.common.confirm;
-                  })}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      )}
+        {error && (
+          <p className="text-sm text-destructive">
+            {t(($) => {
+              return $.billing.plans.usagePacks.planChangeError;
+            })}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" disabled={confirming} onClick={close}>
+            {t(($) => {
+              return $.billing.common.cancel;
+            })}
+          </Button>
+          <Button
+            disabled={confirming}
+            onClick={() => {
+              detach(confirm(pageSignal), Reason.DomCallback);
+            }}
+          >
+            {confirming
+              ? t(($) => {
+                  return $.billing.common.updating;
+                })
+              : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
     </Dialog>
+  );
+}
+
+export function SubscriptionPurchaseConfirmDialog() {
+  const enabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ??
+    false;
+  const state = useGet(subscriptionPurchasePreview$);
+
+  if (!enabled || !state) {
+    return null;
+  }
+
+  return (
+    <SubscriptionPurchaseConfirmDialogContent
+      key={state.preview.previewToken}
+      preview={state.preview}
+    />
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/subscription-purchase-confirm-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/subscription-purchase-confirm-dialog.tsx
@@ -1,0 +1,154 @@
+import { FeatureSwitchKey } from "@okouai/core";
+import { Button } from "@okouai/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@okouai/ui/components/ui/dialog";
+import { useGet, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import { useTranslation } from "react-i18next";
+
+import { formatLocalizedNumber } from "../../../../i18n/format.ts";
+import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
+import {
+  closeSubscriptionPurchasePreview$,
+  confirmSubscriptionPurchase$,
+  subscriptionPurchasePreview$,
+} from "../../../../signals/zero-page/billing.ts";
+
+function formatAmount(amountCents: number, currency: string): string {
+  return formatLocalizedNumber(amountCents / 100, {
+    style: "currency",
+    currency: currency.toUpperCase(),
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+export function SubscriptionPurchaseConfirmDialog() {
+  const { t } = useTranslation();
+  const enabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.SavedBillingCreditPurchase] ??
+    false;
+  const state = useGet(subscriptionPurchasePreview$);
+  const close = useSet(closeSubscriptionPurchasePreview$);
+  const pageSignal = useGet(pageSignal$);
+  const [confirmLoadable, confirm] = useLoadableSet(
+    confirmSubscriptionPurchase$,
+  );
+  const confirming = confirmLoadable.state === "loading";
+  const error = confirmLoadable.state === "hasError";
+  if (!enabled) {
+    return null;
+  }
+  const preview = state?.preview;
+  const planName = preview
+    ? preview.tier === "pro"
+      ? t(($) => {
+          return $.billing.plans.pro.name;
+        })
+      : t(($) => {
+          return $.billing.plans.team.name;
+        })
+    : "";
+
+  return (
+    <Dialog
+      open={state !== null}
+      onOpenChange={(open) => {
+        if (!open && !confirming) {
+          close();
+        }
+      }}
+    >
+      {preview && (
+        <DialogContent className="sm:max-w-[440px]">
+          <DialogHeader>
+            <DialogTitle>
+              {t(($) => {
+                return $.billing.plans.usagePacks.orderSummary;
+              })}
+            </DialogTitle>
+            <DialogDescription>
+              {t(($) => {
+                return $.billing.concurrency.reviewDescription;
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="mt-1 divide-y divide-border/70 border-y border-border/70">
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 py-4">
+              <p className="text-sm font-semibold text-foreground">
+                {t(($) => {
+                  return $.billing.plans.selectedPlan;
+                })}
+              </p>
+              <p className="text-right text-sm font-semibold text-foreground">
+                {planName}
+              </p>
+            </div>
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 py-4">
+              <p className="text-sm font-semibold text-foreground">
+                {t(($) => {
+                  return $.billing.concurrency.dueNow;
+                })}
+              </p>
+              <p className="text-right text-2xl font-semibold tabular-nums tracking-tight text-primary">
+                {formatAmount(preview.immediateAmountCents, preview.currency)}
+              </p>
+            </div>
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 py-4">
+              <p className="text-sm font-semibold text-foreground">
+                {t(($) => {
+                  return $.billing.concurrency.monthlyTotal;
+                })}
+              </p>
+              <p className="text-right text-2xl font-semibold tabular-nums tracking-tight text-primary">
+                {formatAmount(
+                  preview.nextRecurringAmountCents,
+                  preview.currency,
+                )}
+              </p>
+            </div>
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive">
+              {t(($) => {
+                return $.billing.plans.usagePacks.planChangeError;
+              })}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" disabled={confirming} onClick={close}>
+              {t(($) => {
+                return $.billing.common.cancel;
+              })}
+            </Button>
+            <Button
+              disabled={confirming}
+              onClick={() => {
+                detach(confirm(pageSignal), Reason.DomCallback);
+              }}
+            >
+              {confirming
+                ? t(($) => {
+                    return $.billing.common.updating;
+                  })
+                : t(($) => {
+                    return $.billing.common.confirm;
+                  })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -46,6 +46,7 @@ import { ChatShortcutHelpDialog } from "./chat-shortcut-help-dialog.tsx";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { ConcurrencyConfirmDialog } from "./components/org-manage/org-billing-tab.tsx";
 import { CreditPurchaseConfirmDialog } from "./components/org-manage/credit-purchase-confirm-dialog.tsx";
+import { SubscriptionPurchaseConfirmDialog } from "./components/org-manage/subscription-purchase-confirm-dialog.tsx";
 
 function AgentAvatarInTopBar() {
   const agent = useLastResolved(currentChatAgent$);
@@ -339,6 +340,7 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
       <ChatShortcutHelpDialog />
       <ConcurrencyConfirmDialog />
       <CreditPurchaseConfirmDialog />
+      <SubscriptionPurchaseConfirmDialog />
       <QueueDrawer />
       <ZeroSidebar />
       <div

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -8,6 +8,7 @@ import {
 import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 import { Link } from "../router/link.tsx";
 import { CreditPurchaseConfirmDialog } from "./components/org-manage/credit-purchase-confirm-dialog.tsx";
+import { SubscriptionPurchaseConfirmDialog } from "./components/org-manage/subscription-purchase-confirm-dialog.tsx";
 import { SettingsDialog } from "./components/settings/settings-dialog.tsx";
 import { AccountDropdown } from "./zero-sidebar-account";
 
@@ -27,6 +28,7 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
         }}
       />
       <CreditPurchaseConfirmDialog />
+      <SubscriptionPurchaseConfirmDialog />
       <aside className="zero-nav hidden md:flex h-full w-[255px] shrink-0 flex-col bg-sidebar">
         <div className="flex-1" />
         <div className="p-2">

--- a/turbo/packages/api-contracts/src/contracts/org-members.ts
+++ b/turbo/packages/api-contracts/src/contracts/org-members.ts
@@ -94,6 +94,8 @@ export type InviteOrgMemberRequest = z.infer<
 export const previewOrgInvitationPurchaseRequestSchema =
   inviteOrgMemberRequestSchema.extend({
     usagePackUsd: usagePackUsdSchema,
+    supportsInAppPreview: z.boolean().optional(),
+    returnUrl: z.string().url().max(5000).optional(),
   });
 
 export const orgInvitationPurchasePreviewResponseSchema = z.object({
@@ -106,6 +108,8 @@ export const orgInvitationPurchasePreviewResponseSchema = z.object({
   totalCredits: z.number().int().positive(),
   currentPeriodEnd: z.iso.datetime(),
   expiresAt: z.iso.datetime(),
+  paymentMethodPreviewToken: z.string().min(1).optional(),
+  checkoutUrl: z.string().url().optional(),
 });
 export type OrgInvitationPurchasePreviewResponse = z.infer<
   typeof orgInvitationPurchasePreviewResponseSchema

--- a/turbo/packages/api-contracts/src/contracts/zero-billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-billing.ts
@@ -191,6 +191,7 @@ const stripeRedirectUrlSchema = z.string().url().max(5000);
 const checkoutRequestSchema = z.object({
   tier: z.enum(["pro", "team"]),
   supportsInAppPreview: z.boolean().optional(),
+  previewToken: z.string().min(1).optional(),
   successUrl: stripeRedirectUrlSchema,
   cancelUrl: stripeRedirectUrlSchema,
   trialDays: z.literal(7).optional(),
@@ -256,6 +257,7 @@ export type UsagePackCatalogItem = z.infer<typeof usagePackCatalogItemSchema>;
 const usagePackCheckoutRequestSchema = z.object({
   tier: z.enum(["pro", "team"]),
   supportsInAppPreview: z.boolean().optional(),
+  previewToken: z.string().min(1).optional(),
   memberUsagePacks: z.array(memberUsagePackSchema).min(1).max(1000),
   successUrl: z.string().url(),
   cancelUrl: z.string().url(),
@@ -639,10 +641,15 @@ export const zeroBillingCheckoutContract = c.router({
     headers: authHeadersSchema,
     body: checkoutRequestSchema,
     responses: {
-      200: z.union([checkoutResponseSchema, planPurchasePreviewResponseSchema]),
+      200: z.union([
+        checkoutResponseSchema,
+        planPurchasePreviewResponseSchema,
+        billingPurchaseConfirmResponseSchema,
+      ]),
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
+      409: apiErrorSchema,
       500: apiErrorSchema,
       503: apiErrorSchema,
     },
@@ -696,10 +703,12 @@ export const zeroBillingUsagePackCheckoutContract = c.router({
       200: z.union([
         checkoutResponseSchema,
         usagePackPurchasePreviewResponseSchema,
+        billingPurchaseConfirmResponseSchema,
       ]),
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
+      409: apiErrorSchema,
       500: apiErrorSchema,
       503: apiErrorSchema,
     },
@@ -1408,6 +1417,10 @@ export type ZeroBillingRedeemCodeContract =
 export type BillingStatusResponse = z.infer<typeof billingStatusResponseSchema>;
 export type AutoRechargeConfig = z.infer<typeof autoRechargeSchema>;
 export type CheckoutResponse = z.infer<typeof checkoutResponseSchema>;
+export type CheckoutRequest = z.infer<typeof checkoutRequestSchema>;
+export type UsagePackCheckoutRequest = z.infer<
+  typeof usagePackCheckoutRequestSchema
+>;
 export type PlanPurchasePreviewResponse = z.infer<
   typeof planPurchasePreviewResponseSchema
 >;

--- a/turbo/packages/api-contracts/src/contracts/zero-billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-billing.ts
@@ -113,6 +113,42 @@ const checkoutResponseSchema = z.object({
   url: z.string(),
 });
 
+const subscriptionPurchasePreviewBaseSchema = z.object({
+  status: z.literal("preview"),
+  tier: z.enum(["pro", "team"]),
+  immediateAmountCents: z.number().int().nonnegative(),
+  nextRecurringAmountCents: z.number().int().nonnegative(),
+  currency: z.string().length(3),
+  expiresAt: z.iso.datetime(),
+  previewToken: z.string().min(1),
+});
+
+const planPurchasePreviewResponseSchema =
+  subscriptionPurchasePreviewBaseSchema.extend({
+    purchaseType: z.literal("plan"),
+    trialDays: z.literal(7).optional(),
+  });
+
+const usagePackPurchasePreviewResponseSchema =
+  subscriptionPurchasePreviewBaseSchema.extend({
+    purchaseType: z.literal("usage_pack"),
+  });
+
+const billingPurchaseConfirmResponseSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("completed"),
+    hostedInvoiceUrl: z.null(),
+  }),
+  z.object({
+    status: z.literal("pending_payment"),
+    hostedInvoiceUrl: z.string().url(),
+  }),
+  z.object({
+    status: z.literal("checkout_required"),
+    checkoutUrl: z.string().url(),
+  }),
+]);
+
 const checkoutCompleteResponseSchema = z.object({
   completed: z.boolean(),
 });
@@ -154,6 +190,7 @@ const stripeRedirectUrlSchema = z.string().url().max(5000);
 
 const checkoutRequestSchema = z.object({
   tier: z.enum(["pro", "team"]),
+  supportsInAppPreview: z.boolean().optional(),
   successUrl: stripeRedirectUrlSchema,
   cancelUrl: stripeRedirectUrlSchema,
   trialDays: z.literal(7).optional(),
@@ -218,6 +255,7 @@ export type UsagePackCatalogItem = z.infer<typeof usagePackCatalogItemSchema>;
 
 const usagePackCheckoutRequestSchema = z.object({
   tier: z.enum(["pro", "team"]),
+  supportsInAppPreview: z.boolean().optional(),
   memberUsagePacks: z.array(memberUsagePackSchema).min(1).max(1000),
   successUrl: z.string().url(),
   cancelUrl: z.string().url(),
@@ -258,6 +296,8 @@ const usagePackManagementResponseSchema = z.object({
 const usagePackChangePreviewRequestSchema = z.object({
   memberId: z.string().min(1),
   targetUsagePackUsd: usagePackUsdSchema,
+  supportsInAppPreview: z.boolean().optional(),
+  returnUrl: stripeRedirectUrlSchema.optional(),
 });
 
 const usagePackChangePreviewResponseSchema = z.object({
@@ -271,17 +311,27 @@ const usagePackChangePreviewResponseSchema = z.object({
   effectiveAt: z.iso.datetime().nullable(),
   prorationDate: z.iso.datetime(),
   expiresAt: z.iso.datetime(),
+  paymentMethodPreviewToken: z.string().min(1).optional(),
+  checkoutUrl: z.string().url().optional(),
 });
 
-const usagePackChangeConfirmResponseSchema = z.object({
-  status: z.enum(["processing", "pending_payment", "scheduled", "completed"]),
-  effectiveAt: z.iso.datetime().nullable(),
-  hostedInvoiceUrl: z.string().url().nullable(),
-});
+const usagePackChangeConfirmResponseSchema = z.union([
+  z.object({
+    status: z.enum(["processing", "pending_payment", "scheduled", "completed"]),
+    effectiveAt: z.iso.datetime().nullable(),
+    hostedInvoiceUrl: z.string().url().nullable(),
+  }),
+  z.object({
+    status: z.literal("checkout_required"),
+    checkoutUrl: z.string().url(),
+  }),
+]);
 
 const usagePackSubscriptionChangePreviewRequestSchema = z.object({
   targetTier: z.enum(["pro", "team"]),
   memberUsagePacks: z.array(memberUsagePackSchema).min(1).max(1000),
+  supportsInAppPreview: z.boolean().optional(),
+  returnUrl: stripeRedirectUrlSchema.optional(),
 });
 
 const usagePackSubscriptionChangePreviewResponseSchema = z.object({
@@ -302,10 +352,13 @@ const usagePackSubscriptionChangePreviewResponseSchema = z.object({
   effectiveAt: z.iso.datetime(),
   prorationDate: z.iso.datetime(),
   expiresAt: z.iso.datetime(),
+  paymentMethodPreviewToken: z.string().min(1).optional(),
+  checkoutUrl: z.string().url().optional(),
 });
 
 const usagePackSubscriptionChangeConfirmRequestSchema = z.object({
   changeId: z.uuid(),
+  paymentMethodPreviewToken: z.string().min(1).optional(),
 });
 
 export type UsagePackManagementResponse = z.infer<
@@ -397,12 +450,16 @@ const checkoutCompleteRequestSchema = z.object({
 
 const concurrencyCheckoutRequestSchema = z.object({
   quantity: z.number().int().min(1).max(1000),
+  paymentMethodPreviewToken: z.string().min(1).optional(),
   successUrl: stripeRedirectUrlSchema,
   cancelUrl: stripeRedirectUrlSchema,
 });
 
-const concurrencyCheckoutPreviewRequestSchema =
-  concurrencyCheckoutRequestSchema.pick({ quantity: true });
+const concurrencyCheckoutPreviewRequestSchema = z.object({
+  quantity: z.number().int().min(1).max(1000),
+  supportsInAppPreview: z.boolean().optional(),
+  returnUrl: stripeRedirectUrlSchema.optional(),
+});
 
 const concurrencySubscriptionReduceRequestSchema = z.object({
   quantity: z.number().int().min(1).max(1000),
@@ -412,6 +469,13 @@ const concurrencySubscriptionReduceRequestSchema = z.object({
 
 const concurrencySubscriptionChangeRequestSchema = z.object({
   quantity: z.number().int().min(1).max(1000),
+  paymentMethodPreviewToken: z.string().min(1).optional(),
+});
+
+const concurrencySubscriptionChangePreviewRequestSchema = z.object({
+  quantity: z.number().int().min(1).max(1000),
+  supportsInAppPreview: z.boolean().optional(),
+  returnUrl: stripeRedirectUrlSchema.optional(),
 });
 
 const concurrencySubscriptionChangePreviewResponseSchema = z.object({
@@ -421,6 +485,8 @@ const concurrencySubscriptionChangePreviewResponseSchema = z.object({
   nextRecurringAmountCents: z.number().int().nonnegative(),
   currency: z.string().length(3),
   effectiveAt: z.iso.datetime().optional(),
+  paymentMethodPreviewToken: z.string().min(1).optional(),
+  checkoutUrl: z.string().url().optional(),
 });
 
 const concurrencySubscriptionChangeResponseSchema = z.discriminatedUnion(
@@ -441,6 +507,10 @@ const concurrencySubscriptionChangeResponseSchema = z.discriminatedUnion(
       hostedInvoiceUrl: z.null(),
       effectiveAt: z.iso.datetime().optional(),
     }),
+    z.object({
+      status: z.literal("checkout_required"),
+      checkoutUrl: z.string().url(),
+    }),
   ],
 );
 
@@ -458,6 +528,7 @@ const creditCheckoutRequestSchema = z
     credits: z.number().int().min(1000).max(10_000_000),
     customAmount: z.boolean().optional(),
     previewExistingBilling: z.boolean().optional(),
+    supportsInAppPreview: z.boolean().optional(),
     successUrl: stripeRedirectUrlSchema,
     cancelUrl: stripeRedirectUrlSchema,
     autoRecharge: z
@@ -504,16 +575,8 @@ const creditPurchaseStartResponseSchema = z.union([
   creditPurchasePreviewResponseSchema,
 ]);
 
-const creditPurchaseConfirmResponseSchema = z.discriminatedUnion("status", [
-  z.object({
-    status: z.literal("completed"),
-    hostedInvoiceUrl: z.null(),
-  }),
-  z.object({
-    status: z.literal("pending_payment"),
-    hostedInvoiceUrl: z.string().url(),
-  }),
-]);
+const creditPurchaseConfirmResponseSchema =
+  billingPurchaseConfirmResponseSchema;
 
 const autoRechargeUpdateRequestSchema = z
   .object({
@@ -576,7 +639,7 @@ export const zeroBillingCheckoutContract = c.router({
     headers: authHeadersSchema,
     body: checkoutRequestSchema,
     responses: {
-      200: checkoutResponseSchema,
+      200: z.union([checkoutResponseSchema, planPurchasePreviewResponseSchema]),
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
@@ -584,6 +647,22 @@ export const zeroBillingCheckoutContract = c.router({
       503: apiErrorSchema,
     },
     summary: "Create Stripe checkout session",
+  },
+  confirm: {
+    method: "POST",
+    path: "/api/okou/billing/checkout/confirm",
+    headers: authHeadersSchema,
+    body: z.object({ previewToken: z.string().min(1) }),
+    responses: {
+      200: billingPurchaseConfirmResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Confirm a previewed Plan subscription purchase",
   },
   complete: {
     method: "POST",
@@ -614,7 +693,10 @@ export const zeroBillingUsagePackCheckoutContract = c.router({
     headers: authHeadersSchema,
     body: usagePackCheckoutRequestSchema,
     responses: {
-      200: checkoutResponseSchema,
+      200: z.union([
+        checkoutResponseSchema,
+        usagePackPurchasePreviewResponseSchema,
+      ]),
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
@@ -622,6 +704,22 @@ export const zeroBillingUsagePackCheckoutContract = c.router({
       503: apiErrorSchema,
     },
     summary: "Create Stripe checkout session for a plan with usage packs",
+  },
+  confirm: {
+    method: "POST",
+    path: "/api/okou/billing/usage-pack-checkout/confirm",
+    headers: authHeadersSchema,
+    body: z.object({ previewToken: z.string().min(1) }),
+    responses: {
+      200: billingPurchaseConfirmResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      409: apiErrorSchema,
+      500: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Confirm a previewed usage pack subscription purchase",
   },
 });
 
@@ -684,7 +782,9 @@ export const zeroBillingUsagePackManagementContract = c.router({
     path: "/api/okou/billing/usage-pack-subscription/changes/:changeId/confirm",
     pathParams: z.object({ changeId: z.uuid() }),
     headers: authHeadersSchema,
-    body: z.object({}),
+    body: z.object({
+      paymentMethodPreviewToken: z.string().min(1).optional(),
+    }),
     responses: {
       200: usagePackChangeConfirmResponseSchema,
       400: apiErrorSchema,
@@ -902,7 +1002,7 @@ export const zeroBillingConcurrencySubscriptionContract = c.router({
       subscriptionId: z.string().min(1),
     }),
     headers: authHeadersSchema,
-    body: concurrencySubscriptionChangeRequestSchema,
+    body: concurrencySubscriptionChangePreviewRequestSchema,
     responses: {
       200: concurrencySubscriptionChangePreviewResponseSchema,
       400: apiErrorSchema,
@@ -1308,6 +1408,15 @@ export type ZeroBillingRedeemCodeContract =
 export type BillingStatusResponse = z.infer<typeof billingStatusResponseSchema>;
 export type AutoRechargeConfig = z.infer<typeof autoRechargeSchema>;
 export type CheckoutResponse = z.infer<typeof checkoutResponseSchema>;
+export type PlanPurchasePreviewResponse = z.infer<
+  typeof planPurchasePreviewResponseSchema
+>;
+export type UsagePackPurchasePreviewResponse = z.infer<
+  typeof usagePackPurchasePreviewResponseSchema
+>;
+export type BillingPurchaseConfirmResponse = z.infer<
+  typeof billingPurchaseConfirmResponseSchema
+>;
 export type RedeemCodeResponse = z.infer<typeof redeemCodeResponseSchema>;
 export type ConcurrencyCheckoutRequest = z.infer<
   typeof concurrencyCheckoutRequestSchema

--- a/turbo/packages/api-contracts/src/contracts/zero-org-members.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-org-members.ts
@@ -15,6 +15,20 @@ import {
 
 const c = initContract();
 
+const invitationPurchaseConfirmResponseSchema = z.union([
+  orgMessageResponseSchema,
+  z.object({
+    status: z.literal("pending_payment"),
+    hostedInvoiceUrl: z.string().url(),
+    message: z.string().optional(),
+  }),
+  z.object({
+    status: z.literal("checkout_required"),
+    checkoutUrl: z.string().url(),
+    message: z.string().optional(),
+  }),
+]);
+
 /**
  * Zero contract for /api/okou/org/members
  * Proxies to /api/org/members
@@ -111,9 +125,11 @@ export const zeroOrgInviteContract = c.router({
     path: "/api/okou/org/invite/purchase/:purchaseId/confirm",
     pathParams: z.object({ purchaseId: z.uuid() }),
     headers: authHeadersSchema,
-    body: z.object({}),
+    body: z.object({
+      paymentMethodPreviewToken: z.string().min(1).optional(),
+    }),
     responses: {
-      200: orgMessageResponseSchema,
+      200: invitationPurchaseConfirmResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -158,7 +158,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.LatestWebsiteTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SavedBillingCreditPurchase]).toBe(
-      false,
+      true,
     );
   });
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -158,7 +158,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.LatestWebsiteTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.UsagePackPlans]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.SavedBillingCreditPurchase]).toBe(
-      true,
+      false,
     );
   });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -343,8 +343,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "yuma@vm0.ai",
     description:
       "Preview purchases with saved billing and confirm them in the app.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -342,8 +342,9 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.SavedBillingCreditPurchase]: {
     maintainer: "yuma@vm0.ai",
     description:
-      "Preview saved-billing credit purchases and confirm them in the app.",
-    enabled: true,
+      "Preview purchases with saved billing and confirm them in the app.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- unify saved-payment purchase routing for Plan, Usage Pack, Credits, Concurrency, and paid member invitations
- align the Pro-to-Team purchase UI with the Credits confirmation flow and keep confirmation dialogs mounted only while open, preventing first-open and repeated-open flicker
- enable the saved billing purchase flow for every organization
- make Plan and Usage Pack confirmations concurrency-safe and reuse matching pending Usage Pack purchases and allocation snapshots

## Confirmation and payment behavior

- select saved payment methods consistently: subscription default, customer default, attached card, then legacy source
- sign previews and revalidate the price, customer, subscription state, and exact payment method before charging
- submit confirmations through rollout-compatible create routes while preserving support for older clients and APIs
- when a Plan preview becomes stale, the current API returns a refreshed preview with HTTP 200; the dialog updates the quote and requires a second confirmation instead of surfacing a 409 or silently charging a changed amount
- retain client compatibility with older APIs that return 409 by refreshing the preview in place
- explicitly pay open Plan invoices with the saved payment method; redirect to the hosted invoice only when payment remains incomplete or requires customer action

## Billing state fixes

- serialize initial Plan and Usage Pack confirmation per organization to prevent duplicate subscriptions
- make repeated confirmation idempotent and distinguish the active purchase from unrelated pending subscriptions
- create and reuse Usage Pack allocations correctly for granted or pending purchases without breaking consumption paths
- enforce paid invitation previews when the organization needs a Usage Pack
- keep restore visibility based on the actual Stripe schedule instead of stale pending tier metadata

## Compatibility and risk controls

- older clients that omit `supportsInAppPreview` continue to use hosted Checkout
- already issued previews remain confirmable across rollout changes
- current frontend code handles both refreshed 200 responses and legacy 409 responses during independent deployments
- no database migration or new production configuration is required

## Verification

- `pnpm format`
- `pnpm turbo run lint` — 13 tasks passed
- `pnpm check-types` — 14 tasks passed
- `pnpm knip`
- API billing checkout integration tests — 148 passed
- Billing UI integration tests — 47 passed
- Organization member integration tests — 13 passed
- Feature switch integration tests — 24 passed
- browser smoke test confirmed identical first-open and repeated-open Plan dialog rendering