### PR TITLE
refactor(cli): move the web file commands to the neutral root

### DIFF
--- a/turbo/apps/cli/src/commands/web/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/web/__tests__/download-file.test.ts
@@ -12,7 +12,7 @@ import { mkdirSync, rmSync, readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { downloadFileCommand } from "../download-file";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/web/__tests__/upload-file.test.ts
@@ -19,7 +19,7 @@ import {
   CLIENT_TYPE_HEADER,
   CLIENT_VERSION_HEADER,
 } from "@okouai/api-contracts/contracts/client-headers";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { uploadFileCommand } from "../upload-file";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/web/download-file.ts
+++ b/turbo/apps/cli/src/commands/web/download-file.ts
@@ -1,8 +1,8 @@
 import { basename, join } from "path";
 import { tmpdir } from "os";
 import { Command } from "commander";
-import { downloadWebFile } from "../../../lib/api/domains/web";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { downloadWebFile } from "../../lib/api/domains/web";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 /**
  * Derive a local output path for a web-uploaded file id.

--- a/turbo/apps/cli/src/commands/web/index.ts
+++ b/turbo/apps/cli/src/commands/web/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { downloadFileCommand } from "./download-file";
 import { uploadFileCommand } from "./upload-file";
 
-export const zeroWebCommand = new Command()
+export const webCommand = new Command()
   .name("web")
   .description("Upload and download files via the web chat endpoint")
   .addCommand(downloadFileCommand)

--- a/turbo/apps/cli/src/commands/web/upload-file.ts
+++ b/turbo/apps/cli/src/commands/web/upload-file.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
-import { uploadWebFile } from "../../../lib/api/domains/web";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { uploadWebFile } from "../../lib/api/domains/web";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 export const uploadFileCommand = new Command()
   .name("upload-file")

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -270,7 +270,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "web",
     description: "Upload and download files via the web chat endpoint",
     load: async () => {
-      return (await import("./commands/zero/web")).zeroWebCommand;
+      return (await import("./commands/web")).webCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- Move all five Web command files from `commands/zero/web/` to `commands/web/`.
- Rename the internal command export from `zeroWebCommand` to `webCommand`.
- Update the `okou.ts` lazy import and each moved relative import for the shallower neutral command root.

## Contract verification

- `commands/zero/web/` and `zeroWebCommand` are absent, with no bridge, alias, or compatibility copy.
- `lib/api/domains/web.ts` is unchanged, and its generation, recognition, Slack, and video callers have no diff.
- The public `okou web` command, subcommands, flags, help/output text, streamed file bytes, metadata, HTTP/auth/error behavior, and `/api/okou/web/**` routes are unchanged.
- `VM0_API_BACKEND_URL` and the `payload.vm0unknown` fixture remain unchanged.
- Package/bin, npx invocation, API paths, and Agent prompt files have no diff.
- All moved files retain mode `100644`; the focused diff contains only path moves, relative import depth corrections, the internal export rename, and the matching lazy import entry.

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/cli exec vitest run src/commands/web/__tests__/download-file.test.ts` (4 passed)
- `pnpm --filter @okouai/cli exec vitest run src/commands/web/__tests__/upload-file.test.ts` (15 passed)

## Merge order

PR #27304 merged first. This branch was rebased onto the latest `main` containing #27304, Teams #27326, and Intro #27328 before auto-merge.

Closes #27317

## Final rebase verification

- Rebased onto f478078e4b825c11e2efbe21a61a27a8cdf36aee, which contains registry PR #27304, Teams PR #27326, and Intro PR #27328.
- Post-rebase targeted Prettier check, CLI lint, and CLI type-check passed.
- Post-rebase command registry tests passed (6), Web download tests passed (4), and Web upload tests passed (15).
- The final diff remains 6 files with 8 insertions and 8 deletions; the shared Web adapter and all non-Web domains remain unchanged.