### PR TITLE
fix: align first inline feedback item with composer padding

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -614,8 +614,10 @@ function createFeedbackItemNodeView(
   }
   function render(nextNode: ProseMirrorNode): void {
     const { quote, showDivider, fill } = feedbackItemNodeAttributes(nextNode);
-    dom.className = `flex flex-col gap-1.5 pb-1.5 pt-1.5${
-      showDivider ? " border-t border-dashed border-border/60" : ""
+    // The top padding is breathing room for the dashed divider, so only the
+    // items that draw one get it. The first item keeps the editor's own pt-4.
+    dom.className = `flex flex-col gap-1.5 pb-1.5${
+      showDivider ? " border-t border-dashed border-border/60 pt-1.5" : ""
     }`;
     noteDom.className = `relative${fill ? " min-h-[96px]" : ""}`;
     placeholderDom.hidden = nodeText(nextNode).length > 0;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -200,6 +200,18 @@ function feedbackNotes(): HTMLElement[] {
   );
 }
 
+async function findFeedbackItems(count: number): Promise<HTMLElement[]> {
+  return await waitFor(() => {
+    const items = Array.from(
+      document.querySelectorAll("[data-feedback-item]"),
+    ).filter((element): element is HTMLElement => {
+      return element instanceof HTMLElement;
+    });
+    expect(items).toHaveLength(count);
+    return items;
+  });
+}
+
 function pastePlainText(element: HTMLElement, value: string): void {
   fireEvent.paste(element, {
     clipboardData: {
@@ -2062,5 +2074,58 @@ describe("chat inline feedback", () => {
     );
     expect(sentPrompts[0]).toContain("Name owners.");
     expect(sentPrompts[0]).toContain("Add dates.");
+  });
+
+  it("keeps the divider spacing off the first inline feedback item", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The launch summary needs clearer risk ownership.";
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatEvents: [
+        {
+          id: "msg-feedback-spacing-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-spacing",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-spacing-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-spacing",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+    });
+
+    const assistantReplyElement = await screen.findByText(assistantReply);
+
+    selectTextForInlineFeedback(assistantReplyElement);
+    await waitFor(() => {
+      expect(screen.getByText("Quote")).toBeInTheDocument();
+    });
+    await user.click(buttonByText("Quote"));
+
+    // Alone, the quote chip aligns with the editor's own pt-4 inset.
+    const [onlyItem] = await findFeedbackItems(1);
+    expect(onlyItem).not.toHaveClass("pt-1.5");
+
+    selectTextForInlineFeedback(assistantReplyElement);
+    await waitFor(() => {
+      expect(screen.getByText("Quote")).toBeInTheDocument();
+    });
+    await user.click(buttonByText("Quote"));
+
+    const items = await findFeedbackItems(2);
+    expect(items[0]).not.toHaveClass("pt-1.5");
+    expect(items[1]).toHaveClass("pt-1.5", "border-t");
   });
 });


### PR DESCRIPTION
## Problem

Closes #27152.

With a feedback (quote) item attached, the composer's quote chip sat ~22px from the top of the box but ~16px from the left, so the block looked visually off-center inside the rounded container.

## Cause

The editor content already provides the symmetric inset (`px-4 pt-4`, `tiptap-workflow-composer.ts:156`). The feedback item node view then added `pt-1.5` (6px) to *every* item, including the first: 16 + 6 = 22px on top against 16px on the left.

That 6px is breathing room for the dashed divider that separates stacked feedback items — it only makes sense on the items that draw a divider.

## Change

Apply `pt-1.5` only when `showDivider` is true (`showDivider === index > 0`). `pb-1.5` is unchanged, so spacing between stacked items stays the same and only the first item moves up by 6px to align with the left inset.

## Tests

New page test in `chat-inline-feedback.test.tsx`: a lone feedback item carries no divider top padding, and after a second quote the first item still has none while the second has both `pt-1.5` and `border-t`. Verified it fails without the fix.

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx` — 27 passed
- `pnpm -F @okouai/app exec tsc --noEmit` — clean
- `eslint` on both touched files — clean
- prettier 3.8.1 (lockfile-pinned) — no changes