### PR TITLE
refactor(chat): neutralize event snapshot service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -28,9 +28,9 @@ import {
 } from "../services/zero-chat-thread.service";
 import { chatSearch } from "../services/chat-search.service";
 import {
-  zeroChatThreadEventRows,
-  zeroChatThreadEventSnapshot,
-} from "../services/zero-chat-event-snapshot.service";
+  chatThreadEventRows,
+  chatThreadEventSnapshot,
+} from "../services/chat-event-snapshot.service";
 import { resolveChatEventSchemaVersion } from "../services/chat-event-schema-version.service";
 import {
   getChatThreadEventsSince,
@@ -157,7 +157,7 @@ const getChatEventSnapshotInner$ = command(
       version.version.toString(),
     );
     const snapshot = await set(
-      zeroChatThreadEventSnapshot({
+      chatThreadEventSnapshot({
         threadId: params.threadId,
         userId: auth.userId,
       }),
@@ -207,7 +207,7 @@ const listChatEventRowsInner$ = command(
       version.version.toString(),
     );
     const page = await get(
-      zeroChatThreadEventRows({
+      chatThreadEventRows({
         threadId: params.threadId,
         userId: auth.userId,
         ...query,

--- a/turbo/apps/api/src/signals/services/chat-event-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-snapshot.service.ts
@@ -115,7 +115,7 @@ async function validSnapshotCursor(
 }
 
 /** Resolve the current persisted Snapshot pointer. */
-export function zeroChatThreadEventSnapshot(args: {
+export function chatThreadEventSnapshot(args: {
   readonly threadId: string;
   readonly userId: string;
 }) {
@@ -177,7 +177,7 @@ export function zeroChatThreadEventSnapshot(args: {
  * Snapshot. `sinceSeqId: 0` remains the cold start for a thread that has never
  * had a Snapshot.
  */
-export function zeroChatThreadEventRows(
+export function chatThreadEventRows(
   args: ChatEventRowsArgs,
 ): Computed<Promise<ChatEventRowsPage>> {
   return computed(async (get) => {


### PR DESCRIPTION
## Summary

- rename the internal chat-event snapshot reader to `chat-event-snapshot.service.ts`
- rename its two internal exports to `chatThreadEventSnapshot` and `chatThreadEventRows`
- update only the direct `zero-chat-threads.ts` import and invocations, without compatibility aliases

## Behavior

This is an internal naming-only migration. Thread ownership, snapshot schema-version selection, cursor validation, cold starts, migration fallback, S3/R2 keys, presigned URL generation and TTL, row ordering, expiration semantics, API contracts, routes, responses, and errors are unchanged. Other `zeroChat*` declarations in the route remain untouched.

## Verification

- `corepack pnpm exec prettier --check apps/api/src/signals/services/chat-event-snapshot.service.ts apps/api/src/signals/routes/zero-chat-threads.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 corepack pnpm --filter api lint`
- `corepack pnpm knip --workspace api`
- API `check-types` with pnpm 10.33.4 (all bounded stages passed)
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-chat-event-snapshot.test.ts` (1 file, 6 tests passed)
- verified the old service path and both exact old function names are absent from active source
- paginated all files for all 21 open pull requests; no overlap with either service path or the direct route caller

Closes #27481
