### PR TITLE
refactor(banking): neutralize service naming and run copy

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
@@ -4,7 +4,7 @@
 // - Billing settlement needs Stripe webhooks or checkout completion that grants
 //   entitlements. This file asserts the route-visible checkout, portal, invoice,
 //   redeem, status, and usage surfaces without direct database fixtures.
-// - Banking success needs a current zero run, banking connection, account grant,
+// - Banking success needs a current Okou run, banking connection, account grant,
 //   and provider account state. This file covers the public credential gate and
 //   records the success-chain gap instead of seeding banking tables.
 

--- a/turbo/apps/api/src/signals/routes/zero-banking.ts
+++ b/turbo/apps/api/src/signals/routes/zero-banking.ts
@@ -8,10 +8,10 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import {
-  zeroBankingAccounts$,
-  zeroBankingBalances$,
-  zeroBankingTransactions$,
-} from "../services/zero-banking.service";
+  bankingAccounts$,
+  bankingBalances$,
+  bankingTransactions$,
+} from "../services/banking.service";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 
 function zeroTokenRequired() {
@@ -68,11 +68,7 @@ const accountsInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return bodyResult.response;
   }
 
-  return await set(
-    zeroBankingAccounts$,
-    { auth, body: bodyResult.data },
-    signal,
-  );
+  return await set(bankingAccounts$, { auth, body: bodyResult.data }, signal);
 });
 
 const balancesInner$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -91,11 +87,7 @@ const balancesInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return bodyResult.response;
   }
 
-  return await set(
-    zeroBankingBalances$,
-    { auth, body: bodyResult.data },
-    signal,
-  );
+  return await set(bankingBalances$, { auth, body: bodyResult.data }, signal);
 });
 
 const transactionsInner$ = command(
@@ -116,7 +108,7 @@ const transactionsInner$ = command(
     }
 
     return await set(
-      zeroBankingTransactions$,
+      bankingTransactions$,
       { auth, body: bodyResult.data },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/banking.service.ts
+++ b/turbo/apps/api/src/signals/services/banking.service.ts
@@ -39,7 +39,7 @@ const APP_TOKEN_REFRESH_MS = 90 * 60 * 1000;
 const FINICITY_BASE_URL = "https://api.finicity.com";
 const PROVIDER = "finicity";
 
-type ZeroBankingAuth = Extract<ZeroAuthContext, { readonly orgId: string }>;
+type BankingAuth = Extract<ZeroAuthContext, { readonly orgId: string }>;
 type BankingAccountRow = InferSelectModel<typeof bankingAccounts>;
 
 interface CachedFinicityAppToken {
@@ -48,7 +48,7 @@ interface CachedFinicityAppToken {
 }
 
 interface BankingGatewayArgs<TBody> {
-  readonly auth: ZeroBankingAuth;
+  readonly auth: BankingAuth;
   readonly body: TBody;
 }
 
@@ -393,7 +393,7 @@ async function recordBankingAudit(
 
 async function findBankingRun(
   db: Db,
-  auth: ZeroBankingAuth,
+  auth: BankingAuth,
 ): Promise<BankingRunContext | null> {
   const [run] = await db
     .select({
@@ -417,7 +417,7 @@ async function findBankingRun(
 
 async function findBankingGrant(
   db: Db,
-  auth: ZeroBankingAuth,
+  auth: BankingAuth,
   agentId: string,
 ): Promise<BankingGrantContext | null> {
   const nowValue = nowDate();
@@ -460,7 +460,7 @@ async function findBankingGrant(
 
 async function denyBankingAccess(
   db: Db,
-  auth: ZeroBankingAuth,
+  auth: BankingAuth,
   action: BankingOperationScope,
   providerAccountId: string | undefined,
   args: {
@@ -489,7 +489,7 @@ async function denyBankingAccess(
 
 async function enabledBankingAccounts(
   db: Db,
-  auth: ZeroBankingAuth,
+  auth: BankingAuth,
   grant: BankingGrantContext,
 ): Promise<readonly BankingAccountRow[]> {
   return await db
@@ -508,7 +508,7 @@ async function enabledBankingAccounts(
 
 async function authorizeBankingAccess(
   db: Db,
-  auth: ZeroBankingAuth,
+  auth: BankingAuth,
   action: BankingOperationScope,
   providerAccountId: string | undefined,
 ): Promise<BankingAccessResult> {
@@ -516,7 +516,7 @@ async function authorizeBankingAccess(
   if (!run) {
     return await denyBankingAccess(db, auth, action, providerAccountId, {
       failureCode: "RUN_NOT_FOUND",
-      message: "Banking access requires a current zero run",
+      message: "Banking access requires a current Okou run",
     });
   }
 
@@ -605,7 +605,7 @@ async function authorizeBankingAccess(
   };
 }
 
-export const zeroBankingAccounts$ = command(
+export const bankingAccounts$ = command(
   async (
     { set },
     args: BankingGatewayArgs<Record<string, never>>,
@@ -689,7 +689,7 @@ export const zeroBankingAccounts$ = command(
   },
 );
 
-export const zeroBankingBalances$ = command(
+export const bankingBalances$ = command(
   async (
     { set },
     args: BankingGatewayArgs<ZeroBankingBalancesRequest>,
@@ -750,7 +750,7 @@ export const zeroBankingBalances$ = command(
   },
 );
 
-export const zeroBankingTransactions$ = command(
+export const bankingTransactions$ = command(
   async (
     { set },
     args: BankingGatewayArgs<ZeroBankingTransactionsRequest>,


### PR DESCRIPTION
## Summary

- rename the internal banking service to `banking.service.ts`
- neutralize the internal banking auth alias and three banking command names
- update the service error and BDD gap comment to say `current Okou run`

## Compatibility boundary

- preserve every public `ZeroBanking*` contract/data/request/response type and `contracts/zero-banking`
- preserve shared `ZeroAuthContext`, Zero token identifiers/literals, accepted token kinds, and the `zero run token` credential-gate copy
- preserve the route/API surface, request and response shapes, authorization, feature switch, error codes, audits, run/grant/account checks, pagination, Finicity behavior and mapping, and all database or persisted names
- introduce no aliases, compatibility re-exports, fallback paths, or behavior changes

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged non-API, app, and API type-check commands
- post-rebase touched-file Prettier check and API lint
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-banking.test.ts` (17 passed)
- repository-wide compatibility searches for removed and preserved names

Closes #27500