### PR TITLE
refactor(rust): centralize bounded object-download retry policy

### DIFF
--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -36,7 +36,7 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::object_download_policy::{
     OBJECT_DOWNLOAD_MAX_ATTEMPTS, OBJECT_DOWNLOAD_TIMEOUT, is_retryable_http_status,
-    is_retryable_reqwest_error, object_download_retry_delay,
+    is_retryable_reqwest_error, sleep_object_download_retry_delay,
 };
 use crate::restored_session_identity::RestoredSessionHistoryPrefixAttribution;
 use crate::telemetry::{
@@ -901,7 +901,7 @@ async fn download_body(
                     _ = cancel.cancelled() => {
                         return Err(session_history_download_cancelled_error());
                     }
-                    _ = tokio::time::sleep(object_download_retry_delay()) => {}
+                    _ = sleep_object_download_retry_delay() => {}
                 }
                 attempt += 1;
             }

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -34,6 +34,10 @@ use super::session_history_cpu::{
 use super::session_restore::MaterializedResumeSession;
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
+use crate::object_download_policy::{
+    OBJECT_DOWNLOAD_MAX_ATTEMPTS, OBJECT_DOWNLOAD_TIMEOUT, is_retryable_http_status,
+    is_retryable_reqwest_error, object_download_retry_delay,
+};
 use crate::restored_session_identity::RestoredSessionHistoryPrefixAttribution;
 use crate::telemetry::{
     SessionHistoryCacheProbeMetadata, SessionHistoryContentEncodingState,
@@ -45,9 +49,6 @@ use crate::types::{
     ResumeSessionHistoryRefKind,
 };
 
-const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
-const SESSION_HISTORY_DOWNLOAD_MAX_ATTEMPTS: usize = 3;
-const SESSION_HISTORY_DOWNLOAD_RETRY_DELAY: Duration = Duration::from_millis(200);
 const SESSION_HISTORY_PROBE_TTL: Duration = Duration::from_secs(60 * 60);
 const SESSION_HISTORY_PROBE_CAPACITY: usize = 4096;
 
@@ -884,15 +885,14 @@ async fn download_body(
         match result {
             Ok(body) => return Ok(body),
             Err(error) => {
-                let should_retry =
-                    error.is_retryable() && attempt < SESSION_HISTORY_DOWNLOAD_MAX_ATTEMPTS;
+                let should_retry = error.is_retryable() && attempt < OBJECT_DOWNLOAD_MAX_ATTEMPTS;
                 if !should_retry {
                     return Err(error.into_runner_error());
                 }
                 tracing::warn!(
                     action = "session_history_download_retry",
                     attempt,
-                    max_attempts = SESSION_HISTORY_DOWNLOAD_MAX_ATTEMPTS,
+                    max_attempts = OBJECT_DOWNLOAD_MAX_ATTEMPTS,
                     failure_kind = error.kind_value(),
                     "retrying session history encoded body download"
                 );
@@ -901,7 +901,7 @@ async fn download_body(
                     _ = cancel.cancelled() => {
                         return Err(session_history_download_cancelled_error());
                     }
-                    _ = sleep_session_history_download_retry_delay() => {}
+                    _ = tokio::time::sleep(object_download_retry_delay()) => {}
                 }
                 attempt += 1;
             }
@@ -922,7 +922,7 @@ async fn download_body_once(
     let request_started = Instant::now();
     let response = http
         .get(url)
-        .timeout(DOWNLOAD_TIMEOUT)
+        .timeout(OBJECT_DOWNLOAD_TIMEOUT)
         .send()
         .await
         .map_err(|error| SessionHistoryDownloadBodyError::from_reqwest("GET", url, error))?;
@@ -1058,7 +1058,7 @@ impl SessionHistoryDownloadBodyError {
         let kind = match error.status() {
             Some(status) => SessionHistoryDownloadBodyErrorKind::HttpStatus(status),
             None => SessionHistoryDownloadBodyErrorKind::Transport {
-                retryable: reqwest_error_is_retryable(&error),
+                retryable: is_retryable_reqwest_error(&error),
             },
         };
         Self {
@@ -1071,7 +1071,7 @@ impl SessionHistoryDownloadBodyError {
         match self.kind {
             SessionHistoryDownloadBodyErrorKind::Transport { retryable } => retryable,
             SessionHistoryDownloadBodyErrorKind::HttpStatus(status) => {
-                status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+                is_retryable_http_status(status)
             }
             SessionHistoryDownloadBodyErrorKind::ContentLengthMismatch
             | SessionHistoryDownloadBodyErrorKind::DownloadedTooLarge => false,
@@ -1107,25 +1107,6 @@ impl SessionHistoryDownloadBodyError {
 impl fmt::Display for SessionHistoryDownloadBodyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.message)
-    }
-}
-
-fn reqwest_error_is_retryable(error: &reqwest::Error) -> bool {
-    !(error.is_builder() || error.is_redirect())
-}
-
-async fn sleep_session_history_download_retry_delay() {
-    let delay = session_history_download_retry_delay();
-    if !delay.is_zero() {
-        tokio::time::sleep(delay).await;
-    }
-}
-
-fn session_history_download_retry_delay() -> Duration {
-    if cfg!(test) {
-        Duration::ZERO
-    } else {
-        SESSION_HISTORY_DOWNLOAD_RETRY_DELAY
     }
 }
 
@@ -2482,7 +2463,7 @@ mod tests {
         let hash = hex::encode(Sha256::digest(body));
         let server = MultiShotSessionHistoryServer::respond_many(vec![
             MultiShotSessionHistoryResponse::ok(compressed.clone(), None);
-            SESSION_HISTORY_DOWNLOAD_MAX_ATTEMPTS
+            OBJECT_DOWNLOAD_MAX_ATTEMPTS
         ])
         .await;
         let session = zstd_ref_session(server.url(), hash, body.len() as u64, encoded_size + 1);
@@ -2505,9 +2486,7 @@ mod tests {
             }
             _ => panic!("expected failed materialization"),
         }
-        server
-            .assert_served(SESSION_HISTORY_DOWNLOAD_MAX_ATTEMPTS)
-            .await;
+        server.assert_served(OBJECT_DOWNLOAD_MAX_ATTEMPTS).await;
     }
 
     #[tokio::test]
@@ -2518,7 +2497,7 @@ mod tests {
         let hash = hex::encode(Sha256::digest(body));
         let server = MultiShotSessionHistoryServer::respond_many(vec![
             MultiShotSessionHistoryResponse::ok(compressed.clone(), None);
-            SESSION_HISTORY_DOWNLOAD_MAX_ATTEMPTS
+            OBJECT_DOWNLOAD_MAX_ATTEMPTS
         ])
         .await;
         let session = gzip_ref_session(server.url(), hash, body.len() as u64, encoded_size + 1);
@@ -2541,9 +2520,7 @@ mod tests {
             }
             _ => panic!("expected failed materialization"),
         }
-        server
-            .assert_served(SESSION_HISTORY_DOWNLOAD_MAX_ATTEMPTS)
-            .await;
+        server.assert_served(OBJECT_DOWNLOAD_MAX_ATTEMPTS).await;
     }
 
     #[tokio::test]
@@ -2824,7 +2801,7 @@ mod tests {
     async fn attributed_materializer_preserves_body_read_failure() {
         let server = MultiShotSessionHistoryServer::respond_many(vec![
             MultiShotSessionHistoryResponse::ok(b"short", Some(999));
-            SESSION_HISTORY_DOWNLOAD_MAX_ATTEMPTS
+            OBJECT_DOWNLOAD_MAX_ATTEMPTS
         ])
         .await;
         let session = ref_session(
@@ -2852,9 +2829,7 @@ mod tests {
             }
             _ => panic!("expected failed download"),
         }
-        server
-            .assert_served(SESSION_HISTORY_DOWNLOAD_MAX_ATTEMPTS)
-            .await;
+        server.assert_served(OBJECT_DOWNLOAD_MAX_ATTEMPTS).await;
     }
 
     #[test]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -35,6 +35,7 @@ mod network_log_drain;
 mod network_log_manager;
 mod network_log_process;
 mod network_logs;
+mod object_download_policy;
 mod org_name;
 mod parent_death;
 mod paths;

--- a/crates/runner/src/object_download_policy.rs
+++ b/crates/runner/src/object_download_policy.rs
@@ -1,0 +1,141 @@
+//! Shared retry policy for bounded runner-side object downloads.
+
+use std::time::Duration;
+
+use reqwest::{Error, StatusCode};
+
+/// Maximum time allowed for one bounded object-download request.
+pub(crate) const OBJECT_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
+/// Maximum number of total attempts for a bounded object download.
+pub(crate) const OBJECT_DOWNLOAD_MAX_ATTEMPTS: usize = 3;
+/// Delay between retry attempts for a bounded object download.
+pub(crate) const OBJECT_DOWNLOAD_RETRY_DELAY: Duration = Duration::from_millis(200);
+
+/// Return whether an HTTP response status represents a transient download failure.
+pub(crate) fn is_retryable_http_status(status: StatusCode) -> bool {
+    status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+}
+
+/// Return whether a status-free reqwest error represents a transient download failure.
+pub(crate) fn is_retryable_reqwest_error(error: &Error) -> bool {
+    // Truncated/protocol-level body reads can surface as decode-style errors
+    // without a status, and those should retry like other transient downloads.
+    !(error.is_builder() || error.is_redirect())
+}
+
+/// Return the retry delay, disabling sleeps in the test binary.
+pub(crate) const fn object_download_retry_delay() -> Duration {
+    if cfg!(test) {
+        Duration::ZERO
+    } else {
+        OBJECT_DOWNLOAD_RETRY_DELAY
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::io::AsyncWriteExt as _;
+    use tokio::net::TcpListener;
+
+    use super::{
+        OBJECT_DOWNLOAD_MAX_ATTEMPTS, OBJECT_DOWNLOAD_RETRY_DELAY, OBJECT_DOWNLOAD_TIMEOUT,
+        is_retryable_http_status, is_retryable_reqwest_error, object_download_retry_delay,
+    };
+
+    #[test]
+    fn bounded_object_download_policy_values_are_stable() {
+        assert_eq!(OBJECT_DOWNLOAD_TIMEOUT, Duration::from_secs(30));
+        assert_eq!(OBJECT_DOWNLOAD_MAX_ATTEMPTS, 3);
+        assert_eq!(OBJECT_DOWNLOAD_RETRY_DELAY, Duration::from_millis(200));
+        assert_eq!(object_download_retry_delay(), Duration::ZERO);
+    }
+
+    #[test]
+    fn only_rate_limit_and_server_statuses_are_retryable() {
+        assert!(is_retryable_http_status(
+            reqwest::StatusCode::TOO_MANY_REQUESTS
+        ));
+        assert!(is_retryable_http_status(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        ));
+        assert!(is_retryable_http_status(
+            reqwest::StatusCode::SERVICE_UNAVAILABLE
+        ));
+        assert!(!is_retryable_http_status(reqwest::StatusCode::OK));
+        assert!(!is_retryable_http_status(reqwest::StatusCode::BAD_REQUEST));
+        assert!(!is_retryable_http_status(reqwest::StatusCode::NOT_FOUND));
+        assert!(!is_retryable_http_status(reqwest::StatusCode::FOUND));
+    }
+
+    #[tokio::test]
+    async fn transport_predicate_retries_transient_errors_but_excludes_builder_and_redirect() {
+        let builder_error = reqwest::Client::new()
+            .get("not-a-url")
+            .build()
+            .expect_err("invalid URL should produce a builder error");
+        assert!(!is_retryable_reqwest_error(&builder_error));
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("transport test listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("transport test listener should expose an address");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener
+                .accept()
+                .await
+                .expect("transport test should accept a request");
+            drop(stream);
+        });
+        let transport_error = tokio::time::timeout(
+            Duration::from_secs(5),
+            reqwest::Client::new()
+                .get(format!("http://{address}/"))
+                .send(),
+        )
+        .await
+        .expect("transport test request should finish")
+        .expect_err("closed response should produce a transport error");
+        assert!(transport_error.status().is_none());
+        assert!(is_retryable_reqwest_error(&transport_error));
+        server.await.expect("transport test server should finish");
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("redirect test listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("redirect test listener should expose an address");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener
+                .accept()
+                .await
+                .expect("redirect test should accept a request");
+            stream
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: http://example.com/\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .expect("redirect test response should be written");
+        });
+        let redirect_client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::custom(|attempt| {
+                attempt.error("redirect disabled for test")
+            }))
+            .build()
+            .expect("redirect test client should build");
+        let redirect_error = tokio::time::timeout(
+            Duration::from_secs(5),
+            redirect_client.get(format!("http://{address}/")).send(),
+        )
+        .await
+        .expect("redirect test request should finish")
+        .expect_err("redirect policy should produce an error");
+        assert!(redirect_error.is_redirect());
+        assert!(!is_retryable_reqwest_error(&redirect_error));
+        server.await.expect("redirect test server should finish");
+    }
+}

--- a/crates/runner/src/object_download_policy.rs
+++ b/crates/runner/src/object_download_policy.rs
@@ -32,6 +32,14 @@ pub(crate) const fn object_download_retry_delay() -> Duration {
     }
 }
 
+/// Wait between retries while avoiding a timer dependency when tests disable the delay.
+pub(crate) async fn sleep_object_download_retry_delay() {
+    let delay = object_download_retry_delay();
+    if !delay.is_zero() {
+        tokio::time::sleep(delay).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -57,7 +57,7 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
 use crate::object_download_policy::{
     OBJECT_DOWNLOAD_MAX_ATTEMPTS, OBJECT_DOWNLOAD_TIMEOUT, is_retryable_http_status,
-    is_retryable_reqwest_error, object_download_retry_delay,
+    is_retryable_reqwest_error, sleep_object_download_retry_delay,
 };
 use crate::paths::{HomePaths, short_digest, touch_mtime};
 use crate::storage_plan::{ArchiveHandle, StoragePlan};
@@ -2637,10 +2637,7 @@ where
                         exhausted_retry: retryable && attempt >= OBJECT_DOWNLOAD_MAX_ATTEMPTS,
                     });
                 }
-                let delay = object_download_retry_delay();
-                if !delay.is_zero() {
-                    tokio::time::sleep(delay).await;
-                }
+                sleep_object_download_retry_delay().await;
                 attempt += 1;
             }
         }

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -55,6 +55,10 @@ use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
+use crate::object_download_policy::{
+    OBJECT_DOWNLOAD_MAX_ATTEMPTS, OBJECT_DOWNLOAD_TIMEOUT, is_retryable_http_status,
+    is_retryable_reqwest_error, object_download_retry_delay,
+};
 use crate::paths::{HomePaths, short_digest, touch_mtime};
 use crate::storage_plan::{ArchiveHandle, StoragePlan};
 use crate::telemetry::{JobTelemetry, SandboxOpRecord, SandboxOpReporter};
@@ -85,12 +89,6 @@ const GUEST_STAGE_BATCH_MAX_BYTES: usize = 15 * 1024 * 1024;
 const GUEST_STAGE_DIR: &str = "/tmp/vm0-storage-cache";
 
 const HEAD_TIMEOUT: Duration = Duration::from_secs(10);
-/// Storage cache fetches are best-effort and capped to small archives, so a
-/// slow full GET should fall back to guest-download instead of holding the
-/// per-version cache lock for minutes across retry attempts.
-const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
-const CACHE_HTTP_MAX_ATTEMPTS: usize = 3;
-const CACHE_HTTP_RETRY_DELAY: Duration = Duration::from_millis(200);
 const STORAGE_CACHE_STAGE_TOTAL: &str = "storage_cache_stage_total";
 const STORAGE_CACHE_STAGE_BATCH_WRITE: &str = "storage_cache_stage_batch_write";
 const STORAGE_CACHE_STAGE_FAILED: &str = "storage-cache-stage-failed";
@@ -2003,6 +2001,8 @@ pub(crate) async fn prepare_fresh_archive_delivery(
     Ok(delivery)
 }
 
+/// Fresh storage delivery uses the shared bounded timeout and falls back to
+/// guest-download when its best-effort request cannot complete successfully.
 async fn fetch_fresh_archive(
     http: &Client,
     archive_url: &str,
@@ -2010,7 +2010,7 @@ async fn fetch_fresh_archive(
 ) -> Result<(Bytes, FreshArchiveSizeSource), &'static str> {
     let mut response = http
         .get(archive_url)
-        .timeout(DOWNLOAD_TIMEOUT)
+        .timeout(OBJECT_DOWNLOAD_TIMEOUT)
         .send()
         .await
         .map_err(|error| {
@@ -2523,7 +2523,7 @@ impl CacheHttpError {
         if let Some(status) = error.status() {
             return Self::status(phase, status);
         }
-        let retryable = reqwest_error_is_retryable(&error);
+        let retryable = is_retryable_reqwest_error(&error);
         Self::Transport {
             phase,
             detail: reqwest_error(error),
@@ -2547,9 +2547,7 @@ impl fmt::Display for CacheHttpError {
 impl CacheRetryableError for CacheHttpError {
     fn is_retryable(&self) -> bool {
         match self {
-            Self::Status { status, .. } => {
-                *status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
-            }
+            Self::Status { status, .. } => is_retryable_http_status(*status),
             Self::UnexpectedStatus { .. } => false,
             Self::Transport { retryable, .. } => *retryable,
         }
@@ -2631,33 +2629,21 @@ where
             Ok(value) => return Ok(value),
             Err(error) => {
                 let retryable = error.is_retryable();
-                let should_retry = retryable && attempt < CACHE_HTTP_MAX_ATTEMPTS;
+                let should_retry = retryable && attempt < OBJECT_DOWNLOAD_MAX_ATTEMPTS;
                 if !should_retry {
                     return Err(CacheRetryError {
                         error,
                         attempts: attempt,
-                        exhausted_retry: retryable && attempt >= CACHE_HTTP_MAX_ATTEMPTS,
+                        exhausted_retry: retryable && attempt >= OBJECT_DOWNLOAD_MAX_ATTEMPTS,
                     });
                 }
-                sleep_cache_retry_delay().await;
+                let delay = object_download_retry_delay();
+                if !delay.is_zero() {
+                    tokio::time::sleep(delay).await;
+                }
                 attempt += 1;
             }
         }
-    }
-}
-
-async fn sleep_cache_retry_delay() {
-    let delay = cache_http_retry_delay();
-    if !delay.is_zero() {
-        tokio::time::sleep(delay).await;
-    }
-}
-
-fn cache_http_retry_delay() -> Duration {
-    if cfg!(test) {
-        Duration::ZERO
-    } else {
-        CACHE_HTTP_RETRY_DELAY
     }
 }
 
@@ -2718,12 +2704,6 @@ async fn probe_size(http: &Client, url: &str) -> Result<SizeProbe, CacheHttpErro
 
 fn reqwest_error(e: reqwest::Error) -> String {
     e.without_url().to_string()
-}
-
-fn reqwest_error_is_retryable(e: &reqwest::Error) -> bool {
-    // Truncated/protocol-level body reads can surface as decode-style errors
-    // without a status, and those should retry like other transient cache fetches.
-    !(e.is_builder() || e.is_redirect())
 }
 
 /// Parse the total size from the response to our `Range: bytes=0-0` probe.
@@ -2790,7 +2770,7 @@ async fn download_tarball(
 ) -> Result<DownloadBody, CacheDownloadError> {
     let mut resp = http
         .get(url)
-        .timeout(DOWNLOAD_TIMEOUT)
+        .timeout(OBJECT_DOWNLOAD_TIMEOUT)
         .send()
         .await
         .map_err(|e| CacheHttpError::from_reqwest("GET", e))?;
@@ -6361,7 +6341,7 @@ mod tests {
                 .unwrap();
 
         probe.assert_async().await;
-        full.assert_calls_async(CACHE_HTTP_MAX_ATTEMPTS).await;
+        full.assert_calls_async(OBJECT_DOWNLOAD_MAX_ATTEMPTS).await;
         assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
         assert!(sandbox.write_file_calls().is_empty());
         assert!(
@@ -6383,7 +6363,8 @@ mod tests {
         .err()
         .expect("503 downloads should exhaust retries")
         .to_string();
-        full.assert_calls_async(CACHE_HTTP_MAX_ATTEMPTS * 2).await;
+        full.assert_calls_async(OBJECT_DOWNLOAD_MAX_ATTEMPTS * 2)
+            .await;
         assert!(
             reason.contains("retry exhausted after 3 attempts") && reason.contains("503"),
             "unexpected retry exhaustion reason: {reason}"
@@ -7171,7 +7152,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        probe.assert_calls_async(CACHE_HTTP_MAX_ATTEMPTS).await;
+        probe.assert_calls_async(OBJECT_DOWNLOAD_MAX_ATTEMPTS).await;
 
         // archive_url untouched — guest-download will retry via the original URL.
         assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
@@ -7185,7 +7166,9 @@ mod tests {
             .await
             .unwrap_err()
             .to_string();
-        probe.assert_calls_async(CACHE_HTTP_MAX_ATTEMPTS * 2).await;
+        probe
+            .assert_calls_async(OBJECT_DOWNLOAD_MAX_ATTEMPTS * 2)
+            .await;
         assert!(
             error.contains("retry exhausted after 3 attempts") && error.contains("500"),
             "unexpected retry exhaustion reason: {error}"
@@ -7205,7 +7188,7 @@ mod tests {
         let home = home_at(&temp);
         let sandbox = MockSandbox::new("test");
         let mut telemetry = new_telemetry();
-        let responses = vec![Vec::new(); CACHE_HTTP_MAX_ATTEMPTS * 2];
+        let responses = vec![Vec::new(); OBJECT_DOWNLOAD_MAX_ATTEMPTS * 2];
         let (url, handle) = raw_http_sequence_url(responses).await;
 
         let original = format!("{url}?X-Amz-Signature=secret&X-Amz-Credential=credential");
@@ -8224,7 +8207,7 @@ mod tests {
                 .unwrap();
 
         failed_probe
-            .assert_calls_async(CACHE_HTTP_MAX_ATTEMPTS)
+            .assert_calls_async(OBJECT_DOWNLOAD_MAX_ATTEMPTS)
             .await;
         failed_full.assert_calls_async(0).await;
         successful_probe.assert_async().await;
@@ -8374,10 +8357,10 @@ mod tests {
                 .unwrap();
 
         failed_probe_a
-            .assert_calls_async(CACHE_HTTP_MAX_ATTEMPTS)
+            .assert_calls_async(OBJECT_DOWNLOAD_MAX_ATTEMPTS)
             .await;
         failed_probe_b
-            .assert_calls_async(CACHE_HTTP_MAX_ATTEMPTS)
+            .assert_calls_async(OBJECT_DOWNLOAD_MAX_ATTEMPTS)
             .await;
         failed_full_a.assert_calls_async(0).await;
         failed_full_b.assert_calls_async(0).await;


### PR DESCRIPTION
## Summary

- centralize bounded object-download timeout, attempt, delay, and retry classification
- reuse the policy from storage-cache and session-history downloads while keeping consumer loops local
- add shared status and transport classification coverage

## Scope

This preserves the existing 30-second timeout, three total attempts, 200 ms delay, 429/5xx retry rule, builder/redirect exclusions, cancellation, validation, fallback, telemetry, and URL redaction. No API, persistence, guest protocol, or deployment changes are included.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner object_download_policy`
- `cargo test --manifest-path crates/Cargo.toml -p runner storage_cache::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner session_history_download::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`

Closes #27512
