### PR TITLE
perf(runner): attribute sandbox telemetry by runner name

### DIFF
--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -208,8 +208,12 @@ impl ExecutorInvocation {
                 // Panic lost the in-flight telemetry buffer; substitute an
                 // empty collector so the post-complete flush path stays
                 // unconditional. `flush` early-returns on empty pending_ops.
-                let telemetry =
-                    JobTelemetry::new(exec_config_for_panic.http.clone(), run_id, sandbox_token);
+                let telemetry = JobTelemetry::new_with_runner_name(
+                    exec_config_for_panic.http.clone(),
+                    run_id,
+                    sandbox_token,
+                    Some(exec_config_for_panic.runner_name.clone()),
+                );
                 let failure =
                     executor::ExecutionFailure::from_error(format!("executor task panicked: {e}"));
                 let exit_code = failure.exit_code;

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -208,11 +208,11 @@ impl ExecutorInvocation {
                 // Panic lost the in-flight telemetry buffer; substitute an
                 // empty collector so the post-complete flush path stays
                 // unconditional. `flush` early-returns on empty pending_ops.
-                let telemetry = JobTelemetry::new_with_runner_name(
+                let telemetry = JobTelemetry::new(
                     exec_config_for_panic.http.clone(),
                     run_id,
                     sandbox_token,
-                    Some(exec_config_for_panic.runner_name.clone()),
+                    exec_config_for_panic.runner_name.clone(),
                 );
                 let failure =
                     executor::ExecutionFailure::from_error(format!("executor task panicked: {e}"));
@@ -1032,7 +1032,12 @@ mod tests {
             },
             exit_code: 0,
             err: None,
-            telemetry: JobTelemetry::new(test_http_client(), run_id, "sandbox-token".into()),
+            telemetry: JobTelemetry::new(
+                test_http_client(),
+                run_id,
+                "sandbox-token".into(),
+                "test-runner".into(),
+            ),
         }
     }
 
@@ -1052,7 +1057,12 @@ mod tests {
             },
             exit_code: 1,
             err: Some("sandbox unavailable".into()),
-            telemetry: JobTelemetry::new(test_http_client(), run_id, "sandbox-token".into()),
+            telemetry: JobTelemetry::new(
+                test_http_client(),
+                run_id,
+                "sandbox-token".into(),
+                "test-runner".into(),
+            ),
         }
     }
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -744,6 +744,7 @@ async fn run_start_with_home(
 
     let exec_config = Arc::new(ExecutorConfig {
         api_url: server.url,
+        runner_name: name.clone(),
         registry: registry_handle,
         http,
         log_paths,

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -258,6 +258,7 @@ fn build_mock_run_config_with_runtime(
         },
         exec_config: Arc::new(executor::ExecutorConfig {
             api_url: api_url.to_string(),
+            runner_name: "test-runner".to_string(),
             registry,
             http: crate::http::HttpClient::new(crate::http::HttpClientConfig {
                 api_url: api_url.to_string(),

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -600,11 +600,11 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     } = hooks;
     let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
     let run_id = context.run_id;
-    let mut telemetry = JobTelemetry::new_with_runner_name(
+    let mut telemetry = JobTelemetry::new(
         config.http.clone(),
         run_id,
         context.sandbox_token.clone(),
-        Some(config.runner_name.clone()),
+        config.runner_name.clone(),
     );
     spawn_timing.record_claim_to_executor_start(&mut telemetry);
 
@@ -708,11 +708,11 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     } = hooks;
     let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
     let run_id = context.run_id;
-    let mut telemetry = JobTelemetry::new_with_runner_name(
+    let mut telemetry = JobTelemetry::new(
         config.http.clone(),
         run_id,
         context.sandbox_token.clone(),
-        Some(config.runner_name.clone()),
+        config.runner_name.clone(),
     );
     spawn_timing.record_claim_to_executor_start(&mut telemetry);
 

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -187,6 +187,7 @@ fn guest_runtime_path(
 /// Shared configuration for all executions (profile-independent).
 pub struct ExecutorConfig {
     pub api_url: String,
+    pub runner_name: String,
     pub registry: ProxyRegistryHandle,
     pub http: HttpClient,
     pub log_paths: LogPaths,
@@ -599,8 +600,12 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     } = hooks;
     let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
     let run_id = context.run_id;
-    let mut telemetry =
-        JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
+    let mut telemetry = JobTelemetry::new_with_runner_name(
+        config.http.clone(),
+        run_id,
+        context.sandbox_token.clone(),
+        Some(config.runner_name.clone()),
+    );
     spawn_timing.record_claim_to_executor_start(&mut telemetry);
 
     record_reuse_result(&mut telemetry, dispatch.reuse_result);
@@ -703,8 +708,12 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     } = hooks;
     let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
     let run_id = context.run_id;
-    let mut telemetry =
-        JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
+    let mut telemetry = JobTelemetry::new_with_runner_name(
+        config.http.clone(),
+        run_id,
+        context.sandbox_token.clone(),
+        Some(config.runner_name.clone()),
+    );
     spawn_timing.record_claim_to_executor_start(&mut telemetry);
 
     record_reuse_result(&mut telemetry, SandboxReuseResult::Reused);

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -25,6 +25,7 @@ pub(in crate::executor::tests) async fn test_executor_config(dir: &Path) -> Exec
 
     ExecutorConfig {
         api_url: "http://localhost:9999".into(),
+        runner_name: "test-runner".into(),
         registry: proxy::ProxyRegistryHandle::new(registry_path, lock_path),
         http: crate::http::HttpClient::new(HttpClientConfig {
             api_url: "http://localhost:9999".into(),
@@ -115,7 +116,12 @@ pub(in crate::executor::tests) fn test_telemetry(
     config: &ExecutorConfig,
     ctx: &ExecutionContext,
 ) -> JobTelemetry {
-    crate::telemetry::JobTelemetry::new(config.http.clone(), ctx.run_id, ctx.sandbox_token.clone())
+    crate::telemetry::JobTelemetry::new_with_runner_name(
+        config.http.clone(),
+        ctx.run_id,
+        ctx.sandbox_token.clone(),
+        Some(config.runner_name.clone()),
+    )
 }
 
 pub(in crate::executor::tests) async fn assert_proxy_registry_empty(dir: &Path) {

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -116,11 +116,11 @@ pub(in crate::executor::tests) fn test_telemetry(
     config: &ExecutorConfig,
     ctx: &ExecutionContext,
 ) -> JobTelemetry {
-    crate::telemetry::JobTelemetry::new_with_runner_name(
+    crate::telemetry::JobTelemetry::new(
         config.http.clone(),
         ctx.run_id,
         ctx.sandbox_token.clone(),
-        Some(config.runner_name.clone()),
+        config.runner_name.clone(),
     )
 }
 

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -101,7 +101,12 @@ fn new_telemetry() -> JobTelemetry {
         client_session_id: "runner-session-test".to_string(),
     })
     .unwrap();
-    JobTelemetry::new(http, RunId::nil(), "tok".to_string())
+    JobTelemetry::new(
+        http,
+        RunId::nil(),
+        "tok".to_string(),
+        "test-runner".to_string(),
+    )
 }
 
 fn assert_has_action(telemetry: &JobTelemetry, action: &str) {

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3302,7 +3302,12 @@ mod tests {
             client_session_id: "runner-session-test".to_string(),
         })
         .unwrap();
-        JobTelemetry::new(http, RunId::nil(), "test-token".to_string())
+        JobTelemetry::new(
+            http,
+            RunId::nil(),
+            "test-token".to_string(),
+            "test-runner".to_string(),
+        )
     }
 
     fn assert_op(ops: &[(String, bool, Option<String>)], action_type: &str, success: bool) {

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -43,7 +43,7 @@ pub struct JobTelemetry {
     http: HttpClient,
     run_id: RunId,
     sandbox_token: String,
-    runner_name: Option<String>,
+    runner_name: String,
     pending_ops: Vec<SandboxOp>,
     oldest_pending: Option<Instant>,
     in_flight_flushes: Vec<JoinHandle<()>>,
@@ -69,24 +69,19 @@ struct SandboxOp {
 #[serde(rename_all = "camelCase")]
 struct TelemetryPayload {
     run_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    runner_name: Option<String>,
+    runner_name: String,
     sandbox_operations: Vec<SandboxOp>,
 }
 
 impl JobTelemetry {
-    /// Create a new per-job telemetry collector.
-    #[cfg(test)]
-    pub fn new(http: HttpClient, run_id: RunId, sandbox_token: String) -> Self {
-        Self::new_with_runner_name(http, run_id, sandbox_token, None)
-    }
-
-    /// Create a per-job telemetry collector with the runner identity that owns the job.
-    pub(crate) fn new_with_runner_name(
+    /// Create a per-job telemetry collector for the runner that owns the job.
+    ///
+    /// Requiring the name here ensures every payload emitted by a current runner is attributable.
+    pub(crate) fn new(
         http: HttpClient,
         run_id: RunId,
         sandbox_token: String,
-        runner_name: Option<String>,
+        runner_name: String,
     ) -> Self {
         Self {
             http,
@@ -297,7 +292,7 @@ pub(crate) struct SandboxOpReporter {
     http: HttpClient,
     run_id: RunId,
     sandbox_token: String,
-    runner_name: Option<String>,
+    runner_name: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -408,7 +403,7 @@ async fn send_telemetry(
     http: &HttpClient,
     run_id: RunId,
     sandbox_token: &str,
-    runner_name: Option<String>,
+    runner_name: String,
     ops: Vec<SandboxOp>,
 ) {
     if ops.is_empty() {
@@ -541,7 +536,12 @@ mod tests {
 
     #[test]
     fn api_to_spawn_serializes_bounded_startup_metadata() {
-        let mut telemetry = JobTelemetry::new(http_client(), RunId::nil(), "tok".to_string());
+        let mut telemetry = JobTelemetry::new(
+            http_client(),
+            RunId::nil(),
+            "tok".to_string(),
+            "test-runner".to_string(),
+        );
         telemetry.record_api_to_spawn(
             Duration::from_millis(125),
             RunnerStartupPath::Workspace,
@@ -572,7 +572,7 @@ mod tests {
             ));
         let payload = TelemetryPayload {
             run_id: "abc-123".to_string(),
-            runner_name: None,
+            runner_name: "test-runner".to_string(),
             sandbox_operations: vec![SandboxOp {
                 ts: "2026-01-15T10:00:00+00:00".to_string(),
                 action_type: "test".to_string(),
@@ -589,6 +589,7 @@ mod tests {
             json,
             serde_json::json!({
                 "runId": "abc-123",
+                "runnerName": "test-runner",
                 "sandboxOperations": [{
                     "ts": "2026-01-15T10:00:00+00:00",
                     "action_type": "test",
@@ -610,10 +611,10 @@ mod tests {
     }
 
     #[test]
-    fn telemetry_payload_includes_runner_name_when_configured() {
+    fn telemetry_payload_includes_required_runner_name() {
         let payload = TelemetryPayload {
             run_id: "abc-123".to_string(),
-            runner_name: Some("v0.168.14".to_string()),
+            runner_name: "v0.168.14".to_string(),
             sandbox_operations: vec![],
         };
 
@@ -630,7 +631,12 @@ mod tests {
     #[test]
     fn new_creates_empty_telemetry() {
         let http = http_client();
-        let telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
+        let telemetry = JobTelemetry::new(
+            http,
+            RunId::nil(),
+            "tok".to_string(),
+            "test-runner".to_string(),
+        );
         assert!(telemetry.pending_ops.is_empty());
         assert!(telemetry.oldest_pending.is_none());
         assert!(telemetry.in_flight_flushes.is_empty());
@@ -639,7 +645,12 @@ mod tests {
     #[test]
     fn record_buffers_ops() {
         let http = http_client();
-        let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
+        let mut telemetry = JobTelemetry::new(
+            http,
+            RunId::nil(),
+            "tok".to_string(),
+            "test-runner".to_string(),
+        );
 
         telemetry.record("vm_create", Duration::from_millis(500), true, None);
         telemetry.record(
@@ -663,7 +674,12 @@ mod tests {
     #[test]
     fn record_with_session_history_metadata_buffers_low_cardinality_buckets() {
         let http = http_client();
-        let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
+        let mut telemetry = JobTelemetry::new(
+            http,
+            RunId::nil(),
+            "tok".to_string(),
+            "test-runner".to_string(),
+        );
         let metadata = session_history_metadata()
             .with_cache_probe(SessionHistoryCacheProbeMetadata::new(false, true))
             .with_response(SessionHistoryResponseTelemetryMetadata::new(
@@ -694,7 +710,12 @@ mod tests {
     #[test]
     fn record_saturates_large_duration() {
         let http = http_client();
-        let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
+        let mut telemetry = JobTelemetry::new(
+            http,
+            RunId::nil(),
+            "tok".to_string(),
+            "test-runner".to_string(),
+        );
 
         telemetry.record("huge_op", Duration::MAX, true, None);
 
@@ -705,7 +726,12 @@ mod tests {
     #[tokio::test]
     async fn record_within_threshold_does_not_flush() {
         let http = http_client();
-        let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
+        let mut telemetry = JobTelemetry::new(
+            http,
+            RunId::nil(),
+            "tok".to_string(),
+            "test-runner".to_string(),
+        );
 
         telemetry.record("op1", Duration::from_millis(10), true, None);
         telemetry.record("op2", Duration::from_millis(10), true, None);
@@ -731,11 +757,11 @@ mod tests {
                     .body(r#"{"success":true,"id":"ok"}"#);
             })
             .await;
-        let mut telemetry = JobTelemetry::new_with_runner_name(
+        let mut telemetry = JobTelemetry::new(
             http_client_for_api_url(&server.base_url()),
             RunId::nil(),
             "tok".to_string(),
-            Some("v0.168.14".to_string()),
+            "v0.168.14".to_string(),
         );
         let completed_at = DateTime::parse_from_rfc3339("2026-08-11T10:20:30.456Z")
             .unwrap()
@@ -756,7 +782,12 @@ mod tests {
     #[tokio::test]
     async fn auto_flush_triggers_after_threshold() {
         let http = http_client();
-        let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
+        let mut telemetry = JobTelemetry::new(
+            http,
+            RunId::nil(),
+            "tok".to_string(),
+            "test-runner".to_string(),
+        );
 
         telemetry.record("op1", Duration::from_millis(10), true, None);
         assert_eq!(telemetry.pending_ops_snapshot().len(), 1);
@@ -810,11 +841,11 @@ mod tests {
         });
 
         let http = http_client_for_api_url(&api_url);
-        let mut telemetry = JobTelemetry::new_with_runner_name(
+        let mut telemetry = JobTelemetry::new(
             http,
             RunId::nil(),
             "tok".to_string(),
-            Some("v0.168.14".to_string()),
+            "v0.168.14".to_string(),
         );
 
         telemetry.record("op1", Duration::from_millis(10), true, None);
@@ -884,6 +915,7 @@ mod tests {
             http_client_for_api_url(&api_url),
             RunId::nil(),
             "tok".to_string(),
+            "test-runner".to_string(),
         );
         let reporter = telemetry.reporter();
 
@@ -913,7 +945,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn configured_runner_name_is_sent_by_direct_reporter() {
+    async fn required_runner_name_is_sent_by_direct_reporter() {
         use tokio::io::AsyncWriteExt;
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -938,11 +970,11 @@ mod tests {
             request
         });
 
-        let telemetry = JobTelemetry::new_with_runner_name(
+        let telemetry = JobTelemetry::new(
             http_client_for_api_url(&api_url),
             RunId::nil(),
             "tok".to_string(),
-            Some("v0.168.14".to_string()),
+            "v0.168.14".to_string(),
         );
         telemetry
             .reporter()

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -43,6 +43,7 @@ pub struct JobTelemetry {
     http: HttpClient,
     run_id: RunId,
     sandbox_token: String,
+    runner_name: Option<String>,
     pending_ops: Vec<SandboxOp>,
     oldest_pending: Option<Instant>,
     in_flight_flushes: Vec<JoinHandle<()>>,
@@ -68,16 +69,30 @@ struct SandboxOp {
 #[serde(rename_all = "camelCase")]
 struct TelemetryPayload {
     run_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runner_name: Option<String>,
     sandbox_operations: Vec<SandboxOp>,
 }
 
 impl JobTelemetry {
     /// Create a new per-job telemetry collector.
+    #[cfg(test)]
     pub fn new(http: HttpClient, run_id: RunId, sandbox_token: String) -> Self {
+        Self::new_with_runner_name(http, run_id, sandbox_token, None)
+    }
+
+    /// Create a per-job telemetry collector with the runner identity that owns the job.
+    pub(crate) fn new_with_runner_name(
+        http: HttpClient,
+        run_id: RunId,
+        sandbox_token: String,
+        runner_name: Option<String>,
+    ) -> Self {
         Self {
             http,
             run_id,
             sandbox_token,
+            runner_name,
             pending_ops: Vec::new(),
             oldest_pending: None,
             in_flight_flushes: Vec::new(),
@@ -148,6 +163,7 @@ impl JobTelemetry {
             http: self.http.clone(),
             run_id: self.run_id,
             sandbox_token: self.sandbox_token.clone(),
+            runner_name: self.runner_name.clone(),
         }
     }
 
@@ -184,9 +200,10 @@ impl JobTelemetry {
         let ops = std::mem::take(&mut self.pending_ops);
         let in_flight_flushes = std::mem::take(&mut self.in_flight_flushes);
         let run_id = self.run_id;
+        let runner_name = self.runner_name.clone();
 
         tokio::join!(
-            send_telemetry(&self.http, run_id, &self.sandbox_token, ops),
+            send_telemetry(&self.http, run_id, &self.sandbox_token, runner_name, ops,),
             drain_in_flight_flushes(run_id, in_flight_flushes),
         );
     }
@@ -266,9 +283,10 @@ impl JobTelemetry {
         let http = self.http.clone();
         let run_id = self.run_id;
         let sandbox_token = self.sandbox_token.clone();
+        let runner_name = self.runner_name.clone();
 
         let handle = tokio::spawn(async move {
-            send_telemetry(&http, run_id, &sandbox_token, ops).await;
+            send_telemetry(&http, run_id, &sandbox_token, runner_name, ops).await;
         });
         self.in_flight_flushes.push(handle);
     }
@@ -279,6 +297,7 @@ pub(crate) struct SandboxOpReporter {
     http: HttpClient,
     run_id: RunId,
     sandbox_token: String,
+    runner_name: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -319,7 +338,14 @@ impl SandboxOpReporter {
                 )
             })
             .collect();
-        send_telemetry(&self.http, self.run_id, &self.sandbox_token, ops).await;
+        send_telemetry(
+            &self.http,
+            self.run_id,
+            &self.sandbox_token,
+            self.runner_name.clone(),
+            ops,
+        )
+        .await;
     }
 }
 
@@ -382,6 +408,7 @@ async fn send_telemetry(
     http: &HttpClient,
     run_id: RunId,
     sandbox_token: &str,
+    runner_name: Option<String>,
     ops: Vec<SandboxOp>,
 ) {
     if ops.is_empty() {
@@ -390,6 +417,7 @@ async fn send_telemetry(
 
     let payload = TelemetryPayload {
         run_id: run_id.to_string(),
+        runner_name,
         sandbox_operations: ops,
     };
 
@@ -544,6 +572,7 @@ mod tests {
             ));
         let payload = TelemetryPayload {
             run_id: "abc-123".to_string(),
+            runner_name: None,
             sandbox_operations: vec![SandboxOp {
                 ts: "2026-01-15T10:00:00+00:00".to_string(),
                 action_type: "test".to_string(),
@@ -576,6 +605,24 @@ mod tests {
                     "session_history_transfer_encoding_state": "absent",
                     "session_history_download_source": "configured_public_endpoint",
                 }],
+            })
+        );
+    }
+
+    #[test]
+    fn telemetry_payload_includes_runner_name_when_configured() {
+        let payload = TelemetryPayload {
+            run_id: "abc-123".to_string(),
+            runner_name: Some("v0.168.14".to_string()),
+            sandbox_operations: vec![],
+        };
+
+        assert_eq!(
+            serde_json::to_value(&payload).unwrap(),
+            serde_json::json!({
+                "runId": "abc-123",
+                "runnerName": "v0.168.14",
+                "sandboxOperations": [],
             })
         );
     }
@@ -677,16 +724,18 @@ mod tests {
                 when.method(POST)
                     .path("/api/webhooks/agent/telemetry")
                     .body_includes(r#""ts":"2026-08-11T10:20:30.456Z""#)
-                    .body_includes(r#""action_type":"concurrent_operation""#);
+                    .body_includes(r#""action_type":"concurrent_operation""#)
+                    .body_includes(r#""runnerName":"v0.168.14""#);
                 then.status(200)
                     .header("content-type", "application/json")
                     .body(r#"{"success":true,"id":"ok"}"#);
             })
             .await;
-        let mut telemetry = JobTelemetry::new(
+        let mut telemetry = JobTelemetry::new_with_runner_name(
             http_client_for_api_url(&server.base_url()),
             RunId::nil(),
             "tok".to_string(),
+            Some("v0.168.14".to_string()),
         );
         let completed_at = DateTime::parse_from_rfc3339("2026-08-11T10:20:30.456Z")
             .unwrap()
@@ -761,7 +810,12 @@ mod tests {
         });
 
         let http = http_client_for_api_url(&api_url);
-        let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
+        let mut telemetry = JobTelemetry::new_with_runner_name(
+            http,
+            RunId::nil(),
+            "tok".to_string(),
+            Some("v0.168.14".to_string()),
+        );
 
         telemetry.record("op1", Duration::from_millis(10), true, None);
         telemetry.rewind_oldest_pending_for_test(FLUSH_THRESHOLD + Duration::from_millis(1));
@@ -782,6 +836,7 @@ mod tests {
         );
         assert!(request.contains(r#""action_type":"op1""#));
         assert!(request.contains(r#""action_type":"op2""#));
+        assert!(request.contains(r#""runnerName":"v0.168.14""#));
 
         let mut flush = Box::pin(telemetry.flush());
         assert!(
@@ -855,5 +910,54 @@ mod tests {
         assert!(request.contains(r#""action_type":"storage_cache_background_fill_filled""#));
         assert!(request.contains(r#""duration_ms":42"#));
         assert!(request.contains(r#""success":true"#));
+    }
+
+    #[tokio::test]
+    async fn configured_runner_name_is_sent_by_direct_reporter() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await;
+            socket
+                .write_all(
+                    concat!(
+                        "HTTP/1.1 200 OK\r\n",
+                        "content-length: 16\r\n",
+                        "content-type: application/json\r\n",
+                        "connection: close\r\n",
+                        "\r\n",
+                        r#"{"success":true}"#
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            request
+        });
+
+        let telemetry = JobTelemetry::new_with_runner_name(
+            http_client_for_api_url(&api_url),
+            RunId::nil(),
+            "tok".to_string(),
+            Some("v0.168.14".to_string()),
+        );
+        telemetry
+            .reporter()
+            .report(vec![SandboxOpRecord::new(
+                "runner_name_test",
+                Duration::from_millis(1),
+                true,
+                None,
+            )])
+            .await;
+
+        let request = tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("server should receive configured reporter request")
+            .unwrap();
+        assert!(request.contains(r#""runnerName":"v0.168.14"#));
     }
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1495,6 +1495,69 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
 });
 
 describe("WHCB-05: sandbox agent webhook boundaries", () => {
+  it("attributes sandbox operation telemetry to the optional runner name", async () => {
+    const { runId, headers } = await createEventWebhookRun(
+      `runner-name telemetry ${randomUUID()}`,
+    );
+
+    context.mocks.axiom.sdkIngest.mockClear();
+    await api.requestAgentTelemetry(
+      {
+        runId,
+        runnerName: "v0.168.14",
+        sandboxOperations: [
+          {
+            ts: nowDate().toISOString(),
+            action_type: "runner_name_attribution",
+            duration_ms: 12,
+            success: true,
+          },
+        ],
+      },
+      headers,
+      [200],
+    );
+    await flushWaitUntilForTest();
+
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.objectContaining({
+          run_id: runId,
+          op_type: "runner_name_attribution",
+          runner_name: "v0.168.14",
+        }),
+      ],
+    );
+
+    context.mocks.axiom.sdkIngest.mockClear();
+    await api.requestAgentTelemetry(
+      {
+        runId,
+        sandboxOperations: [
+          {
+            ts: nowDate().toISOString(),
+            action_type: "legacy_runner_name_attribution",
+            duration_ms: 8,
+            success: true,
+          },
+        ],
+      },
+      headers,
+      [200],
+    );
+    await flushWaitUntilForTest();
+
+    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
+      "vm0-sandbox-op-log-dev",
+      [
+        expect.not.objectContaining({
+          runner_name: expect.anything(),
+        }),
+      ],
+    );
+  });
+
   it("rejects malformed, unauthenticated, mismatched, and missing-run sandbox reports", async () => {
     const runId = randomUUID();
     const mismatchedRunId = randomUUID();

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -64,9 +64,11 @@ interface SandboxOperationDimensionInput {
 
 function sandboxOperationDimensions(
   op: SandboxOperationDimensionInput,
+  runnerName?: string,
 ): Record<string, string> {
   return {
     source: "sandbox",
+    ...(runnerName ? { runner_name: runnerName } : {}),
     ...(op.error ? { error: op.error } : {}),
     ...(op.outcome ? { outcome: op.outcome } : {}),
     ...(op.reason ? { reason: op.reason } : {}),
@@ -422,7 +424,7 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
         success: op.success,
         runId: body.runId,
         timestamp: op.ts,
-        dimensions: sandboxOperationDimensions(op),
+        dimensions: sandboxOperationDimensions(op, body.runnerName),
       });
     }
   }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -233,6 +233,27 @@ describe("agent completion active input receipts", () => {
 });
 
 describe("webhook telemetry contract", () => {
+  it("accepts an optional bounded runner name", () => {
+    const runId = "00000000-0000-4000-8000-000000000000";
+    expect(
+      webhookTelemetryContract.send.body.parse({ runId }),
+    ).not.toHaveProperty("runnerName");
+
+    expect(
+      webhookTelemetryContract.send.body.parse({
+        runId,
+        runnerName: "v0.168.14",
+      }),
+    ).toMatchObject({ runnerName: "v0.168.14" });
+
+    for (const runnerName of ["", "x".repeat(129)]) {
+      expect(
+        webhookTelemetryContract.send.body.safeParse({ runId, runnerName })
+          .success,
+      ).toBe(false);
+    }
+  });
+
   it("accepts bounded sandbox operation outcome dimensions", () => {
     const result = webhookTelemetryContract.send.body.parse({
       runId: "00000000-0000-4000-8000-000000000000",

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -876,6 +876,8 @@ const sandboxOperationSchema = z.object({
   session_history_download_source: sandboxOperationDownloadSourceSchema,
 });
 
+const telemetryRunnerNameSchema = z.string().min(1).max(128);
+
 /**
  * Webhook telemetry contract for /api/webhooks/agent/telemetry
  */
@@ -890,6 +892,7 @@ export const webhookTelemetryContract = c.router({
     headers: authHeadersSchema,
     body: z.object({
       runId: z.string().min(1, "runId is required"),
+      runnerName: telemetryRunnerNameSchema.optional(),
       systemLog: z.string().optional(),
       metrics: z.array(metricDataSchema).optional(),
       networkLogs: z.array(networkLogEntrySchema).optional(),


### PR DESCRIPTION
## Summary

- Add the configured runner name to runner sandbox telemetry as a required value inside current runner code.
- Preserve the name across fresh and reused executions, automatic/final flushes, direct reporters, and the panic fallback path.
- Keep `runnerName` optional only at the API boundary for rolling-deployment compatibility with older runners, and write it to the `runner_name` Axiom dimension when present.

## Scope and compatibility

- This change only adds telemetry attribution; it does not change sandbox reuse decisions, sidecar identity checks, retries, timeouts, or execution lifecycle behavior.
- Current runners always send a non-optional runner name. Older deployed runners that omit it remain accepted and produce the same dimensions as before.
- The production runner name is the existing versioned logical name (for example, `v0.168.14`); no new runner naming scheme is introduced.

Closes #27463
Relates to delivery parent #27428

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml -p runner`
- `CARGO_BUILD_JOBS=1 cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner telemetry::tests -- --test-threads=1`
- `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::telemetry_tests -- --test-threads=1`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/webhooks.test.ts --maxWorkers=1`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --maxWorkers=1`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm check-types`

## Rollout notes

After deployment, the parent issue's production analysis slice can compare startup tails by `runner_name`. The optimization and lifecycle changes described in the parent remain out of scope for this PR.
