### PR TITLE
refactor(cli): flatten github command module

### DIFF
--- a/turbo/apps/cli/src/commands/github/__tests__/download-file.test.ts
+++ b/turbo/apps/cli/src/commands/github/__tests__/download-file.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync, readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { downloadFileCommand } from "../download-file";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/github/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/github/__tests__/upload-file.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { uploadFileCommand } from "../upload-file";
 import chalk from "chalk";
 

--- a/turbo/apps/cli/src/commands/github/download-file.ts
+++ b/turbo/apps/cli/src/commands/github/download-file.ts
@@ -1,8 +1,8 @@
 import { basename, join } from "path";
 import { tmpdir } from "os";
 import { Command } from "commander";
-import { downloadGithubFile } from "../../../lib/api/domains/integrations-github";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { downloadGithubFile } from "../../lib/api/domains/integrations-github";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 function filenameFromUrl(fileUrl: string): string {
   if (URL.canParse(fileUrl)) {
@@ -64,7 +64,7 @@ How to read the downloaded file:
 
 Notes:
   - The URL comes from a [GitHub file] block
-  - Streams the GitHub file bytes through VM0 directly to disk`,
+  - Streams the GitHub file bytes through Okou directly to disk`,
   )
   .action(
     withErrorHandler(

--- a/turbo/apps/cli/src/commands/github/index.ts
+++ b/turbo/apps/cli/src/commands/github/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { downloadFileCommand } from "./download-file";
 import { uploadFileCommand } from "./upload-file";
 
-export const zeroGithubCommand = new Command()
+export const githubCommand = new Command()
   .name("github")
   .description("Upload and download GitHub files")
   .addCommand(downloadFileCommand)

--- a/turbo/apps/cli/src/commands/github/upload-file.ts
+++ b/turbo/apps/cli/src/commands/github/upload-file.ts
@@ -4,8 +4,8 @@ import { Command } from "commander";
 import {
   completeGithubFileUpload,
   initGithubFileUpload,
-} from "../../../lib/api/domains/integrations-github";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+} from "../../lib/api/domains/integrations-github";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 const MIME_BY_EXTENSION: Record<string, string> = {
   ".png": "image/png",

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -153,7 +153,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "github",
     description: "Upload and download GitHub files",
     load: async () => {
-      return (await import("./commands/zero/github")).zeroGithubCommand;
+      return (await import("./commands/github")).githubCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all five GitHub command and focused test files from `commands/zero/github` to `commands/github`
- rename the internal export from `zeroGithubCommand` to `githubCommand` and update the `okou.ts` lazy import
- update the download help line to say file bytes stream through Okou

## Compatibility

- preserve the public `okou github` command tree, flags, repository examples, stdout schema, upload/download behavior, and error handling
- preserve GitHub API paths, contracts, and `lib/api/domains/integrations-github`
- retain all `vm0-ai/vm0` repository identities and `VM0_API_BACKEND_URL` compatibility references unchanged
- add no old-path bridge, export alias, or unrelated naming cleanup

## Verification

- lockfile-pinned Prettier 3.8.1 check on all changed files
- `pnpm --filter @okouai/cli run lint`
- `pnpm knip --workspace @okouai/cli`
- `pnpm --filter @okouai/cli run check-types`
- GitHub command tests: 2 files, 7 tests passed
- CLI registry tests: 2 files, 90 tests passed
- mechanical-equivalence audit against latest `origin/main`
- full-repository residual scans for `commands/zero/github` and `zeroGithubCommand`
- boundary-count audit preserving 10 `vm0-ai/vm0` and 2 `VM0_API_BACKEND_URL` occurrences in the moved slice

Closes #27369