### PR TITLE
fix(ci): cancel stale cleanup when pull request reopens

### DIFF
--- a/.github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh
+++ b/.github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh
@@ -13,6 +13,18 @@ def named_step(job, name)
 end
 
 cleanup_workflow = YAML.load_file(ARGV.fetch(0))
+workflow_triggers = cleanup_workflow["on"] || cleanup_workflow.fetch(true)
+pull_request_target = workflow_triggers.fetch("pull_request_target")
+unless pull_request_target.fetch("types").sort == %w[closed reopened]
+  raise "cleanup must invalidate close-event runs when a pull request is reopened"
+end
+
+cleanup_workflow.fetch("jobs").each do |job_name, job|
+  unless job.fetch("if", "").include?("github.event.action == 'closed'")
+    raise "cleanup job #{job_name} must run only for closed pull requests"
+  end
+end
+
 cleanup_concurrency = cleanup_workflow.fetch("concurrency")
 unless cleanup_concurrency == {
   "group" => "cleanup-pr-${{ github.event.pull_request.number }}",

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -2,7 +2,7 @@ name: Cleanup Resources
 
 on:
   pull_request_target:
-    types: [closed]
+    types: [closed, reopened]
 
 concurrency:
   group: cleanup-pr-${{ github.event.pull_request.number }}
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   cleanup-app-pages-deployments:
+    if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -45,7 +46,7 @@ jobs:
 
   cleanup-runner:
     # Skip for release-please PRs (only version bumps and changelogs)
-    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
+    if: "github.event.action == 'closed' && !startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -150,7 +151,7 @@ jobs:
 
   cleanup-database:
     # Skip for release-please PRs (only version bumps and changelogs)
-    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
+    if: "github.event.action == 'closed' && !startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622
@@ -167,7 +168,7 @@ jobs:
 
   cleanup-clerk-test-resources:
     # Delete generation-scoped Clerk test users and organizations for this PR.
-    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
+    if: "github.event.action == 'closed' && !startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -191,7 +192,7 @@ jobs:
 
   cleanup-deployments:
     # Skip for release-please PRs (only version bumps and changelogs)
-    if: "!startsWith(github.head_ref || '', 'release-please--branches--')"
+    if: "github.event.action == 'closed' && !startsWith(github.head_ref || '', 'release-please--branches--')"
     runs-on: ubuntu-latest
     permissions:
       deployments: write


### PR DESCRIPTION
## Summary

- trigger `Cleanup Resources` on both `closed` and `reopened` pull-request events
- run every cleanup job only for the `closed` action so a reopen run cannot delete resources
- add workflow contract coverage for the trigger and closed-only job guards

When a PR is reopened, the new run enters the existing `cleanup-pr-<number>` concurrency group and cancels the stale close cleanup. The fail-closed owner barrier, timeout, lifecycle lock, and daily stale cleanup are unchanged.

Closes #27343

## Validation

- `.github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh`
- `.github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh`
- all `.github/scripts/tests/*.sh`
- `actionlint`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `bash -n .github/scripts/tests/*.sh`
- `shellcheck --norc .github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh`
- `pnpm exec prettier --check .github/workflows/cleanup.yml`
- `git diff --check`

