### PR TITLE
refactor(teams): neutralize outbound message route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -153,7 +153,7 @@ import { zeroIntegrationsSlackUploadCompleteRoutes } from "./routes/zero-integra
 import { zeroIntegrationsSlackUploadInitRoutes } from "./routes/zero-integrations-slack-upload-init";
 import { zeroIntegrationsSlackUploadMaterializeRoutes } from "./routes/zero-integrations-slack-upload-materialize";
 import { zeroIntegrationsTeamsDownloadFileRoutes } from "./routes/zero-integrations-teams-download-file";
-import { zeroIntegrationsTeamsMessageRoutes } from "./routes/zero-integrations-teams-message";
+import { integrationsTeamsMessageRoutes } from "./routes/integrations-teams-message";
 import { zeroIntegrationsTeamsUploadCompleteRoutes } from "./routes/zero-integrations-teams-upload-complete";
 import { integrationsTeamsUploadInitRoutes } from "./routes/integrations-teams-upload-init";
 import { zeroIntegrationsTelegramRoutes } from "./routes/zero-integrations-telegram";
@@ -366,7 +366,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroIntegrationsSlackUploadInitRoutes,
   ...zeroIntegrationsSlackUploadMaterializeRoutes,
   ...zeroIntegrationsTeamsDownloadFileRoutes,
-  ...zeroIntegrationsTeamsMessageRoutes,
+  ...integrationsTeamsMessageRoutes,
   ...zeroIntegrationsTeamsUploadCompleteRoutes,
   ...integrationsTeamsUploadInitRoutes,
   ...zeroSlackChannelsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-teams.test.ts
@@ -25,7 +25,7 @@ import {
   teamsFixtureExternalId,
   type TeamsConnectFixture,
 } from "./helpers/zero-teams-connect";
-import { zeroIntegrationsTeamsMessageRoutes } from "../zero-integrations-teams-message";
+import { integrationsTeamsMessageRoutes } from "../integrations-teams-message";
 import { zeroIntegrationsTeamsUploadCompleteRoutes } from "../zero-integrations-teams-upload-complete";
 import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
 
@@ -183,7 +183,7 @@ describe("Microsoft Teams integration CLI routes", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTeamsMessageRoutes,
+      routes: integrationsTeamsMessageRoutes,
     })(integrationsTeamsMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -227,7 +227,7 @@ describe("Microsoft Teams integration CLI routes", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTeamsMessageRoutes,
+      routes: integrationsTeamsMessageRoutes,
     })(integrationsTeamsMessageContract);
     const response = await accept(
       client.sendMessage({

--- a/turbo/apps/api/src/signals/routes/integrations-teams-message.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-teams-message.ts
@@ -258,7 +258,7 @@ const teamsWriteAuth = {
   requiredCapability: "teams:write",
 } as const;
 
-export const zeroIntegrationsTeamsMessageRoutes: readonly RouteEntry[] = [
+export const integrationsTeamsMessageRoutes: readonly RouteEntry[] = [
   {
     route: integrationsTeamsMessageContract.sendMessage,
     handler: authRoute(teamsWriteAuth, sendMessageInner$),


### PR DESCRIPTION
## Summary

- rename the Microsoft Teams outbound-message API route module and export from the legacy Zero shell to neutral integrations naming
- rename the broad Teams route test file and update its direct imports without changing runtime behavior or unrelated Teams symbols
- wire the neutral route export into the shared registry while preserving adjacent naming changes from current `main`

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- bounded non-API, app, and API type-check stages
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations-teams.test.ts` (3 tests passed)

Closes #27197
