### PR TITLE
test(api): scope chat archive lock observations

### DIFF
--- a/turbo/apps/api/src/__tests__/env-stub.ts
+++ b/turbo/apps/api/src/__tests__/env-stub.ts
@@ -6,12 +6,23 @@ export function stubTestTimezone(
   vi.stubEnv("TZ", timezone);
 }
 
-if (!process.env.DATABASE_URL) {
-  vi.stubEnv(
-    "DATABASE_URL",
-    "postgresql://postgres:postgres@localhost:5432/vm0_test",
+function stubTestDatabaseUrl(): void {
+  const vitestWorkerId = process.env.VITEST_WORKER_ID;
+  if (!vitestWorkerId) {
+    throw new Error("Expected VITEST_WORKER_ID in the API test environment");
+  }
+  const databaseUrl = new URL(
+    process.env.DATABASE_URL ??
+      "postgresql://postgres:postgres@localhost:5432/vm0_test",
   );
+  databaseUrl.searchParams.set(
+    "application_name",
+    `vm0-api-test-${process.pid}-${vitestWorkerId}`,
+  );
+  vi.stubEnv("DATABASE_URL", databaseUrl.toString());
 }
+
+stubTestDatabaseUrl();
 vi.stubEnv("CLERK_SECRET_KEY", "sk_test_dummy_for_unit_tests");
 vi.stubEnv("CLERK_PUBLISHABLE_KEY", "pk_test_dummy_for_unit_tests");
 vi.stubEnv(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
@@ -22,6 +22,7 @@ import {
 import {
   holdChatEventReadsFixture,
   queueChatEventPhysicalDeletionFixture,
+  queueOtherWorkerChatEventReadFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { sharedThreadRoutes } from "../shared-threads";
@@ -371,16 +372,31 @@ describe("archived chat event consumers", () => {
     const heldReads = await holdChatEventReadsFixture({
       signal: context.signal,
     });
+    const otherWorkerRead = await queueOtherWorkerChatEventReadFixture({
+      signal: context.signal,
+    });
+    let createRequestDone: Promise<unknown> = Promise.resolve();
+    let deletionDone: Promise<void> = Promise.resolve();
+    onTestFinished(async () => {
+      heldReads.release();
+      await Promise.allSettled([
+        heldReads.done,
+        otherWorkerRead.done,
+        deletionDone,
+        createRequestDone,
+      ]);
+    });
+    await expect.poll(otherWorkerRead.blocked).toBe(true);
+    await expect.poll(heldReads.blockedStatementCounts).toStrictEqual({
+      hotSnapshotReads: 0,
+      physicalDeletions: 0,
+    });
     const createRequest = sharedThreadClient().create({
       params: { threadId: fixture.threadId },
       headers: authenticate(fixture.actor),
       body: { eventIds: [hotEventId] },
     });
-    let deletionDone: Promise<void> = Promise.resolve();
-    onTestFinished(async () => {
-      heldReads.release();
-      await Promise.allSettled([heldReads.done, deletionDone, createRequest]);
-    });
+    createRequestDone = createRequest;
 
     await expect.poll(heldReads.blockedStatementCounts).toStrictEqual({
       hotSnapshotReads: 1,
@@ -400,6 +416,7 @@ describe("archived chat event consumers", () => {
     const [created] = await Promise.all([
       accept(createRequest, [201]),
       heldReads.done,
+      otherWorkerRead.done,
       deletionDone,
     ]);
     await expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-archive-consumers.test.ts
@@ -382,13 +382,19 @@ describe("archived chat event consumers", () => {
       await Promise.allSettled([heldReads.done, deletionDone, createRequest]);
     });
 
-    await expect.poll(heldReads.blockedWaiterCount).toBe(1);
+    await expect.poll(heldReads.blockedStatementCounts).toStrictEqual({
+      hotSnapshotReads: 1,
+      physicalDeletions: 0,
+    });
     const deletion = await queueChatEventPhysicalDeletionFixture({
       eventId: hotEventId,
       signal: context.signal,
     });
     deletionDone = deletion.done;
-    await expect.poll(heldReads.blockedWaiterCount).toBe(2);
+    await expect.poll(heldReads.blockedStatementCounts).toStrictEqual({
+      hotSnapshotReads: 1,
+      physicalDeletions: 1,
+    });
 
     heldReads.release();
     const [created] = await Promise.all([

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -67,6 +67,11 @@ const blockedQueryRowSchema = z.object({ query: z.string() });
 
 type ChatThreadBlockedStatementKind = "select_for_update" | "update" | "other";
 
+interface ChatEventBlockedStatementCounts {
+  readonly hotSnapshotReads: number;
+  readonly physicalDeletions: number;
+}
+
 interface ChatEventContextFixture {
   readonly id: string;
   readonly revokesEventId: string | null;
@@ -950,7 +955,7 @@ export async function holdChatEventReadsFixture(args: {
 }): Promise<{
   readonly release: () => void;
   readonly done: Promise<void>;
-  readonly blockedWaiterCount: () => Promise<number>;
+  readonly blockedStatementCounts: () => Promise<ChatEventBlockedStatementCounts>;
 }> {
   const started = createDeferredPromise<number>(args.signal);
   const released = createDeferredPromise<void>(args.signal);
@@ -977,8 +982,8 @@ export async function holdChatEventReadsFixture(args: {
       }
     },
     done,
-    blockedWaiterCount: async () => {
-      return await directBlockedWaiterCount(holderPid);
+    blockedStatementCounts: async () => {
+      return await directBlockedChatEventStatementCounts(holderPid);
     },
   };
 }
@@ -1218,6 +1223,52 @@ async function directBlockedWaiterCount(holderPid: number): Promise<number> {
   return rows[0]?.waiterCount ?? 0;
 }
 
+function normalizeBlockedQuery(query: string): string {
+  return query.toLowerCase().replaceAll(/\s+/g, " ").trim();
+}
+
+function isSharedThreadHotSnapshotRead(query: string): boolean {
+  return (
+    query.startsWith(
+      `select "id", "event_type", "payload"->>'content', "payload"->'usermessage', "run_id"`,
+    ) &&
+    query.includes('from "chat_events" where') &&
+    query.includes('"chat_events"."chat_thread_id" = $') &&
+    query.includes('"chat_events"."id" in (') &&
+    query.endsWith('order by "chat_events"."seq_id" asc')
+  );
+}
+
+function isChatEventPhysicalDeletion(query: string): boolean {
+  return query === 'lock table "chat_events" in access exclusive mode';
+}
+
+async function directBlockedChatEventStatementCounts(
+  holderPid: number,
+): Promise<ChatEventBlockedStatementCounts> {
+  const rows = await executeRawRows(
+    db(),
+    sql`
+      SELECT activity.query AS "query"
+      FROM pg_stat_activity AS activity
+      WHERE ${holderPid} = ANY(pg_blocking_pids(activity.pid))
+    `,
+    blockedQueryRowSchema,
+  );
+  let hotSnapshotReads = 0;
+  let physicalDeletions = 0;
+  for (const row of rows) {
+    const query = normalizeBlockedQuery(row.query);
+    if (isSharedThreadHotSnapshotRead(query)) {
+      hotSnapshotReads++;
+    }
+    if (isChatEventPhysicalDeletion(query)) {
+      physicalDeletions++;
+    }
+  }
+  return { hotSnapshotReads, physicalDeletions };
+}
+
 async function firstDirectBlockedStatementKind(
   holderPid: number,
 ): Promise<ChatThreadBlockedStatementKind | null> {
@@ -1232,7 +1283,7 @@ async function firstDirectBlockedStatementKind(
     `,
     blockedQueryRowSchema,
   );
-  const query = rows[0]?.query.toLowerCase().replaceAll(/\s+/g, " ").trim();
+  const query = rows[0] ? normalizeBlockedQuery(rows[0].query) : undefined;
   if (!query) {
     return null;
   }

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -25,7 +25,16 @@ import { chatEvents } from "@okouai/db/schema/chat-event";
 import { checkpoints } from "@okouai/db/schema/checkpoint";
 import { orgModelPolicies } from "@okouai/db/schema/org-model-policy";
 import { threadGoals } from "@okouai/db/schema/thread-goal";
-import { and, count, eq, inArray, isNull, sql, type SQL } from "drizzle-orm";
+import {
+  and,
+  asc,
+  count,
+  eq,
+  inArray,
+  isNull,
+  sql,
+  type SQL,
+} from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "../lib/db";
@@ -61,6 +70,10 @@ const VM0_BDD_API_KEY_PREFIXES = [
   "vm0-key-bdd-dev-seed-",
 ] as const;
 const databasePidRowSchema = z.object({ pid: z.int() });
+const databaseConnectionOwnerRowSchema = z.object({
+  applicationName: z.string().min(1),
+  pid: z.int(),
+});
 const waiterCountRowSchema = z.object({ waiterCount: z.int() });
 const blockedByPidRowSchema = z.object({ blocked: z.boolean() });
 const blockedQueryRowSchema = z.object({ query: z.string() });
@@ -957,23 +970,30 @@ export async function holdChatEventReadsFixture(args: {
   readonly done: Promise<void>;
   readonly blockedStatementCounts: () => Promise<ChatEventBlockedStatementCounts>;
 }> {
-  const started = createDeferredPromise<number>(args.signal);
+  const started = createDeferredPromise<{
+    readonly applicationName: string;
+    readonly pid: number;
+  }>(args.signal);
   const released = createDeferredPromise<void>(args.signal);
   const done = db().transaction(async (tx) => {
-    const pidRows = await executeRawRows(
+    const ownerRows = await executeRawRows(
       tx,
-      sql`SELECT pg_backend_pid() AS "pid"`,
-      databasePidRowSchema,
+      sql`
+        SELECT
+          current_setting('application_name') AS "applicationName",
+          pg_backend_pid() AS "pid"
+      `,
+      databaseConnectionOwnerRowSchema,
     );
-    const holderPid = pidRows[0]?.pid;
-    if (!holderPid) {
-      throw new Error("Expected the chat-event read lock holder pid");
+    const owner = ownerRows[0];
+    if (!owner) {
+      throw new Error("Expected the chat-event read lock holder owner");
     }
     await tx.execute(sql`LOCK TABLE ${chatEvents} IN ACCESS EXCLUSIVE MODE`);
-    started.resolve(holderPid);
+    started.resolve(owner);
     await released.promise;
   });
-  const holderPid = await started.promise;
+  const owner = await started.promise;
 
   return {
     release: () => {
@@ -983,8 +1003,48 @@ export async function holdChatEventReadsFixture(args: {
     },
     done,
     blockedStatementCounts: async () => {
-      return await directBlockedChatEventStatementCounts(holderPid);
+      return await directBlockedChatEventStatementCounts(owner);
     },
+  };
+}
+
+/**
+ * Queues a chat-event read under a distinct database owner. This simulates an
+ * unrelated Vitest worker sharing the same test database and lock boundary.
+ */
+export async function queueOtherWorkerChatEventReadFixture(args: {
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly blocked: () => Promise<boolean>;
+  readonly done: Promise<void>;
+}> {
+  const started = createDeferredPromise<void>(args.signal);
+  const applicationName = `vm0-api-test-other-${randomUUID()}`;
+  const missingEventId = randomUUID();
+  const done = onRejection(
+    db().transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT set_config('application_name', ${applicationName}, true)`,
+      );
+      started.resolve(undefined);
+      await tx
+        .select({ id: chatEvents.id })
+        .from(chatEvents)
+        .where(eq(chatEvents.id, missingEventId))
+        .orderBy(asc(chatEvents.seqId));
+    }),
+    (error) => {
+      if (!started.settled()) {
+        started.reject(error);
+      }
+    },
+  );
+  await started.promise;
+  return {
+    blocked: async () => {
+      return await databaseOwnerHasBlockedWaiter(applicationName);
+    },
+    done,
   };
 }
 
@@ -1223,18 +1283,32 @@ async function directBlockedWaiterCount(holderPid: number): Promise<number> {
   return rows[0]?.waiterCount ?? 0;
 }
 
+async function databaseOwnerHasBlockedWaiter(
+  applicationName: string,
+): Promise<boolean> {
+  const rows = await executeRawRows(
+    db(),
+    sql`
+      SELECT EXISTS (
+        SELECT 1
+        FROM pg_stat_activity AS activity
+        WHERE activity.application_name = ${applicationName}
+          AND cardinality(pg_blocking_pids(activity.pid)) > 0
+      ) AS "blocked"
+    `,
+    blockedByPidRowSchema,
+  );
+  return rows[0]?.blocked ?? false;
+}
+
 function normalizeBlockedQuery(query: string): string {
   return query.toLowerCase().replaceAll(/\s+/g, " ").trim();
 }
 
 function isSharedThreadHotSnapshotRead(query: string): boolean {
   return (
-    query.startsWith(
-      `select "id", "event_type", "payload"->>'content', "payload"->'usermessage', "run_id"`,
-    ) &&
-    query.includes('from "chat_events" where') &&
-    query.includes('"chat_events"."chat_thread_id" = $') &&
-    query.includes('"chat_events"."id" in (') &&
+    query.startsWith("select ") &&
+    query.includes(' from "chat_events" ') &&
     query.endsWith('order by "chat_events"."seq_id" asc')
   );
 }
@@ -1243,15 +1317,17 @@ function isChatEventPhysicalDeletion(query: string): boolean {
   return query === 'lock table "chat_events" in access exclusive mode';
 }
 
-async function directBlockedChatEventStatementCounts(
-  holderPid: number,
-): Promise<ChatEventBlockedStatementCounts> {
+async function directBlockedChatEventStatementCounts(owner: {
+  readonly applicationName: string;
+  readonly pid: number;
+}): Promise<ChatEventBlockedStatementCounts> {
   const rows = await executeRawRows(
     db(),
     sql`
       SELECT activity.query AS "query"
       FROM pg_stat_activity AS activity
-      WHERE ${holderPid} = ANY(pg_blocking_pids(activity.pid))
+      WHERE ${owner.pid} = ANY(pg_blocking_pids(activity.pid))
+        AND activity.application_name = ${owner.applicationName}
     `,
     blockedQueryRowSchema,
   );


### PR DESCRIPTION
## Summary

- Scope the held `chat_events` lock observation to the database owner of the shared-thread hot-snapshot read and physical-deletion lock.
- Tag each API Vitest worker's PostgreSQL connections with a unique `application_name`, then classify only the target hot-snapshot read and physical-deletion lock owned by that worker.
- Assert the one-read and one-queued-deletion invariants separately, so duplicate target snapshot reads still fail while unrelated shard work is excluded.

## Root cause

`holdChatEventReadsFixture` acquires an `ACCESS EXCLUSIVE` relation lock, but its former `blockedWaiterCount` returned every backend PID directly blocked by that holder. Vitest files in one `test-api` shard run concurrently against the same PostgreSQL service, so an unrelated `chat_events` statement from another file could become another waiter and be counted as part of this test.

The shared-thread creation path itself issues one sequentially awaited hot-table snapshot `SELECT`, the test starts one create request, and physical deletion is not queued until after the first assertion. The first two failures nevertheless observed two waiters before deletion was queued. A later recurrence reached the second phase and observed three waiters after the deletion was queued. That phase shift, plus a same-SHA pass, shows that one unrelated waiter can arrive on either side of the test's synchronization phases; it does not demonstrate a duplicate product snapshot read.

The API test environment now assigns each Vitest worker a unique PostgreSQL `application_name`. The lock holder captures its backend PID and owner name, and `directBlockedChatEventStatementCounts` first filters directly blocked statements to that owner before classifying normalized SQL. The regression deliberately queues a blocked `chat_events` read under a distinct owner, proves it is excluded, and retains exact `{ hotSnapshotReads: 1, physicalDeletions: 0 }` then `{ hotSnapshotReads: 1, physicalDeletions: 1 }` assertions. Two matching target snapshot reads still produce `hotSnapshotReads: 2` and fail.

## Failure evidence

- Initial failure: [run 31864280809](https://github.com/vm0-ai/vm0/actions/runs/31864280809), [test-api (2)](https://github.com/vm0-ai/vm0/actions/runs/31864280809/job/94962754948) — first phase expected 1, observed 2
- Exact recurrence on the next main push: [run 31864456644](https://github.com/vm0-ai/vm0/actions/runs/31864456644), [test-api (2)](https://github.com/vm0-ai/vm0/actions/runs/31864456644/job/94963216597) — first phase expected 1, observed 2
- Later phase-shifted recurrence: [run 31867479447](https://github.com/vm0-ai/vm0/actions/runs/31867479447), [test-api (2)](https://github.com/vm0-ai/vm0/actions/runs/31867479447/job/94970941189) — second phase expected 2, observed 3
- Same-SHA passing comparison for `12bc419d8e7fe81b155fe7df72c854c7090c70f0`: [run 31867268168](https://github.com/vm0-ai/vm0/actions/runs/31867268168), [test-api (2)](https://github.com/vm0-ai/vm0/actions/runs/31867268168/job/94970248423) — all four tests passed in 897 ms
- Earlier exact passing comparison: [run 31862168622](https://github.com/vm0-ai/vm0/actions/runs/31862168622), [test-api (2)](https://github.com/vm0-ai/vm0/actions/runs/31862168622/job/94957375086) — all four tests passed in 895 ms
- All failing pushes changed unrelated rootfs, guest-agent, or Platform billing files; none touched this API path or fixture. Fail-fast shard cancellations and `ci-gate-turbo` were downstream effects, not independent failures.

## Validation

- Initial focused repair: `DATABASE_URL=postgresql://user@127.0.0.1:55432/postgres pnpm vitest run src/signals/routes/__tests__/chat-event-archive-consumers.test.ts` — five independent processes passed (5/5 runs, 4/4 tests per run)
- The same target command after the initial static checks — 4/4 tests passed
- `DATABASE_URL=postgresql://user@127.0.0.1:55432/postgres pnpm vitest run src/signals/routes/__tests__/cron-retain-chat-events.test.ts` — 5/5 tests passed
- Current head `fc0251741c382dc4fcc65e58f87db1146baf1db8`: PR Turbo `test-api (2)` passed with the explicit foreign-worker regression
- Current-head local DB rerun was unavailable because this workspace has no PostgreSQL service; no local App, API, runner, or development service was started
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` — 13/13 tasks passed, 0 errors
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` — 12/12 tasks passed
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`

## Preview validation

Not applicable. This change is confined to an API test fixture and a PostgreSQL lock-boundary test. The invariant requires a direct test-owned relation lock plus `pg_stat_activity` inspection and has no deployed HTTP, App, or browser surface to exercise on a preview. No production or UI code changes.
