### PR TITLE
refactor(computer-use): neutralize core service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use.ts
@@ -32,7 +32,7 @@ import {
   listComputerUseHosts$,
   startComputerUseHost$,
   stopComputerUseHost$,
-} from "../services/zero-computer-use.service";
+} from "../services/computer-use.service";
 import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import type { RouteEntry } from "../route-entry";
 

--- a/turbo/apps/api/src/signals/services/computer-use-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/computer-use-authorization.service.ts
@@ -24,7 +24,7 @@ import { appendChatThreadEvent } from "./zero-chat-thread-event.service";
 import {
   computerUseHostIsOnline,
   listComputerUseHosts$,
-} from "./zero-computer-use.service";
+} from "./computer-use.service";
 
 const COMPUTER_USE_AUTHORIZATION_REQUEST_TTL_MS = 60 * 60 * 1000;
 const COMPUTER_USE_AUTHORIZATION_URL_PREFIX =

--- a/turbo/apps/api/src/signals/services/computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/computer-use.service.ts
@@ -63,7 +63,7 @@ import type { Tx } from "../../lib/db-types";
 const COMPUTER_USE_HOST_CLOSED_AFTER_MS = 90 * 1000;
 const COMPUTER_USE_RUNNING_COMMAND_DEFAULT_TIMEOUT_MS = 120 * 1000;
 const COMPUTER_USE_HOSTS_CHANGED_TOPIC = "computerUseHostsChanged";
-const L = logger("ZeroComputerUse");
+const L = logger("ComputerUse");
 
 const COMPUTER_USE_READ_COMMANDS = [
   "apps.list",


### PR DESCRIPTION
## Summary

- rename the internal core Computer Use service from `zero-computer-use.service.ts` to `computer-use.service.ts`
- update its two direct imports and change the logger namespace from `ZeroComputerUse` to `ComputerUse`
- keep every existing exported helper and command unchanged, with no compatibility alias

## Behavior invariants

- no route, contract, test, schema, persisted value, token behavior, host/command flow, capability, timeout, screenshot, plugin, S3, audit, chat, realtime, or API behavior changed
- preserved `@okouai/api-contracts/contracts/zero-computer-use`, `./zero-chat-thread-event.service`, `vm0_computer_use_host_stopped`, and `vm0_computer_use_host` exactly
- verified the 2,032-line service matches the original byte-for-byte after normalizing only the logger namespace; the exported-declaration hash is unchanged
- refreshed all direct callers and paginated every file from all 23 open pull requests after rebasing onto the latest `main`; no overlap remains

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks passed)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter=!api --filter=!@okouai/app` (12/12 tasks passed)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/computer-use.bdd.test.ts` (17 passed)

Closes #27488