### PR TITLE
refactor(github): neutralize agent reply footer naming

### DIFF
--- a/turbo/apps/api/src/signals/services/github-agent-reply-footer.service.ts
+++ b/turbo/apps/api/src/signals/services/github-agent-reply-footer.service.ts
@@ -27,7 +27,7 @@ function displayLabel(row: {
   if (agentName) {
     return agentName;
   }
-  return row.composeName.trim() || "zero";
+  return row.composeName.trim() || "Okou";
 }
 
 async function resolveComposeLabel(

--- a/turbo/apps/api/src/signals/services/internal-github-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-github-chat-run-callback.service.ts
@@ -25,7 +25,7 @@ import {
 } from "./github-issues-api.service";
 import { chatEventTypeIn } from "./chat-event-type.service";
 import { canonicalChatEventContent } from "./canonical-chat-event-read.service";
-import { resolveGithubAgentReplyFooterText } from "./zero-github-footer.service";
+import { resolveGithubAgentReplyFooterText } from "./github-agent-reply-footer.service";
 
 const L = logger("InternalCallbacksGithubChat");
 


### PR DESCRIPTION
## Summary

- rename the internal GitHub agent-reply footer service to `github-agent-reply-footer.service.ts`
- update the callback's only direct import while keeping `resolveGithubAgentReplyFooterText` unchanged
- change the missing agent/compose display-label fallback from `zero` to `Okou`

## User-visible behavior

The only user-visible change is that a delivered GitHub reply footer now uses `Okou` when the agent display name, agent name, and trimmed compose name are all empty. Agent/compose/model lookup precedence, installation-default suppression, footer composition and escaping, audit links, delivery, and error behavior are unchanged.

`zeroAgents`, `ZeroDebug`, and the separate Telegram footer fallback remain unchanged. The old service path is removed without a compatibility alias.

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/github-agent-reply-footer.service.ts apps/api/src/signals/services/internal-github-chat-run-callback.service.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api lint`
- `pnpm knip --workspace apps/api`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t 'persists assistant output' --reporter=dot` (1 passed)
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts -t 'GitHub' --reporter=dot` (2 passed)
- verified the old service path and its `zero` fallback are absent, while `zeroAgents`, `ZeroDebug`, and the Telegram `zero` fallback remain
- repeated the complete caller/fallback search and paginated file scan for every open PR; no overlapping files were found

Closes #27489
