### PR TITLE
fix(e2e): restore chat event mock schema headers

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -3,6 +3,9 @@ import { expect, test } from "../fixtures";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(process.env.VM0_API_BACKEND_URL!);
+const chatEventSchemaVersionHeaders = {
+  "X-Chat-Event-Schema-Version": "5",
+};
 const composerConnectorSlugs = ["github", "slack", "asana"] as const;
 const responsiveFollowupThreadId = "b0000000-0000-4000-a000-000000000734";
 const modelChangeThreadId = "b0000000-0000-4000-a000-000000000735";
@@ -415,6 +418,7 @@ async function mockChatThread(
           return typeof row.seqId === "number" && row.seqId > sinceSeqId;
         });
       await route.fulfill({
+        headers: chatEventSchemaVersionHeaders,
         json: { rows },
       });
     },
@@ -443,6 +447,7 @@ async function mockChatThread(
       `/api/okou/chat-threads/${options.threadId}/event-snapshot`,
     async (route) => {
       await route.fulfill({
+        headers: chatEventSchemaVersionHeaders,
         status: 404,
         json: { error: { code: "NOT_FOUND", message: "Not found" } },
       });

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1,11 +1,9 @@
-import type { Locator, Page, Response } from "@playwright/test";
+import type { Locator, Page, Request, Response } from "@playwright/test";
 import { expect, test } from "../fixtures";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(process.env.VM0_API_BACKEND_URL!);
-const chatEventSchemaVersionHeaders = {
-  "X-Chat-Event-Schema-Version": "5",
-};
+const chatEventSchemaVersionHeader = "X-Chat-Event-Schema-Version";
 const composerConnectorSlugs = ["github", "slack", "asana"] as const;
 const responsiveFollowupThreadId = "b0000000-0000-4000-a000-000000000734";
 const modelChangeThreadId = "b0000000-0000-4000-a000-000000000735";
@@ -36,6 +34,19 @@ interface ConnectorCatalogStatusResponse {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+async function negotiatedChatEventHeaders(
+  request: Request,
+): Promise<Record<string, string>> {
+  const version = await request.headerValue(chatEventSchemaVersionHeader);
+  if (version === null) {
+    throw new Error("Chat Event request is missing its schema version");
+  }
+  return {
+    "Access-Control-Expose-Headers": chatEventSchemaVersionHeader,
+    [chatEventSchemaVersionHeader]: version,
+  };
 }
 
 function deferred(): { readonly promise: Promise<void>; resolve(): void } {
@@ -418,7 +429,7 @@ async function mockChatThread(
           return typeof row.seqId === "number" && row.seqId > sinceSeqId;
         });
       await route.fulfill({
-        headers: chatEventSchemaVersionHeaders,
+        headers: await negotiatedChatEventHeaders(route.request()),
         json: { rows },
       });
     },
@@ -447,7 +458,7 @@ async function mockChatThread(
       `/api/okou/chat-threads/${options.threadId}/event-snapshot`,
     async (route) => {
       await route.fulfill({
-        headers: chatEventSchemaVersionHeaders,
+        headers: await negotiatedChatEventHeaders(route.request()),
         status: 404,
         json: { error: { code: "NOT_FOUND", message: "Not found" } },
       });


### PR DESCRIPTION
## Summary

- restore the negotiated ChatEvent schema-version header on Playwright's mocked event-row and Snapshot responses
- unblock the chat layout E2E cases after Platform readers began requiring the response header in #27316

## Root cause

The mocked Snapshot 404 omitted `X-Chat-Event-Schema-Version`, so Platform rejected the response before requesting event rows. Three `chat.spec.ts` cases then waited 120 seconds for an event-row response and exhausted the Playwright job's eight-minute limit.

## Verification

- `cd e2e && corepack pnpm check-types`
- `git diff --check`
- deployed Playwright suite: PR pipeline (requires the deployed preview)

## Evidence

- main regression run: https://github.com/vm0-ai/vm0/actions/runs/31867771969
- affected PR run: https://github.com/vm0-ai/vm0/actions/runs/31869191139
