### PR TITLE
test(api): serialize snapshot model fixture setup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -884,17 +884,19 @@ describe("cron snapshot chat events", () => {
     const agent = await bdd.createAgent(owner, {
       displayName: "Fail-closed snapshot agent",
     });
-    const fixtures = await Promise.all(
-      ["unsupported", "unreadable", "undecodable", "incomplete"].map(
-        async (kind) => {
-          const threadId = await sendNoCreditMessage(owner, {
-            agentId: agent.agentId,
-            prompt: `${kind}-${randomUUID()}`,
-          });
-          return { kind, threadId };
-        },
-      ),
-    );
+    const fixtures: { readonly kind: string; readonly threadId: string }[] = [];
+    for (const kind of [
+      "unsupported",
+      "unreadable",
+      "undecodable",
+      "incomplete",
+    ]) {
+      const threadId = await sendNoCreditMessage(owner, {
+        agentId: agent.agentId,
+        prompt: `${kind}-${randomUUID()}`,
+      });
+      fixtures.push({ kind, threadId });
+    }
     const threadIds = fixtures.map((fixture) => {
       return fixture.threadId;
     });


### PR DESCRIPTION
## Summary

- create the four non-reusable Snapshot head fixtures sequentially because each `sendNoCreditMessage` call mutates the same workspace model-provider and model-policy state
- preserve all four head variants (`unsupported`, `unreadable`, `undecodable`, and `incomplete`) and every Snapshot fail-closed assertion
- leave product code, model selection behavior, Snapshot behavior, timeouts, retries, and test coverage unchanged

## Root cause

The test launched four `sendNoCreditMessage` helpers concurrently for one organization. Every helper first calls `ensureOrgModelProvider`, which upserts the shared provider and performs a wholesale workspace model-policy update. The send helper separately reads the current workspace default model and then submits that model explicitly.

Workspace policy initialization can temporarily seed `deepseek-v4-flash`, while another concurrent policy replacement retains only `claude-sonnet-5`. An interleaving can therefore read the seeded default, delete that policy in a sibling fixture setup, and then reach send admission with a model that no longer has a workspace route. That produces the observed `400 The selected model is not available in this workspace` before Snapshot setup begins.

The four messages are setup for independent head-shape assertions; concurrent workspace configuration is not part of the business invariant. Serial fixture creation gives the shared model configuration one owner at a time without weakening the Snapshot assertions.

## Failure evidence

- Trigger: https://github.com/vm0-ai/vm0/actions/runs/31877292861
- Substantive job: https://github.com/vm0-ai/vm0/actions/runs/31877292861/job/94994833437
- Failing merge-group SHA: `d1f53c633b6406317519e038b22406ec9f4715af`
- Failure: expected message-send HTTP 201, received HTTP 400 with `The selected model is not available in this workspace`
- The represented PR #27331 changed only Billing Platform UI/tests/translations.
- The same PR head, exact merge-group base, and adjacent main run all passed this file 11/11.
- The affected test/helper/model-policy paths are unchanged between the failing SHA and the latest main used for this branch.
- Duplicate guard: no open PR or active repair matched the exact test/error. Open PRs #27335 and #27355 touch this file for Chat Event compatibility cleanup but do not change this fixture setup.

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (12/12 tasks)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`

Targeted Vitest was not run locally: PostgreSQL was unavailable (`pg_isready` reported no response), and the repair contract forbids starting a local service. The PR pipeline is the integration-test authority.

## Preview / browser QA

N/A. This is an API integration-test fixture ordering change with no deployed product code, endpoint behavior, UI, or browser path. A deployment preview cannot execute or validate the Vitest fixture invariant; Turbo CI is the applicable environment.
