### PR TITLE
fix(runner): gate active-input smoke readiness

### DIFF
--- a/.github/scripts/runner-behavior-process-containment.sh
+++ b/.github/scripts/runner-behavior-process-containment.sh
@@ -354,7 +354,8 @@ echo "--- Pressure: sustain CPU saturation with live process control ---"
 PRESSURE_CHAT_THREAD_ID="$CHAT_THREAD_ID"
 PRESSURE_SESSION_ID="e2e-process-containment-pressure"
 PRESSURE_SUBMIT_OUTPUT=$(mktemp)
-# Prime the local input queue before a reused VM can emit its first result.
+# The mock's readiness result is gated on the first forwarded follow-up, so
+# startup scheduling cannot close active input before the queue is observed.
 # Keep the final input after the pressure command so the mock turn cannot
 # finish first.
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
@@ -362,7 +363,7 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --chat-thread-id "$PRESSURE_CHAT_THREAD_ID" \
   --session-id "$PRESSURE_SESSION_ID" \
   --feature-flag sandboxReuse=true \
-  --prompt '@active-input-smoke:8' \
+  --prompt '@active-input-smoke-ready:8' \
   --active-input 'after=1ms,text=cpu-pressure-ready' \
   --active-input 'after=2s,text=cpu-pressure-one' \
   --active-input 'after=4s,text=cpu-pressure-two' \

--- a/crates/guest-agent/tests/claude_active_input_receipt.rs
+++ b/crates/guest-agent/tests/claude_active_input_receipt.rs
@@ -23,7 +23,7 @@ async fn claude_receipts_delivery_only_after_follow_up_reaches_stdin()
     let server = MockServer::start();
 
     unsafe {
-        common::setup_env(&mock, tmp.path(), "@active-input-smoke:1", 3, 1)?;
+        common::setup_env(&mock, tmp.path(), "@active-input-smoke-ready:1", 3, 1)?;
     }
     let runtime = common::guest_runtime_from_process_env()?;
     let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -50,6 +50,10 @@
 //!   @active-input-smoke:<n>   - Stream-json stdin marker. Emit a first result,
 //!                               then read n later user frames from the same
 //!                               stdin stream and emit a deterministic final result.
+//!   @active-input-smoke-ready:<n>
+//!                             - Stream-json stdin marker. Read and buffer the
+//!                               first follow-up before emitting the readiness
+//!                               result, then consume the remaining frames.
 
 mod args;
 mod process;

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -39,12 +39,29 @@ fn run_stream_json_input(parsed: ParsedArgs) -> ExitCode {
             first_frame,
             &mut reader,
             expected_follow_ups,
+            false,
+        ),
+        MockScenario::ActiveInputSmokeReady {
+            expected_follow_ups,
+        } => stream_json_input::run_active_input_smoke_scenario(
+            &parsed.output_format,
+            parsed.replay_user_messages,
+            first_frame,
+            &mut reader,
+            expected_follow_ups,
+            true,
         ),
         MockScenario::InvalidActiveInputSmokeCount(count) => {
             eprintln!(
                 "{}",
-                stream_json_input::invalid_active_input_count_message(count)
+                stream_json_input::invalid_count_message("@active-input-smoke", count)
             );
+            ExitCode::from(1)
+        }
+        MockScenario::InvalidActiveInputSmokeReadyCount(count) => {
+            let message =
+                stream_json_input::invalid_count_message("@active-input-smoke-ready", count);
+            eprintln!("{message}");
             ExitCode::from(1)
         }
         scenario => run_scenario(scenario, first_frame.content(), &parsed.output_format),
@@ -57,15 +74,21 @@ fn run_prompt_scenario(prompt: &str, output_format: &str) -> ExitCode {
 
 fn run_scenario(scenario: MockScenario<'_>, prompt: &str, output_format: &str) -> ExitCode {
     match scenario {
-        MockScenario::ActiveInputSmoke { .. } => {
+        MockScenario::ActiveInputSmoke { .. } | MockScenario::ActiveInputSmokeReady { .. } => {
             eprintln!("@active-input-smoke requires --input-format stream-json");
             ExitCode::from(1)
         }
         MockScenario::InvalidActiveInputSmokeCount(count) => {
             eprintln!(
                 "{}",
-                stream_json_input::invalid_active_input_count_message(count)
+                stream_json_input::invalid_count_message("@active-input-smoke", count)
             );
+            ExitCode::from(1)
+        }
+        MockScenario::InvalidActiveInputSmokeReadyCount(count) => {
+            let message =
+                stream_json_input::invalid_count_message("@active-input-smoke-ready", count);
+            eprintln!("{message}");
             ExitCode::from(1)
         }
         MockScenario::EchoJsonl(payload) => fixtures::run_echo_jsonl_mode(payload, false),

--- a/crates/guest-mock-claude/src/process/stream_json_input.rs
+++ b/crates/guest-mock-claude/src/process/stream_json_input.rs
@@ -31,11 +31,8 @@ pub(super) fn read_initial_user_frame(
     read_next_stream_json_user_frame(reader, StreamJsonFrameKind::First)
 }
 
-pub(super) fn invalid_active_input_count_message(count: &str) -> String {
-    format!(
-        "invalid @active-input-smoke follow-up count ({} bytes)",
-        count.len()
-    )
+pub(super) fn invalid_count_message(marker: &str, count: &str) -> String {
+    format!("invalid {marker} follow-up count ({} bytes)", count.len())
 }
 
 fn read_next_stream_json_user_frame(
@@ -111,6 +108,7 @@ pub(super) fn run_active_input_smoke_scenario(
     initial_frame: StreamJsonUserFrame,
     stdin: &mut impl BufRead,
     expected_follow_ups: usize,
+    ready_after_first_follow_up: bool,
 ) -> ExitCode {
     if output_format != "stream-json" {
         eprintln!("@active-input-smoke requires --output-format stream-json");
@@ -128,38 +126,44 @@ pub(super) fn run_active_input_smoke_scenario(
             &initial_frame.content,
         ));
     }
-    transcript.emit_value(result_event(&session_id, false, ACTIVE_INPUT_READY_RESULT));
-    let _ = std::io::stdout().flush();
-
     let mut follow_up_contents = Vec::new();
-    for index in 1..=expected_follow_ups {
-        let frame = match read_next_stream_json_user_frame(
-            stdin,
-            StreamJsonFrameKind::FollowUp { index },
-        ) {
-            Ok(Some(frame)) => frame,
-            Ok(None) => {
-                eprintln!(
-                    "active-input stdin closed after {} of {expected_follow_ups} follow-up user messages",
-                    follow_up_contents.len()
-                );
-                return ExitCode::from(1);
-            }
-            Err(message) => {
-                eprintln!("{message}");
-                return ExitCode::from(1);
-            }
-        };
+    let mut next_follow_up_index = 1;
+    if ready_after_first_follow_up {
+        let first_frame =
+            match read_follow_up_frame(stdin, 1, follow_up_contents.len(), expected_follow_ups) {
+                Ok(frame) => frame,
+                Err(exit_code) => return exit_code,
+            };
 
-        if replay_user_messages {
-            transcript.emit_value(replayed_user_event(
-                &session_id,
-                frame.uuid.as_deref(),
-                &frame.content,
-            ));
-            let _ = std::io::stdout().flush();
-        }
-        follow_up_contents.push(frame.content);
+        transcript.emit_value(result_event(&session_id, false, ACTIVE_INPUT_READY_RESULT));
+        let _ = std::io::stdout().flush();
+        emit_follow_up(
+            &mut transcript,
+            &session_id,
+            replay_user_messages,
+            first_frame,
+            &mut follow_up_contents,
+        );
+        next_follow_up_index = 2;
+    } else {
+        transcript.emit_value(result_event(&session_id, false, ACTIVE_INPUT_READY_RESULT));
+        let _ = std::io::stdout().flush();
+    }
+
+    for index in next_follow_up_index..=expected_follow_ups {
+        let frame =
+            match read_follow_up_frame(stdin, index, follow_up_contents.len(), expected_follow_ups)
+            {
+                Ok(frame) => frame,
+                Err(exit_code) => return exit_code,
+            };
+        emit_follow_up(
+            &mut transcript,
+            &session_id,
+            replay_user_messages,
+            frame,
+            &mut follow_up_contents,
+        );
     }
 
     transcript.emit_value(result_event(
@@ -170,4 +174,43 @@ pub(super) fn run_active_input_smoke_scenario(
     transcript.write_session_history(&session_id);
     let _ = std::io::stdout().flush();
     ExitCode::SUCCESS
+}
+
+fn read_follow_up_frame(
+    reader: &mut impl BufRead,
+    index: usize,
+    received_follow_ups: usize,
+    expected_follow_ups: usize,
+) -> Result<StreamJsonUserFrame, ExitCode> {
+    match read_next_stream_json_user_frame(reader, StreamJsonFrameKind::FollowUp { index }) {
+        Ok(Some(frame)) => Ok(frame),
+        Ok(None) => {
+            eprintln!(
+                "active-input stdin closed after {received_follow_ups} of {expected_follow_ups} follow-up user messages"
+            );
+            Err(ExitCode::from(1))
+        }
+        Err(message) => {
+            eprintln!("{message}");
+            Err(ExitCode::from(1))
+        }
+    }
+}
+
+fn emit_follow_up(
+    transcript: &mut JsonlTranscript,
+    session_id: &str,
+    replay_user_messages: bool,
+    frame: StreamJsonUserFrame,
+    follow_up_contents: &mut Vec<String>,
+) {
+    if replay_user_messages {
+        transcript.emit_value(replayed_user_event(
+            session_id,
+            frame.uuid.as_deref(),
+            &frame.content,
+        ));
+        let _ = std::io::stdout().flush();
+    }
+    follow_up_contents.push(frame.content);
 }

--- a/crates/guest-mock-claude/src/scenario.rs
+++ b/crates/guest-mock-claude/src/scenario.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 const ACTIVE_INPUT_SMOKE_MARKER: &str = "@active-input-smoke:";
+const ACTIVE_INPUT_SMOKE_READY_MARKER: &str = "@active-input-smoke-ready:";
 const ECHO_HANG_MARKER: &str = "@ECHO-HANG@";
 const ECHO_MARKER: &str = "@ECHO@";
 const FAIL_NO_NEWLINE_MARKER: &str = "@fail-no-newline:";
@@ -26,7 +27,9 @@ const HANG_AFTER_RESULT_MARKER: &str = "@hang-after-result";
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum MockScenario<'a> {
     ActiveInputSmoke { expected_follow_ups: usize },
+    ActiveInputSmokeReady { expected_follow_ups: usize },
     InvalidActiveInputSmokeCount(&'a str),
+    InvalidActiveInputSmokeReadyCount(&'a str),
     EchoJsonl(&'a str),
     EchoJsonlAndHang(&'a str),
     FailNoNewline(&'a str),
@@ -58,6 +61,7 @@ enum ScenarioMatchKind {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ScenarioKind {
     ActiveInputSmoke,
+    ActiveInputSmokeReady,
     EchoJsonl,
     EchoJsonlAndHang,
     FailNoNewline,
@@ -94,6 +98,11 @@ const SCENARIO_RULES: &[ScenarioRule] = &[
         marker: ACTIVE_INPUT_SMOKE_MARKER,
         match_kind: ScenarioMatchKind::PrefixPayload,
         scenario_kind: ScenarioKind::ActiveInputSmoke,
+    },
+    ScenarioRule {
+        marker: ACTIVE_INPUT_SMOKE_READY_MARKER,
+        match_kind: ScenarioMatchKind::PrefixPayload,
+        scenario_kind: ScenarioKind::ActiveInputSmokeReady,
     },
     ScenarioRule {
         marker: ECHO_HANG_MARKER,
@@ -233,14 +242,10 @@ impl ScenarioKind {
     fn to_mock_scenario<'a>(self, scenario_match: ScenarioMatch<'a>) -> Option<MockScenario<'a>> {
         let scenario = match (self, scenario_match) {
             (Self::ActiveInputSmoke, ScenarioMatch::Payload(payload)) => {
-                match payload.parse::<usize>() {
-                    Ok(expected_follow_ups) if expected_follow_ups > 0 => {
-                        MockScenario::ActiveInputSmoke {
-                            expected_follow_ups,
-                        }
-                    }
-                    _ => MockScenario::InvalidActiveInputSmokeCount(payload),
-                }
+                parse_active_input_smoke(payload, false)
+            }
+            (Self::ActiveInputSmokeReady, ScenarioMatch::Payload(payload)) => {
+                parse_active_input_smoke(payload, true)
             }
             (Self::EchoJsonl, ScenarioMatch::Payload(payload)) => MockScenario::EchoJsonl(payload),
             (Self::EchoJsonlAndHang, ScenarioMatch::Payload(payload)) => {
@@ -279,6 +284,29 @@ impl ScenarioKind {
         };
 
         Some(scenario)
+    }
+}
+
+fn parse_active_input_smoke<'a>(
+    payload: &'a str,
+    ready_after_first_follow_up: bool,
+) -> MockScenario<'a> {
+    match payload.parse::<usize>() {
+        Ok(expected_follow_ups) if expected_follow_ups > 0 => {
+            if ready_after_first_follow_up {
+                MockScenario::ActiveInputSmokeReady {
+                    expected_follow_ups,
+                }
+            } else {
+                MockScenario::ActiveInputSmoke {
+                    expected_follow_ups,
+                }
+            }
+        }
+        _ if ready_after_first_follow_up => {
+            MockScenario::InvalidActiveInputSmokeReadyCount(payload)
+        }
+        _ => MockScenario::InvalidActiveInputSmokeCount(payload),
     }
 }
 
@@ -353,6 +381,12 @@ mod tests {
             (
                 "@active-input-smoke:2",
                 MockScenario::ActiveInputSmoke {
+                    expected_follow_ups: 2,
+                },
+            ),
+            (
+                "@active-input-smoke-ready:2",
+                MockScenario::ActiveInputSmokeReady {
                     expected_follow_ups: 2,
                 },
             ),
@@ -564,6 +598,14 @@ mod tests {
         assert_eq!(
             MockScenario::from_prompt("@active-input-smoke:0"),
             MockScenario::InvalidActiveInputSmokeCount("0")
+        );
+        assert_eq!(
+            MockScenario::from_prompt("@active-input-smoke-ready:not-a-number"),
+            MockScenario::InvalidActiveInputSmokeReadyCount("not-a-number")
+        );
+        assert_eq!(
+            MockScenario::from_prompt("@active-input-smoke-ready:0"),
+            MockScenario::InvalidActiveInputSmokeReadyCount("0")
         );
         assert_eq!(
             MockScenario::from_prompt("@fail-no-newline:"),

--- a/crates/guest-mock-claude/tests/active_input.rs
+++ b/crates/guest-mock-claude/tests/active_input.rs
@@ -142,6 +142,120 @@ fn active_input_stream_reads_followups_after_ready() -> Result<(), Box<dyn std::
 }
 
 #[test]
+fn active_input_ready_smoke_gates_readiness_on_first_followup()
+-> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let mut stream = spawn_stream_json_child(home.path(), false)?;
+
+    stream.stdin_mut()?.write_all(
+        stream_json_user_frame_with_uuid("@active-input-smoke-ready:2", "active-initial")
+            .as_bytes(),
+    )?;
+    stream
+        .stdin_mut()?
+        .write_all(stream_json_user_frame_with_uuid("first", "follow-up-1").as_bytes())?;
+    stream.stdin_mut()?.flush()?;
+
+    let mut events = recv_until_result(&stream.rx, ACTIVE_INPUT_READY_RESULT)?;
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        ["system/init", "result/success",]
+    );
+
+    stream
+        .stdin_mut()?
+        .write_all(stream_json_user_frame_with_uuid("second", "follow-up-2").as_bytes())?;
+    stream.stdin_mut()?.flush()?;
+    events.extend(recv_until_result(&stream.rx, "RESULT=first+second")?);
+    stream.close_stdin();
+
+    let (status, stderr) = stream.wait()?;
+    assert!(status.success(), "expected success, stderr: {stderr}");
+    assert!(stderr.is_empty());
+
+    let session_id = init_session_id(&events)?;
+    let history = fs::read_to_string(expected_history_path(home.path(), &session_id))?;
+    assert_eq!(parse_jsonl(history.as_bytes())?, events);
+    Ok(())
+}
+
+#[test]
+fn active_input_ready_smoke_replays_first_followup_after_readiness()
+-> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let mut stream = spawn_stream_json_child(home.path(), true)?;
+
+    stream.stdin_mut()?.write_all(
+        stream_json_user_frame_with_uuid("@active-input-smoke-ready:2", "active-initial")
+            .as_bytes(),
+    )?;
+    stream
+        .stdin_mut()?
+        .write_all(stream_json_user_frame_with_uuid("first", "follow-up-1").as_bytes())?;
+    stream.stdin_mut()?.flush()?;
+
+    let mut events = recv_until_result(&stream.rx, ACTIVE_INPUT_READY_RESULT)?;
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        ["system/init", "user/", "result/success"],
+    );
+
+    stream
+        .stdin_mut()?
+        .write_all(stream_json_user_frame_with_uuid("second", "follow-up-2").as_bytes())?;
+    stream.stdin_mut()?.flush()?;
+    events.extend(recv_until_result(&stream.rx, "RESULT=first+second")?);
+    stream.close_stdin();
+
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        [
+            "system/init",
+            "user/",
+            "result/success",
+            "user/",
+            "user/",
+            "result/success",
+        ],
+    );
+    assert_eq!(
+        events[3]
+            .pointer("/message/content")
+            .and_then(Value::as_str),
+        Some("first")
+    );
+
+    let (status, stderr) = stream.wait()?;
+    assert!(status.success(), "expected success, stderr: {stderr}");
+    assert!(stderr.is_empty());
+
+    let session_id = init_session_id(&events)?;
+    let history = fs::read_to_string(expected_history_path(home.path(), &session_id))?;
+    assert_eq!(parse_jsonl(history.as_bytes())?, events);
+    Ok(())
+}
+
+#[test]
+fn active_input_ready_smoke_rejects_early_eof() -> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let mut stream = spawn_stream_json_child(home.path(), false)?;
+
+    stream.stdin_mut()?.write_all(
+        stream_json_user_frame_with_uuid("@active-input-smoke-ready:2", "active-initial")
+            .as_bytes(),
+    )?;
+    stream.close_stdin();
+
+    let (status, stderr) = stream.wait()?;
+    assert!(!status.success());
+    assert!(
+        stderr.contains("active-input stdin closed after 0 of 2 follow-up user messages"),
+        "unexpected stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
 fn active_input_stream_replays_user_messages() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
     let mut stream = spawn_stream_json_child(home.path(), true)?;


### PR DESCRIPTION
## Summary

Closes #27377

The process-containment pressure lane could lose a startup race: the mock emitted its first `result` before the asynchronous local active-input forwarder delivered any follow-up, so Guest Agent closed stdin and the submit failed with `active-input stdin closed after 0 of 8 follow-up user messages`.

This change adds a dedicated `@active-input-smoke-ready:<n>` mock scenario. It reads and buffers the first follow-up, emits the readiness result while that delivery is still pending, then replays/processes the buffered frame and consumes the remaining follow-ups. The process-containment smoke uses this marker; the existing marker and production active-input lifecycle remain unchanged.

## Changes

- Add and document the readiness-gated mock scenario and parser validation.
- Factor follow-up parsing/emission so gated and existing scenarios preserve EOF diagnostics, replay UUIDs, and session history.
- Add gated-mode integration coverage for event ordering, replay/history, all follow-ups, and early EOF.
- Exercise the gated marker through Guest Agent receipt integration coverage.
- Update the process-containment pressure prompt and comment to use the explicit handshake.

## Explicit exclusions

- No Guest Agent active-input state-machine or result-time closure changes.
- No runner queue payload, persisted state, deployment protocol, or pressure-command changes.
- The full metal process-containment lane is left to CI because the required runner host is not available locally.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-mock-claude --all-targets -- -D warnings`
- `cd crates && cargo test -p guest-mock-claude`
- `cd crates && cargo clippy -p guest-agent --test claude_active_input_receipt -- -D warnings`
- `cd crates && cargo test -p guest-agent --test claude_active_input_receipt`
- `cd crates && cargo test -p guest-agent --test process_control_channel`
- `bash -n .github/scripts/runner-behavior-process-containment.sh`
- `git diff --check`
