### PR TITLE
fix(platform): hide rejected automation replacements

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-event-state.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-state.ts
@@ -150,6 +150,11 @@ export function semanticChatEventsFromChatEvents(
         : [];
     }),
   );
+  const automationInputIds = new Set(
+    events.flatMap((event) => {
+      return event.eventType === "input.automation" ? [event.id] : [];
+    }),
+  );
 
   return events.flatMap((event): SemanticChatEventState[] => {
     if (
@@ -160,6 +165,9 @@ export function semanticChatEventsFromChatEvents(
       isGoalMarkerEvent(event) ||
       isBrowserLifecycleEventType(event.eventType) ||
       isInterruptedAssistantCancellation(event, interruptedRunIds) ||
+      (event.eventType === "input.rejected" &&
+        event.revokesEventId !== undefined &&
+        automationInputIds.has(event.revokesEventId)) ||
       recalledIds.has(event.id) ||
       replacedIds.has(event.id)
     ) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -88,6 +88,85 @@ describe("chat lifecycle", () => {
     expect(screen.queryByText(machineReason)).not.toBeInTheDocument();
   });
 
+  it("hides a rejected automation replacement without hiding other rejected input", async () => {
+    const threadId = "e9000000-0000-4000-a000-000000000021";
+    const automationPrompt = "A run in the watched chat thread completed.";
+    const rejectedPrompt = "Summarize the completed run";
+    const assistantResponse = "The active run has completed.";
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Rejected automation event",
+      chatEvents: [
+        {
+          id: "msg-assistant-response",
+          role: "assistant",
+          content: assistantResponse,
+          createdAt: "2026-08-15T07:13:23Z",
+        },
+        {
+          id: "msg-pending-automation",
+          eventType: "input.automation",
+          content: null,
+          userMessage: {
+            version: 1,
+            parts: [
+              { type: "text", text: automationPrompt },
+              {
+                type: "automation",
+                workflowName: "chat-run-finished-callback",
+              },
+            ],
+          },
+          createdAt: "2026-08-15T07:12:33Z",
+        },
+        {
+          id: "msg-rejected-automation",
+          eventType: "input.rejected",
+          content: automationPrompt,
+          userMessage: {
+            version: 1,
+            parts: [
+              { type: "text", text: automationPrompt },
+              {
+                type: "automation",
+                workflowName: "chat-run-finished-callback",
+              },
+            ],
+          },
+          revokesEventId: "msg-pending-automation",
+          error: "Workflow automation is paused or no longer readable",
+          createdAt: "2026-08-15T07:13:24Z",
+        },
+        {
+          id: "msg-pending-prompt",
+          role: "user",
+          content: rejectedPrompt,
+          createdAt: "2026-08-15T07:13:25Z",
+        },
+        {
+          id: "msg-rejected-prompt",
+          eventType: "input.rejected",
+          content: rejectedPrompt,
+          revokesEventId: "msg-pending-prompt",
+          error: "Prompt could not be started",
+          createdAt: "2026-08-15T07:13:26Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const renderedAssistantResponse =
+      await screen.findByText(assistantResponse);
+    expect(renderedAssistantResponse).toBeInTheDocument();
+    expect(screen.queryByText(automationPrompt)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Workflow chat-run-finished-callback"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(rejectedPrompt)).toBeInTheDocument();
+  });
+
   it("opens run details from assistant message actions", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "e9000000-0000-4000-a000-000000000002";


### PR DESCRIPTION
## Summary

- hide input.rejected events that specifically replace queued input.automation events from the semantic chat timeline
- preserve the existing rendering behavior for rejected non-automation inputs
- add a page-level regression test for an automation rejected after an assistant response

## Context

When a queued workflow automation becomes permanently ineligible, the backend replaces the original input.automation event with input.rejected. The frontend already hid the replaced original event, but classified and rendered the replacement as a normal user bubble after the assistant response.

## Verification

- pnpm format
- pnpm --filter @okouai/app lint
- pnpm knip
- pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@okouai/app
- pnpm --filter @okouai/app run check-types
- pnpm --filter api run check-types
- pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-workflows-and-goals.test.tsx (32 tests passed)

Browser QA was not run because repository instructions prohibit starting a local dev server for this task; the PR preview pipeline will provide the browser-testable build.