### PR TITLE
refactor(github): neutralize file route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -142,8 +142,8 @@ import { integrationsPhoneDownloadFileRoutes } from "./routes/integrations-phone
 import { integrationsPhoneMessageRoutes } from "./routes/integrations-phone-message";
 import { integrationsPhoneUploadCompleteRoutes } from "./routes/integrations-phone-upload-complete";
 import { integrationsPhoneUploadInitRoutes } from "./routes/integrations-phone-upload-init";
-import { zeroIntegrationsGithubDownloadFileRoutes } from "./routes/zero-integrations-github-download-file";
-import { zeroIntegrationsGithubUploadCompleteRoutes } from "./routes/zero-integrations-github-upload-complete";
+import { integrationsGithubDownloadFileRoutes } from "./routes/integrations-github-download-file";
+import { integrationsGithubUploadCompleteRoutes } from "./routes/integrations-github-upload-complete";
 import { integrationsGithubUploadInitRoutes } from "./routes/integrations-github-upload-init";
 import { zeroIntegrationsFeishuFileRoutes } from "./routes/zero-integrations-feishu-files";
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
@@ -355,8 +355,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...integrationsPhoneMessageRoutes,
   ...integrationsPhoneUploadCompleteRoutes,
   ...integrationsPhoneUploadInitRoutes,
-  ...zeroIntegrationsGithubDownloadFileRoutes,
-  ...zeroIntegrationsGithubUploadCompleteRoutes,
+  ...integrationsGithubDownloadFileRoutes,
+  ...integrationsGithubUploadCompleteRoutes,
   ...integrationsGithubUploadInitRoutes,
   ...zeroIntegrationsFeishuFileRoutes,
   ...zeroIntegrationsSlackRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -62,7 +62,7 @@ import { integrationsGithubRoutes } from "../../integrations-github";
 import { testSlackStateRoutes } from "../../test-slack-state";
 import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
 import { zeroIntegrationsAgentPhoneRoutes } from "../../zero-integrations-agentphone";
-import { zeroIntegrationsGithubUploadCompleteRoutes } from "../../zero-integrations-github-upload-complete";
+import { integrationsGithubUploadCompleteRoutes } from "../../integrations-github-upload-complete";
 import { integrationsGithubUploadInitRoutes } from "../../integrations-github-upload-init";
 import { integrationsPhoneDownloadFileRoutes } from "../../integrations-phone-download-file";
 import { integrationsPhoneMessageRoutes } from "../../integrations-phone-message";
@@ -92,7 +92,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...testSlackStateRoutes,
   ...zeroFeatureSwitchesRoutes,
   ...zeroIntegrationsAgentPhoneRoutes,
-  ...zeroIntegrationsGithubUploadCompleteRoutes,
+  ...integrationsGithubUploadCompleteRoutes,
   ...integrationsGithubUploadInitRoutes,
   ...integrationsPhoneDownloadFileRoutes,
   ...integrationsPhoneMessageRoutes,
@@ -1645,7 +1645,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsGithubUploadCompleteRoutes,
+        routes: integrationsGithubUploadCompleteRoutes,
       })(integrationsGithubUploadCompleteContract);
       return await accept(
         client.complete({

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-github-files.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-github-files.test.ts
@@ -20,13 +20,13 @@ import { createGithubBddApi } from "./helpers/api-bdd-github";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createComposesBddApi } from "./helpers/api-bdd-composes";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroIntegrationsGithubUploadCompleteRoutes } from "../zero-integrations-github-upload-complete";
+import { integrationsGithubUploadCompleteRoutes } from "../integrations-github-upload-complete";
 import { integrationsGithubUploadInitRoutes } from "../integrations-github-upload-init";
-import { zeroIntegrationsGithubDownloadFileRoutes } from "../zero-integrations-github-download-file";
+import { integrationsGithubDownloadFileRoutes } from "../integrations-github-download-file";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...zeroIntegrationsGithubDownloadFileRoutes,
-  ...zeroIntegrationsGithubUploadCompleteRoutes,
+  ...integrationsGithubDownloadFileRoutes,
+  ...integrationsGithubUploadCompleteRoutes,
   ...integrationsGithubUploadInitRoutes,
 ]);
 
@@ -49,7 +49,7 @@ function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
 
-function zeroToken(args: {
+function okouToken(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly runId?: string;
@@ -82,7 +82,7 @@ function setupGitHubTokenMock(installationId: string): void {
   );
 }
 
-describe("GitHub zero file integration routes", () => {
+describe("GitHub file integration routes", () => {
   async function seedFixture(): Promise<GitHubFileFixture> {
     const actor = bdd.user();
     if (!actor.orgId) {
@@ -166,7 +166,7 @@ describe("GitHub zero file integration routes", () => {
       {
         method: "GET",
         headers: {
-          authorization: `Bearer ${zeroToken({
+          authorization: `Bearer ${okouToken({
             userId: fixture.userId,
             orgId: fixture.orgId,
             capabilities: ["github:read"],
@@ -207,7 +207,7 @@ describe("GitHub zero file integration routes", () => {
       {
         method: "GET",
         headers: {
-          authorization: `Bearer ${zeroToken({
+          authorization: `Bearer ${okouToken({
             userId: fixture.userId,
             orgId: fixture.orgId,
             capabilities: ["github:read"],
@@ -234,7 +234,7 @@ describe("GitHub zero file integration routes", () => {
       {
         method: "GET",
         headers: {
-          authorization: `Bearer ${zeroToken({
+          authorization: `Bearer ${okouToken({
             userId: fixture.userId,
             orgId: fixture.orgId,
             capabilities: ["github:read"],
@@ -261,7 +261,7 @@ describe("GitHub zero file integration routes", () => {
       {
         method: "GET",
         headers: {
-          authorization: `Bearer ${zeroToken({
+          authorization: `Bearer ${okouToken({
             userId: fixture.userId,
             orgId: fixture.orgId,
             capabilities: ["github:write"],
@@ -294,7 +294,7 @@ describe("GitHub zero file integration routes", () => {
           length: 1234,
         },
         headers: {
-          authorization: `Bearer ${zeroToken({
+          authorization: `Bearer ${okouToken({
             userId: fixture.userId,
             orgId: fixture.orgId,
             capabilities: ["github:write"],
@@ -359,7 +359,7 @@ describe("GitHub zero file integration routes", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsGithubUploadCompleteRoutes,
+      routes: integrationsGithubUploadCompleteRoutes,
     })(integrationsGithubUploadCompleteContract);
     const response = await accept(
       client.complete({
@@ -371,7 +371,7 @@ describe("GitHub zero file integration routes", () => {
           caption: "Daily report",
         },
         headers: {
-          authorization: `Bearer ${zeroToken({
+          authorization: `Bearer ${okouToken({
             userId: fixture.userId,
             orgId: fixture.orgId,
             runId: run.runId,

--- a/turbo/apps/api/src/signals/routes/integrations-github-download-file.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-github-download-file.ts
@@ -228,7 +228,7 @@ const githubReadAuth = {
   requiredCapability: "github:read",
 } as const;
 
-export const zeroIntegrationsGithubDownloadFileRoutes: readonly RouteEntry[] = [
+export const integrationsGithubDownloadFileRoutes: readonly RouteEntry[] = [
   {
     route: githubDownloadFileContract.download,
     handler: authRoute(githubReadAuth, download$),

--- a/turbo/apps/api/src/signals/routes/integrations-github-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-github-upload-complete.ts
@@ -175,10 +175,9 @@ const githubWriteAuth = {
   requiredCapability: "github:write",
 } as const;
 
-export const zeroIntegrationsGithubUploadCompleteRoutes: readonly RouteEntry[] =
-  [
-    {
-      route: integrationsGithubUploadCompleteContract.complete,
-      handler: authRoute(githubWriteAuth, complete$),
-    },
-  ];
+export const integrationsGithubUploadCompleteRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsGithubUploadCompleteContract.complete,
+    handler: authRoute(githubWriteAuth, complete$),
+  },
+];


### PR DESCRIPTION
## Summary
- rename the GitHub download-file and upload-complete route modules and exports to neutral internal names
- update the route registry, BDD helper, and shared focused test shell
- preserve legacy Zero protocol fixtures, endpoint paths, auth, contracts, and behavior

## Validation
- pnpm format
- full workspace lint with 3072 MB heap and single-task concurrency
- pnpm knip
- workspace, app, and API type checks
- focused GitHub file route test: 6 passed
- directly relevant GitHub BDD coverage: 2 passed, 40 skipped
- post-rebase API lint and API type check

Closes #27208