### PR TITLE
test(chat): trim redundant sparse-history coverage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -863,7 +863,6 @@ describe("cron snapshot chat events", () => {
     expect(firstArchivedRow.seqId).toBeGreaterThan(1);
     expect(OBJECT_KEY_PATTERN.exec(put.key)?.[2]).toBe(coveredSeqId.toString());
     const head = await readChatEventSnapshotHead(context, threadId);
-    expect(head.last_event_id).toBe(lastPhysicalRow.id);
     expect(head.last_seq_id).toBe(coveredSeqId);
 
     await sendNoCreditMessage(owner, {
@@ -878,20 +877,6 @@ describe("cron snapshot chat events", () => {
       expect(row.seqId).toBeGreaterThan(previousSeqId);
       previousSeqId = row.seqId;
     }
-
-    const lastTailRow = tail.at(-1);
-    if (lastTailRow === undefined) {
-      throw new Error("Expected a sparse tail event");
-    }
-    await projectChatEventSearch(threadId);
-    const extension = await runSnapshotCron([threadId]);
-    expect(extension.success).toBeTruthy();
-    await expect(
-      readChatEventSnapshotHead(context, threadId),
-    ).resolves.toMatchObject({
-      last_event_id: lastTailRow.id,
-      last_seq_id: lastTailRow.seqId,
-    });
   }, 60_000);
 
   it("refuses V4 to V5 when no lossless Snapshot migration exists", async () => {

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/messages.test.ts
@@ -235,25 +235,18 @@ describe("okou chat messages command", () => {
       "utf8",
     );
     await writeFile(join(threadDirectory, "notes.txt"), "keep me", "utf8");
-    const cursors: { eventId: string | null; seqId: string | null }[] = [];
+    const cursors: string[] = [];
     server.use(
       http.get(SNAPSHOT_URL, () => {
         throw new Error("Snapshot endpoint must not be called");
       }),
       http.get(ROWS_URL, ({ request }) => {
-        const url = new URL(request.url);
-        const seqId = url.searchParams.get("sinceSeqId");
-        if (seqId === null) {
+        const cursor = new URL(request.url).searchParams.get("sinceSeqId");
+        if (cursor === null) {
           throw new Error("Expected a rows cursor");
         }
-        expect(request.headers.get(CHAT_EVENT_SCHEMA_VERSION_HEADER)).toBe(
-          CURRENT_CHAT_EVENT_SCHEMA_VERSION.toString(),
-        );
-        cursors.push({
-          eventId: url.searchParams.get("sinceEventId"),
-          seqId,
-        });
-        expect(seqId).toBe("4");
+        cursors.push(cursor);
+        expect(cursor).toBe("4");
         return HttpResponse.json(
           { rows: [rawEventRow(7), rawEventRow(10)] },
           { headers: CHAT_EVENT_SCHEMA_HEADERS },
@@ -269,7 +262,7 @@ describe("okou chat messages command", () => {
       outputDirectory,
     ]);
 
-    expect(cursors).toStrictEqual([{ eventId: rawEventRow(4).id, seqId: "4" }]);
+    expect(cursors).toStrictEqual(["4"]);
     expect((await readdir(threadDirectory)).sort()).toStrictEqual([
       "event-SEQ_ID_10.json",
       "event-SEQ_ID_4.json",


### PR DESCRIPTION
## Summary

- remove the duplicate Snapshot re-extension assertions from the existing sparse-stream test
- keep the CLI sparse-history test focused on accepting sequence gaps
- rely on the dedicated schema-header and paired-cursor tests instead of repeating those assertions

## Rationale

This is a subtractive follow-up to #26848. The production implementation already removes the invalid contiguous-sequence assumptions and retains fail-closed guards. This PR trims redundant happy-path coverage without adding tombstone tests for deleted behavior.

The retained negative coverage includes non-increasing Raw Event pages, mismatched event/sequence cursors, damaged Snapshots, and missing lossless Snapshot migrations.

## Verification

- pnpm format
- pnpm lint
- pnpm knip
- pnpm check-types
- pnpm --filter @okouai/cli exec vitest run src/commands/zero/chat/__tests__/messages.test.ts
- pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts