### PR TITLE
refactor(feishu): neutralize outbound message route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -148,7 +148,7 @@ import { integrationsGithubUploadInitRoutes } from "./routes/integrations-github
 import { zeroIntegrationsFeishuFileRoutes } from "./routes/zero-integrations-feishu-files";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
 import { zeroIntegrationsSlackMessageRoutes } from "./routes/zero-integrations-slack-message";
-import { zeroIntegrationsFeishuMessageRoutes } from "./routes/zero-integrations-feishu-message";
+import { integrationsFeishuMessageRoutes } from "./routes/integrations-feishu-message";
 import { zeroIntegrationsSlackUploadCompleteRoutes } from "./routes/zero-integrations-slack-upload-complete";
 import { zeroIntegrationsSlackUploadInitRoutes } from "./routes/zero-integrations-slack-upload-init";
 import { zeroIntegrationsSlackUploadMaterializeRoutes } from "./routes/zero-integrations-slack-upload-materialize";
@@ -361,7 +361,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroIntegrationsFeishuFileRoutes,
   ...zeroIntegrationsSlackRoutes,
   ...zeroIntegrationsSlackMessageRoutes,
-  ...zeroIntegrationsFeishuMessageRoutes,
+  ...integrationsFeishuMessageRoutes,
   ...zeroIntegrationsSlackUploadCompleteRoutes,
   ...zeroIntegrationsSlackUploadInitRoutes,
   ...zeroIntegrationsSlackUploadMaterializeRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
@@ -30,13 +30,13 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { zeroFeishuConnectRoutes } from "../zero-feishu-connect";
 import { zeroFeishuOauthRoutes } from "../zero-feishu-oauth";
 import { zeroIntegrationsFeishuFileRoutes } from "../zero-integrations-feishu-files";
-import { zeroIntegrationsFeishuMessageRoutes } from "../zero-integrations-feishu-message";
+import { integrationsFeishuMessageRoutes } from "../integrations-feishu-message";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...zeroFeishuConnectRoutes,
   ...zeroFeishuOauthRoutes,
   ...zeroIntegrationsFeishuFileRoutes,
-  ...zeroIntegrationsFeishuMessageRoutes,
+  ...integrationsFeishuMessageRoutes,
 ]);
 
 const context = testContext();
@@ -61,7 +61,7 @@ interface FeishuRequestBody {
   readonly reply_in_thread?: boolean;
 }
 
-function zeroToken(args: {
+function okouToken(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly runId?: string;
@@ -195,7 +195,7 @@ async function connectCurrentFeishuUser(actor: FeishuTestActor): Promise<void> {
   await flushWaitUntilForTest();
 }
 
-describe("POST /api/zero/integrations/feishu/message", () => {
+describe("POST /api/okou/integrations/feishu/message", () => {
   let captured: CapturedRequest[];
 
   beforeEach(() => {
@@ -300,7 +300,7 @@ describe("POST /api/zero/integrations/feishu/message", () => {
   it("requires authentication and the feishu:write capability", async () => {
     const client = setupApp({
       context,
-      routes: zeroIntegrationsFeishuMessageRoutes,
+      routes: integrationsFeishuMessageRoutes,
     })(integrationsFeishuMessageContract);
     const unauthenticated = await accept(
       client.sendMessage({
@@ -330,10 +330,10 @@ describe("POST /api/zero/integrations/feishu/message", () => {
     const { actor, installationId } = await setupFeishuInstallation();
     await connectCurrentFeishuUser(actor);
     captured = [];
-    const token = zeroToken(actor);
+    const token = okouToken(actor);
     const client = setupApp({
       context,
-      routes: zeroIntegrationsFeishuMessageRoutes,
+      routes: integrationsFeishuMessageRoutes,
     })(integrationsFeishuMessageContract);
 
     const chat = await accept(
@@ -424,10 +424,10 @@ describe("POST /api/zero/integrations/feishu/message", () => {
     );
     const client = setupApp({
       context,
-      routes: zeroIntegrationsFeishuMessageRoutes,
+      routes: integrationsFeishuMessageRoutes,
     })(integrationsFeishuMessageContract);
     const headers = {
-      authorization: `Bearer ${zeroToken(actor)}`,
+      authorization: `Bearer ${okouToken(actor)}`,
     };
     const body = {
       installationId,
@@ -487,7 +487,7 @@ describe("POST /api/zero/integrations/feishu/message", () => {
       `/api/zero/integrations/feishu/download-file?${query.toString()}`,
       {
         headers: {
-          authorization: `Bearer ${zeroToken(actor)}`,
+          authorization: `Bearer ${okouToken(actor)}`,
         },
       },
     );
@@ -518,7 +518,7 @@ describe("POST /api/zero/integrations/feishu/message", () => {
     if (sent.status !== 201 || sent.body.runId === null) {
       throw new Error("Expected chat send to create a run for Feishu upload");
     }
-    const token = zeroToken({ ...actor, runId: sent.body.runId });
+    const token = okouToken({ ...actor, runId: sent.body.runId });
     const content = Buffer.from("feishu upload bytes");
     context.mocks.s3.getSignedUrl.mockResolvedValue(
       "https://storage.test/feishu-upload",

--- a/turbo/apps/api/src/signals/routes/integrations-feishu-message.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-feishu-message.ts
@@ -145,7 +145,7 @@ const sendMessage$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-export const zeroIntegrationsFeishuMessageRoutes: readonly RouteEntry[] = [
+export const integrationsFeishuMessageRoutes: readonly RouteEntry[] = [
   {
     route: integrationsFeishuMessageContract.sendMessage,
     handler: authRoute(


### PR DESCRIPTION
## Summary

- rename the outbound Feishu message route module/export and its existing mixed message/file integration test to neutral names
- update the route registry and direct test references
- rename the test-local token helper to `okouToken` and align the display-only message-route label with `/api/okou/`
- preserve the JWT protocol scope, shared Zero helpers/routes, adjacent file coverage, and `vm0UserId`

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- repository type checks for non-API packages, `@okouai/app`, and `api`
- focused Prettier, Oxlint, and ESLint checks for the three touched files
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations-feishu-message.test.ts` (5 tests)
- source-tree stale-name, retained-name, and normalized-content audits

Closes #27193
