### PR TITLE
fix(python): require platform api scheme match

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -355,8 +355,9 @@ def _prebind_bounded_requestheaders_upstream_destination(
         flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
         if upstream_admission.api_destination_matches(
             api_url,
-            trusted_authority.host,
-            trusted_authority.port,
+            scheme=flow.request.scheme,
+            hostname=trusted_authority.host,
+            port=trusted_authority.port,
         ) and not upstream_admission.request_path_uses_platform_firewall(flow.request.path):
             classification = _classify_request_for_flow_with_trusted_authority(
                 flow,

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -416,8 +416,9 @@ def _classify_request(
 
     if upstream_admission.api_destination_matches(
         api_url,
-        trusted_authority.host,
-        trusted_authority.port,
+        scheme=flow.request.scheme,
+        hostname=trusted_authority.host,
+        port=trusted_authority.port,
     ) and not upstream_admission.request_path_uses_platform_firewall(flow.request.path):
         return ApiAllow(vm_info=vm_info)
 

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -38,6 +38,13 @@ class TlsAdmission:
     sni: str | None = None
 
 
+@dataclass(frozen=True)
+class _ApiDestination:
+    scheme: Literal["http", "https"]
+    host: str
+    port: int
+
+
 def _client_connection_id(client: object) -> str | None:
     client_id = getattr(client, "id", None)
     if isinstance(client_id, str) and client_id:
@@ -128,47 +135,60 @@ def request_path_uses_platform_firewall(path: str) -> bool:
     return path.startswith(_TEST_ENDPOINT_PATH_PREFIX)
 
 
-def api_destination_matches(api_url: str, hostname: str, port: int) -> bool:
+def api_destination_matches(
+    api_url: str,
+    *,
+    scheme: str,
+    hostname: str,
+    port: int,
+) -> bool:
     api_destination = _api_destination(api_url)
     if api_destination is None:
         return False
-    return _hostname_port_matches_api_destination(
+    return _scheme_hostname_port_matches_api_destination(
+        scheme=scheme,
         hostname=hostname,
         port=port,
         api_destination=api_destination,
     )
 
 
-def _hostname_port_matches_api_destination(
+def _scheme_hostname_port_matches_api_destination(
     *,
+    scheme: str,
     hostname: str,
     port: int,
-    api_destination: upstream_destination_binding.NormalizedUpstreamDestination,
+    api_destination: _ApiDestination,
 ) -> bool:
-    return port == api_destination.port and (
-        hostname == api_destination.host or hostname.endswith(f".{api_destination.host}")
+    return (
+        scheme.lower() == api_destination.scheme
+        and port == api_destination.port
+        and (hostname == api_destination.host or hostname.endswith(f".{api_destination.host}"))
     )
 
 
 def _api_destination(
     api_url: str,
-) -> upstream_destination_binding.NormalizedUpstreamDestination | None:
+) -> _ApiDestination | None:
     if not api_url:
         return None
     parsed_api = urllib.parse.urlparse(api_url)
     if not parsed_api.hostname:
         return None
+    api_scheme = parsed_api.scheme.lower()
+    if api_scheme == "http":
+        default_port = 80
+    elif api_scheme == "https":
+        default_port = 443
+    else:
+        return None
     try:
         api_hostname = normalize_trusted_hostname(parsed_api.hostname)
     except (UnicodeError, ValueError):
         return None
-    if parsed_api.port is not None:
-        api_port = parsed_api.port
-    elif parsed_api.scheme.lower() == "http":
-        api_port = 80
-    else:
-        api_port = 443
-    return upstream_destination_binding.NormalizedUpstreamDestination(
+    api_port = parsed_api.port if parsed_api.port is not None else default_port
+    return _ApiDestination(
+        scheme=api_scheme,
         host=api_hostname,
         port=api_port,
     )
@@ -233,8 +253,9 @@ def _bind_privileged_upstream_destination(
         return
     is_api_destination = api_destination_matches(
         api_url,
-        destination.host,
-        destination.port,
+        scheme="https",
+        hostname=destination.host,
+        port=destination.port,
     )
     reusable_kind: upstream_destination_binding.BindingKind = (
         "api_allow" if is_api_destination else "connector_auth"
@@ -299,7 +320,7 @@ def handle_server_connect(
     a binding.
 
     The normalized SNI host and current server destination port select one binding purpose. The
-    configured platform API host and its subdomains at the configured port qualify for
+    configured HTTPS platform API host and its subdomains at the configured port qualify for
     ``api_allow``. Every other exact HTTPS authority qualifies for ``connector_auth`` only when the
     current VM's compiled firewall set admits ordinary credential mutation there. A matching
     direct binding that already has the selected kind may be reused; otherwise the selected purpose
@@ -499,9 +520,10 @@ def ensure_bound_destination(
 
     ``flow`` must already carry validated trusted-authority metadata and the
     request, client, and server connection state to bind. ``kind`` selects the
-    privileged purpose, while ``api_url`` identifies the platform API authority
-    where ``connector_auth`` requires the gated test-endpoint bypass before
-    either binding or reusing a destination.
+    privileged purpose, while ``api_url`` identifies the platform API origin.
+    ``api_allow`` requires the current scheme and authority to match that origin;
+    ``connector_auth`` on that origin requires the gated test-endpoint bypass
+    before either binding or reusing a destination.
 
     A direct server binding may be reused, extended with ``kind``, or refreshed
     only while its authority and current destination remain valid. Otherwise an
@@ -529,18 +551,24 @@ def ensure_bound_destination(
     except (UnicodeError, ValueError):
         return False
 
-    api_destination = _api_destination(api_url) if kind == "connector_auth" else None
+    api_destination = _api_destination(api_url)
+    is_api_destination = api_destination is not None and (
+        _scheme_hostname_port_matches_api_destination(
+            scheme=flow.request.scheme,
+            hostname=destination.host,
+            port=destination.port,
+            api_destination=api_destination,
+        )
+    )
+    if kind == "api_allow" and not is_api_destination:
+        return False
     # Synthetic test providers live on the platform API preview host but
     # intentionally exercise connector auth injection instead of API auto-allow.
     # Keep this path limited to test endpoints gated by the same internal
     # bypass secret that the API route validates.
     if (
-        api_destination is not None
-        and _hostname_port_matches_api_destination(
-            hostname=destination.host,
-            port=destination.port,
-            api_destination=api_destination,
-        )
+        kind == "connector_auth"
+        and is_api_destination
         and not _request_has_platform_test_endpoint_bypass(flow)
     ):
         return False

--- a/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
@@ -217,6 +217,22 @@ async def test_matching_sni_and_host_allows_bound_vm0_api_auto_allow(
             False,
             id="wrong-explicit-port",
         ),
+        pytest.param(
+            "https://api.vm0.ai",
+            "api.vm0.ai",
+            "http",
+            443,
+            False,
+            id="https-configured-http-observed",
+        ),
+        pytest.param(
+            "http://api.vm0.ai:443",
+            "api.vm0.ai",
+            "https",
+            443,
+            False,
+            id="http-configured-https-observed",
+        ),
     ],
 )
 async def test_vm0_api_auto_allow_respects_authority_boundary(
@@ -285,6 +301,51 @@ async def test_vm0_api_wrong_port_uses_matching_firewall_deny_policy(
         client_ip="10.200.0.5",
         host="api.vm0.ai",
         port=8443,
+        path="/restricted",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["reason"] == "permission_denied"
+    assert body["permissions"] == ["read"]
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_vm0_api_wrong_scheme_uses_matching_firewall_deny_policy(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
+    reg_path = _write_registry(
+        tmp_path,
+        client_ip="10.200.0.5",
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="plaintext-api-port",
+            api_entry={
+                "base": "http://api.vm0.ai:443",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "read", "rules": ["GET /restricted"]}],
+            },
+            network_policy={
+                "allow": [],
+                "deny": ["read"],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.vm0.ai",
+        scheme="http",
+        port=443,
         path="/restricted",
     )
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_admission.py
@@ -121,6 +121,36 @@ async def test_matching_sni_and_host_retargets_unconnected_firewall_auth(
     assert binding.original_address == ("203.0.113.10", 443)
 
 
+async def test_same_host_and_port_on_other_api_scheme_uses_normal_connector_auth(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers
+):
+    reg_path = _write_github_firewall_registry(
+        tmp_path,
+        base="https://api.vm0.ai:443",
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.vm0.ai",
+        path="/repos",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="http://api.vm0.ai:443"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.vm0.ai:443"
+    assert flow.request.headers["Authorization"] == "Bearer x"
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
+    assert binding.host == "api.vm0.ai"
+    assert binding.port == 443
+    assert binding.kinds == frozenset(("connector_auth",))
+
+
 async def test_matching_sni_and_host_records_binding_when_unconnected_address_already_matches(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):

--- a/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
@@ -93,6 +93,79 @@ async def test_streamed_api_allow_injects_runner_preview_bypass_before_body(
     assert flow.request.headers["x-vercel-protection-bypass"] == "preview-secret"
 
 
+async def test_streamed_wrong_scheme_does_not_receive_runner_preview_bypass(
+    tmp_path, real_flow, mitm_ctx, headers, monkeypatch
+):
+    reg_path = _write_api_registry(tmp_path, capture_network_bodies=True)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="preview-api.vm6.ai",
+        scheme="http",
+        port=443,
+        method="POST",
+        path="/api/zero/chat/events",
+        request_headers=headers(
+            ("Host", "preview-api.vm6.ai:443"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    monkeypatch.setattr(platform_api, "VERCEL_BYPASS", "preview-secret")
+
+    with mitm_ctx(
+        registry_path=str(reg_path),
+        api_url="https://preview-api.vm6.ai",
+    ):
+        mitm_addon.requestheaders(flow)
+
+        assert callable(flow.request.stream)
+        assert "x-vercel-protection-bypass" not in flow.request.headers
+        assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert "x-vercel-protection-bypass" not in flow.request.headers
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_cached_api_allow_revalidates_scheme_before_final_bypass_injection(
+    tmp_path, real_flow, mitm_ctx, headers, monkeypatch
+):
+    reg_path = _write_api_registry(tmp_path, capture_network_bodies=True)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="preview-api.vm6.ai",
+        method="POST",
+        path="/api/zero/chat/events",
+        request_headers=headers(
+            ("Host", "preview-api.vm6.ai"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    monkeypatch.setattr(platform_api, "VERCEL_BYPASS", "")
+
+    with mitm_ctx(
+        registry_path=str(reg_path),
+        api_url="https://preview-api.vm6.ai",
+    ):
+        mitm_addon.requestheaders(flow)
+
+        assert callable(flow.request.stream)
+        assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY in flow.metadata
+        assert "x-vercel-protection-bypass" not in flow.request.headers
+
+        flow.request.scheme = "http"
+        monkeypatch.setattr(platform_api, "VERCEL_BYPASS", "preview-secret")
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
+    assert "x-vercel-protection-bypass" not in flow.request.headers
+
+
 async def test_capture_enabled_api_allow_blocks_connected_unbound_edge_upstream(
     tmp_path, real_flow, mitm_ctx, headers
 ):

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -319,6 +319,29 @@ def test_server_connect_treats_api_hostname_on_other_port_as_connector(
     assert binding.kinds == frozenset(("connector_auth",))
 
 
+def test_server_connect_treats_api_origin_on_other_scheme_as_connector(
+    tmp_path,
+    mitm_ctx,
+):
+    reg_path = _write_github_firewall_registry(
+        tmp_path,
+        base="https://api.vm0.ai:443",
+    )
+    data = _data(
+        sni="api.vm0.ai",
+        address=("203.0.113.10", 443),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="http://api.vm0.ai:443"):
+        mitm_addon.server_connect(data)
+
+    assert data.server.address == ("api.vm0.ai", 443)
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
+    assert binding.host == "api.vm0.ai"
+    assert binding.port == 443
+    assert binding.kinds == frozenset(("connector_auth",))
+
+
 def test_server_connect_does_not_prebind_platform_connector_auth(tmp_path, mitm_ctx):
     reg_path = _write_registry(
         tmp_path,

--- a/crates/runner/mitm-addon/tests/test_tls_clienthello_hook.py
+++ b/crates/runner/mitm-addon/tests/test_tls_clienthello_hook.py
@@ -68,6 +68,25 @@ class TestTlsClienthello:
         assert binding.kinds == frozenset(("api_allow",))
         assert binding.original_address == ("203.0.113.10", 443)
 
+    def test_registered_vm_does_not_bind_tls_api_host_for_configured_http_origin(
+        self, registry_file, make_tls_data, mitm_ctx
+    ):
+        data = make_tls_data(
+            client_ip="10.200.0.1",
+            sni="pr-test-api.vm6.ai",
+            client_sni="",
+        )
+
+        with mitm_ctx(
+            registry_path=str(registry_file),
+            api_url="http://pr-test-api.vm6.ai:443",
+        ):
+            mitm_addon.tls_clienthello(data)
+
+        assert data.ignore_connection is False
+        assert data.context.server.address == ("203.0.113.10", 443)
+        assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
     def test_registered_vm_does_not_bind_connected_api_edge_from_sni_only(
         self, registry_file, make_tls_data, mitm_ctx
     ):


### PR DESCRIPTION
## Summary

- require the observed request scheme, normalized API host or subdomain, and effective port to match the configured platform API origin
- apply the same origin check to request classification, streamed request headers, TLS prebinding, connector admission, and final bypass-header admission
- preserve same-scheme HTTP development support and keep generic connector bindings scoped to host and port

## Scope

- no database schema, runner protocol, configuration, migration, or documentation changes
- wrong-scheme traffic now follows ordinary firewall or connector behavior and never receives platform API credentials

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_request_handler_api_admission.py tests/test_request_headers_api_admission.py tests/test_server_connect_hook.py tests/test_tls_clienthello_hook.py tests/test_request_handler_connector_admission.py` (95 passed)
- `uv run --no-sync python -m pytest tests/` (5403 passed)

Closes #27100
