### PR TITLE
refactor(cli): flatten internal agent loop command

### DIFF
--- a/turbo/apps/cli/src/commands/__agent-loop.ts
+++ b/turbo/apps/cli/src/commands/__agent-loop.ts
@@ -3,9 +3,9 @@ import { Command } from "commander";
 import {
   piSandboxAgentConfigFromEnv,
   runPiSandboxAgentLoop,
-} from "../../lib/pi-agent-loop";
+} from "../lib/pi-agent-loop";
 
-export const zeroAgentLoopCommand = new Command()
+export const agentLoopCommand = new Command()
   .name("__agent-loop")
   .description("Internal sandbox Pi agent loop")
   .action(async () => {

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -80,8 +80,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "__agent-loop",
     description: "Internal sandbox agent loop",
     load: async () => {
-      return (await import("./commands/zero/__agent-loop"))
-        .zeroAgentLoopCommand;
+      return (await import("./commands/__agent-loop")).agentLoopCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move the internal agent-loop command from `commands/zero/__agent-loop.ts` to `commands/__agent-loop.ts`
- rename the internal export from `zeroAgentLoopCommand` to `agentLoopCommand`
- update the one-level relative import and only the corresponding `okou.ts` lazy registry entry

## Compatibility

- preserve the operational `okou __agent-loop` command literal and hidden visibility exactly
- preserve Pi agent configuration and loop execution, errors, and exit-code behavior
- leave Rust guest-agent invocation, E2E coverage, documentation, audit scripts, and CI smoke behavior unchanged
- add no old-path bridge, export alias, compatibility re-export, or unrelated naming cleanup

## Contract verification

- normalized mechanical-equivalence comparison passes after applying only the approved path-depth and export-name mappings
- repository-wide scans find no `commands/zero/__agent-loop` path or `zeroAgentLoopCommand` reference
- the repository has the same 15 operational `__agent-loop` literal references before and after the migration
- the staged diff contains one 84% file rename and the required registry edit only

## Validation

- lockfile-pinned Prettier 3.8.1 check for the changed CLI files
- CLI lint
- Pi runtime build and CLI `tsc --noEmit`
- CLI registry tests: 1 file, 6 tests passed
- CLI capability visibility tests: 1 file, 84 tests passed
- CLI production build and targeted `okou __agent-loop --help` smoke (exit 0)
- `git diff --check`

Closes #27399
