### PR TITLE
test(api): synchronize chat completion side effects

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -426,6 +426,7 @@ async function completeChatRunInThread(
   const { sandboxHeaders } = await claimChatRun(runnerGroup, run.runId);
   chatCallbacks.mockChatOutputEvents([]);
   await completeChatRunOk(run.runId, sandboxHeaders);
+  await flushWaitUntilForTest();
   await waitForThreadEvents(actor, run.threadId, (events) => {
     return events.some((event) => {
       return event.runId === run.runId && event.eventType === "run.completed";
@@ -1565,6 +1566,7 @@ describe("CHAT-01 chat thread read state", () => {
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(activeRun.runId, activeClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
     await waitForThreadEvents(owner, activeRun.threadId, (events) => {
       return events.some((event) => {
         return (
@@ -1708,6 +1710,7 @@ describe("CHAT-01 chat thread read state", () => {
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(runningRun.runId, runningClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
     await waitForThreadEvents(owner, runningRun.threadId, (events) => {
       return events.some((event) => {
         return (
@@ -1858,6 +1861,7 @@ describe("CHAT-01 chat thread read state", () => {
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(runningRun.runId, runningClaim.sandboxHeaders);
+    await flushWaitUntilForTest();
     await waitForThreadEvents(owner, runningRun.threadId, (events) => {
       return events.some((event) => {
         return (


### PR DESCRIPTION
## Summary

- flush tracked `waitUntil` work before chat thread tests assert persisted `run.completed` markers
- cover the shared completion helper and the three direct completion-to-event assertion paths
- keep the existing assertions and poll timeout unchanged

## Root cause

The agent-complete webhook persists the terminal run state, schedules completion callbacks through `waitUntil`, and then returns HTTP 200. The internal chat callback writes the `run.completed` lifecycle marker. These tests treated the HTTP response as if that tracked background callback had also finished, then polled with Vitest's default one-second timeout. Under CI shard contention, the marker could therefore remain legitimately invisible until after the poll expired.

The repair synchronizes at the existing test-owned `flushWaitUntilForTest()` boundary before reading projected thread events. Product promises remain owned by `waitUntil`, and no timeout, sleep, retry, assertion, or production behavior changes.

Source failure: [Turbo run 31877048781](https://github.com/vm0-ai/vm0/actions/runs/31877048781), [`test-api (7)` job 94994261340](https://github.com/vm0-ai/vm0/actions/runs/31877048781/job/94994261340).

## Validation

- Before the change, exact failing test: 5/5 passed (2.50s, 2.33s, 2.28s, 2.40s, 2.36s); the reported CI failure remains the observed reproduction
- After the change, exact failing test: 5/5 passed (2.21s, 2.21s, 2.99s, 2.06s, 2.27s)
- After rebasing onto current `main`, exact failing test: 1/1 passed (2.24s)
- Full `chat-threads.bdd.test.ts`: 35/35 passed
- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged repository, App, and API type checks

## Preview QA

N/A: this PR changes only API test synchronization and has no runtime or browser-visible path.