### PR TITLE
refactor(workflows): neutralize workflow route shell naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -133,8 +133,8 @@ import { peopleSearchRoutes } from "./routes/people-search";
 import { webSearchRoutes } from "./routes/web-search";
 import { zeroBrowserRoutes } from "./routes/zero-browser";
 import { zeroBrowserAuthorizationRoutes } from "./routes/zero-browser-authorization";
-import { zeroWorkflowsRoutes } from "./routes/zero-workflows";
-import { zeroWorkflowAutomationsRoutes } from "./routes/zero-workflow-automations";
+import { workflowsRoutes } from "./routes/workflows";
+import { workflowAutomationsRoutes } from "./routes/workflow-automations";
 import { strapiIntegrationsRoutes } from "./routes/strapi-integrations";
 import { strapiEventsRoutes } from "./routes/strapi-events";
 import { integrationsGithubRoutes } from "./routes/integrations-github";
@@ -335,8 +335,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroUserPermissionGrantsRoutes,
   ...userPreferencesRoutes,
   ...userModelPreferenceRoutes,
-  ...zeroWorkflowsRoutes,
-  ...zeroWorkflowAutomationsRoutes,
+  ...workflowsRoutes,
+  ...workflowAutomationsRoutes,
   ...strapiIntegrationsRoutes,
   ...integrationsGithubRoutes,
   ...zeroSlackConnectRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/agents-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-update.test.ts
@@ -23,7 +23,7 @@ import { seedOrgMembership$ } from "./helpers/org-membership";
 import { cliAuthRoutes } from "../cli-auth";
 import { zeroAgentInstructionsRoutes } from "../zero-agent-instructions";
 import { zeroAgentsRoutes } from "../zero-agents";
-import { zeroWorkflowsRoutes } from "../zero-workflows";
+import { workflowsRoutes } from "../workflows";
 
 const context = testContext();
 const store = createStore();
@@ -128,7 +128,7 @@ async function createWorkflowFor(
 ): Promise<void> {
   mocks.clerk.session(user.userId, user.orgId);
   await accept(
-    setupApp({ context, routes: zeroWorkflowsRoutes })(
+    setupApp({ context, routes: workflowsRoutes })(
       zeroWorkflowsCollectionContract,
     ).create({
       headers: authHeaders(),

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
@@ -19,7 +19,7 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { chatEventDisplayText } from "./helpers/chat-event";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 
 /**
  * chat-run-finished workflow automations: creation validation and dispatch
@@ -36,7 +36,7 @@ const wf = createWorkflowsBddApi(context);
 const WATCHED_THREAD_TITLE = "Watched chat run";
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -98,8 +98,8 @@ import { zeroConnectorsRoutes } from "../zero-connectors";
 import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
 import { steamPlayerRoutes } from "../steam-player";
 import { zeroUserPermissionGrantsRoutes } from "../zero-user-permission-grants";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
-import { zeroWorkflowsRoutes } from "../zero-workflows";
+import { workflowAutomationsRoutes } from "../workflow-automations";
+import { workflowsRoutes } from "../workflows";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...connectorsSlugCallbackRoutes,
@@ -112,8 +112,8 @@ const TEST_APP_ROUTES = Object.freeze([
   ...zeroFeatureSwitchesRoutes,
   ...steamPlayerRoutes,
   ...zeroUserPermissionGrantsRoutes,
-  ...zeroWorkflowAutomationsRoutes,
-  ...zeroWorkflowsRoutes,
+  ...workflowAutomationsRoutes,
+  ...workflowsRoutes,
 ]);
 
 const context = testContext();
@@ -4044,7 +4044,7 @@ describe("connector catalog valid lifecycle", () => {
     });
     created.agentId = agent.agentId;
     const workflow = await accept(
-      setupApp({ context, routes: zeroWorkflowsRoutes })(
+      setupApp({ context, routes: workflowsRoutes })(
         zeroWorkflowsCollectionContract,
       ).create({
         headers,
@@ -4058,7 +4058,7 @@ describe("connector catalog valid lifecycle", () => {
     );
     created.workflowId = workflow.body.id;
     await accept(
-      setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+      setupApp({ context, routes: workflowAutomationsRoutes })(
         zeroWorkflowAutomationsContract,
       ).create({
         headers,
@@ -4134,7 +4134,7 @@ describe("connector catalog valid lifecycle", () => {
 
     const callsBeforeReadiness = context.mocks.s3.send.mock.calls.length;
     const readiness = await accept(
-      setupApp({ context, routes: zeroWorkflowsRoutes })(
+      setupApp({ context, routes: workflowsRoutes })(
         zeroWorkflowsDetailContract,
       ).connectorReadiness({
         headers,
@@ -4244,7 +4244,7 @@ describe("connector catalog valid lifecycle", () => {
     zeroMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const headers = { authorization: "Bearer clerk-session" };
     const workflow = await accept(
-      setupApp({ context, routes: zeroWorkflowsRoutes })(
+      setupApp({ context, routes: workflowsRoutes })(
         zeroWorkflowsCollectionContract,
       ).create({
         headers,
@@ -4295,7 +4295,7 @@ describe("connector catalog valid lifecycle", () => {
     );
 
     const firstCreate = accept(
-      setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+      setupApp({ context, routes: workflowAutomationsRoutes })(
         zeroWorkflowAutomationsContract,
       ).create({
         headers,
@@ -4339,7 +4339,7 @@ describe("connector catalog valid lifecycle", () => {
     });
 
     await accept(
-      setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+      setupApp({ context, routes: workflowAutomationsRoutes })(
         zeroWorkflowAutomationsContract,
       ).create({
         headers,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -46,7 +46,7 @@ import { zeroModelProvidersRoutes } from "../../zero-model-providers";
 import { orgLogoRoutes } from "../../org-logo";
 import { pushSubscriptionsRoutes } from "../../push-subscriptions";
 import { userPreferencesRoutes } from "../../user-preferences";
-import { zeroWorkflowsRoutes } from "../../zero-workflows";
+import { workflowsRoutes } from "../../workflows";
 
 const zeroPersonalModelProvidersMainTestRoutes = Object.freeze([
   ...zeroMeModelProvidersListRoutes,
@@ -325,7 +325,7 @@ export function createMiscRoutesApi(context: TestContext) {
 
     async listWorkflows(actor: ApiTestUser) {
       return await accept(
-        setupApp({ context, routes: zeroWorkflowsRoutes })(
+        setupApp({ context, routes: workflowsRoutes })(
           zeroWorkflowsCollectionContract,
         ).list({
           headers: authenticate(context, actor),
@@ -345,7 +345,7 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (201 | 400 | 401 | 403 | 409)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroWorkflowsRoutes })(
+        setupApp({ context, routes: workflowsRoutes })(
           zeroWorkflowsCollectionContract,
         ).create({
           headers: authenticate(context, actor),
@@ -368,7 +368,7 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (400 | 401 | 403 | 409)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroWorkflowsRoutes })(
+        setupApp({ context, routes: workflowsRoutes })(
           zeroWorkflowsCollectionContract,
         ).create({
           headers: authenticate(context, actor),
@@ -390,7 +390,7 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroWorkflowsRoutes })(
+        setupApp({ context, routes: workflowsRoutes })(
           zeroWorkflowsDetailContract,
         ).get({
           headers: authenticate(context, actor),
@@ -407,7 +407,7 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (200 | 400 | 401 | 403 | 404)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroWorkflowsRoutes })(
+        setupApp({ context, routes: workflowsRoutes })(
           zeroWorkflowsDetailContract,
         ).update({
           headers: authenticate(context, actor),
@@ -424,7 +424,7 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (204 | 401 | 403 | 404)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroWorkflowsRoutes })(
+        setupApp({ context, routes: workflowsRoutes })(
           zeroWorkflowsDetailContract,
         ).delete({
           headers: authenticate(context, actor),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-workflows.ts
@@ -19,8 +19,8 @@ import { createRunsApi } from "./api-bdd-runs";
 import { createZeroRouteMocks } from "./zero-route-test";
 import { readProjectedChatEvents } from "./chat-event-test-reader";
 import { zeroChatThreadGetRoutes } from "../../zero-chat-threads-get";
-import { zeroWorkflowAutomationsRoutes } from "../../zero-workflow-automations";
-import { zeroWorkflowsRoutes } from "../../zero-workflows";
+import { workflowAutomationsRoutes } from "../../workflow-automations";
+import { workflowsRoutes } from "../../workflows";
 
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
@@ -175,7 +175,7 @@ export function createWorkflowsBddApi(context: TestContext) {
         readonly visibility?: "public" | "private";
       },
     ): Promise<string> {
-      const client = setupApp({ context, routes: zeroWorkflowsRoutes })(
+      const client = setupApp({ context, routes: workflowsRoutes })(
         zeroWorkflowsCollectionContract,
       );
       const response = await accept(
@@ -200,7 +200,7 @@ export function createWorkflowsBddApi(context: TestContext) {
     ): Promise<ZeroWorkflowAutomationSummary> {
       const client = setupApp({
         context,
-        routes: zeroWorkflowAutomationsRoutes,
+        routes: workflowAutomationsRoutes,
       })(zeroWorkflowAutomationsContract);
       const response = await accept(
         client.get({ headers: authHeaders(), params: { id: automationId } }),

--- a/turbo/apps/api/src/signals/routes/__tests__/strapi-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/strapi-integration.test.ts
@@ -21,13 +21,13 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 import { strapiIntegrationsRoutes } from "../strapi-integrations";
 import { strapiEventsRoutes } from "../strapi-events";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...testWorkflowAutomationExecutionRoutes,
   ...strapiEventsRoutes,
   ...strapiIntegrationsRoutes,
-  ...zeroWorkflowAutomationsRoutes,
+  ...workflowAutomationsRoutes,
 ]);
 
 const context = testContext();
@@ -115,7 +115,7 @@ function integrationsClient() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -26,7 +26,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testStripeAutomationEventRoutes } from "../test-stripe-automation-events";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 import { webhooksStripeAutomationEventsRoutes } from "../webhooks-stripe-automation-events";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 
 const context = testContext();
 const connectors = createConnectorBddApi(context);
@@ -66,7 +66,7 @@ function authHeaders() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-invoice-paid-workflow-automation-readiness.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-invoice-paid-workflow-automation-readiness.test.ts
@@ -21,7 +21,7 @@ import {
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testStripeInvoicePaidReadinessRoutes } from "../test-stripe-invoice-paid-readiness";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 
 const context = testContext();
 const connectors = createConnectorBddApi(context);
@@ -62,7 +62,7 @@ function authenticate(scenario: StripeAutomationScenario): void {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -20,12 +20,12 @@ import {
   chatEventDisplayText,
 } from "./helpers/chat-event";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 import { webhooksGithubRoutes } from "../webhooks-github";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...webhooksGithubRoutes,
-  ...zeroWorkflowAutomationsRoutes,
+  ...workflowAutomationsRoutes,
 ]);
 
 const context = testContext();
@@ -42,7 +42,7 @@ function authHeaders() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -37,12 +37,12 @@ import {
 } from "./helpers/chat-event";
 import { seedVm0ManagedModelKey } from "./helpers/runtime-state";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 import { webhooksGmailRoutes } from "../webhooks-gmail";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...webhooksGmailRoutes,
-  ...zeroWorkflowAutomationsRoutes,
+  ...workflowAutomationsRoutes,
 ]);
 
 const context = testContext();
@@ -78,7 +78,7 @@ function authHeaders(actor: ApiTestUser) {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -20,12 +20,12 @@ import {
 } from "./helpers/api-bdd-workflows";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 import { webhooksGoogleCalendarRoutes } from "../webhooks-google-calendar";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...webhooksGoogleCalendarRoutes,
-  ...zeroWorkflowAutomationsRoutes,
+  ...workflowAutomationsRoutes,
 ]);
 
 const context = testContext();
@@ -67,7 +67,7 @@ function authHeaders() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
@@ -21,12 +21,12 @@ import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 import { webhooksGoogleFormsRoutes } from "../webhooks-google-forms";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...webhooksGoogleFormsRoutes,
-  ...zeroWorkflowAutomationsRoutes,
+  ...workflowAutomationsRoutes,
 ]);
 
 const context = testContext();
@@ -58,7 +58,7 @@ function authHeaders() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
@@ -15,7 +15,7 @@ import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { chatEventDisplayText } from "./helpers/chat-event";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { webhooksGoogleWorkspaceEventsRoutes } from "../webhooks-google-workspace-events";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 
 const context = testContext();
 const connectors = createConnectorBddApi(context);
@@ -40,7 +40,7 @@ function authHeaders() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
@@ -26,12 +26,12 @@ import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 import { webhooksNotionRoutes } from "../webhooks-notion";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...testWorkflowAutomationExecutionRoutes,
   ...webhooksNotionRoutes,
-  ...zeroWorkflowAutomationsRoutes,
+  ...workflowAutomationsRoutes,
 ]);
 
 const context = testContext();
@@ -91,7 +91,7 @@ function authHeaders() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-automations.test.ts
@@ -11,12 +11,12 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 import { webhooksWorkflowAutomationsRoutes } from "../webhooks-workflow-automations";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...webhooksWorkflowAutomationsRoutes,
-  ...zeroWorkflowAutomationsRoutes,
+  ...workflowAutomationsRoutes,
 ]);
 
 const context = testContext();
@@ -30,7 +30,7 @@ function authHeaders() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
@@ -32,14 +32,14 @@ import { seedOrgMembership$ } from "./helpers/org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 import { zeroAgentsRoutes } from "../zero-agents";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
-import { zeroWorkflowsRoutes } from "../zero-workflows";
+import { workflowAutomationsRoutes } from "../workflow-automations";
+import { workflowsRoutes } from "../workflows";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...testWorkflowAutomationExecutionRoutes,
   ...zeroAgentsRoutes,
-  ...zeroWorkflowAutomationsRoutes,
-  ...zeroWorkflowsRoutes,
+  ...workflowAutomationsRoutes,
+  ...workflowsRoutes,
 ]);
 
 const context = testContext();
@@ -68,7 +68,7 @@ function authHeaders() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -49,8 +49,8 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { cronRenewGmailWatchesRoutes } from "../cron-renew-gmail-watches";
 import { cronRenewGoogleCalendarWatchesRoutes } from "../cron-renew-google-calendar-watches";
 import { cronRenewGoogleFormsWatchesRoutes } from "../cron-renew-google-forms-watches";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
-import { zeroWorkflowsRoutes } from "../zero-workflows";
+import { workflowAutomationsRoutes } from "../workflow-automations";
+import { workflowsRoutes } from "../workflows";
 import { webhooksGoogleCalendarRoutes } from "../webhooks-google-calendar";
 
 const TEST_APP_ROUTES = Object.freeze([
@@ -58,8 +58,8 @@ const TEST_APP_ROUTES = Object.freeze([
   ...cronRenewGoogleCalendarWatchesRoutes,
   ...cronRenewGoogleFormsWatchesRoutes,
   ...webhooksGoogleCalendarRoutes,
-  ...zeroWorkflowAutomationsRoutes,
-  ...zeroWorkflowsRoutes,
+  ...workflowAutomationsRoutes,
+  ...workflowsRoutes,
 ]);
 
 const context = testContext();
@@ -76,13 +76,13 @@ function authHeaders() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }
 
 function detailClient() {
-  return setupApp({ context, routes: zeroWorkflowsRoutes })(
+  return setupApp({ context, routes: workflowsRoutes })(
     zeroWorkflowsDetailContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -49,7 +49,7 @@ import {
 import { zeroChatEventsRoutes } from "../zero-chat-events";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
 import { zeroModelProvidersRoutes } from "../zero-model-providers";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
+import { workflowAutomationsRoutes } from "../workflow-automations";
 import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 import { webhooksWorkflowAutomationsRoutes } from "../webhooks-workflow-automations";
 
@@ -59,7 +59,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...zeroChatEventsRoutes,
   ...zeroChatThreadRoutes,
   ...zeroModelProvidersRoutes,
-  ...zeroWorkflowAutomationsRoutes,
+  ...workflowAutomationsRoutes,
 ]);
 
 const context = testContext();
@@ -86,7 +86,7 @@ function authHeaders() {
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
@@ -45,8 +45,8 @@ import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
-import { zeroWorkflowAutomationsRoutes } from "../zero-workflow-automations";
-import { zeroWorkflowsRoutes } from "../zero-workflows";
+import { workflowAutomationsRoutes } from "../workflow-automations";
+import { workflowsRoutes } from "../workflows";
 import { testSystemStoragePresignedUrlCacheStateRoutes } from "../test-system-storage-presigned-url-cache-state";
 
 const context = testContext();
@@ -113,13 +113,13 @@ function authHeaders(actor: ApiTestUser): { readonly authorization: string } {
 }
 
 function collectionClient() {
-  return setupApp({ context, routes: zeroWorkflowsRoutes })(
+  return setupApp({ context, routes: workflowsRoutes })(
     zeroWorkflowsCollectionContract,
   );
 }
 
 function detailClient() {
-  return setupApp({ context, routes: zeroWorkflowsRoutes })(
+  return setupApp({ context, routes: workflowsRoutes })(
     zeroWorkflowsDetailContract,
   );
 }
@@ -288,13 +288,13 @@ function mockConnectorReadinessModel(
 }
 
 function visibilityClient() {
-  return setupApp({ context, routes: zeroWorkflowsRoutes })(
+  return setupApp({ context, routes: workflowsRoutes })(
     zeroWorkflowVisibilityContract,
   );
 }
 
 function automationsClient() {
-  return setupApp({ context, routes: zeroWorkflowAutomationsRoutes })(
+  return setupApp({ context, routes: workflowAutomationsRoutes })(
     zeroWorkflowAutomationsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/workflow-automations.ts
+++ b/turbo/apps/api/src/signals/routes/workflow-automations.ts
@@ -412,7 +412,7 @@ const workflowAutomationRouteHandlers: Readonly<
   revealWebhookSecret: authRoute(workflowWriteAuth, revealWebhookSecretInner$),
 };
 
-export const zeroWorkflowAutomationsRoutes: readonly RouteEntry[] = [
+export const workflowAutomationsRoutes: readonly RouteEntry[] = [
   {
     route: zeroWorkflowAutomationsContract.listWorkspace,
     handler: workflowAutomationRouteHandlers.listWorkspace,

--- a/turbo/apps/api/src/signals/routes/workflows.ts
+++ b/turbo/apps/api/src/signals/routes/workflows.ts
@@ -83,7 +83,7 @@ import type { RouteEntry } from "../route-entry";
 import { sendNormalEvent$ } from "../services/zero-chat-events.command";
 import type { Tx } from "../../lib/db-types";
 
-const log = logger("api:zero:workflow-connector-readiness");
+const log = logger("api:workflow-connector-readiness");
 
 const workflowReadAuth = {
   requireOrganization: true,
@@ -1370,7 +1370,7 @@ const demoteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-export const zeroWorkflowsRoutes: readonly RouteEntry[] = [
+export const workflowsRoutes: readonly RouteEntry[] = [
   {
     route: zeroWorkflowsCollectionContract.list,
     handler: authRoute(workflowReadAuth, listWorkflowsInner$),


### PR DESCRIPTION
## Summary

- Rename the two production workflow route shells to `workflow-automations.ts` and `workflows.ts`.
- Rename their route-array exports to `workflowAutomationsRoutes` and `workflowsRoutes`, updating the production registry and the complete test, webhook, and BDD caller surface atomically.
- Neutralize the connector-readiness logger namespace to `api:workflow-connector-readiness`.

## Compatibility

- Preserve route-array contents, ordering, handlers, contracts, HTTP paths, schemas, auth behavior, webhook and schedule behavior, and runtime semantics.
- Preserve public `ZeroWorkflow*` declarations, `zeroWorkflow*Contract` and `zeroWorkflows*Contract`, `zeroPreCreateSource`, run declarations, timing keys, physical database identities, and CLI/Platform/API-contract paths.
- Add no aliases, forwarding files, compatibility re-exports, duplicate route entries, or unrelated cleanup.

## Verification

- Pinned Prettier 3.8.1 on all 22 changed files (unchanged)
- `pnpm -F api lint`
- `pnpm -F api check-types` on the rebased head
- Caller-surface API route tests with one worker and no file parallelism: 17 files, 359 tests passed
- Post-rebase stale-name, target-collision, preserved-identity, and normalized route-module equivalence audits

Closes #27563

Parent: #27432

Compatibility model: #26873
