### PR TITLE
refactor(platform): unify loops and timers

### DIFF
--- a/turbo/apps/platform/src/lib/pptx-renderer.ts
+++ b/turbo/apps/platform/src/lib/pptx-renderer.ts
@@ -8,7 +8,7 @@ import {
   type SlideRendererOptions,
 } from "@aiden0z/pptx-renderer";
 import { domToBlob } from "modern-screenshot";
-import { animationFrame } from "signal-timers";
+import { animationFrame, delay } from "signal-timers";
 
 import {
   createChildAbortController,
@@ -349,14 +349,16 @@ function waitWithDeadline<T>(
   const deadlineSignal = deadlineController.signal;
   const operationPromise = operation(deadlineSignal);
   const waitPromise = waitForAbortablePromise(operationPromise, deadlineSignal);
-  const timeoutId = window.setTimeout(() => {
-    if (!deadlineController.signal.aborted) {
-      deadlineController.abort(timeoutError);
-    }
-  }, PPTX_RENDER_LIMITS.resourceTimeoutMs);
-  return withCleanup(waitPromise, () => {
-    window.clearTimeout(timeoutId);
-    if (!deadlineController.signal.aborted) {
+  const waitForDeadline = async (): Promise<never> => {
+    await delay(PPTX_RENDER_LIMITS.resourceTimeoutMs, {
+      signal: deadlineSignal,
+    });
+    deadlineController.abort(timeoutError);
+    throw timeoutError;
+  };
+  const deadlinePromise = waitForDeadline();
+  return withCleanup(Promise.race([waitPromise, deadlinePromise]), () => {
+    if (!deadlineSignal.aborted) {
       deadlineController.abort(
         new DOMException("PPTX resource operation settled", "AbortError"),
       );

--- a/turbo/apps/platform/src/signals/auth-retry.ts
+++ b/turbo/apps/platform/src/signals/auth-retry.ts
@@ -16,6 +16,7 @@ import {
 import {
   createDeferredPromise,
   onDomEventFn,
+  setLoop,
   settle,
   withCleanup,
 } from "./utils";
@@ -359,34 +360,37 @@ export const setupForegroundCatchUp$ = command(
     }
 
     const runRequestedCatchUps = async (): Promise<void> => {
-      while (true) {
-        const requestRevision = requestedVisibilityRevision;
-        const spanId = createConnectionDiagnosticSpanId();
-        const startedAtMs = now();
-        catchUpSpanId = spanId;
-        publishConnectionDiagnostic({
-          event: "foreground.catch-up",
-          phase: "start",
-          spanId,
-        });
-        await set(
-          runTrackedForegroundCatchUp$,
-          {
+      await setLoop(
+        async (loopSignal) => {
+          const requestRevision = requestedVisibilityRevision;
+          const spanId = createConnectionDiagnosticSpanId();
+          const startedAtMs = now();
+          catchUpSpanId = spanId;
+          publishConnectionDiagnostic({
+            event: "foreground.catch-up",
+            phase: "start",
             spanId,
-            startedAtMs,
-            subscriberCount: get(foregroundCatchUpCommands$).size,
-          },
-          signal,
-        );
-        signal.throwIfAborted();
+          });
+          await set(
+            runTrackedForegroundCatchUp$,
+            {
+              spanId,
+              startedAtMs,
+              subscriberCount: get(foregroundCatchUpCommands$).size,
+            },
+            loopSignal,
+          );
+          loopSignal.throwIfAborted();
 
-        if (
-          requestRevision === requestedVisibilityRevision ||
-          document.visibilityState !== "visible"
-        ) {
-          return;
-        }
-      }
+          return (
+            requestRevision === requestedVisibilityRevision ||
+            document.visibilityState !== "visible"
+          );
+        },
+        0,
+        signal,
+        { retryTransientErrors: false },
+      );
     };
 
     const catchUpForeground = (): Promise<void> => {

--- a/turbo/apps/platform/src/signals/shared-database-invalidation-daemon.ts
+++ b/turbo/apps/platform/src/signals/shared-database-invalidation-daemon.ts
@@ -3,27 +3,37 @@ import { logger } from "./log.ts";
 import { syncActiveChatEvents$ } from "./chat-page/chat-event-signal-registry.ts";
 import { syncEventDrivenChatThreads$ } from "./chat-page/chat-thread-event-sourcing.ts";
 import { takeSharedDatabaseInvalidations$ } from "./shared-database-invalidation-queue.ts";
+import { setLoop } from "./utils.ts";
 
 const L = logger("SharedDatabaseInvalidationDaemon");
 
 export const runSharedDatabaseInvalidationDaemon$ = command(
   async ({ set }, signal: AbortSignal): Promise<void> => {
-    while (!signal.aborted) {
-      const dataKeys = await set(takeSharedDatabaseInvalidations$, signal);
-      signal.throwIfAborted();
-      const results = await Promise.allSettled(
-        dataKeys.map((dataKey) => {
-          return dataKey.kind === "chat-event"
-            ? set(syncActiveChatEvents$, dataKey.threadId, signal)
-            : set(syncEventDrivenChatThreads$, signal);
-        }),
-      );
-      signal.throwIfAborted();
-      for (const result of results) {
-        if (result.status === "rejected") {
-          L.warn("shared database invalidation sync failed", result.reason);
+    await setLoop(
+      async (loopSignal) => {
+        const dataKeys = await set(
+          takeSharedDatabaseInvalidations$,
+          loopSignal,
+        );
+        loopSignal.throwIfAborted();
+        const results = await Promise.allSettled(
+          dataKeys.map((dataKey) => {
+            return dataKey.kind === "chat-event"
+              ? set(syncActiveChatEvents$, dataKey.threadId, loopSignal)
+              : set(syncEventDrivenChatThreads$, loopSignal);
+          }),
+        );
+        loopSignal.throwIfAborted();
+        for (const result of results) {
+          if (result.status === "rejected") {
+            L.warn("shared database invalidation sync failed", result.reason);
+          }
         }
-      }
-    }
+        return false;
+      },
+      0,
+      signal,
+      { retryTransientErrors: false },
+    );
   },
 );


### PR DESCRIPTION
## Summary

- route the shared-database invalidation daemon and foreground catch-up replay through `setLoop`
- pass each existing daemon/catch-up lifecycle signal into the shared loop and preserve prior error propagation with transient retries disabled
- replace the PPTX renderer's native timeout/clear pair with a raced `signal-timers` delay owned by its parent-derived deadline signal

## Validation

- loop scan: only the internal `setLoop` implementation remains
- native timer scan: no matches in Platform source or tests
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- full staged TypeScript checks for non-API packages, Platform, and API
- `pnpm --filter @okouai/app exec vitest run src/lib/__tests__/pptx-renderer-resources.test.ts` (4 passed)
- `pnpm --filter @okouai/app exec vitest run src/signals/__tests__/realtime.test.ts` (32 passed)
- Lefthook pre-commit and commit-msg hooks
