### PR TITLE
fix(runner): let guest reclaim memory before workload oom

### DIFF
--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -348,9 +348,10 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
 
 echo "--- Pressure: sustain CPU saturation with live process control ---"
 # Continue the prepared conversation so the pressure turn must reuse the VM
-# whose containment state and cleanup were verified above.
+# whose containment state and cleanup were verified above. Keep the provider
+# session independent so active input starts with a fresh stream.
 PRESSURE_CHAT_THREAD_ID="$CHAT_THREAD_ID"
-PRESSURE_SESSION_ID="$SESSION_ID"
+PRESSURE_SESSION_ID="e2e-process-containment-pressure"
 PRESSURE_SUBMIT_OUTPUT=$(mktemp)
 # Queue one input immediately while this script resolves the sandbox. Keep the
 # final input after the pressure command so the mock turn cannot finish first.
@@ -671,9 +672,10 @@ rm -f "$PRESSURE_SUBMIT_OUTPUT"
 PRESSURE_SUBMIT_OUTPUT=""
 
 echo "--- Pressure: exhaust workload memory without killing Guest Agent ---"
-# Reuse the pressure VM again to prove reclaim left it safe to park.
+# Reuse the pressure VM again to prove reclaim left it safe to park while
+# isolating terminal OOM from the active-input provider session.
 MEMORY_CHAT_THREAD_ID="$PRESSURE_CHAT_THREAD_ID"
-MEMORY_SESSION_ID="$PRESSURE_SESSION_ID"
+MEMORY_SESSION_ID="e2e-process-containment-memory"
 MEMORY_PROMPT=$(cat <<'PROMPT'
 test -f /tmp/vm0-process-containment/memory-reclaim-vm
 sudo -n python3 - <<'PY'

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -347,8 +347,10 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   || fail "Turn 3 failed; healthy cleanup did not re-enter reuse"
 
 echo "--- Pressure: sustain CPU saturation with live process control ---"
-PRESSURE_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
-PRESSURE_SESSION_ID="e2e-process-containment-pressure"
+# Continue the prepared conversation so the pressure turn must reuse the VM
+# whose containment state and cleanup were verified above.
+PRESSURE_CHAT_THREAD_ID="$CHAT_THREAD_ID"
+PRESSURE_SESSION_ID="$SESSION_ID"
 PRESSURE_SUBMIT_OUTPUT=$(mktemp)
 # Queue one input immediately while this script resolves the sandbox. Keep the
 # final input after the pressure command so the mock turn cannot finish first.
@@ -669,8 +671,9 @@ rm -f "$PRESSURE_SUBMIT_OUTPUT"
 PRESSURE_SUBMIT_OUTPUT=""
 
 echo "--- Pressure: exhaust workload memory without killing Guest Agent ---"
-MEMORY_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
-MEMORY_SESSION_ID="e2e-process-containment-memory"
+# Reuse the pressure VM again to prove reclaim left it safe to park.
+MEMORY_CHAT_THREAD_ID="$PRESSURE_CHAT_THREAD_ID"
+MEMORY_SESSION_ID="$PRESSURE_SESSION_ID"
 MEMORY_PROMPT=$(cat <<'PROMPT'
 test -f /tmp/vm0-process-containment/memory-reclaim-vm
 sudo -n python3 - <<'PY'

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -353,15 +353,16 @@ echo "--- Pressure: sustain CPU saturation with live process control ---"
 PRESSURE_CHAT_THREAD_ID="$CHAT_THREAD_ID"
 PRESSURE_SESSION_ID="e2e-process-containment-pressure"
 PRESSURE_SUBMIT_OUTPUT=$(mktemp)
-# Queue one input immediately while this script resolves the sandbox. Keep the
-# final input after the pressure command so the mock turn cannot finish first.
+# Prime the local input queue before a reused VM can emit its first result.
+# Keep the final input after the pressure command so the mock turn cannot
+# finish first.
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --timeout 80 \
   --chat-thread-id "$PRESSURE_CHAT_THREAD_ID" \
   --session-id "$PRESSURE_SESSION_ID" \
   --feature-flag sandboxReuse=true \
   --prompt '@active-input-smoke:8' \
-  --active-input 'after=100ms,text=cpu-pressure-ready' \
+  --active-input 'after=1ms,text=cpu-pressure-ready' \
   --active-input 'after=2s,text=cpu-pressure-one' \
   --active-input 'after=4s,text=cpu-pressure-two' \
   --active-input 'after=6s,text=cpu-pressure-three' \

--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -113,12 +113,15 @@ for controller in cpu memory pids; do
   grep -qw "$controller" "$parent/cgroup.subtree_control"
 done
 expected_control_memory_min=$((384 * 1024 * 1024))
+expected_workload_memory_reserve=$((128 * 1024 * 1024))
+guest_memory_bytes=$(( $(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) ))
+expected_workload_memory_max=$((guest_memory_bytes - expected_workload_memory_reserve))
 test "$(cat "$base/memory.min")" = "$expected_control_memory_min"
 test "$(cat "$parent/memory.min")" = "$expected_control_memory_min"
 test "$(cat "$parent/control/memory.min")" = "$expected_control_memory_min"
 grep -Eq '^[0-9]+ [0-9]+$' "$parent/workload/cpu.max"
 test "$(cat "$parent/workload/memory.high")" = max
-grep -Eq '^[0-9]+$' "$parent/workload/memory.max"
+test "$(cat "$parent/workload/memory.max")" = "$expected_workload_memory_max"
 test "$(cat "$parent/workload/pids.max")" = max
 test -z "${VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT:-}"
 control_member_count=$(wc -l < "$parent/control/cgroup.procs")
@@ -350,16 +353,19 @@ PRESSURE_SUBMIT_OUTPUT=$(mktemp)
 # Queue one input immediately while this script resolves the sandbox. Keep the
 # final input after the pressure command so the mock turn cannot finish first.
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-  --timeout 45 \
+  --timeout 80 \
   --chat-thread-id "$PRESSURE_CHAT_THREAD_ID" \
   --session-id "$PRESSURE_SESSION_ID" \
   --feature-flag sandboxReuse=true \
-  --prompt '@active-input-smoke:5' \
+  --prompt '@active-input-smoke:8' \
   --active-input 'after=100ms,text=cpu-pressure-ready' \
   --active-input 'after=2s,text=cpu-pressure-one' \
   --active-input 'after=4s,text=cpu-pressure-two' \
   --active-input 'after=6s,text=cpu-pressure-three' \
-  --active-input 'after=9s,text=cpu-pressure-finish' \
+  --active-input 'after=15s,text=memory-reclaim-one' \
+  --active-input 'after=30s,text=memory-reclaim-two' \
+  --active-input 'after=45s,text=memory-reclaim-three' \
+  --active-input 'after=65s,text=pressure-finish' \
   >"$PRESSURE_SUBMIT_OUTPUT" 2>&1 &
 PRESSURE_SUBMIT_PID=$!
 
@@ -441,6 +447,177 @@ grep -E -q '^cpu-pressure-complete throttled_periods=[1-9][0-9]*$' \
   <<<"$CPU_PRESSURE_RESULT" \
   || fail "CPU pressure did not report throttling"
 
+echo "--- Pressure: cross the retired workload memory boundary through Guest reclaim ---"
+PRESSURE_API_SOCK="/run/vm0/sock/$PRESSURE_SANDBOX_ID/api.sock"
+BALLOON_BEFORE=$(sudo curl -sf --unix-socket "$PRESSURE_API_SOCK" \
+  http://localhost/balloon/statistics \
+  | jq -ce '{target_mib, actual_mib, free_memory, available_memory}') \
+  || fail "failed to sample balloon before memory reclaim pressure"
+MEMORY_RECLAIM_COMMAND=$(cat <<'PYTHON'
+import gc
+import json
+import os
+import pathlib
+import time
+
+MIB = 1024 * 1024
+PAGE_SIZE = os.sysconf("SC_PAGE_SIZE")
+CHUNK_SIZE = 32 * MIB
+CONTROL_MEMORY_MIN = 384 * MIB
+WORKLOAD_MEMORY_RESERVE = 128 * MIB
+RETIRED_BOUNDARY_MARGIN = 64 * MIB
+
+
+def read_int(path):
+    return int(path.read_text().strip())
+
+
+def read_key_values(path):
+    values = {}
+    for line in path.read_text().splitlines():
+        fields = line.split()
+        if len(fields) >= 2:
+            values[fields[0]] = int(fields[1])
+    return values
+
+
+def snapshot(workload, control):
+    meminfo = read_key_values(pathlib.Path("/proc/meminfo"))
+    vmstat = read_key_values(pathlib.Path("/proc/vmstat"))
+    reclaim_keys = (
+        "pgscan_kswapd",
+        "pgscan_direct",
+        "pgsteal_kswapd",
+        "pgsteal_direct",
+    )
+    return {
+        "workload_current": read_int(workload / "memory.current"),
+        "workload_peak": read_int(workload / "memory.peak"),
+        "workload_events": read_key_values(workload / "memory.events"),
+        "control_current": read_int(control / "memory.current"),
+        "control_peak": read_int(control / "memory.peak"),
+        "mem_available_bytes": meminfo["MemAvailable:"] * 1024,
+        "vmstat": {key: vmstat.get(key, 0) for key in reclaim_keys},
+    }
+
+
+def guest_agent_control_cgroup():
+    matches = []
+    base = pathlib.Path("/sys/fs/cgroup/vm0-exec")
+    for control in base.glob("exec-*/control"):
+        for pid in control.joinpath("cgroup.procs").read_text().splitlines():
+            if pathlib.Path(f"/proc/{pid}/comm").read_text().strip() == "guest-agent":
+                matches.append(control)
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one Guest Agent control cgroup, found {len(matches)}")
+    return matches[0]
+
+
+relative = next(
+    line.removeprefix("0::").strip()
+    for line in pathlib.Path("/proc/self/cgroup").read_text().splitlines()
+    if line.startswith("0::")
+)
+if not relative.startswith("/vm0-exec/exec-") or not relative.endswith("/workload"):
+    raise RuntimeError(f"memory pressure is outside workload cgroup: {relative}")
+
+workload = pathlib.Path(f"/sys/fs/cgroup{relative}")
+control = guest_agent_control_cgroup()
+marker_dir = pathlib.Path("/tmp/vm0-process-containment")
+if not marker_dir.is_dir():
+    raise RuntimeError("memory pressure did not reuse the prepared VM")
+guest_memory_bytes = os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+legacy_memory_max = guest_memory_bytes - CONTROL_MEMORY_MIN
+configured_memory_max = read_int(workload / "memory.max")
+expected_memory_max = guest_memory_bytes - WORKLOAD_MEMORY_RESERVE
+if configured_memory_max != expected_memory_max:
+    raise RuntimeError(
+        "unexpected workload memory.max: "
+        f"actual={configured_memory_max} expected={expected_memory_max}"
+    )
+
+target = legacy_memory_max + RETIRED_BOUNDARY_MARGIN
+if target >= configured_memory_max:
+    raise RuntimeError(
+        f"memory pressure target reaches current memory.max: target={target} "
+        f"memory_max={configured_memory_max}"
+    )
+
+before = snapshot(workload, control)
+deadline = time.monotonic() + 45
+chunks = []
+while read_int(workload / "memory.current") < target:
+    if time.monotonic() >= deadline:
+        current = read_int(workload / "memory.current")
+        raise RuntimeError(
+            "memory pressure did not reach the retired boundary in 45s: "
+            f"current={current} target={target}"
+        )
+    chunk = bytearray(CHUNK_SIZE)
+    chunk[::PAGE_SIZE] = b"\x01" * (CHUNK_SIZE // PAGE_SIZE)
+    chunks.append(chunk)
+    time.sleep(0.01)
+
+peak = snapshot(workload, control)
+if peak["workload_current"] <= legacy_memory_max:
+    raise RuntimeError(
+        "memory pressure did not cross the retired workload boundary: "
+        f"current={peak['workload_current']} legacy_max={legacy_memory_max}"
+    )
+
+time.sleep(6)
+chunks.clear()
+gc.collect()
+time.sleep(1)
+after = snapshot(workload, control)
+for event in ("max", "oom", "oom_kill", "oom_group_kill"):
+    if after["workload_events"].get(event, 0) != before["workload_events"].get(event, 0):
+        raise RuntimeError(f"memory pressure triggered workload-local {event}")
+marker_dir.joinpath("memory-reclaim-vm").write_text("ready\n")
+print(
+    json.dumps(
+        {
+            "guest_memory_bytes": guest_memory_bytes,
+            "legacy_memory_max": legacy_memory_max,
+            "configured_memory_max": configured_memory_max,
+            "target": target,
+            "before": before,
+            "peak": peak,
+            "after": after,
+        },
+        separators=(",", ":"),
+    )
+)
+PYTHON
+)
+MEMORY_RECLAIM_RESULT=$(sudo "$BIN_DIR/runner" exec \
+  --timeout 60 \
+  --sandbox "$PRESSURE_SANDBOX_ID" \
+  -- python3 -c "$MEMORY_RECLAIM_COMMAND") \
+  || fail "workload could not cross the retired memory boundary"
+printf '%s\n' "$MEMORY_RECLAIM_RESULT"
+MEMORY_RECLAIM_JSON=$(awk '/^\{/{line=$0} END{print line}' <<<"$MEMORY_RECLAIM_RESULT")
+[ -n "$MEMORY_RECLAIM_JSON" ] \
+  || fail "memory reclaim pressure did not emit a usage snapshot"
+jq -e '
+  .peak.workload_current > .legacy_memory_max
+  and .peak.workload_current < .configured_memory_max
+  and .peak.workload_events.max == .before.workload_events.max
+  and .peak.workload_events.oom == .before.workload_events.oom
+  and .peak.workload_events.oom_kill == .before.workload_events.oom_kill
+  and .peak.workload_events.oom_group_kill == .before.workload_events.oom_group_kill
+  and .after.workload_events.max == .before.workload_events.max
+  and .after.workload_events.oom == .before.workload_events.oom
+  and .after.workload_events.oom_kill == .before.workload_events.oom_kill
+  and .after.workload_events.oom_group_kill == .before.workload_events.oom_group_kill
+' >/dev/null <<<"$MEMORY_RECLAIM_JSON" \
+  || fail "memory reclaim pressure crossed a workload-local resource boundary"
+BALLOON_AFTER=$(sudo curl -sf --unix-socket "$PRESSURE_API_SOCK" \
+  http://localhost/balloon/statistics \
+  | jq -ce '{target_mib, actual_mib, free_memory, available_memory}') \
+  || fail "failed to sample balloon after memory reclaim pressure"
+echo "memory-reclaim-balloon before=$BALLOON_BEFORE after=$BALLOON_AFTER"
+
 if wait "$PRESSURE_SUBMIT_PID"; then
   PRESSURE_SUBMIT_STATUS=0
 else
@@ -449,7 +626,7 @@ fi
 PRESSURE_SUBMIT_PID=""
 cat "$PRESSURE_SUBMIT_OUTPUT"
 [ "$PRESSURE_SUBMIT_STATUS" -eq 0 ] \
-  || fail "process control did not remain live during CPU pressure"
+  || fail "process control did not remain live during CPU and memory pressure"
 PRESSURE_SUBMIT_JSON=$(awk '/^\{/{line=$0} END{print line}' "$PRESSURE_SUBMIT_OUTPUT")
 [ -n "$PRESSURE_SUBMIT_JSON" ] \
   || fail "CPU-pressure submit did not return a JSON result"
@@ -459,7 +636,7 @@ SUBMITTED_PRESSURE_RUN_ID=$(jq -r '.run_id // empty' <<<"$PRESSURE_SUBMIT_JSON")
 PRESSURE_STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${PRESSURE_RUN_ID}.log"
 PRESSURE_METRICS_LOG="/var/lib/vm0-runner/logs/metrics-${PRESSURE_RUN_ID}.jsonl"
 sudo grep -F -q \
-  'RESULT=cpu-pressure-ready+cpu-pressure-one+cpu-pressure-two+cpu-pressure-three+cpu-pressure-finish' \
+  'RESULT=cpu-pressure-ready+cpu-pressure-one+cpu-pressure-two+cpu-pressure-three+memory-reclaim-one+memory-reclaim-two+memory-reclaim-three+pressure-finish' \
   "$PRESSURE_STREAM_LOG" \
   || fail "CPU-pressure active inputs were not all consumed in order"
 
@@ -484,8 +661,8 @@ METRICS_SUMMARY=$(sudo jq -sr '
 ' "$PRESSURE_METRICS_LOG") \
   || fail "failed to summarize CPU-pressure Guest metrics"
 read -r METRICS_COUNT METRICS_SPAN_SECS METRICS_MAX_GAP_SECS <<<"$METRICS_SUMMARY"
-[ "$METRICS_SPAN_SECS" -ge 4 ] \
-  || fail "Guest control metrics did not remain live during CPU pressure: ${METRICS_SPAN_SECS}s"
+[ "$METRICS_SPAN_SECS" -ge 50 ] \
+  || fail "Guest control metrics did not span CPU and memory pressure: ${METRICS_SPAN_SECS}s"
 [ "$METRICS_MAX_GAP_SECS" -le 15 ] \
   || fail "Guest control metric cadence exceeded 15s: ${METRICS_MAX_GAP_SECS}s"
 rm -f "$PRESSURE_SUBMIT_OUTPUT"
@@ -495,6 +672,7 @@ echo "--- Pressure: exhaust workload memory without killing Guest Agent ---"
 MEMORY_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
 MEMORY_SESSION_ID="e2e-process-containment-memory"
 MEMORY_PROMPT=$(cat <<'PROMPT'
+test -f /tmp/vm0-process-containment/memory-reclaim-vm
 sudo -n python3 - <<'PY'
 import pathlib
 import time

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -35,7 +35,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 
 use guest_contracts::process_containment::{
-    CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, CONTROL_MEMORY_RESERVE_BYTES, EXEC_CGROUP_BASE_PATH,
+    CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, CONTROL_MEMORY_MIN_BYTES, EXEC_CGROUP_BASE_PATH,
     EXEC_CGROUP_NAME_PREFIX, REQUIRED_CGROUP_CONTROLLERS, WORKLOAD_CGROUP_NAME,
     WorkloadResourcePolicy,
 };
@@ -290,7 +290,7 @@ fn verify_process_containment() -> io::Result<()> {
         "exec cgroup base",
     )?;
     if std::fs::read_to_string(paths.base.join(MEMORY_MIN_FILE))?.trim()
-        != CONTROL_MEMORY_RESERVE_BYTES.to_string()
+        != CONTROL_MEMORY_MIN_BYTES.to_string()
     {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -8,6 +8,9 @@ use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
+use guest_contracts::process_containment::{
+    CONTROL_MEMORY_MIN_BYTES, WORKLOAD_MEMORY_RESERVE_BYTES, WorkloadResourcePolicy,
+};
 use guest_contracts::reuse_preparation::{
     REUSE_PREPARATION_EXIT_CLEANUP_FAILED, REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED,
     REUSE_PREPARATION_EXIT_INVALID_REQUEST, ReusePreparationReport, ReusePreparationRequest,
@@ -418,8 +421,7 @@ fn prepare_for_reuse_rejects_stale_workload_memory_high() -> TestResult {
     let (request, _runtime) = reusable_request()?;
     let containment = ContainmentFixture::new()?;
     let policy =
-        guest_contracts::process_containment::WorkloadResourcePolicy::for_current_guest_capacity()
-            .map_err(std::io::Error::other)?;
+        WorkloadResourcePolicy::for_current_guest_capacity().map_err(std::io::Error::other)?;
     let legacy_memory_high = policy
         .memory_max_bytes
         .checked_sub(256 * 1024 * 1024)
@@ -429,6 +431,33 @@ fn prepare_for_reuse_rejects_stale_workload_memory_high() -> TestResult {
     std::fs::write(
         containment.base.join("exec-current/workload/memory.high"),
         legacy_memory_high.to_string(),
+    )?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
+fn prepare_for_reuse_rejects_stale_workload_memory_max() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    let policy =
+        WorkloadResourcePolicy::for_current_guest_capacity().map_err(std::io::Error::other)?;
+    let retired_reserve_delta = CONTROL_MEMORY_MIN_BYTES - WORKLOAD_MEMORY_RESERVE_BYTES;
+    let legacy_memory_max = policy
+        .memory_max_bytes
+        .checked_sub(retired_reserve_delta)
+        .ok_or_else(|| {
+            std::io::Error::other("test Guest is below the retired memory.max policy")
+        })?;
+    std::fs::write(
+        containment.base.join("exec-current/workload/memory.max"),
+        legacy_memory_max.to_string(),
     )?;
 
     let output = run_helper_with_containment(&request, &containment)?;
@@ -478,7 +507,7 @@ impl ContainmentFixture {
         }
         std::fs::write(
             base.join("memory.min"),
-            guest_contracts::process_containment::CONTROL_MEMORY_RESERVE_BYTES.to_string(),
+            CONTROL_MEMORY_MIN_BYTES.to_string(),
         )?;
         let operation = base.join("exec-current");
         std::fs::create_dir(&operation)?;
@@ -510,8 +539,8 @@ impl ContainmentFixture {
                 std::fs::write(leaf.join(filename), content)?;
             }
         }
-        let policy = guest_contracts::process_containment::WorkloadResourcePolicy::for_current_guest_capacity()
-            .map_err(std::io::Error::other)?;
+        let policy =
+            WorkloadResourcePolicy::for_current_guest_capacity().map_err(std::io::Error::other)?;
         let workload = operation.join("workload");
         for (filename, value) in [
             (

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -53,12 +53,20 @@ pub const CONTROL_CPU_RESERVE_US: u64 = 10_000;
 /// Minimum accumulated CPU throttling reported as material pressure.
 pub const MATERIAL_CPU_THROTTLED_USEC: u64 = 1_000_000;
 
-/// Memory kept outside the workload hard limit for Guest control services.
+/// Minimum protected memory for Guest control services.
 ///
 /// Cgroup v2 limits effective `memory.min` protection by every ancestor. The
 /// exec base, controlled operation, and control leaf must therefore all use
-/// this value so concurrent operation siblings cannot reclaim the reservation.
-pub const CONTROL_MEMORY_RESERVE_BYTES: u64 = 384 * 1024 * 1024;
+/// this value so concurrent operation siblings cannot reclaim protected use.
+pub const CONTROL_MEMORY_MIN_BYTES: u64 = 384 * 1024 * 1024;
+
+/// Memory kept outside the workload hard limit for new Guest control use.
+///
+/// Existing control use is protected from reclaim by [`CONTROL_MEMORY_MIN_BYTES`].
+/// This smaller reserve leaves capacity for control allocations that have not
+/// yet been charged while allowing the Guest to enter whole-memory reclaim
+/// before the workload reaches its local hard limit.
+pub const WORKLOAD_MEMORY_RESERVE_BYTES: u64 = 128 * 1024 * 1024;
 
 /// Value written to workload `memory.high` to avoid unmonitored soft-limit reclaim.
 pub const WORKLOAD_MEMORY_HIGH: &str = "max";
@@ -119,7 +127,7 @@ impl WorkloadResourcePolicy {
     ///
     /// `vcpu` is the number of online processors and `memory_bytes` is physical
     /// memory visible to the Guest. The calculation fails when the Guest cannot
-    /// preserve the fixed control reserve.
+    /// preserve the fixed control memory minimum.
     pub fn for_guest_capacity(vcpu: u32, memory_bytes: u64) -> Result<Self, &'static str> {
         let total_cpu_us = u64::from(vcpu)
             .checked_mul(WORKLOAD_CPU_PERIOD_US)
@@ -129,16 +137,20 @@ impl WorkloadResourcePolicy {
             .filter(|quota| *quota > 0)
             .ok_or("guest CPU capacity cannot preserve control headroom")?;
 
+        memory_bytes
+            .checked_sub(CONTROL_MEMORY_MIN_BYTES)
+            .filter(|remaining| *remaining > 0)
+            .ok_or("guest memory capacity cannot preserve control memory minimum")?;
         let memory_max_bytes = memory_bytes
-            .checked_sub(CONTROL_MEMORY_RESERVE_BYTES)
+            .checked_sub(WORKLOAD_MEMORY_RESERVE_BYTES)
             .filter(|limit| *limit > 0)
-            .ok_or("guest memory capacity cannot preserve control headroom")?;
+            .ok_or("guest memory capacity cannot preserve workload memory reserve")?;
         Ok(Self {
             cpu_quota_us,
             cpu_period_us: WORKLOAD_CPU_PERIOD_US,
             memory_high: WORKLOAD_MEMORY_HIGH,
             memory_max_bytes,
-            control_memory_min_bytes: CONTROL_MEMORY_RESERVE_BYTES,
+            control_memory_min_bytes: CONTROL_MEMORY_MIN_BYTES,
             pids_max: WORKLOAD_PIDS_MAX,
         })
     }
@@ -157,19 +169,19 @@ mod tests {
         assert_eq!(policy.cpu_quota_us, 190_000);
         assert_eq!(policy.cpu_period_us, 100_000);
         assert_eq!(policy.memory_high, "max");
-        assert_eq!(policy.memory_max_bytes, 3712 * 1024 * 1024);
+        assert_eq!(policy.memory_max_bytes, 3968 * 1024 * 1024);
         assert_eq!(policy.control_memory_min_bytes, 384 * 1024 * 1024);
         assert_eq!(policy.pids_max, "max");
     }
 
     #[test]
-    fn rejects_capacity_without_control_memory_headroom() {
-        let error = WorkloadResourcePolicy::for_guest_capacity(1, CONTROL_MEMORY_RESERVE_BYTES)
-            .unwrap_err();
+    fn rejects_capacity_without_control_memory_minimum() {
+        let error =
+            WorkloadResourcePolicy::for_guest_capacity(1, CONTROL_MEMORY_MIN_BYTES).unwrap_err();
 
         assert_eq!(
             error,
-            "guest memory capacity cannot preserve control headroom"
+            "guest memory capacity cannot preserve control memory minimum"
         );
     }
 
@@ -181,7 +193,7 @@ mod tests {
 
         assert_eq!(policy.cpu_quota_us, 90_000);
         assert_eq!(policy.memory_high, "max");
-        assert_eq!(policy.memory_max_bytes, 640 * 1024 * 1024);
+        assert_eq!(policy.memory_max_bytes, 896 * 1024 * 1024);
     }
 
     #[test]
@@ -192,6 +204,6 @@ mod tests {
 
         assert_eq!(policy.cpu_quota_us, 90_000);
         assert_eq!(policy.memory_high, "max");
-        assert_eq!(policy.memory_max_bytes, 631_275_520);
+        assert_eq!(policy.memory_max_bytes, 899_710_976);
     }
 }

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -17,7 +17,7 @@ use std::io;
 use std::path::Path;
 
 use guest_contracts::process_containment::{
-    CGROUP_V2_MOUNT_PATH, CONTROL_MEMORY_RESERVE_BYTES, EXEC_CGROUP_BASE_PATH,
+    CGROUP_V2_MOUNT_PATH, CONTROL_MEMORY_MIN_BYTES, EXEC_CGROUP_BASE_PATH,
     REQUIRED_CGROUP_CONTROLLERS, REQUIRED_CGROUP_SUBTREE_CONTROL,
 };
 
@@ -187,7 +187,7 @@ fn initialize_process_containment() -> Result<(), InitError> {
     let memory_min_path = base.join(MEMORY_MIN_FILE);
     fs::write(
         &memory_min_path,
-        CONTROL_MEMORY_RESERVE_BYTES.to_string().as_bytes(),
+        CONTROL_MEMORY_MIN_BYTES.to_string().as_bytes(),
     )
     .map_err(|source| InitError::Filesystem {
         operation: "configure control memory protection in",
@@ -305,7 +305,7 @@ fn verify_process_containment_base(base: &Path) -> Result<(), InitError> {
             path: base.join(MEMORY_MIN_FILE).display().to_string(),
             source,
         })?;
-    if memory_min.trim() != CONTROL_MEMORY_RESERVE_BYTES.to_string() {
+    if memory_min.trim() != CONTROL_MEMORY_MIN_BYTES.to_string() {
         return Err(InitError::InvalidProcessContainment(format!(
             "exec cgroup base {MEMORY_MIN_FILE} does not preserve control memory"
         )));
@@ -370,7 +370,7 @@ mod tests {
         }
         fs::write(
             base.join(MEMORY_MIN_FILE),
-            CONTROL_MEMORY_RESERVE_BYTES.to_string(),
+            CONTROL_MEMORY_MIN_BYTES.to_string(),
         )
         .unwrap();
     }


### PR DESCRIPTION
## Summary

- keep 384 MiB of effective `memory.min` protection for Guest control services
- reserve 128 MiB, instead of 384 MiB, outside workload `memory.max` so whole-Guest reclaim and balloon relief can run before a workload-local OOM
- reject stale sandboxes carrying the previous workload limit and add production-equivalent reclaim coverage

## Problem

The same 384 MiB constant currently controls both reclaim protection for the Guest Agent and the amount subtracted from workload `memory.max`. Production runs reached that workload-local hard limit and group-killed Codex while the Guest still had memory that whole-Guest reclaim could have recovered.

## Solution

The shared containment policy now models the two requirements independently:

- `CONTROL_MEMORY_MIN_BYTES` remains 384 MiB at the execution base, operation parent, and control leaf.
- `WORKLOAD_MEMORY_RESERVE_BYTES` is 128 MiB and is the only amount subtracted from Guest-visible physical capacity for workload `memory.max`.
- capacity validation still requires more than the larger 384 MiB control minimum.
- reuse preparation continues to verify the exact current policy, so a sandbox with the retired capacity-minus-384-MiB limit falls back to fresh creation.

The production-equivalent behavior lane now charges a reused workload past the retired boundary, records cgroup, Guest-memory, reclaim, and balloon samples, and proves there is no workload-local hard-limit event while active input and Guest metrics remain live. The existing deterministic 256 MiB exhaustion case still verifies bounded group OOM, diagnostics, cleanup, and later reuse.

## Exclusions

- no change to `memory.high=max`, `memory.oom.group=1`, PID limits, or CPU policy
- no change to the Firecracker balloon controller
- no adaptive memory-pressure supervisor or global-OOM victim policy
- no API, database, queue, or public resource-setting change

## Validation

- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- `shellcheck .github/scripts/runner-behavior-process-containment.sh`
- compile the behavior script's embedded Python reclaim probe
- `cargo test -p guest-contracts`
- `cargo test -p guest-init`
- `cargo test -p guest-agent --test reuse_preparation_helper`
- `cargo test -p vsock-guest --lib process_containment`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-features`
- real Firecracker validation on `local-1.aws.vm3.ai`: workload `memory.current` crossed the retired limit (3,723,182,080 bytes) and reached 3,809,665,024 bytes below the new 3,991,617,536-byte limit; balloon relief reached zero, Guest reclaim counters increased, Guest Agent control remained live, and workload `max`/`oom`/`oom_kill`/`oom_group_kill` counters stayed unchanged

The CI production-configuration test creates the required sandbox `user` in its toolchain container; the local development container does not carry that production identity.

Closes #27188
