### PR TITLE
refactor(mail): neutralize mail draft runtime naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-mail.ts
+++ b/turbo/apps/api/src/signals/routes/zero-mail.ts
@@ -7,16 +7,16 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import {
-  deleteZeroMailDraft$,
-  getZeroMailDraftAttachment$,
-  getZeroMailDraft$,
-  linkZeroMailDraft$,
-  sendZeroMailDraft$,
-  type ZeroMailDraftLinkMutationResult,
-  type ZeroMailDraftMutationResult,
-} from "../services/zero-mail.service";
+  deleteMailDraft$,
+  getMailDraftAttachment$,
+  getMailDraft$,
+  linkMailDraft$,
+  sendMailDraft$,
+  type MailDraftLinkMutationResult,
+  type MailDraftMutationResult,
+} from "../services/mail-draft.service";
 
-function mutationResponse(result: ZeroMailDraftMutationResult) {
+function mutationResponse(result: MailDraftMutationResult) {
   switch (result.kind) {
     case "ok": {
       return {
@@ -37,7 +37,7 @@ function mutationResponse(result: ZeroMailDraftMutationResult) {
   }
 }
 
-function linkMutationResponse(result: ZeroMailDraftLinkMutationResult) {
+function linkMutationResponse(result: MailDraftLinkMutationResult) {
   switch (result.kind) {
     case "ok": {
       return {
@@ -66,7 +66,7 @@ const linkDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return bodyResult.response;
   }
   const result = await set(
-    linkZeroMailDraft$,
+    linkMailDraft$,
     {
       orgId: auth.orgId,
       userId: auth.userId,
@@ -82,7 +82,7 @@ const getDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   return mutationResponse(
     await set(
-      getZeroMailDraft$,
+      getMailDraft$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
@@ -111,7 +111,7 @@ const getAttachmentInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const result = await set(
-      getZeroMailDraftAttachment$,
+      getMailDraftAttachment$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
@@ -151,7 +151,7 @@ const deleteDraftParams$ = pathParamsOf(zeroMailContract.deleteDraft);
 const deleteDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const result = await set(
-    deleteZeroMailDraft$,
+    deleteMailDraft$,
     {
       orgId: auth.orgId,
       userId: auth.userId,
@@ -170,7 +170,7 @@ const sendDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   return mutationResponse(
     await set(
-      sendZeroMailDraft$,
+      sendMailDraft$,
       {
         orgId: auth.orgId,
         userId: auth.userId,

--- a/turbo/apps/api/src/signals/services/mail-draft.service.ts
+++ b/turbo/apps/api/src/signals/services/mail-draft.service.ts
@@ -37,7 +37,7 @@ import {
   type ConnectorCredentialConnection,
 } from "./connector-credential-runtime.service";
 
-const L = logger("api:zero-mail");
+const L = logger("api:mail-draft");
 
 const TOKEN_REFRESH_SKEW_MS = 60_000;
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_MS = 60 * 60 * 1000;
@@ -123,7 +123,7 @@ interface MailDraftLinkResult {
   readonly mailDraftUrl: string;
 }
 
-interface MailDraftAttachmentResult {
+interface MailDraftAttachmentSuccess {
   readonly kind: "ok";
   readonly content: Uint8Array;
   readonly contentType: string;
@@ -135,16 +135,14 @@ interface MailDraftErrorResult {
   readonly message: string;
 }
 
-export type ZeroMailDraftMutationResult =
-  | MailDraftResult
-  | MailDraftErrorResult;
+export type MailDraftMutationResult = MailDraftResult | MailDraftErrorResult;
 
-export type ZeroMailDraftLinkMutationResult =
+export type MailDraftLinkMutationResult =
   | MailDraftLinkResult
   | MailDraftErrorResult;
 
-type ZeroMailDraftAttachmentResult =
-  | MailDraftAttachmentResult
+type MailDraftAttachmentResult =
+  | MailDraftAttachmentSuccess
   | MailDraftErrorResult;
 
 const reconnectMailError = Object.freeze({
@@ -1208,7 +1206,7 @@ async function getMailDraft(
     readonly row: MailDraftRow;
   },
   signal: AbortSignal,
-): Promise<ZeroMailDraftMutationResult> {
+): Promise<MailDraftMutationResult> {
   if (args.row.status === "deleted") {
     return okResult(
       args.row.id,
@@ -1479,7 +1477,7 @@ async function sendGmailDraftWithAccess(
     : { kind: "missing" };
 }
 
-export const linkZeroMailDraft$ = command(
+export const linkMailDraft$ = command(
   async (
     { get, set },
     args: {
@@ -1490,7 +1488,7 @@ export const linkZeroMailDraft$ = command(
       readonly gmailDraftId: string;
     },
     signal: AbortSignal,
-  ): Promise<ZeroMailDraftLinkMutationResult> => {
+  ): Promise<MailDraftLinkMutationResult> => {
     const db = get(db$);
     const snapshot = await loadConnectorRuntimeSnapshot(db);
     signal.throwIfAborted();
@@ -1599,7 +1597,7 @@ export const linkZeroMailDraft$ = command(
   },
 );
 
-export const getZeroMailDraft$ = command(
+export const getMailDraft$ = command(
   async (
     { get, set },
     args: {
@@ -1608,7 +1606,7 @@ export const getZeroMailDraft$ = command(
       readonly mailDraftId: string;
     },
     signal: AbortSignal,
-  ): Promise<ZeroMailDraftMutationResult> => {
+  ): Promise<MailDraftMutationResult> => {
     const db = get(db$);
     const row = await loadOwnedMailDraft({ db, ...args });
     signal.throwIfAborted();
@@ -1631,7 +1629,7 @@ export const getZeroMailDraft$ = command(
   },
 );
 
-export const getZeroMailDraftAttachment$ = command(
+export const getMailDraftAttachment$ = command(
   async (
     { get, set },
     args: {
@@ -1641,7 +1639,7 @@ export const getZeroMailDraftAttachment$ = command(
       readonly partId: string;
     },
     signal: AbortSignal,
-  ): Promise<ZeroMailDraftAttachmentResult> => {
+  ): Promise<MailDraftAttachmentResult> => {
     const db = get(db$);
     const row = await loadOwnedMailDraft({ db, ...args });
     signal.throwIfAborted();
@@ -1735,7 +1733,7 @@ export const getZeroMailDraftAttachment$ = command(
   },
 );
 
-export const deleteZeroMailDraft$ = command(
+export const deleteMailDraft$ = command(
   async (
     { get, set },
     args: {
@@ -1744,7 +1742,7 @@ export const deleteZeroMailDraft$ = command(
       readonly mailDraftId: string;
     },
     signal: AbortSignal,
-  ): Promise<ZeroMailDraftMutationResult> => {
+  ): Promise<MailDraftMutationResult> => {
     const db = get(db$);
     const row = await loadOwnedMailDraft({ db, ...args });
     signal.throwIfAborted();
@@ -1805,7 +1803,7 @@ export const deleteZeroMailDraft$ = command(
   },
 );
 
-export const sendZeroMailDraft$ = command(
+export const sendMailDraft$ = command(
   async (
     { get, set },
     args: {
@@ -1814,7 +1812,7 @@ export const sendZeroMailDraft$ = command(
       readonly mailDraftId: string;
     },
     signal: AbortSignal,
-  ): Promise<ZeroMailDraftMutationResult> => {
+  ): Promise<MailDraftMutationResult> => {
     const db = get(db$);
     const row = await loadOwnedMailDraft({ db, ...args });
     signal.throwIfAborted();


### PR DESCRIPTION
## Summary

- rename `zero-mail.service.ts` to `mail-draft.service.ts` atomically
- neutralize the mail draft logger, five command exports, two exported result unions, and the collision-safe attachment success/union names
- update the sole direct caller in `routes/zero-mail.ts` and remove the old internal path and declarations without aliases or compatibility re-exports

## Compatibility

- preserve `@okouai/api-contracts/contracts/zero-mail`, all `ZeroMail*` public contract types, and `zeroMail*Schema` declarations
- preserve `routes/zero-mail.ts`, `zeroMailContract`, `zeroMailRoutes`, API paths, schemas, status codes, authorization behavior, and the `"zero"` auth token literal
- preserve `mailDrafts`, persisted fields, Gmail and connector identifiers, credential refresh, MIME layout, headers, callbacks, attachment handling, delete/send behavior, and user-visible errors

## Verification

- refreshed and rebased onto latest `origin/main`
- repeated repository-wide caller/collision searches and a complete paginated file scan of all 25 open PRs before editing; no owned-file overlap found
- lockfile-pinned Prettier 3.8.1 format/check
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- bounded non-API, Platform, and API type checks
- post-rebase API lint and complete API type checks
- focused Mail route test: 1 file, 12 tests passed
- repository-wide old-path/declaration residual scan: zero matches
- mechanical contract-map content audit: exact match after Prettier normalization

Closes #27535
