### PR TITLE
fix(platform): simplify credit balance card

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1089,11 +1089,9 @@
       "creditsRemaining_other": "Es verbleiben noch {{value}} Credits",
       "expires": "Verfällt am {{date}}",
       "grantsTable": {
-        "added": "Hinzugefügt",
-        "amount": "Betrag",
-        "expires": "Läuft ab",
-        "left": "Übrig",
-        "source": "Quelle"
+        "credits": "Credits",
+        "date": "Datum",
+        "left": "Übrig"
       },
       "left": "{{value}} übrig",
       "member": "Mitglied",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1089,11 +1089,9 @@
       "creditsRemaining_other": "{{value}} credits remaining",
       "expires": "Expires {{date}}",
       "grantsTable": {
-        "added": "Added",
-        "amount": "Amount",
-        "expires": "Expires",
-        "left": "Left",
-        "source": "Source"
+        "credits": "Credits",
+        "date": "Date",
+        "left": "Left"
       },
       "left": "{{value}} left",
       "member": "Member",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1111,11 +1111,9 @@
       "creditsRemaining_other": "{{value}} créditos restantes",
       "expires": "Caduca {{date}}",
       "grantsTable": {
-        "added": "Añadido",
-        "amount": "Importe",
-        "expires": "Caduca",
-        "left": "Restante",
-        "source": "Origen"
+        "credits": "Créditos",
+        "date": "Fecha",
+        "left": "Restante"
       },
       "left": "{{value}} restante",
       "member": "Miembro",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1111,11 +1111,9 @@
       "creditsRemaining_other": "{{value}} crédits restants",
       "expires": "Expire le {{date}}",
       "grantsTable": {
-        "added": "Ajouté",
-        "amount": "Montant",
-        "expires": "Expire",
-        "left": "Restant",
-        "source": "Source"
+        "credits": "Crédits",
+        "date": "Date",
+        "left": "Restant"
       },
       "left": "{{value}} restant",
       "member": "Membre",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1089,11 +1089,9 @@
       "creditsRemaining_other": "{{value}} क्रेडिट शेष",
       "expires": "{{date}} समाप्त हो रहा है",
       "grantsTable": {
-        "added": "जोड़ा गया",
-        "amount": "राशि",
-        "expires": "समाप्ति",
-        "left": "शेष",
-        "source": "स्रोत"
+        "credits": "क्रेडिट",
+        "date": "तारीख",
+        "left": "शेष"
       },
       "left": "{{value}} शेष",
       "member": "सदस्य",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1089,11 +1089,9 @@
       "creditsRemaining_other": "{{value}} kredit tersisa",
       "expires": "Kedaluwarsa {{date}}",
       "grantsTable": {
-        "added": "Ditambahkan",
-        "amount": "Jumlah",
-        "expires": "Kedaluwarsa",
-        "left": "Sisa",
-        "source": "Sumber"
+        "credits": "Kredit",
+        "date": "Tanggal",
+        "left": "Sisa"
       },
       "left": "Sisa {{value}}",
       "member": "Anggota",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1111,11 +1111,9 @@
       "creditsRemaining_other": "{{value}} crediti rimanenti",
       "expires": "Scadenza {{date}}",
       "grantsTable": {
-        "added": "Aggiunto",
-        "amount": "Importo",
-        "expires": "Scade",
-        "left": "Rimanenti",
-        "source": "Origine"
+        "credits": "Crediti",
+        "date": "Data",
+        "left": "Rimanenti"
       },
       "left": "{{value}} rimanenti",
       "member": "Membro",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1089,11 +1089,9 @@
       "creditsRemaining_other": "{{value}} クレジットが残っています",
       "expires": "{{date}}に期限切れ",
       "grantsTable": {
-        "added": "追加日",
-        "amount": "金額",
-        "expires": "有効期限",
-        "left": "残り",
-        "source": "種別"
+        "credits": "クレジット",
+        "date": "日付",
+        "left": "残り"
       },
       "left": "{{value}} 残り",
       "member": "メンバー",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1089,11 +1089,9 @@
       "creditsRemaining_other": "{{value}} 크레딧 남음",
       "expires": "{{date}}에 만료",
       "grantsTable": {
-        "added": "추가일",
-        "amount": "금액",
-        "expires": "만료",
-        "left": "남음",
-        "source": "출처"
+        "credits": "크레딧",
+        "date": "날짜",
+        "left": "남음"
       },
       "left": "{{value}} 남음",
       "member": "멤버",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1111,11 +1111,9 @@
       "creditsRemaining_other": "{{value}} créditos restantes",
       "expires": "Expira em {{date}}",
       "grantsTable": {
-        "added": "Adicionado",
-        "amount": "Valor",
-        "expires": "Expira",
-        "left": "Restante",
-        "source": "Origem"
+        "credits": "Créditos",
+        "date": "Data",
+        "left": "Restante"
       },
       "left": "{{value}} restantes",
       "member": "Membro",

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -34,7 +34,6 @@
   /* Credit balance breakdown segment colors (usage bar chart) */
   --color-credit-free: #3eb7b8;
   --color-credit-promotional: #e88033;
-  --color-credit-pay-as-you-go: #97918a;
   --color-credit-plan-pro: #edc43e;
   --color-credit-plan-team: #6b8de3;
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -226,10 +226,7 @@ describe("organization usage settings", () => {
     expect(
       screen.getByText(expectedAllowanceResetText(WEEKLY_ALLOWANCE_RESET)),
     ).toBeInTheDocument();
-    for (const progressbar of within(allowance).getAllByRole("progressbar")) {
-      expect(progressbar).toHaveClass("bg-muted/40");
-      expect(progressbar.firstElementChild).toHaveClass("bg-usage-kind-model");
-    }
+    expect(within(allowance).getAllByRole("progressbar")).toHaveLength(2);
 
     // The compact additions table keeps only the three values needed for
     // scanning; source and expiry details are available from each row tooltip.
@@ -298,6 +295,7 @@ describe("organization usage settings", () => {
   });
 
   it("draws the composition bar even when one category holds the balance", async () => {
+    const user = userEvent.setup();
     mockUsageStory();
     mockBillingStatus({
       creditBreakdown: [
@@ -313,7 +311,10 @@ describe("organization usage settings", () => {
     const segment = await screen.findByTestId(
       "credit-balance-segment-payAsYouGo",
     );
-    expect(segment).toHaveClass("bg-usage-kind-other");
+    await user.hover(segment);
+    await expect(
+      screen.findByText("Purchased credits — 12,000"),
+    ).resolves.toBeInTheDocument();
   });
 
   it("labels far-future credit grant expiries as never expiring", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -6,7 +6,8 @@ import {
 import { zeroOrgMembersContract } from "@okouai/api-contracts/contracts/zero-org-members";
 import { zeroUsageMembersContract } from "@okouai/api-contracts/contracts/zero-usage";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -212,7 +213,8 @@ describe("organization usage settings", () => {
     await waitFor(() => {
       expect(screen.getByText("12,000")).toBeInTheDocument();
     });
-    expect(screen.getByTestId("usage-allowance-section")).toBeInTheDocument();
+    const allowance = screen.getByTestId("usage-allowance-section");
+    expect(allowance).toBeInTheDocument();
     expect(screen.getByText("Usage allowance")).toBeInTheDocument();
     expect(screen.getByText("5h")).toBeInTheDocument();
     expect(screen.getByText("1w")).toBeInTheDocument();
@@ -224,12 +226,21 @@ describe("organization usage settings", () => {
     expect(
       screen.getByText(expectedAllowanceResetText(WEEKLY_ALLOWANCE_RESET)),
     ).toBeInTheDocument();
+    for (const progressbar of within(allowance).getAllByRole("progressbar")) {
+      expect(progressbar).toHaveClass("bg-muted/40");
+      expect(progressbar.firstElementChild).toHaveClass("bg-usage-kind-model");
+    }
 
-    // The additions table replaces the legend, so every number is printed once.
-    expect(screen.getByTestId("credit-grants-section")).toBeInTheDocument();
-    expect(screen.getByText("March Pro credits")).toBeInTheDocument();
-    expect(screen.getByText("+10,000")).toBeInTheDocument();
-    expect(screen.getByText("8,000")).toBeInTheDocument();
+    // The compact additions table keeps only the three values needed for
+    // scanning; source and expiry details are available from each row tooltip.
+    const grants = screen.getByTestId("credit-grants-section");
+    expect(within(grants).getByText("Date")).toBeInTheDocument();
+    expect(within(grants).getByText("Credits")).toBeInTheDocument();
+    expect(within(grants).getByText("Left")).toBeInTheDocument();
+    expect(within(grants).getByText("Mar 1, 2026")).toBeInTheDocument();
+    expect(within(grants).getByText("+10,000")).toBeInTheDocument();
+    expect(within(grants).getByText("8,000")).toBeInTheDocument();
+    expect(within(grants).queryByText("March Pro credits")).toBeNull();
     expect(screen.queryByTestId("credit-grants-toggle")).toBeNull();
     expect(screen.queryByText("Pro credits")).toBeNull();
     expect(screen.queryByText("Purchased credits")).toBeNull();
@@ -299,14 +310,14 @@ describe("organization usage settings", () => {
     });
     await openCreditBalance();
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("credit-balance-segment-payAsYouGo"),
-      ).toBeInTheDocument();
-    });
+    const segment = await screen.findByTestId(
+      "credit-balance-segment-payAsYouGo",
+    );
+    expect(segment).toHaveClass("bg-usage-kind-other");
   });
 
   it("labels far-future credit grant expiries as never expiring", async () => {
+    const user = userEvent.setup();
     mockUsageStory();
     mockBillingStatus({
       creditGrants: [
@@ -323,8 +334,12 @@ describe("organization usage settings", () => {
     });
     await openCreditBalance();
 
-    const neverExpires = await screen.findByText("Never expires");
-    expect(neverExpires).toBeInTheDocument();
+    const grant = await screen.findByTestId("credit-grants-grant-custom");
+    expect(screen.queryByText("Never expires")).toBeNull();
+    await user.hover(grant);
+    await expect(
+      screen.findByText("Never expires"),
+    ).resolves.toBeInTheDocument();
     expect(screen.queryByText("Dec 31, 2999")).toBeNull();
   });
 
@@ -401,8 +416,12 @@ describe("organization usage settings", () => {
       expect(screen.getByText("3.750 restantes")).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId("credit-grants-section")).toBeInTheDocument();
-    expect(screen.getByText("March Pro credits")).toBeInTheDocument();
+    const grants = screen.getByTestId("credit-grants-section");
+    expect(within(grants).getByText("Data")).toBeInTheDocument();
+    expect(within(grants).getByText("Créditos")).toBeInTheDocument();
+    expect(within(grants).getByText("Restante")).toBeInTheDocument();
+    expect(within(grants).getByText("+10.000")).toBeInTheDocument();
+    expect(within(grants).getByText("8.000")).toBeInTheDocument();
   });
 
   it("localizes team usage in Portuguese", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -36,12 +36,13 @@ type CreditSegment = BillingStatusResponse["creditBreakdown"][number];
 // Segment swatches map to theme tokens defined in
 // `turbo/apps/platform/src/views/css/index.css` under `@theme`. Keep the
 // mapping here purely symbolic so branding/dark-mode tweaks happen in CSS.
+// Pay as you go shares Usage's "other" yellow so the charts stay consistent.
 const CATEGORY_COLORS: Readonly<
   Record<Exclude<CreditSegment["category"], "plan">, string>
 > = {
   free: "bg-credit-free",
   promotional: "bg-credit-promotional",
-  payAsYouGo: "bg-credit-pay-as-you-go",
+  payAsYouGo: "bg-usage-kind-other",
 };
 
 const PLAN_COLORS: Readonly<
@@ -179,27 +180,23 @@ function allowanceRemainingPercent(window: UsageAllowanceWindow): number {
 
 function usageTone(remainingPercent: number | null): {
   readonly barClassName: string;
-  readonly textClassName: string;
   readonly trackClassName: string;
 } {
   if (remainingPercent !== null && remainingPercent < 20) {
     return {
       barClassName: "bg-red-500",
-      textClassName: "text-red-600 dark:text-red-400",
       trackClassName: "bg-red-500/15",
     };
   }
   if (remainingPercent !== null && remainingPercent < 50) {
     return {
       barClassName: "bg-amber-500",
-      textClassName: "text-amber-600 dark:text-amber-400",
       trackClassName: "bg-amber-500/15",
     };
   }
   return {
-    barClassName: "bg-emerald-500",
-    textClassName: "text-emerald-600 dark:text-emerald-400",
-    trackClassName: "bg-emerald-500/15",
+    barClassName: "bg-usage-kind-model",
+    trackClassName: "bg-muted/40",
   };
 }
 
@@ -301,15 +298,15 @@ function UsageAllowanceWindowRow({
     <div className="flex flex-col gap-2">
       <div className="flex min-w-0 items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-sm font-medium text-foreground">{label}</div>
-          <div className="mt-0.5 truncate text-xs text-muted-foreground">
+          <div className="text-sm font-semibold text-foreground">{label}</div>
+          <div className="mt-0.5 truncate text-[13px] text-muted-foreground">
             {formatAllowanceReset(window, splitLayout)}
           </div>
         </div>
         <div
           className={
             splitLayout
-              ? "shrink-0 text-right text-sm tabular-nums text-foreground"
+              ? "shrink-0 text-right text-sm font-semibold tabular-nums text-foreground"
               : "shrink-0 text-right text-xs font-medium tabular-nums text-muted-foreground"
           }
         >
@@ -373,7 +370,7 @@ function UsageAllowanceCard({
       data-testid="usage-allowance-section"
       className="overflow-hidden rounded-xl bg-card px-5 py-4 zero-border"
     >
-      <p className="text-sm font-medium text-foreground">
+      <p className="text-sm font-semibold text-foreground">
         {t(($) => {
           return $.billing.usage.allowance.title;
         })}
@@ -546,11 +543,10 @@ export function CreditAdditionList({
   );
 }
 
-// Every credit addition row shares this grid, so the amount and the remaining
-// balance keep one right edge across the header and the rows. Narrow widths
-// drop the middle columns instead of wrapping them.
+// Every credit addition row shares this three-column grid, so credits and the
+// remaining balance keep one right edge across the header and rows.
 const GRANT_ROW_GRID =
-  "grid grid-cols-[minmax(0,1fr)_5.75rem] items-center gap-x-4 sm:grid-cols-[minmax(0,1fr)_6.5rem_8.5rem_5.75rem_5.75rem]";
+  "grid grid-cols-[minmax(0,1fr)_4.5rem_4.5rem] items-center gap-x-3 sm:grid-cols-[minmax(0,1fr)_7rem_7rem] sm:gap-x-4";
 
 function CreditAdditionTable({
   grants,
@@ -565,36 +561,23 @@ function CreditAdditionTable({
   }
 
   return (
-    <div
-      data-testid={`${testIdPrefix}-section`}
-      className="mt-4 border-t border-border pt-3"
-    >
-      <p className="text-xs font-medium text-muted-foreground">
+    <div data-testid={`${testIdPrefix}-section`} className="mt-4 pt-3">
+      <p className="text-sm font-semibold text-foreground">
         {t(($) => {
           return $.billing.usage.creditAdditions;
         })}
       </p>
       <div
-        className={`${GRANT_ROW_GRID} pb-2 pt-2.5 text-xs text-muted-foreground`}
+        className={`${GRANT_ROW_GRID} pb-2 pt-2.5 text-[13px] text-muted-foreground`}
       >
         <span>
           {t(($) => {
-            return $.billing.usage.grantsTable.source;
+            return $.billing.usage.grantsTable.date;
           })}
         </span>
-        <span className="hidden sm:block">
+        <span className="text-right">
           {t(($) => {
-            return $.billing.usage.grantsTable.added;
-          })}
-        </span>
-        <span className="hidden sm:block">
-          {t(($) => {
-            return $.billing.usage.grantsTable.expires;
-          })}
-        </span>
-        <span className="hidden text-right sm:block">
-          {t(($) => {
-            return $.billing.usage.grantsTable.amount;
+            return $.billing.usage.grantsTable.credits;
           })}
         </span>
         <span className="text-right">
@@ -603,35 +586,45 @@ function CreditAdditionTable({
           })}
         </span>
       </div>
-      {grants.map((grant) => {
-        return (
-          <div
-            key={grant.id}
-            data-testid={`${testIdPrefix}-${grant.id}`}
-            className={`${GRANT_ROW_GRID} border-t border-border/50 py-2.5`}
-          >
-            <span className="truncate text-sm text-foreground">
-              {grant.label}
-            </span>
-            <span className="hidden text-xs text-muted-foreground sm:block">
-              {formatCreditDate(grant.createdAt)}
-            </span>
-            <span className="hidden truncate text-xs text-muted-foreground sm:block">
-              {neverExpires(grant)
-                ? t(($) => {
-                    return $.billing.usage.neverExpires;
-                  })
-                : formatCreditDate(grant.expiresAt)}
-            </span>
-            <span className="hidden text-right text-sm font-medium tabular-nums text-foreground sm:block">
-              {`+${formatLocalizedNumber(grant.amount)}`}
-            </span>
-            <span className="text-right text-sm tabular-nums text-muted-foreground">
-              {formatLocalizedNumber(grant.remaining)}
-            </span>
-          </div>
-        );
-      })}
+      <TooltipProvider delayDuration={100}>
+        {grants.map((grant) => {
+          return (
+            <Tooltip key={grant.id}>
+              <TooltipTrigger asChild>
+                <div
+                  tabIndex={0}
+                  data-testid={`${testIdPrefix}-${grant.id}`}
+                  className={`${GRANT_ROW_GRID} cursor-default border-t border-border/50 py-2.5 outline-none transition-colors hover:bg-state-hover focus-visible:bg-state-hover focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring`}
+                >
+                  <span className="whitespace-nowrap text-[13px] text-foreground">
+                    {formatCreditDate(grant.createdAt)}
+                  </span>
+                  <span className="text-right text-[13px] font-semibold tabular-nums text-foreground">
+                    {`+${formatLocalizedNumber(grant.amount)}`}
+                  </span>
+                  <span className="text-right text-[13px] tabular-nums text-muted-foreground">
+                    {formatLocalizedNumber(grant.remaining)}
+                  </span>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent
+                side="top"
+                sideOffset={8}
+                style={{
+                  backgroundColor: "hsl(var(--popover))",
+                  color: "hsl(var(--popover-foreground))",
+                }}
+                className="border shadow-md"
+              >
+                <div className="font-medium text-foreground">{grant.label}</div>
+                <div className="mt-0.5 text-muted-foreground">
+                  {expiresLabel(grant)}
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </TooltipProvider>
     </div>
   );
 }
@@ -648,7 +641,7 @@ function OrgCreditHeader({
     <div
       className={`flex justify-between gap-3 ${splitLayout ? "items-baseline" : "items-center"}`}
     >
-      <p className="text-sm font-medium text-foreground">
+      <p className="text-sm font-semibold text-foreground">
         {t(($) => {
           return $.billing.usage.orgCredits;
         })}
@@ -656,7 +649,7 @@ function OrgCreditHeader({
       <p
         className={
           splitLayout
-            ? "text-xl font-semibold tabular-nums text-foreground"
+            ? "text-xl font-medium tabular-nums text-foreground"
             : "text-sm font-medium tabular-nums text-foreground"
         }
       >
@@ -849,8 +842,8 @@ function CreditBalanceActions({
     return null;
   }
   return (
-    <div className="-mx-5 -mb-4 mt-4 flex items-center justify-between gap-3 border-t border-border px-5 py-3">
-      <p className="text-xs text-muted-foreground">
+    <div className="-mx-5 -mb-4 mt-4 flex items-center justify-between gap-3 border-t border-border px-5 py-[18px]">
+      <p className="text-[13px] text-muted-foreground">
         {billing.autoRecharge.enabled
           ? t(($) => {
               return $.billing.usage.autoRechargeOn;


### PR DESCRIPTION
## Summary

- align healthy allowance and pay-as-you-go bars with the existing Usage color palette
- simplify credit additions to a responsive Date / Credits / Left ledger and keep source and expiry details in hover and keyboard-focus tooltips
- remove the redundant section divider, tighten the visible type hierarchy, and increase the action footer spacing
- update the ledger column labels across every supported locale

## Verification

- `pnpm exec prettier --check <changed files>`
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/org-usage-tab.test.tsx` (11 tests)
- `pnpm knip --workspace @okouai/app`
