### PR TITLE
refactor(org): neutralize organization data service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-org-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-delete.ts
@@ -4,7 +4,7 @@ import { zeroOrgDeleteContract } from "@okouai/api-contracts/contracts/zero-org"
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
-import { deleteZeroOrg$ } from "../services/zero-org-data.service";
+import { deleteOrg$ } from "../services/org-data.service";
 import type { RouteEntry } from "../route-entry";
 
 const deleteBody$ = bodyResultOf(zeroOrgDeleteContract.delete);
@@ -18,7 +18,7 @@ const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const result = await set(
-    deleteZeroOrg$,
+    deleteOrg$,
     {
       orgId: auth.orgId,
       callerRole: auth.orgRole,

--- a/turbo/apps/api/src/signals/routes/zero-org-members.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-members.ts
@@ -5,9 +5,9 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import {
-  removeZeroOrgMember$,
-  updateZeroOrgMemberRole$,
-} from "../services/zero-org-data.service";
+  removeOrgMember$,
+  updateOrgMemberRole$,
+} from "../services/org-data.service";
 import type { RouteEntry } from "../route-entry";
 
 const updateRoleBody$ = bodyResultOf(zeroOrgMembersContract.updateRole);
@@ -22,7 +22,7 @@ const updateRoleInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const result = await set(
-    updateZeroOrgMemberRole$,
+    updateOrgMemberRole$,
     {
       callerUserId: auth.userId,
       orgId: auth.orgId,
@@ -51,7 +51,7 @@ const removeMemberInner$ = command(
     }
 
     const result = await set(
-      removeZeroOrgMember$,
+      removeOrgMember$,
       {
         orgId: auth.orgId,
         callerUserId: auth.userId,

--- a/turbo/apps/api/src/signals/routes/zero-org-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-org-read.ts
@@ -11,11 +11,11 @@ import { bodyResultOf } from "../context/request";
 import { badRequestMessage, notFound } from "../../lib/error";
 import type { RouteEntry } from "../route-entry";
 import {
-  leaveZeroOrg$,
-  updateZeroOrg$,
-  zeroOrgDetail$,
-  zeroOrgMembersList,
-} from "../services/zero-org-data.service";
+  leaveOrg$,
+  orgDetail$,
+  orgMembersList,
+  updateOrg$,
+} from "../services/org-data.service";
 
 const getOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(authContext$);
@@ -23,7 +23,7 @@ const getOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return notFound("Organization not found");
   }
   const org = await set(
-    zeroOrgDetail$,
+    orgDetail$,
     { orgId: auth.orgId, userId: auth.userId, orgRole: auth.orgRole },
     signal,
   );
@@ -47,7 +47,7 @@ const updateOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const result = await set(
-    updateZeroOrg$,
+    updateOrg$,
     {
       orgId: auth.orgId,
       userId: auth.userId,
@@ -82,7 +82,7 @@ const leaveOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const result = await set(
-    leaveZeroOrg$,
+    leaveOrg$,
     {
       orgId: auth.orgId,
       userId: auth.userId,
@@ -102,7 +102,7 @@ const leaveOrgInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 const membersInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const body = await get(
-    zeroOrgMembersList({
+    orgMembersList({
       orgId: auth.orgId,
       userId: auth.userId,
       // Fall back to "member" when the auth context lacks an explicit role

--- a/turbo/apps/api/src/signals/services/org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/org-data.service.ts
@@ -91,41 +91,41 @@ type OrgDeleteErrorResponse =
   | ReturnType<typeof notFound>
   | typeof orgDeleteForbidden;
 
-type RemoveZeroOrgMemberErrorResponse =
+type RemoveOrgMemberErrorResponse =
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof notFound>
   | typeof forbiddenAccess;
 
-type UpdateZeroOrgMemberRoleErrorResponse =
+type UpdateOrgMemberRoleErrorResponse =
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof notFound>
   | typeof forbiddenAccess;
 
-interface UpdateZeroOrgArgs {
+interface UpdateOrgArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly name: string;
 }
 
-interface LeaveZeroOrgArgs {
+interface LeaveOrgArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly role: OrgRole;
 }
 
-interface DeleteZeroOrgArgs {
+interface DeleteOrgArgs {
   readonly orgId: string;
   readonly callerRole: OrgRole | undefined;
 }
 
-interface RemoveZeroOrgMemberArgs {
+interface RemoveOrgMemberArgs {
   readonly orgId: string;
   readonly callerUserId: string;
   readonly callerRole: OrgRole;
   readonly email: string;
 }
 
-interface UpdateZeroOrgMemberRoleArgs {
+interface UpdateOrgMemberRoleArgs {
   readonly callerUserId: string;
   readonly orgId: string;
   readonly callerRole: OrgRole | undefined;
@@ -179,16 +179,16 @@ async function orgExistsForDelete(args: {
   return true;
 }
 
-interface ZeroOrgDetailArgs {
+interface OrgDetailArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly orgRole?: OrgRole;
 }
 
-export const zeroOrgDetail$ = command(
+export const orgDetail$ = command(
   async (
     { get, set },
-    args: ZeroOrgDetailArgs,
+    args: OrgDetailArgs,
     signal: AbortSignal,
   ): Promise<OrgResponse | null> => {
     const db = get(db$);
@@ -306,10 +306,10 @@ async function commitOrgMemberRemoval(
   commitSignal.throwIfAborted();
 }
 
-export const leaveZeroOrg$ = command(
+export const leaveOrg$ = command(
   async (
     { get, set },
-    args: LeaveZeroOrgArgs,
+    args: LeaveOrgArgs,
     signal: AbortSignal,
   ): Promise<OrgMessageResponse | typeof adminCannotLeave> => {
     if (args.role === "admin") {
@@ -339,12 +339,12 @@ export const leaveZeroOrg$ = command(
   },
 );
 
-export const removeZeroOrgMember$ = command(
+export const removeOrgMember$ = command(
   async (
     { get, set },
-    args: RemoveZeroOrgMemberArgs,
+    args: RemoveOrgMemberArgs,
     signal: AbortSignal,
-  ): Promise<OrgMessageResponse | RemoveZeroOrgMemberErrorResponse> => {
+  ): Promise<OrgMessageResponse | RemoveOrgMemberErrorResponse> => {
     if (args.callerRole !== "admin") {
       return forbiddenAccess;
     }
@@ -404,12 +404,12 @@ export const removeZeroOrgMember$ = command(
   },
 );
 
-export const updateZeroOrgMemberRole$ = command(
+export const updateOrgMemberRole$ = command(
   async (
     { get },
-    args: UpdateZeroOrgMemberRoleArgs,
+    args: UpdateOrgMemberRoleArgs,
     signal: AbortSignal,
-  ): Promise<OrgMessageResponse | UpdateZeroOrgMemberRoleErrorResponse> => {
+  ): Promise<OrgMessageResponse | UpdateOrgMemberRoleErrorResponse> => {
     if (args.callerRole !== "admin") {
       return forbiddenAccess;
     }
@@ -455,10 +455,10 @@ export const updateZeroOrgMemberRole$ = command(
   },
 );
 
-export const updateZeroOrg$ = command(
+export const updateOrg$ = command(
   async (
     { get, set },
-    args: UpdateZeroOrgArgs,
+    args: UpdateOrgArgs,
     signal: AbortSignal,
   ): Promise<OrgResponse | OrgUpdateErrorResponse> => {
     const db = get(db$);
@@ -489,7 +489,7 @@ export const updateZeroOrg$ = command(
     signal.throwIfAborted();
 
     const org = await set(
-      zeroOrgDetail$,
+      orgDetail$,
       { orgId: args.orgId, userId: args.userId },
       signal,
     );
@@ -503,10 +503,10 @@ export const updateZeroOrg$ = command(
   },
 );
 
-export const deleteZeroOrg$ = command(
+export const deleteOrg$ = command(
   async (
     { get, set },
-    args: DeleteZeroOrgArgs,
+    args: DeleteOrgArgs,
     signal: AbortSignal,
   ): Promise<{ readonly message: string } | OrgDeleteErrorResponse> => {
     if (args.callerRole !== "admin") {
@@ -718,7 +718,7 @@ async function fetchUserProfileMap(
   return map;
 }
 
-export function zeroOrgMembersList(
+export function orgMembersList(
   args: OrgMembersListArgs,
 ): Computed<Promise<OrgMembersResponse>> {
   return computed(async (get): Promise<OrgMembersResponse> => {


### PR DESCRIPTION
## Summary

- Rename the internal organization data service to `org-data.service.ts`.
- Neutralize the issue-specified private argument/error types, commands, list helper, and all three production route callers.
- Remove the old path and identifiers without aliases, compatibility re-exports, duplicate implementations, or behavior changes.

## Compatibility boundary

- Preserve public organization contract modules and declarations, route filenames and exports, route paths, request/response schemas, and wire behavior.
- Preserve `contracts/zero-billing` and public or compatibility-owned old-branded contract identifiers.
- Preserve physical database schemas, tables, columns, indexes, persisted keys and identifiers, including `slackOrgConnections.vm0UserId`.
- Preserve Clerk organization/membership behavior, cache and authorization rules, subscription cancellation, Stripe handling, usage-pack reservation/refund/allocation, resource cleanup, and abort-signal sequencing.

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/org-data.service.ts apps/api/src/signals/routes/zero-org-read.ts apps/api/src/signals/routes/zero-org-members.ts apps/api/src/signals/routes/zero-org-delete.ts`
- `pnpm --filter api run lint`
- `pnpm knip`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/org-team.bdd.test.ts` (7 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-billing-checkout.test.ts` (133 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-org-delete-billing.test.ts` (12 passed)
- Repository-wide old-path and renamed-declaration search: zero matches.
- Paginated pull-files scan across all 23 open PRs immediately before push: no target-file overlap.

Closes #27501