### PR TITLE
docs(rust): correct stale codex auth refresh source reference

### DIFF
--- a/crates/guest-agent/src/codex_auth.rs
+++ b/crates/guest-agent/src/codex_auth.rs
@@ -48,10 +48,13 @@ use crate::error::AgentError;
 /// creation; this string only needs to satisfy codex's local parser.
 pub(crate) const PLACEHOLDER_PLAN_TYPE: &str = "plus";
 
-/// Far-future JWT `exp` offset, in seconds. ~100 years from now ensures
-/// codex's `is_stale_for_proactive_refresh`
-/// (`codex-rs/login/src/auth/manager.rs:1786-1806`) always returns false;
-/// codex will not attempt refresh during runs.
+/// Far-future JWT `exp` offset, in seconds. For a parseable access token,
+/// Codex 0.147.0's `AuthManager::should_refresh_proactively` returns true when
+/// its `exp` is no later than five minutes from now:
+/// <https://github.com/openai/codex/blob/rust-v0.147.0/codex-rs/login/src/auth/manager.rs#L2762-L2784>.
+/// This version is pinned by `CODEX_CLI_VERSION` in
+/// `crates/runner/scripts/build-template.sh`; an `exp` ~100 years from now
+/// therefore keeps the predicate false during runs.
 const FAR_FUTURE_EXP_SECS: i64 = 100 * 365 * 24 * 3600;
 
 /// Localhost no-op URL for `CODEX_REFRESH_TOKEN_URL_OVERRIDE`. Defense


### PR DESCRIPTION
## Summary

- replace the stale Codex auth refresh symbol and source location with an immutable Codex 0.147.0 link to `AuthManager::should_refresh_proactively`
- document the five-minute access-token refresh window and trace the cited implementation to the runner's `CODEX_CLI_VERSION` pin
- leave runtime authentication behavior unchanged

## Validation

- `cargo fmt -p guest-agent -- --check`
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p guest-agent --lib codex_auth` (16 passed)
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo clippy -p guest-agent --all-targets -- -D warnings`
- revalidated the local Codex CLI pin and the cited `rust-v0.147.0` upstream source
- `cargo test -p guest-agent` was blocked by a deterministic pre-existing `process_control_env` wrapper assertion: the isolated child succeeds and prints its activation marker, but the parent requires that marker as an exact standalone stdout line

Closes #27514
