### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,7 +113,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.6"
-CLAUDE_CODE_VERSION="2.1.232"
+CLAUDE_CODE_VERSION="2.1.233"
 CODEX_CLI_VERSION="0.147.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"


### PR DESCRIPTION
## Summary

Update pinned rootfs package versions in `crates/runner/scripts/build-template.sh`.

## Updated

- `@anthropic-ai/claude-code`: `2.1.232` → `2.1.233`

## Checked (no newer version available)

- Go: `1.26.6`
- Codex CLI: `0.147.0`
- Google Workspace CLI: `0.22.5`
- xurl: `1.3.1`
- agent-browser: `0.33.0-vm0.1`
- pnpm: `11.21.0`
- Chromium: `151.0.7922.137-1~deb12u1`