### PR TITLE
fix(platform): allow concurrency quantity input

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -327,7 +327,10 @@ export const setConcurrencySubscriptionQuantity$ = command(
   },
 );
 export const openConcurrencyPurchaseDialog$ = command(({ set }) => {
-  set(internalConcurrencySubscriptionQuantity$, null);
+  set(
+    internalConcurrencySubscriptionQuantity$,
+    CONCURRENCY_SUBSCRIPTION_QUANTITY_MIN,
+  );
   set(internalConcurrencyPurchaseDialogOpen$, true);
 });
 export const closeConcurrencyPurchaseDialog$ = command(({ set }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -3028,28 +3028,31 @@ describe("organization billing settings", () => {
     const purchaseDialog = await screen.findByRole("dialog", {
       name: "Buy concurrency",
     });
-    click(
-      within(purchaseDialog).getByLabelText(
-        "Increase additional concurrency quantity",
-      ),
-    );
+    const quantityInput = within(purchaseDialog).getByRole("textbox", {
+      name: "Slots",
+    });
+    expect(quantityInput).toHaveValue("1");
+    fireEvent.change(quantityInput, { target: { value: "" } });
+    expect(quantityInput).toHaveValue("");
+    expect(buttonByText("Buy $0/month", purchaseDialog)).toBeDisabled();
+    fireEvent.change(quantityInput, { target: { value: "5" } });
 
     await waitFor(() => {
       expect(
-        within(purchaseDialog).getByText("Buy $200/month"),
+        within(purchaseDialog).getByText("Buy $500/month"),
       ).toBeInTheDocument();
     });
 
-    click(buttonByText("Buy $200/month", purchaseDialog));
+    click(buttonByText("Buy $500/month", purchaseDialog));
 
     await screen.findByText("$120.00");
     const reviewDialog = screen.getByRole("dialog", {
       name: "Buy concurrency",
     });
     await waitFor(() => {
-      expect(previewedQuantity).toBe(2);
+      expect(previewedQuantity).toBe(5);
       expect(within(reviewDialog).getByText("$120.00")).toBeInTheDocument();
-      expect(within(reviewDialog).getByText("2")).toBeInTheDocument();
+      expect(within(reviewDialog).getByText("5")).toBeInTheDocument();
       expect(
         within(reviewDialog).getByText("$360.00/month"),
       ).toBeInTheDocument();
@@ -3057,7 +3060,7 @@ describe("organization billing settings", () => {
     click(buttonByText("Confirm", reviewDialog));
 
     await waitFor(() => {
-      expect(requestedQuantity).toBe(2);
+      expect(requestedQuantity).toBe(5);
       expect(
         screen.getByText(
           "Concurrency added. Your new slots will become available after Stripe confirms the subscription.",

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -1372,8 +1372,8 @@ function ConcurrencyQuantityControl({
 }: {
   disabled: boolean;
   label: string;
-  onQuantityChange: (quantity: number) => void;
-  quantity: number;
+  onQuantityChange: (quantity: number | null) => void;
+  quantity: number | null;
 }) {
   return (
     <div className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
@@ -1385,33 +1385,67 @@ function ConcurrencyQuantityControl({
             return $.billing.concurrency.decreaseAria;
           })}
           disabled={
-            quantity <= CONCURRENCY_SUBSCRIPTION_QUANTITY_MIN || disabled
+            quantity === null ||
+            quantity <= CONCURRENCY_SUBSCRIPTION_QUANTITY_MIN ||
+            disabled
           }
           variant="quiet"
           size="icon-sm"
           className="rounded-l-lg disabled:opacity-40"
           onClick={() => {
-            onQuantityChange(quantity - 1);
+            if (quantity !== null) {
+              onQuantityChange(quantity - 1);
+            }
           }}
         >
           <Minus size={13} />
         </Button>
-        <span className="flex h-8 w-11 items-center justify-center border-x border-border/70 text-sm font-medium tabular-nums text-foreground">
-          {formatLocalizedNumber(quantity)}
-        </span>
+        <Input
+          type="text"
+          inputMode="numeric"
+          pattern="[1-9][0-9]*"
+          value={quantity ?? ""}
+          disabled={disabled}
+          aria-label={label}
+          className="h-8 w-11 rounded-none border-y-0 border-x border-border/70 bg-transparent px-1 text-center text-sm font-medium tabular-nums shadow-none focus:border-border focus:ring-0"
+          onChange={(event) => {
+            const nextValue = event.currentTarget.value;
+            if (nextValue === "") {
+              onQuantityChange(null);
+              return;
+            }
+            if (!/^[1-9]\d*$/.test(nextValue)) {
+              return;
+            }
+            const nextQuantity = Number(nextValue);
+            if (
+              Number.isInteger(nextQuantity) &&
+              nextQuantity >= CONCURRENCY_SUBSCRIPTION_QUANTITY_MIN &&
+              nextQuantity <= CONCURRENCY_SUBSCRIPTION_QUANTITY_MAX
+            ) {
+              onQuantityChange(nextQuantity);
+            }
+          }}
+        />
         <Button
           type="button"
           aria-label={i18n.t(($) => {
             return $.billing.concurrency.increaseAria;
           })}
           disabled={
-            quantity >= CONCURRENCY_SUBSCRIPTION_QUANTITY_MAX || disabled
+            (quantity !== null &&
+              quantity >= CONCURRENCY_SUBSCRIPTION_QUANTITY_MAX) ||
+            disabled
           }
           variant="quiet"
           size="icon-sm"
           className="rounded-r-lg disabled:opacity-40"
           onClick={() => {
-            onQuantityChange(quantity + 1);
+            onQuantityChange(
+              quantity === null
+                ? CONCURRENCY_SUBSCRIPTION_QUANTITY_MIN
+                : quantity + 1,
+            );
           }}
         >
           <Plus size={13} />
@@ -2105,7 +2139,8 @@ function ConcurrencyPurchaseDialog({
     reviewLoadable.state === "loading" ||
     (confirmDialog?.action === "purchase" &&
       confirmDialog.origin === "billing");
-  const quantity = quantityOverride ?? CONCURRENCY_SUBSCRIPTION_QUANTITY_MIN;
+  const quantity = quantityOverride;
+  const effectiveQuantity = quantity ?? 0;
   const actionLabel = checkoutLoading
     ? i18n.t(($) => {
         return reviewAvailable
@@ -2116,7 +2151,7 @@ function ConcurrencyPurchaseDialog({
         ($) => {
           return $.billing.concurrency.buyAmount;
         },
-        { amount: concurrencyMonthlyPrice(quantity) },
+        { amount: concurrencyMonthlyPrice(effectiveQuantity) },
       );
 
   return (
@@ -2150,7 +2185,7 @@ function ConcurrencyPurchaseDialog({
             quantity={quantity}
           />
           <p className="text-sm font-medium text-foreground">
-            {concurrencyMonthlyPrice(quantity)}
+            {concurrencyMonthlyPrice(effectiveQuantity)}
           </p>
         </div>
 
@@ -2167,8 +2202,11 @@ function ConcurrencyPurchaseDialog({
             })}
           </Button>
           <Button
-            disabled={checkoutLoading}
+            disabled={checkoutLoading || quantity === null}
             onClick={(e) => {
+              if (quantity === null) {
+                return;
+              }
               detach(
                 reviewAvailable
                   ? review(


### PR DESCRIPTION
## Summary

- make the initial concurrency purchase quantity directly editable, matching the queue sidebar control
- allow clearing the quantity and disable purchase until a valid value is entered
- cover direct quantity entry through the preview and checkout flow

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx -t "reviews and confirms an initial concurrency purchase" --maxWorkers=1`
