### PR TITLE
feat(app): seed new chats from the member default video model

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-create.test.ts
@@ -29,6 +29,8 @@ const api = createRunsApi(context);
 const WORKSPACE_DEFAULT_MODEL = "claude-sonnet-5";
 const OTHER_WORKSPACE_MODEL = "claude-opus-4-8";
 const PRIORITY_MODEL = "gpt-5.6-sol";
+const EXPLICIT_VIDEO_MODEL = "fal-ai/veo3.1/fast";
+const INHERITED_VIDEO_MODEL = "MiniMax-H3";
 
 interface AgentFixture {
   readonly userId: string;
@@ -119,6 +121,23 @@ function metadataClient() {
   );
 }
 
+async function readCreatedThreadEvent(threadId: string, token: string) {
+  const response = await accept(
+    threadsClient().events({
+      headers: { authorization: `Bearer ${token}` },
+      query: {},
+    }),
+    [200],
+  );
+  const event = response.body.events.find((candidate) => {
+    return candidate.kind === "created" && candidate.chatThreadId === threadId;
+  });
+  if (!event) {
+    throw new Error(`Created event not found for thread ${threadId}`);
+  }
+  return event;
+}
+
 describe("POST /api/zero/chat-threads", () => {
   it("creates a titled thread with ZERO_TOKEN chat-thread:write capability", async () => {
     const fixture = await seedAgent();
@@ -135,6 +154,7 @@ describe("POST /api/zero/chat-threads", () => {
           agentId: fixture.agentId,
           title: "Deep dive on P2",
           model: OTHER_WORKSPACE_MODEL,
+          videoModel: EXPLICIT_VIDEO_MODEL,
         },
       }),
       [201],
@@ -159,6 +179,9 @@ describe("POST /api/zero/chat-threads", () => {
       selectedModel: OTHER_WORKSPACE_MODEL,
       serviceTier: null,
     });
+    await expect(
+      readCreatedThreadEvent(response.body.id, token),
+    ).resolves.toMatchObject({ selectedVideoModel: EXPLICIT_VIDEO_MODEL });
   });
 
   it("inherits the model of the run that owns the token when model is omitted", async () => {
@@ -199,6 +222,60 @@ describe("POST /api/zero/chat-threads", () => {
     );
     expect(metadataResponse.body.selectedModel).toBe(OTHER_WORKSPACE_MODEL);
     expect(metadataResponse.body.serviceTier).toBeNull();
+  });
+
+  it("inherits the video model from the run's chat thread when omitted", async () => {
+    const fixture = await seedAgent();
+    const sourceToken = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+    });
+    const source = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${sourceToken}` },
+        body: {
+          agentId: fixture.agentId,
+          title: "Video model source",
+          model: OTHER_WORKSPACE_MODEL,
+          videoModel: INHERITED_VIDEO_MODEL,
+        },
+      }),
+      [201],
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId: fixture.agentId,
+        triggerSource: "web",
+        chatThreadId: source.body.id,
+        selectedModel: OTHER_WORKSPACE_MODEL,
+      },
+      context.signal,
+    );
+    const inheritedToken = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+      runId,
+    });
+
+    const inherited = await accept(
+      threadsClient().create({
+        headers: { authorization: `Bearer ${inheritedToken}` },
+        body: {
+          agentId: fixture.agentId,
+          title: "Inherited video model",
+        },
+      }),
+      [201],
+    );
+
+    await expect(
+      readCreatedThreadEvent(inherited.body.id, inheritedToken),
+    ).resolves.toMatchObject({ selectedVideoModel: INHERITED_VIDEO_MODEL });
   });
 
   it("inherits priority from the run's chat thread and allows an explicit standard override", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-create.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-create.ts
@@ -34,8 +34,9 @@ function modelFirstSelection(selectedModel: string) {
 }
 
 /**
- * Model and priority a caller inherits when it omits them. The model belongs to
- * the run that owns its token; priority belongs to that run's chat thread.
+ * Model, priority, and video model a caller inherits when it omits them. The
+ * model belongs to the run that owns its token; the other settings belong to
+ * that run's chat thread.
  */
 async function inheritedRunChatSettings(
   db: Db,
@@ -43,15 +44,21 @@ async function inheritedRunChatSettings(
 ): Promise<{
   readonly selectedModel: string | null;
   readonly codexServiceTier: CodexServiceTier | null;
+  readonly selectedVideoModel: string | null;
 }> {
   if (!runId) {
-    return { selectedModel: null, codexServiceTier: null };
+    return {
+      selectedModel: null,
+      codexServiceTier: null,
+      selectedVideoModel: null,
+    };
   }
 
   const [run] = await db
     .select({
       selectedModel: zeroRuns.selectedModel,
       codexServiceTier: chatThreads.codexServiceTier,
+      selectedVideoModel: chatThreads.selectedVideoModel,
     })
     .from(zeroRuns)
     .leftJoin(chatThreads, eq(zeroRuns.chatThreadId, chatThreads.id))
@@ -60,6 +67,7 @@ async function inheritedRunChatSettings(
   return {
     selectedModel: run?.selectedModel ?? null,
     codexServiceTier: run?.codexServiceTier ?? null,
+    selectedVideoModel: run?.selectedVideoModel ?? null,
   };
 }
 
@@ -99,6 +107,8 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       : body.data.serviceTier === "priority"
         ? "fast"
         : null;
+  const selectedVideoModel =
+    body.data.videoModel ?? inherited.selectedVideoModel;
 
   const pin = await resolveModelSelectionPin({
     db: writeDb,
@@ -133,6 +143,7 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       eventId: body.data.eventId,
       ...chatThreadModelPinColumns(pin),
       codexServiceTier,
+      selectedVideoModel,
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -637,6 +637,7 @@ export const createChatThread$ = command(
       readonly modelProviderCredentialScope: ModelProviderCredentialScope | null;
       readonly selectedModel: string | null;
       readonly codexServiceTier: CodexServiceTier | null;
+      readonly selectedVideoModel: string | null;
     },
     signal: AbortSignal,
   ): Promise<{ id: string; createdAt: Date }> => {
@@ -657,6 +658,7 @@ export const createChatThread$ = command(
           modelProviderCredentialScope: args.modelProviderCredentialScope,
           selectedModel: args.selectedModel,
           codexServiceTier: args.codexServiceTier,
+          selectedVideoModel: args.selectedVideoModel,
         })
         .returning({ id: chatThreads.id, createdAt: chatThreads.createdAt });
       if (!createdThread) {
@@ -674,6 +676,7 @@ export const createChatThread$ = command(
         serviceTier: chatThreadServiceTierFromCodex(args.codexServiceTier),
         computerUseHostId: null,
         cloudBrowserEnabled: false,
+        selectedVideoModel: args.selectedVideoModel,
         createdAt: createdThread.createdAt,
       });
       return createdThread;

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -1,6 +1,10 @@
 import { command, computed } from "ccstate";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
+  DEFAULT_VIDEO_MODEL,
+  type VideoModel,
+} from "@okouai/core/video-model-catalog";
+import {
   chatThreadModelSelectionContract,
   chatThreadsContract,
   type GenerationTemplateRequest,
@@ -77,6 +81,7 @@ interface SendNewThreadMessageRequest {
   editorDocument?: EditorDocumentSnapshot;
   computerUseHostId?: string | null;
   cloudBrowserEnabled?: boolean;
+  videoModel?: VideoModel;
   routeSearchParams?: URLSearchParams;
   forward?: ChatForwardContext;
   onOptimisticSend?: () => void;
@@ -320,6 +325,7 @@ const mintOptimisticThreadWithEvent$ = command(
       readonly serviceTier: "priority" | null;
       readonly computerUseHostId: string | null;
       readonly cloudBrowserEnabled: boolean;
+      readonly selectedVideoModel: VideoModel | null;
     },
     signal: AbortSignal,
   ): void => {
@@ -339,7 +345,7 @@ const mintOptimisticThreadWithEvent$ = command(
       serviceTier: args.serviceTier,
       computerUseHostId: args.computerUseHostId,
       cloudBrowserEnabled: args.cloudBrowserEnabled,
-      selectedVideoModel: null,
+      selectedVideoModel: args.selectedVideoModel,
       createdAt,
     } satisfies OptimisticChatThreadEvent);
   },
@@ -353,6 +359,7 @@ async function createChatThread(
     readonly clientThreadId: string;
     readonly eventId: string;
     readonly modelSelection: ModelProviderSelection;
+    readonly videoModel?: VideoModel;
   },
   signal: AbortSignal,
 ): Promise<void> {
@@ -366,6 +373,7 @@ async function createChatThread(
         model: args.modelSelection.selectedModel,
         serviceTier:
           args.modelSelection.codexServiceTier === "fast" ? "priority" : null,
+        ...(args.videoModel ? { videoModel: args.videoModel } : {}),
         ...(args.title ? { title: args.title } : {}),
       },
       fetchOptions: { signal },
@@ -417,6 +425,7 @@ const startNewChatThreadCreate$ = command(
     if (!modelSelection) {
       throw new Error("A model selection is required");
     }
+    const videoModel = userPreference.selectedVideoModel ?? DEFAULT_VIDEO_MODEL;
     await set(
       mintOptimisticThreadWithEvent$,
       {
@@ -428,6 +437,7 @@ const startNewChatThreadCreate$ = command(
           modelSelection.codexServiceTier === "fast" ? "priority" : null,
         computerUseHostId: null,
         cloudBrowserEnabled: false,
+        selectedVideoModel: videoModel,
       },
       signal,
     );
@@ -443,6 +453,7 @@ const startNewChatThreadCreate$ = command(
           clientThreadId: threadId,
           eventId,
           modelSelection,
+          videoModel,
         },
         signal,
       );
@@ -546,6 +557,7 @@ const sendNewThreadMessage$ = command(
             : null,
         computerUseHostId: computerUseHostId ?? null,
         cloudBrowserEnabled: cloudBrowserEnabled ?? false,
+        selectedVideoModel: request.videoModel ?? null,
       },
       signal,
     );
@@ -565,6 +577,7 @@ const sendNewThreadMessage$ = command(
           clientThreadId: threadId,
           eventId: chatThreadEventId,
           modelSelection: resolvedModelSelection,
+          videoModel: request.videoModel,
         },
         signal,
       );

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -42,6 +42,7 @@ import { userModelPreference$ } from "../external/user-model-preference.ts";
 import {
   featureSwitch$,
   imageRecognitionAvailable$,
+  videoModelSelectionEnabled$,
 } from "../external/feature-switch.ts";
 import { logger } from "../log.ts";
 import {
@@ -425,7 +426,10 @@ const startNewChatThreadCreate$ = command(
     if (!modelSelection) {
       throw new Error("A model selection is required");
     }
-    const videoModel = userPreference.selectedVideoModel ?? DEFAULT_VIDEO_MODEL;
+    const videoModel =
+      (featureSwitches[FeatureSwitchKey.VideoModelSelection] ?? false)
+        ? (userPreference.selectedVideoModel ?? DEFAULT_VIDEO_MODEL)
+        : undefined;
     await set(
       mintOptimisticThreadWithEvent$,
       {
@@ -437,7 +441,7 @@ const startNewChatThreadCreate$ = command(
           modelSelection.codexServiceTier === "fast" ? "priority" : null,
         computerUseHostId: null,
         cloudBrowserEnabled: false,
-        selectedVideoModel: videoModel,
+        selectedVideoModel: videoModel ?? null,
       },
       signal,
     );
@@ -520,6 +524,9 @@ const sendNewThreadMessage$ = command(
       return null;
     }
     const features = get(featureSwitch$);
+    const videoModel = get(videoModelSelectionEnabled$)
+      ? request.videoModel
+      : undefined;
     const userMessage = userMessageForNewThread(request, prepared);
     const annotatedUserMessage = withSelectedModelAnnotation(
       userMessage,
@@ -557,7 +564,7 @@ const sendNewThreadMessage$ = command(
             : null,
         computerUseHostId: computerUseHostId ?? null,
         cloudBrowserEnabled: cloudBrowserEnabled ?? false,
-        selectedVideoModel: request.videoModel ?? null,
+        selectedVideoModel: videoModel ?? null,
       },
       signal,
     );
@@ -577,7 +584,7 @@ const sendNewThreadMessage$ = command(
           clientThreadId: threadId,
           eventId: chatThreadEventId,
           modelSelection: resolvedModelSelection,
-          videoModel: request.videoModel,
+          videoModel,
         },
         signal,
       );

--- a/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
@@ -1,6 +1,10 @@
 import { command, computed, state } from "ccstate";
 import { isSupportedRunModel } from "@okouai/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import {
+  DEFAULT_VIDEO_MODEL,
+  type VideoModel,
+} from "@okouai/core/video-model-catalog";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { currentAgentId$ } from "../agent.ts";
 import {
@@ -9,7 +13,10 @@ import {
 } from "../chat-page/optimistic-chat-thread-page.ts";
 import type { ChatForwardContext } from "../chat-page/chat-forward.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
-import { updateUserModelPreference$ } from "../external/user-model-preference.ts";
+import {
+  updateUserModelPreference$,
+  userModelPreference$,
+} from "../external/user-model-preference.ts";
 import {
   createAgentDraftSignals,
   type EnsuredAgentDraft,
@@ -26,9 +33,12 @@ import type { ChatEvent } from "../chat-page/chat-event-types.ts";
 import {
   chatPageModelSelection$,
   chatPageSelectedModelOauthAvailable$,
+  chatPageVideoModelSelection$,
   configureChatPageSelectedModel$,
   resetChatPageModelSelection$,
+  resetChatPageVideoModelSelection$,
   setChatPageModelSelection$,
+  setChatPageVideoModelSelection$,
 } from "./zero-chat-page.ts";
 import {
   newThreadComputerAccess$,
@@ -65,6 +75,27 @@ const setModelSelection$ = command(
         signal,
       );
     }
+  },
+);
+
+const setVideoModel$ = command(
+  async (
+    { get, set },
+    videoModel: VideoModel | null,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    set(setChatPageVideoModelSelection$, videoModel);
+    const userPreference = await get(userModelPreference$);
+    signal.throwIfAborted();
+    await set(
+      updateUserModelPreference$,
+      {
+        selectedModel: userPreference.selectedModel,
+        serviceTier: userPreference.serviceTier,
+        selectedVideoModel: videoModel,
+      },
+      signal,
+    );
   },
 );
 
@@ -121,7 +152,10 @@ function createAgentComposerSignalsWithDraft(
         return false;
       }
       const access = get(newThreadComputerAccess$);
-      const hosts = await get(computerUseHosts$);
+      const [hosts, videoModelSelection] = await Promise.all([
+        get(computerUseHosts$),
+        get(chatPageVideoModelSelection$),
+      ]);
       signal.throwIfAborted();
       const hostId =
         access.kind === "computerUse"
@@ -138,6 +172,7 @@ function createAgentComposerSignalsWithDraft(
           prompt: submission.prompt,
           generationTemplate: submission.generationTemplate,
           editorDocument: submission.editorDocument,
+          videoModel: videoModelSelection ?? DEFAULT_VIDEO_MODEL,
           ...(access.kind === "computerUse"
             ? { computerUseHostId: hostId }
             : {}),
@@ -154,6 +189,7 @@ function createAgentComposerSignalsWithDraft(
       if (sent) {
         set(resetNewThreadComputerAccess$);
         set(resetChatPageModelSelection$);
+        set(resetChatPageVideoModelSelection$);
       }
       return sent;
     },
@@ -171,6 +207,10 @@ function createAgentComposerSignalsWithDraft(
     selectedModelOauthAvailable$: chatPageSelectedModelOauthAvailable$,
     setModelSelection$,
     configureSelectedModel$: configureChatPageSelectedModel$,
+    videoModel: {
+      selectedVideoModel$: chatPageVideoModelSelection$,
+      setVideoModel$,
+    },
     computerUseHostId$,
     cloudBrowserEnabled$,
     setComputerUseHostId$,

--- a/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
@@ -12,7 +12,10 @@ import {
   sendNewThreadWithoutNavigation$,
 } from "../chat-page/optimistic-chat-thread-page.ts";
 import type { ChatForwardContext } from "../chat-page/chat-forward.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
+import {
+  featureSwitch$,
+  videoModelSelectionEnabled$,
+} from "../external/feature-switch.ts";
 import {
   updateUserModelPreference$,
   userModelPreference$,
@@ -84,6 +87,9 @@ const setVideoModel$ = command(
     videoModel: VideoModel | null,
     signal: AbortSignal,
   ): Promise<void> => {
+    if (!get(videoModelSelectionEnabled$)) {
+      return;
+    }
     set(setChatPageVideoModelSelection$, videoModel);
     const userPreference = await get(userModelPreference$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -160,13 +160,11 @@ interface ComposerModelSignals extends ComposerModelUiSignals {
   readonly configureSelectedModel$: Command<Promise<void>, [AbortSignal]>;
 }
 
-/**
- * Video model pinned to the chat thread. Absent on composers that have no
- * thread to pin to yet, which is why every consumer treats the group as
- * optional rather than reading a null selection.
- */
+/** Video model selected for the composer, when that surface supports it. */
 export interface ComposerVideoModelSignals {
-  readonly selectedVideoModel$: Computed<VideoModel | null>;
+  readonly selectedVideoModel$: Computed<
+    VideoModel | null | Promise<VideoModel | null>
+  >;
   readonly setVideoModel$: Command<
     Promise<void>,
     [VideoModel | null, AbortSignal]

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -1,4 +1,8 @@
 import { command, computed, state } from "ccstate";
+import {
+  DEFAULT_VIDEO_MODEL,
+  type VideoModel,
+} from "@okouai/core/video-model-catalog";
 import { getRandomPrompts } from "../../views/zero-page/zero-ideation-data.ts";
 import {
   codexFastModeEnabled$,
@@ -55,6 +59,10 @@ export const suggestedPrompts$ = computed(async (get) => {
 // current model-first default while "user explicitly picked inherit" stays null.
 const internalChatPageUserOverride$ = state<
   { kind: "unset" } | { kind: "set"; value: ModelProviderSelection | null }
+>({ kind: "unset" });
+
+const internalChatPageVideoModelOverride$ = state<
+  { kind: "unset" } | { kind: "set"; value: VideoModel | null }
 >({ kind: "unset" });
 
 export const chatPageModelSelection$ = computed(
@@ -121,8 +129,31 @@ export const setChatPageModelSelection$ = command(
   },
 );
 
+export const chatPageVideoModelSelection$ = computed(
+  async (get): Promise<VideoModel | null> => {
+    const user = get(internalChatPageVideoModelOverride$);
+    if (user.kind === "set") {
+      return user.value;
+    }
+    const userPreference = await get(userModelPreference$);
+    return userPreference.selectedVideoModel ?? DEFAULT_VIDEO_MODEL;
+  },
+);
+
+export const setChatPageVideoModelSelection$ = command(
+  ({ set }, value: VideoModel | null) => {
+    set(internalChatPageVideoModelOverride$, { kind: "set", value });
+  },
+);
+
 export const resetChatPageModelSelection$ = command(({ get, set }) => {
   if (get(internalChatPageUserOverride$).kind === "set") {
     set(internalChatPageUserOverride$, { kind: "unset" });
+  }
+});
+
+export const resetChatPageVideoModelSelection$ = command(({ get, set }) => {
+  if (get(internalChatPageVideoModelOverride$).kind === "set") {
+    set(internalChatPageVideoModelOverride$, { kind: "unset" });
   }
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3337,6 +3337,134 @@ describe("chat composer video model", () => {
     return { bodies };
   }
 
+  it("uses the live member default for an untouched new chat", async () => {
+    const user = userEvent.setup({ delay: null });
+    const initialPreference: UserModelPreferenceResponse = {
+      selectedModel: null,
+      serviceTier: null,
+      selectedVideoModel: "MiniMax-H3",
+      updatedAt: "2026-08-14T00:00:00Z",
+    };
+    let createdVideoModel: string | undefined;
+
+    mockOrgModelRoutes("claude-fable-5");
+    context.mocks.data.userModelPreference(initialPreference);
+    mockAgent();
+    mockChatLifecycle(context, {
+      onThreadCreate: (body) => {
+        createdVideoModel = body.videoModel;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: true },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await user.click(await findComposerModel("Claude Fable 5"));
+    await user.click(await findVideoPanelButton("Manage more models"));
+    await expect(findVideoPanelButton("MiniMax H3")).resolves.toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    context.mocks.data.userModelPreference({
+      ...initialPreference,
+      selectedVideoModel: "fal-ai/veo3.1/fast",
+      updatedAt: "2026-08-14T00:01:00Z",
+    });
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("userPreferenceChanged"),
+      ).toBeTruthy();
+    });
+    act(() => {
+      triggerAblyEvent("userPreferenceChanged", {
+        kinds: ["defaultVideoModel"],
+      });
+    });
+    await expect(findVideoPanelButton("Veo 3.1 fast")).resolves.toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    await user.keyboard("{Escape}");
+    await sendMessageInUI(
+      user,
+      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      "Use my current video default",
+    );
+
+    await waitFor(() => {
+      expect(createdVideoModel).toBe("fal-ai/veo3.1/fast");
+    });
+  });
+
+  it("writes a landing selection to the member default and new thread", async () => {
+    const user = userEvent.setup({ delay: null });
+    const updates: {
+      selectedModel: string | null;
+      serviceTier: ChatThreadServiceTier | null;
+      selectedVideoModel?: string | null;
+    }[] = [];
+    let createdVideoModel: string | undefined;
+
+    mockOrgModelRoutes("claude-fable-5");
+    context.mocks.data.userModelPreference({
+      selectedModel: null,
+      serviceTier: null,
+      selectedVideoModel: "MiniMax-H3",
+      updatedAt: "2026-08-14T00:00:00Z",
+    });
+    context.mocks.api(
+      zeroUserModelPreferenceContract.update,
+      ({ body, respond }) => {
+        updates.push(body);
+        return respond(200, {
+          ...body,
+          updatedAt: "2026-08-14T00:01:00Z",
+        });
+      },
+    );
+    mockAgent();
+    mockChatLifecycle(context, {
+      onThreadCreate: (body) => {
+        createdVideoModel = body.videoModel;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: true },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await user.click(await findComposerModel("Claude Fable 5"));
+    await user.click(await findVideoPanelButton("Manage more models"));
+    await user.click(await findVideoPanelButton("Veo 3.1 fast"));
+
+    await waitFor(() => {
+      expect(updates).toStrictEqual([
+        {
+          selectedModel: null,
+          serviceTier: null,
+          selectedVideoModel: "fal-ai/veo3.1/fast",
+        },
+      ]);
+    });
+
+    await sendMessageInUI(
+      user,
+      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      "Pin my selected video model",
+    );
+
+    await waitFor(() => {
+      expect(createdVideoModel).toBe("fal-ai/veo3.1/fast");
+    });
+  });
+
   it("pins a video model on the thread from the model picker", async () => {
     const user = userEvent.setup({ delay: null });
     const { bodies } = mockVideoModelThread(null);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3418,7 +3418,7 @@ describe("chat composer video model", () => {
       updatedAt: "2026-08-14T00:00:00Z",
     });
     context.mocks.api(
-      zeroUserModelPreferenceContract.update,
+      userModelPreferenceContract.update,
       ({ body, respond }) => {
         updates.push(body);
         return respond(200, {
@@ -3463,6 +3463,54 @@ describe("chat composer video model", () => {
     await waitFor(() => {
       expect(createdVideoModel).toBe("fal-ai/veo3.1/fast");
     });
+  });
+
+  it("leaves new-chat video defaults disabled while the feature switch is off", async () => {
+    const user = userEvent.setup({ delay: null });
+    let preferenceUpdateCount = 0;
+    let createdThreadBody: { readonly videoModel?: string } | undefined;
+
+    mockOrgModelRoutes("claude-fable-5");
+    context.mocks.data.userModelPreference({
+      selectedModel: null,
+      serviceTier: null,
+      selectedVideoModel: "MiniMax-H3",
+      updatedAt: "2026-08-14T00:00:00Z",
+    });
+    context.mocks.api(
+      userModelPreferenceContract.update,
+      ({ body, respond }) => {
+        preferenceUpdateCount += 1;
+        return respond(200, {
+          ...body,
+          updatedAt: "2026-08-14T00:01:00Z",
+        });
+      },
+    );
+    mockAgent();
+    mockChatLifecycle(context, {
+      onThreadCreate: (body) => {
+        createdThreadBody = body;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: false },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await sendMessageInUI(
+      user,
+      (await screen.findByPlaceholderText(PLACEHOLDER)) as HTMLTextAreaElement,
+      "Keep video model defaults disabled",
+    );
+
+    await waitFor(() => {
+      expect(createdThreadBody).toBeDefined();
+    });
+    expect(createdThreadBody?.videoModel).toBeUndefined();
+    expect(preferenceUpdateCount).toBe(0);
   });
 
   it("pins a video model on the thread from the model picker", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -375,6 +375,7 @@ export function mockChatLifecycle(
       model?: string;
       modelSelection: ModelSelectionRequest;
       serviceTier?: ChatThreadServiceTier | null;
+      videoModel?: string;
     }) => void;
     onModelSelectionUpdate?: (body: {
       model?: string | null;
@@ -774,6 +775,7 @@ export function mockChatLifecycle(
       model: body.model,
       modelSelection,
       serviceTier: body.serviceTier,
+      videoModel: body.videoModel,
     });
     return respond(201, {
       id: threadId,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -416,6 +416,7 @@ describe("zero sidebar", () => {
   it("keeps known threads visible while creating a new chat", async () => {
     prepareDefaultAgent();
     const createDeferred = context.mocks.deferred<void>();
+    let createdThreadBody: { readonly videoModel?: string } | undefined;
     const threads = [
       {
         id: EXISTING_THREAD_ID,
@@ -429,6 +430,7 @@ describe("zero sidebar", () => {
       return threads;
     });
     context.mocks.api(chatThreadsContract.create, async ({ body, respond }) => {
+      createdThreadBody = body;
       await createDeferred.promise;
       return respond(201, {
         id: body.clientThreadId ?? "created-thread-id",
@@ -445,7 +447,11 @@ describe("zero sidebar", () => {
       });
     });
 
-    setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
+    setupSidebarPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: false },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
 
     const newChatButton = await waitFor(() => {
       expect(screen.getByText("Existing conversation")).toBeInTheDocument();
@@ -464,7 +470,9 @@ describe("zero sidebar", () => {
       expect(
         sidebar.querySelectorAll('[data-testid="sidebar-skeleton"]'),
       ).toHaveLength(0);
+      expect(createdThreadBody).toBeDefined();
     });
+    expect(createdThreadBody?.videoModel).toBeUndefined();
 
     createDeferred.resolve();
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -7526,7 +7526,8 @@ function ComposerVideoModelPickerSlot({
   const panelOpen = useGet(signals.model.videoModelPanelOpen$);
   const setPanelOpen = useSet(signals.model.setVideoModelPanelOpen$);
   const setModelPickerOpen = useSet(signals.model.setModelPickerOpen$);
-  const selectedVideoModel = useGet(videoModelSignals.selectedVideoModel$);
+  const selectedVideoModel =
+    useLastResolved(videoModelSignals.selectedVideoModel$) ?? null;
   const setVideoModel = useSet(videoModelSignals.setVideoModel$);
   const pageSignal = useGet(pageSignal$);
   const videoModel: VideoModelPickerState = {

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -871,6 +871,11 @@ const chatThreadCreateBodySchema = z.object({
    * run's chat thread, use `priority` to enable it, or null for standard.
    */
   serviceTier: chatThreadServiceTierSchema.nullable().optional(),
+  /**
+   * Video model for the new thread. Omit it to inherit the calling run's chat
+   * thread video model.
+   */
+  videoModel: videoModelIdSchema.optional(),
   title: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary

- resolve untouched landing-page video selection from the live member default
- persist explicit landing-page video choices back to the member preference
- carry the effective video model through optimistic and API thread creation, including caller-run inheritance when omitted
- gate landing-page selection, preference writeback, and new-chat propagation behind the existing `VideoModelSelection` switch; disabled clients leave the preference untouched and omit create-time `videoModel`

## Testing

- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t "keeps known threads visible while creating a new chat"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-chat-threads-create.test.ts`
- `pnpm check-types` (pre-commit hook)
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
