### PR TITLE
test(api): stabilize clerk compaction lock readiness

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -5440,8 +5440,13 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       type: "organization.deleted",
       data: { id: orgOf(actor) },
     });
-    const redelivery = await api.requestClerkWebhook("{}", {}, [200]);
+    const redelivery = await compactionLock.withAcquisitionAttemptTracking(
+      () => {
+        return api.requestClerkWebhook("{}", {}, [200]);
+      },
+    );
     expect(redelivery.body).toBe("OK");
+    await compactionLock.acquisitionAttempted;
     await expect.poll(compactionLock.waiterCount).toBeGreaterThanOrEqual(1);
     await expect(
       store.set(
@@ -5928,8 +5933,11 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       type: "user.deleted",
       data: { id: doomed.userId },
     });
-    const response = await api.requestClerkWebhook("{}", {}, [200]);
+    const response = await compactionLock.withAcquisitionAttemptTracking(() => {
+      return api.requestClerkWebhook("{}", {}, [200]);
+    });
     expect(response.body).toBe("OK");
+    await compactionLock.acquisitionAttempted;
     await expect.poll(compactionLock.waiterCount).toBeGreaterThanOrEqual(1);
     await expect(
       store.set(

--- a/turbo/apps/api/src/signals/services/usage-event-compaction-lock.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-event-compaction-lock.service.ts
@@ -1,12 +1,27 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { sql } from "drizzle-orm";
 
+import { singleton } from "../../lib/singleton";
 import type { Db } from "../external/db";
 
 type UsageEventCompactionLockDb = Pick<Db, "execute">;
 
+const scopedUsageEventCompactionLockAttempt = singleton(() => {
+  return new AsyncLocalStorage<() => void>();
+});
+
+export async function withUsageEventCompactionLockAttemptTrackingForTest<T>(
+  onAttempt: () => void,
+  work: () => Promise<T>,
+): Promise<T> {
+  return await scopedUsageEventCompactionLockAttempt().run(onAttempt, work);
+}
+
 export async function lockUsageEventCompaction(
   db: UsageEventCompactionLockDb,
 ): Promise<void> {
+  scopedUsageEventCompactionLockAttempt.peek()?.getStore()?.();
   await db.execute(
     sql`SELECT pg_advisory_xact_lock(
       hashtext('vm0'),

--- a/turbo/apps/api/src/test-fixtures/usage-event-compaction.ts
+++ b/turbo/apps/api/src/test-fixtures/usage-event-compaction.ts
@@ -3,7 +3,10 @@ import { z } from "zod";
 
 import { db } from "../lib/db";
 import { executeRawRows } from "../lib/db-raw-rows";
-import { lockUsageEventCompaction } from "../signals/services/usage-event-compaction-lock.service";
+import {
+  lockUsageEventCompaction,
+  withUsageEventCompactionLockAttemptTrackingForTest,
+} from "../signals/services/usage-event-compaction-lock.service";
 import { createDeferredPromise } from "../signals/utils";
 
 const databasePidRowSchema = z.object({ pid: z.int() });
@@ -18,10 +21,15 @@ export async function holdUsageEventCompactionLockFixture(
 ): Promise<{
   readonly release: () => void;
   readonly done: Promise<void>;
+  readonly acquisitionAttempted: Promise<void>;
+  readonly withAcquisitionAttemptTracking: <T>(
+    work: () => Promise<T>,
+  ) => Promise<T>;
   readonly waiterCount: () => Promise<number>;
 }> {
   const started = createDeferredPromise<number>(signal);
   const released = createDeferredPromise<void>(signal);
+  const acquisitionAttempted = createDeferredPromise<void>(signal);
   const done = db().transaction(async (tx) => {
     await lockUsageEventCompaction(tx);
     const rows = await executeRawRows(
@@ -45,6 +53,16 @@ export async function holdUsageEventCompactionLockFixture(
       }
     },
     done,
+    acquisitionAttempted: acquisitionAttempted.promise,
+    withAcquisitionAttemptTracking: async <T>(
+      work: () => Promise<T>,
+    ): Promise<T> => {
+      return await withUsageEventCompactionLockAttemptTrackingForTest(() => {
+        if (!acquisitionAttempted.settled()) {
+          acquisitionAttempted.resolve(undefined);
+        }
+      }, work);
+    },
     waiterCount: async () => {
       const rows = await executeRawRows(
         db(),


### PR DESCRIPTION
## Summary

- add request-scoped test tracking at the usage-event compaction lock attempt boundary
- wait for Clerk organization and user deletion cleanup to reach that boundary before polling PostgreSQL for the blocked waiter
- preserve the early webhook acknowledgement, real advisory-lock waiter proof, pre-release usage assertions, and final account cleanup contract

## Failure evidence

- Triggering run: https://github.com/vm0-ai/vm0/actions/runs/31887349636
- Attempt 1 `test-api (6)` job: https://github.com/vm0-ai/vm0/actions/runs/31887349636/job/95018519231
- Same-SHA attempt 2 passed: https://github.com/vm0-ai/vm0/actions/runs/31887349636/job/95019179261
- The represented PR, #27411, only refactors CLI agent command files and does not touch Clerk deletion, compaction, API test context, or this test.

The first failure was the waiter observation timing out with a count of zero. The webhook intentionally acknowledges before its `waitUntil` cleanup finishes, and that cleanup has several valid asynchronous prerequisites before it calls the compaction lock. The test started the default `expect.poll` window immediately after the early `200`, so a slower shard schedule could exhaust the poll before the cleanup had attempted the lock. The later abort and unhandled rejection were test-context shutdown effects after that timeout, not independent causes.

## Fix

The test fixture now installs request-scoped lock-attempt tracking. Async work created by the webhook request inherits that scope, and the lock helper signals immediately before executing `pg_advisory_xact_lock`. The test first awaits that explicit readiness boundary, then retains the existing `pg_locks` waiter assertion to prove that the cleanup is genuinely blocked behind the independently held lock.

This does not add retries, sleeps, timeout increases, skipped assertions, detached cleanup, or swallowed rejections.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- targeted ESLint and Prettier checks for all changed files
- request-scoped delayed background lock-attempt propagation check: 5/5
- `git diff --check`

The focused API route test was attempted locally, but the API Vitest setup could not connect to PostgreSQL (`ECONNREFUSED` on port 5432) before collecting the test. Per the repair guard, no local database or other service was started; the PR pipeline will execute the real-PostgreSQL route coverage.

Preview validation is not applicable: this is a non-service API test synchronization repair with no app, API, or browser-visible behavior change.
