### PR TITLE
fix(python): decouple error terminal work from network logs

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1852,10 +1852,7 @@ def error(flow: http.HTTPFlow) -> None:
 
 
 def _handle_error(flow: http.HTTPFlow) -> None:
-    """
-    Log connection-level errors (timeout, RST, TLS failure) to the
-    per-run JSONL network log and clean up request tracking state.
-    """
+    """Handle registered-run terminal work after a connection-level error."""
     start_time = flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
     codex_model_catalog_cache.handle_error(flow)
 
@@ -1863,7 +1860,7 @@ def _handle_error(flow: http.HTTPFlow) -> None:
     network_log_path = flow_metadata.network_log_path(flow.metadata)
     proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
 
-    if not run_id or not network_log_path:
+    if not run_id:
         return
 
     latency_ms = elapsed_ms(start_time)
@@ -1875,18 +1872,19 @@ def _handle_error(flow: http.HTTPFlow) -> None:
     request_size = _request_size(flow)
     error_msg = flow.error.msg if flow.error else "unknown error"
 
-    # [NETWORK_LOG_FIELDS] — HTTP error fields; api-contracts is the shared schema boundary.
-    log_entry, raw_url = _http_network_log_entry(
-        flow,
-        action=firewall_action,
-        status_code=0,
-        latency_ms=latency_ms,
-        request_size=request_size,
-        response_size=0,
-    )
-    log_entry["error"] = error_msg
+    if network_log_path:
+        # [NETWORK_LOG_FIELDS] — HTTP error fields; api-contracts is the shared schema boundary.
+        log_entry, raw_url = _http_network_log_entry(
+            flow,
+            action=firewall_action,
+            status_code=0,
+            latency_ms=latency_ms,
+            request_size=request_size,
+            response_size=0,
+        )
+        log_entry["error"] = error_msg
 
-    log_http_network_entry(network_log_path, log_entry, raw_url)
+        log_http_network_entry(network_log_path, log_entry, raw_url)
 
     # Report proxy-extracted usage for model provider responses.
     # The SSE parser may have partially populated model_provider_usage before the

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -151,6 +151,40 @@ class TestErrorHandler:
         assert proxy_entries[0]["upstream_status"] == 0
         assert proxy_entries[1]["type"] == "connection_error"
 
+    async def test_connector_candidate_error_gets_diagnostic_without_network_log(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro",
+            method="POST",
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
+            flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+            flow.metadata.pop(metadata_keys.NETWORK_LOG_TARGET)
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 424
+        content = flow.response.content
+        assert content is not None
+        body = json.loads(content)
+        assert body["error"] == "connector_not_configured_for_run"
+        assert body["connector"] == "fal"
+        assert not (tmp_path / "net.jsonl").exists()
+
+        [connector_entry, connection_entry] = read_jsonl_entries_after_flush(
+            tmp_path / "proxy.jsonl"
+        )
+        assert connector_entry["type"] == "connector_diagnostic"
+        assert connection_entry["type"] == "connection_error"
+
     async def test_head_connector_candidate_error_gets_bodyless_diagnostic(
         self, tmp_path, real_flow, mitm_ctx
     ):
@@ -702,20 +736,13 @@ class TestErrorHandler:
         assert entry["firewall_rule_match"] == "POST /chat.postMessage"
         assert entry["error"] == "timed out"
 
-    def test_error_logs_warning_to_proxy_log(self, tmp_path, real_flow):
+    def test_error_logs_warning_to_proxy_log_without_network_log(self, tmp_path, real_flow):
         flow = real_flow(with_response=False, host="slack.com")
-        log_path = str(tmp_path / "network.jsonl")
         proxy_log = tmp_path / "proxy-run-abc-123.jsonl"
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
-        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
         flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log)
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://slack.com/api/test?api_key=secret#frag"
-        http_network_log.set_target(
-            flow,
-            url="https://slack.com/api/test?api_key=secret#frag",
-            host="slack.com",
-            port=443,
-        )
         flow.error = Error("connection reset by peer")
 
         mitm_addon.error(flow)
@@ -762,7 +789,7 @@ class TestErrorHandler:
         assert secret_userinfo not in serialized_proxy_entry
         assert len(serialized_proxy_entry.encode()) < 1_000
 
-    def test_full_path_error_to_webhook(
+    def test_error_without_network_log_reports_model_usage(
         self, tmp_path, real_flow, mitm_ctx, sync_usage_executor, usage_webhook_api
     ):
         """Integration: error() -> _maybe_report -> _enqueue -> _retry -> webhook.
@@ -770,16 +797,9 @@ class TestErrorHandler:
         Verifies that error() hook delivers partial usage through loopback HTTP.
         """
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        log_path = str(tmp_path / "network.jsonl")
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-int-002"
-        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
-        http_network_log.set_target(
-            flow,
-            url="https://api.anthropic.com/v1/messages",
-            host="api.anthropic.com",
-            port=443,
-        )
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
@@ -835,3 +855,4 @@ class TestErrorHandler:
         observation_key = observation_body["events"][0]["idempotencyKey"]
         uuid.UUID(observation_key)
         assert observation_key != billing_key
+        assert not (tmp_path / "network.jsonl").exists()

--- a/crates/runner/mitm-addon/tests/test_websocket_retention.py
+++ b/crates/runner/mitm-addon/tests/test_websocket_retention.py
@@ -315,6 +315,8 @@ class TestRegisteredWebSocketRetention:
     ):
         flow = real_flow(with_response=False, host="example.com")
         flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://example.com/"
         flow.error = Error("connection reset by peer")
         append_websocket_message(flow, from_client=True, content=b"client")
 

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -710,16 +710,18 @@ class TestXConnectorErrorPipeline:
         assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert flow.response.stream is False
 
-    def test_full_pipeline_stream_error_midflight(
+    def test_full_pipeline_stream_error_without_network_log_reports_verified_rows(
         self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api
     ):
-        """End-to-end: responseheaders -> partial chunks -> error() logs observed counts.
+        """End-to-end: responseheaders -> partial chunks -> error() reports observed counts.
 
         Simulates a real scenario: stream opens successfully, a few tweets
         arrive, then the connection resets.  No pre-populated state: the
         incremental parser must have accumulated counts from the chunks.
         """
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+        flow.metadata.pop(metadata_keys.NETWORK_LOG_TARGET)
 
         # 1. Register parser
         mitm_addon.responseheaders(flow)
@@ -744,6 +746,7 @@ class TestXConnectorErrorPipeline:
         assert len(payloads) == len(by_cat)
         assert by_cat == {"posts.read": 2, "user.read": 1}
         assert "connector_response_report_on_interruption" not in flow.metadata
+        assert not (tmp_path / "network.jsonl").exists()
 
     def test_full_pipeline_stream_error_counts_complete_final_line_without_newline(
         self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api


### PR DESCRIPTION
## Summary

- keep registered-run error terminal handling active when network logging is disabled
- make typed network-log entry construction and writing conditional on a non-empty network-log path
- cover model usage, interrupted connector usage, connector diagnostics, proxy warnings, and registered WebSocket cleanup without network logging

## Scope

- preserves the existing enabled-network-log entry fields and ordering
- preserves `run_id` as the unregistered-flow terminal no-op gate
- does not change APIs, persisted data, queue payloads, dependencies, or cross-version protocols

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_error_handler.py tests/test_x_connector_pipeline.py` (59 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5,426 passed)
- pre-commit Ruff and file-size hooks
- commitlint

Closes #27144
