### PR TITLE
feat(platform): show workflow visibility on hover

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1400,6 +1400,44 @@ describe("workflows routes", () => {
     await expect(screen.findByText("TU")).resolves.toBeInTheDocument();
   });
 
+  it("shows workflow visibility on hover", async () => {
+    const user = userEvent.setup();
+    mockWorkflowApis([salesResearch(), opsPlaybook()]);
+
+    detachedSetupPage({
+      context,
+      path: "/workflows",
+    });
+
+    const publicWorkflow = await waitFor(() => {
+      return articleByText("Sales Research");
+    });
+    const publicIcon = within(publicWorkflow).getByLabelText("Public");
+    await user.hover(publicIcon);
+    await expect(
+      screen.findByText("Public", {
+        selector: '[data-slot="tooltip-content"]',
+      }),
+    ).resolves.toBeInTheDocument();
+
+    await user.unhover(publicIcon);
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Public", {
+          selector: '[data-slot="tooltip-content"]',
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    const privateWorkflow = articleByText("Ops Playbook");
+    await user.hover(within(privateWorkflow).getByLabelText("Private"));
+    await expect(
+      screen.findByText("Private", {
+        selector: '[data-slot="tooltip-content"]',
+      }),
+    ).resolves.toBeInTheDocument();
+  });
+
   it("labels existing Stripe automations on the workspace workflows index", async () => {
     mockWorkflowApis([
       {

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -184,20 +184,27 @@ function VisibilityIcon({
 }) {
   const isPublic = workflow.visibility === "public";
   const Icon = isPublic ? Globe : Lock;
+  const label = isPublic
+    ? i18n.t(($) => {
+        return $.workflows.common.public;
+      })
+    : i18n.t(($) => {
+        return $.workflows.common.private;
+      });
   return (
-    <Icon
-      size={15}
-      className={cn("shrink-0", isPublic ? "text-blue-500" : "text-[#45A7A8]")}
-      aria-label={
-        isPublic
-          ? i18n.t(($) => {
-              return $.workflows.common.public;
-            })
-          : i18n.t(($) => {
-              return $.workflows.common.private;
-            })
-      }
-    />
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span aria-label={label} className="flex shrink-0">
+            <Icon
+              size={15}
+              className={isPublic ? "text-blue-500" : "text-[#45A7A8]"}
+            />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 


### PR DESCRIPTION
## Summary

- show the localized Public or Private label when hovering a workflow visibility icon
- preserve the existing visibility icon styling and accessible label
- cover both visibility states with an interaction test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged Turbo, platform, and API type checks
- `pnpm --filter @okouai/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx -t "shows workflow visibility on hover"`

The full workflows-page test file also runs an unrelated existing TEAM_REQUIRED test that expects `Every weekday at 9:00 AM`; in this environment the UI renders `Every weekday at 5:00 PM`, so that assertion fails independently when run alone.