### PR TITLE
test(rust): cover nbd disconnect revalidation outcomes

### DIFF
--- a/crates/nbd-cow/src/orphan.rs
+++ b/crates/nbd-cow/src/orphan.rs
@@ -707,6 +707,89 @@ mod tests {
     }
 
     #[test]
+    fn disconnect_reports_locked_and_claim_failure_without_netlink() {
+        let candidate = NbdOrphanCandidate::from_dead_owner_observation(3, 123);
+        let locked = disconnect_with(
+            candidate,
+            |_| Ok::<Option<()>, std::io::Error>(None),
+            |_, _| panic!("locked candidate must not be re-read"),
+            |_| panic!("locked candidate must not check liveness"),
+            |_| panic!("locked candidate must not check membership"),
+            |_| panic!("locked candidate must not be disconnected"),
+        );
+        assert!(matches!(locked, NbdOrphanDisconnect::Locked));
+
+        let failed = disconnect_with(
+            candidate,
+            |_| Err::<Option<()>, std::io::Error>(std::io::Error::other("boom")),
+            |_, _| panic!("failed claim must not be re-read"),
+            |_| panic!("failed claim must not check liveness"),
+            |_| panic!("failed claim must not check membership"),
+            |_| panic!("failed claim must not disconnect"),
+        );
+        match failed {
+            NbdOrphanDisconnect::Failed(NbdOrphanError::Claim {
+                device_index,
+                source,
+            }) => {
+                assert_eq!(device_index, 3);
+                assert_eq!(source.to_string(), "boom");
+            }
+            other => panic!("expected claim failure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disconnect_reports_changed_without_netlink_when_state_changes_or_clears() {
+        let candidate = NbdOrphanCandidate::from_dead_owner_observation(3, 123);
+        let changed = disconnect_with(
+            candidate,
+            |_| Ok(Some(())),
+            |_, _| Some(state(456, None)),
+            |_| panic!("changed owner must not check liveness"),
+            |_| panic!("changed owner must not check membership"),
+            |_| panic!("changed owner must not be disconnected"),
+        );
+        assert!(matches!(changed, NbdOrphanDisconnect::Changed));
+
+        let cleared = disconnect_with(
+            candidate,
+            |_| Ok(Some(())),
+            |_, _| None,
+            |_| panic!("cleared owner must not check liveness"),
+            |_| panic!("cleared owner must not check membership"),
+            |_| panic!("cleared owner must not be disconnected"),
+        );
+        assert!(matches!(cleared, NbdOrphanDisconnect::Changed));
+    }
+
+    #[test]
+    fn disconnect_reports_changed_without_netlink_when_size_becomes_zero() {
+        let outcome = disconnect_with(
+            local_or_dead_candidate(3, 123, 8),
+            |_| Ok(Some(())),
+            |_, _| Some(state(123, Some(0))),
+            |_| panic!("zero size must be rejected before liveness"),
+            |_| panic!("zero size must be rejected before membership"),
+            |_| panic!("zero-size candidate must not be disconnected"),
+        );
+        assert!(matches!(outcome, NbdOrphanDisconnect::Changed));
+    }
+
+    #[test]
+    fn disconnect_reports_live_without_netlink_when_dead_owner_revives() {
+        let outcome = disconnect_with(
+            NbdOrphanCandidate::from_dead_owner_observation(3, 123),
+            |_| Ok(Some(())),
+            |_, _| Some(state(123, None)),
+            |_| true,
+            |_| panic!("dead-owner policy must not inspect current-process membership"),
+            |_| panic!("live owner must not be disconnected"),
+        );
+        assert!(matches!(outcome, NbdOrphanDisconnect::Live));
+    }
+
+    #[test]
     fn disconnect_holds_claim_through_netlink_and_returns_revalidated_state() {
         let dropped = Rc::new(Cell::new(false));
         let dropped_for_claim = dropped.clone();

--- a/crates/runner/src/cmd/gc/nbd.rs
+++ b/crates/runner/src/cmd/gc/nbd.rs
@@ -133,7 +133,12 @@ mod tests {
     async fn gc_nbd_orphans_counts_only_disconnected_outcomes() {
         let report = gc_nbd_orphans_with(
             false,
-            || (8, vec![(0, 100), (1, 101), (2, 102), (3, 103), (4, 104)]),
+            || {
+                (
+                    8,
+                    vec![(0, 100), (1, 101), (2, 102), (3, 103), (4, 104), (5, 105)],
+                )
+            },
             |device_index, owner_tid| match device_index {
                 0 | 4 => disconnected(device_index, owner_tid),
                 1 => NbdOrphanDisconnect::Locked,
@@ -144,6 +149,7 @@ mod tests {
                         "netlink failed",
                     )),
                 }),
+                5 => NbdOrphanDisconnect::Live,
                 other => panic!("unexpected device index {other}"),
             },
         )


### PR DESCRIPTION
## Summary

- cover every negative NBD orphan `disconnect_with` revalidation outcome and make forbidden netlink calls fail the tests
- cover the non-zero-size policy becoming ineligible before disconnect
- include `NbdOrphanDisconnect::Live` in runner GC accounting coverage while preserving the disconnected-only count

## Scope

- test-only changes in `nbd-cow` and runner GC
- no production behavior, public API, dependency, persistence, protocol, migration, configuration, or rollout change

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow orphan`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p nbd-cow -p runner --all-features --no-deps`

The focused runner test command was attempted locally, but the final monolithic runner test-binary link was repeatedly killed by the 3.8 GiB, no-swap environment, including with `lld`. Runner Clippy successfully compiled and linted all test targets; PR CI remains required for runner test execution and privileged NBD coverage.

Closes #27322
