### PR TITLE
fix(api): stabilize custom connector firewall ids

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8403,6 +8403,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(initialAvailable.nextSyncAt).toBeUndefined();
     expect(initialAvailable.target).toStrictEqual(targetIdentity);
     expect(initialAvailable.baseUrlVars).toStrictEqual({ tenant: "acme" });
+    expect(initialAvailable.firewall).toStrictEqual(customFirewall);
     const { api: initialApi, body: currentAuthBody } =
       customConnectorRuntimeAuthBody(
         initialAvailable,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4435,14 +4435,16 @@ async function buildNewRunCustomConnectorRuntimeContext(
   };
 }
 
+type CustomConnectorRuntimeFirewall = Omit<Firewall, "apis"> & {
+  readonly apis: (Firewall["apis"][number] & {
+    readonly id: string;
+  })[];
+};
+
 interface CustomConnectorRuntimeExecutionState {
   readonly firewall: Omit<ExecutionFirewallInlineEntry, "firewall"> & {
     readonly customConnectorId: string;
-    readonly firewall: Omit<Firewall, "apis"> & {
-      readonly apis: (Firewall["apis"][number] & {
-        readonly id: string;
-      })[];
-    };
+    readonly firewall: CustomConnectorRuntimeFirewall;
   };
   readonly networkPolicy: NetworkPolicy;
 }
@@ -4472,20 +4474,7 @@ export function customConnectorRuntimeExecutionState(args: {
     firewall: {
       kind: "inline",
       customConnectorId: args.connectorId,
-      firewall: {
-        name: source.name,
-        apis: source.apis.map((api, index) => {
-          return {
-            id: `${firewallName}:${index}`,
-            base: api.base,
-            ...(api.hostPolicy !== undefined
-              ? { hostPolicy: api.hostPolicy }
-              : {}),
-            auth: api.auth,
-            permissions: api.permissions ?? [],
-          };
-        }),
-      },
+      firewall: customConnectorRuntimeFirewall(source),
     },
     networkPolicy,
   };
@@ -4662,6 +4651,21 @@ function runtimeFirewall(firewall: ExpandedFirewallConfig): Firewall {
   };
 }
 
+function customConnectorRuntimeFirewall(
+  firewall: ExpandedFirewallConfig,
+): CustomConnectorRuntimeFirewall {
+  const runtime = runtimeFirewall(firewall);
+  return {
+    ...runtime,
+    apis: runtime.apis.map((api, index) => {
+      return {
+        id: `${runtime.name}:${index}`,
+        ...api,
+      };
+    }),
+  };
+}
+
 function builtinFirewallEntry(
   firewall: ExpandedFirewallConfig,
   vars: Record<string, string> | undefined,
@@ -4740,7 +4744,7 @@ function customConnectorInlineFirewallEntry(
   return {
     kind: "inline",
     customConnectorId,
-    firewall: runtimeFirewall(firewall),
+    firewall: customConnectorRuntimeFirewall(firewall),
   };
 }
 


### PR DESCRIPTION
## Summary

- assign stable API IDs to the initial inline custom-connector firewall snapshot
- build both the runner claim and runtime sync snapshots through the same canonical helper
- assert that the claimed firewall exactly matches the first runtime sync firewall

## Root cause

The initial runner claim omitted custom-connector API IDs, so the runner synthesized run-scoped IDs. The immediately scheduled runtime sync used stable `custom_connector_<id>:<index>` IDs and replaced the registry snapshot. If that replacement landed while credential authorization was in flight, the MITM revalidation correctly treated the firewall authorization as changed and failed closed with HTTP 409 (`firewall_authorization_changed`). The command ignored the curl failure and printed its completion marker, leaving the E2E observer waiting for an allow telemetry event that could never be emitted.

This keeps the security revalidation intact: genuine firewall changes still fail closed, while the initial idempotent sync no longer creates a false authorization change.

## Validation

- demonstrated the new equality assertion fails against the old initial snapshot because its API ID is missing
- focused API regression test: 5/5 passes, plus one pass after rebasing onto latest `main`
- `pnpm exec prettier --check` on both changed files
- targeted Oxlint and ESLint on both changed files
- `pnpm -F api run check-types`

The runner E2E is CI-only and is left to the PR Turbo pipeline, as documented.

Incident: https://github.com/vm0-ai/vm0/actions/runs/31843290292/job/94905496874

Turbo flaky key: `cli-e2e-runner-custom-connector-firewall-telemetry-timeout`