### PR TITLE
refactor(generation): neutralize media service naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
@@ -20,7 +20,7 @@ import {
   recordGeneratedImage$,
   type ImageOptions,
   type ImagePricing,
-} from "../services/zero-image-io-generate.service";
+} from "../services/image-generation.service";
 import {
   completeBuiltInGenerationJob$,
   failBuiltInGenerationJob$,
@@ -51,7 +51,7 @@ import {
   recordGeneratedVideo$,
   type VideoPricing,
   videoPricing$,
-} from "../services/zero-video-io-generate.service";
+} from "../services/video-generation.service";
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import {
@@ -61,7 +61,7 @@ import {
   parseAvatarVideoOptions,
   parseJoggAiWebhookPayload,
   recordGeneratedAvatarVideo$,
-} from "../services/zero-avatar-video.service";
+} from "../services/avatar-video.service";
 
 const L = logger("BuiltInGenerationWebhooks");
 

--- a/turbo/apps/api/src/signals/routes/zero-avatar-video.ts
+++ b/turbo/apps/api/src/signals/routes/zero-avatar-video.ts
@@ -28,7 +28,7 @@ import {
   parseAvatarVideoOptions,
   submitJoggAiAvatarVideo,
   type AvatarVideoOptions,
-} from "../services/zero-avatar-video.service";
+} from "../services/avatar-video.service";
 import {
   builtInGenerationRequestWithInternal,
   createBuiltInGenerationJob$,

--- a/turbo/apps/api/src/signals/routes/zero-image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/zero-image-io-generate.ts
@@ -21,7 +21,7 @@ import {
   submitFalImageQueueGeneration,
   type ImageOptions,
   type ImagePricing,
-} from "../services/zero-image-io-generate.service";
+} from "../services/image-generation.service";
 import {
   builtInGenerationRequestWithInternal,
   createBuiltInGenerationJob$,
@@ -37,7 +37,7 @@ import {
   type RunBuiltInAdmission,
 } from "../services/run-built-in-admission.service";
 
-const L = logger("ZeroImageIoGenerate");
+const L = logger("ImageGeneration");
 const imageBody$ = bodyResultOf(zeroImageIoGenerateContract.post);
 
 interface GenerationError {

--- a/turbo/apps/api/src/signals/routes/zero-video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/zero-video-io-generate.ts
@@ -38,7 +38,7 @@ import {
   videoPricing$,
   videoRequiresPaidPlan,
   videoServiceUnavailable,
-} from "../services/zero-video-io-generate.service";
+} from "../services/video-generation.service";
 import {
   builtInGenerationRequestWithInternal,
   createBuiltInGenerationJob$,

--- a/turbo/apps/api/src/signals/services/avatar-video.service.ts
+++ b/turbo/apps/api/src/signals/services/avatar-video.service.ts
@@ -26,7 +26,7 @@ import {
 import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
 import { processOrgUsageEvents$ } from "./credit-usage.service";
 
-const L = logger("ZeroAvatarVideo");
+const L = logger("AvatarVideo");
 
 const JOGGAI_AVATAR_VIDEO_MODEL = "joggai-talking-avatar";
 const JOGGAI_AVATAR_VIDEO_PRICING_CATEGORY = "output_video_joggai_credits";

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -374,7 +374,7 @@ const IMAGE_MODEL_CONFIGS = {
 } as const;
 
 const IMAGE_MODELS = Object.keys(IMAGE_MODEL_CONFIGS) as ImageModel[];
-const L = logger("ZeroImageIoGenerate");
+const L = logger("ImageGeneration");
 
 type ImageQuality = (typeof IMAGE_QUALITIES)[number];
 type ImageBackground = (typeof IMAGE_BACKGROUNDS)[number];

--- a/turbo/apps/api/src/signals/services/video-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/video-generation.service.ts
@@ -47,7 +47,7 @@ const BYTEPLUS_VIDEO_TASKS_URL =
 const MINIMAX_VIDEO_GENERATION_URL =
   "https://api.minimax.io/v2/video_generation";
 
-const L = logger("ZeroVideoIoGenerate");
+const L = logger("VideoGeneration");
 const VIDEO_IO_MAX_PROMPT_LENGTH = 32_000;
 const MINIMAX_H3_MAX_PROMPT_LENGTH = 7000;
 const PROVIDER_ERROR_BODY_LOG_MAX_LENGTH = 4000;


### PR DESCRIPTION
## Summary

- rename the built-in image, video, and avatar-video service shells to neutral domain paths
- update every direct route and webhook caller atomically
- rename the media-generation logger namespaces while preserving public contracts and persisted provenance

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @okouai/app run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api run check-types`
- focused media-generation route and webhook tests: 4 files, 57 tests passed

Closes #27519
