### PR TITLE
fix(platform): align usage pack credit ledger

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx
@@ -340,14 +340,18 @@ describe("personal usage settings", () => {
     expect(
       within(card).getByTestId("usage-pack-credit-bonus"),
     ).toBeInTheDocument();
+    const grants = within(card).getByTestId("usage-pack-credit-grants-section");
+    expect(within(grants).getByText("Credit additions")).toBeInTheDocument();
+    expect(within(grants).getByText("Date")).toBeInTheDocument();
+    expect(within(grants).getByText("Credits")).toBeInTheDocument();
+    expect(within(grants).getByText("Left")).toBeInTheDocument();
     expect(
-      within(card).getByTestId("usage-pack-credit-grants-toggle"),
-    ).toBeInTheDocument();
+      within(card).queryByTestId("usage-pack-credit-grants-toggle"),
+    ).toBeNull();
     expect(within(card).getByText("20,400")).toBeInTheDocument();
-    expect(within(card).getAllByText("Purchased")).toHaveLength(2);
     expect(within(card).getByText("20,000")).toBeInTheDocument();
-    expect(within(card).getAllByText("Bonus")).toHaveLength(2);
-    expect(within(card).getAllByText("400")).toHaveLength(2);
+    expect(within(grants).getByText("+25,000")).toBeInTheDocument();
+    expect(within(grants).getByText("+400")).toBeInTheDocument();
     expect(screen.queryByTestId("credit-balance-info")).toBeNull();
     expect(screen.queryByText("Team usage")).toBeNull();
     expect(screen.queryByText("Today")).toBeNull();
@@ -361,18 +365,10 @@ describe("personal usage settings", () => {
       screen.findByText("Expires Apr 1, 2026"),
     ).resolves.toBeInTheDocument();
 
-    await user.click(
-      within(card).getByTestId("usage-pack-credit-grants-toggle"),
+    await user.hover(
+      within(grants).getByTestId("usage-pack-credit-grants-grant-purchased"),
     );
-    expect(
-      within(card).getByTestId("usage-pack-credit-grants-section"),
-    ).toHaveAttribute("open");
-    expect(
-      within(card).getByTestId("usage-pack-credit-grants-grant-purchased"),
-    ).toHaveTextContent("Purchased");
-    expect(
-      within(card).getByTestId("usage-pack-credit-grants-grant-purchased"),
-    ).toHaveTextContent("20,000 left");
+    await expect(screen.findByText("Purchased")).resolves.toBeInTheDocument();
   });
 
   it("hides usage pack credits when the organization has no active pack", async () => {
@@ -532,7 +528,7 @@ describe("personal usage settings", () => {
       within(card).getByTestId("usage-pack-credit-bar"),
     ).toBeInTheDocument();
     expect(
-      within(card).getByTestId("usage-pack-credit-grants-toggle"),
+      within(card).getByTestId("usage-pack-credit-grants-section"),
     ).toBeInTheDocument();
 
     await user.click(buttonByAriaLabel("View member balances", card));

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -501,7 +501,7 @@ function CreditAdditionItems({
   );
 }
 
-export function CreditAdditionList({
+function CreditAdditionList({
   grants,
   testIdPrefix = "credit-grants",
 }: {
@@ -548,7 +548,7 @@ export function CreditAdditionList({
 const GRANT_ROW_GRID =
   "grid grid-cols-[minmax(0,1fr)_4.5rem_4.5rem] items-center gap-x-3 sm:grid-cols-[minmax(0,1fr)_7rem_7rem] sm:gap-x-4";
 
-function CreditAdditionTable({
+export function CreditAdditionTable({
   grants,
   testIdPrefix = "credit-grants",
 }: {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx
@@ -29,7 +29,7 @@ import {
   TooltipTrigger,
 } from "@okouai/ui/components/ui/tooltip";
 import {
-  CreditAdditionList,
+  CreditAdditionTable,
   CreditBalanceCard,
   formatCreditDate,
   type CreditAddition,
@@ -193,7 +193,7 @@ function UsagePackSegmentBar({
     <TooltipProvider delayDuration={100}>
       <div
         data-testid={`${testIdPrefix}-bar`}
-        className="flex h-2.5 w-full rounded-full bg-muted/40"
+        className="mt-4 flex h-2 w-full gap-[3px]"
       >
         {segments.map((segment) => {
           return (
@@ -201,7 +201,7 @@ function UsagePackSegmentBar({
               <TooltipTrigger asChild>
                 <div
                   data-testid={`${testIdPrefix}-${segment.key}`}
-                  className={`h-2.5 ${segment.color} cursor-default first:rounded-l-full last:rounded-r-full ring-0 hover:ring-2 hover:ring-foreground/30 hover:z-10 transition-shadow`}
+                  className={`h-2 ${segment.color} cursor-default first:rounded-l-full last:rounded-r-full ring-0 hover:ring-2 hover:ring-foreground/30 hover:z-10 transition-shadow`}
                   style={{
                     width: `${(segment.credits / totalCredits) * 100}%`,
                   }}
@@ -258,35 +258,13 @@ function UsagePackCreditDetails({
   return (
     <>
       {data.totalCredits > 0 && segments.length > 0 ? (
-        <div className="mt-3 flex flex-col gap-2">
-          <UsagePackSegmentBar
-            segments={segments}
-            testIdPrefix={testIdPrefix}
-            totalCredits={data.totalCredits}
-          />
-          {segments.length > 0 ? (
-            <div className="flex flex-wrap gap-x-4 gap-y-1">
-              {segments.map((segment) => {
-                return (
-                  <div
-                    key={segment.key}
-                    className="flex items-center gap-1.5 text-xs text-muted-foreground"
-                  >
-                    <span
-                      className={`h-2 w-2 shrink-0 rounded-full ${segment.color}`}
-                    />
-                    <span>{segment.label}</span>
-                    <span className="tabular-nums">
-                      {formatLocalizedNumber(segment.credits)}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-          ) : null}
-        </div>
+        <UsagePackSegmentBar
+          segments={segments}
+          testIdPrefix={testIdPrefix}
+          totalCredits={data.totalCredits}
+        />
       ) : null}
-      <CreditAdditionList
+      <CreditAdditionTable
         grants={additions}
         testIdPrefix={`${testIdPrefix}-grants`}
       />
@@ -297,7 +275,7 @@ function UsagePackCreditDetails({
 function UsagePackCreditTitle() {
   const { t } = useTranslation();
   return (
-    <p className="text-sm font-medium text-foreground">
+    <p className="text-sm font-semibold text-foreground">
       {t(($) => {
         return $.billing.usage.usagePack.title;
       })}
@@ -313,12 +291,12 @@ function UsagePackCreditHeader({
   totalCredits: number;
 }) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-2">
+    <div className="flex items-baseline justify-between gap-3">
       <div className="flex items-center gap-1">
         <UsagePackCreditTitle />
         {action}
       </div>
-      <p className="text-sm font-medium tabular-nums text-foreground">
+      <p className="text-xl font-medium tabular-nums text-foreground">
         {formatLocalizedNumber(totalCredits)}
       </p>
     </div>
@@ -671,8 +649,8 @@ function UsagePackCreditCard({ isAdmin }: { isAdmin: boolean }) {
     >
       {creditsLoadable.state === "loading" && !data ? (
         <div className="space-y-2">
-          <div className="h-4 w-40 animate-pulse rounded bg-muted/50" />
-          <div className="h-2.5 w-full animate-pulse rounded-full bg-muted/40" />
+          <div className="h-4 w-48 animate-pulse rounded bg-muted/50" />
+          <div className="h-2 w-full animate-pulse rounded-full bg-muted/40" />
         </div>
       ) : data ? (
         <>


### PR DESCRIPTION
## Summary

- match the Usage pack credit card header and balance bar to the adjacent Org credits ledger
- show usage pack credit additions in the same Date / Credits / Left table instead of a collapsed list
- preserve purchased and bonus source details in the existing hover tooltips and update coverage for the ledger layout

## Verification

- `pnpm exec prettier --check apps/platform/src/views/zero-page/components/settings/sections/credit-balance-section.tsx apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx apps/platform/src/views/zero-page/__tests__/personal-usage-tab.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm exec knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/personal-usage-tab.test.tsx`
- PR preview browser QA at 1280x900 and 390x844: matching header typography, 8px balance bars, shared ledger table layout, working hover tooltips, and no horizontal overflow

Preview: https://pr-27496-app.omby.ai
