### PR TITLE
refactor(api): neutralize standalone route shell naming

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -21,10 +21,10 @@ import { mockEnv } from "../lib/env";
 import webClientCompatibility from "../lib/web-client-compatibility.json";
 import { flushWaitUntilForTest } from "../signals/context/wait-until";
 import { healthRoutes } from "../signals/routes/health";
-import { zeroMailRoutes } from "../signals/routes/zero-mail";
+import { mailRoutes } from "../signals/routes/mail";
 import { accept, testContext } from "./test-context";
 import { setupApp } from "./test-helpers";
-const TEST_APP_ROUTES = Object.freeze([...healthRoutes, ...zeroMailRoutes]);
+const TEST_APP_ROUTES = Object.freeze([...healthRoutes, ...mailRoutes]);
 
 const MINIMUM_WEB_CLIENT_VERSION =
   webClientCompatibility.minimumSupportedVersion;

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -75,7 +75,7 @@ import { billingRedeemRoutes } from "./routes/billing-redeem";
 import { billingRestoreRoutes } from "./routes/billing-restore";
 import { billingStatusRoutes } from "./routes/billing-status";
 import { billingUsagePackCreditsRoutes } from "./routes/billing-usage-pack-credits";
-import { zeroBankingRoutes } from "./routes/zero-banking";
+import { bankingRoutes } from "./routes/banking";
 import { chatThreadRoutes } from "./routes/chat-threads";
 import { chatEventsRoutes } from "./routes/chat-events";
 import { sharedThreadRoutes } from "./routes/shared-threads";
@@ -90,17 +90,17 @@ import { connectorsExternalCodeRoutes } from "./routes/connectors-external-code"
 import { connectorsOauthDeviceAuthRoutes } from "./routes/connectors-oauth-device-auth";
 import { connectorsRoutes } from "./routes/connectors";
 import { customConnectorsRoutes } from "./routes/custom-connectors";
-import { zeroEmailInboundRoutes } from "./routes/zero-email-inbound";
-import { zeroFeatureSwitchesRoutes } from "./routes/zero-feature-switches";
+import { emailInboundRoutes } from "./routes/email-inbound";
+import { featureSwitchesRoutes } from "./routes/feature-switches";
 import { financeRoutes } from "./routes/finance";
 import { seoRoutes } from "./routes/seo";
-import { zeroGoalsRoutes } from "./routes/zero-goals";
+import { goalsRoutes } from "./routes/goals";
 import { hostRoutes } from "./routes/host";
 import { builtInGenerationRoutes } from "./routes/built-in-generation";
 import { imageIoGenerateRoutes } from "./routes/image-io-generate";
 import { imageShareXRoutes } from "./routes/image-share-x";
 import { logsRoutes } from "./routes/logs";
-import { zeroMailRoutes } from "./routes/zero-mail";
+import { mailRoutes } from "./routes/mail";
 import { mapsRoutes } from "./routes/maps";
 import { mcpConnectorsRoutes } from "./routes/mcp-connectors";
 import { weatherRoutes } from "./routes/weather";
@@ -267,7 +267,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...billingRestoreRoutes,
   ...billingStatusRoutes,
   ...billingUsagePackCreditsRoutes,
-  ...zeroBankingRoutes,
+  ...bankingRoutes,
   ...chatThreadRoutes,
   ...chatEventsRoutes,
   ...sharedThreadRoutes,
@@ -282,11 +282,11 @@ export const ROUTES: readonly RouteEntry[] = [
   ...connectorsOauthDeviceAuthRoutes,
   ...connectorsRoutes,
   ...customConnectorsRoutes,
-  ...zeroEmailInboundRoutes,
-  ...zeroFeatureSwitchesRoutes,
+  ...emailInboundRoutes,
+  ...featureSwitchesRoutes,
   ...financeRoutes,
   ...seoRoutes,
-  ...zeroGoalsRoutes,
+  ...goalsRoutes,
   ...hostRoutes,
   ...builtInGenerationRoutes,
   ...imageIoGenerateRoutes,
@@ -294,7 +294,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...avatarVideoRoutes,
   ...videoIoGenerateRoutes,
   ...logsRoutes,
-  ...zeroMailRoutes,
+  ...mailRoutes,
   ...mapsRoutes,
   ...mcpConnectorsRoutes,
   ...weatherRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/banking.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/banking.test.ts
@@ -20,7 +20,7 @@ import {
   readBankingAuditEventsState,
   seedBankingState,
 } from "./helpers/banking-state";
-import { zeroBankingRoutes } from "../zero-banking";
+import { bankingRoutes } from "../banking";
 
 const context = testContext();
 
@@ -208,7 +208,7 @@ describe("POST /api/zero/banking/*", () => {
       }),
     );
 
-    const client = setupApp({ context, routes: zeroBankingRoutes })(
+    const client = setupApp({ context, routes: bankingRoutes })(
       zeroBankingContract,
     );
     const response = await accept(
@@ -261,7 +261,7 @@ describe("POST /api/zero/banking/*", () => {
       ),
     );
 
-    const client = setupApp({ context, routes: zeroBankingRoutes })(
+    const client = setupApp({ context, routes: bankingRoutes })(
       zeroBankingContract,
     );
     const response = await accept(
@@ -317,7 +317,7 @@ describe("POST /api/zero/banking/*", () => {
       ),
     );
 
-    const client = setupApp({ context, routes: zeroBankingRoutes })(
+    const client = setupApp({ context, routes: bankingRoutes })(
       zeroBankingContract,
     );
     const response = await accept(
@@ -365,7 +365,7 @@ describe("POST /api/zero/banking/*", () => {
       ),
     );
 
-    const client = setupApp({ context, routes: zeroBankingRoutes })(
+    const client = setupApp({ context, routes: bankingRoutes })(
       zeroBankingContract,
     );
     const response = await accept(
@@ -409,7 +409,7 @@ describe("POST /api/zero/banking/*", () => {
       }),
     );
 
-    const client = setupApp({ context, routes: zeroBankingRoutes })(
+    const client = setupApp({ context, routes: bankingRoutes })(
       zeroBankingContract,
     );
     const response = await accept(
@@ -443,7 +443,7 @@ describe("POST /api/zero/banking/*", () => {
         }),
       );
 
-      const client = setupApp({ context, routes: zeroBankingRoutes })(
+      const client = setupApp({ context, routes: bankingRoutes })(
         zeroBankingContract,
       );
       const response = await accept(
@@ -485,7 +485,7 @@ describe("POST /api/zero/banking/*", () => {
         ),
       );
 
-      const client = setupApp({ context, routes: zeroBankingRoutes })(
+      const client = setupApp({ context, routes: bankingRoutes })(
         zeroBankingContract,
       );
       const response = await accept(
@@ -521,7 +521,7 @@ describe("POST /api/zero/banking/*", () => {
       }),
     );
 
-    const client = setupApp({ context, routes: zeroBankingRoutes })(
+    const client = setupApp({ context, routes: bankingRoutes })(
       zeroBankingContract,
     );
     const response = await accept(
@@ -574,7 +574,7 @@ describe("POST /api/zero/banking/*", () => {
       ),
     );
 
-    const client = setupApp({ context, routes: zeroBankingRoutes })(
+    const client = setupApp({ context, routes: bankingRoutes })(
       zeroBankingContract,
     );
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -50,7 +50,7 @@ import {
   useSecretKmsProbe,
 } from "./helpers/secret-kms-probe";
 import { testBrowserReconcileRoutes } from "../test-browser-reconcile";
-import { zeroGoalsRoutes } from "../zero-goals";
+import { goalsRoutes } from "../goals";
 
 /**
  * CHAT-02 / HOOK-01: signed chat run callbacks through real dispatch.
@@ -69,7 +69,7 @@ const chatCallbacks = createChatCallbacksApi(context);
 const misc = createMiscRoutesApi(context);
 
 function goalsClient() {
-  return setupApp({ context, routes: zeroGoalsRoutes })(zeroGoalsContract);
+  return setupApp({ context, routes: goalsRoutes })(zeroGoalsContract);
 }
 
 const USER_ARTIFACTS_BUCKET = "test-user-artifacts";

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -122,14 +122,14 @@ import {
 import { cronSteerRunTimeBudgetRoutes } from "../cron-steer-run-time-budget";
 import { chatEventsRoutes } from "../chat-events";
 import { chatThreadRoutes } from "../chat-threads";
-import { zeroMailRoutes } from "../zero-mail";
+import { mailRoutes } from "../mail";
 import { modelProviderGatewayRoutes } from "../model-provider-gateways";
 import { zeroModelProvidersRoutes } from "../zero-model-providers";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...chatEventsRoutes,
   ...chatThreadRoutes,
-  ...zeroMailRoutes,
+  ...mailRoutes,
   ...modelProviderGatewayRoutes,
   ...zeroModelProvidersRoutes,
 ]);
@@ -3416,18 +3416,16 @@ describe("CHAT-02: Zero Mail link delivery", () => {
     );
 
     const linked = await accept(
-      setupApp({ context, routes: zeroMailRoutes })(zeroMailContract).linkDraft(
-        {
-          headers: {
-            authorization: `Bearer ${okouTokenFromClaim(claim)}`,
-          },
-          body: {
-            threadId: run.threadId,
-            agentId,
-            gmailDraftId,
-          },
+      setupApp({ context, routes: mailRoutes })(zeroMailContract).linkDraft({
+        headers: {
+          authorization: `Bearer ${okouTokenFromClaim(claim)}`,
         },
-      ),
+        body: {
+          threadId: run.threadId,
+          agentId,
+          gmailDraftId,
+        },
+      }),
       [200],
     );
     const beforeReply = await chat.listThreadEvents(actor, run.threadId);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -83,13 +83,13 @@ import { cronCompactChatThreadSnapshotsRoutes } from "../cron-compact-chat-threa
 import { cronProjectChatEventSearchRoutes } from "../cron-project-chat-event-search";
 import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 import { chatThreadRoutes } from "../chat-threads";
-import { zeroGoalsRoutes } from "../zero-goals";
+import { goalsRoutes } from "../goals";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...cronCompactChatThreadSnapshotsRoutes,
   ...cronProjectChatEventSearchRoutes,
   ...chatThreadRoutes,
-  ...zeroGoalsRoutes,
+  ...goalsRoutes,
 ]);
 
 /**
@@ -445,7 +445,7 @@ const CHAT_THREAD_READ_CAPABILITIES = [
 ] as const satisfies readonly ZeroCapability[];
 
 function goalsClient() {
-  return setupApp({ context, routes: zeroGoalsRoutes })(zeroGoalsContract);
+  return setupApp({ context, routes: goalsRoutes })(zeroGoalsContract);
 }
 
 function zeroCapabilityHeaders(

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
@@ -28,7 +28,7 @@ import {
 } from "./helpers/api-bdd-connectors";
 import { createAuthDeviceApiActions } from "./helpers/api-bdd-auth-device";
 import { connectorCatalogRoutes } from "../connector-catalog";
-import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
+import { featureSwitchesRoutes } from "../feature-switches";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -43,7 +43,7 @@ async function enableFeatureSwitches(
   switches: Partial<Record<FeatureSwitchKey, boolean>>,
 ): Promise<void> {
   mocks.clerk.session(userId, orgId);
-  const client = setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+  const client = setupApp({ context, routes: featureSwitchesRoutes })(
     zeroFeatureSwitchesContract,
   );
   await accept(
@@ -60,7 +60,7 @@ async function deleteFeatureSwitches(
   userId: string,
 ): Promise<void> {
   mocks.clerk.session(userId, orgId);
-  const client = setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+  const client = setupApp({ context, routes: featureSwitchesRoutes })(
     zeroFeatureSwitchesContract,
   );
   await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
@@ -20,11 +20,11 @@ import {
 } from "./helpers/connector-credential-storage-state";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { connectorsRoutes } from "../connectors";
-import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
+import { featureSwitchesRoutes } from "../feature-switches";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...connectorsRoutes,
-  ...zeroFeatureSwitchesRoutes,
+  ...featureSwitchesRoutes,
 ]);
 
 const context = testContext();
@@ -51,7 +51,7 @@ function authHeaders() {
 }
 
 function featureSwitchesClient() {
-  return setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+  return setupApp({ context, routes: featureSwitchesRoutes })(
     zeroFeatureSwitchesContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-search.test.ts
@@ -13,14 +13,14 @@ import { signSandboxJwtForTests } from "../../auth/tokens";
 import { seedOrgMembership$ } from "./helpers/org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { connectorsRoutes } from "../connectors";
-import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
+import { featureSwitchesRoutes } from "../feature-switches";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
 const store = createStore();
 
 function featureSwitchesClient() {
-  return setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+  return setupApp({ context, routes: featureSwitchesRoutes })(
     zeroFeatureSwitchesContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -95,7 +95,7 @@ import { runnersRoutes } from "../runners";
 import { connectorCatalogRoutes } from "../connector-catalog";
 import { connectorCheckRoutes } from "../connector-check";
 import { connectorsRoutes } from "../connectors";
-import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
+import { featureSwitchesRoutes } from "../feature-switches";
 import { steamPlayerRoutes } from "../steam-player";
 import { userPermissionGrantsRoutes } from "../user-permission-grants";
 import { workflowAutomationsRoutes } from "../workflow-automations";
@@ -109,7 +109,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...connectorCatalogRoutes,
   ...connectorCheckRoutes,
   ...connectorsRoutes,
-  ...zeroFeatureSwitchesRoutes,
+  ...featureSwitchesRoutes,
   ...steamPlayerRoutes,
   ...userPermissionGrantsRoutes,
   ...workflowAutomationsRoutes,
@@ -1518,7 +1518,7 @@ async function syncCatalog() {
 async function enableDiagnosticsFeatureSwitch(): Promise<void> {
   zeroMocks.clerk.session(DIAGNOSTICS_USER_ID, DIAGNOSTICS_ORG_ID);
   await accept(
-    setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+    setupApp({ context, routes: featureSwitchesRoutes })(
       zeroFeatureSwitchesContract,
     ).update({
       headers: { authorization: "Bearer clerk-session" },
@@ -1529,7 +1529,7 @@ async function enableDiagnosticsFeatureSwitch(): Promise<void> {
   onTestFinished(async () => {
     zeroMocks.clerk.session(DIAGNOSTICS_USER_ID, DIAGNOSTICS_ORG_ID);
     await accept(
-      setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+      setupApp({ context, routes: featureSwitchesRoutes })(
         zeroFeatureSwitchesContract,
       ).delete({
         headers: { authorization: "Bearer clerk-session" },
@@ -2233,7 +2233,7 @@ describe("connector catalog valid lifecycle", () => {
     })(zeroConnectorCatalogContract);
     const featureClient = setupApp({
       context,
-      routes: zeroFeatureSwitchesRoutes,
+      routes: featureSwitchesRoutes,
     })(zeroFeatureSwitchesContract);
 
     const disabled = await accept(catalogClient.list({ headers }), [200]);
@@ -5516,7 +5516,7 @@ describe("connector catalog executable compatibility", () => {
     })(zeroConnectorCatalogContract);
     const featureClient = setupApp({
       context,
-      routes: zeroFeatureSwitchesRoutes,
+      routes: featureSwitchesRoutes,
     })(zeroFeatureSwitchesContract);
 
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feature-switches.test.ts
@@ -5,12 +5,12 @@ import { describe, expect, it } from "vitest";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
+import { featureSwitchesRoutes } from "../feature-switches";
 
 const context = testContext();
 
 function client() {
-  return setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+  return setupApp({ context, routes: featureSwitchesRoutes })(
     zeroFeatureSwitchesContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
@@ -24,7 +24,7 @@ import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 import { chatThreadRoutes } from "../chat-threads";
-import { zeroGoalsRoutes } from "../zero-goals";
+import { goalsRoutes } from "../goals";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -52,7 +52,7 @@ function currentSecond(): number {
 }
 
 function goalsClient() {
-  return setupApp({ context, routes: zeroGoalsRoutes })(zeroGoalsContract);
+  return setupApp({ context, routes: goalsRoutes })(zeroGoalsContract);
 }
 
 function zeroToken(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device-support.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device-support.ts
@@ -14,7 +14,7 @@ import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import type { RouteEntry } from "../../../route-entry";
 import { connectorsRoutes } from "../../connectors";
-import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
+import { featureSwitchesRoutes } from "../../feature-switches";
 import { meModelProvidersDeleteRoutes } from "../../me-model-providers-delete";
 import { meModelProviderAccountRoutes } from "../../me-model-provider-accounts";
 import { meModelProvidersListRoutes } from "../../me-model-providers-list";
@@ -29,7 +29,7 @@ interface AuthHeaders {
 
 const authDeviceSupportRoutes: readonly RouteEntry[] = [
   ...connectorsRoutes,
-  ...zeroFeatureSwitchesRoutes,
+  ...featureSwitchesRoutes,
   ...meModelProviderAccountRoutes,
   ...meModelProvidersDeleteRoutes,
   ...meModelProvidersListRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -48,7 +48,7 @@ import { testUsageSettlementRoutes } from "../../test-usage-settlement";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 import { acquisitionAttributionRoutes } from "../../acquisition-attribution";
-import { zeroBankingRoutes } from "../../zero-banking";
+import { bankingRoutes } from "../../banking";
 import { billingAutoRechargeRoutes } from "../../billing-auto-recharge";
 import { billingCheckoutRoutes } from "../../billing-checkout";
 import { billingCreditCheckoutRoutes } from "../../billing-credit-checkout";
@@ -60,7 +60,7 @@ import { billingRedeemCodeRoutes } from "../../billing-redeem-code";
 import { billingRestoreRoutes } from "../../billing-restore";
 import { billingStatusRoutes } from "../../billing-status";
 import { builtInGenerationRoutes } from "../../built-in-generation";
-import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
+import { featureSwitchesRoutes } from "../../feature-switches";
 import { imageIoGenerateRoutes } from "../../image-io-generate";
 import { mapsRoutes } from "../../maps";
 import { usageMembersRoutes } from "../../usage-members";
@@ -589,7 +589,7 @@ export function createBillingMediaApi(context: TestContext) {
       actor: ApiTestUser,
       switches: Readonly<Record<string, boolean>>,
     ) {
-      const client = setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+      const client = setupApp({ context, routes: featureSwitchesRoutes })(
         zeroFeatureSwitchesContract,
       );
       return await accept(
@@ -821,7 +821,7 @@ export function createBillingMediaApi(context: TestContext) {
       actor: ApiTestUser | null,
       statuses: readonly (200 | 400 | 401 | 403 | 502 | 503)[],
     ) {
-      const client = setupApp({ context, routes: zeroBankingRoutes })(
+      const client = setupApp({ context, routes: bankingRoutes })(
         zeroBankingContract,
       );
       return await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -80,7 +80,7 @@ import { customConnectorProposalRoutes } from "../../custom-connectors-proposal"
 import { customConnectorDisconnectRoutes } from "../../custom-connectors-disconnect";
 import { customConnectorsUpdateRoutes } from "../../custom-connectors-update";
 import { customConnectorsValuesSetRoutes } from "../../custom-connectors-values-set";
-import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
+import { featureSwitchesRoutes } from "../../feature-switches";
 
 const zeroCustomConnectorByIdTestRoutes = Object.freeze([
   ...customConnectorsDeleteRoutes,
@@ -97,7 +97,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...connectorsOauthDeviceAuthRoutes,
   ...connectorsRoutes,
   ...customConnectorsRoutes,
-  ...zeroFeatureSwitchesRoutes,
+  ...featureSwitchesRoutes,
 ]);
 
 interface AuthHeaders {
@@ -1783,7 +1783,7 @@ export function createConnectorBddApi(context: TestContext) {
       actor: ApiTestUser,
       switches: Readonly<Record<string, boolean>>,
     ): Promise<Readonly<Record<string, boolean>>> {
-      const client = setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+      const client = setupApp({ context, routes: featureSwitchesRoutes })(
         zeroFeatureSwitchesContract,
       );
       const response = await accept(
@@ -1797,7 +1797,7 @@ export function createConnectorBddApi(context: TestContext) {
     },
 
     async deleteFeatureSwitches(actor: ApiTestUser): Promise<void> {
-      const client = setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+      const client = setupApp({ context, routes: featureSwitchesRoutes })(
         zeroFeatureSwitchesContract,
       );
       await accept(client.delete({ headers: authenticate(actor) }), [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-github.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-github.ts
@@ -28,13 +28,13 @@ import { createZeroRouteMocks } from "./zero-route-test";
 import { integrationsGithubRoutes } from "../../integrations-github";
 import { githubOauthRoutes } from "../../github-oauth";
 import { connectorsRoutes } from "../../connectors";
-import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
+import { featureSwitchesRoutes } from "../../feature-switches";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...githubOauthRoutes,
   ...integrationsGithubRoutes,
   ...connectorsRoutes,
-  ...zeroFeatureSwitchesRoutes,
+  ...featureSwitchesRoutes,
 ]);
 
 const GITHUB_APP_SLUG = "vm0-test";
@@ -422,7 +422,7 @@ export function createGithubBddApi(context: TestContext) {
     },
 
     async enableAuditLink(actor: ApiTestUser): Promise<void> {
-      const client = setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+      const client = setupApp({ context, routes: featureSwitchesRoutes })(
         zeroFeatureSwitchesContract,
       );
       await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -60,7 +60,7 @@ import { createZeroRouteMocks } from "./zero-route-test";
 import { githubOauthRoutes } from "../../github-oauth";
 import { integrationsGithubRoutes } from "../../integrations-github";
 import { testSlackStateRoutes } from "../../test-slack-state";
-import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
+import { featureSwitchesRoutes } from "../../feature-switches";
 import { integrationsAgentPhoneRoutes } from "../../integrations-agentphone";
 import { integrationsGithubUploadCompleteRoutes } from "../../integrations-github-upload-complete";
 import { integrationsGithubUploadInitRoutes } from "../../integrations-github-upload-init";
@@ -90,7 +90,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...githubOauthRoutes,
   ...integrationsGithubRoutes,
   ...testSlackStateRoutes,
-  ...zeroFeatureSwitchesRoutes,
+  ...featureSwitchesRoutes,
   ...integrationsAgentPhoneRoutes,
   ...integrationsGithubUploadCompleteRoutes,
   ...integrationsGithubUploadInitRoutes,
@@ -1252,7 +1252,7 @@ export function createBddIntegrationApi(context: TestContext) {
 
     async enableAuditLinkSwitch(actor: ApiTestUser): Promise<void> {
       await accept(
-        setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+        setupApp({ context, routes: featureSwitchesRoutes })(
           zeroFeatureSwitchesContract,
         ).update({
           headers: authenticate(context, routeMocks, actor),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -41,7 +41,7 @@ import { webhooksBuiltInGenerationRoutes } from "../../webhooks-built-in-generat
 import { webhooksClerkRoutes } from "../../webhooks-clerk";
 import { webhooksGithubRoutes } from "../../webhooks-github";
 import { webhooksStripeRoutes } from "../../webhooks-stripe";
-import { zeroEmailInboundRoutes } from "../../zero-email-inbound";
+import { emailInboundRoutes } from "../../email-inbound";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...webhooksAgentCheckpointsRoutes,
@@ -53,7 +53,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...webhooksClerkRoutes,
   ...webhooksGithubRoutes,
   ...webhooksStripeRoutes,
-  ...zeroEmailInboundRoutes,
+  ...emailInboundRoutes,
 ]);
 
 type AgentEventsBody = z.infer<(typeof webhookEventsContract.send)["body"]>;
@@ -404,7 +404,7 @@ export function createWebhookCallbackApi(context: TestContext) {
       statuses: readonly (200 | 401)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroEmailInboundRoutes })(
+        setupApp({ context, routes: emailInboundRoutes })(
           zeroEmailInboundContract,
         ).post({
           headers,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/feature-switches.ts
@@ -3,7 +3,7 @@ import { zeroFeatureSwitchesContract } from "@okouai/api-contracts/contracts/zer
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { setupApp } from "../../../../__tests__/test-helpers";
 import { createZeroRouteMocks } from "./zero-route-test";
-import { zeroFeatureSwitchesRoutes } from "../../zero-feature-switches";
+import { featureSwitchesRoutes } from "../../feature-switches";
 
 type ClerkOrgRole = "org:admin" | "org:member";
 
@@ -14,7 +14,7 @@ interface FeatureSwitchActor {
 }
 
 function featureSwitchesClient(context: TestContext) {
-  return setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+  return setupApp({ context, routes: featureSwitchesRoutes })(
     zeroFeatureSwitchesContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -22,7 +22,7 @@ import {
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { buildInfoRoutes } from "../build-info";
 import { healthRoutes } from "../health";
-import { zeroFeatureSwitchesRoutes } from "../zero-feature-switches";
+import { featureSwitchesRoutes } from "../feature-switches";
 
 /*
 helper gap: HOOK-01 signed callbacks still need API-visible builders for
@@ -50,7 +50,7 @@ function healthAuthClient() {
 }
 
 function featureSwitchesClient() {
-  return setupApp({ context, routes: zeroFeatureSwitchesRoutes })(
+  return setupApp({ context, routes: featureSwitchesRoutes })(
     zeroFeatureSwitchesContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -22,7 +22,7 @@ import {
   setConnectorCredentialStorageState,
   setConnectorSecretOwner,
 } from "./helpers/connector-credential-storage-state";
-import { zeroMailRoutes } from "../zero-mail";
+import { mailRoutes } from "../mail";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -275,7 +275,7 @@ async function seedGmailMailCardFixture() {
 }
 
 function client() {
-  return setupApp({ context, routes: zeroMailRoutes })(zeroMailContract);
+  return setupApp({ context, routes: mailRoutes })(zeroMailContract);
 }
 
 function stateClient() {

--- a/turbo/apps/api/src/signals/routes/banking.ts
+++ b/turbo/apps/api/src/signals/routes/banking.ts
@@ -122,7 +122,7 @@ const bankingAuth = {
   accept: ["zero"],
 } as const;
 
-export const zeroBankingRoutes: readonly RouteEntry[] = [
+export const bankingRoutes: readonly RouteEntry[] = [
   {
     route: zeroBankingContract.accounts,
     handler: authRoute(bankingAuth, accountsInner$),

--- a/turbo/apps/api/src/signals/routes/email-inbound.ts
+++ b/turbo/apps/api/src/signals/routes/email-inbound.ts
@@ -124,7 +124,7 @@ const handleInboundRoute$ = command(
   },
 );
 
-export const zeroEmailInboundRoutes: readonly RouteEntry[] = [
+export const emailInboundRoutes: readonly RouteEntry[] = [
   {
     route: zeroEmailInboundContract.post,
     handler: handleInboundRoute$,

--- a/turbo/apps/api/src/signals/routes/feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/feature-switches.ts
@@ -94,7 +94,7 @@ const deleteFeatureSwitchesInner$ = command(
   },
 );
 
-export const zeroFeatureSwitchesRoutes: readonly RouteEntry[] = [
+export const featureSwitchesRoutes: readonly RouteEntry[] = [
   {
     route: zeroFeatureSwitchesContract.get,
     handler: authRoute(featureSwitchesAuthOptions, getFeatureSwitchesInner$),

--- a/turbo/apps/api/src/signals/routes/goals.ts
+++ b/turbo/apps/api/src/signals/routes/goals.ts
@@ -296,7 +296,7 @@ const clearGoalInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return goalErrorResponse(result);
 });
 
-export const zeroGoalsRoutes: readonly RouteEntry[] = [
+export const goalsRoutes: readonly RouteEntry[] = [
   {
     route: zeroGoalsContract.create,
     handler: authRoute(goalUserControlWriteAuth, createGoalInner$),

--- a/turbo/apps/api/src/signals/routes/mail.ts
+++ b/turbo/apps/api/src/signals/routes/mail.ts
@@ -195,7 +195,7 @@ const mailDraftHumanAuth = Object.freeze({
   accept: Object.freeze(["session"] as const),
 });
 
-export const zeroMailRoutes: readonly RouteEntry[] = [
+export const mailRoutes: readonly RouteEntry[] = [
   {
     route: zeroMailContract.linkDraft,
     handler: authRoute(mailDraftLinkAuth, linkDraftInner$),

--- a/turbo/docs/typecheck-memory-experiments.md
+++ b/turbo/docs/typecheck-memory-experiments.md
@@ -307,7 +307,7 @@ below the raw latest-main full `api` OOM peak. It is not sufficient to make the
 
 Change: migrate `zero-email.test.ts` from raw `createApp` to
 `createAppWithRoutes` using `zeroEmailCallbackRoutes` and
-`zeroEmailInboundRoutes`.
+`emailInboundRoutes`.
 
 - Command:
   `pnpm -F api exec tsc -p tsconfig.tests-pure-context-entries.json --noEmit`


### PR DESCRIPTION
## Summary

- Rename the five standalone banking, inbound-email, feature-switch, goal, and mail route modules to domain-neutral paths.
- Rename only their five route-array exports and update the complete production registry, app-factory, test, benchmark/reference, and BDD-helper caller surface.
- Remove the old paths and exports atomically without aliases, forwarding modules, compatibility re-exports, or duplicate route entries.

## Compatibility

- Preserve every route-array entry, order, handler, contract, API path, HTTP method, schema, status, auth requirement, header, provider/token/secret identity, and user-visible error.
- Preserve feature-switch keys, goal scheduling/runtime behavior, mail and banking semantics, database and persisted identities, environment variables, audit/logging behavior, CLI adapters, Platform files, service names, and all other internal `zero` declarations.
- Keep the five route modules byte-equivalent to current main after applying only the approved export-name mapping.

## Acceptance audit

- All five old route paths and exports are absent; all five neutral paths and exports exist exactly once.
- The production registry spreads each neutral route array exactly once, and every repository caller uses the neutral shell.
- A normalized source comparison passed for all 27 changed files after the approved path/export map and pinned formatting.
- The complete latest open-PR file surface was scanned with `gh pr list --limit 100`; all 28 PR file counts matched GitHub, including both pages and all 185 files of #25722. No open PR touches an owned module or neutral target.

## Verification

- Prettier 3.8.1 check on all 27 changed files
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- Focused API route tests with one worker and no file parallelism: 6 files, 100 tests passed
- Post-rebase old-path/export residual, neutral-target uniqueness, registry-spread uniqueness, preserved-contract, and normalized-equivalence audits

Closes #27576

Parent: #27432

Compatibility model: #26873