### PR TITLE
fix(chat): serialize search projection with thread deletion

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
@@ -13,7 +13,10 @@ import {
   readChatEventSearchProjectionFixture,
   rejectSearchablePromptFixture,
 } from "../../../test-fixtures/chat-event-search";
-import { holdChatEventInsertTransactionFixture } from "../../../test-fixtures/chat-events";
+import {
+  holdChatEventInsertTransactionFixture,
+  holdChatThreadDeleteTransactionFixture,
+} from "../../../test-fixtures/chat-events";
 import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
 import { testChatEventSearchProjectionRoutes } from "../test-chat-event-search-projection";
 import { createBddApi } from "./helpers/api-bdd";
@@ -170,6 +173,43 @@ describe("GET /api/cron/project-chat-event-search", () => {
         text: appendedText,
       }),
     );
+  });
+
+  it("skips a thread whose deletion commits during projection", async () => {
+    const actor = bdd.user();
+    const compose = await chat.createComposeForChatThread(actor);
+    const thread = await chat.createThread(actor, {
+      agentId: compose.composeId,
+      title: `Projection deletion ${randomUUID()}`,
+    });
+    await insertChatSearchProjectionCoverageFixture({
+      chatThreadId: thread.id,
+      promptText: `deleting prompt ${randomUUID()}`,
+      assistantText: `deleting assistant ${randomUUID()}`,
+      errorText: `deleting error ${randomUUID()}`,
+      terminalText: `deleting terminal ${randomUUID()}`,
+    });
+    const heldDeletion = await holdChatThreadDeleteTransactionFixture({
+      threadId: thread.id,
+      signal: context.signal,
+    });
+    const tick = projectOwnedChatEventSearch([thread.id]);
+    onTestFinished(async () => {
+      heldDeletion.release();
+      await Promise.allSettled([heldDeletion.done, tick]);
+    });
+
+    await expect
+      .poll(heldDeletion.firstBlockedStatementKind)
+      .toBe("select_for_key_share");
+    heldDeletion.release();
+    await heldDeletion.done;
+
+    const projected = await tick;
+    expect(projected.success).toBeTruthy();
+    expect(projected.threads).toBe(0);
+    const deleted = await chat.requestReadThread(actor, thread.id, [404]);
+    expect(deleted.status).toBe(404);
   });
 
   it("bounds each projection tick to the configured thread batch", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-project-chat-event-search.test.ts
@@ -196,7 +196,7 @@ describe("GET /api/cron/project-chat-event-search", () => {
     const tick = projectOwnedChatEventSearch([thread.id]);
     onTestFinished(async () => {
       heldDeletion.release();
-      await Promise.allSettled([heldDeletion.done, tick]);
+      await Promise.all([heldDeletion.done, tick]);
     });
 
     await expect

--- a/turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts
@@ -207,14 +207,18 @@ async function visibleSearchEventIds(
   );
 }
 
-async function loadProjectionThread(
+async function lockProjectionThreadAgainstDelete(
   tx: Tx,
   chatThreadId: string,
 ): Promise<{ readonly lastChatEventSeqId: number } | null> {
+  // Keep the FK parent alive until its projection writes commit. KEY SHARE
+  // blocks deletion without conflicting with non-key updates such as event
+  // sequence advancement.
   const [thread] = await tx
     .select({ lastChatEventSeqId: chatThreads.lastChatEventSeqId })
     .from(chatThreads)
     .where(eq(chatThreads.id, chatThreadId))
+    .for("key share")
     .limit(1);
   return thread ?? null;
 }
@@ -400,7 +404,7 @@ async function projectThread(
   thread: CandidateThread,
 ): Promise<ThreadProjectionStats> {
   return await db.transaction(async (tx) => {
-    const projectionThread = await loadProjectionThread(
+    const projectionThread = await lockProjectionThreadAgainstDelete(
       tx,
       thread.chatThreadId,
     );

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -78,7 +78,11 @@ const waiterCountRowSchema = z.object({ waiterCount: z.int() });
 const blockedByPidRowSchema = z.object({ blocked: z.boolean() });
 const blockedQueryRowSchema = z.object({ query: z.string() });
 
-type ChatThreadBlockedStatementKind = "select_for_update" | "update" | "other";
+type ChatThreadBlockedStatementKind =
+  | "select_for_key_share"
+  | "select_for_update"
+  | "update"
+  | "other";
 
 interface ChatEventBlockedStatementCounts {
   readonly hotSnapshotReads: number;
@@ -1366,6 +1370,13 @@ async function firstDirectBlockedStatementKind(
   if (
     query.startsWith("select") &&
     query.includes('from "chat_threads"') &&
+    query.includes("for key share")
+  ) {
+    return "select_for_key_share";
+  }
+  if (
+    query.startsWith("select") &&
+    query.includes('from "chat_threads"') &&
     query.includes("for update")
   ) {
     return "select_for_update";
@@ -1428,6 +1439,58 @@ export async function holdChatThreadRowLockFixture(args: {
     blockedWaiterCount: async () => {
       return await transitiveBlockedWaiterCount(holderPid);
     },
+    firstBlockedStatementKind: async () => {
+      return await firstDirectBlockedStatementKind(holderPid);
+    },
+  };
+}
+
+/**
+ * Deletes one test-owned thread and pauses before commit. Product APIs cannot
+ * pause after DELETE has locked the parent but before the transaction commits,
+ * so this fixture exposes that exact projection/deletion concurrency boundary.
+ */
+export async function holdChatThreadDeleteTransactionFixture(args: {
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly firstBlockedStatementKind: () => Promise<ChatThreadBlockedStatementKind | null>;
+}> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const deleted = await tx
+      .delete(chatThreads)
+      .where(eq(chatThreads.id, args.threadId))
+      .returning({ id: chatThreads.id });
+    if (deleted.length !== 1) {
+      throw new Error("Expected one chat thread to delete");
+    }
+    const pidRows = await executeRawRows(
+      tx,
+      sql`
+        SELECT pg_backend_pid() AS "pid"
+      `,
+      databasePidRowSchema,
+    );
+    const holderPid = pidRows[0]?.pid;
+    if (!holderPid) {
+      throw new Error("Expected the chat thread delete holder pid");
+    }
+    started.resolve(holderPid);
+    await released.promise;
+  });
+  const holderPid = await started.promise;
+
+  return {
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+    done,
     firstBlockedStatementKind: async () => {
       return await firstDirectBlockedStatementKind(holderPid);
     },


### PR DESCRIPTION
## Summary

- keep the chat_threads FK parent alive for the full search-projection transaction with FOR KEY SHARE
- add a deterministic regression that pauses a test-owned thread deletion before commit and proves projection waits, skips the deleted thread, and returns success
- retain the existing regression proving projection does not block non-key thread updates such as event sequence advancement

## Failure evidence

Trigger: https://github.com/vm0-ai/vm0/actions/runs/31877135901/job/94994831627

The first causal error was PostgreSQL 23503 while insertSearchMessages wrote chat_event_search_messages after its chat_threads parent had disappeared. The failing row contained the run ID and text created by the concurrently executing zero-workflow-automation-scheduler test that explicitly deletes its workflow thread. The route-level unknown 500 response was only the wrapper error.

The exact failing SHA passed the same shard immediately beforehand:
https://github.com/vm0-ai/vm0/actions/runs/31876879571/job/94993854214

A nearby merge-group run also passed both the original business scenario and the existing selected-thread deletion regression:
https://github.com/vm0-ai/vm0/actions/runs/31877048781/job/94994261340

## Root cause

The projector read chat_threads without a row lock, then wrote FK-protected projection rows later in the same READ COMMITTED transaction. A concurrent delete could commit between those statements. FOR KEY SHARE closes that interval without conflicting with non-key updates, unlike the earlier FOR UPDATE behavior that blocked event sequence advancement.

If deletion owns the row first, projection waits and then observes no parent. If projection owns the key-share lock first, deletion waits until the projection transaction commits and then cascades its rows normally.

## Validation

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped: 13/13 tasks passed
- pnpm knip
- non-API type checks: 12/12 tasks passed
- App type check passed
- API type check passed, including a fresh post-rebase run on main at 354933a55
- changed-file ESLint with max-warnings 0
- git diff --check

### Targeted regression runs

Local result: 0/5. This regression requires PostgreSQL-backed API test infrastructure; localhost:5432 had no PostgreSQL service, DATABASE_URL was absent, and the repair contract prohibits starting a local service or retrieving secrets. No local service was started. The PR Turbo pipeline is the integration-test authority.

## Preview and browser QA

N/A. This is an API-only database transaction interleaving. The deterministic regression must hold DELETE after it acquires the parent-row lock but before commit, which a deployed browser/API preview cannot control or observe. There is no user-facing browser path or preview hostname relevant to this invariant.

## Duplicate guard

No open PR or active repair thread matched this FK race before editing. The current main change for the snapshot-model fixture addresses a different Turbo flake and does not touch this projector boundary.

No FK, deletion cascade, search assertion, retry, timeout, or schema behavior is weakened.