### PR TITLE
fix(runner): preserve runs after tool process oom

### DIFF
--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -122,6 +122,7 @@ test "$(cat "$parent/control/memory.min")" = "$expected_control_memory_min"
 grep -Eq '^[0-9]+ [0-9]+$' "$parent/workload/cpu.max"
 test "$(cat "$parent/workload/memory.high")" = max
 test "$(cat "$parent/workload/memory.max")" = "$expected_workload_memory_max"
+test "$(cat "$parent/workload/memory.oom.group")" = 0
 test "$(cat "$parent/workload/pids.max")" = max
 test -z "${VM0_WORKLOAD_CGROUP_PROCS_ENDPOINT:-}"
 control_member_count=$(wc -l < "$parent/control/cgroup.procs")
@@ -672,16 +673,29 @@ read -r METRICS_COUNT METRICS_SPAN_SECS METRICS_MAX_GAP_SECS <<<"$METRICS_SUMMAR
 rm -f "$PRESSURE_SUBMIT_OUTPUT"
 PRESSURE_SUBMIT_OUTPUT=""
 
-echo "--- Pressure: exhaust workload memory without killing Guest Agent ---"
+echo "--- Pressure: kill a high-memory tool without terminating the run ---"
 # Reuse the pressure VM again to prove reclaim left it safe to park while
-# isolating terminal OOM from the active-input provider session.
+# isolating workload OOM from the active-input provider session.
 MEMORY_CHAT_THREAD_ID="$PRESSURE_CHAT_THREAD_ID"
 MEMORY_SESSION_ID="e2e-process-containment-memory"
 MEMORY_PROMPT=$(cat <<'PROMPT'
+set -eu
 test -f /tmp/vm0-process-containment/memory-reclaim-vm
 sudo -n python3 - <<'PY'
+import os
 import pathlib
+import signal
+import subprocess
 import time
+
+
+def read_events(path):
+    events = {}
+    for line in path.read_text().splitlines():
+        key, value = line.split()
+        events[key] = int(value)
+    return events
+
 
 relative = next(
     line.removeprefix("0::").strip()
@@ -690,44 +704,73 @@ relative = next(
 )
 workload = pathlib.Path(f"/sys/fs/cgroup{relative}")
 (workload / "memory.max").write_text(str(256 * 1024 * 1024))
-chunk_size = 16 * 1024 * 1024
-chunks = []
-while True:
-    chunk = bytearray(chunk_size)
-    for offset in range(0, chunk_size, 4096):
-        chunk[offset] = 1
-    chunks.append(chunk)
-    time.sleep(0.1)
+before = read_events(workload / "memory.events")
+
+pid = os.fork()
+if pid == 0:
+    chunk_size = 16 * 1024 * 1024
+    chunks = []
+    while True:
+        chunk = bytearray(chunk_size)
+        chunk[::4096] = b"\x01" * (chunk_size // 4096)
+        chunks.append(chunk)
+        time.sleep(0.05)
+
+_, status = os.waitpid(pid, 0)
+if not os.WIFSIGNALED(status) or os.WTERMSIG(status) != signal.SIGKILL:
+    raise RuntimeError(f"memory pressure child was not SIGKILLed: status={status}")
+
+after = read_events(workload / "memory.events")
+if after.get("oom_kill", 0) <= before.get("oom_kill", 0):
+    raise RuntimeError("memory pressure did not record an OOM-killed process")
+if after.get("oom_group_kill", 0) != before.get("oom_group_kill", 0):
+    raise RuntimeError("memory pressure triggered a group OOM kill")
+
+subprocess.run(["/bin/true"], check=True)
+pathlib.Path(
+    "/tmp/vm0-process-containment/memory-oom-runtime-survived"
+).write_text("ready\n")
+print(
+    "memory-oom-runtime-survived "
+    f"oom_kill={after.get('oom_kill', 0) - before.get('oom_kill', 0)} "
+    "oom_group_kill=0"
+)
 PY
 PROMPT
 )
 SECONDS=0
-if MEMORY_RESULT=$(sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+MEMORY_RESULT=$(sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --timeout 30 \
   --chat-thread-id "$MEMORY_CHAT_THREAD_ID" \
   --session-id "$MEMORY_SESSION_ID" \
   --feature-flag sandboxReuse=true \
   --prompt "$MEMORY_PROMPT" \
-  --active-input 'after=1s,text=memory-pressure-control'); then
-  printf '%s\n' "$MEMORY_RESULT"
-  fail "memory exhaustion unexpectedly completed successfully"
-else
-  MEMORY_SUBMIT_STATUS=$?
-fi
+  --active-input 'after=1s,text=memory-pressure-control') \
+  || fail "memory-pressure run did not recover after killing the tool process"
 MEMORY_ELAPSED=$SECONDS
 printf '%s\n' "$MEMORY_RESULT"
-[ "$MEMORY_SUBMIT_STATUS" -ne 0 ] \
-  || fail "memory exhaustion did not fail the workload"
 [ "$MEMORY_ELAPSED" -lt 20 ] \
-  || fail "memory exhaustion was not bounded: ${MEMORY_ELAPSED}s"
+  || fail "memory-pressure recovery was not bounded: ${MEMORY_ELAPSED}s"
 MEMORY_RESULT_JSON=$(awk '/^\{/{line=$0} END{print line}' <<<"$MEMORY_RESULT")
 MEMORY_RUN_ID=$(jq -r '.run_id // empty' <<<"$MEMORY_RESULT_JSON")
 [ -n "$MEMORY_RUN_ID" ] || fail "memory-pressure result omitted run ID"
 MEMORY_STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${MEMORY_RUN_ID}.log"
+sudo grep -F -q 'memory-oom-runtime-survived oom_kill=' "$MEMORY_STREAM_LOG" \
+  || fail "memory-pressure runtime did not continue after the tool was killed"
 sudo grep -F -q 'workload resource limit reached' "$MEMORY_STREAM_LOG" \
-  || fail "memory-pressure failure was not classified"
-sudo grep -E -q 'memory_oom(_kill)?=[1-9][0-9]*' "$MEMORY_STREAM_LOG" \
+  || fail "memory-pressure resource event was not classified"
+sudo grep -E -q 'memory_oom_kill=[1-9][0-9]*' "$MEMORY_STREAM_LOG" \
   || fail "memory-pressure diagnostics omitted the OOM event"
+sudo grep -F -q 'memory_oom_group_kill=0' "$MEMORY_STREAM_LOG" \
+  || fail "memory-pressure diagnostics reported a group OOM kill"
+
+echo "--- Pressure: prove individual OOM preserved VM reuse ---"
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --chat-thread-id "$MEMORY_CHAT_THREAD_ID" \
+  --session-id "$MEMORY_SESSION_ID" \
+  --feature-flag sandboxReuse=true \
+  --prompt 'test -f /tmp/vm0-process-containment/memory-oom-runtime-survived' \
+  || fail "memory-pressure recovery did not preserve safe VM reuse"
 
 echo "--- Pressure: exhaust workload PID capacity and reclaim descendants ---"
 PID_CHAT_THREAD_ID=$(cat /proc/sys/kernel/random/uuid)
@@ -812,13 +855,15 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
 
 LOGS=$(sudo journalctl --no-pager "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
   || fail "failed to read runner logs"
-MEMORY_FAILURE_LOG=$(printf '%s\n' "$LOGS" \
+printf '%s\n' "$LOGS" \
   | grep -F "run_id=$MEMORY_RUN_ID" \
-  | grep -F 'job execution failed' \
-  | tail -1) \
-  || fail "missing memory-pressure terminal failure log"
-if ! grep -E 'workload_memory_oom(_kill)?_events=[1-9][0-9]*' <<<"$MEMORY_FAILURE_LOG" >/dev/null; then
-  fail "memory-pressure terminal log omitted structured workload OOM counters"
+  | grep -F 'job finished' \
+  >/dev/null \
+  || fail "missing successful memory-pressure terminal log"
+if printf '%s\n' "$LOGS" \
+  | grep -F "run_id=$MEMORY_RUN_ID" \
+  | grep -F 'job execution failed' >/dev/null; then
+  fail "memory-pressure run was reported as failed"
 fi
 LEAK_LINE=$(printf '%s\n' "$LOGS" \
   | grep -F 'exec process containment cleaned' \
@@ -854,7 +899,7 @@ PID_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' <<<"$PID_CLEANUP
 echo "PASS: detached user/root descendants were reclaimed"
 echo "PASS: leaked cleanup ${LEAK_CLEANUP_MS}ms; healthy cleanup preserved reuse"
 echo "PASS: compressed CPU pressure kept process control and ${METRICS_COUNT} metric samples live"
-echo "PASS: workload OOM was classified in ${MEMORY_ELAPSED}s without killing Guest Agent"
+echo "PASS: individual workload OOM preserved the run in ${MEMORY_ELAPSED}s and allowed reuse"
 echo "PASS: pids.max cleanup reclaimed ${PID_INITIAL_MEMBERS} members in ${PID_CLEANUP_MS}ms"
 
 sudo "$BIN_DIR/runner" service stop --name "$SVC" --force

--- a/crates/guest-agent/src/reuse_preparation.rs
+++ b/crates/guest-agent/src/reuse_preparation.rs
@@ -481,7 +481,7 @@ fn verify_workload_policy(workload_path: &Path) -> io::Result<()> {
         ),
         (MEMORY_HIGH_FILE, policy.memory_high.to_string()),
         (MEMORY_MAX_FILE, policy.memory_max_bytes.to_string()),
-        (MEMORY_OOM_GROUP_FILE, "1".to_string()),
+        (MEMORY_OOM_GROUP_FILE, policy.memory_oom_group.to_string()),
         (PIDS_MAX_FILE, policy.pids_max.to_string()),
     ] {
         let actual = std::fs::read_to_string(workload_path.join(filename))?;

--- a/crates/guest-agent/tests/reuse_preparation_helper.rs
+++ b/crates/guest-agent/tests/reuse_preparation_helper.rs
@@ -470,6 +470,26 @@ fn prepare_for_reuse_rejects_stale_workload_memory_max() -> TestResult {
 }
 
 #[test]
+fn prepare_for_reuse_rejects_stale_workload_oom_group() -> TestResult {
+    let (request, _runtime) = reusable_request()?;
+    let containment = ContainmentFixture::new()?;
+    std::fs::write(
+        containment
+            .base
+            .join("exec-current/workload/memory.oom.group"),
+        b"1\n",
+    )?;
+
+    let output = run_helper_with_containment(&request, &containment)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(REUSE_PREPARATION_EXIT_CONTAINMENT_FAILED)
+    );
+    Ok(())
+}
+
+#[test]
 fn prepare_for_reuse_rejects_helper_in_control_leaf() -> TestResult {
     let (request, _runtime) = reusable_request()?;
     let containment = ContainmentFixture::new()?;
@@ -549,7 +569,7 @@ impl ContainmentFixture {
             ),
             ("memory.high", policy.memory_high.to_string()),
             ("memory.max", policy.memory_max_bytes.to_string()),
-            ("memory.oom.group", "1".to_string()),
+            ("memory.oom.group", policy.memory_oom_group.to_string()),
             ("pids.max", policy.pids_max.to_string()),
         ] {
             std::fs::write(workload.join(filename), value)?;

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -71,6 +71,13 @@ pub const WORKLOAD_MEMORY_RESERVE_BYTES: u64 = 128 * 1024 * 1024;
 /// Value written to workload `memory.high` to avoid unmonitored soft-limit reclaim.
 pub const WORKLOAD_MEMORY_HIGH: &str = "max";
 
+/// Value written to workload `memory.oom.group` for per-process OOM selection.
+///
+/// The agent runtime and its tool descendants share the workload cgroup. Keeping
+/// group OOM disabled lets the kernel kill an individual high-memory process
+/// without unconditionally terminating the entire agent runtime.
+pub const WORKLOAD_MEMORY_OOM_GROUP: &str = "0";
+
 /// Value written to workload `pids.max` while no production ceiling is calibrated.
 ///
 /// The PID controller remains enabled for accounting and operation-local
@@ -93,6 +100,8 @@ pub struct WorkloadResourcePolicy {
     pub memory_high: &'static str,
     /// Workload hard memory limit in bytes.
     pub memory_max_bytes: u64,
+    /// Value written to the workload `memory.oom.group` cgroup file.
+    pub memory_oom_group: &'static str,
     /// Protected Guest Agent memory in bytes.
     pub control_memory_min_bytes: u64,
     /// Value written to the workload `pids.max` cgroup file.
@@ -150,6 +159,7 @@ impl WorkloadResourcePolicy {
             cpu_period_us: WORKLOAD_CPU_PERIOD_US,
             memory_high: WORKLOAD_MEMORY_HIGH,
             memory_max_bytes,
+            memory_oom_group: WORKLOAD_MEMORY_OOM_GROUP,
             control_memory_min_bytes: CONTROL_MEMORY_MIN_BYTES,
             pids_max: WORKLOAD_PIDS_MAX,
         })
@@ -170,6 +180,7 @@ mod tests {
         assert_eq!(policy.cpu_period_us, 100_000);
         assert_eq!(policy.memory_high, "max");
         assert_eq!(policy.memory_max_bytes, 3968 * 1024 * 1024);
+        assert_eq!(policy.memory_oom_group, "0");
         assert_eq!(policy.control_memory_min_bytes, 384 * 1024 * 1024);
         assert_eq!(policy.pids_max, "max");
     }

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -507,7 +507,7 @@ fn configure_resource_policy(
     write_cgroup_value(
         workload_path,
         MEMORY_OOM_GROUP_FILE,
-        "1",
+        policy.memory_oom_group,
         "configure workload memory.oom.group",
     )?;
     write_cgroup_value(


### PR DESCRIPTION
## Summary

- disable group OOM kills for workload cgroups so the kernel can select the memory-hungry process
- enforce the same policy when preparing reused sandboxes
- update process-containment behavior coverage to prove a tool SIGKILL does not fail the run and the sandbox remains reusable

## Scope

- keeps the existing workload memory limit, control memory protection, CPU/PID policies, and resource diagnostics
- does not introduce nested runtime/tool cgroups or guarantee a specific victim when the agent runtime itself is the largest consumer

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --release --no-default-features --all-targets`
- `cargo doc --manifest-path crates/Cargo.toml --workspace --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test reuse_preparation_helper`
- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- `shellcheck .github/scripts/runner-behavior-process-containment.sh`

The broader Rust suite passed before the final rebase. On the rebased head, an additional full-suite run exposed pre-existing parallel workspace-cache test contention (`LockBusy`); each reported test passes in isolation and the affected tests above pass on the current head.

Closes #27269
