### PR TITLE
refactor(cli): flatten credit command module

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/credit.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/credit.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import chalk from "chalk";
-import { server } from "../../../mocks/server";
-import { zeroCreditCommand } from "../credit";
+import { server } from "../../mocks/server";
+import { creditCommand } from "../credit";
 
 function buildZeroToken(capabilities: readonly string[]): string {
   const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
@@ -80,7 +80,7 @@ describe("okou credit command", () => {
   it("shows current credit status without creating checkout", async () => {
     server.use(stubBillingStatus());
 
-    await zeroCreditCommand.parseAsync(["node", "cli"]);
+    await creditCommand.parseAsync(["node", "cli"]);
 
     expect(output()).toContain("Credit status:");
     expect(output()).toContain("Tier: pro");
@@ -117,7 +117,7 @@ describe("okou credit command", () => {
     );
 
     try {
-      await zeroCreditCommand.parseAsync(["node", "cli", "20000"]);
+      await creditCommand.parseAsync(["node", "cli", "20000"]);
 
       const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
       expect(errorOutput).toContain("Only org admins can buy credits");
@@ -142,7 +142,7 @@ describe("okou credit command", () => {
       ),
     );
 
-    await zeroCreditCommand.parseAsync([
+    await creditCommand.parseAsync([
       "node",
       "cli",
       "20000",
@@ -183,7 +183,7 @@ describe("okou credit command", () => {
       ),
     );
 
-    await zeroCreditCommand.parseAsync(["node", "cli", "20000"]);
+    await creditCommand.parseAsync(["node", "cli", "20000"]);
 
     expect(output()).toContain(
       "Credit purchases are not available for this workspace plan.",
@@ -203,7 +203,7 @@ describe("okou credit command", () => {
       .mockImplementation(() => {});
 
     try {
-      await zeroCreditCommand.parseAsync([
+      await creditCommand.parseAsync([
         "node",
         "cli",
         "20000",
@@ -234,7 +234,7 @@ describe("okou credit command", () => {
     vi.stubEnv("OKOU_TOKEN", buildZeroToken(["billing:write"]));
 
     try {
-      await zeroCreditCommand.parseAsync(["node", "cli"]);
+      await creditCommand.parseAsync(["node", "cli"]);
 
       const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
       expect(errorOutput).toContain(
@@ -257,7 +257,7 @@ describe("okou credit command", () => {
     vi.stubEnv("OKOU_TOKEN", buildZeroToken(["billing:read"]));
 
     try {
-      await zeroCreditCommand.parseAsync(["node", "cli", "20000"]);
+      await creditCommand.parseAsync(["node", "cli", "20000"]);
 
       const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
       expect(errorOutput).toContain(

--- a/turbo/apps/cli/src/commands/credit.ts
+++ b/turbo/apps/cli/src/commands/credit.ts
@@ -6,16 +6,16 @@ import type { BillingStatusResponse } from "@okouai/api-contracts/contracts/zero
 import {
   createZeroCreditCheckout,
   getZeroBillingStatus,
-} from "../../lib/api/domains/zero-billing";
-import { withErrorHandler } from "../../lib/command/with-error-handler";
-import { decodeZeroTokenPayload } from "../../lib/api/zero-token";
-import { getPlatformOrigin } from "../doctor/platform-url";
+} from "../lib/api/domains/zero-billing";
+import { withErrorHandler } from "../lib/command/with-error-handler";
+import { decodeZeroTokenPayload } from "../lib/api/zero-token";
+import { getPlatformOrigin } from "./doctor/platform-url";
 import {
   currentPlanAllowsVideo,
   currentPlanCanBuyCredits,
   currentTokenCanReadBilling,
-} from "../shared/billing-capabilities";
-import { planUpgradeUrl } from "../shared/billing-links";
+} from "./shared/billing-capabilities";
+import { planUpgradeUrl } from "./shared/billing-links";
 
 function parseCredits(value: string): number {
   const credits = Number(value.replaceAll(",", ""));
@@ -25,7 +25,7 @@ function parseCredits(value: string): number {
   return credits;
 }
 
-function requireZeroCapabilityForCreditAction(
+function requireCapabilityForCreditAction(
   capability: ZeroCapability,
   message: string,
 ): void {
@@ -112,7 +112,7 @@ function printCreditStatus(billing: BillingStatusResponse): void {
 }
 
 async function showCreditStatus(options: CreditOptions): Promise<void> {
-  requireZeroCapabilityForCreditAction(
+  requireCapabilityForCreditAction(
     "billing:read",
     "checking credit status requires billing:read capability",
   );
@@ -130,7 +130,7 @@ async function buyCredits(
   credits: number,
   options: CreditOptions,
 ): Promise<void> {
-  requireZeroCapabilityForCreditAction(
+  requireCapabilityForCreditAction(
     "billing:write",
     "buying credits requires billing:write capability",
   );
@@ -161,7 +161,7 @@ async function buyCredits(
   console.log(result.url);
 }
 
-export const zeroCreditCommand = new Command()
+export const creditCommand = new Command()
   .name("credit")
   .description("View credit balance or create a checkout link to buy credits")
   .argument("[credits]", "Number of credits to buy", parseCredits)

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -130,7 +130,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "credit",
     description: "View or buy credits",
     load: async () => {
-      return (await import("./commands/zero/credit")).zeroCreditCommand;
+      return (await import("./commands/credit")).creditCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move the Credit command and focused test from `commands/zero` to the neutral `commands` root
- rename `zeroCreditCommand` to `creditCommand` and the command-owned capability guard to `requireCapabilityForCreditAction`
- update the Credit lazy registry entry and only the relative imports required by the one-level move

## Compatibility

- preserve `ZeroCapability`, `decodeZeroTokenPayload`, `buildZeroToken`, `vm0_sandbox_`, and the `zero-token` protocol coverage
- preserve billing contracts, API paths, capability checks, checkout payloads and URLs, plan gating, auto-recharge behavior, output, errors, `VM0_API_BACKEND_URL`, and the public `okou credit` surface
- keep the root `okou credit` command separate from `okou doctor credit`
- add no old-path bridge, export alias, compatibility re-export, or unrelated naming cleanup

## Verification

- lockfile-pinned Prettier 3.8.1 on the three touched files
- CLI lint
- CLI type-check
- Credit command test: 1 file, 7 tests passed
- CLI registry tests: 2 files, 90 tests passed
- mechanical-equivalence audit for the moved production file, moved test, and Credit registry entry
- full-repository residual scans find no `commands/zero/credit`, `zeroCreditCommand`, or `requireZeroCapabilityForCreditAction`
- `git diff --check`

Closes #27400
