### PR TITLE
feat(platform): name the shared worker okou core service

### DIFF
--- a/turbo/apps/platform/scripts/check-localized-ui.mjs
+++ b/turbo/apps/platform/scripts/check-localized-ui.mjs
@@ -135,6 +135,10 @@ function getInternalAllowedLiterals() {
       "internal run event payload; the rendered cancellation message uses typed i18n",
     ],
     [
+      "src/signals/shared-database-browser.ts\u0000okou core service",
+      "SharedWorker browser identifier, not user-visible UI copy",
+    ],
+    [
       "src/signals/zero-page/tiptap-workflow-composer.ts\u0000paragraph+",
       "Tiptap document schema expression",
     ],

--- a/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SharedDatabasePortLike } from "../../shared-database/bridge.ts";
+import { heartbeatSharedDatabase$ } from "../shared-database.ts";
+import { setupSharedDatabaseBridge$ } from "../shared-database-browser.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+
+class TestSharedWorkerPort implements SharedDatabasePortLike {
+  private listener: ((event: MessageEvent<unknown>) => void) | null = null;
+
+  postMessage(value: unknown): void {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      !("type" in value) ||
+      value.type !== "heartbeat" ||
+      !("requestId" in value) ||
+      typeof value.requestId !== "string"
+    ) {
+      return;
+    }
+    const requestId = value.requestId;
+    queueMicrotask(() => {
+      this.listener?.(
+        new MessageEvent("message", {
+          data: { type: "result", requestId, value: null },
+        }),
+      );
+    });
+  }
+
+  start(): void {}
+
+  close(): void {
+    this.listener = null;
+  }
+
+  addEventListener(
+    _type: "message",
+    listener: (event: MessageEvent<unknown>) => void,
+  ): void {
+    this.listener = listener;
+  }
+
+  removeEventListener(
+    _type: "message",
+    listener: (event: MessageEvent<unknown>) => void,
+  ): void {
+    if (this.listener === listener) {
+      this.listener = null;
+    }
+  }
+}
+
+describe("shared database browser bridge", () => {
+  it("creates the shared worker with the Okou core service identity", async () => {
+    const constructorCalls: {
+      readonly options?: string | WorkerOptions;
+      readonly scriptURL: string | URL;
+    }[] = [];
+
+    class TestSharedWorker {
+      readonly port = new TestSharedWorkerPort();
+
+      constructor(scriptURL: string | URL, options?: string | WorkerOptions) {
+        constructorCalls.push({ scriptURL, options });
+      }
+    }
+
+    vi.stubGlobal("SharedWorker", TestSharedWorker);
+
+    context.store.set(setupSharedDatabaseBridge$, context.signal);
+    await context.store.set(
+      heartbeatSharedDatabase$,
+      {
+        identity: {
+          userId: "shared-worker-user",
+          orgId: "shared-worker-org",
+          token: "shared-worker-token",
+        },
+      },
+      context.signal,
+    );
+
+    expect(constructorCalls).toHaveLength(1);
+    expect(constructorCalls[0]?.options).toStrictEqual({
+      name: "okou core service",
+      type: "module",
+    });
+  });
+});

--- a/turbo/apps/platform/src/signals/shared-database-browser.ts
+++ b/turbo/apps/platform/src/signals/shared-database-browser.ts
@@ -72,7 +72,7 @@ export const setupSharedDatabaseBridge$ = command(
       createBridge: (events) => {
         const worker = new SharedWorker(
           new URL("../shared-database-worker.ts", import.meta.url),
-          { type: "module" },
+          { name: "okou core service", type: "module" },
         );
         return new MessagePortSharedDatabaseBridge(
           worker.port,


### PR DESCRIPTION
## Summary

- name the shared database SharedWorker `okou core service`
- allow the exact internal worker identifier through the localized UI copy check

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- Vitest not run: there is no targeted test file for this constructor-only change; full checks are deferred to PR CI
