### PR TITLE
perf(api): reduce usage event retention to four days

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-compact-usage-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-compact-usage-events.test.ts
@@ -257,15 +257,15 @@ describe("usage event compaction cron", () => {
     ).resolves.not.toBe(usageEventId);
   });
 
-  it("retains seven days of processed events and explicit diagnostic holds", async () => {
+  it("retains four days of processed events and explicit diagnostic holds", async () => {
     const heldFixture = await seedFixture();
     const startedHour = nowDate();
     startedHour.setUTCMinutes(0, 0, 0);
     const expectedCutoffAtStart = new Date(
-      startedHour.getTime() - 7 * 24 * 60 * 60 * 1000,
+      startedHour.getTime() - 4 * 24 * 60 * 60 * 1000,
     );
     const retainedProcessedAt = new Date(
-      startedHour.getTime() - 6 * 24 * 60 * 60 * 1000,
+      startedHour.getTime() - 3 * 24 * 60 * 60 * 1000,
     );
     const eligibleProcessedAt = new Date("0400-01-01T00:30:00.000Z");
 
@@ -316,7 +316,7 @@ describe("usage event compaction cron", () => {
     const completedHour = nowDate();
     completedHour.setUTCMinutes(0, 0, 0);
     const expectedCutoffAtCompletion = new Date(
-      completedHour.getTime() - 7 * 24 * 60 * 60 * 1000,
+      completedHour.getTime() - 4 * 24 * 60 * 60 * 1000,
     );
 
     expect(response.body).toMatchObject({

--- a/turbo/apps/api/src/signals/services/cron-compact-usage-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-usage-events.service.ts
@@ -503,7 +503,7 @@ async function loadCompactionCutoff(db: Pick<Db, "execute">): Promise<Date> {
     sql`
       SELECT (
         date_trunc('hour', timezone('UTC', statement_timestamp()))
-        - interval '7 days'
+        - interval '4 days'
       )::timestamp AS cutoff
     `,
     cutoffRowSchema,

--- a/turbo/packages/db/src/schema/usage-event.ts
+++ b/turbo/packages/db/src/schema/usage-event.ts
@@ -50,7 +50,7 @@ import { agentRuns } from "./agent-run";
  * Writers must keep the same UUID across retries of the same logical
  * event; the UNIQUE index blocks duplicate insertions.
  *
- * Healthy usage remains `processed` for at least seven days before hourly
+ * Healthy usage remains `processed` for at least four days before hourly
  * rollup replacement, after which the source event is deleted.
  */
 export const usageEvent = pgTable(


### PR DESCRIPTION
## Summary

- reduce healthy processed `usage_event` raw retention from seven days to four days before hourly compaction
- preserve the UTC-hour-aligned strict cutoff and all existing diagnostic holds, locking, reconciliation, batching, and source-deletion behavior
- update the focused real-Postgres retention case and usage-event lifecycle documentation

## Behavior and exclusions

The cutoff is now the start of the current UTC database hour minus four days. Events with `processed_at >= cutoff` remain raw, while older healthy processed events use the existing atomic hourly rollup handoff. Pending events and rows with `billing_error` remain held regardless of age.

This intentionally reduces exact event-level forensic history by three days. It does not change pricing, allowance handling, aggregation grain, cron frequency, public contracts, lifecycle statuses, or database schema, and it requires no migration or feature switch.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/cron-compact-usage-events.service.ts apps/api/src/signals/routes/__tests__/cron-compact-usage-events.test.ts packages/db/src/schema/usage-event.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @okouai/db lint`
- `pnpm -F @okouai/db check-types`
- `pnpm knip --workspace api`
- `git diff --check origin/main...HEAD`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-compact-usage-events.test.ts` was attempted, but the local runtime has no PostgreSQL service; suite setup stopped with `ECONNREFUSED` before all 11 tests. PR CI will run the database-backed suite.

Closes #27136
