### PR TITLE
refactor(platform): replace locator landing timer

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -18,9 +18,9 @@ import {
   type Computed,
   type State,
 } from "ccstate";
-import { animationFrame } from "signal-timers";
+import { animationFrame, timeout } from "signal-timers";
 import { logger } from "../log.ts";
-import { onRef } from "../utils.ts";
+import { onRef, resetSignal } from "../utils.ts";
 
 const L = logger("ConversationLocator");
 
@@ -509,8 +509,11 @@ function createJump(
   store: LocatorStore,
   threadId: string,
   scrollContainer$: Computed<HTMLElement | null>,
+  signal: AbortSignal,
 ) {
-  return command(({ get }, turnIndex: number) => {
+  const resetLandedSignal$ = resetSignal();
+
+  return command(({ get, set }, turnIndex: number) => {
     const container = get(scrollContainer$);
     const turn = store.turns[turnIndex];
     if (!container || !turn) {
@@ -521,10 +524,20 @@ function createJump(
       top: Math.max(0, turn.top - container.clientHeight * JUMP_VIEWPORT_RATIO),
       behavior: "smooth",
     });
+    const landedSignal = set(resetLandedSignal$, signal);
     turn.element.dataset.locatorLanded = "";
-    turn.element.ownerDocument.defaultView?.setTimeout(() => {
+    const clearLanded = () => {
       delete turn.element.dataset.locatorLanded;
-    }, LANDED_MARK_MS);
+    };
+    landedSignal.addEventListener("abort", clearLanded, { once: true });
+    timeout(
+      () => {
+        landedSignal.removeEventListener("abort", clearLanded);
+        clearLanded();
+      },
+      LANDED_MARK_MS,
+      { signal: landedSignal },
+    );
   });
 }
 
@@ -867,17 +880,20 @@ function createPreviewOnRef(store: LocatorStore) {
   );
 }
 
-export function createChatConversationLocatorSignals({
-  threadId,
-  scrollContainer$,
-}: {
-  threadId: string;
-  scrollContainer$: Computed<HTMLElement | null>;
-}): ChatConversationLocatorSignals {
+export function createChatConversationLocatorSignals(
+  {
+    threadId,
+    scrollContainer$,
+  }: {
+    threadId: string;
+    scrollContainer$: Computed<HTMLElement | null>;
+  },
+  signal: AbortSignal,
+): ChatConversationLocatorSignals {
   const store = createStore();
   const recompute$ = createRecompute(store, scrollContainer$);
   const paint$ = createPaint(store);
-  const jumpToTurn$ = createJump(store, threadId, scrollContainer$);
+  const jumpToTurn$ = createJump(store, threadId, scrollContainer$, signal);
   const railOnRef$ = createRailOnRef(store, threadId, scrollContainer$, {
     recompute$,
     paint$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -3928,10 +3928,13 @@ function createChatPanelSignalsWithDraft(
     ...artifact,
   };
   const sharing = createChatThreadSharingSignals(threadId, messages.scroll);
-  const locator = createChatConversationLocatorSignals({
-    threadId,
-    scrollContainer$: messages.scroll.scrollContainer$,
-  });
+  const locator = createChatConversationLocatorSignals(
+    {
+      threadId,
+      scrollContainer$: messages.scroll.scrollContainer$,
+    },
+    signal,
+  );
   const runTracking = createRunTracking({
     threadId,
     setupChatEvents$: messages.setup$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-conversation-locator.test.tsx
@@ -431,4 +431,36 @@ describe("chat conversation locator", () => {
       );
     });
   });
+
+  it("moves the landed mark when a later jump replaces it", async () => {
+    const { rail } = await renderLongThread();
+
+    const firstTarget = ticksOf(rail)[8] as HTMLElement;
+    const secondTarget = ticksOf(rail)[12] as HTMLElement;
+    pointerAt(rail, 0, "pointerenter");
+    pointerAt(rail, Number.parseFloat(firstTarget.style.top), "pointermove");
+    await waitFor(() => {
+      expect(firstTarget.dataset.locatorHot).toBe("");
+    });
+    rail.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    const firstLanded = await waitFor(() => {
+      const element = document.querySelector<HTMLElement>(
+        "[data-locator-landed]",
+      );
+      expect(element).not.toBeNull();
+      return element as HTMLElement;
+    });
+
+    pointerAt(rail, Number.parseFloat(secondTarget.style.top), "pointermove");
+    await waitFor(() => {
+      expect(secondTarget.dataset.locatorHot).toBe("");
+    });
+    rail.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await waitFor(() => {
+      const landed = document.querySelectorAll("[data-locator-landed]");
+      expect(landed).toHaveLength(1);
+      expect(landed[0]).not.toBe(firstLanded);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- replace the chat conversation locator native one-shot timer with signal-timers timeout
- pass the chat-panel lifecycle AbortSignal as the parent owner
- use a resetSignal child so a later jump cancels and clears the previous landed marker
- clear the marker on parent abort as well as normal timeout completion

## Violation found

The daily Platform timer scan found one defaultView.setTimeout call in turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts. The custom loop scan otherwise matched only the shared setLoop implementation in signals/utils.ts.

## Signal ownership and preserved behavior

The locator is created inside createChatPanelSignalsWithDraft, so the existing per-pane chat-panel signal owns the timer. A locator-local reset child composes with that parent: every jump still marks its target for 1200 ms, a later jump replaces the earlier marker, and unloading or replacing the thread cancels the timer and removes the marker.

## Local checks

- Prettier on all changed files
- native timer scan: no matches
- custom loop scan: only shared setLoop implementation
- Platform production and test TypeScript checks
- Platform package lint
- targeted chat-conversation-locator test: 9/9 passed

Full repository validation is delegated to the PR pipeline.