### PR TITLE
fix(ui): wrap pinned agents in four-column grid

### DIFF
--- a/e2e/playwright/tests/agents.spec.ts
+++ b/e2e/playwright/tests/agents.spec.ts
@@ -1,13 +1,229 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../fixtures";
 import { deriveAppUrl } from "../playwright.config";
 
 const appUrl = deriveAppUrl(process.env.VM0_API_BACKEND_URL!);
+const pinnedAgentStory = [
+  {
+    id: "c0000000-0000-4000-a000-000000000701",
+    displayName: "Research Agent",
+  },
+  {
+    id: "c0000000-0000-4000-a000-000000000702",
+    displayName: "Support Agent",
+  },
+  {
+    id: "c0000000-0000-4000-a000-000000000703",
+    displayName: "Operations Agent",
+  },
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+async function mockPinnedAgentGrid(
+  page: Page,
+  defaultAgentId: string,
+): Promise<void> {
+  await page.route("**/api/okou/feature-switches", async (route) => {
+    const response = await route.fetch();
+    const body: unknown = await response.json();
+    if (!isRecord(body) || !isRecord(body.effectiveSwitches)) {
+      throw new Error("Feature switches returned an unexpected response");
+    }
+    await route.fulfill({
+      response,
+      json: {
+        ...body,
+        effectiveSwitches: {
+          ...body.effectiveSwitches,
+          threeColumnNav: true,
+        },
+      },
+    });
+  });
+
+  await page.route("**/api/okou/team", async (route) => {
+    const response = await route.fetch();
+    const body: unknown = await response.json();
+    if (!Array.isArray(body) || !body.every(isRecord)) {
+      throw new Error("Team returned an unexpected response");
+    }
+    const defaultAgent = body.find((agent) => {
+      return agent.id === defaultAgentId;
+    });
+    if (!defaultAgent) {
+      throw new Error("Default agent is missing from the team response");
+    }
+    await route.fulfill({
+      response,
+      json: [
+        defaultAgent,
+        ...pinnedAgentStory.map((agent, index) => {
+          return {
+            ...defaultAgent,
+            ...agent,
+            headVersionId: `playwright-version-${index + 1}`,
+          };
+        }),
+      ],
+    });
+  });
+
+  await page.route("**/api/okou/user-preferences", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    const response = await route.fetch();
+    const body: unknown = await response.json();
+    if (!isRecord(body)) {
+      throw new Error("User preferences returned an unexpected response");
+    }
+    await route.fulfill({
+      response,
+      json: {
+        ...body,
+        pinnedAgentIds: pinnedAgentStory.map((agent) => {
+          return agent.id;
+        }),
+      },
+    });
+  });
+}
 
 test("navigate to agents page and verify heading", async ({ page }) => {
   await page.goto(`${appUrl}/agents`);
   await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible({
     timeout: 20_000,
   });
+});
+
+test("pinned agents use four equal columns without horizontal overflow", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(appUrl);
+  await page.waitForURL(/\/agents\/[^/]+\/chat\/?$/, { timeout: 30_000 });
+  const defaultAgentId = new URL(page.url()).pathname.match(
+    /^\/agents\/([^/]+)\/chat\/?$/,
+  )?.[1];
+  if (!defaultAgentId) {
+    throw new Error("Could not resolve the default agent from the sidebar");
+  }
+
+  await mockPinnedAgentGrid(page, defaultAgentId);
+  await page.reload();
+
+  const grid = page.getByTestId("pinned-agents-grid");
+  const cards = grid.getByTestId("pinned-agent-card");
+  const newAgent = grid.getByRole("button", {
+    name: "Open a conversation",
+  });
+  await expect(cards).toHaveCount(4);
+  await expect(newAgent).toBeVisible();
+
+  await expect
+    .poll(async () => {
+      const boxes = await Promise.all([
+        cards.nth(0).boundingBox(),
+        cards.nth(1).boundingBox(),
+        cards.nth(2).boundingBox(),
+        newAgent.boundingBox(),
+      ]);
+      if (boxes.some((box) => box === null)) {
+        return Number.POSITIVE_INFINITY;
+      }
+      const tops = boxes.map((box) => box!.y);
+      return Math.max(...tops) - Math.min(...tops);
+    })
+    .toBeLessThan(2);
+
+  await expect
+    .poll(async () => {
+      const boxes = await Promise.all([
+        cards.nth(0).boundingBox(),
+        cards.nth(1).boundingBox(),
+        cards.nth(2).boundingBox(),
+        newAgent.boundingBox(),
+      ]);
+      if (boxes.some((box) => box === null)) {
+        return 0;
+      }
+      return Math.min(
+        boxes[1]!.x - boxes[0]!.x,
+        boxes[2]!.x - boxes[1]!.x,
+        boxes[3]!.x - boxes[2]!.x,
+      );
+    })
+    .toBeGreaterThan(1);
+
+  await expect
+    .poll(async () => {
+      const boxes = await Promise.all([
+        cards.nth(0).boundingBox(),
+        cards.nth(1).boundingBox(),
+        cards.nth(2).boundingBox(),
+        cards.nth(3).boundingBox(),
+        newAgent.boundingBox(),
+      ]);
+      if (boxes.some((box) => box === null)) {
+        return Number.POSITIVE_INFINITY;
+      }
+      const widths = boxes.map((box) => box!.width);
+      return Math.max(...widths) - Math.min(...widths);
+    })
+    .toBeLessThan(2);
+
+  await expect
+    .poll(async () => {
+      const [gridBox, newAgentBox] = await Promise.all([
+        grid.boundingBox(),
+        newAgent.boundingBox(),
+      ]);
+      if (!gridBox || !newAgentBox) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return Math.abs(
+        newAgentBox.x + newAgentBox.width - (gridBox.x + gridBox.width),
+      );
+    })
+    .toBeLessThan(2);
+
+  await expect
+    .poll(async () => {
+      const [firstCardBox, wrappedCardBox] = await Promise.all([
+        cards.nth(0).boundingBox(),
+        cards.nth(3).boundingBox(),
+      ]);
+      if (!firstCardBox || !wrappedCardBox) {
+        return 0;
+      }
+      return wrappedCardBox.y - firstCardBox.y;
+    })
+    .toBeGreaterThan(1);
+
+  await expect
+    .poll(async () => {
+      const [firstCardBox, wrappedCardBox] = await Promise.all([
+        cards.nth(0).boundingBox(),
+        cards.nth(3).boundingBox(),
+      ]);
+      if (!firstCardBox || !wrappedCardBox) {
+        return Number.POSITIVE_INFINITY;
+      }
+      return Math.abs(wrappedCardBox.x - firstCardBox.x);
+    })
+    .toBeLessThan(2);
+
+  await expect
+    .poll(async () => {
+      return grid.evaluate((element) => {
+        return Math.max(0, element.scrollWidth - element.clientWidth);
+      });
+    })
+    .toBe(0);
 });
 
 test("reveal the default agent unread action from the whole row", async ({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2824,7 +2824,7 @@ describe("zero sidebar", () => {
     ).toBeInTheDocument();
   });
 
-  it("wraps pinned agents after New in the four-column layout", async () => {
+  it("keeps New fourth in the pinned agent navigation order", async () => {
     const team = prepareAgentTeam();
     const operationsAgentId = "c0000000-0000-4000-a000-000000000004";
     context.mocks.data.team([
@@ -2863,9 +2863,6 @@ describe("zero sidebar", () => {
     const supportAgent = pinnedAgentLink(grid, "Support Agent");
     const operationsAgent = pinnedAgentLink(grid, "Operations Agent");
 
-    expect(grid).toHaveClass("grid", "grid-cols-4");
-    expect(grid).not.toHaveClass("overflow-x-auto");
-    expect(newAgent).toHaveClass("col-start-4", "row-start-1", "w-full");
     expect(
       supportAgent.compareDocumentPosition(newAgent) &
         Node.DOCUMENT_POSITION_FOLLOWING,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2824,6 +2824,58 @@ describe("zero sidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("wraps pinned agents after New in the four-column layout", async () => {
+    const team = prepareAgentTeam();
+    const operationsAgentId = "c0000000-0000-4000-a000-000000000004";
+    context.mocks.data.team([
+      ...team,
+      {
+        ...team[1]!,
+        id: operationsAgentId,
+        displayName: "Operations Agent",
+        headVersionId: "version_4",
+      },
+    ]);
+    context.mocks.data.userPreferences({
+      pinnedAgentIds: [RESEARCH_AGENT_ID, SUPPORT_AGENT_ID, operationsAgentId],
+    });
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+      },
+    });
+
+    const pinnedSection = await screen.findByTestId("pinned-agents-horizontal");
+    const grid = within(pinnedSection).getByTestId("pinned-agents-grid");
+    await waitFor(() => {
+      expect(within(grid).getAllByTestId("pinned-agent-card")).toHaveLength(4);
+    });
+
+    const newAgent = queryAllByRoleFast("button", grid).find((candidate) => {
+      return candidate.getAttribute("aria-label") === "Open a conversation";
+    });
+    if (!newAgent) {
+      throw new Error("New agent button not found");
+    }
+    const supportAgent = pinnedAgentLink(grid, "Support Agent");
+    const operationsAgent = pinnedAgentLink(grid, "Operations Agent");
+
+    expect(grid).toHaveClass("grid", "grid-cols-4");
+    expect(grid).not.toHaveClass("overflow-x-auto");
+    expect(newAgent).toHaveClass("col-start-4", "row-start-1", "w-full");
+    expect(
+      supportAgent.compareDocumentPosition(newAgent) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      newAgent.compareDocumentPosition(operationsAgent) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
   it("keeps the single-column sidebar when the three-column flag is off", async () => {
     prepareDefaultAgent();
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -229,6 +229,42 @@ export function PinnedAgentListSection({
     routeAgentId ?? (routeThreadId ? null : sidebarAgentId);
 
   if (layout === "horizontal") {
+    const pinnedAgentCards =
+      pinnedAgentsLoadable.state === "hasData"
+        ? displayedPinnedAgents.map((agent) => {
+            const isPrimarySelected =
+              isChatRoute(activeRoute) && selectedAgentId === agent.id;
+            const hasUnread = unreadAgentIds?.has(agent.id) ?? false;
+            return (
+              <Link
+                key={agent.id}
+                pathname="/agents/:agentId/chat"
+                options={{ pathParams: { agentId: agent.id } }}
+                data-testid="pinned-agent-card"
+                className={`group flex w-full min-w-0 flex-col items-center gap-1.5 rounded-lg p-1.5 no-underline transition-colors duration-200 ${
+                  isPrimarySelected
+                    ? "bg-state-selected text-sidebar-foreground"
+                    : "text-sidebar-foreground hover:bg-state-hover"
+                }`}
+              >
+                <span className="relative">
+                  <AgentAvatarImg
+                    name={agent.id}
+                    alt={agent.displayName ?? agent.id}
+                    className="h-9 w-9 rounded-full object-cover object-top"
+                  />
+                  {hasUnread && (
+                    <span className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-[hsl(var(--primary-700))] ring-2 ring-sidebar" />
+                  )}
+                </span>
+                <span className="w-full truncate text-center text-[11px] leading-tight">
+                  {agent.displayName ?? agent.id}
+                </span>
+              </Link>
+            );
+          })
+        : [];
+
     return (
       <div className="shrink-0" data-testid="pinned-agents-horizontal">
         <span className="block px-1 pb-2 text-[13px] font-medium leading-4 text-sidebar-foreground/50">
@@ -236,40 +272,11 @@ export function PinnedAgentListSection({
             return $.sidebar.pinnedAgents;
           })}
         </span>
-        <div className="flex items-start gap-1 overflow-x-auto pb-1">
-          {pinnedAgentsLoadable.state === "hasData" &&
-            displayedPinnedAgents.map((agent) => {
-              const isPrimarySelected =
-                isChatRoute(activeRoute) && selectedAgentId === agent.id;
-              const hasUnread = unreadAgentIds?.has(agent.id) ?? false;
-              return (
-                <Link
-                  key={agent.id}
-                  pathname="/agents/:agentId/chat"
-                  options={{ pathParams: { agentId: agent.id } }}
-                  data-testid="pinned-agent-card"
-                  className={`group flex w-[60px] shrink-0 flex-col items-center gap-1.5 rounded-lg p-1.5 no-underline transition-colors duration-200 ${
-                    isPrimarySelected
-                      ? "bg-state-selected text-sidebar-foreground"
-                      : "text-sidebar-foreground hover:bg-state-hover"
-                  }`}
-                >
-                  <span className="relative">
-                    <AgentAvatarImg
-                      name={agent.id}
-                      alt={agent.displayName ?? agent.id}
-                      className="h-9 w-9 rounded-full object-cover object-top"
-                    />
-                    {hasUnread && (
-                      <span className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-[hsl(var(--primary-700))] ring-2 ring-sidebar" />
-                    )}
-                  </span>
-                  <span className="w-full truncate text-center text-[11px] leading-tight">
-                    {agent.displayName ?? agent.id}
-                  </span>
-                </Link>
-              );
-            })}
+        <div
+          className="grid min-w-0 grid-cols-4 items-start gap-1 pb-1"
+          data-testid="pinned-agents-grid"
+        >
+          {pinnedAgentCards.slice(0, 3)}
           <button
             type="button"
             onClick={() => {
@@ -278,7 +285,7 @@ export function PinnedAgentListSection({
             aria-label={t(($) => {
               return $.sidebar.openConversation;
             })}
-            className="flex w-[60px] shrink-0 flex-col items-center gap-1.5 rounded-lg p-1.5 text-sidebar-foreground opacity-70 transition-colors hover:opacity-100 hover:bg-state-hover"
+            className="col-start-4 row-start-1 flex w-full min-w-0 flex-col items-center gap-1.5 rounded-lg p-1.5 text-sidebar-foreground opacity-70 transition-colors hover:opacity-100 hover:bg-state-hover"
           >
             <span className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-[hsl(var(--gray-300))]">
               <Plus size={16} />
@@ -289,6 +296,7 @@ export function PinnedAgentListSection({
               })}
             </span>
           </button>
+          {pinnedAgentCards.slice(3)}
         </div>
         <AgentListDialogContainer />
       </div>


### PR DESCRIPTION
## Summary

- replace the three-column pinned-agent scroller with a four-column grid
- keep New in the first row's fourth column and wrap additional agents below it
- stretch agent cards to the available column width while preserving visual and keyboard order

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for non-API workspaces, platform, and API
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx` (56 passed)
- not run: local dev server and browser QA, per repository instructions
