### PR TITLE
refactor(cli): flatten host command module

### DIFF
--- a/turbo/apps/cli/src/commands/host/__tests__/clone.test.ts
+++ b/turbo/apps/cli/src/commands/host/__tests__/clone.test.ts
@@ -13,8 +13,8 @@ import chalk from "chalk";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroHostCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { hostCommand } from "../index";
 
 const FILES_URL = "http://localhost:3000/api/okou/host/sites/:publicSlug/files";
 const HOSTED_SITE_URL =
@@ -42,7 +42,7 @@ describe("okou host clone command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
-    tempDir = join(tmpdir(), `zero-host-clone-${Date.now()}`);
+    tempDir = join(tmpdir(), `host-clone-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });
   });
 
@@ -103,7 +103,7 @@ describe("okou host clone command", () => {
       }),
     );
 
-    await zeroHostCommand.parseAsync([
+    await hostCommand.parseAsync([
       "node",
       "cli",
       "clone",
@@ -163,7 +163,7 @@ describe("okou host clone command", () => {
     const originalCwd = process.cwd();
     process.chdir(tempDir);
     try {
-      await zeroHostCommand.parseAsync([
+      await hostCommand.parseAsync([
         "node",
         "cli",
         "clone",
@@ -185,7 +185,7 @@ describe("okou host clone command", () => {
     writeFileSync(join(destination, "file.txt"), "content");
 
     await expect(async () => {
-      await zeroHostCommand.parseAsync([
+      await hostCommand.parseAsync([
         "node",
         "cli",
         "clone",
@@ -216,7 +216,7 @@ describe("okou host clone command", () => {
     );
 
     await expect(async () => {
-      await zeroHostCommand.parseAsync([
+      await hostCommand.parseAsync([
         "node",
         "cli",
         "clone",

--- a/turbo/apps/cli/src/commands/host/__tests__/publish.test.ts
+++ b/turbo/apps/cli/src/commands/host/__tests__/publish.test.ts
@@ -8,9 +8,9 @@ import chalk from "chalk";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { DEFAULT_HOSTED_SITE_ROBOTS_TXT } from "../../../../lib/host/static-site";
-import { server } from "../../../../mocks/server";
-import { zeroHostCommand } from "../index";
+import { DEFAULT_HOSTED_SITE_ROBOTS_TXT } from "../../../lib/host/static-site";
+import { server } from "../../../mocks/server";
+import { hostCommand } from "../index";
 
 const PREPARE_URL = "http://localhost:3000/api/okou/host/deployments/prepare";
 const COMPLETE_URL =
@@ -46,7 +46,7 @@ describe("okou host publish command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-token");
-    tempDir = join(tmpdir(), `zero-host-publish-${Date.now()}`);
+    tempDir = join(tmpdir(), `host-publish-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });
   });
 
@@ -139,7 +139,7 @@ describe("okou host publish command", () => {
       }),
     );
 
-    await zeroHostCommand.parseAsync([
+    await hostCommand.parseAsync([
       "node",
       "cli",
       tempDir,
@@ -172,9 +172,7 @@ describe("okou host publish command", () => {
     const legacyUrl = `https://${legacyPublicSlug}.sites.example.com`;
 
     writeFileSync(join(tempDir, "index.html"), index);
-    expect(zeroHostCommand.helpInformation()).toContain(
-      "--slug-suffix <suffix>",
-    );
+    expect(hostCommand.helpInformation()).toContain("--slug-suffix <suffix>");
 
     server.use(
       http.post(PREPARE_URL, async ({ request }) => {
@@ -208,7 +206,7 @@ describe("okou host publish command", () => {
       }),
     );
 
-    await zeroHostCommand.parseAsync([
+    await hostCommand.parseAsync([
       "node",
       "cli",
       tempDir,
@@ -260,7 +258,7 @@ describe("okou host publish command", () => {
       );
 
       await expect(
-        zeroHostCommand.parseAsync([
+        hostCommand.parseAsync([
           "node",
           "cli",
           tempDir,

--- a/turbo/apps/cli/src/commands/host/__tests__/versions.test.ts
+++ b/turbo/apps/cli/src/commands/host/__tests__/versions.test.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroHostCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { hostCommand } from "../index";
 
 const DEPLOYMENTS_URL =
   "http://localhost:3000/api/okou/host/sites/:site/deployments";
@@ -61,7 +61,7 @@ describe("okou host versions command", () => {
       }),
     );
 
-    await zeroHostCommand.parseAsync([
+    await hostCommand.parseAsync([
       "node",
       "cli",
       "versions",

--- a/turbo/apps/cli/src/commands/host/clone.ts
+++ b/turbo/apps/cli/src/commands/host/clone.ts
@@ -1,12 +1,12 @@
 import { Command, InvalidArgumentError } from "commander";
 import chalk from "chalk";
 
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 import {
   cloneHostedSite,
   publicSlugFromSite,
-} from "../../../lib/host/clone-hosted-site";
-import { formatBytes } from "../../../lib/utils/file-utils";
+} from "../../lib/host/clone-hosted-site";
+import { formatBytes } from "../../lib/utils/file-utils";
 
 interface CloneOptions {
   readonly json?: boolean;

--- a/turbo/apps/cli/src/commands/host/index.ts
+++ b/turbo/apps/cli/src/commands/host/index.ts
@@ -4,8 +4,8 @@ import {
   hostedArtifactKindSchema,
   type HostedArtifactKind,
 } from "@okouai/api-contracts/contracts/zero-host";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { publishStaticSite } from "../../../lib/host/publish-static-site";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { publishStaticSite } from "../../lib/host/publish-static-site";
 import { cloneHostedSiteCommand } from "./clone";
 import { versionsHostedSiteCommand } from "./versions";
 
@@ -27,7 +27,7 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export const zeroHostCommand = new Command()
+export const hostCommand = new Command()
   .name("host")
   .description("Publish and inspect owned static hosted sites")
   .argument("<dir>", "Static build directory, for example ./dist")

--- a/turbo/apps/cli/src/commands/host/versions.ts
+++ b/turbo/apps/cli/src/commands/host/versions.ts
@@ -1,8 +1,8 @@
 import { Command } from "commander";
 import chalk from "chalk";
 
-import { getHostedSiteDeployments } from "../../../lib/api/domains/zero-host";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { getHostedSiteDeployments } from "../../lib/api/domains/zero-host";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 interface VersionsOptions {
   readonly json?: boolean;

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -284,7 +284,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "host",
     description: "Publish static sites and clone owned hosted site files",
     load: async () => {
-      return (await import("./commands/zero/host")).zeroHostCommand;
+      return (await import("./commands/host")).hostCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all six Host command and focused test files from `commands/zero/host` to `commands/host`
- rename the internal export from `zeroHostCommand` to `hostCommand` and update the `okou.ts` lazy import
- update moved relative imports and replace the test-only temporary prefixes with `host-publish-*` and `host-clone-*`

## Compatibility

- preserve the public `okou host` command tree, flags, help, URLs, JSON/stdout output, errors, and publish/upload/clone/version/alias behavior
- preserve `@okouai/api-contracts/contracts/zero-host`, `lib/api/domains/zero-host`, hosted-site schemas, and `VM0_API_BACKEND_URL`
- add no old-path bridge, export alias, compatibility re-export, or unrelated naming cleanup

## Contract verification

- normalized mechanical-equivalence audit passes for all six moved files and `okou.ts`
- repository-wide scans find no `commands/zero/host`, `zeroHostCommand`, `zero-host-publish-*`, or `zero-host-clone-*` residual
- the staged diff contains six renames and the required Host registry edit only
- the retained contract, adapter, and environment-variable boundary counts match `main`

## Validation

- lockfile-pinned Prettier 3.8.1 full workspace format and post-rebase targeted format check
- full repository lint: 13/13 tasks passed with bounded memory and single concurrency
- full Knip
- staged repository type-checks plus post-rebase CLI type-check
- Host command tests: 3 files, 9 tests passed
- CLI registry tests: 2 files, 90 tests passed
- `git diff --check`

Closes #27384