### PR TITLE
fix(guest-agent): preserve descendant cleanup without pidfd

### DIFF
--- a/crates/guest-agent/src/cli/child_exit_notifier.rs
+++ b/crates/guest-agent/src/cli/child_exit_notifier.rs
@@ -1,9 +1,12 @@
 use std::io;
+use std::time::Duration;
 
 #[cfg(target_os = "linux")]
 use std::os::fd::OwnedFd;
 
 use tokio::process::Child;
+
+const FALLBACK_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 pub(super) struct ChildExitNotifier {
     #[cfg(target_os = "linux")]
@@ -58,6 +61,65 @@ impl ChildExitNotifier {
             "pidfd child exit notification is unavailable",
         ))
     }
+}
+
+pub(super) async fn wait_for_child_exit_without_reaping(child_id: u32) -> io::Result<()> {
+    loop {
+        if child_exited_without_reaping(child_id)? {
+            return Ok(());
+        }
+        tokio::time::sleep(FALLBACK_EXIT_POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(unix)]
+fn child_exited_without_reaping(child_id: u32) -> io::Result<bool> {
+    let child_pid = libc::pid_t::try_from(child_id).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "child PID cannot be represented as libc::pid_t",
+        )
+    })?;
+    let child_wait_id = libc::id_t::try_from(child_pid).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "child PID cannot be represented as libc::id_t",
+        )
+    })?;
+
+    loop {
+        let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::zeroed();
+        // SAFETY: child_wait_id names a direct child still owned by the caller.
+        // WNOWAIT observes terminal state without releasing its PID identity.
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                child_wait_id,
+                info.as_mut_ptr(),
+                libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+            )
+        };
+        if result == 0 {
+            // SAFETY: zero is valid for siginfo_t, and waitid may have updated
+            // it. Zero initialization keeps si_pid() at zero when WNOHANG
+            // observes no status.
+            let info = unsafe { info.assume_init() };
+            return Ok(unsafe { info.si_pid() } != 0);
+        }
+
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn child_exited_without_reaping(_child_id: u32) -> io::Result<bool> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "non-reaping child exit observation is unavailable",
+    ))
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -29,8 +29,10 @@ use tokio::task::JoinHandle;
 use crate::error::AgentError;
 
 use super::{
-    LOG_TAG, child_env, child_exit_notifier::ChildExitNotifier, diagnostics, exec_boundary,
-    line_reader, process_group::ChildProcessGroup,
+    LOG_TAG, child_env,
+    child_exit_notifier::{ChildExitNotifier, wait_for_child_exit_without_reaping},
+    diagnostics, exec_boundary, line_reader,
+    process_group::ChildProcessGroup,
 };
 
 const METHOD_NOT_FOUND: i64 = -32601;
@@ -54,6 +56,7 @@ pub struct CodexAppServerConfig {
     config_overrides: Vec<String>,
     current_dir: Option<PathBuf>,
     opt_out_notification_methods: Vec<String>,
+    pidfd_exit_notification: bool,
     workload_containment: Option<crate::workload_containment::WorkloadContainment>,
 }
 
@@ -79,6 +82,7 @@ impl CodexAppServerConfig {
             config_overrides: Vec::new(),
             current_dir: None,
             opt_out_notification_methods: Vec::new(),
+            pidfd_exit_notification: true,
             workload_containment: None,
         }
     }
@@ -152,6 +156,16 @@ impl CodexAppServerConfig {
         S: Into<String>,
     {
         self.opt_out_notification_methods = methods.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Disable the preferred pidfd exit observer for this client.
+    ///
+    /// This is an integration-test seam for exercising the non-reaping
+    /// fallback observer. Production callers should retain the default.
+    #[doc(hidden)]
+    pub fn without_pidfd_exit_notification(mut self) -> Self {
+        self.pidfd_exit_notification = false;
         self
     }
 }
@@ -398,15 +412,19 @@ impl CodexAppServerClient {
         })?;
         let stderr_handle =
             runtime.spawn(async move { diagnostics::collect_stderr_result_tail(stderr).await });
-        let exit_notifier = match ChildExitNotifier::open(&child) {
-            Ok(exit_notifier) => Some(exit_notifier),
-            Err(error) => {
-                log_warn!(
-                    LOG_TAG,
-                    "Codex app-server pidfd exit notification unavailable; natural exit cleanup will use wait-only fallback: {error}"
-                );
-                None
+        let exit_notifier = if config.pidfd_exit_notification {
+            match ChildExitNotifier::open(&child) {
+                Ok(exit_notifier) => Some(exit_notifier),
+                Err(error) => {
+                    log_warn!(
+                        LOG_TAG,
+                        "Codex app-server pidfd exit notification unavailable; natural exit cleanup will use non-reaping wait fallback: {error}"
+                    );
+                    None
+                }
             }
+        } else {
+            None
         };
 
         Ok(Self {
@@ -781,6 +799,7 @@ impl CodexAppServerClient {
     ) -> Result<IncomingMessage, CodexAppServerError> {
         loop {
             let has_exit_notifier = self.exit_notifier.is_some();
+            let fallback_child_id = self.child.as_ref().and_then(Child::id);
             tokio::select! {
                 biased;
                 line = {
@@ -817,47 +836,47 @@ impl CodexAppServerClient {
                     if let Err(error) = exit {
                         log_warn!(
                             LOG_TAG,
-                            "Codex app-server pidfd exit notification failed; natural exit cleanup will use wait-only fallback: {error}"
+                            "Codex app-server pidfd exit notification failed; natural exit cleanup will use non-reaping wait fallback: {error}"
                         );
                         self.exit_notifier = None;
                         continue;
                     }
-                    self.sigkill_process_group();
-                    let Some(child) = self.child.as_mut() else {
-                        return Err(self.poison_stream("app-server child disappeared"));
-                    };
-                    let result = child.wait().await;
-                    let status = match self.finish_child_wait(result) {
-                        Ok(status) => status,
-                        Err(error) => return Err(self.poison_error(error)),
-                    };
-                    let error = CodexAppServerError::ChildExited {
-                        method: pending_method.to_string(),
-                        status: status.to_string(),
-                    };
-                    return Err(self.poison_error(error));
+                    return Err(self.finish_observed_child_exit(pending_method).await);
                 }
-                result = async {
-                    match self.child.as_mut() {
-                        Some(child) => Some(child.wait().await),
+                exit = async {
+                    match fallback_child_id {
+                        Some(child_id) => {
+                            Some(wait_for_child_exit_without_reaping(child_id).await)
+                        }
                         None => None,
                     }
                 }, if !has_exit_notifier && self.child.is_some() => {
-                    let Some(result) = result else {
-                        return Err(self.poison_stream("app-server child disappeared"));
+                    let Some(exit) = exit else {
+                        return Err(self.poison_stream("app-server child PID disappeared"));
                     };
-                    let status = match self.finish_child_wait(result) {
-                        Ok(status) => status,
-                        Err(error) => return Err(self.poison_error(error)),
-                    };
-                    let error = CodexAppServerError::ChildExited {
-                        method: pending_method.to_string(),
-                        status: status.to_string(),
-                    };
-                    return Err(self.poison_error(error));
+                    if let Err(error) = exit {
+                        return Err(self.poison_error(CodexAppServerError::Io(error)));
+                    }
+                    return Err(self.finish_observed_child_exit(pending_method).await);
                 }
             }
         }
+    }
+
+    async fn finish_observed_child_exit(&mut self, pending_method: &str) -> CodexAppServerError {
+        self.sigkill_process_group();
+        let Some(child) = self.child.as_mut() else {
+            return self.poison_stream("app-server child disappeared");
+        };
+        let result = child.wait().await;
+        let status = match self.finish_child_wait(result) {
+            Ok(status) => status,
+            Err(error) => return self.poison_error(error),
+        };
+        self.poison_error(CodexAppServerError::ChildExited {
+            method: pending_method.to_string(),
+            status: status.to_string(),
+        })
     }
 
     async fn reject_server_request(

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -622,45 +622,81 @@ async fn codex_app_server_child_exit_before_response_fails_pending_request() -> 
 #[tokio::test]
 async fn codex_app_server_unexpected_exit_kills_stdio_holding_descendant_before_reap()
 -> Result<(), String> {
-    let mut client = spawn_client(Some("exit-on-turn-start-with-stderr-holder"))?;
+    assert_unexpected_exit_kills_stdio_holding_descendant(spawn_client(Some(
+        "exit-on-turn-start-with-stderr-holder",
+    ))?)
+    .await
+}
+
+#[tokio::test]
+async fn codex_app_server_pidfd_fallback_kills_stdio_holding_descendant_before_reap()
+-> Result<(), String> {
+    let codex_home = TempDir::new().map_err(|error| format!("create codex home: {error}"))?;
+    let config = new_config(mock_codex_path()?, codex_home.path())
+        .with_env(
+            "MOCK_CODEX_APP_SERVER_SCENARIO",
+            "exit-on-turn-start-with-stderr-holder",
+        )
+        .without_pidfd_exit_notification();
+    let client = CodexAppServerClient::spawn(config).map_err(|error| format!("{error:?}"))?;
+
+    assert_unexpected_exit_kills_stdio_holding_descendant(ClientFixture {
+        client,
+        _codex_home: codex_home,
+    })
+    .await
+}
+
+async fn assert_unexpected_exit_kills_stdio_holding_descendant(
+    mut client: ClientFixture,
+) -> Result<(), String> {
     let pid = client
         .process_id()
         .ok_or_else(|| "app-server child missing pid".to_string())?;
     let process_group = wait_for_child_process_group(pid).await?;
-    wait_result(client.initialize(), "initialize").await?;
+    let test_result = async {
+        wait_result(client.initialize(), "initialize").await?;
 
-    let started = wait_result(
-        client.request_value("thread/start", json!({})),
-        "thread/start",
-    )
-    .await?;
-    let thread_id = started["thread"]["id"]
-        .as_str()
-        .ok_or_else(|| "missing thread id".to_string())?;
+        let started = wait_result(
+            client.request_value("thread/start", json!({})),
+            "thread/start",
+        )
+        .await?;
+        let thread_id = started
+            .get("thread")
+            .and_then(|thread| thread.get("id"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| "missing thread id".to_string())?;
 
-    let result = wait_result_allow_error(
-        client.request_value(
+        let result = wait_result_allow_error(
+            client.request_value(
+                "turn/start",
+                json!({
+                    "threadId": thread_id,
+                    "input": [text_input("initial prompt")]
+                }),
+            ),
             "turn/start",
-            json!({
-                "threadId": thread_id,
-                "input": [text_input("initial prompt")]
-            }),
-        ),
-        "turn/start",
-    )
-    .await;
-    match result {
-        Err(CodexAppServerError::ChildExited { .. }) => {}
-        other => return Err(format!("expected child exit, got {other:?}")),
-    }
-    assert!(client.process_id().is_none());
+        )
+        .await;
+        match result {
+            Err(CodexAppServerError::ChildExited { .. }) => {}
+            other => return Err(format!("expected child exit, got {other:?}")),
+        }
+        assert!(client.process_id().is_none());
 
-    match tokio::time::timeout(Duration::from_millis(1500), client.shutdown()).await {
-        Ok(Ok(())) => {}
-        Ok(Err(error)) => return Err(format!("shutdown failed: {error:?}")),
-        Err(_) => return Err("shutdown waited for stderr drain timeout".to_string()),
+        match tokio::time::timeout(Duration::from_millis(1500), client.shutdown()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => return Err(format!("shutdown failed: {error:?}")),
+            Err(_) => return Err("shutdown waited for stderr drain timeout".to_string()),
+        }
+        Ok(())
     }
-    wait_for_process_group_exit(process_group).await
+    .await;
+    drop(client);
+    let cleanup_result = wait_for_process_group_exit(process_group).await;
+    test_result?;
+    cleanup_result
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add a non-reaping `waitid` fallback when pidfd setup or readiness is unavailable
- signal the owned app-server process group before reaping on both exit-observer paths
- add deterministic real-process coverage for the pidfd-disabled stdio-holder lifecycle

## Safety

- no cached PID or PGID remains signalable after the child is reaped
- production continues to prefer pidfd; the degraded fallback polls every 50 ms
- fallback observation errors poison and terminate the session while the `Child` remains owned

## Scope

- no database, API, queue, runner protocol, persisted-state, cgroup, or mock-scenario changes

## Validation

- `cargo test -p guest-agent --test codex_app_server_client stdio_holding_descendant_before_reap`
- `cargo test -p guest-agent --all-targets`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --all-features --no-deps`
- repository pre-commit hooks

Closes #27150
