### PR TITLE
style(platform): relax plan comparison spacing

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -834,13 +834,13 @@ function planComparisonRows(
 
 function PlanComparison({ tier }: { readonly tier: UsagePackPlanTier }) {
   return (
-    <div className="mt-5 text-muted-foreground">
+    <div className="mt-5 flex flex-1 flex-col text-muted-foreground">
       {planComparisonRows(tier).map((row, index) => {
         return (
           <div
             key={row.label}
-            className={`flex items-baseline justify-between gap-4 py-1.5 text-sm font-medium leading-snug ${
-              index > 0 ? "border-t-[0.7px] border-[hsl(var(--gray-100))]" : ""
+            className={`flex flex-1 items-center justify-between gap-4 text-sm font-medium leading-snug ${
+              index > 0 ? "border-t-[0.7px] border-[hsl(var(--gray-50))]" : ""
             }`}
           >
             <span>{row.label}</span>


### PR DESCRIPTION
## Summary

- distribute the existing plan comparison rows across the available vertical space
- soften comparison dividers from gray-100 to gray-50
- keep the DOM, copy, plan columns, and action placement unchanged

## Verification

- `npx --yes prettier@3.8.1 --check src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx`
- `npx --yes oxlint@1.75.0 src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx`
- `git diff --check`

Full Vitest was not run for this visual-only class adjustment, per repository guidance.
