### PR TITLE
test(runner): avoid executable race in usage flush fixture

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/usage_flush.rs
@@ -41,17 +41,16 @@ fn write_usage_pending_state(
 }
 
 async fn install_usage_flush_child(config: &mut RunConfig) {
-    use std::os::unix::fs::PermissionsExt;
     use tokio::io::AsyncBufReadExt;
 
     std::fs::create_dir_all(config.paths.base_dir.join("mitm-addon")).unwrap();
-    let script = config.paths.base_dir.join("usage-flush-child.sh");
-    std::fs::write(
-        &script,
-        r#"#!/usr/bin/env bash
+    let mut child = tokio::process::Command::new("bash")
+        .arg("-c")
+        .arg(
+            r#"
 set -euo pipefail
-fifo="$0.fifo"
-base_dir="$(dirname "$0")"
+base_dir="$1"
+fifo="$base_dir/usage-flush-child.fifo"
 request="$base_dir/mitm-addon/usage-flush-request"
 pending="$base_dir/mitm-addon/usage-pending"
 jsonl_request="$base_dir/mitm-addon/jsonl-flush-request"
@@ -87,14 +86,13 @@ while true; do
   write_jsonl_flush_state
 done
 "#,
-    )
-    .unwrap();
-    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
-
-    let mut child = tokio::process::Command::new(&script)
+        )
+        .arg("usage-flush-child")
+        .arg(&config.paths.base_dir)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
         .spawn()
         .unwrap();
     let stdout = child.stdout.take().unwrap();


### PR DESCRIPTION
## Summary

- run the usage-flush test child inline through `bash -c` instead of writing, chmodding, and directly executing a temporary script
- pass the fixture base directory explicitly while preserving its readiness, signal, usage-flush, JSONL, and shutdown behavior
- kill the setup child on drop if ownership is not transferred after the readiness handshake

## Why

The direct execution of a newly written test script intermittently returned Linux `ETXTBSY` and failed the entire runner coverage job. The script file, executable mode, and shebang are not part of the integration contract, so removing that boundary is more deterministic than retrying it.

## Scope

Test-only change. This does not modify runner production behavior, APIs, protocols, persisted state, migrations, or deployment compatibility.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner --all-features cmd::start::tests::main_loop::usage_flush -- --nocapture`
- 100 sequential default-harness executions of `job_completion_requests_proxy_usage_flush_without_waiting`, with no lingering fixture child
- `cargo test --manifest-path crates/Cargo.toml -p runner --bin runner --all-features` (3126 passed, 20 ignored)
- `cargo llvm-cov --manifest-path crates/Cargo.toml -p runner --bin runner --all-features --no-report -- cmd::start::tests::main_loop::usage_flush::job_completion_requests_proxy_usage_flush_without_waiting --exact`

Closes #27178
