### PR TITLE
refactor(orgs): neutralize organization and access route shells

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -110,11 +110,11 @@ import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
 import { onboardingCompleteRoutes } from "./routes/onboarding-complete";
 import { onboardingStatusRoutes } from "./routes/onboarding-status";
 import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
-import { zeroOrgDeleteRoutes } from "./routes/zero-org-delete";
+import { orgDeleteRoutes } from "./routes/org-delete";
 import { orgLogoRoutes } from "./routes/org-logo";
-import { zeroOrgMembersRoutes } from "./routes/zero-org-members";
-import { zeroOrgMembershipRequestsRoutes } from "./routes/zero-org-membership-requests";
-import { zeroOrgReadRoutes } from "./routes/zero-org-read";
+import { orgMembersRoutes } from "./routes/org-members";
+import { orgMembershipRequestsRoutes } from "./routes/org-membership-requests";
+import { orgReadRoutes } from "./routes/org-read";
 import { pushSubscriptionsRoutes } from "./routes/push-subscriptions";
 import { queuePositionRoutes } from "./routes/queue-position";
 import { realtimeTokenRoutes } from "./routes/realtime-token";
@@ -176,14 +176,14 @@ import { zeroTeamsBrowserConnectRoutes } from "./routes/zero-teams-browser-conne
 import { zeroTeamsBotRoutes } from "./routes/zero-teams-bot";
 import { zeroTeamsConnectRoutes } from "./routes/zero-teams-connect";
 import { zeroTeamsOauthRoutes } from "./routes/zero-teams-oauth";
-import { zeroTeamRoutes } from "./routes/zero-team";
+import { teamRoutes } from "./routes/team";
 import { uploadsCompleteRoutes } from "./routes/uploads-complete";
 import { uploadsMultipartRoutes } from "./routes/uploads-multipart";
 import { uploadsPrepareRoutes } from "./routes/uploads-prepare";
-import { zeroUsageMembersRoutes } from "./routes/zero-usage-members";
+import { usageMembersRoutes } from "./routes/usage-members";
 import { usageRecordRoutes } from "./routes/usage-record";
 import { userPreferencesRoutes } from "./routes/user-preferences";
-import { zeroUserPermissionGrantsRoutes } from "./routes/zero-user-permission-grants";
+import { userPermissionGrantsRoutes } from "./routes/user-permission-grants";
 import { userModelPreferenceRoutes } from "./routes/user-model-preference";
 import { avatarVideoRoutes } from "./routes/avatar-video";
 import { voiceIoQuotaRoutes } from "./routes/voice-io-quota";
@@ -326,13 +326,13 @@ export const ROUTES: readonly RouteEntry[] = [
   ...onboardingCompleteRoutes,
   ...onboardingStatusRoutes,
   ...zeroOrgInviteRoutes,
-  ...zeroOrgDeleteRoutes,
+  ...orgDeleteRoutes,
   ...orgLogoRoutes,
-  ...zeroOrgMembersRoutes,
-  ...zeroOrgMembershipRequestsRoutes,
-  ...zeroOrgReadRoutes,
+  ...orgMembersRoutes,
+  ...orgMembershipRequestsRoutes,
+  ...orgReadRoutes,
   ...pushSubscriptionsRoutes,
-  ...zeroUserPermissionGrantsRoutes,
+  ...userPermissionGrantsRoutes,
   ...userPreferencesRoutes,
   ...userModelPreferenceRoutes,
   ...workflowsRoutes,
@@ -377,12 +377,12 @@ export const ROUTES: readonly RouteEntry[] = [
   ...integrationsTelegramMessageRoutes,
   ...integrationsTelegramUploadCompleteRoutes,
   ...integrationsTelegramUploadInitRoutes,
-  ...zeroTeamRoutes,
+  ...teamRoutes,
   ...uploadsCompleteRoutes,
   ...uploadsMultipartRoutes,
   ...uploadsPrepareRoutes,
   ...registryResourceDownloadRoutes,
-  ...zeroUsageMembersRoutes,
+  ...usageMembersRoutes,
   ...usageRecordRoutes,
   ...modelStatsRoutes,
   ...presentationImagesRoutes,

--- a/turbo/apps/api/src/signals/routes/__benches__/chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/chat-threads.bench.ts
@@ -59,7 +59,7 @@ import { zeroChatThreadRoutes } from "../zero-chat-threads";
 import { connectorsRoutes } from "../connectors";
 import { zeroMeModelProvidersListRoutes } from "../zero-me-model-providers-list";
 import { zeroMeModelProvidersUpsertRoutes } from "../zero-me-model-providers-upsert";
-import { zeroOrgReadRoutes } from "../zero-org-read";
+import { orgReadRoutes } from "../org-read";
 import { userPreferencesRoutes } from "../user-preferences";
 
 const zeroPersonalModelProvidersMainTestRoutes = Object.freeze([
@@ -114,9 +114,7 @@ const billingStatusClient = setupApp({
   context,
   routes: zeroBillingStatusRoutes,
 })(zeroBillingStatusContract);
-const orgClient = setupApp({ context, routes: zeroOrgReadRoutes })(
-  zeroOrgContract,
-);
+const orgClient = setupApp({ context, routes: orgReadRoutes })(zeroOrgContract);
 const personalModelProvidersClient = setupApp({
   context,
   routes: zeroPersonalModelProvidersMainTestRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -63,9 +63,9 @@ import { zeroBillingConcurrencySubscriptionRoutes } from "../zero-billing-concur
 import { zeroBillingCreditCheckoutRoutes } from "../zero-billing-credit-checkout";
 import { zeroBillingUsagePackCreditsRoutes } from "../zero-billing-usage-pack-credits";
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
-import { zeroOrgMembersRoutes } from "../zero-org-members";
+import { orgMembersRoutes } from "../org-members";
 import { zeroOrgInviteRoutes } from "../zero-org-invite";
-import { zeroOrgReadRoutes } from "../zero-org-read";
+import { orgReadRoutes } from "../org-read";
 import {
   testUsagePackSubscriptionStateContract,
   testUsagePackSubscriptionStateRoutes,
@@ -6424,7 +6424,7 @@ describe("usage pack allocation management", () => {
       status: "succeeded",
     });
 
-    const responsePromise = setupApp({ context, routes: zeroOrgMembersRoutes })(
+    const responsePromise = setupApp({ context, routes: orgMembersRoutes })(
       zeroOrgMembersContract,
     ).removeMember({
       headers: { authorization: "Bearer clerk-session" },
@@ -6654,7 +6654,7 @@ describe("usage pack allocation management", () => {
     });
 
     await accept(
-      setupApp({ context, routes: zeroOrgMembersRoutes })(
+      setupApp({ context, routes: orgMembersRoutes })(
         zeroOrgMembersContract,
       ).removeMember({
         headers: { authorization: "Bearer clerk-session" },
@@ -7121,7 +7121,7 @@ describe("usage pack allocation management", () => {
       ),
     );
     const members = await accept(
-      setupApp({ context, routes: zeroOrgReadRoutes })(
+      setupApp({ context, routes: orgReadRoutes })(
         zeroOrgMembersContract,
       ).members({
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -97,7 +97,7 @@ import { connectorCheckRoutes } from "../connector-check";
 import { connectorsRoutes } from "../connectors";
 import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
 import { steamPlayerRoutes } from "../steam-player";
-import { zeroUserPermissionGrantsRoutes } from "../zero-user-permission-grants";
+import { userPermissionGrantsRoutes } from "../user-permission-grants";
 import { workflowAutomationsRoutes } from "../workflow-automations";
 import { workflowsRoutes } from "../workflows";
 
@@ -111,7 +111,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...connectorsRoutes,
   ...zeroFeatureSwitchesRoutes,
   ...steamPlayerRoutes,
-  ...zeroUserPermissionGrantsRoutes,
+  ...userPermissionGrantsRoutes,
   ...workflowAutomationsRoutes,
   ...workflowsRoutes,
 ]);
@@ -2807,7 +2807,7 @@ describe("connector catalog valid lifecycle", () => {
       "https://api.example.test/custom/",
     ]);
     const grants = await accept(
-      setupApp({ context, routes: zeroUserPermissionGrantsRoutes })(
+      setupApp({ context, routes: userPermissionGrantsRoutes })(
         zeroUserPermissionGrantsContract,
       ).apply({
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -94,13 +94,13 @@ import { customConnectorDisconnectRoutes } from "../../custom-connectors-disconn
 import { customConnectorsValuesSetRoutes } from "../../custom-connectors-values-set";
 import { onboardingCompleteRoutes } from "../../onboarding-complete";
 import { onboardingStatusRoutes } from "../../onboarding-status";
-import { zeroOrgDeleteRoutes } from "../../zero-org-delete";
+import { orgDeleteRoutes } from "../../org-delete";
 import { zeroOrgInviteRoutes } from "../../zero-org-invite";
 import { orgLogoRoutes } from "../../org-logo";
-import { zeroOrgMembersRoutes } from "../../zero-org-members";
-import { zeroOrgMembershipRequestsRoutes } from "../../zero-org-membership-requests";
-import { zeroOrgReadRoutes } from "../../zero-org-read";
-import { zeroTeamRoutes } from "../../zero-team";
+import { orgMembersRoutes } from "../../org-members";
+import { orgMembershipRequestsRoutes } from "../../org-membership-requests";
+import { orgReadRoutes } from "../../org-read";
+import { teamRoutes } from "../../team";
 import { userPreferencesRoutes } from "../../user-preferences";
 import { createBddApi, type OnboardingBootstrapOptions } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
@@ -211,13 +211,13 @@ const authOrgRoutes = [
   ...onboardingStatusRoutes,
   ...onboardingCompleteRoutes,
   ...userPreferencesRoutes,
-  ...zeroOrgReadRoutes,
-  ...zeroOrgDeleteRoutes,
-  ...zeroOrgMembersRoutes,
+  ...orgReadRoutes,
+  ...orgDeleteRoutes,
+  ...orgMembersRoutes,
   ...zeroOrgInviteRoutes,
-  ...zeroOrgMembershipRequestsRoutes,
+  ...orgMembershipRequestsRoutes,
   ...orgLogoRoutes,
-  ...zeroTeamRoutes,
+  ...teamRoutes,
   ...agentsRoutes,
   ...zeroComposesRoutes,
   ...customConnectorsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -63,7 +63,7 @@ import { builtInGenerationRoutes } from "../../built-in-generation";
 import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
 import { imageIoGenerateRoutes } from "../../image-io-generate";
 import { mapsRoutes } from "../../maps";
-import { zeroUsageMembersRoutes } from "../../zero-usage-members";
+import { usageMembersRoutes } from "../../usage-members";
 import { usageRecordRoutes } from "../../usage-record";
 import { videoIoGenerateRoutes } from "../../video-io-generate";
 import { voiceIoQuotaRoutes } from "../../voice-io-quota";
@@ -495,7 +495,7 @@ export function createBillingMediaApi(context: TestContext) {
         readonly tz?: string;
       } = {},
     ) {
-      const client = setupApp({ context, routes: zeroUsageMembersRoutes })(
+      const client = setupApp({ context, routes: usageMembersRoutes })(
         zeroUsageMembersContract,
       );
       return await accept(
@@ -512,7 +512,7 @@ export function createBillingMediaApi(context: TestContext) {
       },
       statuses: readonly (200 | 400 | 401 | 403 | 500)[],
     ) {
-      const client = setupApp({ context, routes: zeroUsageMembersRoutes })(
+      const client = setupApp({ context, routes: usageMembersRoutes })(
         zeroUsageMembersContract,
       );
       return await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -78,7 +78,7 @@ import {
   zeroRunFixtureRoutes,
 } from "../../test-zero-run-fixture";
 import { testBillingReconciliationStateRoutes } from "../../test-billing-reconciliation-state";
-import { zeroUserPermissionGrantsRoutes } from "../../zero-user-permission-grants";
+import { userPermissionGrantsRoutes } from "../../user-permission-grants";
 import { createBddApi, type ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 
@@ -161,7 +161,7 @@ const runRoutes = [
   ...zeroRunsRoutes,
   ...zeroRunsCancelRoutes,
   ...agentsRoutes,
-  ...zeroUserPermissionGrantsRoutes,
+  ...userPermissionGrantsRoutes,
 ] as const;
 
 function runApp(context: TestContext) {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
@@ -27,7 +27,7 @@ import { agentsRoutes } from "../../agents";
 import { agentInstructionsRoutes } from "../../agent-instructions";
 import { onboardingCompleteRoutes } from "../../onboarding-complete";
 import { onboardingStatusRoutes } from "../../onboarding-status";
-import { zeroOrgReadRoutes } from "../../zero-org-read";
+import { orgReadRoutes } from "../../org-read";
 import { userPreferencesRoutes } from "../../user-preferences";
 import { createZeroRouteMocks } from "./zero-route-test";
 
@@ -136,7 +136,7 @@ export function createBddApi(context: TestContext) {
   function orgClient() {
     return setupAppWithRoutes({
       context,
-      routes: zeroOrgReadRoutes,
+      routes: orgReadRoutes,
     })(zeroOrgContract);
   }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/org-delete-billing.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-delete-billing.test.ts
@@ -19,7 +19,7 @@ import {
   type StripeSubscription,
 } from "../../external/stripe-client";
 import { agentsRoutes } from "../agents";
-import { zeroOrgDeleteRoutes } from "../zero-org-delete";
+import { orgDeleteRoutes } from "../org-delete";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
@@ -195,7 +195,7 @@ function mockOrgDeletion(fixture: OrgDeleteBillingFixture): void {
 }
 
 async function requestOrgDeletion() {
-  const client = setupApp({ context, routes: zeroOrgDeleteRoutes })(
+  const client = setupApp({ context, routes: orgDeleteRoutes })(
     zeroOrgDeleteContract,
   );
   return await client.delete({

--- a/turbo/apps/api/src/signals/routes/__tests__/user-permission-grants.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-permission-grants.test.ts
@@ -20,9 +20,9 @@ import {
   seedUsageStateFixture$,
   type UsageStateFixture,
 } from "./helpers/usage-state";
-import { zeroUserPermissionGrantsRoutes } from "../zero-user-permission-grants";
+import { userPermissionGrantsRoutes } from "../user-permission-grants";
 
-const TEST_APP_ROUTES = Object.freeze([...zeroUserPermissionGrantsRoutes]);
+const TEST_APP_ROUTES = Object.freeze([...userPermissionGrantsRoutes]);
 
 const context = testContext();
 const store = createStore();
@@ -68,7 +68,7 @@ async function seedAgent(args: {
 }
 
 function client() {
-  return setupApp({ context, routes: zeroUserPermissionGrantsRoutes })(
+  return setupApp({ context, routes: userPermissionGrantsRoutes })(
     zeroUserPermissionGrantsContract,
   );
 }
@@ -267,7 +267,7 @@ describe("zero user permission grants", () => {
 
     const client = setupApp({
       context,
-      routes: zeroUserPermissionGrantsRoutes,
+      routes: userPermissionGrantsRoutes,
     })(zeroUserPermissionGrantsContract);
 
     mocks.clerk.session(owner.userId, owner.orgId, "org:member");
@@ -328,7 +328,7 @@ describe("zero user permission grants", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const client = setupApp({
       context,
-      routes: zeroUserPermissionGrantsRoutes,
+      routes: userPermissionGrantsRoutes,
     })(zeroUserPermissionGrantsContract);
 
     const malformedConnector = await accept(
@@ -608,7 +608,7 @@ describe("zero user permission grants", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const client = setupApp({
       context,
-      routes: zeroUserPermissionGrantsRoutes,
+      routes: userPermissionGrantsRoutes,
     })(zeroUserPermissionGrantsContract);
 
     const invalidConnector = await accept(
@@ -727,7 +727,7 @@ describe("zero user permission grants", () => {
     mocks.clerk.session(sameOrgUserId, owner.orgId, "org:member");
     const client = setupApp({
       context,
-      routes: zeroUserPermissionGrantsRoutes,
+      routes: userPermissionGrantsRoutes,
     })(zeroUserPermissionGrantsContract);
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/org-delete.ts
+++ b/turbo/apps/api/src/signals/routes/org-delete.ts
@@ -34,7 +34,7 @@ const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 200 as const, body: result };
 });
 
-export const zeroOrgDeleteRoutes: readonly RouteEntry[] = [
+export const orgDeleteRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgDeleteContract.delete,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/org-members.ts
+++ b/turbo/apps/api/src/signals/routes/org-members.ts
@@ -70,7 +70,7 @@ const removeMemberInner$ = command(
   },
 );
 
-export const zeroOrgMembersRoutes: readonly RouteEntry[] = [
+export const orgMembersRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgMembersContract.updateRole,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/org-membership-requests.ts
+++ b/turbo/apps/api/src/signals/routes/org-membership-requests.ts
@@ -95,7 +95,7 @@ const rejectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-export const zeroOrgMembershipRequestsRoutes: readonly RouteEntry[] = [
+export const orgMembershipRequestsRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgMembershipRequestsContract.accept,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/org-read.ts
+++ b/turbo/apps/api/src/signals/routes/org-read.ts
@@ -113,7 +113,7 @@ const membersInner$ = computed(async (get) => {
   return { status: 200 as const, body };
 });
 
-export const zeroOrgReadRoutes: readonly RouteEntry[] = [
+export const orgReadRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgContract.get,
     handler: authRoute({ acceptAnySandboxCapability: true }, getOrgInner$),

--- a/turbo/apps/api/src/signals/routes/team.ts
+++ b/turbo/apps/api/src/signals/routes/team.ts
@@ -26,7 +26,7 @@ const listTeamInner$ = computed(async (get) => {
   return { status: 200 as const, body: [...team] };
 });
 
-export const zeroTeamRoutes: readonly RouteEntry[] = [
+export const teamRoutes: readonly RouteEntry[] = [
   {
     route: zeroTeamContract.list,
     handler: authRoute({}, listTeamInner$),

--- a/turbo/apps/api/src/signals/routes/usage-members.ts
+++ b/turbo/apps/api/src/signals/routes/usage-members.ts
@@ -45,7 +45,7 @@ const getUsageMembersInner$ = command(
   },
 );
 
-export const zeroUsageMembersRoutes: readonly RouteEntry[] = [
+export const usageMembersRoutes: readonly RouteEntry[] = [
   {
     route: zeroUsageMembersContract.get,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/user-permission-grants.ts
+++ b/turbo/apps/api/src/signals/routes/user-permission-grants.ts
@@ -79,7 +79,7 @@ const applyUserPermissionGrantsInner$ = command(
   },
 );
 
-export const zeroUserPermissionGrantsRoutes: readonly RouteEntry[] = [
+export const userPermissionGrantsRoutes: readonly RouteEntry[] = [
   {
     route: zeroUserPermissionGrantsContract.list,
     handler: authRoute(


### PR DESCRIPTION
## Summary

- Rename the seven organization, membership, team, usage, and permission route shell modules to domain-neutral paths.
- Rename their seven route-array exports and update the production registry, benchmark, route tests, and BDD helpers atomically.
- Remove the old paths and exports without aliases, forwarding files, compatibility re-exports, or duplicate route entries.

## Compatibility

- Preserve route-array contents, ordering, handlers, contracts, API paths, schemas, authorization, organization roles, membership/team behavior, usage attribution, billing interactions, persisted identities, and error messages.
- Preserve `zero-org-invite.ts`, `zeroOrgInviteRoutes`, and all invite behavior unchanged.
- Preserve contract, service, CLI, Platform, database, role/permission, protocol, and runtime compatibility names outside the seven exact route shells.

## Verification

- Pinned Prettier 3.8.1 check on all 17 touched files
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- `pnpm -F api check-types` (including type-boundary audit)
- Focused organization/team route cases: 6 passed
- Focused billing/usage route suite: 8 passed
- Focused user-permission-grants route suite: 17 passed
- Focused organization-delete/billing route suite: 12 passed
- The full org/team file's seventh run-scoped-token case stops in its runner-poll setup before any renamed route is called; the identical `poll.body.job` failure was reproduced on a clean `origin/main@02a0424776` worktree, so required PR CI remains authoritative for that baseline case.
- Normalized source audit: all 17 touched files match refreshed main after applying only the approved seven path/export mappings and pinned formatting.
- Post-rebase stale-path/export, neutral-target uniqueness, invite-integrity, route-order, and diff checks

Closes #27577

Parent: #27432

Compatibility model: #26873
