### PR TITLE
refactor(slack): neutralize file upload pipeline naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -149,9 +149,9 @@ import { zeroIntegrationsFeishuFileRoutes } from "./routes/zero-integrations-fei
 import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
 import { integrationsSlackMessageRoutes } from "./routes/integrations-slack-message";
 import { integrationsFeishuMessageRoutes } from "./routes/integrations-feishu-message";
-import { zeroIntegrationsSlackUploadCompleteRoutes } from "./routes/zero-integrations-slack-upload-complete";
-import { zeroIntegrationsSlackUploadInitRoutes } from "./routes/zero-integrations-slack-upload-init";
-import { zeroIntegrationsSlackUploadMaterializeRoutes } from "./routes/zero-integrations-slack-upload-materialize";
+import { integrationsSlackUploadCompleteRoutes } from "./routes/integrations-slack-upload-complete";
+import { integrationsSlackUploadInitRoutes } from "./routes/integrations-slack-upload-init";
+import { integrationsSlackUploadMaterializeRoutes } from "./routes/integrations-slack-upload-materialize";
 import { zeroIntegrationsTeamsDownloadFileRoutes } from "./routes/zero-integrations-teams-download-file";
 import { integrationsTeamsMessageRoutes } from "./routes/integrations-teams-message";
 import { zeroIntegrationsTeamsUploadCompleteRoutes } from "./routes/zero-integrations-teams-upload-complete";
@@ -362,9 +362,9 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroIntegrationsSlackRoutes,
   ...integrationsSlackMessageRoutes,
   ...integrationsFeishuMessageRoutes,
-  ...zeroIntegrationsSlackUploadCompleteRoutes,
-  ...zeroIntegrationsSlackUploadInitRoutes,
-  ...zeroIntegrationsSlackUploadMaterializeRoutes,
+  ...integrationsSlackUploadCompleteRoutes,
+  ...integrationsSlackUploadInitRoutes,
+  ...integrationsSlackUploadMaterializeRoutes,
   ...zeroIntegrationsTeamsDownloadFileRoutes,
   ...integrationsTeamsMessageRoutes,
   ...zeroIntegrationsTeamsUploadCompleteRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -70,8 +70,8 @@ import { integrationsPhoneUploadCompleteRoutes } from "../../integrations-phone-
 import { integrationsPhoneUploadInitRoutes } from "../../integrations-phone-upload-init";
 import { zeroIntegrationsSlackRoutes } from "../../zero-integrations-slack";
 import { integrationsSlackMessageRoutes } from "../../integrations-slack-message";
-import { zeroIntegrationsSlackUploadCompleteRoutes } from "../../zero-integrations-slack-upload-complete";
-import { zeroIntegrationsSlackUploadInitRoutes } from "../../zero-integrations-slack-upload-init";
+import { integrationsSlackUploadCompleteRoutes } from "../../integrations-slack-upload-complete";
+import { integrationsSlackUploadInitRoutes } from "../../integrations-slack-upload-init";
 import { zeroIntegrationsTelegramRoutes } from "../../zero-integrations-telegram";
 import { integrationsTelegramMessageRoutes } from "../../integrations-telegram-message";
 import { integrationsTelegramUploadCompleteRoutes } from "../../integrations-telegram-upload-complete";
@@ -99,8 +99,8 @@ const TEST_APP_ROUTES = Object.freeze([
   ...integrationsPhoneUploadCompleteRoutes,
   ...integrationsPhoneUploadInitRoutes,
   ...integrationsSlackMessageRoutes,
-  ...zeroIntegrationsSlackUploadCompleteRoutes,
-  ...zeroIntegrationsSlackUploadInitRoutes,
+  ...integrationsSlackUploadCompleteRoutes,
+  ...integrationsSlackUploadInitRoutes,
   ...zeroIntegrationsSlackRoutes,
   ...integrationsTelegramMessageRoutes,
   ...integrationsTelegramUploadCompleteRoutes,
@@ -778,7 +778,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsSlackUploadInitRoutes,
+        routes: integrationsSlackUploadInitRoutes,
       })(integrationsSlackUploadInitContract);
       return await accept(
         client.init({
@@ -796,7 +796,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsSlackUploadCompleteRoutes,
+        routes: integrationsSlackUploadCompleteRoutes,
       })(integrationsSlackUploadCompleteContract);
       return await accept(
         client.complete({

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
@@ -44,9 +44,9 @@ import {
   deleteUsageStateFixture$,
   type UsageStateFixture,
 } from "./helpers/usage-state";
-import { zeroIntegrationsSlackUploadCompleteRoutes } from "../zero-integrations-slack-upload-complete";
-import { zeroIntegrationsSlackUploadInitRoutes } from "../zero-integrations-slack-upload-init";
-import { zeroIntegrationsSlackUploadMaterializeRoutes } from "../zero-integrations-slack-upload-materialize";
+import { integrationsSlackUploadCompleteRoutes } from "../integrations-slack-upload-complete";
+import { integrationsSlackUploadInitRoutes } from "../integrations-slack-upload-init";
+import { integrationsSlackUploadMaterializeRoutes } from "../integrations-slack-upload-materialize";
 
 type CompletedChatEvent = Extract<ChatEvent, { eventType: "run.completed" }>;
 
@@ -130,7 +130,7 @@ async function completeRun(args: {
   await flushWaitUntilForTest();
 }
 
-function zeroToken(args: {
+function okouToken(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly runId: string;
@@ -173,7 +173,7 @@ interface RunScopedContext {
   readonly agentId: string;
 }
 
-describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
+describe("POST /api/okou/integrations/slack/upload-file/complete", () => {
   const slackFixtures: SlackIntegrationFixture[] = [];
   const usageFixtures: UsageStateFixture[] = [];
 
@@ -332,7 +332,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
   it("returns 401 when no auth token is provided", async () => {
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     const response = await accept(
       client.complete({
@@ -352,7 +352,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     const response = await accept(
       client.complete({
@@ -366,11 +366,11 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
   it("returns 404 when no Slack installation exists for org", async () => {
     const { orgId, userId } = await seedBaseContext();
-    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+    const token = okouToken({ userId, orgId, runId: `run_${randomUUID()}` });
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     const response = await accept(
       client.complete({
@@ -385,7 +385,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
   it("forwards Slack file info errors as 400 SLACK_ERROR", async () => {
     const { orgId, userId, runId, threadId } = await seedRunScoped();
     const fileId = `F-${randomUUID().slice(0, 8)}`;
-    const token = zeroToken({ userId, orgId, runId });
+    const token = okouToken({ userId, orgId, runId });
     context.mocks.slack.files.info.mockRejectedValueOnce(
       Object.assign(new Error("file_not_found"), {
         data: { ok: false, error: "file_not_found" },
@@ -394,7 +394,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     const response = await accept(
       client.complete({
@@ -419,11 +419,11 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
     const { orgId, userId, runId, threadId } = await seedRunScoped();
     const fileId = `F-${randomUUID().slice(0, 8)}`;
     mockSlackFileInfo(fileId);
-    const token = zeroToken({ userId, orgId, runId });
+    const token = okouToken({ userId, orgId, runId });
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     const response = await accept(
       client.complete({
@@ -474,7 +474,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
       await seedRunScoped();
     const objectStore = chatCallbacks.acceptChatObjectStorage();
     const operationId = randomUUID();
-    const token = zeroToken({ userId, orgId, runId });
+    const token = okouToken({ userId, orgId, runId });
     context.mocks.slack.files.getUploadURLExternal.mockClear();
     context.mocks.slack.files.getUploadURLExternal.mockResolvedValue({
       ok: true,
@@ -485,7 +485,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const initClient = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const initialized = await accept(
       initClient.init({
@@ -538,7 +538,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const materializeClient = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadMaterializeRoutes,
+      routes: integrationsSlackUploadMaterializeRoutes,
     })(integrationsSlackUploadMaterializeContract);
     const materialized = await accept(
       materializeClient.materialize({
@@ -585,7 +585,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const completeClient = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     const completed = await accept(
       completeClient.complete({
@@ -723,10 +723,10 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
       await seedRunScoped();
     chatCallbacks.acceptChatObjectStorage();
     const operationId = randomUUID();
-    const token = zeroToken({ userId, orgId, runId });
+    const token = okouToken({ userId, orgId, runId });
     const initClient = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const initialized = await accept(
       initClient.init({
@@ -783,7 +783,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
     const { orgId, userId, runId } = await seedRunScoped();
     const objectStore = chatCallbacks.acceptChatObjectStorage();
     const operationId = randomUUID();
-    const token = zeroToken({ userId, orgId, runId });
+    const token = okouToken({ userId, orgId, runId });
     const fileId = "F-MISSING-PERMALINK";
     context.mocks.slack.files.getUploadURLExternal.mockResolvedValue({
       ok: true,
@@ -804,7 +804,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const initClient = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const initialized = await accept(
       initClient.init({
@@ -839,7 +839,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const materializeClient = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadMaterializeRoutes,
+      routes: integrationsSlackUploadMaterializeRoutes,
     })(integrationsSlackUploadMaterializeContract);
     const materialized = await accept(
       materializeClient.materialize({
@@ -855,7 +855,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const completeClient = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     const completed = await accept(
       completeClient.complete({
@@ -882,7 +882,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
     const { orgId, userId, runId } = await seedRunScoped();
     const objectStore = chatCallbacks.acceptChatObjectStorage();
     const operationId = randomUUID();
-    const token = zeroToken({ userId, orgId, runId });
+    const token = okouToken({ userId, orgId, runId });
     const allocations: string[] = [];
     const bothAllocationsStarted = createDeferredPromise<void>(context.signal);
     onTestFinished(() => {
@@ -908,7 +908,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const initClient = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const initialized = await accept(
       initClient.init({
@@ -945,7 +945,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const materializeClient = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadMaterializeRoutes,
+      routes: integrationsSlackUploadMaterializeRoutes,
     })(integrationsSlackUploadMaterializeContract);
     const materialize = () => {
       return accept(
@@ -989,7 +989,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const completeClient = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     const staleCompletion = await accept(
       completeClient.complete({
@@ -1088,11 +1088,11 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
         },
       ),
     );
-    const token = zeroToken({ userId, orgId, runId });
+    const token = okouToken({ userId, orgId, runId });
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     await accept(
       client.complete({
@@ -1138,7 +1138,7 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     const response = await accept(
       client.complete({
@@ -1166,11 +1166,11 @@ describe("POST /api/zero/integrations/slack/upload-file/complete", () => {
     const { orgId, userId, runId, threadId } = await seedRunScoped();
     const fileId = `F-${randomUUID().slice(0, 8)}`;
     mockSlackFileInfo(fileId);
-    const token = zeroToken({ userId, orgId, runId });
+    const token = okouToken({ userId, orgId, runId });
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadCompleteRoutes,
+      routes: integrationsSlackUploadCompleteRoutes,
     })(integrationsSlackUploadCompleteContract);
     const body = { fileId, channel: "C123", title: "Retry upload" };
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-init.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-init.test.ts
@@ -14,13 +14,13 @@ import {
   seedSlackOrgInstallation$,
   type SlackIntegrationFixture,
 } from "./helpers/zero-integrations-slack";
-import { zeroIntegrationsSlackUploadInitRoutes } from "../zero-integrations-slack-upload-init";
+import { integrationsSlackUploadInitRoutes } from "../integrations-slack-upload-init";
 
 const context = testContext();
 const store = createStore();
 const LARGE_DIRECT_UPLOAD_BYTES = 100 * 1024 * 1024 + 1;
 
-function zeroToken(args: {
+function okouToken(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly runId: string;
@@ -54,7 +54,7 @@ function sandboxToken(args: {
   });
 }
 
-describe("POST /api/zero/integrations/slack/upload-file/init", () => {
+describe("POST /api/okou/integrations/slack/upload-file/init", () => {
   const slackFixtures: SlackIntegrationFixture[] = [];
 
   beforeEach(() => {
@@ -101,7 +101,7 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
   it("returns 401 when no auth token is provided", async () => {
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const response = await accept(
       client.init({
@@ -121,7 +121,7 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const response = await accept(
       client.init({
@@ -144,11 +144,11 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
       { orgId, userId, role: "admin" },
       context.signal,
     );
-    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+    const token = okouToken({ userId, orgId, runId: `run_${randomUUID()}` });
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const response = await accept(
       client.init({
@@ -165,11 +165,11 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
 
   it("returns 400 for invalid request bodies", async () => {
     const { orgId, userId } = await seedWithInstallation();
-    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+    const token = okouToken({ userId, orgId, runId: `run_${randomUUID()}` });
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const response = await accept(
       client.init({
@@ -187,11 +187,11 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
 
   it("returns a Slack-issued upload URL and file id on the happy path", async () => {
     const { orgId, userId } = await seedWithInstallation();
-    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+    const token = okouToken({ userId, orgId, runId: `run_${randomUUID()}` });
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const response = await accept(
       client.init({
@@ -212,11 +212,11 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
 
   it("rejects large canonical uploads after asset graduation", async () => {
     const { orgId, userId } = await seedWithInstallation();
-    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+    const token = okouToken({ userId, orgId, runId: `run_${randomUUID()}` });
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const response = await accept(
       client.init({
@@ -246,7 +246,7 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
 
   it("forwards Slack non-ok upload URL responses as 400 SLACK_ERROR", async () => {
     const { orgId, userId } = await seedWithInstallation();
-    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+    const token = okouToken({ userId, orgId, runId: `run_${randomUUID()}` });
 
     context.mocks.slack.files.getUploadURLExternal.mockResolvedValueOnce({
       ok: false,
@@ -255,7 +255,7 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const response = await accept(
       client.init({
@@ -271,7 +271,7 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
 
   it("forwards malformed Slack upload URL responses as 400 SLACK_ERROR", async () => {
     const { orgId, userId } = await seedWithInstallation();
-    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+    const token = okouToken({ userId, orgId, runId: `run_${randomUUID()}` });
 
     context.mocks.slack.files.getUploadURLExternal.mockResolvedValueOnce({
       ok: true,
@@ -280,7 +280,7 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const response = await accept(
       client.init({
@@ -296,7 +296,7 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
 
   it("forwards Slack platform errors as 400 SLACK_ERROR", async () => {
     const { orgId, userId } = await seedWithInstallation();
-    const token = zeroToken({ userId, orgId, runId: `run_${randomUUID()}` });
+    const token = okouToken({ userId, orgId, runId: `run_${randomUUID()}` });
 
     context.mocks.slack.files.getUploadURLExternal.mockRejectedValueOnce(
       Object.assign(new Error("invalid_filename"), {
@@ -306,7 +306,7 @@ describe("POST /api/zero/integrations/slack/upload-file/init", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsSlackUploadInitRoutes,
+      routes: integrationsSlackUploadInitRoutes,
     })(integrationsSlackUploadInitContract);
     const response = await accept(
       client.init({

--- a/turbo/apps/api/src/signals/routes/integrations-slack-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-slack-upload-complete.ts
@@ -248,10 +248,9 @@ const slackWriteAuth = {
   requiredCapability: "slack:write",
 } as const;
 
-export const zeroIntegrationsSlackUploadCompleteRoutes: readonly RouteEntry[] =
-  [
-    {
-      route: integrationsSlackUploadCompleteContract.complete,
-      handler: authRoute(slackWriteAuth, completeInner$),
-    },
-  ];
+export const integrationsSlackUploadCompleteRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsSlackUploadCompleteContract.complete,
+    handler: authRoute(slackWriteAuth, completeInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/integrations-slack-upload-init.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-slack-upload-init.ts
@@ -129,7 +129,7 @@ const slackWriteAuth = {
   requiredCapability: "slack:write",
 } as const;
 
-export const zeroIntegrationsSlackUploadInitRoutes: readonly RouteEntry[] = [
+export const integrationsSlackUploadInitRoutes: readonly RouteEntry[] = [
   {
     route: integrationsSlackUploadInitContract.init,
     handler: authRoute(slackWriteAuth, initInner$),

--- a/turbo/apps/api/src/signals/routes/integrations-slack-upload-materialize.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-slack-upload-materialize.ts
@@ -114,10 +114,9 @@ const slackWriteAuth = {
   requiredCapability: "slack:write",
 } as const;
 
-export const zeroIntegrationsSlackUploadMaterializeRoutes: readonly RouteEntry[] =
-  [
-    {
-      route: integrationsSlackUploadMaterializeContract.materialize,
-      handler: authRoute(slackWriteAuth, materializeInner$),
-    },
-  ];
+export const integrationsSlackUploadMaterializeRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsSlackUploadMaterializeContract.materialize,
+    handler: authRoute(slackWriteAuth, materializeInner$),
+  },
+];


### PR DESCRIPTION
## Summary

- rename the Slack upload init, materialize, and complete route shells and exports to neutral integrations naming
- update the route registry and BDD integration helper without changing the upload pipeline behavior
- clean the two owned test shells while retaining protocol, storage, and shared-helper compatibility names

## Testing

- pnpm format
- NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api run lint
- pnpm knip --workspace api
- NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api run check-types
- focused Slack upload init test: 9 passed
- focused Slack upload complete test: 12 passed
- directly relevant integrations BDD scenario: 1 passed

Closes #27209