### PR TITLE
test(e2e): wait for agent page readiness after reload

### DIFF
--- a/e2e/playwright/tests/agents.spec.ts
+++ b/e2e/playwright/tests/agents.spec.ts
@@ -247,6 +247,7 @@ test("reveal the default agent unread action from the whole row", async ({
     });
   });
   await page.reload();
+  await page.locator("#app-bootstrap-skeleton").waitFor({ state: "detached" });
 
   const defaultAgentRow = page.getByTestId("pinned-agent-card").filter({
     has: page.locator(`a[href="/agents/${defaultAgentId}/chat"]`),


### PR DESCRIPTION
## Summary

- wait for the deployed app bootstrap boundary after reloading the mocked unread state
- keep the unread indicator, row-hover transition, menu state, and `Mark all read` assertions unchanged

## Root cause and evidence

- Trigger: https://github.com/vm0-ai/vm0/actions/runs/31884244453
- Failed job: https://github.com/vm0-ai/vm0/actions/runs/31884244453/job/95011364548
- Failed test: `[features] › reveal the default agent unread action from the whole row`
- The failure artifact showed only the full-screen `Loading your workspace` bootstrap skeleton when the 5-second unread assertion expired. `page.reload()` had completed the document load, but the asynchronous app bootstrap had not reached the existing skeleton-detached readiness boundary.
- The later Clerk Testing `Test ended` warning appeared after the test had already failed and was teardown/parallel request noise, not the first causal event.
- The represented PR changed only CLI MCP command paths. The same PR head run and the adjacent merge-group base run both passed this shard, consistent with bootstrap scheduling changing the observation point.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `cd e2e && pnpm check-types`
- `pnpm exec prettier --check ../e2e/playwright/tests/agents.spec.ts`
- `git diff --check`
- Deployed head: `9b912a00e7d0896fe29adb783f1ed26df5388453`
- App preview: https://pr-27404-app.omby.ai
- API preview: https://pr-27404-api.vm6.ai
- Browser fixture: Playwright `Desktop Chrome` 148 at 1440×900 with a fresh Clerk testing organization, its default Zero agent, and onboarding completed through the preview UI. PR-preview feature-switch defaults were used with no overrides. The required per-host preview bypass was established on the first navigation to each protected host.
- The indicators response was narrowed to the same unread-agent fixture as the test; all other app and API behavior used the deployed previews.
- Manual browser check: **5/5 passed**. Every reload waited for `#app-bootstrap-skeleton` to detach, then confirmed the unread indicator was attached within the original 5-second assertion window; idle menu opacity was `0` and unread opacity was `1`; whole-row hover changed them to `1` and `0`; opening the menu kept those values after leaving hover, changed the active background, and exposed exactly one `Mark all read` menu item.
- Preview Turbo run: https://github.com/vm0-ai/vm0/actions/runs/31885614392 — passed.
- Exact Playwright shard: https://github.com/vm0-ai/vm0/actions/runs/31885614392/job/95014668159 — passed, including the repaired test.
- No local app, API, runner, development server, or other service was started.
