### PR TITLE
test(e2e): decouple custom connector probe from upstream status

### DIFF
--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -473,6 +473,7 @@ runner_e2e_wait_for_firewall_log() {
                     .firewall_name == $firewallName and
                     .host == $host and
                     .action == "ALLOW" and
+                    (.firewall_error // null) == null and
                     (((.auth_resolved_secrets // []) | sort) == ($expectedSecrets | sort)) and
                     ($expectedUrlRewrite == "ignore" or
                         .auth_url_rewrite == ($expectedUrlRewrite == "true")))' \

--- a/e2e/tests/03-runner/run-t23-custom-connector.bats
+++ b/e2e/tests/03-runner/run-t23-custom-connector.bats
@@ -8,7 +8,6 @@ setup() {
     runner_e2e_require_environment
     runner_e2e_setup_test
     CUSTOM_CONNECTOR_ID=""
-    WEBHOOK_TOKEN=""
 }
 
 teardown() {
@@ -18,91 +17,23 @@ teardown() {
             -X DELETE \
             >/dev/null 2>&1 || true
     fi
-    if [[ -n "${WEBHOOK_TOKEN:-}" ]]; then
-        curl -fsS \
-            --connect-timeout 10 \
-            --max-time 20 \
-            -X DELETE \
-            "https://webhook.site/token/${WEBHOOK_TOKEN}" \
-            >/dev/null 2>&1 || true
-    fi
 }
 
-wait_for_webhook_request() {
-    local token="$1"
-    local marker="$2"
-    local expected_header="$3"
-    local timeout_seconds="${4:-30}"
-    local started_at=$SECONDS
-    local response='{}'
-
-    while ((SECONDS - started_at < timeout_seconds)); do
-        if response=$(curl -fsS \
-            --connect-timeout 10 \
-            --max-time 20 \
-            "https://webhook.site/token/${token}/request/latest" \
-            2>/dev/null); then
-            if ! jq -e \
-                --arg marker "$marker" \
-                --arg expectedHeader "$expected_header" '
-                    .method == "POST" and
-                    ((.content | fromjson) | .marker == $marker) and
-                    ([
-                        .headers
-                        | to_entries[]
-                        | select(
-                            (.key | ascii_downcase) ==
-                            "x-okou-custom-connector-probe"
-                        )
-                        | .value[]?
-                    ] | any(. == $expectedHeader))
-                ' <<<"$response" >/dev/null; then
-                echo "Webhook.site captured an unexpected custom connector request" >&2
-                return 1
-            fi
-            jq -cn --arg marker "$marker" '{
-                method: "POST",
-                marker: $marker,
-                credentialHeaderInjected: true
-            }'
-            return 0
-        fi
-        sleep 1
-    done
-
-    echo "Timed out waiting for the custom connector request at Webhook.site" >&2
-    return 1
-}
-
-@test "runner delivers a custom connector request with injected credentials" {
-    run create_runner_agent "runner-custom-connector-webhook-${TEST_ID}"
+@test "runner resolves custom connector credentials for an outbound request" {
+    run create_runner_agent "runner-custom-connector-${TEST_ID}"
     echo "$output"
     assert_success
     AGENT_ID="$output"
 
-    local webhook_response
-    run curl -fsS \
-        --connect-timeout 10 \
-        --max-time 20 \
-        -X POST \
-        -H 'Content-Type: application/json' \
-        -d '{"default_status":200,"default_content":"ok","default_content_type":"text/plain"}' \
-        https://webhook.site/token
-    assert_success
-    webhook_response="$output"
-    WEBHOOK_TOKEN=$(jq -er \
-        '.uuid | select(type == "string" and length == 36)' \
-        <<<"$webhook_response")
-
-    local connector_slug="_webhook-site-${TEST_ID}"
+    local connector_slug="_runner-probe-${TEST_ID}"
     local connector_payload
     connector_payload=$(jq -nc \
         --arg slug "$connector_slug" \
-        --arg prefix "https://webhook.site/${WEBHOOK_TOKEN}/" \
+        --arg prefix "https://www.google.com/" \
         '{
             slug: $slug,
             kind: "http",
-            displayName: "Runner Webhook Probe",
+            displayName: "Runner Credential Probe",
             prefixTemplates: [$prefix],
             fields: [{
                 key: "probe_secret",
@@ -127,7 +58,7 @@ wait_for_webhook_request() {
         <<<"$output")
 
     local probe_secret
-    probe_secret="e2e-webhook-$(_runner_uuid)"
+    probe_secret="e2e-custom-connector-$(_runner_uuid)"
     local values_payload
     values_payload=$(jq -nc \
         --arg secret "$probe_secret" \
@@ -168,23 +99,15 @@ wait_for_webhook_request() {
         ' <<<"$output"
     assert_success
 
-    local marker="custom-connector-webhook-${TEST_ID}"
-    local request_url="https://webhook.site/${WEBHOOK_TOKEN}/"
     local prompt
     prompt=$(cat <<'EOF'
 set -euo pipefail
-curl --fail --silent --show-error --max-time 10 \
-    --request POST \
-    --header 'Content-Type: application/json' \
-    --data '{"marker":"__MARKER__"}' \
+curl --silent --show-error --max-time 10 \
     --output /dev/null \
-    '__REQUEST_URL__'
-printf '__OUTPUT_MARKER__\n'
+    'https://www.google.com/robots.txt' || true
+printf 'CUSTOM_CONNECTOR_REQUEST_SENT\n'
 EOF
 )
-    prompt=${prompt//__MARKER__/$marker}
-    prompt=${prompt//__REQUEST_URL__/$request_url}
-    prompt=${prompt//__OUTPUT_MARKER__/CUSTOM_CONNECTOR_REQUEST_SENT}
 
     run runner_e2e_start_chat_run "$AGENT_ID" "$prompt"
     echo "$output"
@@ -207,13 +130,6 @@ EOF
     echo "$output"
     assert_success
 
-    run wait_for_webhook_request \
-        "$WEBHOOK_TOKEN" \
-        "$marker" \
-        "$probe_secret"
-    echo "$output"
-    assert_success
-
     local compact_connector_id="${CUSTOM_CONNECTOR_ID//-/}"
     local firewall_name="custom_connector_${compact_connector_id}"
     local secret_key="CUSTOM_${compact_connector_id}_S_PROBE_SECRET"
@@ -222,7 +138,7 @@ EOF
     run runner_e2e_wait_for_firewall_log \
         "$RUN_ID" \
         "$firewall_name" \
-        webhook.site \
+        www.google.com \
         "$expected_secrets"
     echo "$output"
     assert_success


### PR DESCRIPTION
## Summary

- remove the anonymous Webhook.site token, capture polling, and teardown from the custom connector runner E2E
- make the sandbox completion marker independent of the external target's HTTP status
- require successful firewall telemetry to contain no local `firewall_error`
- rename the test to reflect its provider-independent behavior

## Behavior

The test still creates and configures a custom connector through public APIs, grants it to an agent, sends a sandbox request through the connector firewall, and checks the expected resolved secret in vm0 network telemetry. It now uses an external URL already covered by the runner E2E suite and treats the upstream response as non-authoritative.

This PR does not change production connector, firewall, API, or runner behavior.

## Validation

- `shellcheck -x e2e/tests/03-runner/run-t23-custom-connector.bats`
- `bash -n e2e/helpers/runner-api.bash`
- `shellcheck -x --exclude=SC2034 e2e/helpers/runner-api.bash` (the excluded sourced-variable warning predates this change)
- BATS parse/count check: 1 test
- helper probe: successful telemetry accepted; identical telemetry with `firewall_error=auth_failed` rejected
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test` (35 passed)
- runner shard generation/discovery check
- `.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`

## Risk

The shared firewall-log helper is stricter for all callers. Each caller uses it for a successful firewall/auth path, so rejecting a local `firewall_error` matches the helper's existing contract. The deployed runner E2E shard remains the full end-to-end validation.

Closes #27166
