### PR TITLE
refactor(cli): flatten browser command module

### DIFF
--- a/turbo/apps/cli/src/commands/browser/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/browser/__tests__/index.test.ts
@@ -14,8 +14,8 @@ import {
   vi,
 } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroBrowserCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { browserCommand } from "../index";
 
 const spawnSyncMock = vi.hoisted(() => {
   return vi.fn();
@@ -24,7 +24,7 @@ vi.mock("node:child_process", () => {
   return { spawnSync: spawnSyncMock };
 });
 
-const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "zero-browser-home-"));
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "browser-home-"));
 vi.mock("os", async (importOriginal) => {
   const original = await importOriginal<typeof import("os")>();
   return {
@@ -71,7 +71,7 @@ describe("okou browser command", () => {
       force: true,
     });
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
     spawnSyncMock.mockReturnValue({ status: 0 });
   });
@@ -97,7 +97,7 @@ describe("okou browser command", () => {
 
   it("exposes only thread-keyed lifecycle commands", () => {
     expect(
-      zeroBrowserCommand.commands.map((command) => {
+      browserCommand.commands.map((command) => {
         return command.name();
       }),
     ).toStrictEqual(["use", "lease", "new", "status", "view"]);
@@ -120,7 +120,7 @@ describe("okou browser command", () => {
       ),
     );
 
-    await zeroBrowserCommand.parseAsync([
+    await browserCommand.parseAsync([
       "node",
       "cli",
       "new",
@@ -132,7 +132,7 @@ describe("okou browser command", () => {
       name: "booking",
       proxyCountryCode: null,
     });
-    expect(authorization).toBe("Bearer test-zero-token");
+    expect(authorization).toBe("Bearer test-token");
     expect(spawnSyncMock).toHaveBeenCalledWith(
       "agent-browser",
       ["--session", "zero-browser", "connect", CDP_URL],
@@ -161,7 +161,7 @@ describe("okou browser command", () => {
       }),
     );
 
-    await zeroBrowserCommand.parseAsync(["node", "cli", "use"]);
+    await browserCommand.parseAsync(["node", "cli", "use"]);
 
     expect(useRequests).toBe(1);
     expect(spawnSyncMock).toHaveBeenCalledWith(
@@ -191,7 +191,7 @@ describe("okou browser command", () => {
       ),
     );
 
-    await zeroBrowserCommand.parseAsync(["node", "cli", "lease"]);
+    await browserCommand.parseAsync(["node", "cli", "lease"]);
 
     expect(leaseRequests).toBe(1);
     // The lease is not parameterizable: every call buys the same fixed window.
@@ -211,7 +211,7 @@ describe("okou browser command", () => {
       }),
     );
 
-    await zeroBrowserCommand.parseAsync([
+    await browserCommand.parseAsync([
       "node",
       "cli",
       "new",

--- a/turbo/apps/cli/src/commands/browser/index.ts
+++ b/turbo/apps/cli/src/commands/browser/index.ts
@@ -13,8 +13,8 @@ import {
   getCurrentZeroBrowser,
   leaseZeroBrowser,
   useZeroBrowser,
-} from "../../../lib/api/domains/zero-browser";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+} from "../../lib/api/domains/zero-browser";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 const DEFAULT_AGENT_BROWSER_SESSION = "zero-browser";
 
@@ -202,7 +202,7 @@ const viewCommand = new Command()
     }),
   );
 
-export const zeroBrowserCommand = new Command()
+export const browserCommand = new Command()
   .name("browser")
   .description("Use a managed remote browser through agent-browser")
   .addCommand(useCommand)

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -253,7 +253,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "browser",
     description: "Managed remote browser sessions for agent-browser",
     load: async () => {
-      return (await import("./commands/zero/browser")).zeroBrowserCommand;
+      return (await import("./commands/browser")).browserCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move the complete Browser command slice from `commands/zero/browser` to `commands/browser`
- rename the internal export from `zeroBrowserCommand` to `browserCommand` and update the `okou.ts` lazy registry entry
- adjust only the relative imports required by the one-level move
- replace the Browser test-only `zero-browser-home-` prefix and `test-zero-token` value with `browser-home-` and `test-token`

## Compatibility

- preserve the operational `zero-browser` agent-browser named session in `DEFAULT_AGENT_BROWSER_SESSION`, spawn expectations, help, and JSON output assertions
- preserve `ZERO_BROWSER_IDLE_LEASE_MINUTES`, `zeroBrowserCreateRequestSchema`, `ZeroBrowserSession`, `createZeroBrowser`, `getCurrentZeroBrowser`, `leaseZeroBrowser`, `useZeroBrowser`, and the `zero-browser` contract/API-domain paths
- preserve `.vm0`, `VM0_API_BACKEND_URL`, the `https://app.vm0.ai/browsers/...` viewer URL, API traffic, output/JSON shape, help, options, errors, and Browser lifecycle behavior
- add no old-path bridge, symbol alias, compatibility re-export, or unrelated Zero/vm0 cleanup

## Contract verification

- normalized pre/post move SHA-256 comparisons pass after applying only the approved path-depth, symbol, and test-fixture mappings
- repository-wide scans find no `commands/zero/browser` path or `zeroBrowserCommand` reference
- the runtime and focused-test operational `zero-browser` reference counts match `main`, and every retained occurrence remains byte-for-byte unchanged
- the final diff contains two Browser file renames and the Browser-owned registry edit only

## Validation

- lockfile-pinned Prettier 3.8.1 full-workspace format and post-rebase targeted format check
- full repository lint with bounded memory and single concurrency: 13/13 tasks passed
- full Knip plus post-rebase CLI-scoped Knip
- staged repository type-checks for non-API/Platform packages, Platform, and API; post-rebase CLI type-check
- Browser command test: 1 file, 5 tests passed
- CLI registry tests: 2 files, 90 tests passed
- `git diff --check`

Closes #27409
