### PR TITLE
test(python): cover provider timing during concurrent runner flushes

### DIFF
--- a/crates/runner/mitm-addon/tests/test_provider_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_provider_output_timing.py
@@ -59,6 +59,218 @@ class _RetryContentionLock:
         self._lock.release()
 
 
+class _RetryConcurrencyHarness:
+    def __init__(self, pending_path: Path, *, retry_admitted: bool) -> None:
+        self.pending_path = pending_path
+        self.retry_admitted = retry_admitted
+        self.executor = QueuedUsageExecutor()
+        self.release_retry = threading.Event()
+        self.retry_admission_started = threading.Event()
+        self.retry_admission_resolved = threading.Event()
+        self.retry_finished = threading.Event()
+        self.concurrent_admission = threading.Event()
+        self.contention_lock = _RetryContentionLock(self.release_retry)
+        self.admission_attempts: list[dict[str, object]] = []
+        self.accepted_payloads: list[dict[str, object]] = []
+        self.successful_admissions = 0
+        self._admission_attempt_lock = threading.Lock()
+        self._original_enqueue = usage.webhook.enqueue_webhook_delivery
+        self.retry_thread = ThreadUnderTest(
+            target=self._retry_all_pending,
+            name="provider-timing-retry",
+        )
+
+    @property
+    def expected_successful_admissions(self) -> int:
+        return 2 if self.retry_admitted else 1
+
+    def enqueue_timing_delivery(
+        self,
+        url: str,
+        sandbox_token: str,
+        payload: dict[str, object],
+        proxy_log_path: str,
+        log_type: str,
+    ) -> bool:
+        with self._admission_attempt_lock:
+            self.admission_attempts.append(payload)
+            attempt = len(self.admission_attempts)
+
+        if attempt == 1:
+            return False
+        if attempt == 2:
+            return self._admit_retry(
+                url,
+                sandbox_token,
+                payload,
+                proxy_log_path,
+                log_type,
+            )
+        if attempt == 3:
+            return self._admit_new_milestone(
+                url,
+                sandbox_token,
+                payload,
+                proxy_log_path,
+                log_type,
+            )
+        raise AssertionError(f"unexpected timing admission attempt {attempt}")
+
+    def assert_pending(
+        self,
+        *,
+        buffered: int,
+        reports: int,
+        flush_request_id: str,
+    ) -> None:
+        assert_current_pending(
+            self.pending_path,
+            flows=0,
+            buffered=buffered,
+            reports=reports,
+            flush_request_id=flush_request_id,
+        )
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == reports
+
+    def finish_retry_and_deliver(self) -> None:
+        self.release_retry.set()
+        try:
+            self.retry_thread.join_and_raise(timeout=1)
+        finally:
+            self.executor.run_all()
+
+    def _admit_retry(
+        self,
+        url: str,
+        sandbox_token: str,
+        payload: dict[str, object],
+        proxy_log_path: str,
+        log_type: str,
+    ) -> bool:
+        self.retry_admission_started.set()
+        try:
+            if not self.release_retry.wait(timeout=1):
+                raise AssertionError("concurrent provider event did not release timing retry")
+            if not self.retry_admitted:
+                self.assert_pending(
+                    buffered=1,
+                    reports=0,
+                    flush_request_id="retry-capacity-rejected",
+                )
+                return False
+            return self._admit_through_real_webhook(
+                url,
+                sandbox_token,
+                payload,
+                proxy_log_path,
+                log_type,
+                attempt=2,
+            )
+        finally:
+            self.retry_admission_resolved.set()
+
+    def _admit_new_milestone(
+        self,
+        url: str,
+        sandbox_token: str,
+        payload: dict[str, object],
+        proxy_log_path: str,
+        log_type: str,
+    ) -> bool:
+        if not self.retry_admission_resolved.is_set():
+            self.concurrent_admission.set()
+            self.release_retry.set()
+            if not self.retry_finished.wait(timeout=1):
+                raise AssertionError("unserialized timing retry did not finish")
+        return self._admit_through_real_webhook(
+            url,
+            sandbox_token,
+            payload,
+            proxy_log_path,
+            log_type,
+            attempt=3,
+        )
+
+    def _admit_through_real_webhook(
+        self,
+        url: str,
+        sandbox_token: str,
+        payload: dict[str, object],
+        proxy_log_path: str,
+        log_type: str,
+        *,
+        attempt: int,
+    ) -> bool:
+        self.assert_pending(
+            buffered=1,
+            reports=self.successful_admissions,
+            flush_request_id=f"attempt-{attempt}-before-handoff",
+        )
+        assert self._original_enqueue(
+            url,
+            sandbox_token,
+            payload,
+            proxy_log_path,
+            log_type,
+        )
+        self.accepted_payloads.append(payload)
+        self.successful_admissions += 1
+        self.assert_pending(
+            buffered=1,
+            reports=self.successful_admissions,
+            flush_request_id=f"attempt-{attempt}-after-handoff",
+        )
+        return True
+
+    def _retry_all_pending(self) -> None:
+        try:
+            codex_output_timing.retry_all_pending()
+        finally:
+            self.retry_finished.set()
+
+
+def _assert_delivered_timing_operations(
+    usage_webhook_server: UsageWebhookServer,
+    harness: _RetryConcurrencyHarness,
+    *,
+    client_received_at: float,
+    created_at: str,
+    output_item_at: str,
+    text_at: str,
+) -> None:
+    delivered_requests = [
+        request for request in usage_webhook_server.requests if request.path == _TELEMETRY_PATH
+    ]
+    delivered_payloads = [request.json_body() for request in delivered_requests]
+    assert delivered_payloads == harness.accepted_payloads
+
+    expected_payload_sizes = [3, 2] if harness.retry_admitted else [5]
+    delivered_operations: list[dict[str, object]] = []
+    actual_payload_sizes: list[int] = []
+    for payload in delivered_payloads:
+        operations = payload.get("sandboxOperations")
+        assert isinstance(operations, list)
+        actual_payload_sizes.append(len(operations))
+        for operation in operations:
+            assert isinstance(operation, dict)
+            delivered_operations.append(operation)
+    assert actual_payload_sizes == expected_payload_sizes
+
+    expected_operations = [
+        (
+            _FIRST_GENERATED_RESPONSE_CREATE_SENT,
+            datetime.fromtimestamp(client_received_at, UTC).isoformat(),
+        ),
+        (_FIRST_GENERATED_RESPONSE_CREATED, created_at),
+        (_FIRST_OUTPUT_ITEM_ADDED, output_item_at),
+        (_FIRST_OUTPUT_TEXT_DELTA, text_at),
+        (_FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE, text_at),
+    ]
+    assert [
+        (operation.get("action_type"), operation.get("ts")) for operation in delivered_operations
+    ] == expected_operations
+
+
 def test_provider_stores_keep_independent_lru_capacity(
     tmp_path: Path,
     real_flow,
@@ -180,131 +392,12 @@ def test_retry_serializes_with_new_codex_milestone(
 ) -> None:
     pending_path = tmp_path / "usage-pending"
     usage.set_pending_path(str(pending_path))
-    executor = QueuedUsageExecutor()
-    release_retry = threading.Event()
-    retry_admission_started = threading.Event()
-    retry_admission_resolved = threading.Event()
-    retry_finished = threading.Event()
-    concurrent_admission = threading.Event()
-    contention_lock = _RetryContentionLock(release_retry)
-    admission_attempt_lock = threading.Lock()
-    admission_attempts: list[dict[str, object]] = []
-    accepted_payloads: list[dict[str, object]] = []
-    successful_admissions = 0
-    original_enqueue = usage.webhook.enqueue_webhook_delivery
+    harness = _RetryConcurrencyHarness(pending_path, retry_admitted=retry_admitted)
 
     client_received_at = 1_700_000_000.125
     created_at = "2023-11-14T22:13:21.125000+00:00"
     output_item_at = "2023-11-14T22:13:22.125000+00:00"
     text_at = "2023-11-14T22:13:23.125000+00:00"
-
-    def admit_through_real_webhook(
-        url: str,
-        sandbox_token: str,
-        payload: dict[str, object],
-        proxy_log_path: str,
-        log_type: str,
-        *,
-        attempt: int,
-    ) -> bool:
-        nonlocal successful_admissions
-
-        assert_current_pending(
-            pending_path,
-            flows=0,
-            buffered=1,
-            reports=successful_admissions,
-            flush_request_id=f"attempt-{attempt}-before-handoff",
-        )
-        assert usage.webhook.pending_delivery_payload_count_for_tests() == successful_admissions
-
-        assert original_enqueue(
-            url,
-            sandbox_token,
-            payload,
-            proxy_log_path,
-            log_type,
-        )
-        accepted_payloads.append(payload)
-        successful_admissions += 1
-
-        assert_current_pending(
-            pending_path,
-            flows=0,
-            buffered=1,
-            reports=successful_admissions,
-            flush_request_id=f"attempt-{attempt}-after-handoff",
-        )
-        assert usage.webhook.pending_delivery_payload_count_for_tests() == successful_admissions
-        return True
-
-    def enqueue_timing_delivery(
-        url: str,
-        sandbox_token: str,
-        payload: dict[str, object],
-        proxy_log_path: str,
-        log_type: str,
-    ) -> bool:
-        with admission_attempt_lock:
-            admission_attempts.append(payload)
-            attempt = len(admission_attempts)
-
-        if attempt == 1:
-            return False
-
-        if attempt == 2:
-            retry_admission_started.set()
-            try:
-                if not release_retry.wait(timeout=1):
-                    raise AssertionError("concurrent provider event did not release timing retry")
-                if not retry_admitted:
-                    assert_current_pending(
-                        pending_path,
-                        flows=0,
-                        buffered=1,
-                        reports=0,
-                        flush_request_id="retry-capacity-rejected",
-                    )
-                    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
-                    return False
-                return admit_through_real_webhook(
-                    url,
-                    sandbox_token,
-                    payload,
-                    proxy_log_path,
-                    log_type,
-                    attempt=attempt,
-                )
-            finally:
-                retry_admission_resolved.set()
-
-        if attempt == 3:
-            if not retry_admission_resolved.is_set():
-                concurrent_admission.set()
-                release_retry.set()
-                if not retry_finished.wait(timeout=1):
-                    raise AssertionError("unserialized timing retry did not finish")
-            return admit_through_real_webhook(
-                url,
-                sandbox_token,
-                payload,
-                proxy_log_path,
-                log_type,
-                attempt=attempt,
-            )
-
-        raise AssertionError(f"unexpected timing admission attempt {attempt}")
-
-    def retry_all_pending() -> None:
-        try:
-            codex_output_timing.retry_all_pending()
-        finally:
-            retry_finished.set()
-
-    retry_thread = ThreadUnderTest(
-        target=retry_all_pending,
-        name="provider-timing-retry",
-    )
     flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
 
     with (
@@ -312,10 +405,10 @@ def test_retry_serializes_with_new_codex_milestone(
         patch.object(
             usage.webhook,
             "enqueue_webhook_delivery",
-            side_effect=enqueue_timing_delivery,
+            side_effect=harness.enqueue_timing_delivery,
         ),
-        patch.object(usage.webhook, "usage_executor", executor),
-        patch.object(codex_output_timing._store, "_lock", contention_lock),
+        patch.object(usage.webhook, "usage_executor", harness.executor),
+        patch.object(codex_output_timing._store, "_lock", harness.contention_lock),
         patch.object(
             codex_output_timing,
             "_observation_time",
@@ -326,87 +419,47 @@ def test_retry_serializes_with_new_codex_milestone(
         codex_output_timing.observe_server_event(flow, "response.created")
         codex_output_timing.observe_server_event(flow, "response.output_item.added")
 
-        assert_current_pending(
-            pending_path,
-            flows=0,
+        harness.assert_pending(
             buffered=1,
             reports=0,
             flush_request_id="before-concurrent-retry",
         )
-        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
 
-        retry_thread.start()
+        harness.retry_thread.start()
         try:
             wait_for_event(
-                retry_admission_started,
+                harness.retry_admission_started,
                 timeout=1,
-                threads=(retry_thread,),
+                threads=(harness.retry_thread,),
                 message="timing retry did not reach webhook admission",
             )
             codex_output_timing.observe_server_event(flow, "response.output_text.delta")
-            retry_thread.join_and_raise(timeout=1)
+            harness.retry_thread.join_and_raise(timeout=1)
 
-            assert contention_lock.contention_started.is_set()
-            assert not concurrent_admission.is_set()
-            assert len(admission_attempts) == 3
+            assert harness.contention_lock.contention_started.is_set()
+            assert not harness.concurrent_admission.is_set()
+            assert len(harness.admission_attempts) == 3
 
-            expected_successful_admissions = 2 if retry_admitted else 1
-            assert successful_admissions == expected_successful_admissions
-            assert_current_pending(
-                pending_path,
-                flows=0,
+            assert harness.successful_admissions == harness.expected_successful_admissions
+            harness.assert_pending(
                 buffered=0,
-                reports=expected_successful_admissions,
+                reports=harness.expected_successful_admissions,
                 flush_request_id="after-store-handoff",
             )
-            assert (
-                usage.webhook.pending_delivery_payload_count_for_tests()
-                == expected_successful_admissions
-            )
         finally:
-            release_retry.set()
-            try:
-                retry_thread.join_and_raise(timeout=1)
-            finally:
-                executor.run_all()
+            harness.finish_retry_and_deliver()
 
-        assert_current_pending(
-            pending_path,
-            flows=0,
+        harness.assert_pending(
             buffered=0,
             reports=0,
             flush_request_id="after-delivery",
         )
-        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
 
-    delivered_requests = [
-        request for request in usage_webhook_server.requests if request.path == _TELEMETRY_PATH
-    ]
-    delivered_payloads = [request.json_body() for request in delivered_requests]
-    assert delivered_payloads == accepted_payloads
-
-    expected_payload_sizes = [3, 2] if retry_admitted else [5]
-    delivered_operations: list[dict[str, object]] = []
-    actual_payload_sizes: list[int] = []
-    for payload in delivered_payloads:
-        operations = payload.get("sandboxOperations")
-        assert isinstance(operations, list)
-        actual_payload_sizes.append(len(operations))
-        for operation in operations:
-            assert isinstance(operation, dict)
-            delivered_operations.append(operation)
-    assert actual_payload_sizes == expected_payload_sizes
-
-    expected_operations = [
-        (
-            _FIRST_GENERATED_RESPONSE_CREATE_SENT,
-            datetime.fromtimestamp(client_received_at, UTC).isoformat(),
-        ),
-        (_FIRST_GENERATED_RESPONSE_CREATED, created_at),
-        (_FIRST_OUTPUT_ITEM_ADDED, output_item_at),
-        (_FIRST_OUTPUT_TEXT_DELTA, text_at),
-        (_FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE, text_at),
-    ]
-    assert [
-        (operation.get("action_type"), operation.get("ts")) for operation in delivered_operations
-    ] == expected_operations
+    _assert_delivered_timing_operations(
+        usage_webhook_server,
+        harness,
+        client_received_at=client_received_at,
+        created_at=created_at,
+        output_item_at=output_item_at,
+        text_at=text_at,
+    )

--- a/crates/runner/mitm-addon/tests/test_provider_output_timing.py
+++ b/crates/runner/mitm-addon/tests/test_provider_output_timing.py
@@ -1,8 +1,13 @@
 """Cross-provider integration tests for provider-output timing stores."""
 
+import threading
+from datetime import UTC, datetime
 from pathlib import Path
+from types import TracebackType
+from typing import Self
 from unittest.mock import patch
 
+import pytest
 from mitmproxy import http
 
 import claude_output_timing
@@ -14,6 +19,44 @@ from tests.model_provider_flow_helpers import (
     make_openai_responses_websocket_flow,
 )
 from tests.pending_helpers import assert_current_pending
+from tests.thread_helpers import ThreadUnderTest, wait_for_event
+from tests.usage_helpers import UsageWebhookServer
+from tests.webhook_test_helpers import QueuedUsageExecutor
+
+_FIRST_GENERATED_RESPONSE_CREATE_SENT = "codex_proxy_first_generated_response_create_sent"
+_FIRST_GENERATED_RESPONSE_CREATED = "codex_proxy_first_generated_response_created"
+_FIRST_OUTPUT_ITEM_ADDED = "codex_proxy_first_output_item_added"
+_FIRST_OUTPUT_TEXT_DELTA = "codex_proxy_first_output_text_delta"
+_FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE = "codex_proxy_first_text_in_first_generated_response"
+_TELEMETRY_PATH = "/api/webhooks/agent/telemetry"
+
+
+class _RetryContentionLock:
+    """Release a gated retry when a provider event reaches its held store lock."""
+
+    def __init__(self, release_retry: threading.Event) -> None:
+        self._lock = threading.Lock()
+        self._release_retry = release_retry
+        self.contention_started = threading.Event()
+
+    def __enter__(self) -> Self:
+        if self._lock.acquire(blocking=False):
+            return self
+
+        self.contention_started.set()
+        self._release_retry.set()
+        if not self._lock.acquire(timeout=1):
+            raise AssertionError("provider timing transition did not acquire the retry lock")
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, exc, traceback
+        self._lock.release()
 
 
 def test_provider_stores_keep_independent_lru_capacity(
@@ -119,3 +162,251 @@ def test_provider_stores_keep_independent_lru_capacity(
         ("claude_output_timing", "run-claude-recent"),
         ("codex_output_timing", "run-shared"),
     ]
+
+
+@pytest.mark.parametrize(
+    "retry_admitted",
+    [
+        pytest.param(True, id="retry-admitted"),
+        pytest.param(False, id="retry-capacity-rejected"),
+    ],
+)
+def test_retry_serializes_with_new_codex_milestone(
+    tmp_path: Path,
+    real_flow,
+    mitm_ctx,
+    usage_webhook_server: UsageWebhookServer,
+    retry_admitted: bool,
+) -> None:
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    executor = QueuedUsageExecutor()
+    release_retry = threading.Event()
+    retry_admission_started = threading.Event()
+    retry_admission_resolved = threading.Event()
+    retry_finished = threading.Event()
+    concurrent_admission = threading.Event()
+    contention_lock = _RetryContentionLock(release_retry)
+    admission_attempt_lock = threading.Lock()
+    admission_attempts: list[dict[str, object]] = []
+    accepted_payloads: list[dict[str, object]] = []
+    successful_admissions = 0
+    original_enqueue = usage.webhook.enqueue_webhook_delivery
+
+    client_received_at = 1_700_000_000.125
+    created_at = "2023-11-14T22:13:21.125000+00:00"
+    output_item_at = "2023-11-14T22:13:22.125000+00:00"
+    text_at = "2023-11-14T22:13:23.125000+00:00"
+
+    def admit_through_real_webhook(
+        url: str,
+        sandbox_token: str,
+        payload: dict[str, object],
+        proxy_log_path: str,
+        log_type: str,
+        *,
+        attempt: int,
+    ) -> bool:
+        nonlocal successful_admissions
+
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=1,
+            reports=successful_admissions,
+            flush_request_id=f"attempt-{attempt}-before-handoff",
+        )
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == successful_admissions
+
+        assert original_enqueue(
+            url,
+            sandbox_token,
+            payload,
+            proxy_log_path,
+            log_type,
+        )
+        accepted_payloads.append(payload)
+        successful_admissions += 1
+
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=1,
+            reports=successful_admissions,
+            flush_request_id=f"attempt-{attempt}-after-handoff",
+        )
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == successful_admissions
+        return True
+
+    def enqueue_timing_delivery(
+        url: str,
+        sandbox_token: str,
+        payload: dict[str, object],
+        proxy_log_path: str,
+        log_type: str,
+    ) -> bool:
+        with admission_attempt_lock:
+            admission_attempts.append(payload)
+            attempt = len(admission_attempts)
+
+        if attempt == 1:
+            return False
+
+        if attempt == 2:
+            retry_admission_started.set()
+            try:
+                if not release_retry.wait(timeout=1):
+                    raise AssertionError("concurrent provider event did not release timing retry")
+                if not retry_admitted:
+                    assert_current_pending(
+                        pending_path,
+                        flows=0,
+                        buffered=1,
+                        reports=0,
+                        flush_request_id="retry-capacity-rejected",
+                    )
+                    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+                    return False
+                return admit_through_real_webhook(
+                    url,
+                    sandbox_token,
+                    payload,
+                    proxy_log_path,
+                    log_type,
+                    attempt=attempt,
+                )
+            finally:
+                retry_admission_resolved.set()
+
+        if attempt == 3:
+            if not retry_admission_resolved.is_set():
+                concurrent_admission.set()
+                release_retry.set()
+                if not retry_finished.wait(timeout=1):
+                    raise AssertionError("unserialized timing retry did not finish")
+            return admit_through_real_webhook(
+                url,
+                sandbox_token,
+                payload,
+                proxy_log_path,
+                log_type,
+                attempt=attempt,
+            )
+
+        raise AssertionError(f"unexpected timing admission attempt {attempt}")
+
+    def retry_all_pending() -> None:
+        try:
+            codex_output_timing.retry_all_pending()
+        finally:
+            retry_finished.set()
+
+    retry_thread = ThreadUnderTest(
+        target=retry_all_pending,
+        name="provider-timing-retry",
+    )
+    flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+
+    with (
+        mitm_ctx(api_url=usage_webhook_server.api_url),
+        patch.object(
+            usage.webhook,
+            "enqueue_webhook_delivery",
+            side_effect=enqueue_timing_delivery,
+        ),
+        patch.object(usage.webhook, "usage_executor", executor),
+        patch.object(codex_output_timing._store, "_lock", contention_lock),
+        patch.object(
+            codex_output_timing,
+            "_observation_time",
+            side_effect=(created_at, output_item_at, text_at),
+        ),
+    ):
+        codex_output_timing.observe_client_event(flow, "response.create", client_received_at)
+        codex_output_timing.observe_server_event(flow, "response.created")
+        codex_output_timing.observe_server_event(flow, "response.output_item.added")
+
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=1,
+            reports=0,
+            flush_request_id="before-concurrent-retry",
+        )
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+
+        retry_thread.start()
+        try:
+            wait_for_event(
+                retry_admission_started,
+                timeout=1,
+                threads=(retry_thread,),
+                message="timing retry did not reach webhook admission",
+            )
+            codex_output_timing.observe_server_event(flow, "response.output_text.delta")
+            retry_thread.join_and_raise(timeout=1)
+
+            assert contention_lock.contention_started.is_set()
+            assert not concurrent_admission.is_set()
+            assert len(admission_attempts) == 3
+
+            expected_successful_admissions = 2 if retry_admitted else 1
+            assert successful_admissions == expected_successful_admissions
+            assert_current_pending(
+                pending_path,
+                flows=0,
+                buffered=0,
+                reports=expected_successful_admissions,
+                flush_request_id="after-store-handoff",
+            )
+            assert (
+                usage.webhook.pending_delivery_payload_count_for_tests()
+                == expected_successful_admissions
+            )
+        finally:
+            release_retry.set()
+            try:
+                retry_thread.join_and_raise(timeout=1)
+            finally:
+                executor.run_all()
+
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="after-delivery",
+        )
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+
+    delivered_requests = [
+        request for request in usage_webhook_server.requests if request.path == _TELEMETRY_PATH
+    ]
+    delivered_payloads = [request.json_body() for request in delivered_requests]
+    assert delivered_payloads == accepted_payloads
+
+    expected_payload_sizes = [3, 2] if retry_admitted else [5]
+    delivered_operations: list[dict[str, object]] = []
+    actual_payload_sizes: list[int] = []
+    for payload in delivered_payloads:
+        operations = payload.get("sandboxOperations")
+        assert isinstance(operations, list)
+        actual_payload_sizes.append(len(operations))
+        for operation in operations:
+            assert isinstance(operation, dict)
+            delivered_operations.append(operation)
+    assert actual_payload_sizes == expected_payload_sizes
+
+    expected_operations = [
+        (
+            _FIRST_GENERATED_RESPONSE_CREATE_SENT,
+            datetime.fromtimestamp(client_received_at, UTC).isoformat(),
+        ),
+        (_FIRST_GENERATED_RESPONSE_CREATED, created_at),
+        (_FIRST_OUTPUT_ITEM_ADDED, output_item_at),
+        (_FIRST_OUTPUT_TEXT_DELTA, text_at),
+        (_FIRST_TEXT_IN_FIRST_GENERATED_RESPONSE, text_at),
+    ]
+    assert [
+        (operation.get("action_type"), operation.get("ts")) for operation in delivered_operations
+    ] == expected_operations


### PR DESCRIPTION
## Summary

- add a deterministic cross-thread regression for `ProviderTimingStore.retry_all_pending()` overlapping a new Codex text milestone
- cover both accepted and capacity-rejected retry outcomes with exact, original milestone timestamps
- exercise the real buffered-to-reports ownership handoff, delivery-capacity accounting, queued local webhook delivery, and final counter release
- prove the test detects removal of the shared retry lock without using sleeps

## Compatibility and exclusions

- test-only change; provider timing runtime behavior is unchanged
- no API, database, telemetry schema, runner protocol, dependency, feature switch, migration, or rollout change
- the full runner signal lifecycle remains covered by its existing tests; this regression targets the shared store's atomic snapshot, admission, and clearing boundary

## Validation

- `uv lock --check`
- `uv sync --locked`
- new two-case regression repeated 25 consecutive times
- temporary retry-lock removal: both cases failed; restored source passed
- `uv run --no-sync python -m pytest tests/test_provider_output_timing.py` (`3 passed`)
- `uv run --no-sync python -m pytest tests/test_codex_output_timing.py tests/test_claude_output_timing.py tests/test_runner_usage_flush_signal.py` (`71 passed`)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`5565 passed`, 59 pre-existing warnings)
- `git diff --check`

Closes #27628
