### PR TITLE
refactor(compose): add aggregate-only consolidation preflight

### DIFF
--- a/.github/workflows/agent-compose-consolidation-preflight.yml
+++ b/.github/workflows/agent-compose-consolidation-preflight.yml
@@ -1,0 +1,64 @@
+name: Agent Compose Consolidation Preflight
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-agent-compose-consolidation-preflight
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
+    environment: production
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # transition-validator: #27613; removal-owner: #26938 Stage 8
+      # The workflow definition and implementation always come from main.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
+      - name: Initialize toolchain
+        uses: ./.github/actions/toolchain-init
+
+      - name: Install neonctl
+        run: npm install -g neonctl@2.15.0
+
+      - name: Resolve production database
+        id: database
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if ! database_url=$(
+            neonctl connection-string production \
+              --project-id "$NEON_PROJECT_ID" \
+              --database-name neondb \
+              --role-name neondb_owner \
+              --pooled \
+              2>/dev/null
+          ); then
+            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v1","status":"failed","failureGates":["probe.database_resolution"]}'
+            exit 1
+          fi
+          echo "::add-mask::$database_url"
+          echo "database-url=$database_url" >> "$GITHUB_OUTPUT"
+
+      - name: Run aggregate-only preflight
+        env:
+          DATABASE_URL: ${{ steps.database.outputs.database-url }}
+        working-directory: turbo
+        run: |
+          set -euo pipefail
+          pnpm --filter @okouai/db exec tsx \
+            scripts/agent-compose-consolidation-preflight.ts

--- a/.github/workflows/agent-compose-consolidation-preflight.yml
+++ b/.github/workflows/agent-compose-consolidation-preflight.yml
@@ -51,6 +51,14 @@ jobs:
             echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v1","status":"failed","failureGates":["probe.database_resolution"]}'
             exit 1
           fi
+          if [[ -z "$database_url" ||
+                "$database_url" == *$'\n'* ||
+                "$database_url" == *$'\r'* ||
+                ( "$database_url" != postgres://* &&
+                  "$database_url" != postgresql://* ) ]]; then
+            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v1","status":"failed","failureGates":["probe.database_resolution"]}'
+            exit 1
+          fi
           echo "::add-mask::$database_url"
           echo "database-url=$database_url" >> "$GITHUB_OUTPUT"
 

--- a/turbo/apps/api/src/signals/services/agent-compose-content.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose-content.ts
@@ -1,0 +1,52 @@
+import { createHash } from "node:crypto";
+import { getInstructionsFilename } from "@okouai/core/frameworks";
+
+/**
+ * Canonical application-owned content for a Zero Agent compose.
+ *
+ * This shape is content-addressed in production. Keep the builder and its
+ * canonical hash together so transition validators cannot drift from the
+ * runtime writer.
+ */
+export function buildZeroAgentComposeContent(
+  agentName: string,
+): Record<string, unknown> {
+  const environment: Record<string, string> = {
+    OKOU_AGENT_ID: `\${{ vars.OKOU_AGENT_ID }}`,
+    OKOU_TOKEN: `\${{ secrets.OKOU_TOKEN }}`,
+  };
+
+  const agentDef: Record<string, unknown> = {
+    framework: "claude-code",
+    instructions: getInstructionsFilename("claude-code"),
+    environment,
+  };
+
+  return {
+    version: "1",
+    agents: { [agentName]: agentDef },
+  };
+}
+
+function sortObjectKeys(obj: unknown): unknown {
+  if (obj === null || typeof obj !== "object") {
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys);
+  }
+  const sorted: Record<string, unknown> = {};
+  const keys = Object.keys(obj as Record<string, unknown>).sort();
+  for (const key of keys) {
+    sorted[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
+/** SHA-256 of the runtime canonical-JSON representation of compose content. */
+export function computeComposeVersionId(
+  content: Record<string, unknown>,
+): string {
+  const canonical = JSON.stringify(sortObjectKeys(content));
+  return createHash("sha256").update(canonical).digest("hex");
+}

--- a/turbo/apps/api/src/signals/services/agent-compose.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose.service.ts
@@ -1,5 +1,4 @@
 import { command } from "ccstate";
-import { createHash } from "node:crypto";
 import {
   getInstructionsFilename,
   SUPPORTED_FRAMEWORKS,
@@ -13,34 +12,11 @@ import { eq } from "drizzle-orm";
 
 import { writeDb$ } from "../external/db";
 import { nowDate } from "../../lib/time";
+import {
+  buildZeroAgentComposeContent,
+  computeComposeVersionId,
+} from "./agent-compose-content";
 import { uploadVolumeServerSide$ } from "./storage-volume-upload.service";
-
-/**
- * Build canonical compose content for a zero agent. Pure function — same
- * inputs always yield the same output. The API owns this zero-agent compose
- * shape now; keep it stable because existing compose version hashes depend on
- * the canonical content. Connector environment is injected later from the
- * authorized run context.
- */
-function buildZeroAgentComposeContent(
-  agentName: string,
-): Record<string, unknown> {
-  const environment: Record<string, string> = {
-    OKOU_AGENT_ID: `\${{ vars.OKOU_AGENT_ID }}`,
-    OKOU_TOKEN: `\${{ secrets.OKOU_TOKEN }}`,
-  };
-
-  const agentDef: Record<string, unknown> = {
-    framework: "claude-code",
-    instructions: getInstructionsFilename("claude-code"),
-    environment,
-  };
-
-  return {
-    version: "1",
-    agents: { [agentName]: agentDef },
-  };
-}
 
 function instructionFilesForFramework(args: {
   readonly content: string;
@@ -58,31 +34,6 @@ function instructionFilesForFramework(args: {
   return filenames.map((path) => {
     return { path, content: args.content };
   });
-}
-
-function sortObjectKeys(obj: unknown): unknown {
-  if (obj === null || typeof obj !== "object") {
-    return obj;
-  }
-  if (Array.isArray(obj)) {
-    return obj.map(sortObjectKeys);
-  }
-  const sorted: Record<string, unknown> = {};
-  const keys = Object.keys(obj as Record<string, unknown>).sort();
-  for (const key of keys) {
-    sorted[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
-  }
-  return sorted;
-}
-
-/**
- * SHA-256 of the canonical-JSON form of `content`. This matches the compose
- * create service so API-authored compose versions use the same content
- * addressing.
- */
-function computeComposeVersionId(content: Record<string, unknown>): string {
-  const canonical = JSON.stringify(sortObjectKeys(content));
-  return createHash("sha256").update(canonical).digest("hex");
 }
 
 type RecomposeAgentIfStaleResult =

--- a/turbo/packages/db/MIGRATIONS.md
+++ b/turbo/packages/db/MIGRATIONS.md
@@ -30,6 +30,17 @@ to the last migration in the most recent production release. When that removes a
 referenced migration tag from the journal, the consistency suite fails and the
 expired transition validator must be deleted.
 
+### Active transition validators
+
+The repository inventory below is machine-checked. The removal owner must
+delete the workflow, probe, focused validator, and this entry together.
+
+| Issue  | Validator                                        | Removal owner  |
+| ------ | ------------------------------------------------ | -------------- |
+| #27613 | Agent/Compose consolidation production preflight | #26938 Stage 8 |
+
+<!-- vm0-transition-validator:#27613|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8 -->
+
 ## Migration patterns
 
 [`0811_clear_non_goal_run_groups.sql`](./src/migrations/0811_clear_non_goal_run_groups.sql)

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-fingerprint.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-fingerprint.ts
@@ -1,0 +1,39 @@
+import { createHash } from "node:crypto";
+
+export const PREFLIGHT_SCHEMA_VERSION =
+  "vm0.agent-compose-consolidation-preflight.v1";
+
+const FINGERPRINT_DOMAIN = "vm0:agent-compose-consolidation-preflight:v1";
+
+export interface SetFingerprint {
+  readonly count: number;
+  readonly digest: string;
+}
+
+/**
+ * Fingerprint a sorted opaque-member set with domain separation and
+ * byte-length framing. Empty sets use the SHA-256 of the framed empty domain,
+ * so every output field always has a deterministic 64-character digest.
+ */
+export function fingerprintSortedSet(
+  domain: string,
+  members: readonly string[],
+): SetFingerprint {
+  const uniqueMembers = [...new Set(members)].sort();
+  const hash = createHash("sha256");
+  hash.update(FINGERPRINT_DOMAIN);
+  hash.update("\0");
+  hash.update(domain);
+  hash.update("\0");
+  for (const member of uniqueMembers) {
+    hash.update(Buffer.byteLength(member, "utf8").toString());
+    hash.update(":");
+    hash.update(member);
+    hash.update("\0");
+  }
+  return { count: uniqueMembers.length, digest: hash.digest("hex") };
+}
+
+export function fingerprintMember(domain: string, member: string): string {
+  return fingerprintSortedSet(domain, [member]).digest;
+}

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
@@ -4,12 +4,15 @@ import path from "node:path";
 import ts from "typescript";
 
 export const CATALOG_DEPENDENCY_KINDS = [
-  "foreignKeys",
-  "reviewedNonFk",
+  "constraints",
   "defaults",
-  "indexes",
-  "triggers",
+  "foreignKeys",
   "functions",
+  "indexes",
+  "otherDependents",
+  "reviewedNonFk",
+  "rewriteDependents",
+  "triggers",
 ] as const;
 
 export type CatalogDependencyKind = (typeof CATALOG_DEPENDENCY_KINDS)[number];
@@ -50,6 +53,31 @@ export const EXPECTED_CATALOG_DEPENDENCIES = {
     "public.zero_agent_drafts|zero_agent_drafts_agent_id_zero_agents_id_fk|FOREIGN KEY (agent_id) REFERENCES zero_agents(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
     "public.zero_agents|zero_agents_id_agent_composes_id_fk|FOREIGN KEY (id) REFERENCES agent_composes(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
     "public.zero_workflows|zero_workflows_agent_id_zero_agents_id_fk|FOREIGN KEY (agent_id) REFERENCES zero_agents(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+  ],
+  constraints: [
+    "public.agent_compose_versions|agent_compose_versions_compose_id_agent_composes_id_fk|type=f|FOREIGN KEY (compose_id) REFERENCES agent_composes(id) ON DELETE SET NULL|validated=true|deferrable=false|initially_deferred=false",
+    "public.agent_compose_versions|agent_compose_versions_pkey|type=p|PRIMARY KEY (id)|validated=true|deferrable=false|initially_deferred=false",
+    "public.agent_compose_versions|content|type=n|NOT NULL",
+    "public.agent_compose_versions|created_at|type=n|NOT NULL",
+    "public.agent_compose_versions|id|type=n|NOT NULL",
+    "public.agent_composes|agent_composes_pkey|type=p|PRIMARY KEY (id)|validated=true|deferrable=false|initially_deferred=false",
+    "public.agent_composes|created_at|type=n|NOT NULL",
+    "public.agent_composes|id|type=n|NOT NULL",
+    "public.agent_composes|name|type=n|NOT NULL",
+    "public.agent_composes|org_id|type=n|NOT NULL",
+    "public.agent_composes|updated_at|type=n|NOT NULL",
+    "public.agent_composes|user_id|type=n|NOT NULL",
+    "public.zero_agents|created_at|type=n|NOT NULL",
+    "public.zero_agents|id|type=n|NOT NULL",
+    "public.zero_agents|name|type=n|NOT NULL",
+    "public.zero_agents|org_id|type=n|NOT NULL",
+    "public.zero_agents|owner|type=n|NOT NULL",
+    "public.zero_agents|prefer_personal_provider|type=n|NOT NULL",
+    "public.zero_agents|updated_at|type=n|NOT NULL",
+    "public.zero_agents|visibility|type=n|NOT NULL",
+    "public.zero_agents|zero_agents_id_agent_composes_id_fk|type=f|FOREIGN KEY (id) REFERENCES agent_composes(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.zero_agents|zero_agents_model_provider_id_model_providers_id_fk|type=f|FOREIGN KEY (model_provider_id) REFERENCES model_providers(id) ON DELETE SET NULL|validated=true|deferrable=false|initially_deferred=false",
+    "public.zero_agents|zero_agents_pkey|type=p|PRIMARY KEY (id)|validated=true|deferrable=false|initially_deferred=false",
   ],
   reviewedNonFk: [
     "public.agent_composes|head_version_id|character varying(64)|nullable=true",
@@ -118,6 +146,8 @@ export const EXPECTED_CATALOG_DEPENDENCIES = {
     "public.set_agent_compose_delete_lock_timeout_transition()|kind=f|result=trigger|language=plpgsql|volatility=v|security_definer=false|body_md5=b3f0552e3f7bbb14443665ea8e312427",
     "public.veto_agent_compose_version_delete_transition()|kind=f|result=trigger|language=plpgsql|volatility=v|security_definer=false|body_md5=186bcd97e887d8c241cfba4c810a47d5",
   ],
+  otherDependents: [],
+  rewriteDependents: [],
 } as const satisfies Record<CatalogDependencyKind, readonly string[]>;
 
 export const EXPECTED_REPOSITORY_DEPENDENCIES = {
@@ -372,17 +402,41 @@ export const EXPECTED_REPOSITORY_DEPENDENCIES = {
 } as const satisfies RepositoryDependencyManifest;
 
 /**
- * Catalog discovery is structural: foreign-key keys/actions/validation,
- * reviewed non-target-FK fields, defaults, relevant indexes, trigger
- * definitions, and trigger-function bodies all contribute to the manifest.
+ * Catalog discovery is structural: constraints, foreign-key
+ * keys/actions/validation, reviewed non-target-FK fields, defaults, relevant
+ * indexes, rewrite-backed views/materialized views/rules, trigger definitions,
+ * and trigger-function bodies all contribute to the manifest. A generic
+ * pg_depend inventory catches every other non-internal dependent object.
+ * Internal dependencies and owned row types/storage cannot independently
+ * survive or block contraction, while their owners are inventoried here.
  */
 export const CATALOG_DEPENDENCY_QUERY = `
-WITH target_relations AS (
+WITH RECURSIVE target_relations AS (
   SELECT unnest(ARRAY[
     'public.agent_composes'::regclass,
     'public.zero_agents'::regclass,
     'public.agent_compose_versions'::regclass
   ]) AS oid
+),
+relation_dependency_closure AS (
+  SELECT "oid" FROM target_relations
+  UNION
+  SELECT "rewrite"."ev_class"
+  FROM relation_dependency_closure AS "referenced"
+  INNER JOIN "pg_depend" AS "dependency"
+    ON "dependency"."refclassid" = 'pg_class'::regclass
+    AND "dependency"."refobjid" = "referenced"."oid"
+    AND "dependency"."classid" = 'pg_rewrite'::regclass
+    AND "dependency"."deptype" = 'n'
+  INNER JOIN "pg_rewrite" AS "rewrite"
+    ON "rewrite"."oid" = "dependency"."objid"
+),
+relation_dependency_types AS (
+  SELECT "relation"."reltype" AS "oid"
+  FROM "pg_class" AS "relation"
+  WHERE "relation"."oid" IN (
+    SELECT "oid" FROM relation_dependency_closure
+  )
 ),
 target_fk_columns AS (
   SELECT "conrelid", unnest("conkey") AS "attnum"
@@ -457,6 +511,47 @@ dependency_columns AS (
   UNION
   SELECT "relid", "attnum" FROM reviewed_non_fk
 ),
+constraints AS (
+  SELECT DISTINCT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+    "constraint"."conname" ||
+    '|type=' || "constraint"."contype"::text || '|' ||
+    pg_get_constraintdef("constraint"."oid", false) ||
+    '|validated=' || "constraint"."convalidated"::text ||
+    '|deferrable=' || "constraint"."condeferrable"::text ||
+    '|initially_deferred=' || "constraint"."condeferred"::text AS "entry"
+  FROM "pg_constraint" AS "constraint"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "constraint"."conrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  WHERE "constraint"."contype" <> 'n'
+    AND (
+      "constraint"."conrelid" IN (SELECT "oid" FROM target_relations)
+      OR (
+        "constraint"."contype" <> 'f'
+        AND EXISTS (
+          SELECT 1
+          FROM dependency_columns AS "column"
+          WHERE "column"."relid" = "constraint"."conrelid"
+            AND "column"."attnum" = ANY("constraint"."conkey")
+        )
+      )
+    )
+  UNION
+  SELECT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+    "attribute"."attname" || '|type=n|NOT NULL' AS "entry"
+  FROM "pg_attribute" AS "attribute"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "attribute"."attrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  WHERE "attribute"."attrelid" IN (SELECT "oid" FROM target_relations)
+    AND "attribute"."attnum" > 0
+    AND NOT "attribute"."attisdropped"
+    AND "attribute"."attnotnull"
+),
 indexes AS (
   SELECT DISTINCT
     "namespace"."nspname" || '.' || "table"."relname" || '|' ||
@@ -528,13 +623,90 @@ functions AS (
       AND lower("function"."prosrc") ~
         '(agent_composes|agent_compose_versions|zero_agents)'
     )
+),
+rewrite_dependents AS (
+  SELECT DISTINCT
+    "namespace"."nspname" || '.' || "relation"."relname" ||
+    '|relation_kind=' ||
+    CASE "relation"."relkind"
+      WHEN 'v' THEN 'view'
+      WHEN 'm' THEN 'materialized_view'
+      ELSE 'relation'
+    END ||
+    '|rule=' || "rewrite"."rulename" ||
+    '|event=' || "rewrite"."ev_type"::text ||
+    '|instead=' || "rewrite"."is_instead"::text ||
+    '|definition_md5=' || md5(pg_get_ruledef("rewrite"."oid", false)) AS "entry"
+  FROM "pg_rewrite" AS "rewrite"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "rewrite"."ev_class"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  WHERE "rewrite"."ev_class" IN (SELECT "oid" FROM target_relations)
+    OR EXISTS (
+      SELECT 1
+      FROM "pg_depend" AS "dependency"
+      INNER JOIN relation_dependency_closure AS "referenced"
+        ON "referenced"."oid" = "dependency"."refobjid"
+      WHERE "dependency"."classid" = 'pg_rewrite'::regclass
+        AND "dependency"."objid" = "rewrite"."oid"
+        AND "dependency"."refclassid" = 'pg_class'::regclass
+        AND "dependency"."deptype" = 'n'
+    )
+),
+other_dependents AS (
+  SELECT DISTINCT
+    "dependency"."classid"::regclass::text ||
+    '|dependency_type=' || "dependency"."deptype"::text ||
+    '|object=' || pg_describe_object(
+      "dependency"."classid",
+      "dependency"."objid",
+      "dependency"."objsubid"
+    ) ||
+    '|referenced=' || pg_describe_object(
+      "dependency"."refclassid",
+      "dependency"."refobjid",
+      "dependency"."refobjsubid"
+    ) AS "entry"
+  FROM "pg_depend" AS "dependency"
+  LEFT JOIN "pg_class" AS "dependent_relation"
+    ON "dependency"."classid" = 'pg_class'::regclass
+    AND "dependent_relation"."oid" = "dependency"."objid"
+  WHERE (
+      (
+        "dependency"."refclassid" = 'pg_class'::regclass
+        AND "dependency"."refobjid" IN (
+          SELECT "oid" FROM relation_dependency_closure
+        )
+      )
+      OR (
+        "dependency"."refclassid" = 'pg_type'::regclass
+        AND "dependency"."refobjid" IN (
+          SELECT "oid" FROM relation_dependency_types
+        )
+      )
+    )
+    AND "dependency"."deptype" <> 'i'
+    AND "dependency"."classid" NOT IN (
+      'pg_attrdef'::regclass,
+      'pg_constraint'::regclass,
+      'pg_rewrite'::regclass,
+      'pg_trigger'::regclass
+    )
+    AND NOT (
+      "dependency"."classid" = 'pg_class'::regclass
+      AND "dependent_relation"."relkind" IN ('i', 'I')
+    )
 )
-SELECT 'foreignKeys' AS "kind", "entry" FROM foreign_keys
-UNION ALL SELECT 'reviewedNonFk', "entry" FROM reviewed_non_fk
+SELECT 'constraints' AS "kind", "entry" FROM constraints
 UNION ALL SELECT 'defaults', "entry" FROM defaults
-UNION ALL SELECT 'indexes', "entry" FROM indexes
-UNION ALL SELECT 'triggers', "entry" FROM triggers
+UNION ALL SELECT 'foreignKeys', "entry" FROM foreign_keys
 UNION ALL SELECT 'functions', "entry" FROM functions
+UNION ALL SELECT 'indexes', "entry" FROM indexes
+UNION ALL SELECT 'otherDependents', "entry" FROM other_dependents
+UNION ALL SELECT 'reviewedNonFk', "entry" FROM reviewed_non_fk
+UNION ALL SELECT 'rewriteDependents', "entry" FROM rewrite_dependents
+UNION ALL SELECT 'triggers', "entry" FROM triggers
 ORDER BY "kind", "entry"
 `;
 
@@ -566,7 +738,24 @@ const rawTableTokens = [
   "zero_agents",
 ] as const;
 
-const nonTypeScriptExtensions = new Set([".js", ".mjs", ".rs", ".sql"]);
+const nonTypeScriptExtensions = new Set([
+  ".bash",
+  ".cjs",
+  ".cfg",
+  ".env",
+  ".js",
+  ".json",
+  ".mjs",
+  ".py",
+  ".rs",
+  ".sh",
+  ".sql",
+  ".toml",
+  ".tpl",
+  ".yaml",
+  ".yml",
+]);
+const nonTypeScriptFileNames = new Set(["Dockerfile", "Makefile"]);
 
 function normalizePath(filePath: string): string {
   return filePath.split(path.sep).join("/");
@@ -579,6 +768,7 @@ function isExcluded(relativePath: string): boolean {
     relativePath.includes("/.typecheck/") ||
     relativePath.includes("/__tests__/") ||
     relativePath.includes("/__benches__/") ||
+    relativePath.includes("/tests/") ||
     relativePath.includes("/test-fixtures/") ||
     relativePath.includes("/mocks/") ||
     relativePath.includes("/packages/db/scripts/") ||
@@ -715,7 +905,17 @@ export async function collectRepositoryDependencyManifest(
   const rawTableLiterals = new Set<string>();
   const nonTypeScriptConsumers = new Set<string>();
   const transitionValidators = new Set<string>();
-  const scanRoots = ["turbo/apps", "turbo/packages", "crates"];
+  const scanRoots = [
+    ".github",
+    "ansible",
+    "bin",
+    "crates",
+    "docker",
+    "scripts",
+    "turbo/apps",
+    "turbo/packages",
+    "turbo/scripts",
+  ];
 
   for (const scanRoot of scanRoots) {
     const files = await listFiles(path.join(repositoryRoot, scanRoot));
@@ -726,7 +926,13 @@ export async function collectRepositoryDependencyManifest(
       if (isExcluded(`/${relativePath}`)) continue;
       const extension = path.extname(relativePath);
       if (!relativePath.endsWith(".ts") && !relativePath.endsWith(".tsx")) {
-        if (!nonTypeScriptExtensions.has(extension)) continue;
+        if (
+          !nonTypeScriptExtensions.has(extension) &&
+          !nonTypeScriptFileNames.has(path.basename(relativePath)) &&
+          !relativePath.startsWith("bin/")
+        ) {
+          continue;
+        }
         const sourceText = await fs.readFile(filePath, "utf8");
         const tokens = [
           ...legacyIdentifierTokens,

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
@@ -1,0 +1,790 @@
+import fs from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+export const CATALOG_DEPENDENCY_KINDS = [
+  "foreignKeys",
+  "reviewedNonFk",
+  "defaults",
+  "indexes",
+  "triggers",
+  "functions",
+] as const;
+
+export type CatalogDependencyKind = (typeof CATALOG_DEPENDENCY_KINDS)[number];
+
+export interface CatalogDependencyRow {
+  readonly kind: CatalogDependencyKind;
+  readonly entry: string;
+}
+
+export interface RepositoryDependencyManifest {
+  readonly schemaImports: readonly string[];
+  readonly legacyIdentifiers: readonly string[];
+  readonly rawTableLiterals: readonly string[];
+  readonly nonTypeScriptConsumers: readonly string[];
+  readonly transitionValidators: readonly string[];
+}
+
+export const EXPECTED_CATALOG_DEPENDENCIES = {
+  foreignKeys: [
+    "public.agent_compose_versions|agent_compose_versions_compose_id_agent_composes_id_fk|FOREIGN KEY (compose_id) REFERENCES agent_composes(id) ON DELETE SET NULL|validated=true|deferrable=false|initially_deferred=false",
+    "public.agent_runs|agent_runs_agent_compose_version_id_agent_compose_versions_id_f|FOREIGN KEY (agent_compose_version_id) REFERENCES agent_compose_versions(id) ON DELETE SET NULL|validated=true|deferrable=false|initially_deferred=false",
+    "public.agent_sessions|agent_sessions_agent_compose_id_agent_composes_id_fk|FOREIGN KEY (agent_compose_id) REFERENCES agent_composes(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.agentphone_user_agent_preferences|agentphone_user_agent_preferences_selected_compose_id_agent_com|FOREIGN KEY (selected_compose_id) REFERENCES agent_composes(id) ON DELETE SET NULL|validated=true|deferrable=false|initially_deferred=false",
+    "public.banking_agent_enablements|banking_agent_enablements_agent_id_zero_agents_id_fk|FOREIGN KEY (agent_id) REFERENCES zero_agents(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.chat_threads|chat_threads_agent_compose_id_agent_composes_id_fk|FOREIGN KEY (agent_compose_id) REFERENCES agent_composes(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.feishu_org_installations|feishu_org_installations_default_compose_id_agent_composes_id_f|FOREIGN KEY (default_compose_id) REFERENCES agent_composes(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.feishu_user_agent_preferences|feishu_user_agent_preferences_selected_compose_id_agent_compose|FOREIGN KEY (selected_compose_id) REFERENCES agent_composes(id) ON DELETE SET NULL|validated=true|deferrable=false|initially_deferred=false",
+    "public.github_installations|github_installations_default_compose_id_agent_composes_id_fk|FOREIGN KEY (default_compose_id) REFERENCES agent_composes(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.org_metadata|org_metadata_default_agent_id_agent_composes_id_fk|FOREIGN KEY (default_agent_id) REFERENCES agent_composes(id) ON DELETE SET NULL|validated=true|deferrable=false|initially_deferred=false",
+    "public.slack_user_agent_preferences|slack_user_agent_preferences_selected_compose_id_agent_composes|FOREIGN KEY (selected_compose_id) REFERENCES agent_composes(id) ON DELETE SET NULL|validated=true|deferrable=false|initially_deferred=false",
+    "public.teams_user_agent_preferences|teams_user_agent_preferences_selected_compose_id_agent_composes|FOREIGN KEY (selected_compose_id) REFERENCES agent_composes(id) ON DELETE SET NULL|validated=true|deferrable=false|initially_deferred=false",
+    "public.telegram_installations|telegram_installations_default_compose_id_agent_composes_id_fk|FOREIGN KEY (default_compose_id) REFERENCES agent_composes(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.telegram_user_agent_preferences|telegram_user_agent_preferences_selected_compose_id_agent_compo|FOREIGN KEY (selected_compose_id) REFERENCES agent_composes(id) ON DELETE SET NULL|validated=true|deferrable=false|initially_deferred=false",
+    "public.thread_goals|thread_goals_agent_id_zero_agents_id_fk|FOREIGN KEY (agent_id) REFERENCES zero_agents(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.user_connectors|user_connectors_agent_id_zero_agents_id_fk|FOREIGN KEY (agent_id) REFERENCES zero_agents(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.user_custom_connectors|user_custom_connectors_agent_id_zero_agents_id_fk|FOREIGN KEY (agent_id) REFERENCES zero_agents(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.user_permission_grants|user_permission_grants_agent_id_zero_agents_id_fk|FOREIGN KEY (agent_id) REFERENCES zero_agents(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.zero_agent_drafts|zero_agent_drafts_agent_id_zero_agents_id_fk|FOREIGN KEY (agent_id) REFERENCES zero_agents(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.zero_agents|zero_agents_id_agent_composes_id_fk|FOREIGN KEY (id) REFERENCES agent_composes(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+    "public.zero_workflows|zero_workflows_agent_id_zero_agents_id_fk|FOREIGN KEY (agent_id) REFERENCES zero_agents(id) ON DELETE CASCADE|validated=true|deferrable=false|initially_deferred=false",
+  ],
+  reviewedNonFk: [
+    "public.agent_composes|head_version_id|character varying(64)|nullable=true",
+    "public.agentphone_messages|agentphone_agent_id|character varying(255)|nullable=false",
+    "public.banking_access_audit_events|agent_id|uuid|nullable=true",
+    "public.chat_agent_run_context|source_agent_id|uuid|nullable=false",
+    "public.chat_agentphone_context|agentphone_agent_id|text|nullable=true",
+    "public.chat_event_search_messages|agent_compose_id|uuid|nullable=false",
+    "public.chat_thread_events|agent_compose_id|uuid|nullable=false",
+    "public.checkpoints|agent_compose_snapshot|jsonb|nullable=false",
+    "public.connector_external_code_sessions|agent_id|uuid|nullable=true",
+    "public.connector_oauth_device_authorization_sessions|agent_id|uuid|nullable=true",
+    "public.connector_oauth_states|agent_id|uuid|nullable=true",
+    "public.storages|head_version_id|character varying(64)|nullable=true",
+  ],
+  defaults: [
+    "public.agent_compose_versions|created_at|now()",
+    "public.agent_composes|created_at|now()",
+    "public.agent_composes|id|gen_random_uuid()",
+    "public.agent_composes|name|''::character varying",
+    "public.agent_composes|updated_at|now()",
+    "public.zero_agents|created_at|now()",
+    "public.zero_agents|prefer_personal_provider|false",
+    "public.zero_agents|updated_at|now()",
+    "public.zero_agents|visibility|'public'::character varying",
+  ],
+  indexes: [
+    "public.agent_compose_versions|agent_compose_versions_pkey|CREATE UNIQUE INDEX agent_compose_versions_pkey ON public.agent_compose_versions USING btree (id)|valid=true|ready=true",
+    "public.agent_compose_versions|idx_agent_compose_versions_compose_id|CREATE INDEX idx_agent_compose_versions_compose_id ON public.agent_compose_versions USING btree (compose_id)|valid=true|ready=true",
+    "public.agent_composes|agent_composes_pkey|CREATE UNIQUE INDEX agent_composes_pkey ON public.agent_composes USING btree (id)|valid=true|ready=true",
+    "public.agent_composes|idx_agent_composes_org_name|CREATE UNIQUE INDEX idx_agent_composes_org_name ON public.agent_composes USING btree (org_id, name)|valid=true|ready=true",
+    "public.agent_composes|idx_agent_composes_org|CREATE INDEX idx_agent_composes_org ON public.agent_composes USING btree (org_id)|valid=true|ready=true",
+    "public.agent_sessions|idx_agent_sessions_user_compose|CREATE INDEX idx_agent_sessions_user_compose ON public.agent_sessions USING btree (user_id, agent_compose_id)|valid=true|ready=true",
+    "public.banking_agent_enablements|idx_banking_agent_enablements_agent_user|CREATE INDEX idx_banking_agent_enablements_agent_user ON public.banking_agent_enablements USING btree (agent_id, user_id)|valid=true|ready=true",
+    "public.banking_agent_enablements|idx_banking_agent_enablements_unique|CREATE UNIQUE INDEX idx_banking_agent_enablements_unique ON public.banking_agent_enablements USING btree (org_id, user_id, agent_id, connection_id)|valid=true|ready=true",
+    "public.chat_event_search_messages|chat_event_search_messages_user_org_agent_created_idx|CREATE INDEX chat_event_search_messages_user_org_agent_created_idx ON public.chat_event_search_messages USING btree (user_id, org_id, agent_compose_id, created_at DESC NULLS LAST)|valid=true|ready=true",
+    "public.chat_threads|idx_chat_threads_user_compose_last_message|CREATE INDEX idx_chat_threads_user_compose_last_message ON public.chat_threads USING btree (user_id, agent_compose_id, last_message_at DESC NULLS LAST)|valid=true|ready=true",
+    "public.chat_threads|idx_chat_threads_user_compose_pinned|CREATE INDEX idx_chat_threads_user_compose_pinned ON public.chat_threads USING btree (user_id, agent_compose_id) WHERE (pinned_at IS NOT NULL)|valid=true|ready=true",
+    "public.chat_threads|idx_chat_threads_user_compose_updated|CREATE INDEX idx_chat_threads_user_compose_updated ON public.chat_threads USING btree (user_id, agent_compose_id, updated_at DESC NULLS LAST)|valid=true|ready=true",
+    "public.user_connectors|idx_user_connectors_agent_user|CREATE INDEX idx_user_connectors_agent_user ON public.user_connectors USING btree (agent_id, user_id)|valid=true|ready=true",
+    "public.user_connectors|idx_user_connectors_unique_slug|CREATE UNIQUE INDEX idx_user_connectors_unique_slug ON public.user_connectors USING btree (org_id, user_id, agent_id, connector_slug)|valid=true|ready=true",
+    "public.user_custom_connectors|idx_user_custom_connectors_agent_user|CREATE INDEX idx_user_custom_connectors_agent_user ON public.user_custom_connectors USING btree (agent_id, user_id)|valid=true|ready=true",
+    "public.user_custom_connectors|idx_user_custom_connectors_unique|CREATE UNIQUE INDEX idx_user_custom_connectors_unique ON public.user_custom_connectors USING btree (org_id, user_id, agent_id, custom_connector_id)|valid=true|ready=true",
+    "public.user_permission_grants|idx_user_permission_grants_agent_id|CREATE INDEX idx_user_permission_grants_agent_id ON public.user_permission_grants USING btree (agent_id)|valid=true|ready=true",
+    "public.user_permission_grants|idx_user_permission_grants_lookup|CREATE INDEX idx_user_permission_grants_lookup ON public.user_permission_grants USING btree (org_id, user_id, agent_id)|valid=true|ready=true",
+    "public.user_permission_grants|uq_user_permission_grants_slug_permission|CREATE UNIQUE INDEX uq_user_permission_grants_slug_permission ON public.user_permission_grants USING btree (org_id, user_id, agent_id, connector_slug, permission)|valid=true|ready=true",
+    "public.zero_agent_drafts|idx_zero_agent_drafts_user_org_agent|CREATE UNIQUE INDEX idx_zero_agent_drafts_user_org_agent ON public.zero_agent_drafts USING btree (user_id, org_id, agent_id)|valid=true|ready=true",
+    "public.zero_agents|idx_zero_agents_org_name|CREATE UNIQUE INDEX idx_zero_agents_org_name ON public.zero_agents USING btree (org_id, name)|valid=true|ready=true",
+    "public.zero_agents|idx_zero_agents_org|CREATE INDEX idx_zero_agents_org ON public.zero_agents USING btree (org_id)|valid=true|ready=true",
+    "public.zero_agents|zero_agents_pkey|CREATE UNIQUE INDEX zero_agents_pkey ON public.zero_agents USING btree (id)|valid=true|ready=true",
+    "public.zero_workflows|idx_zero_workflows_agent|CREATE INDEX idx_zero_workflows_agent ON public.zero_workflows USING btree (agent_id, name)|valid=true|ready=true",
+    "public.zero_workflows|idx_zero_workflows_private_owner_agent_name_unique|CREATE UNIQUE INDEX idx_zero_workflows_private_owner_agent_name_unique ON public.zero_workflows USING btree (org_id, agent_id, owner_user_id, name) WHERE ((visibility)::text = 'private'::text)|valid=true|ready=true",
+    "public.zero_workflows|idx_zero_workflows_public_agent_name_unique|CREATE UNIQUE INDEX idx_zero_workflows_public_agent_name_unique ON public.zero_workflows USING btree (org_id, agent_id, name) WHERE ((visibility)::text = 'public'::text)|valid=true|ready=true",
+  ],
+  triggers: [
+    "public.agent_compose_versions|agent_compose_versions_delete_veto|CREATE TRIGGER agent_compose_versions_delete_veto BEFORE DELETE ON public.agent_compose_versions FOR EACH STATEMENT EXECUTE FUNCTION veto_agent_compose_version_delete_transition()|enabled=O",
+    "public.agent_compose_versions|agent_compose_versions_write_provenance|CREATE TRIGGER agent_compose_versions_write_provenance BEFORE INSERT OR UPDATE OF created_by ON public.agent_compose_versions FOR EACH ROW EXECUTE FUNCTION enforce_agent_compose_version_write_transition()|enabled=O",
+    "public.agent_composes|agent_composes_delete_lock_timeout_transition|CREATE TRIGGER agent_composes_delete_lock_timeout_transition BEFORE DELETE ON public.agent_composes FOR EACH STATEMENT EXECUTE FUNCTION set_agent_compose_delete_lock_timeout_transition()|enabled=O",
+    "public.users|users_clerk_cleanup_transition_guard|CREATE TRIGGER users_clerk_cleanup_transition_guard BEFORE DELETE ON public.users FOR EACH STATEMENT EXECUTE FUNCTION guard_clerk_user_cleanup_transition()|enabled=O",
+    "public.zero_agents|bridge_zero_agent_default_avatar_0927|CREATE TRIGGER bridge_zero_agent_default_avatar_0927 BEFORE INSERT ON public.zero_agents FOR EACH ROW EXECUTE FUNCTION bridge_zero_agent_default_avatar_0927()|enabled=O",
+  ],
+  functions: [
+    "public.bridge_zero_agent_default_avatar_0927()|kind=f|result=trigger|language=plpgsql|volatility=v|security_definer=false|body_md5=b93914b9cf86141a4b0b4b803a3bfe6f",
+    "public.enforce_agent_compose_version_write_transition()|kind=f|result=trigger|language=plpgsql|volatility=v|security_definer=false|body_md5=7acddca0ae85d270f257cb5518ff3bda",
+    "public.guard_clerk_user_cleanup_transition()|kind=f|result=trigger|language=plpgsql|volatility=v|security_definer=false|body_md5=c801cd71b6f37934943027f281cabc51",
+    "public.set_agent_compose_delete_lock_timeout_transition()|kind=f|result=trigger|language=plpgsql|volatility=v|security_definer=false|body_md5=b3f0552e3f7bbb14443665ea8e312427",
+    "public.veto_agent_compose_version_delete_transition()|kind=f|result=trigger|language=plpgsql|volatility=v|security_definer=false|body_md5=186bcd97e887d8c241cfba4c810a47d5",
+  ],
+} as const satisfies Record<CatalogDependencyKind, readonly string[]>;
+
+export const EXPECTED_REPOSITORY_DEPENDENCIES = {
+  schemaImports: [
+    "turbo/apps/api/src/signals/routes/agent-instructions.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/routes/agent-instructions.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/routes/agents.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/routes/agents.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/routes/chat-threads-mark-agent-read.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/routes/cli-auth-test.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/routes/cli-auth-test.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/routes/integrations-slack.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/routes/integrations-telegram-bot-id.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/routes/integrations-telegram-link.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/routes/workflows.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/agent-compose-provenance-lifecycle.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/agent-compose.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/agent-connector-scope.service.ts|@okouai/db/schema/zero-agent|type:ZeroAgentVisibility:ZeroAgentVisibility,zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/agent-data.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/agent-data.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/agent-instructions.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/agent-instructions.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/agent-run-create.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/agentphone-shared.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/agentphone-shared.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/chat-goal-queue.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/chat-search.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/chat-thread-event.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/chat-thread.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/connected-connector-authorization.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/connected-connector-authorization.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/feishu-dispatch.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/github-agent-reply-footer.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/github-agent-reply-footer.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/github-oauth.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/integration-agent-response-presentation.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/internal-slack-chat-run-callback.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/internal-teams-chat-run-callback.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/logs.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/logs.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/mail-draft.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/morning-brief-collect.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/onboarding.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/onboarding.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/org-limited-free-bootstrap.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/org-limited-free-bootstrap.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/shared-thread.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/slack-message-context.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/slack-webhooks.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/telegram-data.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/telegram-footer.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/telegram-footer.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/user-connectors.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/user-connectors.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/user-export.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/user-permission-grants.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions",
+    "turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/workflow-automation.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/workflow-data.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-agentphone.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/zero-agentphone.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-browser.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/zero-chat-events.command.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-compose-data.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/zero-feishu-connect.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-feishu-welcome.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-runs-create.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/zero-runs-create.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-runs.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/zero-runs.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-slack-connect.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/zero-slack-connect.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-slack-data.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-teams-connect.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/zero-teams-connect.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-telegram-post.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
+    "turbo/apps/api/src/signals/services/zero-telegram-post.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
+    "turbo/packages/db/src/schema/agent-draft.ts|./zero-agent|zeroAgents:zeroAgents",
+    "turbo/packages/db/src/schema/agent-run-session-conversation.ts|./agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/agentphone-user-agent-preference.ts|./agent-compose|agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/banking.ts|./zero-agent|zeroAgents:zeroAgents",
+    "turbo/packages/db/src/schema/chat-thread.ts|./agent-compose|agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/feishu-org-installation.ts|./agent-compose|agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/feishu-user-agent-preference.ts|./agent-compose|agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/github-installation.ts|./agent-compose|agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/org-metadata.ts|./agent-compose|agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/slack-user-agent-preference.ts|./agent-compose|agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/teams-user-agent-preference.ts|./agent-compose|agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/telegram-installation.ts|./agent-compose|agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/telegram-user-agent-preference.ts|./agent-compose|agentComposes:agentComposes",
+    "turbo/packages/db/src/schema/thread-goal.ts|./zero-agent|zeroAgents:zeroAgents",
+    "turbo/packages/db/src/schema/user-connector.ts|./zero-agent|zeroAgents:zeroAgents",
+    "turbo/packages/db/src/schema/user-custom-connector.ts|./zero-agent|zeroAgents:zeroAgents",
+    "turbo/packages/db/src/schema/user-permission-grant.ts|./zero-agent|zeroAgents:zeroAgents",
+    "turbo/packages/db/src/schema/workflow.ts|./zero-agent|zeroAgents:zeroAgents",
+    "turbo/packages/db/src/schema/zero-agent.ts|./agent-compose|agentComposes:agentComposes",
+  ],
+  legacyIdentifiers: [
+    "turbo/apps/api/src/signals/routes/agent-instructions.ts|agentComposeId,agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/routes/agents.ts|agentComposeId,agentComposes,headVersionId,zeroAgents",
+    "turbo/apps/api/src/signals/routes/chat-threads-computer-use-host.ts|agentComposeId",
+    "turbo/apps/api/src/signals/routes/chat-threads-create.ts|agentComposeId",
+    "turbo/apps/api/src/signals/routes/chat-threads-get.ts|agentComposeId",
+    "turbo/apps/api/src/signals/routes/chat-threads-mark-agent-read.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/routes/chat-threads-mark-read.ts|agentComposeId",
+    "turbo/apps/api/src/signals/routes/chat-threads-model-selection.ts|agentComposeId",
+    "turbo/apps/api/src/signals/routes/chat-threads-pin.ts|agentComposeId",
+    "turbo/apps/api/src/signals/routes/chat-threads-rename.ts|agentComposeId",
+    "turbo/apps/api/src/signals/routes/chat-threads-unpin.ts|agentComposeId",
+    "turbo/apps/api/src/signals/routes/chat-threads-video-model.ts|agentComposeId",
+    "turbo/apps/api/src/signals/routes/chat-threads.ts|agentComposeId",
+    "turbo/apps/api/src/signals/routes/cli-auth-test.ts|agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/routes/integrations-slack.ts|agentComposeVersions,agentComposes,headVersionId",
+    "turbo/apps/api/src/signals/routes/integrations-telegram-bot-id.ts|agentComposes",
+    "turbo/apps/api/src/signals/routes/integrations-telegram-link.ts|agentComposes",
+    "turbo/apps/api/src/signals/routes/runners.ts|agentComposeId,agentComposeVersionId",
+    "turbo/apps/api/src/signals/routes/workflows.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/services/agent-compose-provenance-lifecycle.service.ts|agentComposes",
+    "turbo/apps/api/src/signals/services/agent-compose.service.ts|agentComposeId,agentComposeVersions,agentComposes,headVersionId",
+    "turbo/apps/api/src/signals/services/agent-connector-scope.service.ts|zeroAgents",
+    "turbo/apps/api/src/signals/services/agent-data.service.ts|agentComposes,headVersionId,zeroAgents",
+    "turbo/apps/api/src/signals/services/agent-instructions.service.ts|agentComposeVersions,agentComposes,headVersionId,zeroAgents",
+    "turbo/apps/api/src/signals/services/agent-run-create.service.ts|agentComposeId,agentComposeVersionId,agentComposeVersions,agentComposes,headVersionId",
+    "turbo/apps/api/src/signals/services/agent-run-storage.service.ts|headVersionId",
+    "turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts|agentComposeSnapshot,agentComposeVersionId",
+    "turbo/apps/api/src/signals/services/agentphone-chat-ingress.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/agentphone-queued-launch-context.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/agentphone-shared.service.ts|agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/services/banking.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/browser-authorization.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/chat-event-shared.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/chat-goal-queue.service.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/services/chat-search.service.ts|agentComposeId,agentComposes",
+    "turbo/apps/api/src/signals/services/chat-session-continuity.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/chat-thread-event.service.ts|agentComposeId,agentComposes",
+    "turbo/apps/api/src/signals/services/chat-thread-model.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/chat-thread.service.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/services/computer-use-authorization.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/computer-use.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/connected-connector-authorization.service.ts|agentComposeId,agentComposes,headVersionId,zeroAgents",
+    "turbo/apps/api/src/signals/services/connector-catalog-skill-registration.service.ts|headVersionId,head_version_id",
+    "turbo/apps/api/src/signals/services/connector-runtime-wakeup.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts|agentComposeId,agentComposes",
+    "turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts|agentComposeId,agentComposes,agent_compose_id",
+    "turbo/apps/api/src/signals/services/cron-project-chat-event-search.service.ts|agentComposeId,agentComposes",
+    "turbo/apps/api/src/signals/services/cron-steer-run-time-budget.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/cron-sync-skills.service.ts|headVersionId",
+    "turbo/apps/api/src/signals/services/feishu-chat-ingress.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/feishu-dispatch.service.ts|zeroAgents",
+    "turbo/apps/api/src/signals/services/github-agent-reply-footer.service.ts|agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/services/github-oauth.service.ts|agentComposes",
+    "turbo/apps/api/src/signals/services/github-queued-launch-context.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/goal.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/integration-agent-response-presentation.service.ts|zeroAgents",
+    "turbo/apps/api/src/signals/services/internal-agentphone-chat-run-callback.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/services/internal-feishu-chat-run-callback.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/internal-feishu-org-run-callback.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/internal-github-chat-run-callback.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/internal-slack-chat-run-callback.service.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/services/internal-teams-chat-run-callback.service.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/services/internal-telegram-chat-run-callback.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/logs.service.ts|agentComposeId,agentComposeVersionId,agentComposeVersions,agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/services/mail-draft.service.ts|agentComposeId,agentComposes",
+    "turbo/apps/api/src/signals/services/morning-brief-collect.service.ts|agentComposeId,agentComposes",
+    "turbo/apps/api/src/signals/services/onboarding.service.ts|agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/services/org-limited-free-bootstrap.service.ts|agentComposeId,agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/services/run-mcp-connectors.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/shared-thread.service.ts|agentComposeId,agentComposes",
+    "turbo/apps/api/src/signals/services/slack-chat-ingress.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/slack-message-context.service.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/services/slack-webhooks.service.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/services/storage-volume-publication.service.ts|headVersionId",
+    "turbo/apps/api/src/signals/services/storage-write.service.ts|headVersionId",
+    "turbo/apps/api/src/signals/services/teams-chat-ingress.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/telegram-chat-ingress.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/telegram-data.service.ts|agentComposeVersions,agentComposes,headVersionId",
+    "turbo/apps/api/src/signals/services/telegram-footer.service.ts|agentComposeId,agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/services/telegram-queued-launch-context.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/user-connectors.service.ts|agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/services/user-export.service.ts|agentComposes,headVersionId",
+    "turbo/apps/api/src/signals/services/user-permission-grants.service.ts|zeroAgents",
+    "turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts|agentComposeVersions,zeroAgents",
+    "turbo/apps/api/src/signals/services/workflow-automation.service.ts|zeroAgents",
+    "turbo/apps/api/src/signals/services/workflow-data.service.ts|zeroAgents",
+    "turbo/apps/api/src/signals/services/workflow-user-automation-thread.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/workflow-volume.service.ts|headVersionId",
+    "turbo/apps/api/src/signals/services/zero-agentphone.service.ts|agentComposeId,agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-browser.service.ts|agentComposeId,agentComposes",
+    "turbo/apps/api/src/signals/services/zero-chat-events.command.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-chat-title.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/zero-compose-data.service.ts|agentComposeId,agentComposeVersions,agentComposes",
+    "turbo/apps/api/src/signals/services/zero-feishu-connect.service.ts|zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-feishu-welcome.service.ts|zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-runs-create.service.ts|agentComposeId,agentComposeVersionId,agentComposeVersions,agentComposes,headVersionId,zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-runs.service.ts|agentComposeId,agentComposeVersionId,agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-slack-connect.service.ts|agentComposes,zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-slack-data.service.ts|zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-teams-connect.service.ts|agentComposeVersions,agentComposes,headVersionId,zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts|agentComposeId,zeroAgents",
+    "turbo/apps/api/src/signals/services/zero-telegram-post.service.ts|agentComposeId,agentComposes,zeroAgents",
+    "turbo/apps/platform/src/views/zero-page/zero-telegram-settings-page.tsx|headVersionId",
+    "turbo/packages/api-contracts/src/contracts/composes.ts|headVersionId",
+    "turbo/packages/api-contracts/src/contracts/runners.ts|agentComposeVersionId",
+    "turbo/packages/api-contracts/src/contracts/runs.ts|agentComposeId,agentComposeVersionId",
+    "turbo/packages/api-contracts/src/contracts/zero-runs.ts|agentComposeId",
+    "turbo/packages/api-contracts/src/contracts/zero-team.ts|headVersionId",
+    "turbo/packages/db/src/schema/agent-compose.ts|agentComposeVersions,agentComposes,headVersionId,head_version_id",
+    "turbo/packages/db/src/schema/agent-draft.ts|zeroAgents",
+    "turbo/packages/db/src/schema/agent-run-session-conversation.ts|agentComposeId,agentComposeVersionId,agentComposeVersions,agentComposes,agent_compose_id,agent_compose_version_id",
+    "turbo/packages/db/src/schema/agentphone-user-agent-preference.ts|agentComposes",
+    "turbo/packages/db/src/schema/banking.ts|zeroAgents",
+    "turbo/packages/db/src/schema/chat-event-search.ts|agentComposeId,agent_compose_id",
+    "turbo/packages/db/src/schema/chat-thread-event.ts|agentComposeId,agent_compose_id",
+    "turbo/packages/db/src/schema/chat-thread.ts|agentComposeId,agentComposes,agent_compose_id",
+    "turbo/packages/db/src/schema/checkpoint.ts|agentComposeSnapshot,agent_compose_snapshot",
+    "turbo/packages/db/src/schema/feishu-org-installation.ts|agentComposes",
+    "turbo/packages/db/src/schema/feishu-user-agent-preference.ts|agentComposes",
+    "turbo/packages/db/src/schema/github-installation.ts|agentComposes",
+    "turbo/packages/db/src/schema/org-metadata.ts|agentComposes",
+    "turbo/packages/db/src/schema/slack-user-agent-preference.ts|agentComposes",
+    "turbo/packages/db/src/schema/storage.ts|headVersionId,head_version_id",
+    "turbo/packages/db/src/schema/teams-user-agent-preference.ts|agentComposes",
+    "turbo/packages/db/src/schema/telegram-installation.ts|agentComposes",
+    "turbo/packages/db/src/schema/telegram-user-agent-preference.ts|agentComposes",
+    "turbo/packages/db/src/schema/thread-goal.ts|zeroAgents",
+    "turbo/packages/db/src/schema/user-connector.ts|zeroAgents",
+    "turbo/packages/db/src/schema/user-custom-connector.ts|zeroAgents",
+    "turbo/packages/db/src/schema/user-permission-grant.ts|zeroAgents",
+    "turbo/packages/db/src/schema/workflow.ts|zeroAgents",
+    "turbo/packages/db/src/schema/zero-agent.ts|agentComposes,zeroAgents",
+  ],
+  rawTableLiterals: [
+    "turbo/apps/api/src/signals/services/agent-compose-provenance-lifecycle.service.ts|agent_compose_versions,agent_composes",
+    "turbo/packages/db/src/schema/agent-compose.ts|agent_compose_versions,agent_composes",
+    "turbo/packages/db/src/schema/zero-agent.ts|zero_agents",
+  ],
+  nonTypeScriptConsumers: [
+    "crates/api-contracts/src/generated/decode_paths.rs|agentComposeVersionId",
+  ],
+  transitionValidators: [
+    "#27613|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8",
+  ],
+} as const satisfies RepositoryDependencyManifest;
+
+/**
+ * Catalog discovery is structural: foreign-key keys/actions/validation,
+ * reviewed non-target-FK fields, defaults, relevant indexes, trigger
+ * definitions, and trigger-function bodies all contribute to the manifest.
+ */
+export const CATALOG_DEPENDENCY_QUERY = `
+WITH target_relations AS (
+  SELECT unnest(ARRAY[
+    'public.agent_composes'::regclass,
+    'public.zero_agents'::regclass,
+    'public.agent_compose_versions'::regclass
+  ]) AS oid
+),
+target_fk_columns AS (
+  SELECT "conrelid", unnest("conkey") AS "attnum"
+  FROM "pg_constraint"
+  WHERE "contype" = 'f'
+    AND "confrelid" IN (SELECT "oid" FROM target_relations)
+),
+foreign_keys AS (
+  SELECT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+    "constraint"."conname" || '|' ||
+    pg_get_constraintdef("constraint"."oid", false) ||
+    '|validated=' || "constraint"."convalidated"::text ||
+    '|deferrable=' || "constraint"."condeferrable"::text ||
+    '|initially_deferred=' || "constraint"."condeferred"::text AS "entry"
+  FROM "pg_constraint" AS "constraint"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "constraint"."conrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  WHERE "constraint"."contype" = 'f'
+    AND "constraint"."confrelid" IN (SELECT "oid" FROM target_relations)
+),
+reviewed_non_fk AS (
+  SELECT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+    "attribute"."attname" || '|' ||
+    format_type("attribute"."atttypid", "attribute"."atttypmod") ||
+    '|nullable=' || (NOT "attribute"."attnotnull")::text AS "entry",
+    "attribute"."attrelid" AS "relid",
+    "attribute"."attnum" AS "attnum"
+  FROM "pg_attribute" AS "attribute"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "attribute"."attrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  LEFT JOIN target_fk_columns AS "target_fk"
+    ON "target_fk"."conrelid" = "attribute"."attrelid"
+    AND "target_fk"."attnum" = "attribute"."attnum"
+  WHERE "namespace"."nspname" = 'public'
+    AND "relation"."relkind" IN ('r', 'p')
+    AND "attribute"."attnum" > 0
+    AND NOT "attribute"."attisdropped"
+    AND "target_fk"."attnum" IS NULL
+    AND (
+      "attribute"."attname" IN ('agent_compose_snapshot', 'head_version_id')
+      OR "attribute"."attname" ~ '(^|_)agent(_compose(_version)?)?_id$'
+      OR "attribute"."attname" ~ '(^|_)compose(_version)?_id$'
+      OR "attribute"."attname" ~ '(^|_)agentphone_agent_id$'
+    )
+),
+defaults AS (
+  SELECT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+    "attribute"."attname" || '|' ||
+    pg_get_expr("default"."adbin", "default"."adrelid", false) AS "entry"
+  FROM "pg_attrdef" AS "default"
+  INNER JOIN "pg_attribute" AS "attribute"
+    ON "attribute"."attrelid" = "default"."adrelid"
+    AND "attribute"."attnum" = "default"."adnum"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "default"."adrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  WHERE "default"."adrelid" IN (SELECT "oid" FROM target_relations)
+),
+dependency_columns AS (
+  SELECT "conrelid" AS "relid", unnest("conkey") AS "attnum"
+  FROM "pg_constraint"
+  WHERE "contype" = 'f'
+    AND "confrelid" IN (SELECT "oid" FROM target_relations)
+  UNION
+  SELECT "relid", "attnum" FROM reviewed_non_fk
+),
+indexes AS (
+  SELECT DISTINCT
+    "namespace"."nspname" || '.' || "table"."relname" || '|' ||
+    "index_class"."relname" || '|' ||
+    pg_get_indexdef("index"."indexrelid", 0, false) ||
+    '|valid=' || "index"."indisvalid"::text ||
+    '|ready=' || "index"."indisready"::text AS "entry"
+  FROM "pg_index" AS "index"
+  INNER JOIN "pg_class" AS "index_class"
+    ON "index_class"."oid" = "index"."indexrelid"
+  INNER JOIN "pg_class" AS "table"
+    ON "table"."oid" = "index"."indrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "table"."relnamespace"
+  WHERE "index"."indrelid" IN (SELECT "oid" FROM target_relations)
+    OR EXISTS (
+      SELECT 1
+      FROM dependency_columns AS "column"
+      WHERE "column"."relid" = "index"."indrelid"
+        AND "column"."attnum" = ANY("index"."indkey")
+    )
+),
+triggers AS (
+  SELECT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+    "trigger"."tgname" || '|' ||
+    pg_get_triggerdef("trigger"."oid", false) ||
+    '|enabled=' || "trigger"."tgenabled"::text AS "entry",
+    "trigger"."tgfoid" AS "function_oid"
+  FROM "pg_trigger" AS "trigger"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "trigger"."tgrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  INNER JOIN "pg_proc" AS "function"
+    ON "function"."oid" = "trigger"."tgfoid"
+  WHERE NOT "trigger"."tgisinternal"
+    AND (
+      "trigger"."tgrelid" IN (SELECT "oid" FROM target_relations)
+      OR "trigger"."tgname" IN (
+        'users_clerk_cleanup_transition_guard',
+        'agent_composes_delete_lock_timeout_transition',
+        'agent_compose_versions_delete_veto',
+        'agent_compose_versions_write_provenance',
+        'bridge_zero_agent_default_avatar_0927'
+      )
+      OR lower("function"."prosrc") ~
+        '(agent_composes|agent_compose_versions|zero_agents)'
+    )
+),
+functions AS (
+  SELECT DISTINCT
+    "namespace"."nspname" || '.' || "function"."proname" || '(' ||
+    pg_get_function_identity_arguments("function"."oid") || ')|' ||
+    'kind=' || "function"."prokind"::text ||
+    '|result=' || pg_get_function_result("function"."oid") ||
+    '|language=' || "language"."lanname" ||
+    '|volatility=' || "function"."provolatile"::text ||
+    '|security_definer=' || "function"."prosecdef"::text ||
+    '|body_md5=' || md5("function"."prosrc") AS "entry"
+  FROM "pg_proc" AS "function"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "function"."pronamespace"
+  INNER JOIN "pg_language" AS "language"
+    ON "language"."oid" = "function"."prolang"
+  WHERE "function"."oid" IN (SELECT "function_oid" FROM triggers)
+    OR (
+      "namespace"."nspname" = 'public'
+      AND lower("function"."prosrc") ~
+        '(agent_composes|agent_compose_versions|zero_agents)'
+    )
+)
+SELECT 'foreignKeys' AS "kind", "entry" FROM foreign_keys
+UNION ALL SELECT 'reviewedNonFk', "entry" FROM reviewed_non_fk
+UNION ALL SELECT 'defaults', "entry" FROM defaults
+UNION ALL SELECT 'indexes', "entry" FROM indexes
+UNION ALL SELECT 'triggers', "entry" FROM triggers
+UNION ALL SELECT 'functions', "entry" FROM functions
+ORDER BY "kind", "entry"
+`;
+
+const schemaModules = new Set([
+  "@okouai/db/schema/agent-compose",
+  "@okouai/db/schema/zero-agent",
+]);
+
+const legacyIdentifierTokens = new Set([
+  "agentComposeId",
+  "agentComposeSnapshot",
+  "agentComposeVersionId",
+  "agentComposeVersions",
+  "agentComposes",
+  "headVersionId",
+  "zeroAgents",
+]);
+
+const legacyLiteralTokens = new Set([
+  "agent_compose_id",
+  "agent_compose_snapshot",
+  "agent_compose_version_id",
+  "head_version_id",
+]);
+
+const rawTableTokens = [
+  "agent_composes",
+  "agent_compose_versions",
+  "zero_agents",
+] as const;
+
+const nonTypeScriptExtensions = new Set([".js", ".mjs", ".rs", ".sql"]);
+
+function normalizePath(filePath: string): string {
+  return filePath.split(path.sep).join("/");
+}
+
+function isExcluded(relativePath: string): boolean {
+  return (
+    relativePath.includes("/node_modules/") ||
+    relativePath.includes("/dist/") ||
+    relativePath.includes("/.typecheck/") ||
+    relativePath.includes("/__tests__/") ||
+    relativePath.includes("/__benches__/") ||
+    relativePath.includes("/test-fixtures/") ||
+    relativePath.includes("/mocks/") ||
+    relativePath.includes("/packages/db/scripts/") ||
+    relativePath.includes("/packages/db/src/migrations/") ||
+    relativePath.includes("/apps/api/src/scripts/dev-") ||
+    /\.(?:bench|spec|suite|test)\.[cm]?[jt]sx?$/u.test(relativePath) ||
+    /\/test-[^/]+\.[cm]?[jt]sx?$/u.test(relativePath)
+  );
+}
+
+async function listFiles(directory: string): Promise<string[]> {
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+
+  const files: string[] = [];
+  for (const entry of entries.sort((a, b) => {
+    return a.name.localeCompare(b.name);
+  })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(entryPath)));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function importBindingNames(importClause: ts.ImportClause | undefined): string {
+  if (!importClause) return "side-effect";
+  const names: string[] = [];
+  if (importClause.name) names.push(`default:${importClause.name.text}`);
+  const bindings = importClause.namedBindings;
+  if (bindings && ts.isNamespaceImport(bindings)) {
+    names.push(`namespace:${bindings.name.text}`);
+  }
+  if (bindings && ts.isNamedImports(bindings)) {
+    for (const element of bindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      const local = element.name.text;
+      const typePrefix = element.isTypeOnly ? "type:" : "";
+      names.push(`${typePrefix}${imported}:${local}`);
+    }
+  }
+  return names.sort().join(",");
+}
+
+function isSchemaImport(relativePath: string, moduleName: string): boolean {
+  if (schemaModules.has(moduleName)) return true;
+  return (
+    relativePath.startsWith("turbo/packages/db/src/schema/") &&
+    (moduleName === "./agent-compose" || moduleName === "./zero-agent")
+  );
+}
+
+function collectTypeScriptEntries(args: {
+  readonly relativePath: string;
+  readonly sourceText: string;
+  readonly schemaImports: Set<string>;
+  readonly legacyIdentifiers: Set<string>;
+  readonly rawTableLiterals: Set<string>;
+}): void {
+  const source = ts.createSourceFile(
+    args.relativePath,
+    args.sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    args.relativePath.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const fileLegacyTokens = new Set<string>();
+  const fileRawTables = new Set<string>();
+
+  const inspectLiteral = (text: string): void => {
+    for (const token of legacyLiteralTokens) {
+      if (text.includes(token)) fileLegacyTokens.add(token);
+    }
+    for (const table of rawTableTokens) {
+      if (new RegExp(`\\b${table}\\b`, "u").test(text)) {
+        fileRawTables.add(table);
+      }
+    }
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      const moduleName = node.moduleSpecifier.text;
+      if (isSchemaImport(args.relativePath, moduleName)) {
+        args.schemaImports.add(
+          `${args.relativePath}|${moduleName}|${importBindingNames(node.importClause)}`,
+        );
+      }
+    }
+    if (ts.isIdentifier(node) && legacyIdentifierTokens.has(node.text)) {
+      fileLegacyTokens.add(node.text);
+    }
+    if (
+      ts.isStringLiteral(node) ||
+      ts.isNoSubstitutionTemplateLiteral(node) ||
+      ts.isTemplateHead(node) ||
+      ts.isTemplateMiddle(node) ||
+      ts.isTemplateTail(node)
+    ) {
+      inspectLiteral(node.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  if (fileLegacyTokens.size > 0) {
+    args.legacyIdentifiers.add(
+      `${args.relativePath}|${[...fileLegacyTokens].sort().join(",")}`,
+    );
+  }
+  if (fileRawTables.size > 0) {
+    args.rawTableLiterals.add(
+      `${args.relativePath}|${[...fileRawTables].sort().join(",")}`,
+    );
+  }
+}
+
+export async function collectRepositoryDependencyManifest(
+  repositoryRoot: string,
+): Promise<RepositoryDependencyManifest> {
+  const schemaImports = new Set<string>();
+  const legacyIdentifiers = new Set<string>();
+  const rawTableLiterals = new Set<string>();
+  const nonTypeScriptConsumers = new Set<string>();
+  const transitionValidators = new Set<string>();
+  const scanRoots = ["turbo/apps", "turbo/packages", "crates"];
+
+  for (const scanRoot of scanRoots) {
+    const files = await listFiles(path.join(repositoryRoot, scanRoot));
+    for (const filePath of files) {
+      const relativePath = normalizePath(
+        path.relative(repositoryRoot, filePath),
+      );
+      if (isExcluded(`/${relativePath}`)) continue;
+      const extension = path.extname(relativePath);
+      if (!relativePath.endsWith(".ts") && !relativePath.endsWith(".tsx")) {
+        if (!nonTypeScriptExtensions.has(extension)) continue;
+        const sourceText = await fs.readFile(filePath, "utf8");
+        const tokens = [
+          ...legacyIdentifierTokens,
+          ...legacyLiteralTokens,
+          ...rawTableTokens,
+        ].filter((token) => {
+          return sourceText.includes(token);
+        });
+        if (tokens.length > 0) {
+          nonTypeScriptConsumers.add(
+            `${relativePath}|${[...new Set(tokens)].sort().join(",")}`,
+          );
+        }
+        continue;
+      }
+      collectTypeScriptEntries({
+        relativePath,
+        sourceText: await fs.readFile(filePath, "utf8"),
+        schemaImports,
+        legacyIdentifiers,
+        rawTableLiterals,
+      });
+    }
+  }
+
+  const migrationsDocumentation = await fs.readFile(
+    path.join(repositoryRoot, "turbo/packages/db/MIGRATIONS.md"),
+    "utf8",
+  );
+  for (const match of migrationsDocumentation.matchAll(
+    /<!-- vm0-transition-validator:([^\n]+) -->/gu,
+  )) {
+    transitionValidators.add(match[1]!.trim());
+  }
+
+  return {
+    schemaImports: [...schemaImports].sort(),
+    legacyIdentifiers: [...legacyIdentifiers].sort(),
+    rawTableLiterals: [...rawTableLiterals].sort(),
+    nonTypeScriptConsumers: [...nonTypeScriptConsumers].sort(),
+    transitionValidators: [...transitionValidators].sort(),
+  };
+}
+
+export function manifestsEqual(
+  expected: RepositoryDependencyManifest,
+  observed: RepositoryDependencyManifest,
+): boolean {
+  return (
+    JSON.stringify(expected.schemaImports) ===
+      JSON.stringify(observed.schemaImports) &&
+    JSON.stringify(expected.legacyIdentifiers) ===
+      JSON.stringify(observed.legacyIdentifiers) &&
+    JSON.stringify(expected.rawTableLiterals) ===
+      JSON.stringify(observed.rawTableLiterals) &&
+    JSON.stringify(expected.nonTypeScriptConsumers) ===
+      JSON.stringify(observed.nonTypeScriptConsumers) &&
+    JSON.stringify(expected.transitionValidators) ===
+      JSON.stringify(observed.transitionValidators)
+  );
+}

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
@@ -80,6 +80,11 @@ export const PREFLIGHT_OUTPUT_ALLOWLIST = [
   "danglingHeads.snapshotClassification",
   "danglingHeads.start.count",
   "danglingHeads.start.digest",
+  "dependencies.catalog.constraints.classification",
+  "dependencies.catalog.constraints.expected.count",
+  "dependencies.catalog.constraints.expected.digest",
+  "dependencies.catalog.constraints.observed.count",
+  "dependencies.catalog.constraints.observed.digest",
   "dependencies.catalog.defaults.classification",
   "dependencies.catalog.defaults.expected.count",
   "dependencies.catalog.defaults.expected.digest",
@@ -100,11 +105,21 @@ export const PREFLIGHT_OUTPUT_ALLOWLIST = [
   "dependencies.catalog.indexes.expected.digest",
   "dependencies.catalog.indexes.observed.count",
   "dependencies.catalog.indexes.observed.digest",
+  "dependencies.catalog.otherDependents.classification",
+  "dependencies.catalog.otherDependents.expected.count",
+  "dependencies.catalog.otherDependents.expected.digest",
+  "dependencies.catalog.otherDependents.observed.count",
+  "dependencies.catalog.otherDependents.observed.digest",
   "dependencies.catalog.reviewedNonFk.classification",
   "dependencies.catalog.reviewedNonFk.expected.count",
   "dependencies.catalog.reviewedNonFk.expected.digest",
   "dependencies.catalog.reviewedNonFk.observed.count",
   "dependencies.catalog.reviewedNonFk.observed.digest",
+  "dependencies.catalog.rewriteDependents.classification",
+  "dependencies.catalog.rewriteDependents.expected.count",
+  "dependencies.catalog.rewriteDependents.expected.digest",
+  "dependencies.catalog.rewriteDependents.observed.count",
+  "dependencies.catalog.rewriteDependents.observed.digest",
   "dependencies.catalog.triggers.classification",
   "dependencies.catalog.triggers.expected.count",
   "dependencies.catalog.triggers.expected.digest",
@@ -698,7 +713,7 @@ function classifyVersions(
   const composePresentCreatorNull: VersionInventoryRow[] = [];
   const composeNullCreatorPresent: VersionInventoryRow[] = [];
   const composeNullCreatorNull: VersionInventoryRow[] = [];
-  const orphanVersions: VersionInventoryRow[] = [];
+  const orphanComposeIds: string[] = [];
   const canonicalVersions: VersionInventoryRow[] = [];
   const nonCanonicalVersions: VersionInventoryRow[] = [];
   const invalidVersions: VersionInventoryRow[] = [];
@@ -715,7 +730,7 @@ function classifyVersions(
       composeNullCreatorNull.push(version);
     }
     if (version.composeId !== null && !version.composeExists) {
-      orphanVersions.push(version);
+      orphanComposeIds.push(version.composeId);
     }
 
     const content = classifyVersionContent(version);
@@ -729,7 +744,7 @@ function classifyVersions(
     if (content.hashMismatch) contentHashMismatches.push(version);
   }
 
-  if (orphanVersions.length > 0) {
+  if (orphanComposeIds.length > 0) {
     failureGates.add("versions.orphan_compose");
   }
   if (invalidVersions.length > 0) {
@@ -759,9 +774,9 @@ function classifyVersions(
         composeNullCreatorNull,
       ),
     },
-    orphanComposeIds: recordSet(
-      "versions:orphan-compose-version-ids",
-      orphanVersions,
+    orphanComposeIds: fingerprintSortedSet(
+      "versions:orphan-compose-ids",
+      orphanComposeIds,
     ),
     content: {
       canonicalCurrent: recordSet(

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
@@ -1,0 +1,1433 @@
+#!/usr/bin/env tsx
+import { isDeepStrictEqual } from "node:util";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { agentComposeApiContentSchema } from "@okouai/api-contracts/contracts/composes";
+import { Client, type QueryResultRow } from "pg";
+import {
+  buildZeroAgentComposeContent,
+  computeComposeVersionId,
+} from "../../../apps/api/src/signals/services/agent-compose-content";
+import {
+  CATALOG_DEPENDENCY_KINDS,
+  CATALOG_DEPENDENCY_QUERY,
+  EXPECTED_CATALOG_DEPENDENCIES,
+  EXPECTED_REPOSITORY_DEPENDENCIES,
+  collectRepositoryDependencyManifest,
+  type CatalogDependencyKind,
+  type CatalogDependencyRow,
+  type RepositoryDependencyManifest,
+} from "./agent-compose-consolidation-preflight-manifest";
+import {
+  PREFLIGHT_SCHEMA_VERSION,
+  fingerprintMember,
+  fingerprintSortedSet,
+  type SetFingerprint,
+} from "./agent-compose-consolidation-preflight-fingerprint";
+
+const MINIMUM_SERVER_VERSION = 170000;
+const DEFAULT_LOCK_TIMEOUT_MS = 1000;
+const DEFAULT_STATEMENT_TIMEOUT_MS = 30_000;
+const DEFAULT_EXPECTED_DANGLING_HEAD_COUNT = 17;
+
+/** Safe digests of the six #26938-approved compose-only artifact IDs. */
+export const APPROVED_ARTIFACT_MEMBER_DIGESTS = [
+  "113ad6becc69859c5d32951a5f1a1f0fa4ba80c0d3db8844aa7d03917265220a",
+  "8dfd7409ac22987095db85e8d847b68b79ba5dd10061699a2cd8b342f0aa5a53",
+  "9697088dede8e0c6d34e043d4e9195cb7f02eed78d03c3b5eaeffaf699a6cdad",
+  "96eb4f5d3c590dc9576ebb780be44742b08936936b8230c1b80cb7c52179ae94",
+  "da7f6e8f1e287573ecf9e04e7ae2c1f2cb6605f694cfeae4dd748a9ad86ef934",
+  "e7bf22154afdeb95446d7be90a79f75813073581a292c334807ea37dd8adc37a",
+] as const;
+
+export const APPROVED_ARTIFACT_SET_DIGEST =
+  "a83a3c8751fa88778aca7ac93b7d595a7e4c8e9e79cb08c9696ed1dd9e943b5c";
+
+/** Exact scalar/array paths permitted in a complete production result. */
+export const PREFLIGHT_OUTPUT_ALLOWLIST = [
+  "capabilities.isolationLevel",
+  "capabilities.lockTimeoutMs",
+  "capabilities.requiredExtensionCount",
+  "capabilities.serverVersionClassification",
+  "capabilities.statementTimeoutMs",
+  "capabilities.transactionReadOnly",
+  "checkpoints.absentLegacyReference.count",
+  "checkpoints.absentLegacyReference.digest",
+  "checkpoints.distinctVersionHashes.count",
+  "checkpoints.distinctVersionHashes.digest",
+  "checkpoints.headReferencedVersionHashes.count",
+  "checkpoints.headReferencedVersionHashes.digest",
+  "checkpoints.invalidLegacyReference.count",
+  "checkpoints.invalidLegacyReference.digest",
+  "checkpoints.missingVersionReference.count",
+  "checkpoints.missingVersionReference.digest",
+  "checkpoints.runReferencedVersionHashes.count",
+  "checkpoints.runReferencedVersionHashes.digest",
+  "checkpoints.sharedVersionHashes.count",
+  "checkpoints.sharedVersionHashes.digest",
+  "checkpoints.total",
+  "checkpoints.validLegacyReference.count",
+  "checkpoints.validLegacyReference.digest",
+  "danglingHeads.end.count",
+  "danglingHeads.end.digest",
+  "danglingHeads.exact.count",
+  "danglingHeads.exact.digest",
+  "danglingHeads.expectedCount",
+  "danglingHeads.missingIdentity.count",
+  "danglingHeads.missingIdentity.digest",
+  "danglingHeads.nonExact.count",
+  "danglingHeads.nonExact.digest",
+  "danglingHeads.snapshotClassification",
+  "danglingHeads.start.count",
+  "danglingHeads.start.digest",
+  "dependencies.catalog.defaults.classification",
+  "dependencies.catalog.defaults.expected.count",
+  "dependencies.catalog.defaults.expected.digest",
+  "dependencies.catalog.defaults.observed.count",
+  "dependencies.catalog.defaults.observed.digest",
+  "dependencies.catalog.foreignKeys.classification",
+  "dependencies.catalog.foreignKeys.expected.count",
+  "dependencies.catalog.foreignKeys.expected.digest",
+  "dependencies.catalog.foreignKeys.observed.count",
+  "dependencies.catalog.foreignKeys.observed.digest",
+  "dependencies.catalog.functions.classification",
+  "dependencies.catalog.functions.expected.count",
+  "dependencies.catalog.functions.expected.digest",
+  "dependencies.catalog.functions.observed.count",
+  "dependencies.catalog.functions.observed.digest",
+  "dependencies.catalog.indexes.classification",
+  "dependencies.catalog.indexes.expected.count",
+  "dependencies.catalog.indexes.expected.digest",
+  "dependencies.catalog.indexes.observed.count",
+  "dependencies.catalog.indexes.observed.digest",
+  "dependencies.catalog.reviewedNonFk.classification",
+  "dependencies.catalog.reviewedNonFk.expected.count",
+  "dependencies.catalog.reviewedNonFk.expected.digest",
+  "dependencies.catalog.reviewedNonFk.observed.count",
+  "dependencies.catalog.reviewedNonFk.observed.digest",
+  "dependencies.catalog.triggers.classification",
+  "dependencies.catalog.triggers.expected.count",
+  "dependencies.catalog.triggers.expected.digest",
+  "dependencies.catalog.triggers.observed.count",
+  "dependencies.catalog.triggers.observed.digest",
+  "dependencies.repository.legacyIdentifiers.classification",
+  "dependencies.repository.legacyIdentifiers.expected.count",
+  "dependencies.repository.legacyIdentifiers.expected.digest",
+  "dependencies.repository.legacyIdentifiers.observed.count",
+  "dependencies.repository.legacyIdentifiers.observed.digest",
+  "dependencies.repository.nonTypeScriptConsumers.classification",
+  "dependencies.repository.nonTypeScriptConsumers.expected.count",
+  "dependencies.repository.nonTypeScriptConsumers.expected.digest",
+  "dependencies.repository.nonTypeScriptConsumers.observed.count",
+  "dependencies.repository.nonTypeScriptConsumers.observed.digest",
+  "dependencies.repository.rawTableLiterals.classification",
+  "dependencies.repository.rawTableLiterals.expected.count",
+  "dependencies.repository.rawTableLiterals.expected.digest",
+  "dependencies.repository.rawTableLiterals.observed.count",
+  "dependencies.repository.rawTableLiterals.observed.digest",
+  "dependencies.repository.schemaImports.classification",
+  "dependencies.repository.schemaImports.expected.count",
+  "dependencies.repository.schemaImports.expected.digest",
+  "dependencies.repository.schemaImports.observed.count",
+  "dependencies.repository.schemaImports.observed.digest",
+  "dependencies.repository.transitionValidators.classification",
+  "dependencies.repository.transitionValidators.expected.count",
+  "dependencies.repository.transitionValidators.expected.digest",
+  "dependencies.repository.transitionValidators.observed.count",
+  "dependencies.repository.transitionValidators.observed.digest",
+  "failureGates[]",
+  "heads.crossComposeInsertionProvenanceAgentIds.count",
+  "heads.crossComposeInsertionProvenanceAgentIds.digest",
+  "heads.danglingAgentIds.count",
+  "heads.danglingAgentIds.digest",
+  "heads.distinctHashes.count",
+  "heads.distinctHashes.digest",
+  "heads.fanout.maximumReferenceCount",
+  "heads.fanout.sharedHashCount",
+  "heads.fanout.singleHashCount",
+  "heads.nonNullReferenceCount",
+  "heads.nullInsertionProvenanceAgentIds.count",
+  "heads.nullInsertionProvenanceAgentIds.digest",
+  "heads.presentAgentIds.count",
+  "heads.presentAgentIds.digest",
+  "heads.sharedHashes.count",
+  "heads.sharedHashes.digest",
+  "identity.agentComposesTotal",
+  "identity.approvedComposeOnlyArtifacts.approvedMemberCount",
+  "identity.approvedComposeOnlyArtifacts.classification",
+  "identity.approvedComposeOnlyArtifacts.expectedCount",
+  "identity.approvedComposeOnlyArtifacts.expectedDigest",
+  "identity.approvedComposeOnlyArtifacts.missingApprovedMemberCount",
+  "identity.approvedComposeOnlyArtifacts.observedCount",
+  "identity.approvedComposeOnlyArtifacts.observedDigest",
+  "identity.approvedComposeOnlyArtifacts.unexpected.count",
+  "identity.approvedComposeOnlyArtifacts.unexpected.digest",
+  "identity.composeOnly.count",
+  "identity.composeOnly.digest",
+  "identity.createdTimestamps.equal.count",
+  "identity.createdTimestamps.equal.digest",
+  "identity.createdTimestamps.zeroEarlier.count",
+  "identity.createdTimestamps.zeroEarlier.digest",
+  "identity.createdTimestamps.zeroLater.count",
+  "identity.createdTimestamps.zeroLater.digest",
+  "identity.matched.count",
+  "identity.matched.digest",
+  "identity.nameMismatches.count",
+  "identity.nameMismatches.digest",
+  "identity.orgMismatches.count",
+  "identity.orgMismatches.digest",
+  "identity.ownerMismatches.count",
+  "identity.ownerMismatches.digest",
+  "identity.updatedTimestamps.compose.count",
+  "identity.updatedTimestamps.compose.digest",
+  "identity.updatedTimestamps.equal.count",
+  "identity.updatedTimestamps.equal.digest",
+  "identity.updatedTimestamps.zero.count",
+  "identity.updatedTimestamps.zero.digest",
+  "identity.zeroAgentsTotal",
+  "identity.zeroOnly.count",
+  "identity.zeroOnly.digest",
+  "runs.distinctVersionHashes.count",
+  "runs.distinctVersionHashes.digest",
+  "runs.headReferencedVersionHashes.count",
+  "runs.headReferencedVersionHashes.digest",
+  "runs.missingReferences.count",
+  "runs.missingReferences.digest",
+  "runs.nonNullReferences.count",
+  "runs.nonNullReferences.digest",
+  "runs.nullVersionReferenceCount",
+  "runs.sharedVersionHashes.count",
+  "runs.sharedVersionHashes.digest",
+  "runs.total",
+  "schemaVersion",
+  "status",
+  "versions.content.canonicalCurrent.count",
+  "versions.content.canonicalCurrent.digest",
+  "versions.content.hashMismatches.count",
+  "versions.content.hashMismatches.digest",
+  "versions.content.nonCanonicalLegacy.count",
+  "versions.content.nonCanonicalLegacy.digest",
+  "versions.content.unsupportedOrInvalid.count",
+  "versions.content.unsupportedOrInvalid.digest",
+  "versions.orphanComposeIds.count",
+  "versions.orphanComposeIds.digest",
+  "versions.provenance.composeNullCreatorNull.count",
+  "versions.provenance.composeNullCreatorNull.digest",
+  "versions.provenance.composeNullCreatorPresent.count",
+  "versions.provenance.composeNullCreatorPresent.digest",
+  "versions.provenance.composePresentCreatorNull.count",
+  "versions.provenance.composePresentCreatorNull.digest",
+  "versions.provenance.composePresentCreatorPresent.count",
+  "versions.provenance.composePresentCreatorPresent.digest",
+  "versions.total",
+] as const;
+
+export interface IdentityInventoryRow extends QueryResultRow {
+  readonly id: string;
+  readonly composePresent: boolean;
+  readonly zeroPresent: boolean;
+  readonly orgMismatch: boolean;
+  readonly ownerMismatch: boolean;
+  readonly nameMismatch: boolean;
+  readonly createdRelation: "zeroEarlier" | "equal" | "zeroLater" | null;
+  readonly updatedSource: "compose" | "equal" | "zero" | null;
+}
+
+export interface VersionInventoryRow extends QueryResultRow {
+  readonly id: string;
+  readonly composeId: string | null;
+  readonly composeExists: boolean;
+  readonly creatorPresent: boolean;
+  readonly content: unknown;
+}
+
+export interface HeadInventoryRow extends QueryResultRow {
+  readonly composeId: string;
+  readonly headVersionId: string;
+  readonly versionPresent: boolean;
+  readonly insertionComposeId: string | null;
+}
+
+export interface RunInventoryRow extends QueryResultRow {
+  readonly id: string;
+  readonly versionId: string | null;
+  readonly versionPresent: boolean;
+}
+
+export interface CheckpointInventoryRow extends QueryResultRow {
+  readonly id: string;
+  readonly snapshot: unknown;
+}
+
+export interface DanglingInventoryRow extends QueryResultRow {
+  readonly composeId: string;
+  readonly recordedHash: string;
+  readonly agentName: string | null;
+}
+
+export interface PreflightInventory {
+  readonly identity: readonly IdentityInventoryRow[];
+  readonly versions: readonly VersionInventoryRow[];
+  readonly heads: readonly HeadInventoryRow[];
+  readonly runs: readonly RunInventoryRow[];
+  readonly checkpoints: readonly CheckpointInventoryRow[];
+  readonly danglingStart: readonly DanglingInventoryRow[];
+  readonly danglingEnd: readonly DanglingInventoryRow[];
+  readonly catalogDependencies: readonly CatalogDependencyRow[];
+}
+
+export interface PreflightCapabilities {
+  readonly serverVersionClassification: "supported";
+  readonly transactionReadOnly: true;
+  readonly isolationLevel: "repeatable read";
+  readonly lockTimeoutMs: number;
+  readonly statementTimeoutMs: number;
+  readonly requiredExtensionCount: 0;
+}
+
+export interface PreflightClassificationOptions {
+  readonly approvedArtifactMemberDigests?: readonly string[];
+  readonly approvedArtifactSetDigest?: string;
+  readonly expectedApprovedArtifactCount?: number;
+  readonly expectedDanglingHeadCount?: number;
+  readonly expectedCatalogDependencies?: Readonly<
+    Record<CatalogDependencyKind, readonly string[]>
+  >;
+  readonly expectedRepositoryDependencies?: RepositoryDependencyManifest;
+  readonly observedRepositoryDependencies?: RepositoryDependencyManifest;
+}
+
+export interface ReadOnlySnapshotOptions {
+  readonly signal?: AbortSignal;
+  readonly lockTimeoutMs?: number;
+  readonly statementTimeoutMs?: number;
+}
+
+export class SanitizedPreflightError extends Error {
+  readonly gate: string;
+
+  constructor(gate: string) {
+    super(gate);
+    this.name = "SanitizedPreflightError";
+    this.gate = gate;
+  }
+}
+
+function assertNotAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw new SanitizedPreflightError("probe.cancelled");
+}
+
+function classifyThrownError(error: unknown, fallbackGate: string): never {
+  if (error instanceof SanitizedPreflightError) throw error;
+  if (error instanceof DOMException && error.name === "AbortError") {
+    throw new SanitizedPreflightError("probe.cancelled");
+  }
+  const code = (error as { readonly code?: unknown } | null)?.code;
+  if (code === "57014") {
+    throw new SanitizedPreflightError("probe.statement_timeout");
+  }
+  if (code === "55P03") {
+    throw new SanitizedPreflightError("probe.lock_timeout");
+  }
+  throw new SanitizedPreflightError(fallbackGate);
+}
+
+async function safeQuery<Row extends QueryResultRow>(
+  client: Client,
+  signal: AbortSignal | undefined,
+  text: string,
+  values?: readonly unknown[],
+): Promise<readonly Row[]> {
+  assertNotAborted(signal);
+  const result = await client.query<Row>(text, values as unknown[] | undefined);
+  assertNotAborted(signal);
+  return result.rows;
+}
+
+interface CapabilityRow extends QueryResultRow {
+  readonly serverVersion: number;
+  readonly readOnly: boolean;
+  readonly isolationLevel: string;
+  readonly lockTimeoutMs: number;
+  readonly statementTimeoutMs: number;
+}
+
+export async function withReadOnlySnapshot<Value>(
+  client: Client,
+  options: ReadOnlySnapshotOptions,
+  body: (capabilities: PreflightCapabilities) => Promise<Value>,
+): Promise<{
+  readonly capabilities: PreflightCapabilities;
+  readonly value: Value;
+}> {
+  const lockTimeoutMs = options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+  const statementTimeoutMs =
+    options.statementTimeoutMs ?? DEFAULT_STATEMENT_TIMEOUT_MS;
+  let transactionStarted = false;
+  let bodyError: unknown;
+  let result:
+    | { readonly capabilities: PreflightCapabilities; readonly value: Value }
+    | undefined;
+
+  try {
+    assertNotAborted(options.signal);
+    await client.query(
+      "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+    );
+    transactionStarted = true;
+    await client.query(
+      `SELECT
+         set_config('lock_timeout', $1, true),
+         set_config('statement_timeout', $2, true)`,
+      [`${lockTimeoutMs}ms`, `${statementTimeoutMs}ms`],
+    );
+    const capabilityRows = await safeQuery<CapabilityRow>(
+      client,
+      options.signal,
+      `SELECT
+         current_setting('server_version_num')::integer AS "serverVersion",
+         current_setting('transaction_read_only') = 'on' AS "readOnly",
+         current_setting('transaction_isolation') AS "isolationLevel",
+         (SELECT "setting"::integer FROM "pg_settings"
+          WHERE "name" = 'lock_timeout') AS "lockTimeoutMs",
+         (SELECT "setting"::integer FROM "pg_settings"
+          WHERE "name" = 'statement_timeout') AS "statementTimeoutMs"`,
+    );
+    const capability = capabilityRows[0];
+    if (
+      !capability ||
+      capability.serverVersion < MINIMUM_SERVER_VERSION ||
+      !capability.readOnly ||
+      capability.isolationLevel !== "repeatable read" ||
+      capability.lockTimeoutMs !== lockTimeoutMs ||
+      capability.statementTimeoutMs !== statementTimeoutMs
+    ) {
+      throw new SanitizedPreflightError("probe.capability_gate");
+    }
+    const capabilities: PreflightCapabilities = {
+      serverVersionClassification: "supported",
+      transactionReadOnly: true,
+      isolationLevel: "repeatable read",
+      lockTimeoutMs,
+      statementTimeoutMs,
+      requiredExtensionCount: 0,
+    };
+    result = { capabilities, value: await body(capabilities) };
+  } catch (error) {
+    bodyError = error;
+  }
+
+  if (transactionStarted) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      throw new SanitizedPreflightError("probe.transaction_cleanup");
+    }
+  }
+  if (bodyError !== undefined)
+    classifyThrownError(bodyError, "probe.inventory");
+  if (!result) throw new SanitizedPreflightError("probe.transaction_start");
+  return result;
+}
+
+function frameTuple(parts: readonly string[]): string {
+  return parts
+    .map((part) => {
+      return `${Buffer.byteLength(part, "utf8")}:${part}`;
+    })
+    .join("|");
+}
+
+function comparison(
+  domain: string,
+  expected: readonly string[],
+  observed: readonly string[],
+): {
+  readonly expected: SetFingerprint;
+  readonly observed: SetFingerprint;
+  readonly classification: "exact" | "drift";
+} {
+  const expectedMetric = fingerprintSortedSet(`${domain}:expected`, expected);
+  const observedMetric = fingerprintSortedSet(`${domain}:expected`, observed);
+  return {
+    expected: expectedMetric,
+    observed: observedMetric,
+    classification:
+      expectedMetric.count === observedMetric.count &&
+      expectedMetric.digest === observedMetric.digest
+        ? "exact"
+        : "drift",
+  };
+}
+
+function recordSet(
+  domain: string,
+  rows: readonly { readonly id: string }[],
+): SetFingerprint {
+  return fingerprintSortedSet(
+    domain,
+    rows.map((row) => {
+      return row.id;
+    }),
+  );
+}
+
+function headRecordSet(
+  domain: string,
+  rows: readonly HeadInventoryRow[],
+): SetFingerprint {
+  return fingerprintSortedSet(
+    domain,
+    rows.map((row) => {
+      return row.composeId;
+    }),
+  );
+}
+
+function increment(map: Map<string, number>, key: string): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function checkpointVersionId(
+  snapshot: unknown,
+):
+  | { readonly classification: "absent" }
+  | { readonly classification: "invalid" }
+  | { readonly classification: "valid"; readonly versionId: string } {
+  if (
+    snapshot === null ||
+    typeof snapshot !== "object" ||
+    Array.isArray(snapshot)
+  ) {
+    return { classification: "invalid" };
+  }
+  if (!("agentComposeVersionId" in snapshot)) {
+    return { classification: "absent" };
+  }
+  const value = (snapshot as { readonly agentComposeVersionId?: unknown })
+    .agentComposeVersionId;
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) {
+    return { classification: "invalid" };
+  }
+  return { classification: "valid", versionId: value };
+}
+
+interface IdentityClassificationInput {
+  readonly rows: readonly IdentityInventoryRow[];
+  readonly approvedMemberDigests: ReadonlySet<string>;
+  readonly approvedSetDigest: string;
+  readonly expectedApprovedCount: number;
+}
+
+function classifyIdentity(
+  input: IdentityClassificationInput,
+  failureGates: Set<string>,
+) {
+  const composeRows = input.rows.filter((row) => {
+    return row.composePresent;
+  });
+  const zeroRows = input.rows.filter((row) => {
+    return row.zeroPresent;
+  });
+  const matchedRows = input.rows.filter((row) => {
+    return row.composePresent && row.zeroPresent;
+  });
+  const composeOnlyRows = input.rows.filter((row) => {
+    return row.composePresent && !row.zeroPresent;
+  });
+  const zeroOnlyRows = input.rows.filter((row) => {
+    return !row.composePresent && row.zeroPresent;
+  });
+  const orgMismatchRows = matchedRows.filter((row) => {
+    return row.orgMismatch;
+  });
+  const ownerMismatchRows = matchedRows.filter((row) => {
+    return row.ownerMismatch;
+  });
+  const nameMismatchRows = matchedRows.filter((row) => {
+    return row.nameMismatch;
+  });
+  const composeOnlyIds = composeOnlyRows.map((row) => {
+    return row.id;
+  });
+  const observedApprovedSet = fingerprintSortedSet(
+    "approved-artifact-set",
+    composeOnlyIds,
+  );
+  const approvedIds = composeOnlyIds.filter((id) => {
+    return input.approvedMemberDigests.has(
+      fingerprintMember("approved-artifact-member", id),
+    );
+  });
+  const unexpectedArtifactIds = composeOnlyIds.filter((id) => {
+    return !input.approvedMemberDigests.has(
+      fingerprintMember("approved-artifact-member", id),
+    );
+  });
+  const approvedClassification =
+    composeOnlyIds.length === input.expectedApprovedCount &&
+    approvedIds.length === input.expectedApprovedCount &&
+    observedApprovedSet.digest === input.approvedSetDigest
+      ? "exact"
+      : "drift";
+
+  if (approvedClassification === "drift") {
+    failureGates.add("identity.approved_artifact_drift");
+  }
+  if (zeroOnlyRows.length > 0) failureGates.add("identity.zero_only");
+  if (orgMismatchRows.length > 0) failureGates.add("identity.org_mismatch");
+  if (ownerMismatchRows.length > 0) {
+    failureGates.add("identity.owner_mismatch");
+  }
+  if (nameMismatchRows.length > 0) {
+    failureGates.add("identity.name_mismatch");
+  }
+
+  return {
+    agentComposesTotal: composeRows.length,
+    zeroAgentsTotal: zeroRows.length,
+    matched: recordSet("identity:matched-agent-ids", matchedRows),
+    composeOnly: recordSet("identity:compose-only-agent-ids", composeOnlyRows),
+    zeroOnly: recordSet("identity:zero-only-agent-ids", zeroOnlyRows),
+    orgMismatches: recordSet(
+      "identity:org-mismatch-agent-ids",
+      orgMismatchRows,
+    ),
+    ownerMismatches: recordSet(
+      "identity:owner-mismatch-agent-ids",
+      ownerMismatchRows,
+    ),
+    nameMismatches: recordSet(
+      "identity:name-mismatch-agent-ids",
+      nameMismatchRows,
+    ),
+    createdTimestamps: {
+      zeroEarlier: recordSet(
+        "identity:created-zero-earlier-agent-ids",
+        matchedRows.filter((row) => {
+          return row.createdRelation === "zeroEarlier";
+        }),
+      ),
+      equal: recordSet(
+        "identity:created-equal-agent-ids",
+        matchedRows.filter((row) => {
+          return row.createdRelation === "equal";
+        }),
+      ),
+      zeroLater: recordSet(
+        "identity:created-zero-later-agent-ids",
+        matchedRows.filter((row) => {
+          return row.createdRelation === "zeroLater";
+        }),
+      ),
+    },
+    updatedTimestamps: {
+      compose: recordSet(
+        "identity:updated-compose-agent-ids",
+        matchedRows.filter((row) => {
+          return row.updatedSource === "compose";
+        }),
+      ),
+      equal: recordSet(
+        "identity:updated-equal-agent-ids",
+        matchedRows.filter((row) => {
+          return row.updatedSource === "equal";
+        }),
+      ),
+      zero: recordSet(
+        "identity:updated-zero-agent-ids",
+        matchedRows.filter((row) => {
+          return row.updatedSource === "zero";
+        }),
+      ),
+    },
+    approvedComposeOnlyArtifacts: {
+      expectedCount: input.expectedApprovedCount,
+      expectedDigest: input.approvedSetDigest,
+      observedCount: observedApprovedSet.count,
+      observedDigest: observedApprovedSet.digest,
+      approvedMemberCount: approvedIds.length,
+      missingApprovedMemberCount: Math.max(
+        0,
+        input.expectedApprovedCount - approvedIds.length,
+      ),
+      unexpected: fingerprintSortedSet(
+        "identity:unexpected-compose-only-agent-ids",
+        unexpectedArtifactIds,
+      ),
+      classification: approvedClassification,
+    },
+  };
+}
+
+type VersionContentClassification = "canonical" | "nonCanonical" | "invalid";
+
+function classifyVersionContent(version: VersionInventoryRow): {
+  readonly classification: VersionContentClassification;
+  readonly hashMismatch: boolean;
+} {
+  const content = version.content;
+  if (
+    content === null ||
+    typeof content !== "object" ||
+    Array.isArray(content)
+  ) {
+    return { classification: "invalid", hashMismatch: false };
+  }
+  const exactContentHash =
+    computeComposeVersionId(content as Record<string, unknown>) === version.id;
+  const parsed = agentComposeApiContentSchema.safeParse(content);
+  if (!parsed.success || !exactContentHash) {
+    return { classification: "invalid", hashMismatch: !exactContentHash };
+  }
+  const agentNames = Object.keys(parsed.data.agents);
+  const canonical =
+    agentNames.length === 1 &&
+    isDeepStrictEqual(content, buildZeroAgentComposeContent(agentNames[0]!));
+  return {
+    classification: canonical ? "canonical" : "nonCanonical",
+    hashMismatch: false,
+  };
+}
+
+function classifyVersions(
+  rows: readonly VersionInventoryRow[],
+  failureGates: Set<string>,
+) {
+  const composePresentCreatorPresent: VersionInventoryRow[] = [];
+  const composePresentCreatorNull: VersionInventoryRow[] = [];
+  const composeNullCreatorPresent: VersionInventoryRow[] = [];
+  const composeNullCreatorNull: VersionInventoryRow[] = [];
+  const orphanVersions: VersionInventoryRow[] = [];
+  const canonicalVersions: VersionInventoryRow[] = [];
+  const nonCanonicalVersions: VersionInventoryRow[] = [];
+  const invalidVersions: VersionInventoryRow[] = [];
+  const contentHashMismatches: VersionInventoryRow[] = [];
+
+  for (const version of rows) {
+    if (version.composeId !== null && version.creatorPresent) {
+      composePresentCreatorPresent.push(version);
+    } else if (version.composeId !== null) {
+      composePresentCreatorNull.push(version);
+    } else if (version.creatorPresent) {
+      composeNullCreatorPresent.push(version);
+    } else {
+      composeNullCreatorNull.push(version);
+    }
+    if (version.composeId !== null && !version.composeExists) {
+      orphanVersions.push(version);
+    }
+
+    const content = classifyVersionContent(version);
+    if (content.classification === "canonical") {
+      canonicalVersions.push(version);
+    } else if (content.classification === "nonCanonical") {
+      nonCanonicalVersions.push(version);
+    } else {
+      invalidVersions.push(version);
+    }
+    if (content.hashMismatch) contentHashMismatches.push(version);
+  }
+
+  if (orphanVersions.length > 0) {
+    failureGates.add("versions.orphan_compose");
+  }
+  if (invalidVersions.length > 0) {
+    failureGates.add("versions.invalid_content");
+  }
+  if (contentHashMismatches.length > 0) {
+    failureGates.add("versions.content_hash_mismatch");
+  }
+
+  return {
+    total: rows.length,
+    provenance: {
+      composePresentCreatorPresent: recordSet(
+        "versions:compose-present-creator-present",
+        composePresentCreatorPresent,
+      ),
+      composePresentCreatorNull: recordSet(
+        "versions:compose-present-creator-null",
+        composePresentCreatorNull,
+      ),
+      composeNullCreatorPresent: recordSet(
+        "versions:compose-null-creator-present",
+        composeNullCreatorPresent,
+      ),
+      composeNullCreatorNull: recordSet(
+        "versions:compose-null-creator-null",
+        composeNullCreatorNull,
+      ),
+    },
+    orphanComposeIds: recordSet(
+      "versions:orphan-compose-version-ids",
+      orphanVersions,
+    ),
+    content: {
+      canonicalCurrent: recordSet(
+        "versions:canonical-current",
+        canonicalVersions,
+      ),
+      nonCanonicalLegacy: recordSet(
+        "versions:noncanonical-legacy",
+        nonCanonicalVersions,
+      ),
+      unsupportedOrInvalid: recordSet("versions:invalid", invalidVersions),
+      hashMismatches: recordSet(
+        "versions:content-hash-mismatch",
+        contentHashMismatches,
+      ),
+    },
+  };
+}
+
+function classifyHeads(rows: readonly HeadInventoryRow[]) {
+  const fanout = new Map<string, number>();
+  for (const head of rows) increment(fanout, head.headVersionId);
+  const distinctHashes = [...fanout.keys()];
+  const sharedHashes = [...fanout.entries()]
+    .filter(([, count]) => {
+      return count > 1;
+    })
+    .map(([hash]) => {
+      return hash;
+    });
+  const present = rows.filter((head) => {
+    return head.versionPresent;
+  });
+  const dangling = rows.filter((head) => {
+    return !head.versionPresent;
+  });
+  const crossCompose = present.filter((head) => {
+    return (
+      head.insertionComposeId !== null &&
+      head.insertionComposeId !== head.composeId
+    );
+  });
+  const nullProvenance = present.filter((head) => {
+    return head.insertionComposeId === null;
+  });
+
+  return {
+    distinctHashes,
+    output: {
+      nonNullReferenceCount: rows.length,
+      distinctHashes: fingerprintSortedSet(
+        "heads:distinct-version-hashes",
+        distinctHashes,
+      ),
+      presentAgentIds: headRecordSet("heads:present-agent-ids", present),
+      danglingAgentIds: headRecordSet("heads:dangling-agent-ids", dangling),
+      sharedHashes: fingerprintSortedSet(
+        "heads:shared-version-hashes",
+        sharedHashes,
+      ),
+      fanout: {
+        singleHashCount: [...fanout.values()].filter((count) => {
+          return count === 1;
+        }).length,
+        sharedHashCount: sharedHashes.length,
+        maximumReferenceCount: Math.max(0, ...fanout.values()),
+      },
+      nullInsertionProvenanceAgentIds: headRecordSet(
+        "heads:null-insertion-provenance-agent-ids",
+        nullProvenance,
+      ),
+      crossComposeInsertionProvenanceAgentIds: headRecordSet(
+        "heads:cross-compose-provenance-agent-ids",
+        crossCompose,
+      ),
+    },
+  };
+}
+
+function classifyRuns(
+  rows: readonly RunInventoryRow[],
+  headHashes: ReadonlySet<string>,
+  failureGates: Set<string>,
+) {
+  const fanout = new Map<string, number>();
+  const nonNull = rows.filter((run) => {
+    return run.versionId !== null;
+  });
+  const missing = nonNull.filter((run) => {
+    return !run.versionPresent;
+  });
+  for (const run of nonNull) increment(fanout, run.versionId!);
+  const versionHashes = [...fanout.keys()];
+  const sharedHashes = [...fanout.entries()]
+    .filter(([, count]) => {
+      return count > 1;
+    })
+    .map(([hash]) => {
+      return hash;
+    });
+  const headReferencedHashes = versionHashes.filter((hash) => {
+    return headHashes.has(hash);
+  });
+  if (missing.length > 0) failureGates.add("runs.missing_version");
+
+  return {
+    versionHashes,
+    output: {
+      total: rows.length,
+      nullVersionReferenceCount: rows.length - nonNull.length,
+      nonNullReferences: recordSet("runs:non-null-reference-run-ids", nonNull),
+      missingReferences: recordSet("runs:missing-reference-run-ids", missing),
+      distinctVersionHashes: fingerprintSortedSet(
+        "runs:distinct-version-hashes",
+        versionHashes,
+      ),
+      sharedVersionHashes: fingerprintSortedSet(
+        "runs:shared-version-hashes",
+        sharedHashes,
+      ),
+      headReferencedVersionHashes: fingerprintSortedSet(
+        "runs:head-referenced-version-hashes",
+        headReferencedHashes,
+      ),
+    },
+  };
+}
+
+function classifyCheckpoints(
+  rows: readonly CheckpointInventoryRow[],
+  versionIds: ReadonlySet<string>,
+  runHashes: ReadonlySet<string>,
+  headHashes: ReadonlySet<string>,
+  failureGates: Set<string>,
+) {
+  const absent: CheckpointInventoryRow[] = [];
+  const invalid: CheckpointInventoryRow[] = [];
+  const valid: CheckpointInventoryRow[] = [];
+  const missing: CheckpointInventoryRow[] = [];
+  const fanout = new Map<string, number>();
+
+  for (const checkpoint of rows) {
+    const reference = checkpointVersionId(checkpoint.snapshot);
+    if (reference.classification === "absent") {
+      absent.push(checkpoint);
+    } else if (reference.classification === "invalid") {
+      invalid.push(checkpoint);
+    } else {
+      valid.push(checkpoint);
+      increment(fanout, reference.versionId);
+      if (!versionIds.has(reference.versionId)) missing.push(checkpoint);
+    }
+  }
+  const versionHashes = [...fanout.keys()];
+  const sharedHashes = [...fanout.entries()]
+    .filter(([, count]) => {
+      return count > 1;
+    })
+    .map(([hash]) => {
+      return hash;
+    });
+  const runReferencedHashes = versionHashes.filter((hash) => {
+    return runHashes.has(hash);
+  });
+  const headReferencedHashes = versionHashes.filter((hash) => {
+    return headHashes.has(hash);
+  });
+  if (invalid.length > 0) {
+    failureGates.add("checkpoints.invalid_reference");
+  }
+  if (missing.length > 0) {
+    failureGates.add("checkpoints.missing_version");
+  }
+
+  return {
+    total: rows.length,
+    absentLegacyReference: recordSet(
+      "checkpoints:absent-reference-checkpoint-ids",
+      absent,
+    ),
+    validLegacyReference: recordSet(
+      "checkpoints:valid-reference-checkpoint-ids",
+      valid,
+    ),
+    invalidLegacyReference: recordSet(
+      "checkpoints:invalid-reference-checkpoint-ids",
+      invalid,
+    ),
+    missingVersionReference: recordSet(
+      "checkpoints:missing-reference-checkpoint-ids",
+      missing,
+    ),
+    distinctVersionHashes: fingerprintSortedSet(
+      "checkpoints:distinct-version-hashes",
+      versionHashes,
+    ),
+    sharedVersionHashes: fingerprintSortedSet(
+      "checkpoints:shared-version-hashes",
+      sharedHashes,
+    ),
+    runReferencedVersionHashes: fingerprintSortedSet(
+      "checkpoints:run-referenced-version-hashes",
+      runReferencedHashes,
+    ),
+    headReferencedVersionHashes: fingerprintSortedSet(
+      "checkpoints:head-referenced-version-hashes",
+      headReferencedHashes,
+    ),
+  };
+}
+
+function danglingStabilityMetric(
+  rows: readonly DanglingInventoryRow[],
+): SetFingerprint {
+  return fingerprintSortedSet(
+    "dangling-stability-records",
+    rows.map((row) => {
+      return frameTuple([row.composeId, row.recordedHash, row.agentName ?? ""]);
+    }),
+  );
+}
+
+function classifyDangling(
+  start: readonly DanglingInventoryRow[],
+  end: readonly DanglingInventoryRow[],
+  expectedCount: number,
+  failureGates: Set<string>,
+) {
+  const exact: DanglingInventoryRow[] = [];
+  const nonExact: DanglingInventoryRow[] = [];
+  const missingIdentity: DanglingInventoryRow[] = [];
+
+  for (const dangling of start) {
+    if (dangling.agentName === null) {
+      missingIdentity.push(dangling);
+      continue;
+    }
+    const expectedHash = computeComposeVersionId(
+      buildZeroAgentComposeContent(dangling.agentName),
+    );
+    if (expectedHash === dangling.recordedHash) exact.push(dangling);
+    else nonExact.push(dangling);
+  }
+  const startStability = danglingStabilityMetric(start);
+  const endStability = danglingStabilityMetric(end);
+  const stable =
+    startStability.count === endStability.count &&
+    startStability.digest === endStability.digest;
+
+  if (!stable) failureGates.add("dangling.snapshot_drift");
+  if (start.length !== expectedCount) failureGates.add("dangling.count_drift");
+  if (missingIdentity.length > 0) {
+    failureGates.add("dangling.missing_identity");
+  }
+  if (nonExact.length > 0) failureGates.add("dangling.non_exact");
+
+  return {
+    expectedCount,
+    start: fingerprintSortedSet(
+      "dangling:agent-ids",
+      start.map((row) => {
+        return row.composeId;
+      }),
+    ),
+    end: fingerprintSortedSet(
+      "dangling:agent-ids",
+      end.map((row) => {
+        return row.composeId;
+      }),
+    ),
+    exact: fingerprintSortedSet(
+      "dangling:exact-agent-ids",
+      exact.map((row) => {
+        return row.composeId;
+      }),
+    ),
+    nonExact: fingerprintSortedSet(
+      "dangling:nonexact-agent-ids",
+      nonExact.map((row) => {
+        return row.composeId;
+      }),
+    ),
+    missingIdentity: fingerprintSortedSet(
+      "dangling:missing-identity-agent-ids",
+      missingIdentity.map((row) => {
+        return row.composeId;
+      }),
+    ),
+    snapshotClassification: stable ? "stable" : "drift",
+  };
+}
+
+function classifyDependencies(
+  catalogRows: readonly CatalogDependencyRow[],
+  expectedCatalog: Readonly<Record<CatalogDependencyKind, readonly string[]>>,
+  expectedRepository: RepositoryDependencyManifest,
+  observedRepository: RepositoryDependencyManifest,
+  failureGates: Set<string>,
+) {
+  const catalogObserved = Object.fromEntries(
+    CATALOG_DEPENDENCY_KINDS.map((kind) => {
+      return [
+        kind,
+        catalogRows
+          .filter((row) => {
+            return row.kind === kind;
+          })
+          .map((row) => {
+            return row.entry;
+          })
+          .sort(),
+      ];
+    }),
+  ) as Record<CatalogDependencyKind, string[]>;
+  const catalog = Object.fromEntries(
+    CATALOG_DEPENDENCY_KINDS.map((kind) => {
+      const value = comparison(
+        `dependencies:catalog:${kind}`,
+        expectedCatalog[kind],
+        catalogObserved[kind],
+      );
+      if (value.classification === "drift") {
+        failureGates.add(`dependencies.catalog.${kind}`);
+      }
+      return [kind, value];
+    }),
+  );
+  const repository = {
+    schemaImports: comparison(
+      "dependencies:repository:schema-imports",
+      expectedRepository.schemaImports,
+      observedRepository.schemaImports,
+    ),
+    legacyIdentifiers: comparison(
+      "dependencies:repository:legacy-identifiers",
+      expectedRepository.legacyIdentifiers,
+      observedRepository.legacyIdentifiers,
+    ),
+    rawTableLiterals: comparison(
+      "dependencies:repository:raw-table-literals",
+      expectedRepository.rawTableLiterals,
+      observedRepository.rawTableLiterals,
+    ),
+    nonTypeScriptConsumers: comparison(
+      "dependencies:repository:non-typescript-consumers",
+      expectedRepository.nonTypeScriptConsumers,
+      observedRepository.nonTypeScriptConsumers,
+    ),
+    transitionValidators: comparison(
+      "dependencies:repository:transition-validators",
+      expectedRepository.transitionValidators,
+      observedRepository.transitionValidators,
+    ),
+  };
+  for (const [kind, value] of Object.entries(repository)) {
+    if (value.classification === "drift") {
+      failureGates.add(`dependencies.repository.${kind}`);
+    }
+  }
+  return { catalog, repository };
+}
+
+export function classifyPreflightInventory(
+  capabilities: PreflightCapabilities,
+  inventory: PreflightInventory,
+  options: PreflightClassificationOptions = {},
+) {
+  const expectedApprovedCount = options.expectedApprovedArtifactCount ?? 6;
+  const expectedDanglingCount =
+    options.expectedDanglingHeadCount ?? DEFAULT_EXPECTED_DANGLING_HEAD_COUNT;
+  const expectedCatalog =
+    options.expectedCatalogDependencies ?? EXPECTED_CATALOG_DEPENDENCIES;
+  const expectedRepository =
+    options.expectedRepositoryDependencies ?? EXPECTED_REPOSITORY_DEPENDENCIES;
+  const observedRepository =
+    options.observedRepositoryDependencies ?? expectedRepository;
+  const failureGates = new Set<string>();
+  const identity = classifyIdentity(
+    {
+      rows: inventory.identity,
+      approvedMemberDigests: new Set(
+        options.approvedArtifactMemberDigests ??
+          APPROVED_ARTIFACT_MEMBER_DIGESTS,
+      ),
+      approvedSetDigest:
+        options.approvedArtifactSetDigest ?? APPROVED_ARTIFACT_SET_DIGEST,
+      expectedApprovedCount,
+    },
+    failureGates,
+  );
+  const versions = classifyVersions(inventory.versions, failureGates);
+  const heads = classifyHeads(inventory.heads);
+  const headHashSet = new Set(heads.distinctHashes);
+  const runs = classifyRuns(inventory.runs, headHashSet, failureGates);
+  const checkpoints = classifyCheckpoints(
+    inventory.checkpoints,
+    new Set(
+      inventory.versions.map((version) => {
+        return version.id;
+      }),
+    ),
+    new Set(runs.versionHashes),
+    headHashSet,
+    failureGates,
+  );
+  const danglingHeads = classifyDangling(
+    inventory.danglingStart,
+    inventory.danglingEnd,
+    expectedDanglingCount,
+    failureGates,
+  );
+  const dependencies = classifyDependencies(
+    inventory.catalogDependencies,
+    expectedCatalog,
+    expectedRepository,
+    observedRepository,
+    failureGates,
+  );
+  const sortedFailureGates = [...failureGates].sort();
+
+  return {
+    schemaVersion: PREFLIGHT_SCHEMA_VERSION,
+    status:
+      sortedFailureGates.length === 0
+        ? ("passed" as const)
+        : ("failed" as const),
+    failureGates: sortedFailureGates,
+    capabilities,
+    identity,
+    versions,
+    heads: heads.output,
+    runs: runs.output,
+    checkpoints,
+    danglingHeads,
+    dependencies,
+  };
+}
+
+const DANGLING_QUERY = `
+SELECT
+  "compose"."id"::text AS "composeId",
+  "compose"."head_version_id" AS "recordedHash",
+  "agent"."name" AS "agentName"
+FROM "agent_composes" AS "compose"
+LEFT JOIN "agent_compose_versions" AS "version"
+  ON "version"."id" = "compose"."head_version_id"
+LEFT JOIN "zero_agents" AS "agent" ON "agent"."id" = "compose"."id"
+WHERE "compose"."head_version_id" IS NOT NULL
+  AND "version"."id" IS NULL
+ORDER BY "compose"."id"
+`;
+
+async function collectDatabaseInventory(
+  client: Client,
+  signal: AbortSignal | undefined,
+): Promise<PreflightInventory> {
+  const danglingStart = await safeQuery<DanglingInventoryRow>(
+    client,
+    signal,
+    DANGLING_QUERY,
+  );
+  const identity = await safeQuery<IdentityInventoryRow>(
+    client,
+    signal,
+    `SELECT
+       coalesce("compose"."id", "agent"."id")::text AS "id",
+       "compose"."id" IS NOT NULL AS "composePresent",
+       "agent"."id" IS NOT NULL AS "zeroPresent",
+       coalesce("compose"."org_id" IS DISTINCT FROM "agent"."org_id", false)
+         AS "orgMismatch",
+       coalesce("compose"."user_id" IS DISTINCT FROM "agent"."owner", false)
+         AS "ownerMismatch",
+       coalesce("compose"."name" IS DISTINCT FROM "agent"."name", false)
+         AS "nameMismatch",
+       CASE
+         WHEN "compose"."id" IS NULL OR "agent"."id" IS NULL THEN NULL
+         WHEN "agent"."created_at" < "compose"."created_at" THEN 'zeroEarlier'
+         WHEN "agent"."created_at" = "compose"."created_at" THEN 'equal'
+         ELSE 'zeroLater'
+       END AS "createdRelation",
+       CASE
+         WHEN "compose"."id" IS NULL OR "agent"."id" IS NULL THEN NULL
+         WHEN "compose"."updated_at" > "agent"."updated_at" THEN 'compose'
+         WHEN "compose"."updated_at" = "agent"."updated_at" THEN 'equal'
+         ELSE 'zero'
+       END AS "updatedSource"
+     FROM "agent_composes" AS "compose"
+     FULL OUTER JOIN "zero_agents" AS "agent"
+       ON "agent"."id" = "compose"."id"
+     ORDER BY coalesce("compose"."id", "agent"."id")`,
+  );
+  const versions = await safeQuery<VersionInventoryRow>(
+    client,
+    signal,
+    `SELECT
+       "version"."id",
+       "version"."compose_id"::text AS "composeId",
+       "compose"."id" IS NOT NULL AS "composeExists",
+       "version"."created_by" IS NOT NULL AS "creatorPresent",
+       "version"."content"
+     FROM "agent_compose_versions" AS "version"
+     LEFT JOIN "agent_composes" AS "compose"
+       ON "compose"."id" = "version"."compose_id"
+     ORDER BY "version"."id"`,
+  );
+  const heads = await safeQuery<HeadInventoryRow>(
+    client,
+    signal,
+    `SELECT
+       "compose"."id"::text AS "composeId",
+       "compose"."head_version_id" AS "headVersionId",
+       "version"."id" IS NOT NULL AS "versionPresent",
+       "version"."compose_id"::text AS "insertionComposeId"
+     FROM "agent_composes" AS "compose"
+     LEFT JOIN "agent_compose_versions" AS "version"
+       ON "version"."id" = "compose"."head_version_id"
+     WHERE "compose"."head_version_id" IS NOT NULL
+     ORDER BY "compose"."id"`,
+  );
+  const runs = await safeQuery<RunInventoryRow>(
+    client,
+    signal,
+    `SELECT
+       "run"."id"::text AS "id",
+       "run"."agent_compose_version_id" AS "versionId",
+       "version"."id" IS NOT NULL AS "versionPresent"
+     FROM "agent_runs" AS "run"
+     LEFT JOIN "agent_compose_versions" AS "version"
+       ON "version"."id" = "run"."agent_compose_version_id"
+     ORDER BY "run"."id"`,
+  );
+  const checkpoints = await safeQuery<CheckpointInventoryRow>(
+    client,
+    signal,
+    `SELECT
+       "checkpoint"."id"::text AS "id",
+       "checkpoint"."agent_compose_snapshot" AS "snapshot"
+     FROM "checkpoints" AS "checkpoint"
+     ORDER BY "checkpoint"."id"`,
+  );
+  const catalogDependencies = await safeQuery<CatalogDependencyRow>(
+    client,
+    signal,
+    CATALOG_DEPENDENCY_QUERY,
+  );
+  const danglingEnd = await safeQuery<DanglingInventoryRow>(
+    client,
+    signal,
+    DANGLING_QUERY,
+  );
+  return {
+    identity,
+    versions,
+    heads,
+    runs,
+    checkpoints,
+    danglingStart,
+    danglingEnd,
+    catalogDependencies,
+  };
+}
+
+export async function executeAgentComposeConsolidationPreflight(args: {
+  readonly connectionString: string;
+  readonly repositoryRoot: string;
+  readonly signal?: AbortSignal;
+  readonly classification?: PreflightClassificationOptions;
+  readonly lockTimeoutMs?: number;
+  readonly statementTimeoutMs?: number;
+}) {
+  let repositoryDependencies: RepositoryDependencyManifest;
+  try {
+    repositoryDependencies = await collectRepositoryDependencyManifest(
+      args.repositoryRoot,
+    );
+  } catch (error) {
+    classifyThrownError(error, "probe.repository_inventory");
+  }
+
+  const client = new Client({ connectionString: args.connectionString });
+  client.on("error", () => {});
+  try {
+    await client.connect();
+  } catch (error) {
+    classifyThrownError(error, "probe.database_connection");
+  }
+
+  try {
+    const snapshot = await withReadOnlySnapshot(
+      client,
+      {
+        signal: args.signal,
+        lockTimeoutMs: args.lockTimeoutMs,
+        statementTimeoutMs: args.statementTimeoutMs,
+      },
+      async () => {
+        return collectDatabaseInventory(client, args.signal);
+      },
+    );
+    return classifyPreflightInventory(snapshot.capabilities, snapshot.value, {
+      ...args.classification,
+      observedRepositoryDependencies: repositoryDependencies,
+    });
+  } catch (error) {
+    classifyThrownError(error, "probe.inventory");
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+export function sanitizedFailureResult(error: unknown): {
+  readonly schemaVersion: string;
+  readonly status: "failed";
+  readonly failureGates: readonly string[];
+} {
+  return {
+    schemaVersion: PREFLIGHT_SCHEMA_VERSION,
+    status: "failed",
+    failureGates: [
+      error instanceof SanitizedPreflightError
+        ? error.gate
+        : "probe.unexpected",
+    ],
+  };
+}
+
+async function runCli(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    process.stdout.write(
+      `${JSON.stringify(sanitizedFailureResult(new SanitizedPreflightError("probe.configuration")))}\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const abortController = new AbortController();
+  const abort = (): void => {
+    return abortController.abort();
+  };
+  process.once("SIGINT", abort);
+  process.once("SIGTERM", abort);
+  try {
+    const repositoryRoot = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../..",
+    );
+    const result = await executeAgentComposeConsolidationPreflight({
+      connectionString: databaseUrl,
+      repositoryRoot,
+      signal: abortController.signal,
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    if (result.status !== "passed") process.exitCode = 1;
+  } catch (error) {
+    process.stdout.write(`${JSON.stringify(sanitizedFailureResult(error))}\n`);
+    process.exitCode = 1;
+  } finally {
+    process.off("SIGINT", abort);
+    process.off("SIGTERM", abort);
+  }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  runCli().catch((error: unknown) => {
+    process.stdout.write(`${JSON.stringify(sanitizedFailureResult(error))}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -1,0 +1,965 @@
+#!/usr/bin/env tsx
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+import {
+  buildZeroAgentComposeContent,
+  computeComposeVersionId,
+} from "../../../apps/api/src/signals/services/agent-compose-content";
+import {
+  CATALOG_DEPENDENCY_KINDS,
+  CATALOG_DEPENDENCY_QUERY,
+  EXPECTED_CATALOG_DEPENDENCIES,
+  EXPECTED_REPOSITORY_DEPENDENCIES,
+  collectRepositoryDependencyManifest,
+  manifestsEqual,
+  type CatalogDependencyKind,
+  type CatalogDependencyRow,
+  type RepositoryDependencyManifest,
+} from "./agent-compose-consolidation-preflight-manifest";
+import {
+  fingerprintMember,
+  fingerprintSortedSet,
+} from "./agent-compose-consolidation-preflight-fingerprint";
+import {
+  PREFLIGHT_OUTPUT_ALLOWLIST,
+  SanitizedPreflightError,
+  classifyPreflightInventory,
+  executeAgentComposeConsolidationPreflight,
+  sanitizedFailureResult,
+  withReadOnlySnapshot,
+  type DanglingInventoryRow,
+  type HeadInventoryRow,
+  type IdentityInventoryRow,
+  type PreflightCapabilities,
+  type PreflightClassificationOptions,
+  type PreflightInventory,
+  type VersionInventoryRow,
+} from "./agent-compose-consolidation-preflight";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageDirectory = path.resolve(dirname, "..");
+const repositoryRoot = path.resolve(dirname, "../../../..");
+const testDatabase = "agent_compose_consolidation_preflight_test";
+
+const capabilities: PreflightCapabilities = {
+  serverVersionClassification: "supported",
+  transactionReadOnly: true,
+  isolationLevel: "repeatable read",
+  lockTimeoutMs: 1000,
+  statementTimeoutMs: 30000,
+  requiredExtensionCount: 0,
+};
+
+const emptyCatalog: Record<CatalogDependencyKind, readonly string[]> = {
+  foreignKeys: [],
+  reviewedNonFk: [],
+  defaults: [],
+  indexes: [],
+  triggers: [],
+  functions: [],
+};
+
+const emptyRepository: RepositoryDependencyManifest = {
+  schemaImports: [],
+  legacyIdentifiers: [],
+  rawTableLiterals: [],
+  nonTypeScriptConsumers: [],
+  transitionValidators: [],
+};
+
+function emptyInventory(
+  overrides: Partial<PreflightInventory> = {},
+): PreflightInventory {
+  return {
+    identity: [],
+    versions: [],
+    heads: [],
+    runs: [],
+    checkpoints: [],
+    danglingStart: [],
+    danglingEnd: [],
+    catalogDependencies: [],
+    ...overrides,
+  };
+}
+
+function classificationOptions(
+  args: {
+    readonly approvedIds?: readonly string[];
+    readonly expectedDanglingHeadCount?: number;
+  } = {},
+): PreflightClassificationOptions {
+  const approvedIds = args.approvedIds ?? [];
+  return {
+    approvedArtifactMemberDigests: approvedIds.map((id) => {
+      return fingerprintMember("approved-artifact-member", id);
+    }),
+    approvedArtifactSetDigest: fingerprintSortedSet(
+      "approved-artifact-set",
+      approvedIds,
+    ).digest,
+    expectedApprovedArtifactCount: approvedIds.length,
+    expectedDanglingHeadCount: args.expectedDanglingHeadCount ?? 0,
+    expectedCatalogDependencies: emptyCatalog,
+    expectedRepositoryDependencies: emptyRepository,
+    observedRepositoryDependencies: emptyRepository,
+  };
+}
+
+function identityRow(
+  id: string,
+  overrides: Partial<IdentityInventoryRow> = {},
+): IdentityInventoryRow {
+  return {
+    id,
+    composePresent: true,
+    zeroPresent: true,
+    orgMismatch: false,
+    ownerMismatch: false,
+    nameMismatch: false,
+    createdRelation: "equal",
+    updatedSource: "equal",
+    ...overrides,
+  };
+}
+
+function gatePresent(
+  result: { readonly failureGates: readonly string[] },
+  gate: string,
+): void {
+  assert.ok(result.failureGates.includes(gate), `missing gate ${gate}`);
+}
+
+function testIdentityAndApprovedArtifacts(): void {
+  const matched = identityRow("00000000-0000-4000-8000-000000000001");
+  const exact = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({ identity: [matched] }),
+    classificationOptions(),
+  );
+  assert.equal(exact.status, "passed");
+  assert.equal(exact.identity.matched.count, 1);
+
+  const mismatchCases = [
+    ["identity.org_mismatch", { orgMismatch: true }],
+    ["identity.owner_mismatch", { ownerMismatch: true }],
+    ["identity.name_mismatch", { nameMismatch: true }],
+  ] as const;
+  for (const [gate, override] of mismatchCases) {
+    const result = classifyPreflightInventory(
+      capabilities,
+      emptyInventory({ identity: [identityRow(matched.id, override)] }),
+      classificationOptions(),
+    );
+    gatePresent(result, gate);
+  }
+  const zeroOnly = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      identity: [identityRow(matched.id, { composePresent: false })],
+    }),
+    classificationOptions(),
+  );
+  gatePresent(zeroOnly, "identity.zero_only");
+  const timestampClasses = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      identity: [
+        identityRow("00000000-0000-4000-8000-000000000002", {
+          createdRelation: "zeroEarlier",
+          updatedSource: "compose",
+        }),
+        identityRow("00000000-0000-4000-8000-000000000003", {
+          createdRelation: "zeroLater",
+          updatedSource: "zero",
+        }),
+      ],
+    }),
+    classificationOptions(),
+  );
+  assert.equal(
+    timestampClasses.identity.createdTimestamps.zeroEarlier.count,
+    1,
+  );
+  assert.equal(timestampClasses.identity.createdTimestamps.zeroLater.count, 1);
+  assert.equal(timestampClasses.identity.updatedTimestamps.compose.count, 1);
+  assert.equal(timestampClasses.identity.updatedTimestamps.zero.count, 1);
+
+  const approvedIds = Array.from({ length: 6 }, (_, index) => {
+    return `00000000-0000-4000-8000-${(index + 10).toString().padStart(12, "0")}`;
+  });
+  const composeOnly = approvedIds.map((id) => {
+    return identityRow(id, { zeroPresent: false });
+  });
+  const six = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({ identity: composeOnly }),
+    classificationOptions({ approvedIds }),
+  );
+  assert.equal(six.status, "passed");
+  assert.equal(
+    six.identity.approvedComposeOnlyArtifacts.classification,
+    "exact",
+  );
+
+  const seventhId = "00000000-0000-4000-8000-000000000099";
+  const seven = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      identity: [
+        ...composeOnly,
+        identityRow(seventhId, { zeroPresent: false }),
+      ],
+    }),
+    classificationOptions({ approvedIds }),
+  );
+  gatePresent(seven, "identity.approved_artifact_drift");
+  assert.equal(seven.identity.approvedComposeOnlyArtifacts.unexpected.count, 1);
+
+  const replacement = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      identity: [
+        ...composeOnly.slice(0, 5),
+        identityRow(seventhId, { zeroPresent: false }),
+      ],
+    }),
+    classificationOptions({ approvedIds }),
+  );
+  gatePresent(replacement, "identity.approved_artifact_drift");
+  assert.equal(
+    replacement.identity.approvedComposeOnlyArtifacts
+      .missingApprovedMemberCount,
+    1,
+  );
+
+  const digestDrift = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({ identity: composeOnly }),
+    {
+      ...classificationOptions({ approvedIds }),
+      approvedArtifactSetDigest: "0".repeat(64),
+    },
+  );
+  gatePresent(digestDrift, "identity.approved_artifact_drift");
+}
+
+function canonicalVersion(
+  name: string,
+  composeId: string | null,
+  creatorPresent: boolean,
+): VersionInventoryRow {
+  const content = buildZeroAgentComposeContent(name);
+  return {
+    id: computeComposeVersionId(content),
+    composeId,
+    composeExists: composeId !== null,
+    creatorPresent,
+    content,
+  };
+}
+
+function testVersionHeadRunAndCheckpointClassifications(): void {
+  const firstAgent = "00000000-0000-4000-8000-000000000201";
+  const secondAgent = "00000000-0000-4000-8000-000000000202";
+  const version = canonicalVersion("shared-agent", firstAgent, true);
+  const heads: HeadInventoryRow[] = [firstAgent, secondAgent].map(
+    (composeId) => {
+      return {
+        composeId,
+        headVersionId: version.id,
+        versionPresent: true,
+        insertionComposeId: firstAgent,
+      };
+    },
+  );
+  const shared = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      identity: [identityRow(firstAgent), identityRow(secondAgent)],
+      versions: [version],
+      heads,
+      runs: [
+        {
+          id: "00000000-0000-4000-8000-000000000211",
+          versionId: version.id,
+          versionPresent: true,
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000212",
+          versionId: version.id,
+          versionPresent: true,
+        },
+      ],
+      checkpoints: [
+        {
+          id: "00000000-0000-4000-8000-000000000221",
+          snapshot: { agentComposeVersionId: version.id },
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000222",
+          snapshot: { agentComposeVersionId: version.id },
+        },
+      ],
+    }),
+    classificationOptions(),
+  );
+  assert.equal(shared.status, "passed");
+  assert.equal(shared.heads.sharedHashes.count, 1);
+  assert.equal(shared.heads.crossComposeInsertionProvenanceAgentIds.count, 1);
+  assert.equal(shared.runs.sharedVersionHashes.count, 1);
+  assert.equal(shared.runs.headReferencedVersionHashes.count, 1);
+  assert.equal(shared.checkpoints.sharedVersionHashes.count, 1);
+  assert.equal(shared.checkpoints.runReferencedVersionHashes.count, 1);
+  assert.equal(shared.checkpoints.headReferencedVersionHashes.count, 1);
+
+  const missingHash = "f".repeat(64);
+  const missingReferences = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      runs: [
+        {
+          id: "00000000-0000-4000-8000-000000000231",
+          versionId: missingHash,
+          versionPresent: false,
+        },
+      ],
+      checkpoints: [
+        {
+          id: "00000000-0000-4000-8000-000000000232",
+          snapshot: { agentComposeVersionId: missingHash },
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000233",
+          snapshot: { agentComposeVersionId: "invalid" },
+        },
+      ],
+    }),
+    classificationOptions(),
+  );
+  gatePresent(missingReferences, "runs.missing_version");
+  gatePresent(missingReferences, "checkpoints.missing_version");
+  gatePresent(missingReferences, "checkpoints.invalid_reference");
+
+  const legacyContent = buildZeroAgentComposeContent("legacy-shape") as {
+    agents: Record<string, Record<string, unknown>>;
+  } & Record<string, unknown>;
+  legacyContent.agents["legacy-shape"]!.description = "legacy";
+  const legacyVersion: VersionInventoryRow = {
+    id: computeComposeVersionId(legacyContent),
+    composeId: null,
+    composeExists: false,
+    creatorPresent: false,
+    content: legacyContent,
+  };
+  const contentClasses = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      versions: [
+        legacyVersion,
+        {
+          ...legacyVersion,
+          id: "e".repeat(64),
+          content: { unsupported: true },
+        },
+      ],
+    }),
+    classificationOptions(),
+  );
+  assert.equal(contentClasses.versions.content.nonCanonicalLegacy.count, 1);
+  assert.equal(contentClasses.versions.content.unsupportedOrInvalid.count, 1);
+  assert.equal(contentClasses.versions.content.hashMismatches.count, 1);
+
+  const provenanceVersions = [
+    canonicalVersion("provenance-one", firstAgent, true),
+    canonicalVersion("provenance-two", firstAgent, false),
+    canonicalVersion("provenance-three", null, true),
+    canonicalVersion("provenance-four", null, false),
+  ];
+  const provenance = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({ versions: provenanceVersions }),
+    classificationOptions(),
+  );
+  assert.equal(provenance.status, "passed");
+  assert.equal(
+    provenance.versions.provenance.composePresentCreatorPresent.count,
+    1,
+  );
+  assert.equal(
+    provenance.versions.provenance.composePresentCreatorNull.count,
+    1,
+  );
+  assert.equal(
+    provenance.versions.provenance.composeNullCreatorPresent.count,
+    1,
+  );
+  assert.equal(provenance.versions.provenance.composeNullCreatorNull.count, 1);
+}
+
+function danglingRow(args: {
+  readonly composeId: string;
+  readonly name: string | null;
+  readonly exact?: boolean;
+}): DanglingInventoryRow {
+  const exactHash =
+    args.name === null
+      ? "a".repeat(64)
+      : computeComposeVersionId(buildZeroAgentComposeContent(args.name));
+  return {
+    composeId: args.composeId,
+    recordedHash: args.exact === false ? "b".repeat(64) : exactHash,
+    agentName: args.name,
+  };
+}
+
+function testDanglingClassifications(): void {
+  const composeId = "00000000-0000-4000-8000-000000000301";
+  const exactRow = danglingRow({ composeId, name: "dangling-agent" });
+  const head: HeadInventoryRow = {
+    composeId,
+    headVersionId: exactRow.recordedHash,
+    versionPresent: false,
+    insertionComposeId: null,
+  };
+  const exact = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      identity: [identityRow(composeId)],
+      heads: [head],
+      danglingStart: [exactRow],
+      danglingEnd: [exactRow],
+    }),
+    classificationOptions({ expectedDanglingHeadCount: 1 }),
+  );
+  assert.equal(exact.status, "passed");
+  assert.equal(exact.danglingHeads.exact.count, 1);
+
+  const nonExactRow = danglingRow({
+    composeId,
+    name: "dangling-agent",
+    exact: false,
+  });
+  const nonExact = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      heads: [{ ...head, headVersionId: nonExactRow.recordedHash }],
+      danglingStart: [nonExactRow],
+      danglingEnd: [nonExactRow],
+    }),
+    classificationOptions({ expectedDanglingHeadCount: 1 }),
+  );
+  gatePresent(nonExact, "dangling.non_exact");
+
+  const missingIdentityRow = danglingRow({ composeId, name: null });
+  const missingIdentity = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      danglingStart: [missingIdentityRow],
+      danglingEnd: [missingIdentityRow],
+    }),
+    classificationOptions({ expectedDanglingHeadCount: 1 }),
+  );
+  gatePresent(missingIdentity, "dangling.missing_identity");
+
+  const drift = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      danglingStart: [exactRow],
+      danglingEnd: [{ ...exactRow, recordedHash: "c".repeat(64) }],
+    }),
+    classificationOptions({ expectedDanglingHeadCount: 1 }),
+  );
+  gatePresent(drift, "dangling.snapshot_drift");
+}
+
+function testDependencyDriftAndDeterminism(): void {
+  for (const kind of CATALOG_DEPENDENCY_KINDS) {
+    const result = classifyPreflightInventory(
+      capabilities,
+      emptyInventory({
+        catalogDependencies: [{ kind, entry: `unexpected-${kind}` }],
+      }),
+      classificationOptions(),
+    );
+    gatePresent(result, `dependencies.catalog.${kind}`);
+  }
+
+  const repositoryKinds = [
+    "schemaImports",
+    "legacyIdentifiers",
+    "rawTableLiterals",
+    "nonTypeScriptConsumers",
+    "transitionValidators",
+  ] as const;
+  for (const kind of repositoryKinds) {
+    const observed = { ...emptyRepository, [kind]: ["unexpected-consumer"] };
+    const result = classifyPreflightInventory(capabilities, emptyInventory(), {
+      ...classificationOptions(),
+      observedRepositoryDependencies: observed,
+    });
+    gatePresent(result, `dependencies.repository.${kind}`);
+  }
+
+  const rows = [
+    identityRow("00000000-0000-4000-8000-000000000402"),
+    identityRow("00000000-0000-4000-8000-000000000401"),
+  ];
+  const forward = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({ identity: rows }),
+    classificationOptions(),
+  );
+  const reverse = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({ identity: [...rows].reverse() }),
+    classificationOptions(),
+  );
+  assert.deepEqual(reverse, forward);
+}
+
+function testOutputRedaction(): void {
+  const rawId = "00000000-0000-4000-8000-000000000501";
+  const rawName = "never-emit-agent-name";
+  const dangling = danglingRow({ composeId: rawId, name: rawName });
+  const result = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      versions: [
+        {
+          id: "d".repeat(64),
+          composeId: null,
+          composeExists: false,
+          creatorPresent: false,
+          content: { payload: "never-emit-version-content" },
+        },
+      ],
+      danglingStart: [dangling],
+      danglingEnd: [dangling],
+    }),
+    classificationOptions({ expectedDanglingHeadCount: 1 }),
+  );
+  const serialized = JSON.stringify(result);
+  for (const forbidden of [
+    rawId,
+    rawName,
+    "never-emit-version-content",
+    "OKOU_TOKEN",
+    "user_clerk_fixture",
+    "postgresql://user:secret@host/database",
+  ]) {
+    assert.equal(serialized.includes(forbidden), false);
+  }
+  const failure = JSON.stringify(
+    sanitizedFailureResult(
+      new Error("postgresql://user:secret@host/database never-emit-agent-name"),
+    ),
+  );
+  assert.equal(failure.includes("postgresql://"), false);
+  assert.equal(failure.includes(rawName), false);
+  assert.deepEqual(Object.keys(result), [
+    "schemaVersion",
+    "status",
+    "failureGates",
+    "capabilities",
+    "identity",
+    "versions",
+    "heads",
+    "runs",
+    "checkpoints",
+    "danglingHeads",
+    "dependencies",
+  ]);
+  assert.deepEqual(outputPaths(result), [...PREFLIGHT_OUTPUT_ALLOWLIST]);
+  assertSafeAggregateValues(result);
+}
+
+function assertSafeAggregateValues(value: unknown, pathPrefix = ""): void {
+  if (Array.isArray(value)) {
+    assert.equal(pathPrefix, "failureGates");
+    for (const gate of value) {
+      assert.match(String(gate), /^[A-Za-z]+(?:[._][A-Za-z]+)*$/u);
+    }
+    return;
+  }
+  if (value !== null && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      assertSafeAggregateValues(
+        child,
+        pathPrefix ? `${pathPrefix}.${key}` : key,
+      );
+    }
+    return;
+  }
+  if (typeof value === "number") {
+    assert.equal(Number.isSafeInteger(value) && value >= 0, true);
+    return;
+  }
+  if (typeof value === "boolean") return;
+  assert.equal(typeof value, "string");
+  if (pathPrefix.endsWith(".digest") || pathPrefix.endsWith("Digest")) {
+    assert.match(value as string, /^[0-9a-f]{64}$/u);
+    return;
+  }
+  const allowedClassifications = new Set([
+    "vm0.agent-compose-consolidation-preflight.v1",
+    "passed",
+    "failed",
+    "exact",
+    "drift",
+    "stable",
+    "supported",
+    "repeatable read",
+  ]);
+  assert.equal(allowedClassifications.has(value as string), true);
+}
+
+function outputPaths(value: unknown, prefix = ""): string[] {
+  if (Array.isArray(value)) return [`${prefix}[]`];
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value)
+      .flatMap(([key, child]) => {
+        return outputPaths(child, prefix ? `${prefix}.${key}` : key);
+      })
+      .sort();
+  }
+  return [prefix];
+}
+
+async function testRepositoryAndWorkflowValidators(): Promise<void> {
+  const observed = await collectRepositoryDependencyManifest(repositoryRoot);
+  assert.equal(
+    manifestsEqual(EXPECTED_REPOSITORY_DEPENDENCIES, observed),
+    true,
+  );
+
+  const fixtureRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "agent-compose-preflight-manifest-"),
+  );
+  try {
+    const sourceDirectory = path.join(fixtureRoot, "turbo/apps/api/src");
+    const docsDirectory = path.join(fixtureRoot, "turbo/packages/db");
+    await fs.mkdir(sourceDirectory, { recursive: true });
+    await fs.mkdir(docsDirectory, { recursive: true });
+    await fs.writeFile(
+      path.join(docsDirectory, "MIGRATIONS.md"),
+      "<!-- vm0-transition-validator:fixture-validator -->\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(sourceDirectory, "reviewed.ts"),
+      'import { agentComposes } from "@okouai/db/schema/agent-compose";\nvoid agentComposes;\n',
+      "utf8",
+    );
+    const reviewed = await collectRepositoryDependencyManifest(fixtureRoot);
+    await fs.writeFile(
+      path.join(sourceDirectory, "unexpected.ts"),
+      "export const agentComposeVersionId = 'unexpected';\n",
+      "utf8",
+    );
+    const drifted = await collectRepositoryDependencyManifest(fixtureRoot);
+    assert.equal(manifestsEqual(reviewed, drifted), false);
+    assert.equal(
+      drifted.legacyIdentifiers.length,
+      reviewed.legacyIdentifiers.length + 1,
+    );
+  } finally {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  }
+
+  const workflow = await fs.readFile(
+    path.join(
+      repositoryRoot,
+      ".github/workflows/agent-compose-consolidation-preflight.yml",
+    ),
+    "utf8",
+  );
+  assert.match(workflow, /^on:\n {2}workflow_dispatch:\s*$/mu);
+  assert.match(workflow, /^ {4}environment: production$/mu);
+  assert.match(workflow, /^ {10}ref: main$/mu);
+  assert.match(
+    workflow,
+    /actions\/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1/u,
+  );
+  assert.match(workflow, /ghcr\.io\/vm0-ai\/vm0-toolchain:20260622/u);
+  assert.match(workflow, /^permissions:\n {2}contents: read$/mu);
+  assert.match(workflow, /scripts\/agent-compose-consolidation-preflight\.ts/u);
+  assert.equal(
+    /pull_request:|schedule:|actions\/upload-artifact/iu.test(workflow),
+    false,
+  );
+  assert.equal(/--apply|fallback|REPORT_PATH/iu.test(workflow), false);
+
+  const service = await fs.readFile(
+    path.join(
+      repositoryRoot,
+      "turbo/apps/api/src/signals/services/agent-compose.service.ts",
+    ),
+    "utf8",
+  );
+  const contentOwner = await fs.readFile(
+    path.join(
+      repositoryRoot,
+      "turbo/apps/api/src/signals/services/agent-compose-content.ts",
+    ),
+    "utf8",
+  );
+  assert.equal(
+    service.includes("function buildZeroAgentComposeContent"),
+    false,
+  );
+  assert.equal(service.includes("function computeComposeVersionId"), false);
+  assert.equal(
+    contentOwner.match(/function buildZeroAgentComposeContent/gu)?.length,
+    1,
+  );
+  assert.equal(
+    contentOwner.match(/function computeComposeVersionId/gu)?.length,
+    1,
+  );
+}
+
+function databaseUrlFor(baseUrl: URL, database: string): string {
+  const result = new URL(baseUrl);
+  result.pathname = `/${database}`;
+  return result.toString();
+}
+
+async function catalogRows(client: Client): Promise<CatalogDependencyRow[]> {
+  const result = await client.query<CatalogDependencyRow>(
+    CATALOG_DEPENDENCY_QUERY,
+  );
+  return result.rows;
+}
+
+function catalogCount(
+  rows: readonly CatalogDependencyRow[],
+  kind: CatalogDependencyKind,
+): number {
+  return rows.filter((row) => {
+    return row.kind === kind;
+  }).length;
+}
+
+async function testDatabaseBoundaries(databaseUrl: string): Promise<void> {
+  const sourceUrl = new URL(databaseUrl);
+  const admin = new Client({
+    connectionString: databaseUrlFor(sourceUrl, "postgres"),
+  });
+  await admin.connect();
+  await admin.query(`DROP DATABASE IF EXISTS "${testDatabase}" WITH (FORCE)`);
+  await admin.query(`CREATE DATABASE "${testDatabase}"`);
+  const testUrl = databaseUrlFor(sourceUrl, testDatabase);
+
+  try {
+    execFileSync("tsx", [path.join(dirname, "migrate.ts")], {
+      cwd: packageDirectory,
+      env: { ...process.env, DATABASE_URL: testUrl },
+      stdio: "pipe",
+    });
+    const client = new Client({ connectionString: testUrl });
+    const writer = new Client({ connectionString: testUrl });
+    await client.connect();
+    await writer.connect();
+    try {
+      const emptyApprovedDigest = fingerprintSortedSet(
+        "approved-artifact-set",
+        [],
+      ).digest;
+      const executionOptions: PreflightClassificationOptions = {
+        approvedArtifactMemberDigests: [],
+        approvedArtifactSetDigest: emptyApprovedDigest,
+        expectedApprovedArtifactCount: 0,
+        expectedDanglingHeadCount: 0,
+      };
+      const first = await executeAgentComposeConsolidationPreflight({
+        connectionString: testUrl,
+        repositoryRoot,
+        classification: executionOptions,
+      });
+      const second = await executeAgentComposeConsolidationPreflight({
+        connectionString: testUrl,
+        repositoryRoot,
+        classification: executionOptions,
+      });
+      assert.equal(first.status, "passed");
+      assert.deepEqual(second, first);
+
+      await withReadOnlySnapshot(client, {}, async () => {
+        await assert.rejects(
+          client.query(`INSERT INTO "agent_composes" (
+            "user_id", "name", "org_id"
+          ) VALUES ('readonly-user', 'readonly-agent', 'readonly-org')`),
+          (error: unknown) => {
+            return (error as { readonly code?: unknown }).code === "25006";
+          },
+        );
+      });
+
+      await assert.rejects(
+        withReadOnlySnapshot(client, { statementTimeoutMs: 25 }, async () => {
+          await client.query("SELECT pg_sleep(0.2)");
+        }),
+        (error: unknown) => {
+          return (
+            error instanceof SanitizedPreflightError &&
+            error.gate === "probe.statement_timeout"
+          );
+        },
+      );
+
+      const abortController = new AbortController();
+      abortController.abort();
+      await assert.rejects(
+        withReadOnlySnapshot(
+          client,
+          { signal: abortController.signal },
+          async () => {
+            return undefined;
+          },
+        ),
+        (error: unknown) => {
+          return (
+            error instanceof SanitizedPreflightError &&
+            error.gate === "probe.cancelled"
+          );
+        },
+      );
+
+      const concurrentAgentId = "00000000-0000-4000-8000-000000027613";
+      const firstHead = "a".repeat(64);
+      const secondHead = "b".repeat(64);
+      await writer.query(
+        `INSERT INTO "agent_composes" (
+           "id", "user_id", "name", "head_version_id", "org_id"
+         ) VALUES ($1, 'snapshot-user', 'snapshot-agent', $2, 'snapshot-org')`,
+        [concurrentAgentId, firstHead],
+      );
+      await writer.query(
+        `INSERT INTO "zero_agents" ("id", "org_id", "owner", "name")
+         VALUES ($1, 'snapshot-org', 'snapshot-user', 'snapshot-agent')`,
+        [concurrentAgentId],
+      );
+      await withReadOnlySnapshot(client, {}, async () => {
+        const start = await client.query<{ head: string }>(
+          `SELECT "head_version_id" AS "head" FROM "agent_composes"
+           WHERE "id" = $1`,
+          [concurrentAgentId],
+        );
+        await writer.query(
+          `UPDATE "agent_composes" SET "head_version_id" = $2 WHERE "id" = $1`,
+          [concurrentAgentId, secondHead],
+        );
+        const end = await client.query<{ head: string }>(
+          `SELECT "head_version_id" AS "head" FROM "agent_composes"
+           WHERE "id" = $1`,
+          [concurrentAgentId],
+        );
+        assert.deepEqual(end.rows, start.rows);
+        assert.equal(start.rows[0]?.head, firstHead);
+      });
+      const live = await client.query<{ head: string }>(
+        `SELECT "head_version_id" AS "head" FROM "agent_composes"
+         WHERE "id" = $1`,
+        [concurrentAgentId],
+      );
+      assert.equal(live.rows[0]?.head, secondHead);
+
+      const baselineCatalog = await catalogRows(client);
+      for (const kind of CATALOG_DEPENDENCY_KINDS) {
+        assert.equal(
+          catalogCount(baselineCatalog, kind),
+          EXPECTED_CATALOG_DEPENDENCIES[kind].length,
+        );
+      }
+
+      await client.query(`CREATE TABLE "preflight_unexpected_fk" (
+        "agent_id" uuid REFERENCES "zero_agents" ("id")
+      )`);
+      assert.equal(
+        catalogCount(await catalogRows(client), "foreignKeys"),
+        catalogCount(baselineCatalog, "foreignKeys") + 1,
+      );
+      await client.query(`DROP TABLE "preflight_unexpected_fk"`);
+
+      await client.query(`CREATE TABLE "preflight_unexpected_checkpoint" (
+        "agent_compose_snapshot" jsonb
+      )`);
+      assert.equal(
+        catalogCount(await catalogRows(client), "reviewedNonFk"),
+        catalogCount(baselineCatalog, "reviewedNonFk") + 1,
+      );
+      await client.query(`DROP TABLE "preflight_unexpected_checkpoint"`);
+
+      await client.query(`ALTER TABLE "agent_composes"
+        ALTER COLUMN "head_version_id" SET DEFAULT '${"c".repeat(64)}'`);
+      assert.equal(
+        catalogCount(await catalogRows(client), "defaults"),
+        catalogCount(baselineCatalog, "defaults") + 1,
+      );
+      await client.query(`ALTER TABLE "agent_composes"
+        ALTER COLUMN "head_version_id" DROP DEFAULT`);
+
+      await client.query(`CREATE INDEX "preflight_unexpected_head_idx"
+        ON "agent_composes" ("head_version_id")`);
+      assert.equal(
+        catalogCount(await catalogRows(client), "indexes"),
+        catalogCount(baselineCatalog, "indexes") + 1,
+      );
+      await client.query(`DROP INDEX "preflight_unexpected_head_idx"`);
+
+      await client.query(`CREATE FUNCTION "preflight_unexpected_trigger"()
+        RETURNS trigger LANGUAGE plpgsql AS $body$
+        BEGIN RETURN NEW; END
+        $body$`);
+      await client.query(`CREATE TRIGGER "preflight_unexpected_trigger"
+        BEFORE UPDATE ON "agent_composes" FOR EACH ROW
+        EXECUTE FUNCTION "preflight_unexpected_trigger"()`);
+      const triggerDrift = await catalogRows(client);
+      assert.equal(
+        catalogCount(triggerDrift, "triggers"),
+        catalogCount(baselineCatalog, "triggers") + 1,
+      );
+      assert.equal(
+        catalogCount(triggerDrift, "functions"),
+        catalogCount(baselineCatalog, "functions") + 1,
+      );
+      await client.query(
+        `DROP TRIGGER "preflight_unexpected_trigger" ON "agent_composes"`,
+      );
+      await client.query(`DROP FUNCTION "preflight_unexpected_trigger"()`);
+    } finally {
+      await client.end();
+      await writer.end();
+    }
+  } finally {
+    await admin.query(`DROP DATABASE IF EXISTS "${testDatabase}" WITH (FORCE)`);
+    await admin.end();
+  }
+}
+
+export async function validateAgentComposeConsolidationPreflight(): Promise<void> {
+  testIdentityAndApprovedArtifacts();
+  testVersionHeadRunAndCheckpointClassifications();
+  testDanglingClassifications();
+  testDependencyDriftAndDeterminism();
+  testOutputRedaction();
+  await testRepositoryAndWorkflowValidators();
+
+  const databaseUrl = process.env.DATABASE_URL;
+  assert.ok(databaseUrl, "DATABASE_URL is required");
+  await testDatabaseBoundaries(databaseUrl);
+  console.log("agent compose consolidation preflight passed");
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) {
+  validateAgentComposeConsolidationPreflight().catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -56,12 +56,15 @@ const capabilities: PreflightCapabilities = {
 };
 
 const emptyCatalog: Record<CatalogDependencyKind, readonly string[]> = {
-  foreignKeys: [],
-  reviewedNonFk: [],
+  constraints: [],
   defaults: [],
-  indexes: [],
-  triggers: [],
+  foreignKeys: [],
   functions: [],
+  indexes: [],
+  otherDependents: [],
+  reviewedNonFk: [],
+  rewriteDependents: [],
+  triggers: [],
 };
 
 const emptyRepository: RepositoryDependencyManifest = {
@@ -400,6 +403,24 @@ function testVersionHeadRunAndCheckpointClassifications(): void {
     1,
   );
   assert.equal(provenance.versions.provenance.composeNullCreatorNull.count, 1);
+
+  const missingComposeId = "00000000-0000-4000-8000-000000000203";
+  const orphanVersions = [
+    canonicalVersion("orphan-version-one", missingComposeId, true),
+    canonicalVersion("orphan-version-two", missingComposeId, true),
+  ].map((orphanVersion) => {
+    return { ...orphanVersion, composeExists: false };
+  });
+  const orphanCompose = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({ versions: orphanVersions }),
+    classificationOptions(),
+  );
+  gatePresent(orphanCompose, "versions.orphan_compose");
+  assert.deepEqual(
+    orphanCompose.versions.orphanComposeIds,
+    fingerprintSortedSet("versions:orphan-compose-ids", [missingComposeId]),
+  );
 }
 
 function danglingRow(args: {
@@ -642,8 +663,10 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
     path.join(os.tmpdir(), "agent-compose-preflight-manifest-"),
   );
   try {
+    const workflowDirectory = path.join(fixtureRoot, ".github/workflows");
     const sourceDirectory = path.join(fixtureRoot, "turbo/apps/api/src");
     const docsDirectory = path.join(fixtureRoot, "turbo/packages/db");
+    await fs.mkdir(workflowDirectory, { recursive: true });
     await fs.mkdir(sourceDirectory, { recursive: true });
     await fs.mkdir(docsDirectory, { recursive: true });
     await fs.writeFile(
@@ -662,11 +685,20 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
       "export const agentComposeVersionId = 'unexpected';\n",
       "utf8",
     );
+    await fs.writeFile(
+      path.join(workflowDirectory, "unexpected.yml"),
+      "run: psql agent_compose_versions\n",
+      "utf8",
+    );
     const drifted = await collectRepositoryDependencyManifest(fixtureRoot);
     assert.equal(manifestsEqual(reviewed, drifted), false);
     assert.equal(
       drifted.legacyIdentifiers.length,
       reviewed.legacyIdentifiers.length + 1,
+    );
+    assert.equal(
+      drifted.nonTypeScriptConsumers.length,
+      reviewed.nonTypeScriptConsumers.length + 1,
     );
   } finally {
     await fs.rm(fixtureRoot, { recursive: true, force: true });
@@ -688,6 +720,15 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
   );
   assert.match(workflow, /ghcr\.io\/vm0-ai\/vm0-toolchain:20260622/u);
   assert.match(workflow, /^permissions:\n {2}contents: read$/mu);
+  assert.match(workflow, /\[\[ -z "\$database_url" \|\|/u);
+  assert.match(workflow, /"\$database_url" == \*\$'\\n'\*/u);
+  assert.match(workflow, /"\$database_url" == \*\$'\\r'\*/u);
+  assert.match(workflow, /"\$database_url" != postgres:\/\/\*/u);
+  assert.match(workflow, /"\$database_url" != postgresql:\/\/\*/u);
+  assert.ok(
+    workflow.indexOf('if [[ -z "$database_url"') <
+      workflow.indexOf('>> "$GITHUB_OUTPUT"'),
+  );
   assert.match(workflow, /scripts\/agent-compose-consolidation-preflight\.ts/u);
   assert.equal(
     /pull_request:|schedule:|actions\/upload-artifact/iu.test(workflow),
@@ -878,6 +919,16 @@ async function testDatabaseBoundaries(databaseUrl: string): Promise<void> {
         );
       }
 
+      await client.query(`ALTER TABLE "agent_composes"
+        ADD CONSTRAINT "preflight_unexpected_name_check"
+        CHECK ("name" IS NOT NULL) NOT VALID`);
+      assert.equal(
+        catalogCount(await catalogRows(client), "constraints"),
+        catalogCount(baselineCatalog, "constraints") + 1,
+      );
+      await client.query(`ALTER TABLE "agent_composes"
+        DROP CONSTRAINT "preflight_unexpected_name_check"`);
+
       await client.query(`CREATE TABLE "preflight_unexpected_fk" (
         "agent_id" uuid REFERENCES "zero_agents" ("id")
       )`);
@@ -913,6 +964,94 @@ async function testDatabaseBoundaries(databaseUrl: string): Promise<void> {
       );
       await client.query(`DROP INDEX "preflight_unexpected_head_idx"`);
 
+      await client.query(`CREATE VIEW "preflight_unexpected_agent_view" AS
+        SELECT "id" FROM "agent_composes"`);
+      await client.query(`CREATE VIEW "preflight_unexpected_nested_view" AS
+        SELECT "id" FROM "preflight_unexpected_agent_view"`);
+      const viewDrift = await catalogRows(client);
+      assert.equal(
+        catalogCount(viewDrift, "rewriteDependents"),
+        catalogCount(baselineCatalog, "rewriteDependents") + 2,
+      );
+      gatePresent(
+        classifyPreflightInventory(
+          capabilities,
+          emptyInventory({ catalogDependencies: viewDrift }),
+          {
+            ...classificationOptions(),
+            expectedCatalogDependencies: EXPECTED_CATALOG_DEPENDENCIES,
+          },
+        ),
+        "dependencies.catalog.rewriteDependents",
+      );
+      await client.query(`DROP VIEW "preflight_unexpected_nested_view"`);
+      await client.query(`DROP VIEW "preflight_unexpected_agent_view"`);
+
+      await client.query(
+        `CREATE MATERIALIZED VIEW "preflight_unexpected_agent_materialized" AS
+         SELECT "id" FROM "agent_composes" WITH NO DATA`,
+      );
+      assert.equal(
+        catalogCount(await catalogRows(client), "rewriteDependents"),
+        catalogCount(baselineCatalog, "rewriteDependents") + 1,
+      );
+      await client.query(
+        `DROP MATERIALIZED VIEW "preflight_unexpected_agent_materialized"`,
+      );
+
+      await client.query(`CREATE RULE "preflight_unexpected_agent_rule" AS
+        ON DELETE TO "agent_composes" DO INSTEAD NOTHING`);
+      assert.equal(
+        catalogCount(await catalogRows(client), "rewriteDependents"),
+        catalogCount(baselineCatalog, "rewriteDependents") + 1,
+      );
+      await client.query(
+        `DROP RULE "preflight_unexpected_agent_rule" ON "agent_composes"`,
+      );
+
+      await client.query(
+        `CREATE SEQUENCE "preflight_unexpected_owned_sequence"
+         OWNED BY "agent_composes"."id"`,
+      );
+      const otherDrift = await catalogRows(client);
+      assert.equal(
+        catalogCount(otherDrift, "otherDependents"),
+        catalogCount(baselineCatalog, "otherDependents") + 1,
+      );
+      gatePresent(
+        classifyPreflightInventory(
+          capabilities,
+          emptyInventory({ catalogDependencies: otherDrift }),
+          {
+            ...classificationOptions(),
+            expectedCatalogDependencies: EXPECTED_CATALOG_DEPENDENCIES,
+          },
+        ),
+        "dependencies.catalog.otherDependents",
+      );
+      await client.query(`DROP SEQUENCE "preflight_unexpected_owned_sequence"`);
+
+      await client.query(
+        `CREATE TABLE "preflight_unexpected_composite" (
+          "agent" "agent_composes"
+        )`,
+      );
+      assert.equal(
+        catalogCount(await catalogRows(client), "otherDependents"),
+        catalogCount(baselineCatalog, "otherDependents") + 1,
+      );
+      await client.query(`DROP TABLE "preflight_unexpected_composite"`);
+
+      await client.query(
+        `CREATE TABLE "preflight_unexpected_inherited" ()
+         INHERITS ("agent_composes")`,
+      );
+      assert.equal(
+        catalogCount(await catalogRows(client), "otherDependents"),
+        catalogCount(baselineCatalog, "otherDependents") + 1,
+      );
+      await client.query(`DROP TABLE "preflight_unexpected_inherited"`);
+
       await client.query(`CREATE FUNCTION "preflight_unexpected_trigger"()
         RETURNS trigger LANGUAGE plpgsql AS $body$
         BEGIN RETURN NEW; END
@@ -943,13 +1082,17 @@ async function testDatabaseBoundaries(databaseUrl: string): Promise<void> {
   }
 }
 
-export async function validateAgentComposeConsolidationPreflight(): Promise<void> {
+export async function validateAgentComposeConsolidationPreflightStatic(): Promise<void> {
   testIdentityAndApprovedArtifacts();
   testVersionHeadRunAndCheckpointClassifications();
   testDanglingClassifications();
   testDependencyDriftAndDeterminism();
   testOutputRedaction();
   await testRepositoryAndWorkflowValidators();
+}
+
+export async function validateAgentComposeConsolidationPreflight(): Promise<void> {
+  await validateAgentComposeConsolidationPreflightStatic();
 
   const databaseUrl = process.env.DATABASE_URL;
   assert.ok(databaseUrl, "DATABASE_URL is required");

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -48,6 +48,7 @@ import {
 } from "./test-agent-run-metadata-stage-2-final";
 import { validateAgentRunMetadataStage2Lock } from "./test-agent-run-metadata-stage-2-lock";
 import { validateAgentRunMetadataStage2Preflight } from "./test-agent-run-metadata-stage-2-preflight";
+import { validateAgentComposeConsolidationPreflight } from "./test-agent-compose-consolidation-preflight";
 import {
   AgentComposeProvenanceSchemaUnavailableError,
   deleteClerkAgentLifecycleData,
@@ -11648,6 +11649,7 @@ async function main(): Promise<void> {
     await validateCustomConnectorSecretPlaceholderCanonicalization();
     await validateChatEventSnapshotContraction();
     await validateAgentComposeProvenanceMigration();
+    await validateAgentComposeConsolidationPreflight();
     await validateAgentRunMetadataStage2Preflight();
     await validateAgentRunMetadataStage2Lock();
     await validateAgentRunMetadataStage2Index();


### PR DESCRIPTION
## summary

- add one temporary, manually dispatched, `production` environment approval-gated Agent/Compose consolidation preflight
- run the inventory inside a bounded `REPEATABLE READ READ ONLY` transaction and emit only deterministic counts, classifications, and domain-separated sorted-set SHA-256 digests
- extract the existing application-owned canonical Zero Agent Compose builder/hash without changing its three runtime writer paths
- fail closed on catalog/repository dependency drift and register the focused validator for Stage 8 removal

Closes #27613
Parent #26938

## execution boundary

- the workflow has only `workflow_dispatch`, `contents: read`, a 20-minute job timeout, the existing `production` environment, the pinned `20260622` toolchain, pinned checkout SHA, and `ref: main`
- production DB resolution reuses the release workflow's Neon project/role boundary; the connection string is captured, masked before being placed in `GITHUB_OUTPUT`, and never emitted by the probe
- the probe starts `BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`, verifies read-only/isolation/server capability and the exact bounded 1s lock / 30s statement timeouts, performs only `SELECT`, and always `ROLLBACK`s
- there is no DML, repair, version insertion, provenance synthesis, migration, route, API surface, explicit/table/row/advisory lock, artifact upload, write-capable fallback, or production invocation in this PR
- all failure handling collapses provider/database errors to a fixed schema/version/status/gate envelope; raw errors and row values are never serialized

## exact output allowlist

The result serializer is locked by focused redaction tests to exactly these 190 scalar/array leaf paths. No additional path is accepted. Digest leaves are lowercase 64-character SHA-256 values; all other leaves are non-negative safe-integer counts, booleans, or fixed classifications.

<details>
<summary>190 allowed leaf paths</summary>

- `capabilities.isolationLevel`
- `capabilities.lockTimeoutMs`
- `capabilities.requiredExtensionCount`
- `capabilities.serverVersionClassification`
- `capabilities.statementTimeoutMs`
- `capabilities.transactionReadOnly`
- `checkpoints.absentLegacyReference.count`
- `checkpoints.absentLegacyReference.digest`
- `checkpoints.distinctVersionHashes.count`
- `checkpoints.distinctVersionHashes.digest`
- `checkpoints.headReferencedVersionHashes.count`
- `checkpoints.headReferencedVersionHashes.digest`
- `checkpoints.invalidLegacyReference.count`
- `checkpoints.invalidLegacyReference.digest`
- `checkpoints.missingVersionReference.count`
- `checkpoints.missingVersionReference.digest`
- `checkpoints.runReferencedVersionHashes.count`
- `checkpoints.runReferencedVersionHashes.digest`
- `checkpoints.sharedVersionHashes.count`
- `checkpoints.sharedVersionHashes.digest`
- `checkpoints.total`
- `checkpoints.validLegacyReference.count`
- `checkpoints.validLegacyReference.digest`
- `danglingHeads.end.count`
- `danglingHeads.end.digest`
- `danglingHeads.exact.count`
- `danglingHeads.exact.digest`
- `danglingHeads.expectedCount`
- `danglingHeads.missingIdentity.count`
- `danglingHeads.missingIdentity.digest`
- `danglingHeads.nonExact.count`
- `danglingHeads.nonExact.digest`
- `danglingHeads.snapshotClassification`
- `danglingHeads.start.count`
- `danglingHeads.start.digest`
- `dependencies.catalog.constraints.classification`
- `dependencies.catalog.constraints.expected.count`
- `dependencies.catalog.constraints.expected.digest`
- `dependencies.catalog.constraints.observed.count`
- `dependencies.catalog.constraints.observed.digest`
- `dependencies.catalog.defaults.classification`
- `dependencies.catalog.defaults.expected.count`
- `dependencies.catalog.defaults.expected.digest`
- `dependencies.catalog.defaults.observed.count`
- `dependencies.catalog.defaults.observed.digest`
- `dependencies.catalog.foreignKeys.classification`
- `dependencies.catalog.foreignKeys.expected.count`
- `dependencies.catalog.foreignKeys.expected.digest`
- `dependencies.catalog.foreignKeys.observed.count`
- `dependencies.catalog.foreignKeys.observed.digest`
- `dependencies.catalog.functions.classification`
- `dependencies.catalog.functions.expected.count`
- `dependencies.catalog.functions.expected.digest`
- `dependencies.catalog.functions.observed.count`
- `dependencies.catalog.functions.observed.digest`
- `dependencies.catalog.indexes.classification`
- `dependencies.catalog.indexes.expected.count`
- `dependencies.catalog.indexes.expected.digest`
- `dependencies.catalog.indexes.observed.count`
- `dependencies.catalog.indexes.observed.digest`
- `dependencies.catalog.otherDependents.classification`
- `dependencies.catalog.otherDependents.expected.count`
- `dependencies.catalog.otherDependents.expected.digest`
- `dependencies.catalog.otherDependents.observed.count`
- `dependencies.catalog.otherDependents.observed.digest`
- `dependencies.catalog.reviewedNonFk.classification`
- `dependencies.catalog.reviewedNonFk.expected.count`
- `dependencies.catalog.reviewedNonFk.expected.digest`
- `dependencies.catalog.reviewedNonFk.observed.count`
- `dependencies.catalog.reviewedNonFk.observed.digest`
- `dependencies.catalog.rewriteDependents.classification`
- `dependencies.catalog.rewriteDependents.expected.count`
- `dependencies.catalog.rewriteDependents.expected.digest`
- `dependencies.catalog.rewriteDependents.observed.count`
- `dependencies.catalog.rewriteDependents.observed.digest`
- `dependencies.catalog.triggers.classification`
- `dependencies.catalog.triggers.expected.count`
- `dependencies.catalog.triggers.expected.digest`
- `dependencies.catalog.triggers.observed.count`
- `dependencies.catalog.triggers.observed.digest`
- `dependencies.repository.legacyIdentifiers.classification`
- `dependencies.repository.legacyIdentifiers.expected.count`
- `dependencies.repository.legacyIdentifiers.expected.digest`
- `dependencies.repository.legacyIdentifiers.observed.count`
- `dependencies.repository.legacyIdentifiers.observed.digest`
- `dependencies.repository.nonTypeScriptConsumers.classification`
- `dependencies.repository.nonTypeScriptConsumers.expected.count`
- `dependencies.repository.nonTypeScriptConsumers.expected.digest`
- `dependencies.repository.nonTypeScriptConsumers.observed.count`
- `dependencies.repository.nonTypeScriptConsumers.observed.digest`
- `dependencies.repository.rawTableLiterals.classification`
- `dependencies.repository.rawTableLiterals.expected.count`
- `dependencies.repository.rawTableLiterals.expected.digest`
- `dependencies.repository.rawTableLiterals.observed.count`
- `dependencies.repository.rawTableLiterals.observed.digest`
- `dependencies.repository.schemaImports.classification`
- `dependencies.repository.schemaImports.expected.count`
- `dependencies.repository.schemaImports.expected.digest`
- `dependencies.repository.schemaImports.observed.count`
- `dependencies.repository.schemaImports.observed.digest`
- `dependencies.repository.transitionValidators.classification`
- `dependencies.repository.transitionValidators.expected.count`
- `dependencies.repository.transitionValidators.expected.digest`
- `dependencies.repository.transitionValidators.observed.count`
- `dependencies.repository.transitionValidators.observed.digest`
- `failureGates[]`
- `heads.crossComposeInsertionProvenanceAgentIds.count`
- `heads.crossComposeInsertionProvenanceAgentIds.digest`
- `heads.danglingAgentIds.count`
- `heads.danglingAgentIds.digest`
- `heads.distinctHashes.count`
- `heads.distinctHashes.digest`
- `heads.fanout.maximumReferenceCount`
- `heads.fanout.sharedHashCount`
- `heads.fanout.singleHashCount`
- `heads.nonNullReferenceCount`
- `heads.nullInsertionProvenanceAgentIds.count`
- `heads.nullInsertionProvenanceAgentIds.digest`
- `heads.presentAgentIds.count`
- `heads.presentAgentIds.digest`
- `heads.sharedHashes.count`
- `heads.sharedHashes.digest`
- `identity.agentComposesTotal`
- `identity.approvedComposeOnlyArtifacts.approvedMemberCount`
- `identity.approvedComposeOnlyArtifacts.classification`
- `identity.approvedComposeOnlyArtifacts.expectedCount`
- `identity.approvedComposeOnlyArtifacts.expectedDigest`
- `identity.approvedComposeOnlyArtifacts.missingApprovedMemberCount`
- `identity.approvedComposeOnlyArtifacts.observedCount`
- `identity.approvedComposeOnlyArtifacts.observedDigest`
- `identity.approvedComposeOnlyArtifacts.unexpected.count`
- `identity.approvedComposeOnlyArtifacts.unexpected.digest`
- `identity.composeOnly.count`
- `identity.composeOnly.digest`
- `identity.createdTimestamps.equal.count`
- `identity.createdTimestamps.equal.digest`
- `identity.createdTimestamps.zeroEarlier.count`
- `identity.createdTimestamps.zeroEarlier.digest`
- `identity.createdTimestamps.zeroLater.count`
- `identity.createdTimestamps.zeroLater.digest`
- `identity.matched.count`
- `identity.matched.digest`
- `identity.nameMismatches.count`
- `identity.nameMismatches.digest`
- `identity.orgMismatches.count`
- `identity.orgMismatches.digest`
- `identity.ownerMismatches.count`
- `identity.ownerMismatches.digest`
- `identity.updatedTimestamps.compose.count`
- `identity.updatedTimestamps.compose.digest`
- `identity.updatedTimestamps.equal.count`
- `identity.updatedTimestamps.equal.digest`
- `identity.updatedTimestamps.zero.count`
- `identity.updatedTimestamps.zero.digest`
- `identity.zeroAgentsTotal`
- `identity.zeroOnly.count`
- `identity.zeroOnly.digest`
- `runs.distinctVersionHashes.count`
- `runs.distinctVersionHashes.digest`
- `runs.headReferencedVersionHashes.count`
- `runs.headReferencedVersionHashes.digest`
- `runs.missingReferences.count`
- `runs.missingReferences.digest`
- `runs.nonNullReferences.count`
- `runs.nonNullReferences.digest`
- `runs.nullVersionReferenceCount`
- `runs.sharedVersionHashes.count`
- `runs.sharedVersionHashes.digest`
- `runs.total`
- `schemaVersion`
- `status`
- `versions.content.canonicalCurrent.count`
- `versions.content.canonicalCurrent.digest`
- `versions.content.hashMismatches.count`
- `versions.content.hashMismatches.digest`
- `versions.content.nonCanonicalLegacy.count`
- `versions.content.nonCanonicalLegacy.digest`
- `versions.content.unsupportedOrInvalid.count`
- `versions.content.unsupportedOrInvalid.digest`
- `versions.orphanComposeIds.count`
- `versions.orphanComposeIds.digest`
- `versions.provenance.composeNullCreatorNull.count`
- `versions.provenance.composeNullCreatorNull.digest`
- `versions.provenance.composeNullCreatorPresent.count`
- `versions.provenance.composeNullCreatorPresent.digest`
- `versions.provenance.composePresentCreatorNull.count`
- `versions.provenance.composePresentCreatorNull.digest`
- `versions.provenance.composePresentCreatorPresent.count`
- `versions.provenance.composePresentCreatorPresent.digest`
- `versions.total`

</details>

## complete caller and dependency manifest

The complete machine-readable manifest is single-owned by `agent-compose-consolidation-preflight-manifest.ts`; the probe compares every expected entry with independently collected `pg_catalog` / repository observations and fails on any count or digest drift.

Canonical application owner and callers:

- `agent-compose-content.ts`: the only `buildZeroAgentComposeContent` and `computeComposeVersionId` definitions
- `recomposeAgentIfStale$`: `routes/agents.ts`, `connected-connector-authorization.service.ts`
- `createServerSideZeroAgentCompose$`: `routes/agents.ts`
- `serverSideZeroAgentCompose$`: `routes/agent-instructions.ts`, `routes/agents.ts`, `org-limited-free-bootstrap.service.ts`
- the three writer paths inside `agent-compose.service.ts` continue using the same extracted pure builder/hash; the preflight and focused validator are the only additional consumers

Database catalog manifest:

- 23 exact constraints, including target-table primary/foreign-key constraints and normalized `NOT NULL` state
- 9 defaults across `agent_compose_versions`, `agent_composes`, and `zero_agents`
- 21 inbound FKs: `agent_compose_versions.compose_id`, `agent_runs.agent_compose_version_id`, `agent_sessions.agent_compose_id`, AgentPhone/Feishu/Slack/Teams/Telegram selected/default Compose references, Banking/Thread Goal/User Connector/Custom Connector/Permission Grant/Draft/Workflow Agent references, `org_metadata.default_agent_id`, and the `zero_agents.id -> agent_composes.id` bridge; every exact definition includes update/delete actions, validation and deferrability
- 5 exact functions, including result/language/volatility/security-definer state and function body MD5
- 26 exact indexes across versions, Composes, sessions, banking, chat search/threads, connectors, grants, drafts, Agents, and Workflows, including definitions plus valid/ready state
- 0 baseline `otherDependents`; the structural `pg_depend` inventory fails closed on other non-internal persisted dependencies, including owned sequences, composite row-type consumers, and inheritance
- 12 reviewed non-FKs: `agent_composes.head_version_id`, AgentPhone message/context IDs, banking/chat/search/thread-event Agent IDs, checkpoint `agent_compose_snapshot`, connector authorization/state Agent IDs, and the reviewed unrelated `storages.head_version_id` name collision; every exact type/nullability is locked
- 0 baseline `rewriteDependents`; recursive `pg_depend`/`pg_rewrite` discovery fails closed on direct or transitive views, materialized views, and rules
- 5 exact triggers, including enabled state and complete trigger definition

Manifest count vector in canonical category order (`constraints/defaults/foreignKeys/functions/indexes/otherDependents/reviewedNonFk/rewriteDependents/triggers`): `23/9/21/5/26/0/12/0/5`.

Repository manifest:

- 98 schema imports, collected with the TypeScript AST
- 135 reviewed legacy identifier consumer records, collected with the TypeScript AST
- 3 reviewed raw table literals: provenance lifecycle service, Agent/Compose schema, and Zero Agent schema
- 1 reviewed non-TypeScript consumer: generated Rust `agentComposeVersionId` decode path
- 1 transition validator: `#27613|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8`
- TypeScript tests, mocks, migration history, DB scripts, and dev seed are explicitly excluded from production-consumer discovery; `.js`/`.mjs`/`.rs`/`.sql` scanning is supplemental and fail closed

## transition removal, fallbacks, and deviations

- temporary validator removal owner: **#26938 Stage 8**
- remove the manual workflow, probe, focused validator, and `MIGRATIONS.md` registry entry together
- fallbacks: **none**
- deviations from #27613: **none**
- retained temporary behavior: only the manual, production-approval-gated read-only validator and its migration-consistency registration; it does not run automatically
- production invocation, approval, aggregate acceptance, and any later dangling-head repair decision remain controller-owned and were not performed here

## validation

- `pnpm exec prettier --check <9 changed files>`: passed
- `pnpm -F api lint`: exit 0; pre-existing test warnings only, no errors or changed-file warning
- `pnpm -F api check-types:core`: exit 0
- `pnpm -F @okouai/db check-types`: exit 0
- `pnpm -F @okouai/db lint`: exit 0, including JSONB contracts, oxlint/type-aware and eslint `--max-warnings 0`
- focused Agent/Compose preflight integration against a fresh task-only PostgreSQL migration chain: passed twice; covers deterministic rerun, read-only rejection, timeout/cancellation, stable concurrent snapshots, all catalog drift kinds, repository drift, exact/non-exact/missing dangling classes, identity/version/Run/checkpoint classifications, and redaction
- pure post-refactor allowlist/dependency check: passed with 190 paths, catalog counts `23/9/21/5/26/0/12/0/5`, and repository counts `98/135/3/1/1`
- task-only empty-schema smoke: failed closed as expected on `dangling.count_drift` and `identity.approved_artifact_drift`; an empty inventory is not accepted
- workflow/registry/builder static assertions and `git diff --check`: passed; `actionlint` is unavailable locally
- final fully paged overlap inventory before push: 21 open PRs / 475 changed-file entries / 0 exact overlap; related-only #27616, #27200, #26947, and #25722 do not own this PR's files
- reviewed head: `5a739e71f43ec69efb9eacf08bc4b50fed568342`
- no full local Vitest suite, development server, production DB connection, production workflow run, or production acceptance was used or claimed
