### PR TITLE
refactor(user-model-preference): neutralize the api shell

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -183,7 +183,7 @@ import { zeroUsageMembersRoutes } from "./routes/zero-usage-members";
 import { zeroUsageRecordRoutes } from "./routes/zero-usage-record";
 import { userPreferencesRoutes } from "./routes/user-preferences";
 import { zeroUserPermissionGrantsRoutes } from "./routes/zero-user-permission-grants";
-import { zeroUserModelPreferenceRoutes } from "./routes/zero-user-model-preference";
+import { userModelPreferenceRoutes } from "./routes/user-model-preference";
 import { zeroAvatarVideoRoutes } from "./routes/zero-avatar-video";
 import { voiceIoQuotaRoutes } from "./routes/voice-io-quota";
 import { voiceIoSpeechRoutes } from "./routes/voice-io-speech";
@@ -332,7 +332,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...pushSubscriptionsRoutes,
   ...zeroUserPermissionGrantsRoutes,
   ...userPreferencesRoutes,
-  ...zeroUserModelPreferenceRoutes,
+  ...userModelPreferenceRoutes,
   ...zeroWorkflowsRoutes,
   ...zeroWorkflowAutomationsRoutes,
   ...strapiIntegrationsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -29,7 +29,7 @@ import {
   type UserMessageInputDocument,
   type ZeroIndicators,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { zeroUserModelPreferenceContract } from "@okouai/api-contracts/contracts/zero-user-model-preference";
+import { userModelPreferenceContract } from "@okouai/api-contracts/contracts/user-model-preference";
 import {
   artifactCatalogContract,
   type ArtifactCatalogKind,
@@ -79,7 +79,7 @@ import { zeroHostRoutes } from "../../zero-host";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { zeroUploadsCompleteRoutes } from "../../zero-uploads-complete";
 import { zeroUploadsPrepareRoutes } from "../../zero-uploads-prepare";
-import { zeroUserModelPreferenceRoutes } from "../../zero-user-model-preference";
+import { userModelPreferenceRoutes } from "../../user-model-preference";
 import type { ApiTestUser } from "./api-bdd";
 import {
   projectChatEventRows,
@@ -192,7 +192,7 @@ const chatFilesRoutes = [
   ...zeroUploadsCompleteRoutes,
   ...zeroHostRoutes,
   ...zeroModelPoliciesRoutes,
-  ...zeroUserModelPreferenceRoutes,
+  ...userModelPreferenceRoutes,
 ] as const;
 
 function chatFilesApp(context: TestContext) {
@@ -315,7 +315,7 @@ export function createChatFilesBddApi(context: TestContext) {
   }
 
   function userModelPreferenceClient() {
-    return chatFilesApp(context)(zeroUserModelPreferenceContract);
+    return chatFilesApp(context)(userModelPreferenceContract);
   }
 
   function threadComputerUseHostClient() {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -46,7 +46,7 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { zeroSlackChannelsContract } from "@okouai/api-contracts/contracts/zero-slack-channels";
 import { zeroSlackConnectContract } from "@okouai/api-contracts/contracts/zero-slack-connect";
 import { zeroSlackOauthContract } from "@okouai/api-contracts/contracts/zero-slack-oauth";
-import { zeroUserModelPreferenceContract } from "@okouai/api-contracts/contracts/zero-user-model-preference";
+import { userModelPreferenceContract } from "@okouai/api-contracts/contracts/user-model-preference";
 import { HttpResponse, http } from "msw";
 import { createApp } from "../../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../../lib/env";
@@ -84,7 +84,7 @@ import { zeroSlackConnectRoutes } from "../../zero-slack-connect";
 import { slackEventsRoutes } from "../../slack-events";
 import { slackInteractiveRoutes } from "../../slack-interactive";
 import { zeroSlackOauthRoutes } from "../../zero-slack-oauth";
-import { zeroUserModelPreferenceRoutes } from "../../zero-user-model-preference";
+import { userModelPreferenceRoutes } from "../../user-model-preference";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...githubOauthRoutes,
@@ -114,7 +114,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...slackEventsRoutes,
   ...slackInteractiveRoutes,
   ...zeroSlackOauthRoutes,
-  ...zeroUserModelPreferenceRoutes,
+  ...userModelPreferenceRoutes,
 ]);
 
 interface AuthHeaders {
@@ -1177,8 +1177,8 @@ export function createBddIntegrationApi(context: TestContext) {
     async readUserModelPreference(actor: ApiTestUser) {
       const client = setupApp({
         context,
-        routes: zeroUserModelPreferenceRoutes,
-      })(zeroUserModelPreferenceContract);
+        routes: userModelPreferenceRoutes,
+      })(userModelPreferenceContract);
       const response = await accept(
         client.get({ headers: authenticate(context, routeMocks, actor) }),
         [200],
@@ -1193,8 +1193,8 @@ export function createBddIntegrationApi(context: TestContext) {
     ): Promise<void> {
       const client = setupApp({
         context,
-        routes: zeroUserModelPreferenceRoutes,
-      })(zeroUserModelPreferenceContract);
+        routes: userModelPreferenceRoutes,
+      })(userModelPreferenceContract);
       await accept(
         client.update({
           headers: authenticate(context, routeMocks, actor),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-user-config.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-user-config.ts
@@ -6,10 +6,10 @@ import type { ZeroCapability } from "@okouai/api-contracts/contracts/composes";
 import { pushSubscriptionsContract } from "@okouai/api-contracts/contracts/push-subscriptions";
 import { zeroUserConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import {
-  zeroUserModelPreferenceContract,
+  userModelPreferenceContract,
   type UpdateUserModelPreferenceRequest,
   type UserModelPreferenceResponse,
-} from "@okouai/api-contracts/contracts/zero-user-model-preference";
+} from "@okouai/api-contracts/contracts/user-model-preference";
 import {
   userPreferencesContract,
   type UpdateUserPreferencesRequest,
@@ -26,7 +26,7 @@ import {
 import { authMeRoutes } from "../../auth-me";
 import { zeroAgentsRoutes } from "../../zero-agents";
 import { pushSubscriptionsRoutes } from "../../push-subscriptions";
-import { zeroUserModelPreferenceRoutes } from "../../zero-user-model-preference";
+import { userModelPreferenceRoutes } from "../../user-model-preference";
 import { userPreferencesRoutes } from "../../user-preferences";
 import {
   healthAuthProbeContract,
@@ -81,7 +81,7 @@ const c = initContract();
  * Permissive mirror of the user-model-preference update route used to send
  * contract-invalid bodies through the app (the real contract types reject
  * them at compile time). Mirrors the raw `app.request` cases in the legacy
- * zero-user-model-preference test.
+ * user-model-preference test.
  */
 const rawModelPreferenceContract = c.router({
   update: {
@@ -105,7 +105,7 @@ const userConfigRoutes = [
   ...healthAuthProbeRoutes,
   ...authMeRoutes,
   ...zeroAgentsRoutes,
-  ...zeroUserModelPreferenceRoutes,
+  ...userModelPreferenceRoutes,
   ...pushSubscriptionsRoutes,
   ...userPreferencesRoutes,
 ] as const;
@@ -335,7 +335,7 @@ export function createUserConfigBddApi(context: TestContext) {
       actor: ApiTestUser,
     ): Promise<UserModelPreferenceResponse> {
       const client = setupAppWithRoutes({ context, routes: userConfigRoutes })(
-        zeroUserModelPreferenceContract,
+        userModelPreferenceContract,
       );
       const response = await accept(
         client.get({ headers: authenticate(actor) }),
@@ -349,7 +349,7 @@ export function createUserConfigBddApi(context: TestContext) {
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
       const client = setupAppWithRoutes({ context, routes: userConfigRoutes })(
-        zeroUserModelPreferenceContract,
+        userModelPreferenceContract,
       );
       return await accept(
         client.get({ headers: authenticate(actor) }),
@@ -362,7 +362,7 @@ export function createUserConfigBddApi(context: TestContext) {
       body: UpdateUserModelPreferenceRequest,
     ): Promise<UserModelPreferenceResponse> {
       const client = setupAppWithRoutes({ context, routes: userConfigRoutes })(
-        zeroUserModelPreferenceContract,
+        userModelPreferenceContract,
       );
       const response = await accept(
         client.update({ headers: authenticate(actor), body }),
@@ -377,7 +377,7 @@ export function createUserConfigBddApi(context: TestContext) {
       statuses: readonly (200 | 400 | 401)[],
     ) {
       const client = setupAppWithRoutes({ context, routes: userConfigRoutes })(
-        zeroUserModelPreferenceContract,
+        userModelPreferenceContract,
       );
       return await accept(
         client.update({ headers: authenticate(actor), body }),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@okouai/api-contracts/contracts/model-providers";
 import { zeroModelPoliciesMainContract } from "@okouai/api-contracts/contracts/zero-model-policies";
 import { zeroModelProviderConnectionsMainContract } from "@okouai/api-contracts/contracts/zero-model-provider-gateways";
-import { zeroUserModelPreferenceContract } from "@okouai/api-contracts/contracts/zero-user-model-preference";
+import { userModelPreferenceContract } from "@okouai/api-contracts/contracts/user-model-preference";
 import type { VideoModelId } from "@okouai/api-contracts/contracts/video-models";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { createApp } from "../../../app-factory";
@@ -28,12 +28,12 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { zeroModelPoliciesRoutes } from "../zero-model-policies";
 import { zeroModelProviderGatewayRoutes } from "../zero-model-provider-gateways";
-import { zeroUserModelPreferenceRoutes } from "../zero-user-model-preference";
+import { userModelPreferenceRoutes } from "../user-model-preference";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...zeroModelPoliciesRoutes,
   ...zeroModelProviderGatewayRoutes,
-  ...zeroUserModelPreferenceRoutes,
+  ...userModelPreferenceRoutes,
 ]);
 
 type ModelPolicyFixture = ApiTestUser & { readonly orgId: string };
@@ -446,8 +446,8 @@ describe("GET/PUT /api/zero/model-policies", () => {
     const client = apiClient();
     const preferenceClient = setupApp({
       context,
-      routes: zeroUserModelPreferenceRoutes,
-    })(zeroUserModelPreferenceContract);
+      routes: userModelPreferenceRoutes,
+    })(userModelPreferenceContract);
     const listResponse = await accept(
       client.list({ headers: authHeaders() }),
       [200],
@@ -492,8 +492,8 @@ describe("GET/PUT /api/zero/model-policies", () => {
     const client = apiClient();
     const preferenceClient = setupApp({
       context,
-      routes: zeroUserModelPreferenceRoutes,
-    })(zeroUserModelPreferenceContract);
+      routes: userModelPreferenceRoutes,
+    })(userModelPreferenceContract);
     const listResponse = await accept(
       client.list({ headers: authHeaders() }),
       [200],
@@ -940,8 +940,8 @@ describe("GET/PUT /api/zero/model-policies", () => {
     const client = apiClient();
     const preferenceClient = setupApp({
       context,
-      routes: zeroUserModelPreferenceRoutes,
-    })(zeroUserModelPreferenceContract);
+      routes: userModelPreferenceRoutes,
+    })(userModelPreferenceContract);
     const listResponse = await accept(
       client.list({ headers: authHeaders() }),
       [200],
@@ -1000,8 +1000,8 @@ describe("GET/PUT /api/zero/model-policies", () => {
     useSession(fixture);
     const preferenceClient = setupApp({
       context,
-      routes: zeroUserModelPreferenceRoutes,
-    })(zeroUserModelPreferenceContract);
+      routes: userModelPreferenceRoutes,
+    })(userModelPreferenceContract);
 
     const stored = await accept(
       preferenceClient.update({
@@ -1051,8 +1051,8 @@ describe("GET/PUT /api/zero/model-policies", () => {
     useSession(fixture);
     const preferenceClient = setupApp({
       context,
-      routes: zeroUserModelPreferenceRoutes,
-    })(zeroUserModelPreferenceContract);
+      routes: userModelPreferenceRoutes,
+    })(userModelPreferenceContract);
 
     context.mocks.ably.publish.mockClear();
     await accept(
@@ -1097,8 +1097,8 @@ describe("GET/PUT /api/zero/model-policies", () => {
     useSession(fixture);
     const preferenceClient = setupApp({
       context,
-      routes: zeroUserModelPreferenceRoutes,
-    })(zeroUserModelPreferenceContract);
+      routes: userModelPreferenceRoutes,
+    })(userModelPreferenceContract);
 
     await accept(
       preferenceClient.update({
@@ -1133,8 +1133,8 @@ describe("GET/PUT /api/zero/model-policies", () => {
     useSession(fixture);
     const preferenceClient = setupApp({
       context,
-      routes: zeroUserModelPreferenceRoutes,
-    })(zeroUserModelPreferenceContract);
+      routes: userModelPreferenceRoutes,
+    })(userModelPreferenceContract);
 
     // A run model id is never a video model id; the cast is what a client
     // sending a stale or hand-written id would produce at runtime.

--- a/turbo/apps/api/src/signals/routes/user-model-preference.ts
+++ b/turbo/apps/api/src/signals/routes/user-model-preference.ts
@@ -1,6 +1,6 @@
 import { command, computed } from "ccstate";
 import type { UserPreferenceChangedPayload } from "@okouai/api-contracts/contracts/realtime";
-import { zeroUserModelPreferenceContract } from "@okouai/api-contracts/contracts/zero-user-model-preference";
+import { userModelPreferenceContract } from "@okouai/api-contracts/contracts/user-model-preference";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
@@ -18,7 +18,7 @@ import {
   userModelPreference,
 } from "../services/zero-user-data.service";
 
-const updateBody$ = bodyResultOf(zeroUserModelPreferenceContract.update);
+const updateBody$ = bodyResultOf(userModelPreferenceContract.update);
 
 const getUserModelPreferenceInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
@@ -101,16 +101,16 @@ const updateUserModelPreferenceInner$ = command(
   },
 );
 
-export const zeroUserModelPreferenceRoutes: readonly RouteEntry[] = [
+export const userModelPreferenceRoutes: readonly RouteEntry[] = [
   {
-    route: zeroUserModelPreferenceContract.get,
+    route: userModelPreferenceContract.get,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       getUserModelPreferenceInner$,
     ),
   },
   {
-    route: zeroUserModelPreferenceContract.update,
+    route: userModelPreferenceContract.update,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       updateUserModelPreferenceInner$,

--- a/turbo/apps/api/src/signals/services/zero-user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-data.service.ts
@@ -9,7 +9,7 @@ import {
 import type {
   UpdateUserModelPreferenceRequest,
   UserModelPreferenceResponse,
-} from "@okouai/api-contracts/contracts/zero-user-model-preference";
+} from "@okouai/api-contracts/contracts/user-model-preference";
 import { isSupportedRunModel } from "@okouai/api-contracts/contracts/model-providers";
 import { isVideoModelId } from "@okouai/api-contracts/contracts/video-models";
 import type { ChatThreadServiceTier } from "@okouai/api-contracts/contracts/chat-threads";

--- a/turbo/apps/platform/src/mocks/handlers/api-user-model-preference.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-model-preference.ts
@@ -1,7 +1,7 @@
 import {
   type UserModelPreferenceResponse,
-  zeroUserModelPreferenceContract,
-} from "@okouai/api-contracts/contracts/zero-user-model-preference";
+  userModelPreferenceContract,
+} from "@okouai/api-contracts/contracts/user-model-preference";
 import { nowDate } from "../../lib/time.ts";
 import { mockApi } from "../msw-contract.ts";
 
@@ -28,10 +28,10 @@ export function setMockUserModelPreference(
 }
 
 export const apiUserModelPreferenceHandlers = [
-  mockApi(zeroUserModelPreferenceContract.get, ({ respond }) => {
+  mockApi(userModelPreferenceContract.get, ({ respond }) => {
     return respond(200, mockUserModelPreference);
   }),
-  mockApi(zeroUserModelPreferenceContract.update, ({ body, respond }) => {
+  mockApi(userModelPreferenceContract.update, ({ body, respond }) => {
     mockUserModelPreference = {
       selectedModel: body.selectedModel,
       serviceTier: body.serviceTier,

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -9,7 +9,7 @@ import {
   type UserMessageInputDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import type { OrgModelPoliciesResponse } from "@okouai/api-contracts/contracts/model-providers";
-import type { UserModelPreferenceResponse } from "@okouai/api-contracts/contracts/zero-user-model-preference";
+import type { UserModelPreferenceResponse } from "@okouai/api-contracts/contracts/user-model-preference";
 import { accept } from "../../lib/accept.ts";
 import { startChatNavigationTiming$ } from "../../lib/posthog.ts";
 import { nowDate } from "../../lib/time.ts";

--- a/turbo/apps/platform/src/signals/external/user-model-preference.ts
+++ b/turbo/apps/platform/src/signals/external/user-model-preference.ts
@@ -6,8 +6,8 @@ import {
 import {
   type UpdateUserModelPreferenceRequest,
   type UserModelPreferenceResponse,
-  zeroUserModelPreferenceContract,
-} from "@okouai/api-contracts/contracts/zero-user-model-preference";
+  userModelPreferenceContract,
+} from "@okouai/api-contracts/contracts/user-model-preference";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import { setAblyPayloadLoop$ } from "../realtime.ts";
@@ -17,7 +17,7 @@ const internalReloadUserModelPreference$ = state(0);
 export const userModelPreference$ = computed(async (get) => {
   get(internalReloadUserModelPreference$);
   const createClient = get(zeroClient$);
-  const client = createClient(zeroUserModelPreferenceContract, {
+  const client = createClient(userModelPreferenceContract, {
     apiBase: "api",
   });
   const result = await accept(client.get(), [200]);
@@ -37,7 +37,7 @@ export const updateUserModelPreference$ = command(
     signal: AbortSignal,
   ): Promise<UserModelPreferenceResponse> => {
     const createClient = get(zeroClient$);
-    const client = createClient(zeroUserModelPreferenceContract, {
+    const client = createClient(userModelPreferenceContract, {
       apiBase: "api",
     });
     const result = await accept(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -27,9 +27,9 @@ import { zeroPersonalModelProvidersMainContract } from "@okouai/api-contracts/co
 import { zeroModelPoliciesMainContract } from "@okouai/api-contracts/contracts/zero-model-policies";
 import { zeroBillingStatusContract } from "@okouai/api-contracts/contracts/zero-billing";
 import {
-  zeroUserModelPreferenceContract,
+  userModelPreferenceContract,
   type UserModelPreferenceResponse,
-} from "@okouai/api-contracts/contracts/zero-user-model-preference";
+} from "@okouai/api-contracts/contracts/user-model-preference";
 import { zeroWorkflowsCollectionContract } from "@okouai/api-contracts/contracts/zero-workflows";
 import { IMAGE_RECOGNITION_MAX_FILE_BYTES } from "@okouai/api-contracts/contracts/image-recognition";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -172,7 +172,7 @@ describe("chat composer models", () => {
         workspaceDefaultPolicyId: policy.id,
       });
     });
-    context.mocks.api(zeroUserModelPreferenceContract.get, ({ respond }) => {
+    context.mocks.api(userModelPreferenceContract.get, ({ respond }) => {
       preferenceRequestCount += 1;
       return respond(200, {
         selectedModel: null,
@@ -228,7 +228,7 @@ describe("chat composer models", () => {
       },
     );
     context.mocks.api(
-      zeroUserModelPreferenceContract.get,
+      userModelPreferenceContract.get,
       async ({ respond, withSignal }) => {
         if (blockModelRequests) {
           await withSignal(pendingModelRequests.promise);
@@ -348,11 +348,11 @@ describe("chat composer models", () => {
     const preferenceUpdate = context.mocks.deferred<void>();
 
     mockOrgModelRoutes("claude-fable-5");
-    context.mocks.api(zeroUserModelPreferenceContract.get, ({ respond }) => {
+    context.mocks.api(userModelPreferenceContract.get, ({ respond }) => {
       return respond(200, preference);
     });
     context.mocks.api(
-      zeroUserModelPreferenceContract.update,
+      userModelPreferenceContract.update,
       async ({ body, respond }) => {
         updatedModels.push(body.selectedModel);
         await preferenceUpdate.promise;
@@ -483,7 +483,7 @@ describe("chat composer models", () => {
         updatedAt: "2026-03-10T00:00:00Z",
       });
       context.mocks.api(
-        zeroUserModelPreferenceContract.update,
+        userModelPreferenceContract.update,
         ({ body, respond }) => {
           updatedPreference = body;
           return respond(200, {
@@ -564,7 +564,7 @@ describe("chat composer models", () => {
       updatedAt: "2026-03-10T00:00:00Z",
     });
     context.mocks.api(
-      zeroUserModelPreferenceContract.update,
+      userModelPreferenceContract.update,
       ({ body, respond }) => {
         updatedPreference = body;
         return respond(200, {
@@ -607,7 +607,7 @@ describe("chat composer models", () => {
 
     mockOrgModelRoutes("claude-fable-5");
     context.mocks.api(
-      zeroUserModelPreferenceContract.update,
+      userModelPreferenceContract.update,
       ({ body, respond }) => {
         updatedModel = body.selectedModel;
         return respond(200, {
@@ -1659,7 +1659,7 @@ describe("chat composer models", () => {
 
     mockOrgModelRoutes("claude-fable-5");
     context.mocks.api(
-      zeroUserModelPreferenceContract.get,
+      userModelPreferenceContract.get,
       async ({ respond, withSignal }) => {
         if (holdPreferenceReload) {
           preferenceReloadStarted = true;
@@ -1774,7 +1774,7 @@ describe("chat composer models", () => {
     let preferenceRequestStarted = false;
 
     mockOrgModelRoutes("claude-fable-5");
-    context.mocks.api(zeroUserModelPreferenceContract.get, ({ respond }) => {
+    context.mocks.api(userModelPreferenceContract.get, ({ respond }) => {
       preferenceRequestStarted = true;
       return respond(200, {
         selectedModel: "claude-opus-4-8",

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -175,11 +175,11 @@ export {
 export {
   userModelPreferenceResponseSchema,
   updateUserModelPreferenceRequestSchema,
-  zeroUserModelPreferenceContract,
+  userModelPreferenceContract,
   type UserModelPreferenceResponse,
   type UpdateUserModelPreferenceRequest,
-  type ZeroUserModelPreferenceContract,
-} from "./zero-user-model-preference";
+  type UserModelPreferenceContract,
+} from "./user-model-preference";
 export {
   MAX_FILE_SIZE_BYTES,
   STORAGE_MANIFEST_MAX_FILES,

--- a/turbo/packages/api-contracts/src/contracts/realtime.ts
+++ b/turbo/packages/api-contracts/src/contracts/realtime.ts
@@ -52,7 +52,7 @@ function isUserPreferenceKind(kind: string): kind is UserPreferenceKind {
  * (`docs/fallback.md` §7), so every future kind addition needs this.
  *
  * This does not retroactively fix bundles already in browsers — see the
- * `defaultVideoModel` note in `zero-user-model-preference.ts`.
+ * `defaultVideoModel` note in `user-model-preference.ts`.
  */
 export const userPreferenceChangedPayloadSchema = z.object({
   kinds: z.array(z.string()).transform((kinds) => {

--- a/turbo/packages/api-contracts/src/contracts/user-model-preference.ts
+++ b/turbo/packages/api-contracts/src/contracts/user-model-preference.ts
@@ -45,7 +45,7 @@ export type UpdateUserModelPreferenceRequest = z.infer<
   typeof updateUserModelPreferenceRequestSchema
 >;
 
-export const zeroUserModelPreferenceContract = c.router({
+export const userModelPreferenceContract = c.router({
   get: {
     method: "GET",
     path: "/api/okou/user-model-preference",
@@ -76,5 +76,4 @@ export const zeroUserModelPreferenceContract = c.router({
   },
 });
 
-export type ZeroUserModelPreferenceContract =
-  typeof zeroUserModelPreferenceContract;
+export type UserModelPreferenceContract = typeof userModelPreferenceContract;


### PR DESCRIPTION
## Summary

- rename the user model preference contract and API route modules to `user-model-preference`
- rename the feature shell exports to `userModelPreferenceContract`, `UserModelPreferenceContract`, and `userModelPreferenceRoutes`, updating every in-repository caller atomically
- preserve the canonical endpoint, schemas, persistence, model-policy validation, realtime refresh, Platform cache, mocks, and optimistic model-selection behavior

## Compatibility

- keep `GET` and `PUT /api/okou/user-model-preference` unchanged
- retain the optional response `selectedVideoModel` rollout fallback tracked by #26765
- retain update semantics where an absent `selectedVideoModel` leaves the stored value unchanged and `null` clears it
- add no alias, old-path bridge, API change, migration, or compatibility duplicate

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- API user-config suite: 15 tests passed
- API model-policy suite: 37 tests passed
- affected Platform model-selection and realtime suite: 56 tests passed
- repository-wide old-path and old-symbol search: no matches

Closes #27147

Parent: #26873
