### PR TITLE
refactor(run): persist immutable launch snapshots

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -28,6 +28,7 @@ import { cronSteerRunTimeBudgetContract } from "@okouai/api-contracts/contracts/
 import {
   ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES,
   CANCELLATION_RECOVERY_STALE_AFTER_MS,
+  DEFAULT_PROFILE,
 } from "@okouai/api-contracts/contracts/runners";
 import { zeroMailContract } from "@okouai/api-contracts/contracts/zero-mail";
 import {
@@ -89,6 +90,7 @@ import { chatEventDisplayText } from "./helpers/chat-event";
 import {
   clearThreadSessionBinding,
   readRunAutonomyBudgetFixture,
+  readRunLaunchSnapshotFixture,
   readThreadSessionBinding,
   seedVm0ManagedModelKey as seedVm0ManagedModelKeyState,
   setRunAutonomyBudgetFixture,
@@ -3720,6 +3722,16 @@ describe("CHAT-02: model-first provider policies", () => {
       const firstContext = firstClaim.claim;
 
       expect(firstContext.cliAgentType).toBe("pi");
+      await expect(
+        readRunLaunchSnapshotFixture(context, first.runId),
+      ).resolves.toStrictEqual({
+        exists: true,
+        launch_snapshot: {
+          schemaVersion: 1,
+          framework: firstContext.cliAgentType,
+          runnerProfile: DEFAULT_PROFILE,
+        },
+      });
       expect(firstContext.piSessionId).toBe(first.threadId);
       expect(firstContext.prompt).toBe(firstPrompt);
       expect(firstContext.piLaunchConfig).not.toHaveProperty(
@@ -5541,6 +5553,12 @@ describe("CHAT-02: run-level model overrides", () => {
     if (typeof discardedRunId !== "string") {
       throw new Error("Expected blocked admission timing to identify its run");
     }
+    await expect(
+      readRunLaunchSnapshotFixture(context, discardedRunId),
+    ).resolves.toStrictEqual({
+      exists: false,
+      launch_snapshot: null,
+    });
     const lostTimingEvents = apiDispatchTimingEventsForRun(discardedRunId);
     for (const actionType of [
       "api_dispatch_prepare_run_context",
@@ -5725,6 +5743,16 @@ describe("CHAT-02: run-level model overrides", () => {
       run_session_id: firstBinding.agent_session_id,
     });
     const secondClaim = await claimChatRun(runnerGroup, second.runId);
+    await expect(
+      readRunLaunchSnapshotFixture(context, second.runId),
+    ).resolves.toStrictEqual({
+      exists: true,
+      launch_snapshot: {
+        schemaVersion: 1,
+        framework: secondClaim.claim.cliAgentType,
+        runnerProfile: DEFAULT_PROFILE,
+      },
+    });
     expect(secondClaim.claim.resumeSession?.sessionId).toBe(
       `bdd-cli-${first.runId}`,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -29,6 +29,7 @@ import {
 } from "./helpers/api-bdd-computer-use";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+import { readRunLaunchSnapshotFixture } from "./helpers/runtime-state";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 
 /*
@@ -166,6 +167,12 @@ describe("FILE-03 desktop computer-use runtime", () => {
     const orgId = `org_${randomUUID()}`;
     const actor = bdd.user({ orgId });
     const run = await seedZeroRun({ actor, triggerSource: "web" });
+    await expect(
+      readRunLaunchSnapshotFixture(context, run.runId),
+    ).resolves.toStrictEqual({
+      exists: true,
+      launch_snapshot: null,
+    });
     if (!run.threadId) {
       throw new Error("Expected web run fixture to create a chat thread");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -163,6 +163,11 @@ export async function readRunAutonomyBudgetFixture(
   return response.autonomy_budget ?? null;
 }
 
+/**
+ * Launch snapshots are intentionally writer-only in Stage 2, so persistence
+ * cannot be observed through a production API. Keep this test-only exception
+ * bounded to snapshot, historical-NULL, and no-row retry assertions.
+ */
 export async function readRunLaunchSnapshotFixture(
   context: TestContext,
   runId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -163,6 +163,20 @@ export async function readRunAutonomyBudgetFixture(
   return response.autonomy_budget ?? null;
 }
 
+export async function readRunLaunchSnapshotFixture(
+  context: TestContext,
+  runId: string,
+): Promise<NonNullable<TestRuntimeStateActionResponse["run_launch_snapshot"]>> {
+  const response = await postAction(context, {
+    action: "read-run-launch-snapshot",
+    run_id: runId,
+  });
+  if (!response.run_launch_snapshot) {
+    throw new Error("readRunLaunchSnapshotFixture missing run_launch_snapshot");
+  }
+  return response.run_launch_snapshot;
+}
+
 export async function setRunAutonomyBudgetFixture(
   context: TestContext,
   runId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8,6 +8,7 @@ import {
   type SupportedRunModel,
 } from "@okouai/api-contracts/contracts/model-providers";
 import {
+  DEFAULT_PROFILE,
   CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
   CONNECTOR_RUNTIME_SYNC_TARGETS_MAX,
   type ConnectorRuntimeSyncResult,
@@ -110,6 +111,7 @@ import {
   readRunAutonomyBudgetFixture,
   readRunApiStart,
   readRunClaimOwner,
+  readRunLaunchSnapshotFixture,
   readRunnerJobStorageState,
   readStoragePersistenceState,
   releaseOrgAdmissionLock,
@@ -3611,6 +3613,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       agentComposeVersionId: compose.versionId,
       prompt: "poll with explicit support list",
     });
+    expect(created.status).toBe("pending");
 
     const incompatiblePoll = await api.requestPollRunner(
       true,
@@ -3643,7 +3646,25 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(compatiblePoll.body.job?.runId).toBe(created.runId);
     expect(compatiblePoll.body.job?.experimentalProfile).toBe("vm0/large");
 
+    const launchSnapshot = await readRunLaunchSnapshotFixture(
+      context,
+      created.runId,
+    );
+    expect(launchSnapshot).toStrictEqual({
+      exists: true,
+      launch_snapshot: {
+        schemaVersion: 1,
+        framework: "claude-code",
+        runnerProfile: compatiblePoll.body.job?.experimentalProfile,
+      },
+    });
+    const claim = await api.claimRunnerJob(created.runId);
+    expect(launchSnapshot.launch_snapshot?.framework).toBe(claim.cliAgentType);
+
     await api.requestCancelRun(actor, created.runId, [200]);
+    await expect(
+      readRunLaunchSnapshotFixture(context, created.runId),
+    ).resolves.toStrictEqual(launchSnapshot);
   });
 
   it("skips runner-local exclusions without mutating shared queue state", async () => {
@@ -3749,6 +3770,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(resumed.sessionId).toBe(first.sessionId);
     const resumedClaim = await api.claimRunnerJob(resumed.runId);
     expect(resumedClaim.resumeSession).toBeNull();
+    await expect(
+      readRunLaunchSnapshotFixture(context, resumed.runId),
+    ).resolves.toStrictEqual({
+      exists: true,
+      launch_snapshot: {
+        schemaVersion: 1,
+        framework: resumedClaim.cliAgentType,
+        runnerProfile: DEFAULT_PROFILE,
+      },
+    });
 
     if (!actor.orgId) {
       throw new Error("Expected session owner to have an organization");
@@ -6222,9 +6253,24 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     }
 
     await api.heartbeatRunner(runnerGroup);
+    const poll = await api.pollRunner(runnerGroup);
+    expect(poll.body.job).toMatchObject({
+      runId: sent.body.runId,
+      experimentalProfile: DEFAULT_PROFILE,
+    });
     const claim = await api.claimRunnerJob(sent.body.runId);
 
     expect(claim.cliAgentType).toBe("codex");
+    await expect(
+      readRunLaunchSnapshotFixture(context, sent.body.runId),
+    ).resolves.toStrictEqual({
+      exists: true,
+      launch_snapshot: {
+        schemaVersion: 1,
+        framework: claim.cliAgentType,
+        runnerProfile: poll.body.job?.experimentalProfile,
+      },
+    });
     expect(claim.environment).toMatchObject({
       OPENAI_API_KEY: modelProviderPlaceholder(
         "openai-api-key",
@@ -12883,6 +12929,18 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       modelProvider: "anthropic-api-key",
     });
     expect(queued.status).toBe("queued");
+    const queuedLaunchSnapshot = await readRunLaunchSnapshotFixture(
+      context,
+      queued.runId,
+    );
+    expect(queuedLaunchSnapshot).toStrictEqual({
+      exists: true,
+      launch_snapshot: {
+        schemaVersion: 1,
+        framework: "claude-code",
+        runnerProfile: DEFAULT_PROFILE,
+      },
+    });
     await expect(
       readRunAutonomyBudgetFixture(context, queued.runId),
     ).resolves.toBe(10);
@@ -12908,6 +12966,9 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
 
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(queued.runId);
+    expect(claim.cliAgentType).toBe(
+      queuedLaunchSnapshot.launch_snapshot?.framework,
+    );
     expect(claim.featureFlags).toMatchObject({
       [FeatureSwitchKey.ManualMorningBrief]: true,
     });
@@ -13656,6 +13717,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           framework: "claude-code",
           environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
           experimental_runner: { group: "other/test" },
+          experimental_profile: "vm0/large",
         },
       },
     });
@@ -13665,6 +13727,16 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     });
     expect(failedRun.status).toBe("failed");
     expect(failedRun.error).toBe("Only vm0/* runner groups are supported");
+    await expect(
+      readRunLaunchSnapshotFixture(context, failedRun.runId),
+    ).resolves.toStrictEqual({
+      exists: true,
+      launch_snapshot: {
+        schemaVersion: 1,
+        framework: "claude-code",
+        runnerProfile: "vm0/large",
+      },
+    });
     const storedFailedRun = await api.readRun(actor, failedRun.runId);
     expect(storedFailedRun.status).toBe("failed");
     const failedClaim = await api.requestClaimRunnerJob(

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -735,6 +735,10 @@ type ReadRunClaimOwnerAction = Extract<
   TestRuntimeStateActionBody,
   { action: "read-run-claim-owner" }
 >;
+type ReadRunLaunchSnapshotAction = Extract<
+  TestRuntimeStateActionBody,
+  { action: "read-run-launch-snapshot" }
+>;
 type ReadBrowserScreenshotSchemaStateAction = Extract<
   TestRuntimeStateActionBody,
   { action: "read-browser-screenshot-schema-state" }
@@ -752,6 +756,7 @@ type PersistenceStateAction =
   | ReadStorageStateAction
   | ReadRunnerJobStorageStateAction
   | ReadRunClaimOwnerAction
+  | ReadRunLaunchSnapshotAction
   | ReadBrowserScreenshotSchemaStateAction
   | ReadUsagePackInvitationSchemaStateAction
   | ResetDatabasePoolAction;
@@ -765,7 +770,8 @@ function isPersistenceStateAction(
       return true;
     }
     case "read-runner-job-storage-state":
-    case "read-run-claim-owner": {
+    case "read-run-claim-owner":
+    case "read-run-launch-snapshot": {
       return true;
     }
     case "read-browser-screenshot-schema-state": {
@@ -830,6 +836,24 @@ async function persistenceStateActionResponse(
     }
     case "read-run-claim-owner": {
       return await readRunClaimOwnerActionResponse(db, body, signal);
+    }
+    case "read-run-launch-snapshot": {
+      const [run] = await db
+        .select({ launchSnapshot: agentRuns.launchSnapshot })
+        .from(agentRuns)
+        .where(eq(agentRuns.id, body.run_id))
+        .limit(1);
+      signal.throwIfAborted();
+      return {
+        status: 200 as const,
+        body: {
+          ok: true as const,
+          run_launch_snapshot: {
+            exists: run !== undefined,
+            launch_snapshot: run?.launchSnapshot ?? null,
+          },
+        },
+      };
     }
     case "read-browser-screenshot-schema-state": {
       const available = await browserScreenshotSchemaAvailable(db);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -108,6 +108,7 @@ import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
 import { agentRunQueue } from "@okouai/db/schema/agent-run-queue";
 import { agentRuns } from "@okouai/db/schema/agent-run";
+import type { AgentRunLaunchSnapshot } from "@okouai/db/jsonb-contracts/agent-run-session-conversation";
 import { agentSessions } from "@okouai/db/schema/agent-session";
 import { conversations } from "@okouai/db/schema/conversation";
 import { blobs } from "@okouai/db/schema/blob";
@@ -721,7 +722,7 @@ export function isThreadSessionSnapshotStale(
 interface CommitPreparedLaunchArgs {
   readonly db: Db;
   readonly createArgs: CreateAgentRunArgs;
-  readonly context: PreparedRunContext;
+  readonly context: FinalizedPreparedRunContext;
   readonly identity: LaunchRunIdentity;
   readonly callbackRows: readonly AgentRunCallbackInsert[];
   readonly launch: PreparedRunnerLaunch;
@@ -5732,6 +5733,7 @@ interface LaunchRunRowsArgs {
   readonly zeroRunMetadata: ZeroRunMetadata | undefined;
   readonly apiStartTime: number;
   readonly runnerGroup: string | undefined;
+  readonly launchSnapshot: AgentRunLaunchSnapshot;
   readonly error: string | undefined;
 }
 
@@ -5771,6 +5773,7 @@ function launchRunValues(
     sessionId: args.identity.sessionId,
     lastHeartbeatAt: createdAt,
     runnerGroup: args.runnerGroup ?? null,
+    launchSnapshot: args.launchSnapshot,
     completedAt: args.status === "failed" ? createdAt : null,
     error: args.error ?? null,
     ...metadata,
@@ -6310,6 +6313,7 @@ interface BuildRunnerJobPayloadInput {
   readonly body: CreateRunBody;
   readonly artifacts: readonly ContextArtifact[];
   readonly framework: SupportedFramework;
+  readonly launchSnapshot: AgentRunLaunchSnapshot;
   readonly piSandbox: PiModelConfig | undefined;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly connectorContext: ConnectorRuntimeContext;
@@ -6341,17 +6345,18 @@ function storedExecutionContextWithPiResources(
   context: StoredExecutionContext,
   resources: PreparedPiLaunchResources | undefined,
   chatThreadId: string | undefined,
+  launchFramework: AgentRunLaunchSnapshot["framework"],
 ): StoredExecutionContext {
+  const finalizedContext = { ...context, cliAgentType: launchFramework };
   if (resources === undefined) {
-    return context;
+    return finalizedContext;
   }
   if (chatThreadId === undefined) {
     throw new Error("Pi sandbox execution requires a chat thread");
   }
   return {
-    ...context,
+    ...finalizedContext,
     resumeSession: resources.resumeSession ?? null,
-    cliAgentType: "pi",
     piSessionId: chatThreadId,
     piLaunchConfig: resources.launchConfig,
     piModelConfig: resources.modelConfig,
@@ -6464,7 +6469,7 @@ function buildRunnerJobPayload(
             volumeVersionOverrides: body.volumeVersions,
             additionalVolumes: args.additionalVolumes,
             additionalVolumeSources: args.additionalVolumeSources,
-            framework: args.piSandbox === undefined ? args.framework : "pi",
+            framework: args.launchSnapshot.framework,
             persistedStorageMounts: args.resolved.persistedStorageMounts,
             timing: args.timing,
             stats: storageManifestStats,
@@ -6502,6 +6507,7 @@ function buildRunnerJobPayload(
       builtContext.context,
       piResources,
       args.chatThreadId,
+      args.launchSnapshot.framework,
     );
     const runContextSnapshot = buildRunContextSnapshot({
       runId: args.run.id,
@@ -6516,7 +6522,7 @@ function buildRunnerJobPayload(
     return {
       runnerJobPayload: queuedRunnerJobPayload({
         runnerGroup: group,
-        profile: runnerProfile(args.resolved.content),
+        profile: args.launchSnapshot.runnerProfile,
         cliAgentSessionId,
         reuseKey: runnerReuseKey(args.chatThreadId),
         executionContext: storedContext,
@@ -6553,6 +6559,7 @@ function preparedLaunchRowsArgs(args: {
     zeroRunMetadata: args.commit.createArgs.zeroRunMetadata,
     apiStartTime: args.commit.createArgs.apiStartTime,
     runnerGroup: args.runnerGroup,
+    launchSnapshot: args.commit.context.launchSnapshot,
     error: undefined,
   };
 }
@@ -6949,7 +6956,7 @@ async function claimQueueFirstAssociationForLaunch(args: {
 async function commitFailedLaunch(args: {
   readonly db: Db;
   readonly createArgs: CreateAgentRunArgs;
-  readonly context: PreparedRunContext;
+  readonly context: FinalizedPreparedRunContext;
   readonly identity: LaunchRunIdentity;
   readonly callbackRows: readonly AgentRunCallbackInsert[];
   readonly error: unknown;
@@ -6995,6 +7002,7 @@ async function commitFailedLaunch(args: {
         zeroRunMetadata: args.createArgs.zeroRunMetadata,
         apiStartTime: args.createArgs.apiStartTime,
         runnerGroup: undefined,
+        launchSnapshot: args.context.launchSnapshot,
         error: message,
       });
       if (queueFirstClaim) {
@@ -7460,7 +7468,7 @@ function buildAtomicLaunchPayload(
   db: Db,
   args: {
     readonly createArgs: CreateAgentRunArgs;
-    readonly context: PreparedRunContext;
+    readonly context: FinalizedPreparedRunContext;
     readonly run: Pick<RunRecord, "id" | "sessionId" | "shouldCreateSession">;
     readonly timing: ApiDispatchTimingCollector;
   },
@@ -7473,6 +7481,7 @@ function buildAtomicLaunchPayload(
     body: args.context.body,
     artifacts: args.context.artifacts,
     framework: args.context.framework,
+    launchSnapshot: args.context.launchSnapshot,
     piSandbox: args.context.piSandbox,
     modelProvider: args.context.modelProvider,
     connectorContext: args.context.connectorContext,
@@ -7550,6 +7559,10 @@ interface PreparedRunContext {
   readonly imageRecognitionAvailable: boolean;
   /** Snapshotted onto the run row; see `resolveVideoModelForRun`. */
   readonly selectedVideoModel: string;
+}
+
+interface FinalizedPreparedRunContext extends PreparedRunContext {
+  readonly launchSnapshot: AgentRunLaunchSnapshot;
 }
 
 function isPiSandboxEnabledForRun(
@@ -8719,7 +8732,7 @@ function flushQueueFirstClaimLostTiming(args: {
 interface AtomicLaunchRunInput {
   readonly db: Db;
   readonly args: CreateAgentRunArgs;
-  readonly context: PreparedRunContext;
+  readonly context: FinalizedPreparedRunContext;
   readonly timing: ApiDispatchTimingCollector;
   readonly phaseTiming: ApiDispatchPhaseCollector;
 }
@@ -8977,9 +8990,17 @@ interface CompleteAgentRunArgs {
 function finalizePreparedRunContext(
   prepared: PreparedAgentRun,
   finalAppendSystemPrompt: CreateRunBody["appendSystemPrompt"],
-): PreparedRunContext {
+): FinalizedPreparedRunContext {
   return {
     ...prepared.context,
+    launchSnapshot: {
+      schemaVersion: 1,
+      framework:
+        prepared.context.piSandbox === undefined
+          ? prepared.context.framework
+          : "pi",
+      runnerProfile: runnerProfile(prepared.context.resolved.content),
+    },
     body: withFinalRunAppendSystemPrompt({
       body: {
         ...prepared.context.body,

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -139,6 +139,10 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     run_id: z.uuid(),
   }),
   z.object({
+    action: z.literal("read-run-launch-snapshot"),
+    run_id: z.uuid(),
+  }),
+  z.object({
     action: z.literal("read-thread-session-binding"),
     thread_id: z.uuid(),
   }),
@@ -225,6 +229,19 @@ export const testRuntimeStateActionResponseSchema = z.object({
     .nullable()
     .optional(),
   api_started_at: z.string().nullable().optional(),
+  run_launch_snapshot: z
+    .object({
+      exists: z.boolean(),
+      launch_snapshot: z
+        .object({
+          schemaVersion: z.literal(1),
+          framework: z.enum(["claude-code", "codex", "pi"]),
+          runnerProfile: z.string().min(1).max(255),
+        })
+        .strict()
+        .nullable(),
+    })
+    .optional(),
   thread_session_binding: z
     .object({
       agent_session_id: z.uuid().nullable(),


### PR DESCRIPTION
## Summary

- finalize one strict v1 launch snapshot after Run preparation and reuse its exact framework/profile for both persistence and the Runner payload
- persist that snapshot through the shared Run-row builder for pending, queued, direct, continuation, and prepared-context failure paths
- add focused BDD coverage for payload equality, retries, immutability, and historical NULL rows without adding a read cutover

## Acceptance evidence

- **Single finalized source:** `finalizePreparedRunContext` creates `launchSnapshot` once. Pi resolves to `framework: "pi"`; all other launches use the finalized effective framework. `runnerProfile(...)` is evaluated once, including `DEFAULT_PROFILE`.
- **Payload equality:** storage framework, stored execution-context `cliAgentType`, and `queuedRunnerJobPayload.profile` consume the same finalized snapshot fields that are inserted into `agent_runs`.
- **All production inserts:** repository search found exactly two production `agentRuns` inserts, both in `agent-run-create.service.ts`; the normal atomic CTE and prepared-context failed insert both converge on `launchRunValues`, which now writes `launchSnapshot` in the Run's insert.
- **Framework/profile matrix:** focused tests compare persisted snapshots with Claude Code, Codex, and Pi claim contexts and with default/explicit poll profiles.
- **Path matrix:** focused tests cover direct pending, queued-to-pending promotion, continuation, and a prepared-context dispatch failure with an explicit profile.
- **Retry ownership:** a discarded stale/claim-lost preparation is asserted to have no Run row or snapshot; the successful canonical-binding retry owns a complete snapshot.
- **History and immutability:** a raw historical fixture that omits the column remains NULL, and cancellation leaves an existing snapshot unchanged.
- **Contracts/behavior:** no public API or Runner contract changed. The new inspection action is test-only and is not registered in production or E2E routes.

## Baseline and overlap

- Initial main baseline: `0eac48b359d85af21bb02209933acfe90d8c4d3b`
- Pre-PR fetch/rebase main: `0eac48b359d85af21bb02209933acfe90d8c4d3b` (`git rebase origin/main`: up to date)
- Post-review-fix fetch/rebase main: `0eac48b359d85af21bb02209933acfe90d8c4d3b` (`git rebase origin/main`: up to date)
- #26947 remains open at `eb766f3b0fb4e5a63550ed0923a21a13a726ef72`. Its only overlapping file change adds optional internal `runId` injection in `agent-run-create.service.ts`; this PR does not incorporate or modify that behavior. Whichever PR lands second must rebase and preserve both focused changes.

## Verification

Passed locally with pnpm 10.33.4:

```text
pnpm exec prettier --write <7 changed files>
pnpm --filter @okouai/api-contracts run lint
pnpm --filter api run lint
pnpm exec knip --workspace api --workspace @okouai/api-contracts
pnpm --filter @okouai/api-contracts run check-types
pnpm --filter api run check-types
pnpm --filter api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'filters runner polls by supported profiles|resumes the previous session|claims vm0 GPT 5.6 runs|promotes queued runs with feature flags|returns null claim secretValues'
  5 passed
pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'runs Pi for|does not repeat preparation after a competing run changes the binding|retries preparation when the canonical binding changes'
  4 passed
pnpm --filter api exec vitest run src/signals/routes/__tests__/computer-use.bdd.test.ts -t 'creates a delegated authorization link and applies the selected host to the chat thread'
  1 passed
```

The full Vitest suite was not run locally; the complete pipeline is left to PR CI.

## Non-goals

- no migration, schema/CHECK, default, or NOT NULL change
- no backfill, shadow compare, read cutover, fallback, or feature switch
- no public API, Runner request/response/claim/poll, queue, admission, retry, continuation, checkpoint, storage, model-selection, Agent, Compose, or version-lookup behavior change
- no production rollout or MaskDB acceptance

Closes #27632
