### PR TITLE
perf(api): exclude queued message age from startup timing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1292,7 +1292,7 @@ describe("CHAT-02: completed chat callback", () => {
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
 
-  it("uses the queued event creation time when a message auto-sends", async () => {
+  it("starts queued chat startup timing at message admission", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
@@ -1350,11 +1350,28 @@ describe("CHAT-02: completed chat callback", () => {
     if (!queuedMessage) {
       throw new Error("Expected the original queued Web message");
     }
-    const apiStartedAt = Date.parse(queuedMessage.createdAt);
+    const queuedMessageCreatedAt = Date.parse(queuedMessage.createdAt);
+    const apiStartedAt = dequeuedAt;
 
     const acknowledgedAt = dequeuedAt + 7000;
     const secondClaim = await claimChatRunJob(runnerGroup, claimed.runId);
     expect(secondClaim.apiStartTime).toBe(apiStartedAt);
+    const timingEvents = await expectChatCallbackPreCreateTimingActions(
+      claimed.runId,
+      ["api_dispatch_pre_create_zero_chat_callback_auto_send_queue_age"],
+    );
+    expect(
+      timingEventsForAction(
+        timingEvents,
+        "api_dispatch_pre_create_zero_chat_callback_auto_send_queue_age",
+      ),
+    ).toStrictEqual([
+      expect.objectContaining({
+        duration_ms: dequeuedAt - queuedMessageCreatedAt,
+        op_type:
+          "api_dispatch_pre_create_zero_chat_callback_auto_send_queue_age",
+      }),
+    ]);
     const secondHeaders = {
       authorization: `Bearer ${secondClaim.sandboxToken}`,
     };
@@ -1643,6 +1660,7 @@ describe("CHAT-02: completed chat callback", () => {
       "api_dispatch_pre_create_zero_chat_callback_load_followup_context",
       "api_dispatch_pre_create_zero_chat_callback_auto_send_load_thread",
       "api_dispatch_pre_create_zero_chat_callback_auto_send_lookup_queued_message",
+      "api_dispatch_pre_create_zero_chat_callback_auto_send_queue_age",
       "api_dispatch_pre_create_zero_chat_callback_auto_send_build_input",
       "api_dispatch_pre_create_zero_chat_callback_auto_send_create_run",
       "api_dispatch_pre_create_zero_chat_callback_auto_send_publish_signals",
@@ -3172,6 +3190,7 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
         "api_dispatch_pre_create_zero_chat_callback_load_followup_context",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_load_thread",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_lookup_queued_message",
+        "api_dispatch_pre_create_zero_chat_callback_auto_send_queue_age",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_build_input",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_create_run",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_publish_signals",
@@ -4687,6 +4706,7 @@ describe("CHAT-02: auto-send after failures", () => {
         "api_dispatch_pre_create_zero_chat_callback_prepare_failed",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_load_thread",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_lookup_queued_message",
+        "api_dispatch_pre_create_zero_chat_callback_auto_send_queue_age",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_load_agent",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_build_input",
         "api_dispatch_pre_create_zero_chat_callback_auto_send_create_run",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -44,7 +44,12 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import { z } from "zod";
 import { createApp } from "../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
-import { clearMockNow, mockNow, now } from "../../../lib/time";
+import {
+  clearMockNow,
+  mockNow,
+  now,
+  withMockNowForTest,
+} from "../../../lib/time";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
@@ -8807,16 +8812,19 @@ describe("CHAT-02: shared user message queue", () => {
         { type: "model", selectedModel: "gpt-5.6-sol" },
       ],
     };
-    const sent = await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        prompt: "queue-first direct dispatch",
-        userMessage,
-        clientEventId: messageId,
-      },
-      [201],
-    );
+    const apiStartedAt = now();
+    const sent = await withMockNowForTest(apiStartedAt, async () => {
+      return await chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          prompt: "queue-first direct dispatch",
+          userMessage,
+          clientEventId: messageId,
+        },
+        [201],
+      );
+    });
     if (sent.status !== 201 || !sent.body.runId) {
       throw new Error("Expected an idle-thread queue-first send to dispatch");
     }
@@ -8891,6 +8899,7 @@ describe("CHAT-02: shared user message queue", () => {
       .toBe(true);
 
     const claimedRun = await claimChatRun(runnerGroup, runId);
+    expect(claimedRun.claim.apiStartTime).toBe(apiStartedAt);
     expect(claimedRun.claim.prompt).toBe(
       `queue-first [direct dispatch](/chats/${referencedThreadId})`,
     );

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -237,6 +237,7 @@ type ChatCallbackPreCreateTimingActionType =
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_build_prompt"
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_resolve_attachments"
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_check_active_run"
+  | "api_dispatch_pre_create_zero_chat_callback_auto_send_queue_age"
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_create_run"
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_append_marker"
   | "api_dispatch_pre_create_zero_chat_callback_auto_send_publish_signals";
@@ -670,7 +671,6 @@ interface CreateQueuedChatRunInput {
     readonly secret: string;
     readonly payload: unknown;
   };
-  readonly apiStartTime: number;
   readonly autonomyBudget: number;
   readonly userInfoExtras?: {
     readonly slackDisplayName?: string;
@@ -852,7 +852,9 @@ function buildQueuedCreateZeroRunArgs(
       orgId: input.orgId,
       orgRole: "member" as const,
     },
-    apiStartTime: input.apiStartTime,
+    // Startup metrics begin when the queued message is admitted for dispatch.
+    // The time spent waiting in the chat queue is recorded separately.
+    apiStartTime: admissionTime,
     chatThreadId: input.threadId,
     computerUseHostId: input.computerUseHostGrant?.hostId,
     modelProviderId: input.modelPin.modelProviderId ?? undefined,
@@ -3109,7 +3111,6 @@ async function buildCreateQueuedChatRunInput(
       featureSwitchContext,
     ),
     ...queuedIntegrationLaunchFields(launchMaterial),
-    apiStartTime: args.queuedMessage.createdAt.getTime(),
     autonomyBudget: args.queuedMessage.autonomyBudget.autonomyBudget,
   };
 }
@@ -3923,6 +3924,14 @@ async function autoSendQueuedMessageForThread(
   if (!queuedMessage) {
     return;
   }
+
+  args.timing.recordElapsed({
+    actionType:
+      "api_dispatch_pre_create_zero_chat_callback_auto_send_queue_age",
+    spanKind: "nested",
+    startedAt: queuedMessage.createdAt.getTime(),
+    finishedAt: args.admissionTime,
+  });
 
   const agent = await measureChatCallbackPreCreateTiming(
     args.timing,

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -3087,7 +3087,7 @@ const createNormalChatRun$ = command(
       createQueueFirstZeroRun$,
       {
         ...createRunArgs,
-        apiStartTime: queuedMessage.createdAt.getTime(),
+        apiStartTime: args.apiStartTime,
         zeroRunMetadata: {
           autonomyBudget: queuedMessage.autonomyBudget.autonomyBudget,
         },


### PR DESCRIPTION
## Summary

- Anchor `api_to_spawn` startup timing for queued chat runs to dispatch admission instead of the original queued-message creation time.
- Apply the same admission timestamp to both callback-driven auto-send and inline queue-first chat dispatch paths.
- Record queued-message age as a separate callback timing operation so queue wait remains observable without inflating startup metrics.
- Add integration coverage for the callback queue-age metric and the inline queue-first admission timestamp.

## Scope and compatibility

- Non-queued sends are unchanged.
- Queue ordering, admission policy, retries, cancellation, persisted schemas, runner payloads, and API contracts are unchanged.
- The change is API-side metric attribution only and is compatible with mixed-version deployments.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "dispatches idle-thread sends by appending a run-associated replacement"`
- `pnpm -F api lint` (passes; existing unrelated test warnings remain)
- `pnpm -F api check-types`
- `pnpm check-types` (all 14 workspace tasks passed via the pre-commit hook)
- `pnpm exec prettier --check apps/api/src/signals/services/internal-chat-run-callback.service.ts apps/api/src/signals/services/zero-chat-events.command.ts apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`
- `git diff --check`

Closes #27534
Relates to #27453
