### PR TITLE
chore(rust): remove run-private failure diagnostic schema version

### DIFF
--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -2,9 +2,6 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Current JSON schema version for failure diagnostics.
-pub const FAILURE_DIAGNOSTIC_SCHEMA_VERSION: u8 = 1;
-
 /// Process exit code used for the runner-owned agent execution timeout.
 pub const AGENT_EXECUTION_TIMEOUT_EXIT_CODE: i32 = 124;
 
@@ -21,8 +18,6 @@ const SHELL_SIGNAL_EXIT_CODE_OFFSET: i32 = 128;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FailureDiagnostic {
-    /// Version of the serialized diagnostic schema.
-    pub schema_version: u8,
     /// Coarse failure category used by runner-side handling.
     pub failure_class: FailureClass,
     /// CLI framework that produced the diagnostic.
@@ -64,7 +59,6 @@ impl FailureDiagnostic {
         prompt: PromptMetadata,
     ) -> Self {
         Self {
-            schema_version: FAILURE_DIAGNOSTIC_SCHEMA_VERSION,
             failure_class,
             framework,
             cli_exit_code: None,
@@ -856,7 +850,6 @@ mod tests {
         .with_session_history_status(SessionHistoryStatus::Missing);
 
         let json = serde_json::to_value(&diagnostic).unwrap();
-        assert_eq!(json["schemaVersion"], 1);
         assert_eq!(json["failureClass"], "claude_zero_turn_no_history");
         assert_eq!(json["framework"], "claude_code");
         assert_eq!(json["cliExitCode"], 0);
@@ -1077,7 +1070,6 @@ mod tests {
     #[test]
     fn failure_diagnostic_deserializes_without_observed_exit() {
         let json = serde_json::json!({
-            "schemaVersion": 1,
             "failureClass": "cli_nonzero",
             "framework": "claude_code",
             "cliExitCode": 137,
@@ -1475,23 +1467,11 @@ mod tests {
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(round_trip, diagnostic);
-
-        #[derive(Deserialize)]
-        #[serde(rename_all = "camelCase")]
-        struct OldFailureDiagnostic {
-            schema_version: u8,
-            failure_class: FailureClass,
-        }
-
-        let old_shape: OldFailureDiagnostic = serde_json::from_value(json).unwrap();
-        assert_eq!(old_shape.schema_version, FAILURE_DIAGNOSTIC_SCHEMA_VERSION);
-        assert_eq!(old_shape.failure_class, FailureClass::EventUploadFailed);
     }
 
     #[test]
     fn failure_diagnostic_deserializes_without_optional_fields() {
         let json = serde_json::json!({
-            "schemaVersion": 1,
             "failureClass": "cli_nonzero",
             "framework": "claude_code",
             "cliExitCode": 1,

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -850,6 +850,7 @@ mod tests {
         .with_session_history_status(SessionHistoryStatus::Missing);
 
         let json = serde_json::to_value(&diagnostic).unwrap();
+        assert!(json.get("schemaVersion").is_none());
         assert_eq!(json["failureClass"], "claude_zero_turn_no_history");
         assert_eq!(json["framework"], "claude_code");
         assert_eq!(json["cliExitCode"], 0);

--- a/crates/runner/src/executor/diagnostics/guest_files.rs
+++ b/crates/runner/src/executor/diagnostics/guest_files.rs
@@ -1,5 +1,5 @@
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
-use guest_contracts::diagnostics::{FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureDiagnostic};
+use guest_contracts::diagnostics::FailureDiagnostic;
 use sandbox::Sandbox;
 use tracing::warn;
 
@@ -54,19 +54,7 @@ pub(in crate::executor) async fn read_guest_failure_diagnostic_file(
     match sandbox.read_file(&path, SMALL_GUEST_FILE_MAX_BYTES).await {
         Ok(Some(bytes)) if !bytes.iter().all(|byte| byte.is_ascii_whitespace()) => {
             match serde_json::from_slice::<FailureDiagnostic>(&bytes) {
-                Ok(diagnostic)
-                    if diagnostic.schema_version == FAILURE_DIAGNOSTIC_SCHEMA_VERSION =>
-                {
-                    Some(diagnostic)
-                }
-                Ok(diagnostic) => {
-                    warn!(
-                        run_id = %run_id,
-                        schema_version = diagnostic.schema_version,
-                        "ignoring guest failure diagnostic with unsupported schema version"
-                    );
-                    None
-                }
+                Ok(diagnostic) => Some(diagnostic),
                 Err(e) => {
                     warn!(run_id = %run_id, error = %e, "failed to parse guest failure diagnostic");
                     None

--- a/crates/runner/src/executor/tests/diagnostics_tests/guest_files.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/guest_files.rs
@@ -1,6 +1,6 @@
 use guest_contracts::diagnostics::{
-    AgentFramework, FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureClass, FailureDetailSource,
-    FailureDiagnostic, FailureReason, PromptMetadata, SessionHistoryStatus,
+    AgentFramework, FailureClass, FailureDetailSource, FailureDiagnostic, FailureReason,
+    PromptMetadata, SessionHistoryStatus,
 };
 use sandbox_mock::MockSandbox;
 
@@ -168,22 +168,6 @@ async fn read_guest_failure_diagnostic_file_returns_none_on_empty_content() {
 async fn read_guest_failure_diagnostic_file_returns_none_on_malformed_json() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_read_file_result(Ok(Some(b"{not-json".to_vec())));
-
-    let diagnostic = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
-
-    assert!(diagnostic.is_none());
-}
-
-#[tokio::test]
-async fn read_guest_failure_diagnostic_file_returns_none_on_unsupported_schema() {
-    let sandbox = MockSandbox::new("test");
-    let mut diagnostic = FailureDiagnostic::new(
-        FailureClass::CliNonzero,
-        AgentFramework::ClaudeCode,
-        PromptMetadata::from_prompt("/help"),
-    );
-    diagnostic.schema_version = FAILURE_DIAGNOSTIC_SCHEMA_VERSION + 1;
-    sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
 
     let diagnostic = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
 

--- a/crates/runner/src/executor/tests/diagnostics_tests/guest_files.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/guest_files.rs
@@ -145,6 +145,23 @@ async fn read_guest_failure_diagnostic_file_returns_valid_diagnostic() {
 }
 
 #[tokio::test]
+async fn read_guest_failure_diagnostic_file_accepts_unknown_schema_field() {
+    let sandbox = MockSandbox::new("test");
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("/help"),
+    );
+    let mut json = serde_json::to_value(&diagnostic).unwrap();
+    json["schemaVersion"] = serde_json::json!(999);
+    sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&json).unwrap())));
+
+    let read = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
+
+    assert_eq!(read, Some(diagnostic));
+}
+
+#[tokio::test]
 async fn read_guest_failure_diagnostic_file_returns_none_on_missing_file() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_read_file_result(Ok(None));


### PR DESCRIPTION
## Summary

- remove the unused `FailureDiagnostic` schema version field and constant
- accept parseable run-private diagnostics without a version gate
- keep best-effort handling for missing, empty, malformed, oversized, and unreadable files
- update contract and runner diagnostic tests to cover the versionless shape

This follows the deployment boundary documented in `docs/deployment-compatibility.md`: runner and
guest-agent ship in one artifact, and this file is private to the producing sandbox.

## Scope exclusions

This does not change workspace-cache metadata, session-history sidecar formats, Pi launch payloads,
API contracts, or the diagnostic file's size and parsing safeguards.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p guest-contracts`
- `cargo test -p runner read_guest_failure_diagnostic_file`
- `cargo clippy -p guest-contracts -p runner --all-targets -- -D warnings`
- `cargo doc -p guest-contracts -p runner --no-deps`
- focused search for remaining run-private failure-diagnostic schema references

Closes #27373
