### PR TITLE
fix(billing): align legacy migration notice

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1407,6 +1407,9 @@ describe("organization billing settings", () => {
     });
     expect(conversionNotice).toBeVisible();
     expect(conversionNotice).toHaveTextContent("Scheduled for Sep 1, 2026");
+    expect(
+      within(conversionNotice).getByText("Scheduled for Sep 1, 2026"),
+    ).not.toHaveClass("block");
 
     const reviewConversionButton = buttonByText(
       "Review conversion",
@@ -1453,6 +1456,9 @@ describe("organization billing settings", () => {
     expect(reviewConversionNotice).toHaveTextContent(
       "Scheduled for Sep 1, 2026",
     );
+    expect(
+      within(reviewConversionNotice).getByText("Scheduled for Sep 1, 2026"),
+    ).not.toHaveClass("block");
     expect(reviewConversionNotice.parentElement).toContainElement(
       buttonByText("Confirm", reviewDialog),
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1412,6 +1412,9 @@ describe("organization billing settings", () => {
       "Review conversion",
       orderSummary,
     );
+    expect(conversionNotice.parentElement).toContainElement(
+      reviewConversionButton,
+    );
     click(reviewConversionButton);
     const reviewDialog = await screen.findByRole("dialog", {
       name: "Review plan conversion",
@@ -1443,9 +1446,15 @@ describe("organization billing settings", () => {
     expect(
       within(reviewDialog).getByText("Monthly total").closest("div"),
     ).toHaveTextContent("$229.50/month");
-    expect(
-      within(reviewDialog).getByRole("status", { name: "Convert plan" }),
-    ).toHaveTextContent("Scheduled for Sep 1, 2026");
+    const reviewConversionNotice = within(reviewDialog).getByRole("status", {
+      name: "Convert plan",
+    });
+    expect(reviewConversionNotice).toHaveTextContent(
+      "Scheduled for Sep 1, 2026",
+    );
+    expect(reviewConversionNotice.parentElement).toContainElement(
+      buttonByText("Confirm", reviewDialog),
+    );
 
     click(within(reviewDialog).getByLabelText("Back"));
     const returnedPackagesDialog = await screen.findByRole("dialog", {
@@ -2568,7 +2577,11 @@ describe("organization billing settings", () => {
     expect(
       within(orderSummary).queryByText("Scheduled for Apr 1, 2026"),
     ).not.toBeInTheDocument();
-    click(buttonByText("Confirm", orderSummary));
+    const confirmDowngradeButton = buttonByText("Confirm", orderSummary);
+    expect(downgradeNotice.parentElement).toContainElement(
+      confirmDowngradeButton,
+    );
+    click(confirmDowngradeButton);
     const confirmationDialog = await screen.findByRole("dialog", {
       name: "Review package change",
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1415,6 +1415,7 @@ describe("organization billing settings", () => {
     expect(conversionNotice.parentElement).toContainElement(
       reviewConversionButton,
     );
+    expect(conversionNotice.parentElement).not.toHaveClass("border-t-[0.7px]");
     click(reviewConversionButton);
     const reviewDialog = await screen.findByRole("dialog", {
       name: "Review plan conversion",
@@ -1454,6 +1455,9 @@ describe("organization billing settings", () => {
     );
     expect(reviewConversionNotice.parentElement).toContainElement(
       buttonByText("Confirm", reviewDialog),
+    );
+    expect(reviewConversionNotice.parentElement).not.toHaveClass(
+      "border-t-[0.7px]",
     );
 
     click(within(reviewDialog).getByLabelText("Back"));
@@ -2581,6 +2585,7 @@ describe("organization billing settings", () => {
     expect(downgradeNotice.parentElement).toContainElement(
       confirmDowngradeButton,
     );
+    expect(downgradeNotice.parentElement).not.toHaveClass("border-t-[0.7px]");
     click(confirmDowngradeButton);
     const confirmationDialog = await screen.findByRole("dialog", {
       name: "Review package change",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1402,9 +1402,11 @@ describe("organization billing settings", () => {
     expect(
       within(orderSummary).queryByText("Monthly difference"),
     ).not.toBeInTheDocument();
-    expect(
-      within(orderSummary).getByText("Scheduled for Sep 1, 2026"),
-    ).toBeVisible();
+    const conversionNotice = within(orderSummary).getByRole("status", {
+      name: "Convert plan",
+    });
+    expect(conversionNotice).toBeVisible();
+    expect(conversionNotice).toHaveTextContent("Scheduled for Sep 1, 2026");
 
     const reviewConversionButton = buttonByText(
       "Review conversion",
@@ -1442,8 +1444,8 @@ describe("organization billing settings", () => {
       within(reviewDialog).getByText("Monthly total").closest("div"),
     ).toHaveTextContent("$229.50/month");
     expect(
-      within(reviewDialog).getByText("Scheduled for Sep 1, 2026"),
-    ).toBeInTheDocument();
+      within(reviewDialog).getByRole("status", { name: "Convert plan" }),
+    ).toHaveTextContent("Scheduled for Sep 1, 2026");
 
     click(within(reviewDialog).getByLabelText("Back"));
     const returnedPackagesDialog = await screen.findByRole("dialog", {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -1407,9 +1407,6 @@ describe("organization billing settings", () => {
     });
     expect(conversionNotice).toBeVisible();
     expect(conversionNotice).toHaveTextContent("Scheduled for Sep 1, 2026");
-    expect(
-      within(conversionNotice).getByText("Scheduled for Sep 1, 2026"),
-    ).not.toHaveClass("block");
 
     const reviewConversionButton = buttonByText(
       "Review conversion",
@@ -1418,7 +1415,6 @@ describe("organization billing settings", () => {
     expect(conversionNotice.parentElement).toContainElement(
       reviewConversionButton,
     );
-    expect(conversionNotice.parentElement).not.toHaveClass("border-t-[0.7px]");
     click(reviewConversionButton);
     const reviewDialog = await screen.findByRole("dialog", {
       name: "Review plan conversion",
@@ -1456,14 +1452,8 @@ describe("organization billing settings", () => {
     expect(reviewConversionNotice).toHaveTextContent(
       "Scheduled for Sep 1, 2026",
     );
-    expect(
-      within(reviewConversionNotice).getByText("Scheduled for Sep 1, 2026"),
-    ).not.toHaveClass("block");
     expect(reviewConversionNotice.parentElement).toContainElement(
       buttonByText("Confirm", reviewDialog),
-    );
-    expect(reviewConversionNotice.parentElement).not.toHaveClass(
-      "border-t-[0.7px]",
     );
 
     click(within(reviewDialog).getByLabelText("Back"));
@@ -2591,7 +2581,6 @@ describe("organization billing settings", () => {
     expect(downgradeNotice.parentElement).toContainElement(
       confirmDowngradeButton,
     );
-    expect(downgradeNotice.parentElement).not.toHaveClass("border-t-[0.7px]");
     click(confirmDowngradeButton);
     const confirmationDialog = await screen.findByRole("dialog", {
       name: "Review package change",

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1370,11 +1370,11 @@ const REVIEW_ROW = "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3";
 const REVIEW_HAIRLINE = "border-t-[0.7px] border-[hsl(var(--gray-100))]";
 const REVIEW_RULE = "border-t-[0.7px] border-border";
 
-/* A step's action stays on the frame's foot instead of scrolling away with the
-   body it belongs to: a long member list must never put the decision out of
-   reach. The bar spans the full frame width, so it cancels the body's inset and
-   restores it inside, and it carries the frame's own surface so the rows pass
-   underneath it rather than through it. */
+/* A step's notice and action stay together on the frame's foot instead of
+   scrolling away with the body they belong to: a long member list must never
+   put the decision out of reach or leave its consequence detached above it.
+   The bar spans the full frame width, so it cancels the body's inset and
+   restores it inside, and its gap keeps the notice-to-button spacing stable. */
 const STEP_ACTION_BAR = `sticky bottom-0 -mx-5 mt-auto flex flex-col gap-3 bg-card px-5 py-4 ${REVIEW_RULE}`;
 
 function ReviewSectionLabel({ label }: { readonly label: string }) {
@@ -1824,15 +1824,17 @@ function ScheduledBillingChangeNotice({
 }
 
 function SubscriptionChangeNotice({
+  className = "mt-3",
   description,
   effectiveAt,
 }: {
+  readonly className?: string;
   readonly description: string;
   readonly effectiveAt: string;
 }) {
   return (
     <ScheduledBillingChangeNotice
-      className="mt-3"
+      className={className}
       title={i18n.t(($) => {
         return $.billing.plans.usagePacks.migration.convertPlan;
       })}
@@ -2250,6 +2252,20 @@ function ManagedSubscriptionOrderSummary({
     hasScheduledDowngrade && !hasConfigurationChange
       ? management.currentPeriodEnd
       : null;
+  const downgradeNotice = scheduledDowngradeEffectiveAt ? (
+    <UsagePackDowngradeNotice
+      effectiveAt={scheduledDowngradeEffectiveAt}
+      scheduled
+    />
+  ) : (
+    hasDowngrade &&
+    management.currentPeriodEnd && (
+      <UsagePackDowngradeNotice
+        className={hasSubscriptionAction ? "" : "mb-5 mt-3"}
+        effectiveAt={management.currentPeriodEnd}
+      />
+    )
+  );
   const openPreview = async (): Promise<void> => {
     if (!members) {
       return;
@@ -2269,20 +2285,7 @@ function ManagedSubscriptionOrderSummary({
       })}
       className={scheduledDowngradeEffectiveAt ? "pb-5" : undefined}
     >
-      {scheduledDowngradeEffectiveAt ? (
-        <UsagePackDowngradeNotice
-          effectiveAt={scheduledDowngradeEffectiveAt}
-          scheduled
-        />
-      ) : (
-        hasDowngrade &&
-        management.currentPeriodEnd && (
-          <UsagePackDowngradeNotice
-            className="mb-5 mt-3"
-            effectiveAt={management.currentPeriodEnd}
-          />
-        )
-      )}
+      {!hasSubscriptionAction && downgradeNotice}
       {hasPendingChange && !hasScheduledDowngrade && (
         <p className="mt-3 text-sm text-muted-foreground">
           {i18n.t(($) => {
@@ -2292,6 +2295,7 @@ function ManagedSubscriptionOrderSummary({
       )}
       {hasSubscriptionAction && (
         <div className={STEP_ACTION_BAR}>
+          {downgradeNotice}
           {error && <p className="text-sm text-destructive">{error}</p>}
           <Button
             type="button"
@@ -2452,13 +2456,14 @@ function MigrationOrderSummary({
           />
         </>
       )}
-      <SubscriptionChangeNotice
-        description={i18n.t(($) => {
-          return $.billing.plans.usagePacks.migration.confirmDescription;
-        })}
-        effectiveAt={effectiveAt}
-      />
       <div className={inDialog ? STEP_ACTION_BAR : undefined}>
+        <SubscriptionChangeNotice
+          className={inDialog ? "" : undefined}
+          description={i18n.t(($) => {
+            return $.billing.plans.usagePacks.migration.confirmDescription;
+          })}
+          effectiveAt={effectiveAt}
+        />
         {previewError && (
           <p
             className={
@@ -2547,14 +2552,23 @@ function MigrationRevisionOrderSummary({
           <SubscriptionComparisonTable rows={rows} />
         </>
       )}
-      <SubscriptionChangeNotice
-        description={i18n.t(($) => {
-          return $.billing.plans.usagePacks.migration.confirmDescription;
-        })}
-        effectiveAt={effectiveAt}
-      />
+      {!hasConfigurationChange && (
+        <SubscriptionChangeNotice
+          description={i18n.t(($) => {
+            return $.billing.plans.usagePacks.migration.confirmDescription;
+          })}
+          effectiveAt={effectiveAt}
+        />
+      )}
       {hasConfigurationChange && (
         <div className={inDialog ? STEP_ACTION_BAR : undefined}>
+          <SubscriptionChangeNotice
+            className={inDialog ? "" : undefined}
+            description={i18n.t(($) => {
+              return $.billing.plans.usagePacks.migration.confirmDescription;
+            })}
+            effectiveAt={effectiveAt}
+          />
           {previewError && (
             <p
               className={
@@ -2828,8 +2842,19 @@ function MigrationReviewStepContent({
           return $.billing.plans.usagePacks.migration.reviewDescription;
         })}
       </p>
-      <MigrationPreviewDetails preview={preview} totals={totals} />
+      <MigrationPreviewDetails
+        preview={preview}
+        showChangeNotice={false}
+        totals={totals}
+      />
       <div className={STEP_ACTION_BAR}>
+        <SubscriptionChangeNotice
+          className=""
+          description={i18n.t(($) => {
+            return $.billing.plans.usagePacks.migration.confirmDescription;
+          })}
+          effectiveAt={preview.effectiveAt}
+        />
         {error && (
           <p className="text-sm text-destructive">
             {i18n.t(($) => {
@@ -2860,11 +2885,13 @@ function MigrationReviewStepContent({
 
 function MigrationPreviewDetails({
   preview,
+  showChangeNotice = true,
   totals,
 }: {
   readonly preview:
     | UsagePackMigrationPreviewResponse
     | UsagePackMigrationRevisionPreviewResponse;
+  readonly showChangeNotice?: boolean;
   readonly totals: MemberUsageTotals;
 }) {
   const previewTotals: MemberUsageTotals = {
@@ -2879,12 +2906,14 @@ function MigrationPreviewDetails({
         plan={usagePackPlan(preview.targetTier)}
         totals={previewTotals}
       />
-      <SubscriptionChangeNotice
-        description={i18n.t(($) => {
-          return $.billing.plans.usagePacks.migration.confirmDescription;
-        })}
-        effectiveAt={preview.effectiveAt}
-      />
+      {showChangeNotice && (
+        <SubscriptionChangeNotice
+          description={i18n.t(($) => {
+            return $.billing.plans.usagePacks.migration.confirmDescription;
+          })}
+          effectiveAt={preview.effectiveAt}
+        />
+      )}
     </>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1374,8 +1374,17 @@ const REVIEW_RULE = "border-t-[0.7px] border-border";
    scrolling away with the body they belong to: a long member list must never
    put the decision out of reach or leave its consequence detached above it.
    The bar spans the full frame width, so it cancels the body's inset and
-   restores it inside, and its gap keeps the notice-to-button spacing stable. */
-const STEP_ACTION_BAR = `sticky bottom-0 -mx-5 mt-auto flex flex-col gap-3 bg-card px-5 py-4 ${REVIEW_RULE}`;
+   restores it inside, and its gap keeps the notice-to-button spacing stable.
+   A notice already provides its own visual boundary, so only a bare action bar
+   needs the rule that separates it from the scrolling content. */
+const STEP_ACTION_BAR_BASE =
+  "sticky bottom-0 -mx-5 mt-auto flex flex-col gap-3 bg-card px-5 py-4";
+const STEP_ACTION_BAR = `${STEP_ACTION_BAR_BASE} ${REVIEW_RULE}`;
+const STEP_ACTION_BAR_WITH_NOTICE = STEP_ACTION_BAR_BASE;
+
+function stepActionBarClass(hasNotice: boolean): string {
+  return hasNotice ? STEP_ACTION_BAR_WITH_NOTICE : STEP_ACTION_BAR;
+}
 
 function ReviewSectionLabel({ label }: { readonly label: string }) {
   return (
@@ -2294,7 +2303,7 @@ function ManagedSubscriptionOrderSummary({
         </p>
       )}
       {hasSubscriptionAction && (
-        <div className={STEP_ACTION_BAR}>
+        <div className={stepActionBarClass(Boolean(downgradeNotice))}>
           {downgradeNotice}
           {error && <p className="text-sm text-destructive">{error}</p>}
           <Button
@@ -2456,7 +2465,7 @@ function MigrationOrderSummary({
           />
         </>
       )}
-      <div className={inDialog ? STEP_ACTION_BAR : undefined}>
+      <div className={inDialog ? STEP_ACTION_BAR_WITH_NOTICE : undefined}>
         <SubscriptionChangeNotice
           className={inDialog ? "" : undefined}
           description={i18n.t(($) => {
@@ -2561,7 +2570,7 @@ function MigrationRevisionOrderSummary({
         />
       )}
       {hasConfigurationChange && (
-        <div className={inDialog ? STEP_ACTION_BAR : undefined}>
+        <div className={inDialog ? STEP_ACTION_BAR_WITH_NOTICE : undefined}>
           <SubscriptionChangeNotice
             className={inDialog ? "" : undefined}
             description={i18n.t(($) => {
@@ -2847,7 +2856,7 @@ function MigrationReviewStepContent({
         showChangeNotice={false}
         totals={totals}
       />
-      <div className={STEP_ACTION_BAR}>
+      <div className={STEP_ACTION_BAR_WITH_NOTICE}>
         <SubscriptionChangeNotice
           className=""
           description={i18n.t(($) => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1849,8 +1849,8 @@ function SubscriptionChangeNotice({
       })}
       description={
         <>
-          <span>{description}</span>
-          <span className="mt-0.5 block font-medium">
+          <span>{description}</span>{" "}
+          <span className="font-medium">
             {i18n.t(
               ($) => {
                 return $.billing.plans.usagePacks.management.scheduledFor;

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1793,6 +1793,36 @@ function SubscriptionComparisonTable({
   );
 }
 
+function ScheduledBillingChangeNotice({
+  className = "",
+  description,
+  title,
+}: {
+  readonly className?: string;
+  readonly description: ReactNode;
+  readonly title: string;
+}) {
+  return (
+    <div
+      role="status"
+      aria-label={title}
+      className={`flex items-center gap-3 rounded-xl p-3 ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS} ${className}`}
+    >
+      <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-yellow-100/80 text-yellow-700 dark:bg-yellow-400/15 dark:text-yellow-300">
+        <CalendarDays aria-hidden="true" className="size-4" />
+      </span>
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-yellow-900 dark:text-yellow-100">
+          {title}
+        </p>
+        <div className="mt-0.5 text-sm leading-snug text-yellow-800 dark:text-yellow-200">
+          {description}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function SubscriptionChangeNotice({
   description,
   effectiveAt,
@@ -1801,17 +1831,25 @@ function SubscriptionChangeNotice({
   readonly effectiveAt: string;
 }) {
   return (
-    <div className="mt-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-sm leading-relaxed text-amber-700 dark:border-amber-400/20 dark:bg-amber-400/10 dark:text-amber-300">
-      <p>{description}</p>
-      <p className="mt-1 font-medium">
-        {i18n.t(
-          ($) => {
-            return $.billing.plans.usagePacks.management.scheduledFor;
-          },
-          { date: formatBillingDate(effectiveAt) },
-        )}
-      </p>
-    </div>
+    <ScheduledBillingChangeNotice
+      className="mt-3"
+      title={i18n.t(($) => {
+        return $.billing.plans.usagePacks.migration.convertPlan;
+      })}
+      description={
+        <>
+          <span>{description}</span>
+          <span className="mt-0.5 block font-medium">
+            {i18n.t(
+              ($) => {
+                return $.billing.plans.usagePacks.management.scheduledFor;
+              },
+              { date: formatBillingDate(effectiveAt) },
+            )}
+          </span>
+        </>
+      }
+    />
   );
 }
 
@@ -1832,29 +1870,17 @@ function UsagePackDowngradeNotice({
         return $.billing.plans.downgrade;
       });
   return (
-    <div
-      role="status"
-      aria-label={title}
-      className={`flex items-center gap-3 rounded-xl p-3 ${USAGE_PACK_DOWNGRADE_NOTICE_CLASS} ${className}`}
-    >
-      <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-yellow-100/80 text-yellow-700 dark:bg-yellow-400/15 dark:text-yellow-300">
-        <CalendarDays aria-hidden="true" className="size-4" />
-      </span>
-      <div className="min-w-0">
-        <p className="text-sm font-semibold text-yellow-900 dark:text-yellow-100">
-          {title}
-        </p>
-        <p className="mt-0.5 text-sm leading-snug text-yellow-800 dark:text-yellow-200">
-          {i18n.t(
-            ($) => {
-              return $.billing.plans.usagePacks.management
-                .scheduledDowngradeDescription;
-            },
-            { date: formatBillingDate(effectiveAt) },
-          )}
-        </p>
-      </div>
-    </div>
+    <ScheduledBillingChangeNotice
+      className={className}
+      title={title}
+      description={i18n.t(
+        ($) => {
+          return $.billing.plans.usagePacks.management
+            .scheduledDowngradeDescription;
+        },
+        { date: formatBillingDate(effectiveAt) },
+      )}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

- reuse one scheduled billing change notice for legacy conversion and package downgrades
- align the legacy notice icon, warning surface, title hierarchy, and date treatment
- preserve the existing migration copy and behavior
- add integration coverage for the structured legacy notice in Steps 2 and 3

## Testing

- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx --maxWorkers=1`
- targeted oxlint and ESLint for both changed files
- Prettier for both changed files