### PR TITLE
refactor(cli): flatten slack command module

### DIFF
--- a/turbo/apps/cli/src/commands/slack/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/slack/__tests__/download-file.test.ts
@@ -12,7 +12,7 @@ import { mkdirSync, rmSync, readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { downloadFileCommand } from "../download-file";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/slack/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/slack/__tests__/send.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { sendCommand } from "../message/send";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/slack/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/slack/__tests__/upload-file.test.ts
@@ -12,7 +12,7 @@ import { writeFileSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { uploadFileCommand } from "../upload-file";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/slack/download-file.ts
+++ b/turbo/apps/cli/src/commands/slack/download-file.ts
@@ -1,8 +1,8 @@
 import { basename, join } from "path";
 import { tmpdir } from "os";
 import { Command } from "commander";
-import { downloadSlackFile } from "../../../lib/api/domains/integrations-slack";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { downloadSlackFile } from "../../lib/api/domains/integrations-slack";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 /**
  * Derive a local output path for a Slack file id.

--- a/turbo/apps/cli/src/commands/slack/index.ts
+++ b/turbo/apps/cli/src/commands/slack/index.ts
@@ -1,14 +1,14 @@
 import { Command } from "commander";
-import { zeroSlackMessageCommand } from "./message";
+import { slackMessageCommand } from "./message";
 import { uploadFileCommand } from "./upload-file";
 import { downloadFileCommand } from "./download-file";
 
-export const zeroSlackCommand = new Command()
+export const slackCommand = new Command()
   .name("slack")
   .description(
     "Send messages, upload files, and download files from Slack as the bot",
   )
-  .addCommand(zeroSlackMessageCommand)
+  .addCommand(slackMessageCommand)
   .addCommand(uploadFileCommand)
   .addCommand(downloadFileCommand)
   .addHelpText(

--- a/turbo/apps/cli/src/commands/slack/message/index.ts
+++ b/turbo/apps/cli/src/commands/slack/message/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { sendCommand } from "./send";
 
-export const zeroSlackMessageCommand = new Command()
+export const slackMessageCommand = new Command()
   .name("message")
   .description("Manage Slack messages")
   .addCommand(sendCommand)

--- a/turbo/apps/cli/src/commands/slack/message/send.ts
+++ b/turbo/apps/cli/src/commands/slack/message/send.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "fs";
 import { Command } from "commander";
 import chalk from "chalk";
-import { sendSlackMessage } from "../../../../lib/api/domains/integrations-slack";
-import { withErrorHandler } from "../../../../lib/command/with-error-handler";
+import { sendSlackMessage } from "../../../lib/api/domains/integrations-slack";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
 
 export const sendCommand = new Command()
   .name("send")

--- a/turbo/apps/cli/src/commands/slack/upload-file.ts
+++ b/turbo/apps/cli/src/commands/slack/upload-file.ts
@@ -11,9 +11,9 @@ import {
   completeSlackFileUpload,
   initSlackFileUpload,
   materializeSlackFileUpload,
-} from "../../../lib/api/domains/integrations-slack";
-import { inferWebUploadContentType } from "../../../lib/api/domains/web";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+} from "../../lib/api/domains/integrations-slack";
+import { inferWebUploadContentType } from "../../lib/api/domains/web";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 interface UploadFileOptions {
   readonly file: string;

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -161,7 +161,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     description:
       "Send messages, upload files, and download files from Slack as the bot",
     load: async () => {
-      return (await import("./commands/zero/slack")).zeroSlackCommand;
+      return (await import("./commands/slack")).slackCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all eight Slack command and focused test files from `commands/zero/slack` to `commands/slack`
- rename the internal exports to `slackCommand` and `slackMessageCommand`
- update the moved `lib`/`mocks` relative imports and the `okou.ts` lazy import

## Compatibility

- preserve the public `okou slack` command tree, flags, help text, examples, output, and error behavior
- preserve Slack API adapters, routes, request/response fields, upload/download behavior, message behavior, and wire identities
- retain `VM0_API_BACKEND_URL` unchanged in all three focused tests
- add no old-path bridge, symbol alias, or unrelated naming cleanup

## Validation

- lockfile-pinned Prettier 3.8.1 on all changed files
- `pnpm --filter @okouai/cli run lint`
- `pnpm knip --workspace @okouai/cli`
- `pnpm --filter @okouai/cli run check-types`
- Slack command tests: 3 files, 28 tests passed
- CLI registry tests: 2 files, 90 tests passed
- mechanical-equivalence audit for all eight moved files and `okou.ts`
- repository-wide old path/export scan and CLI `zeroSlack*` residual scan

Closes #27345
