### PR TITLE
perf(runner): expose physical park substage telemetry

### DIFF
--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -911,6 +911,16 @@ mod tests {
         );
     }
 
+    fn assert_telemetry_outcome(telemetry: &JobTelemetry, action: &str, outcome: Option<&str>) {
+        let outcomes = telemetry.pending_ops_with_outcome_snapshot();
+        assert!(
+            outcomes
+                .iter()
+                .any(|op| op.0 == action && op.2.as_deref() == outcome),
+            "expected telemetry action {action} with outcome {outcome:?}, got: {outcomes:?}"
+        );
+    }
+
     struct FinalizationTelemetryFixture {
         _dir: tempfile::TempDir,
         status: Arc<StatusTracker>,
@@ -1141,9 +1151,27 @@ mod tests {
             "runner_host_reuse_preparation",
             "runner_host_physical_park",
             "runner_host_idle_publication",
+            "runner_host_physical_park_balloon_setup",
+            "runner_host_physical_park_balloon_settle",
+            "runner_host_physical_park_vcpu_pause",
         ] {
             assert_telemetry_action(&finalized.telemetry, action);
         }
+        assert_telemetry_outcome(
+            &finalized.telemetry,
+            "runner_host_physical_park_balloon_setup",
+            Some("skipped"),
+        );
+        assert_telemetry_outcome(
+            &finalized.telemetry,
+            "runner_host_physical_park_balloon_settle",
+            Some("skipped"),
+        );
+        assert_telemetry_outcome(
+            &finalized.telemetry,
+            "runner_host_physical_park_vcpu_pause",
+            None,
+        );
         assert_telemetry_action(&finalized.telemetry, "session_history_identity_parked");
         assert_eq!(
             cleanup_state.disposition(),

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -11,7 +11,8 @@ use std::time::{Duration, Instant};
 use chrono::SecondsFormat;
 use futures_util::FutureExt;
 use sandbox::{
-    Sandbox, SandboxFactory, SandboxFinalExecParkObserver, SandboxFinalExecParkStage, SandboxId,
+    Sandbox, SandboxFactory, SandboxFinalExecParkObserver, SandboxFinalExecParkStage,
+    SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome, SandboxId,
 };
 use tracing::{info, warn};
 
@@ -116,6 +117,38 @@ impl SandboxFinalExecParkObserver for FinalizationTelemetry<'_> {
         }
         if stage == SandboxFinalExecParkStage::PhysicalPark && success {
             self.physical_park_completed_at = Some(completed_at);
+        }
+    }
+
+    fn record_substage(
+        &mut self,
+        substage: SandboxFinalExecParkSubstage,
+        duration: Duration,
+        success: bool,
+        outcome: Option<SandboxFinalExecParkSubstageOutcome>,
+    ) {
+        let (action_type, error) = match substage {
+            SandboxFinalExecParkSubstage::BalloonSetup => (
+                "runner_host_physical_park_balloon_setup",
+                (!success).then_some("balloon setup failed"),
+            ),
+            SandboxFinalExecParkSubstage::BalloonSettle => (
+                "runner_host_physical_park_balloon_settle",
+                (!success).then_some("balloon settle failed"),
+            ),
+            SandboxFinalExecParkSubstage::VcpuPause => (
+                "runner_host_physical_park_vcpu_pause",
+                (!success).then_some("vCPU pause failed"),
+            ),
+        };
+        if let Some(telemetry) = self.telemetry.as_deref_mut() {
+            telemetry.record_with_outcome(
+                action_type,
+                duration,
+                success,
+                error,
+                outcome.map(SandboxFinalExecParkSubstageOutcome::as_str),
+            );
         }
     }
 }

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -107,7 +107,19 @@ impl JobTelemetry {
         success: bool,
         error: Option<&str>,
     ) {
-        self.record_inner(action_type, duration, success, error, None);
+        self.record_inner(action_type, duration, success, error, None, None);
+    }
+
+    /// Record a timed operation with an optional bounded terminal outcome.
+    pub(crate) fn record_with_outcome(
+        &mut self,
+        action_type: &str,
+        duration: Duration,
+        success: bool,
+        error: Option<&str>,
+        outcome: Option<&str>,
+    ) {
+        self.record_inner(action_type, duration, success, error, outcome, None);
     }
 
     /// Record a timed operation using the timestamp captured when it completed.
@@ -128,6 +140,7 @@ impl JobTelemetry {
             success,
             error,
             None,
+            None,
             completed_at,
         ));
     }
@@ -138,7 +151,7 @@ impl JobTelemetry {
         runner_startup_path: RunnerStartupPath,
         sandbox_reuse_result: SandboxReuseResult,
     ) {
-        let mut op = sandbox_op("api_to_spawn", duration, true, None, None);
+        let mut op = sandbox_op("api_to_spawn", duration, true, None, None, None);
         op.runner_startup_path = Some(runner_startup_path);
         op.sandbox_reuse_result = Some(sandbox_reuse_result);
         self.push_operation(op);
@@ -152,7 +165,7 @@ impl JobTelemetry {
         outcome: &'static str,
         reason: Option<&'static str>,
     ) {
-        let mut op = sandbox_op(action_type, Duration::ZERO, success, None, None);
+        let mut op = sandbox_op(action_type, Duration::ZERO, success, None, None, None);
         op.outcome = Some(outcome.to_string());
         op.reason = reason.map(str::to_string);
         self.push_operation(op);
@@ -168,7 +181,7 @@ impl JobTelemetry {
         error: Option<&str>,
         metadata: Option<SessionHistoryTelemetryMetadata>,
     ) {
-        self.record_inner(action_type, duration, success, error, metadata);
+        self.record_inner(action_type, duration, success, error, None, metadata);
     }
 
     pub(crate) fn reporter(&self) -> SandboxOpReporter {
@@ -186,9 +199,17 @@ impl JobTelemetry {
         duration: Duration,
         success: bool,
         error: Option<&str>,
+        outcome: Option<&str>,
         metadata: Option<SessionHistoryTelemetryMetadata>,
     ) {
-        self.push_operation(sandbox_op(action_type, duration, success, error, metadata));
+        self.push_operation(sandbox_op(
+            action_type,
+            duration,
+            success,
+            error,
+            outcome,
+            metadata,
+        ));
     }
 
     fn push_operation(&mut self, operation: SandboxOp) {
@@ -366,6 +387,7 @@ impl SandboxOpReporter {
                     record.success,
                     record.error,
                     None,
+                    None,
                 )
             })
             .collect();
@@ -402,9 +424,18 @@ fn sandbox_op(
     duration: Duration,
     success: bool,
     error: Option<&str>,
+    outcome: Option<&str>,
     metadata: Option<SessionHistoryTelemetryMetadata>,
 ) -> SandboxOp {
-    sandbox_op_at(action_type, duration, success, error, metadata, Utc::now())
+    sandbox_op_at(
+        action_type,
+        duration,
+        success,
+        error,
+        outcome,
+        metadata,
+        Utc::now(),
+    )
 }
 
 fn sandbox_op_at(
@@ -412,6 +443,7 @@ fn sandbox_op_at(
     duration: Duration,
     success: bool,
     error: Option<&str>,
+    outcome: Option<&str>,
     metadata: Option<SessionHistoryTelemetryMetadata>,
     completed_at: DateTime<Utc>,
 ) -> SandboxOp {
@@ -421,7 +453,7 @@ fn sandbox_op_at(
         duration_ms: duration_ms(duration),
         success,
         error: error.map(String::from),
-        outcome: None,
+        outcome: outcome.map(String::from),
         reason: None,
         runner_startup_path: None,
         sandbox_reuse_result: None,
@@ -600,6 +632,33 @@ mod tests {
                 "reason": "prepared",
             })
         );
+    }
+
+    #[test]
+    fn record_with_outcome_serializes_bounded_outcome() {
+        let mut telemetry = JobTelemetry::new(
+            http_client(),
+            RunId::nil(),
+            "tok".to_string(),
+            "test-runner".to_string(),
+        );
+        telemetry.record_with_outcome(
+            "runner_host_physical_park_balloon_settle",
+            Duration::from_millis(125),
+            true,
+            None,
+            Some("target_reached"),
+        );
+
+        let json = serde_json::to_value(&telemetry.pending_ops[0]).unwrap();
+        assert_eq!(
+            json["action_type"],
+            "runner_host_physical_park_balloon_settle"
+        );
+        assert_eq!(json["duration_ms"], 125);
+        assert_eq!(json["success"], true);
+        assert_eq!(json["outcome"], "target_reached");
+        assert!(json.get("reason").is_none());
     }
 
     #[test]

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -634,10 +634,26 @@ mod tests {
         );
     }
 
-    #[test]
-    fn record_with_outcome_serializes_bounded_outcome() {
+    #[tokio::test]
+    async fn record_with_outcome_is_sent_in_flush_payload() {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start_async().await;
+        let telemetry_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/api/webhooks/agent/telemetry")
+                    .body_includes(r#""action_type":"runner_host_physical_park_balloon_settle""#)
+                    .body_includes(r#""duration_ms":125"#)
+                    .body_includes(r#""success":true"#)
+                    .body_includes(r#""outcome":"target_reached""#);
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(r#"{"success":true,"id":"ok"}"#);
+            })
+            .await;
         let mut telemetry = JobTelemetry::new(
-            http_client(),
+            http_client_for_api_url(&server.base_url()),
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
@@ -649,16 +665,9 @@ mod tests {
             None,
             Some("target_reached"),
         );
+        telemetry.flush().await;
 
-        let json = serde_json::to_value(&telemetry.pending_ops[0]).unwrap();
-        assert_eq!(
-            json["action_type"],
-            "runner_host_physical_park_balloon_settle"
-        );
-        assert_eq!(json["duration_ms"], 125);
-        assert_eq!(json["success"], true);
-        assert_eq!(json["outcome"], "target_reached");
-        assert!(json.get("reason").is_none());
+        telemetry_mock.assert_calls_async(1).await;
     }
 
     #[test]

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3612,17 +3612,6 @@ fn record_park_substage(
     events.record(substage, duration, success, outcome);
 }
 
-/// Wait until the guest balloon driver inflates close enough to `target_mib`.
-///
-/// The guest needs running vCPUs to inflate, so this must be called
-/// **before** pausing. Returns when `actual_mib >= target_mib`, when
-/// the remaining deficit is within [`balloon_settle_tolerance_mib`],
-/// when guest pressure indicates further reclaim is unsafe, or after
-/// [`BALLOON_SETTLE_TIMEOUT`]. A severe deficit that is still progressing with
-/// enough unused guest memory gets one bounded
-/// [`BALLOON_SETTLE_PROGRESS_GRACE`]. The returned outcome rejects only the
-/// existing severe-deficit classification. Errors from stats fetching are
-/// non-fatal — we log and proceed to pause.
 #[derive(Debug)]
 struct BalloonSettleResult {
     park_outcome: SandboxParkOutcome,
@@ -3636,6 +3625,17 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
         .park_outcome
 }
 
+/// Wait until the guest balloon driver inflates close enough to `target_mib`.
+///
+/// The guest needs running vCPUs to inflate, so this must be called
+/// **before** pausing. Returns when `actual_mib >= target_mib`, when
+/// the remaining deficit is within [`balloon_settle_tolerance_mib`],
+/// when guest pressure indicates further reclaim is unsafe, or after
+/// [`BALLOON_SETTLE_TIMEOUT`]. A severe deficit that is still progressing with
+/// enough unused guest memory gets one bounded
+/// [`BALLOON_SETTLE_PROGRESS_GRACE`]. The returned outcome rejects only the
+/// existing severe-deficit classification. Errors from stats fetching are
+/// non-fatal — we log and proceed to pause.
 async fn wait_for_balloon_with_outcome(
     client: &ApiClient,
     target_mib: u32,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3608,13 +3608,6 @@ struct BalloonSettleResult {
     telemetry_outcome: SandboxFinalExecParkSubstageOutcome,
 }
 
-#[cfg(test)]
-async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> SandboxParkOutcome {
-    wait_for_balloon_with_outcome(client, target_mib, log_id)
-        .await
-        .park_outcome
-}
-
 /// Wait until the guest balloon driver inflates close enough to `target_mib`.
 ///
 /// The guest needs running vCPUs to inflate, so this must be called

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3602,16 +3602,6 @@ fn park_admission_action(outcome: &SandboxParkOutcome) -> &'static str {
     }
 }
 
-fn record_park_substage(
-    events: &mut SandboxFinalExecParkSubstageEvents<'_>,
-    substage: SandboxFinalExecParkSubstage,
-    duration: Duration,
-    success: bool,
-    outcome: Option<SandboxFinalExecParkSubstageOutcome>,
-) {
-    events.record(substage, duration, success, outcome);
-}
-
 #[derive(Debug)]
 struct BalloonSettleResult {
     park_outcome: SandboxParkOutcome,
@@ -3889,8 +3879,7 @@ async fn park_inner_with_guest<'observer>(
     let client = match ApiClient::new(api_sock) {
         Ok(client) => client,
         Err(e) => {
-            record_park_substage(
-                &mut events,
+            events.record(
                 SandboxFinalExecParkSubstage::BalloonSetup,
                 Duration::ZERO,
                 false,
@@ -3928,8 +3917,7 @@ async fn park_inner_with_guest<'observer>(
         }
 
         if let Err(e) = client.patch_balloon(target).await {
-            record_park_substage(
-                &mut events,
+            events.record(
                 SandboxFinalExecParkSubstage::BalloonSetup,
                 balloon_setup_started.elapsed(),
                 false,
@@ -3943,8 +3931,7 @@ async fn park_inner_with_guest<'observer>(
                 }),
             );
         }
-        record_park_substage(
-            &mut events,
+        events.record(
             SandboxFinalExecParkSubstage::BalloonSetup,
             balloon_setup_started.elapsed(),
             true,
@@ -3970,8 +3957,7 @@ async fn park_inner_with_guest<'observer>(
             }
             SandboxParkOutcome::Reusable => {}
         }
-        record_park_substage(
-            &mut events,
+        events.record(
             SandboxFinalExecParkSubstage::BalloonSettle,
             balloon_settle_started.elapsed(),
             true,
@@ -3979,15 +3965,13 @@ async fn park_inner_with_guest<'observer>(
         );
         park_outcome
     } else {
-        record_park_substage(
-            &mut events,
+        events.record(
             SandboxFinalExecParkSubstage::BalloonSetup,
             Duration::ZERO,
             true,
             Some(SandboxFinalExecParkSubstageOutcome::Skipped),
         );
-        record_park_substage(
-            &mut events,
+        events.record(
             SandboxFinalExecParkSubstage::BalloonSettle,
             Duration::ZERO,
             true,
@@ -4001,8 +3985,7 @@ async fn park_inner_with_guest<'observer>(
     // still pause — timer ticks waste CPU regardless of memory size.
     let vcpu_pause_started = Instant::now();
     if let Err(e) = client.pause().await {
-        record_park_substage(
-            &mut events,
+        events.record(
             SandboxFinalExecParkSubstage::VcpuPause,
             vcpu_pause_started.elapsed(),
             false,
@@ -4016,8 +3999,7 @@ async fn park_inner_with_guest<'observer>(
             }),
         );
     }
-    record_park_substage(
-        &mut events,
+    events.record(
         SandboxFinalExecParkSubstage::VcpuPause,
         vcpu_pause_started.elapsed(),
         true,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -12,10 +12,11 @@ use sandbox::{
     ProcessControlAck, ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlMode,
     ProcessControlOutcome, ProcessControlWriteState, ProcessExit, ProcessOutputChunk,
     ProcessOutputMode, Sandbox, SandboxConfig, SandboxError, SandboxFinalExecParkObserver,
-    SandboxFinalExecParkOutcome, SandboxFinalExecParkStage, SandboxIdleTransition,
-    SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
-    SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver, SandboxStartStage,
-    SevereMemoryRetentionDiagnostics, StartProcessRequest, WriteFileEntry,
+    SandboxFinalExecParkOutcome, SandboxFinalExecParkStage, SandboxFinalExecParkSubstage,
+    SandboxFinalExecParkSubstageOutcome, SandboxIdleTransition, SandboxInvalidStateContext,
+    SandboxOperation, SandboxOperationReason, SandboxParkNonReusableReason, SandboxParkOutcome,
+    SandboxStartObserver, SandboxStartStage, SevereMemoryRetentionDiagnostics, StartProcessRequest,
+    WriteFileEntry,
 };
 use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, watch};
@@ -188,6 +189,32 @@ impl<'a> SandboxFinalExecParkTiming<'a> {
         if let Some(observer) = self.observer.as_deref_mut() {
             observer.record_stage(stage, started.elapsed(), success);
         }
+    }
+}
+
+struct SandboxFinalExecParkSubstageEvents<'a> {
+    observer: Option<&'a mut dyn SandboxFinalExecParkObserver>,
+}
+
+impl<'a> SandboxFinalExecParkSubstageEvents<'a> {
+    fn new(observer: Option<&'a mut dyn SandboxFinalExecParkObserver>) -> Self {
+        Self { observer }
+    }
+
+    fn record(
+        &mut self,
+        substage: SandboxFinalExecParkSubstage,
+        duration: Duration,
+        success: bool,
+        outcome: Option<SandboxFinalExecParkSubstageOutcome>,
+    ) {
+        if let Some(observer) = self.observer.as_deref_mut() {
+            observer.record_substage(substage, duration, success, outcome);
+        }
+    }
+
+    fn into_observer(self) -> Option<&'a mut dyn SandboxFinalExecParkObserver> {
+        self.observer
     }
 }
 
@@ -1888,6 +1915,10 @@ impl FirecrackerSandbox {
         let final_exec_guest = Arc::clone(&guest);
         let physical_park_guest = Arc::clone(&guest);
         let id = self.id.clone();
+        let park_id = id.clone();
+        let is_parked = &mut self.is_parked;
+        let memory_mb = self.config.resources.memory_mb;
+        let balloon_controller = self.runtime.balloon_mut();
         let api_sock = self.sock_paths.api_sock();
         let final_exec_request = exec_capture_request(request, timeout_ms, diagnostic_label);
         let (normal_operations_fence, park_outcome, exec_result) =
@@ -1932,15 +1963,18 @@ impl FirecrackerSandbox {
                     })?;
                     guest.quiesce_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
                 },
-                || {
-                    park_inner_with_guest(
-                        &mut self.is_parked,
-                        self.config.resources.memory_mb,
-                        self.runtime.balloon_mut(),
+                |timing, events| async move {
+                    let (events, result) = park_inner_with_guest(
+                        is_parked,
+                        memory_mb,
+                        balloon_controller,
                         &api_sock,
-                        &id,
+                        &park_id,
                         physical_park_guest,
+                        events,
                     )
+                    .await;
+                    (timing, events, result)
                 },
             )
             .await?;
@@ -2183,15 +2217,18 @@ impl Sandbox for FirecrackerSandbox {
                 })?;
                 guest.quiesce_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
             },
-            || {
-                park_inner_with_guest(
+            || async {
+                let (_, result) = park_inner_with_guest(
                     &mut self.is_parked,
                     self.config.resources.memory_mb,
                     self.runtime.balloon_mut(),
                     &api_sock,
                     &id,
                     physical_park_guest,
+                    SandboxFinalExecParkSubstageEvents::new(None),
                 )
+                .await;
+                result
             },
         )
         .await?;
@@ -2750,12 +2787,16 @@ where
         None,
         fence_and_prepare,
         quiesce_guest,
-        park_firecracker,
+        |timing, events| async move {
+            let result = park_firecracker().await;
+            (timing, events, result)
+        },
     )
     .await
 }
 
 async fn park_with_ready_for_park_and_preparation_with_observer<
+    'observer,
     Fence,
     Outcome,
     Preparation,
@@ -2768,7 +2809,7 @@ async fn park_with_ready_for_park_and_preparation_with_observer<
 >(
     log_id: &str,
     coordinator: &ParkCoordinator,
-    observer: Option<&mut dyn SandboxFinalExecParkObserver>,
+    observer: Option<&'observer mut dyn SandboxFinalExecParkObserver>,
     fence_and_prepare: F,
     quiesce_guest: Q,
     park_firecracker: P,
@@ -2778,8 +2819,17 @@ where
     FF: Future<Output = Result<(Fence, Preparation), ParkNormalOperationFenceError>>,
     Q: FnOnce() -> QF,
     QF: Future<Output = io::Result<()>>,
-    P: FnOnce() -> PF,
-    PF: Future<Output = sandbox::Result<Outcome>>,
+    P: FnOnce(
+        SandboxFinalExecParkTiming<'observer>,
+        SandboxFinalExecParkSubstageEvents<'observer>,
+    ) -> PF,
+    PF: Future<
+        Output = (
+            SandboxFinalExecParkTiming<'observer>,
+            SandboxFinalExecParkSubstageEvents<'observer>,
+            sandbox::Result<Outcome>,
+        ),
+    >,
 {
     let mut timing = SandboxFinalExecParkTiming::new(observer);
     let preparation_started = Instant::now();
@@ -2971,7 +3021,11 @@ where
         "sandbox park lifecycle ReadyForPark reached"
     );
     let physical_park_started = Instant::now();
-    let outcome = match park_firecracker().await {
+    let observer = timing.observer.take();
+    let events = SandboxFinalExecParkSubstageEvents::new(observer);
+    let (mut timing, events, park_result) = park_firecracker(timing, events).await;
+    timing.observer = events.into_observer();
+    let outcome = match park_result {
         Ok(outcome) => {
             timing.record(
                 SandboxFinalExecParkStage::PhysicalPark,
@@ -3548,6 +3602,16 @@ fn park_admission_action(outcome: &SandboxParkOutcome) -> &'static str {
     }
 }
 
+fn record_park_substage(
+    events: &mut SandboxFinalExecParkSubstageEvents<'_>,
+    substage: SandboxFinalExecParkSubstage,
+    duration: Duration,
+    success: bool,
+    outcome: Option<SandboxFinalExecParkSubstageOutcome>,
+) {
+    events.record(substage, duration, success, outcome);
+}
+
 /// Wait until the guest balloon driver inflates close enough to `target_mib`.
 ///
 /// The guest needs running vCPUs to inflate, so this must be called
@@ -3559,7 +3623,24 @@ fn park_admission_action(outcome: &SandboxParkOutcome) -> &'static str {
 /// [`BALLOON_SETTLE_PROGRESS_GRACE`]. The returned outcome rejects only the
 /// existing severe-deficit classification. Errors from stats fetching are
 /// non-fatal — we log and proceed to pause.
+#[derive(Debug)]
+struct BalloonSettleResult {
+    park_outcome: SandboxParkOutcome,
+    telemetry_outcome: SandboxFinalExecParkSubstageOutcome,
+}
+
+#[cfg(test)]
 async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> SandboxParkOutcome {
+    wait_for_balloon_with_outcome(client, target_mib, log_id)
+        .await
+        .park_outcome
+}
+
+async fn wait_for_balloon_with_outcome(
+    client: &ApiClient,
+    target_mib: u32,
+    log_id: &str,
+) -> BalloonSettleResult {
     let tolerance_mib = balloon_settle_tolerance_mib(target_mib);
     let mut summary = BalloonSettleSummary::new(target_mib);
     let mut settle_timeout = BALLOON_SETTLE_TIMEOUT;
@@ -3583,7 +3664,10 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                     &summary,
                     &outcome,
                 );
-                return outcome;
+                return BalloonSettleResult {
+                    park_outcome: outcome,
+                    telemetry_outcome: SandboxFinalExecParkSubstageOutcome::Deadline,
+                };
             }
         }
 
@@ -3611,7 +3695,10 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                         reported_total_mib = ?summary.reported_total_mib(),
                         "balloon fully inflated, proceeding to pause"
                     );
-                    return SandboxParkOutcome::Reusable;
+                    return BalloonSettleResult {
+                        park_outcome: SandboxParkOutcome::Reusable,
+                        telemetry_outcome: SandboxFinalExecParkSubstageOutcome::TargetReached,
+                    };
                 }
 
                 if deficit_mib <= tolerance_mib {
@@ -3635,7 +3722,10 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                         reported_total_mib = ?summary.reported_total_mib(),
                         "balloon inflated within tolerance, proceeding to pause"
                     );
-                    return SandboxParkOutcome::Reusable;
+                    return BalloonSettleResult {
+                        park_outcome: SandboxParkOutcome::Reusable,
+                        telemetry_outcome: SandboxFinalExecParkSubstageOutcome::WithinTolerance,
+                    };
                 }
 
                 if summary.is_pressure_limited_partial_reclaim(deficit_mib, tolerance_mib) {
@@ -3660,7 +3750,10 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                         reason = BALLOON_PRESSURE_LIMITED_REASON,
                         "balloon pressure-limited partial reclaim, proceeding to pause"
                     );
-                    return SandboxParkOutcome::Reusable;
+                    return BalloonSettleResult {
+                        park_outcome: SandboxParkOutcome::Reusable,
+                        telemetry_outcome: SandboxFinalExecParkSubstageOutcome::PressureLimited,
+                    };
                 }
 
                 // Balloon timing tests advance paused time only after a completed stats sample.
@@ -3692,7 +3785,10 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                     %e,
                     "balloon stats unavailable, proceeding to pause"
                 );
-                return outcome;
+                return BalloonSettleResult {
+                    park_outcome: outcome,
+                    telemetry_outcome: SandboxFinalExecParkSubstageOutcome::StatsUnavailable,
+                };
             }
             Err(_) => {
                 let outcome = summary.park_outcome();
@@ -3704,7 +3800,10 @@ async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) -> 
                     &summary,
                     &outcome,
                 );
-                return outcome;
+                return BalloonSettleResult {
+                    park_outcome: outcome,
+                    telemetry_outcome: SandboxFinalExecParkSubstageOutcome::Deadline,
+                };
             }
         }
 
@@ -3770,23 +3869,42 @@ async fn terminal_guest_memory_snapshot(
     }
 }
 
-async fn park_inner_with_guest(
+async fn park_inner_with_guest<'observer>(
     is_parked: &mut bool,
     memory_mb: u32,
     balloon_controller: &mut Option<balloon::ControllerHandle>,
     api_sock: &std::path::Path,
     log_id: &str,
     guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
-) -> sandbox::Result<SandboxParkOutcome> {
+    mut events: SandboxFinalExecParkSubstageEvents<'observer>,
+) -> (
+    SandboxFinalExecParkSubstageEvents<'observer>,
+    sandbox::Result<SandboxParkOutcome>,
+) {
     if *is_parked {
-        return Ok(SandboxParkOutcome::Reusable);
+        return (events, Ok(SandboxParkOutcome::Reusable));
     }
 
     let target = memory_mb.saturating_sub(balloon::MIN_GUEST_MIB);
-    let client = ApiClient::new(api_sock).map_err(|e| SandboxError::IdleTransition {
-        transition: SandboxIdleTransition::Park,
-        message: format!("create API client: {e}"),
-    })?;
+    let client = match ApiClient::new(api_sock) {
+        Ok(client) => client,
+        Err(e) => {
+            record_park_substage(
+                &mut events,
+                SandboxFinalExecParkSubstage::BalloonSetup,
+                Duration::ZERO,
+                false,
+                Some(SandboxFinalExecParkSubstageOutcome::Failed),
+            );
+            return (
+                events,
+                Err(SandboxError::IdleTransition {
+                    transition: SandboxIdleTransition::Park,
+                    message: format!("create API client: {e}"),
+                }),
+            );
+        }
+    };
 
     let outcome = if target > 0 {
         // Stop the reactive controller so we're the sole writer to /balloon.
@@ -3804,48 +3922,107 @@ async fn park_inner_with_guest(
         // failure handling is `stop_and_destroy_sandbox`, so the sandbox is
         // dropped (and Drop ensures any leftover handles are aborted) before
         // any further operations can observe the missing controller.
+        let balloon_setup_started = Instant::now();
         if let Some(controller) = balloon_controller.take() {
             controller.abort_and_join().await;
         }
 
-        client
-            .patch_balloon(target)
-            .await
-            .map_err(|e| SandboxError::IdleTransition {
-                transition: SandboxIdleTransition::Park,
-                message: format!("balloon inflate: {e}"),
-            })?;
+        if let Err(e) = client.patch_balloon(target).await {
+            record_park_substage(
+                &mut events,
+                SandboxFinalExecParkSubstage::BalloonSetup,
+                balloon_setup_started.elapsed(),
+                false,
+                Some(SandboxFinalExecParkSubstageOutcome::Failed),
+            );
+            return (
+                events,
+                Err(SandboxError::IdleTransition {
+                    transition: SandboxIdleTransition::Park,
+                    message: format!("balloon inflate: {e}"),
+                }),
+            );
+        }
+        record_park_substage(
+            &mut events,
+            SandboxFinalExecParkSubstage::BalloonSetup,
+            balloon_setup_started.elapsed(),
+            true,
+            None,
+        );
 
         // Wait for the guest to inflate the balloon close enough before
         // pausing vCPUs. The guest balloon driver needs running vCPUs to
         // process the inflate — pausing immediately would negate the memory
         // savings.
-        match wait_for_balloon(&client, target, log_id).await {
+        let balloon_settle_started = Instant::now();
+        let settle_result = wait_for_balloon_with_outcome(&client, target, log_id).await;
+        let BalloonSettleResult {
+            mut park_outcome,
+            telemetry_outcome,
+        } = settle_result;
+        match &mut park_outcome {
             SandboxParkOutcome::NonReusable(
-                SandboxParkNonReusableReason::SevereMemoryRetention(mut diagnostics),
+                SandboxParkNonReusableReason::SevereMemoryRetention(diagnostics),
             ) => {
                 diagnostics.guest_memory_snapshot =
                     terminal_guest_memory_snapshot(&guest, log_id).await;
-                SandboxParkOutcome::NonReusable(
-                    SandboxParkNonReusableReason::SevereMemoryRetention(diagnostics),
-                )
             }
-            outcome => outcome,
+            SandboxParkOutcome::Reusable => {}
         }
+        record_park_substage(
+            &mut events,
+            SandboxFinalExecParkSubstage::BalloonSettle,
+            balloon_settle_started.elapsed(),
+            true,
+            Some(telemetry_outcome),
+        );
+        park_outcome
     } else {
+        record_park_substage(
+            &mut events,
+            SandboxFinalExecParkSubstage::BalloonSetup,
+            Duration::ZERO,
+            true,
+            Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+        );
+        record_park_substage(
+            &mut events,
+            SandboxFinalExecParkSubstage::BalloonSettle,
+            Duration::ZERO,
+            true,
+            Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+        );
         SandboxParkOutcome::Reusable
     };
 
     // Pause vCPUs to eliminate idle CPU overhead (timer ticks, kernel
     // scheduling). For small VMs (target == 0) we skip the balloon but
     // still pause — timer ticks waste CPU regardless of memory size.
-    client
-        .pause()
-        .await
-        .map_err(|e| SandboxError::IdleTransition {
-            transition: SandboxIdleTransition::Park,
-            message: format!("vm pause: {e}"),
-        })?;
+    let vcpu_pause_started = Instant::now();
+    if let Err(e) = client.pause().await {
+        record_park_substage(
+            &mut events,
+            SandboxFinalExecParkSubstage::VcpuPause,
+            vcpu_pause_started.elapsed(),
+            false,
+            Some(SandboxFinalExecParkSubstageOutcome::Failed),
+        );
+        return (
+            events,
+            Err(SandboxError::IdleTransition {
+                transition: SandboxIdleTransition::Park,
+                message: format!("vm pause: {e}"),
+            }),
+        );
+    }
+    record_park_substage(
+        &mut events,
+        SandboxFinalExecParkSubstage::VcpuPause,
+        vcpu_pause_started.elapsed(),
+        true,
+        None,
+    );
 
     *is_parked = true;
     if target > 0 {
@@ -3862,7 +4039,7 @@ async fn park_inner_with_guest(
             "sandbox parked (vCPUs paused, balloon skipped)"
         );
     }
-    Ok(outcome)
+    (events, Ok(outcome))
 }
 
 #[cfg(test)]
@@ -3873,15 +4050,17 @@ async fn park_inner(
     api_sock: &std::path::Path,
     log_id: &str,
 ) -> sandbox::Result<SandboxParkOutcome> {
-    park_inner_with_guest(
+    let (_, result) = park_inner_with_guest(
         is_parked,
         memory_mb,
         balloon_controller,
         api_sock,
         log_id,
         Arc::new(tokio::sync::Mutex::new(None)),
+        SandboxFinalExecParkSubstageEvents::new(None),
     )
-    .await
+    .await;
+    result
 }
 
 async fn unpark_inner(

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -60,6 +60,11 @@ fn expect_severe_memory_retention(outcome: SandboxParkOutcome) -> SevereMemoryRe
 #[derive(Default)]
 struct RecordingFinalExecParkObserver {
     records: Vec<(SandboxFinalExecParkStage, bool)>,
+    substage_records: Vec<(
+        SandboxFinalExecParkSubstage,
+        bool,
+        Option<SandboxFinalExecParkSubstageOutcome>,
+    )>,
 }
 
 impl SandboxFinalExecParkObserver for RecordingFinalExecParkObserver {
@@ -70,6 +75,16 @@ impl SandboxFinalExecParkObserver for RecordingFinalExecParkObserver {
         success: bool,
     ) {
         self.records.push((stage, success));
+    }
+
+    fn record_substage(
+        &mut self,
+        substage: SandboxFinalExecParkSubstage,
+        _duration: Duration,
+        success: bool,
+        outcome: Option<SandboxFinalExecParkSubstageOutcome>,
+    ) {
+        self.substage_records.push((substage, success, outcome));
     }
 }
 
@@ -1102,7 +1117,13 @@ async fn final_exec_park_observer_reports_completed_stages_in_order() {
         Some(&mut observer),
         || async { Ok((TestNormalOperationFence, "prepared")) },
         || async { Ok(()) },
-        || async { Ok(SandboxParkOutcome::Reusable) },
+        |_timing, events| async {
+            (
+                _timing,
+                events,
+                Ok::<SandboxParkOutcome, sandbox::SandboxError>(SandboxParkOutcome::Reusable),
+            )
+        },
     )
     .await
     .unwrap();
@@ -1131,7 +1152,13 @@ async fn final_exec_park_observer_reports_preparation_failure_only() {
             ))
         },
         || async { Ok(()) },
-        || async { Ok(SandboxParkOutcome::Reusable) },
+        |_timing, events| async {
+            (
+                _timing,
+                events,
+                Ok::<SandboxParkOutcome, sandbox::SandboxError>(SandboxParkOutcome::Reusable),
+            )
+        },
     )
     .await;
 
@@ -1153,11 +1180,15 @@ async fn final_exec_park_observer_reports_physical_park_failure() {
         Some(&mut observer),
         || async { Ok((TestNormalOperationFence, ())) },
         || async { Ok(()) },
-        || async {
-            Err::<SandboxParkOutcome, _>(idle_transition_error(
-                SandboxIdleTransition::Park,
-                "physical park failed",
-            ))
+        |_timing, events| async {
+            (
+                _timing,
+                events,
+                Err::<SandboxParkOutcome, _>(idle_transition_error(
+                    SandboxIdleTransition::Park,
+                    "physical park failed",
+                )),
+            )
         },
     )
     .await;
@@ -1170,6 +1201,54 @@ async fn final_exec_park_observer_reports_physical_park_failure() {
             (SandboxFinalExecParkStage::PhysicalPark, false),
         ]
     );
+}
+
+#[tokio::test]
+async fn final_exec_park_observer_keeps_completed_substage_on_cancellation() {
+    let coordinator = ParkCoordinator::new();
+    let mut observer = RecordingFinalExecParkObserver::default();
+    let (substage_started_tx, substage_started_rx) = tokio::sync::oneshot::channel();
+    let (_release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+
+    {
+        let transition = super::park_with_ready_for_park_and_preparation_with_observer(
+            "test-sandbox",
+            &coordinator,
+            Some(&mut observer),
+            || async { Ok((TestNormalOperationFence, ())) },
+            || async { Ok(()) },
+            |timing, mut events| async move {
+                events.record(
+                    SandboxFinalExecParkSubstage::BalloonSetup,
+                    Duration::from_millis(1),
+                    true,
+                    None,
+                );
+                let _ = substage_started_tx.send(());
+                release_rx.await.unwrap();
+                (
+                    timing,
+                    events,
+                    Ok::<SandboxParkOutcome, sandbox::SandboxError>(SandboxParkOutcome::Reusable),
+                )
+            },
+        );
+        tokio::pin!(transition);
+
+        tokio::select! {
+            _result = &mut transition => panic!("park completed unexpectedly"),
+            result = substage_started_rx => result.unwrap(),
+        }
+    }
+
+    assert_eq!(
+        observer.substage_records,
+        vec![(SandboxFinalExecParkSubstage::BalloonSetup, true, None)]
+    );
+    assert!(matches!(
+        coordinator.state(),
+        CoordinatorState::Dirty { .. }
+    ));
 }
 
 #[tokio::test]
@@ -4107,7 +4186,7 @@ async fn advance_balloon_wait_to_progress_grace<F>(
     mut future: std::pin::Pin<&mut F>,
     captured: &CapturedEvents,
 ) where
-    F: Future<Output = SandboxParkOutcome>,
+    F: Future<Output = BalloonSettleResult>,
 {
     for expected_sample_count in 1..=2 {
         if expected_sample_count == 2 {
@@ -4468,7 +4547,7 @@ async fn wait_for_balloon_follows_exact_bounded_poll_schedule() {
     let subscriber = tracing_subscriber::registry().with(captured.clone());
     let guard = tracing::subscriber::set_default(subscriber);
     tracing::callsite::rebuild_interest_cache();
-    let wait = wait_for_balloon(&client, target_mib, "bounded-schedule");
+    let wait = wait_for_balloon_with_outcome(&client, target_mib, "bounded-schedule");
     tokio::pin!(wait);
 
     for (index, delay_ms) in [
@@ -4528,7 +4607,11 @@ async fn wait_for_balloon_follows_exact_bounded_poll_schedule() {
     let outcome = wait.await;
     drop(guard);
 
-    expect_severe_memory_retention(outcome);
+    expect_severe_memory_retention(outcome.park_outcome);
+    assert_eq!(
+        outcome.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::Deadline
+    );
     let requests = api.drain_requests();
     assert_eq!(
         requests
@@ -4560,7 +4643,7 @@ async fn wait_for_balloon_extends_deadline_for_recent_safe_progress() {
     let guard = tracing::subscriber::set_default(subscriber);
     tracing::callsite::rebuild_interest_cache();
     tokio::time::pause();
-    let wait = wait_for_balloon(&client, target_mib, "progress-grace");
+    let wait = wait_for_balloon_with_outcome(&client, target_mib, "progress-grace");
     tokio::pin!(wait);
 
     advance_balloon_wait_to_progress_grace(wait.as_mut(), &captured).await;
@@ -4569,7 +4652,11 @@ async fn wait_for_balloon_extends_deadline_for_recent_safe_progress() {
     drop(guard);
     let events = captured.entries();
 
-    assert_eq!(outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(outcome.park_outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(
+        outcome.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::TargetReached
+    );
     let event = captured_event(
         &events,
         "balloon inflation still progressing, extending settle deadline",
@@ -4609,7 +4696,7 @@ async fn wait_for_balloon_progress_grace_remains_bounded() {
     let guard = tracing::subscriber::set_default(subscriber);
     tracing::callsite::rebuild_interest_cache();
     tokio::time::pause();
-    let wait = wait_for_balloon(&client, target_mib, "bounded-progress-grace");
+    let wait = wait_for_balloon_with_outcome(&client, target_mib, "bounded-progress-grace");
     tokio::pin!(wait);
 
     advance_balloon_wait_to_progress_grace(wait.as_mut(), &captured).await;
@@ -4631,7 +4718,11 @@ async fn wait_for_balloon_progress_grace_remains_bounded() {
     drop(guard);
     let events = captured.entries();
 
-    expect_severe_memory_retention(outcome);
+    expect_severe_memory_retention(outcome.park_outcome);
+    assert_eq!(
+        outcome.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::Deadline
+    );
     assert_eq!(
         captured_message_count(
             &events,
@@ -4662,10 +4753,18 @@ async fn wait_for_balloon_near_target_logs_summary_without_timeout() {
     );
     let client = ApiClient::new(api.socket_path()).unwrap();
 
-    let (outcome, events) =
-        capture_async_log_events(wait_for_balloon(&client, target_mib, "near-target")).await;
+    let (settle_result, events) = capture_async_log_events(wait_for_balloon_with_outcome(
+        &client,
+        target_mib,
+        "near-target",
+    ))
+    .await;
 
-    assert_eq!(outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(settle_result.park_outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(
+        settle_result.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::WithinTolerance
+    );
     assert!(!has_captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway"
@@ -4698,11 +4797,16 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
     );
     let client = ApiClient::new(api.socket_path()).unwrap();
 
-    let (outcome, events) =
-        capture_balloon_timeout_after_sample(wait_for_balloon(&client, target_mib, "stalled"))
-            .await;
+    let (settle_result, events) = capture_balloon_timeout_after_sample(
+        wait_for_balloon_with_outcome(&client, target_mib, "stalled"),
+    )
+    .await;
 
-    assert_eq!(outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(settle_result.park_outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(
+        settle_result.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::Deadline
+    );
     let event = captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway",
@@ -4731,10 +4835,18 @@ async fn wait_for_balloon_accepts_pressure_limited_partial_reclaim() {
     );
     let client = ApiClient::new(api.socket_path()).unwrap();
 
-    let (outcome, events) =
-        capture_async_log_events(wait_for_balloon(&client, target_mib, "pressure-limited")).await;
+    let (settle_result, events) = capture_async_log_events(wait_for_balloon_with_outcome(
+        &client,
+        target_mib,
+        "pressure-limited",
+    ))
+    .await;
 
-    assert_eq!(outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(settle_result.park_outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(
+        settle_result.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::PressureLimited
+    );
     assert!(!has_captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway"
@@ -4827,11 +4939,16 @@ async fn wait_for_balloon_timeout_logs_target_not_observed_reason() {
     );
     let client = ApiClient::new(api.socket_path()).unwrap();
 
-    let (outcome, events) =
-        capture_balloon_timeout_after_sample(wait_for_balloon(&client, target_mib, "stale-target"))
-            .await;
+    let (settle_result, events) = capture_balloon_timeout_after_sample(
+        wait_for_balloon_with_outcome(&client, target_mib, "stale-target"),
+    )
+    .await;
 
-    assert_eq!(outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(settle_result.park_outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(
+        settle_result.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::Deadline
+    );
     let event = captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway",
@@ -4858,7 +4975,7 @@ async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
     let subscriber = tracing_subscriber::registry().with(captured.clone());
     let guard = tracing::subscriber::set_default(subscriber);
     tracing::callsite::rebuild_interest_cache();
-    let wait = wait_for_balloon(&client, target_mib, "slow-stats");
+    let wait = wait_for_balloon_with_outcome(&client, target_mib, "slow-stats");
     tokio::pin!(wait);
     let request = tokio::select! {
         request = api.api.next_request() => request,
@@ -4876,7 +4993,11 @@ async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
     drop(guard);
     let events = captured.entries();
 
-    assert_eq!(outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(outcome.park_outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(
+        outcome.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::Deadline
+    );
     let event = captured_event(
         &events,
         "balloon inflate incomplete after 5s, pausing anyway",
@@ -4900,10 +5021,16 @@ async fn wait_for_balloon_timeout_logs_severe_deficit_and_memory_stats() {
     );
     let client = ApiClient::new(api.socket_path()).unwrap();
 
-    let (outcome, events) =
-        capture_balloon_timeout_after_sample(wait_for_balloon(&client, target_mib, "severe")).await;
+    let (settle_result, events) = capture_balloon_timeout_after_sample(
+        wait_for_balloon_with_outcome(&client, target_mib, "severe"),
+    )
+    .await;
 
-    let diagnostics = expect_severe_memory_retention(outcome);
+    assert_eq!(
+        settle_result.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::Deadline
+    );
+    let diagnostics = expect_severe_memory_retention(settle_result.park_outcome);
     assert_eq!(diagnostics.requested_target_mib, target_mib);
     assert_eq!(diagnostics.first_observed_target_mib, Some(target_mib));
     assert_eq!(diagnostics.observed_target_mib, Some(target_mib));
@@ -4945,15 +5072,21 @@ async fn park_pauses_when_balloon_stats_are_unavailable() {
     );
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
+    let mut observer = RecordingFinalExecParkObserver::default();
 
-    let (result, events) = capture_async_log_events(park_inner(
-        &mut is_parked,
-        2048,
-        &mut controller,
-        api.socket_path(),
-        "stats-error",
-    ))
-    .await;
+    let (result, events) = {
+        let ((_substage_events, result), events) = capture_async_log_events(park_inner_with_guest(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            api.socket_path(),
+            "stats-error",
+            Arc::new(tokio::sync::Mutex::new(None)),
+            SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
+        ))
+        .await;
+        (result, events)
+    };
     result.unwrap();
 
     assert!(is_parked);
@@ -4963,6 +5096,18 @@ async fn park_pauses_when_balloon_stats_are_unavailable() {
     assert_event_field(event, "deficit_mib", "None");
     assert_event_field(event, "sample_count", "0");
     assert_event_field(event, "reason", "stats_unavailable");
+    assert_eq!(
+        observer.substage_records,
+        vec![
+            (SandboxFinalExecParkSubstage::BalloonSetup, true, None,),
+            (
+                SandboxFinalExecParkSubstage::BalloonSettle,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::StatsUnavailable),
+            ),
+            (SandboxFinalExecParkSubstage::VcpuPause, true, None),
+        ]
+    );
     let reqs = api.drain_requests();
     let ps = patches(&reqs);
     assert_eq!(ps.len(), 2, "expected balloon inflate + vm pause");
@@ -5204,15 +5349,21 @@ async fn park_small_vm_skips_balloon_but_pauses_vcpus() {
     let original_id = original_controller.id();
     let mut controller = Some(original_controller);
     let mut is_parked = false;
+    let mut observer = RecordingFinalExecParkObserver::default();
 
-    let result = park_inner(
-        &mut is_parked,
-        512,
-        &mut controller,
-        api.socket_path(),
-        "test-park-small",
-    )
-    .await;
+    let result = {
+        let (_events, result) = park_inner_with_guest(
+            &mut is_parked,
+            512,
+            &mut controller,
+            api.socket_path(),
+            "test-park-small",
+            Arc::new(tokio::sync::Mutex::new(None)),
+            SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
+        )
+        .await;
+        result
+    };
     result.unwrap();
 
     assert!(is_parked, "is_parked should be set");
@@ -5228,6 +5379,22 @@ async fn park_small_vm_skips_balloon_but_pauses_vcpus() {
     assert_eq!(ps.len(), 1, "expected only vm pause, no balloon PATCH");
     assert_eq!(ps[0].path, "/vm");
     assert!(ps[0].body.contains("Paused"));
+    assert_eq!(
+        observer.substage_records,
+        vec![
+            (
+                SandboxFinalExecParkSubstage::BalloonSetup,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+            ),
+            (
+                SandboxFinalExecParkSubstage::BalloonSettle,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+            ),
+            (SandboxFinalExecParkSubstage::VcpuPause, true, None),
+        ]
+    );
 }
 
 #[tokio::test]
@@ -5538,15 +5705,21 @@ async fn park_balloon_failure_leaves_flag_false() {
 
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
+    let mut observer = RecordingFinalExecParkObserver::default();
 
-    let result = park_inner(
-        &mut is_parked,
-        2048,
-        &mut controller,
-        api.socket_path(),
-        "test-park-fail",
-    )
-    .await;
+    let result = {
+        let (_events, result) = park_inner_with_guest(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            api.socket_path(),
+            "test-park-fail",
+            Arc::new(tokio::sync::Mutex::new(None)),
+            SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
+        )
+        .await;
+        result
+    };
 
     assert_idle_transition(result, SandboxIdleTransition::Park);
     assert!(!is_parked, "flag must stay false on failure");
@@ -5556,6 +5729,14 @@ async fn park_balloon_failure_leaves_flag_false() {
     let ps = patches(&reqs);
     assert_eq!(ps.len(), 1, "only balloon inflate should be attempted");
     assert_eq!(ps[0].path, "/balloon");
+    assert_eq!(
+        observer.substage_records,
+        vec![(
+            SandboxFinalExecParkSubstage::BalloonSetup,
+            false,
+            Some(SandboxFinalExecParkSubstageOutcome::Failed),
+        )]
+    );
     // A follow-up unpark must be a clean no-op because is_parked is false.
     let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
     unpark_inner(
@@ -6075,13 +6256,14 @@ async fn severe_park_collects_terminal_guest_memory_before_pause() {
     let park_task = tokio::spawn(async move {
         let mut controller = Some(test_balloon_controller());
         let mut is_parked = false;
-        let outcome = park_inner_with_guest(
+        let (_, outcome) = park_inner_with_guest(
             &mut is_parked,
             2048,
             &mut controller,
             &socket_path,
             "terminal-memory-snapshot",
             guest,
+            SandboxFinalExecParkSubstageEvents::new(None),
         )
         .await;
         (outcome, is_parked)
@@ -6138,17 +6320,21 @@ async fn reusable_park_does_not_request_terminal_guest_memory() {
     let retained_guest = Arc::clone(&guest);
     let mut controller = Some(test_balloon_controller());
     let mut is_parked = false;
+    let mut observer = RecordingFinalExecParkObserver::default();
 
-    let outcome = park_inner_with_guest(
-        &mut is_parked,
-        2048,
-        &mut controller,
-        api.socket_path(),
-        "reusable-no-memory-snapshot",
-        guest,
-    )
-    .await
-    .unwrap();
+    let outcome = {
+        let (_events, outcome) = park_inner_with_guest(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            api.socket_path(),
+            "reusable-no-memory-snapshot",
+            guest,
+            SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
+        )
+        .await;
+        outcome.unwrap()
+    };
 
     assert_eq!(outcome, SandboxParkOutcome::Reusable);
     assert!(is_parked);
@@ -6165,6 +6351,18 @@ async fn reusable_park_does_not_request_terminal_guest_memory() {
         .find(|request| request.path == "/vm")
         .expect("reusable park should pause Firecracker");
     assert!(pause.body.contains("Paused"));
+    assert_eq!(
+        observer.substage_records,
+        vec![
+            (SandboxFinalExecParkSubstage::BalloonSetup, true, None,),
+            (
+                SandboxFinalExecParkSubstage::BalloonSettle,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::TargetReached),
+            ),
+            (SandboxFinalExecParkSubstage::VcpuPause, true, None),
+        ]
+    );
 }
 
 #[tokio::test]
@@ -6178,15 +6376,21 @@ async fn park_small_vm_pause_failure_preserves_controller() {
     let original_id = original_controller.id();
     let mut controller = Some(original_controller);
     let mut is_parked = false;
+    let mut observer = RecordingFinalExecParkObserver::default();
 
-    let result = park_inner(
-        &mut is_parked,
-        512,
-        &mut controller,
-        api.socket_path(),
-        "small-fail",
-    )
-    .await;
+    let result = {
+        let (_events, result) = park_inner_with_guest(
+            &mut is_parked,
+            512,
+            &mut controller,
+            api.socket_path(),
+            "small-fail",
+            Arc::new(tokio::sync::Mutex::new(None)),
+            SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
+        )
+        .await;
+        result
+    };
 
     assert_idle_transition(result, SandboxIdleTransition::Park);
     assert!(!is_parked, "flag must stay false on failure");
@@ -6197,5 +6401,25 @@ async fn park_small_vm_pause_failure_preserves_controller() {
         still_there.id(),
         original_id,
         "controller must not be replaced or aborted"
+    );
+    assert_eq!(
+        observer.substage_records,
+        vec![
+            (
+                SandboxFinalExecParkSubstage::BalloonSetup,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+            ),
+            (
+                SandboxFinalExecParkSubstage::BalloonSettle,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+            ),
+            (
+                SandboxFinalExecParkSubstage::VcpuPause,
+                false,
+                Some(SandboxFinalExecParkSubstageOutcome::Failed),
+            ),
+        ]
     );
 }

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -65,6 +65,7 @@ struct RecordingFinalExecParkObserver {
         bool,
         Option<SandboxFinalExecParkSubstageOutcome>,
     )>,
+    substage_durations: Vec<(SandboxFinalExecParkSubstage, Duration)>,
 }
 
 impl SandboxFinalExecParkObserver for RecordingFinalExecParkObserver {
@@ -80,11 +81,12 @@ impl SandboxFinalExecParkObserver for RecordingFinalExecParkObserver {
     fn record_substage(
         &mut self,
         substage: SandboxFinalExecParkSubstage,
-        _duration: Duration,
+        duration: Duration,
         success: bool,
         outcome: Option<SandboxFinalExecParkSubstageOutcome>,
     ) {
         self.substage_records.push((substage, success, outcome));
+        self.substage_durations.push((substage, duration));
     }
 }
 
@@ -1244,6 +1246,13 @@ async fn final_exec_park_observer_keeps_completed_substage_on_cancellation() {
     assert_eq!(
         observer.substage_records,
         vec![(SandboxFinalExecParkSubstage::BalloonSetup, true, None)]
+    );
+    assert_eq!(
+        observer.substage_durations,
+        vec![(
+            SandboxFinalExecParkSubstage::BalloonSetup,
+            Duration::from_millis(1)
+        )]
     );
     assert!(matches!(
         coordinator.state(),

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -4489,7 +4489,7 @@ async fn wait_for_balloon_rechecks_after_initial_25_ms_delay() {
     let guard = tracing::subscriber::set_default(subscriber);
     tracing::callsite::rebuild_interest_cache();
     tokio::time::pause();
-    let wait = wait_for_balloon(&client, target_mib, "fast-start");
+    let wait = wait_for_balloon_with_outcome(&client, target_mib, "fast-start");
     tokio::pin!(wait);
 
     loop {
@@ -4521,10 +4521,14 @@ async fn wait_for_balloon_rechecks_after_initial_25_ms_delay() {
 
     tokio::time::advance(Duration::from_millis(1)).await;
     tokio::time::resume();
-    let outcome = wait.await;
+    let settle_result = wait.await;
     drop(guard);
 
-    assert_eq!(outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(settle_result.park_outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(
+        settle_result.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::TargetReached
+    );
     requests.extend(api.drain_requests());
     assert_eq!(
         requests

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -392,8 +392,26 @@ impl Sandbox for MockSandbox {
             }
         };
         let physical_park_started = Instant::now();
+        observer.record_substage(
+            SandboxFinalExecParkSubstage::BalloonSetup,
+            Duration::ZERO,
+            true,
+            Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+        );
+        observer.record_substage(
+            SandboxFinalExecParkSubstage::BalloonSettle,
+            Duration::ZERO,
+            true,
+            Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+        );
         let park_outcome = match self.park().await {
             Ok(park_outcome) => {
+                observer.record_substage(
+                    SandboxFinalExecParkSubstage::VcpuPause,
+                    Duration::ZERO,
+                    true,
+                    None,
+                );
                 observer.record_stage(
                     SandboxFinalExecParkStage::PhysicalPark,
                     physical_park_started.elapsed(),
@@ -402,6 +420,12 @@ impl Sandbox for MockSandbox {
                 park_outcome
             }
             Err(error) => {
+                observer.record_substage(
+                    SandboxFinalExecParkSubstage::VcpuPause,
+                    Duration::ZERO,
+                    false,
+                    Some(SandboxFinalExecParkSubstageOutcome::Failed),
+                );
                 observer.record_stage(
                     SandboxFinalExecParkStage::PhysicalPark,
                     physical_park_started.elapsed(),

--- a/crates/sandbox-mock/src/tests/lifecycle.rs
+++ b/crates/sandbox-mock/src/tests/lifecycle.rs
@@ -9,6 +9,7 @@ struct RecordingFinalExecParkObserver {
         bool,
         Option<SandboxFinalExecParkSubstageOutcome>,
     )>,
+    substage_durations: Vec<(SandboxFinalExecParkSubstage, Duration)>,
 }
 
 impl SandboxFinalExecParkObserver for RecordingFinalExecParkObserver {
@@ -24,11 +25,12 @@ impl SandboxFinalExecParkObserver for RecordingFinalExecParkObserver {
     fn record_substage(
         &mut self,
         substage: SandboxFinalExecParkSubstage,
-        _duration: Duration,
+        duration: Duration,
         success: bool,
         outcome: Option<SandboxFinalExecParkSubstageOutcome>,
     ) {
         self.substages.push((substage, success, outcome));
+        self.substage_durations.push((substage, duration));
     }
 }
 
@@ -137,6 +139,14 @@ async fn operation_overrides_preserve_unrelated_sandbox_behavior() {
                 Some(SandboxFinalExecParkSubstageOutcome::Skipped),
             ),
             (SandboxFinalExecParkSubstage::VcpuPause, true, None),
+        ]
+    );
+    assert_eq!(
+        observer.substage_durations,
+        vec![
+            (SandboxFinalExecParkSubstage::BalloonSetup, Duration::ZERO),
+            (SandboxFinalExecParkSubstage::BalloonSettle, Duration::ZERO),
+            (SandboxFinalExecParkSubstage::VcpuPause, Duration::ZERO),
         ]
     );
 }

--- a/crates/sandbox-mock/src/tests/lifecycle.rs
+++ b/crates/sandbox-mock/src/tests/lifecycle.rs
@@ -4,6 +4,11 @@ use std::sync::Arc;
 #[derive(Default)]
 struct RecordingFinalExecParkObserver {
     records: Vec<(SandboxFinalExecParkStage, bool)>,
+    substages: Vec<(
+        SandboxFinalExecParkSubstage,
+        bool,
+        Option<SandboxFinalExecParkSubstageOutcome>,
+    )>,
 }
 
 impl SandboxFinalExecParkObserver for RecordingFinalExecParkObserver {
@@ -14,6 +19,16 @@ impl SandboxFinalExecParkObserver for RecordingFinalExecParkObserver {
         success: bool,
     ) {
         self.records.push((stage, success));
+    }
+
+    fn record_substage(
+        &mut self,
+        substage: SandboxFinalExecParkSubstage,
+        _duration: Duration,
+        success: bool,
+        outcome: Option<SandboxFinalExecParkSubstageOutcome>,
+    ) {
+        self.substages.push((substage, success, outcome));
     }
 }
 
@@ -106,6 +121,22 @@ async fn operation_overrides_preserve_unrelated_sandbox_behavior() {
         vec![
             (SandboxFinalExecParkStage::ReusePreparation, true),
             (SandboxFinalExecParkStage::PhysicalPark, true),
+        ]
+    );
+    assert_eq!(
+        observer.substages,
+        vec![
+            (
+                SandboxFinalExecParkSubstage::BalloonSetup,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+            ),
+            (
+                SandboxFinalExecParkSubstage::BalloonSettle,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+            ),
+            (SandboxFinalExecParkSubstage::VcpuPause, true, None),
         ]
     );
 }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -46,8 +46,9 @@ pub use factory::{
 pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::{
     GuestMemorySnapshot, Sandbox, SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome,
-    SandboxFinalExecParkStage, SandboxParkNonReusableReason, SandboxParkOutcome,
-    SandboxStartObserver, SandboxStartStage, SevereMemoryRetentionDiagnostics,
+    SandboxFinalExecParkStage, SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome,
+    SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver, SandboxStartStage,
+    SevereMemoryRetentionDiagnostics,
 };
 pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -206,6 +206,51 @@ pub enum SandboxFinalExecParkStage {
     PhysicalPark,
 }
 
+/// Fixed low-cardinality provider operations inside the final physical park.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxFinalExecParkSubstage {
+    /// Stops the reactive controller and submits the park-time balloon target.
+    BalloonSetup,
+    /// Waits for the guest balloon to reach the existing settle policy.
+    BalloonSettle,
+    /// Pauses guest vCPUs after balloon handling completes.
+    VcpuPause,
+}
+
+/// Bounded terminal classification for a final physical-park sub-stage.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxFinalExecParkSubstageOutcome {
+    /// The provider operation was not needed, such as a zero balloon target.
+    Skipped,
+    /// The requested balloon target was observed.
+    TargetReached,
+    /// The balloon deficit was within the existing tolerance.
+    WithinTolerance,
+    /// Guest pressure limited reclaim and the existing policy proceeded.
+    PressureLimited,
+    /// The existing settle deadline elapsed.
+    Deadline,
+    /// Balloon statistics were unavailable and the existing policy proceeded.
+    StatsUnavailable,
+    /// The provider operation failed.
+    Failed,
+}
+
+impl SandboxFinalExecParkSubstageOutcome {
+    /// Stable low-cardinality value for telemetry dimensions.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Skipped => "skipped",
+            Self::TargetReached => "target_reached",
+            Self::WithinTolerance => "within_tolerance",
+            Self::PressureLimited => "pressure_limited",
+            Self::Deadline => "deadline",
+            Self::StatsUnavailable => "stats_unavailable",
+            Self::Failed => "failed",
+        }
+    }
+}
+
 /// Receives optional final preparation and physical-park timing records.
 ///
 /// Callbacks describe completed stages only and are informational: they never
@@ -219,6 +264,23 @@ pub enum SandboxFinalExecParkStage {
 pub trait SandboxFinalExecParkObserver: Send {
     /// Records one completed final-exec/park stage.
     fn record_stage(&mut self, stage: SandboxFinalExecParkStage, duration: Duration, success: bool);
+
+    /// Records one completed provider operation inside the physical-park stage.
+    ///
+    /// `success` remains independent from `outcome`: settle deadlines and
+    /// unavailable statistics can be completed, non-error provider paths.
+    /// Providers invoke this at most once for each applicable sub-stage; a
+    /// cancellation can omit the sub-stage that was still in progress.
+    /// Implementations that do not need sub-stage timing can use the default
+    /// no-op method for source compatibility.
+    fn record_substage(
+        &mut self,
+        _substage: SandboxFinalExecParkSubstage,
+        _duration: Duration,
+        _success: bool,
+        _outcome: Option<SandboxFinalExecParkSubstageOutcome>,
+    ) {
+    }
 }
 
 /// A process-isolation environment that runs guest workloads for the runner.


### PR DESCRIPTION
## Summary

- Expose fixed `balloon_setup`, `balloon_settle`, and `vcpu_pause` timings inside the existing
  physical-park observer path.
- Classify settle completion with bounded outcomes and serialize additive runner operation records
  while retaining the aggregate preparation, physical-park, and idle-publication records.
- Preserve completed sub-stage callbacks across cancellation; only an in-progress sub-stage may be
  absent.

## Scope and compatibility

- `SandboxFinalExecParkObserver` receives a default no-op sub-stage callback, preserving existing
  observers.
- Firecracker park ordering, balloon target/tolerance, settle deadline and grace, pause behavior,
  cleanup ownership, reuse eligibility, and cancellation lifecycle are unchanged.
- Mock and runner finalization paths emit deterministic records for mixed-version-safe validation.
- New action names and the optional `outcome` field use only bounded static values; no provider IDs,
  targets, memory values, or raw errors are serialized.
- The branch is rebased onto the current `main` telemetry contract, including runner attribution and
  existing bounded outcome dimensions.
- No API route, database, queue, persisted-state, resource, cgroup, pids, or guest-memory-policy
  changes are included.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sandbox` (33 passed across unit/integration/doc tests)
- `cargo test -p sandbox-fc --lib` (800 passed)
- `cargo test -p sandbox-mock` (87 passed; doc tests passed)
- `cargo test -p runner` (3,145 passed, 20 ignored; guest inventory 1 passed)
- `cargo test --all-targets --all-features --no-run`
- `cargo clippy -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `git diff --check`
- Pre-commit hooks: repository-wide cargo check/clippy, formatting, file-size, and commitlint

Closes #27542

Parent: #27451
