### PR TITLE
fix(billing): align usage pack downgrade feedback

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -981,7 +981,6 @@
           "comparisonDescription": "Ihr aktuelles Abonnement und diese Auswahl im direkten Vergleich",
           "comparisonTitle": "Abonnementvergleich",
           "current": "Aktuell",
-          "downgradeDescription": "Das kleinere Paket beginnt am nächsten Abrechnungstag. Vorhandene Credits bleiben bis zu ihrem Ablauf verfügbar.",
           "downgradesToDate": "Downgrade auf {{package}} am {{date}}.",
           "downgradesToPeriod": "Downgrade auf {{package}} zum nächsten Abrechnungsdatum.",
           "everyMonth": "Monatlich",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -981,7 +981,6 @@
           "comparisonDescription": "Your current subscription and this selection, side by side",
           "comparisonTitle": "Subscription comparison",
           "current": "Current",
-          "downgradeDescription": "The lower package starts at the next billing date. Existing credits remain available until they expire.",
           "downgradesToDate": "Downgrades to {{package}} on {{date}}.",
           "downgradesToPeriod": "Downgrades to {{package}} at the next billing date.",
           "everyMonth": "Every month",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1002,7 +1002,6 @@
           "comparisonDescription": "Tu suscripción actual y esta selección, una al lado de la otra",
           "comparisonTitle": "Comparación de suscripciones",
           "current": "Actual",
-          "downgradeDescription": "El paquete inferior comienza en la próxima fecha de facturación. Los créditos existentes seguirán disponibles hasta que caduquen.",
           "downgradesToDate": "Baja a {{package}} el {{date}}.",
           "downgradesToPeriod": "Baja a {{package}} en la próxima fecha de facturación.",
           "everyMonth": "Cada mes",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1002,7 +1002,6 @@
           "comparisonDescription": "Votre abonnement actuel et cette sélection, côte à côte",
           "comparisonTitle": "Comparaison des abonnements",
           "current": "Actuel",
-          "downgradeDescription": "Le forfait inférieur commence à la prochaine date de facturation. Les crédits existants restent disponibles jusqu’à leur expiration.",
           "downgradesToDate": "Passe à {{package}} le {{date}}.",
           "downgradesToPeriod": "Passe à {{package}} à la prochaine date de facturation.",
           "everyMonth": "Chaque mois",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -981,7 +981,6 @@
           "comparisonDescription": "आपका मौजूदा सब्सक्रिप्शन और यह चयन, साथ-साथ",
           "comparisonTitle": "सब्सक्रिप्शन की तुलना",
           "current": "वर्तमान",
-          "downgradeDescription": "कम पैकेज अगली बिलिंग तारीख से शुरू होगा। मौजूदा क्रेडिट अपनी समाप्ति तक उपलब्ध रहेंगे।",
           "downgradesToDate": "{{date}} को {{package}} पर डाउनग्रेड होगा।",
           "downgradesToPeriod": "अगली बिलिंग तारीख पर {{package}} पर डाउनग्रेड होगा।",
           "everyMonth": "हर महीने",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -981,7 +981,6 @@
           "comparisonDescription": "Langganan Anda saat ini dan pilihan ini, ditampilkan berdampingan",
           "comparisonTitle": "Perbandingan langganan",
           "current": "Saat ini",
-          "downgradeDescription": "Paket yang lebih rendah dimulai pada tanggal penagihan berikutnya. Kredit yang ada tetap tersedia hingga kedaluwarsa.",
           "downgradesToDate": "Turun ke {{package}} pada {{date}}.",
           "downgradesToPeriod": "Turun ke {{package}} pada tanggal penagihan berikutnya.",
           "everyMonth": "Setiap bulan",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1002,7 +1002,6 @@
           "comparisonDescription": "Il tuo abbonamento attuale e questa selezione, affiancati",
           "comparisonTitle": "Confronto degli abbonamenti",
           "current": "Attuale",
-          "downgradeDescription": "Il pacchetto inferiore inizia alla prossima data di fatturazione. I crediti esistenti restano disponibili fino alla scadenza.",
           "downgradesToDate": "Passa a {{package}} il {{date}}.",
           "downgradesToPeriod": "Passa a {{package}} alla prossima data di fatturazione.",
           "everyMonth": "Ogni mese",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -981,7 +981,6 @@
           "comparisonDescription": "現在のサブスクリプションと今回の選択を並べて比較",
           "comparisonTitle": "サブスクリプションの比較",
           "current": "現在",
-          "downgradeDescription": "下位パッケージは次回請求日から開始します。既存のクレジットは有効期限まで利用できます。",
           "downgradesToDate": "{{date}}に{{package}}へダウングレードします。",
           "downgradesToPeriod": "次回請求日に{{package}}へダウングレードします。",
           "everyMonth": "毎月",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -981,7 +981,6 @@
           "comparisonDescription": "현재 구독과 이번 선택을 나란히 비교",
           "comparisonTitle": "구독 비교",
           "current": "현재",
-          "downgradeDescription": "하위 패키지는 다음 결제일부터 시작됩니다. 기존 크레딧은 만료될 때까지 사용할 수 있습니다.",
           "downgradesToDate": "{{date}}에 {{package}}(으)로 다운그레이드됩니다.",
           "downgradesToPeriod": "다음 결제일에 {{package}}(으)로 다운그레이드됩니다.",
           "everyMonth": "매월",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1002,7 +1002,6 @@
           "comparisonDescription": "Sua assinatura atual e esta seleção, lado a lado",
           "comparisonTitle": "Comparação de assinaturas",
           "current": "Atual",
-          "downgradeDescription": "O pacote menor começa na próxima data de cobrança. Os créditos existentes permanecem disponíveis até expirarem.",
           "downgradesToDate": "Muda para {{package}} em {{date}}.",
           "downgradesToPeriod": "Muda para {{package}} na próxima data de cobrança.",
           "everyMonth": "Todo mês",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1385,8 +1385,8 @@ describe("organization billing settings", () => {
       within(orderSummary).queryByText("Monthly difference"),
     ).not.toBeInTheDocument();
     expect(
-      within(orderSummary).getByText("Scheduled for Sep 1, 2026").parentElement,
-    ).toHaveClass("bg-amber-50/70");
+      within(orderSummary).getByText("Scheduled for Sep 1, 2026"),
+    ).toBeVisible();
 
     const reviewConversionButton = buttonByText(
       "Review conversion",
@@ -2050,7 +2050,7 @@ describe("organization billing settings", () => {
     const downgradeNotice = screen.getByText(
       "Downgrades to $50 on Apr 1, 2026.",
     );
-    expect(downgradeNotice).toHaveClass("text-yellow-700");
+    expect(downgradeNotice).toBeVisible();
     expect(screen.queryByText("+4,321 bonus credits")).not.toBeInTheDocument();
     const orderSummary = screen.getByRole("region", {
       name: "Order summary",
@@ -2064,8 +2064,7 @@ describe("organization billing settings", () => {
     const scheduledDowngrade = within(orderSummary).getByRole("status", {
       name: "Downgrade scheduled",
     });
-    expect(scheduledDowngrade).toHaveClass("bg-yellow-50/70");
-    expect(orderSummary).toHaveClass("pb-5");
+    expect(scheduledDowngrade).toBeVisible();
     expect(scheduledDowngrade).toHaveTextContent(
       "Lower package starts Apr 1, 2026 · Existing credits remain available until they expire",
     );
@@ -2218,9 +2217,7 @@ describe("organization billing settings", () => {
         name: "$20 · 21,234 credits · 6% off",
       }),
     );
-    expect(screen.getByText("Downgrades to $20 on Apr 1, 2026.")).toHaveClass(
-      "text-yellow-700",
-    );
+    expect(screen.getByText("Downgrades to $20 on Apr 1, 2026.")).toBeVisible();
     expect(buttonByText("Confirm", orderSummary)).not.toBeDisabled();
 
     click(packageSelect);
@@ -2229,9 +2226,9 @@ describe("organization billing settings", () => {
         name: "$100 · 109,999 credits · 9% off",
       }),
     );
-    expect(screen.getByText("Downgrades to $100 on Apr 1, 2026.")).toHaveClass(
-      "text-yellow-700",
-    );
+    expect(
+      screen.getByText("Downgrades to $100 on Apr 1, 2026."),
+    ).toBeVisible();
     expect(
       screen.queryByText("Downgrades to $50 on Apr 1, 2026."),
     ).not.toBeInTheDocument();
@@ -2524,13 +2521,13 @@ describe("organization billing settings", () => {
     const downgradeNotice = within(orderSummary).getByRole("status", {
       name: "Downgrade",
     });
-    expect(downgradeNotice).toHaveClass("bg-yellow-50/70", "mb-5");
+    expect(downgradeNotice).toBeVisible();
     expect(downgradeNotice).toHaveTextContent(
       "Lower package starts Apr 1, 2026 · Existing credits remain available until they expire",
     );
     expect(
-      downgradeNotice.firstElementChild?.querySelector("svg"),
-    ).not.toBeNull();
+      within(orderSummary).queryByText("Scheduled for Apr 1, 2026"),
+    ).not.toBeInTheDocument();
     click(buttonByText("Confirm", orderSummary));
     const confirmationDialog = await screen.findByRole("dialog", {
       name: "Review package change",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1385,8 +1385,8 @@ describe("organization billing settings", () => {
       within(orderSummary).queryByText("Monthly difference"),
     ).not.toBeInTheDocument();
     expect(
-      within(orderSummary).getByText("Scheduled for Sep 1, 2026"),
-    ).toBeInTheDocument();
+      within(orderSummary).getByText("Scheduled for Sep 1, 2026").parentElement,
+    ).toHaveClass("bg-amber-50/70");
 
     const reviewConversionButton = buttonByText(
       "Review conversion",
@@ -3973,20 +3973,16 @@ describe("organization billing settings", () => {
         screen.getByText(
           "Your Team plan will downgrade to Pro on May 1, 2026.",
         ),
-      ).toHaveClass("text-yellow-700");
+      ).toBeInTheDocument();
     });
 
     click(screen.getByText("Compare all plans"));
 
     await waitFor(() => {
       expect(screen.getByText("Compare plans")).toBeInTheDocument();
-      const downgradeNotices = screen.getAllByText(
-        "Downgrades to Pro on May 1, 2026",
-      );
-      expect(downgradeNotices.length).toBeGreaterThan(0);
-      for (const notice of downgradeNotices) {
-        expect(notice).toHaveClass("bg-yellow-50/70", "mb-5");
-      }
+      expect(
+        screen.getAllByText("Downgrades to Pro on May 1, 2026").length,
+      ).toBeGreaterThan(0);
     });
 
     click(screen.getByText("Restore plan"));
@@ -4083,7 +4079,7 @@ describe("organization billing settings", () => {
       within(downgradeDialog).getByText(
         /After that, this workspace moves to Pro/u,
       ),
-    ).toHaveClass("text-yellow-700");
+    ).toBeInTheDocument();
 
     click(buttonByText("Downgrade to Pro", downgradeDialog));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -2050,7 +2050,7 @@ describe("organization billing settings", () => {
     const downgradeNotice = screen.getByText(
       "Downgrades to $50 on Apr 1, 2026.",
     );
-    expect(downgradeNotice).toHaveClass("text-amber-600");
+    expect(downgradeNotice).toHaveClass("text-yellow-700");
     expect(screen.queryByText("+4,321 bonus credits")).not.toBeInTheDocument();
     const orderSummary = screen.getByRole("region", {
       name: "Order summary",
@@ -2217,7 +2217,7 @@ describe("organization billing settings", () => {
       }),
     );
     expect(screen.getByText("Downgrades to $20 on Apr 1, 2026.")).toHaveClass(
-      "text-amber-600",
+      "text-yellow-700",
     );
     expect(buttonByText("Confirm", orderSummary)).not.toBeDisabled();
 
@@ -2228,7 +2228,7 @@ describe("organization billing settings", () => {
       }),
     );
     expect(screen.getByText("Downgrades to $100 on Apr 1, 2026.")).toHaveClass(
-      "text-amber-600",
+      "text-yellow-700",
     );
     expect(
       screen.queryByText("Downgrades to $50 on Apr 1, 2026."),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -2064,8 +2064,6 @@ describe("organization billing settings", () => {
     const scheduledDowngrade = within(orderSummary).getByRole("status", {
       name: "Downgrade scheduled",
     });
-    expect(scheduledDowngrade).toHaveClass("bg-yellow-50/70");
-    expect(orderSummary).toHaveClass("pb-5");
     expect(scheduledDowngrade).toHaveTextContent(
       "Lower package starts Apr 1, 2026 · Existing credits remain available until they expire",
     );
@@ -2521,10 +2519,11 @@ describe("organization billing settings", () => {
         name: /Monthly total \$180\/month \$20\/month/u,
       }),
     ).toBeInTheDocument();
-    const downgradeDescription = within(orderSummary).getByText(
-      "The lower package starts at the next billing date. Existing credits remain available until they expire.",
-    );
-    expect(downgradeDescription.parentElement).toHaveClass("bg-yellow-50/70");
+    expect(
+      within(orderSummary).getByText(
+        "The lower package starts at the next billing date. Existing credits remain available until they expire.",
+      ),
+    ).toBeInTheDocument();
     expect(
       within(orderSummary).getByText("Scheduled for Apr 1, 2026"),
     ).toBeInTheDocument();
@@ -3970,20 +3969,16 @@ describe("organization billing settings", () => {
         screen.getByText(
           "Your Team plan will downgrade to Pro on May 1, 2026.",
         ),
-      ).toHaveClass("text-yellow-700");
+      ).toBeInTheDocument();
     });
 
     click(screen.getByText("Compare all plans"));
 
     await waitFor(() => {
       expect(screen.getByText("Compare plans")).toBeInTheDocument();
-      const downgradeNotices = screen.getAllByText(
-        "Downgrades to Pro on May 1, 2026",
-      );
-      expect(downgradeNotices.length).toBeGreaterThan(0);
-      for (const notice of downgradeNotices) {
-        expect(notice).toHaveClass("bg-yellow-50/70");
-      }
+      expect(
+        screen.getAllByText("Downgrades to Pro on May 1, 2026").length,
+      ).toBeGreaterThan(0);
     });
 
     click(screen.getByText("Restore plan"));
@@ -4080,7 +4075,7 @@ describe("organization billing settings", () => {
       within(downgradeDialog).getByText(
         /After that, this workspace moves to Pro/u,
       ),
-    ).toHaveClass("text-yellow-700");
+    ).toBeInTheDocument();
 
     click(buttonByText("Downgrade to Pro", downgradeDialog));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -2521,16 +2521,16 @@ describe("organization billing settings", () => {
         name: /Monthly total \$180\/month \$20\/month/u,
       }),
     ).toBeInTheDocument();
-    const downgradeDescription = within(orderSummary).getByText(
-      "The lower package starts at the next billing date. Existing credits remain available until they expire.",
-    );
-    expect(downgradeDescription.parentElement).toHaveClass(
-      "bg-yellow-50/70",
-      "mb-5",
+    const downgradeNotice = within(orderSummary).getByRole("status", {
+      name: "Downgrade",
+    });
+    expect(downgradeNotice).toHaveClass("bg-yellow-50/70", "mb-5");
+    expect(downgradeNotice).toHaveTextContent(
+      "Lower package starts Apr 1, 2026 · Existing credits remain available until they expire",
     );
     expect(
-      within(orderSummary).getByText("Scheduled for Apr 1, 2026"),
-    ).toBeInTheDocument();
+      downgradeNotice.firstElementChild?.querySelector("svg"),
+    ).not.toBeNull();
     click(buttonByText("Confirm", orderSummary));
     const confirmationDialog = await screen.findByRole("dialog", {
       name: "Review package change",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -2064,6 +2064,8 @@ describe("organization billing settings", () => {
     const scheduledDowngrade = within(orderSummary).getByRole("status", {
       name: "Downgrade scheduled",
     });
+    expect(scheduledDowngrade).toHaveClass("bg-yellow-50/70");
+    expect(orderSummary).toHaveClass("pb-5");
     expect(scheduledDowngrade).toHaveTextContent(
       "Lower package starts Apr 1, 2026 · Existing credits remain available until they expire",
     );
@@ -2519,11 +2521,10 @@ describe("organization billing settings", () => {
         name: /Monthly total \$180\/month \$20\/month/u,
       }),
     ).toBeInTheDocument();
-    expect(
-      within(orderSummary).getByText(
-        "The lower package starts at the next billing date. Existing credits remain available until they expire.",
-      ),
-    ).toBeInTheDocument();
+    const downgradeDescription = within(orderSummary).getByText(
+      "The lower package starts at the next billing date. Existing credits remain available until they expire.",
+    );
+    expect(downgradeDescription.parentElement).toHaveClass("bg-yellow-50/70");
     expect(
       within(orderSummary).getByText("Scheduled for Apr 1, 2026"),
     ).toBeInTheDocument();
@@ -3969,16 +3970,20 @@ describe("organization billing settings", () => {
         screen.getByText(
           "Your Team plan will downgrade to Pro on May 1, 2026.",
         ),
-      ).toBeInTheDocument();
+      ).toHaveClass("text-yellow-700");
     });
 
     click(screen.getByText("Compare all plans"));
 
     await waitFor(() => {
       expect(screen.getByText("Compare plans")).toBeInTheDocument();
-      expect(
-        screen.getAllByText("Downgrades to Pro on May 1, 2026").length,
-      ).toBeGreaterThan(0);
+      const downgradeNotices = screen.getAllByText(
+        "Downgrades to Pro on May 1, 2026",
+      );
+      expect(downgradeNotices.length).toBeGreaterThan(0);
+      for (const notice of downgradeNotices) {
+        expect(notice).toHaveClass("bg-yellow-50/70");
+      }
     });
 
     click(screen.getByText("Restore plan"));
@@ -4075,7 +4080,7 @@ describe("organization billing settings", () => {
       within(downgradeDialog).getByText(
         /After that, this workspace moves to Pro/u,
       ),
-    ).toBeInTheDocument();
+    ).toHaveClass("text-yellow-700");
 
     click(buttonByText("Downgrade to Pro", downgradeDialog));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -2064,6 +2064,8 @@ describe("organization billing settings", () => {
     const scheduledDowngrade = within(orderSummary).getByRole("status", {
       name: "Downgrade scheduled",
     });
+    expect(scheduledDowngrade).toHaveClass("bg-yellow-50/70");
+    expect(orderSummary).toHaveClass("pb-5");
     expect(scheduledDowngrade).toHaveTextContent(
       "Lower package starts Apr 1, 2026 · Existing credits remain available until they expire",
     );
@@ -2519,11 +2521,13 @@ describe("organization billing settings", () => {
         name: /Monthly total \$180\/month \$20\/month/u,
       }),
     ).toBeInTheDocument();
-    expect(
-      within(orderSummary).getByText(
-        "The lower package starts at the next billing date. Existing credits remain available until they expire.",
-      ),
-    ).toBeInTheDocument();
+    const downgradeDescription = within(orderSummary).getByText(
+      "The lower package starts at the next billing date. Existing credits remain available until they expire.",
+    );
+    expect(downgradeDescription.parentElement).toHaveClass(
+      "bg-yellow-50/70",
+      "mb-5",
+    );
     expect(
       within(orderSummary).getByText("Scheduled for Apr 1, 2026"),
     ).toBeInTheDocument();
@@ -3969,16 +3973,20 @@ describe("organization billing settings", () => {
         screen.getByText(
           "Your Team plan will downgrade to Pro on May 1, 2026.",
         ),
-      ).toBeInTheDocument();
+      ).toHaveClass("text-yellow-700");
     });
 
     click(screen.getByText("Compare all plans"));
 
     await waitFor(() => {
       expect(screen.getByText("Compare plans")).toBeInTheDocument();
-      expect(
-        screen.getAllByText("Downgrades to Pro on May 1, 2026").length,
-      ).toBeGreaterThan(0);
+      const downgradeNotices = screen.getAllByText(
+        "Downgrades to Pro on May 1, 2026",
+      );
+      expect(downgradeNotices.length).toBeGreaterThan(0);
+      for (const notice of downgradeNotices) {
+        expect(notice).toHaveClass("bg-yellow-50/70", "mb-5");
+      }
     });
 
     click(screen.getByText("Restore plan"));
@@ -4075,7 +4083,7 @@ describe("organization billing settings", () => {
       within(downgradeDialog).getByText(
         /After that, this workspace moves to Pro/u,
       ),
-    ).toBeInTheDocument();
+    ).toHaveClass("text-yellow-700");
 
     click(buttonByText("Downgrade to Pro", downgradeDialog));
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -514,11 +514,8 @@ function PlanScheduleNotice({
   if (!changeDate) {
     return null;
   }
-  const noticeClassName = `mb-5 rounded-lg border px-3 py-2 text-[12px] leading-relaxed ${
-    scheduledChange?.type === "downgrade" || isDowngradeTarget
-      ? "border-yellow-200/70 bg-yellow-50/70 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200"
-      : "border-amber-200/70 bg-amber-50/70 text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300"
-  }`;
+  const noticeClassName =
+    "mb-5 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-[12px] leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300";
 
   if (scheduledChange?.type === "cancel" && isCurrent) {
     return (
@@ -901,7 +898,7 @@ function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
         </DialogHeader>
 
         {isTeam && isLockedTarget && (
-          <p className="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
+          <p className="text-sm text-amber-600 dark:text-amber-400 mt-2">
             {i18n.t(
               ($) => {
                 return $.billing.downgrade.teamWarning;
@@ -912,7 +909,7 @@ function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
         )}
 
         {!isTeam && (
-          <p className="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
+          <p className="text-sm text-amber-600 dark:text-amber-400 mt-2">
             {i18n.t(($) => {
               return $.billing.downgrade.proWarning;
             })}
@@ -2836,7 +2833,7 @@ export function OrgBillingTab() {
                 <>
                   <div className="h-0 zero-border-t mx-5" />
                   <div className="px-5 py-3">
-                    <p className="text-[13px] text-yellow-700 dark:text-yellow-300">
+                    <p className="text-[13px] text-amber-600 dark:text-amber-400">
                       {t(
                         ($) => {
                           return $.billing.plans.downgradeNotice;

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -514,8 +514,11 @@ function PlanScheduleNotice({
   if (!changeDate) {
     return null;
   }
-  const noticeClassName =
-    "mb-5 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-[12px] leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300";
+  const noticeClassName = `mb-5 rounded-lg border px-3 py-2 text-[12px] leading-relaxed ${
+    scheduledChange?.type === "downgrade" || isDowngradeTarget
+      ? "border-yellow-200/70 bg-yellow-50/70 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200"
+      : "border-amber-200/70 bg-amber-50/70 text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300"
+  }`;
 
   if (scheduledChange?.type === "cancel" && isCurrent) {
     return (
@@ -898,7 +901,7 @@ function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
         </DialogHeader>
 
         {isTeam && isLockedTarget && (
-          <p className="text-sm text-amber-600 dark:text-amber-400 mt-2">
+          <p className="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
             {i18n.t(
               ($) => {
                 return $.billing.downgrade.teamWarning;
@@ -909,7 +912,7 @@ function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
         )}
 
         {!isTeam && (
-          <p className="text-sm text-amber-600 dark:text-amber-400 mt-2">
+          <p className="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
             {i18n.t(($) => {
               return $.billing.downgrade.proWarning;
             })}
@@ -2833,7 +2836,7 @@ export function OrgBillingTab() {
                 <>
                   <div className="h-0 zero-border-t mx-5" />
                   <div className="px-5 py-3">
-                    <p className="text-[13px] text-amber-600 dark:text-amber-400">
+                    <p className="text-[13px] text-yellow-700 dark:text-yellow-300">
                       {t(
                         ($) => {
                           return $.billing.plans.downgradeNotice;

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -126,6 +126,9 @@ const USAGE_PACK_PLANS = [
   },
 ] as const satisfies readonly UsagePackPlan[];
 
+const USAGE_PACK_DOWNGRADE_NOTICE_CLASS =
+  "border border-yellow-200/70 bg-yellow-50/70 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200";
+
 function usagePackPlan(tier: UsagePackPlanTier): UsagePackPlan {
   return tier === "pro" ? USAGE_PACK_PLANS[0] : USAGE_PACK_PLANS[1];
 }
@@ -1796,7 +1799,9 @@ function SubscriptionChangeNotice({
   readonly effectiveAt: string;
 }) {
   return (
-    <div className="mt-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-sm leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300">
+    <div
+      className={`mt-3 rounded-lg px-3 py-2 text-sm leading-relaxed ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS}`}
+    >
       <p>{description}</p>
       <p className="mt-1 font-medium">
         {i18n.t(
@@ -1822,7 +1827,7 @@ function ScheduledUsagePackDowngradeNotice({
     <div
       role="status"
       aria-label={title}
-      className="flex items-center gap-3 rounded-xl border border-yellow-200/70 bg-yellow-50/70 p-3 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200"
+      className={`flex items-center gap-3 rounded-xl p-3 ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS}`}
     >
       <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-yellow-100/80 text-yellow-700 dark:bg-yellow-400/15 dark:text-yellow-300">
         <CalendarDays aria-hidden="true" className="size-4" />

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -126,9 +126,6 @@ const USAGE_PACK_PLANS = [
   },
 ] as const satisfies readonly UsagePackPlan[];
 
-const USAGE_PACK_DOWNGRADE_NOTICE_CLASS =
-  "border border-yellow-200/70 bg-yellow-50/70 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200";
-
 function usagePackPlan(tier: UsagePackPlanTier): UsagePackPlan {
   return tier === "pro" ? USAGE_PACK_PLANS[0] : USAGE_PACK_PLANS[1];
 }
@@ -1799,9 +1796,7 @@ function SubscriptionChangeNotice({
   readonly effectiveAt: string;
 }) {
   return (
-    <div
-      className={`mt-3 rounded-lg px-3 py-2 text-sm leading-relaxed ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS}`}
-    >
+    <div className="mt-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-sm leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300">
       <p>{description}</p>
       <p className="mt-1 font-medium">
         {i18n.t(
@@ -1827,7 +1822,7 @@ function ScheduledUsagePackDowngradeNotice({
     <div
       role="status"
       aria-label={title}
-      className={`flex items-center gap-3 rounded-xl p-3 ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS}`}
+      className="flex items-center gap-3 rounded-xl border border-yellow-200/70 bg-yellow-50/70 p-3 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200"
     >
       <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-yellow-100/80 text-yellow-700 dark:bg-yellow-400/15 dark:text-yellow-300">
         <CalendarDays aria-hidden="true" className="size-4" />

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1793,21 +1793,13 @@ function SubscriptionComparisonTable({
 
 function SubscriptionChangeNotice({
   description,
-  downgrade = false,
   effectiveAt,
 }: {
   readonly description: string;
-  readonly downgrade?: boolean;
   readonly effectiveAt: string;
 }) {
   return (
-    <div
-      className={
-        downgrade
-          ? `mb-5 mt-3 rounded-lg px-3 py-2 text-sm leading-relaxed ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS}`
-          : "mt-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-sm leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300"
-      }
-    >
+    <div className="mt-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-sm leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300">
       <p>{description}</p>
       <p className="mt-1 font-medium">
         {i18n.t(
@@ -1821,19 +1813,27 @@ function SubscriptionChangeNotice({
   );
 }
 
-function ScheduledUsagePackDowngradeNotice({
+function UsagePackDowngradeNotice({
+  className = "",
   effectiveAt,
+  scheduled = false,
 }: {
+  readonly className?: string;
   readonly effectiveAt: string;
+  readonly scheduled?: boolean;
 }) {
-  const title = i18n.t(($) => {
-    return $.billing.plans.usagePacks.management.scheduledDowngradeTitle;
-  });
+  const title = scheduled
+    ? i18n.t(($) => {
+        return $.billing.plans.usagePacks.management.scheduledDowngradeTitle;
+      })
+    : i18n.t(($) => {
+        return $.billing.plans.downgrade;
+      });
   return (
     <div
       role="status"
       aria-label={title}
-      className={`flex items-center gap-3 rounded-xl p-3 ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS}`}
+      className={`flex items-center gap-3 rounded-xl p-3 ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS} ${className}`}
     >
       <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-yellow-100/80 text-yellow-700 dark:bg-yellow-400/15 dark:text-yellow-300">
         <CalendarDays aria-hidden="true" className="size-4" />
@@ -2242,17 +2242,15 @@ function ManagedSubscriptionOrderSummary({
       className={scheduledDowngradeEffectiveAt ? "pb-5" : undefined}
     >
       {scheduledDowngradeEffectiveAt ? (
-        <ScheduledUsagePackDowngradeNotice
+        <UsagePackDowngradeNotice
           effectiveAt={scheduledDowngradeEffectiveAt}
+          scheduled
         />
       ) : (
         hasDowngrade &&
         management.currentPeriodEnd && (
-          <SubscriptionChangeNotice
-            description={i18n.t(($) => {
-              return $.billing.plans.usagePacks.management.downgradeDescription;
-            })}
-            downgrade
+          <UsagePackDowngradeNotice
+            className="mb-5 mt-3"
             effectiveAt={management.currentPeriodEnd}
           />
         )

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -126,11 +126,6 @@ const USAGE_PACK_PLANS = [
   },
 ] as const satisfies readonly UsagePackPlan[];
 
-const USAGE_PACK_PRIMARY_ACTION_CLASS =
-  "bg-yellow-400 text-yellow-950 hover:bg-yellow-500 active:bg-yellow-600 focus-visible:ring-yellow-500/40 dark:bg-yellow-400 dark:text-yellow-950 dark:hover:bg-yellow-300 dark:active:bg-yellow-500";
-const USAGE_PACK_NOTICE_CLASS =
-  "border border-yellow-200/70 bg-yellow-50/70 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200";
-
 function usagePackPlan(tier: UsagePackPlanTier): UsagePackPlan {
   return tier === "pro" ? USAGE_PACK_PLANS[0] : USAGE_PACK_PLANS[1];
 }
@@ -944,9 +939,7 @@ function PlanSelectionCard({
         <Button
           type="button"
           variant={plan.popular ? "default" : "outline"}
-          className={`h-10 w-full text-sm font-medium ${
-            plan.popular ? USAGE_PACK_PRIMARY_ACTION_CLASS : ""
-          }`}
+          className="h-10 w-full text-sm font-medium"
           disabled={action === "disabled" || busy}
           onClick={onAction}
         >
@@ -1191,7 +1184,7 @@ function OrderSummary({
         <p className="text-sm text-destructive">{checkoutError}</p>
       )}
       <Button
-        className={`h-10 w-full text-sm font-medium ${USAGE_PACK_PRIMARY_ACTION_CLASS}`}
+        className="h-10 w-full text-sm font-medium"
         disabled={checkoutDisabled || checkoutLoading}
         onClick={onCheckout}
       >
@@ -1803,9 +1796,7 @@ function SubscriptionChangeNotice({
   readonly effectiveAt: string;
 }) {
   return (
-    <div
-      className={`mt-3 rounded-lg px-3 py-2 text-sm leading-relaxed ${USAGE_PACK_NOTICE_CLASS}`}
-    >
+    <div className="mt-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-sm leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300">
       <p>{description}</p>
       <p className="mt-1 font-medium">
         {i18n.t(
@@ -1831,7 +1822,7 @@ function ScheduledUsagePackDowngradeNotice({
     <div
       role="status"
       aria-label={title}
-      className={`flex items-center gap-3 rounded-xl p-3 ${USAGE_PACK_NOTICE_CLASS}`}
+      className="flex items-center gap-3 rounded-xl border border-yellow-200/70 bg-yellow-50/70 p-3 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200"
     >
       <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-yellow-100/80 text-yellow-700 dark:bg-yellow-400/15 dark:text-yellow-300">
         <CalendarDays aria-hidden="true" className="size-4" />
@@ -1967,7 +1958,7 @@ function PackageReviewStep({
         {error && <p className="text-xs text-destructive">{error}</p>}
         <Button
           type="button"
-          className={`h-10 w-full text-sm font-medium ${USAGE_PACK_PRIMARY_ACTION_CLASS}`}
+          className="h-10 w-full text-sm font-medium"
           disabled={confirming}
           onClick={() => {
             detach(submitChange(), Reason.DomCallback);
@@ -2266,7 +2257,7 @@ function ManagedSubscriptionOrderSummary({
           {error && <p className="text-sm text-destructive">{error}</p>}
           <Button
             type="button"
-            className={`h-10 w-full text-sm font-medium ${USAGE_PACK_PRIMARY_ACTION_CLASS}`}
+            className="h-10 w-full text-sm font-medium"
             disabled={
               !members ||
               (hasPendingChange && !hasScheduledDowngrade) ||
@@ -2432,7 +2423,7 @@ function MigrationOrderSummary({
       )}
       <Button
         type="button"
-        className={`mt-4 h-10 w-full text-sm font-medium ${USAGE_PACK_PRIMARY_ACTION_CLASS}`}
+        className="mt-4 h-10 w-full text-sm font-medium"
         disabled={!members || previewing}
         onClick={() => {
           if (!members) {
@@ -2526,7 +2517,7 @@ function MigrationRevisionOrderSummary({
       )}
       <Button
         type="button"
-        className={`mt-4 h-10 w-full text-sm font-medium ${USAGE_PACK_PRIMARY_ACTION_CLASS}`}
+        className="mt-4 h-10 w-full text-sm font-medium"
         disabled={!hasConfigurationChange || previewing}
         onClick={() => {
           if (!members) {
@@ -2619,7 +2610,6 @@ function MigrationReviewDialog({
             })}
           </Button>
           <Button
-            className={USAGE_PACK_PRIMARY_ACTION_CLASS}
             disabled={confirming}
             onClick={() => {
               detach(handleConfirm(), Reason.DomCallback);
@@ -2714,7 +2704,6 @@ function MigrationRevisionReviewDialog({
             })}
           </Button>
           <Button
-            className={USAGE_PACK_PRIMARY_ACTION_CLASS}
             disabled={confirming || !members}
             onClick={() => {
               detach(handleConfirm(), Reason.DomCallback);

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -126,6 +126,9 @@ const USAGE_PACK_PLANS = [
   },
 ] as const satisfies readonly UsagePackPlan[];
 
+const USAGE_PACK_DOWNGRADE_NOTICE_CLASS =
+  "border border-yellow-200/70 bg-yellow-50/70 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200";
+
 function usagePackPlan(tier: UsagePackPlanTier): UsagePackPlan {
   return tier === "pro" ? USAGE_PACK_PLANS[0] : USAGE_PACK_PLANS[1];
 }
@@ -1796,7 +1799,9 @@ function SubscriptionChangeNotice({
   readonly effectiveAt: string;
 }) {
   return (
-    <div className="mt-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-sm leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300">
+    <div
+      className={`mb-5 mt-3 rounded-lg px-3 py-2 text-sm leading-relaxed ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS}`}
+    >
       <p>{description}</p>
       <p className="mt-1 font-medium">
         {i18n.t(
@@ -1822,7 +1827,7 @@ function ScheduledUsagePackDowngradeNotice({
     <div
       role="status"
       aria-label={title}
-      className="flex items-center gap-3 rounded-xl border border-yellow-200/70 bg-yellow-50/70 p-3 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200"
+      className={`flex items-center gap-3 rounded-xl p-3 ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS}`}
     >
       <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-yellow-100/80 text-yellow-700 dark:bg-yellow-400/15 dark:text-yellow-300">
         <CalendarDays aria-hidden="true" className="size-4" />

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -126,6 +126,11 @@ const USAGE_PACK_PLANS = [
   },
 ] as const satisfies readonly UsagePackPlan[];
 
+const USAGE_PACK_PRIMARY_ACTION_CLASS =
+  "bg-yellow-400 text-yellow-950 hover:bg-yellow-500 active:bg-yellow-600 focus-visible:ring-yellow-500/40 dark:bg-yellow-400 dark:text-yellow-950 dark:hover:bg-yellow-300 dark:active:bg-yellow-500";
+const USAGE_PACK_NOTICE_CLASS =
+  "border border-yellow-200/70 bg-yellow-50/70 text-yellow-800 dark:border-yellow-400/20 dark:bg-yellow-400/10 dark:text-yellow-200";
+
 function usagePackPlan(tier: UsagePackPlanTier): UsagePackPlan {
   return tier === "pro" ? USAGE_PACK_PLANS[0] : USAGE_PACK_PLANS[1];
 }
@@ -592,7 +597,7 @@ function MemberUsageRow({
           </SelectContent>
         </Select>
         {downgradeSummary && (
-          <p className="mt-1 truncate text-sm font-medium text-amber-600 dark:text-amber-300">
+          <p className="mt-1 truncate text-sm font-medium text-yellow-700 dark:text-yellow-300">
             {downgradeSummary}
           </p>
         )}
@@ -939,7 +944,9 @@ function PlanSelectionCard({
         <Button
           type="button"
           variant={plan.popular ? "default" : "outline"}
-          className="h-10 w-full text-sm font-medium"
+          className={`h-10 w-full text-sm font-medium ${
+            plan.popular ? USAGE_PACK_PRIMARY_ACTION_CLASS : ""
+          }`}
           disabled={action === "disabled" || busy}
           onClick={onAction}
         >
@@ -1184,7 +1191,7 @@ function OrderSummary({
         <p className="text-sm text-destructive">{checkoutError}</p>
       )}
       <Button
-        className="h-10 w-full text-sm font-medium"
+        className={`h-10 w-full text-sm font-medium ${USAGE_PACK_PRIMARY_ACTION_CLASS}`}
         disabled={checkoutDisabled || checkoutLoading}
         onClick={onCheckout}
       >
@@ -1796,7 +1803,9 @@ function SubscriptionChangeNotice({
   readonly effectiveAt: string;
 }) {
   return (
-    <div className="mt-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-sm leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300">
+    <div
+      className={`mt-3 rounded-lg px-3 py-2 text-sm leading-relaxed ${USAGE_PACK_NOTICE_CLASS}`}
+    >
       <p>{description}</p>
       <p className="mt-1 font-medium">
         {i18n.t(
@@ -1822,14 +1831,16 @@ function ScheduledUsagePackDowngradeNotice({
     <div
       role="status"
       aria-label={title}
-      className="flex items-center gap-3 rounded-xl bg-gray-50 p-3"
+      className={`flex items-center gap-3 rounded-xl p-3 ${USAGE_PACK_NOTICE_CLASS}`}
     >
-      <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-card text-muted-foreground">
+      <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-yellow-100/80 text-yellow-700 dark:bg-yellow-400/15 dark:text-yellow-300">
         <CalendarDays aria-hidden="true" className="size-4" />
       </span>
       <div className="min-w-0">
-        <p className="text-sm font-semibold text-foreground">{title}</p>
-        <p className="mt-0.5 text-sm leading-snug text-muted-foreground">
+        <p className="text-sm font-semibold text-yellow-900 dark:text-yellow-100">
+          {title}
+        </p>
+        <p className="mt-0.5 text-sm leading-snug text-yellow-800 dark:text-yellow-200">
           {i18n.t(
             ($) => {
               return $.billing.plans.usagePacks.management
@@ -1956,7 +1967,7 @@ function PackageReviewStep({
         {error && <p className="text-xs text-destructive">{error}</p>}
         <Button
           type="button"
-          className="h-10 w-full text-sm font-medium"
+          className={`h-10 w-full text-sm font-medium ${USAGE_PACK_PRIMARY_ACTION_CLASS}`}
           disabled={confirming}
           onClick={() => {
             detach(submitChange(), Reason.DomCallback);
@@ -2226,6 +2237,7 @@ function ManagedSubscriptionOrderSummary({
       aria-label={i18n.t(($) => {
         return $.billing.plans.usagePacks.orderSummary;
       })}
+      className={scheduledDowngradeEffectiveAt ? "pb-5" : undefined}
     >
       {scheduledDowngradeEffectiveAt ? (
         <ScheduledUsagePackDowngradeNotice
@@ -2254,7 +2266,7 @@ function ManagedSubscriptionOrderSummary({
           {error && <p className="text-sm text-destructive">{error}</p>}
           <Button
             type="button"
-            className="h-10 w-full text-sm font-medium"
+            className={`h-10 w-full text-sm font-medium ${USAGE_PACK_PRIMARY_ACTION_CLASS}`}
             disabled={
               !members ||
               (hasPendingChange && !hasScheduledDowngrade) ||
@@ -2420,7 +2432,7 @@ function MigrationOrderSummary({
       )}
       <Button
         type="button"
-        className="mt-4 h-10 w-full text-sm font-medium"
+        className={`mt-4 h-10 w-full text-sm font-medium ${USAGE_PACK_PRIMARY_ACTION_CLASS}`}
         disabled={!members || previewing}
         onClick={() => {
           if (!members) {
@@ -2514,7 +2526,7 @@ function MigrationRevisionOrderSummary({
       )}
       <Button
         type="button"
-        className="mt-4 h-10 w-full text-sm font-medium"
+        className={`mt-4 h-10 w-full text-sm font-medium ${USAGE_PACK_PRIMARY_ACTION_CLASS}`}
         disabled={!hasConfigurationChange || previewing}
         onClick={() => {
           if (!members) {
@@ -2607,6 +2619,7 @@ function MigrationReviewDialog({
             })}
           </Button>
           <Button
+            className={USAGE_PACK_PRIMARY_ACTION_CLASS}
             disabled={confirming}
             onClick={() => {
               detach(handleConfirm(), Reason.DomCallback);
@@ -2701,6 +2714,7 @@ function MigrationRevisionReviewDialog({
             })}
           </Button>
           <Button
+            className={USAGE_PACK_PRIMARY_ACTION_CLASS}
             disabled={confirming || !members}
             onClick={() => {
               detach(handleConfirm(), Reason.DomCallback);

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1793,14 +1793,20 @@ function SubscriptionComparisonTable({
 
 function SubscriptionChangeNotice({
   description,
+  downgrade = false,
   effectiveAt,
 }: {
   readonly description: string;
+  readonly downgrade?: boolean;
   readonly effectiveAt: string;
 }) {
   return (
     <div
-      className={`mb-5 mt-3 rounded-lg px-3 py-2 text-sm leading-relaxed ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS}`}
+      className={
+        downgrade
+          ? `mb-5 mt-3 rounded-lg px-3 py-2 text-sm leading-relaxed ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS}`
+          : "mt-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-sm leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300"
+      }
     >
       <p>{description}</p>
       <p className="mt-1 font-medium">
@@ -2246,6 +2252,7 @@ function ManagedSubscriptionOrderSummary({
             description={i18n.t(($) => {
               return $.billing.plans.usagePacks.management.downgradeDescription;
             })}
+            downgrade
             effectiveAt={management.currentPeriodEnd}
           />
         )


### PR DESCRIPTION
## Summary

- align the member-package downgrade date and scheduled-downgrade banner on the yellow feedback palette
- add a 20px bottom inset when the scheduled-downgrade banner is the final passive state
- preserve all existing CTA, plan downgrade, cancellation, and concurrency styling

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm exec prettier --check apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx`
- `pnpm exec oxlint src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx src/views/zero-page/__tests__/org-billing-tab.test.tsx`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx -t "shows and restores a scheduled member package downgrade|allows replacing a scheduled member package downgrade|configures a Team to Pro downgrade on the same page"` (3 passed)
