### PR TITLE
refactor: remove composer connector permissions feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -67,12 +67,6 @@ export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });
 
-export const composerConnectorPermissionsEnabled$ = computed((get): boolean => {
-  return (
-    get(featureSwitch$)[FeatureSwitchKey.ComposerConnectorPermissions] ?? false
-  );
-});
-
 export const customConnectorMcpEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CustomConnectorMcp] ?? false;
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3216,9 +3216,6 @@ describe("chat composer models", () => {
     detachedSetupPage({
       context,
       path: `/chats/${THREAD_ID}?sidebar=${OTHER_AGENT_THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ComposerConnectorPermissions]: true,
-      },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -180,7 +180,6 @@ import {
 } from "../../signals/external/user-model-preference.ts";
 import {
   codexFastModeEnabled$,
-  composerConnectorPermissionsEnabled$,
   customConnectorMcpEnabled$,
   avatarTemplatesEnabled$,
   imageRecognitionAvailable$,
@@ -6452,7 +6451,6 @@ function ConnectorsPopoverButton({
   const setDownloadDialogOpen = useSet(
     signals.computer.setComputerUseDownloadDialogOpen$,
   );
-  const permissionEntryEnabled = useGet(composerConnectorPermissionsEnabled$);
   const permissionConnectorSlug = connectorUi.permissionConnectorSlug;
   const connectorItems: ComposerPopoverConnectorItem[] = [
     ...agentConnectors.map((connector) => {
@@ -6463,12 +6461,11 @@ function ConnectorsPopoverButton({
     }),
   ];
   const showSearch = connectorItems.length > 20;
-  const permissionConnector =
-    permissionEntryEnabled && permissionConnectorSlug
-      ? agentConnectors.find((c) => {
-          return c.slug === permissionConnectorSlug;
-        })
-      : undefined;
+  const permissionConnector = permissionConnectorSlug
+    ? agentConnectors.find((c) => {
+        return c.slug === permissionConnectorSlug;
+      })
+    : undefined;
 
   // Use snapshot order if available, otherwise preserve catalog order.
   const sorted = sortOrder
@@ -6635,8 +6632,7 @@ function ConnectorsPopoverButton({
                       <span className="text-sm flex-1 truncate text-foreground">
                         {connector.label}
                       </span>
-                      {permissionEntryEnabled &&
-                        agentId &&
+                      {agentId &&
                         connector.authorized &&
                         connector.permissionSummary.hasPermissions && (
                           <Button

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -69,7 +69,6 @@ export enum FeatureSwitchKey {
   FeishuIntegration = "feishuIntegration",
   StrapiIntegration = "strapiIntegration",
   WorkflowConnectorReadiness = "workflowConnectorReadiness",
-  ComposerConnectorPermissions = "composerConnectorPermissions",
   CustomConnectorMcp = "customConnectorMcp",
   ThreeColumnNav = "threeColumnNav",
   SharedThreadSharing = "sharedThreadSharing",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -483,12 +483,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ComposerConnectorPermissions]: {
-    maintainer: "ming@vm0.ai",
-    description:
-      "Show the configure-permissions entry in the chat composer connector popover, opening the agent×connector firewall dialog inline.",
-    enabled: false,
-  },
   [FeatureSwitchKey.CustomConnectorMcp]: {
     maintainer: "liangyou@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- permanently enable composer connector permission configuration in the chat composer
- remove the feature-switch key, registry entry, derived signal, and UI gates
- keep the positive integration coverage without a feature-switch override

## Rollout decision

- Terminal state: `fully-rolled-out`
- Decision basis: Ming requested the feature be fully rolled out and the switch removed in this chat on 2026-08-15.
- Introduction: `00ce45ed93a1238fcc0769dd7f960f2b185e1a7b` (#21849)
- Lab follow-up: `5ea1b54d11b0b6daa0c2ff5f0ed910b75d83a2fe` (#22679) made the disabled switch user-overridable.

The parent of the introduction commit had no composer permission entry. The enabled branch added the permission button and agent-scoped firewall dialog. This PR preserves that branch and removes only the disabled fallback and switch plumbing. Later connector naming, localization, and composer-state refactors preserved the same branch semantics.

## Behavior retained

- show the permission action for an identified agent when a built-in connector is authorized and exposes firewall permissions
- resolve the selected connector from composer UI state
- open the agent-scoped permissions dialog and load metadata and grants
- save permission policies, show localized feedback, and preserve split-composer scoping

## Cleanup

- remove `FeatureSwitchKey.ComposerConnectorPermissions` and its registry metadata
- remove `composerConnectorPermissionsEnabled$` and the corresponding `useGet`
- remove the feature gate around connector resolution and the permission button
- remove the test-only `true` override while retaining direct positive behavior coverage

## Search and Knip

Second-pass searches covered `composerConnectorPermissions`, `ComposerConnectorPermissions`, `composerConnectorPermissionsEnabled`, `permissionEntryEnabled`, kebab/snake variants, and the feature implementation names from the introduction diff. No switch or gate references remain. Positive-path names such as `ComposerConnectorPermissionDialog`, `permissionConnectorSlug`, `connectorPermissionMetadata$`, `connectorPermissionGrants$`, and `configurePermissions` remain intentionally. The generated changelog retains its historical #22679 entry.

- Knip baseline: passed with 46 existing configuration hints and no unused-code or dependency findings.
- Knip after cleanup: passed with the same 46 configuration hints and no new findings.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter="!api" --filter="!@okouai/app"`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (24 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx` (59 passed)
- `git diff --check`
- exact-key and second-pass repository searches

The full Vitest suite was not run locally per repository policy and is left to the PR pipeline.