### PR TITLE
refactor(connectors): neutralize custom connector list service

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/zero-custom-connectors.ts
@@ -3,7 +3,7 @@ import { zeroCustomConnectorsContract } from "@okouai/api-contracts/contracts/ze
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { zeroCustomConnectorList } from "../services/zero-catalog-data.service";
+import { customConnectorList } from "../services/custom-connector-list.service";
 import type { RouteEntry } from "../route-entry";
 import { zeroCustomConnectorsCreateRoutes } from "./zero-custom-connectors-create";
 import { zeroCustomConnectorsDeleteRoutes } from "./zero-custom-connectors-delete";
@@ -17,7 +17,7 @@ import { zeroCustomConnectorsValuesSetRoutes } from "./zero-custom-connectors-va
 const listCustomConnectorsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const connectors = await get(
-    zeroCustomConnectorList({ orgId: auth.orgId, userId: auth.userId }),
+    customConnectorList({ orgId: auth.orgId, userId: auth.userId }),
   );
   return { status: 200 as const, body: { connectors: [...connectors] } };
 });

--- a/turbo/apps/api/src/signals/services/custom-connector-list.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-list.service.ts
@@ -16,7 +16,7 @@ import {
   loadConnectedCustomConnectorConnections,
 } from "./custom-connector-credential-access.service";
 
-export function zeroCustomConnectorList(args: {
+export function customConnectorList(args: {
   readonly orgId: string;
   readonly userId: string;
 }): Computed<Promise<readonly CustomConnectorResponse[]>> {


### PR DESCRIPTION
## Summary

- rename `zero-catalog-data.service.ts` to `custom-connector-list.service.ts`
- rename `zeroCustomConnectorList` to `customConnectorList` and update its only route caller
- remove the old internal path and declaration without adding a compatibility alias

## Behavior

The custom-connector list query, joins, ordering, organization and user scope, normalization, serialization, credential markers, connection state, route contract, response shape, and runtime behavior are unchanged. The existing `zero-custom-connectors` contract import and `zero-custom-connector.service` compatibility dependency remain unchanged.

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/custom-connector-list.service.ts apps/api/src/signals/routes/zero-custom-connectors.ts` (passed)
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed)
- `pnpm knip` (passed)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (12/12 tasks passed)
- `pnpm --filter @okouai/app run check-types` (passed)
- `pnpm --filter api run check-types` (passed)
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts -t "validates and normalises custom connector creation through visible create and list responses|keeps custom connector secrets scoped per user and per organization"` (2 passed, 68 skipped)
- verified that the old service path and `zeroCustomConnectorList` are absent and the two compatibility imports are unchanged

Closes #27473
