### PR TITLE
test(platform): stabilize stale message port reconnect

### DIFF
--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -338,9 +338,9 @@ describe("shared database MessagePort protocol", () => {
 
       const key = dataKey(crypto.randomUUID());
       const canonicalRow = row(key.threadId, 1);
-      const topic = `chatThreadMessageCreated:${key.threadId}`;
       const requestedSeqIds: number[] = [];
       let appends = 0;
+      const initialAttach = context.mocks.ably.deferNextSubscribe();
       await staleTab.on(
         key,
         () => {
@@ -348,6 +348,7 @@ describe("shared database MessagePort protocol", () => {
         },
         subscription.signal,
       );
+      await initialAttach.started;
       await vi.waitFor(() => {
         expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
         expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(1);
@@ -374,16 +375,17 @@ describe("shared database MessagePort protocol", () => {
 
       expect(firstTabTransports).toBe(1);
       expect(staleTabTransports).toBe(1);
+      expect(context.mocks.ably.hasChannelSubscription()).toBeFalsy();
+      initialAttach.attach();
+      const recoveredAttach = context.mocks.ably.deferNextSubscribe();
       await staleTab.heartbeat(heartbeat(), staleOwner.signal);
+      await recoveredAttach.started;
       expect(staleTabTransports).toBe(2);
+      recoveredAttach.attach();
       await vi.waitFor(() => {
         expect(context.mocks.ably.hasChannelSubscription()).toBeTruthy();
         expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(2);
         expect(staleTabStatuses.at(-1)).toBe("connected");
-      });
-
-      context.mocks.ably.trigger(topic);
-      await vi.waitFor(() => {
         expect(requestedSeqIds).toStrictEqual([0, 1]);
         expect(appends).toBe(1);
       });


### PR DESCRIPTION
## Summary

- synchronize the initial mocked Ably attach with stale-client pruning so the retired generation cannot begin catch-up after request capture starts
- synchronize and release the recovered attach explicitly, then assert that its production post-attach catch-up requests exactly seqIds `0` and `1`
- retain the restored-subscription and exactly-one-append assertions without sorting, deduplicating, retrying, or weakening expectations

## Root cause

The test treated `hasChannelSubscription()` as proof that the initial realtime lifecycle had settled. In the mock, that predicate becomes true when the subscription callback is registered, before the deferred attach and the production post-attach catch-up complete. Under the failing schedule, the old generation's catch-up started after request capture was installed; the recovered generation then performed its own automatic catch-up, and the test's extra manual realtime trigger requested seqId `1` once more.

Holding the initial attach until capture is installed reproduced the CI result deterministically: `[0, 1, 1, 1]`. The actor high-water mark still allowed exactly one append, so this is missing lifecycle ownership in the fixture rather than duplicate production subscription recovery.

## Trigger evidence

- failing push run: https://github.com/vm0-ai/vm0/actions/runs/31847081031
- failing shard: https://github.com/vm0-ai/vm0/actions/runs/31847081031/job/94915671565
- same SHA passing merge-group run: https://github.com/vm0-ai/vm0/actions/runs/31846689247
- same shard in that run: https://github.com/vm0-ai/vm0/actions/runs/31846689247/job/94914545620
- parent-main run with the shard passing: https://github.com/vm0-ai/vm0/actions/runs/31844357416/job/94907712810

## Preserved invariant

- one initial request from seqId `0`
- one valid recovery request from seqId `1`
- a restored realtime subscription
- exactly one appended row
- exactly one replacement transport for the stale tab

## Verification

- target test passed in 5 independent runs:
  - `pnpm -F @okouai/app exec vitest run src/shared-database/__tests__/message-port.test.ts -t 'reconnects a stale pruned tab and restores its subscription' --reporter=dot`
- `message-port.test.ts`: 5 passed
- `reconnecting-client.test.ts`: 1 passed
- `worker-runtime.test.ts`: 18 passed
- exact failing `@okouai/app` shard passed before the fix, confirming the original schedule sensitivity
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged repository, App, and API type checks
- `git diff --check`

## Preview

Not applicable. This is an in-memory unit-test synchronization change around mocked Ably and SharedWorker MessagePort lifecycles; it changes no production code and has no deployed App, API, or browser surface to validate.
