### PR TITLE
refactor(cli): flatten phone command module

### DIFF
--- a/turbo/apps/cli/src/commands/phone/__tests__/commands.test.ts
+++ b/turbo/apps/cli/src/commands/phone/__tests__/commands.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { http, HttpResponse } from "msw";
 import chalk from "chalk";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { downloadFileCommand } from "../download-file";
 import { messageCommand } from "../message";
 import { uploadFileCommand } from "../upload-file";

--- a/turbo/apps/cli/src/commands/phone/download-file.ts
+++ b/turbo/apps/cli/src/commands/phone/download-file.ts
@@ -1,8 +1,8 @@
 import { basename, join } from "path";
 import { tmpdir } from "os";
 import { Command } from "commander";
-import { downloadPhoneFile } from "../../../lib/api/domains/integrations-phone";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { downloadPhoneFile } from "../../lib/api/domains/integrations-phone";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 function defaultOutPath(fileId: string): string {
   return join(tmpdir(), `phone-${basename(fileId)}`);

--- a/turbo/apps/cli/src/commands/phone/index.ts
+++ b/turbo/apps/cli/src/commands/phone/index.ts
@@ -3,7 +3,7 @@ import { downloadFileCommand } from "./download-file";
 import { messageCommand } from "./message";
 import { uploadFileCommand } from "./upload-file";
 
-export const zeroPhoneCommand = new Command()
+export const phoneCommand = new Command()
   .name("phone")
   .description("Send AgentPhone messages, upload files, and download media")
   .addCommand(messageCommand)

--- a/turbo/apps/cli/src/commands/phone/message.ts
+++ b/turbo/apps/cli/src/commands/phone/message.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "fs";
 import { Command } from "commander";
 import chalk from "chalk";
-import { sendPhoneMessage } from "../../../lib/api/domains/integrations-phone";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { sendPhoneMessage } from "../../lib/api/domains/integrations-phone";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 export const messageCommand = new Command()
   .name("message")
@@ -18,7 +18,7 @@ Examples:
   From stdin:     printf "Hello!" | okou phone message --to +15551234567
 
 Notes:
-  - The phone handle must already be connected to the authenticated VM0 user
+  - The phone handle must already be connected to the authenticated Okou user
   - AgentPhone agent ID is inferred from the conversation when omitted`,
   )
   .action(

--- a/turbo/apps/cli/src/commands/phone/upload-file.ts
+++ b/turbo/apps/cli/src/commands/phone/upload-file.ts
@@ -4,8 +4,8 @@ import { Command } from "commander";
 import {
   completePhoneFileUpload,
   initPhoneFileUpload,
-} from "../../../lib/api/domains/integrations-phone";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+} from "../../lib/api/domains/integrations-phone";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 const MIME_BY_EXTENSION: Record<string, string> = {
   ".png": "image/png",

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -191,7 +191,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "phone",
     description: "Send AgentPhone messages, upload files, and download media",
     load: async () => {
-      return (await import("./commands/zero/phone")).zeroPhoneCommand;
+      return (await import("./commands/phone")).phoneCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all five Phone command and focused test files from `commands/zero/phone` to `commands/phone`
- rename the internal export from `zeroPhoneCommand` to `phoneCommand` and update the `okou.ts` lazy import
- update moved `lib` and `mocks` relative imports for the one-level directory change
- update the message help note to refer to the authenticated Okou user

## Compatibility

- preserve the public `okou phone` command tree, flags, examples, stdout schemas, errors, and AgentPhone behavior
- preserve all Phone API paths, request/response contracts, upload/download/message logic, and the `integrations-phone` adapter
- retain `VM0_API_BACKEND_URL` unchanged in the focused test
- add no old-path bridge, export alias, compatibility re-export, or unrelated naming cleanup

## Contract verification

- normalized mechanical-equivalence audit passes for all five moved files and `okou.ts`
- repository-wide scans find no `commands/zero/phone` path or `zeroPhoneCommand` reference
- the staged diff contains five renames and the required `okou.ts` registry edit only

## Validation

- lockfile-pinned Prettier 3.8.1: full workspace format and post-rebase targeted format check
- full repository lint: 13/13 tasks passed with bounded memory and single concurrency
- full Knip plus post-rebase CLI-scoped Knip
- staged repository type-checks plus post-rebase CLI type-check
- Phone command test: 1 file, 3 tests passed
- CLI registry tests: 2 files, 90 tests passed

Closes #27368
