### PR TITLE
test(e2e): wait for pinned agent fixture readiness

### DIFF
--- a/e2e/playwright/tests/agents.spec.ts
+++ b/e2e/playwright/tests/agents.spec.ts
@@ -114,7 +114,22 @@ test("pinned agents use four equal columns without horizontal overflow", async (
   }
 
   await mockPinnedAgentGrid(page, defaultAgentId);
-  await page.reload();
+  await Promise.all([
+    ...[
+      "/api/okou/feature-switches",
+      "/api/okou/onboarding/status",
+      "/api/okou/team",
+      "/api/okou/user-preferences",
+    ].map((pathname) => {
+      return page.waitForResponse((response) => {
+        return (
+          response.request().method() === "GET" &&
+          new URL(response.url()).pathname === pathname
+        );
+      });
+    }),
+    page.reload(),
+  ]);
 
   const grid = page.getByTestId("pinned-agents-grid");
   const cards = grid.getByTestId("pinned-agent-card");


### PR DESCRIPTION
## Summary

- synchronize the pinned-agent reload with the four GET responses that determine the grid fixture
- keep the exact four-card, equal-column, wrapping, and no-overflow assertions unchanged

## Root cause and evidence

- Trigger: https://github.com/vm0-ai/vm0/actions/runs/31923135210
- Failed job: https://github.com/vm0-ai/vm0/actions/runs/31923135210/job/95106917298
- Failed test: `[features] › pinned agents use four equal columns without horizontal overflow`
- `page.reload()` waited for the document load event, but the test immediately started its five-second card assertion without owning the asynchronous feature-switch, onboarding-status, team, and user-preferences loads that determine `pinnedAgents$`.
- The failure context was already on `/agents/4cc7f4bf-afee-457b-b346-9b962734c7b2/chat`, with the authenticated three-column shell and agent-chat page rendered. It was not a login page, error page, empty Agents page, or the full-screen bootstrap skeleton.
- The assertion observed zero cards 14 times, while the captured failure DOM later contained Zero plus the three mocked Research, Support, and Operations agents. The fixture eventually propagated; the observation began before its data boundary completed.
- Request logs for the reload sequence show `feature-switches`, `indicators`, `onboarding/status`, `user-preferences`, and `team` all returned 200. The corresponding request durations were 6–19 ms, so no API error or slow backend response caused the missing cards.
- The app hides `#app-bootstrap-skeleton` before awaiting `agents$` on the agent-chat route, so the skeleton-detached wait used by #27404 would not establish this test's data readiness.
- The same exact SHA passed this shard 23/23 in merge-group run https://github.com/vm0-ai/vm0/actions/runs/31922923460. PR #27496 only changed usage-credit UI files and did not touch this route or test.
- Clerk `route.fetch: Test ended` messages concerned a separate organization-invitations request path; `ci-gate-turbo` only reflected the substantive shard failure.

## Fix

- register response waits before reload and own them together with `page.reload()` in one `Promise.all`
- wait only for the exact GET endpoints required by the grid, then run the original card and geometry assertions with their original timeouts
- add no retries, sleeps, timeout increases, skipped checks, weakened assertions, or swallowed rejections

## Verification

- `corepack pnpm dlx prettier@3.6.2 --check playwright/tests/agents.spec.ts`
- `corepack pnpm check-types`
- `git diff --check`
- Local Playwright execution: not run because the test requires deployed App/API services; no local service was started
- Turbo run https://github.com/vm0-ai/vm0/actions/runs/31924246501 passed, including `cli-e2e-02-playwright` 23/23: https://github.com/vm0-ai/vm0/actions/runs/31924246501/job/95109467041

## Preview validation

- App: https://pr-27508-app.omby.ai
- API: https://pr-27508-api.vm6.ai
- Head: `a300b7b1bbad457ca6d2af3bc7f526abb9dc7987`
- Validated at 1440 × 900 in a fresh Clerk testing organization with Zero plus the three pinned Research, Support, and Operations agents and `threeColumnNav` enabled.
- Five consecutive reloads passed the original invariant. Every run had four cards and a visible New control; top spread `0 px`, minimum first-row gap `71.75 px`, width spread `0 px`, right-edge delta `0 px`, wrapped-row delta `71.75 px`, wrapped-column delta `0 px`, and horizontal overflow `0 px`.
- A cleared-console final reload produced no uncaught page errors. The only console output was Clerk's expected development-key warning.

![Pinned agents preview](https://cdn.vm0.io/artifacts/m3yn5oswuh.png)
