### PR TITLE
refactor(runner): centralize process identity

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -12,6 +12,7 @@ use crate::idle_pool::IdlePool;
 use crate::lifecycle::RunnerMode;
 use crate::provider::JobProvider;
 use crate::resource_budget::ResourceBudget;
+use crate::runner_process_identity::RunnerProcessIdentity;
 use crate::types::{
     HeartbeatState, HeldSandboxState, HeldWorkspaceState, MAX_HELD_SANDBOX_STATES,
     MAX_WORKSPACE_CACHES_PER_REUSE_KEY,
@@ -31,10 +32,9 @@ const WORKSPACE_CACHE_COMMIT_WAIT: Duration = Duration::from_secs(2);
 #[derive(Clone)]
 pub(super) struct HeartbeatContext<'a> {
     idle_pool: &'a Arc<tokio::sync::Mutex<IdlePool>>,
-    runner_id: &'a str,
+    runner_identity: RunnerProcessIdentity,
     name: &'a str,
     group: &'a str,
-    snapshot_generation: u64,
     profiles: &'a BTreeMap<String, ProfileConfig>,
     budget: &'a ResourceBudget,
     provider: &'a dyn JobProvider,
@@ -45,10 +45,9 @@ pub(super) struct HeartbeatContext<'a> {
 
 pub(super) struct HeartbeatContextInit<'a> {
     pub(super) idle_pool: &'a Arc<tokio::sync::Mutex<IdlePool>>,
-    pub(super) runner_id: &'a str,
+    pub(super) runner_identity: RunnerProcessIdentity,
     pub(super) name: &'a str,
     pub(super) group: &'a str,
-    pub(super) snapshot_generation: u64,
     pub(super) profiles: &'a BTreeMap<String, ProfileConfig>,
     pub(super) budget: &'a ResourceBudget,
     pub(super) provider: &'a dyn JobProvider,
@@ -61,10 +60,9 @@ impl<'a> HeartbeatContext<'a> {
     pub(super) fn new(init: HeartbeatContextInit<'a>) -> Self {
         Self {
             idle_pool: init.idle_pool,
-            runner_id: init.runner_id,
+            runner_identity: init.runner_identity,
             name: init.name,
             group: init.group,
-            snapshot_generation: init.snapshot_generation,
             profiles: init.profiles,
             budget: init.budget,
             provider: init.provider,
@@ -435,10 +433,9 @@ async fn send_heartbeat(
     let pool = hb.idle_pool.lock().await;
     let mut state = collect_heartbeat_state(
         HeartbeatSnapshotMetadata {
-            runner_id: hb.runner_id,
+            runner_identity: hb.runner_identity,
             runner_name: hb.name,
             group: hb.group,
-            generation: hb.snapshot_generation,
             sequence: snapshot_sequence,
         },
         hb.profiles,
@@ -746,10 +743,9 @@ fn admittable_profiles_for_heartbeat(
 
 /// Collect current runner state for heartbeat reporting.
 pub(super) struct HeartbeatSnapshotMetadata<'a> {
-    pub(super) runner_id: &'a str,
+    pub(super) runner_identity: RunnerProcessIdentity,
     pub(super) runner_name: &'a str,
     pub(super) group: &'a str,
-    pub(super) generation: u64,
     pub(super) sequence: u64,
 }
 
@@ -778,10 +774,10 @@ pub(super) fn collect_heartbeat_state(
     let running_count = budget_running.saturating_sub(idle_count);
     let admittable_profiles = admittable_profiles_for_heartbeat(profiles, budget, mode);
     HeartbeatState {
-        runner_id: snapshot.runner_id.to_string(),
+        runner_id: snapshot.runner_identity.runner_id().to_string(),
         runner_name: snapshot.runner_name.to_string(),
         group: snapshot.group.to_string(),
-        snapshot_generation: snapshot.generation,
+        snapshot_generation: snapshot.runner_identity.heartbeat_generation(),
         snapshot_sequence: snapshot.sequence,
         total_vcpu: budget.effective_vcpu(),
         total_memory_mb: budget.effective_memory_mb(),
@@ -820,6 +816,10 @@ mod tests {
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
 
+    fn test_runner_identity() -> RunnerProcessIdentity {
+        RunnerProcessIdentity::new(uuid::Uuid::from_u128(1), 7).unwrap()
+    }
+
     fn test_profiles() -> BTreeMap<String, config::ProfileConfig> {
         let mut m = BTreeMap::new();
         m.insert(
@@ -838,10 +838,9 @@ mod tests {
 
     fn test_snapshot_metadata() -> HeartbeatSnapshotMetadata<'static> {
         HeartbeatSnapshotMetadata {
-            runner_id: "r1",
+            runner_identity: test_runner_identity(),
             runner_name: "runner-1",
             group: "vm0/test",
-            generation: 7,
             sequence: 42,
         }
     }
@@ -1133,10 +1132,9 @@ mod tests {
         let workspace_cache_snapshot = WorkspaceCacheStateSnapshot::new();
         let hb = HeartbeatContext::new(HeartbeatContextInit {
             idle_pool: &idle_pool,
-            runner_id: "runner-1",
+            runner_identity: test_runner_identity(),
             name: "test-runner",
             group: "vm0/test",
-            snapshot_generation: 7,
             profiles: &profiles,
             budget: &budget,
             provider: provider.as_ref(),
@@ -1226,10 +1224,9 @@ mod tests {
         tokio::fs::remove_file(metadata).await.unwrap();
         let hb = HeartbeatContext::new(HeartbeatContextInit {
             idle_pool: &idle_pool,
-            runner_id: "runner-1",
+            runner_identity: test_runner_identity(),
             name: "test-runner",
             group: "vm0/test",
-            snapshot_generation: 7,
             profiles: &profiles,
             budget: &budget,
             provider: provider.as_ref(),

--- a/crates/runner/src/cmd/start/identity.rs
+++ b/crates/runner/src/cmd/start/identity.rs
@@ -4,34 +4,33 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::error::{RunnerError, RunnerResult};
-
-const MAX_HEARTBEAT_ORDER_VALUE: u64 = 9_007_199_254_740_991;
+use crate::runner_process_identity::RunnerProcessIdentity;
 
 /// Load runner ID from `{base_dir}/runner_id`, or generate a new UUID and persist it.
-pub(super) async fn load_or_generate_runner_id(base_dir: &Path) -> RunnerResult<String> {
+async fn load_or_generate_runner_id(base_dir: &Path) -> RunnerResult<Uuid> {
     let path = base_dir.join("runner_id");
     match crate::private_fs::read_private_file_to_string(&path).await? {
-        Some(contents) => {
-            let id = contents.trim().to_string();
-            Uuid::parse_str(&id).map_err(|e| {
-                RunnerError::Config(format!("invalid runner_id in {}: {e}", path.display()))
-            })?;
-            Ok(id)
-        }
+        Some(contents) => Uuid::parse_str(contents.trim()).map_err(|e| {
+            RunnerError::Config(format!("invalid runner_id in {}: {e}", path.display()))
+        }),
         None => {
-            let id = Uuid::new_v4().to_string();
-            crate::private_fs::write_private_file(&path, id.as_bytes()).await?;
+            let id = Uuid::new_v4();
+            let id_text = id.to_string();
+            crate::private_fs::write_private_file(&path, id_text.as_bytes()).await?;
             info!(runner_id = %id, "generated new runner ID");
             Ok(id)
         }
     }
 }
 
-/// Increment and persist the process generation used to order heartbeat snapshots.
+/// Load the runner UUID and allocate its next process generation.
 ///
 /// The caller holds the exclusive runner base-directory lock, so generation
 /// allocation has one writer for the lifetime of this runner identity.
-pub(super) async fn next_heartbeat_generation(base_dir: &Path) -> RunnerResult<u64> {
+pub(super) async fn load_runner_process_identity(
+    base_dir: &Path,
+) -> RunnerResult<RunnerProcessIdentity> {
+    let runner_id = load_or_generate_runner_id(base_dir).await?;
     let path = base_dir.join("heartbeat_generation");
     let previous = match crate::private_fs::read_private_file_to_string(&path).await? {
         Some(contents) => contents.trim().parse::<u64>().map_err(|error| {
@@ -42,17 +41,22 @@ pub(super) async fn next_heartbeat_generation(base_dir: &Path) -> RunnerResult<u
         })?,
         None => 0,
     };
-    let generation = previous
-        .checked_add(1)
-        .filter(|generation| *generation <= MAX_HEARTBEAT_ORDER_VALUE)
-        .ok_or_else(|| {
+    let heartbeat_generation = previous.checked_add(1).ok_or_else(|| {
+        RunnerError::Config(format!(
+            "heartbeat generation in {} exceeds the wire safe-integer range",
+            path.display()
+        ))
+    })?;
+    let identity =
+        RunnerProcessIdentity::new(runner_id, heartbeat_generation).map_err(|error| {
             RunnerError::Config(format!(
-                "heartbeat generation in {} exceeds the wire safe-integer range",
-                path.display()
+                "invalid heartbeat generation in {}: {error}",
+                path.display(),
             ))
         })?;
-    crate::private_fs::write_private_file(&path, generation.to_string().as_bytes()).await?;
-    Ok(generation)
+    crate::private_fs::write_private_file(&path, heartbeat_generation.to_string().as_bytes())
+        .await?;
+    Ok(identity)
 }
 
 #[cfg(test)]
@@ -63,7 +67,6 @@ mod tests {
     async fn runner_id_generate_and_persist() {
         let dir = tempfile::tempdir().unwrap();
         let id1 = load_or_generate_runner_id(dir.path()).await.unwrap();
-        assert!(Uuid::parse_str(&id1).is_ok());
 
         // Second call reads the same ID
         let id2 = load_or_generate_runner_id(dir.path()).await.unwrap();
@@ -73,8 +76,8 @@ mod tests {
     #[tokio::test]
     async fn runner_id_reads_existing() {
         let dir = tempfile::tempdir().unwrap();
-        let expected = Uuid::new_v4().to_string();
-        tokio::fs::write(dir.path().join("runner_id"), &expected)
+        let expected = Uuid::new_v4();
+        tokio::fs::write(dir.path().join("runner_id"), expected.to_string())
             .await
             .unwrap();
         let id = load_or_generate_runner_id(dir.path()).await.unwrap();
@@ -113,7 +116,7 @@ mod tests {
     #[tokio::test]
     async fn runner_id_trims_whitespace() {
         let dir = tempfile::tempdir().unwrap();
-        let expected = Uuid::new_v4().to_string();
+        let expected = Uuid::new_v4();
         // Write with trailing newline (common with echo/editors)
         tokio::fs::write(dir.path().join("runner_id"), format!("  {expected}\n"))
             .await
@@ -136,8 +139,20 @@ mod tests {
     async fn heartbeat_generation_increments_across_starts() {
         let dir = tempfile::tempdir().unwrap();
 
-        assert_eq!(next_heartbeat_generation(dir.path()).await.unwrap(), 1);
-        assert_eq!(next_heartbeat_generation(dir.path()).await.unwrap(), 2);
+        assert_eq!(
+            load_runner_process_identity(dir.path())
+                .await
+                .unwrap()
+                .heartbeat_generation(),
+            1
+        );
+        assert_eq!(
+            load_runner_process_identity(dir.path())
+                .await
+                .unwrap()
+                .heartbeat_generation(),
+            2
+        );
         assert_eq!(
             tokio::fs::read_to_string(dir.path().join("heartbeat_generation"))
                 .await
@@ -160,7 +175,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let result = next_heartbeat_generation(dir.path()).await;
+            let result = load_runner_process_identity(dir.path()).await;
 
             assert!(result.is_err(), "generation state {value:?} must fail");
         }
@@ -175,7 +190,7 @@ mod tests {
         tokio::fs::write(&target, "41").await.unwrap();
         std::os::unix::fs::symlink(&target, &link).unwrap();
 
-        let result = next_heartbeat_generation(dir.path()).await;
+        let result = load_runner_process_identity(dir.path()).await;
 
         assert!(result.is_err());
         assert_eq!(tokio::fs::read_to_string(&target).await.unwrap(), "41");

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -47,6 +47,7 @@ use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::{
     RunCancellationHandle, RunCancellationRegistration, RunCancellationRegistry,
 };
+use crate::runner_process_identity::RunnerProcessIdentity;
 use crate::status::StatusTracker;
 use crate::types::{
     CompleteRequest, ExecutionContext, HeldWorkspaceState, SandboxReuseResult,
@@ -58,8 +59,7 @@ pub(super) struct DiscoveredJob {
 }
 
 pub(super) struct DiscoveredJobContext<'a> {
-    pub(super) runner_id: &'a str,
-    pub(super) heartbeat_generation: u64,
+    pub(super) runner_identity: RunnerProcessIdentity,
     pub(super) profiles: &'a BTreeMap<String, ProfileConfig>,
     pub(super) factories: &'a BTreeMap<String, (SharedFactory, bool)>,
     pub(super) budget: &'a Arc<ResourceBudget>,
@@ -927,7 +927,7 @@ async fn prepare_ranked_preference_candidate(
         device_rate_limits,
         ctx,
     } = request;
-    let selected = preference.targets(ctx.runner_id, ctx.heartbeat_generation);
+    let selected = preference.targets(ctx.runner_identity);
     let history_generation_run_id = candidate.history_generation_run_id();
 
     if ranked_preference_allows(

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -74,6 +74,7 @@ use crate::proxy;
 use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
+use crate::runner_process_identity::RunnerProcessIdentity;
 use crate::status::{StatusTracker, remove_stale_status_file};
 use crate::workspace_image_cache::WorkspaceCacheWatcher;
 use crate::workspace_image_cache::WorkspaceImageCache;
@@ -101,7 +102,7 @@ use heartbeat::{
     HeartbeatSnapshotMetadata, WorkspaceCacheStateSnapshot, collect_heartbeat_state,
     refresh_initial_workspace_cache_snapshot,
 };
-use identity::{load_or_generate_runner_id, next_heartbeat_generation};
+use identity::load_runner_process_identity;
 use idle_lifecycle::{
     SharedIdlePool, cleanup_expired_idle_entries, destroy_idle_jobs_and_wait, drain_idle_pool,
     evict_expired_idle_entries, spawn_idle_destroy_job,
@@ -444,10 +445,12 @@ async fn run_start_with_home(
     let paths = RunnerPaths::new(runner_config.base_dir.clone());
     remove_stale_status_file(&paths.status()).await?;
 
-    // Load or generate a persistent runner identity (UUID).
-    let runner_id = load_or_generate_runner_id(&runner_config.base_dir).await?;
-    let heartbeat_generation = next_heartbeat_generation(&runner_config.base_dir).await?;
-    info!(runner_id = %runner_id, runner_name = %runner_config.name, "runner identity");
+    let runner_identity = load_runner_process_identity(&runner_config.base_dir).await?;
+    info!(
+        runner_id = %runner_identity.runner_id(),
+        runner_name = %runner_config.name,
+        "runner identity"
+    );
 
     // Shared locks on rootfs + snapshot per profile — allows `runner gc` to detect in-use resources.
     let resource_locks =
@@ -726,8 +729,7 @@ async fn run_start_with_home(
             http.clone(),
             server.token,
             ApiProviderConfig {
-                runner_id: runner_id.clone(),
-                heartbeat_generation,
+                runner_identity,
                 group,
                 supported_profiles: profiles,
             },
@@ -792,10 +794,9 @@ async fn run_start_with_home(
     let active_runs = ActiveRuns::new(Arc::clone(&reuse_state_notify));
     let config = RunConfig {
         runner: RunnerInfo {
-            id: runner_id,
+            identity: runner_identity,
             name,
             group: group_name,
-            heartbeat_generation,
             profiles: runner_config.profiles,
         },
         paths: RunPaths {
@@ -878,10 +879,9 @@ struct RunConfig {
 }
 
 struct RunnerInfo {
-    id: String,
+    identity: RunnerProcessIdentity,
     name: String,
     group: String,
-    heartbeat_generation: u64,
     profiles: BTreeMap<String, ProfileConfig>,
 }
 
@@ -1598,10 +1598,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     }
     let hb_ctx = HeartbeatContext::new(HeartbeatContextInit {
         idle_pool: &shared.idle_pool,
-        runner_id: &runner.id,
+        runner_identity: runner.identity,
         name: &runner.name,
         group: &runner.group,
-        snapshot_generation: runner.heartbeat_generation,
         profiles: &runner.profiles,
         budget: &capacity.budget,
         provider: &*provider_state.provider,
@@ -1672,7 +1671,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
     let mut current_mode = startup_mode;
     let spawn_ctx = SpawnContext {
-        runner_id: runner.id.clone(),
+        runner_id: runner.identity.runner_id().to_string(),
         provider: Arc::clone(&provider_state.provider),
         exec_config: Arc::clone(&exec_config),
         idle_pool: Arc::clone(&shared.idle_pool),
@@ -1792,8 +1791,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let result = handle_discovered_job(
                     DiscoveredJob { candidate },
                     DiscoveredJobContext {
-                        runner_id: &runner.id,
-                        heartbeat_generation: runner.heartbeat_generation,
+                        runner_identity: runner.identity,
                         profiles: &runner.profiles,
                         factories: &factories,
                         budget: &capacity.budget,
@@ -1838,8 +1836,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     let result = handle_discovered_job(
                         DiscoveredJob { candidate },
                         DiscoveredJobContext {
-                            runner_id: &runner.id,
-                            heartbeat_generation: runner.heartbeat_generation,
+                            runner_identity: runner.identity,
                             profiles: &runner.profiles,
                             factories: &factories,
                             budget: &capacity.budget,
@@ -2025,8 +2022,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let result = handle_discovered_job(
                     DiscoveredJob { candidate },
                     DiscoveredJobContext {
-                        runner_id: &runner.id,
-                        heartbeat_generation: runner.heartbeat_generation,
+                        runner_identity: runner.identity,
                         profiles: &runner.profiles,
                         factories: &factories,
                         budget: &capacity.budget,
@@ -2059,8 +2055,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     let result = handle_discovered_job(
                         DiscoveredJob { candidate },
                         DiscoveredJobContext {
-                            runner_id: &runner.id,
-                            heartbeat_generation: runner.heartbeat_generation,
+                            runner_identity: runner.identity,
                             profiles: &runner.profiles,
                             factories: &factories,
                             budget: &capacity.budget,
@@ -2134,10 +2129,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         let pool = shared.idle_pool.lock().await;
         let state = collect_heartbeat_state(
             HeartbeatSnapshotMetadata {
-                runner_id: &runner.id,
+                runner_identity: runner.identity,
                 runner_name: &runner.name,
                 group: &runner.group,
-                generation: runner.heartbeat_generation,
                 sequence: final_heartbeat_sequence,
             },
             &runner.profiles,

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -13,6 +13,7 @@ use crate::paths::RunnerPaths;
 use crate::provider::{
     ActiveRunnerPreference, RunnerPreference, RunnerPreferenceClaimState, RunnerPreferenceTier,
 };
+use crate::runner_process_identity::RunnerProcessIdentity;
 use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::WorkspaceImageCache;
 
@@ -46,8 +47,7 @@ fn ranked_candidate_until(
     crate::provider::JobCandidate::new(run_id, "vm0/default".into())
         .with_reuse_key(reuse_key.map(str::to_owned))
         .with_runner_preference_for_test(ActiveRunnerPreference::ranked_for_test(
-            runner_id.parse().unwrap(),
-            heartbeat_generation,
+            RunnerProcessIdentity::new(runner_id.parse().unwrap(), heartbeat_generation).unwrap(),
             tier,
             deadline,
         ))
@@ -107,8 +107,7 @@ fn finalizing_candidate_until(
         .with_reuse_key(Some(reuse_key.to_owned()))
         .with_history_generation_run_id(Some(history_generation_run_id))
         .with_runner_preference_for_test(ActiveRunnerPreference::ranked_for_test(
-            runner_id.parse().unwrap(),
-            heartbeat_generation,
+            RunnerProcessIdentity::new(runner_id.parse().unwrap(), heartbeat_generation).unwrap(),
             RunnerPreferenceTier::FinalizingPredecessor,
             deadline,
         ))
@@ -1672,8 +1671,11 @@ async fn selected_finalizing_candidate_without_reuse_key_uses_ordinary_admission
             crate::provider::JobCandidate::new(run_id, "vm0/default".into())
                 .with_history_generation_run_id(Some(RunId::new_v4()))
                 .with_runner_preference_for_test(ActiveRunnerPreference::ranked_for_test(
-                    TEST_RUNNER_ID.parse().unwrap(),
-                    TEST_HEARTBEAT_GENERATION,
+                    RunnerProcessIdentity::new(
+                        TEST_RUNNER_ID.parse().unwrap(),
+                        TEST_HEARTBEAT_GENERATION,
+                    )
+                    .unwrap(),
                     RunnerPreferenceTier::FinalizingPredecessor,
                     std::time::Instant::now() + Duration::from_secs(30),
                 )),

--- a/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/exact_reuse_speculation.rs
@@ -1,8 +1,8 @@
 use super::super::super::*;
 use super::super::support::{
-    SpeculativeIdleSeedSpec, TEST_HEARTBEAT_GENERATION, TEST_RUNNER_ID, context_with_session,
-    mock_run_config, seed_idle_pool_with_speculative_timezone, shutdown,
-    status_idle_reuse_keys_and_active_runs, test_profiles, wait_budget_count, wait_cancel_handle,
+    SpeculativeIdleSeedSpec, context_with_session, mock_run_config,
+    seed_idle_pool_with_speculative_timezone, shutdown, status_idle_reuse_keys_and_active_runs,
+    test_profiles, test_runner_identity, wait_budget_count, wait_cancel_handle,
     wait_cancel_token_removed, wait_discover_entered, wait_idle_pool_len,
     wait_idle_pool_reuse_keys,
 };
@@ -26,8 +26,7 @@ fn exact_generation_candidate(
         .with_reuse_key(Some(reuse_key.to_owned()))
         .with_history_generation_run_id(Some(history_generation_run_id))
         .with_runner_preference_for_test(ActiveRunnerPreference::ranked_for_test(
-            TEST_RUNNER_ID.parse().unwrap(),
-            TEST_HEARTBEAT_GENERATION,
+            test_runner_identity(),
             RunnerPreferenceTier::ExactSandbox,
             std::time::Instant::now() + Duration::from_secs(30),
         ))

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -8,10 +8,15 @@ use crate::executor;
 use crate::lifecycle::LifecycleController;
 use crate::provider::mock::{MockJobProvider, MockProviderHandle};
 use crate::run_cancellation::RunCancellationRegistry;
+use crate::runner_process_identity::RunnerProcessIdentity;
 use sandbox_mock::MockSandboxRuntime;
 
 pub(in super::super) const TEST_RUNNER_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
 pub(in super::super) const TEST_HEARTBEAT_GENERATION: u64 = 7;
+
+pub(in super::super) fn test_runner_identity() -> RunnerProcessIdentity {
+    RunnerProcessIdentity::new(TEST_RUNNER_ID.parse().unwrap(), TEST_HEARTBEAT_GENERATION).unwrap()
+}
 
 pub(in super::super) fn test_profiles() -> BTreeMap<String, config::ProfileConfig> {
     let mut m = BTreeMap::new();
@@ -207,10 +212,9 @@ fn build_mock_run_config_with_runtime(
 
     let config = RunConfig {
         runner: RunnerInfo {
-            id: TEST_RUNNER_ID.into(),
+            identity: test_runner_identity(),
             name: "test".into(),
             group: "test-group".into(),
-            heartbeat_generation: TEST_HEARTBEAT_GENERATION,
             profiles,
         },
         paths: RunPaths {

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -8,7 +8,7 @@ pub(super) use self::env::{
     MockRunEnv, TEST_HEARTBEAT_GENERATION, TEST_RUNNER_ID, mock_run_config,
     mock_run_config_with_api_url, mock_run_config_with_delay, mock_run_config_with_overrides,
     mock_run_config_with_overrides_and_api_url, mock_run_config_with_runtime, test_profiles,
-    two_profiles,
+    test_runner_identity, two_profiles,
 };
 pub(super) use self::idle_pool::{
     SpeculativeIdleSeedSpec, TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec,

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -52,6 +52,7 @@ mod retry;
 mod run_cancellation;
 mod run_resolution;
 mod runner_dirname;
+mod runner_process_identity;
 mod runtime_overrides;
 mod state_file;
 mod status;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -44,6 +44,7 @@ use crate::error::{ApiStatusError, RunnerError, RunnerResult};
 use crate::http::{ApiRequestBuilder, HttpClient};
 use crate::ids::RunId;
 use crate::run_cancellation::RunCancellationRegistry;
+use crate::runner_process_identity::RunnerProcessIdentity;
 use crate::types::{
     CompleteRequest, ConnectorRuntimeSyncBatchResponse, ConnectorRuntimeTargetRegistration,
     ExecutionContext, HeartbeatState, Job, PollResponse,
@@ -58,15 +59,8 @@ fn supports_thread_active_input(reuse_key: Option<&str>) -> bool {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ClaimRequestBody<'a> {
-    runner_identity: ClaimRunnerIdentity<'a>,
+    runner_identity: &'a RunnerProcessIdentity,
     telemetry: ClaimRequestTelemetry,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ClaimRunnerIdentity<'a> {
-    runner_id: &'a str,
-    heartbeat_generation: u64,
 }
 
 #[derive(Serialize)]
@@ -100,7 +94,7 @@ struct ClaimRequestTelemetry {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PollRequestBody<'a> {
-    runner_id: &'a str,
+    runner_id: uuid::Uuid,
     group: &'a str,
     supported_profiles: &'a [String],
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -238,8 +232,7 @@ enum DiscoveryWakeup {
 /// cooldown and defers all discovery before retrying.
 pub struct ApiProvider {
     api: ApiClient,
-    runner_id: String,
-    heartbeat_generation: u64,
+    runner_identity: RunnerProcessIdentity,
     group: String,
     /// Profile names this runner supports (e.g., ["vm0/default"]).
     /// Sent in poll requests so the server only returns jobs this runner can handle.
@@ -266,8 +259,7 @@ pub struct BuiltinFirewallCatalogCachePaths {
 }
 
 pub struct ApiProviderConfig {
-    pub runner_id: String,
-    pub heartbeat_generation: u64,
+    pub(crate) runner_identity: RunnerProcessIdentity,
     pub group: String,
     pub supported_profiles: Vec<String>,
 }
@@ -283,8 +275,7 @@ impl ApiProvider {
         cancel_tokens: RunCancellationRegistry,
     ) -> Arc<Self> {
         let ApiProviderConfig {
-            runner_id,
-            heartbeat_generation,
+            runner_identity,
             group,
             supported_profiles,
         } = config;
@@ -304,8 +295,7 @@ impl ApiProvider {
         let active_input_notifications = ActiveInputNotifications::new();
         Arc::new(Self {
             api,
-            runner_id,
-            heartbeat_generation,
+            runner_identity,
             group,
             supported_profiles,
             poll_wakeups,
@@ -540,7 +530,7 @@ impl JobProvider for ApiProvider {
                     return None;
                 }
                 result = self.api.poll(
-                    &self.runner_id,
+                    self.runner_identity.runner_id(),
                     &self.group,
                     &self.supported_profiles,
                     &excluded_run_ids,
@@ -641,11 +631,7 @@ impl JobProvider for ApiProvider {
 
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
-        match self
-            .api
-            .claim(&candidate, &self.runner_id, self.heartbeat_generation)
-            .await
-        {
+        match self.api.claim(&candidate, &self.runner_identity).await {
             Ok(Some(ctx)) => {
                 let active_input_source = (ctx.cli_agent_type != "pi"
                     && supports_thread_active_input(ctx.reuse_key.as_deref()))
@@ -681,8 +667,8 @@ impl JobProvider for ApiProvider {
                 self.claim_cooldowns.remove(run_id).await;
                 info!(
                     run_id = %run_id,
-                    runner_id = %self.runner_id,
-                    heartbeat_generation = self.heartbeat_generation,
+                    runner_id = %self.runner_identity.runner_id(),
+                    heartbeat_generation = self.runner_identity.heartbeat_generation(),
                     "job claimed"
                 );
                 Some(claimed)
@@ -989,7 +975,7 @@ impl ApiClient {
     /// Poll for a pending job. The response contains `job: None` when no work is available.
     async fn poll(
         &self,
-        runner_id: &str,
+        runner_id: uuid::Uuid,
         group: &str,
         supported_profiles: &[String],
         excluded_run_ids: &[RunId],
@@ -1042,11 +1028,10 @@ impl ApiClient {
     async fn claim(
         &self,
         candidate: &JobCandidate,
-        runner_id: &str,
-        heartbeat_generation: u64,
+        runner_identity: &RunnerProcessIdentity,
     ) -> Result<Option<ExecutionContext>, ClaimApiError> {
         let run_id = candidate.run_id();
-        let body = claim_request_body(candidate, runner_id, heartbeat_generation);
+        let body = claim_request_body(candidate, runner_identity);
         let run_id = run_id.to_string();
         let resp = send_api(
             self.http
@@ -1082,8 +1067,10 @@ impl ApiClient {
         &self,
         candidate: &JobCandidate,
     ) -> Result<Option<ExecutionContext>, ClaimApiError> {
-        self.claim(candidate, "550e8400-e29b-41d4-a716-446655440000", 7)
-            .await
+        let runner_identity =
+            RunnerProcessIdentity::new("550e8400-e29b-41d4-a716-446655440000".parse().unwrap(), 7)
+                .unwrap();
+        self.claim(candidate, &runner_identity).await
     }
     /// Report job completion. Uses the per-job **sandbox token** for auth.
     async fn complete(&self, sandbox_token: &str, request: &CompleteRequest) -> RunnerResult<()> {
@@ -1190,8 +1177,7 @@ impl ApiClient {
 
 fn claim_request_body<'a>(
     candidate: &JobCandidate,
-    runner_id: &'a str,
-    heartbeat_generation: u64,
+    runner_identity: &'a RunnerProcessIdentity,
 ) -> ClaimRequestBody<'a> {
     let runner_preference_telemetry = candidate.runner_preference_claim_telemetry();
     let is_ably_candidate = candidate.discovery_source() == Some(JobDiscoverySource::Ably);
@@ -1220,10 +1206,7 @@ fn claim_request_body<'a>(
     };
 
     ClaimRequestBody {
-        runner_identity: ClaimRunnerIdentity {
-            runner_id,
-            heartbeat_generation,
-        },
+        runner_identity,
         telemetry: ClaimRequestTelemetry {
             discovery_source: candidate.discovery_source().map(JobDiscoverySource::as_str),
             job_discovered_to_claim_request_ms: claim_telemetry_duration_ms(
@@ -1259,7 +1242,7 @@ fn claim_telemetry_duration_ms(duration: Duration) -> u64 {
 }
 
 fn poll_request_body<'a>(
-    runner_id: &'a str,
+    runner_id: uuid::Uuid,
     group: &'a str,
     supported_profiles: &'a [String],
     excluded_run_ids: &'a [RunId],
@@ -1521,8 +1504,14 @@ mod tests {
 
     const TEST_HEARTBEAT_GENERATION: u64 = 7;
 
-    fn claim_request_body_for_test(candidate: &JobCandidate) -> ClaimRequestBody<'_> {
-        claim_request_body(candidate, TEST_RUNNER_ID, TEST_HEARTBEAT_GENERATION)
+    fn test_runner_identity() -> RunnerProcessIdentity {
+        RunnerProcessIdentity::new(TEST_RUNNER_ID.parse().unwrap(), TEST_HEARTBEAT_GENERATION)
+            .unwrap()
+    }
+
+    fn claim_request_body_for_test(candidate: &JobCandidate) -> serde_json::Value {
+        let runner_identity = test_runner_identity();
+        serde_json::to_value(claim_request_body(candidate, &runner_identity)).unwrap()
     }
 
     #[test]
@@ -1756,8 +1745,7 @@ mod tests {
             connector_runtime_sync: ConnectorRuntimeSyncHandle::new(api.clone()),
             builtin_firewall_catalog_refresh: BuiltinFirewallCatalogRefreshController::disabled(),
             api,
-            runner_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
-            heartbeat_generation: 7,
+            runner_identity: test_runner_identity(),
             group: "default".to_string(),
             supported_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
             poll_wakeups,
@@ -2051,8 +2039,9 @@ mod tests {
     #[test]
     fn poll_request_body_serializes_poll_reason_telemetry() {
         let profiles = vec![crate::profile::DEFAULT_PROFILE.to_string()];
+        let runner_id = TEST_RUNNER_ID.parse().unwrap();
         let body = serde_json::to_value(poll_request_body(
-            "550e8400-e29b-41d4-a716-446655440000",
+            runner_id,
             "vm0/test",
             &profiles,
             &[],
@@ -2070,7 +2059,7 @@ mod tests {
     }
 
     #[test]
-    fn claim_request_body_serializes_runner_timing() {
+    fn claim_request_body_serializes_validated_identity_and_runner_timing() {
         let now = std::time::Instant::now();
         let candidate = JobCandidate::new_with_timing_for_test(
             RunId::nil(),
@@ -2082,7 +2071,7 @@ mod tests {
         .with_poll_reason("deferred")
         .with_poll_timing(Duration::from_millis(19), Duration::from_millis(11));
 
-        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
+        let body = claim_request_body_for_test(&candidate);
 
         assert_eq!(body["runnerIdentity"]["runnerId"], TEST_RUNNER_ID);
         assert_eq!(
@@ -2120,14 +2109,13 @@ mod tests {
     #[test]
     fn claim_request_body_serializes_canonical_preference_at_claim_time() {
         let active_preference = ActiveRunnerPreference::ranked_for_test(
-            TEST_RUNNER_ID.parse().unwrap(),
-            TEST_HEARTBEAT_GENERATION,
+            test_runner_identity(),
             RunnerPreferenceTier::WorkspaceCache,
             Instant::now() + Duration::from_secs(60),
         );
         let active = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
             .with_runner_preference_for_test(active_preference);
-        let active_body = serde_json::to_value(claim_request_body_for_test(&active)).unwrap();
+        let active_body = claim_request_body_for_test(&active);
         assert_eq!(
             active_body["telemetry"]["runnerPreference"]["kind"],
             "preference"
@@ -2146,29 +2134,27 @@ mod tests {
         );
 
         let expired_preference = ActiveRunnerPreference::ranked_for_test(
-            TEST_RUNNER_ID.parse().unwrap(),
-            TEST_HEARTBEAT_GENERATION,
+            test_runner_identity(),
             RunnerPreferenceTier::ExactSandbox,
             Instant::now() - Duration::from_secs(1),
         );
         let expired = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
             .with_runner_preference_for_test(expired_preference);
-        let expired_body = serde_json::to_value(claim_request_body_for_test(&expired)).unwrap();
+        let expired_body = claim_request_body_for_test(&expired);
         assert_eq!(
             expired_body["telemetry"]["runnerPreferenceClaimState"],
             "expired"
         );
 
         let cleared_preference = ActiveRunnerPreference::ranked_for_test(
-            Uuid::from_u128(8),
-            TEST_HEARTBEAT_GENERATION,
+            RunnerProcessIdentity::new(Uuid::from_u128(8), TEST_HEARTBEAT_GENERATION).unwrap(),
             RunnerPreferenceTier::FinalizingPredecessor,
             Instant::now() + Duration::from_secs(60),
         );
         let cleared = JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
             .with_runner_preference_for_test(cleared_preference)
             .without_runner_preference(RunnerPreferenceRemovalReason::Cleared);
-        let cleared_body = serde_json::to_value(claim_request_body_for_test(&cleared)).unwrap();
+        let cleared_body = claim_request_body_for_test(&cleared);
         assert_eq!(
             cleared_body["telemetry"]["runnerPreferenceClaimState"],
             "cleared"
@@ -2176,8 +2162,7 @@ mod tests {
         let no_preference =
             JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
                 .with_no_runner_preference_for_test(RunnerNoPreferenceReason::NoViableHolder);
-        let no_preference_body =
-            serde_json::to_value(claim_request_body_for_test(&no_preference)).unwrap();
+        let no_preference_body = claim_request_body_for_test(&no_preference);
         assert_eq!(
             no_preference_body["telemetry"]["runnerPreference"]["kind"],
             "noPreference"
@@ -2206,7 +2191,7 @@ mod tests {
         candidate.mark_main_loop_handling_started();
         candidate.mark_local_admission_started();
 
-        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
+        let body = claim_request_body_for_test(&candidate);
 
         assert_eq!(body["telemetry"]["discoverySource"], "ably");
         assert_eq!(
@@ -2239,7 +2224,7 @@ mod tests {
         candidate.mark_main_loop_handling_started();
         candidate.mark_local_admission_started();
 
-        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
+        let body = claim_request_body_for_test(&candidate);
 
         assert_eq!(body["telemetry"]["discoverySource"], "poll");
         assert!(
@@ -2273,7 +2258,7 @@ mod tests {
                     Duration::from_millis(CLAIM_TELEMETRY_DURATION_MS_MAX + 1),
                 );
 
-        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
+        let body = claim_request_body_for_test(&candidate);
 
         assert_eq!(
             body["telemetry"]["pollDueToJobDiscoveredMs"],
@@ -2295,7 +2280,7 @@ mod tests {
             None,
         );
 
-        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
+        let body = claim_request_body_for_test(&candidate);
 
         assert!(
             body["telemetry"]["jobDiscoveredToClaimRequestMs"]
@@ -2338,7 +2323,7 @@ mod tests {
             JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
                 .with_discovery_source(JobDiscoverySource::Ably);
 
-        let body = serde_json::to_value(claim_request_body_for_test(&candidate)).unwrap();
+        let body = claim_request_body_for_test(&candidate);
 
         assert_eq!(body["telemetry"]["discoverySource"], "ably");
         assert!(body["telemetry"].get("pollDueToJobDiscoveredMs").is_none());
@@ -2449,7 +2434,15 @@ mod tests {
             .runner_preference()
             .expect("canonical preference should be parsed");
         assert_eq!(preference.tier(), RunnerPreferenceTier::ExactSandbox);
-        assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
+        assert!(
+            preference.targets(
+                RunnerProcessIdentity::new(
+                    "00000000-0000-0000-0000-000000000005".parse().unwrap(),
+                    7,
+                )
+                .unwrap()
+            )
+        );
         let telemetry = discovered
             .runner_preference_claim_telemetry()
             .expect("canonical preference telemetry");
@@ -3308,7 +3301,7 @@ mod tests {
 
         let err = api
             .poll(
-                "550e8400-e29b-41d4-a716-446655440000",
+                TEST_RUNNER_ID.parse().unwrap(),
                 "default",
                 &[],
                 &[],
@@ -3339,7 +3332,7 @@ mod tests {
 
         let err = api
             .poll(
-                "550e8400-e29b-41d4-a716-446655440000",
+                TEST_RUNNER_ID.parse().unwrap(),
                 "default",
                 &[],
                 &[],
@@ -3821,8 +3814,9 @@ mod tests {
             })
             .await;
         let api = api_client_for_server(&server);
+        let runner_id = TEST_RUNNER_ID.parse().unwrap();
         let error = api
-            .poll(TEST_RUNNER_ID, "default", &[], &[], PollReason::Immediate)
+            .poll(runner_id, "default", &[], &[], PollReason::Immediate)
             .await
             .unwrap_err();
         let RunnerError::Api(error) = error else {
@@ -3884,7 +3878,7 @@ mod tests {
 
         let err = api
             .poll(
-                "550e8400-e29b-41d4-a716-446655440000",
+                TEST_RUNNER_ID.parse().unwrap(),
                 "default",
                 &[crate::profile::DEFAULT_PROFILE.to_string()],
                 &[],

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -1880,7 +1880,15 @@ mod tests {
             .runner_preference()
             .expect("canonical preference should be parsed");
         assert_eq!(preference.tier(), RunnerPreferenceTier::ReusableSandbox);
-        assert!(preference.targets("00000000-0000-0000-0000-000000000005", 7));
+        assert!(
+            preference.targets(
+                crate::runner_process_identity::RunnerProcessIdentity::new(
+                    "00000000-0000-0000-0000-000000000005".parse().unwrap(),
+                    7,
+                )
+                .unwrap()
+            )
+        );
         let telemetry = candidate
             .runner_preference_claim_telemetry()
             .expect("canonical preference telemetry");

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -370,6 +370,7 @@ mod tests {
 
     use super::super::{RunnerNoPreferenceReason, RunnerPreference, RunnerPreferenceTier};
     use super::*;
+    use crate::runner_process_identity::RunnerProcessIdentity;
 
     fn run_id(value: u128) -> RunId {
         RunId::from(uuid::Uuid::from_u128(value))
@@ -392,8 +393,7 @@ mod tests {
         deadline: StdInstant,
     ) -> RunnerPreferenceContext {
         RunnerPreferenceContext::for_test(ActiveRunnerPreference::ranked_for_test(
-            uuid::Uuid::from_u128(runner_id),
-            7,
+            RunnerProcessIdentity::new(uuid::Uuid::from_u128(runner_id), 7).unwrap(),
             tier,
             deadline,
         ))
@@ -494,7 +494,9 @@ mod tests {
             .expect("updated canonical preference");
         assert_eq!(preference.tier(), RunnerPreferenceTier::ExactSandbox);
         assert_eq!(preference.deadline(), exact_deadline);
-        assert!(preference.targets(&uuid::Uuid::from_u128(20).to_string(), 7));
+        assert!(
+            preference.targets(RunnerProcessIdentity::new(uuid::Uuid::from_u128(20), 7).unwrap())
+        );
         let telemetry = candidate
             .runner_preference_claim_telemetry()
             .expect("canonical preference telemetry");
@@ -583,7 +585,9 @@ mod tests {
         let preference = candidate.runner_preference().expect("runner preference");
         assert_eq!(preference.tier(), RunnerPreferenceTier::WorkspaceCache);
         assert_eq!(preference.deadline(), first_deadline);
-        assert!(preference.targets(&uuid::Uuid::from_u128(10).to_string(), 7));
+        assert!(
+            preference.targets(RunnerProcessIdentity::new(uuid::Uuid::from_u128(10), 7).unwrap())
+        );
         let telemetry = candidate
             .runner_preference_claim_telemetry()
             .expect("retained canonical preference telemetry");

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -22,17 +22,15 @@ pub(crate) use connector_runtime_sync::{
 pub use local::LocalProvider;
 
 use chrono::{DateTime, FixedOffset, Utc};
-use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
+use serde::{Deserialize, Serialize, de::Error as _};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
-use uuid::Uuid;
 
 use crate::active_input::ActiveInputSource;
 use crate::error::RunnerResult;
 use crate::ids::RunId;
+use crate::runner_process_identity::RunnerProcessIdentity;
 use crate::types::{CompleteRequest, ExecutionContext, HeartbeatState};
-
-const JAVASCRIPT_MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -77,23 +75,6 @@ pub(crate) enum RunnerPreferenceRemovalReason {
     Cleared,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(crate) struct RunnerProcessIdentity {
-    runner_id: Uuid,
-    #[serde(deserialize_with = "deserialize_heartbeat_generation")]
-    heartbeat_generation: u64,
-}
-
-impl RunnerProcessIdentity {
-    fn targets(self, runner_id: &str, heartbeat_generation: u64) -> bool {
-        runner_id
-            .parse::<Uuid>()
-            .is_ok_and(|runner_id| runner_id == self.runner_id)
-            && heartbeat_generation == self.heartbeat_generation
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "kind", deny_unknown_fields)]
 pub(crate) enum RunnerPreference {
@@ -133,23 +114,18 @@ impl ActiveRunnerPreference {
         self.deadline <= Instant::now()
     }
 
-    pub(crate) fn targets(&self, runner_id: &str, heartbeat_generation: u64) -> bool {
-        self.runner_identity
-            .targets(runner_id, heartbeat_generation)
+    pub(crate) fn targets(&self, runner_identity: RunnerProcessIdentity) -> bool {
+        self.runner_identity == runner_identity
     }
 
     #[cfg(test)]
     pub(crate) fn ranked_for_test(
-        runner_id: Uuid,
-        heartbeat_generation: u64,
+        runner_identity: RunnerProcessIdentity,
         tier: RunnerPreferenceTier,
         deadline: Instant,
     ) -> Self {
         Self {
-            runner_identity: RunnerProcessIdentity {
-                runner_id,
-                heartbeat_generation,
-            },
+            runner_identity,
             tier,
             deadline,
         }
@@ -189,19 +165,6 @@ fn preference_deadline(expires_at: DateTime<FixedOffset>) -> Result<Instant, ser
         .unwrap_or_default();
     now.checked_add(remaining)
         .ok_or_else(|| serde_json::Error::custom("runner preference expiry is out of range"))
-}
-
-fn deserialize_heartbeat_generation<'de, D>(deserializer: D) -> Result<u64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value = u64::deserialize(deserializer)?;
-    if value == 0 || value > JAVASCRIPT_MAX_SAFE_INTEGER {
-        return Err(D::Error::custom(
-            "heartbeat generation must be a positive JavaScript safe integer",
-        ));
-    }
-    Ok(value)
 }
 
 /// Low-cardinality source that first discovered a job candidate.

--- a/crates/runner/src/runner_process_identity.rs
+++ b/crates/runner/src/runner_process_identity.rs
@@ -1,0 +1,114 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const JAVASCRIPT_MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+/// Stable identity of one runner process generation.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", try_from = "RunnerProcessIdentityInput")]
+pub(crate) struct RunnerProcessIdentity {
+    runner_id: Uuid,
+    heartbeat_generation: u64,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("heartbeat generation must be a positive JavaScript safe integer")]
+pub(crate) struct RunnerProcessIdentityError;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RunnerProcessIdentityInput {
+    runner_id: Uuid,
+    heartbeat_generation: u64,
+}
+
+impl RunnerProcessIdentity {
+    pub(crate) fn new(
+        runner_id: Uuid,
+        heartbeat_generation: u64,
+    ) -> Result<Self, RunnerProcessIdentityError> {
+        if heartbeat_generation == 0 || heartbeat_generation > JAVASCRIPT_MAX_SAFE_INTEGER {
+            return Err(RunnerProcessIdentityError);
+        }
+        Ok(Self {
+            runner_id,
+            heartbeat_generation,
+        })
+    }
+
+    pub(crate) const fn runner_id(self) -> Uuid {
+        self.runner_id
+    }
+
+    pub(crate) const fn heartbeat_generation(self) -> u64 {
+        self.heartbeat_generation
+    }
+}
+
+impl TryFrom<RunnerProcessIdentityInput> for RunnerProcessIdentity {
+    type Error = RunnerProcessIdentityError;
+
+    fn try_from(input: RunnerProcessIdentityInput) -> Result<Self, Self::Error> {
+        Self::new(input.runner_id, input.heartbeat_generation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RUNNER_ID: Uuid = Uuid::from_u128(1);
+
+    fn wire_value(heartbeat_generation: u64) -> serde_json::Value {
+        serde_json::json!({
+            "runnerId": RUNNER_ID,
+            "heartbeatGeneration": heartbeat_generation,
+        })
+    }
+
+    #[test]
+    fn construction_and_deserialization_accept_wire_bounds() {
+        for heartbeat_generation in [1, JAVASCRIPT_MAX_SAFE_INTEGER] {
+            let constructed = RunnerProcessIdentity::new(RUNNER_ID, heartbeat_generation).unwrap();
+            let deserialized: RunnerProcessIdentity =
+                serde_json::from_value(wire_value(heartbeat_generation)).unwrap();
+
+            assert_eq!(constructed, deserialized);
+            assert_eq!(constructed.runner_id(), RUNNER_ID);
+            assert_eq!(constructed.heartbeat_generation(), heartbeat_generation);
+        }
+    }
+
+    #[test]
+    fn construction_and_deserialization_reject_out_of_range_values() {
+        for heartbeat_generation in [0, JAVASCRIPT_MAX_SAFE_INTEGER + 1] {
+            assert!(RunnerProcessIdentity::new(RUNNER_ID, heartbeat_generation).is_err());
+            assert!(
+                serde_json::from_value::<RunnerProcessIdentity>(wire_value(heartbeat_generation))
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn serde_preserves_strict_camel_case_wire_shape() {
+        let identity = RunnerProcessIdentity::new(RUNNER_ID, 7).unwrap();
+
+        assert_eq!(serde_json::to_value(identity).unwrap(), wire_value(7));
+        assert!(
+            serde_json::from_value::<RunnerProcessIdentity>(serde_json::json!({
+                "runnerId": RUNNER_ID,
+                "heartbeatGeneration": 7,
+                "unexpected": true,
+            }))
+            .is_err()
+        );
+        assert!(
+            serde_json::from_value::<RunnerProcessIdentity>(serde_json::json!({
+                "runnerId": "not-a-uuid",
+                "heartbeatGeneration": 7,
+            }))
+            .is_err()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add one validated runner process identity for the UUID and heartbeat generation
- carry the identity through startup, runtime, provider claims, heartbeats, and preference targeting
- preserve strict camelCase wire shapes and existing persisted files

## Exclusions

- no API contract, database, persisted-file format, or rollout change

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features -- --quiet`

Closes #27626
