### PR TITLE
ci: report rust job peak memory

### DIFF
--- a/.github/actions/report-memory-peak/action.yml
+++ b/.github/actions/report-memory-peak/action.yml
@@ -1,0 +1,17 @@
+name: "Report Peak Memory"
+description: "Report the current job cgroup peak memory to the log and job summary"
+
+inputs:
+  job-label:
+    description: "Label shown in the memory report; defaults to the GitHub job ID"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Read cgroup peak memory
+      shell: bash
+      env:
+        VM0_MEMORY_REPORT_LABEL: ${{ inputs.job-label }}
+      run: bash "$GITHUB_ACTION_PATH/report.sh"

--- a/.github/actions/report-memory-peak/report.sh
+++ b/.github/actions/report-memory-peak/report.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 cgroup_root=${VM0_CGROUP_ROOT:-/sys/fs/cgroup}
 proc_cgroup=${VM0_PROC_CGROUP:-/proc/self/cgroup}
-job_label=${VM0_MEMORY_REPORT_LABEL:-${GITHUB_JOB:-Rust CI}}
+job_label=${VM0_MEMORY_REPORT_LABEL:-${GITHUB_JOB:-CI}}
 
 peak_bytes=""
 peak_source=""
@@ -59,7 +59,7 @@ append_summary() {
   [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
 
   if ! {
-    printf '### Rust CI peak memory\n\n'
+    printf '### CI peak memory\n\n'
     printf -- '- Job: \140%s\140\n' "$job_label"
     if [ -n "$peak_bytes" ]; then
       printf -- '- Peak memory: **%s MiB** (\140%s bytes\140)\n' "$peak_mib" "$peak_bytes"

--- a/.github/scripts/report-cgroup-memory-peak.sh
+++ b/.github/scripts/report-cgroup-memory-peak.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cgroup_root=${VM0_CGROUP_ROOT:-/sys/fs/cgroup}
+proc_cgroup=${VM0_PROC_CGROUP:-/proc/self/cgroup}
+job_label=${VM0_MEMORY_REPORT_LABEL:-${GITHUB_JOB:-Rust CI}}
+
+peak_bytes=""
+peak_source=""
+
+read_peak() {
+  local source=$1 path=$2 value
+
+  [ -r "$path" ] || return 1
+  value=$(<"$path")
+  [[ "$value" =~ ^[0-9]+$ ]] || return 1
+
+  peak_bytes=$value
+  peak_source=$source
+  return 0
+}
+
+v2_path=""
+v1_path=""
+if [ -r "$proc_cgroup" ]; then
+  v2_path=$(awk -F: '$1 == "0" { print $3; exit }' "$proc_cgroup")
+  v1_path=$(awk -F: '$2 ~ /(^|,)memory(,|$)/ { print $3; exit }' "$proc_cgroup")
+fi
+
+if [ -n "$v2_path" ]; then
+  read_peak "cgroup v2 memory.peak" "${cgroup_root}${v2_path%/}/memory.peak" || true
+fi
+if [ -z "$peak_bytes" ]; then
+  read_peak "cgroup v2 memory.peak" "${cgroup_root}/memory.peak" || true
+fi
+
+if [ -z "$peak_bytes" ] && [ -n "$v1_path" ]; then
+  read_peak \
+    "cgroup v1 memory.max_usage_in_bytes" \
+    "${cgroup_root}/memory${v1_path%/}/memory.max_usage_in_bytes" || true
+  if [ -z "$peak_bytes" ]; then
+    read_peak \
+      "cgroup v1 memory.max_usage_in_bytes" \
+      "${cgroup_root}${v1_path%/}/memory.max_usage_in_bytes" || true
+  fi
+fi
+if [ -z "$peak_bytes" ]; then
+  read_peak \
+    "cgroup v1 memory.max_usage_in_bytes" \
+    "${cgroup_root}/memory/memory.max_usage_in_bytes" || true
+fi
+if [ -z "$peak_bytes" ]; then
+  read_peak \
+    "cgroup v1 memory.max_usage_in_bytes" \
+    "${cgroup_root}/memory.max_usage_in_bytes" || true
+fi
+
+append_summary() {
+  [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+
+  if ! {
+    printf '### Rust CI peak memory\n\n'
+    printf -- '- Job: \140%s\140\n' "$job_label"
+    if [ -n "$peak_bytes" ]; then
+      printf -- '- Peak memory: **%s MiB** (\140%s bytes\140)\n' "$peak_mib" "$peak_bytes"
+      printf -- '- Source: \140%s\140\n\n' "$peak_source"
+    else
+      printf -- '- Peak memory: unavailable (no supported readable cgroup metric)\n\n'
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"; then
+    echo "::notice::Could not append peak memory to the job summary"
+  fi
+}
+
+if [ -z "$peak_bytes" ]; then
+  echo "::notice::Peak memory (${job_label}) unavailable: no supported readable cgroup metric"
+  append_summary
+  exit 0
+fi
+
+mib_whole=$((peak_bytes / 1048576))
+mib_remainder=$((peak_bytes % 1048576))
+mib_tenth=$(((mib_remainder * 10 + 524288) / 1048576))
+if [ "$mib_tenth" -eq 10 ]; then
+  mib_whole=$((mib_whole + 1))
+  mib_tenth=0
+fi
+peak_mib="${mib_whole}.${mib_tenth}"
+
+echo "Peak memory (${job_label}): ${peak_mib} MiB (${peak_bytes} bytes; ${peak_source})"
+append_summary

--- a/.github/scripts/tests/report-cgroup-memory-peak-test.sh
+++ b/.github/scripts/tests/report-cgroup-memory-peak-test.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-REPORTER="${SCRIPT_DIR}/report-cgroup-memory-peak.sh"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPORTER="${REPO_ROOT}/.github/actions/report-memory-peak/report.sh"
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 

--- a/.github/scripts/tests/report-cgroup-memory-peak-test.sh
+++ b/.github/scripts/tests/report-cgroup-memory-peak-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPORTER="${SCRIPT_DIR}/report-cgroup-memory-peak.sh"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local value=$1 expected=$2
+  [[ "$value" == *"$expected"* ]] || fail "expected '${expected}' in '${value}'"
+}
+
+run_reporter() {
+  local fixture=$1
+  env -i \
+    PATH="$PATH" \
+    VM0_CGROUP_ROOT="${fixture}/cgroup" \
+    VM0_PROC_CGROUP="${fixture}/proc-self-cgroup" \
+    VM0_MEMORY_REPORT_LABEL="test-job" \
+    GITHUB_STEP_SUMMARY="${fixture}/summary.md" \
+    bash "$REPORTER" 2>&1
+}
+
+fixture="${TEST_ROOT}/v2-nested"
+mkdir -p "${fixture}/cgroup/github/job"
+printf '0::/github/job\n' > "${fixture}/proc-self-cgroup"
+printf '2147483648\n' > "${fixture}/cgroup/github/job/memory.peak"
+output=$(run_reporter "$fixture")
+assert_contains "$output" "Peak memory (test-job): 2048.0 MiB (2147483648 bytes; cgroup v2 memory.peak)"
+assert_contains "$(<"${fixture}/summary.md")" "Peak memory: **2048.0 MiB** (\`2147483648 bytes\`)"
+
+fixture="${TEST_ROOT}/v2-namespaced"
+mkdir -p "${fixture}/cgroup"
+printf '0::/github/job\n' > "${fixture}/proc-self-cgroup"
+printf '1048576\n' > "${fixture}/cgroup/memory.peak"
+output=$(run_reporter "$fixture")
+assert_contains "$output" "Peak memory (test-job): 1.0 MiB (1048576 bytes; cgroup v2 memory.peak)"
+
+fixture="${TEST_ROOT}/v1"
+mkdir -p "${fixture}/cgroup/memory/github/job"
+printf '5:memory:/github/job\n' > "${fixture}/proc-self-cgroup"
+printf '1572864\n' > "${fixture}/cgroup/memory/github/job/memory.max_usage_in_bytes"
+output=$(run_reporter "$fixture")
+assert_contains "$output" "Peak memory (test-job): 1.5 MiB (1572864 bytes; cgroup v1 memory.max_usage_in_bytes)"
+
+fixture="${TEST_ROOT}/unavailable"
+mkdir -p "${fixture}/cgroup/github/job"
+printf '0::/github/job\n' > "${fixture}/proc-self-cgroup"
+printf 'max\n' > "${fixture}/cgroup/github/job/memory.peak"
+output=$(run_reporter "$fixture")
+assert_contains "$output" "Peak memory (test-job) unavailable: no supported readable cgroup metric"
+assert_contains "$(<"${fixture}/summary.md")" "Peak memory: unavailable"
+
+echo "report-cgroup-memory-peak-test: ok"

--- a/.github/scripts/tests/rust-ci-memory-workflow-test.sh
+++ b/.github/scripts/tests/rust-ci-memory-workflow-test.sh
@@ -55,16 +55,4 @@ jq -e '
   )
 ' <<<"$crates_json" >/dev/null || fail "crates change detection must include the peak memory action"
 
-jq -e '
-  . as $workflow |
-  ["crates", "image-inputs"] |
-  all(.[];
-    . as $step_id |
-    any($workflow.jobs.prepare.steps[]?;
-      .id == $step_id and
-      (.run | contains(".github/actions/(setup-ssh-tunnel|provision|report-memory-peak)/"))
-    )
-  )
-' <<<"$runner_image_json" >/dev/null || fail "runner image change detection must include the peak memory action"
-
 echo "rust-ci-memory-workflow-test: ok"

--- a/.github/scripts/tests/rust-ci-memory-workflow-test.sh
+++ b/.github/scripts/tests/rust-ci-memory-workflow-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CRATES_WORKFLOW="${REPO_ROOT}/.github/workflows/crates.yml"
+RUNNER_IMAGE_WORKFLOW="${REPO_ROOT}/.github/workflows/runner-image.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null || fail "yq is required"
+crates_json=$(yq -o=json '.' "$CRATES_WORKFLOW")
+runner_image_json=$(yq -o=json '.' "$RUNNER_IMAGE_WORKFLOW")
+
+jq -e '
+  . as $workflow |
+  ["check", "coverage", "runner-firewall-contract-test", "nbd-cow-test"] |
+  all(.[];
+    . as $job |
+    ($workflow.jobs[$job].steps[-1] |
+      .name == "Report peak memory" and
+      .if == "always()" and
+      .["continue-on-error"] == true and
+      .run == "bash .github/scripts/report-cgroup-memory-peak.sh"
+    )
+  )
+' <<<"$crates_json" >/dev/null || fail "all Rust compilation jobs in crates.yml must report peak memory"
+
+jq -e '
+  .jobs.compile.steps[-1] |
+    .name == "Report peak memory" and
+    .if == "always()" and
+    .["continue-on-error"] == true and
+    .run == "bash .github/scripts/report-cgroup-memory-peak.sh"
+' <<<"$runner_image_json" >/dev/null || fail "runner binary compilation must report peak memory"
+
+echo "rust-ci-memory-workflow-test: ok"

--- a/.github/scripts/tests/rust-ci-memory-workflow-test.sh
+++ b/.github/scripts/tests/rust-ci-memory-workflow-test.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 CRATES_WORKFLOW="${REPO_ROOT}/.github/workflows/crates.yml"
 RUNNER_IMAGE_WORKFLOW="${REPO_ROOT}/.github/workflows/runner-image.yml"
+ACTION="${REPO_ROOT}/.github/actions/report-memory-peak/action.yml"
 
 fail() {
   echo "FAIL: $1" >&2
@@ -14,6 +15,7 @@ fail() {
 command -v yq >/dev/null || fail "yq is required"
 crates_json=$(yq -o=json '.' "$CRATES_WORKFLOW")
 runner_image_json=$(yq -o=json '.' "$RUNNER_IMAGE_WORKFLOW")
+action_json=$(yq -o=json '.' "$ACTION")
 
 jq -e '
   . as $workflow |
@@ -24,7 +26,7 @@ jq -e '
       .name == "Report peak memory" and
       .if == "always()" and
       .["continue-on-error"] == true and
-      .run == "bash .github/scripts/report-cgroup-memory-peak.sh"
+      .uses == "./.github/actions/report-memory-peak"
     )
   )
 ' <<<"$crates_json" >/dev/null || fail "all Rust compilation jobs in crates.yml must report peak memory"
@@ -34,7 +36,35 @@ jq -e '
     .name == "Report peak memory" and
     .if == "always()" and
     .["continue-on-error"] == true and
-    .run == "bash .github/scripts/report-cgroup-memory-peak.sh"
+    .uses == "./.github/actions/report-memory-peak"
 ' <<<"$runner_image_json" >/dev/null || fail "runner binary compilation must report peak memory"
+
+jq -e '
+  .runs.using == "composite" and
+  any(.runs.steps[];
+    .shell == "bash" and
+    .env.VM0_MEMORY_REPORT_LABEL == "${{ inputs.job-label }}" and
+    .run == "bash \"$GITHUB_ACTION_PATH/report.sh\""
+  )
+' <<<"$action_json" >/dev/null || fail "peak memory action must run the bundled cgroup reporter"
+
+jq -e '
+  any(.jobs.detect.steps[]?;
+    .id == "detect" and
+    (.run | contains(".github/actions/(setup-ssh-tunnel|provision|report-memory-peak)/"))
+  )
+' <<<"$crates_json" >/dev/null || fail "crates change detection must include the peak memory action"
+
+jq -e '
+  . as $workflow |
+  ["crates", "image-inputs"] |
+  all(.[];
+    . as $step_id |
+    any($workflow.jobs.prepare.steps[]?;
+      .id == $step_id and
+      (.run | contains(".github/actions/(setup-ssh-tunnel|provision|report-memory-peak)/"))
+    )
+  )
+' <<<"$runner_image_json" >/dev/null || fail "runner image change detection must include the peak memory action"
 
 echo "rust-ci-memory-workflow-test: ok"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -398,6 +398,11 @@ jobs:
               --test production_identity -- \
               --ignored --exact production_env_script_remains_until_operation_cleanup
 
+      - name: Report peak memory
+        if: always()
+        continue-on-error: true
+        run: bash .github/scripts/report-cgroup-memory-peak.sh
+
   coverage:
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 20
@@ -455,6 +460,11 @@ jobs:
           files: crates/lcov.info
           flags: rust
 
+      - name: Report peak memory
+        if: always()
+        continue-on-error: true
+        run: bash .github/scripts/report-cgroup-memory-peak.sh
+
   api-contracts-rust-bindings:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -497,6 +507,11 @@ jobs:
       - name: Check runner firewall base URL contract
         working-directory: crates
         run: cargo test -p runner types::tests::firewall_base_url_validation_matches_shared_contract -- --exact
+
+      - name: Report peak memory
+        if: always()
+        continue-on-error: true
+        run: bash .github/scripts/report-cgroup-memory-peak.sh
 
   mitm-addon-test:
     runs-on: ubuntu-latest
@@ -609,6 +624,11 @@ jobs:
           scp "$TEST_BIN" "${REMOTE}:${REMOTE_BIN}"
           # shellcheck disable=SC2029
           ssh "$REMOTE" "trap 'rm -f ${REMOTE_BIN}' EXIT && sudo modprobe nbd nbds_max=4096 && sudo ${REMOTE_BIN} --ignored --test-threads=1"
+
+      - name: Report peak memory
+        if: always()
+        continue-on-error: true
+        run: bash .github/scripts/report-cgroup-memory-peak.sh
 
   runner-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -96,7 +96,7 @@ jobs:
           BASE_REF=$(.github/scripts/changed-base-ref.sh)
           echo "${{ github.event_name }} mode: comparing against base $BASE_REF"
           # Check if the workflow file or ansible playbooks changed
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/|^ansible/"; then
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision|report-memory-peak)/|^\.github/scripts/|^ansible/"; then
             echo "ci-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "ci-changed=false" >> "$GITHUB_OUTPUT"
@@ -401,7 +401,7 @@ jobs:
       - name: Report peak memory
         if: always()
         continue-on-error: true
-        run: bash .github/scripts/report-cgroup-memory-peak.sh
+        uses: ./.github/actions/report-memory-peak
 
   coverage:
     runs-on: ubuntu-latest-8-cores
@@ -463,7 +463,7 @@ jobs:
       - name: Report peak memory
         if: always()
         continue-on-error: true
-        run: bash .github/scripts/report-cgroup-memory-peak.sh
+        uses: ./.github/actions/report-memory-peak
 
   api-contracts-rust-bindings:
     runs-on: ubuntu-latest
@@ -511,7 +511,7 @@ jobs:
       - name: Report peak memory
         if: always()
         continue-on-error: true
-        run: bash .github/scripts/report-cgroup-memory-peak.sh
+        uses: ./.github/actions/report-memory-peak
 
   mitm-addon-test:
     runs-on: ubuntu-latest
@@ -628,7 +628,7 @@ jobs:
       - name: Report peak memory
         if: always()
         continue-on-error: true
-        run: bash .github/scripts/report-cgroup-memory-peak.sh
+        uses: ./.github/actions/report-memory-peak
 
   runner-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -384,6 +384,11 @@ jobs:
           retention-days: 1
           compression-level: 1
 
+      - name: Report peak memory
+        if: always()
+        continue-on-error: true
+        run: bash .github/scripts/report-cgroup-memory-peak.sh
+
   build:
     name: Build runner image (${{ matrix.label }})
     runs-on: ubuntu-latest

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision|report-memory-peak)/|^\.github/scripts/|^ansible/"; then
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/|^ansible/"; then
             ci_changed=true
           else
             ci_changed=false
@@ -197,7 +197,7 @@ jobs:
           set -euo pipefail
 
           runner_image_ci_changed=false
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision|report-memory-peak)/|^\.github/scripts/runner-binary-build/|^\.github/scripts/(prepare-runner-image|runner-binary-cache|runner-binary-cache-plan|runner-host-architecture-groups|runner-image-context|runner-image-manifest|runner-image-target|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/runner-binary-build/|^\.github/scripts/(prepare-runner-image|runner-binary-cache|runner-binary-cache-plan|runner-host-architecture-groups|runner-image-context|runner-image-manifest|runner-image-target|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
             runner_image_ci_changed=true
           fi
 

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/|^ansible/"; then
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision|report-memory-peak)/|^\.github/scripts/|^ansible/"; then
             ci_changed=true
           else
             ci_changed=false
@@ -197,7 +197,7 @@ jobs:
           set -euo pipefail
 
           runner_image_ci_changed=false
-          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision)/|^\.github/scripts/runner-binary-build/|^\.github/scripts/(prepare-runner-image|runner-binary-cache|runner-binary-cache-plan|runner-host-architecture-groups|runner-image-context|runner-image-manifest|runner-image-target|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
+          if git diff --name-only "$BASE_REF" HEAD | grep -qE "^\.github/workflows/(turbo|crates|runner-image)\.yml$|^\.github/actions/(setup-ssh-tunnel|provision|report-memory-peak)/|^\.github/scripts/runner-binary-build/|^\.github/scripts/(prepare-runner-image|runner-binary-cache|runner-binary-cache-plan|runner-host-architecture-groups|runner-image-context|runner-image-manifest|runner-image-target|wait-runner-image)\.sh$|^ansible/(ansible\.cfg|playbooks/(build-runner|provision-runner|promote-runner|rollback-runner)\.yml)$"; then
             runner_image_ci_changed=true
           fi
 
@@ -387,7 +387,7 @@ jobs:
       - name: Report peak memory
         if: always()
         continue-on-error: true
-        run: bash .github/scripts/report-cgroup-memory-peak.sh
+        uses: ./.github/actions/report-memory-peak
 
   build:
     name: Build runner image (${{ matrix.label }})

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -246,6 +246,7 @@ jobs:
             .github/scripts/pass-release-pr-ci-gates.sh \
             .github/scripts/reconcile-and-start-runner-groups.sh \
             .github/scripts/reconcile-runner-binary-groups.sh \
+            .github/scripts/report-cgroup-memory-peak.sh \
             .github/scripts/resolve-desktop-version-change.sh \
             .github/scripts/run-semgrep.sh \
             .github/scripts/runner-behavior-*.sh \
@@ -277,7 +278,9 @@ jobs:
             .github/scripts/tests/resolve-desktop-version-change-test.sh \
             .github/scripts/tests/runner-promotion-ansible-test.sh \
             .github/scripts/tests/reconcile-runner-binary-groups-test.sh \
+            .github/scripts/tests/report-cgroup-memory-peak-test.sh \
             .github/scripts/tests/runner-lifecycle-lock-test.sh \
+            .github/scripts/tests/rust-ci-memory-workflow-test.sh \
             .github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh \
             .github/scripts/tests/run-semgrep-test.sh \
             .github/scripts/tests/semgrep-results-test.sh \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -225,6 +225,7 @@ jobs:
         run: |
           shopt -s nullglob
           script_files=(
+            .github/actions/report-memory-peak/*.sh
             .github/scripts/*.sh
             .github/scripts/tests/*.sh
           )
@@ -246,7 +247,7 @@ jobs:
             .github/scripts/pass-release-pr-ci-gates.sh \
             .github/scripts/reconcile-and-start-runner-groups.sh \
             .github/scripts/reconcile-runner-binary-groups.sh \
-            .github/scripts/report-cgroup-memory-peak.sh \
+            .github/actions/report-memory-peak/report.sh \
             .github/scripts/resolve-desktop-version-change.sh \
             .github/scripts/run-semgrep.sh \
             .github/scripts/runner-behavior-*.sh \


### PR DESCRIPTION
## Summary

- Add a repository-local `./.github/actions/report-memory-peak` composite action that bundles cgroup v2/v1 peak discovery and supports an optional job label.
- Reuse the action from the Rust `check`, coverage, runner firewall contract, nbd-cow cross-compile, and runner binary compile CI jobs.
- Print each measurement to both the workflow log and GitHub Actions job summary, keeping the action as the final `always()` step without masking the original job result.
- Ensure changes to the action select the relevant Crates CI path without classifying telemetry-only changes as runner image inputs, with focused tests for the action contract, reporter behavior, and workflow wiring.

## Scope

This PR adds observability only. It does not change Cargo concurrency, compiler settings, runner sizes, or memory limits.

## Verification

- `bash .github/scripts/tests/report-cgroup-memory-peak-test.sh`
- `bash .github/scripts/tests/rust-ci-memory-workflow-test.sh`
- `bash .github/scripts/tests/runner-image-workflow-test.sh`
- `shellcheck .github/actions/report-memory-peak/report.sh .github/scripts/tests/report-cgroup-memory-peak-test.sh .github/scripts/tests/rust-ci-memory-workflow-test.sh`
- `actionlint`
- `bash .github/scripts/check-workflow-shell-compatibility.sh`
- `npx --yes prettier@3.8.1 --check .github/actions/report-memory-peak/action.yml .github/workflows/crates.yml .github/workflows/runner-image.yml .github/workflows/security.yml`
- `git diff --check origin/main...HEAD`

Closes #27127
