### PR TITLE
refactor(teams): neutralize file route shell naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -152,9 +152,9 @@ import { integrationsFeishuMessageRoutes } from "./routes/integrations-feishu-me
 import { integrationsSlackUploadCompleteRoutes } from "./routes/integrations-slack-upload-complete";
 import { integrationsSlackUploadInitRoutes } from "./routes/integrations-slack-upload-init";
 import { integrationsSlackUploadMaterializeRoutes } from "./routes/integrations-slack-upload-materialize";
-import { zeroIntegrationsTeamsDownloadFileRoutes } from "./routes/zero-integrations-teams-download-file";
+import { integrationsTeamsDownloadFileRoutes } from "./routes/integrations-teams-download-file";
 import { integrationsTeamsMessageRoutes } from "./routes/integrations-teams-message";
-import { zeroIntegrationsTeamsUploadCompleteRoutes } from "./routes/zero-integrations-teams-upload-complete";
+import { integrationsTeamsUploadCompleteRoutes } from "./routes/integrations-teams-upload-complete";
 import { integrationsTeamsUploadInitRoutes } from "./routes/integrations-teams-upload-init";
 import { zeroIntegrationsTelegramRoutes } from "./routes/zero-integrations-telegram";
 import { integrationsTelegramMessageRoutes } from "./routes/integrations-telegram-message";
@@ -365,9 +365,9 @@ export const ROUTES: readonly RouteEntry[] = [
   ...integrationsSlackUploadCompleteRoutes,
   ...integrationsSlackUploadInitRoutes,
   ...integrationsSlackUploadMaterializeRoutes,
-  ...zeroIntegrationsTeamsDownloadFileRoutes,
+  ...integrationsTeamsDownloadFileRoutes,
   ...integrationsTeamsMessageRoutes,
-  ...zeroIntegrationsTeamsUploadCompleteRoutes,
+  ...integrationsTeamsUploadCompleteRoutes,
   ...integrationsTeamsUploadInitRoutes,
   ...slackChannelsRoutes,
   ...steamPlayerRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-teams.test.ts
@@ -26,7 +26,7 @@ import {
   type TeamsConnectFixture,
 } from "./helpers/zero-teams-connect";
 import { integrationsTeamsMessageRoutes } from "../integrations-teams-message";
-import { zeroIntegrationsTeamsUploadCompleteRoutes } from "../zero-integrations-teams-upload-complete";
+import { integrationsTeamsUploadCompleteRoutes } from "../integrations-teams-upload-complete";
 import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
 
 const context = testContext();
@@ -47,7 +47,7 @@ function currentSecond(): number {
   return Math.floor(now() / 1000);
 }
 
-function zeroToken(args: {
+function okouToken(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly runId: string;
@@ -193,7 +193,7 @@ describe("Microsoft Teams integration CLI routes", () => {
           text: "Hello from Teams CLI",
         },
         headers: {
-          authorization: `Bearer ${zeroToken({
+          authorization: `Bearer ${okouToken({
             userId: fixture.userId,
             orgId: fixture.orgId,
             runId: `run_${randomUUID()}`,
@@ -247,7 +247,7 @@ describe("Microsoft Teams integration CLI routes", () => {
           },
         },
         headers: {
-          authorization: `Bearer ${zeroToken({
+          authorization: `Bearer ${okouToken({
             userId: fixture.userId,
             orgId: fixture.orgId,
             runId: `run_${randomUUID()}`,
@@ -303,7 +303,7 @@ describe("Microsoft Teams integration CLI routes", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTeamsUploadCompleteRoutes,
+      routes: integrationsTeamsUploadCompleteRoutes,
     })(integrationsTeamsUploadCompleteContract);
     const response = await accept(
       client.complete({

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -23,7 +23,7 @@ import { server } from "../../../mocks/server";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
-import { zeroIntegrationsTeamsDownloadFileRoutes } from "../zero-integrations-teams-download-file";
+import { integrationsTeamsDownloadFileRoutes } from "../integrations-teams-download-file";
 import { zeroTeamsBotRoutes } from "../zero-teams-bot";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
@@ -1728,7 +1728,7 @@ describe("POST /api/zero/teams/bot", () => {
 
     const app = createAppWithRoutes({
       signal: context.signal,
-      routes: zeroIntegrationsTeamsDownloadFileRoutes,
+      routes: integrationsTeamsDownloadFileRoutes,
     });
     const downloadResponse = await app.request(
       `/api/zero/integrations/teams/download-file?${new URLSearchParams({
@@ -1815,7 +1815,7 @@ describe("POST /api/zero/teams/bot", () => {
 
     const app = createAppWithRoutes({
       signal: context.signal,
-      routes: zeroIntegrationsTeamsDownloadFileRoutes,
+      routes: integrationsTeamsDownloadFileRoutes,
     });
     const downloadResponse = await app.request(
       `/api/zero/integrations/teams/download-file?${new URLSearchParams({

--- a/turbo/apps/api/src/signals/routes/integrations-teams-download-file.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-teams-download-file.ts
@@ -313,7 +313,7 @@ const teamsWriteAuth = {
   requiredCapability: "teams:write",
 } as const;
 
-export const zeroIntegrationsTeamsDownloadFileRoutes: readonly RouteEntry[] = [
+export const integrationsTeamsDownloadFileRoutes: readonly RouteEntry[] = [
   {
     route: teamsDownloadFileContract.download,
     handler: authRoute(teamsWriteAuth, download$),

--- a/turbo/apps/api/src/signals/routes/integrations-teams-upload-complete.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-teams-upload-complete.ts
@@ -207,10 +207,9 @@ const teamsWriteAuth = {
   requiredCapability: "teams:write",
 } as const;
 
-export const zeroIntegrationsTeamsUploadCompleteRoutes: readonly RouteEntry[] =
-  [
-    {
-      route: integrationsTeamsUploadCompleteContract.complete,
-      handler: authRoute(teamsWriteAuth, complete$),
-    },
-  ];
+export const integrationsTeamsUploadCompleteRoutes: readonly RouteEntry[] = [
+  {
+    route: integrationsTeamsUploadCompleteContract.complete,
+    handler: authRoute(teamsWriteAuth, complete$),
+  },
+];


### PR DESCRIPTION
## Summary

- rename the Microsoft Teams download-file and upload-complete route modules and route arrays to neutral integration naming
- update the route registry and direct Teams test consumers without compatibility aliases
- rename the focused Teams test token helper while preserving the Zero token scope and legacy route coverage

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations-teams.test.ts`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-teams-bot.test.ts`

Closes #27225
