### PR TITLE
fix(billing): refine subscription comparison layout

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -972,6 +972,8 @@
         "currentMember": "Aktuelles Mitglied",
         "management": {
           "comparison": "Vergleich des aktuellen und neuen Abonnements",
+          "comparisonDescription": "Ihr aktuelles Abonnement und diese Auswahl im direkten Vergleich",
+          "comparisonTitle": "Abonnementvergleich",
           "current": "Aktuell",
           "downgradeDescription": "Das kleinere Paket beginnt am nächsten Abrechnungstag. Vorhandene Credits bleiben bis zu ihrem Ablauf verfügbar.",
           "downgradesToDate": "Downgrade auf {{package}} am {{date}}.",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -972,6 +972,8 @@
         "currentMember": "Current member",
         "management": {
           "comparison": "Current and new subscription comparison",
+          "comparisonDescription": "Your current subscription and this selection, side by side",
+          "comparisonTitle": "Subscription comparison",
           "current": "Current",
           "downgradeDescription": "The lower package starts at the next billing date. Existing credits remain available until they expire.",
           "downgradesToDate": "Downgrades to {{package}} on {{date}}.",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -993,6 +993,8 @@
         "currentMember": "Miembro actual",
         "management": {
           "comparison": "Comparación de la suscripción actual y la nueva",
+          "comparisonDescription": "Tu suscripción actual y esta selección, una al lado de la otra",
+          "comparisonTitle": "Comparación de suscripciones",
           "current": "Actual",
           "downgradeDescription": "El paquete inferior comienza en la próxima fecha de facturación. Los créditos existentes seguirán disponibles hasta que caduquen.",
           "downgradesToDate": "Baja a {{package}} el {{date}}.",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -993,6 +993,8 @@
         "currentMember": "Membre actuel",
         "management": {
           "comparison": "Comparaison de l’abonnement actuel et du nouveau",
+          "comparisonDescription": "Votre abonnement actuel et cette sélection, côte à côte",
+          "comparisonTitle": "Comparaison des abonnements",
           "current": "Actuel",
           "downgradeDescription": "Le forfait inférieur commence à la prochaine date de facturation. Les crédits existants restent disponibles jusqu’à leur expiration.",
           "downgradesToDate": "Passe à {{package}} le {{date}}.",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -972,6 +972,8 @@
         "currentMember": "मौजूदा सदस्य",
         "management": {
           "comparison": "वर्तमान और नई सदस्यता की तुलना",
+          "comparisonDescription": "आपका मौजूदा सब्सक्रिप्शन और यह चयन, साथ-साथ",
+          "comparisonTitle": "सब्सक्रिप्शन की तुलना",
           "current": "वर्तमान",
           "downgradeDescription": "कम पैकेज अगली बिलिंग तारीख से शुरू होगा। मौजूदा क्रेडिट अपनी समाप्ति तक उपलब्ध रहेंगे।",
           "downgradesToDate": "{{date}} को {{package}} पर डाउनग्रेड होगा।",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -972,6 +972,8 @@
         "currentMember": "Anggota saat ini",
         "management": {
           "comparison": "Perbandingan langganan saat ini dan baru",
+          "comparisonDescription": "Langganan Anda saat ini dan pilihan ini, ditampilkan berdampingan",
+          "comparisonTitle": "Perbandingan langganan",
           "current": "Saat ini",
           "downgradeDescription": "Paket yang lebih rendah dimulai pada tanggal penagihan berikutnya. Kredit yang ada tetap tersedia hingga kedaluwarsa.",
           "downgradesToDate": "Turun ke {{package}} pada {{date}}.",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -993,6 +993,8 @@
         "currentMember": "Membro attuale",
         "management": {
           "comparison": "Confronto tra abbonamento attuale e nuovo",
+          "comparisonDescription": "Il tuo abbonamento attuale e questa selezione, affiancati",
+          "comparisonTitle": "Confronto degli abbonamenti",
           "current": "Attuale",
           "downgradeDescription": "Il pacchetto inferiore inizia alla prossima data di fatturazione. I crediti esistenti restano disponibili fino alla scadenza.",
           "downgradesToDate": "Passa a {{package}} il {{date}}.",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -972,6 +972,8 @@
         "currentMember": "現在のメンバー",
         "management": {
           "comparison": "現在と新しいサブスクリプションの比較",
+          "comparisonDescription": "現在のサブスクリプションと今回の選択を並べて比較",
+          "comparisonTitle": "サブスクリプションの比較",
           "current": "現在",
           "downgradeDescription": "下位パッケージは次回請求日から開始します。既存のクレジットは有効期限まで利用できます。",
           "downgradesToDate": "{{date}}に{{package}}へダウングレードします。",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -972,6 +972,8 @@
         "currentMember": "현재 구성원",
         "management": {
           "comparison": "현재 및 새 구독 비교",
+          "comparisonDescription": "현재 구독과 이번 선택을 나란히 비교",
+          "comparisonTitle": "구독 비교",
           "current": "현재",
           "downgradeDescription": "하위 패키지는 다음 결제일부터 시작됩니다. 기존 크레딧은 만료될 때까지 사용할 수 있습니다.",
           "downgradesToDate": "{{date}}에 {{package}}(으)로 다운그레이드됩니다.",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -993,6 +993,8 @@
         "currentMember": "Membro atual",
         "management": {
           "comparison": "Comparação entre a assinatura atual e a nova",
+          "comparisonDescription": "Sua assinatura atual e esta seleção, lado a lado",
+          "comparisonTitle": "Comparação de assinaturas",
           "current": "Atual",
           "downgradeDescription": "O pacote menor começa na próxima data de cobrança. Os créditos existentes permanecem disponíveis até expirarem.",
           "downgradesToDate": "Muda para {{package}} em {{date}}.",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -2329,7 +2329,6 @@ describe("organization billing settings", () => {
         name: /Monthly total \$20\/month \$180\/month/u,
       }),
     ).toBeInTheDocument();
-    expect(within(orderSummary).getByText("$180/month")).toBeInTheDocument();
     const confirmButton = buttonByText("Confirm", orderSummary);
 
     click(packageSelect);
@@ -2343,7 +2342,6 @@ describe("organization billing settings", () => {
         name: /Monthly total \$20\/month \$210\/month/u,
       }),
     ).toBeInTheDocument();
-    expect(within(orderSummary).getByText("$210/month")).toBeInTheDocument();
     expect(confirmButton).not.toBeDisabled();
 
     click(packageSelect);
@@ -2352,7 +2350,11 @@ describe("organization billing settings", () => {
         name: "$20 · 21,234 credits · 6% off",
       }),
     );
-    expect(within(orderSummary).getByText("$180/month")).toBeInTheDocument();
+    expect(
+      within(comparison).getByRole("row", {
+        name: /Monthly total \$20\/month \$180\/month/u,
+      }),
+    ).toBeInTheDocument();
 
     const locationBeforeConfirmation = window.location.href;
     click(confirmButton);
@@ -2462,7 +2464,14 @@ describe("organization billing settings", () => {
     const orderSummary = screen.getByRole("region", {
       name: "Order summary",
     });
-    expect(within(orderSummary).getByText("$20/month")).toBeInTheDocument();
+    const comparison = within(orderSummary).getByRole("table", {
+      name: "Current and new subscription comparison",
+    });
+    expect(
+      within(comparison).getByRole("row", {
+        name: /Monthly total \$180\/month \$20\/month/u,
+      }),
+    ).toBeInTheDocument();
     expect(
       within(orderSummary).getByText(
         "The lower package starts at the next billing date. Existing credits remain available until they expire.",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -18,6 +18,7 @@ import {
 } from "@okouai/api-contracts/contracts/zero-billing";
 import { FeatureSwitchKey } from "@okouai/core";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import { describe, expect, it, vi, type Mock } from "vitest";
 
@@ -50,6 +51,15 @@ function buttonByText(
     throw new Error(`${text} button not found`);
   }
   return button;
+}
+
+async function hoverSubscriptionComparison(): Promise<HTMLElement> {
+  const user = userEvent.setup();
+  await user.hover(screen.getByTestId("subscription-comparison-trigger"));
+  const title = await screen.findByText("Subscription comparison");
+  const tooltip = title.closest<HTMLElement>('[data-slot="tooltip-content"]');
+  expect(tooltip).not.toBeNull();
+  return tooltip as HTMLElement;
 }
 
 function activeProBillingStatus(): BillingStatusResponse {
@@ -522,7 +532,7 @@ describe("organization billing settings", () => {
       ),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(
+      within(memberUsage).getByText(
         "One package per member. Any overage uses pay-as-you-go credits.",
       ),
     ).toBeInTheDocument();
@@ -1608,11 +1618,14 @@ describe("organization billing settings", () => {
     const packageSelect = await screen.findByRole("combobox", {
       name: "Usage for Alex Chen",
     });
+    const memberUsage = screen.getByRole("group", {
+      name: "Member usage",
+    });
     const orderSummary = screen.getByRole("region", {
       name: "Order summary",
     });
     expect(
-      within(orderSummary).queryByRole("table", {
+      screen.queryByRole("table", {
         name: "Current and new subscription comparison",
       }),
     ).not.toBeInTheDocument();
@@ -1628,20 +1641,21 @@ describe("organization billing settings", () => {
         name: "$50 · 54,321 credits · 8% off",
       }),
     );
-    // The comparison folds away behind its own totals until it is asked for.
-    const comparisonSummary = within(orderSummary)
-      .getByText("Current and new subscription comparison")
-      .closest("summary");
-    const comparisonDisclosure = comparisonSummary?.closest("details");
-    expect(comparisonDisclosure).not.toHaveAttribute("open");
-    expect(comparisonSummary).toHaveTextContent("$20/month");
-    expect(comparisonSummary).toHaveTextContent("$50/month");
-    expect(comparisonSummary).not.toHaveTextContent("→");
-    click(
-      within(orderSummary).getByText("Current and new subscription comparison"),
+    const comparisonTrigger = within(memberUsage).getByTestId(
+      "subscription-comparison-trigger",
     );
-    expect(comparisonDisclosure).toHaveAttribute("open");
-    const comparison = within(orderSummary).getByRole("table", {
+    expect(comparisonTrigger).toHaveTextContent("$50/month");
+    expect(comparisonTrigger).toHaveClass("decoration-dotted");
+    const comparisonTooltip = await hoverSubscriptionComparison();
+    expect(
+      within(comparisonTooltip).getByText("Subscription comparison"),
+    ).toBeInTheDocument();
+    expect(
+      within(comparisonTooltip).getByText(
+        "Your current subscription and this selection, side by side",
+      ),
+    ).toBeInTheDocument();
+    const comparison = within(comparisonTooltip).getByRole("table", {
       name: "Current and new subscription comparison",
     });
     expect(within(comparison).getByText("Current")).toBeInTheDocument();
@@ -2029,7 +2043,7 @@ describe("organization billing settings", () => {
     });
     expect(screen.queryByText("Change is processing")).not.toBeInTheDocument();
     expect(
-      within(orderSummary).queryByRole("table", {
+      screen.queryByRole("table", {
         name: "Current and new subscription comparison",
       }),
     ).not.toBeInTheDocument();
@@ -2047,7 +2061,8 @@ describe("organization billing settings", () => {
         name: "$100 · 109,999 credits · 9% off",
       }),
     );
-    const comparison = within(orderSummary).getByRole("table", {
+    const comparisonTooltip = await hoverSubscriptionComparison();
+    const comparison = within(comparisonTooltip).getByRole("table", {
       name: "Current and new subscription comparison",
     });
     expect(
@@ -2311,9 +2326,12 @@ describe("organization billing settings", () => {
     const orderSummary = screen.getByRole("region", {
       name: "Order summary",
     });
-    const comparison = within(orderSummary).getByRole("table", {
-      name: "Current and new subscription comparison",
-    });
+    let comparison = within(await hoverSubscriptionComparison()).getByRole(
+      "table",
+      {
+        name: "Current and new subscription comparison",
+      },
+    );
     expect(
       within(comparison).getByRole("row", {
         name: /Plan Pro · \$0 Team · \$160/u,
@@ -2337,6 +2355,12 @@ describe("organization billing settings", () => {
         name: "$50 · 54,321 credits · 8% off",
       }),
     );
+    comparison = within(await hoverSubscriptionComparison()).getByRole(
+      "table",
+      {
+        name: "Current and new subscription comparison",
+      },
+    );
     expect(
       within(comparison).getByRole("row", {
         name: /Monthly total \$20\/month \$210\/month/u,
@@ -2349,6 +2373,12 @@ describe("organization billing settings", () => {
       await screen.findByRole("option", {
         name: "$20 · 21,234 credits · 6% off",
       }),
+    );
+    comparison = within(await hoverSubscriptionComparison()).getByRole(
+      "table",
+      {
+        name: "Current and new subscription comparison",
+      },
     );
     expect(
       within(comparison).getByRole("row", {
@@ -2464,9 +2494,12 @@ describe("organization billing settings", () => {
     const orderSummary = screen.getByRole("region", {
       name: "Order summary",
     });
-    const comparison = within(orderSummary).getByRole("table", {
-      name: "Current and new subscription comparison",
-    });
+    const comparison = within(await hoverSubscriptionComparison()).getByRole(
+      "table",
+      {
+        name: "Current and new subscription comparison",
+      },
+    );
     expect(
       within(comparison).getByRole("row", {
         name: /Monthly total \$180\/month \$20\/month/u,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -53,13 +53,24 @@ function buttonByText(
   return button;
 }
 
+function subscriptionComparisonTrigger(
+  container: ParentNode = document.body,
+): HTMLElement {
+  const trigger = queryAllByRoleFast("button", container).find((candidate) => {
+    return candidate
+      .getAttribute("aria-label")
+      ?.startsWith("Subscription comparison:");
+  });
+  if (!trigger) {
+    throw new Error("Subscription comparison trigger not found");
+  }
+  return trigger;
+}
+
 async function hoverSubscriptionComparison(): Promise<HTMLElement> {
   const user = userEvent.setup();
-  await user.hover(screen.getByTestId("subscription-comparison-trigger"));
-  const title = await screen.findByText("Subscription comparison");
-  const tooltip = title.closest<HTMLElement>('[data-slot="tooltip-content"]');
-  expect(tooltip).not.toBeNull();
-  return tooltip as HTMLElement;
+  await user.hover(subscriptionComparisonTrigger());
+  return await screen.findByRole("tooltip");
 }
 
 function activeProBillingStatus(): BillingStatusResponse {
@@ -1635,18 +1646,21 @@ describe("organization billing settings", () => {
       within(orderSummary).queryByText("Concurrent slots"),
     ).not.toBeInTheDocument();
     expect(queryAllByRoleFast("button", orderSummary)).toHaveLength(0);
-    click(packageSelect);
-    click(
+    const user = userEvent.setup();
+    await user.click(packageSelect);
+    await user.click(
       await screen.findByRole("option", {
         name: "$50 · 54,321 credits · 8% off",
       }),
     );
-    const comparisonTrigger = within(memberUsage).getByTestId(
-      "subscription-comparison-trigger",
+    const comparisonTrigger = subscriptionComparisonTrigger(memberUsage);
+    expect(comparisonTrigger).toHaveAccessibleName(
+      "Subscription comparison: $50/month",
     );
     expect(comparisonTrigger).toHaveTextContent("$50/month");
-    expect(comparisonTrigger).toHaveClass("decoration-dotted");
-    const comparisonTooltip = await hoverSubscriptionComparison();
+    comparisonTrigger.focus();
+    expect(comparisonTrigger).toHaveFocus();
+    const comparisonTooltip = await screen.findByRole("tooltip");
     expect(
       within(comparisonTooltip).getByText("Subscription comparison"),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1629,11 +1629,14 @@ describe("organization billing settings", () => {
       }),
     );
     // The comparison folds away behind its own totals until it is asked for.
-    const comparisonDisclosure = within(orderSummary)
+    const comparisonSummary = within(orderSummary)
       .getByText("Current and new subscription comparison")
-      .closest("details");
+      .closest("summary");
+    const comparisonDisclosure = comparisonSummary?.closest("details");
     expect(comparisonDisclosure).not.toHaveAttribute("open");
-    expect(comparisonDisclosure).toHaveTextContent("$20/month → $50/month");
+    expect(comparisonSummary).toHaveTextContent("$20/month");
+    expect(comparisonSummary).toHaveTextContent("$50/month");
+    expect(comparisonSummary).not.toHaveTextContent("→");
     click(
       within(orderSummary).getByText("Current and new subscription comparison"),
     );
@@ -1663,7 +1666,6 @@ describe("organization billing settings", () => {
         name: /Monthly total \$20\/month \$50\/month/u,
       }),
     ).toBeInTheDocument();
-    expect(within(orderSummary).getByText("$50/month")).toBeInTheDocument();
     expect(screen.queryByText("Review")).not.toBeInTheDocument();
     const locationBeforeConfirmation = window.location.href;
     click(buttonByText("Confirm", orderSummary));

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1639,32 +1639,34 @@ function ManagedSubscriptionComparison({
      -- there it is the whole point of the page. */
   return (
     <details className="group">
-      <summary className="grid cursor-pointer list-none grid-cols-[1.25rem_minmax(0,1fr)_30%_30%] items-center gap-x-2 py-3">
-        <span className="flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
-          <ChevronRight
-            size={14}
-            className="transition-transform group-open:rotate-90"
-          />
-        </span>
-        <span className="min-w-0 truncate text-[13px] font-medium leading-5 text-foreground">
-          {i18n.t(($) => {
-            return $.billing.plans.usagePacks.management.comparison;
-          })}
+      <summary className="grid cursor-pointer list-none grid-cols-[40%_30%_30%] items-center py-3">
+        <span className="grid min-w-0 grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-x-2">
+          <span className="flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
+            <ChevronRight
+              size={14}
+              className="transition-transform group-open:rotate-90"
+            />
+          </span>
+          <span className="min-w-0 truncate text-[13px] font-medium leading-5 text-foreground">
+            {i18n.t(($) => {
+              return $.billing.plans.usagePacks.management.comparison;
+            })}
+          </span>
         </span>
         {monthlyTotal && (
           <>
-            <span className="col-start-3 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
+            <span className="col-start-2 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
               {monthlyTotal.current}
             </span>
-            <span className="col-start-4 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
+            <span className="col-start-3 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
               {monthlyTotal.next}
             </span>
-            <span className="col-start-3 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
+            <span className="col-start-2 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
               {i18n.t(($) => {
                 return $.billing.plans.usagePacks.management.current;
               })}
             </span>
-            <span className="col-start-4 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
+            <span className="col-start-3 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
               {i18n.t(($) => {
                 return $.billing.plans.usagePacks.management.new;
               })}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1697,7 +1697,7 @@ function SubscriptionComparisonTable({
         <thead
           className={
             tooltip
-              ? "text-xs font-normal text-muted-foreground"
+              ? "text-[13px] font-normal leading-5 text-muted-foreground"
               : "bg-muted/40 text-sm font-medium uppercase tracking-wide text-muted-foreground"
           }
         >

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1639,34 +1639,29 @@ function ManagedSubscriptionComparison({
      -- there it is the whole point of the page. */
   return (
     <details className="group">
-      <summary className="grid cursor-pointer list-none grid-cols-[40%_30%_30%] items-center py-3">
-        <span className="grid min-w-0 grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-x-2">
-          <span className="flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
-            <ChevronRight
-              size={14}
-              className="transition-transform group-open:rotate-90"
-            />
-          </span>
-          <span className="min-w-0 truncate text-[13px] font-medium leading-5 text-foreground">
-            {i18n.t(($) => {
-              return $.billing.plans.usagePacks.management.comparison;
-            })}
-          </span>
+      <summary className="grid cursor-pointer list-none grid-cols-[2.5rem_minmax(0,1fr)_30%_30%] items-center py-3">
+        <span className="!flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
+          <ChevronRight size={14} />
+        </span>
+        <span className="-ml-3 min-w-0 truncate text-[13px] font-medium leading-5 text-foreground">
+          {i18n.t(($) => {
+            return $.billing.plans.usagePacks.management.comparison;
+          })}
         </span>
         {monthlyTotal && (
           <>
-            <span className="col-start-2 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
+            <span className="col-start-3 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
               {monthlyTotal.current}
             </span>
-            <span className="col-start-3 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
+            <span className="col-start-4 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
               {monthlyTotal.next}
             </span>
-            <span className="col-start-2 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
+            <span className="col-start-3 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
               {i18n.t(($) => {
                 return $.billing.plans.usagePacks.management.current;
               })}
             </span>
-            <span className="col-start-3 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
+            <span className="col-start-4 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
               {i18n.t(($) => {
                 return $.billing.plans.usagePacks.management.new;
               })}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, CalendarDays, ChevronRight, Info, X } from "lucide-react";
+import { ArrowLeft, CalendarDays, X } from "lucide-react";
 import {
   Button,
   Dialog,
@@ -438,8 +438,8 @@ function usagePackCreditsLabel(item: UsagePackCatalogItem): string {
 function LedgerPlanRow({ plan }: { readonly plan: UsagePackPlan }) {
   return (
     <div className={LEDGER_ROW}>
-      <div className="flex min-w-0 items-center gap-3">
-        <span className="flex h-8 w-8 shrink-0 items-center justify-center">
+      <div className="col-span-2 flex min-w-0 items-center gap-3">
+        <span className="flex size-10 shrink-0 items-center justify-center">
           <img
             src={plan.image}
             alt=""
@@ -447,16 +447,22 @@ function LedgerPlanRow({ plan }: { readonly plan: UsagePackPlan }) {
             className="h-10 w-10 max-w-none object-contain"
           />
         </span>
-        <span className="min-w-0 truncate text-sm font-medium text-foreground">
-          {i18n.t(
-            ($) => {
-              return $.billing.plans.namedPlan;
-            },
-            { plan: planName(plan.tier) },
-          )}
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-medium leading-5 text-foreground">
+            {i18n.t(
+              ($) => {
+                return $.billing.plans.namedPlan;
+              },
+              { plan: planName(plan.tier) },
+            )}
+          </span>
+          <span className="block truncate text-[13px] leading-5 text-muted-foreground">
+            {i18n.t(($) => {
+              return $.billing.plans.usagePacks.memberExclusive;
+            })}
+          </span>
         </span>
       </div>
-      <div />
       <LedgerPrice value={plan.basePriceUsd} />
     </div>
   );
@@ -464,10 +470,12 @@ function LedgerPlanRow({ plan }: { readonly plan: UsagePackPlan }) {
 
 function LedgerTotalRow({
   bonusCredits,
+  comparisonRows,
   credits,
   totalUsd,
 }: {
   readonly bonusCredits: number;
+  readonly comparisonRows?: readonly SubscriptionComparisonRow[];
   readonly credits: number;
   readonly totalUsd: number;
 }) {
@@ -478,7 +486,7 @@ function LedgerTotalRow({
           return $.billing.plans.usagePacks.monthlyTotal;
         })}
       </span>
-      <span className="truncate px-3 text-sm text-muted-foreground">
+      <span className="truncate px-3 text-sm text-foreground">
         {bonusCredits > 0
           ? i18n.t(
               ($) => {
@@ -496,7 +504,14 @@ function LedgerTotalRow({
               { credits: formatLocalizedNumber(credits) },
             )}
       </span>
-      <LedgerPrice strong value={totalUsd} />
+      {comparisonRows ? (
+        <ManagedSubscriptionComparisonTooltip
+          rows={comparisonRows}
+          totalUsd={totalUsd}
+        />
+      ) : (
+        <LedgerPrice strong value={totalUsd} />
+      )}
     </div>
   );
 }
@@ -587,24 +602,6 @@ function MemberUsageRow({
   );
 }
 
-function MemberUsageFooter() {
-  return (
-    <div className="flex items-start gap-2 text-sm leading-relaxed text-muted-foreground">
-      <span
-        aria-hidden="true"
-        className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-gray-50 text-xs font-medium"
-      >
-        <Info className="size-3.5" />
-      </span>
-      <p>
-        {i18n.t(($) => {
-          return $.billing.plans.usagePacks.memberExclusive;
-        })}
-      </p>
-    </div>
-  );
-}
-
 function pendingMemberUsagePack(
   management: UsagePackManagementResponse | null,
   member: MemberDisplay,
@@ -617,6 +614,7 @@ function pendingMemberUsagePack(
 
 function MemberUsageConfiguration({
   catalog,
+  comparisonRows,
   management,
   members,
   onSelectionChange,
@@ -625,6 +623,7 @@ function MemberUsageConfiguration({
   totals,
 }: {
   readonly catalog: readonly UsagePackCatalogItem[];
+  readonly comparisonRows?: readonly SubscriptionComparisonRow[];
   readonly management: UsagePackManagementResponse | null;
   readonly members: readonly MemberDisplay[] | undefined;
   readonly onSelectionChange?: () => void;
@@ -702,6 +701,7 @@ function MemberUsageConfiguration({
 
       <LedgerTotalRow
         bonusCredits={totals.bonusCredits}
+        comparisonRows={comparisonRows}
         credits={totals.totalCredits}
         totalUsd={plan.basePriceUsd + totals.totalUsd}
       />
@@ -1612,65 +1612,52 @@ function managedSubscriptionComparisonRows({
   ];
 }
 
-function ManagedSubscriptionComparison({
-  currentTotals,
-  management,
-  plan,
-  totals,
+function ManagedSubscriptionComparisonTooltip({
+  rows,
+  totalUsd,
 }: {
-  readonly currentTotals: MemberUsageTotals;
-  readonly management: UsagePackManagementResponse;
-  readonly plan: UsagePackPlan;
-  readonly totals: MemberUsageTotals;
+  readonly rows: readonly SubscriptionComparisonRow[];
+  readonly totalUsd: number;
 }) {
-  const currentPlan = usagePackPlan(management.tier);
-  const rows = managedSubscriptionComparisonRows({
-    currentPlan,
-    currentTotals,
-    plan,
-    totals,
-  });
-  const monthlyTotal = rows.at(-1);
-
-  /* The ledger above this already states what the workspace will pay, so the
-     row-by-row comparison opens on demand. The disclosure and copy follow the
-     same icon and text rails as the note above, while the values keep their
-     shared right edges. The migration screens keep their comparison contained
-     -- there it is the whole point of the page. */
   return (
-    <details className="group">
-      <summary className="grid cursor-pointer list-none grid-cols-[2.5rem_minmax(0,1fr)_30%_30%] items-center py-3">
-        <span className="!flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
-          <ChevronRight size={14} />
-        </span>
-        <span className="-ml-3 min-w-0 truncate text-[13px] font-medium leading-5 text-foreground">
-          {i18n.t(($) => {
-            return $.billing.plans.usagePacks.management.comparison;
-          })}
-        </span>
-        {monthlyTotal && (
-          <>
-            <span className="col-start-3 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
-              {monthlyTotal.current}
-            </span>
-            <span className="col-start-4 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
-              {monthlyTotal.next}
-            </span>
-            <span className="col-start-3 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
-              {i18n.t(($) => {
-                return $.billing.plans.usagePacks.management.current;
-              })}
-            </span>
-            <span className="col-start-4 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
-              {i18n.t(($) => {
-                return $.billing.plans.usagePacks.management.new;
-              })}
-            </span>
-          </>
-        )}
-      </summary>
-      <SubscriptionComparisonTable presentation="flat" rows={rows} />
-    </details>
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="justify-self-end cursor-help underline decoration-dotted decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:decoration-foreground"
+            data-testid="subscription-comparison-trigger"
+          >
+            <LedgerPrice strong value={totalUsd} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent
+          align="end"
+          collisionPadding={16}
+          side="bottom"
+          sideOffset={8}
+          className="w-[27.5rem] max-w-[calc(100vw-2rem)] rounded-[12px] border-[0.7px] border-[hsl(var(--gray-400))] p-4 text-left font-normal"
+          style={{
+            backgroundColor: "hsl(var(--popover))",
+            color: "hsl(var(--popover-foreground))",
+            boxShadow:
+              "0 2px 12px hsl(220 12% 50% / 0.04), 0 0 0 0.5px hsl(220 12% 50% / 0.02)",
+          }}
+        >
+          <p className="text-sm font-medium text-foreground">
+            {i18n.t(($) => {
+              return $.billing.plans.usagePacks.management.comparisonTitle;
+            })}
+          </p>
+          <p className="mt-0.5 text-[13px] leading-5 text-muted-foreground">
+            {i18n.t(($) => {
+              return $.billing.plans.usagePacks.management
+                .comparisonDescription;
+            })}
+          </p>
+          <SubscriptionComparisonTable presentation="tooltip" rows={rows} />
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 
@@ -1678,15 +1665,15 @@ function SubscriptionComparisonTable({
   presentation = "contained",
   rows,
 }: {
-  readonly presentation?: "contained" | "flat";
+  readonly presentation?: "contained" | "tooltip";
   readonly rows: readonly SubscriptionComparisonRow[];
 }) {
-  const flat = presentation === "flat";
+  const tooltip = presentation === "tooltip";
   return (
     <div
       className={
-        flat
-          ? "pb-2"
+        tooltip
+          ? "mt-3"
           : "mt-4 overflow-hidden rounded-lg border border-border/70"
       }
     >
@@ -1695,33 +1682,37 @@ function SubscriptionComparisonTable({
           return $.billing.plans.usagePacks.management.comparison;
         })}
         className={
-          flat ? "w-full table-fixed text-[13px]" : "w-full table-fixed text-sm"
+          tooltip
+            ? "w-full table-fixed text-[13px]"
+            : "w-full table-fixed text-sm"
         }
       >
-        {flat && (
+        {tooltip && (
           <colgroup>
-            <col className="w-10" />
-            <col />
-            <col className="w-[30%]" />
-            <col className="w-[30%]" />
+            <col className="w-[48%]" />
+            <col className="w-[26%]" />
+            <col className="w-[26%]" />
           </colgroup>
         )}
         <thead
           className={
-            flat
-              ? "sr-only"
+            tooltip
+              ? "text-xs font-normal text-muted-foreground"
               : "bg-muted/40 text-sm font-medium uppercase tracking-wide text-muted-foreground"
           }
         >
           <tr>
-            {flat && <th scope="col" />}
             <th
               scope="col"
-              className={flat ? "text-left" : "w-[40%] px-3 py-2 text-left"}
+              className={
+                tooltip ? "pb-1 text-left" : "w-[40%] px-3 py-2 text-left"
+              }
             />
             <th
               scope="col"
-              className={flat ? "text-right" : "w-[30%] px-3 py-2 text-right"}
+              className={
+                tooltip ? "pb-1 text-right" : "w-[30%] px-3 py-2 text-right"
+              }
             >
               {i18n.t(($) => {
                 return $.billing.plans.usagePacks.management.current;
@@ -1729,7 +1720,9 @@ function SubscriptionComparisonTable({
             </th>
             <th
               scope="col"
-              className={flat ? "text-right" : "w-[30%] px-3 py-2 text-right"}
+              className={
+                tooltip ? "pb-1 text-right" : "w-[30%] px-3 py-2 text-right"
+              }
             >
               {i18n.t(($) => {
                 return $.billing.plans.usagePacks.management.new;
@@ -1744,17 +1737,16 @@ function SubscriptionComparisonTable({
               <tr
                 key={row.label}
                 className={
-                  flat
+                  tooltip
                     ? ""
                     : `border-t border-border/60 ${monthlyTotal ? "bg-muted/20" : ""}`
                 }
               >
-                {flat && <td aria-hidden="true" />}
                 <th
                   scope="row"
                   className={
-                    flat
-                      ? `${monthlyTotal ? "pb-1.5 pt-3 font-medium text-foreground" : "py-1.5 font-normal text-muted-foreground"} text-left`
+                    tooltip
+                      ? `${monthlyTotal ? "rounded-l-md bg-gray-50 py-2 font-medium text-foreground" : "py-1.5 font-normal text-muted-foreground"} text-left`
                       : `px-3 py-2.5 text-left ${monthlyTotal ? "font-medium text-foreground" : "font-normal text-muted-foreground"}`
                   }
                 >
@@ -1762,19 +1754,19 @@ function SubscriptionComparisonTable({
                 </th>
                 <td
                   className={
-                    flat
-                      ? `${monthlyTotal ? "pb-1.5 pt-3 font-medium" : "py-1.5"} text-right tabular-nums text-muted-foreground`
+                    tooltip
+                      ? `${monthlyTotal ? "bg-gray-50 py-2 font-medium text-foreground" : "py-1.5 text-muted-foreground"} text-right tabular-nums`
                       : `px-3 py-2.5 text-right text-muted-foreground ${monthlyTotal ? "font-medium" : ""}`
                   }
                 >
                   {row.current}
                 </td>
                 {/* Contained comparisons use weight to mark a changed value.
-                    The flat management disclosure keeps both columns quiet. */}
+                    The tooltip keeps both columns quiet and equivalent. */}
                 <td
                   className={
-                    flat
-                      ? `${monthlyTotal ? "pb-1.5 pt-3 font-medium" : "py-1.5"} text-right tabular-nums text-muted-foreground`
+                    tooltip
+                      ? `${monthlyTotal ? "rounded-r-md bg-gray-50 py-2 font-medium text-foreground" : "py-1.5 text-muted-foreground"} text-right tabular-nums`
                       : `px-3 py-2.5 text-right text-foreground ${monthlyTotal || row.changed ? "font-semibold" : "font-medium"}`
                   }
                 >
@@ -2061,12 +2053,10 @@ function PackageReviewStep({
 }
 
 interface ManagedSubscriptionOrderSummaryProps {
-  readonly currentTotals: MemberUsageTotals;
   readonly management: UsagePackManagementResponse;
   readonly members: readonly MemberDisplay[] | undefined;
   readonly plan: UsagePackPlan;
   readonly selections: Readonly<Record<string, MemberUsageSelection>>;
-  readonly totals: MemberUsageTotals;
 }
 
 function managementMembersMatch(
@@ -2266,12 +2256,10 @@ function managedSubscriptionChangeState({
 }
 
 function ManagedSubscriptionOrderSummary({
-  currentTotals,
   management,
   members,
   plan,
   selections,
-  totals,
 }: ManagedSubscriptionOrderSummaryProps) {
   const pageSignal = useGet(pageSignal$);
   const [previewLoadable, previewChange] = useLoadableSet(
@@ -2316,16 +2304,6 @@ function ManagedSubscriptionOrderSummary({
         return $.billing.plans.usagePacks.orderSummary;
       })}
     >
-      {/* Without a change there is nothing to compare, and the ledger above
-          already carries the current totals. */}
-      {hasConfigurationChange && (
-        <ManagedSubscriptionComparison
-          currentTotals={currentTotals}
-          management={management}
-          plan={plan}
-          totals={totals}
-        />
-      )}
       {scheduledDowngradeEffectiveAt ? (
         <ScheduledUsagePackDowngradeNotice
           effectiveAt={scheduledDowngradeEffectiveAt}
@@ -2410,6 +2388,16 @@ function PackageConfigurationStep({
         : undefined
     : allMembers;
   const totals = memberUsageTotals(members ?? [], selections, catalog);
+  const comparisonRows =
+    management &&
+    hasUsagePackConfigurationChange(management, members, plan, selections)
+      ? managedSubscriptionComparisonRows({
+          currentPlan: usagePackPlan(management.tier),
+          currentTotals: managedMemberUsageTotals(management, members, catalog),
+          plan,
+          totals,
+        })
+      : undefined;
 
   /* The review reads the packages configured here, so it stays in this step's
      component and reuses the totals rather than resolving the member list a
@@ -2422,6 +2410,7 @@ function PackageConfigurationStep({
     <div className="flex flex-1 flex-col gap-5">
       <MemberUsageConfiguration
         catalog={catalog}
+        comparisonRows={comparisonRows}
         management={management}
         members={members}
         pendingMembers={paidPendingMembers}
@@ -2429,22 +2418,14 @@ function PackageConfigurationStep({
         totals={totals}
       />
       {/* The frame keeps step 1's height, so a short member list leaves slack
-          below the ledger. Spend it above the fine print and the action, which
-          stay together at the foot of the dialog. */}
-      <div className="mt-auto flex flex-col gap-3.5">
-        <MemberUsageFooter />
+          between the ledger and the action at the foot of the dialog. */}
+      <div className="mt-auto">
         {management ? (
           <ManagedSubscriptionOrderSummary
-            currentTotals={managedMemberUsageTotals(
-              management,
-              members,
-              catalog,
-            )}
             management={management}
             members={members}
             plan={plan}
             selections={selections}
-            totals={totals}
           />
         ) : (
           <CheckoutOrderSummary
@@ -3082,7 +3063,6 @@ export function UsagePackMigrationPage({
             plan={plan}
             totals={totals}
           />
-          <MemberUsageFooter />
           {configuration && migrationId ? (
             <>
               <MigrationRevisionOrderSummary

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1633,56 +1633,107 @@ function ManagedSubscriptionComparison({
   const monthlyTotal = rows.at(-1);
 
   /* The ledger above this already states what the workspace will pay, so the
-     row-by-row comparison opens on demand and keeps only the number that
-     decides the change on screen. The migration screens keep theirs open --
-     there the comparison is the whole point of the page. */
+     row-by-row comparison opens on demand. Its summary and body share the same
+     four rails: disclosure, label, current value, and new value. The migration
+     screens keep their comparison contained -- there it is the whole point of
+     the page. */
   return (
-    <details className="group mt-4">
-      <summary
-        className={`flex cursor-pointer list-none items-center gap-3 py-2.5 ${REVIEW_RULE}`}
-      >
-        <ChevronRight
-          size={14}
-          className="shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
-        />
-        <span className="min-w-0 flex-1 text-[13px] text-muted-foreground">
+    <details className={`group mt-3.5 ${REVIEW_HAIRLINE}`}>
+      <summary className="grid cursor-pointer list-none grid-cols-[2.5rem_minmax(0,1fr)_30%_30%] items-center py-3">
+        <span className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
+          <ChevronRight
+            size={14}
+            className="transition-transform group-open:rotate-90"
+          />
+        </span>
+        <span className="min-w-0 truncate text-[13px] font-medium text-foreground">
           {i18n.t(($) => {
             return $.billing.plans.usagePacks.management.comparison;
           })}
         </span>
         {monthlyTotal && (
-          <span className="shrink-0 text-sm font-medium tabular-nums text-foreground">
-            {monthlyTotal.current} → {monthlyTotal.next}
-          </span>
+          <>
+            <span className="col-start-3 row-start-1 text-right text-[13px] tabular-nums text-muted-foreground group-open:hidden">
+              {monthlyTotal.current}
+            </span>
+            <span className="col-start-4 row-start-1 text-right text-[13px] tabular-nums text-muted-foreground group-open:hidden">
+              {monthlyTotal.next}
+            </span>
+            <span className="col-start-3 row-start-1 hidden text-right text-[13px] text-muted-foreground group-open:block">
+              {i18n.t(($) => {
+                return $.billing.plans.usagePacks.management.current;
+              })}
+            </span>
+            <span className="col-start-4 row-start-1 hidden text-right text-[13px] text-muted-foreground group-open:block">
+              {i18n.t(($) => {
+                return $.billing.plans.usagePacks.management.new;
+              })}
+            </span>
+          </>
         )}
       </summary>
-      <SubscriptionComparisonTable rows={rows} />
+      <SubscriptionComparisonTable presentation="flat" rows={rows} />
     </details>
   );
 }
 
 function SubscriptionComparisonTable({
+  presentation = "contained",
   rows,
 }: {
+  readonly presentation?: "contained" | "flat";
   readonly rows: readonly SubscriptionComparisonRow[];
 }) {
+  const flat = presentation === "flat";
   return (
-    <div className="mt-4 overflow-hidden rounded-lg border border-border/70">
+    <div
+      className={
+        flat
+          ? "pb-2"
+          : "mt-4 overflow-hidden rounded-lg border border-border/70"
+      }
+    >
       <table
         aria-label={i18n.t(($) => {
           return $.billing.plans.usagePacks.management.comparison;
         })}
-        className="w-full table-fixed text-sm"
+        className={
+          flat ? "w-full table-fixed text-[13px]" : "w-full table-fixed text-sm"
+        }
       >
-        <thead className="bg-muted/40 text-sm font-medium uppercase tracking-wide text-muted-foreground">
+        {flat && (
+          <colgroup>
+            <col className="w-10" />
+            <col />
+            <col className="w-[30%]" />
+            <col className="w-[30%]" />
+          </colgroup>
+        )}
+        <thead
+          className={
+            flat
+              ? "sr-only"
+              : "bg-muted/40 text-sm font-medium uppercase tracking-wide text-muted-foreground"
+          }
+        >
           <tr>
-            <th scope="col" className="w-[40%] px-3 py-2 text-left" />
-            <th scope="col" className="w-[30%] px-3 py-2 text-right">
+            {flat && <th scope="col" />}
+            <th
+              scope="col"
+              className={flat ? "text-left" : "w-[40%] px-3 py-2 text-left"}
+            />
+            <th
+              scope="col"
+              className={flat ? "text-right" : "w-[30%] px-3 py-2 text-right"}
+            >
               {i18n.t(($) => {
                 return $.billing.plans.usagePacks.management.current;
               })}
             </th>
-            <th scope="col" className="w-[30%] px-3 py-2 text-right">
+            <th
+              scope="col"
+              className={flat ? "text-right" : "w-[30%] px-3 py-2 text-right"}
+            >
               {i18n.t(($) => {
                 return $.billing.plans.usagePacks.management.new;
               })}
@@ -1695,23 +1746,40 @@ function SubscriptionComparisonTable({
             return (
               <tr
                 key={row.label}
-                className={`border-t border-border/60 ${monthlyTotal ? "bg-muted/20" : ""}`}
+                className={
+                  flat
+                    ? ""
+                    : `border-t border-border/60 ${monthlyTotal ? "bg-muted/20" : ""}`
+                }
               >
+                {flat && <td aria-hidden="true" />}
                 <th
                   scope="row"
-                  className={`px-3 py-2.5 text-left ${monthlyTotal ? "font-medium text-foreground" : "font-normal text-muted-foreground"}`}
+                  className={
+                    flat
+                      ? `${monthlyTotal ? "pb-1.5 pt-3 font-medium text-foreground" : "py-1.5 font-normal text-muted-foreground"} text-left`
+                      : `px-3 py-2.5 text-left ${monthlyTotal ? "font-medium text-foreground" : "font-normal text-muted-foreground"}`
+                  }
                 >
                   {row.label}
                 </th>
                 <td
-                  className={`px-3 py-2.5 text-right text-muted-foreground ${monthlyTotal ? "font-medium" : ""}`}
+                  className={
+                    flat
+                      ? `${monthlyTotal ? "pb-1.5 pt-3 font-medium" : "py-1.5"} text-right tabular-nums text-muted-foreground`
+                      : `px-3 py-2.5 text-right text-muted-foreground ${monthlyTotal ? "font-medium" : ""}`
+                  }
                 >
                   {row.current}
                 </td>
-                {/* Weight alone marks what changed: the numerals are ink, and
-                    the brand colour stays on the action. */}
+                {/* Contained comparisons use weight to mark a changed value.
+                    The flat management disclosure keeps both columns quiet. */}
                 <td
-                  className={`px-3 py-2.5 text-right text-foreground ${monthlyTotal || row.changed ? "font-semibold" : "font-medium"}`}
+                  className={
+                    flat
+                      ? `${monthlyTotal ? "pb-1.5 pt-3 font-medium" : "py-1.5"} text-right tabular-nums text-muted-foreground`
+                      : `px-3 py-2.5 text-right text-foreground ${monthlyTotal || row.changed ? "font-semibold" : "font-medium"}`
+                  }
                 >
                   {row.next}
                 </td>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1633,38 +1633,38 @@ function ManagedSubscriptionComparison({
   const monthlyTotal = rows.at(-1);
 
   /* The ledger above this already states what the workspace will pay, so the
-     row-by-row comparison opens on demand. Its summary and body share the same
-     four rails: disclosure, label, current value, and new value. The migration
-     screens keep their comparison contained -- there it is the whole point of
-     the page. */
+     row-by-row comparison opens on demand. The disclosure and copy follow the
+     same icon and text rails as the note above, while the values keep their
+     shared right edges. The migration screens keep their comparison contained
+     -- there it is the whole point of the page. */
   return (
-    <details className={`group mt-3.5 ${REVIEW_HAIRLINE}`}>
-      <summary className="grid cursor-pointer list-none grid-cols-[2.5rem_minmax(0,1fr)_30%_30%] items-center py-3">
-        <span className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
+    <details className="group">
+      <summary className="grid cursor-pointer list-none grid-cols-[1.25rem_minmax(0,1fr)_30%_30%] items-center gap-x-2 py-3">
+        <span className="flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground">
           <ChevronRight
             size={14}
             className="transition-transform group-open:rotate-90"
           />
         </span>
-        <span className="min-w-0 truncate text-[13px] font-medium text-foreground">
+        <span className="min-w-0 truncate text-[13px] font-medium leading-5 text-foreground">
           {i18n.t(($) => {
             return $.billing.plans.usagePacks.management.comparison;
           })}
         </span>
         {monthlyTotal && (
           <>
-            <span className="col-start-3 row-start-1 text-right text-[13px] tabular-nums text-muted-foreground group-open:hidden">
+            <span className="col-start-3 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
               {monthlyTotal.current}
             </span>
-            <span className="col-start-4 row-start-1 text-right text-[13px] tabular-nums text-muted-foreground group-open:hidden">
+            <span className="col-start-4 row-start-1 text-right text-[13px] leading-5 tabular-nums text-muted-foreground group-open:hidden">
               {monthlyTotal.next}
             </span>
-            <span className="col-start-3 row-start-1 hidden text-right text-[13px] text-muted-foreground group-open:block">
+            <span className="col-start-3 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
               {i18n.t(($) => {
                 return $.billing.plans.usagePacks.management.current;
               })}
             </span>
-            <span className="col-start-4 row-start-1 hidden text-right text-[13px] text-muted-foreground group-open:block">
+            <span className="col-start-4 row-start-1 hidden text-right text-[13px] leading-5 text-muted-foreground group-open:block">
               {i18n.t(($) => {
                 return $.billing.plans.usagePacks.management.new;
               })}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1619,18 +1619,27 @@ function ManagedSubscriptionComparisonTooltip({
   readonly rows: readonly SubscriptionComparisonRow[];
   readonly totalUsd: number;
 }) {
+  const comparisonTitle = i18n.t(($) => {
+    return $.billing.plans.usagePacks.management.comparisonTitle;
+  });
+  const totalLabel = i18n.t(
+    ($) => {
+      return $.billing.plans.pricePerMonth;
+    },
+    { price: formatUsd(totalUsd, 0) },
+  );
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className="justify-self-end cursor-help underline decoration-dotted decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:decoration-foreground"
-            data-testid="subscription-comparison-trigger"
-          >
-            <LedgerPrice strong value={totalUsd} />
-          </span>
+        <TooltipTrigger
+          type="button"
+          aria-label={`${comparisonTitle}: ${totalLabel}`}
+          className="justify-self-end cursor-help appearance-none rounded-sm border-0 bg-transparent p-0 underline decoration-dotted decoration-foreground/40 decoration-[1px] underline-offset-4 transition-colors hover:decoration-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          <LedgerPrice strong value={totalUsd} />
         </TooltipTrigger>
         <TooltipContent
+          role="tooltip"
           align="end"
           collisionPadding={16}
           side="bottom"
@@ -1644,9 +1653,7 @@ function ManagedSubscriptionComparisonTooltip({
           }}
         >
           <p className="text-sm font-medium text-foreground">
-            {i18n.t(($) => {
-              return $.billing.plans.usagePacks.management.comparisonTitle;
-            })}
+            {comparisonTitle}
           </p>
           <p className="mt-0.5 text-[13px] leading-5 text-muted-foreground">
             {i18n.t(($) => {


### PR DESCRIPTION
## Summary

- flatten the managed subscription comparison into a quiet disclosure with only one subtle divider
- keep collapsed totals and expanded Current/New values on the same fixed, right-aligned columns
- use the same muted value color, remove comparison arrows, and preserve the contained migration-table presentation

## Testing

- `npx --yes prettier@3.8.1 --check apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx`
- `pnpm exec oxlint src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx src/views/zero-page/__tests__/org-billing-tab.test.tsx`
- `pnpm exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx -t "previews and confirms a current member package change inline"`
- `pnpm check-types`