### PR TITLE
refactor(cli): flatten model command modules

### DIFF
--- a/turbo/apps/cli/src/commands/model-provider/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/index.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import chalk from "chalk";
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import {
   MODEL_PROVIDER_SET_GUIDANCE,
   setCommand,
-  zeroModelProviderCommand,
+  modelProviderCommand,
 } from "../index";
 
 const MODEL_POLICIES_RESPONSE = {
@@ -69,12 +69,12 @@ describe("okou model-provider command", () => {
   });
 
   it("should expose provider routing subcommands", () => {
-    expect(zeroModelProviderCommand.name()).toBe("model-provider");
-    expect(zeroModelProviderCommand.description()).toBe(
+    expect(modelProviderCommand.name()).toBe("model-provider");
+    expect(modelProviderCommand.description()).toBe(
       "Inspect model provider routing",
     );
     expect(
-      zeroModelProviderCommand.commands.map((command) => {
+      modelProviderCommand.commands.map((command) => {
         return command.name();
       }),
     ).toEqual(["list", "set"]);
@@ -87,7 +87,7 @@ describe("okou model-provider command", () => {
       }),
     );
 
-    await zeroModelProviderCommand.parseAsync(["node", "cli", "ls"]);
+    await modelProviderCommand.parseAsync(["node", "cli", "ls"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("Model Provider Routes:");

--- a/turbo/apps/cli/src/commands/model-provider/index.ts
+++ b/turbo/apps/cli/src/commands/model-provider/index.ts
@@ -1,12 +1,12 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { listZeroModelPolicies } from "../../../lib/api/domains/zero-model-policies";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { listZeroModelPolicies } from "../../lib/api/domains/zero-model-policies";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 import {
   formatModelPolicyStatus,
   getModelProviderRouteKind,
   getModelProviderTypeLabel,
-} from "../../../lib/domain/model-policy-display";
+} from "../../lib/domain/model-policy-display";
 
 export const MODEL_PROVIDER_SET_GUIDANCE = [
   "Model provider routing is configured in the web app.",
@@ -64,7 +64,7 @@ export const setCommand = new Command()
     console.log(MODEL_PROVIDER_SET_GUIDANCE);
   });
 
-export const zeroModelProviderCommand = new Command()
+export const modelProviderCommand = new Command()
   .name("model-provider")
   .description("Inspect model provider routing")
   .addCommand(listCommand)

--- a/turbo/apps/cli/src/commands/model/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/model/__tests__/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import chalk from "chalk";
-import { server } from "../../../../mocks/server";
-import { switchCommand, zeroModelCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { switchCommand, modelCommand } from "../index";
 
 const MODEL_POLICIES_RESPONSE = {
   workspaceDefaultModel: "claude-sonnet-4-6",
@@ -52,12 +52,12 @@ describe("okou model command", () => {
   });
 
   it("should expose model discovery and switching subcommands", () => {
-    expect(zeroModelCommand.name()).toBe("model");
-    expect(zeroModelCommand.description()).toBe(
+    expect(modelCommand.name()).toBe("model");
+    expect(modelCommand.description()).toBe(
       "List available models and model-switching guidance",
     );
     expect(
-      zeroModelCommand.commands.map((command) => {
+      modelCommand.commands.map((command) => {
         return command.name();
       }),
     ).toEqual(["list", "switch"]);
@@ -70,7 +70,7 @@ describe("okou model command", () => {
       }),
     );
 
-    await zeroModelCommand.parseAsync(["node", "cli", "ls"]);
+    await modelCommand.parseAsync(["node", "cli", "ls"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("Allowed Models:");

--- a/turbo/apps/cli/src/commands/model/index.ts
+++ b/turbo/apps/cli/src/commands/model/index.ts
@@ -1,13 +1,13 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { getVm0ModelPriceTier } from "@okouai/api-contracts/contracts/model-providers";
-import { listZeroModelPolicies } from "../../../lib/api/domains/zero-model-policies";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { listZeroModelPolicies } from "../../lib/api/domains/zero-model-policies";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 import {
   formatModelPolicyStatus,
   formatModelProviderRoute,
   getModelProviderRouteKind,
-} from "../../../lib/domain/model-policy-display";
+} from "../../lib/domain/model-policy-display";
 
 function formatPriceTier(tier: string | undefined): string {
   return tier ?? "unknown";
@@ -66,7 +66,7 @@ export const switchCommand = new Command()
     );
   });
 
-export const zeroModelCommand = new Command()
+export const modelCommand = new Command()
   .name("model")
   .description("List available models and model-switching guidance")
   .addCommand(listCommand)

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -88,15 +88,14 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "model",
     description: "List available models and model-switching guidance",
     load: async () => {
-      return (await import("./commands/zero/model")).zeroModelCommand;
+      return (await import("./commands/model")).modelCommand;
     },
   },
   {
     name: "model-provider",
     description: "Inspect model provider routing",
     load: async () => {
-      return (await import("./commands/zero/model-provider"))
-        .zeroModelProviderCommand;
+      return (await import("./commands/model-provider")).modelProviderCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move the model and model-provider command slices to the neutral command root
- rename the internal command exports to `modelCommand` and `modelProviderCommand`
- update the lazy registry entries, moved tests, and one-level relative imports

## Compatibility

- preserve the public `okou model` and `okou model-provider` command trees, flags, guidance, URLs, and output
- retain provider identity `"vm0"`, `getVm0ModelPriceTier`, `zero-model-policies`, `listZeroModelPolicies`, `VM0_APPEND_SYSTEM_PROMPT`, and `VM0_API_BACKEND_URL` unchanged
- preserve model policies, routing, availability, price tiers, labels, contracts, routes, and persistence
- add no old-path bridge, export alias, compatibility re-export, or unrelated naming cleanup

## Verification

- lockfile-pinned Prettier 3.8.1 check on all changed files
- `corepack pnpm --filter @okouai/cli run lint`
- `corepack pnpm knip --workspace @okouai/cli`
- pi-agent-runtime build and CLI TypeScript check with pnpm 10.33.4
- model command test: 1 file, 3 tests passed
- model-provider command test: 1 file, 3 tests passed
- CLI registry tests: 2 files, 90 tests passed
- mechanical-equivalence audit against latest `origin/main`
- repository-wide residual scans for both old command paths and exports
- boundary-count audit preserving every required provider and compatibility identity

Closes #27385
