### PR TITLE
refactor(db): remove zero_runs migration recovery fallback

### DIFF
--- a/turbo/packages/db/MIGRATIONS.md
+++ b/turbo/packages/db/MIGRATIONS.md
@@ -10,13 +10,6 @@ default with a later `SET LOCAL` statement in that migration. Non-transactional
 migrations do not receive these defaults and must manage their own timeout
 requirements.
 
-If production smoke exposes a timeout only after a migration has shipped, keep
-the published SQL and snapshot unchanged. Add an exact-hash, exact-statement
-timeout recovery in `scripts/migration-runner.ts`, restore the normal timeout
-before any blocking DDL, and cover the published migration through the real
-PostgreSQL runner. This preserves the migration ledger hash while keeping the
-recovery narrower than a global timeout increase.
-
 ## Transition validators
 
 A transition validator protects an expand → contract rollout while old and new

--- a/turbo/packages/db/scripts/migration-runner.ts
+++ b/turbo/packages/db/scripts/migration-runner.ts
@@ -10,24 +10,6 @@ type DbMigration = {
 
 export const NON_TRANSACTIONAL_MIGRATION_MARKER = "-- vm0:non-transactional";
 
-// Migration 0924 shipped before its production-scale catalog preflight proved
-// that the single DO statement can need more than its original 10-second
-// budget. Migration files are immutable, so scope the recovery to the exact
-// published hash: extend only the preflight, then restore 10 seconds before
-// the plain DROP TABLE statement.
-const PUBLISHED_MIGRATION_STATEMENT_TIMEOUT_OVERRIDES: ReadonlyMap<
-  string,
-  ReadonlyMap<number, string>
-> = new Map([
-  [
-    "2320f87e1ef46ae844f5a120a918f694bd9469a96048298ea7e57d1ba090b516",
-    new Map([
-      [2, "60s"],
-      [3, "10s"],
-    ]),
-  ],
-]);
-
 export async function applyPendingMigrations(sql: postgres.Sql): Promise<void> {
   const migrations = readMigrationFiles({
     migrationsFolder: DRIZZLE_MIGRATE_OUT,
@@ -81,24 +63,9 @@ export async function applyPendingMigrations(sql: postgres.Sql): Promise<void> {
       await transaction`SET LOCAL lock_timeout = '1s'`;
       await transaction`SET LOCAL statement_timeout = '10s'`;
 
-      const statementTimeoutOverrides =
-        PUBLISHED_MIGRATION_STATEMENT_TIMEOUT_OVERRIDES.get(migration.hash);
-
-      for (const [statementIndex, statement] of migration.sql.entries()) {
+      for (const statement of migration.sql) {
         if (statement.trim().length === 0) {
           continue;
-        }
-
-        const statementTimeoutOverride =
-          statementTimeoutOverrides?.get(statementIndex);
-        if (statementTimeoutOverride) {
-          await transaction`
-            SELECT set_config(
-              'statement_timeout',
-              ${statementTimeoutOverride},
-              true
-            )
-          `;
         }
         await transaction.unsafe(statement);
       }

--- a/turbo/packages/db/scripts/test-zero-runs-stage-6.ts
+++ b/turbo/packages/db/scripts/test-zero-runs-stage-6.ts
@@ -41,21 +41,10 @@ const upgradeDatabase = `migration_zero_runs_stage_6_upgrade_${process.pid}`;
 const freshDatabase = `migration_zero_runs_stage_6_fresh_${process.pid}`;
 const lifecycleRunId = "00000000-0000-4000-8000-000000092401";
 const productRunId = "00000000-0000-4000-8000-000000092402";
-const catalogScaleRoutineCount = 160;
-const catalogRoutineDelaySeconds = 0.07;
 
 function databaseConnectionUrl(databaseName: string): string {
   const url = new URL(databaseUrl);
   url.pathname = `/${databaseName}`;
-  return url.toString();
-}
-
-function catalogLatencyConnectionUrl(databaseName: string): string {
-  const url = new URL(databaseConnectionUrl(databaseName));
-  url.searchParams.set(
-    "options",
-    "-c search_path=stage6_catalog_latency,pg_catalog,public",
-  );
   return url.toString();
 }
 
@@ -419,40 +408,6 @@ async function validateCatalogPreflight(args: {
   });
 }
 
-async function installCatalogLatencyFixture(client: Client): Promise<void> {
-  // A newly created Neon branch can deparse user routines from cold catalog
-  // pages. Put this latency shim ahead of pg_catalog only on the runner test
-  // connection so the actual 0924 DO statement deterministically exceeds its
-  // published 10-second cumulative budget without changing the migration.
-  await client.query(`
-    CREATE SCHEMA "stage6_catalog_latency";
-    CREATE FUNCTION "stage6_catalog_latency"."pg_get_functiondef"(
-      "function_oid" oid
-    ) RETURNS text
-    LANGUAGE sql
-    AS $function$
-      SELECT pg_catalog.pg_get_functiondef("function_oid")
-      FROM pg_catalog.pg_sleep(${catalogRoutineDelaySeconds})
-    $function$;
-
-    CREATE SCHEMA "stage6_catalog_scale";
-    DO $block$
-    DECLARE
-      "routine_index" integer;
-    BEGIN
-      FOR "routine_index" IN 1..${catalogScaleRoutineCount} LOOP
-        EXECUTE format(
-          'CREATE FUNCTION stage6_catalog_scale.%I() '
-          'RETURNS integer LANGUAGE sql IMMUTABLE AS %L',
-          'catalog_probe_' || "routine_index"::text,
-          'SELECT ' || "routine_index"::text
-        );
-      END LOOP;
-    END
-    $block$;
-  `);
-}
-
 async function readAgentRunsSchema(client: Client): Promise<unknown> {
   const columns = await client.query(`
       SELECT
@@ -599,20 +554,9 @@ async function validateStage6(): Promise<void> {
       });
       await locker.query("COMMIT");
 
-      await installCatalogLatencyFixture(control);
       await runner.end();
-      runner = postgres(catalogLatencyConnectionUrl(upgradeDatabase), {
-        max: 1,
-      });
-      const catalogMigrationStartedAt = performance.now();
+      runner = postgres(upgradeUrl, { max: 1 });
       await applyPendingMigrations(runner);
-      const catalogMigrationElapsedMs =
-        performance.now() - catalogMigrationStartedAt;
-      assert.ok(
-        catalogMigrationElapsedMs >= 10_500 &&
-          catalogMigrationElapsedMs < 45_000,
-        `Expected the catalog preflight to exceed its published 10-second budget but finish within the 60-second recovery, got ${String(catalogMigrationElapsedMs)}ms`,
-      );
 
       const migratedState = await control.query<{
         appliedCount: number;
@@ -637,7 +581,7 @@ async function validateStage6(): Promise<void> {
       const upgradeSchema = await readAgentRunsSchema(control);
       await validateFreshReplay(upgradeSchema);
       console.log(
-        `Stage 6 lock failure observed after ${lockFailure.elapsedMs.toFixed(0)}ms; production-scale catalog preflight completed after ${catalogMigrationElapsedMs.toFixed(0)}ms; clean retry and fresh replay succeeded`,
+        `Stage 6 lock failure observed after ${lockFailure.elapsedMs.toFixed(0)}ms; clean retry and fresh replay succeeded`,
       );
     } finally {
       await locker.query("ROLLBACK").catch(() => {


### PR DESCRIPTION
## Summary

- remove the retired exact-hash, exact-statement published-migration timeout recovery guidance and runner override
- restore the ordinary transactional statement loop while retaining the permanent 1-second lock timeout and 10-second statement timeout
- remove only the Stage 6 cold-catalog latency fixture, alternate search path, elapsed-time assertion, and recovery log text
- retain Stage 6 dependency rejection, lock contention, ledger/row/schema integrity, clean retry, upgrade, fresh replay, and migration-consistency coverage

## Scope audit

- only the three files named by #27299 changed
- migration 0924, historical SQL, snapshots, journal entries, timestamps, and hashes are untouched
- no replacement fallback, timeout widening, direct connection, compatibility bridge, alternate migration path, or manual production step was added

## Validation

- `pnpm exec prettier --write packages/db/MIGRATIONS.md packages/db/scripts/migration-runner.ts packages/db/scripts/test-zero-runs-stage-6.ts`
- `pnpm --filter @okouai/db lint`
- `pnpm knip --workspace @okouai/db`
- `pnpm --filter @okouai/db check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/postgres pnpm --filter @okouai/db test:migration-consistency`
  - migration runner timeout defaults validated
  - Stage 6 lock failure observed after 1,011 ms; clean retry and fresh replay succeeded
  - all 119 migrations and snapshots, journal ordering, upgrades, consecutive resets, fresh generation, and normalized schema equivalence passed
- `git diff --check`

No full local Vitest suite or development server was run, per repository instructions.

Closes #27299
