### PR TITLE
test(python): cover authority-form environment proxy normalization

### DIFF
--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -1568,7 +1568,7 @@ class TestFirewallAuthAsyncTransport:
         )
 
         with proxy.run():
-            proxy_url = proxy.api_url.replace(
+            proxy_url = proxy.api_url.removeprefix("http://").replace(
                 "127.0.0.1",
                 "proxy-user:proxy-password@faß.proxy",
             )

--- a/crates/runner/mitm-addon/tests/test_platform_api.py
+++ b/crates/runner/mitm-addon/tests/test_platform_api.py
@@ -8,6 +8,40 @@ import pytest
 import platform_api
 
 
+class TestNormalizeProxyUrl:
+    @pytest.mark.parametrize(
+        ("proxy_url", "expected"),
+        [
+            pytest.param(
+                "proxy-user:proxy-password@faß.proxy:8123",
+                "proxy-user:proxy-password@xn--fa-hia.proxy:8123",
+                id="authority",
+            ),
+            pytest.param(
+                "//proxy-user:proxy-password@faß.proxy:8123",
+                "//proxy-user:proxy-password@xn--fa-hia.proxy:8123",
+                id="prefixed-authority",
+            ),
+            pytest.param(
+                "http://proxy-user:proxy-password@faß.proxy:8123",
+                "http://proxy-user:proxy-password@xn--fa-hia.proxy:8123",
+                id="url",
+            ),
+            pytest.param(
+                "[2001:0DB8:0:0:0:0:0:1]:8443",
+                "[2001:db8::1]:8443",
+                id="ipv6-authority",
+            ),
+        ],
+    )
+    def test_canonicalizes_hostname_and_preserves_proxy_form(
+        self,
+        proxy_url: str,
+        expected: str,
+    ):
+        assert platform_api.normalize_proxy_url(proxy_url) == expected
+
+
 class TestMakeApiRequest:
     def test_builds_platform_api_request_with_standard_headers(self, mitm_ctx):
         with (

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -311,13 +311,21 @@ def test_environment_proxy_rejects_unsafe_hostname_before_dns(
     mock_getaddrinfo.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "proxy_prefix",
+    [
+        pytest.param("http://", id="url"),
+        pytest.param("", id="authority"),
+    ],
+)
 def test_malformed_environment_proxy_does_not_expose_credentials_before_dns(
     tmp_path,
     sync_usage_executor,
+    proxy_prefix: str,
 ):
     password = "sensitive-proxy-password"
     proxy_environment = {
-        "http_proxy": f"http://proxy-user:{password}@proxy\uff1ahost:8123",
+        "http_proxy": f"{proxy_prefix}proxy-user:{password}@proxy\uff1ahost:8123",
         "HTTP_PROXY": "",
         "all_proxy": "",
         "ALL_PROXY": "",


### PR DESCRIPTION
## Summary

- add parameterized coverage for scheme-less, `//`-prefixed, and URL-form proxy normalization
- cover credential-bearing IDNA authorities, bracketed IPv6, explicit ports, and input-form preservation
- exercise a scheme-less environment proxy through connector auth and reject malformed URL/authority forms before DNS without exposing credentials

## Scope

This is a test-only change. It does not change production proxy behavior, dependencies, APIs, persisted data, compatibility paths, or rollout behavior. Existing URL-form and `NO_PROXY` coverage remains in place.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_platform_api.py tests/test_firewall_auth_client.py tests/test_webhook_http_delivery.py` (133 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5,448 passed)

Closes #27527
