### PR TITLE
refactor(cli): neutralize the okou command registry internals

### DIFF
--- a/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Command, Help } from "commander";
-import { buildZeroHelpText, registerZeroCommands } from "../okou";
+import { buildHelpText, registerCommands } from "../okou";
 import { decodeZeroTokenPayload } from "../lib/api/zero-token";
 
 function buildZeroToken(payload: Record<string, unknown>): string {
@@ -51,7 +51,7 @@ function buildCommands(): Command[] {
 
 function buildProgram(): Command {
   const prog = new Command();
-  registerZeroCommands(prog, buildCommands());
+  registerCommands(prog, buildCommands());
   return prog;
 }
 
@@ -155,7 +155,7 @@ describe("decodeZeroTokenPayload", () => {
   });
 });
 
-describe("registerZeroCommands", () => {
+describe("registerCommands", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
@@ -737,7 +737,7 @@ describe("registerZeroCommands", () => {
     const prog = buildProgram();
 
     expect(visibleCommandNames(prog)).toContain("upgrade");
-    expect(buildZeroHelpText()).toContain("Upgrade plan?");
+    expect(buildHelpText()).toContain("Upgrade plan?");
   });
 
   it("should expose browser when its capability is enabled", () => {
@@ -775,7 +775,7 @@ describe("registerZeroCommands", () => {
     });
     vi.stubEnv("OKOU_TOKEN", eligibleToken);
     expect(visibleCommandNames(buildProgram())).toContain("recognize");
-    expect(buildZeroHelpText(decodeZeroTokenPayload(eligibleToken))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(eligibleToken))).toContain(
       "Recognize an image?",
     );
   });
@@ -803,7 +803,7 @@ describe("registerZeroCommands", () => {
     });
     vi.stubEnv("OKOU_TOKEN", capableToken);
     expect(visibleCommandNames(buildProgram())).toContain("translate");
-    expect(buildZeroHelpText(decodeZeroTokenPayload(capableToken))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(capableToken))).toContain(
       "Translate text?",
     );
   });
@@ -813,7 +813,7 @@ describe("registerZeroCommands", () => {
       scope: "okou",
       capabilities: ["billing:read", "billing:write"],
     });
-    const help = buildZeroHelpText(decodeZeroTokenPayload(token));
+    const help = buildHelpText(decodeZeroTokenPayload(token));
 
     expect(help).toContain("Check credits?");
     expect(help).toContain("Buy credits?");
@@ -824,7 +824,7 @@ describe("registerZeroCommands", () => {
       scope: "okou",
       capabilities: ["billing:read"],
     });
-    const help = buildZeroHelpText(decodeZeroTokenPayload(token));
+    const help = buildHelpText(decodeZeroTokenPayload(token));
 
     expect(help).toContain("Check credits?");
     expect(help).toContain("okou credit");
@@ -837,7 +837,7 @@ describe("registerZeroCommands", () => {
       scope: "okou",
       capabilities: ["billing:write"],
     });
-    const help = buildZeroHelpText(decodeZeroTokenPayload(token));
+    const help = buildHelpText(decodeZeroTokenPayload(token));
 
     expect(help).not.toContain("Check credits?");
     expect(help).toContain("Buy credits?");
@@ -848,7 +848,7 @@ describe("registerZeroCommands", () => {
       scope: "okou",
       capabilities: ["agent:read"],
     });
-    const help = buildZeroHelpText(decodeZeroTokenPayload(token));
+    const help = buildHelpText(decodeZeroTokenPayload(token));
 
     expect(help).not.toContain("Check credits?");
     expect(help).not.toContain("Buy credits?");
@@ -860,7 +860,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["maps:read"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Get directions?",
     );
   });
@@ -871,7 +871,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["file:write"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).not.toContain(
       "Get directions?",
     );
   });
@@ -882,7 +882,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["weather:read"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Check weather?",
     );
   });
@@ -893,7 +893,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["file:write"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).not.toContain(
       "Check weather?",
     );
   });
@@ -904,7 +904,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["scrape:read"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Scrape a web page?",
     );
   });
@@ -915,7 +915,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["file:write"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).not.toContain(
       "Scrape a web page?",
     );
   });
@@ -926,7 +926,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["finance:read"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Get a market quote?",
     );
   });
@@ -937,7 +937,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["file:write"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).not.toContain(
       "Get a market quote?",
     );
   });
@@ -952,12 +952,12 @@ describe("registerZeroCommands", () => {
       capabilities: ["file:write"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(visibleToken))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(visibleToken))).toContain(
       "Research SEO data?",
     );
-    expect(
-      buildZeroHelpText(decodeZeroTokenPayload(hiddenToken)),
-    ).not.toContain("Research SEO data?");
+    expect(buildHelpText(decodeZeroTokenPayload(hiddenToken))).not.toContain(
+      "Research SEO data?",
+    );
   });
 
   it("should show the people-search help example when people-search:read capability is present", () => {
@@ -966,7 +966,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["people-search:read"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Find a professional?",
     );
   });
@@ -977,7 +977,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["file:write"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).not.toContain(
       "Find a professional?",
     );
   });
@@ -988,7 +988,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["banking:read"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Read bank data?",
     );
   });
@@ -999,7 +999,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["file:write"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).not.toContain(
       "Read bank data?",
     );
   });
@@ -1010,7 +1010,7 @@ describe("registerZeroCommands", () => {
       capabilities: ["host:write"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Host a static site?",
     );
   });
@@ -1021,10 +1021,10 @@ describe("registerZeroCommands", () => {
       capabilities: ["host:read"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Clone hosted site?",
     );
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).not.toContain(
       "Host a static site?",
     );
   });
@@ -1035,7 +1035,7 @@ describe("registerZeroCommands", () => {
       capabilities: [],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Generate website?",
     );
   });
@@ -1058,10 +1058,10 @@ describe("registerZeroCommands", () => {
       capabilities: ["file:write"],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).not.toContain(
       "Host a static site?",
     );
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).not.toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).not.toContain(
       "Clone hosted site?",
     );
   });
@@ -1072,10 +1072,10 @@ describe("registerZeroCommands", () => {
       capabilities: [],
     });
 
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "List models?",
     );
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Model routing?",
     );
   });
@@ -1104,10 +1104,10 @@ describe("registerZeroCommands", () => {
     const prog = buildProgram();
 
     expect(visibleCommandNames(prog)).toContain("teams");
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Send Teams?",
     );
-    expect(buildZeroHelpText(decodeZeroTokenPayload(token))).toContain(
+    expect(buildHelpText(decodeZeroTokenPayload(token))).toContain(
       "Download Teams?",
     );
   });

--- a/turbo/apps/cli/src/__tests__/okou.test.ts
+++ b/turbo/apps/cli/src/__tests__/okou.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { program, registerZeroCommands } from "../okou";
+import { program, registerCommands } from "../okou";
 
 describe("Okou CLI program", () => {
-  registerZeroCommands(program);
+  registerCommands(program);
   const commandNames = program.commands.map((cmd) => {
     return cmd.name();
   });

--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for computer-use command registration and visibility.
  *
- * Entry points: registerZeroCommands(), formatComputerUseResultForConsole()
+ * Entry points: registerCommands(), formatComputerUseResultForConsole()
  * Mock (external): none
  * Real (internal): Command registration, capability checking, filesystem output
  */
@@ -25,7 +25,7 @@ import {
   zeroComputerUseCommand,
 } from "../index";
 import { computerUseOutputDir } from "../output-artifacts";
-import { registerZeroCommands } from "../../../../okou";
+import { registerCommands } from "../../../../okou";
 
 let testOutputDir = "";
 
@@ -100,7 +100,7 @@ describe("computer-use command visibility", () => {
 
   it("should be visible when no OKOU_TOKEN is set", () => {
     const prog = new Command();
-    registerZeroCommands(prog);
+    registerCommands(prog);
 
     const cmd = prog.commands.find((c) => {
       return c.name() === "computer-use";
@@ -121,7 +121,7 @@ describe("computer-use command visibility", () => {
     vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = new Command();
-    registerZeroCommands(prog);
+    registerCommands(prog);
 
     expect(visibleCommandNames(prog)).toContain("computer-use");
   });
@@ -139,14 +139,14 @@ describe("computer-use command visibility", () => {
     vi.stubEnv("OKOU_TOKEN", token);
 
     const prog = new Command();
-    registerZeroCommands(prog);
+    registerCommands(prog);
 
     expect(hiddenCommandNames(prog)).toContain("computer-use");
   });
 
   it("should have Desktop-backed agent command subcommands", () => {
     const prog = new Command();
-    registerZeroCommands(prog, [zeroComputerUseCommand]);
+    registerCommands(prog, [zeroComputerUseCommand]);
 
     const computerUse = prog.commands.find((c) => {
       return c.name() === "computer-use";
@@ -172,7 +172,7 @@ describe("computer-use command visibility", () => {
 
   it("should not expose host targeting options on agent-facing commands", () => {
     const prog = new Command();
-    registerZeroCommands(prog, [zeroComputerUseCommand]);
+    registerCommands(prog, [zeroComputerUseCommand]);
 
     const computerUse = prog.commands.find((c) => {
       return c.name() === "computer-use";

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -10,7 +10,7 @@ import {
 } from "./lib/api/zero-token.js";
 import { getOkouToken } from "./lib/okou-env.js";
 
-interface ZeroCommandDefinition {
+interface CommandDefinition {
   name: string;
   description: string;
   load: () => Promise<Command>;
@@ -75,7 +75,7 @@ const COMMAND_CAPABILITY_MAP: Record<
 
 const RUN_ONLY_COMMANDS = new Set(["mcp", "recognize", "translate"]);
 
-const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
+const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
   {
     name: "__agent-loop",
     description: "Internal sandbox agent loop",
@@ -359,18 +359,18 @@ const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
   },
 ];
 
-const ZERO_COMMAND_DEFINITION_BY_NAME = new Map(
-  ZERO_COMMAND_DEFINITIONS.map((definition) => {
+const COMMAND_DEFINITION_BY_NAME = new Map(
+  COMMAND_DEFINITIONS.map((definition) => {
     return [definition.name, definition];
   }),
 );
 
-function createZeroCommandStub(definition: ZeroCommandDefinition): Command {
+function createCommandStub(definition: CommandDefinition): Command {
   return new Command(definition.name).description(definition.description);
 }
 
 function buildDefaultCommands(): Command[] {
-  return ZERO_COMMAND_DEFINITIONS.map(createZeroCommandStub);
+  return COMMAND_DEFINITIONS.map(createCommandStub);
 }
 
 function shouldHideCommand(
@@ -390,7 +390,7 @@ function shouldHideCommand(
   return !payload.capabilities.includes(requiredCap);
 }
 
-function addZeroCommand(
+function addCommandWithVisibility(
   prog: Command,
   cmd: Command,
   payload: ZeroTokenPayload | undefined,
@@ -415,7 +415,7 @@ function getNonOptionArgs(argv: string[]): string[] {
   return args;
 }
 
-function getRequestedZeroCommandName(argv = process.argv): string | undefined {
+function getRequestedCommandName(argv = process.argv): string | undefined {
   const [firstArg, secondArg] = getNonOptionArgs(argv);
 
   if (!firstArg) {
@@ -429,14 +429,14 @@ function getRequestedZeroCommandName(argv = process.argv): string | undefined {
   return firstArg;
 }
 
-async function loadZeroCommand(
+async function loadRequestedCommand(
   name: string | undefined,
 ): Promise<Command | undefined> {
   if (!name) {
     return undefined;
   }
 
-  return ZERO_COMMAND_DEFINITION_BY_NAME.get(name)?.load();
+  return COMMAND_DEFINITION_BY_NAME.get(name)?.load();
 }
 
 function commandExampleIfVisible(
@@ -447,7 +447,7 @@ function commandExampleIfVisible(
   return shouldHideCommand(name, payload) ? [] : [example];
 }
 
-export function buildZeroHelpText(
+export function buildHelpText(
   payload: ZeroTokenPayload | undefined = decodeZeroTokenPayload(),
 ): string {
   const canReadHost = !payload || payload.capabilities.includes("host:read");
@@ -573,15 +573,12 @@ export function buildZeroHelpText(
  *
  * @param commands - override default commands (used in tests)
  */
-export function registerZeroCommands(
-  prog: Command,
-  commands?: Command[],
-): void {
+export function registerCommands(prog: Command, commands?: Command[]): void {
   const token = getOkouToken();
   const payload = token ? decodeZeroTokenPayload(token) : undefined;
 
   for (const cmd of commands ?? buildDefaultCommands()) {
-    addZeroCommand(prog, cmd, payload);
+    addCommandWithVisibility(prog, cmd, payload);
   }
 }
 
@@ -594,7 +591,7 @@ program
   .description("Okou CLI — interact with Okou from inside the sandbox")
   .version(__CLI_VERSION__)
   .addHelpText("after", () => {
-    return buildZeroHelpText();
+    return buildHelpText();
   });
 
 export { program };
@@ -605,10 +602,9 @@ if (
   process.argv[1]?.endsWith("okou")
 ) {
   await configureGlobalProxyFromEnv();
-  const requestedCommand = await loadZeroCommand(getRequestedZeroCommandName());
-  registerZeroCommands(
-    program,
-    requestedCommand ? [requestedCommand] : undefined,
+  const requestedCommand = await loadRequestedCommand(
+    getRequestedCommandName(),
   );
+  registerCommands(program, requestedCommand ? [requestedCommand] : undefined);
   program.parse();
 }


### PR DESCRIPTION
## Summary

- Rename all nine internal Okou command registry identifiers from the issue mapping.
- Rename `zero-capability-visibility.test.ts` to `command-capability-visibility.test.ts` and update focused test references and descriptions.
- Preserve command definitions, ordering, descriptions, lazy imports, capability gates, hidden behavior, help text, and the complete public CLI surface.
- Preserve `ZeroTokenPayload`, `decodeZeroTokenPayload()`, token builders, `ZERO_TOKEN`, `vm0_sandbox_`, `commands/zero`, per-domain `zeroXCommand` exports, and dynamic import paths.

## Contract verification

- Canonicalizing the baseline with the issue old-to-new map and the pinned Prettier version produces byte-for-byte identical updated source and focused tests.
- The registry test confirms exactly 38 public commands and keeps `__agent-loop` registered but outside the public surface.
- The Agent command template remains exactly `npx --yes --package="${CLI_PKG_URL}" okou <command>`.
- Guest Agent argv remains `npx --yes --package=<package-url> okou __agent-loop`.
- Package/bin, token helper, cutover documentation, and Guest Agent source files have no diff.

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@okouai/app`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/cli exec vitest run src/__tests__/okou.test.ts` (6 passed)
- `pnpm --filter @okouai/cli exec vitest run src/__tests__/command-capability-visibility.test.ts` (84 passed)
- `pnpm --filter @okouai/cli exec vitest run src/commands/zero/computer-use/__tests__/computer-use.test.ts` (28 passed)

Closes #27300