### PR TITLE
refactor(cli): flatten search command module

### DIFF
--- a/docs/testing/cli-testing.md
+++ b/docs/testing/cli-testing.md
@@ -20,12 +20,11 @@ Place command tests in a neighboring `__tests__/` directory. A command file and
 its test should have matching names:
 
 ```text
-src/commands/zero/
-├── logs/
-│   ├── index.ts
-│   └── __tests__/
-│       └── view.test.ts
-└── whoami.ts
+src/commands/
+└── search/
+    ├── index.ts
+    └── __tests__/
+        └── index.test.ts
 ```
 
 ## Authentication and routing
@@ -54,13 +53,13 @@ the resulting guidance. Keep focused protocol coverage that sets only
 
 ```typescript
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { zeroSearchCommand } from "../index";
+import { searchCommand } from "../index";
 
 describe("okou search --source agent-session", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
   beforeEach(() => {
-    zeroSearchCommand.setOptionValue("source", []);
+    searchCommand.setOptionValue("source", []);
   });
 
   afterEach(() => {
@@ -68,7 +67,7 @@ describe("okou search --source agent-session", () => {
   });
 
   it("prints both local agent session locations", async () => {
-    await zeroSearchCommand.parseAsync([
+    await searchCommand.parseAsync([
       "node",
       "okou",
       "find the failed tool call",

--- a/turbo/apps/cli/src/commands/search/__tests__/agent-session-source.test.ts
+++ b/turbo/apps/cli/src/commands/search/__tests__/agent-session-source.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { zeroSearchCommand } from "../index";
+import { searchCommand } from "../index";
 
 describe("okou search --source agent-session", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
   beforeEach(() => {
-    zeroSearchCommand.setOptionValue("source", []);
+    searchCommand.setOptionValue("source", []);
   });
 
   afterEach(() => {
@@ -14,7 +14,7 @@ describe("okou search --source agent-session", () => {
   });
 
   it("prints both agent session locations and the analysis query", async () => {
-    await zeroSearchCommand.parseAsync([
+    await searchCommand.parseAsync([
       "node",
       "okou",
       "find the failed tool call",

--- a/turbo/apps/cli/src/commands/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/search/__tests__/chat-source.test.ts
@@ -1,15 +1,15 @@
 /**
  * Tests for `okou search --source chat`.
  *
- * Entry point: zeroSearchCommand.parseAsync()
+ * Entry point: searchCommand.parseAsync()
  * Mock (external): Web API via MSW
  * Real (internal): flag parsing, time parsing, renderers, error mapping
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../../mocks/server";
-import { zeroSearchCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { searchCommand } from "../index";
 
 function makeMessage(params: {
   content: string;
@@ -45,7 +45,7 @@ describe("okou search --source chat", () => {
     vi.stubEnv("OKOU_TOKEN", "test-token");
     // Commander retains collector state across parseAsync calls on the
     // same command instance. Reset before each case.
-    zeroSearchCommand.setOptionValue("source", []);
+    searchCommand.setOptionValue("source", []);
   });
 
   afterEach(() => {
@@ -55,7 +55,7 @@ describe("okou search --source chat", () => {
 
   it("rejects whitespace-only queries", async () => {
     await expect(
-      zeroSearchCommand.parseAsync(["node", "cli", "   ", "--source", "chat"]),
+      searchCommand.parseAsync(["node", "cli", "   ", "--source", "chat"]),
     ).rejects.toThrow("process.exit called");
 
     const errors = mockConsoleError.mock.calls.flat().join("\n");
@@ -82,13 +82,7 @@ describe("okou search --source chat", () => {
       }),
     );
 
-    await zeroSearchCommand.parseAsync([
-      "node",
-      "cli",
-      "OOM",
-      "--source",
-      "chat",
-    ]);
+    await searchCommand.parseAsync(["node", "cli", "OOM", "--source", "chat"]);
 
     const logs = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logs).toContain("thread-abc");
@@ -117,13 +111,7 @@ describe("okou search --source chat", () => {
       }),
     );
 
-    await zeroSearchCommand.parseAsync([
-      "node",
-      "cli",
-      "OOM",
-      "--source",
-      "chat",
-    ]);
+    await searchCommand.parseAsync(["node", "cli", "OOM", "--source", "chat"]);
 
     const logs = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logs).toContain("invalid-date");
@@ -137,7 +125,7 @@ describe("okou search --source chat", () => {
       }),
     );
 
-    await zeroSearchCommand.parseAsync([
+    await searchCommand.parseAsync([
       "node",
       "cli",
       "nothing",
@@ -159,7 +147,7 @@ describe("okou search --source chat", () => {
       }),
     );
 
-    await zeroSearchCommand.parseAsync([
+    await searchCommand.parseAsync([
       "node",
       "cli",
       "error",
@@ -183,7 +171,7 @@ describe("okou search --source chat", () => {
       }),
     );
 
-    await zeroSearchCommand.parseAsync([
+    await searchCommand.parseAsync([
       "node",
       "cli",
       "error",
@@ -205,7 +193,7 @@ describe("okou search --source chat", () => {
       }),
     );
 
-    await zeroSearchCommand.parseAsync([
+    await searchCommand.parseAsync([
       "node",
       "cli",
       "error",
@@ -231,7 +219,7 @@ describe("okou search --source chat", () => {
       }),
     );
 
-    await zeroSearchCommand.parseAsync([
+    await searchCommand.parseAsync([
       "node",
       "cli",
       "hello",
@@ -246,7 +234,7 @@ describe("okou search --source chat", () => {
 
   it("rejects non-UUID --agent values", async () => {
     await expect(
-      zeroSearchCommand.parseAsync([
+      searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -261,10 +249,10 @@ describe("okou search --source chat", () => {
     expect(errors).toContain("Invalid agent ID");
 
     mockConsoleError.mockClear();
-    zeroSearchCommand.setOptionValue("source", []);
+    searchCommand.setOptionValue("source", []);
 
     await expect(
-      zeroSearchCommand.parseAsync([
+      searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -281,7 +269,7 @@ describe("okou search --source chat", () => {
 
   it("rejects --limit outside the 1..50 range", async () => {
     await expect(
-      zeroSearchCommand.parseAsync([
+      searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -298,7 +286,7 @@ describe("okou search --source chat", () => {
 
   it("rejects --before-context outside the 0..10 range", async () => {
     await expect(
-      zeroSearchCommand.parseAsync([
+      searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -315,7 +303,7 @@ describe("okou search --source chat", () => {
 
   it("rejects partial numeric context and limit values", async () => {
     await expect(
-      zeroSearchCommand.parseAsync([
+      searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -330,10 +318,10 @@ describe("okou search --source chat", () => {
     expect(errors).toContain("--context must be between 0 and 10");
 
     mockConsoleError.mockClear();
-    zeroSearchCommand.setOptionValue("source", []);
+    searchCommand.setOptionValue("source", []);
 
     await expect(
-      zeroSearchCommand.parseAsync([
+      searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -348,10 +336,10 @@ describe("okou search --source chat", () => {
     expect(errors).toContain("--limit must be between 1 and 50");
 
     mockConsoleError.mockClear();
-    zeroSearchCommand.setOptionValue("source", []);
+    searchCommand.setOptionValue("source", []);
 
     await expect(
-      zeroSearchCommand.parseAsync([
+      searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -366,10 +354,10 @@ describe("okou search --source chat", () => {
     expect(errors).toContain("--context must be between 0 and 10");
 
     mockConsoleError.mockClear();
-    zeroSearchCommand.setOptionValue("source", []);
+    searchCommand.setOptionValue("source", []);
 
     await expect(
-      zeroSearchCommand.parseAsync([
+      searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -402,7 +390,7 @@ describe("okou search --source chat", () => {
       }),
     );
 
-    await zeroSearchCommand.parseAsync([
+    await searchCommand.parseAsync([
       "node",
       "cli",
       "match",
@@ -425,13 +413,7 @@ describe("okou search --source chat", () => {
     );
 
     await expect(
-      zeroSearchCommand.parseAsync([
-        "node",
-        "cli",
-        "error",
-        "--source",
-        "chat",
-      ]),
+      searchCommand.parseAsync(["node", "cli", "error", "--source", "chat"]),
     ).rejects.toThrow();
 
     const errors = mockConsoleError.mock.calls.flat().join("\n");

--- a/turbo/apps/cli/src/commands/search/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/search/__tests__/index.test.ts
@@ -1,13 +1,13 @@
 /**
  * Tests for okou search command scaffold (#10244).
  *
- * Entry point: zeroSearchCommand.parseAsync()
+ * Entry point: searchCommand.parseAsync()
  * Mock (external): none — no API calls in the scaffold
  * Real (internal): all CLI validation and help wiring
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { zeroSearchCommand, SEARCH_EXPLAINER } from "../index";
+import { searchCommand, SEARCH_EXPLAINER } from "../index";
 
 describe("okou search command (scaffold)", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -22,7 +22,7 @@ describe("okou search command (scaffold)", () => {
     // Commander retains parsed option state across parseAsync calls on the
     // same Command instance. Reset the collector value before each test so
     // ordering does not leak state between cases.
-    zeroSearchCommand.setOptionValue("source", []);
+    searchCommand.setOptionValue("source", []);
   });
 
   afterEach(() => {
@@ -32,7 +32,7 @@ describe("okou search command (scaffold)", () => {
   });
 
   it("prints the explainer and exits 0 when --source is omitted", async () => {
-    await zeroSearchCommand.parseAsync(["node", "cli", "hello"]);
+    await searchCommand.parseAsync(["node", "cli", "hello"]);
 
     expect(mockExit).not.toHaveBeenCalled();
     const logs = mockConsoleLog.mock.calls.flat().join("\n");
@@ -44,7 +44,7 @@ describe("okou search command (scaffold)", () => {
 
   it("rejects multiple --source flags", async () => {
     await expect(
-      zeroSearchCommand.parseAsync([
+      searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -61,13 +61,7 @@ describe("okou search command (scaffold)", () => {
 
   it("rejects an unknown --source value", async () => {
     await expect(
-      zeroSearchCommand.parseAsync([
-        "node",
-        "cli",
-        "hello",
-        "--source",
-        "nope",
-      ]),
+      searchCommand.parseAsync(["node", "cli", "hello", "--source", "nope"]),
     ).rejects.toThrow("process.exit called");
 
     const errors = mockConsoleError.mock.calls.flat().join("\n");
@@ -76,7 +70,7 @@ describe("okou search command (scaffold)", () => {
   });
 
   it("routes --source agent-session to local file guidance", async () => {
-    await zeroSearchCommand.parseAsync([
+    await searchCommand.parseAsync([
       "node",
       "cli",
       "hello",
@@ -91,7 +85,7 @@ describe("okou search command (scaffold)", () => {
 
   it("--help output includes the three source descriptions", () => {
     let captured = "";
-    zeroSearchCommand.configureOutput({
+    searchCommand.configureOutput({
       writeOut: (s) => {
         captured += s;
       },
@@ -99,7 +93,7 @@ describe("okou search command (scaffold)", () => {
         captured += s;
       },
     });
-    zeroSearchCommand.outputHelp();
+    searchCommand.outputHelp();
     expect(captured).toContain("agent-session  locates local Claude Code");
     expect(captured).toContain("chat           user/assistant text messages");
     expect(captured).toContain("slack          returns a recipe");

--- a/turbo/apps/cli/src/commands/search/__tests__/slack-source.test.ts
+++ b/turbo/apps/cli/src/commands/search/__tests__/slack-source.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for okou search --source slack (#10263).
  *
- * Entry point: zeroSearchCommand.parseAsync()
+ * Entry point: searchCommand.parseAsync()
  * Mock (external): none — the CLI must make zero outbound HTTP calls.
  *   MSW's global setup (src/test/setup.ts) uses onUnhandledRequest: "error",
  *   so any accidental network call would fail the test. That IS the guard.
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { zeroSearchCommand, buildSlackRecipe } from "../index";
+import { searchCommand, buildSlackRecipe } from "../index";
 
 describe("okou search --source slack", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -23,7 +23,7 @@ describe("okou search --source slack", () => {
   beforeEach(() => {
     // Commander retains parsed option state across parseAsync calls on the
     // same Command instance — match the pattern in the scaffold test.
-    zeroSearchCommand.setOptionValue("source", []);
+    searchCommand.setOptionValue("source", []);
   });
 
   afterEach(() => {
@@ -35,13 +35,7 @@ describe("okou search --source slack", () => {
   describe("zero outbound HTTP", () => {
     it("rejects whitespace-only queries", async () => {
       await expect(
-        zeroSearchCommand.parseAsync([
-          "node",
-          "cli",
-          "   ",
-          "--source",
-          "slack",
-        ]),
+        searchCommand.parseAsync(["node", "cli", "   ", "--source", "slack"]),
       ).rejects.toThrow("process.exit called");
 
       const errors = mockConsoleError.mock.calls.flat().join("\n");
@@ -49,7 +43,7 @@ describe("okou search --source slack", () => {
     });
 
     it("makes no network call (MSW would error on any unhandled request)", async () => {
-      await zeroSearchCommand.parseAsync([
+      await searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -64,7 +58,7 @@ describe("okou search --source slack", () => {
 
   describe("recipe content", () => {
     it("includes the Slack search.messages endpoint and SLACK_TOKEN", async () => {
-      await zeroSearchCommand.parseAsync([
+      await searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -78,7 +72,7 @@ describe("okou search --source slack", () => {
     });
 
     it("includes both diagnostic pointers", async () => {
-      await zeroSearchCommand.parseAsync([
+      await searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -92,7 +86,7 @@ describe("okou search --source slack", () => {
     });
 
     it("links to Slack's search.messages docs", async () => {
-      await zeroSearchCommand.parseAsync([
+      await searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -105,7 +99,7 @@ describe("okou search --source slack", () => {
     });
 
     it("notes that CLI-local flags are ignored for this source", async () => {
-      await zeroSearchCommand.parseAsync([
+      await searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -122,7 +116,7 @@ describe("okou search --source slack", () => {
 
   describe("keyword substitution", () => {
     it("URL-encodes the query with encodeURIComponent", async () => {
-      await zeroSearchCommand.parseAsync([
+      await searchCommand.parseAsync([
         "node",
         "cli",
         "bug report",
@@ -135,7 +129,7 @@ describe("okou search --source slack", () => {
     });
 
     it("encodes special URL characters in the query", async () => {
-      await zeroSearchCommand.parseAsync([
+      await searchCommand.parseAsync([
         "node",
         "cli",
         "foo&bar",
@@ -152,7 +146,7 @@ describe("okou search --source slack", () => {
     it("prints the recipe regardless of connector state (no branching)", async () => {
       // The recipe path does not import getZeroConnector — emission cannot
       // depend on connector state. Calling twice yields identical output.
-      await zeroSearchCommand.parseAsync([
+      await searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -162,9 +156,9 @@ describe("okou search --source slack", () => {
       const first = mockConsoleLog.mock.calls.flat().join("\n");
 
       mockConsoleLog.mockClear();
-      zeroSearchCommand.setOptionValue("source", []);
+      searchCommand.setOptionValue("source", []);
 
-      await zeroSearchCommand.parseAsync([
+      await searchCommand.parseAsync([
         "node",
         "cli",
         "hello",
@@ -177,7 +171,7 @@ describe("okou search --source slack", () => {
     });
 
     it("ignores unrelated flags without erroring", async () => {
-      await zeroSearchCommand.parseAsync([
+      await searchCommand.parseAsync([
         "node",
         "cli",
         "hello",

--- a/turbo/apps/cli/src/commands/search/index.ts
+++ b/turbo/apps/cli/src/commands/search/index.ts
@@ -1,16 +1,16 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { searchZeroChat } from "../../../lib/api/domains/zero-chat";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { searchZeroChat } from "../../lib/api/domains/zero-chat";
 import type {
   ChatSearchMessage,
   ChatSearchResponse,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { parseTime } from "../../../lib/utils/time-parser";
-import { formatIsoTimestamp } from "../../../lib/utils/time-format";
-import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
-import { parseSearchQuery } from "../../../lib/utils/search-query";
-import { isUuid } from "../../../lib/utils/uuid";
+import { parseTime } from "../../lib/utils/time-parser";
+import { formatIsoTimestamp } from "../../lib/utils/time-format";
+import { parseBoundedLogCount } from "../../lib/utils/log-pagination";
+import { parseSearchQuery } from "../../lib/utils/search-query";
+import { isUuid } from "../../lib/utils/uuid";
 
 const SUPPORTED_SOURCES = ["agent-session", "chat", "slack"] as const;
 type Source = (typeof SUPPORTED_SOURCES)[number];
@@ -191,7 +191,7 @@ async function runAgentSessionSource(
   console.log(buildAgentSessionGuidance(query));
 }
 
-export const zeroSearchCommand = new Command()
+export const searchCommand = new Command()
   .name("search")
   .description("Search chat or locate sources for direct analysis")
   .argument("<query>", "Search query")

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -197,7 +197,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "search",
     description: "Search chat or locate sources for direct analysis",
     load: async () => {
-      return (await import("./commands/zero/search")).zeroSearchCommand;
+      return (await import("./commands/search")).searchCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all five Search command and focused test files from `commands/zero/search` to `commands/search`
- rename the internal export from `zeroSearchCommand` to `searchCommand` and update the `okou.ts` lazy registry entry
- update moved relative imports, test entry-point comments, and the CLI testing guide's directory tree and Search integration snippet

## Compatibility

- preserve the public `okou search` sources, flags, query/time/context/limit parsing, local session paths, Slack recipe, API traffic, output, and errors
- preserve `searchZeroChat`, the `getZeroConnector` Slack test comment, `VM0_API_BACKEND_URL`, and the `.vm0` / `VM0_TOKEN` / `ZERO_TOKEN` compatibility guidance exactly
- preserve the numeric `zero outbound HTTP` wording exactly
- add no old-path bridge, export alias, compatibility re-export, or unrelated naming cleanup

## Contract verification

- normalized mechanical-equivalence audit passes for all five moved files after applying only the approved path-depth and symbol mappings
- repository-wide scans find no `commands/zero/search` path or `zeroSearchCommand` reference
- the staged diff contains five complete renames plus only the Search registry and direct testing-guide caller updates
- frozen API, protocol, semantic, local-path, Slack-recipe, output, and error boundaries remain unchanged

## Validation

- lockfile-pinned Prettier 3.8.1 check for all touched CLI and documentation files
- `pnpm -F @okouai/cli lint`
- `pnpm -F @okouai/cli check-types`
- focused Search and CLI registry coverage: 6 files, 123 tests passed
- `git diff --check`
- full-repository old path/export residual searches

Closes #27401
