### PR TITLE
feat(billing): move legacy migration steps into dialog

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -52,19 +52,6 @@ function buttonByText(
   return button;
 }
 
-function buttonByLabel(
-  label: string,
-  container: ParentNode = document.body,
-): HTMLElement {
-  const button = queryAllByRoleFast("button", container).find((candidate) => {
-    return candidate.getAttribute("aria-label") === label;
-  });
-  if (!button) {
-    throw new Error(`${label} button not found`);
-  }
-  return button;
-}
-
 function activeProBillingStatus(): BillingStatusResponse {
   return {
     tier: "pro",
@@ -943,14 +930,21 @@ describe("organization billing settings", () => {
 
     migrationReady.resolve(undefined);
 
-    await screen.findByText("Compare plans");
-    const proPlan = screen.getByRole("article", { name: "Pro plan" });
-    const teamPlan = screen.getByRole("article", { name: "Team plan" });
+    const choosePlanDialog = await screen.findByRole("dialog", {
+      name: "Choose a plan",
+    });
+    expect(
+      within(choosePlanDialog).getByText("Step 1 of 2"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Legacy")).toBeInTheDocument();
+    const proPlan = within(choosePlanDialog).getByRole("article", {
+      name: "Pro plan",
+    });
+    const teamPlan = within(choosePlanDialog).getByRole("article", {
+      name: "Team plan",
+    });
     expect(buttonByText("Convert plan", proPlan)).toBeEnabled();
     expect(buttonByText("Convert plan", teamPlan)).toBeEnabled();
-    expect(
-      screen.queryByRole("heading", { name: "Choose a plan" }),
-    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("heading", { name: "Configure member packages" }),
     ).not.toBeInTheDocument();
@@ -962,9 +956,12 @@ describe("organization billing settings", () => {
       ),
     );
 
-    await screen.findByRole("heading", {
+    const configurePackagesDialog = await screen.findByRole("dialog", {
       name: "Configure member packages",
     });
+    expect(
+      within(configurePackagesDialog).getByText("Step 2 of 2"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("heading", { name: "Choose a plan" }),
     ).not.toBeInTheDocument();
@@ -978,9 +975,16 @@ describe("organization billing settings", () => {
     ).toBeInTheDocument();
     expect(within(comparison).getByText("Monthly total")).toBeInTheDocument();
 
-    click(screen.getByLabelText("Back"));
-    await screen.findByText("Compare plans");
-    click(screen.getByLabelText("Back"));
+    click(within(configurePackagesDialog).getByLabelText("Back"));
+    const returnedChoosePlanDialog = await screen.findByRole("dialog", {
+      name: "Choose a plan",
+    });
+    click(within(returnedChoosePlanDialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Choose a plan" }),
+      ).not.toBeInTheDocument();
+    });
     expect(screen.getByText("Legacy")).toBeInTheDocument();
     expect(
       screen.queryByText("Move to member packages"),
@@ -1006,7 +1010,7 @@ describe("organization billing settings", () => {
     });
 
     click(buttonByText("Convert plan"));
-    await screen.findByText("Compare plans");
+    await screen.findByRole("dialog", { name: "Choose a plan" });
   });
 
   it("shows conversion without upgrade for a legacy Pro plan", async () => {
@@ -1289,15 +1293,17 @@ describe("organization billing settings", () => {
 
     await screen.findByText("Team plan");
     click(buttonByText("Compare all plans"));
-    await screen.findByText("Compare plans");
+    const choosePlanDialog = await screen.findByRole("dialog", {
+      name: "Choose a plan",
+    });
     click(
       buttonByText(
         "Convert plan",
-        screen.getByRole("article", { name: "Team plan" }),
+        within(choosePlanDialog).getByRole("article", { name: "Team plan" }),
       ),
     );
 
-    await screen.findByRole("heading", {
+    const configurePackagesDialog = await screen.findByRole("dialog", {
       name: "Configure member packages",
     });
     expect(
@@ -1407,17 +1413,24 @@ describe("organization billing settings", () => {
       ),
     ).not.toBeInTheDocument();
 
-    click(buttonByLabel("Back"));
-    await screen.findByText("Compare plans");
-    click(buttonByLabel("Back"));
+    click(within(configurePackagesDialog).getByLabelText("Back"));
+    const returnedChoosePlanDialog = await screen.findByRole("dialog", {
+      name: "Choose a plan",
+    });
+    click(within(returnedChoosePlanDialog).getByLabelText("Close"));
     await screen.findByText("Team plan");
     expect(screen.getByText("Legacy")).toBeInTheDocument();
     expect(screen.getByText("Switches to Team on Sep 1, 2026")).toBeVisible();
 
     click(buttonByText("Downgrade"));
-    const proPlan = await screen.findByRole("article", { name: "Pro plan" });
+    const revisionChoosePlanDialog = await screen.findByRole("dialog", {
+      name: "Choose a plan",
+    });
+    const proPlan = within(revisionChoosePlanDialog).getByRole("article", {
+      name: "Pro plan",
+    });
     click(buttonByText("Downgrade", proPlan));
-    await screen.findByRole("heading", {
+    const revisionPackagesDialog = await screen.findByRole("dialog", {
       name: "Configure member packages",
     });
     const reviewRevisionButton = buttonByText("Review conversion");
@@ -1432,9 +1445,11 @@ describe("organization billing settings", () => {
       expect(buttonByText("Current plan")).toBeDisabled();
     });
 
-    click(buttonByLabel("Back"));
-    await screen.findByText("Compare plans");
-    click(buttonByLabel("Back"));
+    click(within(revisionPackagesDialog).getByLabelText("Back"));
+    const returnedRevisionPlanDialog = await screen.findByRole("dialog", {
+      name: "Choose a plan",
+    });
+    click(within(returnedRevisionPlanDialog).getByLabelText("Close"));
     await expect(
       screen.findByText("Switches to Pro on Sep 1, 2026"),
     ).resolves.toBeVisible();

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -99,6 +99,7 @@ import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
 import { openSettingsUsagePackUpgrade$ } from "../../../../signals/zero-page/settings/settings-dialog.ts";
 import {
   UsagePackMigrationPage,
+  UsagePackMigrationDialogs,
   UsagePackMigrationPlanSelectionPage,
   UsagePackPricingDialogs,
 } from "./usage-pack-pricing-page.tsx";
@@ -2450,9 +2451,8 @@ function BillingPricingPage({
   readonly periodEnd: string | null | undefined;
   readonly scheduledChange: ScheduledBillingChange;
 }) {
-  const migrationInProgress = usagePackMigrationInProgress(migration);
-  const scheduledMigrationMissingConfiguration =
-    migration?.status === "scheduled" && !migration.configuration;
+  const migrationNeedsProgressPage =
+    usagePackMigrationNeedsProgressPage(migration);
   return (
     <>
       {migrationLoading ? (
@@ -2460,8 +2460,7 @@ function BillingPricingPage({
           role="status"
           className="h-80 animate-pulse rounded-xl bg-muted/40"
         />
-      ) : migration &&
-        (migrationInProgress || scheduledMigrationMissingConfiguration) ? (
+      ) : migration && migrationNeedsProgressPage ? (
         <UsagePackMigrationProgressPage migration={migration} onBack={onBack} />
       ) : migrationOpen &&
         migration &&
@@ -2518,15 +2517,28 @@ function usagePackMigrationInProgress(
   return migration?.status === "applying";
 }
 
-/* The usage pack plans live in their own dialog over the billing tab.
-   Everything else -- the legacy pricing page and the legacy plan conversion --
-   still takes the tab over, so those keep the sub-page. */
+function usagePackMigrationNeedsProgressPage(
+  migration: UsagePackMigrationStateResponse | null,
+): boolean {
+  return (
+    usagePackMigrationInProgress(migration) ||
+    (migration?.status === "scheduled" && !migration.configuration)
+  );
+}
+
+/* All actionable usage pack pricing steps live in a dialog over the billing
+   tab, including conversion from a legacy plan. The legacy pricing page and a
+   migration that can only report progress still keep the tab sub-page. */
 function showsUsagePackPlanDialogs(
   enabled: boolean,
   migrationLoading: boolean,
   migration: UsagePackMigrationStateResponse | null,
 ): boolean {
-  return enabled && !migrationLoading && migration === null;
+  return (
+    enabled &&
+    !migrationLoading &&
+    !usagePackMigrationNeedsProgressPage(migration)
+  );
 }
 
 function usagePackMigrationConfigurable(
@@ -2587,6 +2599,46 @@ function CurrentPlanTitle({
         </span>
       )}
     </p>
+  );
+}
+
+function UsagePackPricingFlowDialogs({
+  checkoutAllowed,
+  currentTier,
+  migration,
+  migrationOpen,
+  migrationTargetTier,
+  onMigrationBack,
+  onClose,
+  onSelectMigration,
+}: {
+  readonly checkoutAllowed: boolean;
+  readonly currentTier: BillingTier;
+  readonly migration: UsagePackMigrationStateResponse | null;
+  readonly migrationOpen: boolean;
+  readonly migrationTargetTier: "pro" | "team" | null;
+  readonly onMigrationBack: () => void;
+  readonly onClose: () => void;
+  readonly onSelectMigration: (tier: "pro" | "team") => void;
+}) {
+  if (migration) {
+    return (
+      <UsagePackMigrationDialogs
+        migration={migration}
+        migrationOpen={migrationOpen}
+        migrationTargetTier={migrationTargetTier}
+        onBack={onMigrationBack}
+        onClose={onClose}
+        onSelect={onSelectMigration}
+      />
+    );
+  }
+  return (
+    <UsagePackPricingDialogs
+      checkoutAllowed={checkoutAllowed}
+      currentTier={currentTier}
+      onClose={onClose}
+    />
   );
 }
 
@@ -2871,14 +2923,19 @@ export function OrgBillingTab() {
 
       {showConcurrency && <ConcurrencyBillingSection status={status} />}
 
-      {/* Past the early return above, an open billing sub-page can only be the
-          usage pack plan flow. Mount it only while it is open so its catalog
+      {/* Past the early return above, an open billing sub-page is an actionable
+          usage pack pricing flow. Mount it only while it is open so its catalog
           and subscription load with the flow, not with every tab visit. */}
       {pricingOpen && (
-        <UsagePackPricingDialogs
+        <UsagePackPricingFlowDialogs
           checkoutAllowed={canStartUsagePackCheckout(status)}
           currentTier={currentTier}
+          migration={migration}
+          migrationOpen={migrationOpen}
+          migrationTargetTier={migrationTargetTier}
+          onMigrationBack={closeMigrationSubPage}
           onClose={closeBillingSubPage}
+          onSelectMigration={openMigrationPage}
         />
       )}
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -22,6 +22,7 @@ import type {
   UsagePackCatalogItem,
   UsagePackManagementResponse,
   UsagePackMigrationConfiguration,
+  UsagePackMigrationStateResponse,
   UsagePackSubscriptionChangePreviewResponse,
   UsagePackMigrationPreviewResponse,
   UsagePackMigrationRevisionPreviewResponse,
@@ -59,6 +60,7 @@ import {
   memberUsageSelections$,
   MINIMUM_USAGE_PACK_USD,
   selectedUsagePackPlan$,
+  resetUsagePackPricing$,
   setMemberUsageSelection$,
   setMemberUsageSelections$,
   setSelectedUsagePackPlan$,
@@ -1250,19 +1252,19 @@ function CheckoutOrderSummary({
 
 function PlanSelectionStep({
   catalog,
-  checkoutAllowed,
-  currentTier,
-  managedTier,
+  keepsMemberPackages,
   onAction,
+  resolveAction,
 }: {
   readonly catalog: readonly UsagePackCatalogItem[];
-  readonly checkoutAllowed: boolean;
-  readonly currentTier: BillingTier;
-  readonly managedTier: UsagePackPlanTier | null;
+  readonly keepsMemberPackages: boolean;
   readonly onAction: (
     plan: UsagePackPlanTier,
     action: PlanSelectionAction,
   ) => void;
+  readonly resolveAction: (
+    targetTier: UsagePackPlanTier,
+  ) => PlanSelectionAction;
 }) {
   return (
     /* No panel border inside the dialog frame -- the only rule between the two
@@ -1272,12 +1274,7 @@ function PlanSelectionStep({
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="dialog-scrollable grid min-h-0 flex-1 grid-cols-1 overflow-y-auto sm:grid-cols-2">
         {USAGE_PACK_PLANS.map((plan, index) => {
-          const action = usagePackPlanAction(
-            checkoutAllowed,
-            currentTier,
-            managedTier,
-            plan.tier,
-          );
+          const action = resolveAction(plan.tier);
           return (
             <PlanSelectionCard
               key={plan.tier}
@@ -1285,7 +1282,7 @@ function PlanSelectionStep({
               busy={false}
               catalog={catalog}
               divided={index > 0}
-              keepsMemberPackages={managedTier !== null}
+              keepsMemberPackages={keepsMemberPackages}
               plan={plan}
               onAction={() => {
                 onAction(plan.tier, action);
@@ -2843,10 +2840,12 @@ function MigrationPlanComparison({
 
 export function UsagePackMigrationPlanSelectionPage({
   configuration,
+  inDialog = false,
   onBack,
   onSelect,
 }: {
   readonly configuration: UsagePackMigrationConfiguration | null;
+  readonly inDialog?: boolean;
   readonly onBack: () => void;
   readonly onSelect: (tier: UsagePackPlanTier) => void;
 }) {
@@ -2855,6 +2854,40 @@ export function UsagePackMigrationPlanSelectionPage({
   const catalogLoadable = useLoadable(usagePackCatalogAsync$);
   const catalog =
     catalogLoadable.state === "hasData" ? catalogLoadable.data : null;
+  const resolveAction = (
+    targetTier: UsagePackPlanTier,
+  ): PlanSelectionAction => {
+    return configuration
+      ? usagePackPlanAction(
+          false,
+          configuration.tier,
+          configuration.tier,
+          targetTier,
+        )
+      : "convert";
+  };
+  const selectPlan = (targetTier: UsagePackPlanTier): void => {
+    setMemberUsageSelections(
+      configuration ? migrationConfigurationSelections(configuration) : {},
+    );
+    onSelect(targetTier);
+  };
+
+  if (inDialog) {
+    return catalog ? (
+      <PlanSelectionStep
+        catalog={catalog}
+        keepsMemberPackages={configuration !== null}
+        onAction={(targetTier) => {
+          selectPlan(targetTier);
+        }}
+        resolveAction={resolveAction}
+      />
+    ) : (
+      <div className="m-5 flex-1 animate-pulse rounded-xl bg-muted/40" />
+    );
+  }
+
   return (
     <div
       className="flex flex-col gap-5 outline-none"
@@ -2876,14 +2909,7 @@ export function UsagePackMigrationPlanSelectionPage({
       ) : (
         <PlanSelectionPanel>
           {USAGE_PACK_PLANS.map((plan, index) => {
-            const action = configuration
-              ? usagePackPlanAction(
-                  false,
-                  configuration.tier,
-                  configuration.tier,
-                  plan.tier,
-                )
-              : "convert";
+            const action = resolveAction(plan.tier);
             return (
               <PlanSelectionCard
                 key={plan.tier}
@@ -2894,12 +2920,7 @@ export function UsagePackMigrationPlanSelectionPage({
                 keepsMemberPackages={configuration !== null}
                 plan={plan}
                 onAction={() => {
-                  setMemberUsageSelections(
-                    configuration
-                      ? migrationConfigurationSelections(configuration)
-                      : {},
-                  );
-                  onSelect(plan.tier);
+                  selectPlan(plan.tier);
                 }}
               />
             );
@@ -2913,6 +2934,7 @@ export function UsagePackMigrationPlanSelectionPage({
 export function UsagePackMigrationPage({
   configuration,
   effectiveAt,
+  inDialog = false,
   migrationId,
   onBack,
   sourceTier,
@@ -2920,6 +2942,7 @@ export function UsagePackMigrationPage({
 }: {
   readonly configuration: UsagePackMigrationConfiguration | null;
   readonly effectiveAt: string;
+  readonly inDialog?: boolean;
   readonly migrationId: string | null;
   readonly onBack: () => void;
   readonly sourceTier: UsagePackPlanTier;
@@ -2942,7 +2965,9 @@ export function UsagePackMigrationPage({
     : { bonusCredits: 0, totalCredits: 0, totalUsd: 0 };
   return (
     <div
-      className="flex flex-col gap-5 outline-none"
+      className={`flex flex-col gap-5 outline-none ${
+        inDialog ? "flex-1 pb-5" : ""
+      }`}
       ref={usagePackPricingPageRef}
       role="group"
       tabIndex={-1}
@@ -2951,7 +2976,7 @@ export function UsagePackMigrationPage({
         <div className="h-80 animate-pulse rounded-xl bg-muted/40" />
       ) : (
         <>
-          <PricingPageHeader onBack={onBack} step={2} />
+          {!inDialog && <PricingPageHeader onBack={onBack} step={2} />}
           <MemberUsageConfiguration
             catalog={catalog}
             management={null}
@@ -2995,6 +3020,59 @@ export function UsagePackMigrationPage({
         </>
       )}
     </div>
+  );
+}
+
+export function UsagePackMigrationDialogs({
+  migration,
+  migrationOpen,
+  migrationTargetTier,
+  onBack,
+  onClose,
+  onSelect,
+}: {
+  readonly migration: UsagePackMigrationStateResponse;
+  readonly migrationOpen: boolean;
+  readonly migrationTargetTier: UsagePackPlanTier | null;
+  readonly onBack: () => void;
+  readonly onClose: () => void;
+  readonly onSelect: (tier: UsagePackPlanTier) => void;
+}) {
+  const resetPricing = useSet(resetUsagePackPricing$);
+  const configuring =
+    migrationOpen &&
+    migrationTargetTier !== null &&
+    migration.effectiveAt !== null;
+  return (
+    <PricingStepDialog
+      flush={!configuring}
+      step={configuring ? 2 : 1}
+      total={2}
+      onBack={configuring ? onBack : undefined}
+      onClose={() => {
+        resetPricing();
+        onClose();
+      }}
+    >
+      {configuring ? (
+        <UsagePackMigrationPage
+          configuration={migration.configuration ?? null}
+          effectiveAt={migration.effectiveAt}
+          inDialog
+          migrationId={migration.migrationId}
+          onBack={onBack}
+          sourceTier={migration.tier}
+          targetTier={migrationTargetTier}
+        />
+      ) : (
+        <UsagePackMigrationPlanSelectionPage
+          configuration={migration.configuration ?? null}
+          inDialog
+          onBack={onClose}
+          onSelect={onSelect}
+        />
+      )}
+    </PricingStepDialog>
   );
 }
 
@@ -3068,9 +3146,7 @@ export function UsagePackPricingDialogs({
       ) : (
         <PlanSelectionStep
           catalog={catalog}
-          checkoutAllowed={checkoutAllowed}
-          currentTier={currentTier}
-          managedTier={management?.tier ?? null}
+          keepsMemberPackages={management !== null}
           onAction={(plan, action) => {
             if (action === "disabled") {
               return;
@@ -3088,6 +3164,14 @@ export function UsagePackPricingDialogs({
                 : {},
             );
             setSelectedPlan(plan);
+          }}
+          resolveAction={(targetTier) => {
+            return usagePackPlanAction(
+              checkoutAllowed,
+              currentTier,
+              management?.tier ?? null,
+              targetTier,
+            );
           }}
         />
       )}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -3039,10 +3039,16 @@ export function UsagePackMigrationDialogs({
   readonly onSelect: (tier: UsagePackPlanTier) => void;
 }) {
   const resetPricing = useSet(resetUsagePackPricing$);
-  const configuring =
+  const configurationStep =
     migrationOpen &&
     migrationTargetTier !== null &&
-    migration.effectiveAt !== null;
+    migration.effectiveAt !== null
+      ? {
+          effectiveAt: migration.effectiveAt,
+          targetTier: migrationTargetTier,
+        }
+      : null;
+  const configuring = configurationStep !== null;
   return (
     <PricingStepDialog
       flush={!configuring}
@@ -3054,15 +3060,15 @@ export function UsagePackMigrationDialogs({
         onClose();
       }}
     >
-      {configuring ? (
+      {configurationStep ? (
         <UsagePackMigrationPage
           configuration={migration.configuration ?? null}
-          effectiveAt={migration.effectiveAt}
+          effectiveAt={configurationStep.effectiveAt}
           inDialog
           migrationId={migration.migrationId}
           onBack={onBack}
           sourceTier={migration.tier}
-          targetTier={migrationTargetTier}
+          targetTier={configurationStep.targetTier}
         />
       ) : (
         <UsagePackMigrationPlanSelectionPage


### PR DESCRIPTION
## Summary

- render legacy plan conversion over the Billing overview in the shared pricing dialog
- reuse the existing plan comparison frame for step 1 and move step 2 navigation into the dialog header
- reset pricing state on close and cover selection, configuration, back, and close behavior

## Test plan

- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx --reporter=dot`
- `pnpm -F @okouai/app check-types`
- Prettier check on changed files
- Oxlint and type-aware Oxlint on changed files
- ESLint on changed files
- `pnpm knip --workspace @okouai/app`