### PR TITLE
refactor(workflows): neutralize workflow deletion service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflows.ts
@@ -43,7 +43,7 @@ import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { requireAgentPermission } from "../../lib/require-agent-permission";
 import { uploadVolumeServerSide$ } from "../services/storage-volume-upload.service";
-import { deleteZeroWorkflow$ } from "../services/zero-workflow-delete.service";
+import { deleteWorkflow$ } from "../services/workflow-delete.service";
 import { zeroWorkflowDetail } from "../services/zero-workflow-detail.service";
 import {
   ensureWorkflowUserAutomationThread,
@@ -693,7 +693,7 @@ const deleteWorkflowInner$ = command(
     }
 
     const deleted = await set(
-      deleteZeroWorkflow$,
+      deleteWorkflow$,
       { orgId: auth.orgId, workflowId: params.workflowId },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/workflow-delete.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-delete.service.ts
@@ -12,15 +12,15 @@ import { writeDb$ } from "../external/db";
 import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
 import { reconcileAutomationEventWatches } from "./automation-event-watch-lifecycle.service";
 
-interface DeleteZeroWorkflowInput {
+interface DeleteWorkflowInput {
   readonly orgId: string;
   readonly workflowId: string;
 }
 
-export const deleteZeroWorkflow$ = command(
+export const deleteWorkflow$ = command(
   async (
     { get, set },
-    args: DeleteZeroWorkflowInput,
+    args: DeleteWorkflowInput,
     signal: AbortSignal,
   ): Promise<boolean> => {
     const writeDb = set(writeDb$);


### PR DESCRIPTION
## Summary

- rename the workflow deletion service to the domain-neutral path
- rename only the contracted input and command declarations and update their sole route caller
- preserve workflow deletion behavior and remove the old path without a compatibility alias

## Verification

- `pnpm exec prettier --check apps/api/src/signals/routes/zero-workflows.ts apps/api/src/signals/services/workflow-delete.service.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm knip`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-workflows.test.ts -t 'reads and updates workflow content, audit metadata, and deletion through API responses'`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-workflow-automation-scheduler.test.ts -t 'preserves run messages when workflow deletion removes automation provenance'`
- verified all 22 open PRs and 533 paginated changed files have no overlap with the service or route caller
- verified the normalized old service and renamed service have identical SHA-256 content

Closes #27443
