### PR TITLE
refactor(cli): flatten resource command module

### DIFF
--- a/turbo/apps/cli/src/commands/resource/__tests__/fixtures/illustration-archive.ts
+++ b/turbo/apps/cli/src/commands/resource/__tests__/fixtures/illustration-archive.ts
@@ -2,7 +2,7 @@
  * Exact 2.6 KB archive manually published for image-style:vm0-illustration
  * from vm0-ai/vm0-skills@45e237a8311c36a67bf612feb4342b44dbb3c4f6.
  */
-export const VM0_ILLUSTRATION_ARCHIVE = Buffer.from(
+export const ILLUSTRATION_ARCHIVE = Buffer.from(
   `
 H4sIAAAAAAAAA+1ZbXPbuBG+z/oVmMt0ejcjypJlW7abZibOyzXTtM1MkulXgyQkoqYIHgBK1r/v
 swu+QLKSuG93ndb4EhoiFvvy7O6zjC7LxnkrvTZV4tW6LqVXJ5v1NNHRLycf5P0flMyVdScf//ju

--- a/turbo/apps/cli/src/commands/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/resource/__tests__/index.test.ts
@@ -7,9 +7,9 @@ import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { findRegistryResourceForPull, zeroResourceCommand } from "../index";
-import { VM0_ILLUSTRATION_ARCHIVE } from "./fixtures/vm0-illustration-archive";
+import { server } from "../../../mocks/server";
+import { findRegistryResourceForPull, resourceCommand } from "../index";
+import { ILLUSTRATION_ARCHIVE } from "./fixtures/illustration-archive";
 
 const EXPECTED_WEBSITE_TEMPLATE_V2_SHA256: Record<string, string> = {
   "black-slabs":
@@ -171,7 +171,7 @@ describe("okou resource pull command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
-    outputDir = await mkdtemp(path.join(tmpdir(), "zero-resource-pull-test-"));
+    outputDir = await mkdtemp(path.join(tmpdir(), "resource-pull-test-"));
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
@@ -183,9 +183,9 @@ describe("okou resource pull command", () => {
   });
 
   it("downloads, verifies, and extracts an image style archive", async () => {
-    server.use(...registryDownload(VM0_ILLUSTRATION_ARCHIVE));
+    server.use(...registryDownload(ILLUSTRATION_ARCHIVE));
 
-    await zeroResourceCommand.parseAsync([
+    await resourceCommand.parseAsync([
       "node",
       "cli",
       "pull",
@@ -210,7 +210,7 @@ describe("okou resource pull command", () => {
     );
 
     await expect(
-      zeroResourceCommand.parseAsync([
+      resourceCommand.parseAsync([
         "node",
         "cli",
         "pull",

--- a/turbo/apps/cli/src/commands/resource/index.ts
+++ b/turbo/apps/cli/src/commands/resource/index.ts
@@ -20,9 +20,9 @@ import {
   type WebsiteTemplateArchiveVersion,
 } from "@okouai/core/resource-registry";
 
-import { getRegistryResourceDownload } from "../../../lib/api/domains/registry-resources";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { websiteTemplateArchiveVersionFromEnvironment } from "../../shared/website-template-archive-version";
+import { getRegistryResourceDownload } from "../../lib/api/domains/registry-resources";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { websiteTemplateArchiveVersionFromEnvironment } from "../shared/website-template-archive-version";
 
 type PullableRegistryEntry = RegistryEntry | VideoTemplateRegistryEntry;
 
@@ -92,7 +92,7 @@ function verifyArchive(buffer: Buffer, expectedSha256: string): void {
   }
 }
 
-export const zeroResourceCommand = new Command()
+export const resourceCommand = new Command()
   .name("resource")
   .description("Pull registry resources from private R2-backed archives")
   .addCommand(
@@ -140,7 +140,7 @@ export const zeroResourceCommand = new Command()
           verifyArchive(buffer, archive.sha256);
 
           const outputDir = path.resolve(options.dir);
-          const tmpDir = await mkdtemp(path.join(tmpdir(), "zero-resource-"));
+          const tmpDir = await mkdtemp(path.join(tmpdir(), "resource-"));
           const archivePath = path.join(tmpDir, "resource.tar.gz");
           await mkdir(outputDir, { recursive: true });
           await writeFile(archivePath, buffer);

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -212,7 +212,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "resource",
     description: "Pull registry resources from private R2-backed archives",
     load: async () => {
-      return (await import("./commands/zero/resource")).zeroResourceCommand;
+      return (await import("./commands/resource")).resourceCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move the Resource command, focused tests, and fixture wrapper from `commands/zero/resource` to `commands/resource`
- rename `zeroResourceCommand` to `resourceCommand` and update the `okou.ts` lazy registry entry
- replace the approved runtime/test temporary prefixes and mutable fixture wrapper names with their neutral Resource names
- update only the relative imports required by the one-level move

## Compatibility

- preserve the public `okou resource pull` command, flags, output, errors, tar safety, download, digest verification, extraction, and cleanup behavior
- preserve `lib/api/domains/registry-resources`, request/response contracts, resource identity, registry data, `VM0_API_BACKEND_URL`, and all archive-internal paths and content
- add no old-path bridge, export alias, compatibility re-export, or unrelated naming cleanup

## Archive boundary verification

- decoded archive before and after the wrapper rename is byte-for-byte identical: 2,621 bytes with SHA-256 `03e77d6968190b9f1888a900963135e92f75b40a6c37e1c1bae999ea49669a37`
- preserved `image-style:vm0-illustration`, `illustration-template/vm0-illustration`, `# vm0 Illustration`, the fixture URL, and the `vm0-ai/vm0-skills` source evidence exactly
- normalized mechanical-equivalence checks pass for production code, tests, fixture wrapper, and the Resource registry entry
- repository-wide residual scans find no owned `commands/zero/resource`, `zeroResourceCommand`, old temporary prefix, or old wrapper name

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed)
- `pnpm knip`
- bounded staged repository type-checks for non-API/Platform packages, Platform, and API
- post-rebase targeted Prettier, CLI lint, CLI Knip, and CLI type-check
- Resource command tests: 1 file, 8 tests passed
- CLI registry tests: 2 files, 90 tests passed
- `git diff --check`

Closes #27382
