### PR TITLE
refactor(agentphone): neutralize outbound message route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -139,7 +139,7 @@ import { strapiEventsRoutes } from "./routes/strapi-events";
 import { integrationsGithubRoutes } from "./routes/integrations-github";
 import { zeroIntegrationsAgentPhoneRoutes } from "./routes/zero-integrations-agentphone";
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "./routes/zero-integrations-phone-download-file";
-import { zeroIntegrationsPhoneMessageRoutes } from "./routes/zero-integrations-phone-message";
+import { integrationsPhoneMessageRoutes } from "./routes/integrations-phone-message";
 import { zeroIntegrationsPhoneUploadCompleteRoutes } from "./routes/zero-integrations-phone-upload-complete";
 import { integrationsPhoneUploadInitRoutes } from "./routes/integrations-phone-upload-init";
 import { zeroIntegrationsGithubDownloadFileRoutes } from "./routes/zero-integrations-github-download-file";
@@ -352,7 +352,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroTeamsOauthRoutes,
   ...zeroIntegrationsAgentPhoneRoutes,
   ...zeroIntegrationsPhoneDownloadFileRoutes,
-  ...zeroIntegrationsPhoneMessageRoutes,
+  ...integrationsPhoneMessageRoutes,
   ...zeroIntegrationsPhoneUploadCompleteRoutes,
   ...integrationsPhoneUploadInitRoutes,
   ...zeroIntegrationsGithubDownloadFileRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -65,7 +65,7 @@ import { zeroIntegrationsAgentPhoneRoutes } from "../../zero-integrations-agentp
 import { zeroIntegrationsGithubUploadCompleteRoutes } from "../../zero-integrations-github-upload-complete";
 import { integrationsGithubUploadInitRoutes } from "../../integrations-github-upload-init";
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "../../zero-integrations-phone-download-file";
-import { zeroIntegrationsPhoneMessageRoutes } from "../../zero-integrations-phone-message";
+import { integrationsPhoneMessageRoutes } from "../../integrations-phone-message";
 import { zeroIntegrationsPhoneUploadCompleteRoutes } from "../../zero-integrations-phone-upload-complete";
 import { integrationsPhoneUploadInitRoutes } from "../../integrations-phone-upload-init";
 import { zeroIntegrationsSlackRoutes } from "../../zero-integrations-slack";
@@ -95,7 +95,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...zeroIntegrationsGithubUploadCompleteRoutes,
   ...integrationsGithubUploadInitRoutes,
   ...zeroIntegrationsPhoneDownloadFileRoutes,
-  ...zeroIntegrationsPhoneMessageRoutes,
+  ...integrationsPhoneMessageRoutes,
   ...zeroIntegrationsPhoneUploadCompleteRoutes,
   ...integrationsPhoneUploadInitRoutes,
   ...zeroIntegrationsSlackMessageRoutes,
@@ -1817,7 +1817,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsPhoneMessageRoutes,
+        routes: integrationsPhoneMessageRoutes,
       })(integrationsPhoneMessageContract);
       return await accept(
         client.sendMessage({

--- a/turbo/apps/api/src/signals/routes/integrations-phone-message.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-phone-message.ts
@@ -125,7 +125,7 @@ const phoneWriteAuth = {
   requiredCapability: "phone:write",
 } as const;
 
-export const zeroIntegrationsPhoneMessageRoutes: readonly RouteEntry[] = [
+export const integrationsPhoneMessageRoutes: readonly RouteEntry[] = [
   {
     route: integrationsPhoneMessageContract.sendMessage,
     handler: authRoute(phoneWriteAuth, sendMessage$),


### PR DESCRIPTION
## Summary

- rename the outbound AgentPhone message route module to integrations-phone-message.ts
- rename the route export to integrationsPhoneMessageRoutes and update its production and BDD mounts
- preserve the existing endpoint, contract, authorization, delivery, persistence, and error behavior without a compatibility alias

## Testing

- pnpm format
- NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@okouai/app
- pnpm --filter @okouai/app run check-types
- pnpm --filter api run check-types
- DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts -t AgentPhone (7 passed)
- post-rebase focused Prettier, API lint, API type-check, and AgentPhone BDD rerun

Closes #27181
Parent: #26873