### PR TITLE
refactor(strapi): neutralize source shell naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -134,8 +134,8 @@ import { zeroBrowserRoutes } from "./routes/zero-browser";
 import { zeroBrowserAuthorizationRoutes } from "./routes/zero-browser-authorization";
 import { zeroWorkflowsRoutes } from "./routes/zero-workflows";
 import { zeroWorkflowAutomationsRoutes } from "./routes/zero-workflow-automations";
-import { zeroStrapiIntegrationsRoutes } from "./routes/zero-strapi-integrations";
-import { zeroStrapiEventsRoutes } from "./routes/zero-strapi-events";
+import { strapiIntegrationsRoutes } from "./routes/strapi-integrations";
+import { strapiEventsRoutes } from "./routes/strapi-events";
 import { integrationsGithubRoutes } from "./routes/integrations-github";
 import { zeroIntegrationsAgentPhoneRoutes } from "./routes/zero-integrations-agentphone";
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "./routes/zero-integrations-phone-download-file";
@@ -211,7 +211,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...webhooksGoogleWorkspaceEventsRoutes,
   ...webhooksNotionRoutes,
   ...webhooksWorkflowAutomationsRoutes,
-  ...zeroStrapiEventsRoutes,
+  ...strapiEventsRoutes,
   ...webhooksStripeRoutes,
   ...webhooksStripeAutomationEventsRoutes,
   ...webhooksAgentHealthUsageTelemetryRoutes,
@@ -335,7 +335,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroUserModelPreferenceRoutes,
   ...zeroWorkflowsRoutes,
   ...zeroWorkflowAutomationsRoutes,
-  ...zeroStrapiIntegrationsRoutes,
+  ...strapiIntegrationsRoutes,
   ...integrationsGithubRoutes,
   ...zeroSlackConnectRoutes,
   ...zeroSlackOauthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/strapi-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/strapi-integration.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { testWorkflowAutomationExecutionContract } from "@okouai/api-contracts/contracts/test-workflow-automation-execution";
-import { zeroStrapiIntegrationsContract } from "@okouai/api-contracts/contracts/zero-strapi-integrations";
+import { strapiIntegrationsContract } from "@okouai/api-contracts/contracts/strapi-integrations";
 import { zeroWorkflowAutomationsContract } from "@okouai/api-contracts/contracts/zero-workflows";
 import { fnv1a } from "@okouai/core/identity-hash";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -19,14 +19,14 @@ import {
 } from "./helpers/chat-event";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
-import { zeroStrapiIntegrationsRoutes } from "../zero-strapi-integrations";
-import { zeroStrapiEventsRoutes } from "../zero-strapi-events";
+import { strapiIntegrationsRoutes } from "../strapi-integrations";
+import { strapiEventsRoutes } from "../strapi-events";
 import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...testWorkflowAutomationExecutionRoutes,
-  ...zeroStrapiEventsRoutes,
-  ...zeroStrapiIntegrationsRoutes,
+  ...strapiEventsRoutes,
+  ...strapiIntegrationsRoutes,
   ...zeroWorkflowAutomationsRoutes,
 ]);
 
@@ -109,8 +109,8 @@ function authHeaders() {
 }
 
 function integrationsClient() {
-  return setupApp({ context, routes: zeroStrapiIntegrationsRoutes })(
-    zeroStrapiIntegrationsContract,
+  return setupApp({ context, routes: strapiIntegrationsRoutes })(
+    strapiIntegrationsContract,
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/strapi-events.ts
+++ b/turbo/apps/api/src/signals/routes/strapi-events.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 
-import { zeroStrapiEventsContract } from "@okouai/api-contracts/contracts/zero-strapi-integrations";
+import { strapiEventsContract } from "@okouai/api-contracts/contracts/strapi-integrations";
 import { command } from "ccstate";
 
 import { request$ } from "../context/hono";
@@ -24,7 +24,7 @@ function errorResponse(message: string, status: 400 | 401 | 403 | 404 | 413) {
 
 const post$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<Response> => {
-    const params = get(pathParamsOf(zeroStrapiEventsContract.post));
+    const params = get(pathParamsOf(strapiEventsContract.post));
     const request = get(request$);
     const contentLength = Number.parseInt(
       request.raw.headers.get("content-length") ?? "0",
@@ -72,6 +72,6 @@ const post$ = command(
   },
 );
 
-export const zeroStrapiEventsRoutes: readonly RouteEntry[] = [
-  { route: zeroStrapiEventsContract.post, handler: post$ },
+export const strapiEventsRoutes: readonly RouteEntry[] = [
+  { route: strapiEventsContract.post, handler: post$ },
 ];

--- a/turbo/apps/api/src/signals/routes/strapi-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/strapi-integrations.ts
@@ -1,6 +1,6 @@
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { zeroStrapiIntegrationsContract } from "@okouai/api-contracts/contracts/zero-strapi-integrations";
+import { strapiIntegrationsContract } from "@okouai/api-contracts/contracts/strapi-integrations";
 import { command, computed } from "ccstate";
 
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
@@ -75,9 +75,7 @@ const create$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (auth.orgRole !== "admin") {
     return adminRequired();
   }
-  const bodyResult = await get(
-    bodyResultOf(zeroStrapiIntegrationsContract.create),
-  );
+  const bodyResult = await get(bodyResultOf(strapiIntegrationsContract.create));
   signal.throwIfAborted();
   if (!bodyResult.ok) {
     return bodyResult.response;
@@ -109,7 +107,7 @@ const revealSecret$ = computed(async (get) => {
   if (auth.orgRole !== "admin") {
     return adminRequired();
   }
-  const params = get(pathParamsOf(zeroStrapiIntegrationsContract.revealSecret));
+  const params = get(pathParamsOf(strapiIntegrationsContract.revealSecret));
   const secret = await revealStrapiIntegrationSecret(get(db$), {
     orgId: auth.orgId,
     integrationId: params.integrationId,
@@ -127,7 +125,7 @@ const checkTest$ = computed(async (get) => {
   if (auth.orgRole !== "admin") {
     return adminRequired();
   }
-  const params = get(pathParamsOf(zeroStrapiIntegrationsContract.checkTest));
+  const params = get(pathParamsOf(strapiIntegrationsContract.checkTest));
   const result = await checkStrapiIntegrationTest(get(db$), {
     orgId: auth.orgId,
     integrationId: params.integrationId,
@@ -145,7 +143,7 @@ const remove$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (auth.orgRole !== "admin") {
     return adminRequired();
   }
-  const params = get(pathParamsOf(zeroStrapiIntegrationsContract.remove));
+  const params = get(pathParamsOf(strapiIntegrationsContract.remove));
   const result = await removeStrapiIntegration({
     db: set(writeDb$),
     orgId: auth.orgId,
@@ -164,10 +162,7 @@ const remove$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 const handlers: Readonly<
-  Record<
-    keyof typeof zeroStrapiIntegrationsContract,
-    SignalRouteHandler<unknown>
-  >
+  Record<keyof typeof strapiIntegrationsContract, SignalRouteHandler<unknown>>
 > = {
   list: authRoute(strapiIntegrationAuth, list$),
   create: authRoute(strapiIntegrationAuth, create$),
@@ -176,16 +171,16 @@ const handlers: Readonly<
   remove: authRoute(strapiIntegrationAuth, remove$),
 };
 
-export const zeroStrapiIntegrationsRoutes: readonly RouteEntry[] = [
-  { route: zeroStrapiIntegrationsContract.list, handler: handlers.list },
-  { route: zeroStrapiIntegrationsContract.create, handler: handlers.create },
+export const strapiIntegrationsRoutes: readonly RouteEntry[] = [
+  { route: strapiIntegrationsContract.list, handler: handlers.list },
+  { route: strapiIntegrationsContract.create, handler: handlers.create },
   {
-    route: zeroStrapiIntegrationsContract.revealSecret,
+    route: strapiIntegrationsContract.revealSecret,
     handler: handlers.revealSecret,
   },
   {
-    route: zeroStrapiIntegrationsContract.checkTest,
+    route: strapiIntegrationsContract.checkTest,
     handler: handlers.checkTest,
   },
-  { route: zeroStrapiIntegrationsContract.remove, handler: handlers.remove },
+  { route: strapiIntegrationsContract.remove, handler: handlers.remove },
 ];

--- a/turbo/apps/api/src/signals/services/strapi-integration.service.ts
+++ b/turbo/apps/api/src/signals/services/strapi-integration.service.ts
@@ -3,7 +3,7 @@ import { createHash, randomBytes } from "node:crypto";
 import type {
   StrapiIntegration,
   StrapiIntegrationSecret,
-} from "@okouai/api-contracts/contracts/zero-strapi-integrations";
+} from "@okouai/api-contracts/contracts/strapi-integrations";
 import {
   strapiIntegrations,
   strapiWorkflowAutomations,

--- a/turbo/apps/platform/src/signals/zero-page/strapi-settings-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/strapi-settings-page.ts
@@ -2,7 +2,7 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { command } from "ccstate";
 import { createElement } from "react";
 
-import { ZeroStrapiSettingsPage } from "../../views/zero-page/strapi-settings-page.tsx";
+import { StrapiSettingsPage } from "../../views/zero-page/strapi-settings-page.tsx";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
@@ -10,7 +10,7 @@ import { detachedNavigateTo$ } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
-import { resetStrapiSettings$ } from "./zero-strapi.ts";
+import { resetStrapiSettings$ } from "./strapi.ts";
 import { i18n } from "../../i18n/index.ts";
 
 export const setupStrapiSettingsPage$ = command(
@@ -23,7 +23,7 @@ export const setupStrapiSettingsPage$ = command(
       return;
     }
     set(resetStrapiSettings$);
-    set(updatePage$, createElement(ZeroStrapiSettingsPage), "sidebar");
+    set(updatePage$, createElement(StrapiSettingsPage), "sidebar");
     set(
       updateDocumentTitle$,
       i18n.t(($) => {

--- a/turbo/apps/platform/src/signals/zero-page/strapi.ts
+++ b/turbo/apps/platform/src/signals/zero-page/strapi.ts
@@ -1,9 +1,9 @@
 import { command, computed, state } from "ccstate";
 import {
-  zeroStrapiIntegrationsContract,
+  strapiIntegrationsContract,
   type StrapiIntegration,
   type StrapiIntegrationSecret,
-} from "@okouai/api-contracts/contracts/zero-strapi-integrations";
+} from "@okouai/api-contracts/contracts/strapi-integrations";
 import { toast } from "@okouai/ui/components/ui/sonner";
 
 import { i18n } from "../../i18n/index.ts";
@@ -20,7 +20,7 @@ const revealedSecret$ = state<
 export const strapiIntegrations$ = computed(
   async (get): Promise<readonly StrapiIntegration[]> => {
     get(reload$);
-    const client = get(zeroClient$)(zeroStrapiIntegrationsContract);
+    const client = get(zeroClient$)(strapiIntegrationsContract);
     const result = await accept(client.list(), [200]);
     return result.body;
   },
@@ -48,7 +48,7 @@ export const updateStrapiIntegrationForm$ = command(
 export const createStrapiIntegration$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const form = get(strapiIntegrationForm$);
-    const client = get(zeroClient$)(zeroStrapiIntegrationsContract);
+    const client = get(zeroClient$)(strapiIntegrationsContract);
     const result = await accept(
       client.create({ body: form, fetchOptions: { signal } }),
       [201],
@@ -75,7 +75,7 @@ export const createStrapiIntegration$ = command(
 
 export const revealStrapiIntegrationSecret$ = command(
   async ({ get, set }, integrationId: string, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroStrapiIntegrationsContract);
+    const client = get(zeroClient$)(strapiIntegrationsContract);
     const result = await accept(
       client.revealSecret({
         params: { integrationId },
@@ -91,7 +91,7 @@ export const revealStrapiIntegrationSecret$ = command(
 
 export const checkStrapiIntegrationTest$ = command(
   async ({ get, set }, integrationId: string, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroStrapiIntegrationsContract);
+    const client = get(zeroClient$)(strapiIntegrationsContract);
     const result = await accept(
       client.checkTest({
         params: { integrationId },
@@ -122,7 +122,7 @@ export const checkStrapiIntegrationTest$ = command(
 
 export const removeStrapiIntegration$ = command(
   async ({ get, set }, integrationId: string, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroStrapiIntegrationsContract);
+    const client = get(zeroClient$)(strapiIntegrationsContract);
     await accept(
       client.remove({
         params: { integrationId },

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -18,7 +18,7 @@ import {
 } from "@okouai/api-contracts/contracts/zero-workflows";
 import { zeroAgentsByIdContract } from "@okouai/api-contracts/contracts/zero-agents";
 import { integrationsGithubContract } from "@okouai/api-contracts/contracts/integrations-github";
-import { zeroStrapiIntegrationsContract } from "@okouai/api-contracts/contracts/zero-strapi-integrations";
+import { strapiIntegrationsContract } from "@okouai/api-contracts/contracts/strapi-integrations";
 import type { TeamComposeItem } from "@okouai/api-contracts/contracts/zero-team";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
@@ -3312,7 +3312,7 @@ describe("workflow detail page", () => {
     mockCreateWorkflowAutomation((body) => {
       createBodies.push(body);
     });
-    context.mocks.api(zeroStrapiIntegrationsContract.list, ({ respond }) => {
+    context.mocks.api(strapiIntegrationsContract.list, ({ respond }) => {
       return respond(200, [
         {
           id: integrationId,

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -4,7 +4,7 @@
 import type { FormEvent, ReactNode } from "react";
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import type { StrapiIntegration } from "@okouai/api-contracts/contracts/zero-strapi-integrations";
+import type { StrapiIntegration } from "@okouai/api-contracts/contracts/strapi-integrations";
 import type {
   ChatRunFinishedEventConfig,
   ChatRunFinishedRunStatus,
@@ -210,7 +210,7 @@ import {
 import { detach, Reason } from "../../signals/utils.ts";
 import { writeToClipboard } from "../../signals/zero-page/clipboard.ts";
 import { orgPlanCapabilities$ } from "../../signals/zero-page/org-plan-capabilities.ts";
-import { strapiIntegrations$ } from "../../signals/zero-page/zero-strapi.ts";
+import { strapiIntegrations$ } from "../../signals/zero-page/strapi.ts";
 import {
   githubIntegrationData$,
   type GithubIntegrationData,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -11,7 +11,7 @@ import {
   zeroFeishuConnectContract,
   type FeishuConnectStatus,
 } from "@okouai/api-contracts/contracts/zero-feishu-connect";
-import { zeroStrapiIntegrationsContract } from "@okouai/api-contracts/contracts/zero-strapi-integrations";
+import { strapiIntegrationsContract } from "@okouai/api-contracts/contracts/strapi-integrations";
 import { integrationsGithubContract } from "@okouai/api-contracts/contracts/integrations-github";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
@@ -566,7 +566,7 @@ describe("works page", () => {
   it("checks whether Strapi delivered its external test webhook", async () => {
     const integrationId = "00000000-0000-4000-8000-000000000091";
     let tested = false;
-    context.mocks.api(zeroStrapiIntegrationsContract.list, ({ respond }) => {
+    context.mocks.api(strapiIntegrationsContract.list, ({ respond }) => {
       return respond(200, [
         {
           id: integrationId,
@@ -580,16 +580,13 @@ describe("works page", () => {
         },
       ]);
     });
-    context.mocks.api(
-      zeroStrapiIntegrationsContract.checkTest,
-      ({ respond }) => {
-        tested = true;
-        return respond(200, {
-          received: true,
-          lastTestedAt: "2026-07-28T04:00:00.000Z",
-        });
-      },
-    );
+    context.mocks.api(strapiIntegrationsContract.checkTest, ({ respond }) => {
+      tested = true;
+      return respond(200, {
+        received: true,
+        lastTestedAt: "2026-07-28T04:00:00.000Z",
+      });
+    });
 
     detachedSetupPage({
       context,
@@ -612,7 +609,7 @@ describe("works page", () => {
   it("localizes Strapi settings in Portuguese while preserving integration data", async () => {
     const integrationId = "00000000-0000-4000-8000-000000000092";
     context.mocks.data.userPreferences({ locale: "pt-BR" });
-    context.mocks.api(zeroStrapiIntegrationsContract.list, ({ respond }) => {
+    context.mocks.api(strapiIntegrationsContract.list, ({ respond }) => {
       return respond(200, [
         {
           id: integrationId,
@@ -626,15 +623,12 @@ describe("works page", () => {
         },
       ]);
     });
-    context.mocks.api(
-      zeroStrapiIntegrationsContract.checkTest,
-      ({ respond }) => {
-        return respond(200, {
-          received: true,
-          lastTestedAt: "2026-07-28T04:00:00.000Z",
-        });
-      },
-    );
+    context.mocks.api(strapiIntegrationsContract.checkTest, ({ respond }) => {
+      return respond(200, {
+        received: true,
+        lastTestedAt: "2026-07-28T04:00:00.000Z",
+      });
+    });
 
     detachedSetupPage({
       context,

--- a/turbo/apps/platform/src/views/zero-page/strapi-settings-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/strapi-settings-page.tsx
@@ -1,6 +1,6 @@
 import type { FormEvent } from "react";
 
-import type { StrapiIntegration } from "@okouai/api-contracts/contracts/zero-strapi-integrations";
+import type { StrapiIntegration } from "@okouai/api-contracts/contracts/strapi-integrations";
 import {
   ArrowLeft,
   CircleCheck,
@@ -43,7 +43,7 @@ import {
   strapiIntegrations$,
   strapiRevealedSecret$,
   updateStrapiIntegrationForm$,
-} from "../../signals/zero-page/zero-strapi.ts";
+} from "../../signals/zero-page/strapi.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 
@@ -394,7 +394,7 @@ function StrapiIntegrationForm() {
   );
 }
 
-export function ZeroStrapiSettingsPage() {
+export function StrapiSettingsPage() {
   const { t } = useTranslation();
   const integrationsLoadable = useLastLoadable(strapiIntegrations$);
   const adminLoadable = useLastLoadable(isOrgAdmin$);

--- a/turbo/packages/api-contracts/src/contracts/strapi-integrations.ts
+++ b/turbo/packages/api-contracts/src/contracts/strapi-integrations.ts
@@ -27,7 +27,7 @@ export type StrapiIntegrationSecret = z.infer<
 
 const integrationIdParams = z.object({ integrationId: z.string().uuid() });
 
-export const zeroStrapiIntegrationsContract = c.router({
+export const strapiIntegrationsContract = c.router({
   list: {
     method: "GET",
     path: "/api/okou/integrations/strapi",
@@ -106,7 +106,7 @@ export const zeroStrapiIntegrationsContract = c.router({
   },
 });
 
-export const zeroStrapiEventsContract = c.router({
+export const strapiEventsContract = c.router({
   post: {
     method: "POST",
     path: "/api/okou/strapi/events/:integrationId",
@@ -132,6 +132,5 @@ export const zeroStrapiEventsContract = c.router({
   },
 });
 
-export type ZeroStrapiIntegrationsContract =
-  typeof zeroStrapiIntegrationsContract;
-export type ZeroStrapiEventsContract = typeof zeroStrapiEventsContract;
+export type StrapiIntegrationsContract = typeof strapiIntegrationsContract;
+export type StrapiEventsContract = typeof strapiEventsContract;


### PR DESCRIPTION
## Summary

- rename the internal Strapi contracts, API route modules and arrays, focused API test, Platform signal, and settings component to neutral source-shell names
- update every direct API, service, route-registry, Platform, workflow-detail, works-page, and test caller atomically without compatibility aliases
- preserve public API routes, schemas, behavior, persisted identifiers, global legacy API compatibility, and user-visible Zero copy

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/strapi-integration.test.ts` (3 tests)
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/zero-works-page.test.tsx` (25 tests)
- `TZ=UTC pnpm --filter @okouai/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx` (63 tests)
- full-repository TypeScript/TSX and path scans for `zero-strapi`, `zeroStrapi`, and `ZeroStrapi` (zero matches)

Closes #27118
