### PR TITLE
fix: statically import mermaid

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/mermaid-diagram-imports.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/mermaid-diagram-imports.test.ts
@@ -1,0 +1,22 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const sourcePath = [
+  join(process.cwd(), "src/signals/mermaid-diagram.ts"),
+  join(process.cwd(), "apps/platform/src/signals/mermaid-diagram.ts"),
+].find((candidate) => {
+  return existsSync(candidate);
+});
+if (sourcePath === undefined) {
+  throw new Error("Unable to locate mermaid-diagram.ts");
+}
+const source = readFileSync(sourcePath, "utf8");
+
+describe("mermaid diagram imports", () => {
+  it("keeps mermaid in the static import graph", () => {
+    expect(source).toMatch(/^import mermaid from "mermaid";$/m);
+    expect(source).not.toMatch(/\bimport\s*\(\s*["']mermaid["']\s*\)/);
+  });
+});

--- a/turbo/apps/platform/src/signals/mermaid-diagram.ts
+++ b/turbo/apps/platform/src/signals/mermaid-diagram.ts
@@ -1,5 +1,6 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import type { Element, Root } from "hast";
+import mermaid from "mermaid";
 
 import { createObjectUrlResource } from "./object-url-resource.ts";
 import { theme$ } from "./theme.ts";
@@ -8,11 +9,11 @@ import { settle } from "./utils.ts";
 /**
  * Mermaid diagrams render through a pull model. Each diagram source owns one
  * `MermaidDiagramSignals` in the registry of the surface showing it; its
- * `diagram$` computed loads mermaid, lays the diagram out and resolves to an
- * image the view shows in an `<img>` — or to `null` when the parser rejects
- * the source, in which case the fence simply stays a code block. Reading the
- * theme inside the computed makes a theme switch re-render every diagram
- * without any remounting.
+ * `diagram$` computed lays the diagram out and resolves to an image the view
+ * shows in an `<img>` — or to `null` when the parser rejects the source, in
+ * which case the fence simply stays a code block. Reading the theme inside the
+ * computed makes a theme switch re-render every diagram without any
+ * remounting.
  *
  * The command that parses a tree registers each diagram and embeds the
  * returned signals on the marker node, so rendering receives the signals
@@ -68,12 +69,6 @@ export function embedMermaidSignals(
   visitNode(tree);
 }
 
-// mermaid costs ~170 KB gzipped for the first diagram, so it is only fetched
-// once a diagram actually needs rendering; the computed memoizes the promise.
-const mermaidModule$ = computed(() => {
-  return import("mermaid");
-});
-
 /**
  * mermaid needs a DOM id per `render` call. Concurrent renders only happen for
  * distinct code+theme pairs — the same pair is one deduplicated computed — so
@@ -89,7 +84,6 @@ function diagramRenderId(seed: string): string {
 
 /** Returns the diagram SVG, or undefined when the source is not valid mermaid. */
 async function renderDiagramSvg(
-  mermaid: (typeof import("mermaid"))["default"],
   id: string,
   code: string,
 ): Promise<string | undefined> {
@@ -185,10 +179,8 @@ export function createMermaidDiagramSignals(
     if (existing !== undefined) {
       return existing;
     }
-    const mermaidModule = get(mermaidModule$);
     const renderQueue = get(mermaidRenderQueue$);
     const image = (async (): Promise<MermaidDiagramImage | null> => {
-      const { default: mermaid } = await mermaidModule;
       // Read the tail and replace it in the same synchronous block, so two
       // resuming renders cannot both chain onto the same predecessor.
       const previousRender = renderQueue.tail;
@@ -216,11 +208,7 @@ export function createMermaidDiagramSignals(
           themeVariables: { fontSize: "14px" },
           flowchart: { nodeSpacing: 30, rankSpacing: 32, padding: 8 },
         });
-        return renderDiagramSvg(
-          mermaid,
-          diagramRenderId(`${theme}:${code}`),
-          code,
-        );
+        return renderDiagramSvg(diagramRenderId(`${theme}:${code}`), code);
       })();
       renderQueue.tail = render;
       const markup = await render;


### PR DESCRIPTION
## Summary

- replace the platform-owned runtime `import("mermaid")` with a module-level static import
- remove the cached Mermaid module promise while preserving render queue, theme, and image caching behavior
- load Mermaid core with the app module so first diagram rendering no longer depends on fetching that separate lazy entry after a deployment

## Trade-off

- adds Mermaid core (approximately 170 KB gzip) to the initial app dependency graph
- Mermaid's upstream per-diagram renderers remain internally code-split; this PR removes the platform-owned top-level lazy import

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, platform, and API TypeScript checks
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/mermaid-diagram.test.ts`
- `pnpm --filter @okouai/app run build` (confirmed no `mermaid.core-*` top-level lazy asset)
