### PR TITLE
perf(python): bound browser user-agent classification work

### DIFF
--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -63,6 +63,9 @@ _BROWSER_USER_AGENT_MARKERS = (
     " opr/",
     " safari/",
 )
+# User-Agent is only a spoofable business passthrough signal. Values above this
+# budget conservatively continue through ordinary firewall classification.
+_MAX_BROWSER_USER_AGENT_BYTES = 4096
 
 type StaleTlsAdmissionReason = Literal[
     "client_ip_missing",
@@ -559,7 +562,27 @@ def current_public_destination_denial(
     )
 
 
-def is_browser_user_agent(user_agent: str | None) -> bool:
+def is_browser_passthrough_heuristic(flow: http.HTTPFlow) -> bool:
+    # Short-term business passthrough heuristic for browser-originated traffic.
+    # This is not trusted browser provenance: any sandbox client can set this
+    # header. The spoofable User-Agent heuristic is currently accepted as a
+    # known tradeoff until runner-owned browser provenance is prioritized again.
+    user_agent_bytes = 0
+    has_user_agent = False
+    for name, value in flow.request.headers.fields:
+        if name.lower() != b"user-agent":
+            continue
+        if has_user_agent:
+            user_agent_bytes += len(b", ")
+        user_agent_bytes += len(value)
+        if user_agent_bytes > _MAX_BROWSER_USER_AGENT_BYTES:
+            return False
+        has_user_agent = True
+
+    if not has_user_agent:
+        return False
+
+    user_agent = flow.request.headers.get("User-Agent")
     if not user_agent:
         return False
 
@@ -567,14 +590,6 @@ def is_browser_user_agent(user_agent: str | None) -> bool:
     return "mozilla/" in normalized and any(
         marker in normalized for marker in _BROWSER_USER_AGENT_MARKERS
     )
-
-
-def is_browser_passthrough_heuristic(flow: http.HTTPFlow) -> bool:
-    # Short-term business passthrough heuristic for browser-originated traffic.
-    # This is not trusted browser provenance: any sandbox client can set this
-    # header. The spoofable User-Agent heuristic is currently accepted as a
-    # known tradeoff until runner-owned browser provenance is prioritized again.
-    return is_browser_user_agent(flow.request.headers.get("User-Agent"))
 
 
 def restore_request_headers_probe_metadata(

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -1,5 +1,7 @@
 """Ordinary and browser pass-through tests for the request hook."""
 
+import pytest
+
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
@@ -11,6 +13,54 @@ _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) HeadlessChrome/126.0.0.0 Safari/537.36"
 )
+_MAX_BROWSER_USER_AGENT_BYTES = 4096
+_BROWSER_USER_AGENTS = (
+    pytest.param(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+        id="chrome",
+    ),
+    pytest.param(
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chromium/126.0.0.0 Safari/537.36",
+        id="chromium",
+    ),
+    pytest.param(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0",
+        id="edge",
+    ),
+    pytest.param(
+        "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0",
+        id="firefox",
+    ),
+    pytest.param(
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 OPR/112.0.0.0",
+        id="opera",
+    ),
+    pytest.param(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
+        "(KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+        id="safari",
+    ),
+    pytest.param(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.6478.54 "
+        "Mobile/15E148 Safari/604.1",
+        id="ios",
+    ),
+    pytest.param(_BROWSER_USER_AGENT, id="headless-chrome"),
+    pytest.param(
+        _BROWSER_USER_AGENT.ljust(_MAX_BROWSER_USER_AGENT_BYTES, "x"),
+        id="at-limit",
+    ),
+)
+
+
+class _DecodeGuardUserAgent(bytes):
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("oversized User-Agent must not be decoded")
 
 
 async def test_allowed_domain_passes_through(registry_file, real_flow, mitm_ctx):
@@ -99,8 +149,9 @@ async def test_firewall_no_base_match_passes_through(tmp_path, real_flow, mitm_c
     assert metadata_keys.FIREWALL_BASE not in flow.metadata
 
 
+@pytest.mark.parametrize("browser_user_agent", _BROWSER_USER_AGENTS)
 async def test_browser_passthrough_skips_firewall_auth_injection(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, browser_user_agent
 ):
     """Browser-looking UAs use the short-term passthrough heuristic."""
     pending_path = tmp_path / "usage-pending"
@@ -133,7 +184,7 @@ async def test_browser_passthrough_skips_firewall_auth_injection(
         path="/v1/payment_pages/cs_test_123/init",
         request_headers=headers(
             ("Host", "api.stripe.com"),
-            ("User-Agent", _BROWSER_USER_AGENT),
+            ("User-Agent", browser_user_agent),
         ),
     )
 
@@ -172,6 +223,70 @@ async def test_browser_passthrough_skips_firewall_auth_injection(
     network_log_entry = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")[0]
     assert network_log_entry["browser_user_agent"] is True
     assert "firewall_base" not in network_log_entry
+
+
+@pytest.mark.parametrize(
+    "user_agent_values",
+    [
+        pytest.param(
+            (_DecodeGuardUserAgent(b"Mozilla/5.0 " + b"x" * 4096),),
+            id="single-field",
+        ),
+        pytest.param(
+            (
+                _DecodeGuardUserAgent(b"Mozilla/5.0 " + b"x" * (2048 - 12)),
+                _DecodeGuardUserAgent(b"x" * 2047),
+            ),
+            id="combined-fields",
+        ),
+    ],
+)
+async def test_oversized_browser_user_agent_uses_firewall_without_decoding(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, user_agent_values
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="stripe",
+            api_entry={
+                "base": "https://api.stripe.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.STRIPE_TOKEN }}"}},
+                "permissions": [],
+            },
+            network_policy={
+                "allow": [],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+    request_headers = mitm_addon.http.Headers(
+        [(b"Host", b"api.stripe.com")] + [(b"User-Agent", value) for value in user_agent_values]
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.stripe.com",
+        method="POST",
+        path="/v1/payment_pages/cs_test_123/init",
+        request_headers=request_headers,
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as mock_headers,
+    ):
+        await mitm_addon.request(flow)
+
+    mock_headers.assert_awaited_once()
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer x"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.stripe.com"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "stripe"
+    assert metadata_keys.BROWSER_USER_AGENT not in flow.metadata
 
 
 async def test_non_browser_firewall_match_still_injects_auth(


### PR DESCRIPTION
## Summary

- cap the browser pass-through heuristic at a 4,096-byte combined raw User-Agent value
- reject the browser signal before mitmproxy decodes or folds oversized values, while leaving the HTTP request on the ordinary firewall path
- preserve existing browser classification for Chrome, Chromium, Edge, Firefox, Opera, Safari, iOS/CriOS, HeadlessChrome, and the inclusive limit
- structurally cover single-field and duplicate-field overflow without wall-clock assertions

## Behavior

The limit is a work budget for a spoofable business signal, not an HTTP field-size policy. Matching raw values are counted together with the `", "` separator mitmproxy uses to fold duplicate fields. Values above 4,096 bytes are not rejected, truncated, or mutated; they are classified as non-browser and continue through normal authority and firewall handling.

Accepted values retain the existing decode/fold, lowercase, leading-space, Mozilla, and browser-marker behavior. The former single-use string helper is folded into the heuristic so the raw bound and classification decision have one owner.

Deliberately customized browser User-Agent values above the budget can become conservative false negatives and may therefore receive configured firewall denial or credential handling. The representative browser fixtures in this PR are 78–142 bytes, leaving more than 28x margin.

## Performance

The exact `is_browser_passthrough_heuristic()` wrapper was measured on pinned CPython 3.14.0 with real `mitmproxy.http.Headers`. Each raw value and flow was constructed outside the measured region; medians use seven calls.

| Added payload | Before median | Before peak | After median | After peak |
| ---: | ---: | ---: | ---: | ---: |
| 1 MiB | 4.683 ms | 3.00 MiB | 0.000333 ms | 83 bytes |
| 5 MiB | 27.100 ms | 15.00 MiB | 0.000250 ms | 83 bytes |
| 16 MiB | 55.825 ms | 48.00 MiB | 0.000625 ms | 83 bytes |
| 33 MiB | 194.252 ms | 99.00 MiB | 0.000250 ms | 83 bytes |

Reproduction command, run from `crates/runner/mitm-addon` at the relevant before/after revision:

```bash
PYTHONPATH=src uv run --no-sync python -c 'import statistics, time, tracemalloc; from types import SimpleNamespace; from mitmproxy import http; from request_classification import is_browser_passthrough_heuristic
for mib in (1, 5, 16, 33):
 raw = b"Mozilla/5.0 " + b"x" * (mib * 1024 * 1024)
 flow = SimpleNamespace(request=SimpleNamespace(headers=http.Headers([(b"User-Agent", raw)])))
 samples = []
 for _ in range(7):
  start = time.perf_counter_ns(); result = is_browser_passthrough_heuristic(flow); samples.append(time.perf_counter_ns() - start)
 tracemalloc.start(); is_browser_passthrough_heuristic(flow); _, peak = tracemalloc.get_traced_memory(); tracemalloc.stop()
 print(mib, result, round(statistics.median(samples) / 1_000_000, 6), peak)'
```

## Scope exclusions

- does not add a parser-wide request-head or field-size limit
- does not address oversized non-User-Agent fields or work proportional to header count/name length
- does not add a permanent benchmark script, dependency, API, schema, persisted state, protocol, or rollout gate

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_handler_passthrough.py` — 20 passed
- `uv run --no-sync python -m pytest tests/` — 5,573 passed

Closes #27629
