### PR TITLE
test(api): split stripe snapshot scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -564,14 +564,11 @@ describe("Stripe automation event webhook", () => {
     expect(context.mocks.stripe.invoices.list).not.toHaveBeenCalled();
   });
 
-  it("queues every embedded line and current and legacy relationship identity without Stripe enrichment", async () => {
+  it("queues every embedded line and current relationship identities without Stripe enrichment", async () => {
     const current = await setupScenario({
       accountId: "acct_stripe_current_snapshot",
     });
-    const legacy = await setupScenario({
-      accountId: "acct_stripe_legacy_snapshot",
-    });
-    await runs.heartbeatRunner(legacy.runnerGroup);
+    await runs.heartbeatRunner(current.runnerGroup);
     const invoiceListCalls =
       context.mocks.stripe.invoices.list.mock.calls.length;
     const subscriptionRetrieveCalls =
@@ -643,30 +640,9 @@ describe("Stripe automation event webhook", () => {
         },
       }),
     );
-    await postStripeAutomationEvent(
-      invoicePaidEvent({
-        accountId: "acct_stripe_legacy_snapshot",
-        eventId: "evt_legacy_snapshot",
-        invoiceFields: {
-          parent: undefined,
-          subscription: "sub_legacy_snapshot",
-          payment_intent: "pi_legacy_snapshot",
-          payments: {
-            data: [
-              {
-                payment: "pay_legacy_snapshot",
-                payment_intent: "pi_legacy_relationship",
-              },
-            ],
-          },
-        },
-      }),
-    );
     expect((await executeAutomation(current)).body.executed).toBe(1);
-    expect((await executeAutomation(legacy)).body.executed).toBe(1);
 
     const currentClaim = await claimScenarioRun(current);
-    const legacyClaim = await claimScenarioRun(legacy);
     expect(currentClaim.prompt).toContain(
       "normalized, signed Stripe webhook snapshot",
     );
@@ -714,6 +690,51 @@ describe("Stripe automation event webhook", () => {
       .parse(currentContext);
     expect(currentEvent.invoice.lines.data).toHaveLength(31);
 
+    expect(context.mocks.stripe.invoices.list).toHaveBeenCalledTimes(
+      invoiceListCalls,
+    );
+    expect(context.mocks.stripe.subscriptions.retrieve).toHaveBeenCalledTimes(
+      subscriptionRetrieveCalls,
+    );
+    expect(context.mocks.stripe.paymentMethods.retrieve).toHaveBeenCalledTimes(
+      paymentMethodRetrieveCalls,
+    );
+  });
+
+  it("queues legacy relationship identities without Stripe enrichment", async () => {
+    const legacy = await setupScenario({
+      accountId: "acct_stripe_legacy_snapshot",
+    });
+    await runs.heartbeatRunner(legacy.runnerGroup);
+    const invoiceListCalls =
+      context.mocks.stripe.invoices.list.mock.calls.length;
+    const subscriptionRetrieveCalls =
+      context.mocks.stripe.subscriptions.retrieve.mock.calls.length;
+    const paymentMethodRetrieveCalls =
+      context.mocks.stripe.paymentMethods.retrieve.mock.calls.length;
+
+    await postStripeAutomationEvent(
+      invoicePaidEvent({
+        accountId: "acct_stripe_legacy_snapshot",
+        eventId: "evt_legacy_snapshot",
+        invoiceFields: {
+          parent: undefined,
+          subscription: "sub_legacy_snapshot",
+          payment_intent: "pi_legacy_snapshot",
+          payments: {
+            data: [
+              {
+                payment: "pay_legacy_snapshot",
+                payment_intent: "pi_legacy_relationship",
+              },
+            ],
+          },
+        },
+      }),
+    );
+    expect((await executeAutomation(legacy)).body.executed).toBe(1);
+
+    const legacyClaim = await claimScenarioRun(legacy);
     expect(eventContextFromPrompt(legacyClaim.prompt)).toMatchObject({
       relationships: {
         subscriptionId: "sub_legacy_snapshot",


### PR DESCRIPTION
## Summary

- split the current and legacy Stripe snapshot scenarios into independent tests, each with its own complete fixture and runner heartbeat
- preserve embedded-line fan-out, current and legacy relationship identity coverage, exactly-once scoped execution, and the no-Stripe-enrichment contract
- leave the production webhook and automation execution paths unchanged

## Root cause

The push Turbo run [31812991286](https://github.com/vm0-ai/vm0/actions/runs/31812991286) timed out in [`test-api (8)`](https://github.com/vm0-ai/vm0/actions/runs/31812991286/job/94809026776) after this combined test reached 5003 ms. The exact same SHA passed in merge-group run [31812286687](https://github.com/vm0-ai/vm0/actions/runs/31812286687), where the same test took 900 ms. The entire file expanded from 8621 ms to 28701 ms, with neighboring tests also slowing by roughly 2–3x.

#26734 correctly removed the unrelated global cron scan and replaced it with current/legacy automation-ID-scoped execution. That fix is present in the failed SHA. The remaining nondeterministic boundary was the single 5000 ms budget shared by two independent, fully provisioned route scenarios: each scenario creates its own workflow state, dispatches a webhook, drains a scoped automation execution, claims a run, and verifies the resulting prompt. Variable shard/database contention could therefore make their cumulative wall time cross the shared budget even though either scenario was healthy.

The webhook dispatch, scoped automation executor, and workflow queue drains are all awaited. The trace found no floating promise, `waitUntil` ownership gap, shared persisted identity, or causal teardown abort. The triggering #27279 commit only changed platform reconnect code. Splitting the independent scenarios gives each one its own standard test budget and fresh fixture without increasing timeouts, adding retries or sleeps, weakening assertions, or changing product behavior.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check origin/main...HEAD`

The targeted Vitest case was not run locally because PostgreSQL is not running in the repair environment, and this repair must not start local services or load project secrets. The PR's `test-api (8)` check is the runtime verification boundary.

PR preview and browser verification are not applicable: this is a test-only change with no deployable or user-visible behavior.
