### PR TITLE
refactor(slack): neutralize outbound message route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -147,7 +147,7 @@ import { zeroIntegrationsGithubUploadCompleteRoutes } from "./routes/zero-integr
 import { integrationsGithubUploadInitRoutes } from "./routes/integrations-github-upload-init";
 import { zeroIntegrationsFeishuFileRoutes } from "./routes/zero-integrations-feishu-files";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
-import { zeroIntegrationsSlackMessageRoutes } from "./routes/zero-integrations-slack-message";
+import { integrationsSlackMessageRoutes } from "./routes/integrations-slack-message";
 import { integrationsFeishuMessageRoutes } from "./routes/integrations-feishu-message";
 import { zeroIntegrationsSlackUploadCompleteRoutes } from "./routes/zero-integrations-slack-upload-complete";
 import { zeroIntegrationsSlackUploadInitRoutes } from "./routes/zero-integrations-slack-upload-init";
@@ -360,7 +360,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...integrationsGithubUploadInitRoutes,
   ...zeroIntegrationsFeishuFileRoutes,
   ...zeroIntegrationsSlackRoutes,
-  ...zeroIntegrationsSlackMessageRoutes,
+  ...integrationsSlackMessageRoutes,
   ...integrationsFeishuMessageRoutes,
   ...zeroIntegrationsSlackUploadCompleteRoutes,
   ...zeroIntegrationsSlackUploadInitRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -69,7 +69,7 @@ import { integrationsPhoneMessageRoutes } from "../../integrations-phone-message
 import { integrationsPhoneUploadCompleteRoutes } from "../../integrations-phone-upload-complete";
 import { integrationsPhoneUploadInitRoutes } from "../../integrations-phone-upload-init";
 import { zeroIntegrationsSlackRoutes } from "../../zero-integrations-slack";
-import { zeroIntegrationsSlackMessageRoutes } from "../../zero-integrations-slack-message";
+import { integrationsSlackMessageRoutes } from "../../integrations-slack-message";
 import { zeroIntegrationsSlackUploadCompleteRoutes } from "../../zero-integrations-slack-upload-complete";
 import { zeroIntegrationsSlackUploadInitRoutes } from "../../zero-integrations-slack-upload-init";
 import { zeroIntegrationsTelegramRoutes } from "../../zero-integrations-telegram";
@@ -98,7 +98,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...integrationsPhoneMessageRoutes,
   ...integrationsPhoneUploadCompleteRoutes,
   ...integrationsPhoneUploadInitRoutes,
-  ...zeroIntegrationsSlackMessageRoutes,
+  ...integrationsSlackMessageRoutes,
   ...zeroIntegrationsSlackUploadCompleteRoutes,
   ...zeroIntegrationsSlackUploadInitRoutes,
   ...zeroIntegrationsSlackRoutes,
@@ -742,7 +742,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsSlackMessageRoutes,
+        routes: integrationsSlackMessageRoutes,
       })(integrationsSlackMessageContract);
       return await accept(
         client.sendMessage({
@@ -760,7 +760,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsSlackMessageRoutes,
+        routes: integrationsSlackMessageRoutes,
       })(integrationsSlackMessageContract);
       return await accept(
         client.sendMessage({

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-message.test.ts
@@ -16,7 +16,7 @@ import {
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createComposesBddApi } from "./helpers/api-bdd-composes";
 import { createRunsApi } from "./helpers/api-bdd-runs";
-import { zeroIntegrationsSlackMessageRoutes } from "../zero-integrations-slack-message";
+import { integrationsSlackMessageRoutes } from "../integrations-slack-message";
 
 const context = testContext();
 const store = createStore();
@@ -58,7 +58,7 @@ function sandboxToken(args: {
   });
 }
 
-describe("POST /api/zero/integrations/slack/message", () => {
+describe("POST /api/okou/integrations/slack/message", () => {
   beforeEach(() => {
     context.mocks.slack.chat.postMessage.mockResolvedValue({
       ok: true,
@@ -156,7 +156,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
   it("returns 401 when no auth token is provided", async () => {
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -179,7 +179,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -201,7 +201,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -219,7 +219,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -237,7 +237,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -274,7 +274,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -293,7 +293,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -327,7 +327,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -351,7 +351,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -373,7 +373,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -392,7 +392,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({
@@ -437,7 +437,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackMessageRoutes,
+      routes: integrationsSlackMessageRoutes,
     })(integrationsSlackMessageContract);
     const response = await accept(
       client.sendMessage({

--- a/turbo/apps/api/src/signals/routes/integrations-slack-message.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-slack-message.ts
@@ -145,7 +145,7 @@ const slackWriteAuth = {
   requiredCapability: "slack:write",
 } as const;
 
-export const zeroIntegrationsSlackMessageRoutes: readonly RouteEntry[] = [
+export const integrationsSlackMessageRoutes: readonly RouteEntry[] = [
   {
     route: integrationsSlackMessageContract.sendMessage,
     handler: authRoute(slackWriteAuth, sendMessageInner$),


### PR DESCRIPTION
## Summary

- rename the Slack outbound-message route and dedicated test shells to domain-neutral names
- update the route registry, BDD integration helper, and direct test references
- update the display-only test label to the canonical Okou endpoint

## Compatibility

- preserve `integrationsSlackMessageContract` and `POST /api/okou/integrations/slack/message`
- retain the real JWT `scope: "zero"` compatibility value
- retain `zeroSlackOrgInstallation`, `zero-slack-data.service.ts`, `zero-integrations-slack-message.service.ts`, `resolveCurrentUserSlackId`, and `slackMessageSendFooterText`
- preserve Slack auth, installation selection, DM and thread behavior, blocks/footer attribution, responses, and error mapping

## Testing

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- bounded non-API, platform, and API type checks
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations-slack-message.test.ts` (12 tests)
- post-rebase API lint, API type checks, formatting check, and focused test

Closes #27196