### PR TITLE
fix(core): disable video model selection by default

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -107,6 +107,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
     );
+    expect(staffOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       true,
     );
@@ -145,6 +146,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,
     );
+    expect(otherOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -306,7 +306,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Let the chat composer model picker pin the video model a chat thread generates with.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

- remove the staff organization allowlist from `VideoModelSelection`
- keep the switch disabled by default for staff and non-staff organizations
- add rollout-matrix regression coverage for both organization classes

## Testing

- `pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13)
- `pnpm knip`
- staged TypeScript checks for non-App/API packages, App, and API
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (24/24)