### PR TITLE
refactor(agents): neutralize agent route shell naming

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -250,7 +250,7 @@ mocking only external services:
 
 ```typescript
 const context = testContext();
-const client = setupApp({ context, routes: zeroAgentsRoutes })(
+const client = setupApp({ context, routes: agentsRoutes })(
   zeroAgentsMainContract,
 );
 

--- a/docs/testing/api-testing.md
+++ b/docs/testing/api-testing.md
@@ -26,7 +26,7 @@ import { zeroAgentsMainContract } from "@okouai/api-contracts/contracts/zero-age
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { zeroAgentsRoutes } from "../zero-agents";
+import { agentsRoutes } from "../agents";
 
 const context = testContext();
 
@@ -35,9 +35,7 @@ function authHeaders() {
 }
 
 function apiClient() {
-  return setupApp({ context, routes: zeroAgentsRoutes })(
-    zeroAgentsMainContract,
-  );
+  return setupApp({ context, routes: agentsRoutes })(zeroAgentsMainContract);
 }
 
 describe("GET /api/okou/agents", () => {

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -58,8 +58,8 @@ import { webhooksWorkflowAutomationsRoutes } from "./routes/webhooks-workflow-au
 import { webhooksStripeRoutes } from "./routes/webhooks-stripe";
 import { webhooksStripeAutomationEventsRoutes } from "./routes/webhooks-stripe-automation-events";
 import { agentDraftRoutes } from "./routes/agent-draft";
-import { zeroAgentInstructionsRoutes } from "./routes/zero-agent-instructions";
-import { zeroAgentsRoutes } from "./routes/zero-agents";
+import { agentInstructionsRoutes } from "./routes/agent-instructions";
+import { agentsRoutes } from "./routes/agents";
 import { artifactCatalogRoutes } from "./routes/artifact-catalog";
 import { acquisitionAttributionRoutes } from "./routes/acquisition-attribution";
 import { zeroBillingAutoRechargeRoutes } from "./routes/zero-billing-auto-recharge";
@@ -250,8 +250,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...morningBriefRoutes,
   ...emailUnsubscribeRoutes,
   ...agentDraftRoutes,
-  ...zeroAgentInstructionsRoutes,
-  ...zeroAgentsRoutes,
+  ...agentInstructionsRoutes,
+  ...agentsRoutes,
   ...artifactCatalogRoutes,
   ...acquisitionAttributionRoutes,
   ...zeroBillingAutoRechargeRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-custom-connectors.test.ts
@@ -16,7 +16,7 @@ import {
   manualHttpCustomConnectorCreateBody,
 } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
-import { zeroAgentsRoutes } from "../zero-agents";
+import { agentsRoutes } from "../agents";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -28,7 +28,7 @@ function currentSecond(): number {
 }
 
 function agentCustomConnectorsClient() {
-  return setupApp({ context, routes: zeroAgentsRoutes })(
+  return setupApp({ context, routes: agentsRoutes })(
     zeroAgentCustomConnectorsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/agents-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-by-id.test.ts
@@ -17,7 +17,7 @@ import {
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
-import { zeroAgentsRoutes } from "../zero-agents";
+import { agentsRoutes } from "../agents";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -29,9 +29,7 @@ function currentSecond(): number {
 }
 
 function agentsClient() {
-  return setupApp({ context, routes: zeroAgentsRoutes })(
-    zeroAgentsByIdContract,
-  );
+  return setupApp({ context, routes: agentsRoutes })(zeroAgentsByIdContract);
 }
 
 function bearerHeaders(token: string): { readonly authorization: string } {
@@ -49,7 +47,7 @@ async function requestAgentThroughNamespace(
 }> {
   const app = createApp({
     signal: context.signal,
-    routes: zeroAgentsRoutes,
+    routes: agentsRoutes,
   });
   const response = await app.request(`/api/${namespace}/agents/${agentId}`, {
     headers,

--- a/turbo/apps/api/src/signals/routes/__tests__/agents-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-create.test.ts
@@ -14,7 +14,7 @@ import {
   type ApiTestUser,
 } from "./helpers/api-bdd-auth-org";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroAgentsRoutes } from "../zero-agents";
+import { agentsRoutes } from "../agents";
 
 const context = testContext();
 const authOrgApi = createAuthOrgAgentsBddApi(context);
@@ -41,15 +41,11 @@ function authHeaders() {
 }
 
 function agentsClient() {
-  return setupApp({ context, routes: zeroAgentsRoutes })(
-    zeroAgentsMainContract,
-  );
+  return setupApp({ context, routes: agentsRoutes })(zeroAgentsMainContract);
 }
 
 function agentsByIdClient() {
-  return setupApp({ context, routes: zeroAgentsRoutes })(
-    zeroAgentsByIdContract,
-  );
+  return setupApp({ context, routes: agentsRoutes })(zeroAgentsByIdContract);
 }
 
 function currentSecond(): number {

--- a/turbo/apps/api/src/signals/routes/__tests__/agents-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-list.test.ts
@@ -5,7 +5,7 @@ import { zeroAgentsMainContract } from "@okouai/api-contracts/contracts/zero-age
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroAgentsRoutes } from "../zero-agents";
+import { agentsRoutes } from "../agents";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -24,9 +24,7 @@ function authHeaders() {
 }
 
 function apiClient() {
-  return setupApp({ context, routes: zeroAgentsRoutes })(
-    zeroAgentsMainContract,
-  );
+  return setupApp({ context, routes: agentsRoutes })(zeroAgentsMainContract);
 }
 
 describe("GET /api/zero/agents", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/agents-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-update.test.ts
@@ -21,8 +21,8 @@ import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { seedOrgMembership$ } from "./helpers/org-membership";
 import { cliAuthRoutes } from "../cli-auth";
-import { zeroAgentInstructionsRoutes } from "../zero-agent-instructions";
-import { zeroAgentsRoutes } from "../zero-agents";
+import { agentInstructionsRoutes } from "../agent-instructions";
+import { agentsRoutes } from "../agents";
 import { workflowsRoutes } from "../workflows";
 
 const context = testContext();
@@ -89,19 +89,15 @@ async function cliAuthHeaders(
 }
 
 function agentsClient() {
-  return setupApp({ context, routes: zeroAgentsRoutes })(
-    zeroAgentsByIdContract,
-  );
+  return setupApp({ context, routes: agentsRoutes })(zeroAgentsByIdContract);
 }
 
 function agentsCollectionClient() {
-  return setupApp({ context, routes: zeroAgentsRoutes })(
-    zeroAgentsMainContract,
-  );
+  return setupApp({ context, routes: agentsRoutes })(zeroAgentsMainContract);
 }
 
 function instructionsClient() {
-  return setupApp({ context, routes: zeroAgentInstructionsRoutes })(
+  return setupApp({ context, routes: agentInstructionsRoutes })(
     zeroAgentInstructionsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/agents.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents.test.ts
@@ -11,7 +11,7 @@ import {
   updateFeatureSwitchesForUser,
 } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroAgentsRoutes } from "../zero-agents";
+import { agentsRoutes } from "../agents";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -25,7 +25,7 @@ describe("GET /api/zero/agents/:id/user-connectors", () => {
     context.mocks.s3.send.mockResolvedValue({});
 
     const created = await accept(
-      setupApp({ context, routes: zeroAgentsRoutes })(
+      setupApp({ context, routes: agentsRoutes })(
         zeroAgentsMainContract,
       ).create({
         headers: { authorization: "Bearer clerk-session" },
@@ -35,7 +35,7 @@ describe("GET /api/zero/agents/:id/user-connectors", () => {
     );
     const agentId = created.body.agentId;
 
-    const client = setupApp({ context, routes: zeroAgentsRoutes })(
+    const client = setupApp({ context, routes: agentsRoutes })(
       zeroUserConnectorsContract,
     );
 
@@ -78,7 +78,7 @@ describe("GET /api/zero/agents/:id/user-connectors", () => {
     const headers = { authorization: "Bearer clerk-session" };
 
     const created = await accept(
-      setupApp({ context, routes: zeroAgentsRoutes })(
+      setupApp({ context, routes: agentsRoutes })(
         zeroAgentsMainContract,
       ).create({
         headers,
@@ -86,7 +86,7 @@ describe("GET /api/zero/agents/:id/user-connectors", () => {
       }),
       [201],
     );
-    const client = setupApp({ context, routes: zeroAgentsRoutes })(
+    const client = setupApp({ context, routes: agentsRoutes })(
       zeroUserConnectorsContract,
     );
     const params = { id: created.body.agentId };

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -59,7 +59,7 @@ import {
 } from "./helpers/connector-credential-storage-state";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroAgentsRoutes } from "../zero-agents";
+import { agentsRoutes } from "../agents";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
 import { customConnectorsRoutes } from "../custom-connectors";
 import { customConnectorsDeleteRoutes } from "../custom-connectors-delete";
@@ -2502,7 +2502,7 @@ describe("Feishu integration", () => {
       ),
       "Expected managed Feishu custom connector",
     );
-    const agentAccessClient = setupApp({ context, routes: zeroAgentsRoutes })(
+    const agentAccessClient = setupApp({ context, routes: agentsRoutes })(
       zeroAgentCustomConnectorsContract,
     );
     const selectedPermissions = ["messages:send-as-user"];
@@ -2797,7 +2797,7 @@ describe("Feishu integration", () => {
       owner: "organization",
     });
     const customConnectorGrants = await accept(
-      setupApp({ context, routes: zeroAgentsRoutes })(
+      setupApp({ context, routes: agentsRoutes })(
         zeroAgentCustomConnectorsContract,
       ).get({
         headers: { authorization: "Bearer clerk-session" },
@@ -2930,7 +2930,7 @@ describe("Feishu integration", () => {
       unknownPolicy: "deny",
     });
     const permissionGrant = await accept(
-      setupApp({ context, routes: zeroAgentsRoutes })(
+      setupApp({ context, routes: agentsRoutes })(
         zeroAgentCustomConnectorsContract,
       ).update({
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
@@ -44,7 +44,7 @@ import { authMeRoutes } from "../../auth-me";
 import { cliAuthRoutes } from "../../cli-auth";
 import { cliAuthTestRoutes } from "../../cli-auth-test";
 import { desktopAuthRoutes } from "../../desktop-auth";
-import { zeroAgentsRoutes } from "../../zero-agents";
+import { agentsRoutes } from "../../agents";
 import { zeroBillingStatusRoutes } from "../../zero-billing-status";
 import { claudeCodeDeviceAuthRoutes } from "../../claude-code-device-auth";
 import { codexDeviceAuthRoutes } from "../../codex-device-auth";
@@ -82,7 +82,7 @@ const authDeviceRoutes: readonly RouteEntry[] = [
   ...cliAuthRoutes,
   ...cliAuthTestRoutes,
   ...desktopAuthRoutes,
-  ...zeroAgentsRoutes,
+  ...agentsRoutes,
   ...zeroBillingStatusRoutes,
   ...claudeCodeDeviceAuthRoutes,
   ...codexDeviceAuthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -84,7 +84,7 @@ import {
 } from "../../../../test-fixtures/agent-composes";
 import { authMeRoutes } from "../../auth-me";
 import { cliAuthRoutes } from "../../cli-auth";
-import { zeroAgentsRoutes } from "../../zero-agents";
+import { agentsRoutes } from "../../agents";
 import { zeroComposesRoutes } from "../../zero-composes";
 import { customConnectorsRoutes } from "../../custom-connectors";
 import { customConnectorsCreateRoutes } from "../../custom-connectors-create";
@@ -218,7 +218,7 @@ const authOrgRoutes = [
   ...zeroOrgMembershipRequestsRoutes,
   ...orgLogoRoutes,
   ...zeroTeamRoutes,
-  ...zeroAgentsRoutes,
+  ...agentsRoutes,
   ...zeroComposesRoutes,
   ...customConnectorsRoutes,
   ...customConnectorsCreateRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -68,7 +68,7 @@ import { createZeroRouteMocks } from "./zero-route-test";
 import { connectorsSlugCallbackRoutes } from "../../connectors-slug-callback";
 import { githubOauthRoutes } from "../../github-oauth";
 import { integrationsGithubRoutes } from "../../integrations-github";
-import { zeroAgentsRoutes } from "../../zero-agents";
+import { agentsRoutes } from "../../agents";
 import { connectorsRoutes } from "../../connectors";
 import { connectorsExternalCodeRoutes } from "../../connectors-external-code";
 import { connectorsOauthDeviceAuthRoutes } from "../../connectors-oauth-device-auth";
@@ -92,7 +92,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...connectorsSlugCallbackRoutes,
   ...githubOauthRoutes,
   ...integrationsGithubRoutes,
-  ...zeroAgentsRoutes,
+  ...agentsRoutes,
   ...connectorsExternalCodeRoutes,
   ...connectorsOauthDeviceAuthRoutes,
   ...connectorsRoutes,
@@ -2185,7 +2185,7 @@ export function createConnectorBddApi(context: TestContext) {
       agentId: string,
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
-      const client = setupApp({ context, routes: zeroAgentsRoutes })(
+      const client = setupApp({ context, routes: agentsRoutes })(
         zeroAgentCustomConnectorsContract,
       );
       return await accept(
@@ -2229,7 +2229,7 @@ export function createConnectorBddApi(context: TestContext) {
       statuses: readonly (200 | 400 | 401 | 403 | 404)[],
       operation?: "replace" | "add" | "remove",
     ) {
-      const client = setupApp({ context, routes: zeroAgentsRoutes })(
+      const client = setupApp({ context, routes: agentsRoutes })(
         zeroAgentCustomConnectorsContract,
       );
       const body =
@@ -2262,7 +2262,7 @@ export function createConnectorBddApi(context: TestContext) {
     ): Promise<Response> {
       const app = createApp({
         signal: context.signal,
-        routes: zeroAgentsRoutes,
+        routes: agentsRoutes,
       });
       return await app.request(
         `/api/zero/agents/${agentId}/custom-connectors`,
@@ -2303,7 +2303,7 @@ export function createConnectorBddApi(context: TestContext) {
       statuses: readonly (200 | 400 | 401 | 403 | 404)[],
       operation?: "replace" | "add" | "remove",
     ) {
-      const client = setupApp({ context, routes: zeroAgentsRoutes })(
+      const client = setupApp({ context, routes: agentsRoutes })(
         zeroAgentCustomConnectorsContract,
       );
       const body =

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -66,7 +66,7 @@ import { cronProcessUsageEventsRoutes } from "../../cron-process-usage-events";
 import { cronTelegramCleanupRoutes } from "../../cron-telegram-cleanup";
 import { runnersRoutes } from "../../runners";
 import { webhooksStripeRoutes } from "../../webhooks-stripe";
-import { zeroAgentsRoutes } from "../../zero-agents";
+import { agentsRoutes } from "../../agents";
 import { zeroBillingStatusRoutes } from "../../zero-billing-status";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
@@ -160,7 +160,7 @@ const runRoutes = [
   ...zeroRunFixtureRoutes,
   ...zeroRunsRoutes,
   ...zeroRunsCancelRoutes,
-  ...zeroAgentsRoutes,
+  ...agentsRoutes,
   ...zeroUserPermissionGrantsRoutes,
 ] as const;
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-user-config.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-user-config.ts
@@ -24,7 +24,7 @@ import {
   signSandboxJwtForTests,
 } from "../../../auth/tokens";
 import { authMeRoutes } from "../../auth-me";
-import { zeroAgentsRoutes } from "../../zero-agents";
+import { agentsRoutes } from "../../agents";
 import { pushSubscriptionsRoutes } from "../../push-subscriptions";
 import { userModelPreferenceRoutes } from "../../user-model-preference";
 import { userPreferencesRoutes } from "../../user-preferences";
@@ -104,7 +104,7 @@ const rawModelPreferenceContract = c.router({
 const userConfigRoutes = [
   ...healthAuthProbeRoutes,
   ...authMeRoutes,
-  ...zeroAgentsRoutes,
+  ...agentsRoutes,
   ...userModelPreferenceRoutes,
   ...pushSubscriptionsRoutes,
   ...userPreferencesRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
@@ -23,8 +23,8 @@ import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { now } from "../../../../lib/time";
 import { signSandboxJwtForTests } from "../../../auth/tokens";
 import { authMeRoutes } from "../../auth-me";
-import { zeroAgentsRoutes } from "../../zero-agents";
-import { zeroAgentInstructionsRoutes } from "../../zero-agent-instructions";
+import { agentsRoutes } from "../../agents";
+import { agentInstructionsRoutes } from "../../agent-instructions";
 import { onboardingCompleteRoutes } from "../../onboarding-complete";
 import { onboardingStatusRoutes } from "../../onboarding-status";
 import { zeroOrgReadRoutes } from "../../zero-org-read";
@@ -150,21 +150,21 @@ export function createBddApi(context: TestContext) {
   function agentsClient() {
     return setupAppWithRoutes({
       context,
-      routes: zeroAgentsRoutes,
+      routes: agentsRoutes,
     })(zeroAgentsMainContract);
   }
 
   function agentsByIdClient() {
     return setupAppWithRoutes({
       context,
-      routes: zeroAgentsRoutes,
+      routes: agentsRoutes,
     })(zeroAgentsByIdContract);
   }
 
   function agentInstructionsClient() {
     return setupAppWithRoutes({
       context,
-      routes: zeroAgentInstructionsRoutes,
+      routes: agentInstructionsRoutes,
     })(zeroAgentInstructionsContract);
   }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -40,7 +40,7 @@ import {
 } from "./helpers/model-stats-state";
 import { commitMemoryVersion } from "./helpers/memory";
 import { createFixtureTracker } from "./helpers/zero-route-test";
-import { zeroAgentInstructionsRoutes } from "../zero-agent-instructions";
+import { agentInstructionsRoutes } from "../agent-instructions";
 
 /* BILL-02 model stats and OPS-01 user export. */
 
@@ -1320,7 +1320,7 @@ describe("OPS-01: user data export", () => {
       visibility: "private",
     });
     await accept(
-      setupApp({ context, routes: zeroAgentInstructionsRoutes })(
+      setupApp({ context, routes: agentInstructionsRoutes })(
         zeroAgentInstructionsContract,
       ).update({
         params: { id: agent.agentId },

--- a/turbo/apps/api/src/signals/routes/__tests__/org-delete-billing.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-delete-billing.test.ts
@@ -18,7 +18,7 @@ import {
   type StripeInvoiceLine,
   type StripeSubscription,
 } from "../../external/stripe-client";
-import { zeroAgentsRoutes } from "../zero-agents";
+import { agentsRoutes } from "../agents";
 import { zeroOrgDeleteRoutes } from "../zero-org-delete";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
@@ -623,7 +623,7 @@ test("does not delete the org when its proportional refund fails", async () => {
     iat: deletionTimestamp,
     exp: deletionTimestamp + 60,
   });
-  const agents = setupApp({ context, routes: zeroAgentsRoutes })(
+  const agents = setupApp({ context, routes: agentsRoutes })(
     zeroAgentsMainContract,
   );
   const misc = createMiscRoutesApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
@@ -31,13 +31,13 @@ import {
 import { seedOrgMembership$ } from "./helpers/org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
-import { zeroAgentsRoutes } from "../zero-agents";
+import { agentsRoutes } from "../agents";
 import { workflowAutomationsRoutes } from "../workflow-automations";
 import { workflowsRoutes } from "../workflows";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...testWorkflowAutomationExecutionRoutes,
-  ...zeroAgentsRoutes,
+  ...agentsRoutes,
   ...workflowAutomationsRoutes,
   ...workflowsRoutes,
 ]);
@@ -365,7 +365,7 @@ describe("okou workflow automation scheduler", () => {
     mockGmailConnectorOAuth({ email: "automation-user@example.com" });
     await wf.connectConnector(scenario.actor, "gmail");
     await accept(
-      setupApp({ context, routes: zeroAgentsRoutes })(
+      setupApp({ context, routes: agentsRoutes })(
         zeroUserConnectorsContract,
       ).update({
         headers: authHeaders(),
@@ -541,9 +541,7 @@ describe("okou workflow automation scheduler", () => {
     mocks.clerk.session(member.userId, scenario.orgId, "org:member");
     const apiKey = await runsApi.createCliToken(member);
     await accept(
-      setupApp({ context, routes: zeroAgentsRoutes })(
-        zeroAgentsMainContract,
-      ).list({
+      setupApp({ context, routes: agentsRoutes })(zeroAgentsMainContract).list({
         headers: { authorization: `Bearer ${apiKey.token}` },
       }),
       [200],
@@ -566,7 +564,7 @@ describe("okou workflow automation scheduler", () => {
     // The agent owner flips the agent private, hiding it from the member.
     mocks.clerk.session(scenario.userId, scenario.orgId);
     await accept(
-      setupApp({ context, routes: zeroAgentsRoutes })(
+      setupApp({ context, routes: agentsRoutes })(
         zeroAgentsByIdContract,
       ).updateMetadata({
         headers: authHeaders(),
@@ -581,7 +579,7 @@ describe("okou workflow automation scheduler", () => {
     // Restore visibility so the member's product reads work again; the skip
     // already happened during the tick above.
     await accept(
-      setupApp({ context, routes: zeroAgentsRoutes })(
+      setupApp({ context, routes: agentsRoutes })(
         zeroAgentsByIdContract,
       ).updateMetadata({
         headers: authHeaders(),

--- a/turbo/apps/api/src/signals/routes/agent-instructions.ts
+++ b/turbo/apps/api/src/signals/routes/agent-instructions.ts
@@ -147,7 +147,7 @@ const updateAgentInstructionsInner$ = command(
   },
 );
 
-export const zeroAgentInstructionsRoutes: readonly RouteEntry[] = [
+export const agentInstructionsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentInstructionsContract.get,
     handler: authRoute(agentReadAuth, getAgentInstructionsInner$),

--- a/turbo/apps/api/src/signals/routes/agents.ts
+++ b/turbo/apps/api/src/signals/routes/agents.ts
@@ -924,7 +924,7 @@ const agentDeleteAuth = {
   requiredCapability: "agent:delete",
 } as const;
 
-export const zeroAgentsRoutes: readonly RouteEntry[] = [
+export const agentsRoutes: readonly RouteEntry[] = [
   {
     route: zeroAgentsMainContract.create,
     handler: authRoute(agentWriteAuth, createAgentInner$),


### PR DESCRIPTION
## Summary

- rename the agent instructions and agents API route shells to neutral module paths and route-array exports
- update the production registry, every test/BDD caller, and the matching testing documentation examples
- preserve route contents and ordering together with all contract, database, compose/runtime, API, CLI, Platform, service, and error-message identities

## Acceptance criteria

- the two old route paths and exports are removed without aliases, forwarding modules, compatibility re-exports, or duplicate route entries
- the neutral route shells and exports are used by the production registry and all repository callers
- both route modules are byte-for-byte unchanged from `main` after accounting for the two intended export renames

## Verification

- `pnpm exec prettier --check <all touched files>`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api check-types:boundaries`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agents-create.test.ts src/signals/routes/__tests__/agents-list.test.ts src/signals/routes/__tests__/agents-by-id.test.ts src/signals/routes/__tests__/agents-update.test.ts src/signals/routes/__tests__/agents.test.ts src/signals/routes/__tests__/agent-custom-connectors.test.ts --silent=passed-only` (6 files, 88 tests)

Closes #27567
