### PR TITLE
refactor(cli): flatten video command module

### DIFF
--- a/turbo/apps/cli/src/commands/video/__tests__/frames.test.ts
+++ b/turbo/apps/cli/src/commands/video/__tests__/frames.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "child_process";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { framesCommand } from "../frames";
 
 const DOWNLOAD_URL = "http://localhost:3000/api/okou/web/download-file";
@@ -72,11 +72,32 @@ describe("okou video frames command", () => {
     const result = JSON.parse(readStdout()) as {
       frames: { at: string; path: string }[];
     };
-    expect(result.frames).toHaveLength(2);
-    expect(result.frames[0]?.at).toBe("00:21");
-    expect(result.frames[1]?.at).toBe("01:40");
-    expect(result.frames[0]?.path).toContain("frame-001.jpg");
-    expect(result.frames[1]?.path).toContain("frame-002.jpg");
+    expect(result).toEqual({
+      frames: [
+        {
+          at: "00:21",
+          path: expect.stringMatching(
+            /[/\\]video-frames-\d+[/\\]frame-001\.jpg$/,
+          ),
+        },
+        {
+          at: "01:40",
+          path: expect.stringMatching(
+            /[/\\]video-frames-\d+[/\\]frame-002\.jpg$/,
+          ),
+        },
+      ],
+    });
+
+    const curlCalls = vi.mocked(execFileSync).mock.calls.filter((c) => {
+      return c[0] === "curl";
+    });
+    expect(curlCalls).toHaveLength(1);
+    expect(curlCalls[0]?.[1]).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/[/\\]video-input-\d+\.mp4$/),
+      ]),
+    );
 
     const ffmpegCalls = vi.mocked(execFileSync).mock.calls.filter((c) => {
       return c[0] === "ffmpeg";

--- a/turbo/apps/cli/src/commands/video/__tests__/transcribe.test.ts
+++ b/turbo/apps/cli/src/commands/video/__tests__/transcribe.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { transcribeCommand } from "../transcribe";
 
 const STT_URL = "http://localhost:3000/api/okou/voice-io/stt";
@@ -87,6 +87,27 @@ describe("okou video transcribe command", () => {
       expect(output).toContain("## Transcript");
       expect(output).toContain("[00:02-00:05] Hello world.");
       expect(output).toContain("[00:06-00:07] Second sentence.");
+
+      const { execFileSync } = await import("child_process");
+      const execCalls = vi.mocked(execFileSync).mock.calls;
+      const curlCall = execCalls.find((c) => {
+        return c[0] === "curl";
+      });
+      expect(curlCall?.[1]).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/[/\\]video-input-\d+\.mp4$/),
+        ]),
+      );
+
+      const ffmpegCall = execCalls.find((c) => {
+        return c[0] === "ffmpeg";
+      });
+      expect(ffmpegCall?.[1]).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/[/\\]video-input-\d+\.mp4$/),
+          expect.stringMatching(/[/\\]video-audio-\d+\.wav$/),
+        ]),
+      );
     });
   });
 

--- a/turbo/apps/cli/src/commands/video/frames.ts
+++ b/turbo/apps/cli/src/commands/video/frames.ts
@@ -3,8 +3,8 @@ import { mkdirSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { Command } from "commander";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { downloadWebFile } from "../../../lib/api/domains/web";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { downloadWebFile } from "../../lib/api/domains/web";
 
 interface ExtractedFrame {
   readonly at: string;
@@ -29,7 +29,7 @@ Examples:
 
 Output:
   Prints a JSON object to stdout, one entry per timestamp:
-    {"frames":[{"at":"00:21","path":"/tmp/zero-frames-.../frame-001.jpg"}]}
+    {"frames":[{"at":"00:21","path":"/tmp/video-frames-.../frame-001.jpg"}]}
 
 Tip:
   Pair with "okou video transcribe": read the timestamped transcript to find the
@@ -63,10 +63,10 @@ Notes:
           process.exit(1);
         }
 
-        const outDir = join(tmpdir(), `zero-frames-${Date.now()}`);
+        const outDir = join(tmpdir(), `video-frames-${Date.now()}`);
         mkdirSync(outDir, { recursive: true });
 
-        const tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
+        const tmpVideo = join(tmpdir(), `video-input-${Date.now()}.mp4`);
 
         try {
           if (options.url) {

--- a/turbo/apps/cli/src/commands/video/index.ts
+++ b/turbo/apps/cli/src/commands/video/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { transcribeCommand } from "./transcribe";
 import { framesCommand } from "./frames";
 
-export const zeroVideoCommand = new Command()
+export const videoCommand = new Command()
   .name("video")
   .description("Video processing utilities")
   .addCommand(transcribeCommand)

--- a/turbo/apps/cli/src/commands/video/transcribe.ts
+++ b/turbo/apps/cli/src/commands/video/transcribe.ts
@@ -3,12 +3,12 @@ import { unlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { Command } from "commander";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 import {
   downloadWebFile,
   transcribeAudio,
   type TranscribeAudioSegment,
-} from "../../../lib/api/domains/web";
+} from "../../lib/api/domains/web";
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60)
@@ -86,7 +86,7 @@ Notes:
           process.exit(1);
         }
 
-        const tmpAudio = join(tmpdir(), `zero-audio-${Date.now()}.wav`);
+        const tmpAudio = join(tmpdir(), `video-audio-${Date.now()}.wav`);
         let tmpVideo: string | undefined;
 
         try {
@@ -95,7 +95,7 @@ Notes:
           if (options.file) {
             videoPath = options.file;
           } else {
-            tmpVideo = join(tmpdir(), `zero-video-${Date.now()}.mp4`);
+            tmpVideo = join(tmpdir(), `video-input-${Date.now()}.mp4`);
             if (options.url) {
               execFileSync("curl", ["-sS", "-L", "-o", tmpVideo, options.url], {
                 stdio: ["ignore", "ignore", "pipe"],

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -277,7 +277,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "video",
     description: "Video processing utilities",
     load: async () => {
-      return (await import("./commands/zero/video")).zeroVideoCommand;
+      return (await import("./commands/video")).videoCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all five Video command and focused test files from `commands/zero/video` to `commands/video`
- rename the internal export from `zeroVideoCommand` to `videoCommand` and update the `okou.ts` lazy import
- replace the approved temporary prefixes with `video-audio-*`, `video-input-*`, and `video-frames-*`
- update the frames JSON help example and focused tests for the new prefixes

## Compatibility

- preserve the public `okou video` command tree, flags, output schemas, timestamp parsing, transcript behavior, and errors
- preserve curl/ffmpeg arguments, download/transcode/frame extraction flow, frame filenames, and cleanup ownership
- preserve API paths, contracts, `lib/api/domains/web`, and `VM0_API_BACKEND_URL`
- add no old-path bridge, symbol alias, compatibility re-export, or unrelated naming cleanup

## Contract verification

- canonicalizing the latest `main` production files with only the approved path-depth, symbol, and temporary-prefix mappings produces byte-for-byte identical files
- full-repository searches find no owned `commands/zero/video`, `zeroVideoCommand`, `zero-audio-*`, `zero-video-*`, or `zero-frames-*` temporary-path residual
- the frames test locks the exact JSON shape, `video-frames-*` path, and `frame-001.jpg` / `frame-002.jpg` filenames
- the Video URL-flow tests lock `video-input-*` and `video-audio-*` runtime paths

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace type checks for non-API/Platform packages, Platform, and API
- post-rebase targeted Prettier, CLI lint, and CLI type-check
- Video command tests: 2 files, 9 tests passed
- CLI registry tests: 2 files, 90 tests passed
- `git diff --check`

Closes #27367
