### PR TITLE
refactor(platform): use durable chat search identity

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -789,7 +789,7 @@ function ChatMessageCommandItem({
   const title = thread?.title ?? message.agentName;
   return (
     <CommandItem
-      value={`message-${message.matchedMessage.messageId}`}
+      value={`message-${message.matchedMessage.chatThreadId}:${message.matchedMessage.seqId}`}
       onSelect={onSelect}
       className="group w-full gap-2 px-1 py-2"
     >
@@ -1018,7 +1018,7 @@ function AgentListDialogUnifiedSearch({
         if (item.kind === "message") {
           return (
             <ChatMessageCommandItem
-              key={`message-${item.message.matchedMessage.messageId}`}
+              key={`message-${item.message.matchedMessage.chatThreadId}:${item.message.matchedMessage.seqId}`}
               message={item.message}
               thread={item.thread}
               indicator={chatThreadCommandIndicator(


### PR DESCRIPTION
## Summary

- use `(chatThreadId, seqId)` as the durable identity for chat search command item values and React keys
- remove the current Platform dependency on the synthesized `messageId`
- retain the API compatibility fields while already-open clients age out

## Verification

- `pnpm exec prettier --write apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`

## Rollout

This is the client migration phase of #26921. The API fallback remains in place and can be removed after this App deployment has aged past the two-day client-skew window.
