### PR TITLE
refactor(attribution): neutralize acquisition attribution api naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -60,7 +60,7 @@ import { agentDraftRoutes } from "./routes/agent-draft";
 import { zeroAgentInstructionsRoutes } from "./routes/zero-agent-instructions";
 import { zeroAgentsRoutes } from "./routes/zero-agents";
 import { artifactCatalogRoutes } from "./routes/artifact-catalog";
-import { zeroAttributionRoutes } from "./routes/zero-attribution";
+import { acquisitionAttributionRoutes } from "./routes/acquisition-attribution";
 import { zeroBillingAutoRechargeRoutes } from "./routes/zero-billing-auto-recharge";
 import { zeroBillingCheckoutRoutes } from "./routes/zero-billing-checkout";
 import { zeroBillingConcurrencyCheckoutRoutes } from "./routes/zero-billing-concurrency-checkout";
@@ -251,7 +251,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroAgentInstructionsRoutes,
   ...zeroAgentsRoutes,
   ...artifactCatalogRoutes,
-  ...zeroAttributionRoutes,
+  ...acquisitionAttributionRoutes,
   ...zeroBillingAutoRechargeRoutes,
   ...zeroBillingCheckoutRoutes,
   ...zeroBillingConcurrencyCheckoutRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from "node:crypto";
 
-import { zeroAttributionContract } from "@okouai/api-contracts/contracts/zero-attribution";
+import { acquisitionAttributionContract } from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockNow } from "../../../lib/time";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroAttributionRoutes } from "../zero-attribution";
+import { acquisitionAttributionRoutes } from "../acquisition-attribution";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -15,8 +15,8 @@ const mocks = createZeroRouteMocks(context);
 const RECORDED_AT_ISO = "2026-05-30T12:00:00.000Z";
 
 function client() {
-  return setupApp({ context, routes: zeroAttributionRoutes })(
-    zeroAttributionContract,
+  return setupApp({ context, routes: acquisitionAttributionRoutes })(
+    acquisitionAttributionContract,
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type StripeSDK from "stripe";
 import { testUsageSettlementContract } from "@okouai/api-contracts/contracts/test-usage-settlement";
-import { zeroAttributionContract } from "@okouai/api-contracts/contracts/zero-attribution";
+import { acquisitionAttributionContract } from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { zeroBankingContract } from "@okouai/api-contracts/contracts/zero-banking";
 import {
   zeroBillingAutoRechargeContract,
@@ -47,7 +47,7 @@ import { modelStatsContract, modelStatsPublicRoutes } from "../../model-stats";
 import { testUsageSettlementRoutes } from "../../test-usage-settlement";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
-import { zeroAttributionRoutes } from "../../zero-attribution";
+import { acquisitionAttributionRoutes } from "../../acquisition-attribution";
 import { zeroBankingRoutes } from "../../zero-banking";
 import { zeroBillingAutoRechargeRoutes } from "../../zero-billing-auto-recharge";
 import { zeroBillingCheckoutRoutes } from "../../zero-billing-checkout";
@@ -565,9 +565,10 @@ export function createBillingMediaApi(context: TestContext) {
     },
 
     async recordSignupAttribution(actor: ApiTestUser) {
-      const client = setupApp({ context, routes: zeroAttributionRoutes })(
-        zeroAttributionContract,
-      );
+      const client = setupApp({
+        context,
+        routes: acquisitionAttributionRoutes,
+      })(acquisitionAttributionContract);
       return await accept(
         client.recordSignup({
           headers: authenticate(actor),

--- a/turbo/apps/api/src/signals/routes/acquisition-attribution.ts
+++ b/turbo/apps/api/src/signals/routes/acquisition-attribution.ts
@@ -1,8 +1,8 @@
 import { command } from "ccstate";
 import {
-  zeroAttributionContract,
+  acquisitionAttributionContract,
   type AdAttributionMetadata,
-} from "@okouai/api-contracts/contracts/zero-attribution";
+} from "@okouai/api-contracts/contracts/acquisition-attribution";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -21,7 +21,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-const recordSignupBody$ = bodyResultOf(zeroAttributionContract.recordSignup);
+const recordSignupBody$ = bodyResultOf(
+  acquisitionAttributionContract.recordSignup,
+);
 
 const recordSignupInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -95,9 +97,9 @@ const recordSignupInner$ = command(
   },
 );
 
-export const zeroAttributionRoutes: readonly RouteEntry[] = [
+export const acquisitionAttributionRoutes: readonly RouteEntry[] = [
   {
-    route: zeroAttributionContract.recordSignup,
+    route: acquisitionAttributionContract.recordSignup,
     handler: authRoute({ accept: ["session"] }, recordSignupInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-checkout.ts
@@ -8,7 +8,7 @@ import {
   type MemberUsagePack,
   type UsagePackCatalogItem,
 } from "@okouai/api-contracts/contracts/zero-billing";
-import { adAttributionMetadataSchema } from "@okouai/api-contracts/contracts/zero-attribution";
+import { adAttributionMetadataSchema } from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";

--- a/turbo/apps/api/src/signals/services/acquisition-attribution.service.ts
+++ b/turbo/apps/api/src/signals/services/acquisition-attribution.service.ts
@@ -1,7 +1,7 @@
 import {
   adAttributionMetadataSchema,
   type AdAttributionMetadata,
-} from "@okouai/api-contracts/contracts/zero-attribution";
+} from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
 import { and, eq, isNull } from "drizzle-orm";
 import { command } from "ccstate";

--- a/turbo/apps/platform/src/mocks/handlers/api-attribution.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-attribution.ts
@@ -1,8 +1,8 @@
-import { zeroAttributionContract } from "@okouai/api-contracts/contracts/zero-attribution";
+import { acquisitionAttributionContract } from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { mockApi } from "../msw-contract.ts";
 
 export const apiAttributionHandlers = [
-  mockApi(zeroAttributionContract.recordSignup, ({ respond }) => {
+  mockApi(acquisitionAttributionContract.recordSignup, ({ respond }) => {
     return respond(200, { recorded: true });
   }),
 ];

--- a/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  zeroAttributionContract,
+  acquisitionAttributionContract,
   type AdAttributionMetadata,
-} from "@okouai/api-contracts/contracts/zero-attribution";
+} from "@okouai/api-contracts/contracts/acquisition-attribution";
 
 import {
   clearMockedAuthOnAbort,
@@ -101,7 +101,7 @@ describe("signup attribution Google Ads conversion", () => {
     storePaidSignupAttribution();
     setGoogleAnalyticsCookie("GA1.1.123456789.987654321");
     context.mocks.api(
-      zeroAttributionContract.recordSignup,
+      acquisitionAttributionContract.recordSignup,
       ({ body, respond }) => {
         recordedAttribution = body.attribution;
         return respond(200, { recorded: true });
@@ -141,7 +141,7 @@ describe("signup attribution Google Ads conversion", () => {
     mockSignedInUser();
     setGoogleAnalyticsCookie("GA1.1.123456789.987654321");
     context.mocks.api(
-      zeroAttributionContract.recordSignup,
+      acquisitionAttributionContract.recordSignup,
       ({ body, respond }) => {
         recordedAttribution = body.attribution;
         return respond(200, { recorded: true });
@@ -179,10 +179,13 @@ describe("signup attribution Google Ads conversion", () => {
     let attributionRequests = 0;
     mockSignedInUser({ createdAt: dateFromIso(isoFromNowMs(-31 * 60 * 1000)) });
     setGoogleAnalyticsCookie("not-a-ga-cookie");
-    context.mocks.api(zeroAttributionContract.recordSignup, ({ respond }) => {
-      attributionRequests += 1;
-      return respond(200, { recorded: true });
-    });
+    context.mocks.api(
+      acquisitionAttributionContract.recordSignup,
+      ({ respond }) => {
+        attributionRequests += 1;
+        return respond(200, { recorded: true });
+      },
+    );
 
     await context.store.set(recordSignupAttribution$, context.signal);
 
@@ -194,9 +197,12 @@ describe("signup attribution Google Ads conversion", () => {
     const gtag = installGtagMock();
     mockSignedInUser();
     storePaidSignupAttribution();
-    context.mocks.api(zeroAttributionContract.recordSignup, ({ respond }) => {
-      return respond(200, { recorded: false });
-    });
+    context.mocks.api(
+      acquisitionAttributionContract.recordSignup,
+      ({ respond }) => {
+        return respond(200, { recorded: false });
+      },
+    );
 
     await context.store.set(recordSignupAttribution$, context.signal);
 

--- a/turbo/apps/platform/src/signals/bootstrap/ad-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/ad-attribution.ts
@@ -3,7 +3,7 @@ import {
   SOURCE_TYPES,
   type AdAttributionMetadata,
   type SourceType,
-} from "@okouai/api-contracts/contracts/zero-attribution";
+} from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { command } from "ccstate";
 import { registerPostHogAttribution } from "../../lib/posthog.ts";
 import { sessionStorageSignals } from "../external/session-storage.ts";

--- a/turbo/apps/platform/src/signals/bootstrap/paid-funnel-telemetry.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/paid-funnel-telemetry.ts
@@ -4,7 +4,7 @@
 // Ads bids on (`Onboarding Start`, `Checkout Start`) fire from the same call
 // sites as their PostHog counterparts.
 
-import type { AdAttributionMetadata } from "@okouai/api-contracts/contracts/zero-attribution";
+import type { AdAttributionMetadata } from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { command } from "ccstate";
 import { capturePaidOnboardingEvent } from "../../lib/posthog.ts";
 import {

--- a/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
@@ -1,8 +1,8 @@
 import { command } from "ccstate";
 import {
-  zeroAttributionContract,
+  acquisitionAttributionContract,
   type AdAttributionMetadata,
-} from "@okouai/api-contracts/contracts/zero-attribution";
+} from "@okouai/api-contracts/contracts/acquisition-attribution";
 
 import { accept } from "../../lib/accept.ts";
 import { capturePaidOnboardingEvent } from "../../lib/posthog.ts";
@@ -76,7 +76,7 @@ export const recordSignupAttribution$ = command(
 
     if (!recorded) {
       const createClient = get(zeroClient$);
-      const client = createClient(zeroAttributionContract);
+      const client = createClient(acquisitionAttributionContract);
       const result = await accept(
         client.recordSignup({
           body: { attribution },

--- a/turbo/packages/api-contracts/src/contracts/acquisition-attribution.ts
+++ b/turbo/packages/api-contracts/src/contracts/acquisition-attribution.ts
@@ -64,7 +64,7 @@ const recordSignupAttributionResponseSchema = z.object({
   recorded: z.boolean(),
 });
 
-export const zeroAttributionContract = c.router({
+export const acquisitionAttributionContract = c.router({
   recordSignup: {
     method: "POST",
     path: "/api/okou/attribution/signup",
@@ -87,4 +87,5 @@ export type RecordSignupAttributionRequest = z.infer<
 export type RecordSignupAttributionResponse = z.infer<
   typeof recordSignupAttributionResponseSchema
 >;
-export type ZeroAttributionContract = typeof zeroAttributionContract;
+export type AcquisitionAttributionContract =
+  typeof acquisitionAttributionContract;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1243,12 +1243,12 @@ export {
 } from "./github-oauth";
 export {
   adAttributionMetadataSchema,
-  zeroAttributionContract,
+  acquisitionAttributionContract,
   type AdAttributionMetadata,
   type RecordSignupAttributionRequest,
   type RecordSignupAttributionResponse,
-  type ZeroAttributionContract,
-} from "./zero-attribution";
+  type AcquisitionAttributionContract,
+} from "./acquisition-attribution";
 export {
   zeroBillingStatusContract,
   zeroBillingCheckoutContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-billing.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
-import { adAttributionMetadataSchema } from "./zero-attribution";
+import { adAttributionMetadataSchema } from "./acquisition-attribution";
 
 const c = initContract();
 

--- a/turbo/packages/db/scripts/migrations/011-backfill-acquisition-attribution/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/011-backfill-acquisition-attribution/backfill.ts
@@ -23,7 +23,7 @@ import {
 import {
   adAttributionMetadataSchema,
   type AdAttributionMetadata,
-} from "@okouai/api-contracts/contracts/zero-attribution";
+} from "@okouai/api-contracts/contracts/acquisition-attribution";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";


### PR DESCRIPTION
Parent: #26873

## Summary

- rename the acquisition attribution contract, API route, and route test modules to the approved domain-neutral names
- rename the contract and route exports and update every API, Platform, billing, contract, and historical backfill caller
- preserve the canonical endpoint, compatibility test label, persisted identifiers, first-touch behavior, billing fallback, and telemetry without aliases or API changes

## Verification

- `pnpm exec prettier --write <touched files>` (Prettier 3.8.1)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/acquisition-attribution.test.ts` (3 passed)
- `pnpm -F @okouai/app exec vitest run src/signals/__tests__/signup-attribution-conversion.test.ts` (5 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/billing-usage-media.bdd.test.ts -t "chains empty usage records, rankings, and attribution through visible APIs"` (1 passed)
- `pnpm -F @okouai/db exec vitest run scripts/migrations/011-backfill-acquisition-attribution/backfill.test.ts` (10 passed)
- lint and type-check scripts for `api`, `@okouai/app`, `@okouai/api-contracts`, and `@okouai/db`
- `pnpm knip --workspace api --workspace @okouai/app --workspace @okouai/api-contracts --workspace @okouai/db`
- mechanical-rename equivalence audit across all 15 changed files and zero-result old path/symbol search

## Baseline observation

- the individually filtered Billing Checkout attribution test fails on both this branch and a clean `origin/main` worktree before its attribution assertion because the existing Stripe `vi.fn()` arrow mock is not constructible under Vitest 4.1.10; this PR does not modify that mock or Checkout behavior

Closes #27124
