### PR TITLE
fix(runner): start workspace cache lock timeout after contention

### DIFF
--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -100,23 +100,32 @@ enum LockAcquire {
     Busy,
 }
 
-async fn acquire_result_with(path: PathBuf, mode: LockMode) -> RunnerResult<LockAcquire> {
+async fn acquire_result_once(path: &Path, mode: LockMode) -> RunnerResult<LockAcquire> {
+    let attempt_path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || acquire_result_blocking(&attempt_path, mode, |_| Ok(())))
+        .await
+        .map_err(|e| RunnerError::Internal(format!("lock task: {e}")))?
+}
+
+async fn acquire_after_busy(path: &Path, mode: LockMode) -> RunnerResult<Flock<File>> {
+    debug_assert!(mode.waits());
     let mut retry_delay = LOCK_RETRY_INITIAL_DELAY;
     loop {
-        let attempt_path = path.clone();
-        let result = tokio::task::spawn_blocking(move || {
-            acquire_result_blocking(&attempt_path, mode, |_| Ok(()))
-        })
-        .await
-        .map_err(|e| RunnerError::Internal(format!("lock task: {e}")))??;
-
-        match result {
-            LockAcquire::Busy if mode.waits() => {
-                tokio::time::sleep(retry_delay).await;
-                retry_delay = (retry_delay * 2).min(LOCK_RETRY_MAX_DELAY);
-            }
-            result => return Ok(result),
+        tokio::time::sleep(retry_delay).await;
+        retry_delay = (retry_delay * 2).min(LOCK_RETRY_MAX_DELAY);
+        match acquire_result_once(path, mode).await? {
+            LockAcquire::Acquired(lock) => return Ok(lock),
+            LockAcquire::Busy => {}
         }
+    }
+}
+
+async fn acquire_result_with(path: PathBuf, mode: LockMode) -> RunnerResult<LockAcquire> {
+    match acquire_result_once(&path, mode).await? {
+        LockAcquire::Busy if mode.waits() => acquire_after_busy(&path, mode)
+            .await
+            .map(LockAcquire::Acquired),
+        result => Ok(result),
     }
 }
 
@@ -255,6 +264,29 @@ pub async fn acquire_shared(path: PathBuf) -> RunnerResult<Flock<File>> {
 /// The returned guard holds the lock until dropped.
 pub async fn try_acquire(path: PathBuf) -> RunnerResult<Flock<File>> {
     acquire_with(path, LockMode::TryExclusive).await
+}
+
+/// Acquire an exclusive flock, bounding only the wait after observed contention.
+///
+/// Scheduling delay before the first acquisition attempt does not consume the timeout.
+pub async fn acquire_with_contention_timeout(
+    path: PathBuf,
+    contention_timeout: Duration,
+) -> RunnerResult<TryLock> {
+    match acquire_result_once(&path, LockMode::Exclusive).await? {
+        LockAcquire::Acquired(lock) => Ok(TryLock::Acquired(lock)),
+        LockAcquire::Busy => {
+            match tokio::time::timeout(
+                contention_timeout,
+                acquire_after_busy(&path, LockMode::Exclusive),
+            )
+            .await
+            {
+                Ok(result) => result.map(TryLock::Acquired),
+                Err(_) => Ok(TryLock::Busy),
+            }
+        }
+    }
 }
 
 pub async fn try_acquire_or_busy(path: PathBuf) -> RunnerResult<TryLock> {

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -395,19 +395,19 @@ impl WorkspaceImageCache {
 
         let cache_key = common.cache_key(self, reuse_key, working_dir);
         let lock_path = self.entry_lock_path(&cache_key);
-        let lock = match tokio::time::timeout(
+        let lock = match crate::lock::acquire_with_contention_timeout(
+            lock_path,
             WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT,
-            crate::lock::acquire(lock_path),
         )
         .await
         {
-            Ok(Ok(lock)) => lock,
-            Ok(Err(e)) => {
+            Ok(crate::lock::TryLock::Acquired(lock)) => lock,
+            Ok(crate::lock::TryLock::Busy) => {
                 info!(
                     run_id = %common.run_id,
                     cache_key,
-                    error = %e,
-                    "workspace image cache lock unavailable; using fresh workspace image"
+                    wait_ms = duration_ms(WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT),
+                    "workspace image cache lock remained busy; using fresh workspace image"
                 );
                 return workspace_drive(
                     WorkspaceCacheCheckoutResult::LockBusy,
@@ -418,12 +418,12 @@ impl WorkspaceImageCache {
                     true,
                 );
             }
-            Err(_) => {
+            Err(e) => {
                 info!(
                     run_id = %common.run_id,
                     cache_key,
-                    wait_ms = duration_ms(WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT),
-                    "workspace image cache lock remained busy; using fresh workspace image"
+                    error = %e,
+                    "workspace image cache lock unavailable; using fresh workspace image"
                 );
                 return workspace_drive(
                     WorkspaceCacheCheckoutResult::LockBusy,

--- a/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
@@ -1,3 +1,8 @@
+use std::future::{Future as _, poll_fn};
+use std::sync::mpsc;
+use std::task::Poll;
+use std::time::Duration;
+
 use tokio::fs;
 
 use super::super::fs::{allocated_bytes, local_timestamp};
@@ -237,6 +242,68 @@ async fn consumed_cache_hit_invalidation_tolerates_missing_current() {
             .unwrap()
     );
     assert!(!cache.entry_paths(&key).entry_dir().to_path_buf().exists());
+}
+
+#[test]
+fn prepare_waits_for_initial_lock_attempt_before_contention_timeout() {
+    const BLOCKER_WATCHDOG: Duration = Duration::from_secs(1);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .max_blocking_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::time::pause();
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        std::fs::create_dir_all(paths.base_dir()).unwrap();
+        let cache = WorkspaceImageCache::new(paths);
+        let (blocker_started_tx, blocker_started_rx) = mpsc::channel();
+        let (release_blocker_tx, release_blocker_rx) = mpsc::channel();
+        let blocker = tokio::task::spawn_blocking(move || {
+            blocker_started_tx.send(()).unwrap();
+            release_blocker_rx.recv().unwrap();
+        });
+        blocker_started_rx
+            .recv_timeout(BLOCKER_WATCHDOG)
+            .expect("blocking-pool blocker should start");
+
+        let mut prepare = Box::pin(cache.prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some("sess-delayed-first-lock-attempt"),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
+            workspace_drive_required: false,
+        }));
+        let initial_poll = poll_fn(|context| Poll::Ready(prepare.as_mut().poll(context))).await;
+        assert!(initial_poll.is_pending());
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        match poll_fn(|context| Poll::Ready(prepare.as_mut().poll(context))).await {
+            Poll::Pending => {}
+            Poll::Ready(lease) => {
+                release_blocker_tx.send(()).unwrap();
+                blocker.await.unwrap();
+                panic!(
+                    "pre-attempt blocking-pool delay completed prepare as {:?}",
+                    lease.result()
+                );
+            }
+        }
+
+        release_blocker_tx.send(()).unwrap();
+        blocker.await.unwrap();
+        let lease = prepare.await;
+
+        assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Miss);
+        assert!(lease.cache_key.is_some());
+    });
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- start the workspace-cache lock budget only after a real `EWOULDBLOCK` result
- preserve the existing secure first attempt, 5/10/20 ms retry cadence, error propagation, and lock ownership
- add deterministic lifecycle coverage that delays an unlocked entry's first blocking-pool attempt past the old deadline

## Scope

This is runner-only. It changes no API, queue payload, runner/guest protocol, database, persisted cache format, CLI, migration, telemetry contract, or deployment ordering.

## Validation

- regression test confirmed red on the previous end-to-end timeout behavior and green after the fix
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner prepare_waits_for_initial_lock_attempt_before_contention_timeout`
- `cargo test -p runner lock::tests`
- `cargo test -p runner workspace_image_cache::tests`
- `cargo test -p runner executor::tests::sandbox_run_tests::workspace_cache`
- `cargo test -p runner --all-targets --all-features` (3128 passed; 20 existing ignored; guest inventory passed)
- `lefthook run pre-commit`
- `git diff --check`

Closes #27307
