### PR TITLE
refactor(run): neutralize run detail service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-run-detail.ts
+++ b/turbo/apps/api/src/signals/routes/zero-run-detail.ts
@@ -10,10 +10,10 @@ import { authRoute } from "../auth/auth-route";
 import { pathParamsOf, queryOf } from "../context/request";
 import { notFound } from "../../lib/error";
 import {
-  zeroRunAgentEvents,
-  zeroRunContext,
-  zeroRunNetworkLogs,
-} from "../services/zero-run-detail.service";
+  runAgentEvents,
+  runContext,
+  runNetworkLogs,
+} from "../services/run-detail.service";
 import type { RouteEntry } from "../route-entry";
 
 const runReadAuth = {
@@ -27,7 +27,7 @@ const runNotFound = notFound("Agent run not found");
 const getContextInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroRunContextContract.getContext));
-  const result = await get(zeroRunContext(params.id, auth.userId, auth.orgId));
+  const result = await get(runContext(params.id, auth.userId, auth.orgId));
   if (result.kind === "not-found") {
     return runNotFound;
   }
@@ -42,7 +42,7 @@ const getNetworkLogsInner$ = computed(async (get) => {
   const params = get(pathParamsOf(zeroRunNetworkLogsContract.getNetworkLogs));
   const query = get(queryOf(zeroRunNetworkLogsContract.getNetworkLogs));
   const result = await get(
-    zeroRunNetworkLogs({
+    runNetworkLogs({
       runId: params.id,
       userId: auth.userId,
       orgId: auth.orgId,
@@ -64,7 +64,7 @@ const getAgentEventsInner$ = computed(async (get) => {
   const params = get(pathParamsOf(zeroRunAgentEventsContract.getAgentEvents));
   const query = get(queryOf(zeroRunAgentEventsContract.getAgentEvents));
   const result = await get(
-    zeroRunAgentEvents({
+    runAgentEvents({
       runId: params.id,
       userId: auth.userId,
       orgId: auth.orgId,

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -34,7 +34,7 @@ import {
   type ParsedConnectorDiagnosticRequest,
 } from "./connector-diagnostic-runtime.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
-import { zeroRunContext } from "./zero-run-detail.service";
+import { runContext } from "./run-detail.service";
 import {
   getConnectorRuntimeConnector,
   listConnectorRuntimeVisibleSlugs,
@@ -1240,20 +1240,20 @@ export const resolveConnectorCheck$ = command(
 
     let timeline: ConnectorCheckTimeline;
     if (args.stateSource.kind === "run") {
-      const runContext = await get(
-        zeroRunContext(args.stateSource.runId, args.userId, args.orgId),
+      const runContextResult = await get(
+        runContext(args.stateSource.runId, args.userId, args.orgId),
       );
       signal.throwIfAborted();
-      if (runContext.kind === "not-found") {
+      if (runContextResult.kind === "not-found") {
         return { kind: "not-found" };
       }
-      if (runContext.kind === "no-snapshot") {
+      if (runContextResult.kind === "no-snapshot") {
         return {
           kind: "ok",
           diagnostic: { outcome: "run-context-unavailable" },
         };
       }
-      timeline = { kind: "run", context: runContext.context };
+      timeline = { kind: "run", context: runContextResult.context };
     } else {
       const state =
         args.request.mode === "url"

--- a/turbo/apps/api/src/signals/services/run-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/run-detail.service.ts
@@ -64,7 +64,7 @@ type RunContextResult =
   | { readonly kind: "no-snapshot" }
   | { readonly kind: "ok"; readonly context: RunContextResponse };
 
-export function zeroRunContext(
+export function runContext(
   runId: string,
   userId: string,
   orgId: string,
@@ -152,7 +152,7 @@ interface AxiomAgentEvent {
   eventData: Record<string, unknown>;
 }
 
-export function zeroRunAgentEvents(
+export function runAgentEvents(
   params: AgentEventsParams,
 ): Computed<Promise<AgentEventsResponse | null>> {
   return computed(async (get): Promise<AgentEventsResponse | null> => {
@@ -223,7 +223,7 @@ ${paginationFilter}
   });
 }
 
-export function zeroRunNetworkLogs(
+export function runNetworkLogs(
   params: NetworkLogsParams,
 ): Computed<Promise<NetworkLogsResponse | null>> {
   return computed(async (get): Promise<NetworkLogsResponse | null> => {


### PR DESCRIPTION
## Summary

- rename the internal run detail service to `run-detail.service.ts`
- rename its three internal exports to `runContext`, `runAgentEvents`, and `runNetworkLogs`
- update the existing run-detail route and connector-check caller without compatibility aliases
- preserve the `contracts/zero-runs` module, public contract/route/test names, API paths, and runtime behavior

## Behavior

This is an internal naming-only migration. Run ownership, context snapshot normalization, Axiom datasets and APL, filtering, pagination, cursors, ordering, sanitization, statuses, response shapes, and connector-check outcomes are unchanged.

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/run-detail.service.ts apps/api/src/signals/routes/zero-run-detail.ts apps/api/src/signals/services/connector-check.service.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/connector-check.test.ts -t 'uses only an owned Zero snapshot, including dynamic bases and final policies'` (1 passed)
- focused run-detail selection covering event paging, network sanitization/cursors, and context mapping (3 passed; 2 runner-claim cases hit the existing `404 Job not found in queue` local baseline before reaching run-detail assertions)
- reproduced both runner-claim failures unchanged on an unmodified `origin/main@7d3d477` worktree
- verified the old service path and exact old function names are absent from active source
- verified `contracts/zero-runs` and its public exports are unchanged

Closes #27474
