### PR TITLE
test(python): cover webhook enqueue-log capacity rollback

### DIFF
--- a/crates/runner/mitm-addon/tests/test_webhook_delivery_admission.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_delivery_admission.py
@@ -130,6 +130,35 @@ def test_enqueue_sanitizes_sensitive_webhook_url_in_message(tmp_path, sync_usage
         assert_sensitive_webhook_url_parts_absent(entry)
 
 
+def test_enqueue_log_failure_releases_delivery_capacity(tmp_path):
+    pending_path = tmp_path / "usage-pending"
+    executor = QueuedUsageExecutor()
+    errors = [OSError("disk full"), OSError("disk full")]
+    usage.set_pending_path(str(pending_path))
+
+    with (
+        patch.object(usage.webhook, "usage_executor", executor),
+        patch.object(usage.webhook, "_log_webhook_entry", side_effect=errors),
+    ):
+        for error in errors:
+            with pytest.raises(OSError, match="disk full") as exc_info:
+                usage.webhook.enqueue_webhook_delivery(
+                    "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                    "tok",
+                    {"runId": "run-1", "events": []},
+                    str(tmp_path / "proxy.jsonl"),
+                    "usage_event",
+                )
+
+            assert exc_info.value is error
+            assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+
+    assert not executor.submissions
+    assert_current_pending(
+        pending_path, flows=0, buffered=0, reports=0, flush_request_id="enqueue-log-failed"
+    )
+
+
 def test_submit_failure_rolls_back_pending_report(tmp_path):
     pending_path = tmp_path / "usage-pending"
     usage.set_pending_path(str(pending_path))


### PR DESCRIPTION
## Summary

- add deterministic coverage for delivery-capacity rollback when the initial webhook enqueue log write fails
- verify the exact exception propagates, no executor submission occurs, and both delivery capacity and persisted pending usage remain empty across repeated failures
- prove the new assertion detects removal of the rollback call

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`5,396 passed`)
- mutation check: the new test fails with one pending delivery when `_release_delivery_capacity()` is removed from the initial-log failure path, then passes after restoration
- repository format, lint, Knip, and staged TypeScript type checks

## Scope

Test-only change; production behavior is unchanged.

Closes #27107
