### PR TITLE
fix(api): reconcile request parameters with the enforced run video model

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -760,6 +760,96 @@ describe("POST /api/zero/video-io/generate", () => {
     });
   });
 
+  it("drops a request parameter the pinned model cannot honour", async () => {
+    // Reproduces the production failure: the caller sized its parameters for
+    // the model it asked for, enforcement swapped the model, and the request
+    // died on `Unsupported video resolution for minimax-h3: 720p` — an error
+    // naming a model the caller never sent. 720p is valid for
+    // dreamina-seedance-2.0-fast and invalid for the Kling pin.
+    const fixture = await seedVideoFixture();
+    const { composeId } = await store.set(
+      seedCompose$,
+      { orgId: fixture.orgId, userId: fixture.userId },
+      context.signal,
+    );
+    const { runId } = await store.set(
+      seedRun$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        composeId,
+        triggerSource: "web",
+      },
+      context.signal,
+    );
+    await setRunVideoModelFixture({
+      runId,
+      selectedVideoModel: KLING_V3_4K_MODEL,
+    });
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.VideoModelSelection]: true,
+    });
+
+    let observedRequestUrl: string | null = null;
+    server.use(
+      http.post(KLING_V3_4K_QUEUE_URL, ({ request }) => {
+        observedRequestUrl = request.url;
+        return HttpResponse.json({
+          request_id: "reconciled-kling-request",
+          status_url: KLING_STATUS_URL,
+          response_url: KLING_RESPONSE_URL,
+        });
+      }),
+      http.get(KLING_VIDEO_URL, () => {
+        return new HttpResponse(VIDEO_BYTES, {
+          headers: { "content-type": "video/mp4" },
+        });
+      }),
+    );
+
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId,
+    });
+    const app = createVideoIoTestApp(fixture.pricingResolution);
+    const response = await app.request("/api/zero/video-io/generate", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        prompt: "a fluffy golden retriever puppy",
+        model: "dreamina-seedance-2.0-fast",
+        resolution: "720p",
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    const generationId = readAcceptedGenerationId(
+      await response.json(),
+      "video",
+      fixture.userId,
+    );
+    await postFalWebhook(app, observedRequestUrl, {
+      video: {
+        url: KLING_VIDEO_URL,
+        content_type: "video/mp4",
+      },
+    });
+    await flushWaitUntilForTest();
+
+    const statusResponse = await app.request(
+      `/api/zero/built-in-generations/${generationId}`,
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(statusResponse.status).toBe(200);
+    // The pinned model's own resolution, not the one the caller sized for the
+    // model it named, and reported back so the caller can say what was used.
+    expect(readGenerationResult(await statusResponse.json())).toMatchObject({
+      model: KLING_V3_4K_MODEL,
+      resolution: "4k",
+    });
+  });
+
   it("keeps the request model when video model selection is disabled", async () => {
     const fixture = await seedVideoFixture();
     const { composeId } = await store.set(

--- a/turbo/apps/api/src/signals/routes/video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/video-io-generate.ts
@@ -1,9 +1,13 @@
 import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
-import { zeroVideoIoGenerateContract } from "@okouai/api-contracts/contracts/zero-video-io-generate";
+import {
+  zeroVideoIoGenerateContract,
+  type ZeroVideoIoGenerateRequest,
+} from "@okouai/api-contracts/contracts/zero-video-io-generate";
 import type { BuiltInGenerationRealtimeSubscription } from "@okouai/api-contracts/contracts/built-in-generation";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
+import { VIDEO_MODEL_CONFIGS } from "@okouai/core/video-model-catalog";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   isVideoModelId,
@@ -103,6 +107,52 @@ async function loadEnforcedRunVideoModel(
   const runVideoModel = await loadRunVideoModel(db, runId);
   signal.throwIfAborted();
   return runVideoModel;
+}
+
+/**
+ * Swap in the run's pinned model and drop any caller parameter the pin cannot
+ * honour.
+ *
+ * The caller picks aspect ratio, duration, and resolution to match the model it
+ * asked for. Enforcement replaces that model, so those values can be valid for
+ * the request and invalid for the pin — a caller asking for
+ * `dreamina-seedance-2.0-fast` at 720p against a `MiniMax-H3` pin used to get
+ * `Unsupported video resolution for minimax-h3: 720p`, an error about a model
+ * it never named. Dropping the field lets the pinned model's own default apply
+ * instead of failing a request the caller could not have written correctly.
+ *
+ * The effective values come back on the response, so the caller can report what
+ * was actually used.
+ */
+function withEnforcedRunVideoModel(
+  body: ZeroVideoIoGenerateRequest,
+  runVideoModel: VideoModelId,
+): ZeroVideoIoGenerateRequest {
+  const config = VIDEO_MODEL_CONFIGS[runVideoModel];
+  const honours = <T>(
+    supported: readonly T[],
+    value: string | undefined,
+  ): boolean => {
+    return (
+      value !== undefined &&
+      supported.some((entry) => {
+        return entry === (value as T);
+      })
+    );
+  };
+  return {
+    ...body,
+    model: runVideoModel,
+    ...(honours(config.aspectRatios, body.aspectRatio)
+      ? {}
+      : { aspectRatio: undefined }),
+    ...(honours(config.durations, body.duration)
+      ? {}
+      : { duration: undefined }),
+    ...(honours(config.resolutions, body.resolution)
+      ? {}
+      : { resolution: undefined }),
+  };
 }
 
 interface GenerationError {
@@ -378,7 +428,7 @@ const postVideoInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const options = parseVideoOptions(
     runVideoModel === null
       ? bodyResult.data
-      : { ...bodyResult.data, model: runVideoModel },
+      : withEnforcedRunVideoModel(bodyResult.data, runVideoModel),
   );
   if ("status" in options) {
     return options;


### PR DESCRIPTION
Fixes a live failure found in a real chat: the user picked MiniMax in the picker, asked for a puppy video, and the run failed with

```
Unsupported video resolution for minimax-h3: 720p
```

after the agent ran `okou generate video --model dreamina-seedance-2.0-fast --resolution 720p`. The agent then told the user "the command specified seedance", which is true and useless — nothing in the request named MiniMax.

## Root cause

Enforcement (#27068) replaces the caller's model with the run's pin, but kept every other parameter:

```ts
{ ...bodyResult.data, model: runVideoModel }
```

The caller sizes aspect ratio, duration, and resolution *for the model it asked for*. Swapping the model underneath makes those values valid for the request and invalid for the pin. 720p is legal for `dreamina-seedance-2.0-fast` and illegal for `MiniMax-H3` (768p / 2k), so the request died on a model the caller never sent.

## Fix

`withEnforcedRunVideoModel()` swaps the model and drops any aspect ratio, duration, or resolution the pin cannot honour, so the pinned model's own default applies instead of failing. The effective values already come back on the response, so the caller can report what was actually used.

Gated: `loadEnforcedRunVideoModel` returns null while `VideoModelSelection` is off, so this path never runs with the switch disabled.

## Deliberately not done

**No system-prompt injection.** Every run now resolves to some video model, but almost no run generates video — a prompt section announcing the model would spend attention on all of them to help a few. The response already reports the effective model, which is enough for the agent to describe what happened after the fact, and this fallback means it no longer has to guess correctly beforehand.

**No CLI change here.** The CLI hardcodes its own `--model` default (`dreamina-seedance-2.0-fast`), which is the reason the agent sent seedance even when it passed no model at all. That is a second source of truth worth removing, but the CLI cannot read feature switches, so removing it cannot be gated the way this fix is. It is behavior-preserving only because the two defaults happen to coincide — an argument, not a switch. It belongs in its own PR where that risk is reviewed on its own terms. This fix does not depend on it: the test sends exactly what today's CLI sends.

## Worth a reviewer's opinion

Dropping an unhonourable resolution falls back to `config.defaultResolution`, matching `resolveVideoGenerationOptions()`. For a MiniMax pin that turns a 720p request into **2k, which costs more than the 768p the caller was closer to wanting**. Reusing the established fallback beat inventing a nearest-match rule, but if silent cost increases are unacceptable here, the alternative is rejecting with an error that names the substitution.

## Testing

New case reproducing the production failure: request `dreamina-seedance-2.0-fast` at 720p against a Kling 4k-only pin. Verified it fails without the fix and passes with it.

The pre-existing enforcement test happened to send `resolution: "4k"` against a 4k-only pin, so every parameter was compatible by luck — which is why this shipped.

- `video-io-generate.test.ts`: 29 passed
- `check-types` and `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)