### PR TITLE
fix(platform): skip markdown parsing for user messages

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-event-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-body-blocks.ts
@@ -2,7 +2,6 @@ import {
   chatEventCompatibilityRole,
   isChatEventContentTextType,
 } from "@okouai/api-contracts/contracts/chat-events";
-import { escapeHtmlTags } from "../../lib/markdown/pipeline.ts";
 import { messageDocumentToDisplayText } from "../zero-page/user-message-document-codec.ts";
 import {
   isFollowupsEvent,
@@ -66,19 +65,22 @@ function skipsEventBodyRendering(event: ChatEvent): boolean {
   );
 }
 
-/** Whether the event carries a body the transcript renders as markdown. */
+/** Whether the event carries an assistant body rendered as markdown. */
 export function hasChatEventBodyContent(event: ChatEvent): boolean {
   return chatEventTreeContent(event) !== null;
 }
 
 /**
- * The raw body an event's markdown tree is parsed from, or null when the event
- * renders no body. Cheap relative to planning: the visibility-driven ensure
- * pass runs on every scroll capture, so the unchanged-content skip has to cost
- * a lookup, not a card scan.
+ * The raw assistant body a markdown tree is parsed from, or null when the event
+ * does not use markdown rendering. Cheap relative to planning: the
+ * visibility-driven ensure pass runs on every scroll capture, so the
+ * unchanged-content skip has to cost a lookup, not a card scan.
  */
 export function chatEventTreeContent(event: ChatEvent): string | null {
-  if (skipsEventBodyRendering(event)) {
+  if (
+    chatEventCompatibilityRole(event.eventType) !== "assistant" ||
+    skipsEventBodyRendering(event)
+  ) {
     return null;
   }
   const content = chatEventBodyContent(event);
@@ -93,9 +95,7 @@ interface ChatEventTreePlan {
 }
 
 /**
- * Plans the single markdown document an event renders as. Assistant bodies go
- * through card recognition; user bodies are written in a composer, so their
- * newlines are literal and any HTML they contain is text.
+ * Plans the single markdown document an assistant event renders as.
  */
 export function chatEventTreePlan(
   event: ChatEvent,
@@ -105,20 +105,13 @@ export function chatEventTreePlan(
   if (content === null) {
     return null;
   }
-  if (chatEventCompatibilityRole(event.eventType) === "assistant") {
-    const plan = eventBodyPlan(content, {
-      previews: true,
-      browserThreadId: threadId,
-    });
-    return {
-      content,
-      treeSource: plan.treeSource,
-      descriptors: plan.descriptors,
-    };
-  }
+  const plan = eventBodyPlan(content, {
+    previews: true,
+    browserThreadId: threadId,
+  });
   return {
     content,
-    treeSource: escapeHtmlTags(content.replace(/\n/g, "  \n")),
-    descriptors: [],
+    treeSource: plan.treeSource,
+    descriptors: plan.descriptors,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -7658,21 +7658,7 @@ function PagedUserMessage({
               attachments={allAttachments}
               onImageClick={openLightbox}
             />
-          ) : (
-            <>
-              <UserMessageAttachments
-                attachments={allAttachments}
-                onImageClick={openLightbox}
-              />
-              {event.tree !== undefined && (
-                <UserMessageBubble>
-                  <div className="px-4 py-3">
-                    <MarkdownEventBody tree={event.tree} mediaPreview={false} />
-                  </div>
-                </UserMessageBubble>
-              )}
-            </>
-          )}
+          ) : null}
           <UserMessageActions
             canCopy={canCopy}
             copied={copied}


### PR DESCRIPTION
## Summary

- keep user-role events out of Markdown tree planning and parsing
- render user messages only through the existing structured plain-text view
- remove the legacy Markdown fallback from paged user messages

## Why

Large plain-text user inputs could still enter background Markdown parsing even though the UI displayed them literally, causing long main-thread tasks.

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-user-messages.test.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/signals/chat-page/__tests__/event-body-plan.test.ts --maxWorkers=1 --silent=passed-only` (62 tests passed)
