### PR TITLE
refactor(cli): flatten banking command module

### DIFF
--- a/turbo/apps/cli/src/commands/banking/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/banking/__tests__/index.test.ts
@@ -5,10 +5,10 @@ import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
-import { zeroBankingCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { bankingCommand } from "../index";
 
-const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "zero-banking-home-"));
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "banking-home-"));
 
 vi.mock("os", async (importOriginal) => {
   const original = await importOriginal<typeof import("os")>();
@@ -33,7 +33,7 @@ describe("okou banking command", () => {
     await fs.rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
   });
 
   afterEach(async () => {
@@ -68,7 +68,7 @@ describe("okou banking command", () => {
       ),
     );
 
-    await zeroBankingCommand.parseAsync([
+    await bankingCommand.parseAsync([
       "node",
       "cli",
       "transactions",
@@ -123,7 +123,7 @@ describe("okou banking command", () => {
       }),
     );
 
-    await zeroBankingCommand.parseAsync(["node", "cli", "accounts"]);
+    await bankingCommand.parseAsync(["node", "cli", "accounts"]);
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("Banking accounts loaded");
@@ -136,7 +136,7 @@ describe("okou banking command", () => {
     vi.stubEnv("OKOU_TOKEN", undefined);
 
     await expect(
-      zeroBankingCommand.parseAsync(["node", "cli", "accounts"]),
+      bankingCommand.parseAsync(["node", "cli", "accounts"]),
     ).rejects.toThrow("process.exit called");
 
     const errors = mockConsoleError.mock.calls.flat().join("\n");

--- a/turbo/apps/cli/src/commands/banking/index.ts
+++ b/turbo/apps/cli/src/commands/banking/index.ts
@@ -4,8 +4,8 @@ import chalk from "chalk";
 import {
   callZeroBanking,
   type ZeroBankingResponse,
-} from "../../../lib/api/domains/zero-banking";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+} from "../../lib/api/domains/zero-banking";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 interface JsonOption {
   readonly json?: boolean;
@@ -132,7 +132,7 @@ const transactionsCommand = new Command()
     }),
   );
 
-export const zeroBankingCommand = new Command()
+export const bankingCommand = new Command()
   .name("banking")
   .description("Use managed Okou banking services")
   .addCommand(accountsCommand)
@@ -148,6 +148,6 @@ Examples:
 
 Notes:
   - Authenticates via OKOU_TOKEN (requires banking:read capability)
-  - Finicity credentials and app tokens stay on the vm0 API server
+  - Finicity credentials and app tokens stay on the Okou API server
   - Access is limited to accounts enabled for the current agent`,
   );

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -353,7 +353,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "banking",
     description: "Use managed Okou banking services",
     load: async () => {
-      return (await import("./commands/zero/banking")).zeroBankingCommand;
+      return (await import("./commands/banking")).bankingCommand;
     },
   },
 ];


### PR DESCRIPTION
## Summary

- move the Banking command and focused integration test from `commands/zero/banking` to `commands/banking`
- rename the internal command export from `zeroBankingCommand` to `bankingCommand` and update the lazy registry entry
- update the Banking test-only prefixes and the approved `Okou API server` help sentence

## Compatibility

- preserve the `zero-banking` adapter, `ZeroBankingResponse`, and `callZeroBanking`
- preserve `.vm0`, `VM0_API_BACKEND_URL`, `/api/okou/banking`, `banking:read`, Finicity identity, request and response shapes, limits, date parsing, authentication, and public command behavior
- add no old-path bridge, export alias, compatibility re-export, or unrelated naming cleanup

## Verification

- lockfile-pinned Prettier 3.8.1 check on all changed files
- `pnpm --filter @okouai/cli run lint`
- `pnpm knip --workspace @okouai/cli`
- `pnpm --filter @okouai/cli run check-types`
- focused Banking test: 1 file, 3 tests passed
- CLI registry test: 1 file, 6 tests passed
- command capability registry test: 1 file, 84 tests passed
- post-rebase mechanical-equivalence audit against latest `origin/main`
- repository-wide residual scans for `commands/zero/banking`, `zeroBankingCommand`, the old Banking fixture prefix, and the owned vm0-branded help sentence
- boundary-count audit preserving the Banking API adapter, compatibility configuration, API path, capability, and Finicity identity

Closes #27396
