### PR TITLE
test(python): cover auth.base shutdown before active-handle tracking

### DIFF
--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder_lifecycle.py
@@ -259,7 +259,6 @@ class TestForwardRequestAsyncWrapper:
                     wraps=transport.prepare_forward_request,
                 ) as prepare_forward_request,
                 patch.object(loop, "call_later") as schedule_deadline,
-                patch.object(forwarder, "_start_forward_request_worker") as start_worker,
                 fake_forwarder_upstream() as upstream,
             ):
                 with pytest.raises(RuntimeError, match="workers are shut down"):
@@ -273,13 +272,16 @@ class TestForwardRequestAsyncWrapper:
                 track_active_handle.assert_called_once()
                 prepare_forward_request.assert_not_called()
                 schedule_deadline.assert_not_called()
-                start_worker.assert_not_called()
                 assert upstream.resolve_calls == []
                 assert upstream.sockets == []
 
             assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
             with forwarder._forward_request_active_handles_lock:
                 assert not forwarder._forward_request_active_handles
+            with forwarder._forward_request_pending_futures_lock:
+                assert not forwarder._forward_request_pending_futures
+            with forwarder._forward_request_workers_lock:
+                assert not forwarder._forward_request_workers
             assert forwarder._get_forward_request_admission_semaphore() is semaphore
 
             with fake_forwarder_upstream():

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder_lifecycle.py
@@ -243,6 +243,59 @@ class TestForwardRequestAsyncWrapper:
         with forwarder._forward_request_active_handles_lock:
             assert not forwarder._forward_request_active_handles
 
+    async def test_shutdown_before_active_handle_tracking_releases_capacity(self):
+        loop = asyncio.get_running_loop()
+        with patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1):
+            semaphore = forwarder._get_forward_request_admission_semaphore()
+            with (
+                patch.object(
+                    forwarder,
+                    "_track_active_forward_request_handle",
+                    return_value=False,
+                ) as track_active_handle,
+                patch.object(
+                    transport,
+                    "prepare_forward_request",
+                    wraps=transport.prepare_forward_request,
+                ) as prepare_forward_request,
+                patch.object(loop, "call_later") as schedule_deadline,
+                patch.object(forwarder, "_start_forward_request_worker") as start_worker,
+                fake_forwarder_upstream() as upstream,
+            ):
+                with pytest.raises(RuntimeError, match="workers are shut down"):
+                    await forwarder.forward_request(
+                        "https://example.com",
+                        "POST",
+                        [],
+                        b"payload",
+                    )
+
+                track_active_handle.assert_called_once()
+                prepare_forward_request.assert_not_called()
+                schedule_deadline.assert_not_called()
+                start_worker.assert_not_called()
+                assert upstream.resolve_calls == []
+                assert upstream.sockets == []
+
+            assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
+            with forwarder._forward_request_active_handles_lock:
+                assert not forwarder._forward_request_active_handles
+            assert forwarder._get_forward_request_admission_semaphore() is semaphore
+
+            with fake_forwarder_upstream():
+                status, body, _headers = await asyncio.wait_for(
+                    forwarder.forward_request(
+                        "https://example.com",
+                        "GET",
+                        [],
+                        None,
+                    ),
+                    timeout=2,
+                )
+
+        assert status == 200
+        assert body == b"ok"
+
     async def test_shutdown_cancels_dns_before_socket_registration(self):
         lookup_entered = asyncio.Event()
         lookup_cancelled = asyncio.Event()


### PR DESCRIPTION
## Summary

- add deterministic public-path coverage for active-handle tracking refusal after the initial submission check
- assert URL preparation, DNS resolution, deadline-timer registration, and worker startup do not begin after refusal
- verify admission and active-handle cleanup plus same-semaphore capacity reuse through a successful follow-up request

This PR changes tests only; production forwarding behavior is unchanged.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_auth_base_forwarder_lifecycle.py -k shutdown_before_active_handle_tracking_releases_capacity` (`1 passed`)
- temporary fallthrough mutation of the fail-closed branch: focused regression failed as expected; source restored and the test passed again
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_auth_base_forwarder_lifecycle.py` (`34 passed`)
- `uv run --no-sync python -m pytest tests/` (`5426 passed`)

Closes #27146
