### PR TITLE
refactor(goals): neutralize objective brief service naming

### DIFF
--- a/turbo/apps/api/src/signals/services/goal-objective-brief.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-objective-brief.service.ts
@@ -7,7 +7,7 @@ import {
   fallbackGoalObjectiveBrief,
 } from "./goal-objective-brief-normalization.service";
 
-const log = logger("api:zero-goal-objective-brief");
+const log = logger("api:goal-objective-brief");
 const OBJECTIVE_BRIEF_MODEL = "google/gemini-3.1-flash-lite-preview";
 const OBJECTIVE_CONTEXT_CHAR_CAP = 4000;
 export async function generateGoalObjectiveBrief(

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -20,7 +20,7 @@ import {
   appendGoalOpenMarker,
 } from "./chat-goal-marker.service";
 import { normalizeGoalObjectiveBrief } from "./goal-objective-brief-normalization.service";
-import { generateGoalObjectiveBrief } from "./zero-goal-objective-brief.service";
+import { generateGoalObjectiveBrief } from "./goal-objective-brief.service";
 import { lockGoalThread } from "./goal-lock.service";
 import {
   appendChatThreadEvent,


### PR DESCRIPTION
## Summary

- rename the internal goal objective-brief service to `goal-objective-brief.service.ts`
- update its logger namespace and the only direct import in `zero-goal.service.ts`
- keep `generateGoalObjectiveBrief` and all goal behavior unchanged without a compatibility alias

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/goal-objective-brief.service.ts apps/api/src/signals/services/zero-goal.service.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm knip --workspace apps/api`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-goals.test.ts` (15 tests passed)
- verified the old service path and `api:zero-goal-objective-brief` logger namespace are absent
- verified the renamed service is byte-identical after accounting for the expected logger namespace change

## Behavior

This is an internal naming-only migration. The model, system prompt, objective truncation, generated-token limit, normalization, fallback, error handling, logging payload, return values, routes, contracts, tests, API paths, and runtime behavior are unchanged.

Closes #27482
