### PR TITLE
refactor(workflows): neutralize queue drain service naming

### DIFF
--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -21,7 +21,7 @@ import {
 import {
   drainWorkflowQueueForThread$,
   type WorkflowQueueDrainResult,
-} from "./zero-workflow-queue-drain.service";
+} from "./workflow-queue-drain.service";
 import { expiredCancellationRecoveryThreads } from "./chat-active-run.service";
 import { drainGoalQueueForThread$ } from "./zero-goal-queue-drain.service";
 import type { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";

--- a/turbo/apps/api/src/signals/services/workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-queue-drain.service.ts
@@ -23,7 +23,7 @@ import {
   type RunWorkflowAutomationResult,
 } from "./zero-workflow-automation-launch.service";
 
-const log = logger("ZeroWorkflowQueueDrain");
+const log = logger("WorkflowQueueDrain");
 
 // Consecutive stale events or claims invalidated by concurrent queue changes
 // are retried per drain call; a successful run creation always stops the loop.


### PR DESCRIPTION
## Summary

- rename the internal workflow queue drain service to `workflow-queue-drain.service.ts`
- update its logger namespace and only direct caller import
- keep `drainWorkflowQueueForThread$` and the adjacent `zero-workflow-automation-launch.service` compatibility boundary unchanged

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/workflow-queue-drain.service.ts apps/api/src/signals/services/chat-thread-queue-drain.service.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm --filter api run check-types`
- `pnpm knip --workspace apps/api`
- `DATABASE_URL=<local vm0_test database> pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-workflow-queue.test.ts` (30 tests passed)
- verified the old service path and `ZeroWorkflowQueueDrain` namespace are absent while the retained launch import and command name remain unchanged

## Behavior

This is an internal naming-only migration. Queue ordering, claim and retry handling, autonomy budgets, stale-event handling, automation lookup, launch material, failed-run callbacks, realtime publication, result shapes, errors, contracts, and runtime behavior are unchanged.

Closes #27483