### PR TITLE
perf: accelerate chat event retention

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-retain-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-retain-chat-events.test.ts
@@ -111,7 +111,7 @@ describe("chat event retention cron", () => {
     );
     const batchEventIds = await store.set(
       seedRetentionOutputEvents$,
-      { chatThreadId: threadId, count: 500, offsetMs: OLD_OFFSET_MS },
+      { chatThreadId: threadId, count: 2500, offsetMs: OLD_OFFSET_MS },
       context.signal,
     );
     const oldEventIds = [oldEventId, ...batchEventIds];
@@ -131,10 +131,10 @@ describe("chat event retention cron", () => {
     const cutoff = new Date(result.cutoff);
 
     expect(result).toMatchObject({
-      scanLimit: 1000,
-      deleteLimit: 500,
-      candidates: 501,
-      deleted: 500,
+      scanLimit: 5000,
+      deleteLimit: 2500,
+      candidates: 2501,
+      deleted: 2500,
       skippedBatchLimit: 1,
       overlapPrevented: false,
       hasMore: true,
@@ -178,10 +178,10 @@ describe("chat event retention cron", () => {
       context: "api:cron:retain-chat-events",
       deploymentCommitSha: DEPLOYMENT_SHA,
       cutoff: result.cutoff,
-      scanLimit: 1000,
+      scanLimit: 5000,
       scanned: result.scanned,
-      candidates: 501,
-      deleted: 500,
+      candidates: 2501,
+      deleted: 2500,
       skippedSnapshot: 0,
       skippedSearchWatermark: 0,
       skippedPendingRunless: 0,

--- a/turbo/apps/api/src/signals/services/cron-retain-chat-events.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-retain-chat-events.service.ts
@@ -20,8 +20,8 @@ import { writeDb$, type Db } from "../external/db";
 import { tryLockChatEventRetention } from "./chat-event-retention-lock.service";
 
 const CHAT_EVENT_RETENTION_DAYS = 30;
-const CHAT_EVENT_RETENTION_DELETE_LIMIT = 500;
-const CHAT_EVENT_RETENTION_SCAN_LIMIT = 1000;
+const CHAT_EVENT_RETENTION_DELETE_LIMIT = 2500;
+const CHAT_EVENT_RETENTION_SCAN_LIMIT = 5000;
 
 export interface ChatEventRetentionStats {
   readonly cutoff: string;


### PR DESCRIPTION
## Summary

- raise the bounded chat event retention scan limit from 1,000 to 5,000 rows
- raise the per-transaction delete cap from 500 to 2,500 rows
- keep the once-per-minute cadence and all existing retention safety, transaction, ordering, locking, response, and observability behavior unchanged
- expand the existing route integration test to prove that 2,501 eligible rows produce exactly 2,500 deletions, one batch-limited row, and a successful follow-up deletion

## Database pressure and locking

This remains an index-supported bounded scan. The unchanged candidate query filters old rows by `created_at`, orders by `(created_at, id)`, and is supported by `idx_chat_events_created_at_id`. `LIMIT 5000` bounds the rows selected and locked by `FOR UPDATE ... SKIP LOCKED` to at most 5,000 old candidates per invocation. The unchanged advisory try-lock prevents overlapping retention transactions.

The single unchanged `DELETE` statement deletes at most 2,500 selected rows. PostgreSQL takes its normal `ROW EXCLUSIVE` table lock for the delete; that lock is compatible with ordinary `SELECT` (`ACCESS SHARE`) and ordinary `INSERT`/`UPDATE`/`DELETE` (`ROW EXCLUSIVE`), so those operations are not table-level blocked. Current rows are outside the fixed 30-day cutoff and are not row-locked, and writes to other rows do not conflict with the retained candidate row locks. A concurrent writer targeting the same old candidate row can still contend at row level until this transaction completes, while the retention scan itself skips rows already locked elsewhere.

The higher limits can consume more WAL, create more dead tuples for autovacuum, increase index/CPU/I/O work across the existing safety joins, and make the transaction and its row-lock lifetime longer. The unchanged one-minute cadence, advisory no-overlap gate, 5,000-row scan ceiling, and 2,500-row single-delete ceiling keep that work bounded; there is no adaptive loop or unbounded delete within an invocation. No table-level blocking lock, schema change, migration, query, join, index, timeout, or other runtime behavior is introduced.

## Verification

- lockfile-pinned Prettier `3.8.1` check on both changed files
- targeted Oxlint, type-aware Oxlint, and ESLint on both changed files
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-retain-chat-events.test.ts` (5 passed)

The full local Vitest suite was not run.
