### PR TITLE
refactor(cli): move the intro command to the neutral root

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/intro.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/intro.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { zeroIntroCommand } from "../intro";
+import { introCommand } from "../intro";
 
 describe("okou intro", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
@@ -15,7 +15,7 @@ describe("okou intro", () => {
   });
 
   it("prints the cloud capability guide for agents", async () => {
-    await zeroIntroCommand.parseAsync([], { from: "user" });
+    await introCommand.parseAsync([], { from: "user" });
 
     expect(logSpy).toHaveBeenCalledOnce();
     const output = logSpy.mock.calls[0]?.[0] as string;

--- a/turbo/apps/cli/src/commands/intro.ts
+++ b/turbo/apps/cli/src/commands/intro.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 
-const ZERO_INTRO = `
+const INTRO = `
 # Okou Intro
 
 Okou is an AI agent that works from cloud computers to complete real work: deep research, polished artifacts, lightweight coding, connector-backed automation, and 24/7 recurring workflows.
@@ -78,9 +78,9 @@ When a user asks what Okou can do:
 - Give 2-4 starter tasks the user can choose from.
 `.trim();
 
-export const zeroIntroCommand = new Command()
+export const introCommand = new Command()
   .name("intro")
   .description("Print Okou's self-introduction and capability guide for agents")
   .action(() => {
-    console.log(ZERO_INTRO);
+    console.log(INTRO);
   });

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -226,7 +226,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "intro",
     description: "Print Okou's self-introduction and capability guide",
     load: async () => {
-      return (await import("./commands/zero/intro")).zeroIntroCommand;
+      return (await import("./commands/intro")).introCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- Move the intro command module and its focused test from `commands/zero` to the neutral command root.
- Rename `ZERO_INTRO` to `INTRO` and `zeroIntroCommand` to `introCommand` with no compatibility alias.
- Update the `okou.ts` lazy import to load `./commands/intro` and read `introCommand`.
- Preserve the complete intro content, Commander contract, stdout, command visibility, and public CLI behavior.

## Contract verification

- The branch is rebased directly onto registry PR #27304 through `main@62db5c8b6d392f6ad87171bbf7c4681d7a967eb5`.
- Normalizing only the mapped path and symbols makes the source module, focused test, and registry entry byte-for-byte identical to that rebased `main`.
- The rendered intro payload remains 3,622 bytes across 75 lines with SHA-256 `fcb03f2c25e62b60b624b6f250aca4b0068c428554c2dc9f6a36700e0855b40a`.
- The Commander name, description, action, `console.log` behavior, registry description, capability visibility, and command order are unchanged.
- Package/bin identity, npx invocation, token/protocol identity, Agent prompts, API behavior, and unrelated command domains have no diff.

## Validation

Full pre-commit validation:

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- Focused intro and registry tests: 1 + 6 + 84 passed

Post-rebase validation:

- Pinned Prettier check for all three changed files
- `pnpm --filter @okouai/cli run lint`
- `pnpm --filter @okouai/cli run check-types`
- `pnpm --filter @okouai/cli exec vitest run src/commands/__tests__/intro.test.ts` (1 passed)
- `pnpm --filter @okouai/cli exec vitest run src/__tests__/okou.test.ts` (6 passed)
- `pnpm --filter @okouai/cli exec vitest run src/__tests__/command-capability-visibility.test.ts` (84 passed)

## Merge order

- Registry PR #27304 merged first and this branch has been rebased onto its merge commit.
- PRs #27326 and #27327 also touch `okou.ts`; rebase the latest `main` again if either lands first.

Closes #27318
