### PR TITLE
refactor(billing): neutralize invoice service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-billing-invoices.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-invoices.ts
@@ -5,9 +5,9 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { queryOf } from "../context/request";
 import {
-  downloadZeroOrgReceiptArchive$,
-  zeroOrgInvoices,
-} from "../services/zero-billing-invoices.service";
+  downloadOrgReceiptArchive$,
+  orgInvoices,
+} from "../services/billing-invoices.service";
 import type { RouteEntry } from "../route-entry";
 
 const adminRequired = Object.freeze({
@@ -25,7 +25,7 @@ const getInvoicesInner$ = computed(async (get) => {
   if (auth.orgRole !== "admin") {
     return adminRequired;
   }
-  const invoices = await get(zeroOrgInvoices(auth.orgId));
+  const invoices = await get(orgInvoices(auth.orgId));
   return { status: 200 as const, body: invoices };
 });
 
@@ -37,7 +37,7 @@ const downloadReceiptsInner$ = command(
     }
     const query = get(queryOf(zeroBillingInvoicesContract.downloadReceipts));
     const result = await set(
-      downloadZeroOrgReceiptArchive$,
+      downloadOrgReceiptArchive$,
       {
         orgId: auth.orgId,
         startMonth: query.startMonth,

--- a/turbo/apps/api/src/signals/services/billing-invoices.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-invoices.service.ts
@@ -172,7 +172,7 @@ async function assembleReceiptArchive(
   return await Promise.race([done.promise, finalized]);
 }
 
-export function zeroOrgInvoices(
+export function orgInvoices(
   orgId: string,
 ): Computed<Promise<BillingInvoicesResponse>> {
   return computed(async (get): Promise<BillingInvoicesResponse> => {
@@ -206,7 +206,7 @@ export function zeroOrgInvoices(
   });
 }
 
-export const downloadZeroOrgReceiptArchive$ = command(
+export const downloadOrgReceiptArchive$ = command(
   async (
     { get },
     args: {


### PR DESCRIPTION
## Summary

- rename the internal billing invoice service to `billing-invoices.service.ts`
- rename `zeroOrgInvoices` and `downloadZeroOrgReceiptArchive$` to their issue-specified neutral declarations
- update the existing `routes/zero-billing-invoices.ts` caller while preserving the route module, `contracts/zero-billing` imports, and runtime behavior

## Verification

- `pnpm exec prettier --check apps/api/src/signals/routes/zero-billing-invoices.ts apps/api/src/signals/services/billing-invoices.service.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm knip`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-billing-invoices.test.ts` (9 tests passed)
- repeated the repository-wide path and identifier caller search and paginated every file from all 21 open pull requests; no owned service or route overlap was found
- verified the service body differs only by the two approved declaration substitutions, with no residual old path, old identifiers, or compatibility aliases

Closes #27444
