### PR TITLE
refactor(integrations): neutralize feishu and slack route shell naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -147,7 +147,7 @@ import { integrationsGithubDownloadFileRoutes } from "./routes/integrations-gith
 import { integrationsGithubUploadCompleteRoutes } from "./routes/integrations-github-upload-complete";
 import { integrationsGithubUploadInitRoutes } from "./routes/integrations-github-upload-init";
 import { integrationsFeishuFileRoutes } from "./routes/integrations-feishu-files";
-import { zeroIntegrationsSlackRoutes } from "./routes/zero-integrations-slack";
+import { integrationsSlackRoutes } from "./routes/integrations-slack";
 import { integrationsSlackMessageRoutes } from "./routes/integrations-slack-message";
 import { integrationsFeishuMessageRoutes } from "./routes/integrations-feishu-message";
 import { integrationsSlackUploadCompleteRoutes } from "./routes/integrations-slack-upload-complete";
@@ -163,14 +163,14 @@ import { integrationsTelegramUploadCompleteRoutes } from "./routes/integrations-
 import { integrationsTelegramUploadInitRoutes } from "./routes/integrations-telegram-upload-init";
 import { slackChannelsRoutes } from "./routes/slack-channels";
 import { slackCommandsRoutes } from "./routes/slack-commands";
-import { zeroSlackConnectRoutes } from "./routes/zero-slack-connect";
+import { slackConnectRoutes } from "./routes/slack-connect";
 import { slackEventsRoutes } from "./routes/slack-events";
 import { slackInteractiveRoutes } from "./routes/slack-interactive";
-import { zeroSlackOauthRoutes } from "./routes/zero-slack-oauth";
-import { zeroFeishuBrowserConnectRoutes } from "./routes/zero-feishu-browser-connect";
-import { zeroFeishuConnectRoutes } from "./routes/zero-feishu-connect";
+import { slackOauthRoutes } from "./routes/slack-oauth";
+import { feishuBrowserConnectRoutes } from "./routes/feishu-browser-connect";
+import { feishuConnectRoutes } from "./routes/feishu-connect";
 import { feishuEventsRoutes } from "./routes/feishu-events";
-import { zeroFeishuOauthRoutes } from "./routes/zero-feishu-oauth";
+import { feishuOauthRoutes } from "./routes/feishu-oauth";
 import { steamPlayerRoutes } from "./routes/steam-player";
 import { zeroTeamsBrowserConnectRoutes } from "./routes/zero-teams-browser-connect";
 import { zeroTeamsBotRoutes } from "./routes/zero-teams-bot";
@@ -339,15 +339,15 @@ export const ROUTES: readonly RouteEntry[] = [
   ...workflowAutomationsRoutes,
   ...strapiIntegrationsRoutes,
   ...integrationsGithubRoutes,
-  ...zeroSlackConnectRoutes,
-  ...zeroSlackOauthRoutes,
+  ...slackConnectRoutes,
+  ...slackOauthRoutes,
   ...slackCommandsRoutes,
   ...slackEventsRoutes,
   ...slackInteractiveRoutes,
-  ...zeroFeishuBrowserConnectRoutes,
-  ...zeroFeishuConnectRoutes,
+  ...feishuBrowserConnectRoutes,
+  ...feishuConnectRoutes,
   ...feishuEventsRoutes,
-  ...zeroFeishuOauthRoutes,
+  ...feishuOauthRoutes,
   ...zeroTeamsBrowserConnectRoutes,
   ...zeroTeamsBotRoutes,
   ...zeroTeamsConnectRoutes,
@@ -361,7 +361,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...integrationsGithubUploadCompleteRoutes,
   ...integrationsGithubUploadInitRoutes,
   ...integrationsFeishuFileRoutes,
-  ...zeroIntegrationsSlackRoutes,
+  ...integrationsSlackRoutes,
   ...integrationsSlackMessageRoutes,
   ...integrationsFeishuMessageRoutes,
   ...integrationsSlackUploadCompleteRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -37,9 +37,9 @@ import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../../lib/time";
 import { createDeferredPromise } from "../../utils";
-import { zeroFeishuBrowserConnectRoutes } from "../zero-feishu-browser-connect";
+import { feishuBrowserConnectRoutes } from "../feishu-browser-connect";
 import { feishuEventsRoutes } from "../feishu-events";
-import { zeroFeishuOauthRoutes } from "../zero-feishu-oauth";
+import { feishuOauthRoutes } from "../feishu-oauth";
 import { integrationsFeishuFileRoutes } from "../integrations-feishu-files";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import type { ApiTestUser } from "./helpers/api-bdd";
@@ -67,7 +67,7 @@ import { customConnectorsGetRoutes } from "../custom-connectors-get";
 import { customConnectorOAuth2Routes } from "../custom-connectors-oauth2";
 import { customConnectorDisconnectRoutes } from "../custom-connectors-disconnect";
 import { customConnectorsUpdateRoutes } from "../custom-connectors-update";
-import { zeroFeishuConnectRoutes } from "../zero-feishu-connect";
+import { feishuConnectRoutes } from "../feishu-connect";
 
 const zeroCustomConnectorByIdTestRoutes = Object.freeze([
   ...customConnectorsDeleteRoutes,
@@ -351,7 +351,7 @@ async function requestFeishuConfigurationFailure(args: {
 }): Promise<Response> {
   const app = createAppWithRoutes({
     signal: context.signal,
-    routes: zeroFeishuConnectRoutes,
+    routes: feishuConnectRoutes,
   });
   return await app.request(args.path, {
     method: args.method,
@@ -742,7 +742,7 @@ describe("Feishu integration", () => {
     await runsApi.grantProEntitlement(actor);
     await runsApi.ensureOrgModelProvider(actor);
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     const configured = await accept(
@@ -827,7 +827,7 @@ describe("Feishu integration", () => {
     oauthUserOpenId = openId;
     const oauthApp = createAppWithRoutes({
       signal: context.signal,
-      routes: zeroFeishuOauthRoutes,
+      routes: feishuOauthRoutes,
     });
     const callbackResponse = await oauthApp.request(
       `${zeroFeishuOauthContract.callback.path}?${new URLSearchParams({
@@ -876,7 +876,7 @@ describe("Feishu integration", () => {
     );
     const connectApp = createAppWithRoutes({
       signal: context.signal,
-      routes: zeroFeishuBrowserConnectRoutes,
+      routes: feishuBrowserConnectRoutes,
     });
     const response = await connectApp.request("/api/zero/feishu/connect", {
       method: "POST",
@@ -1003,7 +1003,7 @@ describe("Feishu integration", () => {
       fixture.actor.orgId,
       fixture.actor.orgRole,
     );
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     await accept(
@@ -1058,7 +1058,7 @@ describe("Feishu integration", () => {
     await enableFeishuIntegration(doomed);
     await connectFixtureUser(fixture, doomed, "ou_feishu_doomed");
 
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     mocks.clerk.session(doomed.userId, doomed.orgId, "org:member");
@@ -1117,7 +1117,7 @@ describe("Feishu integration", () => {
       orgRole: "org:admin",
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
 
@@ -1150,7 +1150,7 @@ describe("Feishu integration", () => {
       visibility: "public",
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     const configured = await accept(
@@ -1214,7 +1214,7 @@ describe("Feishu integration", () => {
       visibility: "public",
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
 
@@ -1312,7 +1312,7 @@ describe("Feishu integration", () => {
       visibility: "public",
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     const bothTokenRequestsStarted = createDeferredPromise<void>(
@@ -1400,7 +1400,7 @@ describe("Feishu integration", () => {
       visibility: "public",
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     context.mocks.s3.send.mockRejectedValue(
@@ -1524,7 +1524,7 @@ describe("Feishu integration", () => {
       visibility: "public",
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     const configured = await accept(
@@ -1620,7 +1620,7 @@ describe("Feishu integration", () => {
       visibility: "public",
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
 
@@ -1733,7 +1733,7 @@ describe("Feishu integration", () => {
     });
     mockAuthoritativeOrganizationMembers([admin, member]);
     mocks.clerk.session(admin.userId, admin.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     clearConnectorInvalidationMocks();
@@ -1889,7 +1889,7 @@ describe("Feishu integration", () => {
     });
     const oauthApp = createAppWithRoutes({
       signal: context.signal,
-      routes: zeroFeishuOauthRoutes,
+      routes: feishuOauthRoutes,
     });
     clearConnectorInvalidationMocks();
     const customConnectorCallback = await oauthApp.request(
@@ -2242,7 +2242,7 @@ describe("Feishu integration", () => {
       visibility: "public",
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     const configured = await accept(
@@ -2327,7 +2327,7 @@ describe("Feishu integration", () => {
       visibility: "public",
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     const configured = await accept(
@@ -2405,7 +2405,7 @@ describe("Feishu integration", () => {
   it("deduplicates unconnected messages, connects, welcomes, and rejects account rebinding", async () => {
     const fixture = await setupFeishuRunFixture();
     const { actor, appId, callbackUrl, defaultAgentId } = fixture;
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
 
@@ -2445,7 +2445,7 @@ describe("Feishu integration", () => {
 
     const connectApp = createAppWithRoutes({
       signal: context.signal,
-      routes: zeroFeishuBrowserConnectRoutes,
+      routes: feishuBrowserConnectRoutes,
     });
     failedSendTargets.push("ou_feishu_user");
     context.mocks.ably.publish.mockClear();
@@ -2685,7 +2685,7 @@ describe("Feishu integration", () => {
     const fixture = await setupFeishuRunFixture();
     const { appId, callbackUrl } = fixture;
     await connectFixtureUser(fixture);
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     for (const command of [
@@ -3342,7 +3342,7 @@ describe("Feishu integration", () => {
     );
     expect(removedReactions).toHaveLength(1);
 
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     await accept(
@@ -3377,7 +3377,7 @@ describe("Feishu integration", () => {
       assistantText: "Continued Feishu DM answer",
     });
 
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     await accept(
@@ -3434,7 +3434,7 @@ describe("Feishu integration", () => {
       });
     expect(completedQuotedReply?.replyInThread).toBeFalsy();
 
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     await accept(
@@ -3482,7 +3482,7 @@ describe("Feishu integration", () => {
     await runsApi.requestCancelRun(actor, switchedAgentRun.id, [200]);
     await flushWaitUntilForTest();
 
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     await accept(
@@ -3556,7 +3556,7 @@ describe("Feishu integration", () => {
     await runsApi.requestCancelRun(actor, mainDmRun.id, [200]);
     await flushWaitUntilForTest();
 
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     await accept(
@@ -3655,7 +3655,7 @@ describe("Feishu integration", () => {
     await runsApi.requestCancelRun(actor, threadFollowUpRun.id, [200]);
     await flushWaitUntilForTest();
 
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     await accept(
@@ -3723,7 +3723,7 @@ describe("Feishu integration", () => {
       await runsApi.requestCancelRun(actor, run.id, [200]);
     }
     await flushWaitUntilForTest();
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     await accept(
@@ -4152,7 +4152,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
 
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
-    const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
       zeroFeishuConnectContract,
     );
     await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -68,7 +68,7 @@ import { integrationsPhoneDownloadFileRoutes } from "../../integrations-phone-do
 import { integrationsPhoneMessageRoutes } from "../../integrations-phone-message";
 import { integrationsPhoneUploadCompleteRoutes } from "../../integrations-phone-upload-complete";
 import { integrationsPhoneUploadInitRoutes } from "../../integrations-phone-upload-init";
-import { zeroIntegrationsSlackRoutes } from "../../zero-integrations-slack";
+import { integrationsSlackRoutes } from "../../integrations-slack";
 import { integrationsSlackMessageRoutes } from "../../integrations-slack-message";
 import { integrationsSlackUploadCompleteRoutes } from "../../integrations-slack-upload-complete";
 import { integrationsSlackUploadInitRoutes } from "../../integrations-slack-upload-init";
@@ -80,10 +80,10 @@ import { zeroModelPoliciesRoutes } from "../../zero-model-policies";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
 import { slackChannelsRoutes } from "../../slack-channels";
 import { slackCommandsRoutes } from "../../slack-commands";
-import { zeroSlackConnectRoutes } from "../../zero-slack-connect";
+import { slackConnectRoutes } from "../../slack-connect";
 import { slackEventsRoutes } from "../../slack-events";
 import { slackInteractiveRoutes } from "../../slack-interactive";
-import { zeroSlackOauthRoutes } from "../../zero-slack-oauth";
+import { slackOauthRoutes } from "../../slack-oauth";
 import { userModelPreferenceRoutes } from "../../user-model-preference";
 
 const TEST_APP_ROUTES = Object.freeze([
@@ -101,7 +101,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...integrationsSlackMessageRoutes,
   ...integrationsSlackUploadCompleteRoutes,
   ...integrationsSlackUploadInitRoutes,
-  ...zeroIntegrationsSlackRoutes,
+  ...integrationsSlackRoutes,
   ...integrationsTelegramMessageRoutes,
   ...integrationsTelegramUploadCompleteRoutes,
   ...integrationsTelegramUploadInitRoutes,
@@ -110,10 +110,10 @@ const TEST_APP_ROUTES = Object.freeze([
   ...zeroModelProvidersRoutes,
   ...slackChannelsRoutes,
   ...slackCommandsRoutes,
-  ...zeroSlackConnectRoutes,
+  ...slackConnectRoutes,
   ...slackEventsRoutes,
   ...slackInteractiveRoutes,
-  ...zeroSlackOauthRoutes,
+  ...slackOauthRoutes,
   ...userModelPreferenceRoutes,
 ]);
 
@@ -695,7 +695,7 @@ export function createBddIntegrationApi(context: TestContext) {
       action: string | undefined,
       statuses: readonly (200 | 401 | 403 | 404)[],
     ) {
-      const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+      const client = setupApp({ context, routes: integrationsSlackRoutes })(
         zeroIntegrationsSlackContract,
       );
       return await accept(
@@ -711,7 +711,7 @@ export function createBddIntegrationApi(context: TestContext) {
       actor: ApiTestUser | null,
       statuses: readonly (200 | 401)[],
     ) {
-      const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+      const client = setupApp({ context, routes: integrationsSlackRoutes })(
         zeroIntegrationsSlackContract,
       );
       return await accept(
@@ -826,7 +826,7 @@ export function createBddIntegrationApi(context: TestContext) {
       actor: ApiTestUser | null,
       statuses: readonly (200 | 401)[],
     ) {
-      const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+      const client = setupApp({ context, routes: slackConnectRoutes })(
         zeroSlackConnectContract,
       );
       return await accept(
@@ -842,7 +842,7 @@ export function createBddIntegrationApi(context: TestContext) {
       body: SlackConnectBody,
       statuses: readonly (200 | 400 | 401 | 403 | 404)[],
     ) {
-      const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+      const client = setupApp({ context, routes: slackConnectRoutes })(
         zeroSlackConnectContract,
       );
       return await accept(
@@ -863,7 +863,7 @@ export function createBddIntegrationApi(context: TestContext) {
       },
       statuses: readonly (307 | 503)[],
     ) {
-      const client = setupApp({ context, routes: zeroSlackOauthRoutes })(
+      const client = setupApp({ context, routes: slackOauthRoutes })(
         zeroSlackOauthContract,
       );
       return await accept(client.install({ query }), statuses);
@@ -1041,7 +1041,7 @@ export function createBddIntegrationApi(context: TestContext) {
         authed_user: { id: installerSlackUserId },
         scope: SLACK_APP_BOT_SCOPES,
       });
-      const client = setupApp({ context, routes: zeroSlackOauthRoutes })(
+      const client = setupApp({ context, routes: slackOauthRoutes })(
         zeroSlackOauthContract,
       );
       await accept(
@@ -1065,7 +1065,7 @@ export function createBddIntegrationApi(context: TestContext) {
       actor: ApiTestUser,
       body: SlackConnectBody,
     ): Promise<void> {
-      const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+      const client = setupApp({ context, routes: slackConnectRoutes })(
         zeroSlackConnectContract,
       );
       await accept(
@@ -1321,7 +1321,7 @@ export function createBddIntegrationApi(context: TestContext) {
       },
       statuses: readonly (307 | 400 | 404 | 503)[],
     ) {
-      const client = setupApp({ context, routes: zeroSlackOauthRoutes })(
+      const client = setupApp({ context, routes: slackOauthRoutes })(
         zeroSlackOauthContract,
       );
       return await accept(client.connect({ query }), statuses);
@@ -1335,7 +1335,7 @@ export function createBddIntegrationApi(context: TestContext) {
       },
       statuses: readonly (307 | 400 | 503)[],
     ) {
-      const client = setupApp({ context, routes: zeroSlackOauthRoutes })(
+      const client = setupApp({ context, routes: slackOauthRoutes })(
         zeroSlackOauthContract,
       );
       return await accept(client.callback({ query }), statuses);

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
@@ -27,14 +27,14 @@ import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroFeishuConnectRoutes } from "../zero-feishu-connect";
-import { zeroFeishuOauthRoutes } from "../zero-feishu-oauth";
+import { feishuConnectRoutes } from "../feishu-connect";
+import { feishuOauthRoutes } from "../feishu-oauth";
 import { integrationsFeishuFileRoutes } from "../integrations-feishu-files";
 import { integrationsFeishuMessageRoutes } from "../integrations-feishu-message";
 
 const TEST_APP_ROUTES = Object.freeze([
-  ...zeroFeishuConnectRoutes,
-  ...zeroFeishuOauthRoutes,
+  ...feishuConnectRoutes,
+  ...feishuOauthRoutes,
   ...integrationsFeishuFileRoutes,
   ...integrationsFeishuMessageRoutes,
 ]);
@@ -121,7 +121,7 @@ async function setupFeishuInstallation(
     visibility: "public",
   });
   mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
-  const client = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+  const client = setupApp({ context, routes: feishuConnectRoutes })(
     zeroFeishuConnectContract,
   );
   const setup = await accept(
@@ -164,7 +164,7 @@ function requireTestValue<T>(value: T | null | undefined, message: string): T {
 }
 
 async function connectCurrentFeishuUser(actor: FeishuTestActor): Promise<void> {
-  const statusClient = setupApp({ context, routes: zeroFeishuConnectRoutes })(
+  const statusClient = setupApp({ context, routes: feishuConnectRoutes })(
     zeroFeishuConnectContract,
   );
   const status = await accept(
@@ -182,7 +182,7 @@ async function connectCurrentFeishuUser(actor: FeishuTestActor): Promise<void> {
     "Expected Feishu OAuth state",
   );
   mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
-  const oauthClient = setupApp({ context, routes: zeroFeishuOauthRoutes })(
+  const oauthClient = setupApp({ context, routes: feishuOauthRoutes })(
     zeroFeishuOauthContract,
   );
   await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-status.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-status.test.ts
@@ -18,7 +18,7 @@ import {
   createFixtureTracker,
   createZeroRouteMocks,
 } from "./helpers/zero-route-test";
-import { zeroIntegrationsSlackRoutes } from "../zero-integrations-slack";
+import { integrationsSlackRoutes } from "../integrations-slack";
 
 const context = testContext();
 const store = createStore();
@@ -35,7 +35,7 @@ describe("GET /api/zero/integrations/slack", () => {
   });
 
   it("returns 401 when the request is unauthenticated", async () => {
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -47,7 +47,7 @@ describe("GET /api/zero/integrations/slack", () => {
   it("returns 401 when the authenticated session has no organization", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, null);
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -69,7 +69,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId);
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -95,7 +95,7 @@ describe("GET /api/zero/integrations/slack", () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -128,7 +128,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId);
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -156,7 +156,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId);
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -188,7 +188,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -215,7 +215,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -247,7 +247,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId);
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -298,7 +298,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -330,7 +330,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -365,7 +365,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -396,7 +396,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -423,7 +423,7 @@ describe("GET /api/zero/integrations/slack", () => {
     );
     mocks.clerk.session(userId, orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack.test.ts
@@ -27,7 +27,7 @@ import {
   seedSlackOrgInstallation$,
   type SlackIntegrationFixture,
 } from "./helpers/zero-integrations-slack";
-import { zeroIntegrationsSlackRoutes } from "../zero-integrations-slack";
+import { integrationsSlackRoutes } from "../integrations-slack";
 
 const context = testContext();
 const store = createStore();
@@ -155,7 +155,7 @@ describe("GET /api/zero/integrations/slack", () => {
       },
     });
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -191,7 +191,7 @@ describe("GET /api/zero/integrations/slack", () => {
       },
     });
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -225,7 +225,7 @@ describe("GET /api/zero/integrations/slack", () => {
       },
     });
 
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -307,7 +307,7 @@ describe("GET /api/zero/integrations/slack", () => {
 
       mockAdminAuth();
 
-      const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+      const client = setupApp({ context, routes: integrationsSlackRoutes })(
         zeroIntegrationsSlackContract,
       );
 
@@ -332,7 +332,7 @@ describe("GET /api/zero/integrations/slack", () => {
 
       mockAdminAuth();
 
-      const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+      const client = setupApp({ context, routes: integrationsSlackRoutes })(
         zeroIntegrationsSlackContract,
       );
 
@@ -363,7 +363,7 @@ describe("GET /api/zero/integrations/slack", () => {
 
       mockAdminAuth();
 
-      const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+      const client = setupApp({ context, routes: integrationsSlackRoutes })(
         zeroIntegrationsSlackContract,
       );
 
@@ -454,7 +454,7 @@ describe("DELETE /api/zero/integrations/slack", () => {
   }
 
   it("returns 401 when unauthenticated", async () => {
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -469,7 +469,7 @@ describe("DELETE /api/zero/integrations/slack", () => {
   it("returns 404 when the user has no Slack connection", async () => {
     const seeded = await seedDeleteContext({ withConnection: false });
     mocks.clerk.session(seeded.userId, seeded.orgId);
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -497,7 +497,7 @@ describe("DELETE /api/zero/integrations/slack", () => {
       context.signal,
     );
     mocks.clerk.session(seeded.userId, seeded.orgId);
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -606,7 +606,7 @@ describe("DELETE /api/zero/integrations/slack?action=uninstall", () => {
   it("returns 403 when a non-admin tries to uninstall", async () => {
     const seeded = await seedUninstallContext();
     mocks.clerk.session(seeded.userId, seeded.orgId, "org:member");
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -625,7 +625,7 @@ describe("DELETE /api/zero/integrations/slack?action=uninstall", () => {
   it("returns 404 when no installation exists", async () => {
     const seeded = await seedUninstallContext({ withInstallation: false });
     mocks.clerk.session(seeded.userId, seeded.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -653,7 +653,7 @@ describe("DELETE /api/zero/integrations/slack?action=uninstall", () => {
       context.signal,
     );
     mocks.clerk.session(seeded.userId, seeded.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroIntegrationsSlackRoutes })(
+    const client = setupApp({ context, routes: integrationsSlackRoutes })(
       zeroIntegrationsSlackContract,
     );
 
@@ -763,7 +763,7 @@ function requestDownloadFile(
 ): Promise<Response> {
   const app = createApp({
     signal: context.signal,
-    routes: zeroIntegrationsSlackRoutes,
+    routes: integrationsSlackRoutes,
   });
   const headers: Record<string, string> = authorization
     ? { authorization }

--- a/turbo/apps/api/src/signals/routes/__tests__/slack-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/slack-connect.test.ts
@@ -19,9 +19,9 @@ import {
   seedSlackConnectOrg$,
   type SlackConnectFixture,
 } from "./helpers/zero-slack-connect";
-import { zeroSlackConnectRoutes } from "../zero-slack-connect";
+import { slackConnectRoutes } from "../slack-connect";
 
-const TEST_APP_ROUTES = Object.freeze([...zeroSlackConnectRoutes]);
+const TEST_APP_ROUTES = Object.freeze([...slackConnectRoutes]);
 
 const context = testContext();
 const store = createStore();
@@ -94,7 +94,7 @@ describe("GET /api/zero/integrations/slack/connect", () => {
   });
 
   it("returns 401 when the request is unauthenticated", async () => {
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
 
@@ -114,7 +114,7 @@ describe("GET /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, null);
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
 
@@ -139,7 +139,7 @@ describe("GET /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
 
@@ -166,7 +166,7 @@ describe("GET /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
 
@@ -191,7 +191,7 @@ describe("GET /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
 
@@ -211,7 +211,7 @@ describe("GET /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
 
@@ -246,7 +246,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
 
@@ -304,7 +304,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     const response = await accept(
@@ -332,7 +332,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     const response = await accept(
@@ -368,7 +368,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     const response = await accept(
@@ -391,7 +391,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     await accept(
@@ -423,7 +423,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     await accept(
@@ -484,7 +484,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     await accept(
@@ -540,7 +540,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
       }),
     );
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     await accept(
@@ -586,7 +586,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     const response = await accept(
@@ -620,7 +620,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     const response = await accept(
@@ -649,7 +649,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     const response = await accept(
@@ -686,7 +686,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     const response = await accept(
@@ -711,7 +711,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroSlackConnectRoutes })(
+    const client = setupApp({ context, routes: slackConnectRoutes })(
       zeroSlackConnectContract,
     );
     const first = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
@@ -6,7 +6,7 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { testContext } from "../../../__tests__/test-context";
 import { now } from "../../../lib/time";
 import { flushWaitUntilForTest } from "../../context/wait-until";
-import { zeroSlackOauthRoutes } from "../zero-slack-oauth";
+import { slackOauthRoutes } from "../slack-oauth";
 import {
   countSlackOrgConnections$,
   deleteSlackConnectOrg$,
@@ -33,7 +33,7 @@ async function appRequest(
 ): Promise<Response> {
   const app = createAppWithRoutes({
     signal: context.signal,
-    routes: zeroSlackOauthRoutes,
+    routes: slackOauthRoutes,
   });
   return await app.request(`${options.origin ?? "http://api.test"}${path}`, {
     method: "GET",

--- a/turbo/apps/api/src/signals/routes/feishu-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-browser-connect.ts
@@ -327,7 +327,7 @@ const getStatus$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-export const zeroFeishuBrowserConnectRoutes: readonly RouteEntry[] = [
+export const feishuBrowserConnectRoutes: readonly RouteEntry[] = [
   {
     route: zeroFeishuBrowserConnectContract.connect,
     handler: connect$,

--- a/turbo/apps/api/src/signals/routes/feishu-connect.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-connect.ts
@@ -317,7 +317,7 @@ const auth = {
   missingOrganizationStatus: 401,
 } as const;
 
-export const zeroFeishuConnectRoutes: readonly RouteEntry[] = [
+export const feishuConnectRoutes: readonly RouteEntry[] = [
   {
     route: zeroFeishuConnectContract.getStatus,
     handler: authRoute(auth, getStatus$),

--- a/turbo/apps/api/src/signals/routes/feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-oauth.ts
@@ -936,7 +936,7 @@ const callback$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
 });
 
-export const zeroFeishuOauthRoutes: readonly RouteEntry[] = [
+export const feishuOauthRoutes: readonly RouteEntry[] = [
   {
     route: zeroFeishuOauthContract.connect,
     handler: connect$,

--- a/turbo/apps/api/src/signals/routes/integrations-slack.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-slack.ts
@@ -687,7 +687,7 @@ const slackDownloadAuth = {
   requiredCapability: "slack:write",
 } as const;
 
-export const zeroIntegrationsSlackRoutes: readonly RouteEntry[] = [
+export const integrationsSlackRoutes: readonly RouteEntry[] = [
   {
     route: zeroIntegrationsSlackContract.getStatus,
     handler: authRoute(slackReadAuth, getSlackStatusInner$),

--- a/turbo/apps/api/src/signals/routes/slack-connect.ts
+++ b/turbo/apps/api/src/signals/routes/slack-connect.ts
@@ -124,7 +124,7 @@ const slackConnectWriteAuth = {
   requiredCapability: "slack:write",
 } as const;
 
-export const zeroSlackConnectRoutes: readonly RouteEntry[] = [
+export const slackConnectRoutes: readonly RouteEntry[] = [
   {
     route: zeroSlackConnectContract.getStatus,
     handler: authRoute(slackConnectAuth, getSlackConnectStatusInner$),

--- a/turbo/apps/api/src/signals/routes/slack-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/slack-oauth.ts
@@ -648,7 +648,7 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
 });
 
-export const zeroSlackOauthRoutes: readonly RouteEntry[] = [
+export const slackOauthRoutes: readonly RouteEntry[] = [
   {
     route: zeroSlackOauthContract.install,
     handler: installOauth$,

--- a/turbo/docs/typecheck-memory-experiments.md
+++ b/turbo/docs/typecheck-memory-experiments.md
@@ -579,7 +579,7 @@ excludes migrated roots from the remaining dirty chunk.
 
 Change tested: move the one `org-team.bdd.test.ts` Slack cleanup scenario from
 the broad `api-bdd-integrations.ts` helper to a new Slack-only helper backed by
-real `zeroSlackOauthRoutes` and `zeroSlackConnectRoutes`.
+real `slackOauthRoutes` and `slackConnectRoutes`.
 
 Commands:
 


### PR DESCRIPTION
## Summary

- Rename the six Feishu and Slack production route-shell modules and route-array exports listed in #27583 to their domain-neutral names.
- Update every production registry, focused test, BDD helper, and factual typecheck-note caller atomically.
- Preserve route order, handlers, contracts, callback paths, OAuth behavior, provider delivery, and persistence behavior.

## Acceptance criteria

- [x] Rename only the six owned route paths and exports specified by #27583.
- [x] Update all executable and factual callers to the neutral paths and exports.
- [x] Leave no old route exports, old owned module paths, aliases, forwarders, compatibility exports, or duplicate route registration.
- [x] Keep contracts, API/callback paths, OAuth state/PKCE/scopes, tokens/secrets, provider/team/channel IDs, `publicBrand`, delivery behavior, database identities, services, CLI/Platform names, and error text unchanged.
- [x] Compare all six route owners and nine callers against current `main` after reversing only the approved naming substitutions; all normalized files are byte-identical.
- [x] Scan all 29 open PRs with paginated file retrieval; #25722 and #27200 overlap old owned files but do not collide with neutral targets and are not treated as merge gates.

## Verification

- `npx prettier@3.8.1 --check <15 affected files>`
- `pnpm -F api lint`
- `pnpm exec knip --workspace api`
- `pnpm -F api check-types`
- focused Feishu/Slack Vitest run: 9 files passed, 195 tests passed
- residual old-export/path scan and neutral-target scan
- normalized whole-file equivalence audit against current `main`
- paginated open-PR file scan

Closes #27583
