### PR TITLE
refactor(chat): neutralize chat search service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -26,7 +26,7 @@ import {
   zeroChatThreadDraftIds,
   zeroChatThreadUnreads,
 } from "../services/zero-chat-thread.service";
-import { zeroChatSearch } from "../services/zero-chat-search.service";
+import { chatSearch } from "../services/chat-search.service";
 import {
   zeroChatThreadEventRows,
   zeroChatThreadEventSnapshot,
@@ -297,7 +297,7 @@ const searchChatInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const query = get(queryOf(chatSearchContract.search));
   const result = await get(
-    zeroChatSearch({
+    chatSearch({
       userId: auth.userId,
       orgId: auth.orgId,
       keyword: query.keyword,

--- a/turbo/apps/api/src/signals/services/chat-search.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-search.service.ts
@@ -284,7 +284,7 @@ async function loadChatSearchContexts(
   return contextsByMessageId;
 }
 
-export function zeroChatSearch(args: {
+export function chatSearch(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly keyword: string;


### PR DESCRIPTION
## Summary

- rename the internal chat search service to a domain-neutral path
- rename the exported search function and update its sole route caller atomically
- preserve the route, SQL, ranking, pagination, context expansion, and API behavior without a compatibility bridge

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/chat-search.service.ts apps/api/src/signals/routes/zero-chat-threads.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm --filter api run check-types`
- `pnpm knip --workspace api`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-search-reader.test.ts` (2 passed)
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test_chat_bdd_27435 pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'serves index-backed keyword search from the projection by default'` (1 passed)

## Local baseline note

The broader `CHAT-01 chat search` filter ran eight focused cases locally: four passed and four failed. The same four failures reproduced on an unmodified `origin/main` worktree at `926d572bfd86513e6bab8e7de8bc1c047b6a23ce` with a separately migrated database: two millisecond-level `since` boundary assertions and two existing runner-queue 404 assertions. No test or runtime behavior was changed for those baseline failures.

Closes #27435
