### PR TITLE
refactor(cli): move the teams commands to the neutral root

### DIFF
--- a/turbo/apps/cli/src/commands/teams/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/teams/__tests__/download-file.test.ts
@@ -8,7 +8,7 @@ import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import chalk from "chalk";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { downloadFileCommand } from "../download-file";
 
 const DOWNLOAD_URL =

--- a/turbo/apps/cli/src/commands/teams/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/teams/__tests__/send.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import chalk from "chalk";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { sendCommand } from "../message/send";
 
 const TEAMS_MESSAGE_URL =

--- a/turbo/apps/cli/src/commands/teams/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/teams/__tests__/upload-file.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { uploadFileCommand } from "../upload-file";
 
 const UPLOAD_INIT_URL =

--- a/turbo/apps/cli/src/commands/teams/download-file.ts
+++ b/turbo/apps/cli/src/commands/teams/download-file.ts
@@ -1,8 +1,8 @@
 import { basename, join } from "path";
 import { tmpdir } from "os";
 import { Command } from "commander";
-import { downloadTeamsFile } from "../../../lib/api/domains/integrations-teams";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { downloadTeamsFile } from "../../lib/api/domains/integrations-teams";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 function defaultOutPath(fileId: string): string {
   return join(tmpdir(), `teams-${basename(fileId).slice(0, 48)}`);

--- a/turbo/apps/cli/src/commands/teams/index.ts
+++ b/turbo/apps/cli/src/commands/teams/index.ts
@@ -1,14 +1,14 @@
 import { Command } from "commander";
-import { zeroTeamsMessageCommand } from "./message";
+import { teamsMessageCommand } from "./message";
 import { uploadFileCommand } from "./upload-file";
 import { downloadFileCommand } from "./download-file";
 
-export const zeroTeamsCommand = new Command()
+export const teamsCommand = new Command()
   .name("teams")
   .description(
     "Send messages, upload files, and download files from Microsoft Teams as the bot",
   )
-  .addCommand(zeroTeamsMessageCommand)
+  .addCommand(teamsMessageCommand)
   .addCommand(uploadFileCommand)
   .addCommand(downloadFileCommand)
   .addHelpText(

--- a/turbo/apps/cli/src/commands/teams/message/index.ts
+++ b/turbo/apps/cli/src/commands/teams/message/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { sendCommand } from "./send";
 
-export const zeroTeamsMessageCommand = new Command()
+export const teamsMessageCommand = new Command()
   .name("message")
   .description("Manage Microsoft Teams messages")
   .addCommand(sendCommand)

--- a/turbo/apps/cli/src/commands/teams/message/send.ts
+++ b/turbo/apps/cli/src/commands/teams/message/send.ts
@@ -2,8 +2,8 @@ import { readFileSync } from "fs";
 import { Command } from "commander";
 import type { SendTeamsMessageBody } from "@okouai/api-contracts/contracts/integrations";
 import chalk from "chalk";
-import { sendTeamsMessage } from "../../../../lib/api/domains/integrations-teams";
-import { withErrorHandler } from "../../../../lib/command/with-error-handler";
+import { sendTeamsMessage } from "../../../lib/api/domains/integrations-teams";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
 
 type TeamsCardInput = NonNullable<SendTeamsMessageBody["card"]>;
 

--- a/turbo/apps/cli/src/commands/teams/upload-file.ts
+++ b/turbo/apps/cli/src/commands/teams/upload-file.ts
@@ -4,8 +4,8 @@ import { Command } from "commander";
 import {
   completeTeamsFileUpload,
   initTeamsFileUpload,
-} from "../../../lib/api/domains/integrations-teams";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+} from "../../lib/api/domains/integrations-teams";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 const MIME_BY_EXTENSION: Record<string, string> = {
   ".png": "image/png",

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -176,7 +176,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     description:
       "Send Microsoft Teams messages, upload files, and download files",
     load: async () => {
-      return (await import("./commands/zero/teams")).zeroTeamsCommand;
+      return (await import("./commands/teams")).teamsCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all eight Teams command and focused test files from `commands/zero/teams` to `commands/teams`
- rename the internal exports to `teamsCommand` and `teamsMessageCommand`
- update the moved `lib`/`mocks` relative imports and the `okou.ts` lazy import

## Compatibility

- preserve the public `okou teams` command, `message send`, `upload-file`, and `download-file` subcommands, flags, help text, output, and exit behavior
- preserve Teams API adapters, routes, request/response fields, reply/thread handling, file behavior, authentication, and wire identities
- retain `VM0_API_BACKEND_URL` unchanged in all three focused tests
- add no old-path bridge, symbol alias, compatibility copy, or unrelated cleanup

## Contract verification

- canonicalizing the baseline with only the approved path-depth and symbol mappings produces byte-for-byte identical moved files
- the diff contains eight renames and the required `okou.ts` lazy-import edit only; Teams API adapters and package/bin contracts have no diff
- full-repository searches find no active `commands/zero/teams`, `zeroTeamsCommand`, or `zeroTeamsMessageCommand` reference

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- Teams command tests: 3 files, 9 tests passed
- CLI registry tests: 2 files, 90 tests passed
- after rebasing onto #27304: targeted Prettier, CLI lint, CLI type-check, all 5 focused test files, mechanical-equivalence audit, and `git diff --check`

## Merge order

- rebased onto `main` containing the merged #27304 (`62db5c8b6d392f6ad87171bbf7c4681d7a967eb5`)
- if a concurrent `okou.ts` slice lands first, rebase the latest `main` mechanically and repeat the focused verification

Closes #27319
