### PR TITLE
refactor(web-files): neutralize focused test shell naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/web-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-download.test.ts
@@ -26,7 +26,7 @@ function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
 
-function mintZeroToken(args: {
+function mintOkouToken(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly capabilities: readonly ZeroCapability[];
@@ -54,7 +54,7 @@ async function mintFileReadToken(): Promise<{
   return {
     orgId,
     userId,
-    token: mintZeroToken({
+    token: mintOkouToken({
       userId,
       orgId,
       capabilities: ["file:read"],
@@ -162,7 +162,7 @@ describe("GET /api/zero/web/download-file", () => {
   });
 
   it("returns 403 for a zero token without file:read capability", async () => {
-    const token = mintZeroToken({
+    const token = mintOkouToken({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,
       capabilities: ["agent:read"],

--- a/turbo/apps/api/src/signals/routes/__tests__/web-file-url.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-file-url.test.ts
@@ -26,7 +26,7 @@ function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
 
-function mintZeroToken(args: {
+function mintOkouToken(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly capabilities: readonly ZeroCapability[];
@@ -54,7 +54,7 @@ async function mintFileReadToken(): Promise<{
   return {
     orgId,
     userId,
-    token: mintZeroToken({
+    token: mintOkouToken({
       userId,
       orgId,
       capabilities: ["file:read"],
@@ -122,7 +122,7 @@ function artifactKey(userId: string, fileId: string, filename: string): string {
   return `artifacts/${userId}/${fileId}/${filename}`;
 }
 
-describe("GET /api/zero/web/file-url", () => {
+describe("GET /api/okou/web/file-url", () => {
   it("returns 401 when no auth token is provided", async () => {
     const response = await accept(
       client().fileUrl({ headers: {}, query: { file_id: "abc" } }),
@@ -134,7 +134,7 @@ describe("GET /api/zero/web/file-url", () => {
   });
 
   it("returns 403 for a zero token without file:read capability", async () => {
-    const token = mintZeroToken({
+    const token = mintOkouToken({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,
       capabilities: ["agent:read"],


### PR DESCRIPTION
## Summary

- rename the remaining Zero-prefixed Web Files API test shells
- rename both test-local token minters and align the file-url suite label with its canonical Okou contract path
- preserve the Zero-scope JWT protocol values and raw `/api/zero/web/download-file` compatibility coverage

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/web-file-url.test.ts` (8 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/web-download.test.ts` (12 tests)

Closes #27216
