### PR TITLE
fix(runner): fail open on overlapping websocket prewarm correlation

### DIFF
--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -20,7 +20,7 @@ Lifecycle:
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 from mitmproxy import http
 from wsproto.utilities import generate_accept_token
@@ -85,9 +85,61 @@ class _ResponseUsageStreamSetup(NamedTuple):
 
 @dataclass(slots=True)
 class _OpenAIResponsesPrewarmState:
-    pending_response_created: bool = False
-    response_id: str | None = None
-    diagnostic_emitted: bool = False
+    pending_intent: Literal["normal", "prewarm"] | None = None
+    active_intent: Literal["normal", "prewarm"] | None = None
+    active_response_id: str | None = None
+    ignored_response_id: str | None = None
+    ambiguous: bool = False
+    ambiguity_diagnostic_emitted: bool = False
+    ignored_diagnostic_emitted: bool = False
+
+
+_WebSocketCorrelationReason = Literal[
+    "overlapping_request",
+    "unknown_client_event",
+    "invalid_lifecycle",
+    "server_error",
+    "correlation_cap",
+]
+
+
+def _clear_websocket_correlation_candidate(state: _OpenAIResponsesPrewarmState) -> None:
+    state.pending_intent = None
+    state.active_intent = None
+    state.active_response_id = None
+
+
+def _lifecycle_ambiguity_reason(
+    lifecycle: usage.OpenAIResponsesServerLifecycle,
+) -> _WebSocketCorrelationReason:
+    if lifecycle.inspection_error == "work limit exceeded":
+        return "correlation_cap"
+    return "invalid_lifecycle"
+
+
+def _mark_websocket_correlation_ambiguous(
+    flow: http.HTTPFlow,
+    state: _OpenAIResponsesPrewarmState,
+    reason: _WebSocketCorrelationReason,
+) -> None:
+    """Disable prewarm exclusion after ownership can no longer be proven."""
+    state.ambiguous = True
+    _clear_websocket_correlation_candidate(state)
+    if state.ambiguity_diagnostic_emitted:
+        return
+    log_proxy_entry(
+        flow_metadata.proxy_log_path(flow.metadata),
+        "warn",
+        "Model provider WebSocket usage correlation became ambiguous",
+        type="model_usage_correlation",
+        disposition="ambiguous",
+        reason=reason,
+        run_id=flow_metadata.run_id(flow.metadata),
+        flow_id=flow.id,
+        transport="websocket",
+        firewall_name=flow_metadata.firewall_name(flow.metadata),
+    )
+    state.ambiguity_diagnostic_emitted = True
 
 
 def model_usage_protocol(flow: http.HTTPFlow) -> usage.ModelUsageProtocol:
@@ -144,15 +196,79 @@ def observe_model_websocket_client_event(
     flow: http.HTTPFlow,
     event: usage.OpenAIResponsesClientEvent,
 ) -> None:
-    """Track exact non-generating request intent on one WebSocket flow."""
+    """Track bounded request intent on one WebSocket flow."""
     state = flow.metadata.get(_MODEL_WEBSOCKET_PREWARM_STATE)
     if not isinstance(state, _OpenAIResponsesPrewarmState):
         return
 
-    state.pending_response_created = event.is_prewarm
+    if event.request_kind == "unknown":
+        _mark_websocket_correlation_ambiguous(flow, state, "unknown_client_event")
+        return
+    if event.request_kind == "other":
+        return
+    if state.ambiguous:
+        return
+    if state.pending_intent is not None or state.active_intent is not None:
+        _mark_websocket_correlation_ambiguous(flow, state, "overlapping_request")
+        return
+    state.pending_intent = "prewarm" if event.is_prewarm else "normal"
     if event.is_prewarm:
-        state.response_id = None
-        state.diagnostic_emitted = False
+        state.ignored_diagnostic_emitted = False
+
+
+def _observe_websocket_server_lifecycle(
+    flow: http.HTTPFlow,
+    state: _OpenAIResponsesPrewarmState,
+    lifecycle: usage.OpenAIResponsesServerLifecycle,
+) -> None:
+    """Advance request intent state at a server lifecycle boundary."""
+    if state.ambiguous:
+        return
+    if lifecycle.is_error:
+        _mark_websocket_correlation_ambiguous(flow, state, "server_error")
+        return
+    if lifecycle.is_created:
+        if not lifecycle.is_valid:
+            _mark_websocket_correlation_ambiguous(
+                flow,
+                state,
+                _lifecycle_ambiguity_reason(lifecycle),
+            )
+            return
+        if state.pending_intent is None or state.active_intent is not None:
+            _mark_websocket_correlation_ambiguous(flow, state, "invalid_lifecycle")
+            return
+        state.active_intent = state.pending_intent
+        state.active_response_id = lifecycle.response_id
+        state.pending_intent = None
+        return
+    if lifecycle.is_terminal:
+        if not lifecycle.is_valid:
+            if state.pending_intent is not None or state.active_intent is not None:
+                _mark_websocket_correlation_ambiguous(
+                    flow,
+                    state,
+                    _lifecycle_ambiguity_reason(lifecycle),
+                )
+            return
+        if (
+            state.active_intent is None
+            and state.pending_intent is not None
+            and lifecycle.response_id != state.ignored_response_id
+        ):
+            _mark_websocket_correlation_ambiguous(flow, state, "invalid_lifecycle")
+            return
+        if state.active_intent is not None and lifecycle.response_id != state.active_response_id:
+            _mark_websocket_correlation_ambiguous(flow, state, "invalid_lifecycle")
+        return
+    if not lifecycle.is_valid and (
+        state.pending_intent is not None or state.active_intent is not None
+    ):
+        _mark_websocket_correlation_ambiguous(
+            flow,
+            state,
+            _lifecycle_ambiguity_reason(lifecycle),
+        )
 
 
 def _make_response_decode_session(
@@ -584,18 +700,15 @@ def feed_model_websocket_usage(
     if not is_model_websocket_usage_enabled(flow):
         return
     prewarm_state = flow.metadata.get(_MODEL_WEBSOCKET_PREWARM_STATE)
-    if isinstance(prewarm_state, _OpenAIResponsesPrewarmState) and (
-        prewarm_state.pending_response_created
-    ):
+    lifecycle: usage.OpenAIResponsesServerLifecycle | None = None
+    if isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
         lifecycle = usage.inspect_openai_responses_server_lifecycle(event)
-        if lifecycle.event_type == "response.created":
-            prewarm_state.pending_response_created = False
-            prewarm_state.response_id = lifecycle.response_id
-        elif lifecycle.is_terminal:
-            prewarm_state.pending_response_created = False
+        _observe_websocket_server_lifecycle(flow, prewarm_state, lifecycle)
 
     usage_result, inspection_error = usage.extract_openai_responses_usage_from_event(event)
     if inspection_error is not None:
+        if isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
+            _mark_websocket_correlation_ambiguous(flow, prewarm_state, "correlation_cap")
         log_proxy_entry(
             flow_metadata.proxy_log_path(flow.metadata),
             "warn",
@@ -605,18 +718,30 @@ def feed_model_websocket_usage(
             error=inspection_error,
         )
         return
-    if not usage_result:
-        return
-    message_id = usage_result.get("message_id")
-    if isinstance(message_id, str) and message_id:
+
+    message_id_value = usage_result.get("message_id") if usage_result else None
+    message_id = (
+        message_id_value if isinstance(message_id_value, str) and message_id_value else None
+    )
+    has_message_id = message_id is not None
+    suppressed = False
+    if isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
         if (
-            isinstance(prewarm_state, _OpenAIResponsesPrewarmState)
-            and prewarm_state.response_id == message_id
+            usage_result is not None
+            and has_message_id
+            and lifecycle is not None
+            and lifecycle.is_terminal
+            and lifecycle.is_valid
+            and lifecycle.response_id == message_id
         ):
-            lifecycle = usage.inspect_openai_responses_server_lifecycle(event)
-            if lifecycle.is_terminal and lifecycle.response_id == message_id:
-                if not prewarm_state.diagnostic_emitted and usage.has_positive_model_provider_usage(
-                    usage_result
+            if (
+                not prewarm_state.ambiguous
+                and prewarm_state.active_intent == "prewarm"
+                and prewarm_state.active_response_id == message_id
+            ):
+                if (
+                    not prewarm_state.ignored_diagnostic_emitted
+                    and usage.has_positive_model_provider_usage(usage_result)
                 ):
                     usage.log_ignored_model_provider_usage_source(
                         flow,
@@ -625,33 +750,79 @@ def feed_model_websocket_usage(
                         usage_result,
                         reason="responses_generate_false",
                     )
-                    prewarm_state.diagnostic_emitted = True
-                return
-            prewarm_state.response_id = None
-        usage_sources = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE_SOURCES)
-        if not isinstance(usage_sources, dict):
-            usage_sources = {}
-            flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = usage_sources
-        usage_target = usage_sources.get(message_id)
-        if not isinstance(usage_target, dict):
-            usage_target = {}
-            usage_sources[message_id] = usage_target
-        usage.merge_openai_responses_usage_result(usage_target, usage_result)
-        run_id = flow_metadata.run_id(flow.metadata)
-        usage.report_model_provider_usage_source(
-            flow,
-            run_id,
-            message_id,
-            usage_target,
-        )
-        usage_sources.pop(message_id, None)
-        return
+                    prewarm_state.ignored_diagnostic_emitted = True
+                prewarm_state.ignored_response_id = message_id
+                suppressed = True
+            elif (
+                prewarm_state.active_intent is None
+                and prewarm_state.ignored_response_id == message_id
+            ):
+                suppressed = True
+        if (
+            not suppressed
+            and usage_result is not None
+            and (
+                prewarm_state.pending_intent is not None or prewarm_state.active_intent is not None
+            )
+        ):
+            if not has_message_id:
+                if lifecycle is None or not lifecycle.is_terminal:
+                    _mark_websocket_correlation_ambiguous(
+                        flow,
+                        prewarm_state,
+                        "invalid_lifecycle",
+                    )
+            elif prewarm_state.active_intent is not None:
+                active_id = prewarm_state.active_response_id
+                if active_id != message_id or lifecycle is None or not lifecycle.is_terminal:
+                    _mark_websocket_correlation_ambiguous(
+                        flow,
+                        prewarm_state,
+                        "invalid_lifecycle",
+                    )
+            elif lifecycle is None or not lifecycle.is_terminal:
+                _mark_websocket_correlation_ambiguous(
+                    flow,
+                    prewarm_state,
+                    "invalid_lifecycle",
+                )
 
-    usage_target = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
-    if not isinstance(usage_target, dict):
-        usage_target = {}
-        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_target
-    usage.merge_openai_responses_usage_result(usage_target, usage_result)
+    if not suppressed and usage_result:
+        if has_message_id:
+            usage_sources = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE_SOURCES)
+            if not isinstance(usage_sources, dict):
+                usage_sources = {}
+                flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = usage_sources
+            usage_target = usage_sources.get(message_id)
+            if not isinstance(usage_target, dict):
+                usage_target = {}
+                usage_sources[message_id] = usage_target
+            usage.merge_openai_responses_usage_result(usage_target, usage_result)
+            run_id = flow_metadata.run_id(flow.metadata)
+            usage.report_model_provider_usage_source(
+                flow,
+                run_id,
+                message_id,
+                usage_target,
+            )
+            usage_sources.pop(message_id, None)
+        else:
+            usage_target = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
+            if not isinstance(usage_target, dict):
+                usage_target = {}
+                flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_target
+            usage.merge_openai_responses_usage_result(usage_target, usage_result)
+
+    if (
+        isinstance(prewarm_state, _OpenAIResponsesPrewarmState)
+        and lifecycle is not None
+        and lifecycle.is_terminal
+        and lifecycle.is_valid
+        and not prewarm_state.ambiguous
+        and prewarm_state.active_response_id == lifecycle.response_id
+    ):
+        prewarm_state.active_intent = None
+        prewarm_state.active_response_id = None
 
 
 def _finish_connector_response_state(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -111,6 +111,7 @@ _WEBSOCKET_LIFECYCLE_EVENT_TYPES = frozenset(
         "error",
     )
 )
+_JSON_WORK_LIMIT_EXCEEDED = "work limit exceeded"
 
 
 def _clear_websocket_correlation_candidate(state: _OpenAIResponsesPrewarmState) -> None:
@@ -122,7 +123,7 @@ def _clear_websocket_correlation_candidate(state: _OpenAIResponsesPrewarmState) 
 def _lifecycle_ambiguity_reason(
     lifecycle: usage.OpenAIResponsesServerLifecycle,
 ) -> _WebSocketCorrelationReason:
-    if lifecycle.inspection_error == "work limit exceeded":
+    if lifecycle.inspection_error == _JSON_WORK_LIMIT_EXCEEDED:
         return "correlation_cap"
     return "invalid_lifecycle"
 
@@ -215,7 +216,12 @@ def observe_model_websocket_client_event(
         return
 
     if event.request_kind == "unknown":
-        _mark_websocket_correlation_ambiguous(flow, state, "unknown_client_event")
+        reason: _WebSocketCorrelationReason = (
+            "correlation_cap"
+            if event.inspection_error == _JSON_WORK_LIMIT_EXCEEDED
+            else "unknown_client_event"
+        )
+        _mark_websocket_correlation_ambiguous(flow, state, reason)
         return
     if event.request_kind == "other":
         return

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -220,8 +220,6 @@ def observe_model_websocket_client_event(
         )
         _mark_websocket_correlation_ambiguous(flow, state, reason)
         return
-    if event.request_kind == "other":
-        return
     if state.ambiguous:
         return
     if state.pending_intent is not None or state.active_intent is not None:

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -248,6 +248,11 @@ def _observe_websocket_server_lifecycle(
                 _lifecycle_ambiguity_reason(lifecycle),
             )
             return
+        if lifecycle.response_id == state.ignored_response_id:
+            # A retained ID only proves duplicate terminal ownership. Reusing it
+            # at a new created boundary cannot be correlated safely.
+            _mark_websocket_correlation_ambiguous(flow, state, "invalid_lifecycle")
+            return
         if state.pending_intent is None or state.active_intent is not None:
             _mark_websocket_correlation_ambiguous(flow, state, "invalid_lifecycle")
             return

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -135,6 +135,9 @@ def _mark_websocket_correlation_ambiguous(
     """Disable prewarm exclusion after ownership can no longer be proven."""
     state.ambiguous = True
     _clear_websocket_correlation_candidate(state)
+    # Fail-open is sticky for the rest of the flow.  A previously ignored ID
+    # must not remain capable of suppressing usage after that transition.
+    state.ignored_response_id = None
     if state.ambiguity_diagnostic_emitted:
         return
     log_proxy_entry(
@@ -260,6 +263,10 @@ def _observe_websocket_server_lifecycle(
                     state,
                     _lifecycle_ambiguity_reason(lifecycle),
                 )
+            return
+        if lifecycle.response_id == state.ignored_response_id:
+            # A duplicate terminal for an already ignored source is known even
+            # when another request is currently pending or active.
             return
         if (
             state.active_intent is None
@@ -770,10 +777,7 @@ def feed_model_websocket_usage(
                     prewarm_state.ignored_diagnostic_emitted = True
                 prewarm_state.ignored_response_id = message_id
                 suppressed = True
-            elif (
-                prewarm_state.active_intent is None
-                and prewarm_state.ignored_response_id == message_id
-            ):
+            elif not prewarm_state.ambiguous and prewarm_state.ignored_response_id == message_id:
                 suppressed = True
         if (
             not suppressed

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -101,6 +101,16 @@ _WebSocketCorrelationReason = Literal[
     "server_error",
     "correlation_cap",
 ]
+_WEBSOCKET_LIFECYCLE_EVENT_TYPES = frozenset(
+    (
+        "response.created",
+        "response.completed",
+        "response.done",
+        "response.incomplete",
+        "response.failed",
+        "error",
+    )
+)
 
 
 def _clear_websocket_correlation_candidate(state: _OpenAIResponsesPrewarmState) -> None:
@@ -701,7 +711,14 @@ def feed_model_websocket_usage(
         return
     prewarm_state = flow.metadata.get(_MODEL_WEBSOCKET_PREWARM_STATE)
     lifecycle: usage.OpenAIResponsesServerLifecycle | None = None
-    if isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
+    should_inspect_lifecycle = isinstance(prewarm_state, _OpenAIResponsesPrewarmState) and (
+        prewarm_state.pending_intent is not None
+        or prewarm_state.active_intent is not None
+        or prewarm_state.ignored_response_id is not None
+        or event.event_type is None
+        or event.event_type in _WEBSOCKET_LIFECYCLE_EVENT_TYPES
+    )
+    if should_inspect_lifecycle and isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
         lifecycle = usage.inspect_openai_responses_server_lifecycle(event)
         _observe_websocket_server_lifecycle(flow, prewarm_state, lifecycle)
 

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -111,7 +111,6 @@ _WEBSOCKET_LIFECYCLE_EVENT_TYPES = frozenset(
         "error",
     )
 )
-_JSON_WORK_LIMIT_EXCEEDED = "work limit exceeded"
 
 
 def _clear_websocket_correlation_candidate(state: _OpenAIResponsesPrewarmState) -> None:
@@ -123,7 +122,7 @@ def _clear_websocket_correlation_candidate(state: _OpenAIResponsesPrewarmState) 
 def _lifecycle_ambiguity_reason(
     lifecycle: usage.OpenAIResponsesServerLifecycle,
 ) -> _WebSocketCorrelationReason:
-    if lifecycle.inspection_error == _JSON_WORK_LIMIT_EXCEEDED:
+    if lifecycle.work_limit_exceeded:
         return "correlation_cap"
     return "invalid_lifecycle"
 
@@ -217,9 +216,7 @@ def observe_model_websocket_client_event(
 
     if event.request_kind == "unknown":
         reason: _WebSocketCorrelationReason = (
-            "correlation_cap"
-            if event.inspection_error == _JSON_WORK_LIMIT_EXCEEDED
-            else "unknown_client_event"
+            "correlation_cap" if event.work_limit_exceeded else "unknown_client_event"
         )
         _mark_websocket_correlation_ambiguous(flow, state, reason)
         return

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -277,8 +277,12 @@ def _observe_websocket_server_lifecycle(
                 )
             return
         if lifecycle.response_id == state.ignored_response_id:
-            # A duplicate terminal for an already ignored source is known even
-            # when another request is currently pending or active.
+            # A pending request has no bound ID yet, so this could be either an
+            # old duplicate or that request's terminal after a missing created
+            # boundary. Only an idle flow or a differently bound active response
+            # can prove that the retained ID is an old duplicate.
+            if state.pending_intent is not None:
+                _mark_websocket_correlation_ambiguous(flow, state, "invalid_lifecycle")
             return
         if (
             state.active_intent is None

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -238,7 +238,8 @@ def _observe_websocket_server_lifecycle(
     if state.ambiguous:
         return
     if lifecycle.is_error:
-        _mark_websocket_correlation_ambiguous(flow, state, "server_error")
+        reason = "server_error" if lifecycle.is_valid else _lifecycle_ambiguity_reason(lifecycle)
+        _mark_websocket_correlation_ambiguous(flow, state, reason)
         return
     if lifecycle.is_created:
         if not lifecycle.is_valid:

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -731,12 +731,16 @@ def feed_model_websocket_usage(
         return
     prewarm_state = flow.metadata.get(_MODEL_WEBSOCKET_PREWARM_STATE)
     lifecycle: usage.OpenAIResponsesServerLifecycle | None = None
-    should_inspect_lifecycle = isinstance(prewarm_state, _OpenAIResponsesPrewarmState) and (
-        prewarm_state.pending_intent is not None
-        or prewarm_state.active_intent is not None
-        or prewarm_state.ignored_response_id is not None
-        or event.event_type is None
-        or event.event_type in _WEBSOCKET_LIFECYCLE_EVENT_TYPES
+    should_inspect_lifecycle = (
+        isinstance(prewarm_state, _OpenAIResponsesPrewarmState)
+        and not prewarm_state.ambiguous
+        and (
+            prewarm_state.pending_intent is not None
+            or prewarm_state.active_intent is not None
+            or prewarm_state.ignored_response_id is not None
+            or event.event_type is None
+            or event.event_type in _WEBSOCKET_LIFECYCLE_EVENT_TYPES
+        )
     )
     if should_inspect_lifecycle and isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
         lifecycle = usage.inspect_openai_responses_server_lifecycle(event)

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -68,6 +68,7 @@ from .openai_chat_completions import (
 from .openai_responses import (
     OpenAIResponsesClientEvent,
     OpenAIResponsesEvent,
+    OpenAIResponsesServerLifecycle,
     create_openai_responses_json_usage_extractor,
     create_openai_responses_sse_usage_extractor,
     extract_openai_responses_usage_from_event,
@@ -100,6 +101,7 @@ __all__ = [
     "ModelUsageProtocol",
     "OpenAIResponsesClientEvent",
     "OpenAIResponsesEvent",
+    "OpenAIResponsesServerLifecycle",
     "admit_buffered_report",
     "buffer_model_usage_observations",
     "buffer_source_model_usage_observations",

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -149,7 +149,7 @@ class OpenAIResponsesClientEvent:
     event_type: str | None
     is_prewarm: bool
     request_kind: _OpenAIResponsesClientRequestKind = "unknown"
-    inspection_error: str | None = None
+    work_limit_exceeded: bool = False
 
 
 @dataclass(frozen=True)
@@ -159,7 +159,7 @@ class OpenAIResponsesServerLifecycle:
     event_type: str | None
     response_id: str | None
     is_valid: bool = False
-    inspection_error: str | None = None
+    work_limit_exceeded: bool = False
 
     @property
     def is_created(self) -> bool:
@@ -233,7 +233,7 @@ def inspect_openai_responses_client_event_json(body: bytes) -> OpenAIResponsesCl
             observed_event_type,
             False,
             "unknown",
-            result.error,
+            result.error == JSON_WORK_LIMIT_EXCEEDED,
         )
 
     type_is_consistent = extractor.selected_scalar_values_are_consistent(("type",))
@@ -293,7 +293,12 @@ def inspect_openai_responses_server_lifecycle(
     extractor.feed(event._body)
     result = extractor.finish()
     if not result.complete:
-        return OpenAIResponsesServerLifecycle(event.event_type, None, False, result.error)
+        return OpenAIResponsesServerLifecycle(
+            event.event_type,
+            None,
+            False,
+            result.error == JSON_WORK_LIMIT_EXCEEDED,
+        )
     if not extractor.selected_scalar_values_are_consistent(("type",)):
         return OpenAIResponsesServerLifecycle(event.event_type, None, False)
     event_type = result.values.get(("type",))

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -121,7 +121,7 @@ _ResponsesEventTypeClassification = Literal[
     "unresolved",
     "pending",
 ]
-_OpenAIResponsesClientRequestKind = Literal["create", "other", "unknown"]
+_OpenAIResponsesClientRequestKind = Literal["create", "unknown"]
 _RESPONSES_EVENT_TERMINAL: _ResponsesEventTypeClassification = "terminal"
 _RESPONSES_EVENT_KNOWN_NON_USAGE: _ResponsesEventTypeClassification = "known_non_usage"
 _RESPONSES_EVENT_UNKNOWN: _ResponsesEventTypeClassification = "unknown"
@@ -242,7 +242,7 @@ def inspect_openai_responses_client_event_json(body: bytes) -> OpenAIResponsesCl
     if not type_is_consistent or not isinstance(event_type, str):
         return OpenAIResponsesClientEvent(observed_event_type, False, "unknown")
     if event_type != _RESPONSES_CREATE_EVENT:
-        return OpenAIResponsesClientEvent(observed_event_type, False, "other")
+        return OpenAIResponsesClientEvent(observed_event_type, False, "unknown")
     if not generate_is_consistent:
         return OpenAIResponsesClientEvent(observed_event_type, False, "unknown")
 

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -149,6 +149,7 @@ class OpenAIResponsesClientEvent:
     event_type: str | None
     is_prewarm: bool
     request_kind: _OpenAIResponsesClientRequestKind = "unknown"
+    inspection_error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -228,7 +229,12 @@ def inspect_openai_responses_client_event_json(body: bytes) -> OpenAIResponsesCl
     extractor.feed(body)
     result = extractor.finish()
     if not result.complete:
-        return OpenAIResponsesClientEvent(observed_event_type, False, "unknown")
+        return OpenAIResponsesClientEvent(
+            observed_event_type,
+            False,
+            "unknown",
+            result.error,
+        )
 
     type_is_consistent = extractor.selected_scalar_values_are_consistent(("type",))
     generate_is_consistent = extractor.selected_scalar_values_are_consistent(("generate",))

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -121,6 +121,7 @@ _ResponsesEventTypeClassification = Literal[
     "unresolved",
     "pending",
 ]
+_OpenAIResponsesClientRequestKind = Literal["create", "other", "unknown"]
 _RESPONSES_EVENT_TERMINAL: _ResponsesEventTypeClassification = "terminal"
 _RESPONSES_EVENT_KNOWN_NON_USAGE: _ResponsesEventTypeClassification = "known_non_usage"
 _RESPONSES_EVENT_UNKNOWN: _ResponsesEventTypeClassification = "unknown"
@@ -138,6 +139,7 @@ _RESPONSES_MAX_WORK_UNITS = 65_536
 _RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR = "work_limit_exceeded"
 _RESPONSES_CREATE_EVENT = "response.create"
 _RESPONSES_CREATED_EVENT = "response.created"
+_RESPONSES_ERROR_EVENT = "error"
 
 
 @dataclass(frozen=True)
@@ -146,6 +148,7 @@ class OpenAIResponsesClientEvent:
 
     event_type: str | None
     is_prewarm: bool
+    request_kind: _OpenAIResponsesClientRequestKind = "unknown"
 
 
 @dataclass(frozen=True)
@@ -154,10 +157,20 @@ class OpenAIResponsesServerLifecycle:
 
     event_type: str | None
     response_id: str | None
+    is_valid: bool = False
+    inspection_error: str | None = None
+
+    @property
+    def is_created(self) -> bool:
+        return self.event_type == _RESPONSES_CREATED_EVENT
 
     @property
     def is_terminal(self) -> bool:
         return self.event_type in _RESPONSES_TERMINAL_USAGE_EVENTS
+
+    @property
+    def is_error(self) -> bool:
+        return self.event_type == _RESPONSES_ERROR_EVENT
 
 
 @dataclass(frozen=True)
@@ -215,14 +228,22 @@ def inspect_openai_responses_client_event_json(body: bytes) -> OpenAIResponsesCl
     extractor.feed(body)
     result = extractor.finish()
     if not result.complete:
-        return OpenAIResponsesClientEvent(observed_event_type, False)
+        return OpenAIResponsesClientEvent(observed_event_type, False, "unknown")
+
+    type_is_consistent = extractor.selected_scalar_values_are_consistent(("type",))
+    generate_is_consistent = extractor.selected_scalar_values_are_consistent(("generate",))
+    event_type = result.values.get(("type",))
+    if not type_is_consistent or not isinstance(event_type, str):
+        return OpenAIResponsesClientEvent(observed_event_type, False, "unknown")
+    if event_type != _RESPONSES_CREATE_EVENT:
+        return OpenAIResponsesClientEvent(observed_event_type, False, "other")
+    if not generate_is_consistent:
+        return OpenAIResponsesClientEvent(observed_event_type, False, "unknown")
 
     return OpenAIResponsesClientEvent(
         observed_event_type,
-        extractor.selected_scalar_values_are_consistent(("type",))
-        and extractor.selected_scalar_values_are_consistent(("generate",))
-        and result.values.get(("type",)) == _RESPONSES_CREATE_EVENT
-        and result.values.get(("generate",)) is False,
+        result.values.get(("generate",)) is False,
+        "create",
     )
 
 
@@ -250,10 +271,13 @@ def _inspect_openai_responses_event_type_json(body: bytes) -> str | None:
 def inspect_openai_responses_server_lifecycle(
     event: OpenAIResponsesEvent,
 ) -> OpenAIResponsesServerLifecycle:
-    """Inspect an exact created or terminal event for WebSocket correlation."""
-    relevant_event_types = _RESPONSES_TERMINAL_USAGE_EVENTS | {_RESPONSES_CREATED_EVENT}
+    """Inspect a bounded lifecycle boundary for WebSocket correlation."""
+    relevant_event_types = _RESPONSES_TERMINAL_USAGE_EVENTS | {
+        _RESPONSES_CREATED_EVENT,
+        _RESPONSES_ERROR_EVENT,
+    }
     if event.event_type is not None and event.event_type not in relevant_event_types:
-        return OpenAIResponsesServerLifecycle(event.event_type, None)
+        return OpenAIResponsesServerLifecycle(event.event_type, None, True)
 
     extractor = JsonSelectiveExtractor(
         scalar_fields=_RESPONSES_LIFECYCLE_SCALAR_FIELDS,
@@ -263,21 +287,24 @@ def inspect_openai_responses_server_lifecycle(
     extractor.feed(event._body)
     result = extractor.finish()
     if not result.complete:
-        return OpenAIResponsesServerLifecycle(event.event_type, None)
+        return OpenAIResponsesServerLifecycle(event.event_type, None, False, result.error)
     if not extractor.selected_scalar_values_are_consistent(("type",)):
-        return OpenAIResponsesServerLifecycle(event.event_type, None)
+        return OpenAIResponsesServerLifecycle(event.event_type, None, False)
     event_type = result.values.get(("type",))
     if not isinstance(event_type, str):
-        return OpenAIResponsesServerLifecycle(event.event_type, None)
+        return OpenAIResponsesServerLifecycle(event.event_type, None, False)
+    if event_type == _RESPONSES_ERROR_EVENT:
+        return OpenAIResponsesServerLifecycle(event_type, None, True)
+    if event_type not in relevant_event_types:
+        return OpenAIResponsesServerLifecycle(event_type, None, True)
     response_id = result.values.get(("response", "id"))
     if (
-        event_type not in relevant_event_types
-        or not extractor.selected_scalar_values_are_consistent(("response", "id"))
+        not extractor.selected_scalar_values_are_consistent(("response", "id"))
         or not isinstance(response_id, str)
         or not response_id
     ):
-        response_id = None
-    return OpenAIResponsesServerLifecycle(event_type, response_id)
+        return OpenAIResponsesServerLifecycle(event_type, None, False)
+    return OpenAIResponsesServerLifecycle(event_type, response_id, True)
 
 
 def _probe_responses_event_type(body: bytes) -> TopLevelStringFieldProbeResult:

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -457,14 +457,14 @@ class TestModelProviderWebSocketPrewarmUsage:
     ):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
+        over_budget_error = b'{"type":"error","padding":[' + b",".join([b"0"] * 40_000) + b"]}"
 
         with self._usage_webhook_api() as webhook:
-            for request in (
-                {"type": "response.create"},
-                {"type": "response.create", "generate": False},
-                {"type": "response.create"},
-            ):
-                feed_websocket_client_message(flow, json.dumps(request).encode())
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, over_budget_error)
             feed_websocket_server_message(flow, _openai_websocket_created_frame("cap-1"))
             feed_websocket_server_message(
                 flow,
@@ -485,10 +485,7 @@ class TestModelProviderWebSocketPrewarmUsage:
         )
         correlation_entries = _correlation_entries(flow)
         assert len(correlation_entries) == 1
-        assert correlation_entries[0]["reason"] in {
-            "overlapping_request",
-            "correlation_cap",
-        }
+        assert correlation_entries[0]["reason"] == "correlation_cap"
 
     def test_model_websocket_unbound_prewarm_usage_fails_open(self, tmp_path, real_flow):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -266,6 +266,58 @@ class TestModelProviderWebSocketPrewarmUsage:
         [correlation_entry] = _correlation_entries(flow)
         assert correlation_entry["reason"] == "invalid_lifecycle"
 
+    def test_model_websocket_reused_ignored_id_without_created_fails_open(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("reused-id"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("reused-id", input_tokens=5, output_tokens=0),
+            )
+
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create"}).encode(),
+            )
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("reused-id", input_tokens=7, output_tokens=0),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 7)]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        source_entries = model_usage_source_entries(flow)
+        ignored_entries = [
+            entry for entry in source_entries if entry.get("disposition") == "ignored"
+        ]
+        assert len(ignored_entries) == 1
+        reported_entries = [
+            entry
+            for entry in source_entries
+            if entry.get("disposition") != "ignored"
+            and entry.get("provider_response_id") == "reused-id"
+        ]
+        assert len(reported_entries) == 1
+        [correlation_entry] = _correlation_entries(flow)
+        assert correlation_entry["reason"] == "invalid_lifecycle"
+
     @pytest.mark.parametrize(
         "client_requests",
         [

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -438,7 +438,7 @@ class TestModelProviderWebSocketPrewarmUsage:
             )
             feed_websocket_client_message(
                 flow,
-                json.dumps({"type": "response.create", "input": marker}).encode()[:-1],
+                json.dumps({"type": "future.request", "input": marker}).encode(),
             )
             feed_websocket_server_message(flow, _openai_websocket_created_frame("unknown-1"))
             feed_websocket_server_message(

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -487,6 +487,38 @@ class TestModelProviderWebSocketPrewarmUsage:
         assert len(correlation_entries) == 1
         assert correlation_entries[0]["reason"] == "correlation_cap"
 
+    def test_model_websocket_client_correlation_cap_fails_open(self, tmp_path, real_flow):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        over_budget_request = (
+            b'{"type":"response.create","generate":false,"padding":['
+            + b",".join([b"0"] * 40_000)
+            + b"]}"
+        )
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(flow, over_budget_request)
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("client-cap-1"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("client-cap-1", input_tokens=12, output_tokens=0),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 12)]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not any(
+            entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
+        )
+        [correlation_entry] = _correlation_entries(flow)
+        assert correlation_entry["reason"] == "correlation_cap"
+
     def test_model_websocket_unbound_prewarm_usage_fails_open(self, tmp_path, real_flow):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -217,6 +217,55 @@ class TestModelProviderWebSocketPrewarmUsage:
         )
         assert not _correlation_entries(flow)
 
+    def test_model_websocket_reused_ignored_id_fails_open(self, tmp_path, real_flow):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("reused-id"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("reused-id", input_tokens=5, output_tokens=0),
+            )
+
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create"}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("reused-id"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("reused-id", input_tokens=7, output_tokens=0),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 7)]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        source_entries = model_usage_source_entries(flow)
+        ignored_entries = [
+            entry for entry in source_entries if entry.get("disposition") == "ignored"
+        ]
+        assert len(ignored_entries) == 1
+        reported_entries = [
+            entry
+            for entry in source_entries
+            if entry.get("disposition") != "ignored"
+            and entry.get("provider_response_id") == "reused-id"
+        ]
+        assert len(reported_entries) == 1
+        [correlation_entry] = _correlation_entries(flow)
+        assert correlation_entry["reason"] == "invalid_lifecycle"
+
     @pytest.mark.parametrize(
         "client_requests",
         [

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -129,6 +129,94 @@ class TestModelProviderWebSocketPrewarmUsage:
         assert response_streaming.is_model_websocket_usage_enabled(flow) is False
         assert "_model_websocket_prewarm_state" not in flow.metadata
 
+    def test_model_websocket_ignored_id_fails_open_after_ambiguity(self, tmp_path, real_flow):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("warm-ambiguous"))
+            duplicate_terminal = openai_websocket_usage_frame(
+                "warm-ambiguous",
+                input_tokens=5,
+                output_tokens=0,
+            )
+            feed_websocket_server_message(flow, duplicate_terminal)
+
+            feed_websocket_client_message(flow, b"not-json")
+            feed_websocket_server_message(flow, duplicate_terminal)
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 5)]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        source_entries = model_usage_source_entries(flow)
+        ignored_entries = [
+            entry for entry in source_entries if entry.get("disposition") == "ignored"
+        ]
+        assert len(ignored_entries) == 1
+        reported_entries = [
+            entry
+            for entry in source_entries
+            if entry.get("disposition") != "ignored"
+            and entry.get("provider_response_id") == "warm-ambiguous"
+        ]
+        assert len(reported_entries) == 1
+        [correlation_entry] = _correlation_entries(flow)
+        assert correlation_entry["reason"] == "unknown_client_event"
+
+    def test_model_websocket_duplicate_terminal_stays_idempotent_with_active_request(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("warm-duplicate"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("warm-duplicate", input_tokens=5, output_tokens=0),
+            )
+
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create"}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("normal-active"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("warm-duplicate", input_tokens=5, output_tokens=0),
+            )
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("normal-active", input_tokens=4, output_tokens=0),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 4)]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not _correlation_entries(flow)
+
     @pytest.mark.parametrize(
         "client_requests",
         [

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -9,6 +9,7 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 import response_streaming
 import usage
+from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import (
     make_openai_responses_websocket_flow,
     model_provider_usage_sources,
@@ -38,6 +39,17 @@ def _openai_websocket_created_frame(response_id: str) -> bytes:
             "response": {"id": response_id},
         }
     ).encode()
+
+
+def _correlation_entries(flow) -> list[dict]:
+    proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+    if not jsonl_exists_after_flush(proxy_log):
+        return []
+    return [
+        entry
+        for entry in read_jsonl_entries_after_flush(proxy_log)
+        if entry.get("type") == "model_usage_correlation"
+    ]
 
 
 class TestModelProviderWebSocketPrewarmUsage:
@@ -116,6 +128,230 @@ class TestModelProviderWebSocketPrewarmUsage:
         assert model_provider_usage_sources(flow) == {}
         assert response_streaming.is_model_websocket_usage_enabled(flow) is False
         assert "_model_websocket_prewarm_state" not in flow.metadata
+
+    @pytest.mark.parametrize(
+        "client_requests",
+        [
+            pytest.param(
+                [
+                    {"type": "response.create"},
+                    {"type": "response.create", "generate": False},
+                ],
+                id="normal-then-prewarm",
+            ),
+            pytest.param(
+                [
+                    {"type": "response.create", "generate": False},
+                    {"type": "response.create"},
+                ],
+                id="prewarm-then-normal",
+            ),
+        ],
+    )
+    def test_model_websocket_overlapping_creates_fail_open(
+        self,
+        tmp_path,
+        real_flow,
+        client_requests: list[dict[str, object]],
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            for request in client_requests:
+                feed_websocket_client_message(flow, json.dumps(request).encode())
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("overlap-1"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("overlap-1", input_tokens=10, output_tokens=0),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("overlap-2"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("overlap-2", input_tokens=6, output_tokens=0),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [
+            ("gpt-5.5", "tokens.input", 10),
+            ("gpt-5.5", "tokens.input", 6),
+        ]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not any(
+            entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
+        )
+        [correlation_entry] = _correlation_entries(flow)
+        assert correlation_entry["reason"] == "overlapping_request"
+        assert correlation_entry["transport"] == "websocket"
+
+    def test_model_websocket_active_overlap_fails_open(self, tmp_path, real_flow):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create"}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("active-normal"))
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("active-normal", input_tokens=14, output_tokens=0),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("active-warm"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("active-warm", input_tokens=5, output_tokens=0),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [
+            ("gpt-5.5", "tokens.input", 14),
+            ("gpt-5.5", "tokens.input", 5),
+        ]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not any(
+            entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
+        )
+        [correlation_entry] = _correlation_entries(flow)
+        assert correlation_entry["reason"] == "overlapping_request"
+
+    def test_model_websocket_unknown_client_event_emits_one_content_free_diagnostic(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        marker = "unknown-client-sensitive-marker"
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "input": marker}).encode()[:-1],
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("unknown-1"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("unknown-1", input_tokens=8, output_tokens=0),
+            )
+            feed_websocket_client_message(flow, b"not-json")
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("unknown-2"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("unknown-2", input_tokens=7, output_tokens=0),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [
+            ("gpt-5.5", "tokens.input", 8),
+            ("gpt-5.5", "tokens.input", 7),
+        ]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not any(
+            entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
+        )
+        correlation_entries = _correlation_entries(flow)
+        assert len(correlation_entries) == 1
+        assert correlation_entries[0]["reason"] == "unknown_client_event"
+        assert marker not in json.dumps(correlation_entries)
+
+    def test_model_websocket_server_error_fails_open(self, tmp_path, real_flow):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, b'{"type":"error","error":{"code":"busy"}}')
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("error-1"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("error-1", input_tokens=9, output_tokens=0),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 9)]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not any(
+            entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
+        )
+        [correlation_entry] = _correlation_entries(flow)
+        assert correlation_entry["reason"] == "server_error"
+
+    def test_model_websocket_correlation_cap_stays_bounded_and_fails_open(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            for request in (
+                {"type": "response.create"},
+                {"type": "response.create", "generate": False},
+                {"type": "response.create"},
+            ):
+                feed_websocket_client_message(flow, json.dumps(request).encode())
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("cap-1"))
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame("cap-1", input_tokens=11, output_tokens=0),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        expected_rows = [("gpt-5.5", "tokens.input", 11)]
+        assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
+        assert_usage_event_rows(
+            webhook.model_usage_observation_events(),
+            "model",
+            expected_rows,
+        )
+        assert not any(
+            entry.get("disposition") == "ignored" for entry in model_usage_source_entries(flow)
+        )
+        correlation_entries = _correlation_entries(flow)
+        assert len(correlation_entries) == 1
+        assert correlation_entries[0]["reason"] in {
+            "overlapping_request",
+            "correlation_cap",
+        }
 
     def test_model_websocket_unbound_prewarm_usage_fails_open(self, tmp_path, real_flow):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+from mitmproxy import http
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
@@ -41,7 +42,7 @@ def _openai_websocket_created_frame(response_id: str) -> bytes:
     ).encode()
 
 
-def _correlation_entries(flow) -> list[dict]:
+def _correlation_entries(flow: http.HTTPFlow) -> list[dict[str, object]]:
     proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
     if not jsonl_exists_after_flush(proxy_log):
         return []

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -7,6 +7,7 @@ import pytest
 import usage.openai_responses as openai_responses
 from usage import extract_openai_responses_usage_from_event as _extract_usage_with_error
 from usage import (
+    inspect_openai_responses_client_event_json,
     inspect_openai_responses_event_json,
     merge_openai_responses_usage_result,
 )
@@ -48,6 +49,20 @@ def test_extracts_usage_from_wrapped_response_completed_event():
         "tokens.cache_read": 25,
         "tokens.cache_creation": 30,
     }
+
+
+def test_client_inspector_classifies_late_response_create_without_retaining_payload():
+    body = (
+        b'{"padding":"'
+        + b"x" * (openai_responses._RESPONSES_EVENT_PREFILTER_MAX_BYTES + 1)
+        + b'","type":"response.create","generate":false,"input":"secret"}'
+    )
+
+    event = inspect_openai_responses_client_event_json(body)
+
+    assert event.event_type is None
+    assert event.request_kind == "create"
+    assert event.is_prewarm is True
 
 
 def test_extracts_usage_from_wrapped_response_done_event():


### PR DESCRIPTION
## Summary

- Replace the last-write-wins WebSocket prewarm flag with bounded pending/active request-intent correlation.
- Fail open to normal usage reporting whenever request ownership is ambiguous, including overlapping creates, malformed or unknown client frames, invalid lifecycle identities, provider errors, client or server parser work-limit boundaries, and response-ID reuse with or without a created boundary.
- Clear retained suppression IDs on sticky ambiguity while preserving duplicate-terminal idempotency during otherwise unambiguous later requests.
- Preserve exact serialized `generate:false` exclusion, flow cleanup, and content-free one-per-flow ambiguity diagnostics, including `correlation_cap` classification for parser work limits.
- Add public-hook integration coverage for overlap orderings, active overlap, unknown/error/cap paths, retained-ID ambiguity and reuse, lifecycle gaps, and the existing serialized behavior.

## Scope

- Runner-only OpenAI Responses WebSocket accounting change.
- No WebSocket transport serialization, API or database schema changes, migrations, historical refund logic, or feature switch.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (5455 passed)

Closes #27523
