### PR TITLE
fix(agent): resolve deletion ownership through sessions

### DIFF
--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -129,6 +129,52 @@ delete_runner_agent() {
     runner_api_curl "/api/okou/agents/$agent_id" -X DELETE >/dev/null
 }
 
+# Temporary Stage 0 E2E teardown containment. Remove this helper and restore
+# delete_runner_agent when #26938's final version-contract/drop stage removes
+# the production legacy-version deletion veto.
+delete_runner_agent_for_stage0_teardown() {
+    local agent_id="$1"
+    local response http_status response_body
+
+    response="$(runner_api_curl \
+        "/api/okou/agents/$agent_id" \
+        -X DELETE \
+        --no-fail \
+        --write-out $'\n%{http_code}')" || return
+    http_status="${response##*$'\n'}"
+    response_body="${response%$'\n'*}"
+
+    if [[ "$http_status" == "204" && -z "$response_body" ]]; then
+        return 0
+    fi
+
+    if [[ "$http_status" == "404" ]] && jq -e --arg agent_id "$agent_id" '
+        . == {
+            error: {
+                message: ("Agent not found: " + $agent_id),
+                code: "NOT_FOUND"
+            }
+        }
+    ' <<<"$response_body" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [[ "$http_status" == "409" ]] && jq -e '
+        . == {
+            error: {
+                message: "Cannot delete agent while its configuration is being migrated",
+                code: "CONFLICT"
+            }
+        }
+    ' <<<"$response_body" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    printf 'Stage 0 Runner E2E agent teardown failed with HTTP %s: %s\n' \
+        "$http_status" "$response_body" >&2
+    return 1
+}
+
 _runner_uuid() {
     tr -d '\n' < /proc/sys/kernel/random/uuid
 }

--- a/e2e/tests/03-runner/run-t07-codex-smoke.bats
+++ b/e2e/tests/03-runner/run-t07-codex-smoke.bats
@@ -18,7 +18,7 @@ setup_file() {
 
 teardown_file() {
     if [[ -n "${RUNNER_AGENT_ID:-}" ]]; then
-        delete_runner_agent "$RUNNER_AGENT_ID"
+        delete_runner_agent_for_stage0_teardown "$RUNNER_AGENT_ID"
     fi
 }
 

--- a/e2e/tests/03-runner/run-t08-codex-resume.bats
+++ b/e2e/tests/03-runner/run-t08-codex-resume.bats
@@ -18,7 +18,7 @@ setup_file() {
 
 teardown_file() {
     if [[ -n "${RUNNER_AGENT_ID:-}" ]]; then
-        delete_runner_agent "$RUNNER_AGENT_ID"
+        delete_runner_agent_for_stage0_teardown "$RUNNER_AGENT_ID"
     fi
 }
 

--- a/e2e/tests/03-runner/run-t09-real-codex-steer.bats
+++ b/e2e/tests/03-runner/run-t09-real-codex-steer.bats
@@ -24,7 +24,7 @@ setup_file() {
 
 teardown_file() {
     if [[ -n "${RUNNER_AGENT_ID:-}" ]]; then
-        delete_runner_agent "$RUNNER_AGENT_ID"
+        delete_runner_agent_for_stage0_teardown "$RUNNER_AGENT_ID"
     fi
 }
 

--- a/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
@@ -34,7 +34,7 @@ setup_file() {
 
 teardown_file() {
     if [[ -n "${RUNNER_AGENT_ID:-}" ]]; then
-        delete_runner_agent "$RUNNER_AGENT_ID"
+        delete_runner_agent_for_stage0_teardown "$RUNNER_AGENT_ID"
     fi
 }
 

--- a/turbo/apps/api/src/lib/pg-errors.ts
+++ b/turbo/apps/api/src/lib/pg-errors.ts
@@ -1,4 +1,5 @@
 const PG_FOREIGN_KEY_VIOLATION = "23503";
+const PG_LOCK_NOT_AVAILABLE = "55P03";
 const PG_UNIQUE_VIOLATION = "23505";
 
 function pgErrorCode(error: unknown): unknown {
@@ -16,6 +17,10 @@ function pgErrorCode(error: unknown): unknown {
 
 export function isForeignKeyViolation(error: unknown): boolean {
   return pgErrorCode(error) === PG_FOREIGN_KEY_VIOLATION;
+}
+
+export function isLockNotAvailable(error: unknown): boolean {
+  return pgErrorCode(error) === PG_LOCK_NOT_AVAILABLE;
 }
 
 export function isUniqueViolation(error: unknown): boolean {

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts
@@ -1,0 +1,768 @@
+import { randomUUID } from "node:crypto";
+
+import { createStore } from "ccstate";
+import { onTestFinished } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import {
+  holdAgentDeletionRowLockFixture,
+  holdAgentRunInsertFixture,
+  holdAgentRunLocksFixture,
+  holdAgentRunPromotionFixture,
+  holdAgentSessionInsertFixture,
+  holdAgentVersionInsertFixture,
+  holdChatThreadThenSessionFixture,
+  holdUsageEventMutationFixture,
+  readAgentLifecycleCountsFixture,
+  readAgentLifecycleIdsFixture,
+  readDatabaseLockTimeoutFixture,
+  readUsageEventRunIdFixture,
+  referenceAgentHeadFixture,
+  referenceAgentRunVersionFixture,
+  removeAgentLegacyVersionsFixture,
+  setAgentLifecycleOrgFixture,
+  setAgentRunStatusFixture,
+} from "../../../test-fixtures/agent-deletion";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { createStoragesBddApi } from "./helpers/api-bdd-storages";
+import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import {
+  insertUsageEvent$,
+  materializeHourlyUsage$,
+  readUsageStorageCounts$,
+  seedChatThread$,
+} from "./helpers/usage-state";
+
+const context = testContext();
+const store = createStore();
+const bdd = createBddApi(context);
+const api = createRunsApi(context);
+const storages = createStoragesBddApi(context);
+const webhooks = createWebhookCallbackApi(context);
+
+interface HeldBoundary {
+  readonly release: () => void;
+  readonly done: Promise<void>;
+}
+
+function registerHeldBoundary(boundary: HeldBoundary): void {
+  onTestFinished(async () => {
+    boundary.release();
+    await boundary.done;
+  });
+}
+
+function orgIdOf(actor: ApiTestUser): string {
+  if (!actor.orgId) {
+    throw new Error("Expected an org-scoped actor");
+  }
+  return actor.orgId;
+}
+
+async function createAgent(
+  actor: ApiTestUser,
+  displayName: string,
+): Promise<{ readonly agentId: string }> {
+  bdd.acceptAgentStorageWrites();
+  return await bdd.createAgent(actor, { displayName });
+}
+
+async function prepareRunCreation(
+  ...actors: readonly ApiTestUser[]
+): Promise<void> {
+  api.acceptStorageDownloads();
+  api.acceptTelemetryIngest();
+  api.configureRunnerGroup();
+  for (const actor of actors) {
+    await api.grantProEntitlement(actor);
+    await api.ensureOrgModelProvider(actor);
+  }
+}
+
+async function pointTargetAtSurvivorVersion(args: {
+  readonly targetAgentId: string;
+  readonly targetRunIds: readonly string[];
+  readonly survivorAgentId: string;
+}): Promise<string> {
+  const versionId = await referenceAgentHeadFixture({
+    agentId: args.targetAgentId,
+    versionAgentId: args.survivorAgentId,
+  });
+  for (const runId of args.targetRunIds) {
+    await referenceAgentRunVersionFixture({
+      runId,
+      versionAgentId: args.survivorAgentId,
+    });
+  }
+  await removeAgentLegacyVersionsFixture(args.targetAgentId);
+  return versionId;
+}
+
+function expectRetryConflict(response: {
+  readonly status: number;
+  readonly body: unknown;
+}): void {
+  expect(response.status).toBe(409);
+  expect(response.body).toStrictEqual({
+    error: {
+      message: "Cannot delete agent right now; retry shortly",
+      code: "CONFLICT",
+    },
+  });
+}
+
+async function expectCheckpointSucceeds(
+  actor: ApiTestUser,
+  runId: string,
+): Promise<void> {
+  const response = await webhooks.requestAgentCheckpoint(
+    {
+      runId,
+      cliAgentType: "claude-code",
+      cliAgentSessionId: `agent-delete-${runId}`,
+      cliAgentSessionHistoryDisposition: "unavailable",
+    },
+    { authorization: `Bearer ${api.sandboxTokenForRun(actor, runId)}` },
+    [200],
+  );
+  expect(response.status).toBe(200);
+}
+
+describe("DELETE /api/zero/agents/:id bounded deletion interlock", () => {
+  it("vetoes a target-owned legacy version without invalidating a shared Run", async () => {
+    const actor = bdd.user();
+    await prepareRunCreation(actor);
+    const target = await createAgent(actor, "Legacy Version Target");
+    const survivor = await createAgent(actor, "Independent Head Survivor");
+    const targetHistoricalRun = await api.createRun(actor, {
+      agentId: target.agentId,
+      prompt: "retain target lifecycle on veto",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.requestCancelRun(actor, targetHistoricalRun.runId, [200]);
+    const survivorRun = await api.createRun(actor, {
+      agentId: survivor.agentId,
+      prompt: "retain shared provenance",
+      modelProvider: "anthropic-api-key",
+    });
+    const survivorHistoricalRun = await api.createRun(actor, {
+      agentId: survivor.agentId,
+      prompt: "retain historical shared provenance",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.requestCancelRun(actor, survivorHistoricalRun.runId, [200]);
+    const targetVersionId = await referenceAgentRunVersionFixture({
+      runId: survivorRun.runId,
+      versionAgentId: target.agentId,
+    });
+    await referenceAgentRunVersionFixture({
+      runId: survivorHistoricalRun.runId,
+      versionAgentId: target.agentId,
+    });
+    const usageEventId = await store.set(
+      insertUsageEvent$,
+      {
+        orgId: orgIdOf(actor),
+        userId: actor.userId,
+        runId: targetHistoricalRun.runId,
+        status: "pending",
+        creditsCharged: 2,
+      },
+      context.signal,
+    );
+    const volumesBefore = await storages.listStorages(actor, "organization");
+    const lockTimeoutBefore = await readDatabaseLockTimeoutFixture();
+    context.mocks.s3.send.mockClear();
+
+    const response = await bdd.requestDeleteAgent(actor, target.agentId, [409]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "Cannot delete agent while its configuration is being migrated",
+        code: "CONFLICT",
+      },
+    });
+    expect(context.mocks.s3.send).not.toHaveBeenCalled();
+    await expect(bdd.readAgent(actor, target.agentId)).resolves.toMatchObject({
+      agentId: target.agentId,
+    });
+    await expect(
+      readAgentLifecycleCountsFixture(target.agentId),
+    ).resolves.toStrictEqual({ agents: 1, sessions: 1, runs: 1 });
+    await expect(
+      api.readRun(actor, targetHistoricalRun.runId),
+    ).resolves.toMatchObject({
+      runId: targetHistoricalRun.runId,
+      agentComposeVersionId: targetVersionId,
+    });
+    await expect(bdd.readAgent(actor, survivor.agentId)).resolves.toMatchObject(
+      { agentId: survivor.agentId },
+    );
+    await expect(api.readRun(actor, survivorRun.runId)).resolves.toMatchObject({
+      runId: survivorRun.runId,
+      agentComposeVersionId: targetVersionId,
+      status: "pending",
+    });
+    await expect(
+      api.readRun(actor, survivorHistoricalRun.runId),
+    ).resolves.toMatchObject({
+      runId: survivorHistoricalRun.runId,
+      agentComposeVersionId: targetVersionId,
+    });
+    await expectCheckpointSucceeds(actor, survivorRun.runId);
+    await expect(readUsageEventRunIdFixture(usageEventId)).resolves.toBe(
+      targetHistoricalRun.runId,
+    );
+    await expect(
+      storages.listStorages(actor, "organization"),
+    ).resolves.toStrictEqual(volumesBefore);
+    await expect(readDatabaseLockTimeoutFixture()).resolves.toBe(
+      lockTimeoutBefore,
+    );
+    await api.requestCancelRun(actor, survivorRun.runId, [200]);
+  });
+
+  it("detects an active target Run through its Session instead of its version", async () => {
+    const actor = bdd.user();
+    await prepareRunCreation(actor);
+    const survivor = await createAgent(actor, "Active Version Survivor");
+    const target = await createAgent(actor, "Active Session Target");
+    const targetRun = await api.createRun(actor, {
+      agentId: target.agentId,
+      prompt: "block target deletion",
+      modelProvider: "anthropic-api-key",
+    });
+    const versionId = await pointTargetAtSurvivorVersion({
+      targetAgentId: target.agentId,
+      targetRunIds: [targetRun.runId],
+      survivorAgentId: survivor.agentId,
+    });
+
+    const response = await bdd.requestDeleteAgent(actor, target.agentId, [409]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Cannot delete agent: agent is currently running",
+        code: "CONFLICT",
+      },
+    });
+    await expect(api.readRun(actor, targetRun.runId)).resolves.toMatchObject({
+      runId: targetRun.runId,
+      agentComposeVersionId: versionId,
+      status: "pending",
+    });
+    await expect(bdd.readAgent(actor, target.agentId)).resolves.toMatchObject({
+      agentId: target.agentId,
+    });
+    await api.requestCancelRun(actor, targetRun.runId, [200]);
+  });
+
+  it("cascades queued and terminal target Runs while preserving cross-org provenance and billing", async () => {
+    const targetOwner = bdd.user();
+    const survivorOwner = bdd.user();
+    await prepareRunCreation(targetOwner, survivorOwner);
+    const survivor = await createAgent(
+      survivorOwner,
+      "Cross Org Version Survivor",
+    );
+    const target = await createAgent(targetOwner, "Terminal Cleanup Target");
+    const survivorRun = await api.createRun(survivorOwner, {
+      agentId: survivor.agentId,
+      prompt: "survive another org deletion",
+      modelProvider: "anthropic-api-key",
+    });
+    const terminalRun = await api.createRun(targetOwner, {
+      agentId: target.agentId,
+      prompt: "terminal target Run",
+      modelProvider: "anthropic-api-key",
+    });
+    const queuedRun = await api.createRun(targetOwner, {
+      agentId: target.agentId,
+      prompt: "queued target Run",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.requestCancelRun(targetOwner, terminalRun.runId, [200]);
+    await setAgentRunStatusFixture(queuedRun.runId, "queued");
+    const survivorVersionId = await pointTargetAtSurvivorVersion({
+      targetAgentId: target.agentId,
+      targetRunIds: [terminalRun.runId, queuedRun.runId],
+      survivorAgentId: survivor.agentId,
+    });
+    const orgId = orgIdOf(targetOwner);
+    const pendingUsageId = await store.set(
+      insertUsageEvent$,
+      {
+        orgId,
+        userId: targetOwner.userId,
+        runId: terminalRun.runId,
+        status: "pending",
+        creditsCharged: 3,
+      },
+      context.signal,
+    );
+    await store.set(
+      insertUsageEvent$,
+      {
+        orgId,
+        userId: targetOwner.userId,
+        runId: terminalRun.runId,
+        status: "processed",
+        creditsCharged: 5,
+      },
+      context.signal,
+    );
+    await expect(
+      store.set(
+        materializeHourlyUsage$,
+        { orgId, userId: targetOwner.userId, runId: terminalRun.runId },
+        context.signal,
+      ),
+    ).resolves.toBe(1);
+    await expect(
+      store.set(
+        readUsageStorageCounts$,
+        { scope: "organization", id: orgId },
+        context.signal,
+      ),
+    ).resolves.toStrictEqual({ raw: 1, hourly: 1 });
+
+    await bdd.deleteVersionFreeAgent(targetOwner, target.agentId);
+
+    await expect(
+      bdd.requestReadAgent(targetOwner, target.agentId, [404]),
+    ).resolves.toMatchObject({ status: 404 });
+    await expect(
+      api.requestReadRun(targetOwner, terminalRun.runId, [404]),
+    ).resolves.toMatchObject({ status: 404 });
+    await expect(
+      api.requestReadRun(targetOwner, queuedRun.runId, [404]),
+    ).resolves.toMatchObject({ status: 404 });
+    await expect(
+      readAgentLifecycleCountsFixture(target.agentId),
+    ).resolves.toStrictEqual({ agents: 0, sessions: 0, runs: 0 });
+    await expect(
+      bdd.readAgent(survivorOwner, survivor.agentId),
+    ).resolves.toMatchObject({ agentId: survivor.agentId });
+    await expect(
+      api.readRun(survivorOwner, survivorRun.runId),
+    ).resolves.toMatchObject({
+      runId: survivorRun.runId,
+      agentComposeVersionId: survivorVersionId,
+      status: "pending",
+    });
+    await expectCheckpointSucceeds(survivorOwner, survivorRun.runId);
+    await expect(
+      readUsageEventRunIdFixture(pendingUsageId),
+    ).resolves.toBeNull();
+    await expect(
+      store.set(
+        readUsageStorageCounts$,
+        { scope: "organization", id: orgId },
+        context.signal,
+      ),
+    ).resolves.toStrictEqual({ raw: 1, hourly: 1 });
+    await api.requestCancelRun(survivorOwner, survivorRun.runId, [200]);
+  });
+
+  it.each(["session", "run"] as const)(
+    "fails closed when a target %s carries another org identity",
+    async (kind) => {
+      const actor = bdd.user();
+      await prepareRunCreation(actor);
+      const survivor = await createAgent(actor, `Org ${kind} Survivor`);
+      const target = await createAgent(actor, `Org ${kind} Target`);
+      const run = await api.createRun(actor, {
+        agentId: target.agentId,
+        prompt: `corrupt ${kind} org identity`,
+        modelProvider: "anthropic-api-key",
+      });
+      await api.requestCancelRun(actor, run.runId, [200]);
+      await pointTargetAtSurvivorVersion({
+        targetAgentId: target.agentId,
+        targetRunIds: [run.runId],
+        survivorAgentId: survivor.agentId,
+      });
+      const lifecycle = await readAgentLifecycleIdsFixture(target.agentId);
+      const id =
+        kind === "session" ? lifecycle.sessionIds[0] : lifecycle.runIds[0];
+      if (!id) {
+        throw new Error(`Expected a target ${kind}`);
+      }
+      await setAgentLifecycleOrgFixture({
+        kind,
+        id,
+        orgId: `org_corrupt_${randomUUID()}`,
+      });
+
+      const response = await bdd.requestDeleteAgent(
+        actor,
+        target.agentId,
+        [409],
+      );
+
+      expect(response.body).toStrictEqual({
+        error: {
+          message:
+            "Cannot delete agent because its lifecycle ownership is inconsistent",
+          code: "CONFLICT",
+        },
+      });
+      await expect(
+        readAgentLifecycleCountsFixture(target.agentId),
+      ).resolves.toStrictEqual({ agents: 1, sessions: 1, runs: 1 });
+      await expect(bdd.readAgent(actor, target.agentId)).resolves.toMatchObject(
+        {
+          agentId: target.agentId,
+        },
+      );
+    },
+  );
+
+  it.each(["agent", "session", "run"] as const)(
+    "returns a retryable conflict without waiting on a locked target %s",
+    async (kind) => {
+      const actor = bdd.user();
+      await prepareRunCreation(actor);
+      const survivor = await createAgent(actor, `Lock ${kind} Survivor`);
+      const target = await createAgent(actor, `Lock ${kind} Target`);
+      const run = await api.createRun(actor, {
+        agentId: target.agentId,
+        prompt: `lock target ${kind}`,
+        modelProvider: "anthropic-api-key",
+      });
+      await api.requestCancelRun(actor, run.runId, [200]);
+      await pointTargetAtSurvivorVersion({
+        targetAgentId: target.agentId,
+        targetRunIds: [run.runId],
+        survivorAgentId: survivor.agentId,
+      });
+      const lifecycle = await readAgentLifecycleIdsFixture(target.agentId);
+      const id =
+        kind === "agent"
+          ? target.agentId
+          : kind === "session"
+            ? lifecycle.sessionIds[0]
+            : lifecycle.runIds[0];
+      if (!id) {
+        throw new Error(`Expected a target ${kind}`);
+      }
+      const lockTimeoutBefore = await readDatabaseLockTimeoutFixture();
+      const held = await holdAgentDeletionRowLockFixture({
+        kind,
+        id,
+        signal: context.signal,
+      });
+      registerHeldBoundary(held);
+      context.mocks.s3.send.mockClear();
+
+      const startedAt = performance.now();
+      const response = await bdd.requestDeleteAgent(
+        actor,
+        target.agentId,
+        [409],
+      );
+      const elapsedMs = performance.now() - startedAt;
+
+      expectRetryConflict(response);
+      expect(elapsedMs).toBeLessThan(750);
+      await expect(held.blockedWaiterCount()).resolves.toBe(0);
+      expect(context.mocks.s3.send).not.toHaveBeenCalled();
+      await expect(
+        readAgentLifecycleCountsFixture(target.agentId),
+      ).resolves.toStrictEqual({ agents: 1, sessions: 1, runs: 1 });
+      await expect(readDatabaseLockTimeoutFixture()).resolves.toBe(
+        lockTimeoutBefore,
+      );
+
+      held.release();
+      await held.done;
+      await bdd.deleteVersionFreeAgent(actor, target.agentId);
+    },
+  );
+
+  it.each([
+    [
+      "version",
+      [409],
+      {
+        error: {
+          message:
+            "Cannot delete agent while its configuration is being migrated",
+          code: "CONFLICT",
+        },
+      },
+    ],
+    ["session", [204], undefined],
+    [
+      "run",
+      [409],
+      {
+        error: {
+          message: "Cannot delete agent: agent is currently running",
+          code: "CONFLICT",
+        },
+      },
+    ],
+  ] as const)(
+    "serializes a concurrent target %s insert without partial deletion",
+    async (kind, afterReleaseStatuses, expectedAfterReleaseBody) => {
+      const actor = bdd.user();
+      const orgId = orgIdOf(actor);
+      await prepareRunCreation(actor);
+      const survivor = await createAgent(actor, `Insert ${kind} Survivor`);
+      const target = await createAgent(actor, `Insert ${kind} Target`);
+      const run = await api.createRun(actor, {
+        agentId: target.agentId,
+        prompt: `hold target ${kind} insert`,
+        modelProvider: "anthropic-api-key",
+      });
+      await api.requestCancelRun(actor, run.runId, [200]);
+      await pointTargetAtSurvivorVersion({
+        targetAgentId: target.agentId,
+        targetRunIds: [run.runId],
+        survivorAgentId: survivor.agentId,
+      });
+      const lifecycle = await readAgentLifecycleIdsFixture(target.agentId);
+      const sessionId = lifecycle.sessionIds[0];
+      if (!sessionId) {
+        throw new Error("Expected a target Session");
+      }
+      const held =
+        kind === "version"
+          ? await holdAgentVersionInsertFixture({
+              agentId: target.agentId,
+              userId: actor.userId,
+              signal: context.signal,
+            })
+          : kind === "session"
+            ? await holdAgentSessionInsertFixture({
+                agentId: target.agentId,
+                orgId,
+                userId: actor.userId,
+                signal: context.signal,
+              })
+            : await holdAgentRunInsertFixture({
+                sessionId,
+                orgId,
+                userId: actor.userId,
+                signal: context.signal,
+              });
+      registerHeldBoundary(held);
+
+      const response = await bdd.requestDeleteAgent(
+        actor,
+        target.agentId,
+        [409],
+      );
+
+      expectRetryConflict(response);
+      await expect(held.blockedWaiterCount()).resolves.toBe(0);
+      await expect(
+        readAgentLifecycleCountsFixture(target.agentId),
+      ).resolves.toStrictEqual({ agents: 1, sessions: 1, runs: 1 });
+      held.release();
+      await held.done;
+
+      const retry = await bdd.requestDeleteAgent(
+        actor,
+        target.agentId,
+        afterReleaseStatuses,
+      );
+      expect(retry.body).toStrictEqual(expectedAfterReleaseBody);
+    },
+  );
+
+  it("fails fast across reverse Run locks and a queued promotion", async () => {
+    const actor = bdd.user();
+    await prepareRunCreation(actor);
+    const survivor = await createAgent(actor, "Reverse Lock Survivor");
+    const target = await createAgent(actor, "Reverse Lock Target");
+    const first = await api.createRun(actor, {
+      agentId: target.agentId,
+      prompt: "first queued Run",
+      modelProvider: "anthropic-api-key",
+    });
+    const second = await api.createRun(actor, {
+      agentId: target.agentId,
+      prompt: "second queued Run",
+      modelProvider: "anthropic-api-key",
+    });
+    await setAgentRunStatusFixture(first.runId, "queued");
+    await setAgentRunStatusFixture(second.runId, "queued");
+    await pointTargetAtSurvivorVersion({
+      targetAgentId: target.agentId,
+      targetRunIds: [first.runId, second.runId],
+      survivorAgentId: survivor.agentId,
+    });
+    const lifecycle = await readAgentLifecycleIdsFixture(target.agentId);
+    const reverseRunIds = [...lifecycle.runIds].reverse();
+    const reverseLocks = await holdAgentRunLocksFixture({
+      runIds: reverseRunIds,
+      signal: context.signal,
+    });
+    registerHeldBoundary(reverseLocks);
+
+    const reverseResponse = await bdd.requestDeleteAgent(
+      actor,
+      target.agentId,
+      [409],
+    );
+
+    expectRetryConflict(reverseResponse);
+    await expect(reverseLocks.blockedWaiterCount()).resolves.toBe(0);
+    reverseLocks.release();
+    await reverseLocks.done;
+
+    const promotion = await holdAgentRunPromotionFixture({
+      runId: lifecycle.runIds[0] ?? first.runId,
+      signal: context.signal,
+    });
+    registerHeldBoundary(promotion);
+    const promotionResponse = await bdd.requestDeleteAgent(
+      actor,
+      target.agentId,
+      [409],
+    );
+    expectRetryConflict(promotionResponse);
+    await expect(promotion.blockedWaiterCount()).resolves.toBe(0);
+    promotion.release();
+    await promotion.done;
+
+    const activeResponse = await bdd.requestDeleteAgent(
+      actor,
+      target.agentId,
+      [409],
+    );
+    expect(activeResponse.body).toMatchObject({
+      error: { message: "Cannot delete agent: agent is currently running" },
+    });
+  });
+
+  it("bounds the Session and ChatThread reverse path without a deadlock", async () => {
+    const actor = bdd.user();
+    await prepareRunCreation(actor);
+    const survivor = await createAgent(actor, "ChatThread Cycle Survivor");
+    const target = await createAgent(actor, "ChatThread Cycle Target");
+    const run = await api.createRun(actor, {
+      agentId: target.agentId,
+      prompt: "terminal ChatThread cycle Run",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.requestCancelRun(actor, run.runId, [200]);
+    await pointTargetAtSurvivorVersion({
+      targetAgentId: target.agentId,
+      targetRunIds: [run.runId],
+      survivorAgentId: survivor.agentId,
+    });
+    const lifecycle = await readAgentLifecycleIdsFixture(target.agentId);
+    const sessionId = lifecycle.sessionIds[0];
+    if (!sessionId) {
+      throw new Error("Expected a target Session");
+    }
+    const threadId = await store.set(
+      seedChatThread$,
+      { userId: actor.userId, composeId: target.agentId },
+      context.signal,
+    );
+    const lockTimeoutBefore = await readDatabaseLockTimeoutFixture();
+    const held = await holdChatThreadThenSessionFixture({
+      threadId,
+      sessionId,
+      signal: context.signal,
+    });
+    registerHeldBoundary(held);
+
+    const startedAt = performance.now();
+    const deletion = bdd.requestDeleteAgent(actor, target.agentId, [409]);
+    await expect
+      .poll(held.blockedWaiterCount, { interval: 2, timeout: 500 })
+      .toBeGreaterThan(0);
+    held.startSessionLock();
+    const response = await deletion;
+    const elapsedMs = performance.now() - startedAt;
+
+    expectRetryConflict(response);
+    expect(elapsedMs).toBeLessThan(750);
+    await held.sessionLocked;
+    await expect(
+      readAgentLifecycleCountsFixture(target.agentId),
+    ).resolves.toStrictEqual({ agents: 1, sessions: 1, runs: 1 });
+    await expect(readDatabaseLockTimeoutFixture()).resolves.toBe(
+      lockTimeoutBefore,
+    );
+    held.release();
+    await held.done;
+    await bdd.deleteVersionFreeAgent(actor, target.agentId);
+  });
+
+  it("rolls back a cascade-child timeout and retains billing on retry", async () => {
+    const actor = bdd.user();
+    const orgId = orgIdOf(actor);
+    await prepareRunCreation(actor);
+    const survivor = await createAgent(actor, "Cascade Child Survivor");
+    const target = await createAgent(actor, "Cascade Child Target");
+    const run = await api.createRun(actor, {
+      agentId: target.agentId,
+      prompt: "terminal cascade-child Run",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.requestCancelRun(actor, run.runId, [200]);
+    await pointTargetAtSurvivorVersion({
+      targetAgentId: target.agentId,
+      targetRunIds: [run.runId],
+      survivorAgentId: survivor.agentId,
+    });
+    const usageEventId = await store.set(
+      insertUsageEvent$,
+      {
+        orgId,
+        userId: actor.userId,
+        runId: run.runId,
+        status: "pending",
+        creditsCharged: 7,
+      },
+      context.signal,
+    );
+    const lockTimeoutBefore = await readDatabaseLockTimeoutFixture();
+    const held = await holdUsageEventMutationFixture({
+      usageEventId,
+      signal: context.signal,
+    });
+    registerHeldBoundary(held);
+
+    const startedAt = performance.now();
+    const deletion = bdd.requestDeleteAgent(actor, target.agentId, [409]);
+    await expect
+      .poll(held.blockedWaiterCount, { interval: 2, timeout: 500 })
+      .toBeGreaterThan(0);
+    const response = await deletion;
+    const elapsedMs = performance.now() - startedAt;
+
+    expectRetryConflict(response);
+    expect(elapsedMs).toBeLessThan(750);
+    await expect(
+      readAgentLifecycleCountsFixture(target.agentId),
+    ).resolves.toStrictEqual({ agents: 1, sessions: 1, runs: 1 });
+    await expect(readUsageEventRunIdFixture(usageEventId)).resolves.toBe(
+      run.runId,
+    );
+    await expect(readDatabaseLockTimeoutFixture()).resolves.toBe(
+      lockTimeoutBefore,
+    );
+    held.release();
+    await held.done;
+
+    await bdd.deleteVersionFreeAgent(actor, target.agentId);
+
+    await expect(readUsageEventRunIdFixture(usageEventId)).resolves.toBeNull();
+    await expect(
+      store.set(
+        readUsageStorageCounts$,
+        { scope: "organization", id: orgId },
+        context.signal,
+      ),
+    ).resolves.toStrictEqual({ raw: 1, hourly: 0 });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/agent-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-lifecycle.bdd.test.ts
@@ -74,7 +74,7 @@ describe("AGENT-01: zero agent lifecycle through public API", () => {
       visibility: "public",
     });
 
-    await api.deleteAgent(admin, created.agentId);
+    await api.deleteVersionFreeAgent(admin, created.agentId);
 
     const missing = await api.requestReadAgent(admin, created.agentId, [404]);
     expectApiError(missing.body);

--- a/turbo/apps/api/src/signals/routes/__tests__/agents-by-id.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-by-id.test.ts
@@ -9,6 +9,7 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
+import { removeAgentLegacyVersionsFixture } from "../../../test-fixtures/agent-deletion";
 import {
   createBddApi,
   expectApiError,
@@ -437,7 +438,7 @@ describe("DELETE /api/zero/agents/:id", () => {
     const actor = bdd.user();
     const agent = await createAgent(actor);
 
-    await bdd.deleteAgent(actor, agent.agentId);
+    await bdd.deleteVersionFreeAgent(actor, agent.agentId);
 
     const response = await bdd.requestReadAgent(actor, agent.agentId, [404]);
     expect(response.body).toStrictEqual({
@@ -497,7 +498,7 @@ describe("DELETE /api/zero/agents/:id", () => {
       return Promise.resolve({});
     });
 
-    await bdd.deleteAgent(actor, agent.agentId);
+    await bdd.deleteVersionFreeAgent(actor, agent.agentId);
 
     expect(listedPrefix).toMatch(
       new RegExp(
@@ -522,6 +523,7 @@ describe("DELETE /api/zero/agents/:id", () => {
       displayName: "API Key Deletable Agent",
       visibility: "private",
     });
+    await removeAgentLegacyVersionsFixture(agent.agentId);
 
     const response = await accept(
       agentsClient().delete({
@@ -550,7 +552,7 @@ describe("DELETE /api/zero/agents/:id", () => {
     const admin = bdd.user({ orgId: owner.orgId, orgRole: "org:admin" });
     const agent = await createAgent(owner);
 
-    await bdd.deleteAgent(admin, agent.agentId);
+    await bdd.deleteVersionFreeAgent(admin, agent.agentId);
 
     const readAfterDelete = await bdd.requestReadAgent(
       owner,
@@ -579,6 +581,7 @@ describe("DELETE /api/zero/agents/:id", () => {
       prompt: "keep this run pending",
       modelProvider: "anthropic-api-key",
     });
+    await removeAgentLegacyVersionsFixture(agent.agentId);
 
     const response = await bdd.requestDeleteAgent(actor, agent.agentId, [409]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/agents-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-create.test.ts
@@ -7,6 +7,7 @@ import {
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { removeAgentLegacyVersionsFixture } from "../../../test-fixtures/agent-deletion";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import {
@@ -242,6 +243,7 @@ describe("POST /api/zero/agents", () => {
     if (!deletedAgentId) {
       throw new Error("Expected a created agent");
     }
+    await removeAgentLegacyVersionsFixture(deletedAgentId);
     const deleteResponse = await accept(
       agentsByIdClient().delete({
         params: { id: deletedAgentId },

--- a/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifact-catalog.bdd.test.ts
@@ -572,7 +572,7 @@ describe("GET /api/zero/artifacts/catalog", () => {
     ).toHaveLength(1);
 
     await flushWaitUntilForTest();
-    await bdd.deleteAgent(owner.actor, owner.agentId);
+    await bdd.deleteVersionFreeAgent(owner.actor, owner.agentId);
 
     await expect(chat.listArtifactCatalog(owner.actor)).resolves.toStrictEqual({
       artifacts: [],

--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -179,7 +179,7 @@ describe("AUTH-01, ORG-03, AGENT-02, CHAIN-AGENT", () => {
       visibility: "private",
     });
 
-    await api.deleteAgent(admin, created.agentId);
+    await api.deleteVersionFreeAgent(admin, created.agentId);
     const deleted = await api.requestReadAgent(admin, created.agentId, [404]);
     expectApiError(deleted.body);
     expect(deleted.body.error.code).toBe("NOT_FOUND");
@@ -541,7 +541,7 @@ describe("ORG-03 onboarding status mapping", () => {
       },
     });
 
-    await api.deleteAgent(admin, agentId);
+    await api.deleteVersionFreeAgent(admin, agentId);
     const orphaned = await api.readOnboardingStatus(admin);
     expect(orphaned).toMatchObject({
       needsOnboarding: false,
@@ -829,7 +829,7 @@ describe("COMPOSE-01", () => {
       displayName: "BDD Compose Zero",
       visibility: "private",
     });
-    await api.deleteAgent(admin, created.composeId);
+    await api.deleteVersionFreeAgent(admin, created.composeId);
     const deleted = await api.requestReadComposeById(
       admin,
       created.composeId,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1028,7 +1028,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     expect(incrementalCompact.eventsApplied).toBeGreaterThanOrEqual(1);
 
     chat.mockObjectStorageObjectsExist();
-    await authOrg.deleteAgent(actor, deletedAgent.agentId);
+    await authOrg.deleteVersionFreeAgent(actor, deletedAgent.agentId);
 
     mockNow(incrementalSnapshotAt + DAY_MS);
     await compactChatThreadSnapshots();

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -2179,7 +2179,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     ).resolves.toContain(created.id);
 
     await connectorsApi.deleteCustomConnector(admin, created.id);
-    await bdd.deleteAgent(member, agent.agentId);
+    await bdd.deleteVersionFreeAgent(member, agent.agentId);
   });
 
   it("removes OAuth tokens when manual credentials replace the connection", async () => {
@@ -2607,7 +2607,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
 
     await connectorsApi.disconnectCustomConnector(member, created.id);
     await connectorsApi.deleteCustomConnector(admin, created.id);
-    await bdd.deleteAgent(member, agent.agentId);
+    await bdd.deleteVersionFreeAgent(member, agent.agentId);
   });
 
   it("updates OAuth settings and preserves member OAuth data as incompatible", async () => {
@@ -3191,7 +3191,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     ).toBeUndefined();
 
     await connectorsApi.deleteCustomConnector(otherAdmin, otherConnector.id);
-    await bdd.deleteAgent(admin, agent.agentId);
+    await bdd.deleteVersionFreeAgent(admin, agent.agentId);
   });
 
   it("lets an admin agent with an okou-scoped token create a manual definition that Connect can configure", async () => {
@@ -3981,7 +3981,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expectNoVisibleSecret(listed, "proposal-secret");
 
     await connectorsApi.deleteCustomConnector(admin, saved.connector.id);
-    await bdd.deleteAgent(admin, agent.agentId);
+    await bdd.deleteVersionFreeAgent(admin, agent.agentId);
   });
 
   it("preserves selected permissions when a proposal reauthorizes an existing connector", async () => {
@@ -4044,7 +4044,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     ).resolves.toStrictEqual([grant]);
 
     await connectorsApi.deleteCustomConnector(admin, connector.id);
-    await bdd.deleteAgent(admin, agent.agentId);
+    await bdd.deleteVersionFreeAgent(admin, agent.agentId);
   });
 
   it("authorizes a connector proposal before required values are configured", async () => {
@@ -4140,7 +4140,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       emptyComplete.connector.id,
     );
     await connectorsApi.deleteCustomConnector(admin, saved.connector.id);
-    await bdd.deleteAgent(admin, agent.agentId);
+    await bdd.deleteVersionFreeAgent(admin, agent.agentId);
   });
 
   it("rejects connector proposal host variables that change URL structure", async () => {
@@ -4776,7 +4776,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       connectorsApi.readCustomConnector(admin, created.id),
     ).resolves.toMatchObject({ connected: false });
     await connectorsApi.deleteCustomConnector(admin, created.id);
-    await bdd.deleteAgent(admin, agent.agentId);
+    await bdd.deleteVersionFreeAgent(admin, agent.agentId);
   });
 
   it("rejects unsafe MCP endpoints and protected transport headers", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -2755,7 +2755,7 @@ describe("connector catalog valid lifecycle", () => {
         await connectorsApi.deleteCustomConnector(actor, customConnectorId);
       }
       await cleanupConnector();
-      await bdd.deleteAgent(actor, agent.agentId);
+      await bdd.deleteVersionFreeAgent(actor, agent.agentId);
     });
     await connectorsApi.connectManualGrant(
       actor,
@@ -2946,7 +2946,7 @@ describe("connector catalog valid lifecycle", () => {
         await runs.requestCancelRun(actor, created.runId, [200, 404]);
       }
       await connectorsApi.deleteCustomConnector(actor, custom.id);
-      await bdd.deleteAgent(actor, agent.agentId);
+      await bdd.deleteVersionFreeAgent(actor, agent.agentId);
     });
     const run = await runs.createRun(actor, {
       agentId: agent.agentId,
@@ -3213,7 +3213,7 @@ describe("connector catalog valid lifecycle", () => {
           return skill.skill.storageId;
         }),
       );
-      await bdd.deleteAgent(actor, agent.agentId);
+      await bdd.deleteVersionFreeAgent(actor, agent.agentId);
     });
 
     for (const [index, skill] of skills.entries()) {
@@ -3358,7 +3358,7 @@ describe("connector catalog valid lifecycle", () => {
         runtimeStorage.storageId,
       ]);
       await cleanupConnector();
-      await bdd.deleteAgent(actor, agent.agentId);
+      await bdd.deleteVersionFreeAgent(actor, agent.agentId);
     });
     await connectorsApi.connectManualGrant(
       actor,
@@ -3990,7 +3990,7 @@ describe("connector catalog valid lifecycle", () => {
         await miscApi.deleteWorkflow(actor, created.workflowId, [204, 404]);
       }
       if (created.agentId) {
-        await bdd.deleteAgent(actor, created.agentId);
+        await bdd.deleteVersionFreeAgent(actor, created.agentId);
       }
       await deleteOrgPlanEntitlementFixture(orgId);
     });
@@ -4208,7 +4208,7 @@ describe("connector catalog valid lifecycle", () => {
         await miscApi.deleteWorkflow(actor, created.workflowId, [204, 404]);
       }
       if (created.agentId) {
-        await bdd.deleteAgent(actor, created.agentId);
+        await bdd.deleteVersionFreeAgent(actor, created.agentId);
       }
       await deleteOrgPlanEntitlementFixture(orgId);
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -77,6 +77,7 @@ import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { mockEnv } from "../../../../lib/env";
 import { server } from "../../../../mocks/server";
+import { removeAgentLegacyVersionsFixture } from "../../../../test-fixtures/agent-deletion";
 import {
   createAgentComposeFixture,
   readAgentComposeByIdFixture,
@@ -1356,7 +1357,16 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
       );
     },
 
-    async deleteAgent(actor: ApiTestUser, agentId: string): Promise<void> {
+    /**
+     * Constructs the legacy-version-free cohort needed to exercise the
+     * transitional successful-delete path. Conflict tests must call the route
+     * directly so the production preconditions remain observable.
+     */
+    async deleteVersionFreeAgent(
+      actor: ApiTestUser,
+      agentId: string,
+    ): Promise<void> {
+      await removeAgentLegacyVersionsFixture(agentId);
       const client = setupAppWithRoutes({ context, routes: authOrgRoutes })(
         zeroAgentsByIdContract,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
@@ -21,6 +21,7 @@ import { userPreferencesContract } from "@okouai/api-contracts/contracts/user-pr
 import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { now } from "../../../../lib/time";
+import { removeAgentLegacyVersionsFixture } from "../../../../test-fixtures/agent-deletion";
 import { signSandboxJwtForTests } from "../../../auth/tokens";
 import { authMeRoutes } from "../../auth-me";
 import { agentsRoutes } from "../../agents";
@@ -462,7 +463,16 @@ export function createBddApi(context: TestContext) {
       return response.body;
     },
 
-    async deleteAgent(nextUser: ApiTestUser, agentId: string): Promise<void> {
+    /**
+     * Constructs the legacy-version-free cohort needed to exercise the
+     * transitional successful-delete path. Conflict tests must call
+     * requestDeleteAgent so the production preconditions remain observable.
+     */
+    async deleteVersionFreeAgent(
+      nextUser: ApiTestUser,
+      agentId: string,
+    ): Promise<void> {
+      await removeAgentLegacyVersionsFixture(agentId);
       await accept(
         agentsByIdClient().delete({
           params: { id: agentId },

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -3425,7 +3425,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     if (!status.defaultAgentId) {
       throw new Error("Expected onboarding to configure a default agent");
     }
-    await bdd.deleteAgent(onboarded, status.defaultAgentId);
+    await bdd.deleteVersionFreeAgent(onboarded, status.defaultAgentId);
     const missingSlackUserId = uniqueSlackUserId();
     const missingInstall = await integrations.installSlackWorkspace(onboarded, {
       installerSlackUserId: missingSlackUserId,

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -865,7 +865,7 @@ describe("ORG-01/AGENT-02: team listing and default-agent recovery", () => {
 
     // Deleting the default agent clears the FK, then onboarding status lazily
     // restores a usable org default for admins.
-    await api.deleteAgent(admin, defaultAgentId);
+    await api.deleteVersionFreeAgent(admin, defaultAgentId);
     const restored = await api.readOnboardingStatus(admin);
     expect(restored.defaultAgentId).toBeTruthy();
     expect(restored.defaultAgentId).not.toBe(defaultAgentId);

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -3342,7 +3342,10 @@ describe("okou workflow automations", () => {
       }),
       [201],
     );
-    await bdd.deleteAgent(agentScenario.actor, agentScenario.agentId);
+    await bdd.deleteVersionFreeAgent(
+      agentScenario.actor,
+      agentScenario.agentId,
+    );
     expect(watch.calls).toBe(2);
     expect(stop.calls).toBe(2);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
@@ -90,7 +90,7 @@ async function cleanupStaffFixture(fixture: StaffFixture): Promise<void> {
       return;
     }
     case "agent": {
-      await bdd.deleteAgent(fixture.actor, fixture.agentId);
+      await bdd.deleteVersionFreeAgent(fixture.actor, fixture.agentId);
       return;
     }
   }

--- a/turbo/apps/api/src/signals/services/zero-compose-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-compose-data.service.ts
@@ -5,6 +5,7 @@ import {
   agentComposeVersions,
 } from "@okouai/db/schema/agent-compose";
 import { agentRuns } from "@okouai/db/schema/agent-run";
+import { agentSessions } from "@okouai/db/schema/agent-session";
 import { storages } from "@okouai/db/schema/storage";
 import { zeroAgents } from "@okouai/db/schema/zero-agent";
 import { workflowAutomations, workflows } from "@okouai/db/schema/workflow";
@@ -12,12 +13,15 @@ import {
   getInstructionsStorageName,
   VOLUME_ORG_USER_ID,
 } from "@okouai/core/storage-names";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 
 import { db$, writeDb$ } from "../external/db";
+import type { Tx } from "../../lib/db-types";
 import { deleteS3Objects, listS3ObjectsUnderPrefix } from "../external/s3";
 import { env } from "../../lib/env";
 import { conflict } from "../../lib/error";
+import { isLockNotAvailable } from "../../lib/pg-errors";
+import { settle } from "../utils";
 import { reconcileAutomationEventWatches } from "./automation-event-watch-lifecycle.service";
 
 export function zeroComposeExists(args: {
@@ -77,103 +81,198 @@ export function zeroComposeList(
 
 type ConflictResponse = ReturnType<typeof conflict>;
 
-const ACTIVE_RUN_STATUSES = ["pending", "running"] as const;
+const DELETE_AGENT_LOCK_TIMEOUT = "100ms";
+
+interface DeleteComposeArgs {
+  readonly composeId: string;
+  readonly composeName: string;
+  readonly orgId: string;
+}
+
+async function lockAgentLifecycleForDeletion(tx: Tx, args: DeleteComposeArgs) {
+  const [agent] = await tx
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.id, args.composeId),
+        eq(agentComposes.orgId, args.orgId),
+      ),
+    )
+    .for("update", { noWait: true })
+    .limit(1);
+
+  if (!agent) {
+    return { kind: "missing" as const };
+  }
+
+  const [legacyVersion] = await tx
+    .select({ id: agentComposeVersions.id })
+    .from(agentComposeVersions)
+    .where(eq(agentComposeVersions.composeId, args.composeId))
+    .limit(1);
+
+  // Temporary Stage 0 safety veto. Remove only when #26938's final
+  // version-contract stage has removed every legacy version dependency.
+  if (legacyVersion) {
+    return { kind: "legacy-version" as const };
+  }
+
+  const sessions = await tx
+    .select({ id: agentSessions.id, orgId: agentSessions.orgId })
+    .from(agentSessions)
+    .where(eq(agentSessions.agentComposeId, args.composeId))
+    .orderBy(asc(agentSessions.id))
+    .for("update", { noWait: true });
+
+  if (
+    sessions.some((session) => {
+      return session.orgId !== args.orgId;
+    })
+  ) {
+    return { kind: "ownership-conflict" as const };
+  }
+
+  const runs =
+    sessions.length === 0
+      ? []
+      : await tx
+          .select({
+            id: agentRuns.id,
+            orgId: agentRuns.orgId,
+            status: agentRuns.status,
+          })
+          .from(agentRuns)
+          .where(
+            inArray(
+              agentRuns.sessionId,
+              sessions.map((session) => {
+                return session.id;
+              }),
+            ),
+          )
+          .orderBy(asc(agentRuns.id))
+          .for("update", { noWait: true });
+
+  if (
+    runs.some((run) => {
+      return run.orgId !== args.orgId;
+    })
+  ) {
+    return { kind: "ownership-conflict" as const };
+  }
+
+  if (
+    runs.some((run) => {
+      return run.status === "pending" || run.status === "running";
+    })
+  ) {
+    return { kind: "active-run" as const };
+  }
+
+  return { kind: "ready" as const };
+}
+
+async function deleteComposeInTransaction(tx: Tx, args: DeleteComposeArgs) {
+  await tx.execute(
+    sql`SELECT set_config('lock_timeout', ${DELETE_AGENT_LOCK_TIMEOUT}, true)`,
+  );
+
+  const lifecycle = await lockAgentLifecycleForDeletion(tx, args);
+  if (lifecycle.kind !== "ready") {
+    return lifecycle;
+  }
+
+  const automations = await tx
+    .select({
+      orgId: workflowAutomations.orgId,
+      ownerUserId: workflowAutomations.ownerUserId,
+      eventType: workflowAutomations.eventType,
+      eventConfig: workflowAutomations.eventConfig,
+    })
+    .from(workflowAutomations)
+    .innerJoin(workflows, eq(workflowAutomations.workflowId, workflows.id))
+    .where(
+      and(
+        eq(workflows.orgId, args.orgId),
+        eq(workflows.agentId, args.composeId),
+      ),
+    );
+
+  await tx
+    .delete(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.id, args.composeId),
+        eq(agentComposes.orgId, args.orgId),
+      ),
+    );
+
+  const storageName = getInstructionsStorageName(args.composeName);
+  const [storage] = await tx
+    .select({ id: storages.id, s3Prefix: storages.s3Prefix })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, args.orgId),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.name, storageName),
+      ),
+    )
+    .limit(1);
+
+  if (storage) {
+    await tx.delete(storages).where(eq(storages.id, storage.id));
+  }
+
+  return {
+    kind: "deleted" as const,
+    s3Prefix: storage?.s3Prefix ?? null,
+    automations,
+  };
+}
 
 export const deleteComposeById$ = command(
   async (
     { get, set },
-    args: {
-      readonly composeId: string;
-      readonly composeName: string;
-      readonly orgId: string;
-    },
+    args: DeleteComposeArgs,
     signal: AbortSignal,
   ): Promise<ConflictResponse | undefined> => {
     const writeDb = set(writeDb$);
 
-    const result = await writeDb.transaction(async (tx) => {
-      const [activeRun] = await tx
-        .select({ id: agentRuns.id })
-        .from(agentRuns)
-        .innerJoin(
-          agentComposeVersions,
-          eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-        )
-        .where(
-          and(
-            eq(agentComposeVersions.composeId, args.composeId),
-            inArray(agentRuns.status, [...ACTIVE_RUN_STATUSES]),
-          ),
-        )
-        .limit(1);
-
-      if (activeRun) {
-        return { kind: "conflict" as const };
+    const transaction = await settle(
+      writeDb.transaction(async (tx) => {
+        return await deleteComposeInTransaction(tx, args);
+      }),
+      signal,
+    );
+    if (!transaction.ok) {
+      if (isLockNotAvailable(transaction.error)) {
+        return conflict("Cannot delete agent right now; retry shortly");
       }
-
-      const automations = await tx
-        .select({
-          orgId: workflowAutomations.orgId,
-          ownerUserId: workflowAutomations.ownerUserId,
-          eventType: workflowAutomations.eventType,
-          eventConfig: workflowAutomations.eventConfig,
-        })
-        .from(workflowAutomations)
-        .innerJoin(workflows, eq(workflowAutomations.workflowId, workflows.id))
-        .where(
-          and(
-            eq(workflows.orgId, args.orgId),
-            eq(workflows.agentId, args.composeId),
-          ),
-        );
-
-      const versionRows = await tx
-        .select({ id: agentComposeVersions.id })
-        .from(agentComposeVersions)
-        .where(eq(agentComposeVersions.composeId, args.composeId));
-
-      if (versionRows.length > 0) {
-        await tx.delete(agentRuns).where(
-          inArray(
-            agentRuns.agentComposeVersionId,
-            versionRows.map((row) => {
-              return row.id;
-            }),
-          ),
-        );
-      }
-
-      await tx
-        .delete(agentComposes)
-        .where(eq(agentComposes.id, args.composeId));
-
-      const storageName = getInstructionsStorageName(args.composeName);
-      const [storage] = await tx
-        .select({ id: storages.id, s3Prefix: storages.s3Prefix })
-        .from(storages)
-        .where(
-          and(
-            eq(storages.orgId, args.orgId),
-            eq(storages.userId, VOLUME_ORG_USER_ID),
-            eq(storages.name, storageName),
-          ),
-        )
-        .limit(1);
-
-      if (storage) {
-        await tx.delete(storages).where(eq(storages.id, storage.id));
-      }
-
-      return {
-        kind: "deleted" as const,
-        s3Prefix: storage?.s3Prefix ?? null,
-        automations,
-      };
-    });
+      throw transaction.error;
+    }
+    const result = transaction.value;
     signal.throwIfAborted();
 
-    if (result.kind === "conflict") {
+    if (result.kind === "legacy-version") {
+      return conflict(
+        "Cannot delete agent while its configuration is being migrated",
+      );
+    }
+
+    if (result.kind === "ownership-conflict") {
+      return conflict(
+        "Cannot delete agent because its lifecycle ownership is inconsistent",
+      );
+    }
+
+    if (result.kind === "active-run") {
       return conflict("Cannot delete agent: agent is currently running");
+    }
+
+    if (result.kind === "missing") {
+      return undefined;
     }
 
     await reconcileAutomationEventWatches(

--- a/turbo/apps/api/src/test-fixtures/agent-deletion.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-deletion.ts
@@ -1,0 +1,490 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "@okouai/db/schema/agent-compose";
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { agentSessions } from "@okouai/db/schema/agent-session";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { usageEvent } from "@okouai/db/schema/usage-event";
+import { and, asc, count, eq, inArray, sql } from "drizzle-orm";
+import { z } from "zod";
+
+import { db } from "../lib/db";
+import { executeRawRows } from "../lib/db-raw-rows";
+import { createDeferredPromise } from "../signals/utils";
+
+// These fixtures construct transitional and concurrent database states that
+// the production API cannot pause or create. Route tests must opt into their
+// use explicitly and continue exercising deletion through the real endpoint.
+
+const databasePidRowSchema = z.object({ pid: z.int() });
+const waiterCountRowSchema = z.object({ waiterCount: z.int() });
+const lockTimeoutRowSchema = z.object({ lockTimeout: z.string() });
+
+interface HeldDatabaseBoundary {
+  readonly release: () => void;
+  readonly done: Promise<void>;
+  readonly blockedWaiterCount: () => Promise<number>;
+}
+
+async function directBlockedWaiterCount(holderPid: number): Promise<number> {
+  const rows = await executeRawRows(
+    db(),
+    sql`
+      SELECT ${count()}::int AS "waiterCount"
+      FROM pg_stat_activity AS activity
+      WHERE ${holderPid} = ANY(pg_blocking_pids(activity.pid))
+    `,
+    waiterCountRowSchema,
+  );
+  return rows[0]?.waiterCount ?? 0;
+}
+
+async function transactionBackendPid(
+  tx: Parameters<typeof executeRawRows>[0],
+): Promise<number> {
+  const rows = await executeRawRows(
+    tx,
+    sql`SELECT pg_backend_pid() AS "pid"`,
+    databasePidRowSchema,
+  );
+  const pid = rows[0]?.pid;
+  if (!pid) {
+    throw new Error("Expected an agent deletion fixture backend pid");
+  }
+  return pid;
+}
+
+function boundaryFromPid(args: {
+  readonly pid: number;
+  readonly released: ReturnType<typeof createDeferredPromise<void>>;
+  readonly done: Promise<void>;
+}): HeldDatabaseBoundary {
+  return {
+    release: () => {
+      if (!args.released.settled()) {
+        args.released.resolve(undefined);
+      }
+    },
+    done: args.done,
+    blockedWaiterCount: async () => {
+      return await directBlockedWaiterCount(args.pid);
+    },
+  };
+}
+
+export async function removeAgentLegacyVersionsFixture(
+  agentId: string,
+): Promise<readonly string[]> {
+  const rows = await db()
+    .delete(agentComposeVersions)
+    .where(eq(agentComposeVersions.composeId, agentId))
+    .returning({ id: agentComposeVersions.id });
+  return rows.map((row) => {
+    return row.id;
+  });
+}
+
+async function agentHeadVersionId(agentId: string): Promise<string> {
+  const [agent] = await db()
+    .select({ headVersionId: agentComposes.headVersionId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, agentId))
+    .limit(1);
+  if (!agent?.headVersionId) {
+    throw new Error("Expected an agent head version");
+  }
+  return agent.headVersionId;
+}
+
+export async function referenceAgentRunVersionFixture(args: {
+  readonly runId: string;
+  readonly versionAgentId: string;
+}): Promise<string> {
+  const versionId = await agentHeadVersionId(args.versionAgentId);
+  const rows = await db()
+    .update(agentRuns)
+    .set({ agentComposeVersionId: versionId })
+    .where(eq(agentRuns.id, args.runId))
+    .returning({ id: agentRuns.id });
+  if (rows.length !== 1) {
+    throw new Error("Expected one agent Run version reference to change");
+  }
+  return versionId;
+}
+
+export async function referenceAgentHeadFixture(args: {
+  readonly agentId: string;
+  readonly versionAgentId: string;
+}): Promise<string> {
+  const versionId = await agentHeadVersionId(args.versionAgentId);
+  const rows = await db()
+    .update(agentComposes)
+    .set({ headVersionId: versionId })
+    .where(eq(agentComposes.id, args.agentId))
+    .returning({ id: agentComposes.id });
+  if (rows.length !== 1) {
+    throw new Error("Expected one agent head reference to change");
+  }
+  return versionId;
+}
+
+export async function readAgentLifecycleIdsFixture(agentId: string): Promise<{
+  readonly sessionIds: readonly string[];
+  readonly runIds: readonly string[];
+}> {
+  const sessions = await db()
+    .select({ id: agentSessions.id })
+    .from(agentSessions)
+    .where(eq(agentSessions.agentComposeId, agentId))
+    .orderBy(asc(agentSessions.id));
+  const sessionIds = sessions.map((session) => {
+    return session.id;
+  });
+  const runs =
+    sessionIds.length === 0
+      ? []
+      : await db()
+          .select({ id: agentRuns.id })
+          .from(agentRuns)
+          .where(inArray(agentRuns.sessionId, sessionIds))
+          .orderBy(asc(agentRuns.id));
+  return {
+    sessionIds,
+    runIds: runs.map((run) => {
+      return run.id;
+    }),
+  };
+}
+
+export async function readAgentLifecycleCountsFixture(
+  agentId: string,
+): Promise<{
+  readonly agents: number;
+  readonly sessions: number;
+  readonly runs: number;
+}> {
+  const [agentCount] = await db()
+    .select({ value: count() })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, agentId));
+  const lifecycle = await readAgentLifecycleIdsFixture(agentId);
+  return {
+    agents: agentCount?.value ?? 0,
+    sessions: lifecycle.sessionIds.length,
+    runs: lifecycle.runIds.length,
+  };
+}
+
+export async function setAgentLifecycleOrgFixture(args: {
+  readonly kind: "session" | "run";
+  readonly id: string;
+  readonly orgId: string;
+}): Promise<void> {
+  const rows =
+    args.kind === "session"
+      ? await db()
+          .update(agentSessions)
+          .set({ orgId: args.orgId })
+          .where(eq(agentSessions.id, args.id))
+          .returning({ id: agentSessions.id })
+      : await db()
+          .update(agentRuns)
+          .set({ orgId: args.orgId })
+          .where(eq(agentRuns.id, args.id))
+          .returning({ id: agentRuns.id });
+  if (rows.length !== 1) {
+    throw new Error("Expected one lifecycle org fixture row to change");
+  }
+}
+
+export async function setAgentRunStatusFixture(
+  runId: string,
+  status: string,
+): Promise<void> {
+  const rows = await db()
+    .update(agentRuns)
+    .set({ status })
+    .where(eq(agentRuns.id, runId))
+    .returning({ id: agentRuns.id });
+  if (rows.length !== 1) {
+    throw new Error("Expected one agent Run status to change");
+  }
+}
+
+export async function holdAgentDeletionRowLockFixture(args: {
+  readonly kind: "agent" | "session" | "run";
+  readonly id: string;
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const rows =
+      args.kind === "agent"
+        ? await tx
+            .select({ id: agentComposes.id })
+            .from(agentComposes)
+            .where(eq(agentComposes.id, args.id))
+            .for("update")
+        : args.kind === "session"
+          ? await tx
+              .select({ id: agentSessions.id })
+              .from(agentSessions)
+              .where(eq(agentSessions.id, args.id))
+              .for("update")
+          : await tx
+              .select({ id: agentRuns.id })
+              .from(agentRuns)
+              .where(eq(agentRuns.id, args.id))
+              .for("update");
+    if (rows.length !== 1) {
+      throw new Error(`Expected one ${args.kind} deletion fixture row`);
+    }
+    started.resolve(await transactionBackendPid(tx));
+    await released.promise;
+  });
+  return boundaryFromPid({
+    pid: await started.promise,
+    released,
+    done,
+  });
+}
+
+export async function holdAgentRunLocksFixture(args: {
+  readonly runIds: readonly string[];
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    for (const runId of args.runIds) {
+      const rows = await tx
+        .select({ id: agentRuns.id })
+        .from(agentRuns)
+        .where(eq(agentRuns.id, runId))
+        .for("update");
+      if (rows.length !== 1) {
+        throw new Error("Expected a reverse-order Run fixture row");
+      }
+    }
+    started.resolve(await transactionBackendPid(tx));
+    await released.promise;
+  });
+  return boundaryFromPid({
+    pid: await started.promise,
+    released,
+    done,
+  });
+}
+
+export async function holdAgentVersionInsertFixture(args: {
+  readonly agentId: string;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const versionId = createHash("sha256")
+    .update(`agent-delete-version-${randomUUID()}`)
+    .digest("hex");
+  const done = db().transaction(async (tx) => {
+    await tx.insert(agentComposeVersions).values({
+      id: versionId,
+      composeId: args.agentId,
+      content: {
+        version: "1",
+        agents: { fixture: { framework: "claude-code" } },
+      },
+      createdBy: args.userId,
+    });
+    started.resolve(await transactionBackendPid(tx));
+    await released.promise;
+  });
+  return boundaryFromPid({
+    pid: await started.promise,
+    released,
+    done,
+  });
+}
+
+export async function holdAgentSessionInsertFixture(args: {
+  readonly agentId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    await tx.insert(agentSessions).values({
+      agentComposeId: args.agentId,
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+    started.resolve(await transactionBackendPid(tx));
+    await released.promise;
+  });
+  return boundaryFromPid({
+    pid: await started.promise,
+    released,
+    done,
+  });
+}
+
+export async function holdAgentRunInsertFixture(args: {
+  readonly sessionId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    await tx.insert(agentRuns).values({
+      sessionId: args.sessionId,
+      orgId: args.orgId,
+      userId: args.userId,
+      status: "pending",
+      prompt: "held continuation Run insert",
+    });
+    started.resolve(await transactionBackendPid(tx));
+    await released.promise;
+  });
+  return boundaryFromPid({
+    pid: await started.promise,
+    released,
+    done,
+  });
+}
+
+export async function holdAgentRunPromotionFixture(args: {
+  readonly runId: string;
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const rows = await tx
+      .update(agentRuns)
+      .set({ status: "pending" })
+      .where(and(eq(agentRuns.id, args.runId), eq(agentRuns.status, "queued")))
+      .returning({ id: agentRuns.id });
+    if (rows.length !== 1) {
+      throw new Error("Expected one queued Run promotion fixture row");
+    }
+    started.resolve(await transactionBackendPid(tx));
+    await released.promise;
+  });
+  return boundaryFromPid({
+    pid: await started.promise,
+    released,
+    done,
+  });
+}
+
+export async function holdUsageEventMutationFixture(args: {
+  readonly usageEventId: string;
+  readonly signal: AbortSignal;
+}): Promise<HeldDatabaseBoundary> {
+  const started = createDeferredPromise<number>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const rows = await tx
+      .update(usageEvent)
+      .set({ billingError: "agent_delete_fixture" })
+      .where(eq(usageEvent.id, args.usageEventId))
+      .returning({ id: usageEvent.id });
+    if (rows.length !== 1) {
+      throw new Error("Expected one usage event mutation fixture row");
+    }
+    started.resolve(await transactionBackendPid(tx));
+    await released.promise;
+  });
+  return boundaryFromPid({
+    pid: await started.promise,
+    released,
+    done,
+  });
+}
+
+export async function readUsageEventRunIdFixture(
+  usageEventId: string,
+): Promise<string | null> {
+  const [row] = await db()
+    .select({ runId: usageEvent.runId })
+    .from(usageEvent)
+    .where(eq(usageEvent.id, usageEventId))
+    .limit(1);
+  if (!row) {
+    throw new Error("Expected the retained usage event fixture row");
+  }
+  return row.runId;
+}
+
+export async function holdChatThreadThenSessionFixture(args: {
+  readonly threadId: string;
+  readonly sessionId: string;
+  readonly signal: AbortSignal;
+}): Promise<
+  {
+    readonly startSessionLock: () => void;
+    readonly sessionLocked: Promise<void>;
+  } & HeldDatabaseBoundary
+> {
+  const started = createDeferredPromise<number>(args.signal);
+  const attemptSession = createDeferredPromise<void>(args.signal);
+  const sessionLocked = createDeferredPromise<void>(args.signal);
+  const released = createDeferredPromise<void>(args.signal);
+  const done = db().transaction(async (tx) => {
+    const threads = await tx
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, args.threadId))
+      .for("update");
+    if (threads.length !== 1) {
+      throw new Error("Expected one ChatThread fixture row");
+    }
+    started.resolve(await transactionBackendPid(tx));
+    await attemptSession.promise;
+    const sessions = await tx
+      .select({ id: agentSessions.id })
+      .from(agentSessions)
+      .where(eq(agentSessions.id, args.sessionId))
+      .for("update");
+    if (sessions.length !== 1) {
+      throw new Error("Expected one Session fixture row");
+    }
+    sessionLocked.resolve(undefined);
+    await released.promise;
+  });
+  const boundary = boundaryFromPid({
+    pid: await started.promise,
+    released,
+    done,
+  });
+  return {
+    ...boundary,
+    startSessionLock: () => {
+      if (!attemptSession.settled()) {
+        attemptSession.resolve(undefined);
+      }
+    },
+    sessionLocked: sessionLocked.promise,
+  };
+}
+
+export async function readDatabaseLockTimeoutFixture(): Promise<string> {
+  const rows = await executeRawRows(
+    db(),
+    sql`SELECT current_setting('lock_timeout') AS "lockTimeout"`,
+    lockTimeoutRowSchema,
+  );
+  const lockTimeout = rows[0]?.lockTimeout;
+  if (lockTimeout === undefined) {
+    throw new Error("Expected the current database lock_timeout");
+  }
+  return lockTimeout;
+}


### PR DESCRIPTION
## Summary

- replace version-derived Run ownership with the real Agent -> Session -> Run lifecycle path
- lock the authenticated target Agent, every target Session, and every target Run with `FOR UPDATE NOWAIT`, then fail closed on child-org inconsistencies and active target Runs
- veto deletion before child mutation when the target has any legacy version row, and rely on existing lifecycle cascades only for the zero-version cohort
- bound unavoidable cascade-child waits with transaction-local `lock_timeout = 100ms`; map only Drizzle-wrapped `cause.code === 55P03` to a retryable 409 while leaving `40P01` untouched
- contain the temporary Stage 0 migration veto only in the four affected Runner E2E teardown paths, with exact response matching and no production bypass

## Safety and behavior

The transaction locks the root Agent by `id + org_id`, checks the temporary legacy-version veto, locks Sessions and Runs in stable id order without waiting, and evaluates status only after all locks are held. Missing targets remain idempotent. Pending/running target Runs retain the existing conflict; queued and terminal Runs are removed only through Agent -> Session -> Run cascades.

The old `agent_compose_version_id` / version-hash Run selection and explicit Run deletion are removed. Cross-Agent and cross-organization version provenance is therefore never treated as lifecycle ownership. Existing non-destructive usage references retain billing rows when lifecycle rows cascade.

Any explicit lock conflict or cascade wait exceeding 100 ms aborts the whole transaction. The retry response is produced only outside the aborted transaction, and post-commit automation reconciliation and S3 cleanup do not run for failed attempts. There is no automatic retry loop.

The existing create-limit compensation caller receives the same mandated fail-closed legacy-version veto; this PR adds no unsafe bypass or version-sharing classification.

Turbo run 31937319533 exposed a deterministic Stage 0 compatibility failure after the four affected Runner E2E behaviors had passed: their `teardown_file` calls received the mandated migration-veto 409. The new `delete_runner_agent_for_stage0_teardown` helper accepts only an empty 204, the exact idempotent `NOT_FOUND` response for that Agent ID, or the exact temporary migration-veto 409. Transport failures, other 409s, malformed or augmented responses, and every other HTTP response still fail the teardown. The helper is called only by `run-t07-codex-smoke`, `run-t08-codex-resume`, `run-t09-real-codex-steer`, and `run-t10-real-claude-smoke`.

## Production scale

The reviewed 2026-08-16 MaskDB inventory contains 5,966 valid product Agents: 3,129 (52.45%) are temporarily vetoed because they have at least one legacy version row, while 2,837 (47.55%) can enter the no-wait path. In the corresponding all-compose cohort, 2,838 zero-version targets have 2,780 Sessions and 8,019 Runs. Runs per target are p95 11, p99 43, and max 255; only 5 targets exceed 100 and none exceed 1,000.

## Validation

Run sequentially from `turbo/`:

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (the API ESLint findings were fixed, then the affected API lint was rerun after the required main rebase)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts` (14 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/agents-by-id.test.ts` (23 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/agents-create.test.ts` (7 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (2 passed, including the #27538 baseline)

Focused multi-connection coverage includes Agent/Session/Run NOWAIT conflicts, concurrent Version/Session/continuation-Run inserts, queued promotion, reverse Run lock order, the ChatThread/Session reverse path, cascade-child timeout rollback, no blocked-waiter leak, no transaction-local GUC leak, shared provenance/checkpoint survival, org isolation, and raw/hourly billing retention.

After rebasing onto `f76509940f`, the following affected checks were rerun:

- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api run lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter api run check-types`
- `bash -n e2e/helpers/runner-chat.bash`
- Bats `--count` over the four affected files (6 tests parsed)
- sourced-helper response matrix covering the three exact accepted outcomes plus wrong-ID 404, active-Run 409, augmented/malformed migration 409, 500, unexpected 204 body, and transport failure rejection
- exact caller audit confirming only the four affected teardown paths use the temporary helper
- `.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `git range-diff` and `git diff --check`; the final route-shell rebase changed only the baseline `zeroAgentsRoutes` to `agentsRoutes` import context

The focused API tests above passed before the final route-shell-only rebase. A post-rebase rerun was attempted, but no local Postgres was listening on `127.0.0.1/[::1]:5432`, so no tests executed in that attempt; final-head behavioral validation is delegated to PR CI. The full local Vitest suite was not run and no development server was started, per repository policy.

## Fallbacks

- `deleteComposeById$` legacy-version deletion veto: temporary Stage 0 data-transition containment for persisted version-dependent heads, readers, writers, foreign keys, and rollback paths. It remains only until #26938's final version-contract/drop stage removes every legacy dependency and explicitly removes this veto. It never treats `compose_id` as lifecycle ownership and performs no automatic retry.
- `delete_runner_agent_for_stage0_teardown`: temporary test-harness-only containment for the four named Runner E2Es while the production legacy-version veto is present. It does not weaken or bypass production deletion and rejects every response except the exact success/idempotency/migration-veto outcomes above. Remove it and restore `delete_runner_agent` when #26938's final version-contract/drop stage removes the production veto.

## Non-goals

- no schema or migration change (actual migration: none)
- no Clerk cleanup, queue, ChatThread, production Runner, checkpoint, or wire-contract change
- no version retention, version GC, dangling-head repair, membership model, provenance synthesis, or data rewrite

Closes #27529

Parent #26938
