### PR TITLE
refactor(cli): flatten goal command module

### DIFF
--- a/turbo/apps/cli/src/commands/goal/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/goal/__tests__/index.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HttpResponse, http } from "msw";
 
-import { server } from "../../../../mocks/server";
-import { zeroGoalCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { goalCommand } from "../index";
 
 const ACTIVE_GOAL = {
   objective: "ship goal workflows",
@@ -49,7 +49,7 @@ describe("okou goal command", () => {
       }),
     );
 
-    await zeroGoalCommand.parseAsync([
+    await goalCommand.parseAsync([
       "node",
       "okou",
       "create",
@@ -77,7 +77,7 @@ describe("okou goal command", () => {
       }),
     );
 
-    await zeroGoalCommand.parseAsync([
+    await goalCommand.parseAsync([
       "node",
       "okou",
       "edit",
@@ -97,7 +97,7 @@ describe("okou goal command", () => {
       }),
     );
 
-    await zeroGoalCommand.parseAsync(["node", "okou", "get"]);
+    await goalCommand.parseAsync(["node", "okou", "get"]);
 
     expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
       ACTIVE_GOAL,
@@ -122,7 +122,7 @@ describe("okou goal command", () => {
         }),
       );
 
-      await zeroGoalCommand.parseAsync(["node", "okou", command]);
+      await goalCommand.parseAsync(["node", "okou", command]);
 
       expect(
         JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0])),
@@ -137,7 +137,7 @@ describe("okou goal command", () => {
       }),
     );
 
-    await zeroGoalCommand.parseAsync(["node", "okou", "clear"]);
+    await goalCommand.parseAsync(["node", "okou", "clear"]);
 
     expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
       { cleared: true },

--- a/turbo/apps/cli/src/commands/goal/index.ts
+++ b/turbo/apps/cli/src/commands/goal/index.ts
@@ -9,8 +9,8 @@ import {
   getGoal,
   pauseGoal,
   resumeGoal,
-} from "../../../lib/api/domains/zero-goals";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+} from "../../lib/api/domains/zero-goals";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 interface CreateOptions {
   readonly objective: string;
@@ -103,7 +103,7 @@ const clearCommand = new Command()
     }),
   );
 
-export const zeroGoalCommand = new Command()
+export const goalCommand = new Command()
   .name("goal")
   .description("Manage the current thread goal")
   .addCommand(createCommand)

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -240,7 +240,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "goal",
     description: "Manage the current thread goal",
     load: async () => {
-      return (await import("./commands/zero/goal")).zeroGoalCommand;
+      return (await import("./commands/goal")).goalCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move the Goal command and focused integration test from `commands/zero/goal` to `commands/goal`
- rename the internal command export from `zeroGoalCommand` to `goalCommand`
- update the Goal lazy registry entry and relative imports for the shallower directory

## Compatibility

- preserve the public `okou goal` command tree, flags, help, output, and error behavior
- preserve the `zero-goals` adapter, API paths and contracts, goal lifecycle, and JSON shapes
- retain `VM0_API_BACKEND_URL`, `ZERO_TOKEN`, and `ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED` unchanged
- retain the autonomous-goal safety wording byte-for-byte
- add no old-path bridge, export alias, compatibility re-export, or unrelated naming cleanup

## Verification

- lockfile-pinned Prettier 3.8.1 check on all changed files
- `pnpm --filter @okouai/cli run lint`
- `pnpm --filter @okouai/cli run check-types`
- `pnpm knip --workspace @okouai/cli`
- focused Goal test: 1 file, 8 tests passed
- Goal and CLI registry tests: 3 files, 98 tests passed
- post-rebase mechanical-equivalence audit against latest `origin/main`
- repository-wide residual scans for `commands/zero/goal` and `zeroGoalCommand`
- boundary-count audit preserving `zero-goals` and all three compatibility environment names

Closes #27386
