### PR TITLE
refactor(billing): neutralize billing route shell naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -62,19 +62,19 @@ import { agentInstructionsRoutes } from "./routes/agent-instructions";
 import { agentsRoutes } from "./routes/agents";
 import { artifactCatalogRoutes } from "./routes/artifact-catalog";
 import { acquisitionAttributionRoutes } from "./routes/acquisition-attribution";
-import { zeroBillingAutoRechargeRoutes } from "./routes/zero-billing-auto-recharge";
-import { zeroBillingCheckoutRoutes } from "./routes/zero-billing-checkout";
-import { zeroBillingConcurrencyCheckoutRoutes } from "./routes/zero-billing-concurrency-checkout";
-import { zeroBillingConcurrencySubscriptionRoutes } from "./routes/zero-billing-concurrency-subscriptions";
-import { zeroBillingCreditCheckoutRoutes } from "./routes/zero-billing-credit-checkout";
-import { zeroBillingDowngradeRoutes } from "./routes/zero-billing-downgrade";
-import { zeroBillingInvoicesRoutes } from "./routes/zero-billing-invoices";
-import { zeroBillingPortalRoutes } from "./routes/zero-billing-portal";
-import { zeroBillingRedeemCodeRoutes } from "./routes/zero-billing-redeem-code";
-import { zeroBillingRedeemRoutes } from "./routes/zero-billing-redeem";
-import { zeroBillingRestoreRoutes } from "./routes/zero-billing-restore";
-import { zeroBillingStatusRoutes } from "./routes/zero-billing-status";
-import { zeroBillingUsagePackCreditsRoutes } from "./routes/zero-billing-usage-pack-credits";
+import { billingAutoRechargeRoutes } from "./routes/billing-auto-recharge";
+import { billingCheckoutRoutes } from "./routes/billing-checkout";
+import { billingConcurrencyCheckoutRoutes } from "./routes/billing-concurrency-checkout";
+import { billingConcurrencySubscriptionRoutes } from "./routes/billing-concurrency-subscriptions";
+import { billingCreditCheckoutRoutes } from "./routes/billing-credit-checkout";
+import { billingDowngradeRoutes } from "./routes/billing-downgrade";
+import { billingInvoicesRoutes } from "./routes/billing-invoices";
+import { billingPortalRoutes } from "./routes/billing-portal";
+import { billingRedeemCodeRoutes } from "./routes/billing-redeem-code";
+import { billingRedeemRoutes } from "./routes/billing-redeem";
+import { billingRestoreRoutes } from "./routes/billing-restore";
+import { billingStatusRoutes } from "./routes/billing-status";
+import { billingUsagePackCreditsRoutes } from "./routes/billing-usage-pack-credits";
 import { zeroBankingRoutes } from "./routes/zero-banking";
 import { chatThreadRoutes } from "./routes/chat-threads";
 import { chatEventsRoutes } from "./routes/chat-events";
@@ -254,19 +254,19 @@ export const ROUTES: readonly RouteEntry[] = [
   ...agentsRoutes,
   ...artifactCatalogRoutes,
   ...acquisitionAttributionRoutes,
-  ...zeroBillingAutoRechargeRoutes,
-  ...zeroBillingCheckoutRoutes,
-  ...zeroBillingConcurrencyCheckoutRoutes,
-  ...zeroBillingConcurrencySubscriptionRoutes,
-  ...zeroBillingCreditCheckoutRoutes,
-  ...zeroBillingDowngradeRoutes,
-  ...zeroBillingInvoicesRoutes,
-  ...zeroBillingPortalRoutes,
-  ...zeroBillingRedeemCodeRoutes,
-  ...zeroBillingRedeemRoutes,
-  ...zeroBillingRestoreRoutes,
-  ...zeroBillingStatusRoutes,
-  ...zeroBillingUsagePackCreditsRoutes,
+  ...billingAutoRechargeRoutes,
+  ...billingCheckoutRoutes,
+  ...billingConcurrencyCheckoutRoutes,
+  ...billingConcurrencySubscriptionRoutes,
+  ...billingCreditCheckoutRoutes,
+  ...billingDowngradeRoutes,
+  ...billingInvoicesRoutes,
+  ...billingPortalRoutes,
+  ...billingRedeemCodeRoutes,
+  ...billingRedeemRoutes,
+  ...billingRestoreRoutes,
+  ...billingStatusRoutes,
+  ...billingUsagePackCreditsRoutes,
   ...zeroBankingRoutes,
   ...chatThreadRoutes,
   ...chatEventsRoutes,

--- a/turbo/apps/api/src/signals/routes/__benches__/chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/chat-threads.bench.ts
@@ -54,7 +54,7 @@ import { normalizeRunMetadata } from "../../services/agent-run-metadata-write.se
 import { seedUserModelProvider$ } from "./helpers/model-providers";
 import { seedOrgMembership$ } from "../__tests__/helpers/org-membership";
 import { createZeroRouteMocks } from "../__tests__/helpers/zero-route-test";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 import { chatThreadRoutes } from "../chat-threads";
 import { connectorsRoutes } from "../connectors";
 import { zeroMeModelProvidersListRoutes } from "../zero-me-model-providers-list";
@@ -112,7 +112,7 @@ const userPreferencesClient = setupApp({
 })(userPreferencesContract);
 const billingStatusClient = setupApp({
   context,
-  routes: zeroBillingStatusRoutes,
+  routes: billingStatusRoutes,
 })(zeroBillingStatusContract);
 const orgClient = setupApp({ context, routes: orgReadRoutes })(zeroOrgContract);
 const personalModelProvidersClient = setupApp({

--- a/turbo/apps/api/src/signals/routes/__tests__/avatar-video.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/avatar-video.test.ts
@@ -24,7 +24,7 @@ import { createDeferredPromise } from "../../utils";
 import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generations";
 import { artifactCatalogRoutes } from "../artifact-catalog";
 import { avatarVideoRoutes } from "../avatar-video";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 import { builtInGenerationRoutes } from "../built-in-generation";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { seedOrgMembership$ } from "./helpers/org-membership";
@@ -71,7 +71,7 @@ function createAvatarVideoTestApp(
       ...artifactCatalogRoutes,
       ...builtInGenerationRoutes,
       ...webhooksBuiltInGenerationRoutes,
-      ...zeroBillingStatusRoutes,
+      ...billingStatusRoutes,
     ],
     usagePricingResolution,
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-auto-recharge.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-auto-recharge.test.ts
@@ -9,7 +9,7 @@ import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroBillingAutoRechargeRoutes } from "../zero-billing-auto-recharge";
+import { billingAutoRechargeRoutes } from "../billing-auto-recharge";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -26,7 +26,7 @@ const defaultAutoRechargeConfig = Object.freeze({
 type AutoRechargeActor = ApiTestUser & { readonly orgId: string };
 
 function autoRechargeClient() {
-  return setupApp({ context, routes: zeroBillingAutoRechargeRoutes })(
+  return setupApp({ context, routes: billingAutoRechargeRoutes })(
     zeroBillingAutoRechargeContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -57,12 +57,12 @@ import { webhooksStripeRoutes } from "../webhooks-stripe";
 import { readOrgAcquisitionAttributionFixture } from "../../../test-fixtures/org-metadata";
 import { webhooksClerkRoutes } from "../webhooks-clerk";
 import { testBillingReconciliationStateRoutes } from "../test-billing-reconciliation-state";
-import { zeroBillingCheckoutRoutes } from "../zero-billing-checkout";
-import { zeroBillingConcurrencyCheckoutRoutes } from "../zero-billing-concurrency-checkout";
-import { zeroBillingConcurrencySubscriptionRoutes } from "../zero-billing-concurrency-subscriptions";
-import { zeroBillingCreditCheckoutRoutes } from "../zero-billing-credit-checkout";
-import { zeroBillingUsagePackCreditsRoutes } from "../zero-billing-usage-pack-credits";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingCheckoutRoutes } from "../billing-checkout";
+import { billingConcurrencyCheckoutRoutes } from "../billing-concurrency-checkout";
+import { billingConcurrencySubscriptionRoutes } from "../billing-concurrency-subscriptions";
+import { billingCreditCheckoutRoutes } from "../billing-credit-checkout";
+import { billingUsagePackCreditsRoutes } from "../billing-usage-pack-credits";
+import { billingStatusRoutes } from "../billing-status";
 import { orgMembersRoutes } from "../org-members";
 import { zeroOrgInviteRoutes } from "../zero-org-invite";
 import { orgReadRoutes } from "../org-read";
@@ -255,7 +255,7 @@ async function readBillingStatus(
 ): Promise<BillingStatusResponse> {
   authenticateOrg(fixture);
   const response = await accept(
-    setupApp({ context, routes: zeroBillingStatusRoutes })(
+    setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     ).get({
       headers: { authorization: "Bearer clerk-session" },
@@ -299,7 +299,7 @@ async function createStripeCustomerOrgForFixture(
   });
 
   await accept(
-    setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     ).create({
       headers: { authorization: "Bearer clerk-session" },
@@ -710,7 +710,7 @@ describe("POST /api/zero/billing/checkout", () => {
   it("returns 503 when STRIPE_SECRET_KEY is not configured", async () => {
     mockOptionalEnv("STRIPE_SECRET_KEY", undefined);
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -735,7 +735,7 @@ describe("POST /api/zero/billing/checkout", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -758,7 +758,7 @@ describe("POST /api/zero/billing/checkout", () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -779,7 +779,7 @@ describe("POST /api/zero/billing/checkout", () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
     const oversizedSuccessUrl = `${APP_ORIGIN}/billing?state=`.padEnd(
@@ -810,7 +810,7 @@ describe("POST /api/zero/billing/checkout", () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -847,7 +847,7 @@ describe("POST /api/zero/billing/checkout", () => {
       url: "https://checkout.stripe.com/session/test",
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -904,7 +904,7 @@ describe("POST /api/zero/billing/checkout", () => {
       url: "https://checkout.stripe.com/session/preview",
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -962,7 +962,7 @@ describe("POST /api/zero/billing/checkout", () => {
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -999,7 +999,7 @@ describe("POST /api/zero/billing/checkout", () => {
     });
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -1031,7 +1031,7 @@ describe("POST /api/zero/billing/checkout", () => {
     const fixture = await trackedCustomSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -1070,7 +1070,7 @@ describe("POST /api/zero/billing/checkout", () => {
       url: "https://checkout.stripe.com/session/attributed",
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -1163,7 +1163,7 @@ describe("POST /api/zero/billing/checkout", () => {
       url: "https://checkout.stripe.com/session/trial",
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -1210,7 +1210,7 @@ describe("POST /api/zero/billing/checkout", () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -1239,7 +1239,7 @@ describe("POST /api/zero/billing/checkout", () => {
     const fixture = await trackedPendingSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -1268,7 +1268,7 @@ describe("POST /api/zero/billing/checkout", () => {
     const fixture = await trackedSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -1302,7 +1302,7 @@ describe("POST /api/zero/billing/checkout", () => {
       url: "https://checkout.stripe.com/session/so-trial",
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -1328,7 +1328,7 @@ describe("POST /api/zero/billing/checkout", () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, null);
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -1355,7 +1355,7 @@ describe("POST /api/zero/billing/checkout", () => {
     // undefined and the route falls into the "Price not configured" branch.
     mockEnv("ZERO_PRICE_PRO", undefined);
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -1393,7 +1393,7 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
     authenticateOrg(fixture);
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingUsagePackCatalogContract,
       ).get({
         headers: { authorization: "Bearer clerk-session" },
@@ -1418,7 +1418,7 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
     });
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingUsagePackCatalogContract,
       ).get({
         headers: { authorization: "Bearer clerk-session" },
@@ -1466,7 +1466,7 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
     const before = await readUsagePackState(fixture.orgId);
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingUsagePackCheckoutContract,
       ).create({
         body: {
@@ -1576,7 +1576,7 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
     );
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingUsagePackCheckoutContract,
       ).create({
         body: {
@@ -1703,7 +1703,7 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
     );
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingUsagePackCheckoutContract,
       ).create({
         body: {
@@ -2359,7 +2359,7 @@ describe("legacy subscription usage pack migration", () => {
   }
 
   function migrationClient() {
-    return setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    return setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackMigrationContract,
     );
   }
@@ -2532,7 +2532,7 @@ describe("legacy subscription usage pack migration", () => {
     await enableMigration(fixture);
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingUsagePackCheckoutContract,
       ).create({
         body: {
@@ -4375,7 +4375,7 @@ describe("usage pack allocation management", () => {
     mockUsagePackSubscriptionChangePreviews(8000, 16_000);
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingUsagePackManagementContract,
       ).previewSubscriptionChange({
         headers: { authorization: "Bearer clerk-session" },
@@ -4429,7 +4429,7 @@ describe("usage pack allocation management", () => {
       sourceSubscription,
     );
     mockUsagePackSubscriptionChangePreviews(8000, 16_000);
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const body = {
@@ -4556,7 +4556,7 @@ describe("usage pack allocation management", () => {
       id: scheduleId,
     });
     mockUsagePackSubscriptionChangePreviews(8000, 16_000);
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const preview = await accept(
@@ -4638,7 +4638,7 @@ describe("usage pack allocation management", () => {
       sourcePriceId: TEST_PRICE_USAGE_PACK_20,
       targetPriceId: TEST_PRICE_USAGE_PACK_50,
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const body = {
@@ -4687,7 +4687,7 @@ describe("usage pack allocation management", () => {
       proSubscription,
     );
     mockUsagePackSubscriptionChangePreviews(8000, 16_000);
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const preview = await accept(
@@ -4804,7 +4804,7 @@ describe("usage pack allocation management", () => {
       proSubscription,
     );
     mockUsagePackSubscriptionChangePreviews(8000, 16_000);
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const preview = await accept(
@@ -4908,7 +4908,7 @@ describe("usage pack allocation management", () => {
       sourcePriceId: TEST_PRICE_USAGE_PACK_20,
       targetPriceId: TEST_PRICE_USAGE_PACK_50,
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const preview = await accept(
@@ -4994,7 +4994,7 @@ describe("usage pack allocation management", () => {
       sourcePriceId: TEST_PRICE_USAGE_PACK_20,
       targetPriceId: TEST_PRICE_USAGE_PACK_50,
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const preview = await accept(
@@ -5143,7 +5143,7 @@ describe("usage pack allocation management", () => {
       nextRecurringAmountCents: 7000,
       targetPriceId: TEST_PRICE_USAGE_PACK_50,
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const management = await accept(
@@ -5276,7 +5276,7 @@ describe("usage pack allocation management", () => {
         ],
       },
     );
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
 
@@ -5326,7 +5326,7 @@ describe("usage pack allocation management", () => {
     context.mocks.stripe.subscriptionSchedules.update.mockResolvedValue({
       id: scheduleId,
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const downgradePreview = await accept(
@@ -5456,7 +5456,7 @@ describe("usage pack allocation management", () => {
     context.mocks.stripe.subscriptionSchedules.update.mockResolvedValue({
       id: scheduleId,
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const downgradePreview = await accept(
@@ -5638,7 +5638,7 @@ describe("usage pack allocation management", () => {
       sourcePriceId: TEST_PRICE_USAGE_PACK_20,
       targetPriceId: TEST_PRICE_USAGE_PACK_50,
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const preview = await accept(
@@ -5750,7 +5750,7 @@ describe("usage pack allocation management", () => {
     context.mocks.stripe.subscriptionSchedules.update.mockResolvedValue({
       id: "sub_sched_team_to_pro",
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
 
@@ -5837,7 +5837,7 @@ describe("usage pack allocation management", () => {
       ),
     );
     mockUsagePackChangePreviews(1500, 7000);
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
 
@@ -5883,7 +5883,7 @@ describe("usage pack allocation management", () => {
       oldSubscription,
     );
     mockUsagePackChangePreviews(1500, 5000);
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
 
@@ -6038,7 +6038,7 @@ describe("usage pack allocation management", () => {
       oldSubscription,
     );
     mockUsagePackChangePreviews(1500, 5000);
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const preview = await accept(
@@ -6105,7 +6105,7 @@ describe("usage pack allocation management", () => {
     const subscription = managedUsagePackSubscription(fixture, quantities);
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(subscription);
     mockUsagePackChangePreviews(1500, 5000);
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const preview = await accept(
@@ -6179,7 +6179,7 @@ describe("usage pack allocation management", () => {
     context.mocks.stripe.subscriptionSchedules.update.mockResolvedValue({
       id: "sub_sched_usage_pack_downgrade",
     });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const preview = await accept(
@@ -6295,7 +6295,7 @@ describe("usage pack allocation management", () => {
     context.mocks.stripe.subscriptionSchedules.update
       .mockRejectedValueOnce(new Error("temporary Stripe failure"))
       .mockResolvedValue({ id: "sub_sched_usage_pack_retry" });
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingUsagePackManagementContract,
     );
     const preview = await accept(
@@ -6558,7 +6558,7 @@ describe("usage pack allocation management", () => {
     });
     const billingClient = setupApp({
       context,
-      routes: zeroBillingCheckoutRoutes,
+      routes: billingCheckoutRoutes,
     })(zeroBillingUsagePackManagementContract);
     const management = await accept(
       billingClient.get({
@@ -7302,7 +7302,7 @@ describe("usage pack allocation management", () => {
     });
     authenticateOrg(acceptedActor, "org:member");
     const credits = await accept(
-      setupApp({ context, routes: zeroBillingUsagePackCreditsRoutes })(
+      setupApp({ context, routes: billingUsagePackCreditsRoutes })(
         zeroBillingUsagePackCreditsContract,
       ).get({
         headers: { authorization: "Bearer clerk-session" },
@@ -7897,7 +7897,7 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       },
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -7949,7 +7949,7 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       },
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -8003,7 +8003,7 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       },
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -8051,7 +8051,7 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       },
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -8093,7 +8093,7 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       subscription: null,
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -8123,7 +8123,7 @@ describe("POST /api/zero/billing/checkout/complete", () => {
       subscription: `sub_${randomUUID().slice(0, 8)}`,
     });
 
-    const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+    const client = setupApp({ context, routes: billingCheckoutRoutes })(
       zeroBillingCheckoutContract,
     );
 
@@ -8186,7 +8186,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const response = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencyCheckoutRoutes,
+        routes: billingConcurrencyCheckoutRoutes,
       })(zeroBillingConcurrencyCheckoutContract).create({
         body: {
           quantity: 3,
@@ -8314,7 +8314,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencyCheckoutRoutes,
+      routes: billingConcurrencyCheckoutRoutes,
     })(zeroBillingConcurrencyCheckoutContract);
     const preview = await accept(
       client.preview({
@@ -8452,7 +8452,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const response = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencyCheckoutRoutes,
+        routes: billingConcurrencyCheckoutRoutes,
       })(zeroBillingConcurrencyCheckoutContract).preview({
         body: { quantity: 3 },
         headers: { authorization: "Bearer clerk-session" },
@@ -8537,7 +8537,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencyCheckoutRoutes,
+      routes: billingConcurrencyCheckoutRoutes,
     })(zeroBillingConcurrencyCheckoutContract);
     const preview = await accept(
       client.preview({
@@ -8648,7 +8648,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const response = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencyCheckoutRoutes,
+        routes: billingConcurrencyCheckoutRoutes,
       })(zeroBillingConcurrencyCheckoutContract).create({
         body: {
           quantity: 3,
@@ -8731,7 +8731,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const response = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencyCheckoutRoutes,
+        routes: billingConcurrencyCheckoutRoutes,
       })(zeroBillingConcurrencyCheckoutContract).create({
         body: {
           quantity: 1,
@@ -9038,7 +9038,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencyCheckoutRoutes,
+      routes: billingConcurrencyCheckoutRoutes,
     })(zeroBillingConcurrencyCheckoutContract);
     const successUrl = `${APP_ORIGIN}/billing?concurrency=success`;
     const cancelUrl = `${APP_ORIGIN}/billing?concurrency=canceled`;
@@ -9142,7 +9142,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
     const successUrl = `${APP_ORIGIN}/?concurrency=reduced`;
     const cancelUrl = `${APP_ORIGIN}/billing?concurrency=canceled`;
@@ -9219,7 +9219,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const response = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencySubscriptionRoutes,
+        routes: billingConcurrencySubscriptionRoutes,
       })(zeroBillingConcurrencySubscriptionContract).reduce({
         params: { subscriptionId },
         body: {
@@ -9255,7 +9255,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const response = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencySubscriptionRoutes,
+        routes: billingConcurrencySubscriptionRoutes,
       })(zeroBillingConcurrencySubscriptionContract).reduce({
         params: { subscriptionId },
         body: {
@@ -9372,7 +9372,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
 
     const preview = await accept(
@@ -9491,7 +9491,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const preview = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencySubscriptionRoutes,
+        routes: billingConcurrencySubscriptionRoutes,
       })(zeroBillingConcurrencySubscriptionContract).previewChange({
         params: { subscriptionId },
         body: { quantity: 3 },
@@ -9520,7 +9520,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const confirmed = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencySubscriptionRoutes,
+        routes: billingConcurrencySubscriptionRoutes,
       })(zeroBillingConcurrencySubscriptionContract).confirmChange({
         params: { subscriptionId },
         body: { quantity: 3 },
@@ -9630,7 +9630,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
     const preview = await accept(
       client.previewChange({
@@ -9744,7 +9744,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const response = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencySubscriptionRoutes,
+        routes: billingConcurrencySubscriptionRoutes,
       })(zeroBillingConcurrencySubscriptionContract).previewChange({
         params: { subscriptionId },
         body: { quantity: 3 },
@@ -9824,7 +9824,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
     const preview = await accept(
       client.previewChange({
@@ -9946,7 +9946,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
 
     await accept(
@@ -10187,7 +10187,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
     await accept(
       client.previewChange({
@@ -10346,7 +10346,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const response = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencySubscriptionRoutes,
+        routes: billingConcurrencySubscriptionRoutes,
       })(zeroBillingConcurrencySubscriptionContract).previewChange({
         params: { subscriptionId: `sub_${randomUUID()}` },
         body: { quantity: 2 },
@@ -10405,7 +10405,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const response = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencyCheckoutRoutes,
+        routes: billingConcurrencyCheckoutRoutes,
       })(zeroBillingConcurrencyCheckoutContract).create({
         body: {
           quantity: 1,
@@ -10445,7 +10445,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencySubscriptionRoutes,
+        routes: billingConcurrencySubscriptionRoutes,
       })(zeroBillingConcurrencySubscriptionContract).cancel({
         params: { subscriptionId },
         body: {},
@@ -10458,7 +10458,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     const response = await accept(
       setupApp({
         context,
-        routes: zeroBillingConcurrencyCheckoutRoutes,
+        routes: billingConcurrencyCheckoutRoutes,
       })(zeroBillingConcurrencyCheckoutContract).create({
         body: {
           quantity: 1,
@@ -10629,7 +10629,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencyCheckoutRoutes,
+      routes: billingConcurrencyCheckoutRoutes,
     })(zeroBillingConcurrencyCheckoutContract);
 
     const response = await accept(
@@ -10665,7 +10665,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencyCheckoutRoutes,
+      routes: billingConcurrencyCheckoutRoutes,
     })(zeroBillingConcurrencyCheckoutContract);
     const response = await accept(
       client.create({
@@ -10698,7 +10698,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencyCheckoutRoutes,
+      routes: billingConcurrencyCheckoutRoutes,
     })(zeroBillingConcurrencyCheckoutContract);
 
     const response = await accept(
@@ -10736,7 +10736,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
 
     const response = await accept(
@@ -10781,7 +10781,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
 
     await accept(
@@ -10865,7 +10865,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
     context.mocks.stripe.subscriptionSchedules.retrieve.mockResolvedValue({
       id: scheduleId,
@@ -11097,7 +11097,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
 
     await accept(
@@ -11149,7 +11149,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
 
     const response = await accept(
@@ -11171,7 +11171,7 @@ describe("POST /api/zero/billing/concurrency-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingConcurrencySubscriptionRoutes,
+      routes: billingConcurrencySubscriptionRoutes,
     })(zeroBillingConcurrencySubscriptionContract);
 
     const response = await accept(
@@ -11278,7 +11278,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
 
     const response = await accept(
@@ -11310,7 +11310,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
 
     const response = await accept(
@@ -11343,7 +11343,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
 
     const response = await accept(
@@ -11407,7 +11407,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     });
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCreditCheckoutRoutes })(
+      setupApp({ context, routes: billingCreditCheckoutRoutes })(
         zeroBillingCreditCheckoutContract,
       ).create({
         body: {
@@ -11467,7 +11467,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
     const preview = await accept(
       client.create({
@@ -11621,7 +11621,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
     const preview = await accept(
       client.create({
@@ -11728,7 +11728,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
     const preview = await accept(
       client.create({
@@ -11826,7 +11826,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
     const preview = await accept(
       client.create({
@@ -11948,7 +11948,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     });
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCreditCheckoutRoutes })(
+      setupApp({ context, routes: billingCreditCheckoutRoutes })(
         zeroBillingCreditCheckoutContract,
       ).create({
         body: {
@@ -11977,7 +11977,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingCreditCheckoutRoutes })(
+      setupApp({ context, routes: billingCreditCheckoutRoutes })(
         zeroBillingCreditCheckoutContract,
       ).create({
         body: {
@@ -12020,7 +12020,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
 
     const response = await accept(
@@ -12058,7 +12058,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
 
     const response = await accept(
@@ -12122,7 +12122,7 @@ describe("POST /api/zero/billing/credit-checkout", () => {
 
     const client = setupApp({
       context,
-      routes: zeroBillingCreditCheckoutRoutes,
+      routes: billingCreditCheckoutRoutes,
     })(zeroBillingCreditCheckoutContract);
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-downgrade.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-downgrade.test.ts
@@ -19,8 +19,8 @@ import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
-import { zeroBillingDowngradeRoutes } from "../zero-billing-downgrade";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingDowngradeRoutes } from "../billing-downgrade";
+import { billingStatusRoutes } from "../billing-status";
 
 const context = testContext();
 const store = createStore();
@@ -34,7 +34,7 @@ const TEST_USAGE_PACK_50 = "price_test_usage_pack_50";
 
 async function readBillingStatus() {
   return await accept(
-    setupApp({ context, routes: zeroBillingStatusRoutes })(
+    setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     ).get({
       headers: { authorization: "Bearer clerk-session" },
@@ -56,7 +56,7 @@ describe("POST /api/zero/billing/downgrade", () => {
   it("returns 503 when STRIPE_SECRET_KEY is not configured", async () => {
     mockOptionalEnv("STRIPE_SECRET_KEY", undefined);
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -76,7 +76,7 @@ describe("POST /api/zero/billing/downgrade", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -96,7 +96,7 @@ describe("POST /api/zero/billing/downgrade", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -121,7 +121,7 @@ describe("POST /api/zero/billing/downgrade", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await client.create({
@@ -138,7 +138,7 @@ describe("POST /api/zero/billing/downgrade", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -172,7 +172,7 @@ describe("POST /api/zero/billing/downgrade", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -241,7 +241,7 @@ describe("POST /api/zero/billing/downgrade", () => {
       id: scheduleId,
     });
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -352,7 +352,7 @@ describe("POST /api/zero/billing/downgrade", () => {
       id: scheduleId,
     });
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -436,7 +436,7 @@ describe("POST /api/zero/billing/downgrade", () => {
       id: scheduleId,
     });
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -535,7 +535,7 @@ describe("POST /api/zero/billing/downgrade", () => {
       url: checkoutUrl,
     });
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -619,7 +619,7 @@ describe("POST /api/zero/billing/downgrade", () => {
     });
     context.mocks.stripe.subscriptions.update.mockResolvedValue({ id: subId });
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -691,7 +691,7 @@ describe("POST /api/zero/billing/downgrade", () => {
     });
     context.mocks.stripe.subscriptions.update.mockResolvedValue({ id: subId });
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -752,7 +752,7 @@ describe("POST /api/zero/billing/downgrade", () => {
     });
     context.mocks.stripe.subscriptions.update.mockResolvedValue({ id: subId });
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -827,7 +827,7 @@ describe("POST /api/zero/billing/downgrade", () => {
       },
     });
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -911,7 +911,7 @@ describe("POST /api/zero/billing/downgrade", () => {
       id: scheduleId,
     });
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(
@@ -991,7 +991,7 @@ describe("POST /api/zero/billing/downgrade", () => {
       id: scheduleId,
     });
 
-    const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
       zeroBillingDowngradeContract,
     );
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-invoices.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-invoices.test.ts
@@ -19,7 +19,7 @@ import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
-import { zeroBillingInvoicesRoutes } from "../zero-billing-invoices";
+import { billingInvoicesRoutes } from "../billing-invoices";
 
 const context = testContext();
 const store = createStore();
@@ -31,7 +31,7 @@ describe("GET /api/zero/billing/invoices", () => {
   });
 
   it("returns 401 when the request is unauthenticated", async () => {
-    const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+    const client = setupApp({ context, routes: billingInvoicesRoutes })(
       zeroBillingInvoicesContract,
     );
 
@@ -49,7 +49,7 @@ describe("GET /api/zero/billing/invoices", () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, null);
 
-    const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+    const client = setupApp({ context, routes: billingInvoicesRoutes })(
       zeroBillingInvoicesContract,
     );
 
@@ -74,7 +74,7 @@ describe("GET /api/zero/billing/invoices", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+    const client = setupApp({ context, routes: billingInvoicesRoutes })(
       zeroBillingInvoicesContract,
     );
 
@@ -134,7 +134,7 @@ describe("GET /api/zero/billing/invoices", () => {
       ]);
     });
 
-    const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+    const client = setupApp({ context, routes: billingInvoicesRoutes })(
       zeroBillingInvoicesContract,
     );
 
@@ -225,7 +225,7 @@ describe("GET /api/zero/billing/invoices", () => {
       }),
     );
 
-    const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+    const client = setupApp({ context, routes: billingInvoicesRoutes })(
       zeroBillingInvoicesContract,
     );
     const response = await accept(
@@ -331,7 +331,7 @@ describe("GET /api/zero/billing/invoices", () => {
       ),
     );
 
-    const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+    const client = setupApp({ context, routes: billingInvoicesRoutes })(
       zeroBillingInvoicesContract,
     );
     const responsePromise = accept(
@@ -396,7 +396,7 @@ describe("GET /api/zero/billing/invoices", () => {
       }),
     );
 
-    const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+    const client = setupApp({ context, routes: billingInvoicesRoutes })(
       zeroBillingInvoicesContract,
     );
     const response = await accept(
@@ -425,7 +425,7 @@ describe("GET /api/zero/billing/invoices", () => {
       throw new Error("Stripe invoices should not be listed without customer");
     });
 
-    const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+    const client = setupApp({ context, routes: billingInvoicesRoutes })(
       zeroBillingInvoicesContract,
     );
 
@@ -461,7 +461,7 @@ describe("GET /api/zero/billing/invoices", () => {
       return Promise.resolve([]);
     });
 
-    const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+    const client = setupApp({ context, routes: billingInvoicesRoutes })(
       zeroBillingInvoicesContract,
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-portal.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-portal.test.ts
@@ -21,7 +21,7 @@ import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
-import { zeroBillingPortalRoutes } from "../zero-billing-portal";
+import { billingPortalRoutes } from "../billing-portal";
 
 const context = testContext();
 const store = createStore();
@@ -61,7 +61,7 @@ describe("POST /api/zero/billing/portal", () => {
     mockOptionalEnv("STRIPE_SECRET_KEY", undefined);
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
-    const client = setupApp({ context, routes: zeroBillingPortalRoutes })(
+    const client = setupApp({ context, routes: billingPortalRoutes })(
       zeroBillingPortalContract,
     );
     const response = await accept(
@@ -81,7 +81,7 @@ describe("POST /api/zero/billing/portal", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    const client = setupApp({ context, routes: zeroBillingPortalRoutes })(
+    const client = setupApp({ context, routes: billingPortalRoutes })(
       zeroBillingPortalContract,
     );
 
@@ -104,7 +104,7 @@ describe("POST /api/zero/billing/portal", () => {
   it("returns 400 when returnUrl is missing", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
-    const client = setupApp({ context, routes: zeroBillingPortalRoutes })(
+    const client = setupApp({ context, routes: billingPortalRoutes })(
       zeroBillingPortalContract,
     );
     const response = await accept(
@@ -121,7 +121,7 @@ describe("POST /api/zero/billing/portal", () => {
   it("returns 400 when returnUrl is not a valid URL", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
-    const client = setupApp({ context, routes: zeroBillingPortalRoutes })(
+    const client = setupApp({ context, routes: billingPortalRoutes })(
       zeroBillingPortalContract,
     );
     const response = await accept(
@@ -142,7 +142,7 @@ describe("POST /api/zero/billing/portal", () => {
       "org:member",
     );
 
-    const client = setupApp({ context, routes: zeroBillingPortalRoutes })(
+    const client = setupApp({ context, routes: billingPortalRoutes })(
       zeroBillingPortalContract,
     );
     const response = await accept(
@@ -186,7 +186,7 @@ describe("POST /api/zero/billing/portal", () => {
       url: "https://billing.stripe.com/session/test",
     });
 
-    const client = setupApp({ context, routes: zeroBillingPortalRoutes })(
+    const client = setupApp({ context, routes: billingPortalRoutes })(
       zeroBillingPortalContract,
     );
     const response = await accept(
@@ -231,7 +231,7 @@ describe("POST /api/zero/billing/portal", () => {
 
     const returnUrl = `${APP_ORIGIN}/settings/billing`;
     const response = await accept(
-      setupApp({ context, routes: zeroBillingPortalRoutes })(
+      setupApp({ context, routes: billingPortalRoutes })(
         zeroBillingPortalContract,
       ).create({
         body: { returnUrl },
@@ -274,7 +274,7 @@ describe("POST /api/zero/billing/portal", () => {
     });
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingPortalRoutes })(
+      setupApp({ context, routes: billingPortalRoutes })(
         zeroBillingPortalContract,
       ).create({
         body: { returnUrl },
@@ -353,7 +353,7 @@ describe("POST /api/zero/billing/portal", () => {
     });
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingPortalRoutes })(
+      setupApp({ context, routes: billingPortalRoutes })(
         zeroBillingPortalContract,
       ).create({
         body: {
@@ -415,7 +415,7 @@ describe("POST /api/zero/billing/portal", () => {
     });
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingPortalRoutes })(
+      setupApp({ context, routes: billingPortalRoutes })(
         zeroBillingPortalContract,
       ).create({
         body: {
@@ -449,7 +449,7 @@ describe("POST /api/zero/billing/portal", () => {
       "org:admin",
     );
 
-    const client = setupApp({ context, routes: zeroBillingPortalRoutes })(
+    const client = setupApp({ context, routes: billingPortalRoutes })(
       zeroBillingPortalContract,
     );
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-redeem-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-redeem-code.test.ts
@@ -8,7 +8,7 @@ import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroBillingRedeemCodeRoutes } from "../zero-billing-redeem-code";
+import { billingRedeemCodeRoutes } from "../billing-redeem-code";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -58,7 +58,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+    const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
       zeroBillingRedeemCodeContract,
     );
 
@@ -92,7 +92,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
       "org:member",
     );
 
-    const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+    const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
       zeroBillingRedeemCodeContract,
     );
     const response = await accept(
@@ -118,7 +118,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
     mockEnv("ENV", "production");
     setAdminSession();
 
-    const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+    const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
       zeroBillingRedeemCodeContract,
     );
     const response = await accept(
@@ -142,7 +142,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
     mockOptionalEnv("VM0_MACHINE_SECRET_KEY", undefined);
     setAdminSession();
 
-    const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+    const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
       zeroBillingRedeemCodeContract,
     );
     const response = await accept(
@@ -175,7 +175,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
     );
     setAdminSession();
 
-    const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+    const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
       zeroBillingRedeemCodeContract,
     );
     const response = await accept(
@@ -203,7 +203,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
     );
     setAdminSession();
 
-    const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+    const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
       zeroBillingRedeemCodeContract,
     );
     const response = await accept(
@@ -230,7 +230,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
     );
     setAdminSession();
 
-    const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+    const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
       zeroBillingRedeemCodeContract,
     );
     const response = await accept(
@@ -284,7 +284,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
       );
       setAdminSession();
 
-      const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+      const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
         zeroBillingRedeemCodeContract,
       );
       const response = await accept(
@@ -315,7 +315,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
     );
     setAdminSession();
 
-    const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+    const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
       zeroBillingRedeemCodeContract,
     );
     const response = await accept(
@@ -346,7 +346,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
       }),
     );
 
-    const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+    const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
       zeroBillingRedeemCodeContract,
     );
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-redeem.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-redeem.test.ts
@@ -9,7 +9,7 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { postOneTimePurchaseCompleted } from "./helpers/stripe-billing-webhook";
-import { zeroBillingRedeemRoutes } from "../zero-billing-redeem";
+import { billingRedeemRoutes } from "../billing-redeem";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -48,7 +48,7 @@ function postRedeem(options?: {
   readonly successUrl?: string;
   readonly headers?: { readonly authorization?: string };
 }) {
-  const client = setupApp({ context, routes: zeroBillingRedeemRoutes })(
+  const client = setupApp({ context, routes: billingRedeemRoutes })(
     zeroBillingRedeemContract,
   );
   return client.create({

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-restore.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-restore.test.ts
@@ -18,8 +18,8 @@ import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
-import { zeroBillingRestoreRoutes } from "../zero-billing-restore";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingRestoreRoutes } from "../billing-restore";
+import { billingStatusRoutes } from "../billing-status";
 
 const context = testContext();
 const store = createStore();
@@ -39,7 +39,7 @@ function mockSubscriptionWithPaymentMethod(
 
 async function readBillingStatus() {
   return await accept(
-    setupApp({ context, routes: zeroBillingStatusRoutes })(
+    setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     ).get({
       headers: { authorization: "Bearer clerk-session" },
@@ -60,7 +60,7 @@ describe("POST /api/zero/billing/restore", () => {
   it("returns 503 when STRIPE_SECRET_KEY is not configured", async () => {
     mockOptionalEnv("STRIPE_SECRET_KEY", undefined);
 
-    const client = setupApp({ context, routes: zeroBillingRestoreRoutes })(
+    const client = setupApp({ context, routes: billingRestoreRoutes })(
       zeroBillingRestoreContract,
     );
     const response = await accept(
@@ -80,7 +80,7 @@ describe("POST /api/zero/billing/restore", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    const client = setupApp({ context, routes: zeroBillingRestoreRoutes })(
+    const client = setupApp({ context, routes: billingRestoreRoutes })(
       zeroBillingRestoreContract,
     );
     const response = await accept(
@@ -100,7 +100,7 @@ describe("POST /api/zero/billing/restore", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroBillingRestoreRoutes })(
+    const client = setupApp({ context, routes: billingRestoreRoutes })(
       zeroBillingRestoreContract,
     );
     const response = await accept(
@@ -125,7 +125,7 @@ describe("POST /api/zero/billing/restore", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingRestoreRoutes })(
+    const client = setupApp({ context, routes: billingRestoreRoutes })(
       zeroBillingRestoreContract,
     );
     const response = await accept(
@@ -160,7 +160,7 @@ describe("POST /api/zero/billing/restore", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroBillingRestoreRoutes })(
+    const client = setupApp({ context, routes: billingRestoreRoutes })(
       zeroBillingRestoreContract,
     );
     const response = await accept(
@@ -200,7 +200,7 @@ describe("POST /api/zero/billing/restore", () => {
     mockSubscriptionWithPaymentMethod(subId, customerId);
     context.mocks.stripe.subscriptions.update.mockResolvedValue({ id: subId });
 
-    const client = setupApp({ context, routes: zeroBillingRestoreRoutes })(
+    const client = setupApp({ context, routes: billingRestoreRoutes })(
       zeroBillingRestoreContract,
     );
     const response = await accept(
@@ -249,7 +249,7 @@ describe("POST /api/zero/billing/restore", () => {
       id: scheduleId,
     });
 
-    const client = setupApp({ context, routes: zeroBillingRestoreRoutes })(
+    const client = setupApp({ context, routes: billingRestoreRoutes })(
       zeroBillingRestoreContract,
     );
     const response = await accept(
@@ -307,7 +307,7 @@ describe("POST /api/zero/billing/restore", () => {
       url: checkoutUrl,
     });
 
-    const client = setupApp({ context, routes: zeroBillingRestoreRoutes })(
+    const client = setupApp({ context, routes: billingRestoreRoutes })(
       zeroBillingRestoreContract,
     );
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-status.test.ts
@@ -30,7 +30,7 @@ import {
 } from "./helpers/zero-route-test";
 import { createBddApi } from "./helpers/api-bdd";
 import { signSandboxJwtForTests } from "../../auth/tokens";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 
 const context = testContext();
 const store = createStore();
@@ -83,7 +83,7 @@ describe("GET /api/zero/billing/status", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -96,7 +96,7 @@ describe("GET /api/zero/billing/status", () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, null);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -119,7 +119,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -151,7 +151,7 @@ describe("GET /api/zero/billing/status", () => {
       capabilities: ["billing:read"],
     });
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -170,7 +170,7 @@ describe("GET /api/zero/billing/status", () => {
       capabilities: [],
     });
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -205,7 +205,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -245,7 +245,7 @@ describe("GET /api/zero/billing/status", () => {
       mocks.clerk.session(fixture.userId, fixture.orgId);
 
       const response = await accept(
-        setupApp({ context, routes: zeroBillingStatusRoutes })(
+        setupApp({ context, routes: billingStatusRoutes })(
           zeroBillingStatusContract,
         ).get({
           headers: { authorization: "Bearer clerk-session" },
@@ -269,7 +269,7 @@ describe("GET /api/zero/billing/status", () => {
     });
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -310,7 +310,7 @@ describe("GET /api/zero/billing/status", () => {
       mocks.clerk.session(fixture.userId, fixture.orgId);
 
       const response = await accept(
-        setupApp({ context, routes: zeroBillingStatusRoutes })(
+        setupApp({ context, routes: billingStatusRoutes })(
           zeroBillingStatusContract,
         ).get({
           headers: { authorization: "Bearer clerk-session" },
@@ -348,7 +348,7 @@ describe("GET /api/zero/billing/status", () => {
       mocks.clerk.session(fixture.userId, fixture.orgId);
 
       const response = await accept(
-        setupApp({ context, routes: zeroBillingStatusRoutes })(
+        setupApp({ context, routes: billingStatusRoutes })(
           zeroBillingStatusContract,
         ).get({
           headers: { authorization: "Bearer clerk-session" },
@@ -379,7 +379,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -421,7 +421,7 @@ describe("GET /api/zero/billing/status", () => {
     mocks.clerk.session(userId, orgId);
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingStatusRoutes })(
+      setupApp({ context, routes: billingStatusRoutes })(
         zeroBillingStatusContract,
       ).get({
         headers: { authorization: "Bearer clerk-session" },
@@ -455,7 +455,7 @@ describe("GET /api/zero/billing/status", () => {
     });
     mocks.clerk.session(userId, orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
     const initialResponse = await accept(
@@ -522,7 +522,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -589,7 +589,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -666,7 +666,7 @@ describe("GET /api/zero/billing/status", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const response = await accept(
-      setupApp({ context, routes: zeroBillingStatusRoutes })(
+      setupApp({ context, routes: billingStatusRoutes })(
         zeroBillingStatusContract,
       ).get({
         headers: { authorization: "Bearer clerk-session" },
@@ -727,7 +727,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -764,7 +764,7 @@ describe("GET /api/zero/billing/status", () => {
     });
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -796,7 +796,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -837,7 +837,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -860,7 +860,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -892,7 +892,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -922,7 +922,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -958,7 +958,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -1007,7 +1007,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -1059,7 +1059,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -1104,7 +1104,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -1142,7 +1142,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -1188,7 +1188,7 @@ describe("GET /api/zero/billing/status", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 
@@ -1222,7 +1222,7 @@ describe("GET /api/zero/billing/status", () => {
     const orgId = `org_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
 
-    const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+    const client = setupApp({ context, routes: billingStatusRoutes })(
       zeroBillingStatusContract,
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-usage-pack-credits.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-usage-pack-credits.test.ts
@@ -19,7 +19,7 @@ import {
   testUsagePackSubscriptionStateContract,
   testUsagePackSubscriptionStateRoutes,
 } from "../test-usage-pack-subscription-state";
-import { zeroBillingUsagePackCreditsRoutes } from "../zero-billing-usage-pack-credits";
+import { billingUsagePackCreditsRoutes } from "../billing-usage-pack-credits";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -44,7 +44,7 @@ function authenticate(
 }
 
 function creditsClient() {
-  return setupApp({ context, routes: zeroBillingUsagePackCreditsRoutes })(
+  return setupApp({ context, routes: billingUsagePackCreditsRoutes })(
     zeroBillingUsagePackCreditsContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/finance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/finance.test.ts
@@ -17,12 +17,12 @@ import {
 } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 import { financeRoutes } from "../finance";
 
 const context = testContext();
 const FINANCE_ROUTES = Object.freeze([
-  ...zeroBillingStatusRoutes,
+  ...billingStatusRoutes,
   ...financeRoutes,
 ]);
 const APIDOJO_BASE_URL = "https://apidojo-yahoo-finance-v1.p.rapidapi.com";

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
@@ -45,7 +45,7 @@ import { cliAuthRoutes } from "../../cli-auth";
 import { cliAuthTestRoutes } from "../../cli-auth-test";
 import { desktopAuthRoutes } from "../../desktop-auth";
 import { agentsRoutes } from "../../agents";
-import { zeroBillingStatusRoutes } from "../../zero-billing-status";
+import { billingStatusRoutes } from "../../billing-status";
 import { claudeCodeDeviceAuthRoutes } from "../../claude-code-device-auth";
 import { codexDeviceAuthRoutes } from "../../codex-device-auth";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
@@ -83,7 +83,7 @@ const authDeviceRoutes: readonly RouteEntry[] = [
   ...cliAuthTestRoutes,
   ...desktopAuthRoutes,
   ...agentsRoutes,
-  ...zeroBillingStatusRoutes,
+  ...billingStatusRoutes,
   ...claudeCodeDeviceAuthRoutes,
   ...codexDeviceAuthRoutes,
   ...zeroModelProvidersRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -49,16 +49,16 @@ import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 import { acquisitionAttributionRoutes } from "../../acquisition-attribution";
 import { zeroBankingRoutes } from "../../zero-banking";
-import { zeroBillingAutoRechargeRoutes } from "../../zero-billing-auto-recharge";
-import { zeroBillingCheckoutRoutes } from "../../zero-billing-checkout";
-import { zeroBillingCreditCheckoutRoutes } from "../../zero-billing-credit-checkout";
-import { zeroBillingDowngradeRoutes } from "../../zero-billing-downgrade";
-import { zeroBillingInvoicesRoutes } from "../../zero-billing-invoices";
-import { zeroBillingPortalRoutes } from "../../zero-billing-portal";
-import { zeroBillingRedeemRoutes } from "../../zero-billing-redeem";
-import { zeroBillingRedeemCodeRoutes } from "../../zero-billing-redeem-code";
-import { zeroBillingRestoreRoutes } from "../../zero-billing-restore";
-import { zeroBillingStatusRoutes } from "../../zero-billing-status";
+import { billingAutoRechargeRoutes } from "../../billing-auto-recharge";
+import { billingCheckoutRoutes } from "../../billing-checkout";
+import { billingCreditCheckoutRoutes } from "../../billing-credit-checkout";
+import { billingDowngradeRoutes } from "../../billing-downgrade";
+import { billingInvoicesRoutes } from "../../billing-invoices";
+import { billingPortalRoutes } from "../../billing-portal";
+import { billingRedeemRoutes } from "../../billing-redeem";
+import { billingRedeemCodeRoutes } from "../../billing-redeem-code";
+import { billingRestoreRoutes } from "../../billing-restore";
+import { billingStatusRoutes } from "../../billing-status";
 import { builtInGenerationRoutes } from "../../built-in-generation";
 import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
 import { imageIoGenerateRoutes } from "../../image-io-generate";
@@ -290,7 +290,7 @@ export function createBillingMediaApi(context: TestContext) {
     async readBillingStatus(
       actor: ApiTestUser,
     ): Promise<BillingStatusResponse> {
-      const client = setupApp({ context, routes: zeroBillingStatusRoutes })(
+      const client = setupApp({ context, routes: billingStatusRoutes })(
         zeroBillingStatusContract,
       );
       const response = await accept(
@@ -301,7 +301,7 @@ export function createBillingMediaApi(context: TestContext) {
     },
 
     async startCheckout(actor: ApiTestUser, body: CheckoutBody) {
-      const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      const client = setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingCheckoutContract,
       );
       return await accept(
@@ -315,7 +315,7 @@ export function createBillingMediaApi(context: TestContext) {
       body: CheckoutBody,
       statuses: readonly CheckoutStatus[],
     ) {
-      const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      const client = setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingCheckoutContract,
       );
       return await accept(
@@ -329,7 +329,7 @@ export function createBillingMediaApi(context: TestContext) {
       body: { readonly sessionId: string },
       statuses: readonly (200 | 400 | 401 | 403 | 500 | 503)[],
     ) {
-      const client = setupApp({ context, routes: zeroBillingCheckoutRoutes })(
+      const client = setupApp({ context, routes: billingCheckoutRoutes })(
         zeroBillingCheckoutContract,
       );
       return await accept(
@@ -341,7 +341,7 @@ export function createBillingMediaApi(context: TestContext) {
     async startCreditCheckout(actor: ApiTestUser, body: CreditCheckoutRequest) {
       const client = setupApp({
         context,
-        routes: zeroBillingCreditCheckoutRoutes,
+        routes: billingCreditCheckoutRoutes,
       })(zeroBillingCreditCheckoutContract);
       return await accept(
         client.create({ headers: authenticate(actor), body }),
@@ -356,7 +356,7 @@ export function createBillingMediaApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroBillingCreditCheckoutRoutes,
+        routes: billingCreditCheckoutRoutes,
       })(zeroBillingCreditCheckoutContract);
       return await accept(
         client.create({ headers: authenticate(actor), body }),
@@ -365,7 +365,7 @@ export function createBillingMediaApi(context: TestContext) {
     },
 
     async openPortal(actor: ApiTestUser, body: PortalBody) {
-      const client = setupApp({ context, routes: zeroBillingPortalRoutes })(
+      const client = setupApp({ context, routes: billingPortalRoutes })(
         zeroBillingPortalContract,
       );
       return await accept(
@@ -377,7 +377,7 @@ export function createBillingMediaApi(context: TestContext) {
     async readAutoRecharge(actor: ApiTestUser): Promise<AutoRechargeConfig> {
       const client = setupApp({
         context,
-        routes: zeroBillingAutoRechargeRoutes,
+        routes: billingAutoRechargeRoutes,
       })(zeroBillingAutoRechargeContract);
       const response = await accept(
         client.get({ headers: authenticate(actor) }),
@@ -393,7 +393,7 @@ export function createBillingMediaApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroBillingAutoRechargeRoutes,
+        routes: billingAutoRechargeRoutes,
       })(zeroBillingAutoRechargeContract);
       return await accept(
         client.update({ headers: authenticate(actor), body }),
@@ -402,7 +402,7 @@ export function createBillingMediaApi(context: TestContext) {
     },
 
     async readInvoices(actor: ApiTestUser): Promise<BillingInvoicesResponse> {
-      const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+      const client = setupApp({ context, routes: billingInvoicesRoutes })(
         zeroBillingInvoicesContract,
       );
       const response = await accept(
@@ -416,7 +416,7 @@ export function createBillingMediaApi(context: TestContext) {
       actor: ApiTestUser | null,
       statuses: readonly (200 | 401 | 403 | 500)[],
     ) {
-      const client = setupApp({ context, routes: zeroBillingInvoicesRoutes })(
+      const client = setupApp({ context, routes: billingInvoicesRoutes })(
         zeroBillingInvoicesContract,
       );
       return await accept(
@@ -433,7 +433,7 @@ export function createBillingMediaApi(context: TestContext) {
       },
       statuses: readonly BillingMutationStatus[],
     ) {
-      const client = setupApp({ context, routes: zeroBillingDowngradeRoutes })(
+      const client = setupApp({ context, routes: billingDowngradeRoutes })(
         zeroBillingDowngradeContract,
       );
       return await accept(
@@ -447,7 +447,7 @@ export function createBillingMediaApi(context: TestContext) {
       body: { readonly returnUrl?: string },
       statuses: readonly (200 | 401 | 403 | 409 | 500 | 503)[],
     ) {
-      const client = setupApp({ context, routes: zeroBillingRestoreRoutes })(
+      const client = setupApp({ context, routes: billingRestoreRoutes })(
         zeroBillingRestoreContract,
       );
       return await accept(
@@ -461,7 +461,7 @@ export function createBillingMediaApi(context: TestContext) {
       campaign: string,
       body: RedeemRequest,
     ) {
-      const client = setupApp({ context, routes: zeroBillingRedeemRoutes })(
+      const client = setupApp({ context, routes: billingRedeemRoutes })(
         zeroBillingRedeemContract,
       );
       return await accept(
@@ -479,7 +479,7 @@ export function createBillingMediaApi(context: TestContext) {
       body: RedeemCodeRequest,
       statuses: readonly (200 | 400 | 401 | 403 | 500 | 503)[],
     ) {
-      const client = setupApp({ context, routes: zeroBillingRedeemCodeRoutes })(
+      const client = setupApp({ context, routes: billingRedeemCodeRoutes })(
         zeroBillingRedeemCodeContract,
       );
       return await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-maps-billing.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-maps-billing.ts
@@ -8,7 +8,7 @@ import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { mockEnv } from "../../../../lib/env";
 import type { RouteEntry } from "../../../route-entry";
-import { zeroBillingStatusRoutes } from "../../zero-billing-status";
+import { billingStatusRoutes } from "../../billing-status";
 import { mapsRoutes } from "../../maps";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
@@ -49,7 +49,7 @@ interface OsmRenderBody extends OsmAreaBody {
 }
 
 const mapsBillingRoutes: readonly RouteEntry[] = [
-  ...zeroBillingStatusRoutes,
+  ...billingStatusRoutes,
   ...mapsRoutes,
 ];
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -67,7 +67,7 @@ import { cronTelegramCleanupRoutes } from "../../cron-telegram-cleanup";
 import { runnersRoutes } from "../../runners";
 import { webhooksStripeRoutes } from "../../webhooks-stripe";
 import { agentsRoutes } from "../../agents";
-import { zeroBillingStatusRoutes } from "../../zero-billing-status";
+import { billingStatusRoutes } from "../../billing-status";
 import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
 import { zeroRunDetailRoutes } from "../../zero-run-detail";
@@ -153,7 +153,7 @@ const runRoutes = [
   ...cronTelegramCleanupRoutes,
   ...runnersRoutes,
   ...webhooksStripeRoutes,
-  ...zeroBillingStatusRoutes,
+  ...billingStatusRoutes,
   ...zeroModelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
   ...zeroRunDetailRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -17,7 +17,7 @@ import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createDeferredPromise } from "../../utils";
 import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generations";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 import { builtInGenerationRoutes } from "../built-in-generation";
 import { imageIoGenerateRoutes } from "../image-io-generate";
 import { usageRecordRoutes } from "../usage-record";
@@ -136,7 +136,7 @@ function createImageIoTestApp(
       ...builtInGenerationRoutes,
       ...imageIoGenerateRoutes,
       ...webhooksBuiltInGenerationRoutes,
-      ...zeroBillingStatusRoutes,
+      ...billingStatusRoutes,
       ...usageRecordRoutes,
     ],
     usagePricingResolution,

--- a/turbo/apps/api/src/signals/routes/__tests__/people-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/people-search.test.ts
@@ -25,7 +25,7 @@ import {
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { now } from "../../../lib/time";
 import type { RouteEntry } from "../../route-entry";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 import { peopleSearchRoutes } from "../people-search";
 import { webSearchRoutes } from "../web-search";
 import {
@@ -43,7 +43,7 @@ const PERPLEXITY_SEARCH_URL = "https://api.perplexity.ai/search";
 const MAX_PROVIDER_RESPONSE_BYTES = 512 * 1024;
 
 const peopleSearchTestRoutes: readonly RouteEntry[] = [
-  ...zeroBillingStatusRoutes,
+  ...billingStatusRoutes,
   ...peopleSearchRoutes,
 ];
 

--- a/turbo/apps/api/src/signals/routes/__tests__/scrape.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/scrape.test.ts
@@ -21,7 +21,7 @@ import { createDeferredPromise } from "../../utils";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { now } from "../../../lib/time";
 import type { RouteEntry } from "../../route-entry";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 import { scrapeRoutes } from "../scrape";
 import {
   createBddApi,
@@ -34,7 +34,7 @@ const context = testContext();
 const FIRECRAWL_SCRAPE_URL = "https://api.firecrawl.dev/v2/scrape";
 
 const scrapeTestRoutes: readonly RouteEntry[] = [
-  ...zeroBillingStatusRoutes,
+  ...billingStatusRoutes,
   ...scrapeRoutes,
 ];
 

--- a/turbo/apps/api/src/signals/routes/__tests__/seo.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/seo.test.ts
@@ -24,11 +24,11 @@ import {
 } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 import { seoRoutes } from "../seo";
 
 const context = testContext();
-const SEO_ROUTES = Object.freeze([...zeroBillingStatusRoutes, ...seoRoutes]);
+const SEO_ROUTES = Object.freeze([...billingStatusRoutes, ...seoRoutes]);
 const DATAFORSEO_BASE_URL = "https://api.dataforseo.com";
 
 type OrgApiTestUser = ApiTestUser & {

--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -18,7 +18,7 @@ import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { now } from "../../../lib/time";
 import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generations";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 import { builtInGenerationRoutes } from "../built-in-generation";
 import { videoIoGenerateRoutes } from "../video-io-generate";
 import {
@@ -231,7 +231,7 @@ function createVideoIoTestApp(
       ...builtInGenerationRoutes,
       ...videoIoGenerateRoutes,
       ...webhooksBuiltInGenerationRoutes,
-      ...zeroBillingStatusRoutes,
+      ...billingStatusRoutes,
     ],
     usagePricingResolution,
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-post.test.ts
@@ -16,7 +16,7 @@ import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { now } from "../../../lib/time";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 import { voiceIoSpeechRoutes } from "../voice-io-speech";
 import { voiceIoSttRoutes } from "../voice-io-stt";
 import { voiceIoQuotaRoutes } from "../voice-io-quota";
@@ -78,7 +78,7 @@ function createVoiceIoTestApp(
       ...voiceIoQuotaRoutes,
       ...voiceIoSpeechRoutes,
       ...voiceIoSttRoutes,
-      ...zeroBillingStatusRoutes,
+      ...billingStatusRoutes,
     ],
     usagePricingResolution,
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/web-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-search.test.ts
@@ -28,7 +28,7 @@ import { signSandboxJwtForTests } from "../../auth/tokens";
 import { now, nowDate } from "../../../lib/time";
 import type { RouteEntry } from "../../route-entry";
 import { createDeferredPromise } from "../../utils";
-import { zeroBillingStatusRoutes } from "../zero-billing-status";
+import { billingStatusRoutes } from "../billing-status";
 import { webSearchRoutes } from "../web-search";
 import {
   createBddApi,
@@ -48,7 +48,7 @@ const PERPLEXITY_SEARCH_URL = "https://api.perplexity.ai/search";
 const MAX_PROVIDER_RESPONSE_BYTES = 512 * 1024;
 
 const webSearchTestRoutes: readonly RouteEntry[] = [
-  ...zeroBillingStatusRoutes,
+  ...billingStatusRoutes,
   ...webSearchRoutes,
 ];
 

--- a/turbo/apps/api/src/signals/routes/billing-auto-recharge.ts
+++ b/turbo/apps/api/src/signals/routes/billing-auto-recharge.ts
@@ -71,7 +71,7 @@ const updateAutoRechargeInner$ = command(
   },
 );
 
-export const zeroBillingAutoRechargeRoutes: readonly RouteEntry[] = [
+export const billingAutoRechargeRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingAutoRechargeContract.get,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -1334,7 +1334,7 @@ const checkoutComplete$ = command(async ({ set }, signal: AbortSignal) => {
   );
 });
 
-export const zeroBillingCheckoutRoutes: readonly RouteEntry[] = [
+export const billingCheckoutRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingCheckoutContract.create,
     handler: checkout$,

--- a/turbo/apps/api/src/signals/routes/billing-concurrency-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-concurrency-checkout.ts
@@ -270,7 +270,7 @@ const concurrencyCheckout$ = command(async ({ set }, signal: AbortSignal) => {
   );
 });
 
-export const zeroBillingConcurrencyCheckoutRoutes: readonly RouteEntry[] = [
+export const billingConcurrencyCheckoutRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingConcurrencyCheckoutContract.preview,
     handler: concurrencyCheckoutPreview$,

--- a/turbo/apps/api/src/signals/routes/billing-concurrency-subscriptions.ts
+++ b/turbo/apps/api/src/signals/routes/billing-concurrency-subscriptions.ts
@@ -384,7 +384,7 @@ const restoreConcurrencySubscriptionRoute$ = command(
   },
 );
 
-export const zeroBillingConcurrencySubscriptionRoutes: readonly RouteEntry[] = [
+export const billingConcurrencySubscriptionRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingConcurrencySubscriptionContract.previewChange,
     handler: previewConcurrencySubscriptionChangeRoute$,

--- a/turbo/apps/api/src/signals/routes/billing-credit-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-credit-checkout.ts
@@ -232,7 +232,7 @@ const creditPurchaseConfirm$ = command(async ({ set }, signal: AbortSignal) => {
   );
 });
 
-export const zeroBillingCreditCheckoutRoutes: readonly RouteEntry[] = [
+export const billingCreditCheckoutRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingCreditCheckoutContract.create,
     handler: creditCheckout$,

--- a/turbo/apps/api/src/signals/routes/billing-downgrade.ts
+++ b/turbo/apps/api/src/signals/routes/billing-downgrade.ts
@@ -86,7 +86,7 @@ const downgrade$ = command(async ({ set }, signal: AbortSignal) => {
   );
 });
 
-export const zeroBillingDowngradeRoutes: readonly RouteEntry[] = [
+export const billingDowngradeRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingDowngradeContract.create,
     handler: downgrade$,

--- a/turbo/apps/api/src/signals/routes/billing-invoices.ts
+++ b/turbo/apps/api/src/signals/routes/billing-invoices.ts
@@ -81,7 +81,7 @@ const downloadReceiptsInner$ = command(
   },
 );
 
-export const zeroBillingInvoicesRoutes: readonly RouteEntry[] = [
+export const billingInvoicesRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingInvoicesContract.get,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/billing-portal.ts
+++ b/turbo/apps/api/src/signals/routes/billing-portal.ts
@@ -50,7 +50,7 @@ const portalInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return { status: 200 as const, body: { url } };
 });
 
-export const zeroBillingPortalRoutes: readonly RouteEntry[] = [
+export const billingPortalRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingPortalContract.create,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/billing-redeem-code.ts
+++ b/turbo/apps/api/src/signals/routes/billing-redeem-code.ts
@@ -255,7 +255,7 @@ const redeemCode$ = command(async ({ set }, signal: AbortSignal) => {
   );
 });
 
-export const zeroBillingRedeemCodeRoutes: readonly RouteEntry[] = [
+export const billingRedeemCodeRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingRedeemCodeContract.create,
     handler: redeemCode$,

--- a/turbo/apps/api/src/signals/routes/billing-redeem.ts
+++ b/turbo/apps/api/src/signals/routes/billing-redeem.ts
@@ -123,7 +123,7 @@ const redeem$ = command(async ({ set }, signal: AbortSignal) => {
   );
 });
 
-export const zeroBillingRedeemRoutes: readonly RouteEntry[] = [
+export const billingRedeemRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingRedeemContract.create,
     handler: redeem$,

--- a/turbo/apps/api/src/signals/routes/billing-restore.ts
+++ b/turbo/apps/api/src/signals/routes/billing-restore.ts
@@ -81,7 +81,7 @@ const restore$ = command(async ({ set }, signal: AbortSignal) => {
   );
 });
 
-export const zeroBillingRestoreRoutes: readonly RouteEntry[] = [
+export const billingRestoreRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingRestoreContract.create,
     handler: restore$,

--- a/turbo/apps/api/src/signals/routes/billing-status.ts
+++ b/turbo/apps/api/src/signals/routes/billing-status.ts
@@ -12,7 +12,7 @@ const getBillingStatusInner$ = computed(async (get) => {
   return { status: 200 as const, body };
 });
 
-export const zeroBillingStatusRoutes: readonly RouteEntry[] = [
+export const billingStatusRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingStatusContract.get,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/billing-usage-pack-credits.ts
+++ b/turbo/apps/api/src/signals/routes/billing-usage-pack-credits.ts
@@ -77,7 +77,7 @@ const getUsagePackCredits$ = command(async ({ get }, signal: AbortSignal) => {
   return { status: 200 as const, body: { ...body, hasUsagePack: true } };
 });
 
-export const zeroBillingUsagePackCreditsRoutes: readonly RouteEntry[] = [
+export const billingUsagePackCreditsRoutes: readonly RouteEntry[] = [
   {
     route: zeroBillingUsagePackCreditsContract.get,
     handler: authRoute(


### PR DESCRIPTION
## Summary

- rename the 13 billing route modules and their route-array exports to domain-neutral billing naming
- update the production registry, benchmark, focused route tests, and BDD helpers atomically
- preserve every route entry, order, handler, imported contract declaration, and compatibility-facing billing identity

## Compatibility

- no contract, API path, schema, Stripe object or identifier, billing state machine, credit/concurrency/redeem behavior, database identity, service, CLI, Platform, or error-message changes
- no aliases, forwarding files, compatibility re-exports, duplicate routes, or unrelated renames
- #27128 remains unmerged and none of its feature code was cherry-picked or simulated

## Acceptance audit

- all 13 old route paths and route-array exports are absent; all 13 neutral paths and exports are present
- all 25 production-registry, benchmark, test, and BDD-helper callers use the neutral shells
- normalized source audit confirms all 38 affected files differ from the implementation base only by the approved path/export mappings
- rebases preserve the route-shell changes from #27573 and #27574 already present on current `main`
- contract, API, Stripe, persisted, service, CLI, Platform, and error compatibility names remain unchanged

## Verification

- Prettier 3.8.1 check on all 38 affected files
- `pnpm -F api lint`
- `pnpm exec knip --workspace api`
- `pnpm -F api check-types`
- focused API route tests: 11 files passed, 278 tests passed
- residual old-name scan, neutral-target collision scan, and paginated open-PR file scan (28 PRs, 584 files; all 185 files of #25722 across two pages)
- full local Vitest suite not run and no development server started, per repository policy

Closes #27581
