### PR TITLE
refactor(cli): flatten feishu command module

### DIFF
--- a/turbo/apps/cli/src/commands/feishu/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/feishu/__tests__/download-file.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { downloadFileCommand } from "../download-file";
 
 const DOWNLOAD_URL =

--- a/turbo/apps/cli/src/commands/feishu/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/feishu/__tests__/send.test.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { sendCommand } from "../message/send";
 
 const FEISHU_MESSAGE_URL =

--- a/turbo/apps/cli/src/commands/feishu/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/feishu/__tests__/upload-file.test.ts
@@ -6,7 +6,7 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FEISHU_FILE_UPLOAD_MAX_BYTES } from "@okouai/api-contracts/contracts/integrations";
 
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { uploadFileCommand } from "../upload-file";
 
 const UPLOAD_INIT_URL =

--- a/turbo/apps/cli/src/commands/feishu/download-file.ts
+++ b/turbo/apps/cli/src/commands/feishu/download-file.ts
@@ -4,8 +4,8 @@ import { basename, join } from "node:path";
 import { Command } from "commander";
 import type { FeishuResourceType } from "@okouai/api-contracts/contracts/integrations";
 
-import { downloadFeishuFile } from "../../../lib/api/domains/integrations-feishu";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { downloadFeishuFile } from "../../lib/api/domains/integrations-feishu";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 function defaultOutPath(fileKey: string): string {
   return join(tmpdir(), `feishu-${basename(fileKey).slice(0, 80)}`);

--- a/turbo/apps/cli/src/commands/feishu/index.ts
+++ b/turbo/apps/cli/src/commands/feishu/index.ts
@@ -1,13 +1,13 @@
 import { Command } from "commander";
 
 import { downloadFileCommand } from "./download-file";
-import { zeroFeishuMessageCommand } from "./message";
+import { feishuMessageCommand } from "./message";
 import { uploadFileCommand } from "./upload-file";
 
-export const zeroFeishuCommand = new Command()
+export const feishuCommand = new Command()
   .name("feishu")
   .description("Send messages and transfer files through Feishu")
-  .addCommand(zeroFeishuMessageCommand)
+  .addCommand(feishuMessageCommand)
   .addCommand(downloadFileCommand)
   .addCommand(uploadFileCommand)
   .addHelpText(

--- a/turbo/apps/cli/src/commands/feishu/message/index.ts
+++ b/turbo/apps/cli/src/commands/feishu/message/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 
 import { sendCommand } from "./send";
 
-export const zeroFeishuMessageCommand = new Command()
+export const feishuMessageCommand = new Command()
   .name("message")
   .description("Send Feishu messages")
   .addCommand(sendCommand);

--- a/turbo/apps/cli/src/commands/feishu/message/send.ts
+++ b/turbo/apps/cli/src/commands/feishu/message/send.ts
@@ -3,8 +3,8 @@ import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import { Command } from "commander";
 
-import { sendFeishuMessage } from "../../../../lib/api/domains/integrations-feishu";
-import { withErrorHandler } from "../../../../lib/command/with-error-handler";
+import { sendFeishuMessage } from "../../../lib/api/domains/integrations-feishu";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
 
 interface SendFeishuOptions {
   readonly installation?: string;

--- a/turbo/apps/cli/src/commands/feishu/upload-file.ts
+++ b/turbo/apps/cli/src/commands/feishu/upload-file.ts
@@ -7,8 +7,8 @@ import { FEISHU_FILE_UPLOAD_MAX_BYTES } from "@okouai/api-contracts/contracts/in
 import {
   completeFeishuFileUpload,
   initFeishuFileUpload,
-} from "../../../lib/api/domains/integrations-feishu";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+} from "../../lib/api/domains/integrations-feishu";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 const MIME_BY_EXTENSION: Readonly<Record<string, string>> = {
   ".csv": "text/csv",

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -168,7 +168,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "feishu",
     description: "Send messages to Feishu as an organization bot",
     load: async () => {
-      return (await import("./commands/zero/feishu")).zeroFeishuCommand;
+      return (await import("./commands/feishu")).feishuCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all eight Feishu command and focused test files from `commands/zero/feishu` to `commands/feishu`
- rename the internal exports to `feishuCommand` and `feishuMessageCommand`
- update the moved `lib`/`mocks` relative imports and the `okou.ts` lazy import

## Compatibility

- preserve the public `okou feishu` command tree, flags, help text, examples, stdout, stderr, exit behavior, and errors
- preserve Feishu API adapters, routes, request/response contracts, and integration behavior
- retain `VM0_API_BACKEND_URL` unchanged in all three focused tests
- add no old-path bridge, symbol alias, compatibility re-export, or unrelated naming cleanup

## Contract verification

- canonicalizing the baseline with only the approved path-depth and symbol mappings produces byte-for-byte identical moved files
- the diff contains eight renames and the required `okou.ts` lazy-import edit only
- full `turbo/apps/cli/src` searches find no `commands/zero/feishu` or `zeroFeishu*` reference
- all five Feishu help surfaces retain identical pre/post byte lengths and SHA-256 hashes

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- Feishu command tests: 3 files, 13 tests passed
- CLI registry tests: 2 files, 90 tests passed
- after rebasing onto `0e00c5375`: targeted Prettier, CLI lint, CLI type-check, all 5 focused test files, mechanical-equivalence audit, help snapshot audit, and `git diff --check`

Closes #27347