### PR TITLE
refactor(org): neutralize organization invite route shell

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -109,7 +109,7 @@ import { zeroModelProviderGatewayRoutes } from "./routes/zero-model-provider-gat
 import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
 import { onboardingCompleteRoutes } from "./routes/onboarding-complete";
 import { onboardingStatusRoutes } from "./routes/onboarding-status";
-import { zeroOrgInviteRoutes } from "./routes/zero-org-invite";
+import { orgInviteRoutes } from "./routes/org-invite";
 import { orgDeleteRoutes } from "./routes/org-delete";
 import { orgLogoRoutes } from "./routes/org-logo";
 import { orgMembersRoutes } from "./routes/org-members";
@@ -325,7 +325,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroRunsCancelRoutes,
   ...onboardingCompleteRoutes,
   ...onboardingStatusRoutes,
-  ...zeroOrgInviteRoutes,
+  ...orgInviteRoutes,
   ...orgDeleteRoutes,
   ...orgLogoRoutes,
   ...orgMembersRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -64,7 +64,7 @@ import { zeroBillingCreditCheckoutRoutes } from "../zero-billing-credit-checkout
 import { zeroBillingUsagePackCreditsRoutes } from "../zero-billing-usage-pack-credits";
 import { zeroBillingStatusRoutes } from "../zero-billing-status";
 import { orgMembersRoutes } from "../org-members";
-import { zeroOrgInviteRoutes } from "../zero-org-invite";
+import { orgInviteRoutes } from "../org-invite";
 import { orgReadRoutes } from "../org-read";
 import {
   testUsagePackSubscriptionStateContract,
@@ -3182,7 +3182,7 @@ describe("legacy subscription usage pack migration", () => {
     });
 
     await accept(
-      setupApp({ context, routes: zeroOrgInviteRoutes })(
+      setupApp({ context, routes: orgInviteRoutes })(
         zeroOrgInviteContract,
       ).revoke({
         headers: { authorization: "Bearer clerk-session" },
@@ -3356,7 +3356,7 @@ describe("legacy subscription usage pack migration", () => {
     );
 
     const revokeResponse = await accept(
-      setupApp({ context, routes: zeroOrgInviteRoutes })(
+      setupApp({ context, routes: orgInviteRoutes })(
         zeroOrgInviteContract,
       ).revoke({
         headers: { authorization: "Bearer clerk-session" },
@@ -3984,7 +3984,7 @@ describe("usage pack allocation management", () => {
     );
     mockUsagePackChangePreviews(1000, 2000);
     const preview = await accept(
-      setupApp({ context, routes: zeroOrgInviteRoutes })(
+      setupApp({ context, routes: orgInviteRoutes })(
         zeroOrgInviteContract,
       ).previewPurchase({
         headers: { authorization: "Bearer clerk-session" },
@@ -6719,7 +6719,7 @@ describe("usage pack allocation management", () => {
       const billing = await readBillingStatus(fixture);
       expect(billing.memberInviteUsagePackRequired).toBeTruthy();
 
-      const client = setupApp({ context, routes: zeroOrgInviteRoutes })(
+      const client = setupApp({ context, routes: orgInviteRoutes })(
         zeroOrgInviteContract,
       );
       const blocked = await accept(
@@ -6750,7 +6750,7 @@ describe("usage pack allocation management", () => {
         { id: `inv_${randomUUID()}` },
       );
       const invited = await accept(
-        setupApp({ context, routes: zeroOrgInviteRoutes })(
+        setupApp({ context, routes: orgInviteRoutes })(
           zeroOrgInviteContract,
         ).invite({
           headers: { authorization: "Bearer clerk-session" },
@@ -6766,7 +6766,7 @@ describe("usage pack allocation management", () => {
     const fixture = await seedManagedUsagePack([
       { userId: `user_${randomUUID()}`, usagePackUsd: 20 },
     ]);
-    const client = setupApp({ context, routes: zeroOrgInviteRoutes })(
+    const client = setupApp({ context, routes: orgInviteRoutes })(
       zeroOrgInviteContract,
     );
     const blocked = await accept(
@@ -6804,7 +6804,7 @@ describe("usage pack allocation management", () => {
     const fixture = await seedManagedUsagePack([
       { userId: `user_${randomUUID()}`, usagePackUsd: 20 },
     ]);
-    const client = setupApp({ context, routes: zeroOrgInviteRoutes })(
+    const client = setupApp({ context, routes: orgInviteRoutes })(
       zeroOrgInviteContract,
     );
 
@@ -6852,7 +6852,7 @@ describe("usage pack allocation management", () => {
     });
 
     const response = await accept(
-      setupApp({ context, routes: zeroOrgInviteRoutes })(
+      setupApp({ context, routes: orgInviteRoutes })(
         zeroOrgInviteContract,
       ).previewPurchase({
         headers: { authorization: "Bearer clerk-session" },
@@ -6913,7 +6913,7 @@ describe("usage pack allocation management", () => {
     mockUsagePackChangePreviews(1000, 2000);
     context.mocks.stripe.checkout.sessions.create.mockClear();
 
-    const client = setupApp({ context, routes: zeroOrgInviteRoutes })(
+    const client = setupApp({ context, routes: orgInviteRoutes })(
       zeroOrgInviteContract,
     );
     const previewBody = {
@@ -7669,7 +7669,7 @@ describe("usage pack allocation management", () => {
       id: `re_${randomUUID()}`,
       status: "succeeded",
     });
-    const client = setupApp({ context, routes: zeroOrgInviteRoutes })(
+    const client = setupApp({ context, routes: orgInviteRoutes })(
       zeroOrgInviteContract,
     );
     await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -96,7 +96,7 @@ import { customConnectorsValuesSetRoutes } from "../../custom-connectors-values-
 import { onboardingCompleteRoutes } from "../../onboarding-complete";
 import { onboardingStatusRoutes } from "../../onboarding-status";
 import { orgDeleteRoutes } from "../../org-delete";
-import { zeroOrgInviteRoutes } from "../../zero-org-invite";
+import { orgInviteRoutes } from "../../org-invite";
 import { orgLogoRoutes } from "../../org-logo";
 import { orgMembersRoutes } from "../../org-members";
 import { orgMembershipRequestsRoutes } from "../../org-membership-requests";
@@ -215,7 +215,7 @@ const authOrgRoutes = [
   ...orgReadRoutes,
   ...orgDeleteRoutes,
   ...orgMembersRoutes,
-  ...zeroOrgInviteRoutes,
+  ...orgInviteRoutes,
   ...orgMembershipRequestsRoutes,
   ...orgLogoRoutes,
   ...teamRoutes,

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -280,7 +280,7 @@ const purchaseConfirmInner$ = command(
   },
 );
 
-export const zeroOrgInviteRoutes: readonly RouteEntry[] = [
+export const orgInviteRoutes: readonly RouteEntry[] = [
   {
     route: zeroOrgInviteContract.invite,
     handler: authRoute(


### PR DESCRIPTION
## Summary

- rename the organization invite route shell from zero-org-invite.ts to org-invite.ts
- rename only the local route-table export to orgInviteRoutes and update every production/test caller
- preserve zeroOrgInviteContract, route ordering, handlers, contracts, and all Clerk, Stripe, usage-pack, persistence, auth, and error behavior

## Verification

- pnpm format
- NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- pnpm turbo run check-types --concurrency=1 excluding api and @okouai/app, followed by dedicated app and API checks
- post-rebase focused Prettier, API lint, and API type checks
- pnpm --filter api exec vitest run src/signals/routes/__tests__/auth-org-agents.bdd.test.ts (10 passed)
- pnpm --filter api exec vitest run src/signals/routes/__tests__/billing-checkout.test.ts (133 passed)

Closes #27591