### PR TITLE
fix(runner): canonicalize credential endpoint hostnames

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -221,13 +221,6 @@ def _get_https_context() -> ssl.SSLContext:
     return context
 
 
-def _normalized_host(host: str) -> str:
-    try:
-        return ipaddress.ip_address(host).compressed
-    except ValueError:
-        return host.encode("idna").decode("ascii")
-
-
 def _format_authority(host: str, port: int, *, include_port: bool) -> str:
     rendered_host = f"[{host}]" if ":" in host else host
     return f"{rendered_host}:{port}" if include_port else rendered_host
@@ -261,7 +254,8 @@ def _proxy_plan(
     configured_proxy = urllib.request.getproxies().get(scheme)
     if not configured_proxy:
         return None
-    proxy_url = configured_proxy if "://" in configured_proxy else f"http://{configured_proxy}"
+    normalized_proxy = platform_api.normalize_proxy_url(configured_proxy)
+    proxy_url = normalized_proxy if "://" in normalized_proxy else f"http://{normalized_proxy}"
     parsed = urllib.parse.urlsplit(proxy_url)
     if parsed.scheme.lower() != "http":
         raise ValueError("Firewall auth supports only HTTP environment proxies")
@@ -270,7 +264,7 @@ def _proxy_plan(
     if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
         raise ValueError("Invalid firewall auth HTTP proxy URL")
     return (
-        _normalized_host(parsed.hostname),
+        parsed.hostname,
         _parsed_port(parsed, _DEFAULT_HTTP_PORT, subject="firewall auth HTTP proxy"),
         _proxy_authorization(parsed),
     )
@@ -285,7 +279,7 @@ def _build_connection_plan(req: urllib.request.Request) -> _ConnectionPlan:
         raise ValueError("Platform API URL must not contain user information")
 
     default_port = _DEFAULT_HTTPS_PORT if scheme == "https" else _DEFAULT_HTTP_PORT
-    origin_host = _normalized_host(parsed.hostname)
+    origin_host = parsed.hostname
     origin_port = _parsed_port(parsed, default_port, subject="platform API")
     origin_authority = _format_authority(
         origin_host,

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -248,13 +248,12 @@ def _proxy_plan(
     scheme: str,
     origin_authority: str,
 ) -> tuple[str, int, str | None] | None:
-    if urllib.request.proxy_bypass(origin_authority):
-        return None
-
     configured_proxy = urllib.request.getproxies().get(scheme)
     if not configured_proxy:
         return None
     normalized_proxy = platform_api.normalize_proxy_url(configured_proxy)
+    if urllib.request.proxy_bypass(origin_authority):
+        return None
     proxy_url = normalized_proxy if "://" in normalized_proxy else f"http://{normalized_proxy}"
     parsed = urllib.parse.urlsplit(proxy_url)
     if parsed.scheme.lower() != "http":

--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -7,6 +7,9 @@ import uuid
 
 from mitmproxy import ctx, http
 
+from authority_utils import authority_has_empty_port, format_url_host
+from url_utils import normalize_trusted_hostname
+
 # Vercel bypass secret (still from environment as it's a secret)
 VERCEL_BYPASS = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
 _VERCEL_BYPASS_HEADER = "x-vercel-protection-bypass"
@@ -33,9 +36,73 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
         return None
 
 
+def _parsed_port(parsed_url: urllib.parse.SplitResult, *, subject: str) -> int | None:
+    if authority_has_empty_port(parsed_url.netloc):
+        raise ValueError(f"{subject} has an invalid port")
+    try:
+        return parsed_url.port
+    except ValueError as exc:
+        raise ValueError(f"{subject} has an invalid port") from exc
+
+
+def _canonical_platform_url(url: str) -> str:
+    parsed_url = urllib.parse.urlsplit(url)
+    scheme = parsed_url.scheme.lower()
+    if scheme not in {"http", "https"} or not parsed_url.netloc or parsed_url.hostname is None:
+        raise ValueError("Platform API URL must be an absolute http(s) URL")
+    if parsed_url.username is not None or parsed_url.password is not None:
+        raise ValueError("Platform API URL must not contain user information")
+
+    port = _parsed_port(parsed_url, subject="Platform API URL")
+    authority = format_url_host(normalize_trusted_hostname(parsed_url.hostname))
+    if port is not None:
+        authority = f"{authority}:{port}"
+    return urllib.parse.urlunsplit(
+        (scheme, authority, parsed_url.path, parsed_url.query, parsed_url.fragment)
+    )
+
+
+def normalize_proxy_url(proxy_url: str) -> str:
+    """Canonicalize the hostname in a URL or authority-form proxy setting."""
+    has_scheme = "://" in proxy_url
+    has_authority_prefix = proxy_url.startswith("//")
+    parsed_url = urllib.parse.urlsplit(
+        proxy_url if has_scheme or has_authority_prefix else f"//{proxy_url}"
+    )
+    if not parsed_url.netloc or parsed_url.hostname is None:
+        raise ValueError("Proxy URL must include a host")
+
+    port = _parsed_port(parsed_url, subject="Proxy URL")
+    authority = format_url_host(normalize_trusted_hostname(parsed_url.hostname))
+    if port is not None:
+        authority = f"{authority}:{port}"
+    userinfo, separator, _host = parsed_url.netloc.rpartition("@")
+    if separator:
+        authority = f"{userinfo}@{authority}"
+
+    normalized_url = urllib.parse.urlunsplit(
+        (parsed_url.scheme, authority, parsed_url.path, parsed_url.query, parsed_url.fragment)
+    )
+    if has_scheme or has_authority_prefix:
+        return normalized_url
+    return normalized_url.removeprefix("//")
+
+
+class _CanonicalProxyHandler(urllib.request.ProxyHandler):
+    """Apply vm0 hostname identity policy to the proxy selected by urllib."""
+
+    def proxy_open(
+        self,
+        req: urllib.request.Request,
+        proxy: str,
+        request_type: str,
+    ) -> object | None:
+        return super().proxy_open(req, normalize_proxy_url(proxy), request_type)
+
+
 def build_api_opener() -> urllib.request.OpenerDirector:
     """Build an opener that returns redirects as HTTP errors."""
-    return urllib.request.build_opener(_NoRedirect)
+    return urllib.request.build_opener(_CanonicalProxyHandler(), _NoRedirect)
 
 
 def configure_client_headers(*, client_session_id: str, client_version: str) -> None:
@@ -64,16 +131,14 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
     redirects, using :func:`build_api_opener` or an equivalent transport policy,
     before contacting another URL.
     """
-    parsed_url = urllib.parse.urlsplit(url)
-    if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
-        raise ValueError("Platform API URL must be an absolute http(s) URL")
+    canonical_url = _canonical_platform_url(url)
     client_session_id, client_version = _CLIENT_HEADERS
 
     # S310 (suspicious-url-open-usage): callers build `url` from the
     # operator-configured platform API URL, and the scheme is validated above
     # before urllib can consume the request.
     req = urllib.request.Request(  # noqa: S310
-        url,
+        canonical_url,
         data=data,
         headers={
             "Content-Type": "application/json",

--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -45,8 +45,19 @@ def _parsed_port(parsed_url: urllib.parse.SplitResult, *, subject: str) -> int |
         raise ValueError(f"{subject} has an invalid port") from exc
 
 
+def _split_url_without_value_diagnostics(
+    value: str,
+    *,
+    subject: str,
+) -> urllib.parse.SplitResult:
+    try:
+        return urllib.parse.urlsplit(value)
+    except ValueError:
+        raise ValueError(f"{subject} is invalid") from None
+
+
 def _canonical_platform_url(url: str) -> str:
-    parsed_url = urllib.parse.urlsplit(url)
+    parsed_url = _split_url_without_value_diagnostics(url, subject="Platform API URL")
     scheme = parsed_url.scheme.lower()
     if scheme not in {"http", "https"} or not parsed_url.netloc or parsed_url.hostname is None:
         raise ValueError("Platform API URL must be an absolute http(s) URL")
@@ -66,8 +77,9 @@ def normalize_proxy_url(proxy_url: str) -> str:
     """Canonicalize the hostname in a URL or authority-form proxy setting."""
     has_scheme = "://" in proxy_url
     has_authority_prefix = proxy_url.startswith("//")
-    parsed_url = urllib.parse.urlsplit(
-        proxy_url if has_scheme or has_authority_prefix else f"//{proxy_url}"
+    parsed_url = _split_url_without_value_diagnostics(
+        proxy_url if has_scheme or has_authority_prefix else f"//{proxy_url}",
+        subject="Proxy URL",
     )
     if not parsed_url.netloc or parsed_url.hostname is None:
         raise ValueError("Proxy URL must include a host")

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -1613,8 +1613,8 @@ class TestFirewallAuthAsyncTransport:
             "HTTP_PROXY": "",
             "all_proxy": "",
             "ALL_PROXY": "",
-            "no_proxy": "",
-            "NO_PROXY": "",
+            "no_proxy": "platform.example",
+            "NO_PROXY": "platform.example",
         }
         with (
             patch.dict(os.environ, proxy_environment),

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -1562,12 +1562,15 @@ class TestFirewallAuthAsyncTransport:
     ):
         proxy = FakeAuthEndpoint()
         proxy.queue_json_response(firewall_auth_success_response({}))
+        resolver = _OrderedResolver(
+            expected_host="xn--fa-hia.proxy",
+            addresses=("127.0.0.1",),
+        )
 
         with proxy.run():
             proxy_url = proxy.api_url.replace(
-                "http://",
-                "http://proxy-user:proxy-password@",
-                1,
+                "127.0.0.1",
+                "proxy-user:proxy-password@faß.proxy",
             )
             proxy_environment = {
                 "http_proxy": proxy_url,
@@ -1579,6 +1582,7 @@ class TestFirewallAuthAsyncTransport:
             }
             with (
                 patch.dict(os.environ, proxy_environment),
+                patch.object(auth_client, "_dns_resolver", resolver),
                 mitm_ctx(api_url="http://platform.example:8123"),
                 patch.object(platform_api, "VERCEL_BYPASS", ""),
             ):
@@ -1595,6 +1599,32 @@ class TestFirewallAuthAsyncTransport:
         assert proxy.requests[0].headers["host"] == "platform.example:8123"
         assert proxy.requests[0].headers["proxy-authorization"] == expected_proxy_authorization
         assert proxy.requests[0].headers["authorization"] == "Bearer tok-xyz"
+
+    async def test_environment_proxy_rejects_unsafe_hostname_before_dns(self, mitm_ctx):
+        resolved_hosts: list[str] = []
+
+        class RecordingResolver:
+            async def lookup_ip(self, host: str) -> list[str]:
+                resolved_hosts.append(host)
+                return []
+
+        proxy_environment = {
+            "http_proxy": "http://proxy-user:proxy-password@\uff26\uff2f\uff2f.proxy:8123",
+            "HTTP_PROXY": "",
+            "all_proxy": "",
+            "ALL_PROXY": "",
+            "no_proxy": "",
+            "NO_PROXY": "",
+        }
+        with (
+            patch.dict(os.environ, proxy_environment),
+            patch.object(auth_client, "_dns_resolver", RecordingResolver()),
+            mitm_ctx(api_url="http://platform.example:8123"),
+            pytest.raises(UnicodeError, match="unsafe IDNA compatibility mapping"),
+        ):
+            await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        assert resolved_hosts == []
 
     async def test_no_proxy_bypasses_environment_proxy(self, mitm_ctx):
         origin = FakeAuthEndpoint()

--- a/crates/runner/mitm-addon/tests/test_platform_api.py
+++ b/crates/runner/mitm-addon/tests/test_platform_api.py
@@ -120,6 +120,16 @@ class TestMakeApiRequest:
         with pytest.raises(ValueError, match=message):
             platform_api.make_api_request(url, b"{}", "tok-xyz")
 
+    def test_malformed_platform_authority_does_not_expose_credentials(self):
+        password = "sensitive-platform-password"
+        url = f"https://platform-user:{password}@api\uff1avm0.ai/base"
+
+        with pytest.raises(ValueError, match="Platform API URL is invalid") as exc_info:
+            platform_api.make_api_request(url, b"{}", "tok-xyz")
+
+        assert password not in str(exc_info.value)
+        assert url not in str(exc_info.value)
+
     @pytest.mark.parametrize(
         "url",
         [

--- a/crates/runner/mitm-addon/tests/test_platform_api.py
+++ b/crates/runner/mitm-addon/tests/test_platform_api.py
@@ -56,6 +56,71 @@ class TestMakeApiRequest:
         assert unredirected_headers["x-vercel-protection-bypass"] == "secret-bypass-value"
 
     @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            pytest.param(
+                "https://faß.de.:443/base?event=1#batch",
+                "https://xn--fa-hia.de:443/base?event=1#batch",
+                id="unicode",
+            ),
+            pytest.param(
+                "https://xn--fa-hia.de/base",
+                "https://xn--fa-hia.de/base",
+                id="alabel",
+            ),
+            pytest.param(
+                "https://api。vm0.ai/base",
+                "https://api.vm0.ai/base",
+                id="idna-dot",
+            ),
+            pytest.param(
+                "http://192.0.2.10:8080/base",
+                "http://192.0.2.10:8080/base",
+                id="ipv4",
+            ),
+            pytest.param(
+                "https://[2001:0DB8:0:0:0:0:0:1]:8443/base",
+                "https://[2001:db8::1]:8443/base",
+                id="ipv6",
+            ),
+        ],
+    )
+    def test_canonicalizes_platform_hostname_identity(self, url: str, expected: str):
+        req = platform_api.make_api_request(url, b"{}", "tok-xyz")
+
+        assert req.full_url == expected
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            pytest.param(
+                "https://\uff26\uff2f\uff2f.vm0.ai/base",
+                id="unsafe-compatibility-alias",
+            ),
+            pytest.param("http://127.1/base", id="noncanonical-ipv4"),
+        ],
+    )
+    def test_rejects_noncanonical_platform_hostname_identity(self, url: str):
+        with pytest.raises(UnicodeError):
+            platform_api.make_api_request(url, b"{}", "tok-xyz")
+
+    @pytest.mark.parametrize(
+        ("url", "message"),
+        [
+            pytest.param(
+                "https://user:secret@api.vm0.ai/base",
+                "user information",
+                id="userinfo",
+            ),
+            pytest.param("https://api.vm0.ai:/base", "invalid port", id="empty-port"),
+            pytest.param("https://api.vm0.ai:65536/base", "invalid port", id="port-range"),
+        ],
+    )
+    def test_rejects_invalid_platform_authority(self, url: str, message: str):
+        with pytest.raises(ValueError, match=message):
+            platform_api.make_api_request(url, b"{}", "tok-xyz")
+
+    @pytest.mark.parametrize(
         "url",
         [
             pytest.param("file:///etc/passwd", id="file"),

--- a/crates/runner/mitm-addon/tests/test_webhook_delivery_admission.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_delivery_admission.py
@@ -1,6 +1,5 @@
 """Tests for usage webhook delivery admission and accounting."""
 
-import contextlib
 import json
 import time
 import urllib.request
@@ -102,8 +101,7 @@ def test_enqueue_sanitizes_sensitive_webhook_url_in_message(tmp_path, sync_usage
     with patch.object(
         urllib.request.OpenerDirector,
         "open",
-        return_value=contextlib.nullcontext(),
-    ):
+    ) as mock_open:
         assert usage.webhook.enqueue_webhook_delivery(
             SENSITIVE_WEBHOOK_URL,
             "tok",
@@ -111,6 +109,10 @@ def test_enqueue_sanitizes_sensitive_webhook_url_in_message(tmp_path, sync_usage
             str(proxy_log),
             "usage_event",
         )
+        with pytest.raises(ValueError, match="user information"):
+            sync_usage_executor.shutdown(wait=True)
+
+    mock_open.assert_not_called()
 
     assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
     assert_current_pending(

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -249,6 +249,38 @@ def test_environment_proxy_uses_canonical_hostname_and_credentials(
     assert request.header("authorization") == "Bearer tok"
 
 
+def test_environment_proxy_respects_no_proxy(
+    tmp_path,
+    sync_usage_executor,
+    usage_webhook_server,
+):
+    proxy_environment = {
+        "http_proxy": "http://proxy-user:proxy-password@127.0.0.1:1",
+        "HTTP_PROXY": "",
+        "all_proxy": "",
+        "ALL_PROXY": "",
+        "no_proxy": "127.0.0.1",
+        "NO_PROXY": "127.0.0.1",
+    }
+    with (
+        patch.dict(os.environ, proxy_environment),
+        patch.object(usage.webhook, "_opener", platform_api.build_api_opener()),
+    ):
+        assert usage.webhook.enqueue_webhook_delivery(
+            usage_webhook_server.url("/usage"),
+            "tok",
+            {"runId": "run-1", "events": []},
+            str(tmp_path / "proxy.jsonl"),
+            "usage_event",
+        )
+        sync_usage_executor.shutdown(wait=True)
+
+    assert usage_webhook_server.request_count == 1
+    request = usage_webhook_server.requests[0]
+    assert request.path == "/usage"
+    assert request.header("proxy-authorization") is None
+
+
 def test_environment_proxy_rejects_unsafe_hostname_before_dns(
     tmp_path,
     sync_usage_executor,
@@ -276,6 +308,38 @@ def test_environment_proxy_rejects_unsafe_hostname_before_dns(
         with pytest.raises(UnicodeError, match="unsafe IDNA compatibility mapping"):
             sync_usage_executor.shutdown(wait=True)
 
+    mock_getaddrinfo.assert_not_called()
+
+
+def test_malformed_environment_proxy_does_not_expose_credentials_before_dns(
+    tmp_path,
+    sync_usage_executor,
+):
+    password = "sensitive-proxy-password"
+    proxy_environment = {
+        "http_proxy": f"http://proxy-user:{password}@proxy\uff1ahost:8123",
+        "HTTP_PROXY": "",
+        "all_proxy": "",
+        "ALL_PROXY": "",
+        "no_proxy": "",
+        "NO_PROXY": "",
+    }
+    with (
+        patch.dict(os.environ, proxy_environment),
+        patch.object(socket, "getaddrinfo") as mock_getaddrinfo,
+        patch.object(usage.webhook, "_opener", platform_api.build_api_opener()),
+    ):
+        assert usage.webhook.enqueue_webhook_delivery(
+            "http://platform.example:8123/usage",
+            "tok",
+            {"runId": "run-1", "events": []},
+            str(tmp_path / "proxy.jsonl"),
+            "usage_event",
+        )
+        with pytest.raises(ValueError, match="Proxy URL is invalid") as exc_info:
+            sync_usage_executor.shutdown(wait=True)
+
+    assert password not in str(exc_info.value)
     mock_getaddrinfo.assert_not_called()
 
 

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -1,6 +1,9 @@
 """Tests for usage webhook HTTP delivery behavior."""
 
+import base64
 import json
+import os
+import socket
 import time
 import urllib.error
 import urllib.request
@@ -21,7 +24,6 @@ from tests.jsonl_log_helpers import (
 from tests.pending_helpers import assert_current_pending
 from tests.webhook_test_helpers import (
     SANITIZED_WEBHOOK_URL,
-    SENSITIVE_WEBHOOK_URL,
     assert_body_free_webhook_entry,
     assert_client_headers,
     assert_sensitive_webhook_url_parts_absent,
@@ -191,6 +193,90 @@ def test_succeeds_on_first_attempt(tmp_path, real_flow, sync_usage_executor, usa
             event_count=1,
             payload_bytes=None if "enqueued" in entry["message"] else payload_bytes,
         )
+
+
+def test_environment_proxy_uses_canonical_hostname_and_credentials(
+    tmp_path,
+    sync_usage_executor,
+    usage_webhook_server,
+):
+    resolved_hosts: list[str] = []
+    real_getaddrinfo = socket.getaddrinfo
+
+    def resolve_proxy(
+        host: str,
+        port: int,
+        family: int = 0,
+        socket_type: int = 0,
+        proto: int = 0,
+        flags: int = 0,
+    ):
+        resolved_hosts.append(host)
+        return real_getaddrinfo("127.0.0.1", port, family, socket_type, proto, flags)
+
+    proxy_port = usage_webhook_server.api_url.rsplit(":", maxsplit=1)[1]
+    proxy_environment = {
+        "http_proxy": f"http://proxy-user:proxy-password@faß.proxy:{proxy_port}",
+        "HTTP_PROXY": "",
+        "all_proxy": "",
+        "ALL_PROXY": "",
+        "no_proxy": "",
+        "NO_PROXY": "",
+    }
+    payload = {"runId": "run-1", "events": []}
+    with (
+        patch.dict(os.environ, proxy_environment),
+        patch.object(socket, "getaddrinfo", side_effect=resolve_proxy),
+        patch.object(usage.webhook, "_opener", platform_api.build_api_opener()),
+    ):
+        assert usage.webhook.enqueue_webhook_delivery(
+            "http://platform.example:8123/usage",
+            "tok",
+            payload,
+            str(tmp_path / "proxy.jsonl"),
+            "usage_event",
+        )
+        sync_usage_executor.shutdown(wait=True)
+
+    expected_proxy_authorization = "Basic " + base64.b64encode(b"proxy-user:proxy-password").decode(
+        "ascii"
+    )
+    assert resolved_hosts == ["xn--fa-hia.proxy"]
+    assert usage_webhook_server.request_count == 1
+    request = usage_webhook_server.requests[0]
+    assert request.path == "http://platform.example:8123/usage"
+    assert request.header("proxy-authorization") == expected_proxy_authorization
+    assert request.header("authorization") == "Bearer tok"
+
+
+def test_environment_proxy_rejects_unsafe_hostname_before_dns(
+    tmp_path,
+    sync_usage_executor,
+):
+    proxy_environment = {
+        "http_proxy": "http://proxy-user:proxy-password@\uff26\uff2f\uff2f.proxy:8123",
+        "HTTP_PROXY": "",
+        "all_proxy": "",
+        "ALL_PROXY": "",
+        "no_proxy": "",
+        "NO_PROXY": "",
+    }
+    with (
+        patch.dict(os.environ, proxy_environment),
+        patch.object(socket, "getaddrinfo") as mock_getaddrinfo,
+        patch.object(usage.webhook, "_opener", platform_api.build_api_opener()),
+    ):
+        assert usage.webhook.enqueue_webhook_delivery(
+            "http://platform.example:8123/usage",
+            "tok",
+            {"runId": "run-1", "events": []},
+            str(tmp_path / "proxy.jsonl"),
+            "usage_event",
+        )
+        with pytest.raises(UnicodeError, match="unsafe IDNA compatibility mapping"):
+            sync_usage_executor.shutdown(wait=True)
+
+    mock_getaddrinfo.assert_not_called()
 
 
 def test_adds_vercel_bypass_header(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
@@ -406,17 +492,16 @@ def test_retry_failure_sanitizes_sensitive_webhook_url_in_message_and_error(
     proxy_log = tmp_path / "proxy.jsonl"
     payload = {"runId": "run-1", "events": []}
     payload_bytes = len(json.dumps(payload).encode())
-    url_without_fragment = SENSITIVE_WEBHOOK_URL.removesuffix("#frag")
+    retry_url = "https://api.vm0.ai/api/webhooks/agent/usage-event?token=secret#frag"
+    url_without_fragment = retry_url.removesuffix("#frag")
 
     with patch.object(
         urllib.request.OpenerDirector,
         "open",
-        side_effect=urllib.error.URLError(
-            f"failed {SENSITIVE_WEBHOOK_URL} and {url_without_fragment}"
-        ),
+        side_effect=urllib.error.URLError(f"failed {retry_url} and {url_without_fragment}"),
     ):
         assert usage.webhook.enqueue_webhook_delivery(
-            SENSITIVE_WEBHOOK_URL,
+            retry_url,
             "tok",
             payload,
             str(proxy_log),

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -290,8 +290,8 @@ def test_environment_proxy_rejects_unsafe_hostname_before_dns(
         "HTTP_PROXY": "",
         "all_proxy": "",
         "ALL_PROXY": "",
-        "no_proxy": "",
-        "NO_PROXY": "",
+        "no_proxy": "platform.example",
+        "NO_PROXY": "platform.example",
     }
     with (
         patch.dict(os.environ, proxy_environment),

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -279,7 +279,7 @@ pub(crate) fn validate_concurrency_factor(value: f64) -> RunnerResult<()> {
 /// The URL is later copied into guest-visible config and log-adjacent paths,
 /// so reject components that can carry credentials or other sensitive values.
 pub(crate) fn normalize_api_base_url(value: &str) -> RunnerResult<String> {
-    let parsed = url::Url::parse(value)
+    let mut parsed = url::Url::parse(value)
         .map_err(|_| RunnerError::Config("server.url must be an absolute http(s) URL".into()))?;
 
     if !matches!(parsed.scheme(), "http" | "https") {
@@ -304,6 +304,24 @@ pub(crate) fn normalize_api_base_url(value: &str) -> RunnerResult<String> {
         return Err(RunnerError::Config(
             "server.url must not include a fragment".into(),
         ));
+    }
+
+    let raw_authority = crate::firewall_hostname_policy::raw_url_authority(value)
+        .ok_or_else(|| RunnerError::Config("server.url must include a host".into()))?;
+    crate::firewall_hostname_policy::validate_raw_url_host(
+        crate::firewall_hostname_policy::raw_host_from_authority(raw_authority),
+        "server.url",
+    )
+    .map_err(RunnerError::Config)?;
+
+    let host_without_trailing_dot = parsed
+        .host_str()
+        .and_then(|host| host.strip_suffix('.'))
+        .map(str::to_owned);
+    if let Some(host) = host_without_trailing_dot {
+        parsed
+            .set_host(Some(&host))
+            .map_err(|_| RunnerError::Config("server.url has an invalid host".into()))?;
     }
 
     Ok(parsed.as_str().trim_end_matches('/').to_string())

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -189,11 +189,22 @@ fn normalize_api_base_url_accepts_http_https_and_preserves_path_prefix() {
         ("https://api.example.com", "https://api.example.com"),
         ("https://api.example.com/", "https://api.example.com"),
         ("http://localhost:3000/api/", "http://localhost:3000/api"),
+        ("https://faß.de/base", "https://xn--fa-hia.de/base"),
+        ("https://xn--fa-hia.de/base", "https://xn--fa-hia.de/base"),
+        (
+            "https://api。example.com.:8443/base/",
+            "https://api.example.com:8443/base",
+        ),
+        ("http://192.0.2.10:8080/base", "http://192.0.2.10:8080/base"),
         (
             "https://api.example.com/prefix/v1",
             "https://api.example.com/prefix/v1",
         ),
         ("http://[::1]:8080/base/", "http://[::1]:8080/base"),
+        (
+            "https://[2001:0db8:0:0:0:0:0:1]:8443/base",
+            "https://[2001:db8::1]:8443/base",
+        ),
     ];
 
     for (input, expected) in cases {
@@ -211,6 +222,11 @@ fn normalize_api_base_url_rejects_sensitive_or_non_base_components() {
         ("ftp://api.example.com", "http or https"),
         ("https://", "absolute http(s) URL"),
         ("api.example.com", "absolute http(s) URL"),
+        (
+            "https://ＦＯＯ.example.com",
+            "unsafe IDNA compatibility mappings",
+        ),
+        ("http://127.1", "canonical IPv4"),
     ];
 
     for (input, expected) in cases {

--- a/crates/runner/src/firewall_hostname_policy.rs
+++ b/crates/runner/src/firewall_hostname_policy.rs
@@ -1,8 +1,9 @@
-//! Raw hostname checks for the shared firewall base URL contract.
+//! Raw hostname checks for the shared credential endpoint identity contract.
 //!
 //! URL parsers intentionally canonicalize legacy IPv4 and IDNA spellings. The
-//! firewall contract rejects spellings that hide authority identity, so these
-//! checks run before `url::Url` can discard the original representation.
+//! shared firewall contract pins the behavior that rejects spellings hiding
+//! authority identity, so these checks run while callers still own the original
+//! representation.
 
 use unicode_normalization::UnicodeNormalization;
 
@@ -95,34 +96,54 @@ const UNICODE_17_ASSIGNMENT_RANGES: [(u32, u32); 47] = [
     (0x323b0, 0x33479),
 ];
 
-pub(crate) fn validate_base_host_for_cache(raw_host: &str) -> Result<(), String> {
+pub(crate) fn raw_url_authority(value: &str) -> Option<&str> {
+    let rest = value.split_once("://").map(|(_, rest)| rest)?;
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    Some(&rest[..authority_end])
+}
+
+pub(crate) fn raw_host_from_authority(authority: &str) -> &str {
+    let without_userinfo = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if without_userinfo.starts_with('[') {
+        return without_userinfo
+            .find(']')
+            .map_or(without_userinfo, |end| &without_userinfo[..=end]);
+    }
+    without_userinfo
+        .rsplit_once(':')
+        .map_or(without_userinfo, |(host, _)| host)
+}
+
+pub(crate) fn validate_raw_url_host(raw_host: &str, subject: &str) -> Result<(), String> {
     if raw_host.starts_with('[') && raw_host.ends_with(']') {
         return Ok(());
     }
     if raw_host.is_empty() {
-        return Err("base URL must include a host".to_string());
+        return Err(format!("{subject} must include a host"));
     }
 
-    validate_percent_encoding(raw_host)?;
+    validate_percent_encoding(raw_host, subject)?;
     let decoded_host = percent_decode(raw_host)
-        .ok_or_else(|| "base URL host has invalid percent encoding".to_string())?;
+        .ok_or_else(|| format!("{subject} host has invalid percent encoding"))?;
     let normalized_host = translate_idna_dots(&decoded_host);
     let host = normalized_host
         .strip_suffix('.')
         .unwrap_or(&normalized_host);
     if host.is_empty() || host.ends_with('.') || host.split('.').any(str::is_empty) {
-        return Err("base URL host labels must be non-empty".to_string());
+        return Err(format!("{subject} host labels must be non-empty"));
     }
     if host
         .chars()
         .any(|ch| matches!(ch, '*' | ',' | '<' | '>' | '[' | ']' | '^' | '|'))
     {
-        return Err("base URL host contains forbidden syntax".to_string());
+        return Err(format!("{subject} host contains forbidden syntax"));
     }
 
-    validate_canonical_ipv4(&decoded_host, host)?;
+    validate_canonical_ipv4(&decoded_host, host, subject)?;
     for label in host.split('.') {
-        validate_hostname_policy_label(label)?;
+        validate_hostname_policy_label(label, subject)?;
     }
     Ok(())
 }
@@ -142,12 +163,18 @@ pub(crate) fn is_ipv4_literal_like(host: &str) -> bool {
         })
 }
 
-fn validate_canonical_ipv4(raw_host: &str, normalized_host: &str) -> Result<(), String> {
+fn validate_canonical_ipv4(
+    raw_host: &str,
+    normalized_host: &str,
+    subject: &str,
+) -> Result<(), String> {
     let raw_host = raw_host.strip_suffix('.').unwrap_or(raw_host);
     if is_ipv4_literal_like(normalized_host)
         && (raw_host != normalized_host || !is_canonical_ipv4(normalized_host))
     {
-        return Err("base URL host must use canonical IPv4 address syntax".to_string());
+        return Err(format!(
+            "{subject} host must use canonical IPv4 address syntax"
+        ));
     }
     Ok(())
 }
@@ -165,7 +192,7 @@ fn is_canonical_ipv4(host: &str) -> bool {
         })
 }
 
-fn validate_percent_encoding(host: &str) -> Result<(), String> {
+fn validate_percent_encoding(host: &str, subject: &str) -> Result<(), String> {
     let bytes = host.as_bytes();
     let mut index = 0;
     while let Some(&byte) = bytes.get(index) {
@@ -185,12 +212,12 @@ fn validate_percent_encoding(host: &str) -> Result<(), String> {
                     .and_then(|byte| hex_value(*byte))
                     .is_none()
             {
-                return Err("base URL host has invalid percent encoding".to_string());
+                return Err(format!("{subject} host has invalid percent encoding"));
             }
             index += 3;
         }
         let decoded = percent_decode(&host[start..index])
-            .ok_or_else(|| "base URL host has invalid percent encoding".to_string())?;
+            .ok_or_else(|| format!("{subject} host has invalid percent encoding"))?;
         if decoded.chars().any(|ch| {
             ch <= '\u{20}'
                 || ch == '\u{7f}'
@@ -201,18 +228,22 @@ fn validate_percent_encoding(host: &str) -> Result<(), String> {
                 || ch == '.'
                 || IDNA_DOT_EQUIVALENTS.contains(&ch)
         }) {
-            return Err("base URL host contains encoded authority syntax".to_string());
+            return Err(format!("{subject} host contains encoded authority syntax"));
         }
     }
     Ok(())
 }
 
-fn validate_hostname_policy_label(label: &str) -> Result<(), String> {
+fn validate_hostname_policy_label(label: &str, subject: &str) -> Result<(), String> {
     if label.chars().any(has_unsafe_uts46_mapping) {
-        return Err("base URL host contains unsafe IDNA compatibility mappings".to_string());
+        return Err(format!(
+            "{subject} host contains unsafe IDNA compatibility mappings"
+        ));
     }
     if label.chars().any(is_post_policy_assignment) || alabel_uses_post_policy_assignment(label) {
-        return Err("base URL host exceeds the supported Unicode policy".to_string());
+        return Err(format!(
+            "{subject} host exceeds the supported Unicode policy"
+        ));
     }
     if !label.is_ascii() {
         let normalized: String = label
@@ -222,7 +253,9 @@ fn validate_hostname_policy_label(label: &str) -> Result<(), String> {
             .flat_map(char::to_lowercase)
             .collect();
         if normalized.is_ascii() {
-            return Err("base URL host contains unsafe IDNA compatibility mappings".to_string());
+            return Err(format!(
+                "{subject} host contains unsafe IDNA compatibility mappings"
+            ));
         }
     }
     Ok(())

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -6,6 +6,7 @@ use sandbox::SandboxId;
 use serde::{Deserialize, Serialize};
 use unicode_normalization::UnicodeNormalization;
 
+use crate::firewall_hostname_policy::{raw_host_from_authority, raw_url_authority};
 use crate::ids::RunId;
 use crate::storage_manifest::StorageManifest;
 
@@ -590,9 +591,10 @@ fn validate_firewall_base_for_cache(base: &str) -> Result<(), String> {
     if raw_authority_has_empty_port(raw_syntax_target) {
         return Err("base URL authority must not include an empty port".to_string());
     }
-    crate::firewall_hostname_policy::validate_base_host_for_cache(raw_host_from_authority(
-        authority,
-    ))?;
+    crate::firewall_hostname_policy::validate_raw_url_host(
+        raw_host_from_authority(authority),
+        "base URL",
+    )?;
 
     let scheme = parsed.scheme();
     if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
@@ -836,7 +838,7 @@ fn validate_parameterized_firewall_base_authority(
     materialized_host: &str,
     port_suffix: &str,
 ) -> Result<(), String> {
-    crate::firewall_hostname_policy::validate_base_host_for_cache(materialized_host)?;
+    crate::firewall_hostname_policy::validate_raw_url_host(materialized_host, "base URL")?;
     let syntax_target = format!("{scheme}://{materialized_host}{port_suffix}");
     let parsed = url::Url::parse(&syntax_target)
         .map_err(|_| "parameterized base URL authority is invalid".to_string())?;
@@ -1211,26 +1213,6 @@ fn raw_authority_has_empty_port(value: &str) -> bool {
         return false;
     };
     authority.ends_with(':')
-}
-
-fn raw_url_authority(value: &str) -> Option<&str> {
-    let rest = value.split_once("://").map(|(_, rest)| rest)?;
-    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
-    Some(&rest[..authority_end])
-}
-
-fn raw_host_from_authority(authority: &str) -> &str {
-    let without_userinfo = authority
-        .rsplit_once('@')
-        .map_or(authority, |(_, host)| host);
-    if without_userinfo.starts_with('[') {
-        return without_userinfo
-            .find(']')
-            .map_or(without_userinfo, |end| &without_userinfo[..=end]);
-    }
-    without_userinfo
-        .rsplit_once(':')
-        .map_or(without_userinfo, |(host, _)| host)
 }
 
 fn raw_url_path(value: &str) -> &str {


### PR DESCRIPTION
## Summary

- validate raw runner `server.url` hostnames with the existing shared hostname policy before the
  original spelling is discarded
- canonicalize platform request and selected environment-proxy hostnames before credentials, DNS,
  HTTP authority construction, or TLS SNI
- route urllib usage delivery through a canonicalizing proxy handler while preserving proxy
  discovery, `NO_PROXY`, credentials, and redirect rejection
- keep malformed platform and proxy URL diagnostics free of credential-bearing input values
- cover Unicode/A-label equivalence, IDNA dots, unsafe compatibility aliases, canonical IP
  literals, ports, proxy credentials, bypass behavior, and fail-before-I/O behavior

## Scope

This reuses the existing `vm0-uts46-16.0-v1` Rust and Python policy implementations. It does not add
a new normalization algorithm or dependency, and it does not change backend APIs, queue payloads,
persisted state, or database schema.

## Validation

Python addon:

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5415 passed)

Runner:

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner` (3121 passed, 20 ignored; guest inventory passed)

Closes #27115
