### PR TITLE
feat(api): add private presentation template records

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -179,6 +179,7 @@ import { teamRoutes } from "./routes/team";
 import { uploadsCompleteRoutes } from "./routes/uploads-complete";
 import { uploadsMultipartRoutes } from "./routes/uploads-multipart";
 import { uploadsPrepareRoutes } from "./routes/uploads-prepare";
+import { zeroPresentationTemplatesRoutes } from "./routes/zero-presentation-templates";
 import { usageMembersRoutes } from "./routes/usage-members";
 import { usageRecordRoutes } from "./routes/usage-record";
 import { userPreferencesRoutes } from "./routes/user-preferences";
@@ -379,6 +380,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...uploadsCompleteRoutes,
   ...uploadsMultipartRoutes,
   ...uploadsPrepareRoutes,
+  ...zeroPresentationTemplatesRoutes,
   ...registryResourceDownloadRoutes,
   ...usageMembersRoutes,
   ...usageRecordRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-presentation-templates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-presentation-templates.test.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroPresentationTemplatesContract } from "@okouai/api-contracts/contracts/zero-presentation-templates";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { zeroPresentationTemplatesRoutes } from "../zero-presentation-templates";
+
+const context = testContext();
+const bdd = createBddApi(context);
+const mocks = createZeroRouteMocks(context);
+
+function webHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+async function enablePresentationTemplates(actor: ApiTestUser): Promise<void> {
+  if (!actor.orgId) {
+    throw new Error("Presentation template tests require an organization");
+  }
+  await updateFeatureSwitchesForUser(
+    context,
+    { ...actor, orgId: actor.orgId },
+    { [FeatureSwitchKey.PresentationTemplates]: true },
+  );
+}
+
+function templateClient() {
+  return setupApp({ context, routes: zeroPresentationTemplatesRoutes })(
+    zeroPresentationTemplatesContract,
+  );
+}
+
+beforeEach(() => {
+  mockEnv("R2_USER_ARTIFACTS_BUCKET_NAME", "test-user-artifacts");
+});
+
+describe("presentation template owner routes", () => {
+  it("keeps the owner collection behind the feature switch", async () => {
+    const actor = bdd.user();
+    mocks.clerk.session(actor.userId, actor.orgId);
+    const client = templateClient();
+
+    await accept(client.list({ headers: webHeaders() }), [403]);
+
+    await enablePresentationTemplates(actor);
+    const response = await accept(
+      client.list({ headers: webHeaders() }),
+      [200],
+    );
+    expect(response.body).toStrictEqual([]);
+  });
+
+  it("does not expose an unknown template through owner routes", async () => {
+    const actor = bdd.user();
+    await enablePresentationTemplates(actor);
+    mocks.clerk.session(actor.userId, actor.orgId);
+    const client = templateClient();
+    const templateId = randomUUID();
+
+    await accept(
+      client.get({ headers: webHeaders(), params: { templateId } }),
+      [404],
+    );
+    await accept(
+      client.update({
+        headers: webHeaders(),
+        params: { templateId },
+        body: { title: "Renamed" },
+      }),
+      [404],
+    );
+    await accept(
+      client.delete({ headers: webHeaders(), params: { templateId } }),
+      [404],
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-presentation-templates.ts
+++ b/turbo/apps/api/src/signals/routes/zero-presentation-templates.ts
@@ -1,0 +1,240 @@
+import { command, computed } from "ccstate";
+import { zeroPresentationTemplatesContract } from "@okouai/api-contracts/contracts/zero-presentation-templates";
+import { isFeatureEnabled } from "@okouai/core/feature-switch";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { presentationTemplates } from "@okouai/db/schema/presentation-template";
+import { and, eq } from "drizzle-orm";
+
+import { notFound } from "../../lib/error";
+import { env } from "../../lib/env";
+import { nowDate } from "../../lib/time";
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { db$, writeDb$ } from "../external/db";
+import { generatePresignedGetUrl } from "../external/s3";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  listOwnedPresentationTemplates,
+  loadOwnedPresentationTemplate,
+  presentationTemplateSummary,
+  type PresentationTemplateRow,
+} from "../services/presentation-template-data.service";
+import { deletePresentationTemplate$ } from "../services/presentation-template-delete.service";
+import type { RouteEntry } from "../route-entry";
+
+const PRESIGNED_URL_TTL_SECONDS = 15 * 60;
+
+const templateReadAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "agent:read",
+} as const;
+
+const templateWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "agent:write",
+} as const;
+
+const presentationTemplatesDisabled = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Presentation templates are not enabled",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+const presentationTemplatesEnabled$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  return isFeatureEnabled(FeatureSwitchKey.PresentationTemplates, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  });
+});
+
+function templateNotFound(templateId: string) {
+  return notFound(`Presentation template not found: ${templateId}`);
+}
+
+function presentationTemplatePageFilename(index: number): string {
+  return `page-${(index + 1).toString().padStart(3, "0")}.png`;
+}
+
+async function signedPageUrls(
+  row: PresentationTemplateRow,
+  sign: (key: string, index: number) => Promise<string>,
+): Promise<readonly string[]> {
+  if (row.status !== "processing" && row.status !== "ready") {
+    return [];
+  }
+  return await Promise.all(
+    row.pageKeys.map(async (key, index) => {
+      return await sign(key, index);
+    }),
+  );
+}
+
+const listInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  if (!(await get(presentationTemplatesEnabled$))) {
+    return presentationTemplatesDisabled;
+  }
+  const rows = await listOwnedPresentationTemplates(get(db$), {
+    orgId: auth.orgId,
+    ownerUserId: auth.userId,
+  });
+  const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+  const summaries = await Promise.all(
+    rows.map(async (row) => {
+      const coverKey = row.pageKeys[0];
+      const coverUrl =
+        coverKey && (row.status === "processing" || row.status === "ready")
+          ? await get(
+              generatePresignedGetUrl(
+                bucket,
+                coverKey,
+                PRESIGNED_URL_TTL_SECONDS,
+                presentationTemplatePageFilename(0),
+                true,
+              ),
+            )
+          : null;
+      return presentationTemplateSummary(row, coverUrl);
+    }),
+  );
+  return { status: 200 as const, body: summaries };
+});
+
+const getParams$ = pathParamsOf(zeroPresentationTemplatesContract.get);
+const getInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  if (!(await get(presentationTemplatesEnabled$))) {
+    return presentationTemplatesDisabled;
+  }
+  const params = get(getParams$);
+  const row = await loadOwnedPresentationTemplate(get(db$), {
+    orgId: auth.orgId,
+    ownerUserId: auth.userId,
+    templateId: params.templateId,
+  });
+  if (!row) {
+    return templateNotFound(params.templateId);
+  }
+  const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+  const pageUrls = await signedPageUrls(row, async (key, index) => {
+    return await get(
+      generatePresignedGetUrl(
+        bucket,
+        key,
+        PRESIGNED_URL_TTL_SECONDS,
+        presentationTemplatePageFilename(index),
+        true,
+      ),
+    );
+  });
+  return {
+    status: 200 as const,
+    body: {
+      ...presentationTemplateSummary(row, pageUrls[0] ?? null),
+      pageUrls,
+    },
+  };
+});
+
+const updateParams$ = pathParamsOf(zeroPresentationTemplatesContract.update);
+const updateBody$ = bodyResultOf(zeroPresentationTemplatesContract.update);
+const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (!(await get(presentationTemplatesEnabled$))) {
+    return presentationTemplatesDisabled;
+  }
+  const params = get(updateParams$);
+  const bodyResult = await get(updateBody$);
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  const [row] = await set(writeDb$)
+    .update(presentationTemplates)
+    .set({
+      title: bodyResult.data.title,
+      updatedAt: nowDate(),
+      updatedBy: auth.userId,
+    })
+    .where(
+      and(
+        eq(presentationTemplates.id, params.templateId),
+        eq(presentationTemplates.orgId, auth.orgId),
+        eq(presentationTemplates.ownerUserId, auth.userId),
+      ),
+    )
+    .returning();
+  signal.throwIfAborted();
+  if (!row) {
+    return templateNotFound(params.templateId);
+  }
+  const coverKey = row.pageKeys[0];
+  const coverUrl =
+    coverKey && (row.status === "processing" || row.status === "ready")
+      ? await get(
+          generatePresignedGetUrl(
+            env("R2_USER_ARTIFACTS_BUCKET_NAME"),
+            coverKey,
+            PRESIGNED_URL_TTL_SECONDS,
+            presentationTemplatePageFilename(0),
+            true,
+          ),
+        )
+      : null;
+  return {
+    status: 200 as const,
+    body: presentationTemplateSummary(row, coverUrl),
+  };
+});
+
+const deleteParams$ = pathParamsOf(zeroPresentationTemplatesContract.delete);
+const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  if (!(await get(presentationTemplatesEnabled$))) {
+    return presentationTemplatesDisabled;
+  }
+  const params = get(deleteParams$);
+  const deleted = await set(
+    deletePresentationTemplate$,
+    {
+      orgId: auth.orgId,
+      ownerUserId: auth.userId,
+      templateId: params.templateId,
+    },
+    signal,
+  );
+  return deleted
+    ? { status: 204 as const, body: undefined }
+    : templateNotFound(params.templateId);
+});
+
+export const zeroPresentationTemplatesRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroPresentationTemplatesContract.list,
+    handler: authRoute(templateReadAuth, listInner$),
+  },
+  {
+    route: zeroPresentationTemplatesContract.get,
+    handler: authRoute(templateReadAuth, getInner$),
+  },
+  {
+    route: zeroPresentationTemplatesContract.update,
+    handler: authRoute(templateWriteAuth, updateInner$),
+  },
+  {
+    route: zeroPresentationTemplatesContract.delete,
+    handler: authRoute(templateWriteAuth, deleteInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/presentation-template-data.service.ts
+++ b/turbo/apps/api/src/signals/services/presentation-template-data.service.ts
@@ -1,0 +1,65 @@
+import type { PresentationTemplateSummary } from "@okouai/api-contracts/contracts/zero-presentation-templates";
+import { presentationTemplates } from "@okouai/db/schema/presentation-template";
+import { and, desc, eq, ne } from "drizzle-orm";
+
+import type { ReadonlyDb } from "../external/db";
+
+export type PresentationTemplateRow = typeof presentationTemplates.$inferSelect;
+
+export function presentationTemplateSummary(
+  row: PresentationTemplateRow,
+  coverUrl: string | null,
+): PresentationTemplateSummary {
+  const hasCommittedPages =
+    row.status === "processing" || row.status === "ready";
+  return {
+    id: row.id,
+    title: row.title,
+    status: row.status,
+    error: row.error,
+    sourceFilename: row.sourceFilename,
+    coverUrl: hasCommittedPages ? coverUrl : null,
+    pageCount: hasCommittedPages ? row.pageKeys.length : 0,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export async function loadOwnedPresentationTemplate(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly ownerUserId: string;
+    readonly templateId: string;
+  },
+): Promise<PresentationTemplateRow | null> {
+  const [row] = await db
+    .select()
+    .from(presentationTemplates)
+    .where(
+      and(
+        eq(presentationTemplates.id, args.templateId),
+        eq(presentationTemplates.orgId, args.orgId),
+        eq(presentationTemplates.ownerUserId, args.ownerUserId),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+export async function listOwnedPresentationTemplates(
+  db: ReadonlyDb,
+  args: { readonly orgId: string; readonly ownerUserId: string },
+): Promise<readonly PresentationTemplateRow[]> {
+  return await db
+    .select()
+    .from(presentationTemplates)
+    .where(
+      and(
+        eq(presentationTemplates.orgId, args.orgId),
+        eq(presentationTemplates.ownerUserId, args.ownerUserId),
+        ne(presentationTemplates.status, "pending"),
+      ),
+    )
+    .orderBy(desc(presentationTemplates.createdAt));
+}

--- a/turbo/apps/api/src/signals/services/presentation-template-delete.service.ts
+++ b/turbo/apps/api/src/signals/services/presentation-template-delete.service.ts
@@ -1,0 +1,68 @@
+import { command } from "ccstate";
+import { presentationTemplates } from "@okouai/db/schema/presentation-template";
+import { and, eq } from "drizzle-orm";
+
+import { nowDate } from "../../lib/time";
+import { writeDb$ } from "../external/db";
+import { lockPresentationTemplateLifecycle } from "./presentation-template-lifecycle.service";
+
+export const deletePresentationTemplate$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly ownerUserId: string;
+      readonly templateId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const db = set(writeDb$);
+    const template = await db.transaction(async (tx) => {
+      await lockPresentationTemplateLifecycle(tx, args.templateId);
+      signal.throwIfAborted();
+      const [row] = await tx
+        .select({ id: presentationTemplates.id })
+        .from(presentationTemplates)
+        .where(
+          and(
+            eq(presentationTemplates.id, args.templateId),
+            eq(presentationTemplates.orgId, args.orgId),
+            eq(presentationTemplates.ownerUserId, args.ownerUserId),
+          ),
+        )
+        .limit(1);
+      if (!row) {
+        return null;
+      }
+      await tx
+        .update(presentationTemplates)
+        .set({
+          status: "failed",
+          updatedAt: nowDate(),
+          updatedBy: args.ownerUserId,
+        })
+        .where(eq(presentationTemplates.id, row.id));
+      return row;
+    });
+    signal.throwIfAborted();
+    if (!template) {
+      return false;
+    }
+
+    // Source and page objects are normal user uploads. Deleting a template must
+    // not delete independently owned attachments that may be reused elsewhere.
+    const [deleted] = await db
+      .delete(presentationTemplates)
+      .where(
+        and(
+          eq(presentationTemplates.id, template.id),
+          eq(presentationTemplates.orgId, args.orgId),
+          eq(presentationTemplates.ownerUserId, args.ownerUserId),
+          eq(presentationTemplates.status, "failed"),
+        ),
+      )
+      .returning({ id: presentationTemplates.id });
+    signal.throwIfAborted();
+    return deleted !== undefined;
+  },
+);

--- a/turbo/apps/api/src/signals/services/presentation-template-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/presentation-template-lifecycle.service.ts
@@ -1,0 +1,12 @@
+import { sql } from "drizzle-orm";
+
+import type { Tx } from "../../lib/db-types";
+
+export async function lockPresentationTemplateLifecycle(
+  db: Tx,
+  templateId: string,
+): Promise<void> {
+  await db.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtextextended(${`presentation_template:${templateId}`}, 0))`,
+  );
+}

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1724,6 +1724,18 @@ export {
   type UploadPrepareResponse,
 } from "./zero-uploads";
 export {
+  MAX_PRESENTATION_TEMPLATE_PAGE_BYTES,
+  MAX_PRESENTATION_TEMPLATE_PAGES,
+  MAX_PRESENTATION_TEMPLATE_SOURCE_BYTES,
+  MAX_PRESENTATION_TEMPLATE_TOTAL_PAGE_BYTES,
+  PRESENTATION_TEMPLATE_PAGE_CONTENT_TYPE,
+  PRESENTATION_TEMPLATE_SOURCE_CONTENT_TYPE,
+  presentationTemplateStatusSchema,
+  zeroPresentationTemplatesContract,
+  type PresentationTemplateSummary,
+  type ZeroPresentationTemplatesContract,
+} from "./zero-presentation-templates";
+export {
   zeroGoalsContract,
   zeroGoalCreateRequestSchema,
   zeroGoalEditRequestSchema,

--- a/turbo/packages/api-contracts/src/contracts/zero-presentation-templates.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-presentation-templates.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const MAX_PRESENTATION_TEMPLATE_SOURCE_BYTES = 100 * 1024 * 1024;
+export const MAX_PRESENTATION_TEMPLATE_PAGES = 100;
+export const MAX_PRESENTATION_TEMPLATE_PAGE_BYTES = 25 * 1024 * 1024;
+export const MAX_PRESENTATION_TEMPLATE_TOTAL_PAGE_BYTES = 500 * 1024 * 1024;
+export const PRESENTATION_TEMPLATE_SOURCE_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+export const PRESENTATION_TEMPLATE_PAGE_CONTENT_TYPE = "image/png";
+
+export const presentationTemplateStatusSchema = z.enum([
+  "pending",
+  "processing",
+  "ready",
+  "failed",
+]);
+
+const presentationTemplateErrorSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+});
+
+const presentationTemplateSummarySchema = z.object({
+  id: z.uuid(),
+  title: z.string(),
+  status: presentationTemplateStatusSchema,
+  error: presentationTemplateErrorSchema.nullable(),
+  sourceFilename: z.string(),
+  coverUrl: z.string().url().nullable(),
+  pageCount: z.number().int().nonnegative(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const presentationTemplateDetailSchema =
+  presentationTemplateSummarySchema.extend({
+    pageUrls: z.array(z.string().url()),
+  });
+
+const presentationTemplateIdParamsSchema = z.object({
+  templateId: z.uuid(),
+});
+
+const updatePresentationTemplateBodySchema = z.object({
+  title: z.string().trim().min(1).max(255),
+});
+
+export const zeroPresentationTemplatesContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/okou/presentation-templates",
+    headers: authHeadersSchema,
+    responses: {
+      200: z.array(presentationTemplateSummarySchema),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List presentation templates owned by the current user",
+  },
+  get: {
+    method: "GET",
+    path: "/api/okou/presentation-templates/:templateId",
+    pathParams: presentationTemplateIdParamsSchema,
+    headers: authHeadersSchema,
+    responses: {
+      200: presentationTemplateDetailSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get a presentation template",
+  },
+  update: {
+    method: "PATCH",
+    path: "/api/okou/presentation-templates/:templateId",
+    pathParams: presentationTemplateIdParamsSchema,
+    headers: authHeadersSchema,
+    body: updatePresentationTemplateBodySchema,
+    responses: {
+      200: presentationTemplateSummarySchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Rename a presentation template",
+  },
+  delete: {
+    method: "DELETE",
+    path: "/api/okou/presentation-templates/:templateId",
+    pathParams: presentationTemplateIdParamsSchema,
+    headers: authHeadersSchema,
+    body: c.noBody(),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Delete a presentation template record",
+  },
+});
+
+export type ZeroPresentationTemplatesContract =
+  typeof zeroPresentationTemplatesContract;
+export type PresentationTemplateSummary = z.infer<
+  typeof presentationTemplateSummarySchema
+>;

--- a/turbo/packages/db/src/schema/presentation-template.ts
+++ b/turbo/packages/db/src/schema/presentation-template.ts
@@ -27,9 +27,9 @@ export type PresentationTemplateVisibility =
   (typeof PRESENTATION_TEMPLATE_VISIBILITIES)[number];
 
 /**
- * Import lifecycle. `pending` is written when the row is created, `processing`
- * once page images exist, `ready` once the package is published. `failed` is
- * terminal and carries `error`.
+ * Import lifecycle. `pending` is written only after the source and every page
+ * upload have been validated, `processing` once analysis has started, `ready`
+ * once the package is published. `failed` is terminal and carries `error`.
  */
 export const PRESENTATION_TEMPLATE_STATUSES = [
   "pending",
@@ -48,12 +48,13 @@ export type PresentationTemplateStatus =
  * `zero_workflows` derives `custom-skill@{workflowId}`. One authoritative
  * location, nothing to keep in sync.
  *
- * `page_keys` holds R2 object keys rather than URLs, so how a page is served
- * stays a read-time decision. Array position is the page number and element 0
- * is the cover, so the page count is `array_length(page_keys, 1)` and never a
- * stored column. Page images are deliberately not `run_uploaded_files` rows:
- * that table's catalog trigger would project every slide crop into the user's
- * artifact catalog.
+ * `source_storage_key` and `page_keys` reference independently owned objects
+ * created by the normal private upload route. URLs remain a read-time
+ * decision. Array position is the page number and element 0 is the cover, so
+ * the page count is `array_length(page_keys, 1)` and never a stored column.
+ * The template commit resolves those uploads directly instead of registering
+ * the page images as `run_uploaded_files`, which would project every slide
+ * crop into the user's artifact catalog.
  */
 export const presentationTemplates = pgTable(
   "presentation_templates",
@@ -71,14 +72,14 @@ export const presentationTemplates = pgTable(
       .notNull()
       .default("pending"),
     error: jsonb("error").$type<PresentationTemplateError>(),
-    /** Object key of the uploaded deck, as assigned by the upload route. */
+    /** Private artifact object key assigned by the normal upload route. */
     sourceStorageKey: text("source_storage_key").notNull(),
     sourceFilename: text("source_filename").notNull(),
     pageKeys: text("page_keys")
       .array()
       .notNull()
       .default(sql`'{}'::text[]`),
-    /** Page width divided by height, written when the pages are committed. */
+    /** Legacy compatibility column retained until #26578; new imports leave it null. */
     aspectRatio: real("aspect_ratio"),
     createdBy: text("created_by").notNull(),
     updatedBy: text("updated_by").notNull(),


### PR DESCRIPTION
## Summary

- add feature-gated owner list, get, rename, and delete routes for private presentation template records
- store only the original PPTX key and filename plus ordered PNG keys; keep URLs short-lived, omit persisted byte sizes, and keep `aspectRatio` out of the contract
- sign reads directly from committed storage keys without an R2 HEAD preflight, so missing or replaced objects surface when the signed URL is actually fetched
- add the lifecycle lock needed by the stacked atomic commit implementation and preserve independently owned source/page uploads when a template record is deleted

The final schema matches the existing database shape after removing the unmerged `source_size_bytes` and `page_sizes_bytes` proposal, so this PR intentionally contains no generated migration or snapshot changes.

## Upload transport

This foundation deliberately does **not** add a presentation-specific prepare/upload protocol or change the shared S3 presigner. The browser uses the existing authenticated `/api/okou/uploads/prepare` flow once for the PPTX and once per PNG, then passes those file IDs to the commit endpoint added by #26947.

The template flow does not call ordinary `/uploads/complete`, so page screenshots are not registered in `run_uploaded_files` or projected into the artifact catalog.

## Stack

This is the independently reviewable foundation for #26947. The stacked PR adds `sourceFileId + ordered pageFileIds` commit validation, exact-once analysis launch, run-scoped reads, callbacks, and private package publication.

The scope is PPTX only, fixed 16:9, with browser-generated PNG pages. It does not depend on browser renderer internals from #26571 and does not restore the sandbox conversion path removed by #26646.

## Verification

- changed-file Prettier write and check
- `@okouai/api-contracts`, `@okouai/db`, and `api` typechecks
- `pnpm db:generate` (`No schema changes`) and migration against temporary PostgreSQL
- `pnpm exec vitest run src/signals/routes/__tests__/zero-presentation-templates.test.ts` (2 passed on the base layer)
- `pnpm knip`

Refs #26576
Refs #21350
