### PR TITLE
refactor(media): neutralize generation and upload route shells

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -97,7 +97,7 @@ import { seoRoutes } from "./routes/seo";
 import { zeroGoalsRoutes } from "./routes/zero-goals";
 import { zeroHostRoutes } from "./routes/zero-host";
 import { builtInGenerationRoutes } from "./routes/built-in-generation";
-import { zeroImageIoGenerateRoutes } from "./routes/zero-image-io-generate";
+import { imageIoGenerateRoutes } from "./routes/image-io-generate";
 import { imageShareXRoutes } from "./routes/image-share-x";
 import { logsRoutes } from "./routes/logs";
 import { zeroMailRoutes } from "./routes/zero-mail";
@@ -177,19 +177,19 @@ import { zeroTeamsBotRoutes } from "./routes/zero-teams-bot";
 import { zeroTeamsConnectRoutes } from "./routes/zero-teams-connect";
 import { zeroTeamsOauthRoutes } from "./routes/zero-teams-oauth";
 import { zeroTeamRoutes } from "./routes/zero-team";
-import { zeroUploadsCompleteRoutes } from "./routes/zero-uploads-complete";
-import { zeroUploadsMultipartRoutes } from "./routes/zero-uploads-multipart";
-import { zeroUploadsPrepareRoutes } from "./routes/zero-uploads-prepare";
+import { uploadsCompleteRoutes } from "./routes/uploads-complete";
+import { uploadsMultipartRoutes } from "./routes/uploads-multipart";
+import { uploadsPrepareRoutes } from "./routes/uploads-prepare";
 import { zeroUsageMembersRoutes } from "./routes/zero-usage-members";
 import { usageRecordRoutes } from "./routes/usage-record";
 import { userPreferencesRoutes } from "./routes/user-preferences";
 import { zeroUserPermissionGrantsRoutes } from "./routes/zero-user-permission-grants";
 import { userModelPreferenceRoutes } from "./routes/user-model-preference";
-import { zeroAvatarVideoRoutes } from "./routes/zero-avatar-video";
+import { avatarVideoRoutes } from "./routes/avatar-video";
 import { voiceIoQuotaRoutes } from "./routes/voice-io-quota";
 import { voiceIoSpeechRoutes } from "./routes/voice-io-speech";
 import { voiceIoSttRoutes } from "./routes/voice-io-stt";
-import { zeroVideoIoGenerateRoutes } from "./routes/zero-video-io-generate";
+import { videoIoGenerateRoutes } from "./routes/video-io-generate";
 import { webDownloadRoutes } from "./routes/web-download";
 import { webFileUrlRoutes } from "./routes/web-file-url";
 
@@ -289,10 +289,10 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroGoalsRoutes,
   ...zeroHostRoutes,
   ...builtInGenerationRoutes,
-  ...zeroImageIoGenerateRoutes,
+  ...imageIoGenerateRoutes,
   ...imageShareXRoutes,
-  ...zeroAvatarVideoRoutes,
-  ...zeroVideoIoGenerateRoutes,
+  ...avatarVideoRoutes,
+  ...videoIoGenerateRoutes,
   ...logsRoutes,
   ...zeroMailRoutes,
   ...mapsRoutes,
@@ -378,9 +378,9 @@ export const ROUTES: readonly RouteEntry[] = [
   ...integrationsTelegramUploadCompleteRoutes,
   ...integrationsTelegramUploadInitRoutes,
   ...zeroTeamRoutes,
-  ...zeroUploadsCompleteRoutes,
-  ...zeroUploadsMultipartRoutes,
-  ...zeroUploadsPrepareRoutes,
+  ...uploadsCompleteRoutes,
+  ...uploadsMultipartRoutes,
+  ...uploadsPrepareRoutes,
   ...registryResourceDownloadRoutes,
   ...zeroUsageMembersRoutes,
   ...usageRecordRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/avatar-video.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/avatar-video.test.ts
@@ -23,7 +23,7 @@ import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
 import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generations";
 import { artifactCatalogRoutes } from "../artifact-catalog";
-import { zeroAvatarVideoRoutes } from "../zero-avatar-video";
+import { avatarVideoRoutes } from "../avatar-video";
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
 import { builtInGenerationRoutes } from "../built-in-generation";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
@@ -67,7 +67,7 @@ function createAvatarVideoTestApp(
   return createAppWithRoutes({
     signal: context.signal,
     routes: [
-      ...zeroAvatarVideoRoutes,
+      ...avatarVideoRoutes,
       ...artifactCatalogRoutes,
       ...builtInGenerationRoutes,
       ...webhooksBuiltInGenerationRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -61,11 +61,11 @@ import { zeroBillingRestoreRoutes } from "../../zero-billing-restore";
 import { zeroBillingStatusRoutes } from "../../zero-billing-status";
 import { builtInGenerationRoutes } from "../../built-in-generation";
 import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
-import { zeroImageIoGenerateRoutes } from "../../zero-image-io-generate";
+import { imageIoGenerateRoutes } from "../../image-io-generate";
 import { mapsRoutes } from "../../maps";
 import { zeroUsageMembersRoutes } from "../../zero-usage-members";
 import { usageRecordRoutes } from "../../usage-record";
-import { zeroVideoIoGenerateRoutes } from "../../zero-video-io-generate";
+import { videoIoGenerateRoutes } from "../../video-io-generate";
 import { voiceIoQuotaRoutes } from "../../voice-io-quota";
 import { voiceIoSpeechRoutes } from "../../voice-io-speech";
 import { voiceIoSttRoutes } from "../../voice-io-stt";
@@ -662,7 +662,7 @@ export function createBillingMediaApi(context: TestContext) {
       },
       statuses: readonly ImageIoStatus[],
     ) {
-      const client = setupApp({ context, routes: zeroImageIoGenerateRoutes })(
+      const client = setupApp({ context, routes: imageIoGenerateRoutes })(
         zeroImageIoGenerateContract,
       );
       return await accept(
@@ -692,7 +692,7 @@ export function createBillingMediaApi(context: TestContext) {
       },
       statuses: readonly VideoIoStatus[],
     ) {
-      const client = setupApp({ context, routes: zeroVideoIoGenerateRoutes })(
+      const client = setupApp({ context, routes: videoIoGenerateRoutes })(
         zeroVideoIoGenerateContract,
       );
       return await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -82,8 +82,8 @@ import { zeroChatThreadUnpinRoutes } from "../../zero-chat-threads-unpin";
 import { zeroChatThreadsArtifactsSyncRoutes } from "../../zero-chat-threads-artifacts-sync";
 import { zeroHostRoutes } from "../../zero-host";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
-import { zeroUploadsCompleteRoutes } from "../../zero-uploads-complete";
-import { zeroUploadsPrepareRoutes } from "../../zero-uploads-prepare";
+import { uploadsCompleteRoutes } from "../../uploads-complete";
+import { uploadsPrepareRoutes } from "../../uploads-prepare";
 import { userModelPreferenceRoutes } from "../../user-model-preference";
 import type { ApiTestUser } from "./api-bdd";
 import {
@@ -204,8 +204,8 @@ const chatFilesRoutes = [
   ...zeroChatThreadComputerUseHostRoutes,
   ...zeroChatThreadsArtifactsSyncRoutes,
   ...zeroChatEventsRoutes,
-  ...zeroUploadsPrepareRoutes,
-  ...zeroUploadsCompleteRoutes,
+  ...uploadsPrepareRoutes,
+  ...uploadsCompleteRoutes,
   ...zeroHostRoutes,
   ...zeroModelPoliciesRoutes,
   ...userModelPreferenceRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -19,7 +19,7 @@ import { createDeferredPromise } from "../../utils";
 import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generations";
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
 import { builtInGenerationRoutes } from "../built-in-generation";
-import { zeroImageIoGenerateRoutes } from "../zero-image-io-generate";
+import { imageIoGenerateRoutes } from "../image-io-generate";
 import { usageRecordRoutes } from "../usage-record";
 import {
   createUsagePricingFixture,
@@ -134,7 +134,7 @@ function createImageIoTestApp(
     signal: context.signal,
     routes: [
       ...builtInGenerationRoutes,
-      ...zeroImageIoGenerateRoutes,
+      ...imageIoGenerateRoutes,
       ...webhooksBuiltInGenerationRoutes,
       ...zeroBillingStatusRoutes,
       ...usageRecordRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-multipart.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-multipart.test.ts
@@ -13,14 +13,14 @@ import { zeroUploadsContract } from "@okouai/api-contracts/contracts/zero-upload
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroUploadsCompleteRoutes } from "../zero-uploads-complete";
-import { zeroUploadsMultipartRoutes } from "../zero-uploads-multipart";
-import { zeroUploadsPrepareRoutes } from "../zero-uploads-prepare";
+import { uploadsCompleteRoutes } from "../uploads-complete";
+import { uploadsMultipartRoutes } from "../uploads-multipart";
+import { uploadsPrepareRoutes } from "../uploads-prepare";
 
 const zeroUploadsTestRoutes = Object.freeze([
-  ...zeroUploadsCompleteRoutes,
-  ...zeroUploadsMultipartRoutes,
-  ...zeroUploadsPrepareRoutes,
+  ...uploadsCompleteRoutes,
+  ...uploadsMultipartRoutes,
+  ...uploadsPrepareRoutes,
 ]);
 
 const context = testContext();

--- a/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/uploads-prepare.test.ts
@@ -18,14 +18,14 @@ import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { createBddApi } from "./helpers/api-bdd";
 import { seedOrgMembership$ } from "./helpers/org-membership";
-import { zeroUploadsCompleteRoutes } from "../zero-uploads-complete";
-import { zeroUploadsMultipartRoutes } from "../zero-uploads-multipart";
-import { zeroUploadsPrepareRoutes } from "../zero-uploads-prepare";
+import { uploadsCompleteRoutes } from "../uploads-complete";
+import { uploadsMultipartRoutes } from "../uploads-multipart";
+import { uploadsPrepareRoutes } from "../uploads-prepare";
 
 const zeroUploadsTestRoutes = Object.freeze([
-  ...zeroUploadsCompleteRoutes,
-  ...zeroUploadsMultipartRoutes,
-  ...zeroUploadsPrepareRoutes,
+  ...uploadsCompleteRoutes,
+  ...uploadsMultipartRoutes,
+  ...uploadsPrepareRoutes,
 ]);
 
 const context = testContext();

--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -20,7 +20,7 @@ import { now } from "../../../lib/time";
 import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generations";
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
 import { builtInGenerationRoutes } from "../built-in-generation";
-import { zeroVideoIoGenerateRoutes } from "../zero-video-io-generate";
+import { videoIoGenerateRoutes } from "../video-io-generate";
 import {
   createUsagePricingFixture,
   seedOrgMetadata,
@@ -229,7 +229,7 @@ function createVideoIoTestApp(
     signal: context.signal,
     routes: [
       ...builtInGenerationRoutes,
-      ...zeroVideoIoGenerateRoutes,
+      ...videoIoGenerateRoutes,
       ...webhooksBuiltInGenerationRoutes,
       ...zeroBillingStatusRoutes,
     ],

--- a/turbo/apps/api/src/signals/routes/avatar-video.ts
+++ b/turbo/apps/api/src/signals/routes/avatar-video.ts
@@ -281,7 +281,7 @@ const getVoicesInner$ = command(async ({ get }, signal: AbortSignal) => {
   return { status: 200 as const, body: result };
 });
 
-export const zeroAvatarVideoRoutes: readonly RouteEntry[] = [
+export const avatarVideoRoutes: readonly RouteEntry[] = [
   {
     route: zeroAvatarVideoContract.generate,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -276,7 +276,7 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return acceptedImageResponse(generationId, realtime);
 });
 
-export const zeroImageIoGenerateRoutes: readonly RouteEntry[] = [
+export const imageIoGenerateRoutes: readonly RouteEntry[] = [
   {
     route: zeroImageIoGenerateContract.post,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/uploads-complete.ts
+++ b/turbo/apps/api/src/signals/routes/uploads-complete.ts
@@ -82,7 +82,7 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-export const zeroUploadsCompleteRoutes: readonly RouteEntry[] = [
+export const uploadsCompleteRoutes: readonly RouteEntry[] = [
   {
     route: zeroUploadsContract.complete,
     handler: authRoute({ requiredCapability: "file:write" }, completeInner$),

--- a/turbo/apps/api/src/signals/routes/uploads-multipart.ts
+++ b/turbo/apps/api/src/signals/routes/uploads-multipart.ts
@@ -111,7 +111,7 @@ const abortMultipartInner$ = command(
   },
 );
 
-export const zeroUploadsMultipartRoutes: readonly RouteEntry[] = [
+export const uploadsMultipartRoutes: readonly RouteEntry[] = [
   {
     route: zeroUploadsContract.completeMultipart,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/uploads-prepare.ts
+++ b/turbo/apps/api/src/signals/routes/uploads-prepare.ts
@@ -141,7 +141,7 @@ const prepareUploadInner$ = command(
   },
 );
 
-export const zeroUploadsPrepareRoutes: readonly RouteEntry[] = [
+export const uploadsPrepareRoutes: readonly RouteEntry[] = [
   {
     route: zeroUploadsContract.prepare,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/video-io-generate.ts
@@ -475,7 +475,7 @@ const postVideoInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return acceptedVideoResponse(generationId, realtime);
 });
 
-export const zeroVideoIoGenerateRoutes: readonly RouteEntry[] = [
+export const videoIoGenerateRoutes: readonly RouteEntry[] = [
   {
     route: zeroVideoIoGenerateContract.post,
     handler: authRoute(


### PR DESCRIPTION
## Summary

- rename the six media-generation and upload API route modules to domain-neutral paths
- rename the six route-array exports and update the production registry, focused tests, and BDD helpers
- preserve API contracts and paths, `tokenType: "zero"`, `Zero run` runtime terminology, and all model/provider/billing/storage/upload semantics

## Validation

- `pnpm exec prettier --check <14 changed files>`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- focused Vitest: avatar video, image generation, video generation, upload prepare, and multipart upload (5 files, 75 tests)

Closes #27569
