### PR TITLE
chore(api): refresh thinking indicator preview marker

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed again on 2026-07-31)
+// (no-op API release marker refreshed for thinking indicator QA on 2026-08-15)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary

- Refresh the existing no-op API release marker to provision an isolated App/API preview.
- Preserve runtime behavior.

## Purpose

Browser-only QA for the mobile thinking-indicator rendering regression around smooth automatic tail scrolling. This PR is a disposable deployment fixture and must not be merged as a product change.

## Validation

- `git diff --check`
- Runtime behavior unchanged; comment-only diff.