### PR TITLE
fix(platform): hide idle member package action

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -970,7 +970,6 @@
         "configurePackages": "Mitgliederpakete konfigurieren",
         "credits": "Credits",
         "currentMember": "Aktuelles Mitglied",
-        "existingPackagesUnchanged": "Bestehende Mitgliederpakete bleiben unverändert.",
         "management": {
           "comparison": "Vergleich des aktuellen und neuen Abonnements",
           "current": "Aktuell",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -970,7 +970,6 @@
         "configurePackages": "Configure member packages",
         "credits": "Credits",
         "currentMember": "Current member",
-        "existingPackagesUnchanged": "Existing member packages stay unchanged.",
         "management": {
           "comparison": "Current and new subscription comparison",
           "current": "Current",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -991,7 +991,6 @@
         "configurePackages": "Configurar paquetes de miembros",
         "credits": "Créditos",
         "currentMember": "Miembro actual",
-        "existingPackagesUnchanged": "Los paquetes actuales de los miembros no cambian.",
         "management": {
           "comparison": "Comparación de la suscripción actual y la nueva",
           "current": "Actual",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -991,7 +991,6 @@
         "configurePackages": "Configurer les forfaits des membres",
         "credits": "Crédits",
         "currentMember": "Membre actuel",
-        "existingPackagesUnchanged": "Les forfaits actuels des membres restent inchangés.",
         "management": {
           "comparison": "Comparaison de l’abonnement actuel et du nouveau",
           "current": "Actuel",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -970,7 +970,6 @@
         "configurePackages": "सदस्य पैकेज कॉन्फ़िगर करें",
         "credits": "क्रेडिट",
         "currentMember": "मौजूदा सदस्य",
-        "existingPackagesUnchanged": "सदस्यों के मौजूदा पैकेज अपरिवर्तित रहेंगे।",
         "management": {
           "comparison": "वर्तमान और नई सदस्यता की तुलना",
           "current": "वर्तमान",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -970,7 +970,6 @@
         "configurePackages": "Konfigurasikan paket anggota",
         "credits": "Kredit",
         "currentMember": "Anggota saat ini",
-        "existingPackagesUnchanged": "Paket anggota yang ada tetap tidak berubah.",
         "management": {
           "comparison": "Perbandingan langganan saat ini dan baru",
           "current": "Saat ini",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -991,7 +991,6 @@
         "configurePackages": "Configura i pacchetti dei membri",
         "credits": "Crediti",
         "currentMember": "Membro attuale",
-        "existingPackagesUnchanged": "I pacchetti esistenti dei membri restano invariati.",
         "management": {
           "comparison": "Confronto tra abbonamento attuale e nuovo",
           "current": "Attuale",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -970,7 +970,6 @@
         "configurePackages": "メンバーパッケージを設定",
         "credits": "クレジット",
         "currentMember": "現在のメンバー",
-        "existingPackagesUnchanged": "既存のメンバーパッケージは変更されません。",
         "management": {
           "comparison": "現在と新しいサブスクリプションの比較",
           "current": "現在",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -970,7 +970,6 @@
         "configurePackages": "구성원 패키지 설정",
         "credits": "크레딧",
         "currentMember": "현재 구성원",
-        "existingPackagesUnchanged": "기존 멤버 패키지는 변경되지 않습니다.",
         "management": {
           "comparison": "현재 및 새 구독 비교",
           "current": "현재",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -991,7 +991,6 @@
         "configurePackages": "Configurar pacotes dos membros",
         "credits": "Créditos",
         "currentMember": "Membro atual",
-        "existingPackagesUnchanged": "Os pacotes atuais dos membros permanecem inalterados.",
         "management": {
           "comparison": "Comparação entre a assinatura atual e a nova",
           "current": "Atual",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1606,7 +1606,7 @@ describe("organization billing settings", () => {
     expect(
       within(orderSummary).queryByText("Concurrent slots"),
     ).not.toBeInTheDocument();
-    expect(buttonByText("Current plan", orderSummary)).toBeDisabled();
+    expect(within(orderSummary).queryByRole("button")).not.toBeInTheDocument();
     click(packageSelect);
     click(
       await screen.findByRole("option", {
@@ -1738,6 +1738,11 @@ describe("organization billing settings", () => {
       name: "Configure member packages",
     });
     await screen.findByText("Change is processing");
+    expect(
+      within(screen.getByRole("region", { name: "Order summary" })).queryByRole(
+        "button",
+      ),
+    ).not.toBeInTheDocument();
     expect(confirmationRequests).toBe(1);
     expect(successToast).toHaveBeenCalledWith("Subscription change confirmed.");
     expect(window.location.href).toBe(locationBeforeConfirmation);
@@ -1762,6 +1767,11 @@ describe("organization billing settings", () => {
     await expect(
       screen.findByRole("combobox", { name: "Usage for Alex Chen" }),
     ).resolves.toHaveTextContent("54,321 credits · 8% off");
+    expect(
+      within(screen.getByRole("region", { name: "Order summary" })).queryByRole(
+        "button",
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("hides a retained allocation after its member leaves the workspace", async () => {
@@ -1858,7 +1868,7 @@ describe("organization billing settings", () => {
     const orderSummary = screen.getByRole("region", {
       name: "Order summary",
     });
-    expect(buttonByText("Current plan", orderSummary)).toBeDisabled();
+    expect(within(orderSummary).queryByRole("button")).not.toBeInTheDocument();
 
     const packageSelect = within(memberUsage).getByRole("combobox", {
       name: "Usage for Alex Chen",
@@ -2004,7 +2014,7 @@ describe("organization billing settings", () => {
         name: "Current and new subscription comparison",
       }),
     ).not.toBeInTheDocument();
-    expect(buttonByText("Current plan", orderSummary)).toBeDisabled();
+    expect(within(orderSummary).queryByRole("button")).not.toBeInTheDocument();
 
     click(packageSelect);
     click(
@@ -2039,11 +2049,10 @@ describe("organization billing settings", () => {
       screen.queryByText("Downgrades to $50 on Apr 1, 2026."),
     ).not.toBeInTheDocument();
     expect(
-      buttonByText(
-        "Current plan",
-        screen.getByRole("region", { name: "Order summary" }),
+      within(screen.getByRole("region", { name: "Order summary" })).queryByRole(
+        "button",
       ),
-    ).toBeDisabled();
+    ).not.toBeInTheDocument();
   });
 
   it("allows replacing a scheduled member package downgrade", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1582,9 +1582,9 @@ describe("organization billing settings", () => {
     expect(buttonByText("Manage", proPlan)).not.toBeDisabled();
     expect(proPlan).toHaveTextContent("from $20/month");
     expect(teamPlan).toHaveTextContent("from $180/month");
-    expect(
-      within(teamPlan).getByText("Existing member packages stay unchanged."),
-    ).toBeInTheDocument();
+    expect(teamPlan).toHaveTextContent(
+      "Plan $160 · member packages $20–$200 each",
+    );
     click(buttonByText("Manage", proPlan));
 
     await screen.findByRole("heading", {
@@ -1606,7 +1606,7 @@ describe("organization billing settings", () => {
     expect(
       within(orderSummary).queryByText("Concurrent slots"),
     ).not.toBeInTheDocument();
-    expect(within(orderSummary).queryByRole("button")).not.toBeInTheDocument();
+    expect(queryAllByRoleFast("button", orderSummary)).toHaveLength(0);
     click(packageSelect);
     click(
       await screen.findByRole("option", {
@@ -1739,10 +1739,11 @@ describe("organization billing settings", () => {
     });
     await screen.findByText("Change is processing");
     expect(
-      within(screen.getByRole("region", { name: "Order summary" })).queryByRole(
+      queryAllByRoleFast(
         "button",
+        screen.getByRole("region", { name: "Order summary" }),
       ),
-    ).not.toBeInTheDocument();
+    ).toHaveLength(0);
     expect(confirmationRequests).toBe(1);
     expect(successToast).toHaveBeenCalledWith("Subscription change confirmed.");
     expect(window.location.href).toBe(locationBeforeConfirmation);
@@ -1768,10 +1769,11 @@ describe("organization billing settings", () => {
       screen.findByRole("combobox", { name: "Usage for Alex Chen" }),
     ).resolves.toHaveTextContent("54,321 credits · 8% off");
     expect(
-      within(screen.getByRole("region", { name: "Order summary" })).queryByRole(
+      queryAllByRoleFast(
         "button",
+        screen.getByRole("region", { name: "Order summary" }),
       ),
-    ).not.toBeInTheDocument();
+    ).toHaveLength(0);
   });
 
   it("hides a retained allocation after its member leaves the workspace", async () => {
@@ -1868,7 +1870,7 @@ describe("organization billing settings", () => {
     const orderSummary = screen.getByRole("region", {
       name: "Order summary",
     });
-    expect(within(orderSummary).queryByRole("button")).not.toBeInTheDocument();
+    expect(queryAllByRoleFast("button", orderSummary)).toHaveLength(0);
 
     const packageSelect = within(memberUsage).getByRole("combobox", {
       name: "Usage for Alex Chen",
@@ -2014,7 +2016,7 @@ describe("organization billing settings", () => {
         name: "Current and new subscription comparison",
       }),
     ).not.toBeInTheDocument();
-    expect(within(orderSummary).queryByRole("button")).not.toBeInTheDocument();
+    expect(queryAllByRoleFast("button", orderSummary)).toHaveLength(0);
 
     click(packageSelect);
     click(
@@ -2049,10 +2051,11 @@ describe("organization billing settings", () => {
       screen.queryByText("Downgrades to $50 on Apr 1, 2026."),
     ).not.toBeInTheDocument();
     expect(
-      within(screen.getByRole("region", { name: "Order summary" })).queryByRole(
+      queryAllByRoleFast(
         "button",
+        screen.getByRole("region", { name: "Order summary" }),
       ),
-    ).not.toBeInTheDocument();
+    ).toHaveLength(0);
   });
 
   it("allows replacing a scheduled member package downgrade", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -706,11 +706,9 @@ function MemberUsageConfiguration({
 function PlanPrice({
   basePriceUsd,
   catalog,
-  keepsMemberPackages,
 }: {
   readonly basePriceUsd: number;
   readonly catalog: readonly UsagePackCatalogItem[];
-  readonly keepsMemberPackages: boolean;
 }) {
   const packagePrices = catalog.map((item) => {
     return item.priceUsd;
@@ -733,20 +731,16 @@ function PlanPrice({
         </span>
       </p>
       <p className="mt-2 text-sm leading-snug text-muted-foreground">
-        {keepsMemberPackages
-          ? i18n.t(($) => {
-              return $.billing.plans.usagePacks.existingPackagesUnchanged;
-            })
-          : i18n.t(
-              ($) => {
-                return $.billing.plans.usagePacks.planPlusPackages;
-              },
-              {
-                highest: formatUsd(highestPackageUsd, 0),
-                lowest: formatUsd(lowestPackageUsd, 0),
-                plan: formatUsd(basePriceUsd, 0),
-              },
-            )}
+        {i18n.t(
+          ($) => {
+            return $.billing.plans.usagePacks.planPlusPackages;
+          },
+          {
+            highest: formatUsd(highestPackageUsd, 0),
+            lowest: formatUsd(lowestPackageUsd, 0),
+            plan: formatUsd(basePriceUsd, 0),
+          },
+        )}
       </p>
     </div>
   );
@@ -863,7 +857,6 @@ function PlanSelectionCard({
   busy,
   catalog,
   divided,
-  keepsMemberPackages,
   onAction,
   plan,
 }: {
@@ -871,7 +864,6 @@ function PlanSelectionCard({
   readonly busy: boolean;
   readonly catalog: readonly UsagePackCatalogItem[];
   readonly divided: boolean;
-  readonly keepsMemberPackages: boolean;
   readonly onAction: () => void;
   readonly plan: UsagePackPlan;
 }) {
@@ -928,11 +920,7 @@ function PlanSelectionCard({
         {planDescription(plan.tier)}
       </p>
 
-      <PlanPrice
-        basePriceUsd={plan.basePriceUsd}
-        catalog={catalog}
-        keepsMemberPackages={keepsMemberPackages}
-      />
+      <PlanPrice basePriceUsd={plan.basePriceUsd} catalog={catalog} />
 
       <PlanComparison tier={plan.tier} />
 
@@ -1285,7 +1273,6 @@ function PlanSelectionStep({
               busy={false}
               catalog={catalog}
               divided={index > 0}
-              keepsMemberPackages={managedTier !== null}
               plan={plan}
               onAction={() => {
                 onAction(plan.tier, action);
@@ -2204,7 +2191,8 @@ function ManagedSubscriptionOrderSummary({
     restoresScheduledDowngrade,
   } = managedSubscriptionChangeState({ management, members, plan, selections });
   const hasSubscriptionAction =
-    hasConfigurationChange || restoresScheduledDowngrade;
+    (hasConfigurationChange || restoresScheduledDowngrade) &&
+    (!hasPendingChange || hasScheduledDowngrade);
   const openPreview = async (): Promise<void> => {
     if (!members) {
       return;
@@ -2888,7 +2876,6 @@ export function UsagePackMigrationPlanSelectionPage({
                 busy={false}
                 catalog={catalog}
                 divided={index > 0}
-                keepsMemberPackages={configuration !== null}
                 plan={plan}
                 onAction={() => {
                   setMemberUsageSelections(

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -2131,7 +2131,6 @@ function hasUsagePackDowngrade(
 }
 
 function managedSubscriptionActionLabel(args: {
-  readonly hasConfigurationChange: boolean;
   readonly previewing: boolean;
   readonly restoresScheduledDowngrade: boolean;
 }): string {
@@ -2145,13 +2144,9 @@ function managedSubscriptionActionLabel(args: {
       return $.billing.common.restore;
     });
   }
-  return args.hasConfigurationChange
-    ? i18n.t(($) => {
-        return $.billing.common.confirm;
-      })
-    : i18n.t(($) => {
-        return $.billing.plans.currentPlan;
-      });
+  return i18n.t(($) => {
+    return $.billing.common.confirm;
+  });
 }
 
 function managedSubscriptionChangeState({
@@ -2208,6 +2203,8 @@ function ManagedSubscriptionOrderSummary({
     hasScheduledDowngrade,
     restoresScheduledDowngrade,
   } = managedSubscriptionChangeState({ management, members, plan, selections });
+  const hasSubscriptionAction =
+    hasConfigurationChange || restoresScheduledDowngrade;
   const openPreview = async (): Promise<void> => {
     if (!members) {
       return;
@@ -2251,28 +2248,28 @@ function ManagedSubscriptionOrderSummary({
           })}
         </p>
       )}
-      <div className={STEP_ACTION_BAR}>
-        {error && <p className="text-sm text-destructive">{error}</p>}
-        <Button
-          type="button"
-          className="h-10 w-full text-sm font-medium"
-          disabled={
-            !members ||
-            (hasPendingChange && !hasScheduledDowngrade) ||
-            (!hasConfigurationChange && !restoresScheduledDowngrade) ||
-            previewing
-          }
-          onClick={() => {
-            detach(openPreview(), Reason.DomCallback);
-          }}
-        >
-          {managedSubscriptionActionLabel({
-            hasConfigurationChange,
-            previewing,
-            restoresScheduledDowngrade,
-          })}
-        </Button>
-      </div>
+      {hasSubscriptionAction && (
+        <div className={STEP_ACTION_BAR}>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <Button
+            type="button"
+            className="h-10 w-full text-sm font-medium"
+            disabled={
+              !members ||
+              (hasPendingChange && !hasScheduledDowngrade) ||
+              previewing
+            }
+            onClick={() => {
+              detach(openPreview(), Reason.DomCallback);
+            }}
+          >
+            {managedSubscriptionActionLabel({
+              previewing,
+              restoresScheduledDowngrade,
+            })}
+          </Button>
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- use the same plan and member-package price breakdown in new, managed, and migration plan selection
- hide the managed Step 2 action bar when there is no new action or a non-restorable change is already processing
- preserve Confirm, Restore, and Updating states when an action exists
- update page-level billing tests for idle, processing, scheduled, restored, and plan-selection states

## Scope

- removes the active-plan-only `Existing member packages stay unchanged.` pricing detail from the shared plan chooser
- the CTA visibility rule only affects Configure member packages, Step 2 of 3
- does not change Step 3, initial checkout Step 2 of 2, invite, or migration package flows

## Verification

- `npx --yes prettier@3.8.1 --check` on all touched TypeScript and locale files
- `npx --yes oxlint@1.75.0` on the touched TypeScript files
- `git diff --check`
- targeted Vitest was not run locally because monorepo dependencies are not installed; PR CI will run the platform checks
