### PR TITLE
refactor(usage-record): neutralize the personal usage vertical slice

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -180,7 +180,7 @@ import { zeroUploadsCompleteRoutes } from "./routes/zero-uploads-complete";
 import { zeroUploadsMultipartRoutes } from "./routes/zero-uploads-multipart";
 import { zeroUploadsPrepareRoutes } from "./routes/zero-uploads-prepare";
 import { zeroUsageMembersRoutes } from "./routes/zero-usage-members";
-import { zeroUsageRecordRoutes } from "./routes/zero-usage-record";
+import { usageRecordRoutes } from "./routes/usage-record";
 import { userPreferencesRoutes } from "./routes/user-preferences";
 import { zeroUserPermissionGrantsRoutes } from "./routes/zero-user-permission-grants";
 import { userModelPreferenceRoutes } from "./routes/user-model-preference";
@@ -381,7 +381,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroUploadsPrepareRoutes,
   ...registryResourceDownloadRoutes,
   ...zeroUsageMembersRoutes,
-  ...zeroUsageRecordRoutes,
+  ...usageRecordRoutes,
   ...modelStatsRoutes,
   ...presentationImagesRoutes,
   ...runnersRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -28,9 +28,9 @@ import { zeroImageIoGenerateContract } from "@okouai/api-contracts/contracts/zer
 import { mapsContract } from "@okouai/api-contracts/contracts/maps";
 import { zeroUsageMembersContract } from "@okouai/api-contracts/contracts/zero-usage";
 import {
-  zeroUsageRecordContract,
+  usageRecordContract,
   type UsageRecordRange,
-} from "@okouai/api-contracts/contracts/zero-usage-record";
+} from "@okouai/api-contracts/contracts/usage-record";
 import { zeroVideoIoGenerateContract } from "@okouai/api-contracts/contracts/zero-video-io-generate";
 import { voiceIoQuotaContract } from "@okouai/api-contracts/contracts/voice-io-quota";
 import { voiceIoSpeechContract } from "@okouai/api-contracts/contracts/voice-io-speech";
@@ -64,7 +64,7 @@ import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
 import { zeroImageIoGenerateRoutes } from "../../zero-image-io-generate";
 import { mapsRoutes } from "../../maps";
 import { zeroUsageMembersRoutes } from "../../zero-usage-members";
-import { zeroUsageRecordRoutes } from "../../zero-usage-record";
+import { usageRecordRoutes } from "../../usage-record";
 import { zeroVideoIoGenerateRoutes } from "../../zero-video-io-generate";
 import { voiceIoQuotaRoutes } from "../../voice-io-quota";
 import { voiceIoSpeechRoutes } from "../../voice-io-speech";
@@ -522,8 +522,8 @@ export function createBillingMediaApi(context: TestContext) {
     },
 
     async readUsageRecord(actor: ApiTestUser) {
-      const client = setupApp({ context, routes: zeroUsageRecordRoutes })(
-        zeroUsageRecordContract,
+      const client = setupApp({ context, routes: usageRecordRoutes })(
+        usageRecordContract,
       );
       return await accept(
         client.get({

--- a/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
@@ -6,7 +6,7 @@ import {
   imageRecognitionContract,
 } from "@okouai/api-contracts/contracts/image-recognition";
 import type { ZeroCapability } from "@okouai/api-contracts/contracts/composes";
-import { zeroUsageRecordContract } from "@okouai/api-contracts/contracts/zero-usage-record";
+import { usageRecordContract } from "@okouai/api-contracts/contracts/usage-record";
 import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
 
@@ -26,7 +26,7 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { readUsageStorageCounts$ } from "./helpers/usage-state";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { imageRecognitionRoutes } from "../image-recognition";
-import { zeroUsageRecordRoutes } from "../zero-usage-record";
+import { usageRecordRoutes } from "../usage-record";
 
 const context = testContext();
 const store = createStore();
@@ -195,9 +195,7 @@ async function readUsageRecord(actor: RecognitionActor) {
   mockClerkUserLookup();
   mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
   const response = await accept(
-    setupApp({ context, routes: zeroUsageRecordRoutes })(
-      zeroUsageRecordContract,
-    ).get({
+    setupApp({ context, routes: usageRecordRoutes })(usageRecordContract).get({
       headers: { authorization: "Bearer clerk-session" },
       query: {
         page: 1,

--- a/turbo/apps/api/src/signals/routes/__tests__/people-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/people-search.test.ts
@@ -5,7 +5,7 @@ import {
   type PeopleSearchRequest,
 } from "@okouai/api-contracts/contracts/people-search";
 import { zeroBillingStatusContract } from "@okouai/api-contracts/contracts/zero-billing";
-import { zeroUsageRecordContract } from "@okouai/api-contracts/contracts/zero-usage-record";
+import { usageRecordContract } from "@okouai/api-contracts/contracts/usage-record";
 import { webSearchContract } from "@okouai/api-contracts/contracts/web-search";
 import { HttpResponse, http, type JsonBodyType } from "msw";
 import { describe, expect, it, onTestFinished } from "vitest";
@@ -35,7 +35,7 @@ import {
 } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroUsageRecordRoutes } from "../zero-usage-record";
+import { usageRecordRoutes } from "../usage-record";
 
 const context = testContext();
 const PERPLEXITY_AGENT_URL = "https://api.perplexity.ai/v1/agent";
@@ -834,18 +834,18 @@ describe("okou people-search route", () => {
       [200],
     );
     const usage = await accept(
-      setupApp({ context, routes: zeroUsageRecordRoutes })(
-        zeroUsageRecordContract,
-      ).get({
-        headers: authenticate(actor),
-        query: {
-          page: 1,
-          pageSize: 100,
-          scope: "mine",
-          range: "today",
-          tz: "UTC",
+      setupApp({ context, routes: usageRecordRoutes })(usageRecordContract).get(
+        {
+          headers: authenticate(actor),
+          query: {
+            page: 1,
+            pageSize: 100,
+            scope: "mine",
+            range: "today",
+            tz: "UTC",
+          },
         },
-      }),
+      ),
       [200],
     );
     const usageRow = usage.body.rows.find((row) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/translation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/translation.test.ts
@@ -5,7 +5,7 @@ import {
   TRANSLATION_MAX_SOURCE_TEXT_CHARS,
   translationContract,
 } from "@okouai/api-contracts/contracts/translation";
-import { zeroUsageRecordContract } from "@okouai/api-contracts/contracts/zero-usage-record";
+import { usageRecordContract } from "@okouai/api-contracts/contracts/usage-record";
 import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
 
@@ -23,7 +23,7 @@ import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { translationRoutes } from "../translation";
-import { zeroUsageRecordRoutes } from "../zero-usage-record";
+import { usageRecordRoutes } from "../usage-record";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -161,9 +161,7 @@ async function readUsageRecord(actor: TranslationActor) {
   context.mocks.clerk.users.getUserList.mockResolvedValue({ data: [] });
   mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
   const response = await accept(
-    setupApp({ context, routes: zeroUsageRecordRoutes })(
-      zeroUsageRecordContract,
-    ).get({
+    setupApp({ context, routes: usageRecordRoutes })(usageRecordContract).get({
       headers: { authorization: "Bearer clerk-session" },
       query: {
         page: 1,

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-record.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-record.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { createStore } from "ccstate";
 import type { TriggerSource } from "@okouai/api-contracts/contracts/logs";
 import { mapsContract } from "@okouai/api-contracts/contracts/maps";
-import { zeroUsageRecordContract } from "@okouai/api-contracts/contracts/zero-usage-record";
+import { usageRecordContract } from "@okouai/api-contracts/contracts/usage-record";
 import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
 
@@ -29,7 +29,7 @@ import {
   readUsageStorageCounts$,
 } from "./helpers/usage-state";
 import { mapsRoutes } from "../maps";
-import { zeroUsageRecordRoutes } from "../zero-usage-record";
+import { usageRecordRoutes } from "../usage-record";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -90,9 +90,7 @@ function authHeaders() {
 }
 
 function apiClient() {
-  return setupApp({ context, routes: zeroUsageRecordRoutes })(
-    zeroUsageRecordContract,
-  );
+  return setupApp({ context, routes: usageRecordRoutes })(usageRecordContract);
 }
 
 function createdAt(minutesAgo: number): Date {

--- a/turbo/apps/api/src/signals/routes/__tests__/web-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-search.test.ts
@@ -10,7 +10,7 @@ import {
   type WebSearchRequest,
 } from "@okouai/api-contracts/contracts/web-search";
 import { zeroBillingStatusContract } from "@okouai/api-contracts/contracts/zero-billing";
-import { zeroUsageRecordContract } from "@okouai/api-contracts/contracts/zero-usage-record";
+import { usageRecordContract } from "@okouai/api-contracts/contracts/usage-record";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -41,7 +41,7 @@ import {
   postUsageAllowanceInvoicePaid,
 } from "./helpers/stripe-billing-webhook";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroUsageRecordRoutes } from "../zero-usage-record";
+import { usageRecordRoutes } from "../usage-record";
 
 const context = testContext();
 const PERPLEXITY_SEARCH_URL = "https://api.perplexity.ai/search";
@@ -298,18 +298,18 @@ describe("okou web-search route", () => {
       ],
     });
     const usage = await accept(
-      setupApp({ context, routes: zeroUsageRecordRoutes })(
-        zeroUsageRecordContract,
-      ).get({
-        headers: authenticate(actor),
-        query: {
-          page: 1,
-          pageSize: 20,
-          scope: "mine",
-          range: "24h",
-          tz: "UTC",
+      setupApp({ context, routes: usageRecordRoutes })(usageRecordContract).get(
+        {
+          headers: authenticate(actor),
+          query: {
+            page: 1,
+            pageSize: 20,
+            scope: "mine",
+            range: "24h",
+            tz: "UTC",
+          },
         },
-      }),
+      ),
       [200],
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -20,7 +20,7 @@ import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generation
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
 import { builtInGenerationRoutes } from "../built-in-generation";
 import { zeroImageIoGenerateRoutes } from "../zero-image-io-generate";
-import { zeroUsageRecordRoutes } from "../zero-usage-record";
+import { usageRecordRoutes } from "../usage-record";
 import {
   createUsagePricingFixture,
   seedOrgMetadata,
@@ -137,7 +137,7 @@ function createImageIoTestApp(
       ...zeroImageIoGenerateRoutes,
       ...webhooksBuiltInGenerationRoutes,
       ...zeroBillingStatusRoutes,
-      ...zeroUsageRecordRoutes,
+      ...usageRecordRoutes,
     ],
     usagePricingResolution,
   });

--- a/turbo/apps/api/src/signals/routes/usage-record.ts
+++ b/turbo/apps/api/src/signals/routes/usage-record.ts
@@ -1,11 +1,11 @@
 import { command } from "ccstate";
-import { zeroUsageRecordContract } from "@okouai/api-contracts/contracts/zero-usage-record";
+import { usageRecordContract } from "@okouai/api-contracts/contracts/usage-record";
 
 import { badRequestMessage } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
-import { zeroUsageRecord$ } from "../services/zero-usage-record.service";
+import { usageRecord$ } from "../services/usage-record.service";
 import type { RouteEntry } from "../route-entry";
 import { isValidTimeZone } from "../utils";
 
@@ -24,7 +24,7 @@ function teamUsageRecordsUnavailable() {
 const getUsageRecordInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const query = get(queryOf(zeroUsageRecordContract.get));
+    const query = get(queryOf(usageRecordContract.get));
 
     if (!isValidTimeZone(query.tz)) {
       return badRequestMessage(`Invalid timezone: ${query.tz}`);
@@ -35,7 +35,7 @@ const getUsageRecordInner$ = command(
     }
 
     const body = await set(
-      zeroUsageRecord$,
+      usageRecord$,
       {
         userId: auth.userId,
         orgId: auth.orgId,
@@ -54,9 +54,9 @@ const getUsageRecordInner$ = command(
   },
 );
 
-export const zeroUsageRecordRoutes: readonly RouteEntry[] = [
+export const usageRecordRoutes: readonly RouteEntry[] = [
   {
-    route: zeroUsageRecordContract.get,
+    route: usageRecordContract.get,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
       getUsageRecordInner$,

--- a/turbo/apps/api/src/signals/services/usage-period.ts
+++ b/turbo/apps/api/src/signals/services/usage-period.ts
@@ -1,4 +1,4 @@
-import type { UsageRecordRange } from "@okouai/api-contracts/contracts/zero-usage-record";
+import type { UsageRecordRange } from "@okouai/api-contracts/contracts/usage-record";
 
 import { nowDate } from "../../lib/time";
 

--- a/turbo/apps/api/src/signals/services/usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-record.service.ts
@@ -7,7 +7,7 @@ import {
   type UsageRecordSource,
   usageRecordKindSchema,
   usageRecordSourceSchema,
-} from "@okouai/api-contracts/contracts/zero-usage-record";
+} from "@okouai/api-contracts/contracts/usage-record";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import {
@@ -582,7 +582,7 @@ async function queryUsageRecordBreakdown(
   return breakdownByRow;
 }
 
-export const zeroUsageRecord$ = command(
+export const usageRecord$ = command(
   async (
     { get, set },
     args: UsageRecordArgs,

--- a/turbo/apps/api/src/signals/services/zero-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage.service.ts
@@ -4,7 +4,7 @@ import type {
   MemberUsage,
   UsageMembersResponse,
 } from "@okouai/api-contracts/contracts/zero-usage";
-import type { UsageRecordRange } from "@okouai/api-contracts/contracts/zero-usage-record";
+import type { UsageRecordRange } from "@okouai/api-contracts/contracts/usage-record";
 import { userCache } from "@okouai/db/schema/user-cache";
 import { clerk$, type ClerkUser } from "../external/clerk";
 import { writeDb$ } from "../external/db";

--- a/turbo/apps/platform/src/mocks/handlers/api-usage-record.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-usage-record.ts
@@ -5,9 +5,9 @@
  */
 
 import {
-  zeroUsageRecordContract,
+  usageRecordContract,
   type UsageRecordResponse,
-} from "@okouai/api-contracts/contracts/zero-usage-record";
+} from "@okouai/api-contracts/contracts/usage-record";
 import { mockApi } from "../msw-contract.ts";
 
 const defaultResponse: UsageRecordResponse = {
@@ -32,7 +32,7 @@ export function resetMockUsageRecord(): void {
 }
 
 export const apiUsageRecordHandlers = [
-  mockApi(zeroUsageRecordContract.get, ({ query, respond }) => {
+  mockApi(usageRecordContract.get, ({ query, respond }) => {
     const page = query.page;
     const pageSize = query.pageSize;
     const source = query.source;

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
@@ -1,9 +1,9 @@
 import { command, computed, state } from "ccstate";
 import {
-  zeroUsageRecordContract,
+  usageRecordContract,
   type UsageRecordRange,
   type UsageRecordScope,
-} from "@okouai/api-contracts/contracts/zero-usage-record";
+} from "@okouai/api-contracts/contracts/usage-record";
 import { zeroUsageMembersContract } from "@okouai/api-contracts/contracts/zero-usage";
 import { accept } from "../../../lib/accept.ts";
 import { zeroClient$ } from "../../api-client.ts";
@@ -102,7 +102,7 @@ export const myUsageRecordAsync$ = computed(async (get) => {
   const pageSize = get(myUsagePageSize$);
   const range = get(myUsageRangeState$);
   const createClient = get(zeroClient$);
-  const client = createClient(zeroUsageRecordContract);
+  const client = createClient(usageRecordContract);
   const result = await accept(
     client.get({
       query: {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -4,9 +4,9 @@ import {
   type UsagePackCreditsResponse,
 } from "@okouai/api-contracts/contracts/zero-billing";
 import {
-  zeroUsageRecordContract,
+  usageRecordContract,
   type UsageRecordRow,
-} from "@okouai/api-contracts/contracts/zero-usage-record";
+} from "@okouai/api-contracts/contracts/usage-record";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -218,7 +218,7 @@ function mockPersonalUsageStory(
     role,
   });
   mockBillingStatus(tier);
-  context.mocks.api(zeroUsageRecordContract.get, ({ query, respond }) => {
+  context.mocks.api(usageRecordContract.get, ({ query, respond }) => {
     requestedRanges.push(query.range);
     const offset = (query.page - 1) * query.pageSize;
 
@@ -787,7 +787,7 @@ describe("personal usage settings", () => {
     });
     mockBillingStatus();
     let usageRequests = 0;
-    context.mocks.api(zeroUsageRecordContract.get, ({ query, respond }) => {
+    context.mocks.api(usageRecordContract.get, ({ query, respond }) => {
       usageRequests += 1;
       const rows =
         usageRequests === 1

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -16,7 +16,7 @@ import type {
   UsageRecordRow,
   UsageRecordScope,
   UsageRecordSource,
-} from "@okouai/api-contracts/contracts/zero-usage-record";
+} from "@okouai/api-contracts/contracts/usage-record";
 import type { UsageMembersResponse } from "@okouai/api-contracts/contracts/zero-usage";
 import {
   Button,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1404,19 +1404,19 @@ export {
   type UsageMembersResponse,
 } from "./zero-usage";
 export {
-  zeroUsageRecordContract,
+  usageRecordContract,
   usageRecordKindSchema,
   usageRecordRangeSchema,
   usageRecordScopeSchema,
   usageRecordSourceSchema,
-  type ZeroUsageRecordContract,
+  type UsageRecordContract,
   type UsageRecordKind,
   type UsageRecordRange,
   type UsageRecordResponse,
   type UsageRecordRow,
   type UsageRecordScope,
   type UsageRecordSource,
-} from "./zero-usage-record";
+} from "./usage-record";
 export {
   zeroTeamContract,
   teamComposeItemSchema,

--- a/turbo/packages/api-contracts/src/contracts/usage-record.ts
+++ b/turbo/packages/api-contracts/src/contracts/usage-record.ts
@@ -106,7 +106,7 @@ const usageRecordResponseSchema = z.object({
   }),
 });
 
-export const zeroUsageRecordContract = c.router({
+export const usageRecordContract = c.router({
   get: {
     method: "GET",
     path: "/api/okou/usage/record",
@@ -131,6 +131,6 @@ export const zeroUsageRecordContract = c.router({
   },
 });
 
-export type ZeroUsageRecordContract = typeof zeroUsageRecordContract;
+export type UsageRecordContract = typeof usageRecordContract;
 export type UsageRecordResponse = z.infer<typeof usageRecordResponseSchema>;
 export type UsageRecordRow = z.infer<typeof usageRecordRowSchema>;

--- a/turbo/packages/api-contracts/src/contracts/zero-usage.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
-import { usageRecordRangeSchema } from "./zero-usage-record";
+import { usageRecordRangeSchema } from "./usage-record";
 
 const c = initContract();
 


### PR DESCRIPTION
## Summary

- rename the Usage Record contract, API route, aggregation service module, and focused test to domain-neutral source paths and exports
- update all API registry, helper, managed-feature, Usage Members import, contract barrel, and Platform personal-usage consumers
- preserve endpoint, auth, query, aggregation, reconciliation, billing, pagination, rendering, and compatibility behavior

## Compatibility audit

- `GET /api/okou/usage/record` is unchanged
- the compatibility-facing `GET /api/zero/usage/record` test label and request coverage are retained
- provider breakdown `usageKinds` remains optional with the exact promotion-skew comment; this is a retained version-migration fallback
- no DB/protocol identifiers, adjacent Usage Members modules, compatibility aliases, migrations, or user-visible copy were changed

## Validation

- Usage Record API suite: 13/13 passed
- Platform personal-usage suite: 11/11 passed
- affected API batch: 89/90 passed; the one existing web-search allowance assertion (`0/0` received vs `5/5` expected) reproduced identically on untouched `origin/main@1c6837ba` with a fresh database, so PR CI is the canonical validation for that fixed-base/local-environment failure
- Prettier checks passed for all changed files
- lint passed for `@okouai/api-contracts`, `api`, and `@okouai/app` (existing unrelated warnings only)
- type checks passed for `@okouai/api-contracts`, `api`, and `@okouai/app`
- focused Knip check passed for the three touched workspaces
- repository-wide stale path/declaration search returned no old Usage Record source names

Closes #27157
