### PR TITLE
feat(chat): smooth automatic tail scrolling

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -509,6 +509,7 @@ function createJump(
   store: LocatorStore,
   threadId: string,
   scrollContainer$: Computed<HTMLElement | null>,
+  setIgnoreContentResizeScroll$: Command<void, [boolean]>,
   signal: AbortSignal,
 ) {
   const resetLandedSignal$ = resetSignal();
@@ -519,6 +520,7 @@ function createJump(
     if (!container || !turn) {
       return;
     }
+    set(setIgnoreContentResizeScroll$, false);
     L.debug("jump to turn", { threadId, turnIndex });
     container.scrollTo({
       top: Math.max(0, turn.top - container.clientHeight * JUMP_VIEWPORT_RATIO),
@@ -884,16 +886,24 @@ export function createChatConversationLocatorSignals(
   {
     threadId,
     scrollContainer$,
+    setIgnoreContentResizeScroll$,
   }: {
     threadId: string;
     scrollContainer$: Computed<HTMLElement | null>;
+    setIgnoreContentResizeScroll$: Command<void, [boolean]>;
   },
   signal: AbortSignal,
 ): ChatConversationLocatorSignals {
   const store = createStore();
   const recompute$ = createRecompute(store, scrollContainer$);
   const paint$ = createPaint(store);
-  const jumpToTurn$ = createJump(store, threadId, scrollContainer$, signal);
+  const jumpToTurn$ = createJump(
+    store,
+    threadId,
+    scrollContainer$,
+    setIgnoreContentResizeScroll$,
+    signal,
+  );
   const railOnRef$ = createRailOnRef(store, threadId, scrollContainer$, {
     recompute$,
     paint$,

--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -168,6 +168,8 @@ export interface ChatPanelSignals {
   // True when the event list is scrolled away from the bottom - drives the
   // feature-gated scroll-to-bottom button. Read-only outside scroll signals.
   readonly awayFromBottom$: Computed<boolean>;
+  readonly ignoreContentResizeScroll$: Computed<boolean>;
+  readonly setIgnoreContentResizeScroll$: Command<void, [boolean]>;
   readonly composer: ComposerSignals;
   readonly feedback: ChatThreadFeedbackSignals;
   readonly sharing: ChatThreadSharingSignals;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -5,6 +5,7 @@ import { onDomEventFn, onRef } from "../utils.ts";
 
 const L = logger("AutoScroll");
 const AT_BOTTOM_THRESHOLD_PX = 10;
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 const SCROLL_ANCHOR_ATTRIBUTE = "data-chat-scroll-anchor-event-id";
 const SCROLL_COMMIT_REVISION_ATTRIBUTE = "data-chat-scroll-commit-revision";
 const SCROLL_COMMIT_TO_TAIL_ATTRIBUTE = "data-chat-scroll-commit-to-tail";
@@ -42,6 +43,8 @@ export interface ChatThreadScrollSignals {
   readonly scrollContainer$: Computed<HTMLElement | null>;
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   readonly awayFromBottom$: Computed<boolean>;
+  readonly ignoreContentResizeScroll$: Computed<boolean>;
+  readonly setIgnoreContentResizeScroll$: Command<void, [boolean]>;
   readonly readRenderedThreadScrollPosition$: Command<
     ThreadScrollPosition | null,
     []
@@ -84,6 +87,17 @@ function isAtBottom(container: HTMLElement): boolean {
   return (
     container.scrollHeight - container.scrollTop - container.clientHeight <=
     AT_BOTTOM_THRESHOLD_PX
+  );
+}
+
+function maximumScrollTop(container: HTMLElement): number {
+  return Math.max(0, container.scrollHeight - container.clientHeight);
+}
+
+function prefersReducedMotion(container: HTMLElement): boolean {
+  return (
+    container.ownerDocument.defaultView?.matchMedia(REDUCED_MOTION_QUERY)
+      .matches ?? false
   );
 }
 
@@ -203,6 +217,21 @@ interface ScrollRuntime {
   // event measure as "not at the bottom" and park the thread on an anchor
   // nobody chose.
   programmaticScrollTop: number | null;
+  smoothAutoScrollTarget: number | null;
+}
+
+function clearSmoothAutoScrollRuntime(runtime: ScrollRuntime): void {
+  runtime.smoothAutoScrollTarget = null;
+}
+
+function smoothScrollToBottom(
+  runtime: ScrollRuntime,
+  container: HTMLElement,
+): void {
+  const target = maximumScrollTop(container);
+  runtime.programmaticScrollTop = null;
+  runtime.smoothAutoScrollTarget = target;
+  container.scrollTo({ top: target, behavior: "smooth" });
 }
 
 function createInternalScrollSignals(
@@ -211,10 +240,21 @@ function createInternalScrollSignals(
   afterThreadScrollPositionChanged$: Command<Promise<void>, [AbortSignal]>,
 ) {
   const internalScrollContainer$ = state<HTMLElement | null>(null);
+  const internalIgnoreContentResizeScroll$ = state(false);
   const scrollContainer$ = computed((get) => {
     return get(internalScrollContainer$);
   });
   const { threadScrollPosition$, awayFromBottom$ } = position;
+  const ignoreContentResizeScroll$ = computed((get) => {
+    return get(internalIgnoreContentResizeScroll$);
+  });
+  const setIgnoreContentResizeScroll$ = command(
+    ({ get, set }, ignore: boolean): void => {
+      if (get(internalIgnoreContentResizeScroll$) !== ignore) {
+        set(internalIgnoreContentResizeScroll$, ignore);
+      }
+    },
+  );
 
   // The held position feeds the render window, so every write below runs the
   // window's ensure step afterwards — parsing is command-driven, and this is
@@ -311,6 +351,8 @@ function createInternalScrollSignals(
     scrollContainer$,
     threadScrollPosition$,
     awayFromBottom$,
+    ignoreContentResizeScroll$,
+    setIgnoreContentResizeScroll$,
     readRenderedThreadScrollPosition$,
     syncThreadScrollPosition$,
     clearThreadScrollPosition$,
@@ -321,17 +363,49 @@ function createInternalScrollSignals(
 
 type InternalScrollSignals = ReturnType<typeof createInternalScrollSignals>;
 
+function createContentResizeRestoreSignal(
+  threadId: string,
+  scroll: InternalScrollSignals,
+  runtime: ScrollRuntime,
+  restoreAfterResize$: Command<Promise<void>, [AbortSignal]>,
+) {
+  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    if (!runtime.initialized) {
+      return;
+    }
+    if (get(scroll.ignoreContentResizeScroll$)) {
+      const container = get(scroll.scrollContainer$);
+      if (!container) {
+        throw new Error("Chat scroll container is not mounted");
+      }
+      if (isAtBottom(container)) {
+        clearSmoothAutoScrollRuntime(runtime);
+        set(scroll.setIgnoreContentResizeScroll$, false);
+        return;
+      }
+      if (runtime.smoothAutoScrollTarget !== maximumScrollTop(container)) {
+        smoothScrollToBottom(runtime, container);
+      }
+      return;
+    }
+    L.debug("content resize scroll restore", { threadId });
+    await set(restoreAfterResize$, signal);
+  });
+}
+
 function createScrollNavigationSignals(
   threadId: string,
   scroll: InternalScrollSignals,
   runtime: ScrollRuntime,
   pendingScrollAfterRenderRequest$: Computed<ScrollAfterRenderRequest | null>,
 ) {
-  const scrollTo$ = command(({ get }, position: ThreadScrollPosition) => {
+  const scrollTo$ = command(({ get, set }, position: ThreadScrollPosition) => {
     const container = get(scroll.scrollContainer$);
     if (!container) {
       throw new Error("Chat scroll container is not mounted");
     }
+    set(scroll.setIgnoreContentResizeScroll$, false);
+    clearSmoothAutoScrollRuntime(runtime);
     if (!scrollToPosition(runtime, container, position)) {
       throw new Error(
         `Chat scroll target is not rendered: ${position.targetEventId}`,
@@ -339,7 +413,6 @@ function createScrollNavigationSignals(
     }
     runtime.initialized = true;
   });
-
   const scrollToBottom$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       const container = get(scroll.scrollContainer$);
@@ -353,6 +426,8 @@ function createScrollNavigationSignals(
         heldTargetEventId:
           get(scroll.threadScrollPosition$)?.targetEventId ?? null,
       });
+      set(scroll.setIgnoreContentResizeScroll$, false);
+      clearSmoothAutoScrollRuntime(runtime);
       // The DOM write happens before the awaited state clear so the jump is
       // part of the current task and cannot paint at the old offset first.
       applyScrollTop(runtime, container, container.scrollHeight);
@@ -360,13 +435,14 @@ function createScrollNavigationSignals(
       await set(scroll.clearThreadScrollPosition$, signal);
     },
   );
-
   const scrollToTop$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       const container = get(scroll.scrollContainer$);
       if (!container) {
         throw new Error("Chat scroll container is not mounted");
       }
+      set(scroll.setIgnoreContentResizeScroll$, false);
+      clearSmoothAutoScrollRuntime(runtime);
       applyScrollTop(runtime, container, 0);
       runtime.initialized = true;
       await set(scroll.syncThreadScrollPosition$, container, true, signal);
@@ -386,6 +462,8 @@ function createScrollNavigationSignals(
         throw new Error("Chat scroll container is not mounted");
       }
       if (position) {
+        set(scroll.setIgnoreContentResizeScroll$, false);
+        clearSmoothAutoScrollRuntime(runtime);
         if (scrollToPosition(runtime, container, position)) {
           runtime.initialized = true;
           return;
@@ -432,21 +510,16 @@ function createScrollNavigationSignals(
     },
   );
 
-  // Content growth restores in the same frame that produced it. ResizeObserver
-  // callbacks run after layout and before paint, so a scroll written here is
-  // part of that frame; waiting for the next one would paint the grown content
-  // at the old offset first, which reads as a flash before the view snaps back.
-  // Deliberately outside `resizeScheduled`: sharing that flag would fold this
-  // restore into the deferred pass, which is the frame of delay it exists to
-  // avoid.
-  const restoreAfterContentResize$ = command(
-    async ({ set }, signal: AbortSignal): Promise<void> => {
-      if (!runtime.initialized) {
-        return;
-      }
-      L.debug("content resize scroll restore", { threadId });
-      await set(restoreAfterResize$, signal);
-    },
+  // Content growth normally restores in the same frame that produced it.
+  // While smooth tail-follow is active, the render commit already owns the
+  // motion, so this observer only retargets that animation when the bottom
+  // moves. Otherwise ResizeObserver's before-paint delivery keeps the existing
+  // exact anchor-or-tail correction and avoids a one-frame flash.
+  const restoreAfterContentResize$ = createContentResizeRestoreSignal(
+    threadId,
+    scroll,
+    runtime,
+    restoreAfterResize$,
   );
 
   return {
@@ -463,6 +536,7 @@ function createRenderScrollSignals(
   threadId: string,
   scroll: InternalScrollSignals,
   runtime: ScrollRuntime,
+  smoothAutoScrollEnabled$: Computed<boolean>,
 ) {
   const internalPendingRequest$ = state<ScrollAfterRenderRequest | null>(null);
   const pendingScrollAfterRenderRequest$ = computed((get) => {
@@ -505,14 +579,29 @@ function createRenderScrollSignals(
           SCROLL_COMMIT_TO_TAIL_ATTRIBUTE,
         );
         if (commitToTail) {
-          applyScrollTop(runtime, container, container.scrollHeight);
-        } else if (
-          !request.position ||
-          !scrollToPosition(runtime, container, request.position)
-        ) {
-          throw new Error(
-            `Chat scroll target is not rendered: ${request.position?.targetEventId ?? "none"}`,
-          );
+          const smooth =
+            runtime.initialized &&
+            get(smoothAutoScrollEnabled$) &&
+            !prefersReducedMotion(container) &&
+            !isAtBottom(container);
+          set(scroll.setIgnoreContentResizeScroll$, smooth);
+          if (smooth) {
+            smoothScrollToBottom(runtime, container);
+          } else {
+            clearSmoothAutoScrollRuntime(runtime);
+            applyScrollTop(runtime, container, container.scrollHeight);
+          }
+        } else {
+          set(scroll.setIgnoreContentResizeScroll$, false);
+          clearSmoothAutoScrollRuntime(runtime);
+          if (
+            !request.position ||
+            !scrollToPosition(runtime, container, request.position)
+          ) {
+            throw new Error(
+              `Chat scroll target is not rendered: ${request.position?.targetEventId ?? "none"}`,
+            );
+          }
         }
         runtime.initialized = true;
         set(clearPendingRequest$, revision);
@@ -524,8 +613,8 @@ function createRenderScrollSignals(
           scrollTop: container.scrollTop,
         });
         if (commitToTail) {
-          // After the DOM write: the commit runs during React's ref phase, and
-          // the offset must be applied before this frame paints.
+          // After selecting the initial instant position or starting the later
+          // smooth motion: the render window can now resume following the tail.
           await set(scroll.clearThreadScrollPosition$, signal);
         }
       },
@@ -565,14 +654,77 @@ function createRenderScrollSignals(
 
 type ScrollNavigationSignals = ReturnType<typeof createScrollNavigationSignals>;
 
+function isUserScrollKey(key: string): boolean {
+  return (
+    key === "PageUp" ||
+    key === "PageDown" ||
+    key === "ArrowUp" ||
+    key === "ArrowDown" ||
+    key === "Home" ||
+    key === "End" ||
+    key === " "
+  );
+}
+
+function createInterruptSmoothAutoScrollSignal(
+  scroll: InternalScrollSignals,
+  runtime: ScrollRuntime,
+) {
+  return command(
+    async (
+      { get, set },
+      container: HTMLElement,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      if (!get(scroll.ignoreContentResizeScroll$)) {
+        return;
+      }
+      applyScrollTop(runtime, container, container.scrollTop);
+      clearSmoothAutoScrollRuntime(runtime);
+      set(scroll.setIgnoreContentResizeScroll$, false);
+      await set(scroll.syncThreadScrollPosition$, container, true, signal);
+    },
+  );
+}
+
+function attachSmoothAutoScrollInterruptionListeners(
+  container: HTMLElement,
+  interrupt: (event: Event) => void,
+  signal: AbortSignal,
+): void {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (isUserScrollKey(event.key)) {
+      interrupt(event);
+    }
+  };
+  container.addEventListener("wheel", interrupt, { passive: true });
+  container.addEventListener("touchmove", interrupt, { passive: true });
+  container.addEventListener("pointerdown", interrupt, { passive: true });
+  container.addEventListener("keydown", handleKeyDown, { passive: true });
+  signal.addEventListener(
+    "abort",
+    () => {
+      container.removeEventListener("wheel", interrupt);
+      container.removeEventListener("touchmove", interrupt);
+      container.removeEventListener("pointerdown", interrupt);
+      container.removeEventListener("keydown", handleKeyDown);
+    },
+    { once: true },
+  );
+}
+
 function createScrollContainerOnRef(
   threadId: string,
   scroll: InternalScrollSignals,
   navigation: ScrollNavigationSignals,
   runtime: ScrollRuntime,
 ) {
+  const interruptSmoothAutoScroll$ = createInterruptSmoothAutoScrollSignal(
+    scroll,
+    runtime,
+  );
   return onRef(
-    command(({ set }, container: HTMLElement, signal: AbortSignal) => {
+    command(({ get, set }, container: HTMLElement, signal: AbortSignal) => {
       set(scroll.bindScrollContainer$, container);
       L.debug("container bound", {
         threadId,
@@ -590,6 +742,19 @@ function createScrollContainerOnRef(
           // too. Where they sit says nothing about where the thread sits.
           return;
         }
+        if (get(scroll.ignoreContentResizeScroll$)) {
+          if (!isAtBottom(container)) {
+            return;
+          }
+          clearSmoothAutoScrollRuntime(runtime);
+          set(scroll.setIgnoreContentResizeScroll$, false);
+          return set(
+            scroll.syncThreadScrollPosition$,
+            container,
+            false,
+            signal,
+          );
+        }
         const programmatic =
           runtime.programmaticScrollTop === container.scrollTop;
         if (!programmatic) {
@@ -606,6 +771,9 @@ function createScrollContainerOnRef(
           signal,
         );
       });
+      const handleSmoothInterruption = onDomEventFn((_event: Event) => {
+        return set(interruptSmoothAutoScroll$, container, signal);
+      });
       const scheduleRestoreAfterResize = () => {
         set(navigation.scheduleRestoreAfterResize$, signal);
       };
@@ -615,6 +783,11 @@ function createScrollContainerOnRef(
         capture: true,
         passive: true,
       });
+      attachSmoothAutoScrollInterruptionListeners(
+        container,
+        handleSmoothInterruption,
+        signal,
+      );
       resizeObserver.observe(container);
       container.ownerDocument.defaultView?.visualViewport?.addEventListener(
         "resize",
@@ -637,6 +810,8 @@ function createScrollContainerOnRef(
           set(scroll.clearScrollContainer$, container);
           runtime.initialized = false;
           runtime.programmaticScrollTop = null;
+          clearSmoothAutoScrollRuntime(runtime);
+          set(scroll.setIgnoreContentResizeScroll$, false);
           L.debug("container unbound", { threadId });
         },
         { once: true },
@@ -686,19 +861,26 @@ export function createChatThreadScrollSignals(
   threadId: string,
   position: ThreadScrollPositionSignals,
   afterThreadScrollPositionChanged$: Command<Promise<void>, [AbortSignal]>,
+  smoothAutoScrollEnabled$: Computed<boolean>,
 ): ChatThreadScrollSignals {
   const runtime: ScrollRuntime = {
     initialized: false,
     resizeScheduled: false,
     latestRenderRequestRevision: 0,
     programmaticScrollTop: null,
+    smoothAutoScrollTarget: null,
   };
   const scroll = createInternalScrollSignals(
     threadId,
     position,
     afterThreadScrollPositionChanged$,
   );
-  const render = createRenderScrollSignals(threadId, scroll, runtime);
+  const render = createRenderScrollSignals(
+    threadId,
+    scroll,
+    runtime,
+    smoothAutoScrollEnabled$,
+  );
   const navigation = createScrollNavigationSignals(
     threadId,
     scroll,
@@ -721,6 +903,8 @@ export function createChatThreadScrollSignals(
     scrollContainer$: scroll.scrollContainer$,
     threadScrollPosition$: scroll.threadScrollPosition$,
     awayFromBottom$: scroll.awayFromBottom$,
+    ignoreContentResizeScroll$: scroll.ignoreContentResizeScroll$,
+    setIgnoreContentResizeScroll$: scroll.setIgnoreContentResizeScroll$,
     readRenderedThreadScrollPosition$: scroll.readRenderedThreadScrollPosition$,
     autoScroll$: render.autoScroll$,
     scrollTo$: navigation.scrollTo$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2223,6 +2223,9 @@ function createChatThreadMessagePipeline(
   // position state: the render window computes from the read-only position
   // view, and the scroll signals that write the position are wired afterwards
   // with the window's ensure step.
+  const smoothAutoScrollEnabled$ = computed((get): boolean => {
+    return get(featureSwitch$)[FeatureSwitchKey.ChatSmoothAutoScroll] ?? false;
+  });
   const position = createThreadScrollPositionSignals(threadId);
   const resources = createPagedEventResources(
     threadId,
@@ -2253,6 +2256,7 @@ function createChatThreadMessagePipeline(
     threadId,
     position,
     renderWindow.ensureVisibleEventTrees$,
+    smoothAutoScrollEnabled$,
   );
   const initialEventsReady$ = state(false);
   const effects = createEventChangeEffects(
@@ -3917,6 +3921,8 @@ function createChatPanelSignalsWithDraft(
     {
       threadId,
       scrollContainer$: messages.scroll.scrollContainer$,
+      setIgnoreContentResizeScroll$:
+        messages.scroll.setIgnoreContentResizeScroll$,
     },
     signal,
   );
@@ -3942,6 +3948,9 @@ function createChatPanelSignalsWithDraft(
     scrollContainer$: messages.scroll.scrollContainer$,
     threadScrollPosition$: messages.scroll.threadScrollPosition$,
     awayFromBottom$: messages.scroll.awayFromBottom$,
+    ignoreContentResizeScroll$: messages.scroll.ignoreContentResizeScroll$,
+    setIgnoreContentResizeScroll$:
+      messages.scroll.setIgnoreContentResizeScroll$,
     scrollTo$: messages.scroll.scrollTo$,
     scrollToTop$: messages.scroll.scrollToTop$,
     scrollToBottom$: messages.scroll.scrollToBottom$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -40,6 +40,11 @@ interface ResizeObserverController {
   trigger: (target: Element) => void;
 }
 
+interface SmoothScrollController {
+  readonly calls: readonly ScrollToOptions[];
+  finish: (container: HTMLElement) => void;
+}
+
 const CHAT_VIEWPORT_TOP = 100;
 
 function domRect(top: number, height: number): DOMRect {
@@ -232,6 +237,41 @@ function installChatLayout(layouts: ReadonlyMap<string, ThreadLayout>): void {
     },
     { once: true },
   );
+}
+
+function installSmoothScroll(): SmoothScrollController {
+  const prototype = HTMLElement.prototype;
+  const scrollToDescriptor = Object.getOwnPropertyDescriptor(
+    prototype,
+    "scrollTo",
+  );
+  const calls: ScrollToOptions[] = [];
+
+  Object.defineProperty(prototype, "scrollTo", {
+    configurable: true,
+    value(this: HTMLElement, options: ScrollToOptions): void {
+      calls.push(options);
+    },
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      restorePrototypeProperty(prototype, "scrollTo", scrollToDescriptor);
+    },
+    { once: true },
+  );
+
+  return {
+    calls,
+    finish: (container) => {
+      const top = calls.at(-1)?.top;
+      if (top === undefined) {
+        throw new Error("No smooth scroll to finish");
+      }
+      container.scrollTop = top;
+      fireEvent.scroll(container);
+    },
+  };
 }
 
 function installImmediateAnimationFrames(): void {
@@ -689,6 +729,7 @@ describe("chat scroll position", () => {
       initialEvents,
       appendedEvents,
     });
+    const smoothScroll = installSmoothScroll();
     installChatLayout(
       new Map([
         [
@@ -715,7 +756,13 @@ describe("chat scroll position", () => {
       ]),
     );
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatSmoothAutoScroll]: false,
+      },
+    });
 
     const container = await waitFor(() => {
       expect(screen.getByText("tail-follow message 7")).toBeInTheDocument();
@@ -729,6 +776,111 @@ describe("chat scroll position", () => {
     await waitFor(() => {
       expect(screen.getByText("tail-follow message 8")).toBeInTheDocument();
       expect(container.scrollTop).toBe(800);
+      expect(smoothScroll.calls).toHaveLength(0);
+    });
+  });
+
+  it("smoothly follows later messages without letting content resize snap to the tail", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000817";
+    const initialEvents = simpleUserEvents(threadId, "smooth-tail", 8);
+    const appendedEvents = simpleUserEvents(threadId, "smooth-tail", 9).slice(
+      8,
+    );
+    const { publishAppendedEvents } = mockLiveThread({
+      threadId,
+      initialEvents,
+      appendedEvents,
+    });
+    const smoothScroll = installSmoothScroll();
+    const resizeObserver = installResizeObserver();
+    let lateGrowth = 0;
+    installChatLayout(
+      new Map([
+        [
+          threadId,
+          {
+            clientHeight: () => {
+              return 300;
+            },
+            scrollHeight: () => {
+              const rendered = document.body.textContent?.includes(
+                "smooth-tail message 8",
+              )
+                ? 1100
+                : 1000;
+              return rendered + lateGrowth;
+            },
+            eventRect: (eventId) => {
+              const index = Number(eventId.split("-").at(-1));
+              return Number.isFinite(index)
+                ? { top: index * 100, height: 80 }
+                : undefined;
+            },
+          },
+        ],
+      ]),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatSmoothAutoScroll]: true,
+      },
+    });
+
+    const container = await waitFor(() => {
+      expect(screen.getByText("smooth-tail message 7")).toBeInTheDocument();
+      const current = chatScrollContainer();
+      expect(current.scrollTop).toBe(700);
+      expect(smoothScroll.calls).toHaveLength(0);
+      return current;
+    });
+
+    await publishAppendedEvents();
+
+    await waitFor(() => {
+      expect(screen.getByText("smooth-tail message 8")).toBeInTheDocument();
+      expect(smoothScroll.calls).toStrictEqual([
+        { top: 800, behavior: "smooth" },
+      ]);
+      expect(container.scrollTop).toBe(700);
+    });
+    const messageContainer = container.querySelector(
+      "[data-message-container]",
+    );
+    if (!messageContainer) {
+      throw new Error("Chat message container not found");
+    }
+
+    // The observer delivery for the event batch is already represented by the
+    // active smooth target, so it must not replace the animation with an
+    // immediate scroll.
+    resizeObserver.trigger(messageContainer);
+    expect(smoothScroll.calls).toHaveLength(1);
+    expect(container.scrollTop).toBe(700);
+
+    // Content that grows while the animation is active retargets that same
+    // smooth scroll instead of snapping or abandoning the tail.
+    lateGrowth = 400;
+    resizeObserver.trigger(messageContainer);
+    expect(smoothScroll.calls).toStrictEqual([
+      { top: 800, behavior: "smooth" },
+      { top: 1200, behavior: "smooth" },
+    ]);
+    expect(container.scrollTop).toBe(700);
+
+    smoothScroll.finish(container);
+    await waitFor(() => {
+      expect(container.scrollTop).toBe(1200);
+      expect(document.querySelector("[data-scroll-to-bottom]")).toBeNull();
+    });
+
+    lateGrowth = 500;
+    resizeObserver.trigger(messageContainer);
+    await waitFor(() => {
+      expect(container.scrollTop).toBe(1300);
+      expect(smoothScroll.calls).toHaveLength(2);
     });
   });
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -100,6 +100,7 @@ describe("getAllFeatureStates", () => {
     expect(
       staffOrgStates[FeatureSwitchKey.ChatRunContinuationPresentation],
     ).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ChatSmoothAutoScroll]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
@@ -133,6 +134,7 @@ describe("getAllFeatureStates", () => {
     expect(
       otherOrgStates[FeatureSwitchKey.ChatRunContinuationPresentation],
     ).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ChatSmoothAutoScroll]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -58,6 +58,7 @@ export enum FeatureSwitchKey {
   ChatErrorRecovery = "chatErrorRecovery",
   ChatForward = "chatForward",
   ChatRunContinuationPresentation = "chatRunContinuationPresentation",
+  ChatSmoothAutoScroll = "chatSmoothAutoScroll",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   ConnectorDiscovery = "connectorDiscovery",
   ConnectorCatalogCount = "connectorCatalogCount",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -379,6 +379,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ChatSmoothAutoScroll]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Smoothly follow new chat content after the thread's initial scroll position is committed.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.EmojiPickerCategoryRail]: {
     maintainer: "tongx@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add a staff-gated `chatSmoothAutoScroll` feature switch
- keep initial thread positioning instant while smoothly following later tail commits
- coordinate active smooth scrolling with content ResizeObserver retargeting and explicit navigation or user interruption
- preserve instant behavior when the switch is disabled or reduced motion is requested

## Test plan

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, App, and API TypeScript checks
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-scroll-position.test.tsx`