### PR TITLE
refactor(agents): neutralize data and instruction service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/agent-draft.ts
+++ b/turbo/apps/api/src/signals/routes/agent-draft.ts
@@ -9,7 +9,7 @@ import { bodyResultOf, pathParamsOf } from "../context/request";
 import { db$, writeDb$ } from "../external/db";
 import { nowDate } from "../../lib/time";
 import { notFound } from "../../lib/error";
-import { zeroAgentExists } from "../services/zero-agent-data.service";
+import { agentExists } from "../services/agent-data.service";
 import type { RouteEntry } from "../route-entry";
 
 const agentReadAuth = {
@@ -26,14 +26,14 @@ const getAgentDraftInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(agentDraftContract.get));
 
-  const agentExists = await get(
-    zeroAgentExists({
+  const exists = await get(
+    agentExists({
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
     }),
   );
-  if (!agentExists) {
+  if (!exists) {
     return agentNotFound(params.id);
   }
 
@@ -72,15 +72,15 @@ const patchAgentDraftInner$ = command(
       return bodyResult.response;
     }
 
-    const agentExists = await get(
-      zeroAgentExists({
+    const exists = await get(
+      agentExists({
         orgId: auth.orgId,
         userId: auth.userId,
         agentId: params.id,
       }),
     );
     signal.throwIfAborted();
-    if (!agentExists) {
+    if (!exists) {
       return agentNotFound(params.id);
     }
 

--- a/turbo/apps/api/src/signals/routes/zero-agent-instructions.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agent-instructions.ts
@@ -17,8 +17,8 @@ import { serverSideZeroAgentCompose$ } from "../services/agent-compose.service";
 import {
   agentResponse,
   defaultAgentResponse,
-} from "../services/zero-agent-data.service";
-import { zeroAgentInstructions } from "../services/zero-agent-instructions.service";
+} from "../services/agent-data.service";
+import { agentInstructions } from "../services/agent-instructions.service";
 import type { RouteEntry } from "../route-entry";
 
 const agentReadAuth = {
@@ -37,7 +37,7 @@ const getAgentInstructionsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroAgentInstructionsContract.get));
   const result = await get(
-    zeroAgentInstructions({
+    agentInstructions({
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -32,13 +32,13 @@ import { deleteComposeById$ } from "../services/zero-compose-data.service";
 import {
   agentResponse,
   defaultAgentResponse,
-  zeroAgentDetail,
-  zeroAgentEnabledConnectorSlugs,
-  zeroAgentCustomConnectorGrants,
-  zeroAgentExists,
-  zeroAgentList,
-  visibleJoinedZeroAgentCondition,
-} from "../services/zero-agent-data.service";
+  agentDetail,
+  agentEnabledConnectorSlugs,
+  agentCustomConnectorGrants,
+  agentExists,
+  agentList,
+  visibleJoinedAgentCondition,
+} from "../services/agent-data.service";
 import { connectorActionResolver } from "../services/connector-action-resolver.service";
 import {
   updateUserConnectors,
@@ -451,7 +451,7 @@ const createAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 const listAgentsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  const agents = await get(zeroAgentList(auth.orgId, auth.userId));
+  const agents = await get(agentList(auth.orgId, auth.userId));
   return { status: 200 as const, body: [...agents] };
 });
 
@@ -459,7 +459,7 @@ const getAgentInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroAgentsByIdContract.get));
   const agent = await get(
-    zeroAgentDetail({
+    agentDetail({
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
@@ -475,7 +475,7 @@ const getAgentUserConnectorsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroUserConnectorsContract.get));
   const exists = await get(
-    zeroAgentExists({
+    agentExists({
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
@@ -486,7 +486,7 @@ const getAgentUserConnectorsInner$ = computed(async (get) => {
   }
 
   const enabledConnectorSlugs = await get(
-    zeroAgentEnabledConnectorSlugs({
+    agentEnabledConnectorSlugs({
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
@@ -516,7 +516,7 @@ const getAgentCustomConnectorsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const params = get(pathParamsOf(zeroAgentCustomConnectorsContract.get));
   const exists = await get(
-    zeroAgentExists({
+    agentExists({
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
@@ -527,7 +527,7 @@ const getAgentCustomConnectorsInner$ = computed(async (get) => {
   }
 
   const grants = await get(
-    zeroAgentCustomConnectorGrants({
+    agentCustomConnectorGrants({
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
@@ -747,7 +747,7 @@ const updateAgentCustomConnectorsInner$ = command(
     }
 
     const exists = await get(
-      zeroAgentExists({
+      agentExists({
         orgId: auth.orgId,
         userId: auth.userId,
         agentId: params.id,
@@ -833,7 +833,7 @@ const updateAgentUserConnectorsInner$ = command(
         and(
           eq(agentComposes.orgId, auth.orgId),
           eq(agentComposes.id, params.id),
-          visibleJoinedZeroAgentCondition(auth.userId),
+          visibleJoinedAgentCondition(auth.userId),
         ),
       )
       .limit(1);

--- a/turbo/apps/api/src/signals/routes/zero-team.ts
+++ b/turbo/apps/api/src/signals/routes/zero-team.ts
@@ -3,7 +3,7 @@ import { zeroTeamContract } from "@okouai/api-contracts/contracts/zero-team";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { zeroTeam } from "../services/zero-agent-data.service";
+import { teamComposeList } from "../services/agent-data.service";
 import type { RouteEntry } from "../route-entry";
 
 const noActiveOrg = Object.freeze({
@@ -22,7 +22,7 @@ const listTeamInner$ = computed(async (get) => {
     return noActiveOrg;
   }
 
-  const team = await get(zeroTeam(auth.orgId, auth.userId));
+  const team = await get(teamComposeList(auth.orgId, auth.userId));
   return { status: 200 as const, body: [...team] };
 });
 

--- a/turbo/apps/api/src/signals/services/agent-data.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-data.service.ts
@@ -31,7 +31,7 @@ export function agentResponse(row: {
 }): ZeroAgentResponse {
   const ownerId = row.owner ?? row.composeUserId;
   if (!ownerId) {
-    throw new Error(`Zero agent ${row.agentId} is missing an owner`);
+    throw new Error(`Agent ${row.agentId} is missing an owner`);
   }
 
   return {
@@ -66,11 +66,11 @@ export function defaultAgentResponse(args: {
   };
 }
 
-function visibleZeroAgentCondition(userId: string) {
+function visibleAgentCondition(userId: string) {
   return or(eq(zeroAgents.visibility, "public"), eq(zeroAgents.owner, userId));
 }
 
-export function visibleJoinedZeroAgentCondition(userId: string) {
+export function visibleJoinedAgentCondition(userId: string) {
   return or(
     isNull(zeroAgents.id),
     eq(zeroAgents.visibility, "public"),
@@ -78,7 +78,7 @@ export function visibleJoinedZeroAgentCondition(userId: string) {
   );
 }
 
-export function zeroAgentExists(args: {
+export function agentExists(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
@@ -91,7 +91,7 @@ export function zeroAgentExists(args: {
         and(
           eq(zeroAgents.orgId, args.orgId),
           eq(zeroAgents.id, args.agentId),
-          visibleZeroAgentCondition(args.userId),
+          visibleAgentCondition(args.userId),
         ),
       )
       .limit(1);
@@ -100,7 +100,7 @@ export function zeroAgentExists(args: {
   });
 }
 
-export function zeroAgentList(
+export function agentList(
   orgId: string,
   userId: string,
 ): Computed<Promise<readonly ZeroAgentResponse[]>> {
@@ -120,16 +120,14 @@ export function zeroAgentList(
       })
       .from(zeroAgents)
       .innerJoin(agentComposes, eq(zeroAgents.id, agentComposes.id))
-      .where(
-        and(eq(zeroAgents.orgId, orgId), visibleZeroAgentCondition(userId)),
-      )
+      .where(and(eq(zeroAgents.orgId, orgId), visibleAgentCondition(userId)))
       .orderBy(desc(zeroAgents.updatedAt));
 
     return rows.map(agentResponse);
   });
 }
 
-export function zeroAgentDetail(args: {
+export function agentDetail(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
@@ -155,7 +153,7 @@ export function zeroAgentDetail(args: {
         and(
           eq(zeroAgents.orgId, args.orgId),
           eq(zeroAgents.id, args.agentId),
-          visibleZeroAgentCondition(args.userId),
+          visibleAgentCondition(args.userId),
         ),
       )
       .limit(1);
@@ -164,7 +162,7 @@ export function zeroAgentDetail(args: {
   });
 }
 
-export function zeroAgentEnabledConnectorSlugs(args: {
+export function agentEnabledConnectorSlugs(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
@@ -188,7 +186,7 @@ export function zeroAgentEnabledConnectorSlugs(args: {
   });
 }
 
-export function zeroAgentCustomConnectorGrants(args: {
+export function agentCustomConnectorGrants(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
@@ -228,7 +226,7 @@ export function zeroAgentCustomConnectorGrants(args: {
   );
 }
 
-export function zeroTeam(
+export function teamComposeList(
   orgId: string,
   userId: string,
 ): Computed<Promise<readonly TeamComposeItem[]>> {
@@ -247,9 +245,7 @@ export function zeroTeam(
       })
       .from(agentComposes)
       .innerJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
-      .where(
-        and(eq(agentComposes.orgId, orgId), visibleZeroAgentCondition(userId)),
-      )
+      .where(and(eq(agentComposes.orgId, orgId), visibleAgentCondition(userId)))
       .orderBy(desc(agentComposes.updatedAt));
 
     return rows.map((row) => {

--- a/turbo/apps/api/src/signals/services/agent-instructions.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-instructions.service.ts
@@ -18,7 +18,7 @@ import { db$ } from "../external/db";
 import { downloadS3Buffer, downloadManifest } from "../external/s3";
 import { env } from "../../lib/env";
 import { extractFileFromTarGz } from "../../lib/tar";
-import { visibleJoinedZeroAgentCondition } from "./zero-agent-data.service";
+import { visibleJoinedAgentCondition } from "./agent-data.service";
 
 interface AgentInstructionsResult {
   readonly content: string | null;
@@ -26,13 +26,13 @@ interface AgentInstructionsResult {
 }
 
 /**
- * Retrieve the instructions content for a zero agent.
+ * Retrieve the instructions content for an agent.
  *
  * Looks up the agent by ID within the given org, locates the instructions
  * storage volume, and extracts the canonical instructions file from the
  * S3 archive. Returns null when the agent is not found.
  */
-export function zeroAgentInstructions(args: {
+export function agentInstructions(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
@@ -54,7 +54,7 @@ export function zeroAgentInstructions(args: {
         and(
           eq(agentComposes.orgId, args.orgId),
           eq(agentComposes.id, args.agentId),
-          visibleJoinedZeroAgentCondition(args.userId),
+          visibleJoinedAgentCondition(args.userId),
         ),
       )
       .limit(1);

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -153,7 +153,7 @@ function validationError(message: string): ValidationErrorResponse {
   };
 }
 
-function visibleZeroAgentCondition(userId: string) {
+function visibleAgentCondition(userId: string) {
   return or(eq(zeroAgents.visibility, "public"), eq(zeroAgents.owner, userId));
 }
 
@@ -168,7 +168,7 @@ async function findVisibleAgent(
       and(
         eq(zeroAgents.orgId, scope.orgId),
         eq(zeroAgents.id, scope.agentId),
-        visibleZeroAgentCondition(scope.userId),
+        visibleAgentCondition(scope.userId),
       ),
     )
     .limit(1);
@@ -657,7 +657,7 @@ async function lockVisibleAgentForUpdate(
       and(
         eq(zeroAgents.orgId, scope.orgId),
         eq(zeroAgents.id, scope.agentId),
-        visibleZeroAgentCondition(scope.userId),
+        visibleAgentCondition(scope.userId),
       ),
     )
     .for("update")


### PR DESCRIPTION
## Summary

- rename the internal agent data and instruction services and neutralize their declarations
- update every direct route and inter-service caller without changing runtime behavior
- remove the remaining repository-wide homonymous private declaration and neutralize the approved JSDoc and exception copy

## Compatibility boundary

- preserves `contracts/zero-agents`, `contracts/zero-team`, `contracts/zero-agent-custom-connectors`, `ZeroAgentResponse`, and `TeamComposeItem`
- preserves `@okouai/db/schema/zero-agent`, the physical `zeroAgents` declaration, and the literal `<!-- ZERO_PROFILE` marker
- preserves route filenames and exports, API paths, wire schemas, authentication, permissions, visibility and query semantics, connector grants, storage lookup, and instruction handling
- keeps the Agent/Compose architecture boundary unchanged; this PR contains no schema or table migration, service collapse, lifecycle refactor, or functional change

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- non-API workspace type-check, `@okouai/app` type-check, and `pnpm --filter api run check-types` (`missing=0`, `extra=0`, `overlaps=0`)
- latest-main API lint plus targeted Prettier, Oxlint, and ESLint for the additional homonymous private declaration
- 7 focused Vitest files covering agent draft, agent list/detail/update, custom connectors, route behavior, and permission grants: 101 tests passed
- repository-wide absence checks for both old service paths, all renamed declarations, and both approved prose strings
- preserved-boundary checks for contracts, types, schema identity, physical declaration, and the legacy content marker
- paginated pull-files overlap scan of all 25 open PRs: no overlap

Closes #27499
