### PR TITLE
refactor(cli): flatten telegram command module

### DIFF
--- a/turbo/apps/cli/src/commands/telegram/__tests__/bot-list.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/bot-list.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { listCommand } from "../bot/list";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/telegram/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/download-file.test.ts
@@ -7,7 +7,7 @@ import { mkdirSync, rmSync, readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { downloadFileCommand } from "../download-file";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/telegram/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/send.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { sendCommand } from "../message/send";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/telegram/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/telegram/__tests__/upload-file.test.ts
@@ -7,7 +7,7 @@ import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { uploadFileCommand } from "../upload-file";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/telegram/bot/index.ts
+++ b/turbo/apps/cli/src/commands/telegram/bot/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { listCommand } from "./list";
 
-export const zeroTelegramBotCommand = new Command()
+export const telegramBotCommand = new Command()
   .name("bot")
   .description("Inspect Telegram bots")
   .addCommand(listCommand)

--- a/turbo/apps/cli/src/commands/telegram/bot/list.ts
+++ b/turbo/apps/cli/src/commands/telegram/bot/list.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { listTelegramBots } from "../../../../lib/api/domains/integrations-telegram";
-import { withErrorHandler } from "../../../../lib/command/with-error-handler";
+import { listTelegramBots } from "../../../lib/api/domains/integrations-telegram";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import type { TelegramBotListItem } from "@okouai/api-contracts/contracts/integrations";
 
 function usernameLabel(bot: TelegramBotListItem): string {

--- a/turbo/apps/cli/src/commands/telegram/download-file.ts
+++ b/turbo/apps/cli/src/commands/telegram/download-file.ts
@@ -1,8 +1,8 @@
 import { basename, join } from "path";
 import { tmpdir } from "os";
 import { Command } from "commander";
-import { downloadTelegramFile } from "../../../lib/api/domains/integrations-telegram";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { downloadTelegramFile } from "../../lib/api/domains/integrations-telegram";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 /**
  * Derive a local output path for a Telegram file id.

--- a/turbo/apps/cli/src/commands/telegram/index.ts
+++ b/turbo/apps/cli/src/commands/telegram/index.ts
@@ -1,16 +1,16 @@
 import { Command } from "commander";
-import { zeroTelegramBotCommand } from "./bot";
+import { telegramBotCommand } from "./bot";
 import { downloadFileCommand } from "./download-file";
-import { zeroTelegramMessageCommand } from "./message";
+import { telegramMessageCommand } from "./message";
 import { uploadFileCommand } from "./upload-file";
 
-export const zeroTelegramCommand = new Command()
+export const telegramCommand = new Command()
   .name("telegram")
   .description(
     "Inspect bots, send messages, upload files, and download files from Telegram",
   )
-  .addCommand(zeroTelegramBotCommand)
-  .addCommand(zeroTelegramMessageCommand)
+  .addCommand(telegramBotCommand)
+  .addCommand(telegramMessageCommand)
   .addCommand(downloadFileCommand)
   .addCommand(uploadFileCommand)
   .addHelpText(

--- a/turbo/apps/cli/src/commands/telegram/message/index.ts
+++ b/turbo/apps/cli/src/commands/telegram/message/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { sendCommand } from "./send";
 
-export const zeroTelegramMessageCommand = new Command()
+export const telegramMessageCommand = new Command()
   .name("message")
   .description("Manage Telegram messages")
   .addCommand(sendCommand)

--- a/turbo/apps/cli/src/commands/telegram/message/send.ts
+++ b/turbo/apps/cli/src/commands/telegram/message/send.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "fs";
 import { Command } from "commander";
 import chalk from "chalk";
-import { sendTelegramMessage } from "../../../../lib/api/domains/integrations-telegram";
-import { withErrorHandler } from "../../../../lib/command/with-error-handler";
+import { sendTelegramMessage } from "../../../lib/api/domains/integrations-telegram";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
 
 function parsePositiveInteger(value: string, flag: string): number {
   const parsed = Number(value);

--- a/turbo/apps/cli/src/commands/telegram/upload-file.ts
+++ b/turbo/apps/cli/src/commands/telegram/upload-file.ts
@@ -4,8 +4,8 @@ import { Command } from "commander";
 import {
   completeTelegramFileUpload,
   initTelegramFileUpload,
-} from "../../../lib/api/domains/integrations-telegram";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+} from "../../lib/api/domains/integrations-telegram";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 const MIME_BY_EXTENSION: Record<string, string> = {
   ".png": "image/png",

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -184,7 +184,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     description:
       "Inspect bots, send messages, upload files, and download files from Telegram",
     load: async () => {
-      return (await import("./commands/zero/telegram")).zeroTelegramCommand;
+      return (await import("./commands/telegram")).telegramCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all 11 Telegram command and focused test files from `commands/zero/telegram` to `commands/telegram`
- rename the internal exports to `telegramCommand`, `telegramBotCommand`, and `telegramMessageCommand`
- update the moved `lib`/`mocks` relative imports and the `okou.ts` lazy registry import

## Compatibility

- preserve the public `okou telegram` command tree, flags, help text, examples, output, and error behavior
- preserve Telegram API paths, request/response contracts, bot/message/file-transfer behavior, and wire shapes
- retain `VM0_API_BACKEND_URL` unchanged in all four focused tests
- add no old-path bridge, symbol alias, callback-persistence change, or unrelated naming cleanup

## Verification

- mechanical-equivalence audit against the latest `main`
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace type checks for non-API/Platform packages, Platform, and API
- post-rebase targeted Prettier, CLI lint, and CLI type-check
- Telegram command tests: 4 files, 16 tests passed
- CLI registry tests: 2 files, 90 tests passed
- full-repository residual searches for `commands/zero/telegram` and CLI `zeroTelegram*` identifiers

Closes #27346
