### PR TITLE
refactor(chat): neutralize chat event and thread route shell naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -76,8 +76,8 @@ import { zeroBillingRestoreRoutes } from "./routes/zero-billing-restore";
 import { zeroBillingStatusRoutes } from "./routes/zero-billing-status";
 import { zeroBillingUsagePackCreditsRoutes } from "./routes/zero-billing-usage-pack-credits";
 import { zeroBankingRoutes } from "./routes/zero-banking";
-import { zeroChatThreadRoutes } from "./routes/zero-chat-threads";
-import { zeroChatEventsRoutes } from "./routes/zero-chat-events";
+import { chatThreadRoutes } from "./routes/chat-threads";
+import { chatEventsRoutes } from "./routes/chat-events";
 import { sharedThreadRoutes } from "./routes/shared-threads";
 import { claudeCodeDeviceAuthRoutes } from "./routes/claude-code-device-auth";
 import { zeroComposesRoutes } from "./routes/zero-composes";
@@ -268,8 +268,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroBillingStatusRoutes,
   ...zeroBillingUsagePackCreditsRoutes,
   ...zeroBankingRoutes,
-  ...zeroChatThreadRoutes,
-  ...zeroChatEventsRoutes,
+  ...chatThreadRoutes,
+  ...chatEventsRoutes,
   ...sharedThreadRoutes,
   ...claudeCodeDeviceAuthRoutes,
   ...zeroComposesRoutes,

--- a/turbo/apps/api/src/signals/routes/__benches__/chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/chat-threads.bench.ts
@@ -55,7 +55,7 @@ import { seedUserModelProvider$ } from "./helpers/model-providers";
 import { seedOrgMembership$ } from "../__tests__/helpers/org-membership";
 import { createZeroRouteMocks } from "../__tests__/helpers/zero-route-test";
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
+import { chatThreadRoutes } from "../chat-threads";
 import { connectorsRoutes } from "../connectors";
 import { zeroMeModelProvidersListRoutes } from "../zero-me-model-providers-list";
 import { zeroMeModelProvidersUpsertRoutes } from "../zero-me-model-providers-upsert";
@@ -100,7 +100,7 @@ const BENCH_CONNECTOR_CATALOG_KEY =
   `connectors/v${String(SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION)}/` +
   `releases/${BENCH_CONNECTOR_CATALOG_VERSION}/catalog.json`;
 
-const chatThreadClient = setupApp({ context, routes: zeroChatThreadRoutes })(
+const chatThreadClient = setupApp({ context, routes: chatThreadRoutes })(
   chatThreadByIdContract,
 );
 const connectorsClient = setupApp({ context, routes: connectorsRoutes })(

--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -39,13 +39,13 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testBrowserReconcileRoutes } from "../test-browser-reconcile";
 import { browserRoutes } from "../browser";
 import { browserAuthorizationRoutes } from "../browser-authorization";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
-import { zeroChatThreadComputerUseHostRoutes } from "../zero-chat-threads-computer-use-host";
+import { chatThreadRoutes } from "../chat-threads";
+import { chatThreadComputerUseHostRoutes } from "../chat-threads-computer-use-host";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...browserAuthorizationRoutes,
   ...browserRoutes,
-  ...zeroChatThreadRoutes,
+  ...chatThreadRoutes,
 ]);
 
 const context = testContext();
@@ -93,13 +93,11 @@ function authorizationClient() {
 }
 
 function chatThreadsClient() {
-  return setupApp({ context, routes: zeroChatThreadRoutes })(
-    chatThreadsContract,
-  );
+  return setupApp({ context, routes: chatThreadRoutes })(chatThreadsContract);
 }
 
 function chatThreadComputerUseHostClient() {
-  return setupApp({ context, routes: zeroChatThreadComputerUseHostRoutes })(
+  return setupApp({ context, routes: chatThreadComputerUseHostRoutes })(
     chatThreadComputerUseHostContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-event-snapshot.test.ts
@@ -17,7 +17,7 @@ import { setupApp, setupRawAppRequest } from "../../../__tests__/test-helpers";
 import { mockNow, now } from "../../../lib/time";
 import { testChatEventSearchProjectionRoutes } from "../test-chat-event-search-projection";
 import { testChatEventSnapshotRoutes } from "../test-chat-event-snapshot";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
+import { chatThreadRoutes } from "../chat-threads";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
@@ -80,7 +80,7 @@ function authenticate(actor: ApiTestUser) {
 }
 
 function eventsClient() {
-  return setupApp({ context, routes: zeroChatThreadRoutes })(
+  return setupApp({ context, routes: chatThreadRoutes })(
     chatThreadEventsContract,
   );
 }
@@ -273,7 +273,7 @@ describe("chat event snapshot read endpoints", () => {
     const { authorization } = authenticate(owner);
     const rawRequest = setupRawAppRequest({
       context,
-      routes: zeroChatThreadRoutes,
+      routes: chatThreadRoutes,
     });
     const missingVersionPaths = [
       `/api/okou/chat-threads/${threadId}/event-snapshot`,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events-auth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events-auth.test.ts
@@ -7,14 +7,12 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
-import { zeroChatEventsRoutes } from "../zero-chat-events";
+import { chatEventsRoutes } from "../chat-events";
 
 const context = testContext();
 
 function client() {
-  return setupApp({ context, routes: zeroChatEventsRoutes })(
-    chatEventsContract,
-  );
+  return setupApp({ context, routes: chatEventsRoutes })(chatEventsContract);
 }
 
 describe("POST /api/zero/chat/events authorization", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -120,15 +120,15 @@ import {
   timeoutRunWithoutCallbacksFixture,
 } from "../../../test-fixtures/chat-events";
 import { cronSteerRunTimeBudgetRoutes } from "../cron-steer-run-time-budget";
-import { zeroChatEventsRoutes } from "../zero-chat-events";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
+import { chatEventsRoutes } from "../chat-events";
+import { chatThreadRoutes } from "../chat-threads";
 import { zeroMailRoutes } from "../zero-mail";
 import { zeroModelProviderGatewayRoutes } from "../zero-model-provider-gateways";
 import { zeroModelProvidersRoutes } from "../zero-model-providers";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...zeroChatEventsRoutes,
-  ...zeroChatThreadRoutes,
+  ...chatEventsRoutes,
+  ...chatThreadRoutes,
   ...zeroMailRoutes,
   ...zeroModelProviderGatewayRoutes,
   ...zeroModelProvidersRoutes,
@@ -954,15 +954,11 @@ function modelProviderConnectionsByIdClient() {
 }
 
 function chatEventsClient() {
-  return setupApp({ context, routes: zeroChatEventsRoutes })(
-    chatEventsContract,
-  );
+  return setupApp({ context, routes: chatEventsRoutes })(chatEventsContract);
 }
 
 function chatThreadsClient() {
-  return setupApp({ context, routes: zeroChatThreadRoutes })(
-    chatThreadsContract,
-  );
+  return setupApp({ context, routes: chatThreadRoutes })(chatThreadsContract);
 }
 
 describe("CHAT-02: thread run admission invariant", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -18,8 +18,8 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { seedOrgMembership$ } from "./helpers/org-membership";
 import { seedRun$ } from "./helpers/usage-state";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
-import { zeroChatThreadGetRoutes } from "../zero-chat-threads-get";
+import { chatThreadRoutes } from "../chat-threads";
+import { chatThreadGetRoutes } from "../chat-threads-get";
 
 const context = testContext();
 const store = createStore();
@@ -110,13 +110,11 @@ function zeroToken(args: {
 }
 
 function threadsClient() {
-  return setupApp({ context, routes: zeroChatThreadRoutes })(
-    chatThreadsContract,
-  );
+  return setupApp({ context, routes: chatThreadRoutes })(chatThreadsContract);
 }
 
 function metadataClient() {
-  return setupApp({ context, routes: zeroChatThreadGetRoutes })(
+  return setupApp({ context, routes: chatThreadGetRoutes })(
     chatThreadMetadataContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-get.test.ts
@@ -11,7 +11,7 @@ import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createBddApi } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { seedOrgMembership$ } from "./helpers/org-membership";
-import { zeroChatThreadGetRoutes } from "../zero-chat-threads-get";
+import { chatThreadGetRoutes } from "../chat-threads-get";
 
 const context = testContext();
 const store = createStore();
@@ -75,7 +75,7 @@ function zeroToken(args: {
 }
 
 function client() {
-  return setupApp({ context, routes: zeroChatThreadGetRoutes })(
+  return setupApp({ context, routes: chatThreadGetRoutes })(
     chatThreadMetadataContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-model-selection.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-model-selection.test.ts
@@ -16,8 +16,8 @@ import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { seedOrgMembership$ } from "./helpers/org-membership";
-import { zeroChatThreadGetRoutes } from "../zero-chat-threads-get";
-import { zeroChatThreadModelSelectionRoutes } from "../zero-chat-threads-model-selection";
+import { chatThreadGetRoutes } from "../chat-threads-get";
+import { chatThreadModelSelectionRoutes } from "../chat-threads-model-selection";
 
 const context = testContext();
 const store = createStore();
@@ -95,13 +95,13 @@ function zeroToken(args: {
 }
 
 function modelSelectionClient() {
-  return setupApp({ context, routes: zeroChatThreadModelSelectionRoutes })(
+  return setupApp({ context, routes: chatThreadModelSelectionRoutes })(
     chatThreadModelSelectionContract,
   );
 }
 
 function metadataClient() {
-  return setupApp({ context, routes: zeroChatThreadGetRoutes })(
+  return setupApp({ context, routes: chatThreadGetRoutes })(
     chatThreadMetadataContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-rename.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-rename.test.ts
@@ -14,8 +14,8 @@ import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createBddApi } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { seedOrgMembership$ } from "./helpers/org-membership";
-import { zeroChatThreadGetRoutes } from "../zero-chat-threads-get";
-import { zeroChatThreadRenameRoutes } from "../zero-chat-threads-rename";
+import { chatThreadGetRoutes } from "../chat-threads-get";
+import { chatThreadRenameRoutes } from "../chat-threads-rename";
 
 const context = testContext();
 const store = createStore();
@@ -79,13 +79,13 @@ function zeroToken(args: {
 }
 
 function renameClient() {
-  return setupApp({ context, routes: zeroChatThreadRenameRoutes })(
+  return setupApp({ context, routes: chatThreadRenameRoutes })(
     chatThreadRenameContract,
   );
 }
 
 function metadataClient() {
-  return setupApp({ context, routes: zeroChatThreadGetRoutes })(
+  return setupApp({ context, routes: chatThreadGetRoutes })(
     chatThreadMetadataContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-video-model.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-video-model.test.ts
@@ -17,9 +17,9 @@ import { createBddApi } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { seedOrgMembership$ } from "./helpers/org-membership";
-import { zeroChatThreadGetRoutes } from "../zero-chat-threads-get";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
-import { zeroChatThreadVideoModelRoutes } from "../zero-chat-threads-video-model";
+import { chatThreadGetRoutes } from "../chat-threads-get";
+import { chatThreadRoutes } from "../chat-threads";
+import { chatThreadVideoModelRoutes } from "../chat-threads-video-model";
 
 const context = testContext();
 const store = createStore();
@@ -84,19 +84,17 @@ function zeroToken(args: {
 }
 
 function videoModelClient() {
-  return setupApp({ context, routes: zeroChatThreadVideoModelRoutes })(
+  return setupApp({ context, routes: chatThreadVideoModelRoutes })(
     chatThreadVideoModelContract,
   );
 }
 
 function threadsClient() {
-  return setupApp({ context, routes: zeroChatThreadRoutes })(
-    chatThreadsContract,
-  );
+  return setupApp({ context, routes: chatThreadRoutes })(chatThreadsContract);
 }
 
 function metadataClient() {
-  return setupApp({ context, routes: zeroChatThreadGetRoutes })(
+  return setupApp({ context, routes: chatThreadGetRoutes })(
     chatThreadMetadataContract,
   );
 }
@@ -113,7 +111,7 @@ function rawVideoModelRequest(
 ) {
   return setupRawAppRequest({
     context,
-    routes: zeroChatThreadVideoModelRoutes,
+    routes: chatThreadVideoModelRoutes,
   })(`/api/okou/chat-threads/${threadId}/video-model`, {
     method: "POST",
     headers: {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -82,13 +82,13 @@ import {
 import { cronCompactChatThreadSnapshotsRoutes } from "../cron-compact-chat-thread-snapshots";
 import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
 import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
+import { chatThreadRoutes } from "../chat-threads";
 import { zeroGoalsRoutes } from "../zero-goals";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...cronCompactChatThreadSnapshotsRoutes,
   ...cronProjectChatEventSearchRoutes,
-  ...zeroChatThreadRoutes,
+  ...chatThreadRoutes,
   ...zeroGoalsRoutes,
 ]);
 
@@ -595,7 +595,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
         },
       ],
     });
-    const zeroClient = setupApp({ context, routes: zeroChatThreadRoutes })(
+    const zeroClient = setupApp({ context, routes: chatThreadRoutes })(
       chatThreadsContract,
     );
     const zeroHeaders = zeroCapabilityHeaders(

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -52,7 +52,7 @@ import {
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 import { cronExecuteMorningBriefsRoutes } from "../cron-execute-morning-briefs";
 import { emailMorningBriefUnsubscribeRoutes } from "../email-morning-brief-unsubscribe";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
+import { chatThreadRoutes } from "../chat-threads";
 import { zeroModelProvidersRoutes } from "../zero-model-providers";
 import { morningBriefRoutes } from "../morning-brief";
 import { userPreferencesRoutes } from "../user-preferences";
@@ -60,7 +60,7 @@ import { userPreferencesRoutes } from "../user-preferences";
 const TEST_APP_ROUTES = Object.freeze([
   ...cronExecuteMorningBriefsRoutes,
   ...emailMorningBriefUnsubscribeRoutes,
-  ...zeroChatThreadRoutes,
+  ...chatThreadRoutes,
   ...zeroModelProvidersRoutes,
   ...morningBriefRoutes,
   ...userPreferencesRoutes,
@@ -495,12 +495,12 @@ async function findMorningBriefThreadIdOrNull(
 ): Promise<string | null> {
   routeMocks.clerk.session(scenario.actor.userId, scenario.actor.orgId);
   const threadEvents = await accept(
-    setupApp({ context, routes: zeroChatThreadRoutes })(
-      chatThreadsContract,
-    ).events({
-      headers: actorHeaders(),
-      query: {},
-    }),
+    setupApp({ context, routes: chatThreadRoutes })(chatThreadsContract).events(
+      {
+        headers: actorHeaders(),
+        query: {},
+      },
+    ),
     [200],
   );
   const thread = threadEvents.body.events.find((event) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -60,7 +60,7 @@ import {
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { agentsRoutes } from "../agents";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
+import { chatThreadRoutes } from "../chat-threads";
 import { customConnectorsRoutes } from "../custom-connectors";
 import { customConnectorsDeleteRoutes } from "../custom-connectors-delete";
 import { customConnectorsGetRoutes } from "../custom-connectors-get";
@@ -2974,7 +2974,7 @@ describe("Feishu integration", () => {
 
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const threadEvents = await accept(
-      setupApp({ context, routes: zeroChatThreadRoutes })(
+      setupApp({ context, routes: chatThreadRoutes })(
         chatThreadsContract,
       ).events({
         headers: { authorization: "Bearer clerk-session" },
@@ -3179,7 +3179,7 @@ describe("Feishu integration", () => {
     const run = await findRun(actor, "do the Feishu task");
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const threadEvents = await accept(
-      setupApp({ context, routes: zeroChatThreadRoutes })(
+      setupApp({ context, routes: chatThreadRoutes })(
         chatThreadsContract,
       ).events({
         headers: { authorization: "Bearer clerk-session" },
@@ -3811,7 +3811,7 @@ describe("Feishu integration", () => {
 
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const threadEvents = await accept(
-      setupApp({ context, routes: zeroChatThreadRoutes })(
+      setupApp({ context, routes: chatThreadRoutes })(
         chatThreadsContract,
       ).events({
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
@@ -23,7 +23,7 @@ import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
+import { chatThreadRoutes } from "../chat-threads";
 import { zeroGoalsRoutes } from "../zero-goals";
 
 const context = testContext();
@@ -790,7 +790,7 @@ describe("zero goals", () => {
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const unreads = await accept(
-      setupApp({ context, routes: zeroChatThreadRoutes })(
+      setupApp({ context, routes: chatThreadRoutes })(
         chatThreadsContract,
       ).unreads({
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -67,19 +67,19 @@ import {
   sanitizeArtifactFilename,
 } from "../../../../lib/file-url";
 import { createAgentComposeFixture } from "../../../../test-fixtures/agent-composes";
-import { zeroChatEventsRoutes } from "../../zero-chat-events";
+import { chatEventsRoutes } from "../../chat-events";
 import { artifactCatalogRoutes } from "../../artifact-catalog";
-import { zeroChatThreadComputerUseHostRoutes } from "../../zero-chat-threads-computer-use-host";
-import { zeroChatThreadCreateRoutes } from "../../zero-chat-threads-create";
-import { zeroChatThreadDeleteRoutes } from "../../zero-chat-threads-delete";
-import { zeroChatThreadMarkReadRoutes } from "../../zero-chat-threads-mark-read";
-import { zeroChatThreadModelSelectionRoutes } from "../../zero-chat-threads-model-selection";
-import { zeroChatThreadPatchRoutes } from "../../zero-chat-threads-patch";
-import { zeroChatThreadPinRoutes } from "../../zero-chat-threads-pin";
-import { zeroChatThreadRenameRoutes } from "../../zero-chat-threads-rename";
-import { zeroChatThreadRoutes } from "../../zero-chat-threads";
-import { zeroChatThreadUnpinRoutes } from "../../zero-chat-threads-unpin";
-import { zeroChatThreadsArtifactsSyncRoutes } from "../../zero-chat-threads-artifacts-sync";
+import { chatThreadComputerUseHostRoutes } from "../../chat-threads-computer-use-host";
+import { chatThreadCreateRoutes } from "../../chat-threads-create";
+import { chatThreadDeleteRoutes } from "../../chat-threads-delete";
+import { chatThreadMarkReadRoutes } from "../../chat-threads-mark-read";
+import { chatThreadModelSelectionRoutes } from "../../chat-threads-model-selection";
+import { chatThreadPatchRoutes } from "../../chat-threads-patch";
+import { chatThreadPinRoutes } from "../../chat-threads-pin";
+import { chatThreadRenameRoutes } from "../../chat-threads-rename";
+import { chatThreadRoutes } from "../../chat-threads";
+import { chatThreadUnpinRoutes } from "../../chat-threads-unpin";
+import { chatThreadsArtifactsSyncRoutes } from "../../chat-threads-artifacts-sync";
 import { hostRoutes } from "../../host";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { uploadsCompleteRoutes } from "../../uploads-complete";
@@ -192,18 +192,18 @@ function mockObjectStorageObjectsExist(context: TestContext): void {
 
 const chatFilesRoutes = [
   ...artifactCatalogRoutes,
-  ...zeroChatThreadRoutes,
-  ...zeroChatThreadCreateRoutes,
-  ...zeroChatThreadDeleteRoutes,
-  ...zeroChatThreadPatchRoutes,
-  ...zeroChatThreadMarkReadRoutes,
-  ...zeroChatThreadPinRoutes,
-  ...zeroChatThreadUnpinRoutes,
-  ...zeroChatThreadRenameRoutes,
-  ...zeroChatThreadModelSelectionRoutes,
-  ...zeroChatThreadComputerUseHostRoutes,
-  ...zeroChatThreadsArtifactsSyncRoutes,
-  ...zeroChatEventsRoutes,
+  ...chatThreadRoutes,
+  ...chatThreadCreateRoutes,
+  ...chatThreadDeleteRoutes,
+  ...chatThreadPatchRoutes,
+  ...chatThreadMarkReadRoutes,
+  ...chatThreadPinRoutes,
+  ...chatThreadUnpinRoutes,
+  ...chatThreadRenameRoutes,
+  ...chatThreadModelSelectionRoutes,
+  ...chatThreadComputerUseHostRoutes,
+  ...chatThreadsArtifactsSyncRoutes,
+  ...chatEventsRoutes,
   ...uploadsPrepareRoutes,
   ...uploadsCompleteRoutes,
   ...hostRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-workflows.ts
@@ -18,7 +18,7 @@ import { createConnectorBddApi } from "./api-bdd-connectors";
 import { createRunsApi } from "./api-bdd-runs";
 import { createZeroRouteMocks } from "./zero-route-test";
 import { readProjectedChatEvents } from "./chat-event-test-reader";
-import { zeroChatThreadGetRoutes } from "../../zero-chat-threads-get";
+import { chatThreadGetRoutes } from "../../chat-threads-get";
 import { workflowAutomationsRoutes } from "../../workflow-automations";
 import { workflowsRoutes } from "../../workflows";
 
@@ -210,7 +210,7 @@ export function createWorkflowsBddApi(context: TestContext) {
     },
 
     async readThreadSelectedModel(threadId: string): Promise<string | null> {
-      const client = setupApp({ context, routes: zeroChatThreadGetRoutes })(
+      const client = setupApp({ context, routes: chatThreadGetRoutes })(
         chatThreadMetadataContract,
       );
       const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/chat-event-test-reader.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/chat-event-test-reader.ts
@@ -13,7 +13,7 @@ import {
 
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { setupApp } from "../../../../__tests__/test-helpers";
-import { zeroChatThreadRoutes } from "../../zero-chat-threads";
+import { chatThreadRoutes } from "../../chat-threads";
 
 const MAX_EVENT_ROWS_PER_PAGE = 50;
 
@@ -41,7 +41,7 @@ export async function readProjectedChatEvents(
     | { readonly sinceSeqId: number; readonly sinceEventId: string }
   ),
 ): Promise<readonly ChatEvent[]> {
-  const client = setupApp({ context, routes: zeroChatThreadRoutes })(
+  const client = setupApp({ context, routes: chatThreadRoutes })(
     chatThreadEventsContract,
   );
   const limit = args.limit ?? MAX_EVENT_ROWS_PER_PAGE;

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -41,7 +41,7 @@ import {
   teamsMessageActivityForTest,
   type TeamsConnectFixture,
 } from "./helpers/zero-teams-connect";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
+import { chatThreadRoutes } from "../chat-threads";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -1034,7 +1034,7 @@ describe("Teams chat callbacks", () => {
     });
     mocks.clerk.session(teams.fixture.userId, teams.fixture.orgId, "org:admin");
     const threadEvents = await accept(
-      setupApp({ context, routes: zeroChatThreadRoutes })(
+      setupApp({ context, routes: chatThreadRoutes })(
         chatThreadsContract,
       ).events({
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -45,7 +45,7 @@ import {
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
+import { chatThreadRoutes } from "../chat-threads";
 import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
 
 const context = testContext();
@@ -1658,7 +1658,7 @@ describe("POST /api/zero/teams/bot", () => {
 
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const threadEvents = await accept(
-      setupApp({ context, routes: zeroChatThreadRoutes })(
+      setupApp({ context, routes: chatThreadRoutes })(
         chatThreadsContract,
       ).events({
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -46,8 +46,8 @@ import {
   setQueuedUserMessageCreatedAtFixture,
   setWorkflowQueueEventCreatedAtFixture,
 } from "../../../test-fixtures/chat-events";
-import { zeroChatEventsRoutes } from "../zero-chat-events";
-import { zeroChatThreadRoutes } from "../zero-chat-threads";
+import { chatEventsRoutes } from "../chat-events";
+import { chatThreadRoutes } from "../chat-threads";
 import { zeroModelProvidersRoutes } from "../zero-model-providers";
 import { workflowAutomationsRoutes } from "../workflow-automations";
 import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
@@ -56,8 +56,8 @@ import { webhooksWorkflowAutomationsRoutes } from "../webhooks-workflow-automati
 const TEST_APP_ROUTES = Object.freeze([
   ...testWorkflowAutomationExecutionRoutes,
   ...webhooksWorkflowAutomationsRoutes,
-  ...zeroChatEventsRoutes,
-  ...zeroChatThreadRoutes,
+  ...chatEventsRoutes,
+  ...chatThreadRoutes,
   ...zeroModelProvidersRoutes,
   ...workflowAutomationsRoutes,
 ]);
@@ -106,9 +106,7 @@ function cleanupSandboxesClient() {
 }
 
 function chatEventsClient() {
-  return setupApp({ context, routes: zeroChatEventsRoutes })(
-    chatEventsContract,
-  );
+  return setupApp({ context, routes: chatEventsRoutes })(chatEventsContract);
 }
 
 function modelProvidersByTypeClient() {

--- a/turbo/apps/api/src/signals/routes/chat-events.ts
+++ b/turbo/apps/api/src/signals/routes/chat-events.ts
@@ -20,7 +20,7 @@ const sendChatEventInner$ = command(
   },
 );
 
-export const zeroChatEventsRoutes: readonly RouteEntry[] = [
+export const chatEventsRoutes: readonly RouteEntry[] = [
   {
     route: chatEventsContract.send,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/chat-threads-artifacts-sync.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-artifacts-sync.ts
@@ -42,7 +42,7 @@ const syncInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return result;
 });
 
-export const zeroChatThreadsArtifactsSyncRoutes: readonly RouteEntry[] = [
+export const chatThreadsArtifactsSyncRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadArtifactsContract.syncGoogleDrive,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/chat-threads-computer-use-host.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-computer-use-host.ts
@@ -149,7 +149,7 @@ const updateComputerUseHostInner$ = command(
   },
 );
 
-export const zeroChatThreadComputerUseHostRoutes: readonly RouteEntry[] = [
+export const chatThreadComputerUseHostRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadComputerUseHostContract.update,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/chat-threads-create.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-create.ts
@@ -164,7 +164,7 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-export const zeroChatThreadCreateRoutes: readonly RouteEntry[] = [
+export const chatThreadCreateRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadsContract.create,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/chat-threads-delete.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-delete.ts
@@ -67,7 +67,7 @@ const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 204 as const, body: undefined };
 });
 
-export const zeroChatThreadDeleteRoutes: readonly RouteEntry[] = [
+export const chatThreadDeleteRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadByIdContract.delete,
     handler: authRoute({}, deleteInner$),

--- a/turbo/apps/api/src/signals/routes/chat-threads-draft-get.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-draft-get.ts
@@ -21,7 +21,7 @@ const getThreadDraftInner$ = computed(async (get) => {
   return { status: 200 as const, body: draft };
 });
 
-export const zeroChatThreadDraftGetRoutes: readonly RouteEntry[] = [
+export const chatThreadDraftGetRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadDraftContract.get,
     handler: authRoute({}, getThreadDraftInner$),

--- a/turbo/apps/api/src/signals/routes/chat-threads-get.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-get.ts
@@ -48,7 +48,7 @@ const getInner$ = command(async ({ get }, signal: AbortSignal) => {
   };
 });
 
-export const zeroChatThreadGetRoutes: readonly RouteEntry[] = [
+export const chatThreadGetRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadMetadataContract.get,
     handler: authRoute({ requiredCapability: "chat-thread:read" }, getInner$),

--- a/turbo/apps/api/src/signals/routes/chat-threads-mark-agent-read.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-mark-agent-read.ts
@@ -84,7 +84,7 @@ const markAgentReadInner$ = command(
   },
 );
 
-export const zeroChatThreadMarkAgentReadRoutes: readonly RouteEntry[] = [
+export const chatThreadMarkAgentReadRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadMarkAgentReadContract.markAgentRead,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-mark-read.ts
@@ -93,7 +93,7 @@ const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-export const zeroChatThreadMarkReadRoutes: readonly RouteEntry[] = [
+export const chatThreadMarkReadRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadMarkReadContract.markRead,
     handler: authRoute({}, markReadInner$),

--- a/turbo/apps/api/src/signals/routes/chat-threads-model-selection.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-model-selection.ts
@@ -137,7 +137,7 @@ const updateModelSelectionInner$ = command(
   },
 );
 
-export const zeroChatThreadModelSelectionRoutes: readonly RouteEntry[] = [
+export const chatThreadModelSelectionRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadModelSelectionContract.update,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/chat-threads-patch.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-patch.ts
@@ -41,7 +41,7 @@ const patchInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 204 as const, body: undefined };
 });
 
-export const zeroChatThreadPatchRoutes: readonly RouteEntry[] = [
+export const chatThreadPatchRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadByIdContract.patch,
     handler: authRoute({}, patchInner$),

--- a/turbo/apps/api/src/signals/routes/chat-threads-pin.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-pin.ts
@@ -56,7 +56,7 @@ const pinInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 204 as const, body: undefined };
 });
 
-export const zeroChatThreadPinRoutes: readonly RouteEntry[] = [
+export const chatThreadPinRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadPinContract.pin,
     handler: authRoute({}, pinInner$),

--- a/turbo/apps/api/src/signals/routes/chat-threads-rename.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-rename.ts
@@ -64,7 +64,7 @@ const renameInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 204 as const, body: undefined };
 });
 
-export const zeroChatThreadRenameRoutes: readonly RouteEntry[] = [
+export const chatThreadRenameRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadRenameContract.rename,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/chat-threads-unpin.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-unpin.ts
@@ -56,7 +56,7 @@ const unpinInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 204 as const, body: undefined };
 });
 
-export const zeroChatThreadUnpinRoutes: readonly RouteEntry[] = [
+export const chatThreadUnpinRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadUnpinContract.unpin,
     handler: authRoute({}, unpinInner$),

--- a/turbo/apps/api/src/signals/routes/chat-threads-video-model.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-video-model.ts
@@ -70,7 +70,7 @@ const updateVideoModelInner$ = command(
   },
 );
 
-export const zeroChatThreadVideoModelRoutes: readonly RouteEntry[] = [
+export const chatThreadVideoModelRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadVideoModelContract.update,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads.ts
@@ -37,20 +37,20 @@ import {
   getChatThreadSnapshot,
 } from "../services/chat-thread-event.service";
 import type { RouteEntry } from "../route-entry";
-import { zeroChatThreadsArtifactsSyncRoutes } from "./zero-chat-threads-artifacts-sync";
-import { zeroChatThreadComputerUseHostRoutes } from "./zero-chat-threads-computer-use-host";
-import { zeroChatThreadCreateRoutes } from "./zero-chat-threads-create";
-import { zeroChatThreadDeleteRoutes } from "./zero-chat-threads-delete";
-import { zeroChatThreadDraftGetRoutes } from "./zero-chat-threads-draft-get";
-import { zeroChatThreadGetRoutes } from "./zero-chat-threads-get";
-import { zeroChatThreadMarkAgentReadRoutes } from "./zero-chat-threads-mark-agent-read";
-import { zeroChatThreadMarkReadRoutes } from "./zero-chat-threads-mark-read";
-import { zeroChatThreadModelSelectionRoutes } from "./zero-chat-threads-model-selection";
-import { zeroChatThreadVideoModelRoutes } from "./zero-chat-threads-video-model";
-import { zeroChatThreadPatchRoutes } from "./zero-chat-threads-patch";
-import { zeroChatThreadPinRoutes } from "./zero-chat-threads-pin";
-import { zeroChatThreadRenameRoutes } from "./zero-chat-threads-rename";
-import { zeroChatThreadUnpinRoutes } from "./zero-chat-threads-unpin";
+import { chatThreadsArtifactsSyncRoutes } from "./chat-threads-artifacts-sync";
+import { chatThreadComputerUseHostRoutes } from "./chat-threads-computer-use-host";
+import { chatThreadCreateRoutes } from "./chat-threads-create";
+import { chatThreadDeleteRoutes } from "./chat-threads-delete";
+import { chatThreadDraftGetRoutes } from "./chat-threads-draft-get";
+import { chatThreadGetRoutes } from "./chat-threads-get";
+import { chatThreadMarkAgentReadRoutes } from "./chat-threads-mark-agent-read";
+import { chatThreadMarkReadRoutes } from "./chat-threads-mark-read";
+import { chatThreadModelSelectionRoutes } from "./chat-threads-model-selection";
+import { chatThreadVideoModelRoutes } from "./chat-threads-video-model";
+import { chatThreadPatchRoutes } from "./chat-threads-patch";
+import { chatThreadPinRoutes } from "./chat-threads-pin";
+import { chatThreadRenameRoutes } from "./chat-threads-rename";
+import { chatThreadUnpinRoutes } from "./chat-threads-unpin";
 
 const chatThreadIdSchema = z.string().uuid();
 
@@ -129,7 +129,7 @@ const listChatThreadLifecycleEventsInner$ = computed(async (get) => {
   };
 });
 
-const listZeroIndicatorsInner$ = computed(async (get) => {
+const listChatIndicatorsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   const indicators = await get(
     chatIndicators({
@@ -315,12 +315,12 @@ const searchChatInner$ = computed(async (get) => {
   };
 });
 
-export const zeroChatThreadRoutes: readonly RouteEntry[] = [
+export const chatThreadRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadsContract.indicators,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
-      listZeroIndicatorsInner$,
+      listChatIndicatorsInner$,
     ),
   },
   {
@@ -386,18 +386,18 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
       searchChatInner$,
     ),
   },
-  ...zeroChatThreadsArtifactsSyncRoutes,
-  ...zeroChatThreadComputerUseHostRoutes,
-  ...zeroChatThreadCreateRoutes,
-  ...zeroChatThreadDeleteRoutes,
-  ...zeroChatThreadDraftGetRoutes,
-  ...zeroChatThreadGetRoutes,
-  ...zeroChatThreadMarkAgentReadRoutes,
-  ...zeroChatThreadMarkReadRoutes,
-  ...zeroChatThreadModelSelectionRoutes,
-  ...zeroChatThreadPatchRoutes,
-  ...zeroChatThreadPinRoutes,
-  ...zeroChatThreadRenameRoutes,
-  ...zeroChatThreadUnpinRoutes,
-  ...zeroChatThreadVideoModelRoutes,
+  ...chatThreadsArtifactsSyncRoutes,
+  ...chatThreadComputerUseHostRoutes,
+  ...chatThreadCreateRoutes,
+  ...chatThreadDeleteRoutes,
+  ...chatThreadDraftGetRoutes,
+  ...chatThreadGetRoutes,
+  ...chatThreadMarkAgentReadRoutes,
+  ...chatThreadMarkReadRoutes,
+  ...chatThreadModelSelectionRoutes,
+  ...chatThreadPatchRoutes,
+  ...chatThreadPinRoutes,
+  ...chatThreadRenameRoutes,
+  ...chatThreadUnpinRoutes,
+  ...chatThreadVideoModelRoutes,
 ];


### PR DESCRIPTION
## Summary

- rename the 16 chat event/thread route shells and route-array exports to domain-neutral names
- rename `listZeroIndicatorsInner$` to `listChatIndicatorsInner$` and update all registry, benchmark, test, and BDD helper callers
- preserve contracts, API paths, route contents/order/handlers, public `ZeroIndicator` identities, and runtime behavior without aliases

## Verification

- pinned Prettier 3.8.1 check
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- focused chat event/thread route tests: 10 files, 172 tests passed
- path/export/handler residual audit: 16 neutral paths present; old paths/names absent
- normalized route-module comparison: 16/16 match after the approved naming map

Closes #27564