### PR TITLE
refactor(feishu): neutralize file route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -145,7 +145,7 @@ import { integrationsPhoneUploadInitRoutes } from "./routes/integrations-phone-u
 import { zeroIntegrationsGithubDownloadFileRoutes } from "./routes/zero-integrations-github-download-file";
 import { zeroIntegrationsGithubUploadCompleteRoutes } from "./routes/zero-integrations-github-upload-complete";
 import { integrationsGithubUploadInitRoutes } from "./routes/integrations-github-upload-init";
-import { zeroIntegrationsFeishuFileRoutes } from "./routes/zero-integrations-feishu-files";
+import { integrationsFeishuFileRoutes } from "./routes/integrations-feishu-files";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
 import { integrationsSlackMessageRoutes } from "./routes/integrations-slack-message";
 import { integrationsFeishuMessageRoutes } from "./routes/integrations-feishu-message";
@@ -358,7 +358,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroIntegrationsGithubDownloadFileRoutes,
   ...zeroIntegrationsGithubUploadCompleteRoutes,
   ...integrationsGithubUploadInitRoutes,
-  ...zeroIntegrationsFeishuFileRoutes,
+  ...integrationsFeishuFileRoutes,
   ...zeroIntegrationsSlackRoutes,
   ...integrationsSlackMessageRoutes,
   ...integrationsFeishuMessageRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -40,7 +40,7 @@ import { createDeferredPromise } from "../../utils";
 import { zeroFeishuBrowserConnectRoutes } from "../zero-feishu-browser-connect";
 import { feishuEventsRoutes } from "../feishu-events";
 import { zeroFeishuOauthRoutes } from "../zero-feishu-oauth";
-import { zeroIntegrationsFeishuFileRoutes } from "../zero-integrations-feishu-files";
+import { integrationsFeishuFileRoutes } from "../integrations-feishu-files";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
@@ -3036,7 +3036,7 @@ describe("Feishu integration", () => {
     );
     const app = createAppWithRoutes({
       signal: context.signal,
-      routes: zeroIntegrationsFeishuFileRoutes,
+      routes: integrationsFeishuFileRoutes,
     });
     const downloadResponse = await app.request(
       `/api/zero/integrations/feishu/download-file?${new URLSearchParams({

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
@@ -29,13 +29,13 @@ import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { zeroFeishuConnectRoutes } from "../zero-feishu-connect";
 import { zeroFeishuOauthRoutes } from "../zero-feishu-oauth";
-import { zeroIntegrationsFeishuFileRoutes } from "../zero-integrations-feishu-files";
+import { integrationsFeishuFileRoutes } from "../integrations-feishu-files";
 import { integrationsFeishuMessageRoutes } from "../integrations-feishu-message";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...zeroFeishuConnectRoutes,
   ...zeroFeishuOauthRoutes,
-  ...zeroIntegrationsFeishuFileRoutes,
+  ...integrationsFeishuFileRoutes,
   ...integrationsFeishuMessageRoutes,
 ]);
 
@@ -525,7 +525,7 @@ describe("POST /api/okou/integrations/feishu/message", () => {
     );
     const initClient = setupApp({
       context,
-      routes: zeroIntegrationsFeishuFileRoutes,
+      routes: integrationsFeishuFileRoutes,
     })(integrationsFeishuUploadInitContract);
     const initialized = await accept(
       initClient.init({
@@ -587,7 +587,7 @@ describe("POST /api/okou/integrations/feishu/message", () => {
     captured = [];
     const completeClient = setupApp({
       context,
-      routes: zeroIntegrationsFeishuFileRoutes,
+      routes: integrationsFeishuFileRoutes,
     })(integrationsFeishuUploadCompleteContract);
     const completed = await accept(
       completeClient.complete({

--- a/turbo/apps/api/src/signals/routes/integrations-feishu-files.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-feishu-files.ts
@@ -571,7 +571,7 @@ const feishuWriteAuth = {
   requiredCapability: "feishu:write",
 } as const;
 
-export const zeroIntegrationsFeishuFileRoutes: readonly RouteEntry[] = [
+export const integrationsFeishuFileRoutes: readonly RouteEntry[] = [
   {
     route: integrationsFeishuDownloadFileContract.download,
     handler: authRoute(feishuWriteAuth, download$),


### PR DESCRIPTION
## Summary

- rename the aggregate Feishu file route module and export to neutral integration naming
- update direct imports and rename the broad Feishu integration test file
- preserve legacy protocol routes, contracts, persisted schema fields, helper names, and environment keys

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/feishu-integration.test.ts -t "runs a Feishu DM file with downloadable resource context"`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations-feishu-message.test.ts`

Closes #27210