### PR TITLE
refactor(browser): neutralize browser computer-use and host route shell naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -81,8 +81,8 @@ import { zeroChatEventsRoutes } from "./routes/zero-chat-events";
 import { sharedThreadRoutes } from "./routes/shared-threads";
 import { claudeCodeDeviceAuthRoutes } from "./routes/claude-code-device-auth";
 import { zeroComposesRoutes } from "./routes/zero-composes";
-import { zeroComputerUseAuthorizationRoutes } from "./routes/zero-computer-use-authorization";
-import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
+import { computerUseAuthorizationRoutes } from "./routes/computer-use-authorization";
+import { computerUseRoutes } from "./routes/computer-use";
 import { codexDeviceAuthRoutes } from "./routes/codex-device-auth";
 import { connectorCatalogRoutes } from "./routes/connector-catalog";
 import { connectorCheckRoutes } from "./routes/connector-check";
@@ -95,7 +95,7 @@ import { zeroFeatureSwitchesRoutes } from "./routes/zero-feature-switches";
 import { financeRoutes } from "./routes/finance";
 import { seoRoutes } from "./routes/seo";
 import { zeroGoalsRoutes } from "./routes/zero-goals";
-import { zeroHostRoutes } from "./routes/zero-host";
+import { hostRoutes } from "./routes/host";
 import { builtInGenerationRoutes } from "./routes/built-in-generation";
 import { imageIoGenerateRoutes } from "./routes/image-io-generate";
 import { imageShareXRoutes } from "./routes/image-share-x";
@@ -131,8 +131,8 @@ import { zeroMeModelProvidersUpsertRoutes } from "./routes/zero-me-model-provide
 import { scrapeRoutes } from "./routes/scrape";
 import { peopleSearchRoutes } from "./routes/people-search";
 import { webSearchRoutes } from "./routes/web-search";
-import { zeroBrowserRoutes } from "./routes/zero-browser";
-import { zeroBrowserAuthorizationRoutes } from "./routes/zero-browser-authorization";
+import { browserRoutes } from "./routes/browser";
+import { browserAuthorizationRoutes } from "./routes/browser-authorization";
 import { workflowsRoutes } from "./routes/workflows";
 import { workflowAutomationsRoutes } from "./routes/workflow-automations";
 import { strapiIntegrationsRoutes } from "./routes/strapi-integrations";
@@ -273,8 +273,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...sharedThreadRoutes,
   ...claudeCodeDeviceAuthRoutes,
   ...zeroComposesRoutes,
-  ...zeroComputerUseAuthorizationRoutes,
-  ...zeroComputerUseRoutes,
+  ...computerUseAuthorizationRoutes,
+  ...computerUseRoutes,
   ...codexDeviceAuthRoutes,
   ...connectorCatalogRoutes,
   ...connectorCheckRoutes,
@@ -287,7 +287,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...financeRoutes,
   ...seoRoutes,
   ...zeroGoalsRoutes,
-  ...zeroHostRoutes,
+  ...hostRoutes,
   ...builtInGenerationRoutes,
   ...imageIoGenerateRoutes,
   ...imageShareXRoutes,
@@ -301,8 +301,8 @@ export const ROUTES: readonly RouteEntry[] = [
   ...scrapeRoutes,
   ...peopleSearchRoutes,
   ...webSearchRoutes,
-  ...zeroBrowserRoutes,
-  ...zeroBrowserAuthorizationRoutes,
+  ...browserRoutes,
+  ...browserAuthorizationRoutes,
   ...zeroModelPoliciesRoutes,
   ...zeroModelProviderGatewayRoutes,
   ...zeroModelProvidersRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -37,14 +37,14 @@ import {
 } from "./helpers/runtime-state";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testBrowserReconcileRoutes } from "../test-browser-reconcile";
-import { zeroBrowserRoutes } from "../zero-browser";
-import { zeroBrowserAuthorizationRoutes } from "../zero-browser-authorization";
+import { browserRoutes } from "../browser";
+import { browserAuthorizationRoutes } from "../browser-authorization";
 import { zeroChatThreadRoutes } from "../zero-chat-threads";
 import { zeroChatThreadComputerUseHostRoutes } from "../zero-chat-threads-computer-use-host";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...zeroBrowserAuthorizationRoutes,
-  ...zeroBrowserRoutes,
+  ...browserAuthorizationRoutes,
+  ...browserRoutes,
   ...zeroChatThreadRoutes,
 ]);
 
@@ -83,11 +83,11 @@ function isoAt(offsetMs: number): string {
 }
 
 function client() {
-  return setupApp({ context, routes: zeroBrowserRoutes })(zeroBrowserContract);
+  return setupApp({ context, routes: browserRoutes })(zeroBrowserContract);
 }
 
 function authorizationClient() {
-  return setupApp({ context, routes: zeroBrowserAuthorizationRoutes })(
+  return setupApp({ context, routes: browserAuthorizationRoutes })(
     zeroBrowserAuthorizationRequestsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -80,7 +80,7 @@ import { zeroChatThreadRenameRoutes } from "../../zero-chat-threads-rename";
 import { zeroChatThreadRoutes } from "../../zero-chat-threads";
 import { zeroChatThreadUnpinRoutes } from "../../zero-chat-threads-unpin";
 import { zeroChatThreadsArtifactsSyncRoutes } from "../../zero-chat-threads-artifacts-sync";
-import { zeroHostRoutes } from "../../zero-host";
+import { hostRoutes } from "../../host";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { uploadsCompleteRoutes } from "../../uploads-complete";
 import { uploadsPrepareRoutes } from "../../uploads-prepare";
@@ -206,7 +206,7 @@ const chatFilesRoutes = [
   ...zeroChatEventsRoutes,
   ...uploadsPrepareRoutes,
   ...uploadsCompleteRoutes,
-  ...zeroHostRoutes,
+  ...hostRoutes,
   ...zeroModelPoliciesRoutes,
   ...userModelPreferenceRoutes,
 ] as const;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -36,8 +36,8 @@ import { signSandboxJwtForTests } from "../../../auth/tokens";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 import { cronComputerUseScreenshotCleanupRoutesForTest } from "../../cron-computer-use-screenshot-cleanup";
-import { zeroComputerUseRoutes } from "../../zero-computer-use";
-import { zeroComputerUseAuthorizationRoutes } from "../../zero-computer-use-authorization";
+import { computerUseRoutes } from "../../computer-use";
+import { computerUseAuthorizationRoutes } from "../../computer-use-authorization";
 
 interface AuthHeaders {
   readonly authorization?: string;
@@ -358,49 +358,49 @@ export function createComputerUseBddApi(context: TestContext) {
   }
 
   function hostsClient() {
-    return setupApp({ context, routes: zeroComputerUseRoutes })(
+    return setupApp({ context, routes: computerUseRoutes })(
       zeroComputerUseHostsContract,
     );
   }
 
   function heartbeatClient() {
-    return setupApp({ context, routes: zeroComputerUseRoutes })(
+    return setupApp({ context, routes: computerUseRoutes })(
       zeroComputerUseHeartbeatContract,
     );
   }
 
   function commandClient() {
-    return setupApp({ context, routes: zeroComputerUseRoutes })(
+    return setupApp({ context, routes: computerUseRoutes })(
       zeroComputerUseCommandContract,
     );
   }
 
   function writeCommandClient() {
-    return setupApp({ context, routes: zeroComputerUseRoutes })(
+    return setupApp({ context, routes: computerUseRoutes })(
       zeroComputerUseWriteCommandContract,
     );
   }
 
   function pluginCommandClient() {
-    return setupApp({ context, routes: zeroComputerUseRoutes })(
+    return setupApp({ context, routes: computerUseRoutes })(
       zeroComputerUsePluginCommandContract,
     );
   }
 
   function hostCommandsClient() {
-    return setupApp({ context, routes: zeroComputerUseRoutes })(
+    return setupApp({ context, routes: computerUseRoutes })(
       zeroComputerUseHostCommandsContract,
     );
   }
 
   function auditEventsClient() {
-    return setupApp({ context, routes: zeroComputerUseRoutes })(
+    return setupApp({ context, routes: computerUseRoutes })(
       zeroComputerUseAuditEventsContract,
     );
   }
 
   function authorizationRequestsClient() {
-    return setupApp({ context, routes: zeroComputerUseAuthorizationRoutes })(
+    return setupApp({ context, routes: computerUseAuthorizationRoutes })(
       zeroComputerUseAuthorizationRequestsContract,
     );
   }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-host-maps.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-host-maps.ts
@@ -11,7 +11,7 @@ import { mapsContract } from "@okouai/api-contracts/contracts/maps";
 import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import type { RouteEntry } from "../../../route-entry";
-import { zeroHostRoutes } from "../../zero-host";
+import { hostRoutes } from "../../host";
 import { mapsRoutes } from "../../maps";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
@@ -105,10 +105,7 @@ function notFoundS3Error(key: string): Error {
   return error;
 }
 
-const hostMapsRoutes: readonly RouteEntry[] = [
-  ...zeroHostRoutes,
-  ...mapsRoutes,
-];
+const hostMapsRoutes: readonly RouteEntry[] = [...hostRoutes, ...mapsRoutes];
 
 export function createHostMapsBddApi(context: TestContext) {
   function hostClient() {

--- a/turbo/apps/api/src/signals/routes/browser-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/browser-authorization.ts
@@ -1,14 +1,14 @@
 import { command } from "ccstate";
-import { zeroComputerUseAuthorizationRequestsContract } from "@okouai/api-contracts/contracts/zero-computer-use";
+import { zeroBrowserAuthorizationRequestsContract } from "@okouai/api-contracts/contracts/zero-browser";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import {
-  applyComputerUseAuthorizationRequest$,
-  createComputerUseAuthorizationRequest$,
-  readComputerUseAuthorizationRequest$,
-} from "../services/computer-use-authorization.service";
+  applyBrowserAuthorizationRequest$,
+  createBrowserAuthorizationRequest$,
+  readBrowserAuthorizationRequest$,
+} from "../services/browser-authorization.service";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import type { RouteEntry } from "../route-entry";
 
@@ -17,7 +17,7 @@ function expired() {
     status: 410 as const,
     body: {
       error: {
-        message: "Computer Use authorization request expired",
+        message: "Cloud browser authorization request expired",
         code: "GONE",
       },
     },
@@ -25,29 +25,25 @@ function expired() {
 }
 
 const unsupportedContext = conflict(
-  "Computer Use authorization links are only available from web chat and Slack thread runs",
+  "Cloud browser authorization links are only available from chat thread runs",
 );
 
 const createBody$ = bodyResultOf(
-  zeroComputerUseAuthorizationRequestsContract.create,
+  zeroBrowserAuthorizationRequestsContract.create,
 );
-const getParams$ = pathParamsOf(
-  zeroComputerUseAuthorizationRequestsContract.get,
-);
+const getParams$ = pathParamsOf(zeroBrowserAuthorizationRequestsContract.get);
 const applyParams$ = pathParamsOf(
-  zeroComputerUseAuthorizationRequestsContract.apply,
+  zeroBrowserAuthorizationRequestsContract.apply,
 );
-const applyBody$ = bodyResultOf(
-  zeroComputerUseAuthorizationRequestsContract.apply,
-);
+const applyBody$ = bodyResultOf(zeroBrowserAuthorizationRequestsContract.apply);
 
-const computerUseAuthorizationAuthOptions = {
+const browserAuthorizationAuthOptions = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
 } as const;
 
-const computerUseAuthorizationCreateAuthOptions = {
-  ...computerUseAuthorizationAuthOptions,
+const browserAuthorizationCreateAuthOptions = {
+  ...browserAuthorizationAuthOptions,
   acceptAnySandboxCapability: true,
   accept: ["zero", "sandbox"],
 } as const;
@@ -60,32 +56,28 @@ const createAuthorizationRequestInner$ = command(
     if (!body.ok) {
       return body.response;
     }
-
     if (auth.tokenType !== "zero" && auth.tokenType !== "sandbox") {
       return badRequestMessage(
-        "Computer Use authorization requires a run token",
+        "Cloud browser authorization requires a run token",
       );
     }
 
     const result = await set(
-      createComputerUseAuthorizationRequest$,
+      createBrowserAuthorizationRequest$,
       { orgId: auth.orgId, userId: auth.userId, runId: auth.runId },
       signal,
     );
     signal.throwIfAborted();
-
     if (result.status === "run_not_found") {
       return notFound("Run not found");
     }
     if (result.status === "unsupported_context") {
       return unsupportedContext;
     }
-
     return {
       status: 200 as const,
       body: {
         authorizationUrl: result.authorizationUrl,
-        source: result.source,
         expiresAt: result.expiresAt,
       },
     };
@@ -95,34 +87,28 @@ const createAuthorizationRequestInner$ = command(
 const getAuthorizationRequestInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const params = get(getParams$);
-
     const result = await set(
-      readComputerUseAuthorizationRequest$,
+      readBrowserAuthorizationRequest$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        requestToken: params.requestToken,
+        requestToken: get(getParams$).requestToken,
       },
       signal,
     );
     signal.throwIfAborted();
-
     if (result.status === "not_found") {
-      return notFound("Computer Use authorization request not found");
+      return notFound("Cloud browser authorization request not found");
     }
     if (result.status === "expired") {
       return expired();
     }
-
     return {
       status: 200 as const,
       body: {
-        source: result.source,
         expiresAt: result.expiresAt,
         completedAt: result.completedAt,
-        computerUseHostId: result.computerUseHostId,
-        hosts: result.hosts,
+        cloudBrowserEnabled: result.cloudBrowserEnabled,
       },
     };
   },
@@ -131,68 +117,56 @@ const getAuthorizationRequestInner$ = command(
 const applyAuthorizationRequestInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const params = get(applyParams$);
     const body = await get(applyBody$);
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
     }
-
     const result = await set(
-      applyComputerUseAuthorizationRequest$,
+      applyBrowserAuthorizationRequest$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        requestToken: params.requestToken,
-        computerUseHostId: body.data.computerUseHostId,
+        requestToken: get(applyParams$).requestToken,
       },
       signal,
     );
     signal.throwIfAborted();
-
     if (result.status === "not_found") {
-      return notFound("Computer Use authorization request not found");
+      return notFound("Cloud browser authorization request not found");
     }
     if (result.status === "expired") {
       return expired();
     }
-    if (result.status === "host_not_found") {
-      return notFound("Computer-use host not found");
-    }
     if (result.status === "scope_not_found") {
-      return notFound("Computer Use authorization scope not found");
+      return notFound("Cloud browser authorization scope not found");
     }
-
     return {
       status: 200 as const,
-      body: {
-        ok: true as const,
-        source: result.source,
-        computerUseHostId: result.computerUseHostId,
-      },
+      body: { ok: true as const, cloudBrowserEnabled: true as const },
     };
   },
 );
 
-export const zeroComputerUseAuthorizationRoutes: readonly RouteEntry[] = [
+export const browserAuthorizationRoutes: readonly RouteEntry[] = [
   {
-    route: zeroComputerUseAuthorizationRequestsContract.create,
+    route: zeroBrowserAuthorizationRequestsContract.create,
     handler: authRoute(
-      computerUseAuthorizationCreateAuthOptions,
+      browserAuthorizationCreateAuthOptions,
       createAuthorizationRequestInner$,
     ),
   },
   {
-    route: zeroComputerUseAuthorizationRequestsContract.get,
+    route: zeroBrowserAuthorizationRequestsContract.get,
     handler: authRoute(
-      computerUseAuthorizationAuthOptions,
+      browserAuthorizationAuthOptions,
       getAuthorizationRequestInner$,
     ),
   },
   {
-    route: zeroComputerUseAuthorizationRequestsContract.apply,
+    route: zeroBrowserAuthorizationRequestsContract.apply,
     handler: authRoute(
-      computerUseAuthorizationAuthOptions,
+      browserAuthorizationAuthOptions,
       applyAuthorizationRequestInner$,
     ),
   },

--- a/turbo/apps/api/src/signals/routes/browser.ts
+++ b/turbo/apps/api/src/signals/routes/browser.ts
@@ -274,7 +274,7 @@ const browserCurrentAuth = Object.freeze({
   accept: Object.freeze(["zero"] as const),
 });
 
-export const zeroBrowserRoutes: readonly RouteEntry[] = [
+export const browserRoutes: readonly RouteEntry[] = [
   {
     route: zeroBrowserContract.create,
     handler: authRoute(browserWriteAuth, createBrowserInner$),

--- a/turbo/apps/api/src/signals/routes/computer-use-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/computer-use-authorization.ts
@@ -1,14 +1,14 @@
 import { command } from "ccstate";
-import { zeroBrowserAuthorizationRequestsContract } from "@okouai/api-contracts/contracts/zero-browser";
+import { zeroComputerUseAuthorizationRequestsContract } from "@okouai/api-contracts/contracts/zero-computer-use";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import {
-  applyBrowserAuthorizationRequest$,
-  createBrowserAuthorizationRequest$,
-  readBrowserAuthorizationRequest$,
-} from "../services/browser-authorization.service";
+  applyComputerUseAuthorizationRequest$,
+  createComputerUseAuthorizationRequest$,
+  readComputerUseAuthorizationRequest$,
+} from "../services/computer-use-authorization.service";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import type { RouteEntry } from "../route-entry";
 
@@ -17,7 +17,7 @@ function expired() {
     status: 410 as const,
     body: {
       error: {
-        message: "Cloud browser authorization request expired",
+        message: "Computer Use authorization request expired",
         code: "GONE",
       },
     },
@@ -25,25 +25,29 @@ function expired() {
 }
 
 const unsupportedContext = conflict(
-  "Cloud browser authorization links are only available from chat thread runs",
+  "Computer Use authorization links are only available from web chat and Slack thread runs",
 );
 
 const createBody$ = bodyResultOf(
-  zeroBrowserAuthorizationRequestsContract.create,
+  zeroComputerUseAuthorizationRequestsContract.create,
 );
-const getParams$ = pathParamsOf(zeroBrowserAuthorizationRequestsContract.get);
+const getParams$ = pathParamsOf(
+  zeroComputerUseAuthorizationRequestsContract.get,
+);
 const applyParams$ = pathParamsOf(
-  zeroBrowserAuthorizationRequestsContract.apply,
+  zeroComputerUseAuthorizationRequestsContract.apply,
 );
-const applyBody$ = bodyResultOf(zeroBrowserAuthorizationRequestsContract.apply);
+const applyBody$ = bodyResultOf(
+  zeroComputerUseAuthorizationRequestsContract.apply,
+);
 
-const browserAuthorizationAuthOptions = {
+const computerUseAuthorizationAuthOptions = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
 } as const;
 
-const browserAuthorizationCreateAuthOptions = {
-  ...browserAuthorizationAuthOptions,
+const computerUseAuthorizationCreateAuthOptions = {
+  ...computerUseAuthorizationAuthOptions,
   acceptAnySandboxCapability: true,
   accept: ["zero", "sandbox"],
 } as const;
@@ -56,28 +60,32 @@ const createAuthorizationRequestInner$ = command(
     if (!body.ok) {
       return body.response;
     }
+
     if (auth.tokenType !== "zero" && auth.tokenType !== "sandbox") {
       return badRequestMessage(
-        "Cloud browser authorization requires a run token",
+        "Computer Use authorization requires a run token",
       );
     }
 
     const result = await set(
-      createBrowserAuthorizationRequest$,
+      createComputerUseAuthorizationRequest$,
       { orgId: auth.orgId, userId: auth.userId, runId: auth.runId },
       signal,
     );
     signal.throwIfAborted();
+
     if (result.status === "run_not_found") {
       return notFound("Run not found");
     }
     if (result.status === "unsupported_context") {
       return unsupportedContext;
     }
+
     return {
       status: 200 as const,
       body: {
         authorizationUrl: result.authorizationUrl,
+        source: result.source,
         expiresAt: result.expiresAt,
       },
     };
@@ -87,28 +95,34 @@ const createAuthorizationRequestInner$ = command(
 const getAuthorizationRequestInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
+    const params = get(getParams$);
+
     const result = await set(
-      readBrowserAuthorizationRequest$,
+      readComputerUseAuthorizationRequest$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        requestToken: get(getParams$).requestToken,
+        requestToken: params.requestToken,
       },
       signal,
     );
     signal.throwIfAborted();
+
     if (result.status === "not_found") {
-      return notFound("Cloud browser authorization request not found");
+      return notFound("Computer Use authorization request not found");
     }
     if (result.status === "expired") {
       return expired();
     }
+
     return {
       status: 200 as const,
       body: {
+        source: result.source,
         expiresAt: result.expiresAt,
         completedAt: result.completedAt,
-        cloudBrowserEnabled: result.cloudBrowserEnabled,
+        computerUseHostId: result.computerUseHostId,
+        hosts: result.hosts,
       },
     };
   },
@@ -117,56 +131,68 @@ const getAuthorizationRequestInner$ = command(
 const applyAuthorizationRequestInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
+    const params = get(applyParams$);
     const body = await get(applyBody$);
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
     }
+
     const result = await set(
-      applyBrowserAuthorizationRequest$,
+      applyComputerUseAuthorizationRequest$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
-        requestToken: get(applyParams$).requestToken,
+        requestToken: params.requestToken,
+        computerUseHostId: body.data.computerUseHostId,
       },
       signal,
     );
     signal.throwIfAborted();
+
     if (result.status === "not_found") {
-      return notFound("Cloud browser authorization request not found");
+      return notFound("Computer Use authorization request not found");
     }
     if (result.status === "expired") {
       return expired();
     }
-    if (result.status === "scope_not_found") {
-      return notFound("Cloud browser authorization scope not found");
+    if (result.status === "host_not_found") {
+      return notFound("Computer-use host not found");
     }
+    if (result.status === "scope_not_found") {
+      return notFound("Computer Use authorization scope not found");
+    }
+
     return {
       status: 200 as const,
-      body: { ok: true as const, cloudBrowserEnabled: true as const },
+      body: {
+        ok: true as const,
+        source: result.source,
+        computerUseHostId: result.computerUseHostId,
+      },
     };
   },
 );
 
-export const zeroBrowserAuthorizationRoutes: readonly RouteEntry[] = [
+export const computerUseAuthorizationRoutes: readonly RouteEntry[] = [
   {
-    route: zeroBrowserAuthorizationRequestsContract.create,
+    route: zeroComputerUseAuthorizationRequestsContract.create,
     handler: authRoute(
-      browserAuthorizationCreateAuthOptions,
+      computerUseAuthorizationCreateAuthOptions,
       createAuthorizationRequestInner$,
     ),
   },
   {
-    route: zeroBrowserAuthorizationRequestsContract.get,
+    route: zeroComputerUseAuthorizationRequestsContract.get,
     handler: authRoute(
-      browserAuthorizationAuthOptions,
+      computerUseAuthorizationAuthOptions,
       getAuthorizationRequestInner$,
     ),
   },
   {
-    route: zeroBrowserAuthorizationRequestsContract.apply,
+    route: zeroComputerUseAuthorizationRequestsContract.apply,
     handler: authRoute(
-      browserAuthorizationAuthOptions,
+      computerUseAuthorizationAuthOptions,
       applyAuthorizationRequestInner$,
     ),
   },

--- a/turbo/apps/api/src/signals/routes/computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/computer-use.ts
@@ -632,7 +632,7 @@ const computerUseHostListAuthOptions = {
   requiredCapability: "computer-use:write",
 } as const;
 
-export const zeroComputerUseRoutes: readonly RouteEntry[] = [
+export const computerUseRoutes: readonly RouteEntry[] = [
   {
     route: zeroComputerUseHostsContract.start,
     handler: authRoute(computerUseAuthOptions, hostStartInner$),

--- a/turbo/apps/api/src/signals/routes/host.ts
+++ b/turbo/apps/api/src/signals/routes/host.ts
@@ -152,7 +152,7 @@ const deploymentsInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 200 as const, body: result.body };
 });
 
-export const zeroHostRoutes: readonly RouteEntry[] = [
+export const hostRoutes: readonly RouteEntry[] = [
   {
     route: zeroHostContract.prepare,
     handler: authRoute(


### PR DESCRIPTION
## Summary

- Rename the five Browser, Computer Use, and Host API route shell modules to neutral paths.
- Rename their five route-array exports and update the production registry, route test, and BDD helper callers atomically.
- Preserve contracts, API paths, auth protocol values, Browser service/runtime names, CLI adapters, Platform names, route contents, and runtime behavior.

## Verification

- `pnpm exec prettier --check <10 touched files>`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- Structural old-path/export absence, neutral-target uniqueness, and normalized content-hash checks
- Focused Browser, Computer Use, and Host Vitest suites were attempted locally; the runtime has no PostgreSQL server on `localhost:5432`, so they stopped before test execution and remain covered by required PR CI.

Closes #27568
