### PR TITLE
refactor(billing): neutralize redemption service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-billing-redeem.ts
+++ b/turbo/apps/api/src/signals/routes/zero-billing-redeem.ts
@@ -8,7 +8,7 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { getCampaign } from "../services/one-time-products";
-import { startOrResumeRedemption$ } from "../services/zero-billing-redeem.service";
+import { startOrResumeRedemption$ } from "../services/billing-redeem.service";
 import type { RouteEntry } from "../route-entry";
 
 const billingUnavailable = Object.freeze({

--- a/turbo/apps/api/src/signals/services/billing-redeem.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-redeem.service.ts
@@ -17,7 +17,7 @@ import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 import { getCampaign } from "./one-time-products";
 import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 
-const log = logger("zero-billing-redeem");
+const log = logger("billing-redeem");
 
 /**
  * Result of attempting to start or resume a one-time campaign redemption.


### PR DESCRIPTION
## Summary

- rename the internal billing redemption service file to `billing-redeem.service.ts`
- update its logger namespace and only direct route import
- keep `startOrResumeRedemption$`, route/test/contract names, API paths, and billing behavior unchanged

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/billing-redeem.service.ts apps/api/src/signals/routes/zero-billing-redeem.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm knip --workspace apps/api`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-billing-redeem.test.ts` (21 tests passed)
- verified the old service import and logger namespace are absent while the retained route, test, contract, and command names remain

## Behavior

This is an internal naming-only migration. Stripe, campaign, promo redemption, credit, redirect, error, retry, logging fields, response, authentication, contract, and API behavior are unchanged.

Closes #27472
