### PR TITLE
refactor(telegram): neutralize upload-complete route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -158,7 +158,7 @@ import { zeroIntegrationsTeamsUploadCompleteRoutes } from "./routes/zero-integra
 import { integrationsTeamsUploadInitRoutes } from "./routes/integrations-teams-upload-init";
 import { zeroIntegrationsTelegramRoutes } from "./routes/zero-integrations-telegram";
 import { integrationsTelegramMessageRoutes } from "./routes/integrations-telegram-message";
-import { zeroIntegrationsTelegramUploadCompleteRoutes } from "./routes/zero-integrations-telegram-upload-complete";
+import { integrationsTelegramUploadCompleteRoutes } from "./routes/integrations-telegram-upload-complete";
 import { integrationsTelegramUploadInitRoutes } from "./routes/integrations-telegram-upload-init";
 import { zeroSlackChannelsRoutes } from "./routes/zero-slack-channels";
 import { slackCommandsRoutes } from "./routes/slack-commands";
@@ -373,7 +373,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...steamPlayerRoutes,
   ...zeroIntegrationsTelegramRoutes,
   ...integrationsTelegramMessageRoutes,
-  ...zeroIntegrationsTelegramUploadCompleteRoutes,
+  ...integrationsTelegramUploadCompleteRoutes,
   ...integrationsTelegramUploadInitRoutes,
   ...zeroTeamRoutes,
   ...zeroUploadsCompleteRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -74,7 +74,7 @@ import { zeroIntegrationsSlackUploadCompleteRoutes } from "../../zero-integratio
 import { zeroIntegrationsSlackUploadInitRoutes } from "../../zero-integrations-slack-upload-init";
 import { zeroIntegrationsTelegramRoutes } from "../../zero-integrations-telegram";
 import { integrationsTelegramMessageRoutes } from "../../integrations-telegram-message";
-import { zeroIntegrationsTelegramUploadCompleteRoutes } from "../../zero-integrations-telegram-upload-complete";
+import { integrationsTelegramUploadCompleteRoutes } from "../../integrations-telegram-upload-complete";
 import { integrationsTelegramUploadInitRoutes } from "../../integrations-telegram-upload-init";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
@@ -103,7 +103,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...zeroIntegrationsSlackUploadInitRoutes,
   ...zeroIntegrationsSlackRoutes,
   ...integrationsTelegramMessageRoutes,
-  ...zeroIntegrationsTelegramUploadCompleteRoutes,
+  ...integrationsTelegramUploadCompleteRoutes,
   ...integrationsTelegramUploadInitRoutes,
   ...zeroIntegrationsTelegramRoutes,
   ...zeroModelPoliciesRoutes,
@@ -1561,7 +1561,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramUploadCompleteRoutes,
+        routes: integrationsTelegramUploadCompleteRoutes,
       })(integrationsTelegramUploadCompleteContract);
       return await accept(
         client.complete({

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-upload-complete.test.ts
@@ -20,7 +20,7 @@ import {
   seedTelegramInstallation$,
   type TelegramFixture,
 } from "./helpers/zero-telegram";
-import { zeroIntegrationsTelegramUploadCompleteRoutes } from "../zero-integrations-telegram-upload-complete";
+import { integrationsTelegramUploadCompleteRoutes } from "../integrations-telegram-upload-complete";
 
 const context = testContext();
 const store = createStore();
@@ -145,7 +145,7 @@ async function seedSendableContext(): Promise<UploadCompleteFixture> {
   };
 }
 
-describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
+describe("POST /api/okou/integrations/telegram/upload-file/complete", () => {
   const fixtures: UploadCompleteFixture[] = [];
 
   afterEach(async () => {
@@ -196,7 +196,7 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramUploadCompleteRoutes,
+      routes: integrationsTelegramUploadCompleteRoutes,
     })(integrationsTelegramUploadCompleteContract);
     const response = await accept(
       client.complete({
@@ -258,7 +258,7 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramUploadCompleteRoutes,
+      routes: integrationsTelegramUploadCompleteRoutes,
     })(integrationsTelegramUploadCompleteContract);
     const response = await accept(
       client.complete({
@@ -285,7 +285,7 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramUploadCompleteRoutes,
+      routes: integrationsTelegramUploadCompleteRoutes,
     })(integrationsTelegramUploadCompleteContract);
 
     const response = await accept(
@@ -334,7 +334,7 @@ describe("POST /api/zero/integrations/telegram/upload-file/complete", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramUploadCompleteRoutes,
+      routes: integrationsTelegramUploadCompleteRoutes,
     })(integrationsTelegramUploadCompleteContract);
     const response = await accept(
       client.complete({

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-upload-complete.ts
@@ -193,10 +193,9 @@ const telegramWriteAuth = {
   requiredCapability: "telegram:write",
 } as const;
 
-export const zeroIntegrationsTelegramUploadCompleteRoutes: readonly RouteEntry[] =
-  [
-    {
-      route: integrationsTelegramUploadCompleteContract.complete,
-      handler: authRoute(telegramWriteAuth, completeInner$),
-    },
-  ];
+export const integrationsTelegramUploadCompleteRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsTelegramUploadCompleteContract.complete,
+    handler: authRoute(telegramWriteAuth, completeInner$),
+  },
+];


### PR DESCRIPTION
## Summary

- Rename the Telegram upload-complete route module and export to neutral integrations naming.
- Update the production route registry, BDD helper, and dedicated route test references.
- Rename the dedicated test shell and its display-only route label while preserving runtime and protocol behavior.

## Verification

- `corepack pnpm exec prettier --write apps/api/src/signals/route.ts apps/api/src/signals/routes/integrations-telegram-upload-complete.ts apps/api/src/signals/routes/__tests__/integrations-telegram-upload-complete.test.ts apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts`
- `corepack pnpm -F api lint`
- Pinned API type-check stages: dependency build, boundaries, gateways, core, bootstrap, tests, and bootstrap-wiring
- `corepack pnpm -F api exec vitest run src/signals/routes/__tests__/integrations-telegram-upload-complete.test.ts` (4 passed)

Closes #27195
