### PR TITLE
refactor(cli): flatten doctor and upgrade command modules

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/upgrade.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/upgrade.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import chalk from "chalk";
 
-import { zeroUpgradeCommand } from "../upgrade";
+import { upgradeCommand } from "../upgrade";
 
 describe("okou upgrade command", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -17,7 +17,7 @@ describe("okou upgrade command", () => {
   });
 
   it("prints the plan link recognized by web chat", async () => {
-    await zeroUpgradeCommand.parseAsync(["node", "cli", "pro"]);
+    await upgradeCommand.parseAsync(["node", "cli", "pro"]);
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("Upgrade to Pro");

--- a/turbo/apps/cli/src/commands/doctor/__tests__/credit.test.ts
+++ b/turbo/apps/cli/src/commands/doctor/__tests__/credit.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import chalk from "chalk";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import { creditCommand } from "../credit";
 
 function stubOrg(overrides: { readonly name?: string } = {}) {

--- a/turbo/apps/cli/src/commands/doctor/credit.ts
+++ b/turbo/apps/cli/src/commands/doctor/credit.ts
@@ -1,15 +1,15 @@
 import { Command } from "commander";
 import chalk from "chalk";
 
-import { getZeroBillingStatus } from "../../../lib/api/domains/zero-billing";
-import { getZeroOrg } from "../../../lib/api/domains/zero-orgs";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { getZeroBillingStatus } from "../../lib/api/domains/zero-billing";
+import { getZeroOrg } from "../../lib/api/domains/zero-orgs";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { getPlatformOrigin } from "./platform-url";
 import {
   currentPlanAllowsVideo,
   currentPlanCanBuyCredits,
-} from "../../shared/billing-capabilities";
-import { planUpgradeUrl } from "../../shared/billing-links";
+} from "../shared/billing-capabilities";
+import { planUpgradeUrl } from "../shared/billing-links";
 
 export const creditCommand = new Command()
   .name("credit")

--- a/turbo/apps/cli/src/commands/doctor/index.ts
+++ b/turbo/apps/cli/src/commands/doctor/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { creditCommand } from "./credit";
 
-export const zeroDoctorCommand = new Command()
+export const doctorCommand = new Command()
   .name("doctor")
   .description("Diagnose account and runtime issues")
   .addCommand(creditCommand)

--- a/turbo/apps/cli/src/commands/doctor/platform-url.ts
+++ b/turbo/apps/cli/src/commands/doctor/platform-url.ts
@@ -1,5 +1,5 @@
-import { getApiUrl } from "../../../lib/api/config";
-import { getOkouAppUrl } from "../../../lib/okou-env";
+import { getApiUrl } from "../../lib/api/config";
+import { getOkouAppUrl } from "../../lib/okou-env";
 
 /**
  * Transform the API host to the platform (app) host.

--- a/turbo/apps/cli/src/commands/upgrade.ts
+++ b/turbo/apps/cli/src/commands/upgrade.ts
@@ -1,9 +1,9 @@
 import { Command, InvalidArgumentError } from "commander";
 import chalk from "chalk";
 
-import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { withErrorHandler } from "../lib/command/with-error-handler";
 import { getPlatformOrigin } from "./doctor/platform-url";
-import { planUpgradeUrl } from "../shared/billing-links";
+import { planUpgradeUrl } from "./shared/billing-links";
 
 type UpgradePlan = "pro";
 
@@ -14,7 +14,7 @@ function parseUpgradePlan(value: string): UpgradePlan {
   return value;
 }
 
-export const zeroUpgradeCommand = new Command()
+export const upgradeCommand = new Command()
   .name("upgrade")
   .description("Create a link to compare and upgrade workspace plans")
   .argument("[plan]", "Plan to upgrade to: pro", parseUpgradePlan, "pro")

--- a/turbo/apps/cli/src/commands/zero/connector/check.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/check.ts
@@ -14,7 +14,7 @@ import {
 import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import { getOkouAgentId } from "../../../lib/okou-env";
-import { toPlatformUrl } from "../doctor/platform-url";
+import { toPlatformUrl } from "../../doctor/platform-url";
 import {
   isComputerUsePermissionTarget,
   printComputerUsePermissionGuidance,

--- a/turbo/apps/cli/src/commands/zero/connector/custom/create.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/custom/create.ts
@@ -12,7 +12,7 @@ import {
   connectorActionUrl,
   printCallbackActionUrlExample,
 } from "../action-url";
-import { getPlatformOrigin } from "../../doctor/platform-url";
+import { getPlatformOrigin } from "../../../doctor/platform-url";
 import { createCustomConnectorDefinitionFileSchema } from "./definition";
 
 interface CreateOptions {

--- a/turbo/apps/cli/src/commands/zero/connector/permission-request.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/permission-request.ts
@@ -2,7 +2,7 @@ import { Command, Option } from "commander";
 import { UNKNOWN_PERMISSION_GRANT } from "@okouai/connectors/firewall-types";
 import type { ConnectorCheckPolicy } from "@okouai/api-contracts/contracts/connector-check";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { getPlatformOrigin } from "../doctor/platform-url";
+import { getPlatformOrigin } from "../../doctor/platform-url";
 import {
   isComputerUsePermissionTarget,
   printComputerUsePermissionGuidance,

--- a/turbo/apps/cli/src/commands/zero/connector/status.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/status.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { listZeroConnectorCatalogStatus } from "../../../lib/api/domains/zero-connectors";
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import { resolveAgentContext } from "./agent-context";
-import { getPlatformOrigin } from "../doctor/platform-url";
+import { getPlatformOrigin } from "../../doctor/platform-url";
 import {
   availableConnectorSlugs,
   findConnectorStatusItem,

--- a/turbo/apps/cli/src/commands/zero/credit.ts
+++ b/turbo/apps/cli/src/commands/zero/credit.ts
@@ -9,7 +9,7 @@ import {
 } from "../../lib/api/domains/zero-billing";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { decodeZeroTokenPayload } from "../../lib/api/zero-token";
-import { getPlatformOrigin } from "./doctor/platform-url";
+import { getPlatformOrigin } from "../doctor/platform-url";
 import {
   currentPlanAllowsVideo,
   currentPlanCanBuyCredits,

--- a/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
@@ -3,7 +3,7 @@ import type { ZeroConnectorCatalogStatus } from "../../../../lib/api/domains/zer
 import { getZeroBillingStatus } from "../../../../lib/api/domains/zero-billing";
 import { getZeroAgentUserConnectors } from "../../../../lib/api/domains/zero-agents";
 import { listZeroConnectorCatalogStatus } from "../../../../lib/api/domains/zero-connectors";
-import { getPlatformOrigin } from "../../doctor/platform-url";
+import { getPlatformOrigin } from "../../../doctor/platform-url";
 import {
   currentPlanAllowsVideo,
   currentTokenCanReadBilling,

--- a/turbo/apps/cli/src/commands/zero/mail/connect.ts
+++ b/turbo/apps/cli/src/commands/zero/mail/connect.ts
@@ -5,7 +5,7 @@ import { listZeroConnectorCatalogStatus } from "../../../lib/api/domains/zero-co
 import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import { resolveAgentContext } from "../connector/agent-context";
 import { findConnectorStatusItem } from "../connector/public-catalog";
-import { getPlatformOrigin } from "../doctor/platform-url";
+import { getPlatformOrigin } from "../../doctor/platform-url";
 import {
   MAIL_CONNECTOR_SLUG_BY_PROVIDER,
   currentAgentId,

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -138,7 +138,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "upgrade",
     description: "Create a workspace plan upgrade link",
     load: async () => {
-      return (await import("./commands/zero/upgrade")).zeroUpgradeCommand;
+      return (await import("./commands/upgrade")).upgradeCommand;
     },
   },
   {
@@ -146,7 +146,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     description:
       "Diagnose runtime issues (connector health, permission denials)",
     load: async () => {
-      return (await import("./commands/zero/doctor")).zeroDoctorCommand;
+      return (await import("./commands/doctor")).doctorCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move Doctor's four source and focused test files from `commands/zero/doctor` to `commands/doctor`
- move Upgrade and its focused test to the neutral command root
- rename the internal exports to `doctorCommand` and `upgradeCommand`, update the lazy registry, and repoint every direct `doctor/platform-url` caller

## Compatibility

- preserve the public `okou doctor` and `okou upgrade` command trees, flags, help, output, URLs, credit behavior, and errors
- retain `zero-billing`, `zero-orgs`, `getZeroBillingStatus`, and `getZeroOrg` unchanged
- retain every operational `*.vm0.ai`, `vm6.ai`, and `vm7.ai` hostname transformation and example unchanged
- retain `VM0_API_BACKEND_URL` unchanged and add no old-path bridge, export alias, or unrelated naming cleanup

## Contract verification

- normalized mechanical-equivalence audit passes for all six moved files
- repository scans find no `commands/zero/doctor`, `commands/zero/upgrade`, `zeroDoctorCommand`, or `zeroUpgradeCommand` residual in `turbo/apps/cli/src`
- boundary-count audit confirms the owned `zero-billing`, `zero-orgs`, `getZeroBillingStatus`, `getZeroOrg`, `VM0_API_BACKEND_URL`, and operational hostname references are unchanged
- staged diff contains six renames, seven required platform URL import updates, and the two owned `okou.ts` registry entries only

## Verification

- Prettier 3.8.1 on all changed files
- `pnpm --filter @okouai/cli run lint`
- `pnpm knip --workspace @okouai/cli`
- `pnpm --filter @okouai/cli run check-types`
- Doctor command test: 1 file, 4 tests passed
- Upgrade command test: 1 file, 1 test passed
- CLI registry tests: 2 files, 90 tests passed
- connector/platform URL test: 1 file, 72 tests passed
- `git diff --cached --check`

Closes #27381
