### PR TITLE
test(api): synchronize agent deletion billing fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-deletion-interlock.bdd.test.ts
@@ -23,6 +23,7 @@ import {
   setAgentLifecycleOrgFixture,
   setAgentRunStatusFixture,
 } from "../../../test-fixtures/agent-deletion";
+import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
@@ -284,6 +285,7 @@ describe("DELETE /api/zero/agents/:id bounded deletion interlock", () => {
       modelProvider: "anthropic-api-key",
     });
     await api.requestCancelRun(targetOwner, terminalRun.runId, [200]);
+    await flushWaitUntilForTest();
     await setAgentRunStatusFixture(queuedRun.runId, "queued");
     const survivorVersionId = await pointTargetAtSurvivorVersion({
       targetAgentId: target.agentId,


### PR DESCRIPTION
## Summary

- wait for the terminal Run cancellation's tracked `waitUntil` work before seeding the test-owned usage fixtures
- preserve the deletion cascade, cross-organization provenance, and billing cardinality assertions unchanged
- avoid retries, sleeps, timeout changes, detached cleanup, and assertion weakening

## Root cause

[Turbo run 31939070573](https://github.com/vm0-ai/vm0/actions/runs/31939070573) failed `test-api (7)` in `agent-deletion-interlock.bdd.test.ts` with `expected 2 to be 1`. The same shard passed on the [same final SHA](https://github.com/vm0-ai/vm0/actions/runs/31938806297/job/95144879168), and the exact assertion also failed in [run 31938559614](https://github.com/vm0-ai/vm0/actions/runs/31938559614/job/95144255060).

The same pre-fix fingerprint recurred in PR #27596's [merge-group run 31940593610](https://github.com/vm0-ai/vm0/actions/runs/31940593610/job/95149088542): the identical test and assertion received `2`, with exactly 1 failed and 342 passed tests. That merge-group SHA predates this PR's fix commit. PR #27596 changes the organization-invite route shell, while this assertion had already failed independently on `main`, so the recurrence strengthens the scheduling diagnosis rather than attributing the failure to #27596 or showing a failure of this fix.

The cancellation request returns after registering cancellation side effects with the request's `waitUntil` tracker. Those side effects process every pending usage event for the target organization. The test previously inserted its artificial pending and processed billing rows immediately after the response. Depending on scheduling, the still-running cancellation side effect could observe and process the newly inserted pending row, so the later materialization query found two processed rows instead of one.

Each BDD user receives a UUID-scoped organization, which rules out persistent rows from another test as the extra cardinality. The extra row is the pending fixture created by this test and promoted by its own unawaited cancellation work. Aggregate-gate output and fixture WARN/ERROR logs occur outside the first causal assertion.

This change flushes the tracked cancellation work at the ownership boundary before the test creates synthetic billing state.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm --filter api run lint` on the final rebased commit
- `pnpm knip`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @okouai/app run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api run check-types` on the final rebased commit
- focused Prettier check and `git diff --check`

The focused API integration test requires PostgreSQL. It was not run locally because this repair task explicitly prohibits starting local services; the PR pipeline is the authoritative service-backed execution environment.

## Preview applicability

Not applicable. This PR changes only a Vitest test file and calls a test-harness-only `flushWaitUntilForTest` helper. Reproducing the invariant requires direct fixture insertion and the test-owned waitUntil tracker; no production App or API behavior changes, and a deployed browser preview cannot exercise this assertion.
