### PR TITLE
refactor(runner): centralize human-readable byte formatting

### DIFF
--- a/crates/runner/src/byte_size.rs
+++ b/crates/runner/src/byte_size.rs
@@ -1,0 +1,47 @@
+/// Format a byte count using the runner's binary units for human-readable output.
+pub(crate) fn human_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let b = bytes as f64;
+    if b >= GIB {
+        format!("{:.1} GiB", b / GIB)
+    } else if b >= MIB {
+        format!("{:.1} MiB", b / MIB)
+    } else if b >= KIB {
+        format!("{:.1} KiB", b / KIB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::human_bytes;
+
+    #[test]
+    fn human_bytes_formatting() {
+        const MIB: u64 = 1024 * 1024;
+        const GIB: u64 = MIB * 1024;
+        let cases: &[(u64, &str)] = &[
+            (0, "0 B"),
+            (1, "1 B"),
+            (1023, "1023 B"),
+            (1024, "1.0 KiB"),
+            (1025, "1.0 KiB"),
+            (1536, "1.5 KiB"),
+            (MIB - 1, "1024.0 KiB"),
+            (MIB, "1.0 MiB"),
+            (MIB + 1, "1.0 MiB"),
+            (10 * MIB, "10.0 MiB"),
+            (GIB - 1, "1024.0 MiB"),
+            (GIB, "1.0 GiB"),
+            (GIB + 1, "1.0 GiB"),
+            (2 * GIB + GIB / 2, "2.5 GiB"),
+            (u64::MAX, "17179869184.0 GiB"),
+        ];
+        for &(input, expected) in cases {
+            assert_eq!(human_bytes(input), expected, "human_bytes({input})");
+        }
+    }
+}

--- a/crates/runner/src/cmd/build/sizes.rs
+++ b/crates/runner/src/cmd/build/sizes.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use crate::byte_size::human_bytes;
+
 /// Return `(logical, disk)` as human-readable strings (e.g. "65.2 MiB").
 ///
 /// `logical` is the apparent file size; `disk` is the actual disk usage
@@ -17,45 +19,11 @@ pub(super) async fn file_sizes(path: &Path) -> (String, String) {
     }
 }
 
-fn human_bytes(bytes: u64) -> String {
-    const KIB: f64 = 1024.0;
-    const MIB: f64 = KIB * 1024.0;
-    const GIB: f64 = MIB * 1024.0;
-    let b = bytes as f64;
-    if b >= GIB {
-        format!("{:.1} GiB", b / GIB)
-    } else if b >= MIB {
-        format!("{:.1} MiB", b / MIB)
-    } else if b >= KIB {
-        format!("{:.1} KiB", b / KIB)
-    } else {
-        format!("{bytes} B")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::os::unix::fs::MetadataExt;
 
     use super::*;
-
-    #[test]
-    fn human_bytes_formatting() {
-        let cases: &[(u64, &str)] = &[
-            (0, "0 B"),
-            (1, "1 B"),
-            (1023, "1023 B"),
-            (1024, "1.0 KiB"),
-            (1536, "1.5 KiB"),
-            (1048576, "1.0 MiB"),
-            (10 * 1048576, "10.0 MiB"),
-            (1073741824, "1.0 GiB"),
-            (2 * 1073741824 + 536870912, "2.5 GiB"),
-        ];
-        for &(input, expected) in cases {
-            assert_eq!(human_bytes(input), expected, "human_bytes({input})");
-        }
-    }
 
     #[tokio::test]
     async fn file_sizes_reports_sparse_logical_and_disk_usage() {

--- a/crates/runner/src/cmd/gc/debootstrap.rs
+++ b/crates/runner/src/cmd/gc/debootstrap.rs
@@ -3,13 +3,14 @@ use std::time::SystemTime;
 
 use tracing::info;
 
+use crate::byte_size::human_bytes;
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
 use super::GC_MIN_AGE;
 use super::filesystem::{next_entry_warn_or_stop, read_dir_or_missing};
 use super::lock_file::{LockProbe, probe_lock};
-use super::report::{GcReport, human_bytes};
+use super::report::GcReport;
 
 /// Remove cached debootstrap tarballs, keeping the `keep_latest` most recent.
 pub(super) async fn gc_debootstrap(

--- a/crates/runner/src/cmd/gc/images.rs
+++ b/crates/runner/src/cmd/gc/images.rs
@@ -4,6 +4,7 @@ use std::time::SystemTime;
 
 use tracing::{info, warn};
 
+use crate::byte_size::human_bytes;
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::HomePaths;
 
@@ -14,7 +15,7 @@ use super::filesystem::{
 };
 use super::image_refs::{ProtectedImageRefs, is_protected_image_ref};
 use super::lock_file::{LockProbe, probe_lock};
-use super::report::{GcReport, human_bytes};
+use super::report::GcReport;
 
 const TEMPLATE_WARM_DIR_PREFIX: &str = "template-warm-";
 

--- a/crates/runner/src/cmd/gc/job_logs.rs
+++ b/crates/runner/src/cmd/gc/job_logs.rs
@@ -3,11 +3,12 @@ use std::time::{Duration, SystemTime};
 
 use tracing::{info, warn};
 
+use crate::byte_size::human_bytes;
 use crate::error::RunnerResult;
 use crate::paths::{HomePaths, LogPaths};
 
 use super::filesystem::{next_entry_warn_or_stop, read_dir_or_missing};
-use super::report::{GcReport, human_bytes};
+use super::report::GcReport;
 
 /// Per-job log files older than this are eligible for GC.
 const JOB_LOG_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 3600);

--- a/crates/runner/src/cmd/gc/report.rs
+++ b/crates/runner/src/cmd/gc/report.rs
@@ -1,3 +1,4 @@
+use crate::byte_size::human_bytes;
 use tracing::info;
 
 #[derive(Debug, Default, Eq, PartialEq)]
@@ -77,22 +78,6 @@ pub(super) fn log_gc_summary(report: &GcReport, dry_run: bool) {
     }
 }
 
-pub(super) fn human_bytes(bytes: u64) -> String {
-    const KIB: f64 = 1024.0;
-    const MIB: f64 = KIB * 1024.0;
-    const GIB: f64 = MIB * 1024.0;
-    let b = bytes as f64;
-    if b >= GIB {
-        format!("{:.1} GiB", b / GIB)
-    } else if b >= MIB {
-        format!("{:.1} MiB", b / MIB)
-    } else if b >= KIB {
-        format!("{:.1} KiB", b / KIB)
-    } else {
-        format!("{bytes} B")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,15 +97,6 @@ mod tests {
             .filter_map(|event| event.fields.get("message").cloned())
             .collect()
     }
-    #[test]
-    fn human_bytes_formats_correctly() {
-        assert_eq!(human_bytes(0), "0 B");
-        assert_eq!(human_bytes(512), "512 B");
-        assert_eq!(human_bytes(1024), "1.0 KiB");
-        assert_eq!(human_bytes(1024 * 1024), "1.0 MiB");
-        assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GiB");
-    }
-
     #[test]
     fn gc_report_composition_preserves_all_summary_fields() {
         let mut report = GcReport::cleanup(2, 512);

--- a/crates/runner/src/cmd/gc/storage.rs
+++ b/crates/runner/src/cmd/gc/storage.rs
@@ -5,6 +5,7 @@ use std::time::SystemTime;
 use nix::fcntl::Flock;
 use tracing::{info, warn};
 
+use crate::byte_size::human_bytes;
 use crate::error::RunnerResult;
 use crate::paths::HomePaths;
 
@@ -14,7 +15,7 @@ use super::filesystem::{
     next_entry_warn_or_stop, read_dir_or_missing,
 };
 use super::lock_file::{LockProbe, probe_lock};
-use super::report::{GcReport, human_bytes};
+use super::report::GcReport;
 
 /// Per-host storage archive cache size cap. Enforced by `gc_storage_cache`
 /// as an LRU by `<version>/` dir mtime.

--- a/crates/runner/src/cmd/gc/workspaces.rs
+++ b/crates/runner/src/cmd/gc/workspaces.rs
@@ -9,13 +9,14 @@ use std::time::SystemTime;
 use nix::fcntl::Flock;
 use tracing::{info, warn};
 
+use crate::byte_size::human_bytes;
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, base_dir_lock_name};
 
 use super::GC_MIN_AGE;
 use super::filesystem::{GcDirStatus, dir_stats, gc_path_dir_status};
 use super::lock_file::{ExistingLockProbe, probe_existing_lock, remove_unused_lock_after_probe};
-use super::report::{GcReport, human_bytes};
+use super::report::GcReport;
 
 type RemoveDirAllFuture<'a> = Pin<Box<dyn Future<Output = std::io::Result<()>> + 'a>>;
 type RemoveDirAllFn = for<'a> fn(&'a Path) -> RemoveDirAllFuture<'a>;

--- a/crates/runner/src/cmd/workspace_image_cache.rs
+++ b/crates/runner/src/cmd/workspace_image_cache.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
+use crate::byte_size::human_bytes;
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, RunnerPaths};
 use crate::workspace_image_cache::{
@@ -292,22 +293,6 @@ fn status_rank(status: WorkspaceImageCacheInspectionStatus) -> u8 {
         WorkspaceImageCacheInspectionStatus::Stale => 2,
         WorkspaceImageCacheInspectionStatus::TemporaryOnly => 3,
         WorkspaceImageCacheInspectionStatus::Reusable => 4,
-    }
-}
-
-fn human_bytes(bytes: u64) -> String {
-    const KIB: f64 = 1024.0;
-    const MIB: f64 = KIB * 1024.0;
-    const GIB: f64 = MIB * 1024.0;
-    let b = bytes as f64;
-    if b >= GIB {
-        format!("{:.1} GiB", b / GIB)
-    } else if b >= MIB {
-        format!("{:.1} MiB", b / MIB)
-    } else if b >= KIB {
-        format!("{:.1} KiB", b / KIB)
-    } else {
-        format!("{bytes} B")
     }
 }
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -2,6 +2,7 @@
 mod active_input;
 mod axiom_layer;
 mod bounded_command;
+mod byte_size;
 mod ca;
 mod child_cleanup;
 mod cmd;


### PR DESCRIPTION
## Summary

- Add one private runner-crate utility for binary human-readable byte formatting.
- Route build size logs, GC summaries/details, and workspace-image-cache text output through it.
- Consolidate raw-byte, threshold, fractional, and large-`u64` coverage while preserving existing
  strings.

## Compatibility and scope

- The existing `f64` conversion, binary thresholds, one-decimal precision, and `B`/`KiB`/`MiB`/`GiB`
  suffixes are unchanged.
- Workspace-image-cache numeric JSON, file metadata accounting, and unrelated byte-limit messages
  remain unchanged and out of scope.

## Validation

From `crates/`:

- `cargo test -p runner byte_size::tests -- --nocapture`
- `cargo test -p runner cmd::build::sizes`
- `cargo test -p runner cmd::gc::report`
- `cargo test -p runner cmd::workspace_image_cache`
- `cargo test -p runner` (3127 passed, 20 ignored)
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`

Repository checks:

- `lefthook run pre-commit`
- `git diff --check`

Closes #27329
