### PR TITLE
fix(platform): align credit balance bar radius

### DIFF
--- a/e2e/playwright/tests/billing-payment.spec.ts
+++ b/e2e/playwright/tests/billing-payment.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "../fixtures";
 import { authHeadersForToken } from "../lib/onboarding";
 import { deriveAppUrl } from "../playwright.config";
@@ -8,6 +8,13 @@ const appUrl = deriveAppUrl(apiUrl);
 
 async function openBillingSettings(page: Page): Promise<void> {
   await page.goto(`${appUrl}/?settings=billing`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByRole("dialog")).toBeVisible({ timeout: 30_000 });
+}
+
+async function openCreditBalanceSettings(page: Page): Promise<void> {
+  await page.goto(`${appUrl}/?settings=usage`, {
     waitUntil: "domcontentloaded",
   });
   await expect(page.getByRole("dialog")).toBeVisible({ timeout: 30_000 });
@@ -25,6 +32,121 @@ test("billing settings reflects limited free onboarding", async ({ page }) => {
   await expect(page.getByText(/^Pro plan$/)).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Downgrade" })).toHaveCount(0);
 });
+
+test("credit balance bars render with matching outer corner radii", async ({
+  page,
+}) => {
+  await enableUsagePackPlans(page);
+  await mockCreditBalance(page);
+  await openCreditBalanceSettings(page);
+
+  const allowanceBar = page.getByRole("progressbar").first();
+  const firstOrgCreditBar = page.getByTestId("credit-balance-segment-plan:pro");
+  const lastOrgCreditBar = page.getByTestId(
+    "credit-balance-segment-payAsYouGo",
+  );
+  await expect(allowanceBar).toBeVisible({ timeout: 30_000 });
+  await expect(firstOrgCreditBar).toBeVisible();
+  await expect(lastOrgCreditBar).toBeVisible();
+
+  const allowanceRadii = await renderedCornerRadii(allowanceBar);
+  const firstOrgCreditRadii = await renderedCornerRadii(firstOrgCreditBar);
+  const lastOrgCreditRadii = await renderedCornerRadii(lastOrgCreditBar);
+
+  expect(firstOrgCreditRadii.topLeft).toBe(allowanceRadii.topLeft);
+  expect(firstOrgCreditRadii.bottomLeft).toBe(allowanceRadii.bottomLeft);
+  expect(lastOrgCreditRadii.topRight).toBe(allowanceRadii.topRight);
+  expect(lastOrgCreditRadii.bottomRight).toBe(allowanceRadii.bottomRight);
+  expect(allowanceRadii.topLeft).not.toBe("0px");
+  expect([
+    firstOrgCreditRadii.topRight,
+    firstOrgCreditRadii.bottomRight,
+    lastOrgCreditRadii.topLeft,
+    lastOrgCreditRadii.bottomLeft,
+  ]).toEqual(["0px", "0px", "0px", "0px"]);
+});
+
+async function enableUsagePackPlans(page: Page): Promise<void> {
+  await page.route("**/api/okou/feature-switches", async (route) => {
+    const response = await route.fetch();
+    const body: unknown = await response.json();
+    if (!isRecord(body) || !isRecord(body.effectiveSwitches)) {
+      throw new Error("Feature switches returned an unexpected response");
+    }
+    await route.fulfill({
+      response,
+      json: {
+        ...body,
+        effectiveSwitches: {
+          ...body.effectiveSwitches,
+          usagePackPlans: true,
+        },
+      },
+    });
+  });
+}
+
+async function mockCreditBalance(page: Page): Promise<void> {
+  await page.route("**/api/okou/billing/status", async (route) => {
+    const response = await route.fetch();
+    const body: unknown = await response.json();
+    if (!isRecord(body)) {
+      throw new Error("Billing status returned an unexpected response");
+    }
+    await route.fulfill({
+      response,
+      json: {
+        ...body,
+        tier: "pro",
+        credits: 12_000,
+        creditBreakdown: [
+          {
+            category: "plan",
+            tier: "pro",
+            label: "Pro credits",
+            credits: 8000,
+          },
+          {
+            category: "payAsYouGo",
+            label: "Purchased credits",
+            credits: 4000,
+          },
+        ],
+        creditGrants: [],
+        usageAllowance: {
+          windows: [
+            {
+              kind: "short",
+              windowSeconds: 18_000,
+              unitLimit: 5000,
+              consumedUnits: 1250,
+              remainingUnits: 3750,
+              startsAt: "2026-03-01T00:00:00Z",
+              expiresAt: "2026-03-01T05:00:00Z",
+            },
+          ],
+        },
+      },
+    });
+  });
+}
+
+async function renderedCornerRadii(locator: Locator): Promise<{
+  readonly topLeft: string;
+  readonly topRight: string;
+  readonly bottomRight: string;
+  readonly bottomLeft: string;
+}> {
+  return locator.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      topLeft: style.borderTopLeftRadius,
+      topRight: style.borderTopRightRadius,
+      bottomRight: style.borderBottomRightRadius,
+      bottomLeft: style.borderBottomLeftRadius,
+    };
+  });
+}
 
 async function expectLimitedFreeBillingStatus(page: Page): Promise<void> {
   const token = await currentClerkSessionToken(page);
@@ -66,4 +188,8 @@ function hasBillingTier(value: unknown): value is { readonly tier: string } {
     "tier" in value &&
     typeof value.tier === "string"
   );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/e2e/playwright/tests/billing-payment.spec.ts
+++ b/e2e/playwright/tests/billing-payment.spec.ts
@@ -40,7 +40,10 @@ test("credit balance bars render with matching outer corner radii", async ({
   await mockCreditBalance(page);
   await openCreditBalanceSettings(page);
 
-  const allowanceBar = page.getByRole("progressbar").first();
+  const allowanceBar = page
+    .getByTestId("usage-allowance-section")
+    .getByRole("progressbar")
+    .locator("span");
   const firstOrgCreditBar = page.getByTestId("credit-balance-segment-plan:pro");
   const lastOrgCreditBar = page.getByTestId(
     "credit-balance-segment-payAsYouGo",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -311,7 +311,6 @@ describe("organization usage settings", () => {
     const segment = await screen.findByTestId(
       "credit-balance-segment-payAsYouGo",
     );
-    expect(segment).toHaveClass("first:rounded-l-full", "last:rounded-r-full");
     await user.hover(segment);
     await expect(
       screen.findByText("Purchased credits — 12,000"),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -311,6 +311,7 @@ describe("organization usage settings", () => {
     const segment = await screen.findByTestId(
       "credit-balance-segment-payAsYouGo",
     );
+    expect(segment).toHaveClass("first:rounded-l-full", "last:rounded-r-full");
     await user.hover(segment);
     await expect(
       screen.findByText("Purchased credits — 12,000"),

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -696,7 +696,7 @@ function CreditBreakdownBar({
                 <TooltipTrigger asChild>
                   <div
                     data-testid={`credit-balance-segment-${segmentKey(s)}`}
-                    className={`${splitLayout ? "h-2 rounded-[2px]" : "h-2.5 first:rounded-l-full last:rounded-r-full"} ${color} cursor-default ring-0 hover:ring-2 hover:ring-foreground/30 hover:z-10 transition-shadow`}
+                    className={`${splitLayout ? "h-2" : "h-2.5"} first:rounded-l-full last:rounded-r-full ${color} cursor-default ring-0 hover:ring-2 hover:ring-foreground/30 hover:z-10 transition-shadow`}
                     style={{
                       width: `${(s.credits / total) * 100}%`,
                     }}


### PR DESCRIPTION
## Summary

- align the split Org credits bar outer radius with the Usage allowance meters
- preserve the existing 3px gap between credit categories
- cover the single-category pill shape with a regression assertion

## Checks

- `npx --yes prettier@3.8.1 --check apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx`
- `npx --yes oxlint@1.75.0 src/views/zero-page/components/org-manage/org-usage-tab.tsx src/views/zero-page/__tests__/org-usage-tab.test.tsx`
- full tests and preview via the PR pipeline