### PR TITLE
refactor(sandbox-fc): use upstream abort-on-drop handle

### DIFF
--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -19,7 +19,7 @@ sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["process", "fs", "rt", "rt-multi-thread", "macros", "sync", "io-util", "net", "time"] }
-tokio-util.workspace = true
+tokio-util = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 vsock-host.workspace = true

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -1,10 +1,7 @@
-use std::future::Future;
 use std::io;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use std::time::Duration;
 
-use tokio::task::JoinHandle;
+use tokio_util::task::AbortOnDropHandle;
 use tracing::info;
 use vsock_proto::ExecTermination;
 
@@ -27,37 +24,6 @@ const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Pre-warm should be quiet; keep diagnostics bounded and explicit.
 const PREWARM_EXEC_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
-
-struct AbortOnDropTask<T> {
-    handle: JoinHandle<T>,
-}
-
-impl<T> AbortOnDropTask<T> {
-    fn new(handle: JoinHandle<T>) -> Self {
-        Self { handle }
-    }
-
-    fn abort(&self) {
-        self.handle.abort();
-    }
-}
-
-impl<T> Future for AbortOnDropTask<T> {
-    type Output = Result<T, tokio::task::JoinError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-        Pin::new(&mut this.handle).poll(cx)
-    }
-}
-
-impl<T> Drop for AbortOnDropTask<T> {
-    fn drop(&mut self) {
-        if !self.handle.is_finished() {
-            self.handle.abort();
-        }
-    }
-}
 
 pub(super) async fn run_snapshot_workflow(
     config: &SnapshotCreateConfig,
@@ -101,7 +67,7 @@ async fn run_with_firecracker(
 
     // 7. Bind vsock listener BEFORE starting the instance (race: guest connects ~300ms after boot).
     let vsock_path_for_listen = vsock_uds_str.clone();
-    let vsock_task = AbortOnDropTask::new(tokio::spawn(async move {
+    let vsock_task = AbortOnDropHandle::new(tokio::spawn(async move {
         vsock_host::VsockHost::wait_for_connection(&vsock_path_for_listen, VSOCK_CONNECT_TIMEOUT)
             .await
     }));
@@ -536,14 +502,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn abort_on_drop_task_aborts_vsock_listener() {
+    async fn abort_on_drop_handle_aborts_vsock_listener() {
         let dir = tempfile::tempdir().expect("tempdir");
         let base = dir.path().join("snapshot-vsock");
         let listener =
             std::path::PathBuf::from(format!("{}_{}", base.display(), vsock_proto::VSOCK_PORT));
         let base = base.display().to_string();
 
-        let task = AbortOnDropTask::new(tokio::spawn(async move {
+        let task = AbortOnDropHandle::new(tokio::spawn(async move {
             vsock_host::VsockHost::wait_for_connection(&base, Duration::from_secs(30)).await
         }));
 
@@ -567,14 +533,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn abort_on_drop_task_explicit_abort_removes_vsock_listener() {
+    async fn abort_on_drop_handle_explicit_abort_removes_vsock_listener() {
         let dir = tempfile::tempdir().expect("tempdir");
         let base = dir.path().join("snapshot-vsock-explicit-abort");
         let listener =
             std::path::PathBuf::from(format!("{}_{}", base.display(), vsock_proto::VSOCK_PORT));
         let base = base.display().to_string();
 
-        let task = AbortOnDropTask::new(tokio::spawn(async move {
+        let task = AbortOnDropHandle::new(tokio::spawn(async move {
             vsock_host::VsockHost::wait_for_connection(&base, Duration::from_secs(30)).await
         }));
 


### PR DESCRIPTION
## Summary

- enable `tokio-util/rt` for `sandbox-fc` and use `AbortOnDropHandle` for the snapshot vsock listener
- remove the duplicate local `Future`/`Drop` wrapper while preserving explicit abort-and-await cleanup
- keep real listener-socket coverage for implicit drop and explicit abort cancellation

## Scope

This is an internal task-ownership refactor. It does not change public APIs, protocols, persisted state, deployment compatibility, or dependency versions.

## Validation

- `cargo test -p sandbox-fc --lib snapshot::runtime::tests::abort_on_drop_handle`
- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc --no-deps`
- `cargo test -p sandbox-fc` (800 lib tests, 1 integration test, 0 ignored)
- pre-commit hook: workspace Cargo format, documentation, and Clippy checks; file-size check; commitlint

Closes #27625
