### PR TITLE
refactor(platform): refine models settings layout

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4263,6 +4263,7 @@
         "apiKeyDescription": "Ein gemeinsam genutzter Arbeitsbereichsschlüssel. Am besten ist es, wenn das Team über ein Konto abrechnet.",
         "apiKeyPlaceholder": "Geben Sie Ihren API-Schlüssel ein",
         "apiKeyRequired": "API-Schlüssel ist erforderlich",
+        "availableModels": "Verfügbare Modelle",
         "builtIn": "Eingebaut",
         "builtInDescription": "Arbeitsbereichs-Credits decken die Nutzung ab.",
         "claudeSubscription": "Claude-Abonnement",
@@ -4281,16 +4282,17 @@
         "model": "Modell",
         "noAvailableModels": "Keine verfügbaren Modelle",
         "noMappedGateway": "Diesem Modell ist keine Anbieterverbindung zugeordnet.",
+        "pricing": "Preise",
         "providedBy": "Bereitgestellt von",
         "provider": "Anbieter",
         "providerApiKey": "{{provider}} API-Schlüssel",
+        "runsThrough": "Ausführung über",
         "secretStored": "In den Workspace-Secrets gespeichert.",
         "selectDefaultModel": "Wählen Sie ein Standardmodell aus",
         "selectGateway": "Anbieterverbindung auswählen",
         "selectModel": "Wählen Sie ein Modell aus",
         "selectProvider": "Wählen Sie einen Anbieter aus",
-        "workspaceDescription": "Verfügbar für alle in diesem Arbeitsbereich.",
-        "workspaceTitle": "Arbeitsbereich"
+        "workspaceDescription": "Verfügbar für alle in diesem Arbeitsbereich."
       },
       "reset": {
         "confirmDescription": "Verwenden Sie einen Codex-Reset, um Ihre aktuellen Nutzungsfenster zurückzusetzen. Sie haben {{remaining}}.",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4263,6 +4263,7 @@
         "apiKeyDescription": "A shared workspace key. Best when the team bills through one account.",
         "apiKeyPlaceholder": "Enter your API key",
         "apiKeyRequired": "API key is required",
+        "availableModels": "Available models",
         "builtIn": "Built-in",
         "builtInDescription": "Workspace credits cover usage.",
         "claudeSubscription": "Claude subscription",
@@ -4281,16 +4282,17 @@
         "model": "Model",
         "noAvailableModels": "No available models",
         "noMappedGateway": "No provider connection maps this model.",
+        "pricing": "Pricing",
         "providedBy": "Provided by",
         "provider": "Provider",
         "providerApiKey": "{{provider}} API key",
+        "runsThrough": "Runs through",
         "secretStored": "Stored in workspace secrets.",
         "selectDefaultModel": "Select a default model",
         "selectGateway": "Select a provider connection",
         "selectModel": "Select a model",
         "selectProvider": "Select a provider",
-        "workspaceDescription": "Available to everyone in this workspace.",
-        "workspaceTitle": "Workspace"
+        "workspaceDescription": "Available to everyone in this workspace."
       },
       "reset": {
         "confirmDescription": "Use one Codex reset to reset your current usage windows. You have {{remaining}}.",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -4313,6 +4313,7 @@
         "apiKeyDescription": "Una clave compartida por el espacio de trabajo, ideal cuando el equipo factura mediante una sola cuenta.",
         "apiKeyPlaceholder": "Introduce tu clave API",
         "apiKeyRequired": "Se requiere clave API",
+        "availableModels": "Modelos disponibles",
         "builtIn": "Integrado",
         "builtInDescription": "Los créditos de espacio de trabajo cubren el uso.",
         "claudeSubscription": "Suscripción de Claude",
@@ -4331,16 +4332,17 @@
         "model": "Modelo",
         "noAvailableModels": "No hay modelos disponibles",
         "noMappedGateway": "Ninguna conexión de proveedor asigna este modelo.",
+        "pricing": "Precios",
         "providedBy": "Proporcionado por",
         "provider": "Proveedor",
         "providerApiKey": "Clave API de {{provider}}",
+        "runsThrough": "Se ejecuta mediante",
         "secretStored": "Almacenado en secretos del espacio de trabajo.",
         "selectDefaultModel": "Seleccionar un modelo por defecto",
         "selectGateway": "Seleccionar una conexión de proveedor",
         "selectModel": "Seleccionar un modelo",
         "selectProvider": "Seleccionar un proveedor",
-        "workspaceDescription": "Disponible para todos en este espacio de trabajo.",
-        "workspaceTitle": "Espacio de trabajo"
+        "workspaceDescription": "Disponible para todos en este espacio de trabajo."
       },
       "reset": {
         "confirmDescription": "Usa un restablecimiento de Codex para reiniciar tus periodos de consumo actuales. Te quedan {{remaining}}.",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -4313,6 +4313,7 @@
         "apiKeyDescription": "Une clé d'espace de travail partagée. Idéal lorsque l'équipe facture via un seul compte.",
         "apiKeyPlaceholder": "Entrez votre clé API",
         "apiKeyRequired": "La clé API est requise",
+        "availableModels": "Modèles disponibles",
         "builtIn": "Intégré",
         "builtInDescription": "Les crédits de l'espace de travail couvrent l'utilisation.",
         "claudeSubscription": "Abonnement Claude",
@@ -4331,16 +4332,17 @@
         "model": "Modèle",
         "noAvailableModels": "Aucun modèle disponible",
         "noMappedGateway": "Aucune connexion au fournisseur ne correspond à ce modèle.",
+        "pricing": "Tarification",
         "providedBy": "Fourni par",
         "provider": "Fournisseur",
         "providerApiKey": "Clé API {{provider}}",
+        "runsThrough": "Exécuté via",
         "secretStored": "Stocké dans les secrets de l'espace de travail.",
         "selectDefaultModel": "Sélectionner un modèle par défaut",
         "selectGateway": "Sélectionner une connexion au fournisseur",
         "selectModel": "Sélectionner un modèle",
         "selectProvider": "Sélectionner un fournisseur",
-        "workspaceDescription": "Disponible pour tous les membres de cet espace de travail.",
-        "workspaceTitle": "Espace de travail"
+        "workspaceDescription": "Disponible pour tous les membres de cet espace de travail."
       },
       "reset": {
         "confirmDescription": "Utilisez une réinitialisation de Codex pour remettre à zéro vos fenêtres d'utilisation actuelles. Il vous en reste {{remaining}}.",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4263,6 +4263,7 @@
         "apiKeyDescription": "एक साझा वर्कस्पेस कुंजी। सबसे अच्छा तब होता है जब टीम एक खाते के माध्यम से बिल देती है।",
         "apiKeyPlaceholder": "अपनी API कुंजी दर्ज करें",
         "apiKeyRequired": "API कुंजी आवश्यक है",
+        "availableModels": "उपलब्ध मॉडल",
         "builtIn": "में निर्मित",
         "builtInDescription": "वर्कस्पेस क्रेडिट उपयोग को कवर करता है।",
         "claudeSubscription": "Claude सदस्यता",
@@ -4281,16 +4282,17 @@
         "model": "मॉडल",
         "noAvailableModels": "कोई उपलब्ध मॉडल नहीं",
         "noMappedGateway": "कोई प्रदाता कनेक्शन इस मॉडल से मैप नहीं है।",
+        "pricing": "मूल्य",
         "providedBy": "द्वारा उपलब्ध कराया गया",
         "provider": "प्रोवाइडर",
         "providerApiKey": "{{provider}} API कुंजी",
+        "runsThrough": "रन का माध्यम",
         "secretStored": "वर्कस्पेस में रहस्य संग्रहीत।",
         "selectDefaultModel": "एक डिफ़ॉल्ट मॉडल चुनें",
         "selectGateway": "प्रदाता कनेक्शन चुनें",
         "selectModel": "एक मॉडल चुनें",
         "selectProvider": "एक प्रोवाइडर चुनें",
-        "workspaceDescription": "इस वर्कस्पेस में सभी के लिए उपलब्ध है।",
-        "workspaceTitle": "वर्कस्पेस"
+        "workspaceDescription": "इस वर्कस्पेस में सभी के लिए उपलब्ध है।"
       },
       "reset": {
         "confirmDescription": "अपनी वर्तमान उपयोग विंडो को रीसेट करने के लिए एक Codex रीसेट का उपयोग करें। आपके पास {{remaining}} है।",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4262,6 +4262,7 @@
         "apiKeyDescription": "Kunci ruang kerja bersama. Paling cocok saat tim menagih melalui satu akun.",
         "apiKeyPlaceholder": "Masukkan kunci API Anda",
         "apiKeyRequired": "Kunci API wajib diisi",
+        "availableModels": "Model yang tersedia",
         "builtIn": "Bawaan",
         "builtInDescription": "Kredit ruang kerja menanggung penggunaan.",
         "claudeSubscription": "Langganan Claude",
@@ -4280,16 +4281,17 @@
         "model": "Model",
         "noAvailableModels": "Tidak ada model yang tersedia",
         "noMappedGateway": "Tidak ada koneksi penyedia yang memetakan model ini.",
+        "pricing": "Harga",
         "providedBy": "Disediakan oleh",
         "provider": "Provider",
         "providerApiKey": "Kunci API {{provider}}",
+        "runsThrough": "Dijalankan melalui",
         "secretStored": "Disimpan di rahasia ruang kerja.",
         "selectDefaultModel": "Pilih model default",
         "selectGateway": "Pilih koneksi penyedia",
         "selectModel": "Pilih model",
         "selectProvider": "Pilih provider",
-        "workspaceDescription": "Tersedia untuk semua orang di ruang kerja ini.",
-        "workspaceTitle": "Ruang kerja"
+        "workspaceDescription": "Tersedia untuk semua orang di ruang kerja ini."
       },
       "reset": {
         "confirmDescription": "Gunakan satu reset Codex untuk mereset jendela penggunaan saat ini. Anda memiliki {{remaining}}.",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -4313,6 +4313,7 @@
         "apiKeyDescription": "Una chiave dell'area di lavoro condivisa. È meglio quando il team fattura tramite un unico account.",
         "apiKeyPlaceholder": "Inserisci la tua chiave API",
         "apiKeyRequired": "La chiave API è obbligatoria",
+        "availableModels": "Modelli disponibili",
         "builtIn": "Integrato",
         "builtInDescription": "I crediti dell'area di lavoro coprono l'utilizzo.",
         "claudeSubscription": "Claude abbonamento",
@@ -4331,16 +4332,17 @@
         "model": "Modello",
         "noAvailableModels": "Nessun modello disponibile",
         "noMappedGateway": "Nessuna connessione al provider mappa questo modello.",
+        "pricing": "Prezzi",
         "providedBy": "Fornito da",
         "provider": "Provider",
         "providerApiKey": "Chiave API {{provider}}",
+        "runsThrough": "Eseguito tramite",
         "secretStored": "Archiviati nei segreti dell'area di lavoro.",
         "selectDefaultModel": "Seleziona un modello predefinito",
         "selectGateway": "Seleziona una connessione al provider",
         "selectModel": "Seleziona un modello",
         "selectProvider": "Seleziona un provider",
-        "workspaceDescription": "Disponibile per tutti in quest'area di lavoro.",
-        "workspaceTitle": "Area di lavoro"
+        "workspaceDescription": "Disponibile per tutti in quest'area di lavoro."
       },
       "reset": {
         "confirmDescription": "Usa un ripristino Codex per reimpostare le finestre di utilizzo correnti. Te ne restano {{remaining}}.",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4262,6 +4262,7 @@
         "apiKeyDescription": "共有ワークスペースキー。チームが 1 つのアカウントを通じて請求する場合に最適です。",
         "apiKeyPlaceholder": "API キーを入力してください",
         "apiKeyRequired": "APIキーが必要です",
+        "availableModels": "利用可能なモデル",
         "builtIn": "内蔵",
         "builtInDescription": "ワークスペース クレジットで使用量がカバーされます。",
         "claudeSubscription": "Claude サブスクリプション",
@@ -4280,16 +4281,17 @@
         "model": "モデル",
         "noAvailableModels": "利用可能なモデルはありません",
         "noMappedGateway": "このモデルにマッピングされたプロバイダー接続はありません。",
+        "pricing": "料金",
         "providedBy": "提供元",
         "provider": "プロバイダー",
         "providerApiKey": "{{provider}} API キー",
+        "runsThrough": "実行経路",
         "secretStored": "ワークスペースのシークレットに保存されます。",
         "selectDefaultModel": "デフォルトのモデルを選択してください",
         "selectGateway": "プロバイダー接続を選択してください",
         "selectModel": "モデルを選択してください",
         "selectProvider": "プロバイダーを選択してください",
-        "workspaceDescription": "このワークスペース内の全員が利用できます。",
-        "workspaceTitle": "ワークスペース"
+        "workspaceDescription": "このワークスペース内の全員が利用できます。"
       },
       "reset": {
         "confirmDescription": "Codexリセットを1回使用して、現在の使用枠をリセットします。{{remaining}}。",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4262,6 +4262,7 @@
         "apiKeyDescription": "공유 워크스페이스 키입니다. 팀이 하나의 계정으로 청구할 때 가장 적합합니다.",
         "apiKeyPlaceholder": "API 키 입력",
         "apiKeyRequired": "API 키가 필요합니다.",
+        "availableModels": "사용 가능한 모델",
         "builtIn": "내장형",
         "builtInDescription": "워크스페이스 크레딧으로 사용량을 충당합니다.",
         "claudeSubscription": "Claude 구독",
@@ -4280,16 +4281,17 @@
         "model": "모델",
         "noAvailableModels": "사용 가능한 모델 없음",
         "noMappedGateway": "이 모델에 매핑된 공급자 연결이 없습니다.",
+        "pricing": "요금",
         "providedBy": "제공자",
         "provider": "공급자",
         "providerApiKey": "{{provider}} API 키",
+        "runsThrough": "실행 경로",
         "secretStored": "워크스페이스 비밀에 저장됨.",
         "selectDefaultModel": "기본 모델 선택",
         "selectGateway": "공급자 연결 선택",
         "selectModel": "모델 선택",
         "selectProvider": "공급자 선택",
-        "workspaceDescription": "이 워크스페이스의 모든 사용자에게 제공됨.",
-        "workspaceTitle": "워크스페이스"
+        "workspaceDescription": "이 워크스페이스의 모든 사용자에게 제공됨."
       },
       "reset": {
         "confirmDescription": "현재 사용량 창을 재설정하려면 Codex 재설정 1회를 사용하세요. 남은 횟수: {{remaining}}.",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4313,6 +4313,7 @@
         "apiKeyDescription": "Uma chave compartilhada do espaço de trabalho. Ideal quando a equipe fatura o uso por uma única conta.",
         "apiKeyPlaceholder": "Insira sua chave de API",
         "apiKeyRequired": "A chave de API é obrigatória",
+        "availableModels": "Modelos disponíveis",
         "builtIn": "Integrado",
         "builtInDescription": "Os créditos do espaço de trabalho cobrem o uso.",
         "claudeSubscription": "Assinatura do Claude",
@@ -4331,16 +4332,17 @@
         "model": "Modelo",
         "noAvailableModels": "Nenhum modelo disponível",
         "noMappedGateway": "Nenhuma conexão de provedor mapeia este modelo.",
+        "pricing": "Preços",
         "providedBy": "Disponibilizado por",
         "provider": "Provedor",
         "providerApiKey": "Chave de API da {{provider}}",
+        "runsThrough": "Executado por",
         "secretStored": "Armazenado nos segredos do espaço de trabalho.",
         "selectDefaultModel": "Selecionar um modelo padrão",
         "selectGateway": "Selecionar uma conexão de provedor",
         "selectModel": "Selecionar um modelo",
         "selectProvider": "Selecionar um provedor",
-        "workspaceDescription": "Disponível para todos neste espaço de trabalho.",
-        "workspaceTitle": "Espaço de trabalho"
+        "workspaceDescription": "Disponível para todos neste espaço de trabalho."
       },
       "reset": {
         "confirmDescription": "Use uma redefinição do Codex para redefinir suas janelas de uso atuais. Você tem {{remaining}}.",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-providers-tab.test.tsx
@@ -416,6 +416,40 @@ describe("organization model providers settings", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("prioritizes the default model and available routes before provider connections", async () => {
+    mockAdminOrg();
+    context.mocks.data.orgModelProviders([]);
+    context.mocks.data.orgModelPolicies([
+      builtInPolicy(
+        "00000000-0000-4000-a000-000000000211",
+        "gpt-5.6-luna",
+        "GPT 5.6 Luna",
+        true,
+      ),
+    ]);
+
+    await openProvidersTab();
+
+    const defaultModel = screen.getByTestId("default-model-row");
+    const availableModels = screen.getByRole("heading", {
+      name: "Available models",
+    });
+    const providerConnections = screen.getByRole("heading", {
+      name: "Provider connections",
+    });
+
+    expect(
+      defaultModel.compareDocumentPosition(availableModels) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      availableModels.compareDocumentPosition(providerConnections) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(screen.getByText("Runs through")).toBeInTheDocument();
+    expect(screen.getByText("Pricing")).toBeInTheDocument();
+  });
+
   it("clears a gateway draft when settings closes", async () => {
     mockAdminOrg();
     context.mocks.data.orgModelProviders([]);

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/model-provider-connections-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/model-provider-connections-section.tsx
@@ -525,7 +525,10 @@ export function ModelProviderConnectionsSection() {
         action={<AddConnectionMenu />}
       />
       {connections.length === 0 ? (
-        <p className="rounded-xl bg-muted/20 px-4 py-5 text-sm text-muted-foreground">
+        <p
+          className="rounded-xl bg-card px-4 py-5 text-sm text-muted-foreground"
+          style={ZERO_BORDER}
+        >
           {t(($) => {
             return $.settings.models.gateways.empty;
           })}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/model-provider-connections-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/model-provider-connections-section.tsx
@@ -125,7 +125,10 @@ function ConnectionCard({
     return null;
   }
   return (
-    <div className="zero-card flex items-center gap-3 px-4 py-3">
+    <div
+      className="flex items-center gap-3 rounded-xl bg-card px-4 py-3"
+      style={ZERO_BORDER}
+    >
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium text-foreground">
           {connection.displayName}
@@ -511,44 +514,30 @@ export function ModelProviderConnectionsSection() {
     return null;
   }
   return (
-    <section className="flex flex-col gap-3">
+    <section className="flex flex-col gap-4">
+      <SettingsSectionHeading
+        title={t(($) => {
+          return $.settings.models.gateways.title;
+        })}
+        description={t(($) => {
+          return $.settings.models.gateways.description;
+        })}
+        action={<AddConnectionMenu />}
+      />
       {connections.length === 0 ? (
-        <div className="zero-card flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="min-w-0">
-            <h3 className="text-sm font-medium text-foreground">
-              {t(($) => {
-                return $.settings.models.gateways.title;
-              })}
-            </h3>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              {t(($) => {
-                return $.settings.models.gateways.empty;
-              })}
-            </p>
-          </div>
-          <div className="shrink-0">
-            <AddConnectionMenu />
-          </div>
-        </div>
+        <p className="rounded-xl bg-muted/20 px-4 py-5 text-sm text-muted-foreground">
+          {t(($) => {
+            return $.settings.models.gateways.empty;
+          })}
+        </p>
       ) : (
-        <>
-          <SettingsSectionHeading
-            title={t(($) => {
-              return $.settings.models.gateways.title;
-            })}
-            description={t(($) => {
-              return $.settings.models.gateways.description;
-            })}
-            action={<AddConnectionMenu />}
-          />
-          <div className="grid gap-2">
-            {connections.map((connection) => {
-              return (
-                <ConnectionCard key={connection.id} connection={connection} />
-              );
-            })}
-          </div>
-        </>
+        <div className="grid gap-2">
+          {connections.map((connection) => {
+            return (
+              <ConnectionCard key={connection.id} connection={connection} />
+            );
+          })}
+        </div>
       )}
       <ConnectionDialog />
       <DeleteConnectionDialog />

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/model-provider-connections-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/model-provider-connections-section.tsx
@@ -125,10 +125,7 @@ function ConnectionCard({
     return null;
   }
   return (
-    <div
-      className="flex items-center gap-3 rounded-xl bg-card px-4 py-3"
-      style={ZERO_BORDER}
-    >
+    <div className="zero-card flex items-center gap-3 px-4 py-3">
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium text-foreground">
           {connection.displayName}
@@ -514,30 +511,44 @@ export function ModelProviderConnectionsSection() {
     return null;
   }
   return (
-    <section className="flex flex-col gap-4">
-      <SettingsSectionHeading
-        title={t(($) => {
-          return $.settings.models.gateways.title;
-        })}
-        description={t(($) => {
-          return $.settings.models.gateways.description;
-        })}
-        action={<AddConnectionMenu />}
-      />
+    <section className="flex flex-col gap-3">
       {connections.length === 0 ? (
-        <p className="rounded-xl bg-muted/20 px-4 py-5 text-sm text-muted-foreground">
-          {t(($) => {
-            return $.settings.models.gateways.empty;
-          })}
-        </p>
-      ) : (
-        <div className="grid gap-2">
-          {connections.map((connection) => {
-            return (
-              <ConnectionCard key={connection.id} connection={connection} />
-            );
-          })}
+        <div className="zero-card flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium text-foreground">
+              {t(($) => {
+                return $.settings.models.gateways.title;
+              })}
+            </h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {t(($) => {
+                return $.settings.models.gateways.empty;
+              })}
+            </p>
+          </div>
+          <div className="shrink-0">
+            <AddConnectionMenu />
+          </div>
         </div>
+      ) : (
+        <>
+          <SettingsSectionHeading
+            title={t(($) => {
+              return $.settings.models.gateways.title;
+            })}
+            description={t(($) => {
+              return $.settings.models.gateways.description;
+            })}
+            action={<AddConnectionMenu />}
+          />
+          <div className="grid gap-2">
+            {connections.map((connection) => {
+              return (
+                <ConnectionCard key={connection.id} connection={connection} />
+              );
+            })}
+          </div>
+        </>
       )}
       <ConnectionDialog />
       <DeleteConnectionDialog />

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -321,8 +321,7 @@ function DefaultModelRow({
   return (
     <div
       data-testid="default-model-row"
-      className="flex flex-col gap-3 overflow-hidden rounded-xl bg-card px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
-      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+      className="zero-card flex flex-col gap-3 overflow-hidden px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
     >
       <div className="min-w-0">
         <p className="text-sm font-medium text-foreground">
@@ -361,10 +360,7 @@ function DefaultModelRow({
           }}
           disabled={disabled}
         >
-          <SelectTrigger
-            className="h-9 w-full shrink-0 rounded-lg bg-card sm:w-[280px]"
-            style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-          >
+          <SelectTrigger className="h-9 w-full shrink-0 rounded-lg bg-card sm:w-[280px]">
             <SelectValue
               placeholder={t(($) => {
                 return $.settings.models.policies.selectDefaultModel;
@@ -601,9 +597,8 @@ function AddModelButton({
   return (
     <Button
       type="button"
-      variant="outline"
       size="sm"
-      className="zero-btn-morandi h-9 gap-2 rounded-lg border"
+      className="h-9 gap-2 bg-foreground text-background hover:bg-foreground-hover active:bg-foreground-pressed"
       disabled={disabled}
       onClick={onClick}
     >
@@ -651,17 +646,14 @@ function PolicyRow({
   return (
     <div
       data-testid={`org-model-policy-row-${policy.model}`}
-      className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 px-4 py-3 sm:grid-cols-[minmax(0,1fr)_236px_auto]"
+      className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-2 px-4 py-3 lg:grid-cols-[minmax(0,1fr)_236px_96px_36px]"
     >
-      <div className="flex min-w-0 flex-col justify-center">
-        <div className="flex items-center gap-2">
+      <div className="col-start-1 row-start-1 flex min-w-0 flex-col justify-center">
+        <div className="flex min-w-0 items-center gap-2">
           {modelIconType && <ProviderIcon type={modelIconType} size={18} />}
-          <p className="truncate text-sm font-medium text-foreground">
+          <p className="min-w-0 truncate text-sm font-medium text-foreground">
             {policy.modelLabel}
           </p>
-          {builtInPriceTier !== undefined && (
-            <PriceTierBadge tier={builtInPriceTier} />
-          )}
           {policy.routeStatus !== "valid" && (
             <span className="inline-flex items-center gap-1 rounded bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300">
               <AlertTriangle size={12} />
@@ -681,7 +673,7 @@ function PolicyRow({
           </p>
         )}
       </div>
-      <div className="flex items-center justify-end sm:order-4">
+      <div className="col-start-2 row-start-1 flex items-center justify-end lg:col-start-4">
         <PolicyActionsMenu
           policy={policy}
           disabled={disabled}
@@ -690,11 +682,18 @@ function PolicyRow({
           onDelete={onDelete}
         />
       </div>
-      <div className="col-span-2 flex min-w-0 flex-col justify-center sm:order-3 sm:col-span-1 sm:items-start">
+      <div className="col-start-1 row-start-2 flex min-w-0 flex-col justify-center lg:col-start-2 lg:row-start-1">
         <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
           <ProviderIcon type={routeSummary.iconType} size={16} />
           <span className="min-w-0 truncate">{routeSummary.label}</span>
         </div>
+      </div>
+      <div className="col-start-2 row-start-2 flex items-center justify-end lg:col-start-3 lg:row-start-1 lg:justify-start">
+        {builtInPriceTier === undefined ? (
+          <span className="text-xs text-muted-foreground">—</span>
+        ) : (
+          <PriceTierBadge tier={builtInPriceTier} />
+        )}
       </div>
     </div>
   );
@@ -1798,22 +1797,7 @@ export function OrgModelPoliciesSection() {
   };
 
   return (
-    <section className="flex flex-col gap-4">
-      <SettingsSectionHeading
-        title={t(($) => {
-          return $.settings.models.policies.workspaceTitle;
-        })}
-        description={t(($) => {
-          return $.settings.models.policies.workspaceDescription;
-        })}
-        action={
-          <AddModelButton
-            hasModels={addableModels.length > 0}
-            disabled={saving}
-            onClick={handleOpenAddModel}
-          />
-        }
-      />
+    <section className="flex flex-col gap-6">
       <DefaultModelRow
         policies={visiblePolicies}
         workspaceDefaultModel={data.workspaceDefaultModel}
@@ -1822,25 +1806,57 @@ export function OrgModelPoliciesSection() {
         onChange={handleDefaultModelChange}
         onUpgrade={openComparePlans}
       />
-      <div
-        className="overflow-hidden rounded-xl bg-card"
-        style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-      >
-        <div className="divide-y divide-border/50">
-          {visiblePolicies.map((policy) => {
-            return (
-              <PolicyRow
-                key={policy.id}
-                policy={policy}
-                providers={providers}
-                connections={connections}
-                disabled={false}
-                canDelete={policies.length > 1}
-                onEdit={handleEditPolicy}
-                onDelete={handleDeletePolicy}
-              />
-            );
+      <div className="flex flex-col gap-3">
+        <SettingsSectionHeading
+          title={t(($) => {
+            return $.settings.models.policies.availableModels;
           })}
+          description={t(($) => {
+            return $.settings.models.policies.workspaceDescription;
+          })}
+          action={
+            <AddModelButton
+              hasModels={addableModels.length > 0}
+              disabled={saving}
+              onClick={handleOpenAddModel}
+            />
+          }
+        />
+        <div className="zero-card overflow-hidden">
+          <div className="hidden grid-cols-[minmax(0,1fr)_236px_96px_36px] gap-3 border-b border-border/50 bg-muted/20 px-4 py-2.5 text-xs font-medium text-muted-foreground lg:grid">
+            <span>
+              {t(($) => {
+                return $.settings.models.policies.model;
+              })}
+            </span>
+            <span>
+              {t(($) => {
+                return $.settings.models.policies.runsThrough;
+              })}
+            </span>
+            <span>
+              {t(($) => {
+                return $.settings.models.policies.pricing;
+              })}
+            </span>
+            <span />
+          </div>
+          <div className="divide-y divide-border/50">
+            {visiblePolicies.map((policy) => {
+              return (
+                <PolicyRow
+                  key={policy.id}
+                  policy={policy}
+                  providers={providers}
+                  connections={connections}
+                  disabled={false}
+                  canDelete={policies.length > 1}
+                  onEdit={handleEditPolicy}
+                  onDelete={handleDeletePolicy}
+                />
+              );
+            })}
+          </div>
         </div>
       </div>
       <ModelPolicyRouteDialog

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -321,7 +321,8 @@ function DefaultModelRow({
   return (
     <div
       data-testid="default-model-row"
-      className="zero-card flex flex-col gap-3 overflow-hidden px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+      className="flex flex-col gap-3 overflow-hidden rounded-xl bg-card px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
     >
       <div className="min-w-0">
         <p className="text-sm font-medium text-foreground">
@@ -360,7 +361,10 @@ function DefaultModelRow({
           }}
           disabled={disabled}
         >
-          <SelectTrigger className="h-9 w-full shrink-0 rounded-lg bg-card sm:w-[280px]">
+          <SelectTrigger
+            className="h-9 w-full shrink-0 rounded-lg bg-card sm:w-[280px]"
+            style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          >
             <SelectValue
               placeholder={t(($) => {
                 return $.settings.models.policies.selectDefaultModel;
@@ -597,8 +601,9 @@ function AddModelButton({
   return (
     <Button
       type="button"
+      variant="outline"
       size="sm"
-      className="h-9 gap-2 bg-foreground text-background hover:bg-foreground-hover active:bg-foreground-pressed"
+      className="zero-btn-morandi h-9 gap-2 rounded-lg border"
       disabled={disabled}
       onClick={onClick}
     >
@@ -1822,7 +1827,10 @@ export function OrgModelPoliciesSection() {
             />
           }
         />
-        <div className="zero-card overflow-hidden">
+        <div
+          className="overflow-hidden rounded-xl bg-card"
+          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+        >
           <div className="hidden grid-cols-[minmax(0,1fr)_236px_96px_36px] gap-3 border-b border-border/50 bg-muted/20 px-4 py-2.5 text-xs font-medium text-muted-foreground lg:grid">
             <span>
               {t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -27,10 +27,10 @@ export function OrgProvidersTab() {
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
 
   return (
-    <div className="flex flex-col gap-8">
-      {isAdmin && <ModelProviderConnectionsSection />}
+    <div className="flex flex-col gap-6">
       {isAdmin && <OrgModelPoliciesSection />}
       <StaleBannerSection />
+      {isAdmin && <ModelProviderConnectionsSection />}
       <ClaudeCodeDeviceAuthDialog />
       <CodexDeviceAuthDialog />
       {isAdmin && (


### PR DESCRIPTION
## Summary

- prioritize the default model and reorganize available models into consistent Model, Runs through, and Pricing columns
- preserve the existing controls while presenting the empty provider connection state as a white card
- move provider connections after model policies, add localized labels, and cover the content order with a page-level regression test

## Testing

- `npx --yes prettier@3.8.1 --check <changed files>`
- `npx --yes oxlint@1.75.0 <changed platform files>`
- locale JSON parsing and `git diff --check`
- local Vitest and i18n extraction were not run because workspace dependencies are not installed; PR checks will cover them
