### PR TITLE
refactor(cli): flatten whoami command module

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/whoami.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import chalk from "chalk";
 import { http, HttpResponse } from "msw";
-import { server } from "../../../mocks/server";
+import { server } from "../../mocks/server";
 import {
   catalogPermissionDetail,
   stubConnectorCatalogPermissions,
-} from "./helpers/connector-catalog";
-import { zeroWhoamiCommand } from "../whoami";
+} from "../zero/__tests__/helpers/connector-catalog";
+import { whoamiCommand } from "../whoami";
 
 function buildJwt(payload: Record<string, unknown>, prefix: string): string {
   const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
@@ -96,7 +96,7 @@ describe("okou whoami command", () => {
   }
 
   async function runWhoami(args: string[] = []): Promise<void> {
-    await zeroWhoamiCommand.parseAsync(["node", "cli", ...args]);
+    await whoamiCommand.parseAsync(["node", "cli", ...args]);
   }
 
   describe("sandbox mode (OKOU_AGENT_ID set)", () => {

--- a/turbo/apps/cli/src/commands/whoami.ts
+++ b/turbo/apps/cli/src/commands/whoami.ts
@@ -5,21 +5,21 @@ import {
   getActiveOrg,
   getToken,
   decodeZeroTokenPayload,
-} from "../../lib/api/config";
-import { listZeroConnectors } from "../../lib/api/domains/zero-connectors";
+} from "../lib/api/config";
+import { listZeroConnectors } from "../lib/api/domains/zero-connectors";
 import {
   getZeroAgentUserConnectors,
   listZeroUserPermissionGrants,
-} from "../../lib/api/domains/zero-agents";
-import { getZeroOrg } from "../../lib/api/domains/zero-orgs";
-import { withErrorHandler } from "../../lib/command/with-error-handler";
-import { getOkouAgentId } from "../../lib/okou-env";
-import { policyIcon } from "../../lib/utils/format-utils";
+} from "../lib/api/domains/zero-agents";
+import { getZeroOrg } from "../lib/api/domains/zero-orgs";
+import { withErrorHandler } from "../lib/command/with-error-handler";
+import { getOkouAgentId } from "../lib/okou-env";
+import { policyIcon } from "../lib/utils/format-utils";
 import {
   loadConnectorPermissionInfos,
   connectorPermissionGrantsToFirewallPolicies,
   type ConnectorPermissionInfo,
-} from "../shared/firewall-permissions";
+} from "./shared/firewall-permissions";
 
 /**
  * Detect if running inside an agent sandbox.
@@ -222,7 +222,7 @@ async function showLocalInfo(): Promise<void> {
   }
 }
 
-export const zeroWhoamiCommand = new Command()
+export const whoamiCommand = new Command()
   .name("whoami")
   .description("Show agent identity, run ID, and capabilities")
   .option("--permissions", "Show full permission details for each connector")

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -217,7 +217,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "whoami",
     description: "Show agent identity, run ID, and capabilities",
     load: async () => {
-      return (await import("./commands/zero/whoami")).zeroWhoamiCommand;
+      return (await import("./commands/whoami")).whoamiCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move `turbo/apps/cli/src/commands/zero/whoami.ts` to `turbo/apps/cli/src/commands/whoami.ts`
- move the focused test to `turbo/apps/cli/src/commands/__tests__/whoami.test.ts`
- rename `zeroWhoamiCommand` to `whoamiCommand` and update only the Whoami lazy registry entry in `okou.ts`
- mechanically adjust relative imports for the one-level move

## Preserved boundaries

- keep the shared connector-catalog helper at `commands/zero/__tests__/helpers/connector-catalog.ts`; the moved test imports that single existing helper
- add no old-path bridge, export alias, or compatibility re-export
- preserve `buildZeroToken`, `decodeZeroTokenPayload`, `vm0_sandbox_`, `not-a-zero-token`, and the `zeroToken` protocol fixture
- preserve `listZeroConnectors`, `getZeroAgentUserConnectors`, `listZeroUserPermissionGrants`, `getZeroOrg`, the `zero-agents`/`zero-connectors`/`zero-orgs` API-domain module names, and `VM0_API_BACKEND_URL`
- preserve Whoami API traffic, token compatibility, output, errors, options, help, and public `okou whoami` behavior

## Validation

- normalized mechanical-equivalence audit against latest `origin/main` for the moved command, moved test, and Whoami registry entry
- repository-wide residual search confirms no old owned path or `zeroWhoamiCommand` reference remains
- preserved protocol/API/environment boundary counts match `main`; the shared helper is unchanged
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed)
- `pnpm knip`
- staged repository type checks for non-API/Platform packages, Platform, and API
- post-rebase pinned Prettier check, CLI lint, CLI-scoped Knip, and CLI type-check
- Whoami focused test: 1 file, 22 tests passed
- CLI registry tests: 2 files, 90 tests passed
- `git diff --check`

Closes #27410
