### PR TITLE
refactor(api): remove chat search identity fallbacks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-search-reader.test.ts
@@ -89,14 +89,12 @@ describe("GET /api/okou/chat/search durable reader", () => {
       throw new Error("Expected one durable chat search result");
     }
 
-    expect(result.matchedMessage).toStrictEqual({
-      messageId: `${source.threadId}:${second.prompt.seqId}`,
+    expect(result.matchedMessage).toMatchObject({
       chatThreadId: source.threadId,
       role: "user",
       content: `find ${keyword}`,
       createdAt: expect.any(String),
       seqId: second.prompt.seqId,
-      sequenceNumber: null,
       runId: null,
     });
     expect(
@@ -111,24 +109,21 @@ describe("GET /api/okou/chat/search durable reader", () => {
     ).toStrictEqual(["context assistant after"]);
 
     expect(result.contextBefore[0]).toMatchObject({
-      messageId: `${source.threadId}:${first.prompt.seqId}`,
+      chatThreadId: source.threadId,
       role: "user",
       seqId: first.prompt.seqId,
-      sequenceNumber: null,
       runId: null,
     });
     expect(result.contextBefore[1]).toMatchObject({
-      messageId: `${source.threadId}:${first.assistant.seqId}`,
+      chatThreadId: source.threadId,
       role: "assistant",
       seqId: first.assistant.seqId,
-      sequenceNumber: null,
       runId: first.assistantRunId,
     });
     expect(result.contextAfter[0]).toMatchObject({
-      messageId: `${source.threadId}:${second.assistant.seqId}`,
+      chatThreadId: source.threadId,
       role: "assistant",
       seqId: second.assistant.seqId,
-      sequenceNumber: null,
       runId: second.assistantRunId,
     });
 
@@ -176,7 +171,7 @@ describe("GET /api/okou/chat/search durable reader", () => {
       chatThreadId: primary.threadId,
       agentName: currentAgentName,
       matchedMessage: {
-        messageId: `${primary.threadId}:${prompt.seqId}`,
+        chatThreadId: primary.threadId,
         seqId: prompt.seqId,
       },
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2855,7 +2855,10 @@ describe("CHAT-01 chat search", () => {
       ).toBeTruthy();
       expect(
         [...match.contextBefore, ...match.contextAfter].some((message) => {
-          return message.messageId === match.matchedMessage.messageId;
+          return (
+            message.chatThreadId === match.matchedMessage.chatThreadId &&
+            message.seqId === match.matchedMessage.seqId
+          );
         }),
       ).toBeFalsy();
 
@@ -2898,7 +2901,13 @@ describe("CHAT-01 chat search", () => {
     // remains associated with both overlapping windows.
     expect(sharedAfterAlpha).toHaveLength(1);
     expect(sharedBeforeBeta).toHaveLength(1);
-    expect(sharedAfterAlpha[0]?.messageId).toBe(sharedBeforeBeta[0]?.messageId);
+    expect([
+      sharedAfterAlpha[0]?.chatThreadId,
+      sharedAfterAlpha[0]?.seqId,
+    ]).toStrictEqual([
+      sharedBeforeBeta[0]?.chatThreadId,
+      sharedBeforeBeta[0]?.seqId,
+    ]);
 
     const beforeOnly = await chat.searchChat(owner, `${marker} needle`, {
       limit: 3,

--- a/turbo/apps/api/src/signals/services/chat-search.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-search.service.ts
@@ -59,7 +59,7 @@ const contextSearchMessageColumns = {
   text: contextSearchMessage.text,
 } as const;
 
-function chatSearchMessageId(
+function chatSearchMessageKey(
   row: Pick<ChatSearchMessageRow, "chatThreadId" | "seqId">,
 ): string {
   return `${row.chatThreadId}:${row.seqId}`;
@@ -67,17 +67,11 @@ function chatSearchMessageId(
 
 function toChatSearchMessage(row: ChatSearchMessageRow): ChatSearchMessage {
   return {
-    // Old Platform/App clients can use messageId as a React key for up to the
-    // ~2-day client-skew window. Keep it derived from durable identity until
-    // #26921 migrates current clients to (chatThreadId, seqId), then remove
-    // messageId/sequenceNumber after that client deploy has aged past 2 days.
-    messageId: chatSearchMessageId(row),
     chatThreadId: row.chatThreadId,
     role: row.role,
     content: row.text,
     createdAt: row.createdAt.toISOString(),
     seqId: row.seqId,
-    sequenceNumber: null,
     runId: row.runId,
   };
 }
@@ -205,13 +199,13 @@ async function loadChatSearchContexts(
     readonly after: number;
   },
 ): Promise<ReadonlyMap<string, ChatSearchContext>> {
-  const contextsByMessageId = new Map<string, ChatSearchContext>(
+  const contextsByMessageKey = new Map<string, ChatSearchContext>(
     args.matches.map((match): readonly [string, ChatSearchContext] => {
-      return [chatSearchMessageId(match), { before: [], after: [] }];
+      return [chatSearchMessageKey(match), { before: [], after: [] }];
     }),
   );
   if (args.matches.length === 0 || (args.before === 0 && args.after === 0)) {
-    return contextsByMessageId;
+    return contextsByMessageKey;
   }
 
   const contextQuery =
@@ -263,11 +257,11 @@ async function loadChatSearchContexts(
     .orderBy(resultOrdinality, asc(context.seqId));
 
   for (const row of rows) {
-    const matchedMessageId = chatSearchMessageId({
+    const matchedMessageKey = chatSearchMessageKey({
       chatThreadId: row.matchedChatThreadId,
       seqId: row.matchedSeqId,
     });
-    const matchedContext = contextsByMessageId.get(matchedMessageId);
+    const matchedContext = contextsByMessageKey.get(matchedMessageKey);
     if (!matchedContext) {
       throw new Error(
         "chat search context returned an unknown matched message",
@@ -281,7 +275,7 @@ async function loadChatSearchContexts(
     }
   }
 
-  return contextsByMessageId;
+  return contextsByMessageKey;
 }
 
 export function chatSearch(args: {
@@ -313,14 +307,14 @@ export function chatSearch(args: {
 
     const hasMore = matches.length > args.limit;
     const truncated = hasMore ? matches.slice(0, args.limit) : matches;
-    const contextsByMessageId = await loadChatSearchContexts(db, {
+    const contextsByMessageKey = await loadChatSearchContexts(db, {
       matches: truncated,
       before: args.before,
       after: args.after,
     });
     const results = truncated.map((match): ChatSearchResult => {
-      const messageId = chatSearchMessageId(match);
-      const context = contextsByMessageId.get(messageId);
+      const messageKey = chatSearchMessageKey(match);
+      const context = contextsByMessageKey.get(messageKey);
       if (!context) {
         throw new Error("chat search context is missing a matched message");
       }

--- a/turbo/apps/cli/src/commands/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/search/__tests__/chat-source.test.ts
@@ -15,15 +15,14 @@ function makeMessage(params: {
   content: string;
   role?: "user" | "assistant";
   createdAt?: string;
-  messageId?: string;
+  seqId?: number;
 }) {
   return {
-    messageId: params.messageId ?? "msg-1",
     chatThreadId: "thread-1",
     role: params.role ?? "user",
     content: params.content,
     createdAt: params.createdAt ?? "2024-01-15T10:30:00Z",
-    sequenceNumber: null,
+    seqId: params.seqId ?? 1,
     runId: null,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1981,16 +1981,11 @@ describe("zero sidebar", () => {
             chatThreadId: RESEARCH_THREAD_ID,
             agentName: "Research Agent",
             matchedMessage: {
-              messageId: `a0000000-0000-4000-a000-${String(index + 1).padStart(
-                12,
-                "0",
-              )}`,
               chatThreadId: RESEARCH_THREAD_ID,
               role: "user" as const,
               content: `Production deploy ${index + 1} finished successfully`,
               createdAt: "2026-03-10T00:10:00Z",
               seqId: index + 1,
-              sequenceNumber: null,
               runId: null,
             },
             matchedRanges: [{ start: 11, end: 17 }],

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1446,19 +1446,14 @@ export const chatEventsContract = c.router({
 /**
  * Single chat message in a search result.
  * `(chatThreadId, seqId)` is the stable identity and `runId` carries optional
- * run ownership. `messageId` and `sequenceNumber` bridge old Platform/App
- * clients for the ~2-day client-skew window. #26921 migrates current clients
- * to the stable identity and removes these fields after that deployment has
- * aged past 2 days.
+ * run ownership.
  */
 const chatSearchMessageSchema = z.object({
-  messageId: z.string(),
   chatThreadId: z.string(),
   role: z.enum(["user", "assistant"]),
   content: z.string(),
   createdAt: z.string(),
   seqId: z.number().int().positive(),
-  sequenceNumber: z.number().nullable(),
   runId: z.string().nullable(),
 });
 


### PR DESCRIPTION
## Summary

- remove the expired `messageId` and `sequenceNumber` compatibility fields from chat-search response messages
- stop emitting those fields from `toChatSearchMessage` and keep the internal context-map key derived only from `(chatThreadId, seqId)`
- update only the API, App, and CLI fixtures/assertions that depended on the removed response fields

## Safety gate

- PR #27215 merged as `9c4c233e1280088243affb048eb98aa03c68b520` and migrated the App consumer to `(chatThreadId, seqId)`.
- The previous production App artifact, `app-v0.750.1` at `09689458b061bfd57c24438bd3d2f116e7d75dba`, does not contain that merge commit.
- The first production App artifact that contains it is `app-v0.751.0` at `0ebdd7402e1ebb9e845565717c866296597ef256`. Git ancestry verifies `9c4c233e1280088243affb048eb98aa03c68b520` is an ancestor of that deployed commit.
- GitHub Deployment `5905414950` marked that artifact live at `2026-08-14T11:37:00Z` (`2026-08-14 19:37:00 Asia/Shanghai`). At the gate check on `2026-08-16T12:37:07Z`, it had been live for 49 hours; the 48-hour window closed at `2026-08-16T11:37:00Z`.
- A whole-repository search covered `matchedMessage.messageId`, `ChatSearchMessage`, `chatSearchMessageSchema`, `toChatSearchMessage`, `messageId`, `sequenceNumber`, chat-search fixtures, mocks, and tests. No production client reads either compatibility field: the App reads `(chatThreadId, seqId)`, and the CLI reads role/content/timestamp fields. The remaining similarly named fields belong to chat events, workflow queues, or client event IDs and are unrelated to the chat-search response contract.

## Removed symbols

- `chatSearchMessageSchema.messageId`
- `chatSearchMessageSchema.sequenceNumber`
- `toChatSearchMessage` compatibility emissions and rollout comment
- stale response fixture/assertion fields in API, App, and CLI tests
- the misleading internal `chatSearchMessageId` name, now `chatSearchMessageKey` while preserving the same durable composite key

## Verification

- focused Prettier over all six changed files
- package lint: `@okouai/api-contracts`, `api`, `@okouai/app`, and `@okouai/cli`
- `pnpm knip`
- package type checks: `@okouai/api-contracts`, `api`, `@okouai/app`, and `@okouai/cli`
- Lefthook pre-commit: Prettier, Knip, all 14 repository TypeScript tasks, file-size checks, and commitlint
- runtime API schema generation
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-search-reader.test.ts` (2 passed)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'associates batched context windows across matches and threads'` (1 passed, 34 skipped)
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t 'unifies local thread titles with indexed message matches'` (1 passed, 55 skipped)
- `pnpm --filter @okouai/cli exec vitest run src/commands/search/__tests__/chat-source.test.ts` (14 passed)

An initial whole-file diagnostic run of `chat-threads.bdd.test.ts` completed with 18 passing and 17 failing tests: 14 failures were unrelated runner-queue claims returning `404 Job not found`, and three were result-count assertions outside the changed test against the shared local database. The changed context-window test passes independently as listed above; the PR pipeline remains the source of truth for the full file.

This finishes the response-identity compatibility cleanup enabled by #27215.

Closes #26921
