### PR TITLE
refactor(sandbox-fc): centralize firecracker boot configuration

### DIFF
--- a/crates/sandbox-fc/src/api/client.rs
+++ b/crates/sandbox-fc/src/api/client.rs
@@ -2,6 +2,10 @@ use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use crate::boot_config::{
+    BalloonConfig, BootSourceConfig, DriveConfig, MachineConfig, NetworkInterfaceConfig,
+    VsockConfig,
+};
 use crate::config::RateLimiterConfig;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use reqwest::Method;
@@ -226,16 +230,19 @@ impl ApiClient {
         vcpu_count: u32,
         mem_size_mib: u32,
     ) -> Result<(), ApiError> {
-        self.send_json(
-            Method::PUT,
-            "/machine-config",
-            &serde_json::json!({
-                "vcpu_count": vcpu_count,
-                "mem_size_mib": mem_size_mib,
-            }),
-            REQUEST_TIMEOUT,
-        )
+        self.configure_machine_payload(&MachineConfig {
+            vcpu_count,
+            mem_size_mib,
+        })
         .await
+    }
+
+    pub(crate) async fn configure_machine_payload(
+        &self,
+        config: &MachineConfig,
+    ) -> Result<(), ApiError> {
+        self.send_json(Method::PUT, "/machine-config", config, REQUEST_TIMEOUT)
+            .await
     }
 
     /// Configure the boot source via PUT /boot-source.
@@ -244,16 +251,19 @@ impl ApiClient {
         kernel_image_path: &str,
         boot_args: &str,
     ) -> Result<(), ApiError> {
-        self.send_json(
-            Method::PUT,
-            "/boot-source",
-            &serde_json::json!({
-                "kernel_image_path": kernel_image_path,
-                "boot_args": boot_args,
-            }),
-            REQUEST_TIMEOUT,
-        )
+        self.configure_boot_source_payload(&BootSourceConfig {
+            kernel_image_path: kernel_image_path.to_owned(),
+            boot_args: boot_args.to_owned(),
+        })
         .await
+    }
+
+    pub(crate) async fn configure_boot_source_payload(
+        &self,
+        config: &BootSourceConfig,
+    ) -> Result<(), ApiError> {
+        self.send_json(Method::PUT, "/boot-source", config, REQUEST_TIMEOUT)
+            .await
     }
 
     /// Configure a drive via PUT /drives/{drive_id}.
@@ -265,30 +275,23 @@ impl ApiClient {
         is_read_only: bool,
         rate_limiter: Option<&RateLimiterConfig>,
     ) -> Result<(), ApiError> {
-        let path = format!("/drives/{drive_id}");
-        let mut body = serde_json::Map::from_iter([
-            ("drive_id".to_string(), serde_json::json!(drive_id)),
-            ("path_on_host".to_string(), serde_json::json!(path_on_host)),
-            (
-                "is_root_device".to_string(),
-                serde_json::json!(is_root_device),
-            ),
-            ("is_read_only".to_string(), serde_json::json!(is_read_only)),
-        ]);
-        if let Some(rate_limiter) = rate_limiter {
-            body.insert(
-                "rate_limiter".to_string(),
-                serde_json::to_value(rate_limiter)
-                    .map_err(|e| ApiError::Other(format!("json: {e}")))?,
-            );
-        }
-        self.send_json(
-            Method::PUT,
-            &path,
-            &serde_json::Value::Object(body),
-            REQUEST_TIMEOUT,
-        )
+        self.configure_drive_payload(&DriveConfig {
+            drive_id: drive_id.to_owned(),
+            path_on_host: path_on_host.to_owned(),
+            is_root_device,
+            is_read_only,
+            rate_limiter: rate_limiter.cloned(),
+        })
         .await
+    }
+
+    pub(crate) async fn configure_drive_payload(
+        &self,
+        config: &DriveConfig,
+    ) -> Result<(), ApiError> {
+        let path = format!("/drives/{}", config.drive_id);
+        self.send_json(Method::PUT, &path, config, REQUEST_TIMEOUT)
+            .await
     }
 
     /// Update a drive rate limiter via PATCH /drives/{drive_id}.
@@ -319,36 +322,23 @@ impl ApiClient {
         rx_rate_limiter: Option<&RateLimiterConfig>,
         tx_rate_limiter: Option<&RateLimiterConfig>,
     ) -> Result<(), ApiError> {
-        let path = format!("/network-interfaces/{iface_id}");
-        let mut body = serde_json::Map::from_iter([
-            ("iface_id".to_string(), serde_json::json!(iface_id)),
-            ("guest_mac".to_string(), serde_json::json!(guest_mac)),
-            (
-                "host_dev_name".to_string(),
-                serde_json::json!(host_dev_name),
-            ),
-        ]);
-        if let Some(rx_rate_limiter) = rx_rate_limiter {
-            body.insert(
-                "rx_rate_limiter".to_string(),
-                serde_json::to_value(rx_rate_limiter)
-                    .map_err(|e| ApiError::Other(format!("json: {e}")))?,
-            );
-        }
-        if let Some(tx_rate_limiter) = tx_rate_limiter {
-            body.insert(
-                "tx_rate_limiter".to_string(),
-                serde_json::to_value(tx_rate_limiter)
-                    .map_err(|e| ApiError::Other(format!("json: {e}")))?,
-            );
-        }
-        self.send_json(
-            Method::PUT,
-            &path,
-            &serde_json::Value::Object(body),
-            REQUEST_TIMEOUT,
-        )
+        self.configure_network_interface_payload(&NetworkInterfaceConfig {
+            iface_id: iface_id.to_owned(),
+            guest_mac: guest_mac.to_owned(),
+            host_dev_name: host_dev_name.to_owned(),
+            rx_rate_limiter: rx_rate_limiter.cloned(),
+            tx_rate_limiter: tx_rate_limiter.cloned(),
+        })
         .await
+    }
+
+    pub(crate) async fn configure_network_interface_payload(
+        &self,
+        config: &NetworkInterfaceConfig,
+    ) -> Result<(), ApiError> {
+        let path = format!("/network-interfaces/{}", config.iface_id);
+        self.send_json(Method::PUT, &path, config, REQUEST_TIMEOUT)
+            .await
     }
 
     /// Update network interface rate limiters via PATCH /network-interfaces/{iface_id}.
@@ -374,16 +364,19 @@ impl ApiClient {
 
     /// Configure the vsock device via PUT /vsock.
     pub async fn configure_vsock(&self, guest_cid: u32, uds_path: &str) -> Result<(), ApiError> {
-        self.send_json(
-            Method::PUT,
-            "/vsock",
-            &serde_json::json!({
-                "guest_cid": guest_cid,
-                "uds_path": uds_path,
-            }),
-            REQUEST_TIMEOUT,
-        )
+        self.configure_vsock_payload(&VsockConfig {
+            guest_cid,
+            uds_path: uds_path.to_owned(),
+        })
         .await
+    }
+
+    pub(crate) async fn configure_vsock_payload(
+        &self,
+        config: &VsockConfig,
+    ) -> Result<(), ApiError> {
+        self.send_json(Method::PUT, "/vsock", config, REQUEST_TIMEOUT)
+            .await
     }
 
     /// Update balloon target size at runtime via PATCH /balloon.
@@ -423,17 +416,20 @@ impl ApiClient {
         deflate_on_oom: bool,
         stats_polling_interval_s: u32,
     ) -> Result<(), ApiError> {
-        self.send_json(
-            Method::PUT,
-            "/balloon",
-            &serde_json::json!({
-                "amount_mib": amount_mib,
-                "deflate_on_oom": deflate_on_oom,
-                "stats_polling_interval_s": stats_polling_interval_s,
-            }),
-            REQUEST_TIMEOUT,
-        )
+        self.configure_balloon_payload(&BalloonConfig {
+            amount_mib,
+            deflate_on_oom,
+            stats_polling_interval_s,
+        })
         .await
+    }
+
+    pub(crate) async fn configure_balloon_payload(
+        &self,
+        config: &BalloonConfig,
+    ) -> Result<(), ApiError> {
+        self.send_json(Method::PUT, "/balloon", config, REQUEST_TIMEOUT)
+            .await
     }
 
     /// Start the VM instance via PUT /actions.
@@ -483,14 +479,16 @@ impl ApiClient {
         .map_err(|_| ApiError::Other(format!("request timed out after {timeout:?}")))?
     }
 
-    async fn send_json(
+    async fn send_json<T: serde::Serialize + ?Sized>(
         &self,
         method: Method,
         path: &str,
-        value: &serde_json::Value,
+        value: &T,
         timeout: Duration,
     ) -> Result<(), ApiError> {
-        self.send_status(method, path, Some(value), timeout).await
+        let value = serde_json::to_value(value)
+            .map_err(|error| ApiError::Other(format!("json: {error}")))?;
+        self.send_status(method, path, Some(&value), timeout).await
     }
 }
 

--- a/crates/sandbox-fc/src/boot_config.rs
+++ b/crates/sandbox-fc/src/boot_config.rs
@@ -1,0 +1,151 @@
+use std::num::NonZeroU64;
+
+use crate::config::{FirecrackerDeviceRateLimits, RateLimiterConfig};
+use crate::factory::InvariantConfig;
+
+pub(crate) const ROOTFS_DRIVE_ID: &str = "rootfs";
+pub(crate) const WORKSPACE_DRIVE_ID: &str = "workspace";
+
+pub(crate) fn nonzero_drive_count(count: usize) -> Result<NonZeroU64, String> {
+    let count = u64::try_from(count)
+        .map_err(|_| "block drive count exceeds the Firecracker limit".to_string())?;
+    NonZeroU64::new(count).ok_or_else(|| "block drive count must be non-zero".to_string())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct MachineConfig {
+    pub(crate) vcpu_count: u32,
+    pub(crate) mem_size_mib: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct BootSourceConfig {
+    pub(crate) kernel_image_path: String,
+    pub(crate) boot_args: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct DriveConfig {
+    pub(crate) drive_id: String,
+    pub(crate) path_on_host: String,
+    pub(crate) is_root_device: bool,
+    pub(crate) is_read_only: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) rate_limiter: Option<RateLimiterConfig>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct NetworkInterfaceConfig {
+    pub(crate) iface_id: String,
+    pub(crate) guest_mac: String,
+    pub(crate) host_dev_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) rx_rate_limiter: Option<RateLimiterConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tx_rate_limiter: Option<RateLimiterConfig>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct VsockConfig {
+    pub(crate) guest_cid: u32,
+    pub(crate) uds_path: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct BalloonConfig {
+    pub(crate) amount_mib: u32,
+    pub(crate) deflate_on_oom: bool,
+    pub(crate) stats_polling_interval_s: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct FirecrackerBootConfig {
+    #[serde(rename = "boot-source")]
+    pub(crate) boot_source: BootSourceConfig,
+    pub(crate) drives: Vec<DriveConfig>,
+    #[serde(rename = "machine-config")]
+    pub(crate) machine_config: MachineConfig,
+    #[serde(rename = "network-interfaces")]
+    pub(crate) network_interfaces: [NetworkInterfaceConfig; 1],
+    pub(crate) vsock: VsockConfig,
+    pub(crate) balloon: BalloonConfig,
+}
+
+pub(crate) struct BootConfigInput<'a> {
+    pub(crate) invariant: &'a InvariantConfig,
+    pub(crate) vcpu_count: u32,
+    pub(crate) memory_mb: u32,
+    pub(crate) kernel_path: String,
+    pub(crate) rootfs_path: String,
+    pub(crate) workspace_path: Option<String>,
+    pub(crate) vsock_path: String,
+}
+
+impl FirecrackerBootConfig {
+    pub(crate) fn new(input: BootConfigInput<'_>) -> Self {
+        let BootConfigInput {
+            invariant,
+            vcpu_count,
+            memory_mb,
+            kernel_path,
+            rootfs_path,
+            workspace_path,
+            vsock_path,
+        } = input;
+        let mut drives = vec![DriveConfig {
+            drive_id: ROOTFS_DRIVE_ID.to_owned(),
+            path_on_host: rootfs_path,
+            is_root_device: true,
+            is_read_only: false,
+            rate_limiter: None,
+        }];
+        if let Some(workspace_path) = workspace_path {
+            drives.push(DriveConfig {
+                drive_id: WORKSPACE_DRIVE_ID.to_owned(),
+                path_on_host: workspace_path,
+                is_root_device: false,
+                is_read_only: false,
+                rate_limiter: None,
+            });
+        }
+
+        Self {
+            boot_source: BootSourceConfig {
+                kernel_image_path: kernel_path,
+                boot_args: invariant.boot_args.clone(),
+            },
+            drives,
+            machine_config: MachineConfig {
+                vcpu_count,
+                mem_size_mib: memory_mb,
+            },
+            network_interfaces: [NetworkInterfaceConfig {
+                iface_id: invariant.iface_id.to_owned(),
+                guest_mac: invariant.guest_mac.to_owned(),
+                host_dev_name: invariant.tap_name.to_owned(),
+                rx_rate_limiter: None,
+                tx_rate_limiter: None,
+            }],
+            vsock: VsockConfig {
+                guest_cid: invariant.guest_cid,
+                uds_path: vsock_path,
+            },
+            balloon: invariant.balloon.clone(),
+        }
+    }
+
+    pub(crate) fn with_device_rate_limits(
+        mut self,
+        rate_limits: &FirecrackerDeviceRateLimits,
+    ) -> Result<Self, String> {
+        let drive_count = nonzero_drive_count(self.drives.len())?;
+        let drive_rate_limiter = rate_limits.block_drive_limiter(drive_count)?;
+        for drive in &mut self.drives {
+            drive.rate_limiter = Some(drive_rate_limiter.clone());
+        }
+        let [network_interface] = &mut self.network_interfaces;
+        network_interface.rx_rate_limiter = Some(rate_limits.net_rx.clone());
+        network_interface.tx_rate_limiter = Some(rate_limits.net_tx.clone());
+        Ok(self)
+    }
+}

--- a/crates/sandbox-fc/src/factory/invariant.rs
+++ b/crates/sandbox-fc/src/factory/invariant.rs
@@ -1,6 +1,14 @@
 use sha2::{Digest, Sha256};
 
+use crate::boot_config::{BalloonConfig, BootConfigInput, FirecrackerBootConfig};
 use crate::network::{GUEST_NETWORK, generate_boot_args};
+
+const HASH_VCPU_COUNT: u32 = 1;
+const HASH_MEMORY_MB: u32 = 1;
+const HASH_KERNEL_PATH: &str = "/kernel";
+const HASH_ROOTFS_PATH: &str = "/rootfs";
+const HASH_WORKSPACE_PATH: &str = "/workspace";
+const HASH_VSOCK_PATH: &str = "/vsock";
 
 /// Shell command executed during snapshot creation to pre-warm guest state.
 /// Changing this invalidates all cached snapshots (included in [`config_hash`]).
@@ -30,14 +38,6 @@ pub const PREWARM_SCRIPT: &str = "\
     (claude --print --verbose --output-format stream-json hi 2>/dev/null || true); \
     (codex --help >/dev/null 2>&1 || true)";
 
-/// Balloon device configuration (invariant across all sandboxes).
-#[derive(serde::Serialize)]
-pub struct BalloonConfig {
-    pub amount_mib: u32,
-    pub deflate_on_oom: bool,
-    pub stats_polling_interval_s: u32,
-}
-
 /// Invariant configuration shared by all sandboxes.
 ///
 /// These parameters affect snapshot output and are used by:
@@ -45,12 +45,9 @@ pub struct BalloonConfig {
 /// - [`crate::sandbox::FirecrackerSandbox::build_config`] — fresh boot JSON configuration
 /// - Snapshot creation API calls in `snapshot.rs`
 ///
-/// Adding a field here automatically changes the config hash (via `Serialize`)
-/// and makes it available to all consumers.
-///
-/// **Important:** `serde_json` serializes struct fields in declaration order.
-/// Reordering fields changes the hash and invalidates all cached snapshots.
-#[derive(serde::Serialize)]
+/// Topology-owned values are serialized through the shared boot configuration
+/// in [`config_hash`]. The remaining snapshot-affecting values are included
+/// alongside that topology.
 pub struct InvariantConfig {
     pub boot_args: String,
     pub guest_mac: &'static str,
@@ -62,10 +59,13 @@ pub struct InvariantConfig {
     pub guest_cid: u32,
     pub balloon: BalloonConfig,
     pub prewarm_script: &'static str,
-    /// Drive layout identifier. Changing the number or type of drives
-    /// requires a new snapshot — bump this constant to invalidate the
-    /// config hash and force re-creation.
-    pub drive_layout: &'static str,
+}
+
+#[derive(serde::Serialize)]
+struct ConfigHashInput<'a> {
+    boot_config: &'a FirecrackerBootConfig,
+    tap_mac: &'a str,
+    prewarm_script: &'a str,
 }
 
 impl InvariantConfig {
@@ -83,7 +83,6 @@ impl InvariantConfig {
                 stats_polling_interval_s: 5,
             },
             prewarm_script: PREWARM_SCRIPT,
-            drive_layout: "nbd-cow-workspace-v1",
         }
     }
 }
@@ -91,19 +90,47 @@ impl InvariantConfig {
 /// SHA-256 fingerprint of all sandbox-fc internal configuration that affects
 /// snapshot output.
 ///
-/// Derived from `InvariantConfig` serialization — adding a field to that
-/// struct automatically changes this hash.
+/// Derived from a canonical snapshot boot topology plus snapshot-affecting
+/// invariants that are not part of the Firecracker configuration document.
 ///
 /// This is the backing implementation for [`sandbox::SandboxFactory::config_hash`].
 /// It is also available as a free function so callers that don't have a
 /// factory instance (e.g. the snapshot subcommand) can compute the hash.
 /// # Panics
-/// Cannot panic — `InvariantConfig` contains only primitives and `String`.
+/// Cannot panic — the hash input contains only serializable primitives,
+/// strings, vectors, and structs.
 #[allow(clippy::expect_used)]
 pub fn config_hash() -> String {
-    let config = InvariantConfig::new();
-    let json = serde_json::to_string(&config).expect("serialize invariant config");
-    hex::encode(Sha256::digest(json.as_bytes()))
+    let invariant = InvariantConfig::new();
+    let boot_config = canonical_snapshot_boot_config(&invariant);
+    config_hash_for(&boot_config, invariant.tap_mac, invariant.prewarm_script)
+        .expect("serialize Firecracker config hash input")
+}
+
+fn canonical_snapshot_boot_config(invariant: &InvariantConfig) -> FirecrackerBootConfig {
+    FirecrackerBootConfig::new(BootConfigInput {
+        invariant,
+        vcpu_count: HASH_VCPU_COUNT,
+        memory_mb: HASH_MEMORY_MB,
+        kernel_path: HASH_KERNEL_PATH.to_owned(),
+        rootfs_path: HASH_ROOTFS_PATH.to_owned(),
+        workspace_path: Some(HASH_WORKSPACE_PATH.to_owned()),
+        vsock_path: HASH_VSOCK_PATH.to_owned(),
+    })
+}
+
+fn config_hash_for(
+    boot_config: &FirecrackerBootConfig,
+    tap_mac: &str,
+    prewarm_script: &str,
+) -> Result<String, serde_json::Error> {
+    let input = ConfigHashInput {
+        boot_config,
+        tap_mac,
+        prewarm_script,
+    };
+    let json = serde_json::to_string(&input)?;
+    Ok(hex::encode(Sha256::digest(json.as_bytes())))
 }
 
 #[cfg(test)]
@@ -131,23 +158,27 @@ mod tests {
     }
 
     #[test]
-    fn invariant_config_has_all_expected_fields() {
-        let config = InvariantConfig::new();
-        let json = serde_json::to_value(&config).unwrap();
-        let obj = json.as_object().unwrap();
+    fn canonical_snapshot_topology_has_all_shared_sections_and_ordered_drives() {
+        let invariant = InvariantConfig::new();
+        let config = canonical_snapshot_boot_config(&invariant);
+        assert_eq!(
+            config
+                .drives
+                .iter()
+                .map(|drive| drive.drive_id.as_str())
+                .collect::<Vec<_>>(),
+            ["rootfs", "workspace"]
+        );
 
-        // Guard against accidental field additions/removals that would
-        // silently change the config hash and invalidate all snapshots.
+        let json = serde_json::to_value(config).unwrap();
+        let obj = json.as_object().unwrap();
         let expected_fields = [
-            "boot_args",
-            "guest_mac",
-            "tap_name",
-            "tap_mac",
-            "iface_id",
-            "guest_cid",
+            "boot-source",
+            "drives",
+            "machine-config",
+            "network-interfaces",
+            "vsock",
             "balloon",
-            "prewarm_script",
-            "drive_layout",
         ];
         for field in &expected_fields {
             assert!(obj.contains_key(*field), "missing field: {field}");
@@ -155,8 +186,22 @@ mod tests {
         assert_eq!(
             obj.len(),
             expected_fields.len(),
-            "unexpected field count — adding/removing fields changes the config hash"
+            "unexpected Firecracker boot config section"
         );
+    }
+
+    #[test]
+    fn topology_change_changes_config_hash() {
+        let invariant = InvariantConfig::new();
+        let config = canonical_snapshot_boot_config(&invariant);
+        let original =
+            config_hash_for(&config, invariant.tap_mac, invariant.prewarm_script).unwrap();
+        let mut reordered = config.clone();
+        reordered.drives.reverse();
+        let changed =
+            config_hash_for(&reordered, invariant.tap_mac, invariant.prewarm_script).unwrap();
+
+        assert_ne!(original, changed);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -25,6 +25,7 @@
 
 mod api;
 mod balloon;
+mod boot_config;
 mod command;
 mod config;
 pub mod control;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1,6 +1,5 @@
 use std::future::Future;
 use std::io;
-use std::num::NonZeroU64;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
@@ -35,6 +34,7 @@ use nbd_cow::PooledNbdCowDevice;
 
 use crate::api::ApiClient;
 use crate::balloon;
+use crate::boot_config::{BootConfigInput, FirecrackerBootConfig};
 use crate::config::{FirecrackerConfig, FirecrackerDeviceRateLimits};
 use crate::control;
 use crate::exec_operation_result::{
@@ -196,106 +196,32 @@ struct SnapshotLoadPaths {
     memory: String,
 }
 
-fn build_fresh_boot_firecracker_config(
+pub(crate) fn build_fresh_boot_firecracker_config(
+    invariant: &InvariantConfig,
     resources: &sandbox::ResourceLimits,
     kernel_path: String,
     cow_device_path: String,
     workspace_device_path: Option<String>,
     vsock_path: String,
     device_rate_limits: Option<&FirecrackerDeviceRateLimits>,
-) -> sandbox::Result<serde_json::Value> {
-    let inv = InvariantConfig::new();
-    let mut drive = serde_json::Map::from_iter([
-        ("drive_id".to_string(), serde_json::json!("rootfs")),
-        (
-            "path_on_host".to_string(),
-            serde_json::json!(cow_device_path),
-        ),
-        ("is_root_device".to_string(), serde_json::json!(true)),
-        ("is_read_only".to_string(), serde_json::json!(false)),
-    ]);
-    let mut workspace_drive = workspace_device_path.map(|workspace_device_path| {
-        serde_json::Map::from_iter([
-            ("drive_id".to_string(), serde_json::json!("workspace")),
-            (
-                "path_on_host".to_string(),
-                serde_json::json!(workspace_device_path),
-            ),
-            ("is_root_device".to_string(), serde_json::json!(false)),
-            ("is_read_only".to_string(), serde_json::json!(false)),
-        ])
+) -> sandbox::Result<FirecrackerBootConfig> {
+    let config = FirecrackerBootConfig::new(BootConfigInput {
+        invariant,
+        vcpu_count: resources.cpu_count,
+        memory_mb: resources.memory_mb,
+        kernel_path,
+        rootfs_path: cow_device_path,
+        workspace_path: workspace_device_path,
+        vsock_path,
     });
-    let mut network_interface = serde_json::Map::from_iter([
-        ("iface_id".to_string(), serde_json::json!(inv.iface_id)),
-        ("guest_mac".to_string(), serde_json::json!(inv.guest_mac)),
-        ("host_dev_name".to_string(), serde_json::json!(inv.tap_name)),
-    ]);
-    if let Some(rate_limits) = device_rate_limits {
-        let block_drive_count = if workspace_drive.is_some() { 2 } else { 1 };
-        let drive_rate_limiter = rate_limits
-            .block_drive_limiter(nonzero_block_drive_count(block_drive_count)?)
-            .map_err(|e| SandboxError::Start {
-                message: format!("build drive rate limiter: {e}"),
-            })?;
-        drive.insert(
-            "rate_limiter".to_string(),
-            serde_json::to_value(&drive_rate_limiter).map_err(|e| SandboxError::Start {
-                message: format!("serialize drive rate limiter: {e}"),
-            })?,
-        );
-        if let Some(workspace_drive) = workspace_drive.as_mut() {
-            workspace_drive.insert(
-                "rate_limiter".to_string(),
-                serde_json::to_value(&drive_rate_limiter).map_err(|e| SandboxError::Start {
-                    message: format!("serialize workspace drive rate limiter: {e}"),
-                })?,
-            );
-        }
-        network_interface.insert(
-            "rx_rate_limiter".to_string(),
-            serde_json::to_value(&rate_limits.net_rx).map_err(|e| SandboxError::Start {
-                message: format!("serialize network rx rate limiter: {e}"),
-            })?,
-        );
-        network_interface.insert(
-            "tx_rate_limiter".to_string(),
-            serde_json::to_value(&rate_limits.net_tx).map_err(|e| SandboxError::Start {
-                message: format!("serialize network tx rate limiter: {e}"),
-            })?,
-        );
+    match device_rate_limits {
+        Some(rate_limits) => config
+            .with_device_rate_limits(rate_limits)
+            .map_err(|error| SandboxError::Start {
+                message: format!("build drive rate limiter: {error}"),
+            }),
+        None => Ok(config),
     }
-    let mut drives = vec![serde_json::Value::Object(drive)];
-    if let Some(workspace_drive) = workspace_drive {
-        drives.push(serde_json::Value::Object(workspace_drive));
-    }
-
-    Ok(serde_json::json!({
-        "boot-source": {
-            "kernel_image_path": kernel_path,
-            "boot_args": inv.boot_args,
-        },
-        "drives": drives,
-        "machine-config": {
-            "vcpu_count": resources.cpu_count,
-            "mem_size_mib": resources.memory_mb,
-        },
-        "network-interfaces": [serde_json::Value::Object(network_interface)],
-        "vsock": {
-            "guest_cid": inv.guest_cid,
-            "uds_path": vsock_path,
-        },
-        "balloon": {
-            "amount_mib": inv.balloon.amount_mib,
-            "deflate_on_oom": inv.balloon.deflate_on_oom,
-            "stats_polling_interval_s": inv.balloon.stats_polling_interval_s,
-        },
-    }))
-}
-
-fn nonzero_block_drive_count(count: u64) -> sandbox::Result<NonZeroU64> {
-    NonZeroU64::new(count).ok_or_else(|| SandboxError::Start {
-        message: "block drive count must be non-zero".into(),
-    })
 }
 
 struct ProcessMonitorHandle {
@@ -1085,7 +1011,8 @@ impl FirecrackerSandbox {
     }
 
     /// Build the Firecracker JSON configuration for fresh boot.
-    fn build_config(&self) -> sandbox::Result<serde_json::Value> {
+    fn build_config(&self) -> sandbox::Result<FirecrackerBootConfig> {
+        let invariant = InvariantConfig::new();
         let kernel_path = self.factory_config.kernel_path.display().to_string();
         let cow_device_path = self.cow_device()?.device_path().display().to_string();
         let workspace_device_path = self
@@ -1096,6 +1023,7 @@ impl FirecrackerSandbox {
         let vsock_path = self.sock_paths.vsock().display().to_string();
 
         build_fresh_boot_firecracker_config(
+            &invariant,
             &self.config.resources,
             kernel_path,
             cow_device_path,

--- a/crates/sandbox-fc/src/sandbox/snapshot_restore.rs
+++ b/crates/sandbox-fc/src/sandbox/snapshot_restore.rs
@@ -7,6 +7,7 @@ use sandbox::SandboxError;
 use tracing::info;
 
 use crate::api::ApiClient;
+use crate::boot_config::{ROOTFS_DRIVE_ID, WORKSPACE_DRIVE_ID, nonzero_drive_count};
 use crate::config::FirecrackerDeviceRateLimits;
 use crate::factory::InvariantConfig;
 
@@ -26,18 +27,21 @@ pub(super) async fn load_snapshot_and_apply_rate_limits(
         })?;
     if let Some(rate_limits) = rate_limits {
         let drive_rate_limiter = rate_limits
-            .block_drive_limiter(super::nonzero_block_drive_count(2)?)
+            .block_drive_limiter(
+                nonzero_drive_count([ROOTFS_DRIVE_ID, WORKSPACE_DRIVE_ID].len())
+                    .map_err(|error| SandboxError::Start { message: error })?,
+            )
             .map_err(|e| SandboxError::Start {
                 message: format!("build snapshot drive rate limiter: {e}"),
             })?;
         client
-            .patch_drive_rate_limiter("rootfs", &drive_rate_limiter)
+            .patch_drive_rate_limiter(ROOTFS_DRIVE_ID, &drive_rate_limiter)
             .await
             .map_err(|e| SandboxError::Start {
                 message: format!("snapshot drive rate limiter patch failed: {e}"),
             })?;
         client
-            .patch_drive_rate_limiter("workspace", &drive_rate_limiter)
+            .patch_drive_rate_limiter(WORKSPACE_DRIVE_ID, &drive_rate_limiter)
             .await
             .map_err(|e| SandboxError::Start {
                 message: format!("snapshot workspace drive rate limiter patch failed: {e}"),

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -611,17 +611,27 @@ fn test_rate_limits() -> FirecrackerDeviceRateLimits {
     }
 }
 
-#[test]
-fn fresh_boot_config_omits_rate_limiters_when_disabled() {
+fn fresh_boot_config_json(
+    workspace_device_path: Option<String>,
+    rate_limits: Option<&FirecrackerDeviceRateLimits>,
+) -> serde_json::Value {
+    let invariant = InvariantConfig::new();
     let config = build_fresh_boot_firecracker_config(
+        &invariant,
         &test_resources(),
         "/kernel".to_string(),
         "/dev/nbd0".to_string(),
-        None,
+        workspace_device_path,
         "/run/vsock.sock".to_string(),
-        None,
+        rate_limits,
     )
     .unwrap();
+    serde_json::to_value(config).unwrap()
+}
+
+#[test]
+fn fresh_boot_config_omits_rate_limiters_when_disabled() {
+    let config = fresh_boot_config_json(None, None);
 
     assert!(config["drives"][0].get("rate_limiter").is_none());
     assert!(
@@ -639,15 +649,7 @@ fn fresh_boot_config_omits_rate_limiters_when_disabled() {
 #[test]
 fn fresh_boot_config_includes_rate_limiters_when_enabled() {
     let rate_limits = test_rate_limits();
-    let config = build_fresh_boot_firecracker_config(
-        &test_resources(),
-        "/kernel".to_string(),
-        "/dev/nbd0".to_string(),
-        None,
-        "/run/vsock.sock".to_string(),
-        Some(&rate_limits),
-    )
-    .unwrap();
+    let config = fresh_boot_config_json(None, Some(&rate_limits));
 
     assert_eq!(
         config["drives"][0]["rate_limiter"],
@@ -672,15 +674,7 @@ fn fresh_boot_config_includes_rate_limiters_when_enabled() {
 
 #[test]
 fn fresh_boot_config_includes_workspace_drive_without_rate_limiters() {
-    let config = build_fresh_boot_firecracker_config(
-        &test_resources(),
-        "/kernel".to_string(),
-        "/dev/nbd0".to_string(),
-        Some("/workspaces/test/workspace.ext4".to_string()),
-        "/run/vsock.sock".to_string(),
-        None,
-    )
-    .unwrap();
+    let config = fresh_boot_config_json(Some("/workspaces/test/workspace.ext4".to_string()), None);
 
     assert_eq!(config["drives"][0]["drive_id"], "rootfs");
     assert_eq!(config["drives"][1]["drive_id"], "workspace");
@@ -697,15 +691,10 @@ fn fresh_boot_config_includes_workspace_drive_without_rate_limiters() {
 #[test]
 fn fresh_boot_config_includes_workspace_drive_and_splits_block_limiters() {
     let rate_limits = test_rate_limits();
-    let config = build_fresh_boot_firecracker_config(
-        &test_resources(),
-        "/kernel".to_string(),
-        "/dev/nbd0".to_string(),
+    let config = fresh_boot_config_json(
         Some("/workspaces/test/workspace.ext4".to_string()),
-        "/run/vsock.sock".to_string(),
         Some(&rate_limits),
-    )
-    .unwrap();
+    );
 
     assert_eq!(config["drives"][0]["drive_id"], "rootfs");
     assert_eq!(config["drives"][1]["drive_id"], "workspace");

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -9,6 +9,7 @@ use tracing::info;
 use vsock_proto::ExecTermination;
 
 use crate::api::ApiClient;
+use crate::boot_config::{BootConfigInput, FirecrackerBootConfig};
 use crate::config::SnapshotConfig;
 use crate::exec_operation_result::{captured_exec_output_bytes, reject_stream_overflow};
 use crate::factory::InvariantConfig;
@@ -235,46 +236,61 @@ async fn configure_snapshot_vm(
     sock_paths: &SockPaths,
     inv: &InvariantConfig,
 ) -> Result<String, SnapshotError> {
-    // The COW-device bind mount was established inside `unshare --mount`
-    // at spawn time; `configure_drive` only needs the path string FC will
-    // open inside its private mount namespace.
-    let drive_bind_str = paths.cow_device_bind().display().to_string();
-    let workspace_drive_bind_str = paths.workspace_device_bind().display().to_string();
-
-    // 6. Configure VM via API. Keep drive requests ordered so snapshot creation
-    // matches the fresh-boot config path: rootfs first, workspace second.
-    let kernel_path = config.kernel_path.display().to_string();
     prepare_runtime_socket_dir(sock_paths)?;
-    let vsock_uds_str = sock_paths.vsock().display().to_string();
+    let boot_config = build_snapshot_boot_config(config, paths, sock_paths, inv);
+    let vsock_uds_str = boot_config.vsock.uds_path.clone();
+    let FirecrackerBootConfig {
+        boot_source,
+        drives,
+        machine_config,
+        network_interfaces: [network_interface],
+        vsock,
+        balloon,
+    } = boot_config;
 
-    client
-        .configure_drive("rootfs", &drive_bind_str, true, false, None)
-        .await?;
-    client
-        .configure_drive("workspace", &workspace_drive_bind_str, false, false, None)
-        .await?;
+    for drive in &drives {
+        client.configure_drive_payload(drive).await?;
+    }
 
     tokio::try_join!(
-        client.configure_machine(config.vcpu_count, config.memory_mb),
-        client.configure_boot_source(&kernel_path, &inv.boot_args),
-        client.configure_network_interface(inv.iface_id, inv.guest_mac, inv.tap_name, None, None),
-        client.configure_vsock(inv.guest_cid, &vsock_uds_str),
-        client.configure_balloon(
-            inv.balloon.amount_mib,
-            inv.balloon.deflate_on_oom,
-            inv.balloon.stats_polling_interval_s
-        ),
+        client.configure_machine_payload(&machine_config),
+        client.configure_boot_source_payload(&boot_source),
+        client.configure_network_interface_payload(&network_interface),
+        client.configure_vsock_payload(&vsock),
+        client.configure_balloon_payload(&balloon),
     )?;
 
     Ok(vsock_uds_str)
 }
 
+fn build_snapshot_boot_config(
+    config: &SnapshotCreateConfig,
+    paths: &SandboxPaths,
+    sock_paths: &SockPaths,
+    invariant: &InvariantConfig,
+) -> FirecrackerBootConfig {
+    // The COW-device bind mounts are established inside `unshare --mount`
+    // at spawn time. Firecracker opens these stable paths inside that private
+    // mount namespace, and the workspace drive is mandatory for snapshots.
+    FirecrackerBootConfig::new(BootConfigInput {
+        invariant,
+        vcpu_count: config.vcpu_count,
+        memory_mb: config.memory_mb,
+        kernel_path: config.kernel_path.display().to_string(),
+        rootfs_path: paths.cow_device_bind().display().to_string(),
+        workspace_path: Some(paths.workspace_device_bind().display().to_string()),
+        vsock_path: sock_paths.vsock().display().to_string(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::path::PathBuf;
     use std::time::Duration;
 
     use crate::api::test_support::{MOCK_REQUEST_READ_TIMEOUT, MockFirecrackerApi, MockResponse};
+    use crate::sandbox::build_fresh_boot_firecracker_config;
     use crate::snapshot::SnapshotError;
 
     use super::*;
@@ -427,18 +443,70 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn configure_snapshot_vm_orders_rootfs_before_workspace_drive() {
+    async fn snapshot_api_configuration_matches_fresh_boot_topology() {
         let mut api = MockFirecrackerApi::repeating(MockResponse::no_content());
         let dir = tempfile::tempdir().expect("tempdir");
         let paths = SandboxPaths::new(dir.path().join("work"));
         let sock_paths = SockPaths::new(dir.path().join("sock"));
         let client = ApiClient::new(api.socket_path()).unwrap();
         let config = snapshot_create_config(dir.path().join("snapshot-output"));
-        let inv = InvariantConfig::new();
+        let invariant = InvariantConfig::new();
+        let snapshot_boot_config =
+            build_snapshot_boot_config(&config, &paths, &sock_paths, &invariant);
+        let fresh_boot_config = build_fresh_boot_firecracker_config(
+            &invariant,
+            &sandbox::ResourceLimits {
+                cpu_count: config.vcpu_count,
+                memory_mb: config.memory_mb,
+            },
+            config.kernel_path.display().to_string(),
+            paths.cow_device_bind().display().to_string(),
+            Some(paths.workspace_device_bind().display().to_string()),
+            sock_paths.vsock().display().to_string(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(fresh_boot_config, snapshot_boot_config);
+
+        let FirecrackerBootConfig {
+            boot_source,
+            drives,
+            machine_config,
+            network_interfaces: [network_interface],
+            vsock,
+            balloon,
+        } = snapshot_boot_config;
+        let mut expected_bodies = HashMap::from([
+            (
+                "/machine-config".to_string(),
+                serde_json::to_value(machine_config).unwrap(),
+            ),
+            (
+                "/boot-source".to_string(),
+                serde_json::to_value(boot_source).unwrap(),
+            ),
+            (
+                format!("/network-interfaces/{}", network_interface.iface_id),
+                serde_json::to_value(network_interface).unwrap(),
+            ),
+            ("/vsock".to_string(), serde_json::to_value(vsock).unwrap()),
+            (
+                "/balloon".to_string(),
+                serde_json::to_value(balloon).unwrap(),
+            ),
+        ]);
+        for drive in drives {
+            let path = format!("/drives/{}", drive.drive_id);
+            assert!(
+                expected_bodies
+                    .insert(path, serde_json::to_value(drive).unwrap())
+                    .is_none()
+            );
+        }
 
         tokio::time::timeout(
             MOCK_REQUEST_READ_TIMEOUT,
-            configure_snapshot_vm(&client, &config, &paths, &sock_paths, &inv),
+            configure_snapshot_vm(&client, &config, &paths, &sock_paths, &invariant),
         )
         .await
         .expect("snapshot VM configuration should finish")
@@ -454,23 +522,16 @@ mod tests {
         assert_eq!(requests[1].method, "PUT");
         assert_eq!(requests[1].path, "/drives/workspace");
 
-        let mut paths: Vec<&str> = requests
-            .iter()
-            .map(|request| request.path.as_str())
-            .collect();
-        paths.sort_unstable();
-        assert_eq!(
-            paths,
-            [
-                "/balloon",
-                "/boot-source",
-                "/drives/rootfs",
-                "/drives/workspace",
-                "/machine-config",
-                "/network-interfaces/eth0",
-                "/vsock",
-            ]
-        );
+        for request in requests {
+            assert_eq!(request.method, "PUT");
+            let expected_body = expected_bodies
+                .remove(&request.path)
+                .unwrap_or_else(|| panic!("unexpected API request path: {}", request.path));
+            let actual_body: serde_json::Value = serde_json::from_str(&request.body)
+                .unwrap_or_else(|error| panic!("invalid API request body: {error}"));
+            assert_eq!(actual_body, expected_body, "path: {}", request.path);
+        }
+        assert!(expected_bodies.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- introduce one typed Firecracker boot configuration for fresh boots and snapshot creation
- preserve the public `ApiClient` configuration methods while routing snapshot setup through typed payloads
- derive snapshot cache invalidation from the canonical boot topology instead of a manual drive-layout marker
- verify fresh and snapshot builders produce identical topology and API request bodies

## Compatibility

- preserves Firecracker field names, device IDs, drive ordering, and non-drive request concurrency
- keeps workspace optional for fresh boots and mandatory for snapshot creation
- keeps rate limits on fresh boot and snapshot restore, while snapshot creation remains unlimited
- intentionally changes the provider configuration hash once so new runners rebuild cached snapshots; no public API or persisted protocol changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc --all-features --no-deps`
- `cargo test -q -p sandbox-fc --all-targets --all-features` (799 tests passed across all targets)
- repository pre-commit Rust formatting, Clippy, documentation, and file-size checks
- `git diff --check`

Closes #27088
