### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -16,16 +16,12 @@ import { server } from "../../../../mocks/server";
 import { createCommand } from "../create";
 import chalk from "chalk";
 
-const mockAgentWithoutVisibility = {
+const mockAgent = {
   agentId: "comp_xyz789",
   displayName: "New Agent",
   description: null,
   sound: null,
   avatarUrl: null,
-};
-
-const mockAgent = {
-  ...mockAgentWithoutVisibility,
   visibility: "private",
 };
 
@@ -127,25 +123,6 @@ describe("okou agent create command", () => {
       expect(capturedBody?.visibility).toBe("public");
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Visibility:   public");
-    });
-
-    it("should handle a create response without visibility", async () => {
-      server.use(
-        http.post("http://localhost:3000/api/okou/agents", () => {
-          return HttpResponse.json(mockAgentWithoutVisibility, { status: 201 });
-        }),
-      );
-
-      await createCommand.parseAsync([
-        "node",
-        "cli",
-        "--display-name",
-        "New Agent",
-      ]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain('Agent "comp_xyz789" created');
-      expect(logCalls).not.toContain("Visibility:");
     });
 
     it("should send preset avatar in request body", async () => {

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/list.test.ts
@@ -13,15 +13,11 @@ import { server } from "../../../../mocks/server";
 import { listCommand } from "../list";
 import chalk from "chalk";
 
-const mockAgentWithoutVisibility = {
+const mockAgent = {
   agentId: "my-agent",
   displayName: "My Agent",
   description: null,
   sound: null,
-};
-
-const mockAgent = {
-  ...mockAgentWithoutVisibility,
   visibility: "private",
 };
 
@@ -74,21 +70,6 @@ describe("okou agent list command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No agents found");
-    });
-
-    it("should show a placeholder when visibility is missing", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/okou/agents", () => {
-          return HttpResponse.json([mockAgentWithoutVisibility]);
-        }),
-      );
-
-      await listCommand.parseAsync(["node", "cli"]);
-
-      const agentRow = mockConsoleLog.mock.calls.flat().find((line) => {
-        return line.includes("my-agent");
-      });
-      expect(agentRow).toMatch(/My Agent\s+-\s*$/);
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -17,15 +17,11 @@ import {
 import { viewCommand } from "../view";
 import chalk from "chalk";
 
-const mockAgentWithoutVisibility = {
+const mockAgent = {
   agentId: "comp_abc123",
   displayName: "My Agent",
   description: "A test agent",
   sound: "professional",
-};
-
-const mockAgent = {
-  ...mockAgentWithoutVisibility,
   visibility: "private",
 };
 
@@ -170,27 +166,6 @@ describe("okou agent view command", () => {
       expect(logCalls).toContain(
         "preset:2 (medium skin, pink hair, neutral, chill)",
       );
-    });
-
-    it("should handle an agent response without visibility", async () => {
-      server.use(
-        http.get("http://localhost:3000/api/okou/agents/my-agent", () => {
-          return HttpResponse.json(mockAgentWithoutVisibility);
-        }),
-        http.get(
-          "http://localhost:3000/api/okou/agents/my-agent/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledConnectorSlugs: [] });
-          },
-        ),
-        mockConnectorListHandler(),
-      );
-
-      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Agent ID:     comp_abc123");
-      expect(logCalls).not.toContain("Visibility:");
     });
 
     it("should display custom svg avatar", async () => {

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -111,11 +111,7 @@ Examples:
         if (agent.displayName) {
           console.log(`  Display Name: ${agent.displayName}`);
         }
-        // Commit-addressed CLI/backend responses may omit visibility. Remove
-        // after #26761 verifies producers and queued/active contexts have drained.
-        if (agent.visibility) {
-          console.log(`  Visibility:   ${agent.visibility}`);
-        }
+        console.log(`  Visibility:   ${agent.visibility}`);
 
         console.log();
         console.log("Next steps to authorize connectors for this agent:");

--- a/turbo/apps/cli/src/commands/zero/agent/list.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/list.ts
@@ -55,9 +55,7 @@ Notes:
         const row = [
           agent.agentId.padEnd(idWidth),
           (agent.displayName ?? "-").padEnd(displayWidth),
-          // Commit-addressed CLI/backend responses may omit visibility. Remove
-          // after #26761 verifies producers and queued/active contexts have drained.
-          (agent.visibility ?? "-").padEnd(visibilityWidth),
+          agent.visibility.padEnd(visibilityWidth),
         ].join("  ");
         console.log(row);
       }

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -119,9 +119,7 @@ Examples:
         if (agent.displayName) console.log(chalk.dim(agent.displayName));
         console.log();
         console.log(`Agent ID:     ${agent.agentId}`);
-        // Commit-addressed CLI/backend responses may omit visibility. Remove
-        // after #26761 verifies producers and queued/active contexts have drained.
-        if (agent.visibility) console.log(`Visibility:   ${agent.visibility}`);
+        console.log(`Visibility:   ${agent.visibility}`);
 
         const storedPolicies = options.permissions
           ? connectorPermissionGrantsToFirewallPolicies(

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -193,6 +193,7 @@ export const apiAgentsHandlers = [
       modelProviderId: null,
       selectedModel: null,
       preferPersonalProvider: false,
+      visibility: "public",
     });
   }),
 

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -87,6 +87,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(
@@ -211,6 +212,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(
@@ -265,6 +267,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
@@ -341,6 +344,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
@@ -393,6 +397,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
@@ -443,6 +448,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
@@ -493,6 +499,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(
@@ -562,6 +569,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
@@ -615,6 +623,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
@@ -692,6 +701,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
@@ -741,6 +751,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
@@ -784,6 +795,7 @@ describe("permission allow page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -504,6 +504,7 @@ function mockTeamAPIs({
       modelProviderId: null,
       selectedModel: null,
       preferPersonalProvider: false,
+      visibility: "public",
     });
   });
   context.mocks.api(zeroAgentInstructionsContract.get, ({ respond }) => {
@@ -1127,6 +1128,7 @@ describe("team page navigation", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
 
@@ -1209,6 +1211,7 @@ describe("team page navigation", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -2817,6 +2817,7 @@ describe("chat composer models", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-test-helpers.ts
@@ -314,6 +314,7 @@ export function mockAgent(options?: {
       modelProviderId: isOtherAgent ? null : (options?.modelProviderId ?? null),
       selectedModel: isOtherAgent ? null : (options?.selectedModel ?? null),
       preferPersonalProvider: false,
+      visibility: "public",
     });
   });
   context.mocks.api(zeroAgentInstructionsContract.get, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -3445,6 +3445,7 @@ describe("chat event action cards", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
+        visibility: "public",
       });
     });
     context.mocks.api(
@@ -3844,6 +3845,7 @@ describe("chat event action cards", () => {
           modelProviderId: null,
           selectedModel: null,
           preferPersonalProvider: false,
+          visibility: "public",
         });
       },
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
@@ -55,7 +55,7 @@ function mockAgentsPage(team: TeamComposeItem[]): void {
       modelProviderId: null,
       selectedModel: null,
       preferPersonalProvider: false,
-      visibility: agent.visibility,
+      visibility: agent.visibility ?? "public",
     });
   });
 }
@@ -239,7 +239,7 @@ describe("zero jobs page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
-        visibility: agent.visibility,
+        visibility: agent.visibility ?? "public",
       });
     });
     context.mocks.api(
@@ -427,7 +427,7 @@ describe("zero jobs page", () => {
         modelProviderId: null,
         selectedModel: null,
         preferPersonalProvider: false,
-        visibility: agent.visibility,
+        visibility: agent.visibility ?? "public",
       });
     });
     context.mocks.api(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -142,6 +142,7 @@ function prepareAgentTeam(): TeamComposeItem[] {
       modelProviderId: null,
       selectedModel: null,
       preferPersonalProvider: false,
+      visibility: "public",
     });
   });
   return team;

--- a/turbo/packages/api-contracts/src/contracts/zero-agents.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-agents.ts
@@ -20,7 +20,7 @@ export const zeroAgentResponseSchema = z.object({
   modelProviderId: z.string().uuid().nullable().default(null),
   selectedModel: z.string().nullable().default(null),
   preferPersonalProvider: z.boolean().default(false),
-  visibility: zeroAgentVisibilitySchema.optional(),
+  visibility: zeroAgentVisibilitySchema,
 });
 
 /**


### PR DESCRIPTION
Daily deployment-compatibility cleanup. One cohort survived evidence collection; everything else is inside its window, owned by a dedicated automation, or blocked by an active PR, and is listed at the bottom rather than split into a second PR.

## Cohort — require agent response `visibility`, drop the CLI tolerance (#26761)

**Old → new boundary.** `zeroAgentResponseSchema.visibility` has been `.optional()` since private agents landed in [#12655](https://github.com/vm0-ai/vm0/pull/12655). [PR #26736](https://github.com/vm0-ai/vm0/pull/26736) added CLI rendering for visibility and had to tolerate a response that omits it, because the shared contract still permitted that shape: `okou agent create` and `okou agent view` skipped the `Visibility:` line entirely, and `okou agent list` printed `-`.

**Window.** API-response compatibility for the commit-addressed CLI. #26761's gate is: every `ZeroAgentResponse` producer returns `visibility`, no supported external producer can omit it, and pre-change queued/active CLI execution contexts have drained. #26736 merged 2026-08-13T03:02:47Z — **42 hours** ago, well beyond the documented commit-addressed CLI drain (15-minute queued-run TTL + 2-hour execution timeout + 90-second finalization + 10-second terminal grace ≈ 2 h 17 m).

**Producer evidence — source level, exhaustive.** This is the criterion that matters, and it is provable statically rather than inferred:

- `agentResponse(row)` in `zero-agent-data.service.ts` declares `readonly visibility: "public" | "private"` — non-nullable — so TypeScript already rejects any caller that could pass `undefined` or `null`.
- Every query feeding it (`zeroAgentList`, `zeroAgentDetail`, `readAgentForResponse`, the team projection) selects `zeroAgents.visibility` through an **inner** join or a direct `from(zeroAgents)`; none uses the `leftJoin` that could yield `null`.
- `defaultAgentResponse()` hardcodes `visibility: "public"`.
- The column is `varchar("visibility", { length: 16 }).$type<ZeroAgentVisibility>().notNull().default("public")`.

**MaskDB evidence** (`vm0-prod-ro`, read-only aggregates): `zero_agents` holds **5,848** rows — 5,666 `public`, 182 `private` — and **0** rows with `visibility IS NULL`. No production row can produce a response missing the field.

**Axiom coverage** (`vm0-request-log-prod`, explicit bounds `2026-08-13T21:00:00Z → 2026-08-14T21:30:00Z`, `_time` predicate applied before the path filter): the agent surface is live and healthy — `/api/okou/agents/:id` GET 4,228 requests with **0** 5xx, plus 1,691 draft PATCH and 1,110 custom-connector GET, all 0 5xx. Stated honestly: this establishes that the routes are serving, **not** that the field is present, because the request log has no per-field instrumentation. The field-presence proof is the source and MaskDB evidence above, not an absence-of-logs argument.

**Removed.** `.optional()` on the response field; the `if (agent.visibility)` guards in `create.ts` and `view.ts`; the `?? "-"` placeholder in `list.ts`; and the three compatibility tests (`should handle a create response without visibility`, `should handle an agent response without visibility`, `should show a placeholder when visibility is missing`) together with the now-unused `mockAgentWithoutVisibility` fixture in each file.

**Deliberately kept.** `zeroAgentRequestSchema.visibility` and `zeroAgentMetadataRequestSchema.visibility` stay optional. Those are *request* fields where omission means "leave unchanged"; they are not compatibility shims.

**Fixture fallout.** Making the field required surfaced eleven test/mock literals that built an agent response without it. Each now sets `visibility: "public"`, except the three `zero-jobs-page` sites that project a `TeamComposeItem` (whose own `visibility` is separately optional) and use `?? "public"`. No production behavior changes.

## Checks

Run once against the combined diff:

- `pnpm format`; `pnpm check-types` (all tasks, no errors); `pnpm knip` (exit 0)
- lint: `@okouai/api-contracts`, `@okouai/cli`, `@okouai/app` — all exit 0
- `@okouai/cli` `agent create/view/list` → 3 files, **33 passed**
- `@okouai/app` `permission-allow-page` + `zero-jobs-page` → **17 passed**
- `@okouai/app` `team-navigation` + `zero-sidebar` → **79 passed**
- `@okouai/app` `chat-event-action-cards` + `chat-composer-model-selection-and-providers` → **100 passed**

Per repo guidance the full local Vitest suite was not run and no dev server was started.

## Open-PR overlap

**None.** No open PR touches any of the fifteen changed files.

Deferred this run, with the exact blocker:

- **#26152** concurrency billing fallbacks — window expired long ago (the app build carrying #26116 reached `app/production` 2026-08-10T13:15:40Z). Yesterday's blocker was a test defect where `org-billing-tab.test.tsx > "recovers from a billing load failure..."` was coupled to the MSW handler count; that is **now fixed** — #26959 landed and the removal no longer breaks it, verified by re-running the exact experiment on today's base. The new blocker is **#27128** ("unify saved billing purchase routing"), which edits inside `reduceConcurrencySubscription$` and is anchored on `concurrencySubscriptionReduceRequestSchema` — a live symbol-level conflict with every part of the cohort.
- **#26842** saved-billing credit purchase compatibility — same #27128 rework owns that surface.
- **#26921** chat-search identity fallback and **#27194 / #27174** chat-event schema/snapshot fallbacks — dedicated `pr-27215-chat-search-fallback-cleanup` and `pr-27278-chat-snapshot-fallback-cleanup` automations own them; the #27194/#27174 windows also opened only today.
- **#26765** video-model persistence compatibility — introduced 2026-08-13, inside its window.
- **#26672 / #26519** Website template archive pins — gate is a product decision (latency target, switch enabled for all users); `LatestWebsiteTemplates` is still `enabled: false`.
- **#26487** route-entry Phase A namespace compatibility — removable only in a separately authorized change.
- **#25620** avatar flat-field read fallback — still needs a jsonb backfill first.
- `browser_*` identity contraction — unchanged blocker: dropping `browser_sessions.id` as the physical primary key requires proving `chat_thread_id` is globally unique across retained rows, and the existing `uq_browser_sessions_thread_owned` is a *partial* index. MaskDB exposes no `browser_*` table, so that uniqueness cannot be established from here.
