### PR TITLE
fix(guest-agent): make agent log persistence best effort

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -6,7 +6,6 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use serde_json::{Map, Value, json};
-use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
@@ -25,9 +24,9 @@ use super::codex_app_server_events::{
 };
 use super::event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use super::{
-    AgentExecutionDeadline, CliEventIngestor, CliExecutionControls, CliExecutionResult,
-    CliRuntimeConfig, HeartbeatMonitor, HeartbeatStatus, LOG_TAG, ParsedEventAction,
-    codex_runtime_config,
+    AgentExecutionDeadline, BestEffortAgentLog, CliEventIngestor, CliExecutionControls,
+    CliExecutionResult, CliRuntimeConfig, HeartbeatMonitor, HeartbeatStatus, LOG_TAG,
+    ParsedEventAction, codex_runtime_config,
 };
 use crate::active_input::{ActiveInputController, ActiveInputFrame, ActiveInputWriter};
 use guest_common::{log_info, log_warn};
@@ -62,7 +61,7 @@ struct ThreadIdentity {
 struct EventIngestSink<'a, 'startup> {
     ingestor: &'a mut CliEventIngestor<'startup>,
     output_timing: &'a mut CodexOutputTiming,
-    log_file: &'a mut tokio::fs::File,
+    agent_log: &'a mut BestEffortAgentLog,
     masker: &'a SecretMasker,
     should_send_events: bool,
     event_tx: &'a EventDeliverySender,
@@ -243,8 +242,7 @@ async fn run_codex_app_server(
         codex_startup,
         workload_containment,
     } = controls;
-    let log_file = guest_contracts::runtime_paths::create_private(runtime.agent_log_file.as_ref())?;
-    let mut log_file = tokio::fs::File::from_std(log_file);
+    let mut agent_log = BestEffortAgentLog::open(runtime.agent_log_file.as_ref());
     let mut ingestor = CliEventIngestor::new(runtime, codex_startup);
     let mut output_timing = CodexOutputTiming::default();
     let resume_thread_id = resume_thread_id_from_runtime(runtime)?;
@@ -280,7 +278,7 @@ async fn run_codex_app_server(
             let mut sink = EventIngestSink {
                 ingestor: &mut ingestor,
                 output_timing: &mut output_timing,
-                log_file: &mut log_file,
+                agent_log: &mut agent_log,
                 masker,
                 should_send_events,
                 event_tx,
@@ -302,7 +300,7 @@ async fn run_codex_app_server(
             let mut sink = EventIngestSink {
                 ingestor: &mut ingestor,
                 output_timing: &mut output_timing,
-                log_file: &mut log_file,
+                agent_log: &mut agent_log,
                 masker,
                 should_send_events,
                 event_tx,
@@ -345,7 +343,7 @@ async fn run_codex_app_server(
                     let mut sink = EventIngestSink {
                         ingestor: &mut ingestor,
                         output_timing: &mut output_timing,
-                        log_file: &mut log_file,
+                        agent_log: &mut agent_log,
                         masker,
                         should_send_events,
                         event_tx,
@@ -388,7 +386,7 @@ async fn run_codex_app_server(
                     let mut sink = EventIngestSink {
                         ingestor: &mut ingestor,
                         output_timing: &mut output_timing,
-                        log_file: &mut log_file,
+                        agent_log: &mut agent_log,
                         masker,
                         should_send_events,
                         event_tx,
@@ -461,19 +459,7 @@ async fn run_codex_app_server(
     let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
     // Complete the final event-log write after the child is stopped and
     // before callers observe the finished app-server execution.
-    let log_flush_error = log_file.flush().await.err();
-    let has_primary_failure = active_input_delivery_ids.is_err()
-        || shutdown_result.is_err()
-        || !matches!(
-            &run_outcome,
-            AppServerRunOutcome::Completed(result) if result.is_ok()
-        );
-    if has_primary_failure && let Some(error) = &log_flush_error {
-        log_warn!(
-            LOG_TAG,
-            "Agent log flush failed after an earlier app-server failure: {error}"
-        );
-    }
+    agent_log.flush().await;
     let active_input_delivery_ids = match active_input_delivery_ids {
         Ok(delivery_ids) => delivery_ids,
         Err(active_input_error) => {
@@ -490,9 +476,6 @@ async fn run_codex_app_server(
     match run_outcome {
         AppServerRunOutcome::Completed(run_result) => match (*run_result, shutdown_result) {
             (Ok(mut result), Ok(())) => {
-                if let Some(error) = log_flush_error {
-                    return Err(AgentError::Io(error));
-                }
                 result.stderr_lines = stderr_lines;
                 result.active_input_delivery_ids = active_input_delivery_ids;
                 Ok(result)
@@ -1105,13 +1088,13 @@ async fn ingest_event(event: Value, sink: &mut EventIngestSink<'_, '_>) -> Resul
     match sink
         .ingestor
         .begin_event(
-            sink.log_file,
+            sink.agent_log,
             raw_line,
             &event,
             sink.masker,
             Framework::Codex,
         )
-        .await?
+        .await
     {
         ParsedEventAction::Forward => {
             if let Some(text) = codex_agent_message_text(&event) {

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -461,7 +461,19 @@ async fn run_codex_app_server(
     let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
     // Complete the final event-log write after the child is stopped and
     // before callers observe the finished app-server execution.
-    let _ = log_file.flush().await;
+    let log_flush_error = log_file.flush().await.err();
+    let has_primary_failure = active_input_delivery_ids.is_err()
+        || shutdown_result.is_err()
+        || !matches!(
+            &run_outcome,
+            AppServerRunOutcome::Completed(result) if result.is_ok()
+        );
+    if has_primary_failure && let Some(error) = &log_flush_error {
+        log_warn!(
+            LOG_TAG,
+            "Agent log flush failed after an earlier app-server failure: {error}"
+        );
+    }
     let active_input_delivery_ids = match active_input_delivery_ids {
         Ok(delivery_ids) => delivery_ids,
         Err(active_input_error) => {
@@ -478,6 +490,9 @@ async fn run_codex_app_server(
     match run_outcome {
         AppServerRunOutcome::Completed(run_result) => match (*run_result, shutdown_result) {
             (Ok(mut result), Ok(())) => {
+                if let Some(error) = log_flush_error {
+                    return Err(AgentError::Io(error));
+                }
                 result.stderr_lines = stderr_lines;
                 result.active_input_delivery_ids = active_input_delivery_ids;
                 Ok(result)

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -625,9 +625,13 @@ impl<'a> CliEventIngestor<'a> {
         timing::record_e2e_from_api_start_at(op_name, &self.api_start_time, observed_at_ms);
     }
 
-    async fn write_raw_line(log_file: &mut tokio::fs::File, raw_line: impl AsRef<[u8]>) {
-        let _ = log_file.write_all(raw_line.as_ref()).await;
-        let _ = log_file.write_all(b"\n").await;
+    async fn write_raw_line(
+        log_file: &mut tokio::fs::File,
+        raw_line: impl AsRef<[u8]>,
+    ) -> Result<(), AgentError> {
+        log_file.write_all(raw_line.as_ref()).await?;
+        log_file.write_all(b"\n").await?;
+        Ok(())
     }
 
     async fn begin_event(
@@ -647,7 +651,7 @@ impl<'a> CliEventIngestor<'a> {
         {
             codex_startup.record_success_at(Instant::now());
         }
-        Self::write_raw_line(log_file, raw_line).await;
+        Self::write_raw_line(log_file, raw_line).await?;
 
         if is_stream_event {
             return Ok(ParsedEventAction::Skip);
@@ -1188,46 +1192,56 @@ async fn execute_cli_inner(
                         }
 
                         if let Ok(event) = serde_json::from_str::<serde_json::Value>(stripped) {
-                            if replay_user_messages {
+                            let replay_marker: Option<&[u8]> = if replay_user_messages {
                                 match active_input_controller.replay_user_event_action(&event) {
-                                    ReplayUserEventAction::External => {}
-                                    ReplayUserEventAction::InternalInitialPrompt => {
-                                        let _ = log_file
-                                            .write_all(
-                                                br#"{"type":"vm0_internal","event":"filtered_replayed_initial_prompt"}"#,
-                                            )
-                                            .await;
-                                        let _ = log_file.write_all(b"\n").await;
-                                        continue;
-                                    }
-                                    ReplayUserEventAction::InternalActiveInput => {
-                                        let _ = log_file
-                                            .write_all(
-                                                br#"{"type":"vm0_internal","event":"filtered_replayed_active_input"}"#,
-                                            )
-                                            .await;
-                                        let _ = log_file.write_all(b"\n").await;
-                                        continue;
-                                    }
+                                    ReplayUserEventAction::External => None,
+                                    ReplayUserEventAction::InternalInitialPrompt => Some(
+                                        br#"{"type":"vm0_internal","event":"filtered_replayed_initial_prompt"}"#,
+                                    ),
+                                    ReplayUserEventAction::InternalActiveInput => Some(
+                                        br#"{"type":"vm0_internal","event":"filtered_replayed_active_input"}"#,
+                                    ),
                                     ReplayUserEventAction::UnknownPromptUser => {
-                                        let _ = log_file
-                                            .write_all(
-                                                br#"{"type":"vm0_internal","event":"filtered_unknown_prompt_user"}"#,
-                                            )
-                                            .await;
-                                        let _ = log_file.write_all(b"\n").await;
                                         log_warn!(
                                             LOG_TAG,
                                             "Filtered unknown top-level Claude user replay event"
                                         );
-                                        continue;
+                                        Some(
+                                            br#"{"type":"vm0_internal","event":"filtered_unknown_prompt_user"}"#,
+                                        )
                                     }
                                 }
+                            } else {
+                                None
+                            };
+                            if let Some(replay_marker) = replay_marker {
+                                if let Err(error) = CliEventIngestor::write_raw_line(
+                                    &mut log_file,
+                                    replay_marker,
+                                )
+                                .await
+                                {
+                                    stdout_closed = true;
+                                    let context = StdoutIngestionFailureContext {
+                                        child: &mut child,
+                                        cli_status: &mut cli_status,
+                                        cli_exit_at: &mut cli_exit_at,
+                                        active_input_controller: &active_input_controller,
+                                        termination_runtime: &mut termination_runtime,
+                                        drain_deadline: drain_deadline.as_mut(),
+                                        termination_deadline: termination_deadline.as_mut(),
+                                    };
+                                    match begin_stdout_ingestion_failure(error, context) {
+                                        Ok(()) => continue,
+                                        Err(error) => break Err(error),
+                                    }
+                                }
+                                continue;
                             }
 
                             let post_result_cleanup_was_armed =
                                 termination_runtime.has_post_result_cleanup();
-                            match event_ingestor
+                            let event_action = match event_ingestor
                                 .begin_event(
                                     &mut log_file,
                                     line.as_bytes(),
@@ -1235,8 +1249,27 @@ async fn execute_cli_inner(
                                     masker,
                                     runtime.framework,
                                 )
-                                .await?
+                                .await
                             {
+                                Ok(action) => action,
+                                Err(error) => {
+                                    stdout_closed = true;
+                                    let context = StdoutIngestionFailureContext {
+                                        child: &mut child,
+                                        cli_status: &mut cli_status,
+                                        cli_exit_at: &mut cli_exit_at,
+                                        active_input_controller: &active_input_controller,
+                                        termination_runtime: &mut termination_runtime,
+                                        drain_deadline: drain_deadline.as_mut(),
+                                        termination_deadline: termination_deadline.as_mut(),
+                                    };
+                                    match begin_stdout_ingestion_failure(error, context) {
+                                        Ok(()) => continue,
+                                        Err(error) => break Err(error),
+                                    }
+                                }
+                            };
+                            match event_action {
                                 ParsedEventAction::Forward => {}
                                 ParsedEventAction::Skip => continue,
                             }
@@ -1327,7 +1360,25 @@ async fn execute_cli_inner(
                                 );
                             }
                         } else {
-                            CliEventIngestor::write_raw_line(&mut log_file, line.as_bytes()).await;
+                            if let Err(error) =
+                                CliEventIngestor::write_raw_line(&mut log_file, line.as_bytes())
+                                    .await
+                            {
+                                stdout_closed = true;
+                                let context = StdoutIngestionFailureContext {
+                                    child: &mut child,
+                                    cli_status: &mut cli_status,
+                                    cli_exit_at: &mut cli_exit_at,
+                                    active_input_controller: &active_input_controller,
+                                    termination_runtime: &mut termination_runtime,
+                                    drain_deadline: drain_deadline.as_mut(),
+                                    termination_deadline: termination_deadline.as_mut(),
+                                };
+                                match begin_stdout_ingestion_failure(error, context) {
+                                    Ok(()) => {}
+                                    Err(error) => break Err(error),
+                                }
+                            }
                         }
                     }
                     Ok(None) => {
@@ -1366,31 +1417,18 @@ async fn execute_cli_inner(
                             }
                         };
 
-                        if cli_status.is_some() {
-                            break Err(error);
-                        }
-                        match try_observe_cli_exit(
-                            &mut child,
-                            &mut cli_status,
-                            &mut cli_exit_at,
-                            &active_input_controller,
-                            &mut termination_runtime,
-                            stdout_closed,
-                            drain_deadline.as_mut(),
-                        )? {
-                            CliExitObservation::NoNewExit => {
-                                let error_log = error.to_string();
-                                termination_runtime.begin_control_failure(
-                                    TerminationReason::StdoutIngestion,
-                                    error,
-                                    ControlTerminationLog::StdoutIngestionFailed {
-                                        error: error_log,
-                                    },
-                                    termination_deadline.as_mut(),
-                                );
-                            }
-                            CliExitObservation::ExitedDrainingStdout
-                            | CliExitObservation::ExitedAndStdoutClosed => break Err(error),
+                        let context = StdoutIngestionFailureContext {
+                            child: &mut child,
+                            cli_status: &mut cli_status,
+                            cli_exit_at: &mut cli_exit_at,
+                            active_input_controller: &active_input_controller,
+                            termination_runtime: &mut termination_runtime,
+                            drain_deadline: drain_deadline.as_mut(),
+                            termination_deadline: termination_deadline.as_mut(),
+                        };
+                        match begin_stdout_ingestion_failure(error, context) {
+                            Ok(()) => {}
+                            Err(error) => break Err(error),
                         }
                     }
                 }
@@ -1540,7 +1578,7 @@ async fn execute_cli_inner(
     // `tokio::fs::File` may still own an in-flight blocking write after
     // `write_all` returns. Wait for it before callers observe the completed
     // execution and read the run log.
-    let _ = log_file.flush().await;
+    let mut log_flush_error = log_file.flush().await.err();
 
     active_input_controller.close_terminal();
     let mut active_input_error = None;
@@ -1615,8 +1653,16 @@ async fn execute_cli_inner(
     } else if has_control_error {
         None
     } else {
-        event_result.err()
+        event_result
+            .err()
+            .or_else(|| log_flush_error.take().map(AgentError::Io))
     };
+    if let Some(error) = &log_flush_error {
+        log_warn!(
+            LOG_TAG,
+            "Agent log flush failed after an earlier execution failure: {error}"
+        );
+    }
 
     // On success, boundedly drain accepted events. On any execution or
     // control error, abort unsent delivery rather than stalling on retries.
@@ -1716,6 +1762,59 @@ enum CliExitObservation {
     NoNewExit,
     ExitedDrainingStdout,
     ExitedAndStdoutClosed,
+}
+
+struct StdoutIngestionFailureContext<'a> {
+    child: &'a mut tokio::process::Child,
+    cli_status: &'a mut Option<ExitStatus>,
+    cli_exit_at: &'a mut Option<Instant>,
+    active_input_controller: &'a ActiveInputController,
+    termination_runtime: &'a mut CliTerminationRuntime,
+    drain_deadline: Pin<&'a mut Sleep>,
+    termination_deadline: Pin<&'a mut Sleep>,
+}
+
+fn begin_stdout_ingestion_failure(
+    error: AgentError,
+    context: StdoutIngestionFailureContext<'_>,
+) -> Result<(), AgentError> {
+    let StdoutIngestionFailureContext {
+        child,
+        cli_status,
+        cli_exit_at,
+        active_input_controller,
+        termination_runtime,
+        drain_deadline,
+        termination_deadline,
+    } = context;
+    active_input_controller.close_terminal();
+    if cli_status.is_some() {
+        return Err(error);
+    }
+
+    match try_observe_cli_exit(
+        child,
+        cli_status,
+        cli_exit_at,
+        active_input_controller,
+        termination_runtime,
+        true,
+        drain_deadline,
+    )? {
+        CliExitObservation::NoNewExit => {
+            let error_log = error.to_string();
+            termination_runtime.begin_control_failure(
+                TerminationReason::StdoutIngestion,
+                error,
+                ControlTerminationLog::StdoutIngestionFailed { error: error_log },
+                termination_deadline,
+            );
+            Ok(())
+        }
+        CliExitObservation::ExitedDrainingStdout | CliExitObservation::ExitedAndStdoutClosed => {
+            Err(error)
+        }
+    }
 }
 
 fn try_observe_cli_exit(

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -593,6 +593,61 @@ enum ParsedEventAction {
     Skip,
 }
 
+struct BestEffortAgentLog {
+    file: Option<tokio::fs::File>,
+}
+
+impl BestEffortAgentLog {
+    fn open(path: &str) -> Self {
+        match guest_contracts::runtime_paths::create_private(path) {
+            Ok(file) => Self {
+                file: Some(tokio::fs::File::from_std(file)),
+            },
+            Err(error) => {
+                Self::warn_failure("open", &error);
+                Self { file: None }
+            }
+        }
+    }
+
+    async fn write_raw_line(&mut self, raw_line: impl AsRef<[u8]>) {
+        let result = {
+            let Some(file) = self.file.as_mut() else {
+                return;
+            };
+            match file.write_all(raw_line.as_ref()).await {
+                Ok(()) => file.write_all(b"\n").await,
+                Err(error) => Err(error),
+            }
+        };
+        if let Err(error) = result {
+            self.disable("write", error);
+        }
+    }
+
+    async fn flush(&mut self) {
+        let result = match self.file.as_mut() {
+            Some(file) => file.flush().await,
+            None => return,
+        };
+        if let Err(error) = result {
+            self.disable("flush", error);
+        }
+    }
+
+    fn disable(&mut self, operation: &str, error: std::io::Error) {
+        self.file = None;
+        Self::warn_failure(operation, &error);
+    }
+
+    fn warn_failure(operation: &str, error: &std::io::Error) {
+        log_warn!(
+            LOG_TAG,
+            "Agent log {operation} failed; continuing without local transcript: {error}"
+        );
+    }
+}
+
 struct CliEventIngestor<'a> {
     framework: env::Framework,
     seq: u32,
@@ -625,23 +680,14 @@ impl<'a> CliEventIngestor<'a> {
         timing::record_e2e_from_api_start_at(op_name, &self.api_start_time, observed_at_ms);
     }
 
-    async fn write_raw_line(
-        log_file: &mut tokio::fs::File,
-        raw_line: impl AsRef<[u8]>,
-    ) -> Result<(), AgentError> {
-        log_file.write_all(raw_line.as_ref()).await?;
-        log_file.write_all(b"\n").await?;
-        Ok(())
-    }
-
     async fn begin_event(
         &mut self,
-        log_file: &mut tokio::fs::File,
+        agent_log: &mut BestEffortAgentLog,
         raw_line: impl AsRef<[u8]>,
         event: &serde_json::Value,
         masker: &SecretMasker,
         framework: env::Framework,
-    ) -> Result<ParsedEventAction, AgentError> {
+    ) -> ParsedEventAction {
         let is_stream_event =
             event.get("type").and_then(serde_json::Value::as_str) == Some("stream_event");
         if !is_stream_event
@@ -651,10 +697,10 @@ impl<'a> CliEventIngestor<'a> {
         {
             codex_startup.record_success_at(Instant::now());
         }
-        Self::write_raw_line(log_file, raw_line).await?;
+        agent_log.write_raw_line(raw_line).await;
 
         if is_stream_event {
-            return Ok(ParsedEventAction::Skip);
+            return ParsedEventAction::Skip;
         }
         self.last_read_event_at = Some(Instant::now());
         if self.seq == 0 {
@@ -684,7 +730,7 @@ impl<'a> CliEventIngestor<'a> {
             }
         }
 
-        Ok(ParsedEventAction::Forward)
+        ParsedEventAction::Forward
     }
 
     fn replace_failure_diagnostic(&mut self, diagnostic: CliFailureDiagnostic) {
@@ -938,10 +984,9 @@ async fn execute_cli_inner(
         workload_containment.configure_command(&mut cmd)?;
     }
 
-    // Open the run log before spawning the CLI. If the run-id-scoped path is
-    // invalid or unavailable, fail without starting a child process.
-    let log_file = guest_contracts::runtime_paths::create_private(runtime.agent_log_file.as_ref())?;
-    let mut log_file = tokio::fs::File::from_std(log_file);
+    // The local transcript is best-effort observability. A backend must not
+    // fail an otherwise healthy run because this sink is unavailable.
+    let mut agent_log = BestEffortAgentLog::open(runtime.agent_log_file.as_ref());
 
     let mut child = cmd.spawn()?;
 
@@ -1215,60 +1260,21 @@ async fn execute_cli_inner(
                                 None
                             };
                             if let Some(replay_marker) = replay_marker {
-                                if let Err(error) = CliEventIngestor::write_raw_line(
-                                    &mut log_file,
-                                    replay_marker,
-                                )
-                                .await
-                                {
-                                    stdout_closed = true;
-                                    let context = StdoutIngestionFailureContext {
-                                        child: &mut child,
-                                        cli_status: &mut cli_status,
-                                        cli_exit_at: &mut cli_exit_at,
-                                        active_input_controller: &active_input_controller,
-                                        termination_runtime: &mut termination_runtime,
-                                        drain_deadline: drain_deadline.as_mut(),
-                                        termination_deadline: termination_deadline.as_mut(),
-                                    };
-                                    match begin_stdout_ingestion_failure(error, context) {
-                                        Ok(()) => continue,
-                                        Err(error) => break Err(error),
-                                    }
-                                }
+                                agent_log.write_raw_line(replay_marker).await;
                                 continue;
                             }
 
                             let post_result_cleanup_was_armed =
                                 termination_runtime.has_post_result_cleanup();
-                            let event_action = match event_ingestor
+                            let event_action = event_ingestor
                                 .begin_event(
-                                    &mut log_file,
+                                    &mut agent_log,
                                     line.as_bytes(),
                                     &event,
                                     masker,
                                     runtime.framework,
                                 )
-                                .await
-                            {
-                                Ok(action) => action,
-                                Err(error) => {
-                                    stdout_closed = true;
-                                    let context = StdoutIngestionFailureContext {
-                                        child: &mut child,
-                                        cli_status: &mut cli_status,
-                                        cli_exit_at: &mut cli_exit_at,
-                                        active_input_controller: &active_input_controller,
-                                        termination_runtime: &mut termination_runtime,
-                                        drain_deadline: drain_deadline.as_mut(),
-                                        termination_deadline: termination_deadline.as_mut(),
-                                    };
-                                    match begin_stdout_ingestion_failure(error, context) {
-                                        Ok(()) => continue,
-                                        Err(error) => break Err(error),
-                                    }
-                                }
-                            };
+                                .await;
                             match event_action {
                                 ParsedEventAction::Forward => {}
                                 ParsedEventAction::Skip => continue,
@@ -1360,25 +1366,7 @@ async fn execute_cli_inner(
                                 );
                             }
                         } else {
-                            if let Err(error) =
-                                CliEventIngestor::write_raw_line(&mut log_file, line.as_bytes())
-                                    .await
-                            {
-                                stdout_closed = true;
-                                let context = StdoutIngestionFailureContext {
-                                    child: &mut child,
-                                    cli_status: &mut cli_status,
-                                    cli_exit_at: &mut cli_exit_at,
-                                    active_input_controller: &active_input_controller,
-                                    termination_runtime: &mut termination_runtime,
-                                    drain_deadline: drain_deadline.as_mut(),
-                                    termination_deadline: termination_deadline.as_mut(),
-                                };
-                                match begin_stdout_ingestion_failure(error, context) {
-                                    Ok(()) => {}
-                                    Err(error) => break Err(error),
-                                }
-                            }
+                            agent_log.write_raw_line(line.as_bytes()).await;
                         }
                     }
                     Ok(None) => {
@@ -1417,18 +1405,31 @@ async fn execute_cli_inner(
                             }
                         };
 
-                        let context = StdoutIngestionFailureContext {
-                            child: &mut child,
-                            cli_status: &mut cli_status,
-                            cli_exit_at: &mut cli_exit_at,
-                            active_input_controller: &active_input_controller,
-                            termination_runtime: &mut termination_runtime,
-                            drain_deadline: drain_deadline.as_mut(),
-                            termination_deadline: termination_deadline.as_mut(),
-                        };
-                        match begin_stdout_ingestion_failure(error, context) {
-                            Ok(()) => {}
-                            Err(error) => break Err(error),
+                        if cli_status.is_some() {
+                            break Err(error);
+                        }
+                        match try_observe_cli_exit(
+                            &mut child,
+                            &mut cli_status,
+                            &mut cli_exit_at,
+                            &active_input_controller,
+                            &mut termination_runtime,
+                            stdout_closed,
+                            drain_deadline.as_mut(),
+                        )? {
+                            CliExitObservation::NoNewExit => {
+                                let error_log = error.to_string();
+                                termination_runtime.begin_control_failure(
+                                    TerminationReason::StdoutIngestion,
+                                    error,
+                                    ControlTerminationLog::StdoutIngestionFailed {
+                                        error: error_log,
+                                    },
+                                    termination_deadline.as_mut(),
+                                );
+                            }
+                            CliExitObservation::ExitedDrainingStdout
+                            | CliExitObservation::ExitedAndStdoutClosed => break Err(error),
                         }
                     }
                 }
@@ -1578,7 +1579,7 @@ async fn execute_cli_inner(
     // `tokio::fs::File` may still own an in-flight blocking write after
     // `write_all` returns. Wait for it before callers observe the completed
     // execution and read the run log.
-    let mut log_flush_error = log_file.flush().await.err();
+    agent_log.flush().await;
 
     active_input_controller.close_terminal();
     let mut active_input_error = None;
@@ -1653,16 +1654,8 @@ async fn execute_cli_inner(
     } else if has_control_error {
         None
     } else {
-        event_result
-            .err()
-            .or_else(|| log_flush_error.take().map(AgentError::Io))
+        event_result.err()
     };
-    if let Some(error) = &log_flush_error {
-        log_warn!(
-            LOG_TAG,
-            "Agent log flush failed after an earlier execution failure: {error}"
-        );
-    }
 
     // On success, boundedly drain accepted events. On any execution or
     // control error, abort unsent delivery rather than stalling on retries.
@@ -1762,59 +1755,6 @@ enum CliExitObservation {
     NoNewExit,
     ExitedDrainingStdout,
     ExitedAndStdoutClosed,
-}
-
-struct StdoutIngestionFailureContext<'a> {
-    child: &'a mut tokio::process::Child,
-    cli_status: &'a mut Option<ExitStatus>,
-    cli_exit_at: &'a mut Option<Instant>,
-    active_input_controller: &'a ActiveInputController,
-    termination_runtime: &'a mut CliTerminationRuntime,
-    drain_deadline: Pin<&'a mut Sleep>,
-    termination_deadline: Pin<&'a mut Sleep>,
-}
-
-fn begin_stdout_ingestion_failure(
-    error: AgentError,
-    context: StdoutIngestionFailureContext<'_>,
-) -> Result<(), AgentError> {
-    let StdoutIngestionFailureContext {
-        child,
-        cli_status,
-        cli_exit_at,
-        active_input_controller,
-        termination_runtime,
-        drain_deadline,
-        termination_deadline,
-    } = context;
-    active_input_controller.close_terminal();
-    if cli_status.is_some() {
-        return Err(error);
-    }
-
-    match try_observe_cli_exit(
-        child,
-        cli_status,
-        cli_exit_at,
-        active_input_controller,
-        termination_runtime,
-        true,
-        drain_deadline,
-    )? {
-        CliExitObservation::NoNewExit => {
-            let error_log = error.to_string();
-            termination_runtime.begin_control_failure(
-                TerminationReason::StdoutIngestion,
-                error,
-                ControlTerminationLog::StdoutIngestionFailed { error: error_log },
-                termination_deadline,
-            );
-            Ok(())
-        }
-        CliExitObservation::ExitedDrainingStdout | CliExitObservation::ExitedAndStdoutClosed => {
-            Err(error)
-        }
-    }
 }
 
 fn try_observe_cli_exit(

--- a/crates/guest-agent/tests/cli_agent_log_open_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_open_failure.rs
@@ -1,17 +1,18 @@
-//! CLI setup should fail before spawning the agent when local log setup fails.
+//! Agent-log setup is best-effort and must not block CLI execution.
 //!
 //! This test lives in its own binary to isolate process env, working directory,
 //! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::error::AgentError;
-use std::io::ErrorKind;
 use std::time::Duration;
 
+const AGENT_LOG_WARNING: &str = "Agent log open failed; continuing without local transcript";
+
 #[tokio::test]
-async fn agent_log_open_failure_happens_before_cli_spawn() -> Result<(), Box<dyn std::error::Error>>
-{
+async fn agent_log_open_failure_warns_and_keeps_cli_run_successful()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let run_id = format!("cli-log-parent-file-{}", std::process::id());
     let runtime_dir = tmp.path().join("guest-runtime");
@@ -37,37 +38,30 @@ async fn agent_log_open_failure_happens_before_cli_spawn() -> Result<(), Box<dyn
         std::env::set_var("VM0_API_TOKEN", "");
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
         std::env::set_var("USE_MOCK_CLAUDE", "true");
-        std::env::set_var(
-            "VM0_MOCK_CLAUDE_PATH",
-            "/definitely/missing/guest-mock-claude",
-        );
+        std::env::set_var("VM0_MOCK_CLAUDE_PATH", &mock);
         std::env::set_var("HOME", tmp.path());
     }
     common::ensure_canonical_workspace_for_test()?;
 
     let runtime = common::guest_runtime_from_process_env()?;
-
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let system_log_path = tmp.path().join("system.log");
+    let _system_log = common::SystemLogOverrideGuard::set(&system_log_path);
     let masker = guest_agent::masker::SecretMasker::from_raw("");
-    let heartbeat = common::spawn_heartbeat_monitor(async { Ok::<(), AgentError>(()) });
 
-    let result = tokio::time::timeout(
-        Duration::from_secs(1),
-        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
+    let execution = tokio::time::timeout(
+        Duration::from_secs(5),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
-    .expect("log setup failure should return promptly");
+    .expect("CLI run should complete promptly without its local agent log")?;
 
-    match result {
-        Err(AgentError::Io(err)) => assert!(
-            matches!(
-                err.kind(),
-                ErrorKind::AlreadyExists | ErrorKind::NotADirectory
-            ),
-            "unexpected IO error: {err:?}",
-        ),
-        Err(err) => return Err(format!("expected IO error from agent log setup, got {err}").into()),
-        Ok(_) => return Err("expected execute_cli to fail before spawning CLI".into()),
-    }
+    assert_eq!(execution.exit_code, common::CLEAN_EXIT);
+    assert!(execution.control_error.is_none());
+    assert!(execution.cli_termination.is_none());
+    assert!(execution.claude_result.is_some());
+    let system_log = std::fs::read_to_string(system_log_path)?;
+    assert_eq!(system_log.matches(AGENT_LOG_WARNING).count(), 1);
 
     Ok(())
 }

--- a/crates/guest-agent/tests/cli_agent_log_persistence_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_persistence_failure.rs
@@ -1,0 +1,75 @@
+//! Post-open Claude agent-log failures must terminate and reap the live child.
+
+mod common;
+
+use guest_agent::error::AgentError;
+use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::time::Duration;
+
+const RAW_RECORD: &str = r#"{"type":"test"}"#;
+
+#[tokio::test]
+async fn agent_log_delimiter_failure_terminates_live_claude_process()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let (mut gate, gated_mock) = common::PostOpenMockGate::create(tmp.path(), &mock)?;
+    let prompt = format!("@ECHO-HANG@\n{RAW_RECORD}\n{RAW_RECORD}");
+    unsafe {
+        common::setup_env(&gated_mock, tmp.path(), &prompt, 3, 1)?;
+    }
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let masker = guest_agent::masker::SecretMasker::from_raw("");
+    let execution =
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat());
+    tokio::pin!(execution);
+
+    tokio::select! {
+        outcome = &mut execution => {
+            return Err(format!("CLI execution completed before the mock gate opened: {outcome:?}").into());
+        }
+        ready = gate.wait_until_ready(Duration::from_secs(5)) => ready?,
+    }
+
+    let limit = u64::try_from(RAW_RECORD.len())?;
+    let limit_guard = common::set_soft_file_size_limit(limit)?;
+    gate.release()?;
+    let outcome = match tokio::time::timeout(Duration::from_secs(5), &mut execution).await {
+        Ok(outcome) => outcome,
+        Err(_) => {
+            let log = std::fs::read(runtime.paths.agent_log_file())?;
+            return Err(format!(
+                "agent-log persistence failure did not terminate promptly; log_len={} log={:?}",
+                log.len(),
+                String::from_utf8_lossy(&log)
+            )
+            .into());
+        }
+    };
+    limit_guard.restore()?;
+    let execution = outcome?;
+
+    match execution.control_error.as_ref() {
+        Some(AgentError::Io(error)) => {
+            assert_eq!(error.raw_os_error(), Some(libc::EFBIG));
+        }
+        other => return Err(format!("expected controlled EFBIG error, got {other:?}").into()),
+    }
+    let termination = execution
+        .cli_termination
+        .as_ref()
+        .ok_or("agent-log failure omitted termination diagnostics")?;
+    assert_eq!(termination.reason, CliTerminationReason::StdoutIngestion);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
+    assert!(!termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGTERM_EXIT));
+    assert_eq!(execution.last_event_sequence, None);
+    assert_eq!(
+        std::fs::read(runtime.paths.agent_log_file())?,
+        RAW_RECORD.as_bytes()
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/cli_agent_log_persistence_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_persistence_failure.rs
@@ -14,6 +14,8 @@ async fn agent_log_delimiter_failure_terminates_live_claude_process()
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let (mut gate, gated_mock) = common::PostOpenMockGate::create(tmp.path(), &mock)?;
+    // Tokio may accept the delimiter into its blocking-write buffer. The next
+    // record forces that pending write to complete and surface EFBIG.
     let prompt = format!("@ECHO-HANG@\n{RAW_RECORD}\n{RAW_RECORD}");
     unsafe {
         common::setup_env(&gated_mock, tmp.path(), &prompt, 3, 1)?;

--- a/crates/guest-agent/tests/cli_agent_log_persistence_failure.rs
+++ b/crates/guest-agent/tests/cli_agent_log_persistence_failure.rs
@@ -1,22 +1,21 @@
-//! Post-open Claude agent-log failures must terminate and reap the live child.
+//! Post-open Claude agent-log failures must not fail an otherwise healthy run.
 
 mod common;
 
-use guest_agent::error::AgentError;
-use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use guest_agent::cli::ClaudeResultStatus;
 use std::time::Duration;
 
-const RAW_RECORD: &str = r#"{"type":"test"}"#;
+const RESULT_RECORD: &str = r#"{"type":"result","subtype":"success","session_id":"00000000-0000-4000-8000-000000000001","is_error":false,"duration_ms":1,"num_turns":1,"result":"Done.","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0}}"#;
 
 #[tokio::test]
-async fn agent_log_delimiter_failure_terminates_live_claude_process()
+async fn agent_log_flush_failure_keeps_claude_run_successful()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     let (mut gate, gated_mock) = common::PostOpenMockGate::create(tmp.path(), &mock)?;
-    // Tokio may accept the delimiter into its blocking-write buffer. The next
-    // record forces that pending write to complete and surface EFBIG.
-    let prompt = format!("@ECHO-HANG@\n{RAW_RECORD}\n{RAW_RECORD}");
+    // The raw record reaches the file while Tokio buffers the delimiter. The
+    // final flush surfaces EFBIG after the result has already been processed.
+    let prompt = format!("@ECHO@\n{RESULT_RECORD}");
     unsafe {
         common::setup_env(&gated_mock, tmp.path(), &prompt, 3, 1)?;
     }
@@ -35,7 +34,7 @@ async fn agent_log_delimiter_failure_terminates_live_claude_process()
         ready = gate.wait_until_ready(Duration::from_secs(5)) => ready?,
     }
 
-    let limit = u64::try_from(RAW_RECORD.len())?;
+    let limit = u64::try_from(RESULT_RECORD.len())?;
     let limit_guard = common::set_soft_file_size_limit(limit)?;
     gate.release()?;
     let outcome = match tokio::time::timeout(Duration::from_secs(5), &mut execution).await {
@@ -43,7 +42,7 @@ async fn agent_log_delimiter_failure_terminates_live_claude_process()
         Err(_) => {
             let log = std::fs::read(runtime.paths.agent_log_file())?;
             return Err(format!(
-                "agent-log persistence failure did not terminate promptly; log_len={} log={:?}",
+                "Claude run did not complete promptly after agent-log failure; log_len={} log={:?}",
                 log.len(),
                 String::from_utf8_lossy(&log)
             )
@@ -53,24 +52,17 @@ async fn agent_log_delimiter_failure_terminates_live_claude_process()
     limit_guard.restore()?;
     let execution = outcome?;
 
-    match execution.control_error.as_ref() {
-        Some(AgentError::Io(error)) => {
-            assert_eq!(error.raw_os_error(), Some(libc::EFBIG));
-        }
-        other => return Err(format!("expected controlled EFBIG error, got {other:?}").into()),
-    }
-    let termination = execution
-        .cli_termination
-        .as_ref()
-        .ok_or("agent-log failure omitted termination diagnostics")?;
-    assert_eq!(termination.reason, CliTerminationReason::StdoutIngestion);
-    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
-    assert!(!termination.escalated);
-    assert_eq!(termination.observed_exit_code, Some(common::SIGTERM_EXIT));
+    assert_eq!(execution.exit_code, common::CLEAN_EXIT);
+    assert!(execution.control_error.is_none());
+    assert!(execution.cli_termination.is_none());
+    assert_eq!(
+        execution.claude_result.map(|result| result.status),
+        Some(ClaudeResultStatus::Success)
+    );
     assert_eq!(execution.last_event_sequence, None);
     assert_eq!(
         std::fs::read(runtime.paths.agent_log_file())?,
-        RAW_RECORD.as_bytes()
+        RESULT_RECORD.as_bytes()
     );
 
     Ok(())

--- a/crates/guest-agent/tests/codex_app_server_agent_log_persistence_failure.rs
+++ b/crates/guest-agent/tests/codex_app_server_agent_log_persistence_failure.rs
@@ -1,0 +1,59 @@
+//! Post-open Codex agent-log failures must terminate the app-server child.
+
+mod common;
+
+use guest_agent::error::AgentError;
+use guest_agent::masker::SecretMasker;
+use std::time::Duration;
+
+#[tokio::test]
+async fn first_agent_log_write_failure_fails_codex_execution_promptly()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let (mut gate, gated_mock) = common::PostOpenMockGate::create(tmp.path(), &mock)?;
+    unsafe {
+        common::setup_codex_app_server_env(
+            &gated_mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-agent-log-persistence-failure-test",
+                prompt: "fail the first local event write",
+                scenario: Some("runtime-turn-complete-without-thread-started"),
+                resume_session_id: None,
+            },
+        )?;
+    }
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let masker = SecretMasker::from_raw("");
+    let execution =
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat());
+    tokio::pin!(execution);
+
+    tokio::select! {
+        outcome = &mut execution => {
+            return Err(format!("Codex execution completed before the mock gate opened: {outcome:?}").into());
+        }
+        ready = gate.wait_until_ready(Duration::from_secs(5)) => ready?,
+    }
+
+    let limit_guard = common::set_soft_file_size_limit(0)?;
+    gate.release()?;
+    let outcome = tokio::time::timeout(Duration::from_secs(5), &mut execution)
+        .await
+        .expect("agent-log persistence failure should terminate Codex promptly");
+    limit_guard.restore()?;
+    let error = outcome.expect_err("Codex execution must not succeed without its local event log");
+
+    match error {
+        AgentError::Io(error) => assert_eq!(error.raw_os_error(), Some(libc::EFBIG)),
+        other => {
+            return Err(format!("expected EFBIG from Codex agent-log write, got {other}").into());
+        }
+    }
+    assert_eq!(std::fs::metadata(runtime.paths.agent_log_file())?.len(), 0);
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_app_server_agent_log_persistence_failure.rs
+++ b/crates/guest-agent/tests/codex_app_server_agent_log_persistence_failure.rs
@@ -1,13 +1,12 @@
-//! Post-open Codex agent-log failures must terminate the app-server child.
+//! Post-open Codex agent-log failures must not fail an otherwise healthy run.
 
 mod common;
 
-use guest_agent::error::AgentError;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
 #[tokio::test]
-async fn first_agent_log_write_failure_fails_codex_execution_promptly()
+async fn first_agent_log_write_failure_keeps_codex_run_successful()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
@@ -43,16 +42,13 @@ async fn first_agent_log_write_failure_fails_codex_execution_promptly()
     gate.release()?;
     let outcome = tokio::time::timeout(Duration::from_secs(5), &mut execution)
         .await
-        .expect("agent-log persistence failure should terminate Codex promptly");
+        .expect("Codex run should complete promptly after agent-log failure");
     limit_guard.restore()?;
-    let error = outcome.expect_err("Codex execution must not succeed without its local event log");
+    let execution = outcome?;
 
-    match error {
-        AgentError::Io(error) => assert_eq!(error.raw_os_error(), Some(libc::EFBIG)),
-        other => {
-            return Err(format!("expected EFBIG from Codex agent-log write, got {other}").into());
-        }
-    }
+    assert_eq!(execution.exit_code, common::CLEAN_EXIT);
+    assert!(execution.control_error.is_none());
+    assert!(execution.cli_termination.is_none());
     assert_eq!(std::fs::metadata(runtime.paths.agent_log_file())?.len(), 0);
 
     Ok(())

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -22,11 +22,14 @@ mod system_log;
 
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use serde_json::Value;
+use shell_quote::quote_shell_arg;
 use std::collections::HashMap;
-use std::ffi::OsStr;
+use std::ffi::{CString, OsStr};
 use std::future::Future;
 use std::io;
-use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Output, Stdio};
@@ -679,6 +682,163 @@ pub fn build_and_locate_mock() -> Result<PathBuf, String> {
 /// current test profile.
 pub fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
     build_and_locate_mock_package("guest-mock-codex", "guest-mock-codex")
+}
+
+pub struct PostOpenMockGate {
+    writer: std::fs::File,
+    ready_file: PathBuf,
+}
+
+impl PostOpenMockGate {
+    pub fn create(dir: &Path, mock: &Path) -> Result<(Self, PathBuf), String> {
+        let fifo = dir.join("agent-log-mock-start.fifo");
+        let fifo_c = CString::new(fifo.as_os_str().as_bytes())
+            .map_err(|error| format!("encode mock gate path: {error}"))?;
+        // SAFETY: fifo_c is a valid NUL-terminated path and the mode is a
+        // normal POSIX permission mask for this test-only FIFO.
+        if unsafe { libc::mkfifo(fifo_c.as_ptr(), 0o600) } != 0 {
+            return Err(format!(
+                "create mock gate {}: {}",
+                fifo.display(),
+                io::Error::last_os_error()
+            ));
+        }
+
+        // Keep both FIFO ends open so release can happen immediately after
+        // readiness even if the wrapper has not entered its read yet.
+        // SAFETY: fifo_c remains valid for the call and ownership of the
+        // returned descriptor transfers to File below.
+        let fd = unsafe {
+            libc::open(
+                fifo_c.as_ptr(),
+                libc::O_RDWR | libc::O_NONBLOCK | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(format!(
+                "open mock gate {}: {}",
+                fifo.display(),
+                io::Error::last_os_error()
+            ));
+        }
+        // SAFETY: fd is a fresh descriptor owned by this function.
+        let writer = unsafe { std::fs::File::from_raw_fd(fd) };
+
+        let ready_file = dir.join("agent-log-mock-ready");
+        let wrapper = dir.join("gated-agent-log-mock.sh");
+        let script = format!(
+            "#!/bin/sh\nprintf 'ready\\n' > {}\nIFS= read -r _ < {}\nexec {} \"$@\"\n",
+            quote_shell_arg(&ready_file.to_string_lossy()),
+            quote_shell_arg(&fifo.to_string_lossy()),
+            quote_shell_arg(&mock.to_string_lossy()),
+        );
+        std::fs::write(&wrapper, script)
+            .map_err(|error| format!("write mock gate wrapper: {error}"))?;
+        let mut permissions = std::fs::metadata(&wrapper)
+            .map_err(|error| format!("read mock gate wrapper metadata: {error}"))?
+            .permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&wrapper, permissions)
+            .map_err(|error| format!("set mock gate wrapper permissions: {error}"))?;
+
+        Ok((Self { writer, ready_file }, wrapper))
+    }
+
+    pub async fn wait_until_ready(&self, timeout: Duration) -> io::Result<()> {
+        wait_for_file_contains(&self.ready_file, "ready\n", timeout).await
+    }
+
+    pub fn release(&mut self) -> io::Result<()> {
+        std::io::Write::write_all(&mut self.writer, b"start\n")
+    }
+}
+
+pub struct SoftFileSizeLimitGuard {
+    original_limit: Option<libc::rlimit>,
+    original_sigxfsz: libc::sighandler_t,
+}
+
+impl SoftFileSizeLimitGuard {
+    pub fn restore(mut self) -> Result<(), String> {
+        self.restore_inner()
+    }
+
+    fn restore_inner(&mut self) -> Result<(), String> {
+        let Some(original_limit) = self.original_limit else {
+            return Ok(());
+        };
+        // SAFETY: original_limit was returned by getrlimit for this process.
+        if unsafe { libc::setrlimit(libc::RLIMIT_FSIZE, &original_limit) } != 0 {
+            return Err(format!(
+                "restore RLIMIT_FSIZE: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        // SAFETY: original_sigxfsz was returned by signal for SIGXFSZ.
+        if unsafe { libc::signal(libc::SIGXFSZ, self.original_sigxfsz) } == libc::SIG_ERR {
+            return Err(format!(
+                "restore SIGXFSZ disposition: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        self.original_limit = None;
+        Ok(())
+    }
+}
+
+impl Drop for SoftFileSizeLimitGuard {
+    fn drop(&mut self) {
+        if let Err(error) = self.restore_inner() {
+            eprintln!("{error}");
+        }
+    }
+}
+
+pub fn set_soft_file_size_limit(limit: u64) -> Result<SoftFileSizeLimitGuard, String> {
+    let mut current = std::mem::MaybeUninit::<libc::rlimit>::uninit();
+    // SAFETY: current points to writable storage for one rlimit value.
+    if unsafe { libc::getrlimit(libc::RLIMIT_FSIZE, current.as_mut_ptr()) } != 0 {
+        return Err(format!("read RLIMIT_FSIZE: {}", io::Error::last_os_error()));
+    }
+    // SAFETY: successful getrlimit initialized current.
+    let current = unsafe { current.assume_init() };
+    let target: libc::rlim_t = limit;
+    if target > current.rlim_max {
+        return Err(format!(
+            "requested RLIMIT_FSIZE {target} exceeds hard limit {}",
+            current.rlim_max
+        ));
+    }
+
+    // SAFETY: installing SIG_IGN for SIGXFSZ is process-local and restored by
+    // SoftFileSizeLimitGuard after the isolated integration execution.
+    let original_sigxfsz = unsafe { libc::signal(libc::SIGXFSZ, libc::SIG_IGN) };
+    if original_sigxfsz == libc::SIG_ERR {
+        return Err(format!("ignore SIGXFSZ: {}", io::Error::last_os_error()));
+    }
+
+    let next = libc::rlimit {
+        rlim_cur: target,
+        rlim_max: current.rlim_max,
+    };
+    // SAFETY: next preserves the current hard limit and uses a checked soft limit.
+    if unsafe { libc::setrlimit(libc::RLIMIT_FSIZE, &next) } != 0 {
+        let limit_error = io::Error::last_os_error();
+        // SAFETY: original_sigxfsz came from the successful signal call above.
+        let restore_result = unsafe { libc::signal(libc::SIGXFSZ, original_sigxfsz) };
+        if restore_result == libc::SIG_ERR {
+            return Err(format!(
+                "set RLIMIT_FSIZE: {limit_error}; restore SIGXFSZ disposition: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        return Err(format!("set RLIMIT_FSIZE: {limit_error}"));
+    }
+
+    Ok(SoftFileSizeLimitGuard {
+        original_limit: Some(current),
+        original_sigxfsz,
+    })
 }
 
 fn build_and_locate_mock_package(package: &str, binary: &str) -> Result<PathBuf, String> {


### PR DESCRIPTION
## Summary

- treat the local agent transcript as best-effort observability for Claude, Pi, and Codex runs
- warn once and disable the transcript sink after open, write, delimiter, replay-marker, or final-flush failures
- preserve normal event processing and successful run outcomes when only transcript persistence fails
- add fast real-I/O regressions for open, write, and flush failures without fixed sleeps

## Scope

This changes only guest-agent local transcript persistence and its integration coverage. Real agent execution, protocol, event-delivery, control, and shutdown errors remain fatal under their existing rules. No public API, payload, runtime path, or deployment contract changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent`
- `cargo test -p guest-agent --test cli_agent_log_open_failure --test cli_agent_log_persistence_failure --test codex_app_server_agent_log_persistence_failure`

Closes #27089
