### PR TITLE
fix(chat): avoid locking threads during search projection

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { cronProjectChatEventSearchContract } from "@okouai/api-contracts/contracts/cron";
 import { testChatEventSearchProjectionContract } from "@okouai/api-contracts/contracts/test-chat-event-search-projection";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -13,6 +13,7 @@ import {
   readChatEventSearchProjectionFixture,
   rejectSearchablePromptFixture,
 } from "../../../test-fixtures/chat-event-search";
+import { holdChatEventInsertTransactionFixture } from "../../../test-fixtures/chat-events";
 import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
 import { testChatEventSearchProjectionRoutes } from "../test-chat-event-search-projection";
 import { createBddApi } from "./helpers/api-bdd";
@@ -102,7 +103,7 @@ describe("GET /api/cron/project-chat-event-search", () => {
     expect(projection.indexedSeqId).toBe(projection.lastChatEventSeqId);
   });
 
-  it("serializes overlapping projection ticks idempotently", async () => {
+  it("keeps overlapping projection ticks idempotent", async () => {
     const chatThreadId = await createProjectionThread();
     const assistantText = `overlap assistant ${randomUUID()}`;
     await insertChatSearchProjectionCoverageFixture({
@@ -130,6 +131,45 @@ describe("GET /api/cron/project-chat-event-search", () => {
         return message.text === assistantText;
       }),
     ).toHaveLength(1);
+  });
+
+  it("does not take a thread lock that conflicts with event writes", async () => {
+    const chatThreadId = await createProjectionThread();
+    await insertChatSearchProjectionCoverageFixture({
+      chatThreadId,
+      promptText: `nonblocking prompt ${randomUUID()}`,
+      assistantText: `nonblocking assistant ${randomUUID()}`,
+      errorText: `nonblocking error ${randomUUID()}`,
+      terminalText: `nonblocking terminal ${randomUUID()}`,
+    });
+    const appendedText = `writer remains live ${randomUUID()}`;
+    const heldWriter = await holdChatEventInsertTransactionFixture({
+      threadId: chatThreadId,
+      content: appendedText,
+      signal: context.signal,
+    });
+    const firstTick = projectOwnedChatEventSearch([chatThreadId]);
+    onTestFinished(async () => {
+      heldWriter.release();
+      await Promise.allSettled([heldWriter.done, firstTick]);
+    });
+
+    const projected = await firstTick;
+    expect(projected.indexedEvents).toBe(2);
+
+    heldWriter.release();
+    await heldWriter.done;
+    const caughtUp = await projectOwnedChatEventSearch([chatThreadId]);
+    expect(caughtUp.indexedEvents).toBe(1);
+    const projection = await readChatEventSearchProjectionFixture(chatThreadId);
+    expect(projection.indexedSeqId).toBe(projection.lastChatEventSeqId);
+    expect(projection.messages).toContainEqual(
+      expect.objectContaining({
+        seqId: heldWriter.event.seqId,
+        role: "assistant",
+        text: appendedText,
+      }),
+    );
   });
 
   it("bounds each projection tick to the configured thread batch", async () => {

--- a/turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts
@@ -207,17 +207,14 @@ async function visibleSearchEventIds(
   );
 }
 
-async function lockProjectionThread(
+async function loadProjectionThread(
   tx: Tx,
   chatThreadId: string,
 ): Promise<{ readonly lastChatEventSeqId: number } | null> {
-  // An update lock keeps the parent alive and serializes overlapping projector
-  // ticks, so a stale tick cannot resurrect a row after a revoker.
   const [thread] = await tx
     .select({ lastChatEventSeqId: chatThreads.lastChatEventSeqId })
     .from(chatThreads)
     .where(eq(chatThreads.id, chatThreadId))
-    .for("update")
     .limit(1);
   return thread ?? null;
 }
@@ -403,14 +400,17 @@ async function projectThread(
   thread: CandidateThread,
 ): Promise<ThreadProjectionStats> {
   return await db.transaction(async (tx) => {
-    const lockedThread = await lockProjectionThread(tx, thread.chatThreadId);
-    if (!lockedThread) {
+    const projectionThread = await loadProjectionThread(
+      tx,
+      thread.chatThreadId,
+    );
+    if (!projectionThread) {
       return emptyThreadProjectionStats();
     }
     const progress = await loadThreadProjectionProgress(
       tx,
       thread.chatThreadId,
-      lockedThread.lastChatEventSeqId,
+      projectionThread.lastChatEventSeqId,
     );
 
     const batch = await buildSearchProjectionBatch(tx, thread, progress);
@@ -418,7 +418,7 @@ async function projectThread(
     await advanceProjectionWatermark(
       tx,
       thread.chatThreadId,
-      lockedThread.lastChatEventSeqId,
+      projectionThread.lastChatEventSeqId,
       progress,
     );
 


### PR DESCRIPTION
## Summary

- replace the search projector's per-thread `SELECT ... FOR UPDATE` with a plain read, so projection work no longer holds a write-conflicting lock on `chat_threads`
- keep overlapping ticks idempotent through the existing projection primary key and monotonic watermark; the rare overlapping revoke race remains an eventual-consistency tradeoff, with no reconciler added in this PR
- add a concurrency regression test that holds an event-write transaction open, proves projection can still finish, then verifies the next tick catches up the committed event

## Why

Search projection can spend seconds writing GIN-backed message rows. Holding the thread row for that whole transaction blocks event writers when they advance `last_chat_event_seq_id`, which can surface as lock timeouts on chat callbacks.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, platform, and API type checks
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-project-chat-event-search.test.ts` (5 tests passed)
