### PR TITLE
refactor(cli): flatten mail command module

### DIFF
--- a/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
@@ -2,13 +2,13 @@ import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
+import { server } from "../../../mocks/server";
 import {
   authCodeMethod,
   catalogStatusItem,
   stubConnectorCatalogStatus,
-} from "../../__tests__/helpers/connector-catalog";
-import { zeroMailCommand } from "../index";
+} from "../../zero/__tests__/helpers/connector-catalog";
+import { mailCommand } from "../index";
 
 const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
 const THREAD_ID = "550e8400-e29b-41d4-a716-446655440001";
@@ -66,7 +66,7 @@ describe("okou mail", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
@@ -79,7 +79,7 @@ describe("okou mail", () => {
   it("lists agent-authorized mail accounts and returns a connect link", async () => {
     server.use(mailCatalog(), ...stubAgentContext(["gmail"]));
 
-    await zeroMailCommand.parseAsync(["node", "cli", "list"]);
+    await mailCommand.parseAsync(["node", "cli", "list"]);
 
     const listOutput = mockConsoleLog.mock.calls.flat().join("\n");
     expect(listOutput).toContain("gmail");
@@ -89,7 +89,7 @@ describe("okou mail", () => {
     expect(listOutput).toContain("connect");
 
     mockConsoleLog.mockClear();
-    await zeroMailCommand.parseAsync([
+    await mailCommand.parseAsync([
       "node",
       "cli",
       "connect",
@@ -112,7 +112,7 @@ describe("okou mail", () => {
         "http://localhost:3000/api/okou/mail/drafts/link",
         async ({ request }) => {
           expect(request.headers.get("authorization")).toBe(
-            "Bearer test-zero-token",
+            "Bearer test-token",
           );
           expect(await request.json()).toStrictEqual({
             threadId: THREAD_ID,
@@ -130,7 +130,7 @@ describe("okou mail", () => {
       ),
     );
 
-    await zeroMailCommand.parseAsync(["node", "cli", "link", "r-test-draft"]);
+    await mailCommand.parseAsync(["node", "cli", "link", "r-test-draft"]);
 
     expect(mockConsoleLog).toHaveBeenCalledOnce();
     expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -151,7 +151,7 @@ describe("okou mail", () => {
       }),
     );
 
-    await zeroMailCommand.parseAsync([
+    await mailCommand.parseAsync([
       "node",
       "cli",
       "link",

--- a/turbo/apps/cli/src/commands/mail/connect.ts
+++ b/turbo/apps/cli/src/commands/mail/connect.ts
@@ -1,11 +1,11 @@
 import chalk from "chalk";
 import { Command } from "commander";
 
-import { listZeroConnectorCatalogStatus } from "../../../lib/api/domains/zero-connectors";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { resolveAgentContext } from "../connector/agent-context";
-import { findConnectorStatusItem } from "../connector/public-catalog";
-import { getPlatformOrigin } from "../../doctor/platform-url";
+import { listZeroConnectorCatalogStatus } from "../../lib/api/domains/zero-connectors";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { getPlatformOrigin } from "../doctor/platform-url";
+import { resolveAgentContext } from "../zero/connector/agent-context";
+import { findConnectorStatusItem } from "../zero/connector/public-catalog";
 import {
   MAIL_CONNECTOR_SLUG_BY_PROVIDER,
   currentAgentId,

--- a/turbo/apps/cli/src/commands/mail/index.ts
+++ b/turbo/apps/cli/src/commands/mail/index.ts
@@ -4,7 +4,7 @@ import { connectCommand } from "./connect";
 import { linkCommand } from "./link";
 import { listCommand } from "./list";
 
-export const zeroMailCommand = new Command()
+export const mailCommand = new Command()
   .name("mail")
   .description("Review linked Gmail drafts")
   .addCommand(listCommand)

--- a/turbo/apps/cli/src/commands/mail/link.ts
+++ b/turbo/apps/cli/src/commands/mail/link.ts
@@ -1,13 +1,13 @@
 import { Command, Option } from "commander";
 
-import { linkZeroMailDraft } from "../../../lib/api/domains/zero-mail";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { getOkouChatThreadId } from "../../../lib/okou-env";
+import { linkZeroMailDraft } from "../../lib/api/domains/zero-mail";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { getOkouChatThreadId } from "../../lib/okou-env";
 import {
   addRequestedCallbackSearchParams,
   connectorActionCallbackAvailable,
   printCallbackTurnInstruction,
-} from "../connector/action-url";
+} from "../zero/connector/action-url";
 import { currentAgentId } from "./shared";
 
 function currentChatThreadId(): string {

--- a/turbo/apps/cli/src/commands/mail/list.ts
+++ b/turbo/apps/cli/src/commands/mail/list.ts
@@ -1,10 +1,10 @@
 import chalk from "chalk";
 import { Command } from "commander";
 
-import { listZeroConnectorCatalogStatus } from "../../../lib/api/domains/zero-connectors";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { resolveAgentContext } from "../connector/agent-context";
-import { findConnectorStatusItem } from "../connector/public-catalog";
+import { listZeroConnectorCatalogStatus } from "../../lib/api/domains/zero-connectors";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { resolveAgentContext } from "../zero/connector/agent-context";
+import { findConnectorStatusItem } from "../zero/connector/public-catalog";
 import { MAIL_CONNECTOR_SLUG_BY_PROVIDER, currentAgentId } from "./shared";
 
 export const listCommand = new Command()

--- a/turbo/apps/cli/src/commands/mail/shared.ts
+++ b/turbo/apps/cli/src/commands/mail/shared.ts
@@ -1,5 +1,5 @@
 import type { ZeroMailProvider } from "@okouai/api-contracts/contracts/zero-mail";
-import { getOkouAgentId } from "../../../lib/okou-env";
+import { getOkouAgentId } from "../../lib/okou-env";
 
 export const MAIL_CONNECTOR_SLUG_BY_PROVIDER = {
   gmail: "gmail",

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -123,7 +123,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "mail",
     description: "Review and send mail through Gmail or Outlook Mail",
     load: async () => {
-      return (await import("./commands/zero/mail")).zeroMailCommand;
+      return (await import("./commands/mail")).mailCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all six Mail command files from `commands/zero/mail` to `commands/mail`
- rename the internal command export from `zeroMailCommand` to `mailCommand`
- update the Mail lazy registry entry and each relative import for the shallower directory
- replace the Mail-only `test-zero-token` fixture with `test-token`

## Compatibility

- preserve the public `okou mail` command tree, flags, help, output, and error behavior
- retain `zero-mail`, `ZeroMailProvider`, `linkZeroMailDraft`, `zero-connectors`, `VM0_API_BACKEND_URL`, and the deployed `https://app.vm0.ai/mail/drafts/...` review URL unchanged
- preserve API paths, callback semantics, provider behavior, auth behavior, and response shapes
- keep Connector command helpers and the shared Connector test helper under `commands/zero`, while importing Doctor from its neutral root
- add no old-path bridge, export alias, compatibility re-export, or unrelated naming cleanup

## Verification

- lockfile-pinned Prettier 3.8.1 check on all changed files
- `corepack pnpm --filter @okouai/cli run lint`
- `corepack pnpm knip --workspace @okouai/cli`
- pi-agent-runtime build and CLI `tsc --noEmit` with pnpm 10.33.4
- focused Mail test: 1 file, 3 tests passed
- CLI registry tests: 2 files, 90 tests passed
- post-rebase diff audit against latest `origin/main`
- repository-wide residual scans for `commands/zero/mail` and `zeroMailCommand`
- compatibility-boundary count audit for frozen names, paths, environment variables, and URLs

Closes #27395
