### PR TITLE
fix(platform): preserve credit balance during refresh

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { mockNow } from "../../../__tests__/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 const MOCK_NOW = "2026-03-01T01:00:00Z";
@@ -39,8 +40,10 @@ function expectedAllowanceResetText(value: string): string {
 
 function mockBillingStatus(
   overrides: Partial<BillingStatusResponse> = {},
+  beforeResponse?: () => Promise<void> | void,
 ): void {
-  context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+  context.mocks.api(zeroBillingStatusContract.get, async ({ respond }) => {
+    await beforeResponse?.();
     return respond(200, {
       tier: "pro",
       credits: 12_000,
@@ -244,6 +247,79 @@ describe("organization usage settings", () => {
 
     // Usage records moved to their own section.
     expect(screen.queryByText("Team usage")).toBeNull();
+  });
+
+  it("keeps the rendered credit balance mounted during realtime refresh", async () => {
+    const reloadStarted = createDeferredPromise<void>(context.signal);
+    const releaseReload = createDeferredPromise<void>(context.signal);
+    let holdReload = false;
+    let statusRequests = 0;
+    mockUsageStory();
+    mockBillingStatus({}, async () => {
+      statusRequests += 1;
+      if (holdReload) {
+        reloadStarted.resolve();
+        await releaseReload.promise;
+      }
+    });
+
+    await openCreditBalance();
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("billing:changed"),
+      ).toBeTruthy();
+      expect(statusRequests).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("3,750 left")).toBeInTheDocument();
+    });
+
+    const url = window.location.href;
+    const allowance = screen.getByTestId("usage-allowance-section");
+    const firstSegment = screen.getByTestId("credit-balance-segment-plan:pro");
+    const lastSegment = screen.getByTestId("credit-balance-segment-payAsYouGo");
+    expect(allowance).toBeVisible();
+    expect(firstSegment).toBeVisible();
+    expect(lastSegment).toBeVisible();
+
+    const requestsBeforeReload = statusRequests;
+    holdReload = true;
+    context.mocks.ably.trigger("billing:changed");
+    await reloadStarted.promise;
+
+    const whileReloading = {
+      allowanceConnected: allowance.isConnected,
+      allowanceCount: screen.queryAllByTestId("usage-allowance-section").length,
+      firstSegmentConnected: firstSegment.isConnected,
+      firstSegmentCount: screen.queryAllByTestId(
+        "credit-balance-segment-plan:pro",
+      ).length,
+      lastSegmentConnected: lastSegment.isConnected,
+      lastSegmentCount: screen.queryAllByTestId(
+        "credit-balance-segment-payAsYouGo",
+      ).length,
+      url: window.location.href,
+    };
+    releaseReload.resolve();
+
+    await waitFor(() => {
+      expect(statusRequests).toBeGreaterThan(requestsBeforeReload);
+      expect(screen.getByText("3,750 left")).toBeInTheDocument();
+    });
+    expect(whileReloading).toStrictEqual({
+      allowanceConnected: true,
+      allowanceCount: 1,
+      firstSegmentConnected: true,
+      firstSegmentCount: 1,
+      lastSegmentConnected: true,
+      lastSegmentCount: 1,
+      url,
+    });
+    expect(screen.getByTestId("usage-allowance-section")).toBe(allowance);
+    expect(screen.getByTestId("credit-balance-segment-plan:pro")).toBe(
+      firstSegment,
+    );
+    expect(screen.getByTestId("credit-balance-segment-payAsYouGo")).toBe(
+      lastSegment,
+    );
   });
 
   it("moves from the balance to the usage records through the section link", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -1,4 +1,4 @@
-import { useLoadable } from "ccstate-react";
+import { useLastLoadable } from "ccstate-react";
 import { Button } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
 import type { OrgMember } from "@okouai/api-contracts/contracts/org-members";
@@ -893,7 +893,7 @@ export function CreditBalanceCard({
   splitLayout: boolean;
 }) {
   const { t } = useTranslation();
-  const billingLoadable = useLoadable(billingStatusAsync$);
+  const billingLoadable = useLastLoadable(billingStatusAsync$);
   const billing =
     billingLoadable.state === "hasData" ? billingLoadable.data : null;
   const billingLoading = billingLoadable.state === "loading";


### PR DESCRIPTION
## Summary

- keep the last resolved credit-balance data mounted while billing status revalidates
- add a page-level regression that holds a realtime billing refresh in flight and verifies the allowance and both organization-credit segments remain visible, connected, and owned by the same DOM nodes
- preserve the existing matching outer-radius and square inner-seam assertions unchanged

## Failures and renewed root cause

This PR owns five recurrences of the same Turbo flaky key across main and merge-group runs:

- [run 31930659178, `cli-e2e-02-playwright`](https://github.com/vm0-ai/vm0/actions/runs/31930659178/job/95125095418), main SHA `1d471702000bfd645bad9cf8a0caa6b37e92aa26`: Usage allowance radius was empty while the first organization-credit radius was `3.35544e+07px`.
- [run 31933100308, `cli-e2e-02-playwright`](https://github.com/vm0-ai/vm0/actions/runs/31933100308/job/95131036200), main SHA `ba7cd416e693d66e8d0f9f943070cf1a7e462377`: the direction inverted—the Usage allowance radius was `3.35544e+07px` while the first organization-credit radius was empty.
- [run 31993584906, `cli-e2e-02-playwright`](https://github.com/vm0-ai/vm0/actions/runs/31993584906/job/95282239341), main SHA `a9d6aaaedf36eff09108427c99ed5218dc5a955b`: Usage allowance was empty and first organization credit was again `3.35544e+07px`; 1 failed and 24 passed.
- [run 32006786561, `cli-e2e-02-playwright`](https://github.com/vm0-ai/vm0/actions/runs/32006786561/job/95318362856), main SHA `dbb411f15a94a4fe20051f73d2b7a692fa8da77c`: Usage allowance was empty and first organization credit was `3.35544e+07px`; 1 failed and 24 passed. The same exact SHA passed all 25 tests in the identical shard minutes earlier in [merge-group run 32006069184](https://github.com/vm0-ai/vm0/actions/runs/32006069184/job/95316933170).
- [run 32052040516, `cli-e2e-02-playwright`](https://github.com/vm0-ai/vm0/actions/runs/32052040516/job/95454225675), merge-group SHA `dc69c41bec3cb11a5c6989146a08e17a79632d8b` for PR #27811: Usage allowance was empty while first organization credit was `3.35544e+07px`; 1 failed and 24 passed. Its [PR-head shard](https://github.com/vm0-ai/vm0/actions/runs/32050576276/job/95450679862) passed all 25 tests about fourteen minutes earlier.

All five Playwright error contexts showed that the Settings dialog was already on **Credit balance**, with the mocked Usage allowance (`5h`, `3,750 left`) and Org credits (`12,000`) rendered. The newest artifact also shows the Usage allowance progressbar in the accessibility snapshot. The test navigated to `/?settings=usage` and performs no later navigation. The aggregate `ci-gate-turbo` failures only reflected their shard failures.

This is a recurrence after merged [PR #27423](https://github.com/vm0-ai/vm0/pull/27423), whose final commit `613413dae92fefaaae96e047dc7e378506e2cf54` replaced the page-global progressbar locator with the fill inside `usage-allowance-section`. The scoped locator is correct, but it did not make the selected element's render owner stable.

The renewed cause is the billing revalidation lifecycle:

1. `CreditBalanceCard` read `billingStatusAsync$` through `useLoadable`.
2. `billingStatusResource$` creates a new request whenever `billingReload$` changes. `setupBillingRealtime$` drives that reload on subscription and on every `billing:changed` event (`runOnSubscribe: true`).
3. During that revalidation, `useLoadable` temporarily stopped exposing the previously resolved billing data, so the Usage allowance and Org-credit chart subtrees were unmounted. The response then mounted replacement nodes.
4. The E2E test awaits visibility and evaluates the three locators separately. Depending on the exact revalidation boundary, either the previously selected allowance element or a previously selected organization-credit segment can be evaluated after detachment. The recurrences' opposite empty values are the two scheduling directions of this same replacement window.

A controlled page-level red test proved the lifecycle before the production change. It started with all three targets visible and count `1`, held the `/billing/status` response for a real mocked `billing:changed` refresh, and observed during the pending response:

- unchanged URL
- allowance `isConnected=false`, count `0`
- first Org-credit segment `isConnected=false`, count `0`
- last Org-credit segment `isConnected=false`, count `0`

After the response, all three locators resolved replacement nodes. With this PR, `useLastLoadable` retains the last resolved billing data during background revalidation, and the same controlled test proves the original three DOM references stay connected, visible, and uniquely owned before, during, and after the refresh (`isConnected=true`, count `1`, unchanged URL, identical node references). This matches `ccstate-react`'s tested contract that `useLastLoadable` keeps the prior resolved value while a new promise is pending.

The failed-run artifacts do not contain a Playwright trace, so they cannot directly report `isConnected` at the exact `getComputedStyle` call. They establish the ready page/data state and the empty computed-style observation; the controlled red/green lifecycle test establishes the detach-and-replace mechanism. No console or network error appears before the causal assertion in the newest artifact or job log.

## Triggering changes and non-causes

The billing-adjacent [PR #27504](https://github.com/vm0-ai/vm0/pull/27504) did not edit the failing test, `CreditBalanceCard`, or the radius rendering. Its merge-group shard passed all 23 tests on the same SHA in [run 31930407202](https://github.com/vm0-ai/vm0/actions/runs/31930407202/job/95124442886).

The later billing-adjacent [PR #27503](https://github.com/vm0-ai/vm0/pull/27503) changed usage-pack downgrade feedback and its tests, but did not edit the failing test or `CreditBalanceCard`. Its exact main SHA passed the identical 23-test shard five minutes earlier in [run 31932867933](https://github.com/vm0-ai/vm0/actions/runs/31932867933/job/95130491626).

The billing-owned [PR #27083](https://github.com/vm0-ai/vm0/pull/27083) changed scheduled subscription transitions and added two parallel billing-transition E2E tests, but did not edit the failing test, `CreditBalanceCard`, `billingStatusAsync$`, or its realtime subscription. Those tests create separate Clerk users and organizations; `billing:changed` is published only to the changed organization's admin user IDs, so they cannot inject a billing event into the feature test's user channel. Its exact SHA passed all 25 tests in the same shard seven minutes earlier in [run 31993175330](https://github.com/vm0-ai/vm0/actions/runs/31993175330/job/95280558478).

[PR #27706](https://github.com/vm0-ai/vm0/pull/27706) removed the `videoTemplateOptions` feature switch and related video-template code. It did not edit the billing view, billing resource/realtime ownership, the radius test, or any shared rendering helper used here. Its exact SHA passed the identical 25-test shard in the merge group immediately before the main push.

The newest triggering [PR #27811](https://github.com/vm0-ai/vm0/pull/27811) changes only `turbo/pnpm-lock.yaml` and `turbo/pnpm-workspace.yaml`, adding a `deepmerge-ts` override. Its one-parent merge-group commit has exactly those two file changes relative to parent main `c28f7791949d1cd36b6b0a834fa4a2bae94efefd`; it does not edit billing, the failing test, or shared rendering code. Its PR-head shard passed all 25 tests before the merge-group recurrence.

The Clerk Testing `route.fetch: Test ended` warnings are parallel/end-of-test lifecycle warnings, not the first causal browser state. The job continued after those warnings and ultimately reported the computed-style assertion as its only failed test; the artifact's first incorrect observable is the empty radius for one otherwise-ready target. No timeout, retry, sleep, assertion weakening, animation override, manual detached cleanup, or swallowed rejection is used.

## Verification

Current head `2d97f8d8b4` is rebased onto current `origin/main` `c28f7791949d1cd36b6b0a834fa4a2bae94efefd`. No relevant billing, radius-test, or rendering-helper file changed between the previous base and this main revision.

- Red test before the production fix: during the held realtime reload, all three original nodes were disconnected and all three target counts were `0`; after the response, the locators resolved replacement nodes
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/org-usage-tab.test.tsx` — **5/5 consecutive runs passed, 12/12 tests per run**
- `pnpm --filter @okouai/app run lint` — passed (repository-wide existing warnings only)
- `pnpm --filter @okouai/app run check-types` — passed
- `pnpm knip --workspace apps/platform` — passed
- `pnpm exec prettier --check apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx` — passed
- `git diff --check` — passed
- Previous deployed PR head `3d0a31f0e20ca341043abab061f6dc02abf2c14e`: Turbo's `cli-e2e-02-playwright` passed all 25 tests in [run 31994934090](https://github.com/vm0-ai/vm0/actions/runs/31994934090/job/95285246109)

The deployed Playwright case is service-dependent and was not run locally. No local application, API, runner, development server, secret manager, or full repository Vitest suite was started or used.

## Preview validation

Pending the actual App and API preview URLs reported for head `2d97f8d8b4`. The PR remains draft until `/staging-browser` verifies the original outer-radius and inner-seam invariant, the connected-node lifecycle, and the requested reload/org-switch scenarios five times on that deployed preview.
