### PR TITLE
refactor(run): neutralize mcp connector and model-selection service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/mcp-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/mcp-connectors.ts
@@ -4,7 +4,7 @@ import { mcpConnectorsContract } from "@okouai/api-contracts/contracts/mcp-conne
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import type { RouteEntry } from "../route-entry";
-import { zeroRunMcpConnectorList } from "../services/zero-run-mcp-connectors.service";
+import { runMcpConnectorList } from "../services/run-mcp-connectors.service";
 
 const listRunMcpConnectorsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -12,7 +12,7 @@ const listRunMcpConnectorsInner$ = computed(async (get) => {
     throw new Error("Run MCP connector route requires Zero authentication");
   }
   const connectors = await get(
-    zeroRunMcpConnectorList({
+    runMcpConnectorList({
       orgId: auth.orgId,
       userId: auth.userId,
       runId: auth.runId,

--- a/turbo/apps/api/src/signals/services/integration-agent-response-presentation.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-agent-response-presentation.service.ts
@@ -12,7 +12,7 @@ import { zeroAgents } from "@okouai/db/schema/zero-agent";
 
 import { env } from "../../lib/env";
 import type { Db } from "../external/db";
-import { resolveZeroRunModelSelection } from "./zero-run-model-selection.service";
+import { resolveRunModelSelection } from "./run-model-selection.service";
 
 const ORG_SENTINEL_USER_ID = "__org__";
 
@@ -78,7 +78,7 @@ async function resolveModelLabel(args: {
   readonly orgId: string;
   readonly runId: string;
 }): Promise<string | undefined> {
-  const runModel = await resolveZeroRunModelSelection(args.db, args.runId);
+  const runModel = await resolveRunModelSelection(args.db, args.runId);
   const model =
     runModel?.selectedModel ??
     (await resolveOrgDefaultModelProviderSelectedModel(args.db, args.orgId));

--- a/turbo/apps/api/src/signals/services/run-mcp-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/run-mcp-connectors.service.ts
@@ -20,7 +20,7 @@ import {
   serialiseCustomConnector,
 } from "./zero-custom-connector.service";
 
-export function zeroRunMcpConnectorList(args: {
+export function runMcpConnectorList(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly runId: string;

--- a/turbo/apps/api/src/signals/services/run-model-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/run-model-selection.service.ts
@@ -4,15 +4,15 @@ import { and, eq, isNotNull } from "drizzle-orm";
 
 import type { ReadonlyDb } from "../external/db";
 
-interface ZeroRunModelSelection {
+interface RunModelSelection {
   readonly selectedModel: string | null;
   readonly codexServiceTier: CodexServiceTier | null;
 }
 
-export async function resolveZeroRunModelSelection(
+export async function resolveRunModelSelection(
   db: ReadonlyDb,
   runId: string,
-): Promise<ZeroRunModelSelection | undefined> {
+): Promise<RunModelSelection | undefined> {
   const [row] = await db
     .select({
       selectedModel: agentRuns.selectedModel,

--- a/turbo/apps/api/src/signals/services/zero-integrations-slack-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-integrations-slack-message.service.ts
@@ -9,7 +9,7 @@ import { and, eq } from "drizzle-orm";
 
 import { db$, type ReadonlyDb } from "../external/db";
 import { tapError } from "../utils";
-import { resolveZeroRunModelSelection } from "./zero-run-model-selection.service";
+import { resolveRunModelSelection } from "./run-model-selection.service";
 
 async function resolveAgentLabel(
   db: ReadonlyDb,
@@ -35,7 +35,7 @@ async function resolveModelLabel(
   db: ReadonlyDb,
   runId: string,
 ): Promise<string | undefined> {
-  const row = await resolveZeroRunModelSelection(db, runId);
+  const row = await resolveRunModelSelection(db, runId);
   if (!row || row.selectedModel === null) {
     return undefined;
   }

--- a/turbo/apps/api/src/signals/services/zero-telegram-footer.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-footer.service.ts
@@ -16,7 +16,7 @@ import { and, eq } from "drizzle-orm";
 import { isOfficialTelegramBotId } from "../external/telegram-official";
 import { db$, type ReadonlyDb } from "../external/db";
 import { escapeHtml } from "../../lib/telegram-format";
-import { resolveZeroRunModelSelection } from "./zero-run-model-selection.service";
+import { resolveRunModelSelection } from "./run-model-selection.service";
 
 const ORG_SENTINEL_USER_ID = "__org__";
 
@@ -123,7 +123,7 @@ async function resolveAgentReplyModelLabel(args: {
   readonly orgId: string;
   readonly runId: string;
 }): Promise<string | undefined> {
-  const runModel = await resolveZeroRunModelSelection(args.db, args.runId);
+  const runModel = await resolveRunModelSelection(args.db, args.runId);
   const model =
     runModel?.selectedModel ??
     (await resolveOrgDefaultModelProviderSelectedModel(args.db, args.orgId));
@@ -241,7 +241,7 @@ export function telegramMessageSendFooterText(args: {
         runId: args.authRunId,
         botId: args.botId,
       }),
-      resolveZeroRunModelSelection(db, args.authRunId),
+      resolveRunModelSelection(db, args.authRunId),
     ]);
 
     const parts: string[] = [];


### PR DESCRIPTION
## Summary

- rename the run MCP-connector and model-selection service paths to domain-neutral names
- rename the declarations from the issue map and update every direct caller atomically
- preserve the adjacent `zero-custom-connector.service.ts` dependency and all runtime behavior

## Verification

- `pnpm exec prettier --check apps/api/src/signals/routes/mcp-connectors.ts apps/api/src/signals/services/run-mcp-connectors.service.ts apps/api/src/signals/services/run-model-selection.service.ts apps/api/src/signals/services/zero-telegram-footer.service.ts apps/api/src/signals/services/integration-agent-response-presentation.service.ts apps/api/src/signals/services/zero-integrations-slack-message.service.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm --filter api run check-types`
- `pnpm knip --workspace api`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/mcp-connectors.test.ts` (3 passed)
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations-telegram-message.test.ts -t 'sends a Telegram message and appends the audit footer'` (1 passed)
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations-slack-message.test.ts -t "appends 'Sent via' footer when agent is resolvable from run"` (1 passed)
- verified that both old paths and all three old declarations are absent repository-wide

## Local baseline note

The two queue-dependent Fast-footer cases in `integrations.bdd.test.ts` both stopped at the shared `pollRunnerRun` helper before reaching footer behavior. The same two failures reproduced with the same command and database on an unmodified `main` worktree at `926d572bfd`, so they are not caused by this naming-only change; required PR CI remains authoritative for those callback paths.

## Compatibility

No compatibility aliases, old-path re-exports, or behavior fallbacks are retained.

Closes #27433
