### PR TITLE
test(api): split canonical slack queue scenarios

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1721,7 +1721,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     await flushWaitUntilForTest();
   });
 
-  it("keeps queued Web and Slack sends on one canonical session", async () => {
+  it("keeps queued Web and Slack inputs on one canonical route", async () => {
     const actor = bdd.user();
     runs.acceptStorageDownloads();
     runs.acceptTelemetryIngest();
@@ -1729,10 +1729,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
     integrations.configureSlackAppMocks();
     await runs.grantProEntitlement(actor);
     await runs.ensureOrgModelProvider(actor);
-    if (!actor.orgId) {
-      throw new Error("Expected canonical Slack actor to belong to an org");
-    }
-    const orgId = actor.orgId;
     const slackUserId = uniqueSlackUserId();
     const { teamId, botUserId } = await integrations.installSlackWorkspace(
       actor,
@@ -1785,7 +1781,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       throw new Error("Expected canonical Slack route to own a chat thread");
     }
     const run1Id = await pollSlackRun(runnerGroup);
-    const claim1 = await runs.claimRunnerJob(run1Id);
+    await runs.claimRunnerJob(run1Id);
     const defaultAgentId = state.default_agent?.id;
     if (!defaultAgentId) {
       throw new Error("Expected canonical Slack thread to use a default agent");
@@ -1896,6 +1892,94 @@ describe("INT-01: Slack app deep webhook flows", () => {
         return part.type === "source";
       }),
     ).toStrictEqual({ type: "source", kind: "slack" });
+  });
+
+  it("keeps queued Web and Slack sends on one canonical session", async () => {
+    const actor = bdd.user();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    const runnerGroup = runs.configureRunnerGroup();
+    integrations.configureSlackAppMocks();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    if (!actor.orgId) {
+      throw new Error("Expected canonical Slack actor to belong to an org");
+    }
+    const orgId = actor.orgId;
+    const slackUserId = uniqueSlackUserId();
+    const { teamId, botUserId } = await integrations.installSlackWorkspace(
+      actor,
+      {
+        installerSlackUserId: slackUserId,
+      },
+    );
+    const channelId = "C_BDD_CANONICAL_SESSION_REUSE";
+    const threadTs = "2911.000100";
+    const event = {
+      type: "app_mention",
+      user: slackUserId,
+      text: `<@${botUserId}> establish the canonical session`,
+      ts: threadTs,
+      channel: channelId,
+      channel_type: "channel",
+    };
+    const eventBody = JSON.stringify({
+      type: "event_callback",
+      team_id: teamId,
+      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
+      event,
+    });
+    await integrations.requestSlackEvent(
+      eventBody,
+      integrations.signedSlackIngressHeaders(eventBody),
+      [200],
+    );
+    await flushWaitUntilForTest();
+
+    let state = await integrations.readSlackTestState(teamId);
+    const canonicalChatThreadId = state.chat_thread_routes[0]?.chatThreadId;
+    if (!canonicalChatThreadId) {
+      throw new Error("Expected canonical Slack route to own a chat thread");
+    }
+    const run1Id = await pollSlackRun(runnerGroup);
+    const claim1 = await runs.claimRunnerJob(run1Id);
+    const defaultAgentId = state.default_agent?.id;
+    if (!defaultAgentId) {
+      throw new Error("Expected canonical Slack thread to use a default agent");
+    }
+    const queuedWebMessage = await chat.requestSendEvent(
+      actor,
+      {
+        agentId: defaultAgentId,
+        prompt: "keep the web session separate",
+        threadId: canonicalChatThreadId,
+        clientEventId: randomUUID(),
+      },
+      [201],
+    );
+    expect(queuedWebMessage.body).toMatchObject({
+      runId: null,
+      threadId: canonicalChatThreadId,
+    });
+
+    const stickyBody = JSON.stringify({
+      type: "event_callback",
+      team_id: teamId,
+      event_id: `EvBDD${randomUUID().replace(/-/g, "")}`,
+      event: {
+        ...event,
+        text: "stay canonical on the same route",
+        ts: "2911.000200",
+        thread_ts: threadTs,
+      },
+    });
+    await integrations.requestSlackEvent(
+      stickyBody,
+      integrations.signedSlackIngressHeaders(stickyBody),
+      [200],
+    );
+    await flushWaitUntilForTest();
+
     context.mocks.slack.chat.postMessage.mockClear();
     await completeSlackTriggeredRun({
       runId: run1Id,


### PR DESCRIPTION
## Summary

- split the canonical Slack queue coverage into independently seeded input/route and send/session scenarios
- keep the original queued Web/Slack ordering, delivery, telemetry, and shared canonical-session assertions intact
- avoid retries, sleeps, timeout changes, skipped coverage, detached cleanup, and product-code changes

## Root cause evidence

- Triggering main run: [Turbo 31817313302](https://github.com/vm0-ai/vm0/actions/runs/31817313302), [`test-api (3)` job 94822059671](https://github.com/vm0-ai/vm0/actions/runs/31817313302/job/94822059671)
  - `keeps queued Web and Slack sends on one canonical session` timed out at 5,018 ms
  - `integrations.bdd.test.ts` took 44,976 ms; the other 41 tests passed
  - adjacent `deduplicates canonical Slack retries` expanded to 3,293 ms
- Same-SHA comparison: [Turbo 31816940810](https://github.com/vm0-ai/vm0/actions/runs/31816940810), [`test-api (3)` job 94820853085](https://github.com/vm0-ai/vm0/actions/runs/31816940810/job/94820853085)
  - the exact test passed in 1,153 ms and the file took 15,915 ms
  - the adjacent retry test took 792 ms
- The first canonical completion's observed log gap expanded from about 117 ms in the successful job to about 2,406 ms in the failed job. The failure contained no preceding assertion failure, rejected background task, missing queued item, or session mismatch.
- The route owns its durable Slack ingress through `waitUntil`, the test flushes that ownership boundary, runner completion is awaited, and queued sends are drained through the canonical thread queue. Fixture identities are unique. The causal non-determinism is therefore CI shard scheduling/database contention exhausting one combined scenario's per-test budget, not a product invariant failure.
- The failed SHA came from #27285, which changed only `stripe-automation-events.test.ts`; the same SHA passed this scenario in merge-group. Current `main` did not contain an equivalent repair when this branch was created.

## Verification

- `pnpm exec prettier --check src/signals/routes/__tests__/integrations.bdd.test.ts`
- `pnpm exec eslint src/signals/routes/__tests__/integrations.bdd.test.ts --max-warnings 0`
- `pnpm exec oxlint src/signals/routes/__tests__/integrations.bdd.test.ts`
- `pnpm --filter api run check-types`
- `pnpm knip --workspace api`
- `git diff --check`
- Narrow local Vitest invocation was attempted without starting any service. Suite setup stopped before test execution with `ECONNREFUSED 127.0.0.1:5432` and all 43 tests skipped because PostgreSQL is unavailable; PR Turbo is the runtime verification source.

## Preview

Not applicable. This PR only partitions one API BDD test into independent fixtures and changes no deployable app, API, auth, or runner behavior. The original canonical-session invariant remains asserted by the review-ready PR's Turbo `test-api` check.
