### PR TITLE
refactor(telegram): neutralize outbound message route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -157,7 +157,7 @@ import { zeroIntegrationsTeamsMessageRoutes } from "./routes/zero-integrations-t
 import { zeroIntegrationsTeamsUploadCompleteRoutes } from "./routes/zero-integrations-teams-upload-complete";
 import { integrationsTeamsUploadInitRoutes } from "./routes/integrations-teams-upload-init";
 import { zeroIntegrationsTelegramRoutes } from "./routes/zero-integrations-telegram";
-import { zeroIntegrationsTelegramMessageRoutes } from "./routes/zero-integrations-telegram-message";
+import { integrationsTelegramMessageRoutes } from "./routes/integrations-telegram-message";
 import { zeroIntegrationsTelegramUploadCompleteRoutes } from "./routes/zero-integrations-telegram-upload-complete";
 import { integrationsTelegramUploadInitRoutes } from "./routes/integrations-telegram-upload-init";
 import { zeroSlackChannelsRoutes } from "./routes/zero-slack-channels";
@@ -372,7 +372,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroSlackChannelsRoutes,
   ...steamPlayerRoutes,
   ...zeroIntegrationsTelegramRoutes,
-  ...zeroIntegrationsTelegramMessageRoutes,
+  ...integrationsTelegramMessageRoutes,
   ...zeroIntegrationsTelegramUploadCompleteRoutes,
   ...integrationsTelegramUploadInitRoutes,
   ...zeroTeamRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -73,7 +73,7 @@ import { zeroIntegrationsSlackMessageRoutes } from "../../zero-integrations-slac
 import { zeroIntegrationsSlackUploadCompleteRoutes } from "../../zero-integrations-slack-upload-complete";
 import { zeroIntegrationsSlackUploadInitRoutes } from "../../zero-integrations-slack-upload-init";
 import { zeroIntegrationsTelegramRoutes } from "../../zero-integrations-telegram";
-import { zeroIntegrationsTelegramMessageRoutes } from "../../zero-integrations-telegram-message";
+import { integrationsTelegramMessageRoutes } from "../../integrations-telegram-message";
 import { zeroIntegrationsTelegramUploadCompleteRoutes } from "../../zero-integrations-telegram-upload-complete";
 import { integrationsTelegramUploadInitRoutes } from "../../integrations-telegram-upload-init";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
@@ -102,7 +102,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...zeroIntegrationsSlackUploadCompleteRoutes,
   ...zeroIntegrationsSlackUploadInitRoutes,
   ...zeroIntegrationsSlackRoutes,
-  ...zeroIntegrationsTelegramMessageRoutes,
+  ...integrationsTelegramMessageRoutes,
   ...zeroIntegrationsTelegramUploadCompleteRoutes,
   ...integrationsTelegramUploadInitRoutes,
   ...zeroIntegrationsTelegramRoutes,
@@ -1579,7 +1579,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramMessageRoutes,
+        routes: integrationsTelegramMessageRoutes,
       })(integrationsTelegramMessageContract);
       return await accept(
         client.sendMessage({
@@ -1597,7 +1597,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramMessageRoutes,
+        routes: integrationsTelegramMessageRoutes,
       })(integrationsTelegramMessageContract);
       return await accept(
         client.sendMessage({

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-message.test.ts
@@ -19,7 +19,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { createBddApi } from "./helpers/api-bdd";
 import { createComposesBddApi } from "./helpers/api-bdd-composes";
 import { createRunsApi } from "./helpers/api-bdd-runs";
-import { zeroIntegrationsTelegramMessageRoutes } from "../zero-integrations-telegram-message";
+import { integrationsTelegramMessageRoutes } from "../integrations-telegram-message";
 
 const context = testContext();
 const store = createStore();
@@ -164,7 +164,7 @@ describe("POST /api/zero/integrations/telegram/message", () => {
   it("returns 401 when no auth token is provided", async () => {
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramMessageRoutes,
+      routes: integrationsTelegramMessageRoutes,
     })(integrationsTelegramMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -191,7 +191,7 @@ describe("POST /api/zero/integrations/telegram/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramMessageRoutes,
+      routes: integrationsTelegramMessageRoutes,
     })(integrationsTelegramMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -213,7 +213,7 @@ describe("POST /api/zero/integrations/telegram/message", () => {
     mocks.clerk.session(`user_${randomUUID()}`, null);
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramMessageRoutes,
+      routes: integrationsTelegramMessageRoutes,
     })(integrationsTelegramMessageContract);
 
     const response = await accept(
@@ -269,7 +269,7 @@ describe("POST /api/zero/integrations/telegram/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramMessageRoutes,
+      routes: integrationsTelegramMessageRoutes,
     })(integrationsTelegramMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -340,7 +340,7 @@ describe("POST /api/zero/integrations/telegram/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramMessageRoutes,
+      routes: integrationsTelegramMessageRoutes,
     })(integrationsTelegramMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -379,7 +379,7 @@ describe("POST /api/zero/integrations/telegram/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramMessageRoutes,
+      routes: integrationsTelegramMessageRoutes,
     })(integrationsTelegramMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -419,7 +419,7 @@ describe("POST /api/zero/integrations/telegram/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramMessageRoutes,
+      routes: integrationsTelegramMessageRoutes,
     })(integrationsTelegramMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -462,7 +462,7 @@ describe("POST /api/zero/integrations/telegram/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramMessageRoutes,
+      routes: integrationsTelegramMessageRoutes,
     })(integrationsTelegramMessageContract);
     const response = await accept(
       client.sendMessage({

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-message.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-message.ts
@@ -96,7 +96,7 @@ const telegramWriteAuth = {
   requiredCapability: "telegram:write",
 } as const;
 
-export const zeroIntegrationsTelegramMessageRoutes: readonly RouteEntry[] = [
+export const integrationsTelegramMessageRoutes: readonly RouteEntry[] = [
   {
     route: integrationsTelegramMessageContract.sendMessage,
     handler: authRoute(telegramWriteAuth, sendMessageInner$),


### PR DESCRIPTION
## Summary

- rename the outbound Telegram message route module and focused test to `integrations-telegram-message`
- rename the route export to `integrationsTelegramMessageRoutes` and update the shared registry and BDD helper callers
- remove all stale route-shell name references from the API source tree

## Compatibility

- keep `POST /api/okou/integrations/telegram/message` unchanged
- keep the compatibility-facing `POST /api/zero/integrations/telegram/message` describe label unchanged
- preserve schemas, organization auth, `telegram:write`, bot ownership and token lookup, audit footer, HTML formatting, reply and topic-thread support, response mapping, and every user-visible string
- add no alias, fallback, contract change, migration, or behavioral refactor

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- focused Telegram message route suite: 1 file and 8 tests passed
- rebased-tree pinned Prettier, API lint, Knip, API type checks, and focused test rerun passed
- API source stale-name search: no matches

Closes #27163

Parent: #26873
