### PR TITLE
fix(billing): align credit purchase review ledger

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -813,7 +813,6 @@
       "concurrentRun_other": "{{value}} gleichzeitige Ausführungen",
       "continueToStripe": "Weiter zu Stripe",
       "decreaseAria": "Verringern Sie die zusätzliche Parallelitätsmenge",
-      "dueNow": "Jetzt fällig",
       "dueToday": "Heute fällig",
       "emptyDescription": "Kaufen Sie zusätzliche gleichzeitige Ausführungen für diesen Arbeitsbereich.",
       "emptyTitle": "Keine Parallelitätsabonnements",
@@ -844,15 +843,19 @@
       "amount": "Betrag",
       "amountRangeError": "Geben Sie zwischen {{minimum}} und {{maximum}} ein.",
       "anyAmount": "Beliebiger Betrag",
+      "creditsAdded": "Credits hinzugefügt",
       "custom": "Benutzerdefiniert",
       "customAmountAria": "Benutzerdefinierter Dollarbetrag",
+      "dueNow": "Jetzt fällig",
       "exchangeRate": "Credits verfallen nie. 1 USD = {{credits}} Credits.",
+      "payAndAddCredits": "Bezahlen und Credits hinzufügen",
       "quickBuy": "Schnellkauf",
       "quickBuyAmount": "Schnellkauf {{amount}}",
       "reviewDescription": "Bestätigen Sie diese einmalige Zahlung mit Ihrer gespeicherten Zahlungsmethode.",
       "reviewError": "Der Credit-Kauf konnte nicht abgeschlossen werden. Prüfen Sie Ihre Zahlungsdaten und versuchen Sie es erneut.",
       "reviewTitle": "Credit-Kauf prüfen",
-      "title": "Credits kaufen"
+      "title": "Credits kaufen",
+      "today": "Heute"
     },
     "downgrade": {
       "cancelSubscription": "Abo kündigen",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -813,7 +813,6 @@
       "concurrentRun_other": "{{value}} concurrent runs",
       "continueToStripe": "Continue to Stripe",
       "decreaseAria": "Decrease additional concurrency quantity",
-      "dueNow": "Due now",
       "dueToday": "Due today",
       "emptyDescription": "Buy additional concurrent runs for this workspace.",
       "emptyTitle": "No concurrency subscriptions",
@@ -844,15 +843,19 @@
       "amount": "Amount",
       "amountRangeError": "Enter between {{minimum}} and {{maximum}}",
       "anyAmount": "Any amount",
+      "creditsAdded": "Credits added",
       "custom": "Custom",
       "customAmountAria": "Custom dollar amount",
+      "dueNow": "Due now",
       "exchangeRate": "Credits never expire. 1 USD = {{credits}} credits.",
+      "payAndAddCredits": "Pay and add credits",
       "quickBuy": "Quick buy",
       "quickBuyAmount": "Quick buy {{amount}}",
       "reviewDescription": "Confirm this one-time charge with your saved payment method.",
       "reviewError": "Could not complete this credit purchase. Review your billing details and try again.",
       "reviewTitle": "Review credit purchase",
-      "title": "Buy credits"
+      "title": "Buy credits",
+      "today": "Today"
     },
     "downgrade": {
       "cancelSubscription": "Cancel subscription",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -833,7 +833,6 @@
       "concurrentRun_other": "{{value}} ejecuciones simultáneas",
       "continueToStripe": "Continuar a Stripe",
       "decreaseAria": "Reducir la cantidad adicional de concurrencia",
-      "dueNow": "A pagar ahora",
       "dueToday": "A pagar hoy",
       "emptyDescription": "Compra ejecuciones concurrentes adicionales para este espacio de trabajo.",
       "emptyTitle": "No hay suscripciones de concurrencia",
@@ -865,15 +864,19 @@
       "amount": "Cantidad",
       "amountRangeError": "Introduce un valor entre {{minimum}} y {{maximum}}",
       "anyAmount": "Cualquier cantidad",
+      "creditsAdded": "Créditos añadidos",
       "custom": "Personalizado",
       "customAmountAria": "Cantidad personalizada en dólares",
+      "dueNow": "A pagar ahora",
       "exchangeRate": "Los créditos nunca caducan. 1 USD = {{credits}} créditos.",
+      "payAndAddCredits": "Pagar y añadir créditos",
       "quickBuy": "Compra rápida",
       "quickBuyAmount": "Compra rápida {{amount}}",
       "reviewDescription": "Confirma este cargo único con tu método de pago guardado.",
       "reviewError": "No se pudo completar esta compra de créditos. Revisa tus datos de facturación e inténtalo de nuevo.",
       "reviewTitle": "Revisar compra de créditos",
-      "title": "Comprar créditos"
+      "title": "Comprar créditos",
+      "today": "Hoy"
     },
     "downgrade": {
       "cancelSubscription": "Cancelar suscripción",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -833,7 +833,6 @@
       "concurrentRun_other": "{{value}} exécutions concurrentes",
       "continueToStripe": "Continuer vers Stripe",
       "decreaseAria": "Diminuer la quantité de concurrence supplémentaire",
-      "dueNow": "À payer maintenant",
       "dueToday": "À payer aujourd’hui",
       "emptyDescription": "Acheter des exécutions concurrentes supplémentaires pour cet espace de travail.",
       "emptyTitle": "Aucun abonnement de concurrence",
@@ -865,15 +864,19 @@
       "amount": "Montant",
       "amountRangeError": "Entrez entre {{minimum}} et {{maximum}}",
       "anyAmount": "N'importe quel montant",
+      "creditsAdded": "Crédits ajoutés",
       "custom": "Personnalisé",
       "customAmountAria": "Montant en dollars personnalisé",
+      "dueNow": "À payer maintenant",
       "exchangeRate": "Les crédits n'expirent jamais. 1 USD = {{credits}} crédits.",
+      "payAndAddCredits": "Payer et ajouter des crédits",
       "quickBuy": "Achat rapide",
       "quickBuyAmount": "Achat rapide {{amount}}",
       "reviewDescription": "Confirmez ce paiement unique avec votre moyen de paiement enregistré.",
       "reviewError": "Impossible de finaliser cet achat de crédits. Vérifiez vos informations de facturation et réessayez.",
       "reviewTitle": "Vérifier l'achat de crédits",
-      "title": "Acheter des crédits"
+      "title": "Acheter des crédits",
+      "today": "Aujourd’hui"
     },
     "downgrade": {
       "cancelSubscription": "Annuler l'abonnement",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -813,7 +813,6 @@
       "concurrentRun_other": "{{value}} समवर्ती चलता है",
       "continueToStripe": "Stripe पर जारी रखें",
       "decreaseAria": "अतिरिक्त समवर्ती मात्रा कम करें",
-      "dueNow": "अभी देय",
       "dueToday": "आज देय",
       "emptyDescription": "इस वर्कस्पेस के लिए अतिरिक्त समवर्ती रन खरीदें।",
       "emptyTitle": "कोई समवर्ती सदस्यता नहीं",
@@ -844,15 +843,19 @@
       "amount": "मात्रा",
       "amountRangeError": "{{minimum}} और {{maximum}} के बीच दर्ज करें",
       "anyAmount": "कोई भी राशि",
+      "creditsAdded": "क्रेडिट जोड़े गए",
       "custom": "रिवाज़",
       "customAmountAria": "कस्टम डॉलर राशि",
+      "dueNow": "अभी देय",
       "exchangeRate": "क्रेडिट कभी समाप्त नहीं होते. 1 USD = {{credits}} क्रेडिट।",
+      "payAndAddCredits": "भुगतान करें और क्रेडिट जोड़ें",
       "quickBuy": "जल्दी खरीदो",
       "quickBuyAmount": "जल्दी से {{amount}} खरीदें",
       "reviewDescription": "अपने सहेजे गए भुगतान तरीके से इस एकमुश्त शुल्क की पुष्टि करें।",
       "reviewError": "यह क्रेडिट खरीद पूरी नहीं हो सकी। अपनी बिलिंग जानकारी जांचें और फिर कोशिश करें।",
       "reviewTitle": "क्रेडिट खरीद की समीक्षा करें",
-      "title": "क्रेडिट खरीदें"
+      "title": "क्रेडिट खरीदें",
+      "today": "आज"
     },
     "downgrade": {
       "cancelSubscription": "सदस्यता रद्द करें",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -813,7 +813,6 @@
       "concurrentRun_other": "{{value}} eksekusi concurrent",
       "continueToStripe": "Lanjutkan ke Stripe",
       "decreaseAria": "Kurangi jumlah concurrency tambahan",
-      "dueNow": "Jatuh tempo sekarang",
       "dueToday": "Jatuh tempo hari ini",
       "emptyDescription": "Beli eksekusi concurrent tambahan untuk ruang kerja ini.",
       "emptyTitle": "Tidak ada langganan concurrency",
@@ -844,15 +843,19 @@
       "amount": "Jumlah",
       "amountRangeError": "Masukkan antara {{minimum}} dan {{maximum}}",
       "anyAmount": "Jumlah apa pun",
+      "creditsAdded": "Kredit ditambahkan",
       "custom": "Kustom",
       "customAmountAria": "Jumlah dolar kustom",
+      "dueNow": "Jatuh tempo sekarang",
       "exchangeRate": "Kredit tidak pernah kedaluwarsa. 1 USD = {{credits}} kredit.",
+      "payAndAddCredits": "Bayar dan tambahkan kredit",
       "quickBuy": "Beli cepat",
       "quickBuyAmount": "Beli cepat {{amount}}",
       "reviewDescription": "Konfirmasikan tagihan satu kali ini dengan metode pembayaran tersimpan.",
       "reviewError": "Pembelian kredit ini tidak dapat diselesaikan. Periksa detail penagihan Anda dan coba lagi.",
       "reviewTitle": "Tinjau pembelian kredit",
-      "title": "Beli kredit"
+      "title": "Beli kredit",
+      "today": "Hari ini"
     },
     "downgrade": {
       "cancelSubscription": "Batalkan langganan",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -833,7 +833,6 @@
       "concurrentRun_other": "{{value}} esecuzioni simultanee",
       "continueToStripe": "Continua su Stripe",
       "decreaseAria": "Diminuire la quantità di concorrenza aggiuntiva",
-      "dueNow": "Da pagare ora",
       "dueToday": "Da pagare oggi",
       "emptyDescription": "Acquista ulteriori esecuzioni simultanee per questa area di lavoro.",
       "emptyTitle": "Nessun abbonamento simultaneo",
@@ -865,15 +864,19 @@
       "amount": "Importo",
       "amountRangeError": "Inserisci tra {{minimum}} e {{maximum}}",
       "anyAmount": "Qualsiasi importo",
+      "creditsAdded": "Crediti aggiunti",
       "custom": "Personalizzato",
       "customAmountAria": "Importo in dollari personalizzato",
+      "dueNow": "Da pagare ora",
       "exchangeRate": "I crediti non scadono mai. 1 USD = {{credits}} crediti.",
+      "payAndAddCredits": "Paga e aggiungi crediti",
       "quickBuy": "Acquisto veloce",
       "quickBuyAmount": "Acquisto veloce {{amount}}",
       "reviewDescription": "Conferma questo addebito una tantum con il metodo di pagamento salvato.",
       "reviewError": "Impossibile completare questo acquisto di crediti. Controlla i dati di fatturazione e riprova.",
       "reviewTitle": "Rivedi l'acquisto di crediti",
-      "title": "Acquista crediti"
+      "title": "Acquista crediti",
+      "today": "Oggi"
     },
     "downgrade": {
       "cancelSubscription": "Annulla l'abbonamento",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -813,7 +813,6 @@
       "concurrentRun_other": "{{value}} 同時実行数",
       "continueToStripe": "Stripe に進む",
       "decreaseAria": "追加の同時実行数を減らす",
-      "dueNow": "今回のお支払い",
       "dueToday": "本日のお支払い",
       "emptyDescription": "このワークスペースに対して追加の同時実行を購入します。",
       "emptyTitle": "同時実行サブスクリプションなし",
@@ -844,15 +843,19 @@
       "amount": "金額",
       "amountRangeError": "{{minimum}} と {{maximum}} の間を入力してください",
       "anyAmount": "いくらでも",
+      "creditsAdded": "追加されるクレジット",
       "custom": "カスタム",
       "customAmountAria": "カスタムドル額",
+      "dueNow": "今回のお支払い",
       "exchangeRate": "クレジットに有効期限はありません。 1 USD = {{credits}} クレジット。",
+      "payAndAddCredits": "支払ってクレジットを追加",
       "quickBuy": "すぐに購入",
       "quickBuyAmount": "クイック購入 {{amount}}",
       "reviewDescription": "保存済みのお支払い方法で今回の請求を確定します。",
       "reviewError": "クレジットの購入を完了できませんでした。請求情報を確認して、もう一度お試しください。",
       "reviewTitle": "クレジット購入を確認",
-      "title": "クレジットを購入する"
+      "title": "クレジットを購入する",
+      "today": "本日"
     },
     "downgrade": {
       "cancelSubscription": "サブスクリプションをキャンセルする",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -813,7 +813,6 @@
       "concurrentRun_other": "{{value}}개의 동시 실행",
       "continueToStripe": "Stripe로 계속",
       "decreaseAria": "추가 동시 실행 수 감소",
-      "dueNow": "지금 결제",
       "dueToday": "오늘 결제",
       "emptyDescription": "이 워크스페이스에 추가 동시 실행을 구매하세요.",
       "emptyTitle": "동시 실행 구독 없음",
@@ -844,15 +843,19 @@
       "amount": "금액",
       "amountRangeError": "{{minimum}}에서 {{maximum}} 사이로 입력하세요",
       "anyAmount": "임의 금액",
+      "creditsAdded": "추가되는 크레딧",
       "custom": "사용자 지정",
       "customAmountAria": "사용자 지정 금액",
+      "dueNow": "지금 결제",
       "exchangeRate": "크레딧은 만료되지 않습니다. 1 USD = {{credits}} 크레딧.",
+      "payAndAddCredits": "결제하고 크레딧 추가",
       "quickBuy": "빠른 구매",
       "quickBuyAmount": "빠른 구매 {{amount}}",
       "reviewDescription": "저장된 결제 수단으로 이번 일회성 결제를 확인하세요.",
       "reviewError": "크레딧 구매를 완료할 수 없습니다. 결제 정보를 확인한 후 다시 시도하세요.",
       "reviewTitle": "크레딧 구매 검토",
-      "title": "크레딧 구매"
+      "title": "크레딧 구매",
+      "today": "오늘"
     },
     "downgrade": {
       "cancelSubscription": "구독 취소",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -833,7 +833,6 @@
       "concurrentRun_other": "{{value}} execuções simultâneas",
       "continueToStripe": "Continuar para o Stripe",
       "decreaseAria": "Diminuir a quantidade adicional de simultaneidade",
-      "dueNow": "A pagar agora",
       "dueToday": "A pagar hoje",
       "emptyDescription": "Compre execuções simultâneas adicionais para este workspace.",
       "emptyTitle": "Nenhuma assinatura de simultaneidade",
@@ -865,15 +864,19 @@
       "amount": "Valor",
       "amountRangeError": "Insira um valor entre {{minimum}} e {{maximum}}",
       "anyAmount": "Qualquer valor",
+      "creditsAdded": "Créditos adicionados",
       "custom": "Personalizado",
       "customAmountAria": "Valor personalizado em dólares",
+      "dueNow": "A pagar agora",
       "exchangeRate": "Os créditos nunca expiram. 1 USD = {{credits}} créditos.",
+      "payAndAddCredits": "Pagar e adicionar créditos",
       "quickBuy": "Compra rápida",
       "quickBuyAmount": "Compra rápida de {{amount}}",
       "reviewDescription": "Confirme esta cobrança única com sua forma de pagamento salva.",
       "reviewError": "Não foi possível concluir esta compra de créditos. Revise seus dados de cobrança e tente novamente.",
       "reviewTitle": "Revisar compra de créditos",
-      "title": "Comprar créditos"
+      "title": "Comprar créditos",
+      "today": "Hoje"
     },
     "downgrade": {
       "cancelSubscription": "Cancelar assinatura",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -3736,6 +3736,10 @@ describe("organization billing settings", () => {
         "Confirm this one-time charge with your saved payment method.",
       ),
     ).toBeInTheDocument();
+    expect(within(reviewDialog).getByText("Today")).toBeInTheDocument();
+    expect(within(reviewDialog).getByText("Due now")).toBeInTheDocument();
+    expect(within(reviewDialog).getByText("Credits added")).toBeInTheDocument();
+    expect(within(reviewDialog).queryByText("Every month")).toBeNull();
     expect(within(reviewDialog).getByText("$18.00")).toBeInTheDocument();
     expect(within(reviewDialog).getByText("+20,000")).toBeInTheDocument();
     expect(startRequest).toMatchObject({
@@ -3744,7 +3748,7 @@ describe("organization billing settings", () => {
     });
     expect(window.location.href).toBe(locationBeforePurchase);
 
-    click(buttonByText("Confirm", reviewDialog));
+    click(buttonByText("Pay and add credits", reviewDialog));
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/credit-purchase-confirm-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/credit-purchase-confirm-dialog.tsx
@@ -74,27 +74,32 @@ export function CreditPurchaseConfirmDialog() {
             </DialogDescription>
           </DialogHeader>
 
-          <div className="mt-1 divide-y divide-border/70 border-y border-border/70">
-            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 py-4">
-              <p className="text-sm font-semibold text-foreground">
+          <div className="mt-1">
+            <p className="pb-0.5 pt-1 text-xs font-medium text-muted-foreground">
+              {t(($) => {
+                return $.billing.credits.today;
+              })}
+            </p>
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-border py-3.5">
+              <p className="text-sm font-medium text-foreground">
                 {t(($) => {
-                  return $.billing.concurrency.dueNow;
+                  return $.billing.credits.dueNow;
                 })}
               </p>
-              <p className="text-right text-2xl font-semibold tabular-nums tracking-tight text-primary">
+              <p className="text-right text-3xl font-light tracking-tight tabular-nums text-foreground">
                 {formatCreditPurchaseAmount(
                   preview.amountCents,
                   preview.currency,
                 )}
               </p>
             </div>
-            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 py-4">
-              <p className="text-sm font-semibold text-foreground">
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t-[0.7px] border-[hsl(var(--gray-100))] py-2.5">
+              <p className="text-sm font-medium text-foreground">
                 {t(($) => {
-                  return $.billing.common.credits;
+                  return $.billing.credits.creditsAdded;
                 })}
               </p>
-              <p className="text-right text-2xl font-semibold tabular-nums tracking-tight text-primary">
+              <p className="text-right text-sm font-medium tabular-nums text-foreground">
                 +{formatLocalizedNumber(preview.credits)}
               </p>
             </div>
@@ -125,7 +130,7 @@ export function CreditPurchaseConfirmDialog() {
                     return $.billing.common.updating;
                   })
                 : t(($) => {
-                    return $.billing.common.confirm;
+                    return $.billing.credits.payAndAddCredits;
                   })}
             </Button>
           </DialogFooter>


### PR DESCRIPTION
## Summary

- present one-time credit purchases as a Today billing ledger
- keep payment and credit amounts in foreground ink while reserving brand color for the modal action
- use the action-specific Pay and add credits CTA across Billing and chat recovery
- localize the new ledger copy and cover the saved-billing purchase flow

## Testing

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 with API and Platform excluded
- pnpm --filter @okouai/app run check-types
- pnpm --filter api run check-types
- pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx