### PR TITLE
refactor(agentphone): neutralize upload-complete route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -140,7 +140,7 @@ import { integrationsGithubRoutes } from "./routes/integrations-github";
 import { zeroIntegrationsAgentPhoneRoutes } from "./routes/zero-integrations-agentphone";
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "./routes/zero-integrations-phone-download-file";
 import { integrationsPhoneMessageRoutes } from "./routes/integrations-phone-message";
-import { zeroIntegrationsPhoneUploadCompleteRoutes } from "./routes/zero-integrations-phone-upload-complete";
+import { integrationsPhoneUploadCompleteRoutes } from "./routes/integrations-phone-upload-complete";
 import { integrationsPhoneUploadInitRoutes } from "./routes/integrations-phone-upload-init";
 import { zeroIntegrationsGithubDownloadFileRoutes } from "./routes/zero-integrations-github-download-file";
 import { zeroIntegrationsGithubUploadCompleteRoutes } from "./routes/zero-integrations-github-upload-complete";
@@ -353,7 +353,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroIntegrationsAgentPhoneRoutes,
   ...zeroIntegrationsPhoneDownloadFileRoutes,
   ...integrationsPhoneMessageRoutes,
-  ...zeroIntegrationsPhoneUploadCompleteRoutes,
+  ...integrationsPhoneUploadCompleteRoutes,
   ...integrationsPhoneUploadInitRoutes,
   ...zeroIntegrationsGithubDownloadFileRoutes,
   ...zeroIntegrationsGithubUploadCompleteRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
@@ -26,7 +26,7 @@ import {
 } from "./api-bdd-integrations";
 import { sessionHistoryBlobBodyForKey } from "./api-bdd-session-history";
 import { createZeroRouteMocks } from "./zero-route-test";
-import { zeroIntegrationsPhoneUploadCompleteRoutes } from "../../zero-integrations-phone-upload-complete";
+import { integrationsPhoneUploadCompleteRoutes } from "../../integrations-phone-upload-complete";
 import { integrationsPhoneUploadInitRoutes } from "../../integrations-phone-upload-init";
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "../../zero-integrations-phone-download-file";
 import { logsRoutes } from "../../logs";
@@ -35,7 +35,7 @@ import { zeroModelProvidersRoutes } from "../../zero-model-providers";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...zeroIntegrationsPhoneDownloadFileRoutes,
-  ...zeroIntegrationsPhoneUploadCompleteRoutes,
+  ...integrationsPhoneUploadCompleteRoutes,
   ...integrationsPhoneUploadInitRoutes,
   ...logsRoutes,
   ...zeroModelPoliciesRoutes,
@@ -320,7 +320,7 @@ export function createAgentPhoneBddApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsPhoneUploadCompleteRoutes,
+        routes: integrationsPhoneUploadCompleteRoutes,
       })(integrationsPhoneUploadCompleteContract);
       return await accept(
         client.complete({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -66,7 +66,7 @@ import { zeroIntegrationsGithubUploadCompleteRoutes } from "../../zero-integrati
 import { integrationsGithubUploadInitRoutes } from "../../integrations-github-upload-init";
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "../../zero-integrations-phone-download-file";
 import { integrationsPhoneMessageRoutes } from "../../integrations-phone-message";
-import { zeroIntegrationsPhoneUploadCompleteRoutes } from "../../zero-integrations-phone-upload-complete";
+import { integrationsPhoneUploadCompleteRoutes } from "../../integrations-phone-upload-complete";
 import { integrationsPhoneUploadInitRoutes } from "../../integrations-phone-upload-init";
 import { zeroIntegrationsSlackRoutes } from "../../zero-integrations-slack";
 import { zeroIntegrationsSlackMessageRoutes } from "../../zero-integrations-slack-message";
@@ -96,7 +96,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...integrationsGithubUploadInitRoutes,
   ...zeroIntegrationsPhoneDownloadFileRoutes,
   ...integrationsPhoneMessageRoutes,
-  ...zeroIntegrationsPhoneUploadCompleteRoutes,
+  ...integrationsPhoneUploadCompleteRoutes,
   ...integrationsPhoneUploadInitRoutes,
   ...zeroIntegrationsSlackMessageRoutes,
   ...zeroIntegrationsSlackUploadCompleteRoutes,
@@ -1781,7 +1781,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsPhoneUploadCompleteRoutes,
+        routes: integrationsPhoneUploadCompleteRoutes,
       })(integrationsPhoneUploadCompleteContract);
       return await accept(
         client.complete({

--- a/turbo/apps/api/src/signals/routes/integrations-phone-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-phone-upload-complete.ts
@@ -205,10 +205,9 @@ const phoneWriteAuth = {
   requiredCapability: "phone:write",
 } as const;
 
-export const zeroIntegrationsPhoneUploadCompleteRoutes: readonly RouteEntry[] =
-  [
-    {
-      route: integrationsPhoneUploadCompleteContract.complete,
-      handler: authRoute(phoneWriteAuth, complete$),
-    },
-  ];
+export const integrationsPhoneUploadCompleteRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsPhoneUploadCompleteContract.complete,
+    handler: authRoute(phoneWriteAuth, complete$),
+  },
+];


### PR DESCRIPTION
## Summary

- Rename the AgentPhone upload-complete route module and exported route array to domain-neutral names.
- Update the production route registry and both BDD helpers to use the neutral route export.
- Preserve the existing contract, endpoint, authorization, artifact lookup, AgentPhone delivery, metadata, persistence, responses, and errors.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/agentphone.bdd.test.ts -t "uploads and streams phone media with a real run-scoped zero token"`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts`

## Compatibility audit

- No compatibility alias, migration, protocol change, fallback, or retained old route name.

Parent: #26873

Closes #27192
