### PR TITLE
refactor(integrations): neutralize teams telegram and agentphone route shell naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -138,7 +138,7 @@ import { workflowAutomationsRoutes } from "./routes/workflow-automations";
 import { strapiIntegrationsRoutes } from "./routes/strapi-integrations";
 import { strapiEventsRoutes } from "./routes/strapi-events";
 import { integrationsGithubRoutes } from "./routes/integrations-github";
-import { zeroIntegrationsAgentPhoneRoutes } from "./routes/zero-integrations-agentphone";
+import { integrationsAgentPhoneRoutes } from "./routes/integrations-agentphone";
 import { integrationsPhoneDownloadFileRoutes } from "./routes/integrations-phone-download-file";
 import { integrationsPhoneMessageRoutes } from "./routes/integrations-phone-message";
 import { integrationsPhoneUploadCompleteRoutes } from "./routes/integrations-phone-upload-complete";
@@ -157,7 +157,7 @@ import { integrationsTeamsDownloadFileRoutes } from "./routes/integrations-teams
 import { integrationsTeamsMessageRoutes } from "./routes/integrations-teams-message";
 import { integrationsTeamsUploadCompleteRoutes } from "./routes/integrations-teams-upload-complete";
 import { integrationsTeamsUploadInitRoutes } from "./routes/integrations-teams-upload-init";
-import { zeroIntegrationsTelegramRoutes } from "./routes/zero-integrations-telegram";
+import { integrationsTelegramRoutes } from "./routes/integrations-telegram";
 import { integrationsTelegramMessageRoutes } from "./routes/integrations-telegram-message";
 import { integrationsTelegramUploadCompleteRoutes } from "./routes/integrations-telegram-upload-complete";
 import { integrationsTelegramUploadInitRoutes } from "./routes/integrations-telegram-upload-init";
@@ -172,10 +172,10 @@ import { feishuConnectRoutes } from "./routes/feishu-connect";
 import { feishuEventsRoutes } from "./routes/feishu-events";
 import { feishuOauthRoutes } from "./routes/feishu-oauth";
 import { steamPlayerRoutes } from "./routes/steam-player";
-import { zeroTeamsBrowserConnectRoutes } from "./routes/zero-teams-browser-connect";
-import { zeroTeamsBotRoutes } from "./routes/zero-teams-bot";
-import { zeroTeamsConnectRoutes } from "./routes/zero-teams-connect";
-import { zeroTeamsOauthRoutes } from "./routes/zero-teams-oauth";
+import { teamsBrowserConnectRoutes } from "./routes/teams-browser-connect";
+import { teamsBotRoutes } from "./routes/teams-bot";
+import { teamsConnectRoutes } from "./routes/teams-connect";
+import { teamsOauthRoutes } from "./routes/teams-oauth";
 import { teamRoutes } from "./routes/team";
 import { uploadsCompleteRoutes } from "./routes/uploads-complete";
 import { uploadsMultipartRoutes } from "./routes/uploads-multipart";
@@ -348,11 +348,11 @@ export const ROUTES: readonly RouteEntry[] = [
   ...feishuConnectRoutes,
   ...feishuEventsRoutes,
   ...feishuOauthRoutes,
-  ...zeroTeamsBrowserConnectRoutes,
-  ...zeroTeamsBotRoutes,
-  ...zeroTeamsConnectRoutes,
-  ...zeroTeamsOauthRoutes,
-  ...zeroIntegrationsAgentPhoneRoutes,
+  ...teamsBrowserConnectRoutes,
+  ...teamsBotRoutes,
+  ...teamsConnectRoutes,
+  ...teamsOauthRoutes,
+  ...integrationsAgentPhoneRoutes,
   ...integrationsPhoneDownloadFileRoutes,
   ...integrationsPhoneMessageRoutes,
   ...integrationsPhoneUploadCompleteRoutes,
@@ -373,7 +373,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...integrationsTeamsUploadInitRoutes,
   ...slackChannelsRoutes,
   ...steamPlayerRoutes,
-  ...zeroIntegrationsTelegramRoutes,
+  ...integrationsTelegramRoutes,
   ...integrationsTelegramMessageRoutes,
   ...integrationsTelegramUploadCompleteRoutes,
   ...integrationsTelegramUploadInitRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -61,7 +61,7 @@ import { githubOauthRoutes } from "../../github-oauth";
 import { integrationsGithubRoutes } from "../../integrations-github";
 import { testSlackStateRoutes } from "../../test-slack-state";
 import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
-import { zeroIntegrationsAgentPhoneRoutes } from "../../zero-integrations-agentphone";
+import { integrationsAgentPhoneRoutes } from "../../integrations-agentphone";
 import { integrationsGithubUploadCompleteRoutes } from "../../integrations-github-upload-complete";
 import { integrationsGithubUploadInitRoutes } from "../../integrations-github-upload-init";
 import { integrationsPhoneDownloadFileRoutes } from "../../integrations-phone-download-file";
@@ -72,7 +72,7 @@ import { integrationsSlackRoutes } from "../../integrations-slack";
 import { integrationsSlackMessageRoutes } from "../../integrations-slack-message";
 import { integrationsSlackUploadCompleteRoutes } from "../../integrations-slack-upload-complete";
 import { integrationsSlackUploadInitRoutes } from "../../integrations-slack-upload-init";
-import { zeroIntegrationsTelegramRoutes } from "../../zero-integrations-telegram";
+import { integrationsTelegramRoutes } from "../../integrations-telegram";
 import { integrationsTelegramMessageRoutes } from "../../integrations-telegram-message";
 import { integrationsTelegramUploadCompleteRoutes } from "../../integrations-telegram-upload-complete";
 import { integrationsTelegramUploadInitRoutes } from "../../integrations-telegram-upload-init";
@@ -91,7 +91,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...integrationsGithubRoutes,
   ...testSlackStateRoutes,
   ...zeroFeatureSwitchesRoutes,
-  ...zeroIntegrationsAgentPhoneRoutes,
+  ...integrationsAgentPhoneRoutes,
   ...integrationsGithubUploadCompleteRoutes,
   ...integrationsGithubUploadInitRoutes,
   ...integrationsPhoneDownloadFileRoutes,
@@ -105,7 +105,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...integrationsTelegramMessageRoutes,
   ...integrationsTelegramUploadCompleteRoutes,
   ...integrationsTelegramUploadInitRoutes,
-  ...zeroIntegrationsTelegramRoutes,
+  ...integrationsTelegramRoutes,
   ...zeroModelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
   ...slackChannelsRoutes,
@@ -1347,7 +1347,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(zeroIntegrationsTelegramContract);
       return await accept(
         client.list({
@@ -1363,7 +1363,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(integrationsTelegramBotListContract);
       return await accept(
         client.listBots({
@@ -1376,7 +1376,7 @@ export function createBddIntegrationApi(context: TestContext) {
     async readTelegramLinkStatus(actor: ApiTestUser, botId: string) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(zeroIntegrationsTelegramContract);
       const response = await accept(
         client.getLinkStatus({
@@ -1391,7 +1391,7 @@ export function createBddIntegrationApi(context: TestContext) {
     async requestTelegramAuthCallback(statuses: readonly 200[]) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(zeroIntegrationsTelegramContract);
       return await accept(client.authCallback(), statuses);
     },
@@ -1404,7 +1404,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(zeroIntegrationsTelegramContract);
       return await accept(
         client.avatar({
@@ -1423,7 +1423,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(zeroIntegrationsTelegramContract);
       return await accept(
         client.link({
@@ -1441,7 +1441,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(zeroIntegrationsTelegramContract);
       return await accept(
         client.unlink({
@@ -1460,7 +1460,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(zeroIntegrationsTelegramContract);
       return await accept(
         client.updateBot({
@@ -1479,7 +1479,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(zeroIntegrationsTelegramContract);
       return await accept(
         client.disconnect({
@@ -1507,7 +1507,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(zeroIntegrationsTelegramContract);
       return await accept(
         client.register({
@@ -1525,7 +1525,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsTelegramRoutes,
+        routes: integrationsTelegramRoutes,
       })(zeroIntegrationsTelegramContract);
       return await accept(
         client.setupStatus({
@@ -1659,7 +1659,7 @@ export function createBddIntegrationApi(context: TestContext) {
     async getAgentPhoneLinkStatus(actor: ApiTestUser) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsAgentPhoneRoutes,
+        routes: integrationsAgentPhoneRoutes,
       })(zeroIntegrationsAgentPhoneContract);
       const response = await accept(
         client.getLinkStatus({
@@ -1677,7 +1677,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsAgentPhoneRoutes,
+        routes: integrationsAgentPhoneRoutes,
       })(zeroIntegrationsAgentPhoneContract);
       return await accept(
         client.startLink({
@@ -1694,7 +1694,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsAgentPhoneRoutes,
+        routes: integrationsAgentPhoneRoutes,
       })(zeroIntegrationsAgentPhoneContract);
       return await accept(
         client.unlink({
@@ -1717,7 +1717,7 @@ export function createBddIntegrationApi(context: TestContext) {
     ) {
       const client = setupApp({
         context,
-        routes: zeroIntegrationsAgentPhoneRoutes,
+        routes: integrationsAgentPhoneRoutes,
       })(zeroIntegrationsAgentPhoneContract);
       return await accept(
         client.connectAgentPhone({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/teams-connect.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/teams-connect.ts
@@ -11,7 +11,7 @@ import { createAppWithRoutes } from "../../../../app-factory-core";
 import { mockEnv } from "../../../../lib/env";
 import { now } from "../../../../lib/time";
 import { server } from "../../../../mocks/server";
-import { zeroTeamsBotRoutes } from "../../zero-teams-bot";
+import { teamsBotRoutes } from "../../teams-bot";
 
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const TEAMS_APP_TENANT_ID = "11111111-1111-1111-1111-111111111111";
@@ -236,7 +236,7 @@ export async function postTeamsActivityForTest(args: {
   const appSignal = AbortSignal.any([args.signal]);
   const app = createAppWithRoutes({
     signal: appSignal,
-    routes: zeroTeamsBotRoutes,
+    routes: teamsBotRoutes,
   });
   return await app.request("http://api.test/api/zero/teams/bot", {
     method: "POST",

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-teams.test.ts
@@ -27,7 +27,7 @@ import {
 } from "./helpers/teams-connect";
 import { integrationsTeamsMessageRoutes } from "../integrations-teams-message";
 import { integrationsTeamsUploadCompleteRoutes } from "../integrations-teams-upload-complete";
-import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
+import { teamsConnectRoutes } from "../teams-connect";
 
 const context = testContext();
 const store = createStore();
@@ -140,7 +140,7 @@ async function seedConnectedTeams(fixture: TeamsConnectFixture): Promise<void> {
   await installTeamsForTest(context.signal, fixture);
   mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-  const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+  const client = setupApp({ context, routes: teamsConnectRoutes })(
     zeroTeamsConnectContract,
   );
   await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-delete.test.ts
@@ -17,7 +17,7 @@ import {
 } from "./helpers/telegram";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
-import { zeroIntegrationsTelegramRoutes } from "../zero-integrations-telegram";
+import { integrationsTelegramRoutes } from "../integrations-telegram";
 
 const context = testContext();
 const store = createStore();
@@ -198,7 +198,7 @@ describe("DELETE /api/integrations/telegram", () => {
   }
 
   function client() {
-    return setupApp({ context, routes: zeroIntegrationsTelegramRoutes })(
+    return setupApp({ context, routes: integrationsTelegramRoutes })(
       zeroIntegrationsTelegramContract,
     );
   }

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-patch.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-patch.test.ts
@@ -19,7 +19,7 @@ import {
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { server } from "../../../mocks/server";
-import { zeroIntegrationsTelegramRoutes } from "../zero-integrations-telegram";
+import { integrationsTelegramRoutes } from "../integrations-telegram";
 
 const context = testContext();
 const store = createStore();
@@ -73,7 +73,7 @@ describe("PATCH /api/integrations/telegram/:botId", () => {
   });
 
   function client() {
-    return setupApp({ context, routes: zeroIntegrationsTelegramRoutes })(
+    return setupApp({ context, routes: integrationsTelegramRoutes })(
       zeroIntegrationsTelegramContract,
     );
   }

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
@@ -36,9 +36,9 @@ import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { testTelegramStateRoutes } from "../test-telegram-state";
-import { zeroIntegrationsTelegramRoutes } from "../zero-integrations-telegram";
+import { integrationsTelegramRoutes } from "../integrations-telegram";
 
-const TEST_APP_ROUTES = Object.freeze([...zeroIntegrationsTelegramRoutes]);
+const TEST_APP_ROUTES = Object.freeze([...integrationsTelegramRoutes]);
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -292,7 +292,7 @@ afterEach(() => {
 });
 
 function telegramClient() {
-  return setupApp({ context, routes: zeroIntegrationsTelegramRoutes })(
+  return setupApp({ context, routes: integrationsTelegramRoutes })(
     zeroIntegrationsTelegramContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram.test.ts
@@ -32,9 +32,9 @@ import {
 } from "./helpers/telegram";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
-import { zeroIntegrationsTelegramRoutes } from "../zero-integrations-telegram";
+import { integrationsTelegramRoutes } from "../integrations-telegram";
 
-const TEST_APP_ROUTES = Object.freeze([...zeroIntegrationsTelegramRoutes]);
+const TEST_APP_ROUTES = Object.freeze([...integrationsTelegramRoutes]);
 
 const context = testContext();
 const store = createStore();
@@ -160,7 +160,7 @@ function signConnectParams(args: {
 async function listTelegramBots(
   token: string,
 ): Promise<TelegramListResponse["bots"]> {
-  const client = setupApp({ context, routes: zeroIntegrationsTelegramRoutes })(
+  const client = setupApp({ context, routes: integrationsTelegramRoutes })(
     zeroIntegrationsTelegramContract,
   );
   const response = await accept(
@@ -218,7 +218,7 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
   it("returns 401 when no auth token is provided", async () => {
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(integrationsTelegramBotListContract);
 
     const response = await accept(client.listBots({ headers: {} }), [401]);
@@ -240,7 +240,7 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(integrationsTelegramBotListContract);
 
     const response = await accept(
@@ -255,7 +255,7 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
     mocks.clerk.session(`user_${randomUUID()}`, null);
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(integrationsTelegramBotListContract);
 
     const response = await accept(
@@ -342,7 +342,7 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(integrationsTelegramBotListContract);
 
     const response = await accept(
@@ -401,7 +401,7 @@ describe("GET /api/zero/integrations/telegram/bots", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(integrationsTelegramBotListContract);
 
     const response = await accept(
@@ -438,7 +438,7 @@ describe("GET /api/integrations/telegram", () => {
   it("returns 401 when no auth token is provided", async () => {
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(client.list({ headers: {} }), [401]);
@@ -459,7 +459,7 @@ describe("GET /api/integrations/telegram", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -544,7 +544,7 @@ describe("GET /api/integrations/telegram", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -612,7 +612,7 @@ describe("GET /api/integrations/telegram", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -708,7 +708,7 @@ describe("GET /api/integrations/telegram", () => {
     });
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -785,7 +785,7 @@ describe("GET /api/integrations/telegram/link", () => {
   it("returns 401 when no auth token is provided", async () => {
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -803,7 +803,7 @@ describe("GET /api/integrations/telegram/link", () => {
     const { token } = await seedLinkContext();
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -840,7 +840,7 @@ describe("GET /api/integrations/telegram/link", () => {
     );
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -886,7 +886,7 @@ describe("GET /api/integrations/telegram/link", () => {
 
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
     const linkedResponse = await accept(
       client.getLinkStatus({
@@ -934,7 +934,7 @@ describe("GET /api/integrations/telegram/link", () => {
     server.use(telegramOauthHead("2048", "https://app.example.com"));
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -963,7 +963,7 @@ describe("GET /api/integrations/telegram/link", () => {
     const { token } = await seedLinkContext();
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1007,7 +1007,7 @@ describe("GET /api/integrations/telegram/link", () => {
     fixtures.push(freezeTelegramFixture(builder));
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1025,7 +1025,7 @@ describe("GET /api/integrations/telegram/link", () => {
     const { token } = await seedLinkContext();
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1090,7 +1090,7 @@ describe("POST /api/integrations/telegram/link", () => {
   it("returns 401 when not authenticated", async () => {
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1108,7 +1108,7 @@ describe("POST /api/integrations/telegram/link", () => {
     const { token } = await seedLinkContext();
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1126,7 +1126,7 @@ describe("POST /api/integrations/telegram/link", () => {
     const { token } = await seedLinkContext();
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1157,7 +1157,7 @@ describe("POST /api/integrations/telegram/link", () => {
     fixtures.push(freezeTelegramFixture(builder));
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1188,7 +1188,7 @@ describe("POST /api/integrations/telegram/link", () => {
     fixtures.push(freezeTelegramFixture(builder));
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1244,7 +1244,7 @@ describe("POST /api/integrations/telegram/link", () => {
     const telegramUserId = Number(newTelegramBotId());
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
     server.use(telegramOauthHead("0"));
 
@@ -1284,7 +1284,7 @@ describe("POST /api/integrations/telegram/link", () => {
     const telegramUserId = Number(newTelegramBotId());
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1334,7 +1334,7 @@ describe("POST /api/integrations/telegram/link", () => {
     );
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1381,7 +1381,7 @@ describe("POST /api/integrations/telegram/link", () => {
     );
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1424,7 +1424,7 @@ describe("POST /api/integrations/telegram/link", () => {
     );
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1478,7 +1478,7 @@ describe("POST /api/integrations/telegram/link", () => {
     );
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1525,7 +1525,7 @@ describe("POST /api/integrations/telegram/link", () => {
     );
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1583,7 +1583,7 @@ describe("POST /api/integrations/telegram/link", () => {
     const telegramUserId = "99005";
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1646,7 +1646,7 @@ describe("POST /api/integrations/telegram/link", () => {
     fixtures.push(freezeTelegramFixture(builder));
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1677,7 +1677,7 @@ describe("POST /api/integrations/telegram/link", () => {
     fixtures.push(freezeTelegramFixture(builder));
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1713,7 +1713,7 @@ describe("POST /api/integrations/telegram/link", () => {
     fixtures.push(freezeTelegramFixture(builder));
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(
@@ -1752,7 +1752,7 @@ describe("POST /api/integrations/telegram/link", () => {
     const telegramUserId = "99008";
     const client = setupApp({
       context,
-      routes: zeroIntegrationsTelegramRoutes,
+      routes: integrationsTelegramRoutes,
     })(zeroIntegrationsTelegramContract);
 
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -18,7 +18,7 @@ import {
   readChatEventContextFixture,
 } from "../../../test-fixtures/chat-events";
 import { flushWaitUntilForTest } from "../../context/wait-until";
-import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
+import { teamsConnectRoutes } from "../teams-connect";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
@@ -340,7 +340,7 @@ async function connectTeamsFixture(
   mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
   const client = setupApp({
     context,
-    routes: zeroTeamsConnectRoutes,
+    routes: teamsConnectRoutes,
   })(zeroTeamsConnectContract);
   await accept(
     client.connect({

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -24,7 +24,7 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
 import { integrationsTeamsDownloadFileRoutes } from "../integrations-teams-download-file";
-import { zeroTeamsBotRoutes } from "../zero-teams-bot";
+import { teamsBotRoutes } from "../teams-bot";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { createRunsApi } from "./helpers/api-bdd-runs";
@@ -46,7 +46,7 @@ import {
 } from "./helpers/zero-route-test";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { chatThreadRoutes } from "../chat-threads";
-import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
+import { teamsConnectRoutes } from "../teams-connect";
 
 const context = testContext();
 const callbackStore = createStore();
@@ -718,7 +718,7 @@ async function postTeamsActivity(
 ): Promise<Response> {
   const app = createAppWithRoutes({
     signal,
-    routes: zeroTeamsBotRoutes,
+    routes: teamsBotRoutes,
   });
   const headers: Record<string, string> = {
     "content-type": "application/json",
@@ -800,7 +800,7 @@ async function connectTeamsFixture(
   fixture: TeamsConnectFixture,
 ): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-  const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+  const client = setupApp({ context, routes: teamsConnectRoutes })(
     zeroTeamsConnectContract,
   );
   await accept(
@@ -1102,7 +1102,7 @@ describe("POST /api/zero/teams/bot", () => {
     expect(outboundRequests[0]?.body).not.toHaveProperty("text");
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     await accept(
@@ -3293,7 +3293,7 @@ describe("POST /api/zero/teams/bot", () => {
     });
     await flushWaitUntilForTest();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-browser-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-browser-connect.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { zeroTeamsBrowserConnectRoutes } from "../zero-teams-browser-connect";
+import { teamsBrowserConnectRoutes } from "../teams-browser-connect";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -17,7 +17,7 @@ import {
   teamsFixtureExternalId,
   type TeamsConnectFixture,
 } from "./helpers/teams-connect";
-import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
+import { teamsConnectRoutes } from "../teams-connect";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -91,7 +91,7 @@ async function requestConnect(
 ): Promise<Response> {
   const app = createAppWithRoutes({
     signal: context.signal,
-    routes: zeroTeamsBrowserConnectRoutes,
+    routes: teamsBrowserConnectRoutes,
   });
   const requestHeaders = headers ?? { cookie: "__session=opaque" };
   return await app.request(url, { method: "GET", headers: requestHeaders });
@@ -129,7 +129,7 @@ async function bindTeamsInstallation(
   userId: string,
 ): Promise<void> {
   mocks.clerk.session(userId, fixture.orgId, "org:admin");
-  const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+  const client = setupApp({ context, routes: teamsConnectRoutes })(
     zeroTeamsConnectContract,
   );
   await accept(
@@ -152,7 +152,7 @@ async function expectTeamsConnected(
     readonly teamName?: string | null;
   } = {},
 ): Promise<void> {
-  const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+  const client = setupApp({ context, routes: teamsConnectRoutes })(
     zeroTeamsConnectContract,
   );
   const status = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-connect.test.ts
@@ -21,7 +21,7 @@ import {
   teamsMessageActivityForTest,
   type TeamsConnectFixture,
 } from "./helpers/teams-connect";
-import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
+import { teamsConnectRoutes } from "../teams-connect";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -159,7 +159,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
   });
 
   it("returns 401 when the request is unauthenticated", async () => {
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
 
@@ -177,7 +177,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
     const fixture = teamsConnectFixture();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
 
@@ -205,7 +205,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
     mockEnv("VM0_API_BACKEND_URL", undefined);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
 
@@ -235,7 +235,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
     const fixture = await seedTeamsInstallation(track);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     await accept(
@@ -278,7 +278,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
   it("returns a Teams reinstall URL to admins when the installed app id is stale", async () => {
     const fixture = await seedTeamsInstallation(track);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     await accept(
@@ -324,7 +324,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
     const fixture = await seedTeamsInstallation(track);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
@@ -378,7 +378,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     const fixture = await seedTeamsInstallation(track);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     const response = await accept(
@@ -422,7 +422,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     const fixture = await seedTeamsInstallation(track);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     const response = await accept(
@@ -447,7 +447,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
       "aad-member-user",
     );
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
@@ -480,7 +480,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
 
   it("rejects users from the wrong org with a clear error", async () => {
     const fixture = await seedTeamsInstallation(track);
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
 
@@ -509,7 +509,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     const fixture = await seedTeamsInstallation(track);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     const first = await accept(
@@ -544,7 +544,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     mockEnv("MICROSOFT_TEAMS_BOT_APP_PASSWORD", BOT_APP_PASSWORD);
     const welcomeRequests = teamsWelcomeHandlers(fixture);
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     const body = {
@@ -619,7 +619,7 @@ describe("DELETE /api/zero/integrations/teams/connect", () => {
     const fixture = await seedTeamsInstallation(track);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     await accept(
@@ -655,7 +655,7 @@ describe("DELETE /api/zero/integrations/teams/connect", () => {
     const fixture = await seedTeamsInstallation(track);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -8,7 +8,7 @@ import { mockEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
-import { zeroTeamsOauthRoutes } from "../zero-teams-oauth";
+import { teamsOauthRoutes } from "../teams-oauth";
 import {
   createFixtureTracker,
   createZeroRouteMocks,
@@ -21,7 +21,7 @@ import {
   teamsConnectFixture,
   type TeamsConnectFixture,
 } from "./helpers/teams-connect";
-import { zeroTeamsConnectRoutes } from "../zero-teams-connect";
+import { teamsConnectRoutes } from "../teams-connect";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -44,7 +44,7 @@ async function appRequest(
 ): Promise<Response> {
   const app = createAppWithRoutes({
     signal: context.signal,
-    routes: zeroTeamsOauthRoutes,
+    routes: teamsOauthRoutes,
   });
   return await app.request(`${options.origin ?? "http://api.test"}${path}`, {
     method: "GET",
@@ -232,7 +232,7 @@ describe("Teams OAuth API routes", () => {
     );
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     const pendingStatus = await accept(
@@ -287,7 +287,7 @@ describe("Teams OAuth API routes", () => {
     );
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     const status = await accept(
@@ -308,7 +308,7 @@ describe("Teams OAuth API routes", () => {
     const fixture = await seedTeamsInstallation(track);
     await seedMembership(fixture.orgId, fixture.userId, "admin");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroTeamsConnectRoutes })(
+    const client = setupApp({ context, routes: teamsConnectRoutes })(
       zeroTeamsConnectContract,
     );
     await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
@@ -18,7 +18,7 @@ import { testContext } from "../../../__tests__/test-context";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { testSlackStateRoutes } from "../test-slack-state";
 import { testTelegramStateRoutes } from "../test-telegram-state";
-import { zeroIntegrationsTelegramRoutes } from "../zero-integrations-telegram";
+import { integrationsTelegramRoutes } from "../integrations-telegram";
 import { seedRun$ } from "./helpers/usage-state";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 
@@ -57,7 +57,7 @@ function requestApp(path: string, init?: RequestInit): Promise<Response> {
     signal: context.signal,
     routes: [
       ...testTelegramStateRoutes,
-      ...zeroIntegrationsTelegramRoutes,
+      ...integrationsTelegramRoutes,
       ...testSlackStateRoutes,
     ],
   });

--- a/turbo/apps/api/src/signals/routes/integrations-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-agentphone.ts
@@ -967,7 +967,7 @@ const webhook$ = command(async ({ get, set }, signal: AbortSignal) => {
   return okText();
 });
 
-export const zeroIntegrationsAgentPhoneRoutes: readonly RouteEntry[] = [
+export const integrationsAgentPhoneRoutes: readonly RouteEntry[] = [
   {
     route: zeroIntegrationsAgentPhoneContract.connectAgentPhone,
     handler: authRoute(agentPhoneAuthOptions, connectAgentPhone$),

--- a/turbo/apps/api/src/signals/routes/integrations-telegram.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram.ts
@@ -503,7 +503,7 @@ const getIntegrationTelegramAuthCallback$ = computed((): Response => {
   });
 });
 
-export const zeroIntegrationsTelegramRoutes: readonly RouteEntry[] = [
+export const integrationsTelegramRoutes: readonly RouteEntry[] = [
   ...integrationsTelegramLinkRoutes,
   ...integrationsTelegramBotIdRoutes,
   {

--- a/turbo/apps/api/src/signals/routes/teams-bot.ts
+++ b/turbo/apps/api/src/signals/routes/teams-bot.ts
@@ -430,7 +430,7 @@ const handleZeroTeamsBot$ = command(
   },
 );
 
-export const zeroTeamsBotRoutes: readonly RouteEntry[] = [
+export const teamsBotRoutes: readonly RouteEntry[] = [
   {
     route: zeroTeamsBotContract.post,
     handler: handleZeroTeamsBot$,

--- a/turbo/apps/api/src/signals/routes/teams-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/teams-browser-connect.ts
@@ -264,7 +264,7 @@ const browserConnect$ = command(async ({ get, set }, signal: AbortSignal) => {
   return connectSuccess(query, result.installation);
 });
 
-export const zeroTeamsBrowserConnectRoutes: readonly RouteEntry[] = [
+export const teamsBrowserConnectRoutes: readonly RouteEntry[] = [
   {
     route: zeroTeamsBrowserConnectContract.connect,
     handler: browserConnect$,

--- a/turbo/apps/api/src/signals/routes/teams-connect.ts
+++ b/turbo/apps/api/src/signals/routes/teams-connect.ts
@@ -164,7 +164,7 @@ const teamsConnectAuth = {
   missingOrganizationStatus: 401,
 } as const;
 
-export const zeroTeamsConnectRoutes: readonly RouteEntry[] = [
+export const teamsConnectRoutes: readonly RouteEntry[] = [
   {
     route: zeroTeamsConnectContract.getStatus,
     handler: authRoute(teamsConnectAuth, getTeamsConnectStatusInner$),

--- a/turbo/apps/api/src/signals/routes/teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/teams-oauth.ts
@@ -425,7 +425,7 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
   });
 });
 
-export const zeroTeamsOauthRoutes: readonly RouteEntry[] = [
+export const teamsOauthRoutes: readonly RouteEntry[] = [
   {
     route: zeroTeamsOauthContract.connect,
     handler: connectOauth$,


### PR DESCRIPTION
## Summary

- rename the six Teams, Telegram, and AgentPhone route shell modules listed in #27582
- rename their exported route arrays and update the complete caller surface
- preserve every route contract, API and callback path, OAuth, install, bot, provider, tenant, chat, and phone identity, `publicBrand` value, delivery behavior, persistence identity, service name, CLI and Platform name, and error message

## Scope audit

- verified normalized equivalence for all six owned route modules after the approved export substitutions
- verified normalized equivalence for all fourteen callers after the approved import-path and export substitutions
- confirmed zero residual old exports, old relative imports, or old owned filenames
- repeated the neutral-target scan and paginated open-PR file scan; #27200 and #25722 overlap this surface but are not merge gates
- rebased whenever `main` moved during implementation and retained all newly merged route registry behavior

## Verification

- pinned Prettier 3.8.1 check
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm exec knip --workspace api`
- 134 focused Teams, Telegram, and AgentPhone route tests passed locally
- broader caller-focused probe: 219 of 266 tests passed; the remaining 47 asynchronous run-queue and callback failures were reproduced on pristine `main` in the same local environment, so PR CI is authoritative for those paths
- no full local Vitest run and no dev server

Closes #27582
