### PR TITLE
perf(api): attribute pre-queue launch phases

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -225,6 +225,13 @@ const API_DISPATCH_REUSED_THREAD_READ_ACTION_TYPES = [
 const API_DISPATCH_ATOMIC_PERSISTENCE_ACTION_TYPES = [
   "api_dispatch_persist_atomic_launch",
 ] as const;
+const API_DISPATCH_PRE_QUEUE_PHASE_ACTION_TYPES = [
+  "api_dispatch_phase_pre_create",
+  "api_dispatch_phase_prepare_context",
+  "api_dispatch_phase_prepare_launch",
+] as const;
+const API_DISPATCH_QUEUE_INSERT_PHASE_ACTION_TYPE =
+  "api_dispatch_phase_queue_insert";
 const API_DISPATCH_PI_LAUNCH_RESOURCE_ACTION_TYPES = [
   "api_dispatch_prepare_pi_launch_resources",
   "api_dispatch_prepare_pi_launch_resume_session",
@@ -5550,6 +5557,24 @@ describe("CHAT-02: run-level model overrides", () => {
         }),
       ).toHaveLength(1);
     }
+    for (const actionType of API_DISPATCH_PRE_QUEUE_PHASE_ACTION_TYPES) {
+      expect(
+        lostTimingEvents.filter((event) => {
+          return event.op_type === actionType;
+        }),
+      ).toStrictEqual([
+        expect.objectContaining({
+          api_start_source: "user_message",
+          queue_first_launch_outcome: "claim_lost",
+          run_preparation_retry_count: "0",
+        }),
+      ]);
+    }
+    expect(
+      lostTimingEvents.filter((event) => {
+        return event.op_type === API_DISPATCH_QUEUE_INSERT_PHASE_ACTION_TYPE;
+      }),
+    ).toHaveLength(0);
     expect(
       sandboxOperationEvents().filter((event) => {
         return (
@@ -5667,6 +5692,23 @@ describe("CHAT-02: run-level model overrides", () => {
         }),
       ).toHaveLength(2);
     }
+    for (const actionType of API_DISPATCH_PRE_QUEUE_PHASE_ACTION_TYPES) {
+      expect(
+        retryTimingEvents.filter((event) => {
+          return event.op_type === actionType;
+        }),
+      ).toStrictEqual([
+        expect.objectContaining({
+          api_start_source: "user_message",
+          run_preparation_retry_count: "1",
+        }),
+      ]);
+    }
+    expect(
+      retryTimingEvents.filter((event) => {
+        return event.op_type === API_DISPATCH_QUEUE_INSERT_PHASE_ACTION_TYPE;
+      }),
+    ).toHaveLength(1);
     expect(retryTimingEvents).toContainEqual(
       expect.objectContaining({
         op_type: "api_dispatch_resolve_queue_first_admission",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -268,8 +268,15 @@ const RUNNER_CLAIM_POLL_TIMING_ACTION_TYPES = [
   "runner_poll_due_to_job_discovered",
   "runner_poll_http_request",
 ] as const;
+const API_DISPATCH_PHASE_ACTION_TYPES = [
+  "api_dispatch_phase_pre_create",
+  "api_dispatch_phase_prepare_context",
+  "api_dispatch_phase_prepare_launch",
+  "api_dispatch_phase_queue_insert",
+] as const;
 const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_pre_create_agent_run",
+  ...API_DISPATCH_PHASE_ACTION_TYPES,
   "api_dispatch_check_run_admission",
   "api_dispatch_prepare_run_callbacks",
   "api_dispatch_prepare_run_context",
@@ -1451,6 +1458,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     const prompt = "api dispatch timing should not leak prompt";
+    const apiCommitSha = "a".repeat(40);
+    mockEnv("GIT_COMMIT_SHA", apiCommitSha);
 
     const created = await api.createRun(actor, {
       agentId,
@@ -1466,6 +1475,31 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
     expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
+    expectApiDispatchSpanKind(
+      timingEvents,
+      API_DISPATCH_PHASE_ACTION_TYPES,
+      "top_level",
+    );
+    const phaseEvents = API_DISPATCH_PHASE_ACTION_TYPES.map((actionType) => {
+      return singleApiDispatchEvent(timingEvents, actionType);
+    });
+    for (const event of phaseEvents) {
+      expect(event.api_start_source).toBe("request");
+      expect(event.api_commit_sha).toBe(apiCommitSha);
+      expect(event.run_preparation_retry_count).toBe("0");
+      expect(event.duration_ms).toStrictEqual(expect.any(Number));
+      expect(Number(event.duration_ms)).toBeGreaterThanOrEqual(0);
+    }
+    const apiStartedAtIso = await readRunApiStart(context, created.runId);
+    if (apiStartedAtIso === null) {
+      throw new Error("Expected the run to retain its API start time");
+    }
+    let previousBoundaryAt = Date.parse(apiStartedAtIso);
+    for (const event of phaseEvents) {
+      const finishedAt = Date.parse(String(event._time));
+      expect(finishedAt - Number(event.duration_ms)).toBe(previousBoundaryAt);
+      previousBoundaryAt = finishedAt;
+    }
     expectApiDispatchActions(
       timingEvents,
       API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES,
@@ -1480,11 +1514,19 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       acceptedCacheOutcome: "miss",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
-      validation: { outcome: "attested" },
+      validation: {
+        outcome: "full_fallback",
+        fallbackReason: "different_authority",
+      },
     });
-    expectNoApiDispatchActions(
+    expectApiDispatchActions(
       timingEvents,
       API_DISPATCH_CONNECTOR_CATALOG_COMPLETE_VALIDATION_ACTION_TYPES,
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_COMPLETE_VALIDATION_ACTION_TYPES,
+      "nested",
     );
     expectNoApiDispatchActions(timingEvents, ["api_dispatch_check_org_tier"]);
     expectApiDispatchActions(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -276,6 +276,7 @@ import {
 } from "./zero-run-admission.service";
 import { activateUsageAllowanceWindowsForRun } from "./usage-allowance.service";
 import {
+  ApiDispatchPhaseCollector,
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
   type ApiDispatchTimingActionType,
@@ -871,6 +872,16 @@ export interface CreateAgentRunArgs {
   readonly zeroRunModelPin?: ZeroRunModelPin;
   readonly timing?: ApiDispatchTimingCollector;
   readonly timingDimensions?: ApiDispatchTimingDimensions;
+}
+
+function timingDimensionsForCreateArgs(
+  args: CreateAgentRunArgs,
+): ApiDispatchTimingDimensions {
+  return {
+    api_start_source: "request",
+    run_preparation_retry_count: "0",
+    ...args.timingDimensions,
+  };
 }
 
 function assertThreadBoundRunHasQueueAssociation(
@@ -8596,6 +8607,7 @@ function committedAtomicLaunchResponse(args: {
   readonly committed: CommittedAtomicLaunchResult;
   readonly transactionReturnedAt: number;
   readonly timing: ApiDispatchTimingCollector;
+  readonly phaseTiming: ApiDispatchPhaseCollector;
   readonly launch: PreparedRunnerLaunch;
 }): Extract<CreateRunRouteResult, { readonly status: 201 }> {
   if (args.committed.threadSessionBinding) {
@@ -8610,15 +8622,14 @@ function committedAtomicLaunchResponse(args: {
       queueDepth: args.committed.queueDepth,
       timestamp: args.committed.telemetryTimestamp,
     });
+    args.phaseTiming.appendTo(args.timing);
     ingestRunContextSnapshot(args.committed.runContextSnapshot);
     args.timing.flush({
       runId: args.committed.run.id,
       runnerGroup: args.committed.runnerJobPayload.runnerGroup,
       profile: args.committed.runnerJobPayload.profile,
       dispatchPath: "direct",
-      ...(args.createArgs.timingDimensions
-        ? { dimensions: args.createArgs.timingDimensions }
-        : {}),
+      dimensions: timingDimensionsForCreateArgs(args.createArgs),
       ...(args.createArgs.body.triggerSource
         ? { triggerSource: args.createArgs.body.triggerSource }
         : {}),
@@ -8631,6 +8642,11 @@ function committedAtomicLaunchResponse(args: {
       : response;
   }
 
+  args.phaseTiming.checkpoint(
+    "api_dispatch_phase_queue_insert",
+    args.committed.runnerJobCreatedAt.getTime(),
+  );
+  args.phaseTiming.appendTo(args.timing);
   ingestRunContextSnapshot(args.committed.runContextSnapshot);
   const runContextRegisteredAt = now();
   const dispatchedProfile = args.committed.runnerJobPayload.profile;
@@ -8639,9 +8655,7 @@ function committedAtomicLaunchResponse(args: {
     runnerGroup: args.committed.runnerJobPayload.runnerGroup,
     profile: dispatchedProfile,
     dispatchPath: "direct",
-    ...(args.createArgs.timingDimensions
-      ? { dimensions: args.createArgs.timingDimensions }
-      : {}),
+    dimensions: timingDimensionsForCreateArgs(args.createArgs),
     ...(args.createArgs.body.triggerSource
       ? { triggerSource: args.createArgs.body.triggerSource }
       : {}),
@@ -8684,14 +8698,16 @@ function flushQueueFirstClaimLostTiming(args: {
   readonly identity: LaunchRunIdentity;
   readonly launch: PreparedRunnerLaunch;
   readonly timing: ApiDispatchTimingCollector;
+  readonly phaseTiming: ApiDispatchPhaseCollector;
 }): void {
+  args.phaseTiming.appendTo(args.timing);
   args.timing.flush({
     runId: args.identity.runId,
     runnerGroup: args.launch.runnerJobPayload.runnerGroup,
     profile: args.launch.runnerJobPayload.profile,
     dispatchPath: "direct",
     dimensions: {
-      ...args.createArgs.timingDimensions,
+      ...timingDimensionsForCreateArgs(args.createArgs),
       queue_first_launch_outcome: "claim_lost",
     },
     ...(args.createArgs.body.triggerSource
@@ -8705,6 +8721,7 @@ interface AtomicLaunchRunInput {
   readonly args: CreateAgentRunArgs;
   readonly context: PreparedRunContext;
   readonly timing: ApiDispatchTimingCollector;
+  readonly phaseTiming: ApiDispatchPhaseCollector;
 }
 
 function isQueuePayloadRequiredResult(
@@ -8737,6 +8754,7 @@ function finalizeAtomicLaunchCommit(
       identity: args.identity,
       launch: args.launch,
       timing: args.input.timing,
+      phaseTiming: args.input.phaseTiming,
     });
     return committed;
   }
@@ -8751,6 +8769,7 @@ function finalizeAtomicLaunchCommit(
     committed,
     transactionReturnedAt: args.committed.transactionReturnedAt,
     timing: args.input.timing,
+    phaseTiming: args.input.phaseTiming,
     launch: args.launch,
   });
 }
@@ -8883,6 +8902,7 @@ function createAtomicLaunchRun(
     }
 
     const launch = launchResult.value;
+    input.phaseTiming.checkpoint("api_dispatch_phase_prepare_launch", now());
 
     const commitLaunch: CommitAtomicLaunch = async (
       encryptedQueuedParams: string | undefined,
@@ -8935,11 +8955,13 @@ interface PreparedAgentRun {
   readonly args: CreateAgentRunArgs;
   readonly context: PreparedRunContext;
   readonly timing: ApiDispatchTimingCollector;
+  readonly phaseTiming: ApiDispatchPhaseCollector;
 }
 
 interface PrepareAgentRunArgs {
   readonly args: CreateAgentRunArgs;
   readonly timing: ApiDispatchTimingCollector;
+  readonly phaseTiming: ApiDispatchPhaseCollector;
   readonly checkOrgPlanStatusBeforeContext: boolean;
   readonly preloadedFeatureSwitchContext?: FeatureSwitchContext;
   // Undefined means not preloaded; null is an authoritative missing value.
@@ -9034,7 +9056,8 @@ export const prepareAgentRun$ = command(
       return context;
     }
 
-    return { args, context, timing };
+    input.phaseTiming.checkpoint("api_dispatch_phase_prepare_context", now());
+    return { args, context, timing, phaseTiming: input.phaseTiming };
   },
 );
 
@@ -9089,6 +9112,7 @@ export const completeAgentRun$ = command(
           args,
           context,
           timing,
+          phaseTiming: input.prepared.phaseTiming,
         },
         signal,
       ),
@@ -9131,14 +9155,21 @@ export const createAgentRun$ = command(
     signal: AbortSignal,
   ): Promise<CreateRunRouteResult> => {
     const timing = args.timing ?? new ApiDispatchTimingCollector();
+    const phaseTiming = new ApiDispatchPhaseCollector(args.apiStartTime);
     timing.recordElapsed(
       "api_dispatch_pre_create_agent_run",
       "top_level",
       args.apiStartTime,
     );
+    phaseTiming.checkpoint("api_dispatch_phase_pre_create", now());
     const prepared = await set(
       prepareAgentRun$,
-      { args, timing, checkOrgPlanStatusBeforeContext: true },
+      {
+        args,
+        timing,
+        phaseTiming,
+        checkOrgPlanStatusBeforeContext: true,
+      },
       signal,
     );
     if (isRouteError(prepared)) {

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -2,6 +2,8 @@ import { performance } from "node:perf_hooks";
 
 import type { TriggerSource } from "@okouai/api-contracts/contracts/logs";
 
+import { env } from "../../lib/env";
+import { normalizeBuildCommitSha } from "../../lib/build-info";
 import { now } from "../../lib/time";
 import { recordSandboxOperations } from "../external/sandbox-op-log";
 import { safeSync } from "../utils";
@@ -189,7 +191,56 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_connector_catalog_validate_compatibility"
   | "api_dispatch_connector_catalog_materialize_accepted_snapshot"
   | "api_dispatch_connector_catalog_materialize_runtime_snapshot"
-  | "api_dispatch_connector_catalog_materialize_server_firewalls";
+  | "api_dispatch_connector_catalog_materialize_server_firewalls"
+  | "api_dispatch_phase_pre_create"
+  | "api_dispatch_phase_prepare_context"
+  | "api_dispatch_phase_prepare_launch"
+  | "api_dispatch_phase_queue_insert";
+
+type ApiDispatchPhaseActionType =
+  | "api_dispatch_phase_pre_create"
+  | "api_dispatch_phase_prepare_context"
+  | "api_dispatch_phase_prepare_launch"
+  | "api_dispatch_phase_queue_insert";
+
+interface ApiDispatchPhaseRecord {
+  readonly actionType: ApiDispatchPhaseActionType;
+  readonly startedAt: number;
+  readonly finishedAt: number;
+}
+
+export class ApiDispatchPhaseCollector {
+  private readonly records: ApiDispatchPhaseRecord[] = [];
+  private previousBoundaryAt: number;
+
+  constructor(startedAt: number) {
+    this.previousBoundaryAt = startedAt;
+  }
+
+  checkpoint(
+    actionType: ApiDispatchPhaseActionType,
+    finishedAt: number = now(),
+  ): void {
+    const boundedFinishedAt = Math.max(this.previousBoundaryAt, finishedAt);
+    this.records.push({
+      actionType,
+      startedAt: this.previousBoundaryAt,
+      finishedAt: boundedFinishedAt,
+    });
+    this.previousBoundaryAt = boundedFinishedAt;
+  }
+
+  appendTo(timing: ApiDispatchTimingCollector): void {
+    for (const record of this.records.splice(0)) {
+      timing.recordElapsed(
+        record.actionType,
+        "top_level",
+        record.startedAt,
+        record.finishedAt,
+      );
+    }
+  }
+}
 
 interface ApiDispatchTimingRecord {
   readonly actionType: ApiDispatchTimingActionType;
@@ -284,6 +335,7 @@ export class ApiDispatchTimingCollector {
     readonly dimensions?: ApiDispatchTimingDimensions;
   }): void {
     const records = this.records.splice(0);
+    const apiCommitSha = normalizeBuildCommitSha(env("GIT_COMMIT_SHA"));
     recordSandboxOperations(
       records.map((record) => {
         return {
@@ -300,6 +352,7 @@ export class ApiDispatchTimingCollector {
             profile: args.profile,
             dispatch_path: args.dispatchPath,
             span_kind: record.spanKind,
+            ...(apiCommitSha ? { api_commit_sha: apiCommitSha } : {}),
             ...(args.triggerSource
               ? { trigger_source: args.triggerSource }
               : {}),

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -21,6 +21,7 @@ import type { z } from "zod";
 
 import { env } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
+import { now } from "../../lib/time";
 import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import {
@@ -40,6 +41,7 @@ import {
   type ChatThreadSessionRoute,
 } from "./chat-session-continuity.service";
 import {
+  ApiDispatchPhaseCollector,
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
   type ApiDispatchTimingActionType,
@@ -533,10 +535,16 @@ function buildZeroRunExtraEnvironment(args: {
 
 function zeroRunTimingDimensions(args: {
   readonly origin: ZeroRunOrigin;
+  readonly command: AnyCreateZeroRunCommandArgs;
   readonly source?: ZeroPreCreateSource;
 }): ApiDispatchTimingDimensions {
+  const apiStartSource =
+    "queueFirstAssociation" in args.command
+      ? args.command.queueFirstAssociation.kind
+      : "request";
   return {
     zero_run_origin: args.origin,
+    api_start_source: apiStartSource,
     ...(args.source ? { zero_pre_create_source: args.source } : {}),
   };
 }
@@ -847,6 +855,7 @@ function buildZeroCreateAgentRunArgs(args: {
       origin: zeroRunOrigin({
         command,
       }),
+      command,
       source: command.zeroPreCreateSource,
     }),
   };
@@ -935,7 +944,7 @@ const createAgentRunAfterZeroPreCreate$ = command(
     ) {
       const attemptInput = await resolveThreadSessionForZeroRun(db, input);
       signal.throwIfAborted();
-      const createAgentRunArgs = await measureZeroPreCreate(
+      const baseCreateAgentRunArgs = await measureZeroPreCreate(
         input.timing,
         "api_dispatch_pre_create_zero_build_create_run_args",
         () => {
@@ -943,16 +952,28 @@ const createAgentRunAfterZeroPreCreate$ = command(
         },
       );
       signal.throwIfAborted();
+      const createAgentRunArgs: CreateAgentRunArgs = {
+        ...baseCreateAgentRunArgs,
+        timingDimensions: {
+          ...baseCreateAgentRunArgs.timingDimensions,
+          run_preparation_retry_count: String(attempt),
+        },
+      };
+      const phaseTiming = new ApiDispatchPhaseCollector(
+        input.command.apiStartTime,
+      );
       input.timing.recordElapsed(
         "api_dispatch_pre_create_agent_run",
         "top_level",
         input.command.apiStartTime,
       );
+      phaseTiming.checkpoint("api_dispatch_phase_pre_create", now());
       const preparedAgentRun = await set(
         prepareAgentRun$,
         {
           args: createAgentRunArgs,
           timing: input.timing,
+          phaseTiming,
           checkOrgPlanStatusBeforeContext: false,
           preloadedFeatureSwitchContext: input.featureSwitchContext,
           preloadedUserTimezone: input.userInfo.timezone,


### PR DESCRIPTION
## Summary

- Add normalized `api_commit_sha`, bounded `api_start_source`, and preparation-retry dimensions to API dispatch telemetry.
- Attribute the API start-to-runner-queue boundary with four additive, non-overlapping phases: pre-create, context preparation, launch preparation, and queue insertion.
- Thread attempt-local phase timing through direct, Zero, queue-first retry, and claim-lost paths. A queue-insertion phase is emitted only when a runner-job row was persisted.
- Add integration coverage for phase arithmetic, build identity, source dimensions, retry isolation, claim-lost behavior, non-negative durations, and redaction.

## Behavior and compatibility

- Run admission, queue ownership, persistence, cancellation, payloads, and runner protocols are unchanged.
- Existing timing actions and dimensions remain available; the new fields and actions are additive.
- Telemetry is flushed through the existing best-effort path. Malformed build identities are omitted.
- For analysis, select a fixed API commit and runner deployment/artifact window, join phase and queue events by `run_id`, and use `run_preparation_retry_count = "0"` for the baseline. Failure counts must come from durable run/queue outcomes; missing telemetry is not success.

Closes #27426

Parent context: #24203

## Validation

- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1 --silent=passed-only` (256 passed)
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm knip --workspace api`
- `cd turbo && pnpm format`
- `cd turbo && pnpm -F api build`
- Commit hooks: `cd turbo && pnpm check-types` (14 tasks passed)
