### PR TITLE
refactor(api): retire zero_runs application writes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1200,14 +1200,12 @@ describe("CHAT-02: completed chat callback", () => {
       .toBe(true);
     const completedMetadata = await readRunMetadataPair(context, first.runId);
     expect(completedMetadata.agent_run).toStrictEqual(
-      completedMetadata.zero_run,
-    );
-    expect(completedMetadata.zero_run).toStrictEqual(
       expect.objectContaining({
         first_assistant_event_acknowledged_at: expect.any(String),
         summary: "Generated summary",
       }),
     );
+    expect(completedMetadata.zero_run).toBeNull();
 
     const afterAutoSend = await waitForThreadMessages(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -170,37 +170,12 @@ export async function setRunAutonomyBudgetFixture(
   context: TestContext,
   runId: string,
   autonomyBudget: number,
-  options?: { readonly disableBridge?: boolean },
 ): Promise<void> {
   await postAction(context, {
     action: "set-run-autonomy-budget",
     run_id: runId,
     autonomy_budget: autonomyBudget,
-    ...(options?.disableBridge === true ? { disable_bridge: true } : {}),
   });
-}
-
-export async function readPairedRunAutonomyBudgets(
-  context: TestContext,
-  runId: string,
-): Promise<{
-  readonly zeroRun: number | null;
-  readonly agentRun: number | null;
-}> {
-  const response = await postAction(context, {
-    action: "read-run-autonomy-budget",
-    run_id: runId,
-  });
-  if (
-    !("autonomy_budget" in response) ||
-    !("agent_autonomy_budget" in response)
-  ) {
-    throw new Error("readPairedRunAutonomyBudgets missing paired budgets");
-  }
-  return {
-    zeroRun: response.autonomy_budget ?? null,
-    agentRun: response.agent_autonomy_budget ?? null,
-  };
 }
 
 export async function readRunMetadataPair(
@@ -233,57 +208,6 @@ export async function saveRunSummaryFixture(
     prompt: args.prompt,
     result_text: args.resultText,
   });
-}
-
-export async function measureRunMetadataBridgeTargetUpdates(
-  context: TestContext,
-  runId: string,
-  autonomyBudget: number,
-): Promise<number> {
-  const response = await postAction(context, {
-    action: "measure-run-metadata-bridge-target-updates",
-    run_id: runId,
-    autonomy_budget: autonomyBudget,
-  });
-  if (response.agent_run_update_count === undefined) {
-    throw new Error(
-      "measureRunMetadataBridgeTargetUpdates missing update count",
-    );
-  }
-  return response.agent_run_update_count;
-}
-
-export async function verifyRunMetadataTargetFailureRollback(
-  context: TestContext,
-  runId: string,
-  autonomyBudget: number,
-): Promise<{
-  readonly targetWriteFailed: boolean;
-  readonly errorCode: string | null;
-  readonly zeroRun: number | null;
-  readonly agentRun: number | null;
-}> {
-  const response = await postAction(context, {
-    action: "verify-run-metadata-target-failure-rollback",
-    run_id: runId,
-    autonomy_budget: autonomyBudget,
-  });
-  if (
-    response.target_write_failed === undefined ||
-    !("target_write_error_code" in response) ||
-    !("autonomy_budget" in response) ||
-    !("agent_autonomy_budget" in response)
-  ) {
-    throw new Error(
-      "verifyRunMetadataTargetFailureRollback missing rollback evidence",
-    );
-  }
-  return {
-    targetWriteFailed: response.target_write_failed,
-    errorCode: response.target_write_error_code ?? null,
-    zeroRun: response.autonomy_budget ?? null,
-    agentRun: response.agent_autonomy_budget ?? null,
-  };
 }
 
 export async function readWorkflowAutomationAutonomyFixture(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -5752,8 +5752,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     const stored = await api.readRun(actor, failed.runId);
     expect(stored.status).toBe("failed");
     const failedMetadata = await readRunMetadataPair(context, failed.runId);
-    expect(failedMetadata.agent_run).toStrictEqual(failedMetadata.zero_run);
-    expect(failedMetadata.zero_run).toStrictEqual(
+    expect(failedMetadata.agent_run).toStrictEqual(
       expect.objectContaining({
         autonomy_budget: 10,
         api_started_at: expect.any(String),
@@ -5761,6 +5760,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
         summary: null,
       }),
     );
+    expect(failedMetadata.zero_run).toBeNull();
     const queue = await api.readRunQueue(actor);
     expect(queue.body.queue).not.toContainEqual(
       expect.objectContaining({ runId: failed.runId }),
@@ -12861,8 +12861,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     });
     expect(queued.status).toBe("queued");
     const queuedMetadata = await readRunMetadataPair(context, queued.runId);
-    expect(queuedMetadata.agent_run).toStrictEqual(queuedMetadata.zero_run);
-    expect(queuedMetadata.zero_run).toStrictEqual(
+    expect(queuedMetadata.agent_run).toStrictEqual(
       expect.objectContaining({
         autonomy_budget: 10,
         api_started_at: null,
@@ -12870,6 +12869,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
         summary: null,
       }),
     );
+    expect(queuedMetadata.zero_run).toBeNull();
     const queueState = await api.readRunQueue(actor);
     expect(queueState.body.queue[0]?.runId).toBe(queued.runId);
 
@@ -12886,10 +12886,10 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     );
     expect(promoted.status).toBe("pending");
     const promotedMetadata = await readRunMetadataPair(context, queued.runId);
-    expect(promotedMetadata.agent_run).toStrictEqual(promotedMetadata.zero_run);
-    expect(promotedMetadata.zero_run?.api_started_at).toBe(
+    expect(promotedMetadata.agent_run?.api_started_at).toBe(
       new Date(promotedAt).toISOString(),
     );
+    expect(promotedMetadata.zero_run).toBeNull();
 
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(queued.runId);
@@ -14559,13 +14559,13 @@ describe("HOOK-02/CHAT-02: assistant events reach optional chat consumers", () =
       }),
     ]);
     const acknowledgedMetadata = await readRunMetadataPair(context, runId);
-    expect(acknowledgedMetadata.agent_run).toStrictEqual(
-      acknowledgedMetadata.zero_run,
-    );
     expect(
-      acknowledgedMetadata.zero_run?.first_assistant_event_acknowledged_at,
+      acknowledgedMetadata.agent_run?.first_assistant_event_acknowledged_at,
     ).toBe(new Date(acknowledgedAt).toISOString());
-    expect(acknowledgedMetadata.zero_run?.api_started_at).toBe(apiStartedAtIso);
+    expect(acknowledgedMetadata.agent_run?.api_started_at).toBe(
+      apiStartedAtIso,
+    );
+    expect(acknowledgedMetadata.zero_run).toBeNull();
 
     await api.requestCancelRun(actor, runId, [200]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-metadata-writes.bdd.test.ts
@@ -11,19 +11,16 @@ import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { createBddApi } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import {
-  measureRunMetadataBridgeTargetUpdates,
-  readPairedRunAutonomyBudgets,
   readRunMetadataPair,
   saveRunSummaryFixture,
   setRunAutonomyBudgetFixture,
-  verifyRunMetadataTargetFailureRollback,
 } from "./helpers/runtime-state";
 
 const context = testContext();
 const bdd = createBddApi(context);
 const api = createRunsApi(context);
 
-test("normalizes metadata and preserves compatibility-writer transaction semantics", async () => {
+test("normalizes metadata and writes only agent run metadata", async () => {
   const actor = bdd.user();
   if (!actor.orgId) {
     throw new Error("Expected the metadata writer actor to have an org");
@@ -49,8 +46,7 @@ test("normalizes metadata and preserves compatibility-writer transaction semanti
   });
 
   const initialMetadata = await readRunMetadataPair(context, run.runId);
-  expect(initialMetadata.agent_run).toStrictEqual(initialMetadata.zero_run);
-  expect(initialMetadata.zero_run).toStrictEqual({
+  expect(initialMetadata.agent_run).toStrictEqual({
     trigger_source: "test",
     autonomy_budget: 10,
     workflow_automation_id: null,
@@ -67,34 +63,12 @@ test("normalizes metadata and preserves compatibility-writer transaction semanti
     summary: null,
     trigger_brief: null,
   });
+  expect(initialMetadata.zero_run).toBeNull();
 
-  await expect(
-    readPairedRunAutonomyBudgets(context, run.runId),
-  ).resolves.toStrictEqual({ zeroRun: 10, agentRun: 10 });
-
-  await setRunAutonomyBudgetFixture(context, run.runId, 4, {
-    disableBridge: true,
-  });
-
-  await expect(
-    readPairedRunAutonomyBudgets(context, run.runId),
-  ).resolves.toStrictEqual({ zeroRun: 4, agentRun: 4 });
-
-  await expect(
-    measureRunMetadataBridgeTargetUpdates(context, run.runId, 5),
-  ).resolves.toBe(1);
-  await expect(
-    readPairedRunAutonomyBudgets(context, run.runId),
-  ).resolves.toStrictEqual({ zeroRun: 5, agentRun: 5 });
-
-  await expect(
-    verifyRunMetadataTargetFailureRollback(context, run.runId, 6),
-  ).resolves.toStrictEqual({
-    targetWriteFailed: true,
-    errorCode: "55P03",
-    zeroRun: 5,
-    agentRun: 5,
-  });
+  await setRunAutonomyBudgetFixture(context, run.runId, 4);
+  const updatedMetadata = await readRunMetadataPair(context, run.runId);
+  expect(updatedMetadata.agent_run?.autonomy_budget).toBe(4);
+  expect(updatedMetadata.zero_run).toBeNull();
 
   mockOptionalEnv("OPENROUTER_API_KEY", "metadata-summary-key");
   let generatedSummary = "Initial metadata summary";
@@ -112,10 +86,8 @@ test("normalizes metadata and preserves compatibility-writer transaction semanti
     resultText: "the metadata writer completed",
   });
   let summarizedMetadata = await readRunMetadataPair(context, run.runId);
-  expect(summarizedMetadata.agent_run).toStrictEqual(
-    summarizedMetadata.zero_run,
-  );
-  expect(summarizedMetadata.zero_run?.summary).toBe(generatedSummary);
+  expect(summarizedMetadata.agent_run?.summary).toBe(generatedSummary);
+  expect(summarizedMetadata.zero_run).toBeNull();
 
   generatedSummary = "Replacement metadata summary";
   await saveRunSummaryFixture(context, {
@@ -125,8 +97,6 @@ test("normalizes metadata and preserves compatibility-writer transaction semanti
     resultText: "the replacement completed",
   });
   summarizedMetadata = await readRunMetadataPair(context, run.runId);
-  expect(summarizedMetadata.agent_run).toStrictEqual(
-    summarizedMetadata.zero_run,
-  );
-  expect(summarizedMetadata.zero_run?.summary).toBe(generatedSummary);
+  expect(summarizedMetadata.agent_run?.summary).toBe(generatedSummary);
+  expect(summarizedMetadata.zero_run).toBeNull();
 });

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -180,9 +180,13 @@ async function seedRunForAction(
   }
 
   const threadless = readOptionalBoolean(body, "threadless") === true;
-  const pairedMetadata = threadless
-    ? normalizeRunMetadata({ triggerSource: triggerSource.data })
-    : null;
+  const status = readOptionalString(body, "status") ?? "pending";
+  // Queued fixtures can be promoted through the production metadata writer.
+  // Lifecycle-only fixtures that never enter that path intentionally stay null.
+  const runMetadata =
+    threadless || status === "queued"
+      ? normalizeRunMetadata({ triggerSource: triggerSource.data })
+      : null;
   const [run] = await db
     .insert(agentRuns)
     .values({
@@ -190,7 +194,7 @@ async function seedRunForAction(
       orgId,
       agentComposeVersionId,
       sessionId: session.id,
-      status: readOptionalString(body, "status") ?? "pending",
+      status,
       prompt: readOptionalString(body, "prompt") ?? "cleanup sandboxes test",
       sandboxId:
         readOptionalString(body, "sandbox_id") ?? `sandbox-${randomUUID()}`,
@@ -201,7 +205,7 @@ async function seedRunForAction(
         body,
         "cancellation_recovery_completed",
       ),
-      ...pairedMetadata,
+      ...runMetadata,
     })
     .returning({ id: agentRuns.id, sandboxId: agentRuns.sandboxId });
   signal.throwIfAborted();
@@ -209,8 +213,8 @@ async function seedRunForAction(
     return actionBadRequest("failed to seed run");
   }
 
-  if (pairedMetadata) {
-    await db.insert(zeroRuns).values({ id: run.id, ...pairedMetadata });
+  if (threadless && runMetadata) {
+    await db.insert(zeroRuns).values({ id: run.id, ...runMetadata });
     signal.throwIfAborted();
   }
 
@@ -788,7 +792,7 @@ async function attachRunThreadForAction(
   }
   await writeRunMetadata(db, {
     patch: { chatThreadId: thread.id },
-    where: eq(zeroRuns.id, runId),
+    where: eq(agentRuns.id, runId),
   });
   signal.throwIfAborted();
   return actionOk({ thread_id: thread.id });

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -28,7 +28,6 @@ import { and, count, desc, eq, isNotNull, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 import { closeDbPool } from "../../lib/db";
 import { executeRawRows } from "../../lib/db-raw-rows";
-import type { Tx } from "../../lib/db-types";
 import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
@@ -38,7 +37,6 @@ import type { RouteEntry } from "../route-entry";
 import {
   createDeferredPromise,
   onRejection,
-  settle,
   settleIncludingAbort,
 } from "../utils";
 import {
@@ -51,7 +49,6 @@ import { encryptPersistentSecretValue } from "../services/crypto.utils";
 import {
   type RunMetadataValues,
   writeRunMetadata,
-  writeRunMetadataInTransaction,
 } from "../services/agent-run-metadata-write.service";
 import { saveRunSummary } from "../services/run-summary.service";
 import {
@@ -79,40 +76,6 @@ const orgAdmissionLockStateRowSchema = z.object({
   held: z.boolean(),
   waiting: z.boolean(),
 });
-const transactionUpdateCountRowSchema = z.object({
-  updatedRows: z.int().nonnegative(),
-});
-
-async function transactionAgentRunUpdateCount(tx: Tx): Promise<number> {
-  const [row] = await executeRawRows(
-    tx,
-    sql`
-      SELECT n_tup_upd::integer AS "updatedRows"
-      FROM pg_stat_xact_user_tables
-      WHERE relname = 'agent_runs'
-    `,
-    transactionUpdateCountRowSchema,
-  );
-  return row?.updatedRows ?? 0;
-}
-
-function postgresErrorCode(error: unknown): string | null {
-  let current = error;
-  for (let depth = 0; depth < 4; depth += 1) {
-    if (typeof current !== "object" || current === null) {
-      return null;
-    }
-    if ("code" in current && typeof current.code === "string") {
-      return current.code;
-    }
-    if (!("cause" in current)) {
-      return null;
-    }
-    current = current.cause;
-  }
-  return null;
-}
-
 type StoredRunMetadata = Pick<
   typeof agentRuns.$inferSelect,
   keyof RunMetadataValues
@@ -155,6 +118,7 @@ async function runMetadataReadFixtureActionResponse(
   body: RunMetadataReadFixtureAction,
   signal: AbortSignal,
 ) {
+  // Test-only physical-table probe retained for Stage 6 drop verification.
   const [agentRows, zeroRows] = await Promise.all([
     db.select().from(agentRuns).where(eq(agentRuns.id, body.run_id)).limit(1),
     db.select().from(zeroRuns).where(eq(zeroRuns.id, body.run_id)).limit(1),
@@ -410,7 +374,7 @@ async function clearRunApiStart(
 ): Promise<void> {
   const [cleared] = await writeRunMetadata(db, {
     patch: { apiStartedAt: null },
-    where: eq(zeroRuns.id, runId),
+    where: eq(agentRuns.id, runId),
   });
   signal.throwIfAborted();
   if (!cleared) {
@@ -481,97 +445,6 @@ async function clearThreadSessionBinding(
   }
 }
 
-type RunMetadataWriterFixtureAction = Extract<
-  TestRuntimeStateActionBody,
-  {
-    action:
-      | "measure-run-metadata-bridge-target-updates"
-      | "verify-run-metadata-target-failure-rollback";
-  }
->;
-
-function isRunMetadataWriterFixtureAction(
-  body: TestRuntimeStateActionBody,
-): body is RunMetadataWriterFixtureAction {
-  return (
-    body.action === "measure-run-metadata-bridge-target-updates" ||
-    body.action === "verify-run-metadata-target-failure-rollback"
-  );
-}
-
-async function runMetadataWriterFixtureActionResponse(
-  db: Db,
-  body: RunMetadataWriterFixtureAction,
-  signal: AbortSignal,
-) {
-  if (body.action === "measure-run-metadata-bridge-target-updates") {
-    return await db.transaction(async (tx) => {
-      const before = await transactionAgentRunUpdateCount(tx);
-      const rows = await writeRunMetadataInTransaction(tx, {
-        patch: { autonomyBudget: body.autonomy_budget },
-        where: eq(zeroRuns.id, body.run_id),
-      });
-      signal.throwIfAborted();
-      if (rows.length === 0) {
-        throw new Error("Expected the bridge target-update run fixture");
-      }
-      const after = await transactionAgentRunUpdateCount(tx);
-      return {
-        status: 200 as const,
-        body: {
-          ok: true as const,
-          agent_run_update_count: after - before,
-        },
-      };
-    });
-  }
-
-  const outcome = await db.transaction(async (lockingTx) => {
-    await lockingTx.execute(sql`
-      SELECT ${agentRuns.id}
-      FROM ${agentRuns}
-      WHERE ${agentRuns.id} = ${body.run_id}
-      FOR UPDATE
-    `);
-    signal.throwIfAborted();
-    return await settle(
-      db.transaction(async (writerTx) => {
-        await writerTx.execute(
-          sql`SET LOCAL session_replication_role = replica`,
-        );
-        await writerTx.execute(sql`SET LOCAL lock_timeout = '100ms'`);
-        return await writeRunMetadataInTransaction(writerTx, {
-          patch: { autonomyBudget: body.autonomy_budget },
-          where: eq(zeroRuns.id, body.run_id),
-        });
-      }),
-      signal,
-    );
-  });
-  signal.throwIfAborted();
-  const [run] = await db
-    .select({
-      autonomyBudget: zeroRuns.autonomyBudget,
-      agentAutonomyBudget: agentRuns.autonomyBudget,
-    })
-    .from(zeroRuns)
-    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
-    .where(eq(zeroRuns.id, body.run_id))
-    .limit(1);
-  return {
-    status: 200 as const,
-    body: {
-      ok: true as const,
-      target_write_failed: !outcome.ok,
-      target_write_error_code: outcome.ok
-        ? null
-        : postgresErrorCode(outcome.error),
-      autonomy_budget: run?.autonomyBudget ?? null,
-      agent_autonomy_budget: run?.agentAutonomyBudget ?? null,
-    },
-  };
-}
-
 type AutonomyBudgetFixtureAction = Extract<
   TestRuntimeStateActionBody,
   {
@@ -605,16 +478,10 @@ async function autonomyBudgetFixtureActionResponse(
 ) {
   switch (body.action) {
     case "set-run-autonomy-budget": {
-      const writeArgs = {
+      const rows = await writeRunMetadata(db, {
         patch: { autonomyBudget: body.autonomy_budget },
-        where: eq(zeroRuns.id, body.run_id),
-      };
-      const rows = body.disable_bridge
-        ? await db.transaction(async (tx) => {
-            await tx.execute(sql`SET LOCAL session_replication_role = replica`);
-            return await writeRunMetadataInTransaction(tx, writeArgs);
-          })
-        : await writeRunMetadata(db, writeArgs);
+        where: eq(agentRuns.id, body.run_id),
+      });
       signal.throwIfAborted();
       if (rows.length === 0) {
         throw new Error("Expected the autonomy-budget run fixture");
@@ -623,13 +490,9 @@ async function autonomyBudgetFixtureActionResponse(
     }
     case "read-run-autonomy-budget": {
       const [run] = await db
-        .select({
-          autonomyBudget: zeroRuns.autonomyBudget,
-          agentAutonomyBudget: agentRuns.autonomyBudget,
-        })
-        .from(zeroRuns)
-        .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
-        .where(eq(zeroRuns.id, body.run_id))
+        .select({ autonomyBudget: agentRuns.autonomyBudget })
+        .from(agentRuns)
+        .where(eq(agentRuns.id, body.run_id))
         .limit(1);
       signal.throwIfAborted();
       return {
@@ -637,7 +500,6 @@ async function autonomyBudgetFixtureActionResponse(
         body: {
           ok: true as const,
           autonomy_budget: run?.autonomyBudget ?? null,
-          agent_autonomy_budget: run?.agentAutonomyBudget ?? null,
         },
       };
     }
@@ -1417,7 +1279,6 @@ async function setRunnerJobContextProfileAsPreviousApi(
 }
 
 type CompatibilityFixtureAction =
-  | RunMetadataWriterFixtureAction
   | AutonomyBudgetFixtureAction
   | LegacyArtifactCatalogFileAction
   | PreviousApiHostedSiteAction
@@ -1571,8 +1432,6 @@ function isCompatibilityFixtureAction(
   return [
     "set-run-autonomy-budget",
     "read-run-autonomy-budget",
-    "measure-run-metadata-bridge-target-updates",
-    "verify-run-metadata-target-failure-rollback",
     "set-workflow-automation-autonomy-budget",
     "read-workflow-automation-autonomy-state",
     "read-latest-workflow-automation-run",
@@ -1592,9 +1451,6 @@ async function compatibilityFixtureActionResponse(
   body: CompatibilityFixtureAction,
   signal: AbortSignal,
 ) {
-  if (isRunMetadataWriterFixtureAction(body)) {
-    return await runMetadataWriterFixtureActionResponse(db, body, signal);
-  }
   if (isAutonomyBudgetFixtureAction(body)) {
     return await autonomyBudgetFixtureActionResponse(db, body, signal);
   }

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -712,7 +712,7 @@ async function updateRunForAction(
     patch: {
       selectedModel: readActionNullableString(body, "selected_model") ?? null,
     },
-    where: eq(zeroRuns.id, runId),
+    where: eq(agentRuns.id, runId),
   });
   signal.throwIfAborted();
   return actionOk();
@@ -1337,6 +1337,7 @@ async function seedRunningRunForAction(
     return actionBadRequest("failed to seed agent session");
   }
   const startedAt = nowDate();
+  const metadata = normalizeRunMetadata({ triggerSource: "telegram" });
   await db.insert(agentRuns).values({
     userId: required.user_id!,
     orgId: required.org_id!,
@@ -1346,6 +1347,7 @@ async function seedRunningRunForAction(
     prompt: "existing running telegram run",
     startedAt,
     lastHeartbeatAt: startedAt,
+    ...metadata,
   });
   signal.throwIfAborted();
   return actionOk({ agent_session_id: sessionId });

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-run-output.service.ts
@@ -1,7 +1,7 @@
 import { command } from "ccstate";
 import { and, eq, isNotNull, isNull, lte, sql } from "drizzle-orm";
+import { agentRuns } from "@okouai/db/schema/agent-run";
 import { runOutputMaterializations } from "@okouai/db/schema/run-output-materialization";
-import { zeroRuns } from "@okouai/db/schema/zero-run";
 
 import type {
   AgentEvent,
@@ -341,9 +341,9 @@ async function materializeRunOutputEvents(
 
     const acknowledgedAt = nowDate();
     const firstAssistantClaimWhere = and(
-      eq(zeroRuns.id, payload.runId),
-      isNotNull(zeroRuns.apiStartedAt),
-      isNull(zeroRuns.firstAssistantEventAcknowledgedAt),
+      eq(agentRuns.id, payload.runId),
+      isNotNull(agentRuns.apiStartedAt),
+      isNull(agentRuns.firstAssistantEventAcknowledgedAt),
     );
     if (!firstAssistantClaimWhere) {
       throw new Error("First assistant acknowledgement predicate is empty");

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -128,7 +128,6 @@ import { userCache } from "@okouai/db/schema/user-cache";
 import { vm0ApiKeys } from "@okouai/db/schema/vm0-api-key";
 import { variables } from "@okouai/db/schema/variable";
 import { zeroAgents } from "@okouai/db/schema/zero-agent";
-import { zeroRuns } from "@okouai/db/schema/zero-run";
 import type { PersistedStorageMount } from "@okouai/db/types";
 import {
   and,
@@ -5800,7 +5799,6 @@ async function insertLaunchRunRows(
   const createdAt = nowDate();
   const metadata = launchRunMetadataValues(args);
   await tx.insert(agentRuns).values(launchRunValues(args, createdAt, metadata));
-  await tx.insert(zeroRuns).values({ id: args.identity.runId, ...metadata });
 
   if (args.callbackRows.length > 0) {
     await tx.insert(agentRunCallbacks).values([...args.callbackRows]);
@@ -6714,15 +6712,6 @@ function buildAtomicLaunchCteContext(args: PersistAtomicLaunchRowsArgs) {
       .returning({ id: agentRuns.id, createdAt: agentRuns.createdAt }),
   );
   ctes.push(insertedRun);
-
-  const zeroRunValues = {
-    ...metadata,
-    id: returnedCteId(insertedRun),
-  };
-  const insertedZeroRun = args.tx
-    .$with("inserted_launch_zero_run")
-    .as(args.tx.insert(zeroRuns).values(zeroRunValues));
-  ctes.push(insertedZeroRun);
 
   appendLaunchCallbackCte({
     tx: args.tx,

--- a/turbo/apps/api/src/signals/services/agent-run-metadata-write.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-metadata-write.service.ts
@@ -1,12 +1,11 @@
 import { agentRuns } from "@okouai/db/schema/agent-run";
-import { zeroRuns } from "@okouai/db/schema/zero-run";
-import { and, inArray, or, sql, type SQL } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
 
 import type { Tx } from "../../lib/db-types";
 import type { Db } from "../external/db";
 
-export type RunMetadataValues = Pick<
-  typeof zeroRuns.$inferSelect,
+type StoredRunMetadataValues = Pick<
+  typeof agentRuns.$inferSelect,
   | "triggerSource"
   | "autonomyBudget"
   | "workflowAutomationId"
@@ -22,6 +21,17 @@ export type RunMetadataValues = Pick<
   | "firstAssistantEventAcknowledgedAt"
   | "summary"
   | "triggerBrief"
+>;
+
+export type RunMetadataValues = Readonly<
+  Omit<StoredRunMetadataValues, "triggerSource" | "autonomyBudget"> & {
+    readonly triggerSource: NonNullable<
+      StoredRunMetadataValues["triggerSource"]
+    >;
+    readonly autonomyBudget: NonNullable<
+      StoredRunMetadataValues["autonomyBudget"]
+    >;
+  }
 >;
 
 type RunMetadataInput = Readonly<
@@ -40,7 +50,7 @@ interface RunMetadataWriteArgs {
   readonly where: SQL;
 }
 
-interface RunMetadataSourceRow {
+interface RunMetadataRow {
   readonly id: string;
   readonly apiStartedAt: Date | null;
 }
@@ -68,129 +78,21 @@ export function normalizeRunMetadata(
   };
 }
 
-function targetMetadataDiffPredicate(patch: RunMetadataPatch): SQL {
-  const predicates: SQL[] = [];
-
-  if (patch.triggerSource !== undefined) {
-    predicates.push(
-      sql`${agentRuns.triggerSource} IS DISTINCT FROM ${patch.triggerSource}`,
-    );
-  }
-  if (patch.autonomyBudget !== undefined) {
-    predicates.push(
-      sql`${agentRuns.autonomyBudget} IS DISTINCT FROM ${patch.autonomyBudget}`,
-    );
-  }
-  if (patch.workflowAutomationId !== undefined) {
-    predicates.push(
-      sql`${agentRuns.workflowAutomationId} IS DISTINCT FROM ${patch.workflowAutomationId}`,
-    );
-  }
-  if (patch.goalId !== undefined) {
-    predicates.push(sql`${agentRuns.goalId} IS DISTINCT FROM ${patch.goalId}`);
-  }
-  if (patch.modelProvider !== undefined) {
-    predicates.push(
-      sql`${agentRuns.modelProvider} IS DISTINCT FROM ${patch.modelProvider}`,
-    );
-  }
-  if (patch.modelProviderId !== undefined) {
-    predicates.push(
-      sql`${agentRuns.modelProviderId} IS DISTINCT FROM ${patch.modelProviderId}`,
-    );
-  }
-  if (patch.modelProviderCredentialScope !== undefined) {
-    predicates.push(
-      sql`${agentRuns.modelProviderCredentialScope} IS DISTINCT FROM ${patch.modelProviderCredentialScope}`,
-    );
-  }
-  if (patch.selectedModel !== undefined) {
-    predicates.push(
-      sql`${agentRuns.selectedModel} IS DISTINCT FROM ${patch.selectedModel}`,
-    );
-  }
-  if (patch.codexServiceTier !== undefined) {
-    predicates.push(
-      sql`${agentRuns.codexServiceTier} IS DISTINCT FROM ${patch.codexServiceTier}`,
-    );
-  }
-  if (patch.selectedVideoModel !== undefined) {
-    predicates.push(
-      sql`${agentRuns.selectedVideoModel} IS DISTINCT FROM ${patch.selectedVideoModel}`,
-    );
-  }
-  if (patch.chatThreadId !== undefined) {
-    predicates.push(
-      sql`${agentRuns.chatThreadId} IS DISTINCT FROM ${patch.chatThreadId}`,
-    );
-  }
-  if (patch.apiStartedAt !== undefined) {
-    predicates.push(
-      sql`${agentRuns.apiStartedAt} IS DISTINCT FROM ${patch.apiStartedAt}`,
-    );
-  }
-  if (patch.firstAssistantEventAcknowledgedAt !== undefined) {
-    predicates.push(
-      sql`${agentRuns.firstAssistantEventAcknowledgedAt} IS DISTINCT FROM ${patch.firstAssistantEventAcknowledgedAt}`,
-    );
-  }
-  if (patch.summary !== undefined) {
-    predicates.push(
-      sql`${agentRuns.summary} IS DISTINCT FROM ${patch.summary}`,
-    );
-  }
-  if (patch.triggerBrief !== undefined) {
-    predicates.push(
-      sql`${agentRuns.triggerBrief} IS DISTINCT FROM ${patch.triggerBrief}`,
-    );
-  }
-
-  const predicate = or(...predicates);
-  if (!predicate) {
-    throw new Error("Run metadata patch must contain at least one field");
-  }
-  return predicate;
-}
-
-// DB/API compatibility for mixed Stage 3/4 rollout (observed up to ~102 minutes).
-// Remove via #26924 only after Stage 4 read cutover and bridge removal, once old
-// API revisions and deferred callbacks have drained through production gates.
 export async function writeRunMetadataInTransaction(
   tx: Tx,
   args: RunMetadataWriteArgs,
-): Promise<readonly RunMetadataSourceRow[]> {
-  const sourceRows = await tx
-    .update(zeroRuns)
-    .set(args.patch)
-    .where(args.where)
-    .returning({ id: zeroRuns.id, apiStartedAt: zeroRuns.apiStartedAt });
-
-  if (sourceRows.length === 0) {
-    return sourceRows;
-  }
-
-  await tx
+): Promise<readonly RunMetadataRow[]> {
+  return await tx
     .update(agentRuns)
     .set(args.patch)
-    .where(
-      and(
-        inArray(
-          agentRuns.id,
-          sourceRows.map((row) => {
-            return row.id;
-          }),
-        ),
-        targetMetadataDiffPredicate(args.patch),
-      ),
-    );
-
-  return sourceRows;
+    .where(args.where)
+    .returning({ id: agentRuns.id, apiStartedAt: agentRuns.apiStartedAt });
 }
 
 export function writeRunMetadata(
   db: Db,
   args: RunMetadataWriteArgs,
-): Promise<readonly RunMetadataSourceRow[]> {
+): Promise<readonly RunMetadataRow[]> {
   return db.transaction(async (tx) => {
     return await writeRunMetadataInTransaction(tx, args);
   });

--- a/turbo/apps/api/src/signals/services/run-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/run-summary.service.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import { eq } from "drizzle-orm";
-import { zeroRuns } from "@okouai/db/schema/zero-run";
+import { agentRuns } from "@okouai/db/schema/agent-run";
 
 import { logger } from "../../lib/log";
 import { optionalEnv } from "../../lib/env";
@@ -141,7 +141,7 @@ export async function saveRunSummary(
 
       await writeRunMetadata(db, {
         patch: { summary },
-        where: eq(zeroRuns.id, args.runId),
+        where: eq(agentRuns.id, args.runId),
       });
       signal?.throwIfAborted();
     })(),

--- a/turbo/apps/api/src/signals/services/zero-chat-first-assistant-event-metric.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-first-assistant-event-metric.service.ts
@@ -1,5 +1,5 @@
 import { elapsedSinceApiStartMs } from "@okouai/api-contracts/contracts/runners";
-import { zeroRuns } from "@okouai/db/schema/zero-run";
+import { agentRuns } from "@okouai/db/schema/agent-run";
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
@@ -33,9 +33,9 @@ async function recordFirstAssistantEventAcknowledgement(args: {
   readonly acknowledgedAt: number;
 }): Promise<void> {
   const firstAssistantClaimWhere = and(
-    eq(zeroRuns.id, args.runId),
-    isNotNull(zeroRuns.apiStartedAt),
-    isNull(zeroRuns.firstAssistantEventAcknowledgedAt),
+    eq(agentRuns.id, args.runId),
+    isNotNull(agentRuns.apiStartedAt),
+    isNull(agentRuns.firstAssistantEventAcknowledgedAt),
   );
   if (!firstAssistantClaimWhere) {
     throw new Error("First assistant acknowledgement predicate is empty");

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -718,15 +718,16 @@ interface ThreadRunToCancel {
 /**
  * Delete a chat thread after winding down everything attached to it. Deleting a
  * thread on its own leaves the linked automations firing and any in-flight runs
- * executing: both metadata copies use `ON DELETE SET NULL`, so a running run
- * simply loses its thread reference and keeps consuming credits.
+ * executing: the canonical run metadata uses `ON DELETE SET NULL`, so a running
+ * run simply loses its thread reference and keeps consuming credits.
  *
  * Lock the thread row while deleting it and collecting active runs. Inserts into
- * either `agent_runs.chatThreadId` or the rollback copy in
- * `zero_runs.chatThreadId` take a FK lock on the same parent row, so this closes
+ * `agent_runs.chatThreadId` take a FK lock on the same parent row, so this closes
  * the race where a new run attaches after the active-run scan but before the
- * thread delete. Cancellation still happens after the delete transaction
- * because it has runner notifications and queue-drain side effects.
+ * thread delete. Older binaries may also write the retained `zero_runs` rollback
+ * row during a rolling deployment; its foreign key takes the same parent lock.
+ * Cancellation still happens after the delete transaction because it has runner
+ * notifications and queue-drain side effects.
  *
  * Run cancellation has side effects that cannot participate in the thread's
  * delete transaction (`cancelRun$` opens its own transaction and the runner
@@ -795,7 +796,8 @@ export const deleteChatThread$ = command(
         );
 
       // Delete the thread last inside the lock. Cascades chat_events; captured
-      // active runs will have both metadata copies' chatThreadId set to NULL.
+      // active runs lose their canonical chatThreadId, while any retained legacy
+      // row is independently nulled by its own foreign key.
       const [deletedThread] = await tx
         .delete(chatThreads)
         .where(eq(chatThreads.id, ownedThread.id))

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -2,7 +2,6 @@ import { command } from "ccstate";
 import { agentRunQueue } from "@okouai/db/schema/agent-run-queue";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { runnerJobQueue } from "@okouai/db/schema/runner-job-queue";
-import { zeroRuns } from "@okouai/db/schema/zero-run";
 import {
   and,
   count,
@@ -187,7 +186,7 @@ async function insertPromotedRunnerJob(
 
   await writeRunMetadataInTransaction(tx, {
     patch: { apiStartedAt: new Date(promotedAt) },
-    where: eq(zeroRuns.id, args.runId),
+    where: eq(agentRuns.id, args.runId),
   });
 
   const timestamps = runnerJobQueueTimestamps();

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -50,7 +50,6 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     action: z.literal("set-run-autonomy-budget"),
     run_id: z.uuid(),
     autonomy_budget: z.int().min(0).max(10),
-    disable_bridge: z.boolean().optional(),
   }),
   z.object({
     action: z.literal("read-run-autonomy-budget"),
@@ -66,16 +65,6 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     trigger_source: z.string(),
     prompt: z.string(),
     result_text: z.string(),
-  }),
-  z.object({
-    action: z.literal("measure-run-metadata-bridge-target-updates"),
-    run_id: z.uuid(),
-    autonomy_budget: z.int().min(0).max(10),
-  }),
-  z.object({
-    action: z.literal("verify-run-metadata-target-failure-rollback"),
-    run_id: z.uuid(),
-    autonomy_budget: z.int().min(0).max(10),
   }),
   z.object({
     action: z.literal("set-workflow-automation-autonomy-budget"),
@@ -228,10 +217,6 @@ export const testRuntimeStateActionResponseSchema = z.object({
   browser_screenshot_schema_available: z.boolean().optional(),
   usage_pack_invitation_schema_available: z.boolean().optional(),
   autonomy_budget: z.int().min(0).max(10).nullable().optional(),
-  agent_autonomy_budget: z.int().min(0).max(10).nullable().optional(),
-  agent_run_update_count: z.int().nonnegative().optional(),
-  target_write_failed: z.boolean().optional(),
-  target_write_error_code: z.string().nullable().optional(),
   run_metadata_pair: z
     .object({
       agent_run: testRunMetadataSchema.nullable(),


### PR DESCRIPTION
## Summary

- stop normal and atomic run creation from inserting `zero_runs`
- collapse run-metadata writes, predicates, and `RETURNING` to `agent_runs` while preserving first-assistant compare-and-set and returned `apiStartedAt`
- retire the Stage 3 bridge-only test action/contract chain while retaining the physical legacy-table probe needed for Stage 6

Implements #27202 as Stage 5 of #26924. Keep #27202 open for release and production acceptance.

## Final write/reference inventory

Inventory was repeated after the final rebase onto `2ad92f9a10603f085ba1af0980b060cb67a91549`; candidate head is `7e584e7ff43f383c0e05ef5e6e43205a32176966`.

### Production

- `agent-run-create.service.ts`: the normal insert and atomic `inserted_launch_run` CTE write the complete metadata tuple only to `agent_runs`; `inserted_launch_zero_run` is removed. The atomic terminal queries still select from `inserted_launch_run` and join the queue CTE, while callback and thread-binding CTEs still consume its returned ID.
- `agent-run-metadata-write.service.ts`: types derive from `agentRuns`; the helper performs one `UPDATE agent_runs ... RETURNING id, api_started_at`.
- Production metadata callers now use `agentRuns` predicates: queue promotion, run summary, event-consumer acknowledgement, and chat first-assistant acknowledgement. Both acknowledgement paths retain `api_started_at IS NOT NULL AND first_assistant_event_acknowledged_at IS NULL` compare-and-set semantics.
- Exhaustive typed and raw-SQL searches found zero production `zero_runs` INSERT/UPDATE/DELETE paths and zero production table imports or queries. The only production text reference is rolling-deployment documentation in `zero-chat-thread.service.ts` explaining that an older binary may still write the retained row and acquire the same parent FK lock.

### Intentionally retained physical-table references

- Dev/benchmark: `apps/api/src/scripts/dev-bench-seed.ts` and `routes/__benches__/zero-chat-threads.bench.ts`.
- Test-only fixture routes: computer-use, cron cleanup, cron monitor, Slack, Teams, Telegram, and usage state routes retain explicit fixture insert/delete capability.
- Stage 6 probe: `test-runtime-state.ts` retains `read-run-metadata-pair`, the only test-runtime `zeroRuns` query, to inspect both physical tables.
- Historical/migration validation: Stage 2 fixture/final/lock/preflight scripts and `test-migration-consistency-schema.ts` retain deliberate raw writes. Historical custom migration backfills plus 132 immutable migration/snapshot artifacts remain unchanged.
- Schema capability: `schema/zero-run.ts`, the DB root export, and its static schema test remain unchanged.

No migration, schema, journal, snapshot, MaskDB policy, historical-row, retired `vm0-insights`, or accepted 16 lifecycle-only-row change is included. The Stage 3-only `disable_bridge`, bridge measurement, target-failure rollback, and paired target response vocabulary has no remaining reference.

## Behavior preserved

- `normalizeRunMetadata` still emits all 15 fields and defaults `autonomy_budget` to 10.
- Queue timing, callback rows, summaries, model/provider/service-tier/video-model snapshots, trigger provenance, thread/session binding, billing, authorization, and lifecycle behavior remain on the existing `agent_runs` row.
- Test fixtures that can enter active/queue metadata write paths now seed the canonical complete `agent_runs` tuple without synthesizing runtime provenance or creating a production fallback. Explicit lifecycle-only fixtures remain all-NULL, and physical `zero_runs` fixtures remain only for classified Stage 6/test coverage.
- #27204's sparse/non-contiguous chat-event sequence behavior is inherited unchanged; the overlapping callback test keeps its sequence-gap assertions alongside Stage 5's canonical `agent_run` metadata and `zero_run: null` assertion.
- #27068.s agent-owned run video-model behavior and #27151's new-chat `selectedVideoModel` creation/binding behavior remain intact.
- #26947 is still open/CLEAN and #26848 is still open/BLOCKED; neither landed before this final rebase, and their current behavior was not overwritten.

## Rollout and rollback floor

The pre-cutover Stage 4 production baseline is recorded in [#27202 comment 5292269032](https://github.com/vm0-ai/vm0/issues/27202#issuecomment-5292269032): exact revision `72082a5ab2a572a70473e687e163bb242def89b7`, Axiom window `[2026-08-14T10:20:00Z, 2026-08-14T10:25:00Z)`, 4,674 requests with 0 HTTP 5xx, 25 `UPDATE zero_runs` spans in five minutes, and live MaskDB counts of 121,836 `agent_runs` versus 121,820 `zero_runs` (the accepted difference of 16).

- The Stage 4 database is forward-compatible with this application-only cutover; no schema ordering is required.
- During rollout, old Stage 4 binaries may continue dual-writing while this revision writes only `agent_runs`; that bounded mixed window is expected.
- The new rollback floor begins when the first Stage 5-only run commits without a `zero_runs` row. From that point, any application binary that reads or requires `zero_runs` is unsafe. Schema-related failures must be fixed forward; this PR does not recreate, backfill, or resume legacy writes.
- Production acceptance must record the exact promoted merge/release revision and timestamp that establish that floor. The retained physical table is Stage 6 verification capability, not a runtime write fallback.

## Verification

Passed locally:

- `pnpm format`
- memory-bounded, single-thread API + api-contracts lint: 7/7 tasks
- `pnpm knip`
- single-thread type-check stages: non-API/app 12/12, `@okouai/app` 6/6, refreshed api-contracts 2/2, refreshed API 8/8
- pre-commit rerun for the fixture correction: focused Prettier, Knip, and repository type-check 14/14
- post-rebase focused Prettier, Oxlint, type-aware Oxlint, and ESLint for both corrected test-state routes
- post-rebase API type-check: all seven stages passed; type boundary inventory is `roots=1062`, `missing=0`, `extra=0`, `overlaps=0`
- latest-main overlap gate: focused Prettier, Oxlint, type-aware Oxlint, and ESLint passed for `chat-callbacks.bdd.test.ts`; API core and tests type-check passed after rebuilding the renamed Feishu core artifact
- `pnpm --filter @okouai/db exec vitest run src/__tests__/agent-run-schema.test.ts` (1/1)
- `pnpm --filter @okouai/db exec vitest run src/__tests__/chat-event.test.ts` (4/4), proving the legacy Drizzle schema/export remains available
- final `git diff --check`, 15-file scope check, bridge-vocabulary search, production typed/raw write search, full reference classification, and overlap audit on exact head `7e584e7ff43f383c0e05ef5e6e43205a32176966`

The first PR pipeline on superseded head `b014dc9bcd053c10378ec3f46c4a9fa0d445dc44` found the cron queued fixture using an all-NULL lifecycle-only metadata row before queue promotion. PostgreSQL correctly rejected the partial `api_started_at` update with `agent_runs_metadata_presence_check`. Exact head `7e584e7ff43f383c0e05ef5e6e43205a32176966` corrects active/queued test fixture semantics by seeding canonical complete agent-only metadata while preserving explicit lifecycle-only and physical-table fixtures; the new PR pipeline is authoritative for the DB-backed regression.

The local runner initially had no PostgreSQL service at `localhost:5432`; an API Vitest attempt exited from global setup with `ECONNREFUSED` before executing its 18 tests. Per repository guidance, PostgreSQL-backed BDD coverage (normal/atomic creation, queue promotion, concurrent first-assistant CAS/returned timing, callback/summary) and migration consistency are authoritative in the PR pipeline, which provisions PostgreSQL. No full local Vitest suite or dev server was run.



