### PR TITLE
refactor(cli): flatten chat command module

### DIFF
--- a/turbo/apps/cli/src/commands/chat/__tests__/cancel.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/cancel.test.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroChatCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { chatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const AGENT_ID = "00000000-0000-4000-8000-000000000010";
@@ -24,7 +24,7 @@ describe("okou chat cancel command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
     server.use(
       http.get(METADATA_URL, () => {
@@ -68,7 +68,7 @@ describe("okou chat cancel command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "cancel",
@@ -108,7 +108,7 @@ describe("okou chat cancel command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "cancel",
@@ -123,7 +123,7 @@ describe("okou chat cancel command", () => {
 
   it("requires exactly one cancellation target", async () => {
     await expect(async () => {
-      await zeroChatCommand.parseAsync([
+      await chatCommand.parseAsync([
         "node",
         "cli",
         "cancel",

--- a/turbo/apps/cli/src/commands/chat/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/create.test.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroChatCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { chatCommand } from "../index";
 
 const CURRENT_THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const NEW_THREAD_ID = "00000000-0000-4000-8000-000000000002";
@@ -27,7 +27,7 @@ describe("okou chat create command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", CURRENT_THREAD_ID);
   });
 
@@ -50,9 +50,7 @@ describe("okou chat create command", () => {
         });
       }),
       http.post(CREATE_URL, async ({ request }) => {
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer test-zero-token",
-        );
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
         const body = (await request.json()) as Record<string, unknown>;
         expect(body).toStrictEqual({
           agentId: AGENT_ID,
@@ -71,7 +69,7 @@ describe("okou chat create command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "create",
@@ -114,7 +112,7 @@ describe("okou chat create command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "create",
@@ -160,7 +158,7 @@ describe("okou chat create command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "create",
@@ -181,12 +179,7 @@ describe("okou chat create command", () => {
     vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync([
-        "node",
-        "cli",
-        "create",
-        "Launch plan",
-      ]);
+      await chatCommand.parseAsync(["node", "cli", "create", "Launch plan"]);
     }).rejects.toThrow("process.exit called");
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");

--- a/turbo/apps/cli/src/commands/chat/__tests__/get.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/get.test.ts
@@ -11,8 +11,8 @@ import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroChatCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { chatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const AGENT_ID = "00000000-0000-4000-8000-000000000010";
@@ -32,7 +32,7 @@ describe("okou chat get command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
 
@@ -46,9 +46,7 @@ describe("okou chat get command", () => {
   it("loads the current chat thread and prints a human-readable summary", async () => {
     server.use(
       http.get(GET_URL, ({ request }) => {
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer test-zero-token",
-        );
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
         return HttpResponse.json({
           id: THREAD_ID,
           agentId: AGENT_ID,
@@ -58,7 +56,7 @@ describe("okou chat get command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync(["node", "cli", "get"]);
+    await chatCommand.parseAsync(["node", "cli", "get"]);
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("Chat thread loaded");
@@ -80,7 +78,7 @@ describe("okou chat get command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync(["node", "cli", "get", "--json"]);
+    await chatCommand.parseAsync(["node", "cli", "get", "--json"]);
 
     expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
       {
@@ -104,7 +102,7 @@ describe("okou chat get command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync(["node", "cli", "get"]);
+    await chatCommand.parseAsync(["node", "cli", "get"]);
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("Title:  (untitled)");
@@ -124,7 +122,7 @@ describe("okou chat get command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "get",
@@ -141,7 +139,7 @@ describe("okou chat get command", () => {
     vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync(["node", "cli", "get"]);
+      await chatCommand.parseAsync(["node", "cli", "get"]);
     }).rejects.toThrow("process.exit called");
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");

--- a/turbo/apps/cli/src/commands/chat/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/list.test.ts
@@ -6,8 +6,8 @@ import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroChatCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { chatCommand } from "../index";
 
 const AGENT_ID = "00000000-0000-4000-8000-000000000101";
 const OTHER_AGENT_ID = "00000000-0000-4000-8000-000000000102";
@@ -83,7 +83,7 @@ describe("okou chat list command", () => {
 
   beforeEach(async () => {
     chalk.level = 0;
-    cacheDirectory = await mkdtemp(join(tmpdir(), "zero-chat-list-"));
+    cacheDirectory = await mkdtemp(join(tmpdir(), "chat-list-"));
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", zeroToken());
     vi.stubEnv("OKOU_AGENT_ID", AGENT_ID);
@@ -168,7 +168,7 @@ describe("okou chat list command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "list",
@@ -192,7 +192,7 @@ describe("okou chat list command", () => {
     );
 
     mockConsoleLog.mockClear();
-    await zeroChatCommand.parseAsync(["node", "cli", "list", "--json"]);
+    await chatCommand.parseAsync(["node", "cli", "list", "--json"]);
 
     const secondOutput = JSON.parse(
       String(mockConsoleLog.mock.calls[0]?.[0]),
@@ -251,9 +251,9 @@ describe("okou chat list command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync(["node", "cli", "list", "--json"]);
+    await chatCommand.parseAsync(["node", "cli", "list", "--json"]);
     mockConsoleLog.mockClear();
-    await zeroChatCommand.parseAsync(["node", "cli", "list", "--json"]);
+    await chatCommand.parseAsync(["node", "cli", "list", "--json"]);
 
     const output = JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0])) as {
       readonly threads: readonly { readonly title: string }[];
@@ -290,7 +290,7 @@ describe("okou chat list command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "list",
@@ -319,7 +319,7 @@ describe("okou chat list command", () => {
     vi.stubEnv("OKOU_AGENT_ID", "");
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync(["node", "cli", "list"]);
+      await chatCommand.parseAsync(["node", "cli", "list"]);
     }).rejects.toThrow("process.exit called");
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");

--- a/turbo/apps/cli/src/commands/chat/__tests__/messages.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/messages.test.ts
@@ -23,8 +23,8 @@ import {
   vi,
 } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroChatCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { chatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const SNAPSHOT_URL = `http://localhost:3000/api/okou/chat-threads/${THREAD_ID}/event-snapshot`;
@@ -80,7 +80,7 @@ describe("okou chat messages command", () => {
 
   beforeEach(() => {
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
 
@@ -98,9 +98,7 @@ describe("okou chat messages command", () => {
     const hotRow = rawEventRow(3);
     server.use(
       http.get(SNAPSHOT_URL, ({ request }) => {
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer test-zero-token",
-        );
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
         expect(request.headers.get(CHAT_EVENT_SCHEMA_VERSION_HEADER)).toBe(
           CURRENT_CHAT_EVENT_SCHEMA_VERSION.toString(),
         );
@@ -132,7 +130,7 @@ describe("okou chat messages command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "messages",
@@ -192,7 +190,7 @@ describe("okou chat messages command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "messages",
@@ -254,7 +252,7 @@ describe("okou chat messages command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "messages",
@@ -294,7 +292,7 @@ describe("okou chat messages command", () => {
     );
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync([
+      await chatCommand.parseAsync([
         "node",
         "cli",
         "messages",
@@ -329,7 +327,7 @@ describe("okou chat messages command", () => {
     );
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync([
+      await chatCommand.parseAsync([
         "node",
         "cli",
         "messages",
@@ -406,7 +404,7 @@ describe("okou chat messages command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "messages",
@@ -432,7 +430,7 @@ describe("okou chat messages command", () => {
     vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync(["node", "cli", "messages"]);
+      await chatCommand.parseAsync(["node", "cli", "messages"]);
     }).rejects.toThrow("process.exit called");
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");
@@ -457,7 +455,7 @@ describe("okou chat messages command", () => {
     );
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync([
+      await chatCommand.parseAsync([
         "node",
         "cli",
         "messages",

--- a/turbo/apps/cli/src/commands/chat/__tests__/model.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/model.test.ts
@@ -11,8 +11,8 @@ import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroChatCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { chatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const OTHER_THREAD_ID = "00000000-0000-4000-8000-000000000002";
@@ -67,7 +67,7 @@ describe("okou chat model command", () => {
     vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
 
@@ -86,7 +86,7 @@ describe("okou chat model command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync(["node", "cli", "model", "--help"]);
+    await chatCommand.parseAsync(["node", "cli", "model", "--help"]);
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("Usage: chat model");
@@ -101,9 +101,7 @@ describe("okou chat model command", () => {
   it("prints the current chat model and switchable models without an argument", async () => {
     server.use(
       http.get(GET_URL, ({ request }) => {
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer test-zero-token",
-        );
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
         return HttpResponse.json({
           id: THREAD_ID,
           title: "Launch plan",
@@ -115,7 +113,7 @@ describe("okou chat model command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync(["node", "cli", "model"]);
+    await chatCommand.parseAsync(["node", "cli", "model"]);
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("Chat thread loaded");
@@ -139,7 +137,7 @@ describe("okou chat model command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "model",
@@ -159,9 +157,7 @@ describe("okou chat model command", () => {
         return HttpResponse.json(MODEL_POLICIES_RESPONSE);
       }),
       http.post(OTHER_MODEL_SELECTION_URL, async ({ request }) => {
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer test-zero-token",
-        );
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
         await expect(request.json()).resolves.toStrictEqual({
           model: "claude-sonnet-5",
         });
@@ -169,7 +165,7 @@ describe("okou chat model command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "model",
@@ -192,7 +188,7 @@ describe("okou chat model command", () => {
     );
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync(["node", "cli", "model", "gpt-5.5"]);
+      await chatCommand.parseAsync(["node", "cli", "model", "gpt-5.5"]);
     }).rejects.toThrow("process.exit called");
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");

--- a/turbo/apps/cli/src/commands/chat/__tests__/rename.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/rename.test.ts
@@ -11,8 +11,8 @@ import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroChatCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { chatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const OTHER_THREAD_ID = "00000000-0000-4000-8000-000000000002";
@@ -31,7 +31,7 @@ describe("okou chat rename command", () => {
   beforeEach(() => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
 
@@ -45,9 +45,7 @@ describe("okou chat rename command", () => {
   it("renames the current chat thread and prints a human-readable summary", async () => {
     server.use(
       http.post(RENAME_URL, async ({ request }) => {
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer test-zero-token",
-        );
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
         await expect(request.json()).resolves.toStrictEqual({
           title: "Launch plan",
         });
@@ -55,13 +53,7 @@ describe("okou chat rename command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
-      "node",
-      "cli",
-      "rename",
-      "Launch",
-      "plan",
-    ]);
+    await chatCommand.parseAsync(["node", "cli", "rename", "Launch", "plan"]);
 
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("Chat title updated");
@@ -79,7 +71,7 @@ describe("okou chat rename command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "rename",
@@ -107,7 +99,7 @@ describe("okou chat rename command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "rename",
@@ -128,7 +120,7 @@ describe("okou chat rename command", () => {
 
   it("rejects whitespace-only titles before calling the API", async () => {
     await expect(async () => {
-      await zeroChatCommand.parseAsync(["node", "cli", "rename", "   "]);
+      await chatCommand.parseAsync(["node", "cli", "rename", "   "]);
     }).rejects.toThrow("process.exit called");
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");
@@ -141,12 +133,7 @@ describe("okou chat rename command", () => {
     vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync([
-        "node",
-        "cli",
-        "rename",
-        "Launch plan",
-      ]);
+      await chatCommand.parseAsync(["node", "cli", "rename", "Launch plan"]);
     }).rejects.toThrow("process.exit called");
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");

--- a/turbo/apps/cli/src/commands/chat/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/send.test.ts
@@ -6,8 +6,8 @@ import chalk from "chalk";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { server } from "../../../../mocks/server";
-import { zeroChatCommand } from "../index";
+import { server } from "../../../mocks/server";
+import { chatCommand } from "../index";
 
 const THREAD_ID = "00000000-0000-4000-8000-000000000001";
 const OTHER_THREAD_ID = "00000000-0000-4000-8000-000000000002";
@@ -38,9 +38,9 @@ describe("okou chat send command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
-    tempDir = mkdtempSync(path.join(tmpdir(), "zero-chat-send-"));
+    tempDir = mkdtempSync(path.join(tmpdir(), "chat-send-"));
     vi.stubEnv("VM0_API_BACKEND_URL", "http://localhost:3000");
-    vi.stubEnv("OKOU_TOKEN", "test-zero-token");
+    vi.stubEnv("OKOU_TOKEN", "test-token");
     vi.stubEnv("OKOU_CHAT_THREAD_ID", THREAD_ID);
   });
 
@@ -64,9 +64,7 @@ describe("okou chat send command", () => {
         });
       }),
       http.post(SEND_URL, async ({ request }) => {
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer test-zero-token",
-        );
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
         const body = (await request.json()) as Record<string, unknown>;
         sentEventId = String(body.clientEventId);
         expect(body).toMatchObject({
@@ -97,7 +95,7 @@ describe("okou chat send command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "send",
@@ -143,7 +141,7 @@ describe("okou chat send command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "send",
@@ -162,13 +160,7 @@ describe("okou chat send command", () => {
 
   it("rejects whitespace-only message text before calling the API", async () => {
     await expect(async () => {
-      await zeroChatCommand.parseAsync([
-        "node",
-        "cli",
-        "send",
-        "--text",
-        "   ",
-      ]);
+      await chatCommand.parseAsync(["node", "cli", "send", "--text", "   "]);
     }).rejects.toThrow("process.exit called");
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");
@@ -225,7 +217,7 @@ describe("okou chat send command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "send",
@@ -273,7 +265,7 @@ describe("okou chat send command", () => {
       }),
     );
 
-    await zeroChatCommand.parseAsync([
+    await chatCommand.parseAsync([
       "node",
       "cli",
       "send",
@@ -293,7 +285,7 @@ describe("okou chat send command", () => {
     });
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync([
+      await chatCommand.parseAsync([
         "node",
         "cli",
         "send",
@@ -318,7 +310,7 @@ describe("okou chat send command", () => {
     });
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync([
+      await chatCommand.parseAsync([
         "node",
         "cli",
         "send",
@@ -340,7 +332,7 @@ describe("okou chat send command", () => {
     });
 
     await expect(async () => {
-      await zeroChatCommand.parseAsync([
+      await chatCommand.parseAsync([
         "node",
         "cli",
         "send",

--- a/turbo/apps/cli/src/commands/chat/cancel.ts
+++ b/turbo/apps/cli/src/commands/chat/cancel.ts
@@ -6,9 +6,9 @@ import { Command } from "commander";
 import {
   getZeroChatThreadAgentId,
   sendZeroChatEvent,
-} from "../../../lib/api/domains/zero-chat";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { isUuid } from "../../../lib/utils/uuid";
+} from "../../lib/api/domains/zero-chat";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { isUuid } from "../../lib/utils/uuid";
 import { printChatUsageError, resolveChatThreadId } from "./shared";
 
 interface CancelOptions {

--- a/turbo/apps/cli/src/commands/chat/chat-event-history.ts
+++ b/turbo/apps/cli/src/commands/chat/chat-event-history.ts
@@ -15,7 +15,7 @@ import type { ChatEventCursor } from "@okouai/api-contracts/contracts/chat-event
 import {
   getZeroChatEventSnapshot,
   listZeroChatEventRows,
-} from "../../../lib/api/domains/zero-chat";
+} from "../../lib/api/domains/zero-chat";
 
 const CHAT_EVENT_ROWS_PAGE_LIMIT = 50;
 const THREAD_START_SEQ_ID = 0;

--- a/turbo/apps/cli/src/commands/chat/chat-thread-cache.ts
+++ b/turbo/apps/cli/src/commands/chat/chat-thread-cache.ts
@@ -17,8 +17,8 @@ import {
   listZeroChatThreadEvents,
   type ZeroChatThreadEvent,
   type ZeroChatThreadSnapshot,
-} from "../../../lib/api/domains/zero-chat";
-import { decodeZeroTokenPayload, getApiUrl } from "../../../lib/api/config";
+} from "../../lib/api/domains/zero-chat";
+import { decodeZeroTokenPayload, getApiUrl } from "../../lib/api/config";
 
 const CACHE_VERSION = 2;
 const MAX_EVENT_PAGES_PER_SYNC = 20;

--- a/turbo/apps/cli/src/commands/chat/create.ts
+++ b/turbo/apps/cli/src/commands/chat/create.ts
@@ -4,10 +4,10 @@ import { Command } from "commander";
 import {
   createZeroChatThread,
   getZeroChatThreadAgentId,
-} from "../../../lib/api/domains/zero-chat";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { isUuid } from "../../../lib/utils/uuid";
-import { getOkouChatThreadId } from "../../../lib/okou-env";
+} from "../../lib/api/domains/zero-chat";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { isUuid } from "../../lib/utils/uuid";
+import { getOkouChatThreadId } from "../../lib/okou-env";
 import { printChatUsageError } from "./shared";
 
 interface CreateOptions {

--- a/turbo/apps/cli/src/commands/chat/get.ts
+++ b/turbo/apps/cli/src/commands/chat/get.ts
@@ -1,8 +1,8 @@
 import chalk from "chalk";
 import { Command } from "commander";
 
-import { getZeroChatThread } from "../../../lib/api/domains/zero-chat";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { getZeroChatThread } from "../../lib/api/domains/zero-chat";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { resolveChatThreadId } from "./shared";
 
 interface GetOptions {

--- a/turbo/apps/cli/src/commands/chat/index.ts
+++ b/turbo/apps/cli/src/commands/chat/index.ts
@@ -9,7 +9,7 @@ import { modelCommand } from "./model";
 import { renameCommand } from "./rename";
 import { sendCommand } from "./send";
 
-export const zeroChatCommand = new Command()
+export const chatCommand = new Command()
   .name("chat")
   .description("Manage web chat threads")
   .addCommand(createCommand)

--- a/turbo/apps/cli/src/commands/chat/list.ts
+++ b/turbo/apps/cli/src/commands/chat/list.ts
@@ -1,11 +1,11 @@
 import chalk from "chalk";
 import { Command } from "commander";
 
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { formatIsoTimestamp } from "../../../lib/utils/time-format";
-import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
-import { isUuid } from "../../../lib/utils/uuid";
-import { getOkouAgentId } from "../../../lib/okou-env";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { formatIsoTimestamp } from "../../lib/utils/time-format";
+import { parseBoundedLogCount } from "../../lib/utils/log-pagination";
+import { isUuid } from "../../lib/utils/uuid";
+import { getOkouAgentId } from "../../lib/okou-env";
 import { syncCachedChatThreads } from "./chat-thread-cache";
 
 const DEFAULT_LIMIT = 20;

--- a/turbo/apps/cli/src/commands/chat/messages.ts
+++ b/turbo/apps/cli/src/commands/chat/messages.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { resolveChatThreadId } from "./shared";
 import { syncRawChatHistory } from "./chat-event-history";
 

--- a/turbo/apps/cli/src/commands/chat/model.ts
+++ b/turbo/apps/cli/src/commands/chat/model.ts
@@ -9,12 +9,12 @@ import { getModelDisplayName } from "@okouai/core/model-display-name";
 import {
   getZeroChatThread,
   updateZeroChatThreadModelSelection,
-} from "../../../lib/api/domains/zero-chat";
-import { listZeroModelPolicies } from "../../../lib/api/domains/zero-model-policies";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { formatModelProviderRoute } from "../../../lib/domain/model-policy-display";
-import { isUuid } from "../../../lib/utils/uuid";
-import { getOkouChatThreadId } from "../../../lib/okou-env";
+} from "../../lib/api/domains/zero-chat";
+import { listZeroModelPolicies } from "../../lib/api/domains/zero-model-policies";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { formatModelProviderRoute } from "../../lib/domain/model-policy-display";
+import { isUuid } from "../../lib/utils/uuid";
+import { getOkouChatThreadId } from "../../lib/okou-env";
 
 interface ModelOptions {
   readonly help?: boolean;

--- a/turbo/apps/cli/src/commands/chat/rename.ts
+++ b/turbo/apps/cli/src/commands/chat/rename.ts
@@ -1,10 +1,10 @@
 import chalk from "chalk";
 import { Command } from "commander";
 
-import { renameZeroChatThread } from "../../../lib/api/domains/zero-chat";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
-import { isUuid } from "../../../lib/utils/uuid";
-import { getOkouChatThreadId } from "../../../lib/okou-env";
+import { renameZeroChatThread } from "../../lib/api/domains/zero-chat";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
+import { isUuid } from "../../lib/utils/uuid";
+import { getOkouChatThreadId } from "../../lib/okou-env";
 
 interface RenameOptions {
   readonly json?: boolean;

--- a/turbo/apps/cli/src/commands/chat/send.ts
+++ b/turbo/apps/cli/src/commands/chat/send.ts
@@ -11,8 +11,8 @@ import {
 import {
   getZeroChatThreadAgentId,
   sendZeroChatEvent,
-} from "../../../lib/api/domains/zero-chat";
-import { withErrorHandler } from "../../../lib/command/with-error-handler";
+} from "../../lib/api/domains/zero-chat";
+import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { printChatUsageError, resolveChatThreadId } from "./shared";
 
 // Non-authoritative plain-text views of a document that carries no text part.

--- a/turbo/apps/cli/src/commands/chat/shared.ts
+++ b/turbo/apps/cli/src/commands/chat/shared.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 
-import { isUuid } from "../../../lib/utils/uuid";
-import { getOkouChatThreadId } from "../../../lib/okou-env";
+import { isUuid } from "../../lib/utils/uuid";
+import { getOkouChatThreadId } from "../../lib/okou-env";
 
 export function printChatUsageError(message: string, hint: string): never {
   console.error(chalk.red(`✗ ${message}`));

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -203,7 +203,7 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     name: "chat",
     description: "Manage the current web chat thread",
     load: async () => {
-      return (await import("./commands/zero/chat")).zeroChatCommand;
+      return (await import("./commands/chat")).chatCommand;
     },
   },
   {


### PR DESCRIPTION
## Summary

- move all 20 Chat implementation and focused test files from `commands/zero/chat` to `commands/chat`
- rename the internal command export from `zeroChatCommand` to `chatCommand`
- update every one-level relative import, all eight focused tests, and only the Chat lazy registry entry
- replace the Chat-only test fixtures `test-zero-token`, `zero-chat-list-`, and `zero-chat-send-` with their neutral forms

## Compatibility

- preserve the persisted `vm0/zero/chat-threads` cache identity byte-for-byte, including cache hashing, serialization, synchronization, and invalidation behavior
- preserve `zeroToken()`, the `vm0_sandbox_` wire fixture, `decodeZeroTokenPayload`, `ZeroChat*`, `getZeroChat*`, and `sendZeroChatEvent`
- preserve `zero-chat`, `zero-model-policies`, `VM0_API_BACKEND_URL`, API routes and payloads, output and error text, arguments, options, help, and public `okou chat` behavior
- add no old-path bridge, export alias, compatibility re-export, or unrelated Zero/vm0 cleanup

## Verification

- lockfile-pinned Prettier 3.8.1 check on all changed files
- `pnpm --filter @okouai/cli run lint`
- `pnpm knip --workspace @okouai/cli`
- `pnpm --filter @okouai/cli run check-types`
- all eight focused Chat test files: 42 tests passed
- CLI registry coverage: 2 files, 90 tests passed
- post-rebase mechanical-equivalence audit against latest `origin/main`
- repository-wide residual scans for `commands/zero/chat` and `zeroChatCommand`
- exact cache-path and compatibility-token fixture comparisons against `origin/main`

Closes #27415
