### PR TITLE
fix(db): recover published zero_runs migration timeout

### DIFF
--- a/turbo/packages/db/MIGRATIONS.md
+++ b/turbo/packages/db/MIGRATIONS.md
@@ -10,6 +10,13 @@ default with a later `SET LOCAL` statement in that migration. Non-transactional
 migrations do not receive these defaults and must manage their own timeout
 requirements.
 
+If production smoke exposes a timeout only after a migration has shipped, keep
+the published SQL and snapshot unchanged. Add an exact-hash, exact-statement
+timeout recovery in `scripts/migration-runner.ts`, restore the normal timeout
+before any blocking DDL, and cover the published migration through the real
+PostgreSQL runner. This preserves the migration ledger hash while keeping the
+recovery narrower than a global timeout increase.
+
 ## Transition validators
 
 A transition validator protects an expand → contract rollout while old and new

--- a/turbo/packages/db/scripts/migration-runner.ts
+++ b/turbo/packages/db/scripts/migration-runner.ts
@@ -10,6 +10,24 @@ type DbMigration = {
 
 export const NON_TRANSACTIONAL_MIGRATION_MARKER = "-- vm0:non-transactional";
 
+// Migration 0924 shipped before its production-scale catalog preflight proved
+// that the single DO statement can need more than its original 10-second
+// budget. Migration files are immutable, so scope the recovery to the exact
+// published hash: extend only the preflight, then restore 10 seconds before
+// the plain DROP TABLE statement.
+const PUBLISHED_MIGRATION_STATEMENT_TIMEOUT_OVERRIDES: ReadonlyMap<
+  string,
+  ReadonlyMap<number, string>
+> = new Map([
+  [
+    "2320f87e1ef46ae844f5a120a918f694bd9469a96048298ea7e57d1ba090b516",
+    new Map([
+      [2, "60s"],
+      [3, "10s"],
+    ]),
+  ],
+]);
+
 export async function applyPendingMigrations(sql: postgres.Sql): Promise<void> {
   const migrations = readMigrationFiles({
     migrationsFolder: DRIZZLE_MIGRATE_OUT,
@@ -63,9 +81,24 @@ export async function applyPendingMigrations(sql: postgres.Sql): Promise<void> {
       await transaction`SET LOCAL lock_timeout = '1s'`;
       await transaction`SET LOCAL statement_timeout = '10s'`;
 
-      for (const statement of migration.sql) {
+      const statementTimeoutOverrides =
+        PUBLISHED_MIGRATION_STATEMENT_TIMEOUT_OVERRIDES.get(migration.hash);
+
+      for (const [statementIndex, statement] of migration.sql.entries()) {
         if (statement.trim().length === 0) {
           continue;
+        }
+
+        const statementTimeoutOverride =
+          statementTimeoutOverrides?.get(statementIndex);
+        if (statementTimeoutOverride) {
+          await transaction`
+            SELECT set_config(
+              'statement_timeout',
+              ${statementTimeoutOverride},
+              true
+            )
+          `;
         }
         await transaction.unsafe(statement);
       }

--- a/turbo/packages/db/scripts/test-zero-runs-stage-6.ts
+++ b/turbo/packages/db/scripts/test-zero-runs-stage-6.ts
@@ -41,10 +41,21 @@ const upgradeDatabase = `migration_zero_runs_stage_6_upgrade_${process.pid}`;
 const freshDatabase = `migration_zero_runs_stage_6_fresh_${process.pid}`;
 const lifecycleRunId = "00000000-0000-4000-8000-000000092401";
 const productRunId = "00000000-0000-4000-8000-000000092402";
+const catalogScaleRoutineCount = 160;
+const catalogRoutineDelaySeconds = 0.07;
 
 function databaseConnectionUrl(databaseName: string): string {
   const url = new URL(databaseUrl);
   url.pathname = `/${databaseName}`;
+  return url.toString();
+}
+
+function catalogLatencyConnectionUrl(databaseName: string): string {
+  const url = new URL(databaseConnectionUrl(databaseName));
+  url.searchParams.set(
+    "options",
+    "-c search_path=stage6_catalog_latency,pg_catalog,public",
+  );
   return url.toString();
 }
 
@@ -413,6 +424,40 @@ async function validateCatalogPreflight(args: {
   });
 }
 
+async function installCatalogLatencyFixture(client: Client): Promise<void> {
+  // A newly created Neon branch can deparse user routines from cold catalog
+  // pages. Put this latency shim ahead of pg_catalog only on the runner test
+  // connection so the actual 0924 DO statement deterministically exceeds its
+  // published 10-second cumulative budget without changing the migration.
+  await client.query(`
+    CREATE SCHEMA "stage6_catalog_latency";
+    CREATE FUNCTION "stage6_catalog_latency"."pg_get_functiondef"(
+      "function_oid" oid
+    ) RETURNS text
+    LANGUAGE sql
+    AS $function$
+      SELECT pg_catalog.pg_get_functiondef("function_oid")
+      FROM pg_catalog.pg_sleep(${catalogRoutineDelaySeconds})
+    $function$;
+
+    CREATE SCHEMA "stage6_catalog_scale";
+    DO $block$
+    DECLARE
+      "routine_index" integer;
+    BEGIN
+      FOR "routine_index" IN 1..${catalogScaleRoutineCount} LOOP
+        EXECUTE format(
+          'CREATE FUNCTION stage6_catalog_scale.%I() '
+          'RETURNS integer LANGUAGE sql IMMUTABLE AS %L',
+          'catalog_probe_' || "routine_index"::text,
+          'SELECT ' || "routine_index"::text
+        );
+      END LOOP;
+    END
+    $block$;
+  `);
+}
+
 async function readAgentRunsSchema(client: Client): Promise<unknown> {
   const columns = await client.query(`
       SELECT
@@ -559,9 +604,20 @@ async function validateStage6(): Promise<void> {
       });
       await locker.query("COMMIT");
 
+      await installCatalogLatencyFixture(control);
       await runner.end();
-      runner = postgres(upgradeUrl, { max: 1 });
+      runner = postgres(catalogLatencyConnectionUrl(upgradeDatabase), {
+        max: 1,
+      });
+      const catalogMigrationStartedAt = performance.now();
       await applyPendingMigrations(runner);
+      const catalogMigrationElapsedMs =
+        performance.now() - catalogMigrationStartedAt;
+      assert.ok(
+        catalogMigrationElapsedMs >= 10_500 &&
+          catalogMigrationElapsedMs < 45_000,
+        `Expected the catalog preflight to exceed its published 10-second budget but finish within the 60-second recovery, got ${String(catalogMigrationElapsedMs)}ms`,
+      );
 
       const migratedState = await control.query<{
         appliedCount: number;
@@ -586,7 +642,7 @@ async function validateStage6(): Promise<void> {
       const upgradeSchema = await readAgentRunsSchema(control);
       await validateFreshReplay(upgradeSchema);
       console.log(
-        `Stage 6 lock failure observed after ${lockFailure.elapsedMs.toFixed(0)}ms; clean retry and fresh replay succeeded`,
+        `Stage 6 lock failure observed after ${lockFailure.elapsedMs.toFixed(0)}ms; production-scale catalog preflight completed after ${catalogMigrationElapsedMs.toFixed(0)}ms; clean retry and fresh replay succeeded`,
       );
     } finally {
       await locker.query("ROLLBACK").catch(() => {


### PR DESCRIPTION
## Summary

- Preserve the released `0924_drop_zero_runs.sql`, its snapshot, journal timestamp, and ledger hash unchanged.
- Recover the unpublished-to-production migration through an exact-hash, exact-statement runner override: only the dependency-preflight `DO` receives a 60-second budget, and the normal 10-second budget is restored before `DROP TABLE`.
- Add real-PostgreSQL coverage that drives the actual pooled runner through a deterministic cold-catalog workload exceeding the published 10-second budget while retaining all Stage 6 dependency, lock, ledger, row-integrity, retry, and fresh-replay checks.

## Root cause

PostgreSQL applies `statement_timeout` to the entire top-level statement. Migration 0924 placed all catalog dependency preflights inside one `DO`, so their cumulative catalog work shares one 10-second clock. Production smoke reached PostgreSQL `57014` after that clock expired before any DDL or ledger mutation.

The migration has already shipped in `@okouai/db@1.199.1`, and repository policy makes shipped SQL and snapshots append-only. A new later migration cannot recover production because the runner must first apply pending 0924. The recovery therefore lives in the pooled migration runner and is pinned to the immutable 0924 SHA-256:

`2320f87e1ef46ae844f5a120a918f694bd9469a96048298ea7e57d1ba090b516`

## Safety boundaries

- `lock_timeout` remains 1 second for the whole transaction.
- `statement_timeout` returns to 10 seconds before the plain restrictive drop.
- No `CASCADE`, direct connection, explicit table lock, row rewrite, migration bypass, manual production mutation, or schema/runtime compatibility surface is added.
- Every external constraint, user trigger, retired transition object, stored routine, view/materialized view/rule, and non-allowlisted `pg_depend` object remains rejected before the drop.
- `agent_runs` and all application code are unchanged; no `zero_runs` bridge, fallback, compatibility view, or dual write is introduced.

## Evidence

- Lock-contended pooled execution: PostgreSQL `55P03` after 1,056 ms; `zero_runs`, its seeded row, `agent_runs` digest, and the migration ledger stayed unchanged.
- Cold-catalog pooled execution: actual 0924 preflight completed in 23,205 ms through the scoped recovery, then clean retry and fresh replay succeeded.
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip` (existing configuration hints only)
- staged non-API, platform, and API type checks
- `DATABASE_URL=postgresql://postgres@localhost:5432/postgres pnpm --filter @okouai/db test:migration-consistency`
  - runner timeout defaults
  - Stage 6 dependency/lock/timeout/retry/fresh-replay coverage
  - 117/117 snapshot chain and journal ordering
  - latest snapshot accuracy, full upgrades, consecutive resets, fresh generation, and normalized schema equivalence

No full Vitest suite or development server was run, per repository instructions.

Refs #27282. The issue remains controller-owned for the post-merge release approval and production acceptance gates.