### PR TITLE
fix(billing): align legacy conversion dialog flow

### DIFF
--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -235,6 +235,7 @@ export interface StripeCreditNoteParams {
 export interface StripeInvoiceLine {
   readonly id?: string;
   readonly amount: number;
+  readonly discount_amounts?: readonly { readonly amount: number }[] | null;
   readonly subtotal?: number | null;
   readonly metadata?: Record<string, string> | null;
   readonly quantity?: number | null;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -1744,6 +1744,7 @@ describe("legacy subscription usage pack migration", () => {
   }
 
   interface MigrationStripeController {
+    readonly discountId: string | null;
     readonly scheduleId: string;
     readonly invoice: () => object;
     readonly cancelSubscription: () => MigrationSubscriptionMock;
@@ -1761,6 +1762,7 @@ describe("legacy subscription usage pack migration", () => {
     readonly pending_update: null;
     readonly latest_invoice: string | null;
     readonly metadata: Readonly<Record<string, string>>;
+    readonly discounts: readonly string[];
     readonly items: {
       readonly data: readonly {
         readonly id: string;
@@ -1854,6 +1856,7 @@ describe("legacy subscription usage pack migration", () => {
     value: unknown,
     effectiveAt: number,
     amountDue: number,
+    discountAmount = 0,
   ): object {
     const items = migrationPreviewItems(value).flatMap((item) => {
       if (
@@ -1954,14 +1957,28 @@ describe("legacy subscription usage pack migration", () => {
         data: [
           ...noiseLines,
           ...items.map((item, index) => {
+            const exclusiveTaxAmount = index === 0 && scheduled ? 100 : 0;
+            const appliedDiscountAmount = index === 0 ? discountAmount : 0;
             return {
               id: `il_migration_preview_${index}`,
-              amount: index === 0 ? amountDue - (scheduled ? 100 : 0) : 0,
+              amount:
+                index === 0
+                  ? amountDue - exclusiveTaxAmount + appliedDiscountAmount
+                  : 0,
+              discount_amounts:
+                appliedDiscountAmount > 0
+                  ? [{ amount: appliedDiscountAmount }]
+                  : [],
               quantity: item.quantity,
               pricing: { price_details: { price: item.price } },
               taxes:
-                index === 0 && scheduled
-                  ? [{ amount: 100, tax_behavior: "exclusive" }]
+                exclusiveTaxAmount > 0
+                  ? [
+                      {
+                        amount: exclusiveTaxAmount,
+                        tax_behavior: "exclusive",
+                      },
+                    ]
                   : [],
               period: {
                 start: effectiveAt,
@@ -2076,6 +2093,7 @@ describe("legacy subscription usage pack migration", () => {
 
   function legacyMigrationSubscription(
     fixture: LegacyMigrationFixture,
+    discounts: readonly string[] = [],
   ): MigrationSubscriptionMock {
     return {
       id: fixture.subscriptionId,
@@ -2087,6 +2105,7 @@ describe("legacy subscription usage pack migration", () => {
       pending_update: null,
       latest_invoice: null,
       metadata: { orgId: fixture.orgId },
+      discounts,
       items: {
         data: [
           {
@@ -2111,6 +2130,7 @@ describe("legacy subscription usage pack migration", () => {
     readonly currentRecurringAmountCents: number;
     readonly amountDueCents: number;
     readonly amountPaidCents: number;
+    readonly discountAmountCents?: number;
   }): MigrationStripeController {
     const targetTier = args.targetTier ?? args.fixture.tier;
     const planPriceId =
@@ -2120,6 +2140,10 @@ describe("legacy subscription usage pack migration", () => {
     const invoiceId = `in_migration_${randomUUID()}`;
     const paymentIntentId = `pi_migration_${randomUUID()}`;
     const scheduleId = `sub_sched_migration_${randomUUID()}`;
+    const discountId = args.discountAmountCents
+      ? `di_migration_${randomUUID()}`
+      : null;
+    const discounts = discountId ? [discountId] : [];
     const packageLineAmount = 2000 * args.packageQuantity;
     const renewedPeriod = {
       start: args.fixture.period.end,
@@ -2206,7 +2230,7 @@ describe("legacy subscription usage pack migration", () => {
     };
     const appliedSubscription = (): MigrationSubscriptionMock => {
       return {
-        ...legacyMigrationSubscription(args.fixture),
+        ...legacyMigrationSubscription(args.fixture, discounts),
         schedule: scheduleId,
         latest_invoice: invoiceId,
         items: {
@@ -2238,6 +2262,7 @@ describe("legacy subscription usage pack migration", () => {
     let invoice = paidInvoice();
     let subscription: MigrationSubscriptionMock = legacyMigrationSubscription(
       args.fixture,
+      discounts,
     );
     const syncRetrievalMocks = () => {
       context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
@@ -2273,6 +2298,7 @@ describe("legacy subscription usage pack migration", () => {
           params,
           args.fixture.period.end,
           amountDue,
+          args.discountAmountCents,
         ),
       );
     });
@@ -2305,6 +2331,7 @@ describe("legacy subscription usage pack migration", () => {
       },
     );
     return {
+      discountId,
       scheduleId,
       invoice: () => {
         return invoice;
@@ -2325,7 +2352,7 @@ describe("legacy subscription usage pack migration", () => {
       },
       cancelSchedule: () => {
         invoice = { ...openInvoice(), status: "void" };
-        subscription = legacyMigrationSubscription(args.fixture);
+        subscription = legacyMigrationSubscription(args.fixture, discounts);
         syncRetrievalMocks();
       },
     };
@@ -2705,7 +2732,7 @@ describe("legacy subscription usage pack migration", () => {
     expect(delayedState.grants).toHaveLength(2);
   });
 
-  it("revises a scheduled migration and exposes its current configuration", async () => {
+  it("revises a discounted scheduled migration and exposes its configuration", async () => {
     const fixture = await seedLegacyMigrationFixture({ tier: "pro" });
     await enableMigration(fixture);
     const stripe = mockMigrationStripe({
@@ -2715,6 +2742,7 @@ describe("legacy subscription usage pack migration", () => {
       currentRecurringAmountCents: 2000,
       amountDueCents: 18_000,
       amountPaidCents: 18_000,
+      discountAmountCents: 3000,
     });
     const preview = await previewMigration(fixture, "team");
     await accept(
@@ -2747,7 +2775,12 @@ describe("legacy subscription usage pack migration", () => {
         ? 21_000
         : 18_000;
       return Promise.resolve(
-        migrationRecurringPreviewInvoice(params, fixture.period.end, amountDue),
+        migrationRecurringPreviewInvoice(
+          params,
+          fixture.period.end,
+          amountDue,
+          3000,
+        ),
       );
     });
     context.mocks.stripe.subscriptionSchedules.update.mockClear();
@@ -2775,6 +2808,7 @@ describe("legacy subscription usage pack migration", () => {
     });
     const revisionPreviewParams =
       context.mocks.stripe.invoices.createPreview.mock.calls.at(-1)?.at(0);
+    expect(stripe.discountId).not.toBeNull();
     expect(revisionPreviewParams).toMatchObject({
       schedule: stripe.scheduleId,
       preview_mode: "next",
@@ -2782,8 +2816,11 @@ describe("legacy subscription usage pack migration", () => {
         end_behavior: "release",
         proration_behavior: "none",
         phases: [
-          expect.any(Object),
           expect.objectContaining({
+            discounts: [{ discount: stripe.discountId }],
+          }),
+          expect.objectContaining({
+            discounts: [{ discount: stripe.discountId }],
             items: expect.arrayContaining([
               { price: TEST_PRICE_USAGE_PACK_PLAN_TEAM, quantity: 1 },
               { price: TEST_PRICE_USAGE_PACK_50, quantity: 1 },
@@ -2814,8 +2851,11 @@ describe("legacy subscription usage pack migration", () => {
       expect.any(String),
       expect.objectContaining({
         phases: [
-          expect.any(Object),
           expect.objectContaining({
+            discounts: [{ discount: stripe.discountId }],
+          }),
+          expect.objectContaining({
+            discounts: [{ discount: stripe.discountId }],
             items: expect.arrayContaining([
               { price: TEST_PRICE_USAGE_PACK_PLAN_TEAM, quantity: 1 },
               { price: TEST_PRICE_USAGE_PACK_50, quantity: 1 },

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -1744,6 +1744,7 @@ describe("legacy subscription usage pack migration", () => {
   }
 
   interface MigrationStripeController {
+    readonly scheduleId: string;
     readonly invoice: () => object;
     readonly cancelSubscription: () => MigrationSubscriptionMock;
     readonly cancelSchedule: () => void;
@@ -1799,24 +1800,40 @@ describe("legacy subscription usage pack migration", () => {
   }
 
   function migrationPreviewItems(value: unknown): readonly unknown[] {
-    if (
-      typeof value !== "object" ||
-      value === null ||
-      !("subscription_details" in value)
-    ) {
-      throw new Error("Expected migration subscription preview details");
+    if (typeof value !== "object" || value === null) {
+      throw new Error("Expected migration preview details");
     }
-    const details = value.subscription_details;
-    if (
-      typeof details !== "object" ||
-      details === null ||
-      !("items" in details) ||
-      !Array.isArray(details.items)
-    ) {
-      throw new Error("Expected migration subscription preview items");
+    if ("subscription_details" in value) {
+      const details = value.subscription_details;
+      if (
+        typeof details === "object" &&
+        details !== null &&
+        "items" in details &&
+        Array.isArray(details.items)
+      ) {
+        return details.items;
+      }
     }
-    const items: readonly unknown[] = details.items;
-    return items;
+    if ("schedule_details" in value) {
+      const details = value.schedule_details;
+      if (
+        typeof details === "object" &&
+        details !== null &&
+        "phases" in details &&
+        Array.isArray(details.phases)
+      ) {
+        const phase: unknown = details.phases.at(-1);
+        if (
+          typeof phase === "object" &&
+          phase !== null &&
+          "items" in phase &&
+          Array.isArray(phase.items)
+        ) {
+          return phase.items;
+        }
+      }
+    }
+    throw new Error("Expected migration preview items");
   }
 
   function migrationPreviewPriceIds(value: unknown): readonly string[] {
@@ -1831,6 +1848,134 @@ describe("legacy subscription usage pack migration", () => {
       }
       return [item.price];
     });
+  }
+
+  function migrationRecurringPreviewInvoice(
+    value: unknown,
+    effectiveAt: number,
+    amountDue: number,
+  ): object {
+    const items = migrationPreviewItems(value).flatMap((item) => {
+      if (
+        typeof item !== "object" ||
+        item === null ||
+        !("price" in item) ||
+        typeof item.price !== "string"
+      ) {
+        return [];
+      }
+      const quantity =
+        "quantity" in item && typeof item.quantity === "number"
+          ? item.quantity
+          : 1;
+      return [{ price: item.price, quantity }];
+    });
+    const scheduled =
+      typeof value === "object" &&
+      value !== null &&
+      "schedule_details" in value;
+    const firstItem = items.at(0);
+    const noiseLines =
+      scheduled && firstItem
+        ? [
+            {
+              id: "il_migration_pending_item",
+              amount: 9000,
+              quantity: firstItem.quantity,
+              pricing: { price_details: { price: firstItem.price } },
+              taxes: [],
+              period: {
+                start: effectiveAt,
+                end: effectiveAt + 30 * 86_400,
+              },
+              parent: {
+                type: "invoice_item_details",
+                invoice_item_details: { proration: false },
+              },
+            },
+            {
+              id: "il_migration_proration",
+              amount: 8000,
+              quantity: firstItem.quantity,
+              pricing: { price_details: { price: firstItem.price } },
+              taxes: [],
+              period: {
+                start: effectiveAt,
+                end: effectiveAt + 30 * 86_400,
+              },
+              parent: {
+                type: "subscription_item_details",
+                subscription_item_details: { proration: true },
+              },
+            },
+            {
+              id: "il_migration_current_phase",
+              amount: 7000,
+              quantity: firstItem.quantity,
+              pricing: { price_details: { price: firstItem.price } },
+              taxes: [],
+              period: {
+                start: effectiveAt - 30 * 86_400,
+                end: effectiveAt,
+              },
+              parent: {
+                type: "subscription_item_details",
+                subscription_item_details: { proration: false },
+              },
+            },
+            {
+              id: "il_migration_unrelated",
+              amount: 6000,
+              quantity: 1,
+              pricing: {
+                price_details: { price: "price_unrelated_preview_item" },
+              },
+              taxes: [],
+              period: {
+                start: effectiveAt,
+                end: effectiveAt + 30 * 86_400,
+              },
+              parent: {
+                type: "subscription_item_details",
+                subscription_item_details: { proration: false },
+              },
+            },
+          ]
+        : [];
+    const noiseAmount = noiseLines.reduce((total, line) => {
+      return total + line.amount;
+    }, 0);
+    return {
+      id: `in_migration_preview_${randomUUID()}`,
+      amount_due: amountDue + noiseAmount,
+      currency: "usd",
+      lines: {
+        has_more: false,
+        data: [
+          ...noiseLines,
+          ...items.map((item, index) => {
+            return {
+              id: `il_migration_preview_${index}`,
+              amount: index === 0 ? amountDue - (scheduled ? 100 : 0) : 0,
+              quantity: item.quantity,
+              pricing: { price_details: { price: item.price } },
+              taxes:
+                index === 0 && scheduled
+                  ? [{ amount: 100, tax_behavior: "exclusive" }]
+                  : [],
+              period: {
+                start: effectiveAt,
+                end: effectiveAt + 30 * 86_400,
+              },
+              parent: {
+                type: "subscription_item_details",
+                subscription_item_details: { proration: false },
+              },
+            };
+          }),
+        ],
+      },
+    };
   }
 
   function paidMigrationTimestamp(): number | null {
@@ -2102,6 +2247,16 @@ describe("legacy subscription usage pack migration", () => {
     };
     syncRetrievalMocks();
     context.mocks.stripe.invoices.createPreview.mockImplementation((params) => {
+      if (
+        subscription.schedule &&
+        typeof params === "object" &&
+        params !== null &&
+        "subscription_details" in params
+      ) {
+        throw new Error(
+          "Scheduled migration previews must use schedule details",
+        );
+      }
       const targetPreview = migrationPreviewItems(params).some((item) => {
         return (
           typeof item === "object" &&
@@ -2110,12 +2265,16 @@ describe("legacy subscription usage pack migration", () => {
           item.price === planPriceId
         );
       });
-      return Promise.resolve({
-        amount_due: targetPreview
-          ? args.amountDueCents
-          : args.currentRecurringAmountCents,
-        currency: "usd",
-      });
+      const amountDue = targetPreview
+        ? args.amountDueCents
+        : args.currentRecurringAmountCents;
+      return Promise.resolve(
+        migrationRecurringPreviewInvoice(
+          params,
+          args.fixture.period.end,
+          amountDue,
+        ),
+      );
     });
     context.mocks.stripe.subscriptionSchedules.create.mockImplementation(() => {
       subscription = { ...subscription, schedule: scheduleId };
@@ -2146,6 +2305,7 @@ describe("legacy subscription usage pack migration", () => {
       },
     );
     return {
+      scheduleId,
       invoice: () => {
         return invoice;
       },
@@ -2548,7 +2708,7 @@ describe("legacy subscription usage pack migration", () => {
   it("revises a scheduled migration and exposes its current configuration", async () => {
     const fixture = await seedLegacyMigrationFixture({ tier: "pro" });
     await enableMigration(fixture);
-    mockMigrationStripe({
+    const stripe = mockMigrationStripe({
       fixture,
       targetTier: "team",
       packageQuantity: 1,
@@ -2583,10 +2743,12 @@ describe("legacy subscription usage pack migration", () => {
 
     context.mocks.stripe.invoices.createPreview.mockImplementation((params) => {
       const priceIds = migrationPreviewPriceIds(params);
-      return Promise.resolve({
-        amount_due: priceIds.includes(TEST_PRICE_USAGE_PACK_50) ? 7000 : 18_000,
-        currency: "usd",
-      });
+      const amountDue = priceIds.includes(TEST_PRICE_USAGE_PACK_50)
+        ? 21_000
+        : 18_000;
+      return Promise.resolve(
+        migrationRecurringPreviewInvoice(params, fixture.period.end, amountDue),
+      );
     });
     context.mocks.stripe.subscriptionSchedules.update.mockClear();
     const memberUsagePacks = [
@@ -2595,7 +2757,7 @@ describe("legacy subscription usage pack migration", () => {
     const revisionPreview = await accept(
       migrationClient().previewRevision({
         params: { migrationId: preview.migrationId },
-        body: { targetTier: "pro", memberUsagePacks },
+        body: { targetTier: "team", memberUsagePacks },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -2603,25 +2765,41 @@ describe("legacy subscription usage pack migration", () => {
     expect(revisionPreview.body).toMatchObject({
       migrationId: preview.migrationId,
       tier: "team",
-      targetTier: "pro",
+      targetTier: "team",
       currentRecurringAmountCents: 18_000,
-      nextRecurringAmountCents: 7000,
-      recurringDifferenceCents: -11_000,
+      nextRecurringAmountCents: 21_000,
+      recurringDifferenceCents: 3000,
       purchasedCredits: 50_000,
       bonusCredits: 2600,
       totalCredits: 52_600,
     });
-    expect(
-      context.mocks.stripe.invoices.createPreview,
-    ).toHaveBeenLastCalledWith(
-      expect.objectContaining({ subscription: fixture.subscriptionId }),
-    );
+    const revisionPreviewParams =
+      context.mocks.stripe.invoices.createPreview.mock.calls.at(-1)?.at(0);
+    expect(revisionPreviewParams).toMatchObject({
+      schedule: stripe.scheduleId,
+      preview_mode: "next",
+      schedule_details: {
+        end_behavior: "release",
+        proration_behavior: "none",
+        phases: [
+          expect.any(Object),
+          expect.objectContaining({
+            items: expect.arrayContaining([
+              { price: TEST_PRICE_USAGE_PACK_PLAN_TEAM, quantity: 1 },
+              { price: TEST_PRICE_USAGE_PACK_50, quantity: 1 },
+            ]),
+          }),
+        ],
+      },
+    });
+    expect(revisionPreviewParams).not.toHaveProperty("subscription");
+    expect(revisionPreviewParams).not.toHaveProperty("subscription_details");
 
     const confirmation = await accept(
       migrationClient().confirmRevision({
         params: { migrationId: preview.migrationId },
         body: {
-          targetTier: "pro",
+          targetTier: "team",
           memberUsagePacks,
           previewToken: revisionPreview.body.previewToken,
         },
@@ -2639,7 +2817,7 @@ describe("legacy subscription usage pack migration", () => {
           expect.any(Object),
           expect.objectContaining({
             items: expect.arrayContaining([
-              { price: TEST_PRICE_USAGE_PACK_PLAN_PRO, quantity: 1 },
+              { price: TEST_PRICE_USAGE_PACK_PLAN_TEAM, quantity: 1 },
               { price: TEST_PRICE_USAGE_PACK_50, quantity: 1 },
             ]),
           }),
@@ -2659,7 +2837,7 @@ describe("legacy subscription usage pack migration", () => {
       migrationClient().confirmRevision({
         params: { migrationId: preview.migrationId },
         body: {
-          targetTier: "pro",
+          targetTier: "team",
           memberUsagePacks,
           previewToken: revisionPreview.body.previewToken,
         },
@@ -2679,11 +2857,11 @@ describe("legacy subscription usage pack migration", () => {
     );
     expect(revised.body).toMatchObject({
       status: "scheduled",
-      targetTier: "pro",
+      targetTier: "team",
       configuration: {
-        tier: "pro",
+        tier: "team",
         memberUsagePacks,
-        recurringAmountCents: 7000,
+        recurringAmountCents: 21_000,
         currency: "usd",
       },
     });
@@ -2713,7 +2891,9 @@ describe("legacy subscription usage pack migration", () => {
       const amountDue = priceIds.includes(TEST_PRICE_USAGE_PACK_100)
         ? 28_000
         : 7000;
-      return Promise.resolve({ amount_due: amountDue, currency: "usd" });
+      return Promise.resolve(
+        migrationRecurringPreviewInvoice(params, fixture.period.end, amountDue),
+      );
     });
     const firstMemberUsagePacks = [
       { memberId: fixture.userId, usagePackUsd: 50 as const },

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription-migration.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription-migration.service.ts
@@ -204,17 +204,21 @@ function safeInvoiceAmount(invoice: StripeInvoice, label: string): number {
 
 function migrationInvoiceLinePriceId(line: StripeInvoiceLine): string | null {
   const price = line.pricing?.price_details?.price;
-  return typeof price === "string"
-    ? price
-    : (price?.id ?? line.price?.id ?? null);
+  return typeof price === "string" ? price : (price?.id ?? null);
 }
 
 function migrationInvoiceLineAmountWithTax(line: StripeInvoiceLine): number {
+  const discountAmount = (line.discount_amounts ?? []).reduce(
+    (total, discount) => {
+      return total + discount.amount;
+    },
+    0,
+  );
   const exclusiveTax = (line.taxes ?? []).reduce((total, tax) => {
     return tax.tax_behavior === "exclusive" ? total + tax.amount : total;
   }, 0);
-  const amount = line.amount + exclusiveTax;
-  if (!Number.isSafeInteger(amount)) {
+  const amount = line.amount - discountAmount + exclusiveTax;
+  if (!Number.isSafeInteger(amount) || amount < 0) {
     throw new Error("Stripe migration preview line has an invalid amount");
   }
   return amount;

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription-migration.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription-migration.service.ts
@@ -26,6 +26,7 @@ import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 import {
   getStripeClient,
+  type StripeClient,
   type StripeInvoice,
   type StripeInvoiceLine,
   type StripePriceRecurring,
@@ -59,6 +60,7 @@ import {
 
 const PREVIEW_TTL_MS = 30 * 60 * 1000;
 const RECONCILIATION_DELAY_MS = 5 * 60 * 1000;
+const STRIPE_INVOICE_LINE_PAGE_SIZE = 100;
 const OPEN_MIGRATION_STATUSES = [
   "previewed",
   "applying",
@@ -198,6 +200,115 @@ function safeInvoiceAmount(invoice: StripeInvoice, label: string): number {
     throw new Error(`Stripe ${label} migration preview has an invalid amount`);
   }
   return invoice.amount_due;
+}
+
+function migrationInvoiceLinePriceId(line: StripeInvoiceLine): string | null {
+  const price = line.pricing?.price_details?.price;
+  return typeof price === "string"
+    ? price
+    : (price?.id ?? line.price?.id ?? null);
+}
+
+function migrationInvoiceLineAmountWithTax(line: StripeInvoiceLine): number {
+  const exclusiveTax = (line.taxes ?? []).reduce((total, tax) => {
+    return tax.tax_behavior === "exclusive" ? total + tax.amount : total;
+  }, 0);
+  const amount = line.amount + exclusiveTax;
+  if (!Number.isSafeInteger(amount)) {
+    throw new Error("Stripe migration preview line has an invalid amount");
+  }
+  return amount;
+}
+
+async function listCompleteMigrationPreviewLines(
+  stripe: StripeClient,
+  invoice: StripeInvoice,
+  signal: AbortSignal,
+): Promise<readonly StripeInvoiceLine[]> {
+  if (!invoice.lines.has_more) {
+    return invoice.lines.data;
+  }
+  const lines: StripeInvoiceLine[] = [];
+  let startingAfter: string | undefined;
+  while (true) {
+    const page = await stripe.invoices.listLineItems(invoice.id, {
+      limit: STRIPE_INVOICE_LINE_PAGE_SIZE,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+    signal.throwIfAborted();
+    lines.push(...page.data);
+    if (!page.has_more) {
+      return lines;
+    }
+    const last = page.data.at(-1);
+    if (!last?.id) {
+      throw new Error(
+        `Stripe invoice ${invoice.id} returned an incomplete line-item page`,
+      );
+    }
+    startingAfter = last.id;
+  }
+}
+
+function migrationItemQuantities(
+  items: readonly StripeSchedulePhaseItemParam[],
+): ReadonlyMap<string, number> {
+  const quantities = new Map<string, number>();
+  for (const item of items) {
+    const quantity = item.quantity ?? 1;
+    if (!Number.isSafeInteger(quantity) || quantity < 1) {
+      throw new Error("Stripe migration schedule item has an invalid quantity");
+    }
+    quantities.set(item.price, (quantities.get(item.price) ?? 0) + quantity);
+  }
+  return quantities;
+}
+
+function migrationFutureRecurringAmount(
+  invoice: StripeInvoice,
+  lines: readonly StripeInvoiceLine[],
+  effectiveAt: number,
+  items: readonly StripeSchedulePhaseItemParam[],
+): number {
+  const expectedQuantities = migrationItemQuantities(items);
+  const actualQuantities = new Map<string, number>();
+  let amount = 0;
+  for (const line of lines) {
+    const priceId = migrationInvoiceLinePriceId(line);
+    if (
+      line.parent?.type !== "subscription_item_details" ||
+      line.parent.subscription_item_details?.proration !== false ||
+      line.period.start !== effectiveAt ||
+      line.period.end <= effectiveAt ||
+      priceId === null ||
+      !expectedQuantities.has(priceId)
+    ) {
+      continue;
+    }
+    const quantity = line.quantity ?? 1;
+    if (!Number.isSafeInteger(quantity) || quantity < 1) {
+      throw new Error("Stripe migration preview line has an invalid quantity");
+    }
+    actualQuantities.set(
+      priceId,
+      (actualQuantities.get(priceId) ?? 0) + quantity,
+    );
+    amount += migrationInvoiceLineAmountWithTax(line);
+  }
+  const hasExactItems = [...expectedQuantities].every(([priceId, quantity]) => {
+    return actualQuantities.get(priceId) === quantity;
+  });
+  if (
+    invoice.currency.length !== 3 ||
+    !hasExactItems ||
+    !Number.isSafeInteger(amount) ||
+    amount < 0
+  ) {
+    throw new Error(
+      "Stripe migration future recurring preview has an invalid amount",
+    );
+  }
+  return amount;
 }
 
 function migrationOwnerId(owner: UsagePackMigrationOwner): string {
@@ -940,6 +1051,12 @@ interface PreparedMigrationRevision {
   readonly expiresAt: Date;
 }
 
+interface MigrationScheduleConfiguration {
+  readonly end_behavior: "release";
+  readonly proration_behavior: "none";
+  readonly phases: StripeSchedulePhaseParam[];
+}
+
 type PrepareMigrationRevisionResult =
   | { readonly status: "ready"; readonly prepared: PreparedMigrationRevision }
   | { readonly status: "not_found" }
@@ -1013,37 +1130,48 @@ async function prepareMigrationRevision(
       `${args.targetTier} usage pack plan Price is not configured`,
     );
   }
-  const subscription = await getStripeClient().subscriptions.retrieve(
+  const stripe = getStripeClient();
+  const subscription = await stripe.subscriptions.retrieve(
     stored.migration.stripeSubscriptionId,
   );
   signal.throwIfAborted();
   if (!legacyMigrationShape(stored.migration, subscription)) {
     return { status: "conflict" };
   }
-  const customerId = stripeObjectId(subscription.customer);
-  if (!customerId) {
-    throw new Error(
-      `Legacy subscription ${subscription.id} has no Stripe customer`,
-    );
+  const legacyItem = legacyPlanItem(subscription, stored.migration.sourceTier);
+  if (!legacyItem) {
+    return { status: "conflict" };
   }
-  const targetPreview = await getStripeClient().invoices.createPreview({
-    subscription: subscription.id,
-    preview_mode: "recurring",
-    subscription_details: {
-      items: targetMigrationConfigurationItems(
-        subscription,
-        stripePlanPriceId,
-        desiredSelections,
-      ),
-    },
+  const scheduleDetails = migrationScheduleConfiguration(
+    stored.migration,
+    stripePlanPriceId,
+    desiredSelections,
+    subscription,
+    legacyItem,
+  );
+  const targetItems = scheduleDetails.phases.at(-1)?.items;
+  if (!targetItems) {
+    throw new Error("Stripe migration revision has no future phase");
+  }
+  const targetPreview = await stripe.invoices.createPreview({
+    schedule: stored.migration.stripeScheduleId,
+    preview_mode: "next",
+    schedule_details: scheduleDetails,
   });
   signal.throwIfAborted();
   if (targetPreview.currency !== stored.migration.currency) {
     throw new Error("Stripe migration revision changed currency");
   }
-  const nextRecurringAmountCents = safeInvoiceAmount(
+  const targetLines = await listCompleteMigrationPreviewLines(
+    stripe,
     targetPreview,
-    "revision recurring",
+    signal,
+  );
+  const nextRecurringAmountCents = migrationFutureRecurringAmount(
+    targetPreview,
+    targetLines,
+    Math.floor(stored.migration.effectiveAt.getTime() / 1000),
+    targetItems,
   );
   const recurringDifferenceCents =
     nextRecurringAmountCents - stored.migration.currentRecurringAmountCents;
@@ -2043,6 +2171,45 @@ function targetMigrationConfigurationItems(
   ];
 }
 
+function migrationScheduleConfiguration(
+  migration: MigrationRow,
+  stripePlanPriceId: string,
+  selections: readonly { readonly stripePriceId: string }[],
+  subscription: StripeSubscription,
+  legacyItem: StripeSubscriptionItem,
+): MigrationScheduleConfiguration {
+  const period = migrationPeriod(legacyItem);
+  const discounts = migrationPhaseDiscounts(subscription);
+  return {
+    end_behavior: "release",
+    proration_behavior: "none",
+    phases: [
+      migrationPhaseWithDiscounts(
+        {
+          start_date: period.start,
+          end_date: period.end,
+          items: migrationPhaseItems(subscription),
+          proration_behavior: "none",
+        },
+        discounts,
+      ),
+      migrationPhaseWithDiscounts(
+        {
+          start_date: period.end,
+          duration: migrationRecurringDuration(legacyItem),
+          items: targetMigrationConfigurationItems(
+            subscription,
+            stripePlanPriceId,
+            selections,
+          ),
+          proration_behavior: "none",
+        },
+        discounts,
+      ),
+    ],
+  };
+}
+
 function scheduledMigrationResponse(
   migration: MigrationRow,
 ): UsagePackMigrationConfirmResponse {
@@ -2085,45 +2252,19 @@ async function scheduleMigration(
   if (attachedScheduleId && attachedScheduleId !== scheduleId) {
     throw new Error(`Legacy subscription ${subscription.id} schedule changed`);
   }
-  const period = migrationPeriod(legacyItem);
-  const discounts = migrationPhaseDiscounts(subscription);
-  await stripe.subscriptionSchedules.update(
-    scheduleId,
-    {
-      end_behavior: "release",
-      proration_behavior: "none",
-      phases: [
-        migrationPhaseWithDiscounts(
-          {
-            start_date: period.start,
-            end_date: period.end,
-            items: migrationPhaseItems(subscription),
-            proration_behavior: "none",
-          },
-          discounts,
-        ),
-        migrationPhaseWithDiscounts(
-          {
-            start_date: period.end,
-            duration: migrationRecurringDuration(legacyItem),
-            items: targetMigrationConfigurationItems(
-              subscription,
-              migration.stripePlanPriceId,
-              selections,
-            ),
-            proration_behavior: "none",
-          },
-          discounts,
-        ),
-      ],
-    },
-    {
-      idempotencyKey:
-        migration.status === "revising"
-          ? `usage-pack-migration:${migration.id}:schedule-revision:${migrationScheduleRevisionHash(migration, selections)}`
-          : `usage-pack-migration:${migration.id}:schedule-update`,
-    },
+  const scheduleConfiguration = migrationScheduleConfiguration(
+    migration,
+    migration.stripePlanPriceId,
+    selections,
+    subscription,
+    legacyItem,
   );
+  await stripe.subscriptionSchedules.update(scheduleId, scheduleConfiguration, {
+    idempotencyKey:
+      migration.status === "revising"
+        ? `usage-pack-migration:${migration.id}:schedule-revision:${migrationScheduleRevisionHash(migration, selections)}`
+        : `usage-pack-migration:${migration.id}:schedule-update`,
+  });
   signal?.throwIfAborted();
   const updatedAt = nowDate();
   const [scheduled] = await db

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -955,7 +955,7 @@ describe("organization billing settings", () => {
       name: "Choose a plan",
     });
     expect(
-      within(choosePlanDialog).getByText("Step 1 of 2"),
+      within(choosePlanDialog).getByText("Step 1 of 3"),
     ).toBeInTheDocument();
     expect(screen.getByText("Legacy")).toBeInTheDocument();
     const proPlan = within(choosePlanDialog).getByRole("article", {
@@ -981,14 +981,22 @@ describe("organization billing settings", () => {
       name: "Configure member packages",
     });
     expect(
-      within(configurePackagesDialog).getByText("Step 2 of 2"),
+      within(configurePackagesDialog).getByText("Step 2 of 3"),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("heading", { name: "Choose a plan" }),
     ).not.toBeInTheDocument();
-    const comparison = screen.getByRole("table", {
-      name: "Current and new subscription comparison",
-    });
+    expect(
+      screen.queryByRole("table", {
+        name: "Current and new subscription comparison",
+      }),
+    ).not.toBeInTheDocument();
+    const comparison = within(await hoverSubscriptionComparison()).getByRole(
+      "table",
+      {
+        name: "Current and new subscription comparison",
+      },
+    );
     expect(
       within(comparison).getByRole("row", {
         name: /Plan Team Legacy Pro/u,
@@ -1328,6 +1336,9 @@ describe("organization billing settings", () => {
       name: "Configure member packages",
     });
     expect(
+      within(configurePackagesDialog).getByText("Step 2 of 3"),
+    ).toBeInTheDocument();
+    expect(
       screen.queryByRole("heading", { name: "Choose a plan" }),
     ).not.toBeInTheDocument();
     const memberUsage = screen.getByRole("group", { name: "Member usage" });
@@ -1348,7 +1359,14 @@ describe("organization billing settings", () => {
     const orderSummary = screen.getByRole("region", {
       name: "Order summary",
     });
-    const orderComparison = within(orderSummary).getByRole("table", {
+    expect(
+      within(orderSummary).queryByRole("table", {
+        name: "Current and new subscription comparison",
+      }),
+    ).not.toBeInTheDocument();
+    const orderComparison = within(
+      await hoverSubscriptionComparison(),
+    ).getByRole("table", {
       name: "Current and new subscription comparison",
     });
     expect(
@@ -1396,8 +1414,11 @@ describe("organization billing settings", () => {
     const reviewDialog = await screen.findByRole("dialog", {
       name: "Review plan conversion",
     });
-    expect(reviewConversionButton).toHaveTextContent("Review conversion");
-    expect(reviewConversionButton).toBeDisabled();
+    expect(within(reviewDialog).getByText("Step 3 of 3")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Configure member packages" }),
+    ).not.toBeInTheDocument();
+    expect(queryButtonByText("Review conversion")).toBeUndefined();
     expect(
       within(reviewDialog).queryByRole("table", {
         name: "Current and new subscription comparison",
@@ -1424,26 +1445,46 @@ describe("organization billing settings", () => {
       within(reviewDialog).getByText("Scheduled for Sep 1, 2026"),
     ).toBeInTheDocument();
 
-    click(buttonByText("Confirm", reviewDialog));
-    await waitFor(() => {
-      expect(buttonByText("Current plan")).toBeInTheDocument();
+    click(within(reviewDialog).getByLabelText("Back"));
+    const returnedPackagesDialog = await screen.findByRole("dialog", {
+      name: "Configure member packages",
     });
+    expect(
+      within(returnedPackagesDialog).getByText("Step 2 of 3"),
+    ).toBeInTheDocument();
+    click(buttonByText("Review conversion", returnedPackagesDialog));
+    const returnedReviewDialog = await screen.findByRole("dialog", {
+      name: "Review plan conversion",
+    });
+    click(buttonByText("Confirm", returnedReviewDialog));
+    await expect(
+      screen.findByText("Switches to Team on Sep 1, 2026"),
+    ).resolves.toBeVisible();
     expect(
       screen.queryByText(
         "Conversion scheduled for Sep 1, 2026. Your current plan and entitlements remain active until then.",
       ),
     ).not.toBeInTheDocument();
-
-    click(within(configurePackagesDialog).getByLabelText("Back"));
-    const returnedChoosePlanDialog = await screen.findByRole("dialog", {
-      name: "Choose a plan",
-    });
-    click(within(returnedChoosePlanDialog).getByLabelText("Close"));
-    await screen.findByText("Team plan");
     expect(screen.getByText("Legacy")).toBeInTheDocument();
-    expect(screen.getByText("Switches to Team on Sep 1, 2026")).toBeVisible();
 
     click(buttonByText("Downgrade"));
+    const unchangedChoosePlanDialog = await screen.findByRole("dialog", {
+      name: "Choose a plan",
+    });
+    const teamPlan = within(unchangedChoosePlanDialog).getByRole("article", {
+      name: "Team plan",
+    });
+    click(buttonByText("Manage", teamPlan));
+    const unchangedPackagesDialog = await screen.findByRole("dialog", {
+      name: "Configure member packages",
+    });
+    expect(
+      within(unchangedPackagesDialog).getByText("Step 2 of 3"),
+    ).toBeInTheDocument();
+    expect(queryButtonByText("Current plan")).toBeUndefined();
+    expect(queryButtonByText("Review conversion")).toBeUndefined();
+
+    click(within(unchangedPackagesDialog).getByLabelText("Back"));
     const revisionChoosePlanDialog = await screen.findByRole("dialog", {
       name: "Choose a plan",
     });
@@ -1454,23 +1495,20 @@ describe("organization billing settings", () => {
     const revisionPackagesDialog = await screen.findByRole("dialog", {
       name: "Configure member packages",
     });
-    const reviewRevisionButton = buttonByText("Review conversion");
+    expect(
+      within(revisionPackagesDialog).getByText("Step 2 of 3"),
+    ).toBeInTheDocument();
+    const reviewRevisionButton = buttonByText(
+      "Review conversion",
+      revisionPackagesDialog,
+    );
     click(reviewRevisionButton);
     const revisionDialog = await screen.findByRole("dialog", {
-      name: "Review package change",
+      name: "Review plan conversion",
     });
-    expect(reviewRevisionButton).toHaveTextContent("Review conversion");
-    expect(reviewRevisionButton).toBeDisabled();
+    expect(within(revisionDialog).getByText("Step 3 of 3")).toBeInTheDocument();
+    expect(queryButtonByText("Review conversion")).toBeUndefined();
     click(buttonByText("Confirm", revisionDialog));
-    await waitFor(() => {
-      expect(buttonByText("Current plan")).toBeDisabled();
-    });
-
-    click(within(revisionPackagesDialog).getByLabelText("Back"));
-    const returnedRevisionPlanDialog = await screen.findByRole("dialog", {
-      name: "Choose a plan",
-    });
-    click(within(returnedRevisionPlanDialog).getByLabelText("Close"));
     await expect(
       screen.findByText("Switches to Pro on Sep 1, 2026"),
     ).resolves.toBeVisible();

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1100,6 +1100,7 @@ function PricingStepDialog({
   onBack,
   onClose,
   step,
+  title,
   total,
 }: {
   readonly children: ReactNode;
@@ -1107,6 +1108,7 @@ function PricingStepDialog({
   readonly onBack?: () => void;
   readonly onClose: () => void;
   readonly step: PricingStep;
+  readonly title?: string;
   readonly total: PricingStepTotal;
 }) {
   const { t } = useTranslation();
@@ -1130,7 +1132,7 @@ function PricingStepDialog({
         <DialogHeader className="h-14 flex-row shrink-0 items-center gap-3 space-y-0 border-b-[0.7px] border-[hsl(var(--gray-200))] py-0 pl-6 pr-4 text-left">
           {onBack && <PricingBackButton inDialogHeader onBack={onBack} />}
           <DialogTitle className="min-w-0 flex-1 text-base font-medium leading-none">
-            {pricingStepTitle(step)}
+            {title ?? pricingStepTitle(step)}
           </DialogTitle>
           <PricingStepIndicator current={step} total={total} />
           <DialogClose
@@ -2364,6 +2366,7 @@ function PackageConfigurationStep({
 
 function MigrationOrderSummary({
   effectiveAt,
+  inDialog = false,
   members,
   plan,
   selections,
@@ -2371,6 +2374,7 @@ function MigrationOrderSummary({
   totals,
 }: {
   readonly effectiveAt: string;
+  readonly inDialog?: boolean;
   readonly members: readonly MemberDisplay[] | undefined;
   readonly plan: UsagePackPlan;
   readonly selections: Readonly<Record<string, MemberUsageSelection>>;
@@ -2391,79 +2395,94 @@ function MigrationOrderSummary({
       aria-label={i18n.t(($) => {
         return $.billing.plans.usagePacks.orderSummary;
       })}
-      className="rounded-xl bg-card p-4 zero-border"
+      className={inDialog ? undefined : "rounded-xl bg-card p-4 zero-border"}
     >
-      <h4 className="text-sm font-medium text-foreground">
-        {i18n.t(($) => {
-          return $.billing.plans.usagePacks.orderSummary;
-        })}
-      </h4>
-      <MigrationPlanComparison
-        currentAmountCents={currentMonthlyTotal * 100}
-        nextAmountCents={monthlyTotal * 100}
-        nextTotals={totals}
-        sourceTier={sourceTier}
-        targetTier={plan.tier}
-      />
+      {!inDialog && (
+        <>
+          <h4 className="text-sm font-medium text-foreground">
+            {i18n.t(($) => {
+              return $.billing.plans.usagePacks.orderSummary;
+            })}
+          </h4>
+          <MigrationPlanComparison
+            currentAmountCents={currentMonthlyTotal * 100}
+            nextAmountCents={monthlyTotal * 100}
+            nextTotals={totals}
+            sourceTier={sourceTier}
+            targetTier={plan.tier}
+          />
+        </>
+      )}
       <SubscriptionChangeNotice
         description={i18n.t(($) => {
           return $.billing.plans.usagePacks.migration.confirmDescription;
         })}
         effectiveAt={effectiveAt}
       />
-      {previewError && (
-        <p className="mt-3 text-xs text-destructive">
+      <div className={inDialog ? STEP_ACTION_BAR : undefined}>
+        {previewError && (
+          <p
+            className={
+              inDialog
+                ? "text-sm text-destructive"
+                : "mt-3 text-xs text-destructive"
+            }
+          >
+            {i18n.t(($) => {
+              return $.billing.plans.usagePacks.migration.error;
+            })}
+          </p>
+        )}
+        <Button
+          type="button"
+          className={`${inDialog ? "" : "mt-4 "}h-10 w-full text-sm font-medium`}
+          disabled={!members || previewing}
+          onClick={() => {
+            if (!members) {
+              return;
+            }
+            detach(
+              previewMigration(
+                {
+                  targetTier: plan.tier,
+                  memberUsagePacks: checkoutMemberUsagePacks(
+                    members,
+                    selections,
+                  ),
+                },
+                pageSignal,
+              ),
+              Reason.DomCallback,
+            );
+          }}
+        >
           {i18n.t(($) => {
-            return $.billing.plans.usagePacks.migration.error;
+            return $.billing.plans.usagePacks.migration.review;
           })}
-        </p>
-      )}
-      <Button
-        type="button"
-        className="mt-4 h-10 w-full text-sm font-medium"
-        disabled={!members || previewing}
-        onClick={() => {
-          if (!members) {
-            return;
-          }
-          detach(
-            previewMigration(
-              {
-                targetTier: plan.tier,
-                memberUsagePacks: checkoutMemberUsagePacks(members, selections),
-              },
-              pageSignal,
-            ),
-            Reason.DomCallback,
-          );
-        }}
-      >
-        {i18n.t(($) => {
-          return $.billing.plans.usagePacks.migration.review;
-        })}
-      </Button>
+        </Button>
+      </div>
     </section>
   );
 }
 
 function MigrationRevisionOrderSummary({
-  catalog,
-  configuration,
   effectiveAt,
+  hasConfigurationChange,
+  inDialog = false,
   members,
   migrationId,
   plan,
-  selections,
-  totals,
+  requested,
+  rows,
 }: {
-  readonly catalog: readonly UsagePackCatalogItem[];
-  readonly configuration: UsagePackMigrationConfiguration;
   readonly effectiveAt: string;
+  readonly hasConfigurationChange: boolean;
+  readonly inDialog?: boolean;
   readonly members: readonly MemberDisplay[] | undefined;
   readonly migrationId: string;
   readonly plan: UsagePackPlan;
-  readonly selections: Readonly<Record<string, MemberUsageSelection>>;
-  readonly totals: MemberUsageTotals;
+  readonly requested: readonly MemberUsagePack[];
+  readonly rows: readonly SubscriptionComparisonRow[];
 }) {
   const pageSignal = useGet(pageSignal$);
   const [previewLoadable, previewRevision] = useLoadableSet(
@@ -2472,82 +2491,82 @@ function MigrationRevisionOrderSummary({
   const preview = useGet(usagePackMigrationRevisionPreview$);
   const previewing = previewLoadable.state === "loading" || preview !== null;
   const previewError = previewLoadable.state === "hasError";
-  const currentPlan = usagePackPlan(configuration.tier);
-  const currentTotals = migrationConfigurationTotals(configuration, catalog);
-  const requested = members
-    ? checkoutMemberUsagePacks(members, selections)
-    : [];
-  const hasConfigurationChange =
-    members !== undefined &&
-    migrationConfigurationChanged(configuration, plan.tier, requested);
-  const rows = managedSubscriptionComparisonRows({
-    currentPlan,
-    currentTotals,
-    plan,
-    totals,
-  });
   return (
     <section
       aria-label={i18n.t(($) => {
         return $.billing.plans.usagePacks.orderSummary;
       })}
-      className="rounded-xl bg-card p-4 zero-border"
+      className={inDialog ? undefined : "rounded-xl bg-card p-4 zero-border"}
     >
-      <h4 className="text-sm font-medium text-foreground">
-        {i18n.t(($) => {
-          return $.billing.plans.usagePacks.orderSummary;
-        })}
-      </h4>
-      <SubscriptionComparisonTable rows={rows} />
+      {!inDialog && (
+        <>
+          <h4 className="text-sm font-medium text-foreground">
+            {i18n.t(($) => {
+              return $.billing.plans.usagePacks.orderSummary;
+            })}
+          </h4>
+          <SubscriptionComparisonTable rows={rows} />
+        </>
+      )}
       <SubscriptionChangeNotice
         description={i18n.t(($) => {
           return $.billing.plans.usagePacks.migration.confirmDescription;
         })}
         effectiveAt={effectiveAt}
       />
-      {previewError && (
-        <p className="mt-3 text-xs text-destructive">
-          {i18n.t(($) => {
-            return $.billing.plans.usagePacks.migration.error;
-          })}
-        </p>
-      )}
-      <Button
-        type="button"
-        className="mt-4 h-10 w-full text-sm font-medium"
-        disabled={!hasConfigurationChange || previewing}
-        onClick={() => {
-          if (!members) {
-            return;
-          }
-          detach(
-            previewRevision(
-              {
-                migrationId,
-                targetTier: plan.tier,
-                memberUsagePacks: requested,
-              },
-              pageSignal,
-            ),
-            Reason.DomCallback,
-          );
-        }}
-      >
-        {hasConfigurationChange
-          ? i18n.t(($) => {
+      {hasConfigurationChange && (
+        <div className={inDialog ? STEP_ACTION_BAR : undefined}>
+          {previewError && (
+            <p
+              className={
+                inDialog
+                  ? "text-sm text-destructive"
+                  : "mt-3 text-xs text-destructive"
+              }
+            >
+              {i18n.t(($) => {
+                return $.billing.plans.usagePacks.migration.error;
+              })}
+            </p>
+          )}
+          <Button
+            type="button"
+            className={`${inDialog ? "" : "mt-4 "}h-10 w-full text-sm font-medium`}
+            disabled={!members || previewing}
+            onClick={() => {
+              if (!members) {
+                return;
+              }
+              detach(
+                previewRevision(
+                  {
+                    migrationId,
+                    targetTier: plan.tier,
+                    memberUsagePacks: requested,
+                  },
+                  pageSignal,
+                ),
+                Reason.DomCallback,
+              );
+            }}
+          >
+            {i18n.t(($) => {
               return $.billing.plans.usagePacks.migration.review;
-            })
-          : i18n.t(($) => {
-              return $.billing.plans.currentPlan;
             })}
-      </Button>
+          </Button>
+        </div>
+      )}
     </section>
   );
 }
 
 function MigrationReviewDialog({
+  inDialog = false,
+  onComplete,
   totals,
 }: {
+  readonly inDialog?: boolean;
+  readonly onComplete?: () => void;
   readonly totals: MemberUsageTotals;
 }) {
   const pageSignal = useGet(pageSignal$);
@@ -2563,7 +2582,19 @@ function MigrationReviewDialog({
       return;
     }
     await confirmMigration(preview.migrationId, pageSignal);
+    onComplete?.();
   };
+  if (inDialog) {
+    return preview ? (
+      <MigrationReviewStepContent
+        confirming={confirming}
+        error={error}
+        onConfirm={handleConfirm}
+        preview={preview}
+        totals={totals}
+      />
+    ) : null;
+  }
   return (
     <Dialog
       open={preview !== null}
@@ -2627,13 +2658,17 @@ function MigrationReviewDialog({
 }
 
 function MigrationRevisionReviewDialog({
+  inDialog = false,
   members,
   migrationId,
+  onComplete,
   selections,
   totals,
 }: {
+  readonly inDialog?: boolean;
   readonly members: readonly MemberDisplay[] | undefined;
   readonly migrationId: string;
+  readonly onComplete?: () => void;
   readonly selections: Readonly<Record<string, MemberUsageSelection>>;
   readonly totals: MemberUsageTotals;
 }) {
@@ -2657,7 +2692,19 @@ function MigrationRevisionReviewDialog({
       },
       pageSignal,
     );
+    onComplete?.();
   };
+  if (inDialog) {
+    return preview && members ? (
+      <MigrationReviewStepContent
+        confirming={confirming}
+        error={error}
+        onConfirm={handleConfirm}
+        preview={preview}
+        totals={totals}
+      />
+    ) : null;
+  }
   return (
     <Dialog
       open={preview !== null}
@@ -2720,6 +2767,58 @@ function MigrationRevisionReviewDialog({
   );
 }
 
+function MigrationReviewStepContent({
+  confirming,
+  error,
+  onConfirm,
+  preview,
+  totals,
+}: {
+  readonly confirming: boolean;
+  readonly error: boolean;
+  readonly onConfirm: () => Promise<void>;
+  readonly preview:
+    | UsagePackMigrationPreviewResponse
+    | UsagePackMigrationRevisionPreviewResponse;
+  readonly totals: MemberUsageTotals;
+}) {
+  return (
+    <div className="flex flex-1 flex-col gap-5">
+      <p className="text-[13px] text-muted-foreground">
+        {i18n.t(($) => {
+          return $.billing.plans.usagePacks.migration.reviewDescription;
+        })}
+      </p>
+      <MigrationPreviewDetails preview={preview} totals={totals} />
+      <div className={STEP_ACTION_BAR}>
+        {error && (
+          <p className="text-sm text-destructive">
+            {i18n.t(($) => {
+              return $.billing.plans.usagePacks.migration.error;
+            })}
+          </p>
+        )}
+        <Button
+          type="button"
+          className="h-10 w-full text-sm font-medium"
+          disabled={confirming}
+          onClick={() => {
+            detach(onConfirm(), Reason.DomCallback);
+          }}
+        >
+          {confirming
+            ? i18n.t(($) => {
+                return $.billing.common.updating;
+              })
+            : i18n.t(($) => {
+                return $.billing.common.confirm;
+              })}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 function MigrationPreviewDetails({
   preview,
   totals,
@@ -2751,19 +2850,21 @@ function MigrationPreviewDetails({
   );
 }
 
-function MigrationPlanComparison({
-  currentAmountCents,
-  nextAmountCents,
-  nextTotals,
-  sourceTier,
-  targetTier,
-}: {
+interface MigrationPlanComparisonProps {
   readonly currentAmountCents: number;
   readonly nextAmountCents: number;
   readonly nextTotals: MemberUsageTotals;
   readonly sourceTier: UsagePackPlanTier;
   readonly targetTier: UsagePackPlanTier;
-}) {
+}
+
+function migrationPlanComparisonRows({
+  currentAmountCents,
+  nextAmountCents,
+  nextTotals,
+  sourceTier,
+  targetTier,
+}: MigrationPlanComparisonProps): readonly SubscriptionComparisonRow[] {
   const rows: readonly SubscriptionComparisonRow[] = [
     {
       label: i18n.t(($) => {
@@ -2839,7 +2940,13 @@ function MigrationPlanComparison({
     },
   ];
 
-  return <SubscriptionComparisonTable rows={rows} />;
+  return rows;
+}
+
+function MigrationPlanComparison(props: MigrationPlanComparisonProps) {
+  return (
+    <SubscriptionComparisonTable rows={migrationPlanComparisonRows(props)} />
+  );
 }
 
 export function UsagePackMigrationPlanSelectionPage({
@@ -2933,12 +3040,173 @@ export function UsagePackMigrationPlanSelectionPage({
   );
 }
 
+interface MigrationConfigurationViewState {
+  readonly comparisonRows: readonly SubscriptionComparisonRow[] | undefined;
+  readonly hasConfigurationChange: boolean;
+  readonly requested: readonly MemberUsagePack[];
+  readonly revisionRows: readonly SubscriptionComparisonRow[];
+  readonly revising: boolean;
+}
+
+function migrationConfigurationViewState({
+  catalog,
+  configuration,
+  members,
+  migrationId,
+  plan,
+  selections,
+  sourceTier,
+  totals,
+}: {
+  readonly catalog: readonly UsagePackCatalogItem[] | null;
+  readonly configuration: UsagePackMigrationConfiguration | null;
+  readonly members: readonly MemberDisplay[] | undefined;
+  readonly migrationId: string | null;
+  readonly plan: UsagePackPlan;
+  readonly selections: Readonly<Record<string, MemberUsageSelection>>;
+  readonly sourceTier: UsagePackPlanTier;
+  readonly totals: MemberUsageTotals;
+}): MigrationConfigurationViewState {
+  const requested = members
+    ? checkoutMemberUsagePacks(members, selections)
+    : [];
+  if (!configuration || !migrationId) {
+    return {
+      comparisonRows: migrationPlanComparisonRows({
+        currentAmountCents: (sourceTier === "pro" ? 20 : 200) * 100,
+        nextAmountCents: (plan.basePriceUsd + totals.totalUsd) * 100,
+        nextTotals: totals,
+        sourceTier,
+        targetTier: plan.tier,
+      }),
+      hasConfigurationChange: false,
+      requested,
+      revisionRows: [],
+      revising: false,
+    };
+  }
+  const hasConfigurationChange =
+    members !== undefined &&
+    migrationConfigurationChanged(configuration, plan.tier, requested);
+  const revisionRows = catalog
+    ? managedSubscriptionComparisonRows({
+        currentPlan: usagePackPlan(configuration.tier),
+        currentTotals: migrationConfigurationTotals(configuration, catalog),
+        plan,
+        totals,
+      })
+    : [];
+  return {
+    comparisonRows: hasConfigurationChange ? revisionRows : undefined,
+    hasConfigurationChange,
+    requested,
+    revisionRows,
+    revising: true,
+  };
+}
+
+function UsagePackMigrationConfigurationStep({
+  catalog,
+  configuration,
+  effectiveAt,
+  inDialog,
+  members,
+  migrationId,
+  onBack,
+  plan,
+  selections,
+  sourceTier,
+  totals,
+  viewState,
+}: {
+  readonly catalog: readonly UsagePackCatalogItem[] | null;
+  readonly configuration: UsagePackMigrationConfiguration | null;
+  readonly effectiveAt: string;
+  readonly inDialog: boolean;
+  readonly members: readonly MemberDisplay[] | undefined;
+  readonly migrationId: string | null;
+  readonly onBack: () => void;
+  readonly plan: UsagePackPlan;
+  readonly selections: Readonly<Record<string, MemberUsageSelection>>;
+  readonly sourceTier: UsagePackPlanTier;
+  readonly totals: MemberUsageTotals;
+  readonly viewState: MigrationConfigurationViewState;
+}) {
+  const usagePackPricingPageRef = useSet(usagePackPricingPageRef$);
+  return (
+    <div
+      className={`flex flex-col gap-5 outline-none ${inDialog ? "flex-1" : ""}`}
+      ref={usagePackPricingPageRef}
+      role="group"
+      tabIndex={-1}
+    >
+      {!catalog ? (
+        <div className="h-80 animate-pulse rounded-xl bg-muted/40" />
+      ) : (
+        <>
+          {!inDialog && <PricingPageHeader onBack={onBack} step={2} />}
+          <MemberUsageConfiguration
+            catalog={catalog}
+            {...(inDialog && viewState.comparisonRows
+              ? { comparisonRows: viewState.comparisonRows }
+              : {})}
+            management={null}
+            members={members}
+            plan={plan}
+            totals={totals}
+          />
+          {configuration && migrationId ? (
+            <>
+              <div className={inDialog ? "mt-auto" : undefined}>
+                <MigrationRevisionOrderSummary
+                  effectiveAt={effectiveAt}
+                  hasConfigurationChange={viewState.hasConfigurationChange}
+                  inDialog={inDialog}
+                  members={members}
+                  migrationId={migrationId}
+                  plan={plan}
+                  requested={viewState.requested}
+                  rows={viewState.revisionRows}
+                />
+              </div>
+              {!inDialog && (
+                <MigrationRevisionReviewDialog
+                  members={members}
+                  migrationId={migrationId}
+                  selections={selections}
+                  totals={totals}
+                />
+              )}
+            </>
+          ) : (
+            <>
+              <div className={inDialog ? "mt-auto" : undefined}>
+                <MigrationOrderSummary
+                  effectiveAt={effectiveAt}
+                  inDialog={inDialog}
+                  members={members}
+                  plan={plan}
+                  selections={selections}
+                  sourceTier={sourceTier}
+                  totals={totals}
+                />
+              </div>
+              {!inDialog && <MigrationReviewDialog totals={totals} />}
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 export function UsagePackMigrationPage({
   configuration,
   effectiveAt,
   inDialog = false,
   migrationId,
   onBack,
+  onComplete,
   sourceTier,
   targetTier,
 }: {
@@ -2947,12 +3215,14 @@ export function UsagePackMigrationPage({
   readonly inDialog?: boolean;
   readonly migrationId: string | null;
   readonly onBack: () => void;
+  readonly onComplete?: () => void;
   readonly sourceTier: UsagePackPlanTier;
   readonly targetTier: UsagePackPlanTier;
 }) {
   const selections = useGet(memberUsageSelections$);
   const members = useUsagePackMembers();
-  const usagePackPricingPageRef = useSet(usagePackPricingPageRef$);
+  const migrationPreview = useGet(usagePackMigrationPreview$);
+  const migrationRevisionPreview = useGet(usagePackMigrationRevisionPreview$);
   const catalogLoadable = useLoadable(usagePackCatalogAsync$);
   const catalog =
     catalogLoadable.state === "hasData" ? catalogLoadable.data : null;
@@ -2965,62 +3235,54 @@ export function UsagePackMigrationPage({
   const totals = catalog
     ? memberUsageTotals(members ?? [], selections, catalog)
     : { bonusCredits: 0, totalCredits: 0, totalUsd: 0 };
+  const viewState = migrationConfigurationViewState({
+    catalog,
+    configuration,
+    members,
+    migrationId,
+    plan,
+    selections,
+    sourceTier,
+    totals,
+  });
+  const complete = onComplete ?? onBack;
+  if (
+    inDialog &&
+    viewState.revising &&
+    migrationId &&
+    migrationRevisionPreview
+  ) {
+    return (
+      <MigrationRevisionReviewDialog
+        inDialog
+        members={members}
+        migrationId={migrationId}
+        onComplete={complete}
+        selections={selections}
+        totals={totals}
+      />
+    );
+  }
+  if (inDialog && !viewState.revising && migrationPreview) {
+    return (
+      <MigrationReviewDialog inDialog onComplete={complete} totals={totals} />
+    );
+  }
   return (
-    <div
-      className={`flex flex-col gap-5 outline-none ${
-        inDialog ? "flex-1 pb-5" : ""
-      }`}
-      ref={usagePackPricingPageRef}
-      role="group"
-      tabIndex={-1}
-    >
-      {!catalog ? (
-        <div className="h-80 animate-pulse rounded-xl bg-muted/40" />
-      ) : (
-        <>
-          {!inDialog && <PricingPageHeader onBack={onBack} step={2} />}
-          <MemberUsageConfiguration
-            catalog={catalog}
-            management={null}
-            members={members}
-            plan={plan}
-            totals={totals}
-          />
-          {configuration && migrationId ? (
-            <>
-              <MigrationRevisionOrderSummary
-                catalog={catalog}
-                configuration={configuration}
-                effectiveAt={effectiveAt}
-                members={members}
-                migrationId={migrationId}
-                plan={plan}
-                selections={selections}
-                totals={totals}
-              />
-              <MigrationRevisionReviewDialog
-                members={members}
-                migrationId={migrationId}
-                selections={selections}
-                totals={totals}
-              />
-            </>
-          ) : (
-            <>
-              <MigrationOrderSummary
-                effectiveAt={effectiveAt}
-                members={members}
-                plan={plan}
-                selections={selections}
-                sourceTier={sourceTier}
-                totals={totals}
-              />
-              <MigrationReviewDialog totals={totals} />
-            </>
-          )}
-        </>
-      )}
-    </div>
+    <UsagePackMigrationConfigurationStep
+      catalog={catalog}
+      configuration={configuration}
+      effectiveAt={effectiveAt}
+      inDialog={inDialog}
+      members={members}
+      migrationId={migrationId}
+      onBack={onBack}
+      plan={plan}
+      selections={selections}
+      sourceTier={sourceTier}
+      totals={totals}
+      viewState={viewState}
+    />
   );
 }
 
@@ -3040,6 +3302,12 @@ export function UsagePackMigrationDialogs({
   readonly onSelect: (tier: UsagePackPlanTier) => void;
 }) {
   const resetPricing = useSet(resetUsagePackPricing$);
+  const migrationPreview = useGet(usagePackMigrationPreview$);
+  const migrationRevisionPreview = useGet(usagePackMigrationRevisionPreview$);
+  const closeMigrationPreview = useSet(closeUsagePackMigrationPreview$);
+  const closeMigrationRevisionPreview = useSet(
+    closeUsagePackMigrationRevisionPreview$,
+  );
   const configurationStep =
     migrationOpen &&
     migrationTargetTier !== null &&
@@ -3050,16 +3318,38 @@ export function UsagePackMigrationDialogs({
         }
       : null;
   const configuring = configurationStep !== null;
+  const revising =
+    (migration.configuration ?? null) !== null &&
+    migration.migrationId !== null;
+  const reviewing =
+    configuring &&
+    (revising ? migrationRevisionPreview !== null : migrationPreview !== null);
+  const closeFlow = () => {
+    resetPricing();
+    onClose();
+  };
   return (
     <PricingStepDialog
       flush={!configuring}
-      step={configuring ? 2 : 1}
-      total={2}
-      onBack={configuring ? onBack : undefined}
-      onClose={() => {
-        resetPricing();
-        onClose();
-      }}
+      step={reviewing ? 3 : configuring ? 2 : 1}
+      title={
+        reviewing
+          ? i18n.t(($) => {
+              return $.billing.plans.usagePacks.migration.reviewTitle;
+            })
+          : undefined
+      }
+      total={3}
+      onBack={
+        reviewing
+          ? revising
+            ? closeMigrationRevisionPreview
+            : closeMigrationPreview
+          : configuring
+            ? onBack
+            : undefined
+      }
+      onClose={closeFlow}
     >
       {configurationStep ? (
         <UsagePackMigrationPage
@@ -3068,6 +3358,7 @@ export function UsagePackMigrationDialogs({
           inDialog
           migrationId={migration.migrationId}
           onBack={onBack}
+          onComplete={closeFlow}
           sourceTier={migration.tier}
           targetTier={configurationStep.targetTier}
         />


### PR DESCRIPTION
## Summary

- make legacy plan conversion use the same fixed three-step dialog frame as managed subscription changes
- move conversion review into Step 3 instead of stacking a second confirmation dialog
- align Step 2 with the billing ledger, comparison tooltip, and pinned action treatment
- close the conversion flow after confirmation and omit the action bar whenever the current configuration has no change
- preview scheduled migration revisions against the Stripe subscription schedule, using the same complete phase configuration as confirmation
- derive revision recurring totals from the exact future recurring invoice lines and harden the Stripe mock against the invalid subscription-preview path

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- targeted platform legacy conversion interaction tests: 2 passed, 35 skipped
- targeted API tests for initial scheduling, scheduled revision, and stale/tampered revision rejection: 3 passed, 132 skipped in each targeted run
- `git diff --check`
- PR preview browser walkthrough with `usagePackPlans` explicitly and effectively enabled:
  - legacy Team checkout and conversion to Team + $20 member package
  - Step 1 -> Step 2 -> Step 3, including Back navigation and successful confirmation
  - scheduled Team revision with unchanged $20 package showing no CTA
  - $20 -> $50 package revision preview and confirmation returning 200, with $210/month shown in Step 3
  - confirmed revision reopening with $50 as the baseline and no CTA
  - frontend and backend build SHAs matched the PR merge SHA

## PR preview evidence

`usagePackPlans` enabled in the real Lab UI:

![usagePackPlans enabled](https://cdn.vm0.io/artifacts/yobr7qce4k.png)

Scheduled revision with no configuration change and therefore no CTA:

![unchanged Step 2](https://cdn.vm0.io/artifacts/91q9hmbldw.png)

Changing the member package to $50 introduces the review action:

![changed Step 2](https://cdn.vm0.io/artifacts/zw941rrpmh.png)

The repaired schedule preview reaches Step 3 with the future $210 monthly ledger:

![revision Step 3](https://cdn.vm0.io/artifacts/iykztpf0om.png)
