### PR TITLE
refactor(onboarding): neutralize focused test shell naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/onboarding.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/onboarding.test.ts
@@ -38,7 +38,7 @@ function orgActor(role: "org:admin" | "org:member" = "org:admin") {
   } as const;
 }
 
-describe("GET /api/zero/onboarding/status", () => {
+describe("GET /api/okou/onboarding/status", () => {
   it("returns 401 when the request is unauthenticated", async () => {
     const response = await accept(
       onboardingStatusClient().getStatus({ headers: {} }),
@@ -71,7 +71,7 @@ describe("GET /api/zero/onboarding/status", () => {
   });
 });
 
-describe("POST /api/zero/onboarding/complete", () => {
+describe("POST /api/okou/onboarding/complete", () => {
   it("returns 403 when an organization member tries to complete onboarding", async () => {
     const actor = orgActor("org:member");
     mocks.clerk.session(actor.userId, actor.orgId, actor.role);


### PR DESCRIPTION
## Summary

- rename the focused onboarding route test from `zero-onboarding.test.ts` to `onboarding.test.ts`
- update the two typed-client suite labels to the canonical `/api/okou/onboarding/**` paths
- preserve all test behavior, `createZeroRouteMocks`, and the real `/api/zero/**` namespace alias compatibility

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/onboarding.test.ts` (4 tests passed)

Closes #27218
