### PR TITLE
docs(sandbox-fc): refresh snapshot workflow documentation

### DIFF
--- a/crates/sandbox-fc/src/snapshot/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/mod.rs
@@ -40,10 +40,12 @@ use self::runtime::run_snapshot_workflow;
 /// discards the uncommitted artifacts and returns the original publish error;
 /// any discard error is intentionally suppressed.
 ///
-/// This is the Rust equivalent of the TS `commands/snapshot.ts` workflow:
+/// The current Rust workflow spans orchestration in this module, live VM execution in
+/// `snapshot/runtime.rs`, resource ownership and cleanup in `snapshot/attempt/`, and stable
+/// artifact publication in `snapshot/publish.rs`:
 ///  1. Create work directory
 ///  2. Create NBD COW device backed by the rootfs image
-///  3. Create network namespace
+///  3. Initialize the pre-warmed network namespace pool and acquire a namespace lease
 ///  4. Spawn Firecracker with `--api-sock`
 ///  5. Wait for API socket ready
 ///  6. Configure VM via API (ordered drives, then parallel remaining PUT calls)
@@ -141,7 +143,7 @@ async fn create_uncommitted_snapshot(
 
     info!(device = %cow_device.device_path().display(), "NBD COW device created");
 
-    // 3. Create network namespace (pool of 1, index auto-allocated via flock).
+    // 3. Initialize a pre-warmed network namespace pool (index auto-allocated via flock).
     let netns_pool = match NetnsPool::create_checked(netns_config).await {
         Ok(pool) => pool,
         Err(e) => {

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -64,6 +64,7 @@ pub(super) async fn run_snapshot_workflow(
     attempt: &mut SnapshotAttempt,
 ) -> Result<SnapshotConfig, SnapshotError> {
     attempt.prepare_firecracker_files(config).await?;
+    // 3. Acquire a namespace lease from the pre-warmed pool.
     attempt.acquire_network().await?;
     attempt.spawn_firecracker(config).await?;
 
@@ -124,9 +125,9 @@ async fn run_with_firecracker(
 
     info!("guest connected");
 
-    // 9.5. Pre-warm caches (PAM/nsswitch, CLI modules) so post-restore calls
-    //      are fast. The snapshot captures memory + disk state, so caches
-    //      populated here persist across restores.
+    // 10. Pre-warm caches (PAM/nsswitch, CLI modules) so post-restore calls
+    //     are fast. The snapshot captures memory + disk state, so caches
+    //     populated here persist across restores.
     let prewarm_result = guest
         .exec_operation_capture(vsock_host::ExecCaptureRequest {
             command: inv.prewarm_script,
@@ -145,12 +146,12 @@ async fn run_with_firecracker(
     validate_prewarm_exec_result(prewarm_result)?;
     info!("pre-warm complete");
 
-    // 10. Pause VM.
+    // 11. Pause VM.
     client.pause().await?;
 
     info!("VM paused");
 
-    // 11. Create snapshot — Firecracker writes directly to output_dir.
+    // 12. Create snapshot — Firecracker writes directly to output_dir.
     //
     // File content durability is guaranteed upstream: as of Firecracker
     // v1.15.1 (see `FIRECRACKER_VERSION` in `runner/src/deps.rs`), both


### PR DESCRIPTION
## Summary

- replace the removed TypeScript snapshot provenance with the current Rust module ownership
- describe the pre-warmed namespace pool and acquired lease accurately
- align snapshot runtime lifecycle comments with the public 14-step workflow

## Scope

This PR changes documentation comments only. It does not change snapshot runtime behavior, public APIs, artifact formats, cleanup semantics, compatibility, or rollout behavior.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo doc -p sandbox-fc --all-features --no-deps`

Closes #27321
