### PR TITLE
chore(api): observe integration identity compatibility

### DIFF
--- a/turbo/apps/api/src/lib/integration-user-id-compat.ts
+++ b/turbo/apps/api/src/lib/integration-user-id-compat.ts
@@ -1,6 +1,54 @@
-type IntegrationUserIdResolution =
-  | { readonly ok: true; readonly userId: string | null }
-  | { readonly ok: false };
+import { logger } from "./log";
+
+const L = logger("IntegrationIdentityCompatibility");
+
+export type IntegrationUserIdResolutionOutcome =
+  | "empty"
+  | "canonical_only"
+  | "legacy_only_accepted"
+  | "matching_dual_accepted"
+  | "conflicting_dual_rejected";
+
+export type IntegrationUserIdResolution =
+  | {
+      readonly ok: true;
+      readonly userId: null;
+      readonly outcome: "empty";
+    }
+  | {
+      readonly ok: true;
+      readonly userId: string;
+      readonly outcome:
+        | "canonical_only"
+        | "legacy_only_accepted"
+        | "matching_dual_accepted";
+    }
+  | { readonly ok: false; readonly outcome: "conflicting_dual_rejected" };
+
+type IntegrationIdentityCompatibilityOutcome =
+  | IntegrationUserIdResolutionOutcome
+  | "legacy_signature_accepted";
+
+/**
+ * Emits only value-free compatibility dimensions. Canonical-only and empty
+ * inputs are intentionally silent so normal traffic does not create noise.
+ */
+export function logIntegrationIdentityCompatibility(args: {
+  readonly provider: "slack" | "teams" | "github";
+  readonly surface: "query" | "state" | "signature";
+  readonly outcome: IntegrationIdentityCompatibilityOutcome;
+}): void {
+  if (args.outcome === "canonical_only" || args.outcome === "empty") {
+    return;
+  }
+
+  // Every emitted outcome is actionable for the time-boxed Contract gate.
+  L.warn("Integration identity compatibility", {
+    provider: args.provider,
+    surface: args.surface,
+    outcome: args.outcome,
+  });
+}
 
 /**
  * Resolves the canonical and legacy integration-owner keys without allowing
@@ -14,15 +62,25 @@ export function resolveIntegrationUserId(
   userId: string | null | undefined,
   legacyUserId: string | null | undefined,
 ): IntegrationUserIdResolution {
-  if (
-    userId !== null &&
-    userId !== undefined &&
-    legacyUserId !== null &&
-    legacyUserId !== undefined &&
-    userId !== legacyUserId
-  ) {
-    return { ok: false };
+  if (userId === null || userId === undefined) {
+    if (legacyUserId === null || legacyUserId === undefined) {
+      return { ok: true, userId: null, outcome: "empty" };
+    }
+
+    return {
+      ok: true,
+      userId: legacyUserId,
+      outcome: "legacy_only_accepted",
+    };
   }
 
-  return { ok: true, userId: userId ?? legacyUserId ?? null };
+  if (legacyUserId === null || legacyUserId === undefined) {
+    return { ok: true, userId, outcome: "canonical_only" };
+  }
+
+  if (userId !== legacyUserId) {
+    return { ok: false, outcome: "conflicting_dual_rejected" };
+  }
+
+  return { ok: true, userId, outcome: "matching_dual_accepted" };
 }

--- a/turbo/apps/api/src/lib/integration-user-id-compat.ts
+++ b/turbo/apps/api/src/lib/integration-user-id-compat.ts
@@ -2,14 +2,14 @@ import { logger } from "./log";
 
 const L = logger("IntegrationIdentityCompatibility");
 
-export type IntegrationUserIdResolutionOutcome =
+type IntegrationUserIdResolutionOutcome =
   | "empty"
   | "canonical_only"
   | "legacy_only_accepted"
   | "matching_dual_accepted"
   | "conflicting_dual_rejected";
 
-export type IntegrationUserIdResolution =
+type IntegrationUserIdResolution =
   | {
       readonly ok: true;
       readonly userId: null;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/integration-identity-compatibility.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/integration-identity-compatibility.ts
@@ -1,0 +1,45 @@
+import { EVENT } from "@axiomhq/logging";
+
+const INTEGRATION_IDENTITY_COMPATIBILITY_MESSAGE =
+  "Integration identity compatibility";
+
+type EmittedIntegrationIdentityCompatibilityOutcome =
+  | "legacy_only_accepted"
+  | "matching_dual_accepted"
+  | "conflicting_dual_rejected"
+  | "legacy_signature_accepted";
+
+interface ExpectedIntegrationIdentityCompatibilityEvent {
+  readonly provider: "slack" | "teams" | "github";
+  readonly surface: "query" | "state" | "signature";
+  readonly outcome: EmittedIntegrationIdentityCompatibilityOutcome;
+}
+
+export function integrationIdentityCompatibilityEvents(
+  calls: readonly (readonly unknown[])[],
+): readonly Readonly<Record<PropertyKey, unknown>>[] {
+  return calls.flatMap((call) => {
+    const [message, fields] = call;
+    if (
+      message !== INTEGRATION_IDENTITY_COMPATIBILITY_MESSAGE ||
+      typeof fields !== "object" ||
+      fields === null ||
+      Array.isArray(fields)
+    ) {
+      return [];
+    }
+    return [fields as Readonly<Record<PropertyKey, unknown>>];
+  });
+}
+
+export function expectedIntegrationIdentityCompatibilityEvent(
+  args: ExpectedIntegrationIdentityCompatibilityEvent,
+): Readonly<Record<PropertyKey, unknown>> {
+  return {
+    [EVENT]: { source: "api" },
+    provider: args.provider,
+    surface: args.surface,
+    outcome: args.outcome,
+    context: "IntegrationIdentityCompatibility",
+  };
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -30,6 +30,10 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 import { readThreadSessionBinding } from "./helpers/runtime-state";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+import {
+  expectedIntegrationIdentityCompatibilityEvent,
+  integrationIdentityCompatibilityEvents,
+} from "./helpers/integration-identity-compatibility";
 
 /*
 helper gap:
@@ -617,6 +621,15 @@ function githubConnectSignature(args: {
         args.githubUsername?.trim().replace(/^@+/, "") ?? "",
       ].join(":"),
     )
+    .digest("hex");
+}
+
+function legacyGithubOauthStateSignature(args: {
+  readonly userId: string;
+  readonly composeId: string | null;
+}): string {
+  return createHmac("sha256", env("SECRETS_ENCRYPTION_KEY"))
+    .update(`${args.userId}:${args.composeId ?? ""}`)
     .digest("hex");
 }
 
@@ -5518,6 +5531,7 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
     ).toBeTruthy();
     expect(install.headers.get("Cache-Control")).toBe("no-store");
 
+    context.mocks.axiomLogging.warn.mockClear();
     const legacyInstall = await integrations.requestGithubOauthInstall(
       { vm0UserId: "user_legacy_query" },
       [307],
@@ -5529,7 +5543,19 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
     ) as Record<string, unknown>;
     expect(legacyInstallState.userId).toBe("user_legacy_query");
     expect(legacyInstallState).not.toHaveProperty("vm0UserId");
+    expect(
+      integrationIdentityCompatibilityEvents(
+        context.mocks.axiomLogging.warn.mock.calls,
+      ),
+    ).toStrictEqual([
+      expectedIntegrationIdentityCompatibilityEvent({
+        provider: "github",
+        surface: "query",
+        outcome: "legacy_only_accepted",
+      }),
+    ]);
 
+    context.mocks.axiomLogging.warn.mockClear();
     const conflictingInstall = await integrations.requestGithubOauthInstall(
       { userId: "user_canonical", vm0UserId: "user_legacy" },
       [307],
@@ -5537,6 +5563,17 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
     expect(conflictingInstall.headers.get("location") ?? "").toContain(
       "Invalid%20OAuth%20identity",
     );
+    expect(
+      integrationIdentityCompatibilityEvents(
+        context.mocks.axiomLogging.warn.mock.calls,
+      ),
+    ).toStrictEqual([
+      expectedIntegrationIdentityCompatibilityEvent({
+        provider: "github",
+        surface: "query",
+        outcome: "conflicting_dual_rejected",
+      }),
+    ]);
 
     const admin = integrations.user();
     const orgId = admin.orgId;
@@ -5769,6 +5806,7 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
       ...signedStateWithoutUserId,
       vm0UserId: signedUserId,
     });
+    context.mocks.axiomLogging.warn.mockClear();
     const setupLegacyState = await integrations.requestGithubAppSetupCallback(
       {
         setup_action: "request",
@@ -5779,11 +5817,23 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
     expect(setupLegacyState.headers.get("location") ?? "").toContain(
       "permission%20to%20install%20this%20GitHub%20App",
     );
+    expect(
+      integrationIdentityCompatibilityEvents(
+        context.mocks.axiomLogging.warn.mock.calls,
+      ),
+    ).toStrictEqual([
+      expectedIntegrationIdentityCompatibilityEvent({
+        provider: "github",
+        surface: "state",
+        outcome: "legacy_only_accepted",
+      }),
+    ]);
 
     const conflictingSignedState = JSON.stringify({
       ...parsedSignedState,
       vm0UserId: "user_conflict",
     });
+    context.mocks.axiomLogging.warn.mockClear();
     const setupConflictingState =
       await integrations.requestGithubAppSetupCallback(
         {
@@ -5796,6 +5846,72 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
     expect(setupConflictingState.headers.get("location") ?? "").toContain(
       "Invalid%20OAuth%20state",
     );
+    expect(
+      integrationIdentityCompatibilityEvents(
+        context.mocks.axiomLogging.warn.mock.calls,
+      ),
+    ).toStrictEqual([
+      expectedIntegrationIdentityCompatibilityEvent({
+        provider: "github",
+        surface: "state",
+        outcome: "conflicting_dual_rejected",
+      }),
+    ]);
+
+    const legacySignatureState = JSON.stringify({
+      userId: signedUserId,
+      composeId: agent.agentId,
+      sig: legacyGithubOauthStateSignature({
+        userId: signedUserId,
+        composeId: agent.agentId,
+      }),
+    });
+    context.mocks.axiomLogging.warn.mockClear();
+    const setupLegacySignature =
+      await integrations.requestGithubAppSetupCallback(
+        {
+          setup_action: "request",
+          state: legacySignatureState,
+        },
+        [307],
+      );
+    expect(setupLegacySignature.headers.get("location") ?? "").toContain(
+      "permission%20to%20install%20this%20GitHub%20App",
+    );
+    expect(
+      integrationIdentityCompatibilityEvents(
+        context.mocks.axiomLogging.warn.mock.calls,
+      ),
+    ).toStrictEqual([
+      expectedIntegrationIdentityCompatibilityEvent({
+        provider: "github",
+        surface: "signature",
+        outcome: "legacy_signature_accepted",
+      }),
+    ]);
+
+    const rejectedLegacySignatureState = JSON.stringify({
+      userId: signedUserId,
+      composeId: agent.agentId,
+      sig: "0".repeat(64),
+    });
+    context.mocks.axiomLogging.warn.mockClear();
+    const setupRejectedLegacySignature =
+      await integrations.requestGithubAppSetupCallback(
+        {
+          setup_action: "request",
+          state: rejectedLegacySignatureState,
+        },
+        [307],
+      );
+    expect(
+      setupRejectedLegacySignature.headers.get("location") ?? "",
+    ).toContain("Invalid%20state%20signature");
+    expect(
+      integrationIdentityCompatibilityEvents(
+        context.mocks.axiomLogging.warn.mock.calls,
+      ),
+    ).toStrictEqual([]);
 
     const tamperedState = JSON.stringify({
       ...parsedSignedState,

--- a/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/slack-oauth.test.ts
@@ -15,6 +15,10 @@ import {
   seedSlackConnectOrg$,
   type SlackConnectFixture,
 } from "./helpers/slack-connect";
+import {
+  expectedIntegrationIdentityCompatibilityEvent,
+  integrationIdentityCompatibilityEvents,
+} from "./helpers/integration-identity-compatibility";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 import { seedOrgMembership$ } from "./helpers/org-membership";
 
@@ -142,6 +146,11 @@ describe("Slack OAuth API routes", () => {
       expect(scopes).toContain("files:write");
       expect(redirectUrl.searchParams.get("state")).toBeNull();
       expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(
+        integrationIdentityCompatibilityEvents(
+          context.mocks.axiomLogging.warn.mock.calls,
+        ),
+      ).toStrictEqual([]);
     });
 
     it("includes platform state and truncates prompt by codepoint", async () => {
@@ -164,6 +173,11 @@ describe("Slack OAuth API routes", () => {
       for (const char of state.prompt) {
         expect(char).toBe("\u{1F600}");
       }
+      expect(
+        integrationIdentityCompatibilityEvents(
+          context.mocks.axiomLogging.warn.mock.calls,
+        ),
+      ).toStrictEqual([]);
     });
 
     it("accepts the legacy query key but writes only canonical state", async () => {
@@ -178,6 +192,42 @@ describe("Slack OAuth API routes", () => {
       ) as Record<string, unknown>;
       expect(state).toStrictEqual({ orgId: "org_1", userId: "user_1" });
       expect(state).not.toHaveProperty("vm0UserId");
+      expect(
+        integrationIdentityCompatibilityEvents(
+          context.mocks.axiomLogging.warn.mock.calls,
+        ),
+      ).toStrictEqual([
+        expectedIntegrationIdentityCompatibilityEvent({
+          provider: "slack",
+          surface: "query",
+          outcome: "legacy_only_accepted",
+        }),
+      ]);
+    });
+
+    it("accepts matching canonical and legacy query keys", async () => {
+      const response = await appRequest(
+        "/api/zero/slack/oauth/install?orgId=org_1&userId=user_1&vm0UserId=user_1",
+      );
+
+      expect(response.status).toBe(307);
+      const redirectUrl = new URL(response.headers.get("location")!);
+      const state = JSON.parse(
+        redirectUrl.searchParams.get("state")!,
+      ) as Record<string, unknown>;
+      expect(state).toStrictEqual({ orgId: "org_1", userId: "user_1" });
+      expect(state).not.toHaveProperty("vm0UserId");
+      expect(
+        integrationIdentityCompatibilityEvents(
+          context.mocks.axiomLogging.warn.mock.calls,
+        ),
+      ).toStrictEqual([
+        expectedIntegrationIdentityCompatibilityEvent({
+          provider: "slack",
+          surface: "query",
+          outcome: "matching_dual_accepted",
+        }),
+      ]);
     });
 
     it("fails closed when canonical and legacy query keys conflict", async () => {
@@ -189,6 +239,17 @@ describe("Slack OAuth API routes", () => {
       expect(response.headers.get("location")).toContain(
         "/slack/failed?error=",
       );
+      expect(
+        integrationIdentityCompatibilityEvents(
+          context.mocks.axiomLogging.warn.mock.calls,
+        ),
+      ).toStrictEqual([
+        expectedIntegrationIdentityCompatibilityEvent({
+          provider: "slack",
+          surface: "query",
+          outcome: "conflicting_dual_rejected",
+        }),
+      ]);
     });
 
     it("includes the pending prompt in install state when provided", async () => {
@@ -356,6 +417,61 @@ describe("Slack OAuth API routes", () => {
         orgId: fixture.orgId,
         userId: fixture.userId,
       });
+    });
+
+    it("accepts the legacy user query key for connect", async () => {
+      const fixture = await track(
+        store.set(seedSlackConnectOrg$, {}, context.signal),
+      );
+
+      const response = await appRequest(
+        `/api/zero/slack/oauth/connect?orgId=${fixture.orgId}&vm0UserId=${fixture.userId}`,
+      );
+
+      expect(response.status).toBe(307);
+      const redirectUrl = new URL(response.headers.get("location")!);
+      const state = JSON.parse(
+        redirectUrl.searchParams.get("state")!,
+      ) as Record<string, unknown>;
+      expect(state).toMatchObject({
+        flow: "connect",
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+      });
+      expect(state).not.toHaveProperty("vm0UserId");
+      expect(
+        integrationIdentityCompatibilityEvents(
+          context.mocks.axiomLogging.warn.mock.calls,
+        ),
+      ).toStrictEqual([
+        expectedIntegrationIdentityCompatibilityEvent({
+          provider: "slack",
+          surface: "query",
+          outcome: "legacy_only_accepted",
+        }),
+      ]);
+    });
+
+    it("fails closed when connect query keys conflict", async () => {
+      const response = await appRequest(
+        "/api/zero/slack/oauth/connect?orgId=org_1&userId=user_1&vm0UserId=user_2",
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({
+        error: "Conflicting userId values",
+      });
+      expect(
+        integrationIdentityCompatibilityEvents(
+          context.mocks.axiomLogging.warn.mock.calls,
+        ),
+      ).toStrictEqual([
+        expectedIntegrationIdentityCompatibilityEvent({
+          provider: "slack",
+          surface: "query",
+          outcome: "conflicting_dual_rejected",
+        }),
+      ]);
     });
 
     it("uses the web rewrite origin for connect callback URLs", async () => {
@@ -1035,6 +1151,17 @@ describe("Slack OAuth API routes", () => {
 
       await flushWaitUntilForTest();
       expect(slackPostMessageContaining("summarize my inbox")).toBeTruthy();
+      expect(
+        integrationIdentityCompatibilityEvents(
+          context.mocks.axiomLogging.warn.mock.calls,
+        ),
+      ).toStrictEqual([
+        expectedIntegrationIdentityCompatibilityEvent({
+          provider: "slack",
+          surface: "state",
+          outcome: "legacy_only_accepted",
+        }),
+      ]);
     });
 
     it("fails closed when canonical and legacy callback state conflicts", async () => {
@@ -1054,6 +1181,17 @@ describe("Slack OAuth API routes", () => {
         "/slack/failed?error=",
       );
       expect(context.mocks.slack.oauth.v2.access).not.toHaveBeenCalled();
+      expect(
+        integrationIdentityCompatibilityEvents(
+          context.mocks.axiomLogging.warn.mock.calls,
+        ),
+      ).toStrictEqual([
+        expectedIntegrationIdentityCompatibilityEvent({
+          provider: "slack",
+          surface: "state",
+          outcome: "conflicting_dual_rejected",
+        }),
+      ]);
     });
 
     it("does not send a pending prompt DM in the connect flow without a prompt", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -21,6 +21,10 @@ import {
   teamsConnectFixture,
   type TeamsConnectFixture,
 } from "./helpers/teams-connect";
+import {
+  expectedIntegrationIdentityCompatibilityEvent,
+  integrationIdentityCompatibilityEvents,
+} from "./helpers/integration-identity-compatibility";
 import { teamsConnectRoutes } from "../teams-connect";
 
 const context = testContext();
@@ -196,6 +200,17 @@ describe("Teams OAuth API routes", () => {
     >;
     expect(state).toStrictEqual({ orgId: "org_1", userId: "user_1" });
     expect(state).not.toHaveProperty("vm0UserId");
+    expect(
+      integrationIdentityCompatibilityEvents(
+        context.mocks.axiomLogging.warn.mock.calls,
+      ),
+    ).toStrictEqual([
+      expectedIntegrationIdentityCompatibilityEvent({
+        provider: "teams",
+        surface: "query",
+        outcome: "legacy_only_accepted",
+      }),
+    ]);
   });
 
   it("fails closed when canonical and legacy query keys conflict", async () => {
@@ -207,6 +222,17 @@ describe("Teams OAuth API routes", () => {
     await expect(response.json()).resolves.toStrictEqual({
       error: "Conflicting userId values",
     });
+    expect(
+      integrationIdentityCompatibilityEvents(
+        context.mocks.axiomLogging.warn.mock.calls,
+      ),
+    ).toStrictEqual([
+      expectedIntegrationIdentityCompatibilityEvent({
+        provider: "teams",
+        surface: "query",
+        outcome: "conflicting_dual_rejected",
+      }),
+    ]);
   });
 
   it("keeps API-host connect requests on the API callback origin", async () => {
@@ -272,6 +298,17 @@ describe("Teams OAuth API routes", () => {
       isConnected: false,
       installUrl: teamsInstallUrl(fixture.teamsTenantId),
     });
+    expect(
+      integrationIdentityCompatibilityEvents(
+        context.mocks.axiomLogging.warn.mock.calls,
+      ),
+    ).toStrictEqual([
+      expectedIntegrationIdentityCompatibilityEvent({
+        provider: "teams",
+        surface: "state",
+        outcome: "legacy_only_accepted",
+      }),
+    ]);
 
     await installTeamsForTest(context.signal, fixture);
     const installedStatus = await accept(
@@ -412,5 +449,16 @@ describe("Teams OAuth API routes", () => {
     expect(new URL(location!).searchParams.get("error")).toBe(
       "Invalid connect state.",
     );
+    expect(
+      integrationIdentityCompatibilityEvents(
+        context.mocks.axiomLogging.warn.mock.calls,
+      ),
+    ).toStrictEqual([
+      expectedIntegrationIdentityCompatibilityEvent({
+        provider: "teams",
+        surface: "state",
+        outcome: "conflicting_dual_rejected",
+      }),
+    ]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/github-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/github-oauth.ts
@@ -55,7 +55,10 @@ import {
   getOAuthCanonicalRedirectUrl,
   getOAuthWebOrigin,
 } from "../../lib/oauth-origin";
-import { resolveIntegrationUserId } from "../../lib/integration-user-id-compat";
+import {
+  logIntegrationIdentityCompatibility,
+  resolveIntegrationUserId,
+} from "../../lib/integration-user-id-compat";
 
 const REDIRECT_STATUS = 307;
 const GITHUB_CONNECTOR_SLUG = "github";
@@ -574,6 +577,11 @@ const installGithubOauth$ = command(
 
     const query = get(queryOf(githubOauthContract.install));
     const userId = resolveIntegrationUserId(query.userId, query.vm0UserId);
+    logIntegrationIdentityCompatibility({
+      provider: "github",
+      surface: "query",
+      outcome: userId.outcome,
+    });
     if (!userId.ok) {
       return worksErrorRedirect("Invalid OAuth identity.");
     }

--- a/turbo/apps/api/src/signals/routes/slack-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/slack-oauth.ts
@@ -30,7 +30,10 @@ import {
   getOAuthCanonicalRedirectUrl,
   getOAuthWebOrigin,
 } from "../../lib/oauth-origin";
-import { resolveIntegrationUserId } from "../../lib/integration-user-id-compat";
+import {
+  logIntegrationIdentityCompatibility,
+  resolveIntegrationUserId,
+} from "../../lib/integration-user-id-compat";
 
 const L = logger("SlackOAuth");
 const SLACK_OAUTH_URL = "https://slack.com/oauth/v2/authorize";
@@ -125,6 +128,11 @@ function parseOAuthState(state: string | undefined): OAuthState | null {
     // Remove in #27602 after legacy producers and callbacks have drained.
     optionalString(record.vm0UserId),
   );
+  logIntegrationIdentityCompatibility({
+    provider: "slack",
+    surface: "state",
+    outcome: userId.outcome,
+  });
   if (!userId.ok) {
     return null;
   }
@@ -167,6 +175,11 @@ const installOauth$ = computed((get) => {
 
   const query = get(queryOf(zeroSlackOauthContract.install));
   const userId = resolveIntegrationUserId(query.userId, query.vm0UserId);
+  logIntegrationIdentityCompatibility({
+    provider: "slack",
+    surface: "query",
+    outcome: userId.outcome,
+  });
   if (!userId.ok) {
     return failedRedirect("Invalid OAuth identity.");
   }
@@ -216,6 +229,11 @@ const connectOauth$ = command(async ({ get }, signal: AbortSignal) => {
 
   const query = get(queryOf(zeroSlackOauthContract.connect));
   const userId = resolveIntegrationUserId(query.userId, query.vm0UserId);
+  logIntegrationIdentityCompatibility({
+    provider: "slack",
+    surface: "query",
+    outcome: userId.outcome,
+  });
   if (!userId.ok) {
     return jsonErrorResponse("Conflicting userId values", 400);
   }

--- a/turbo/apps/api/src/signals/routes/teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/teams-oauth.ts
@@ -17,7 +17,10 @@ import {
 import { safeJsonParse, tapError } from "../utils";
 import type { RouteEntry } from "../route-entry";
 import { getOAuthApiOrigin } from "../../lib/oauth-origin";
-import { resolveIntegrationUserId } from "../../lib/integration-user-id-compat";
+import {
+  logIntegrationIdentityCompatibility,
+  resolveIntegrationUserId,
+} from "../../lib/integration-user-id-compat";
 
 const L = logger("TeamsOAuth");
 const MICROSOFT_AUTHORIZATION_URL =
@@ -138,6 +141,11 @@ function parseOAuthState(state: string | undefined): OAuthState | null {
     // Remove in #27602 after legacy producers and callbacks have drained.
     optionalString(record.vm0UserId),
   );
+  logIntegrationIdentityCompatibility({
+    provider: "teams",
+    surface: "state",
+    outcome: userId.outcome,
+  });
   if (!userId.ok) {
     return null;
   }
@@ -305,6 +313,11 @@ const connectOauth$ = command(({ get }) => {
 
   const query = get(queryOf(zeroTeamsOauthContract.connect));
   const userId = resolveIntegrationUserId(query.userId, query.vm0UserId);
+  logIntegrationIdentityCompatibility({
+    provider: "teams",
+    surface: "query",
+    outcome: userId.outcome,
+  });
   if (!userId.ok) {
     return jsonErrorResponse("Conflicting userId values", 400);
   }

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -26,7 +26,10 @@ import {
 } from "../../lib/connector-oauth-state";
 import { now } from "../../lib/time";
 import { logger } from "../../lib/log";
-import { resolveIntegrationUserId } from "../../lib/integration-user-id-compat";
+import {
+  logIntegrationIdentityCompatibility,
+  resolveIntegrationUserId,
+} from "../../lib/integration-user-id-compat";
 import { encryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 
@@ -486,6 +489,11 @@ export function parseGithubOauthState(
     // Remove in #27602 after legacy producers and callbacks have drained.
     typeof stateObject.vm0UserId === "string" ? stateObject.vm0UserId : null,
   );
+  logIntegrationIdentityCompatibility({
+    provider: "github",
+    surface: "state",
+    outcome: userId.outcome,
+  });
   if (!userId.ok) {
     return null;
   }
@@ -530,7 +538,18 @@ export async function isGithubOauthStateSignatureValid(args: {
     secretsEncryptionKey: args.secretsEncryptionKey,
   });
 
-  return signaturesMatch(args.state.sig, legacyExpectedSig);
+  const legacySignatureValid = signaturesMatch(
+    args.state.sig,
+    legacyExpectedSig,
+  );
+  if (legacySignatureValid) {
+    logIntegrationIdentityCompatibility({
+      provider: "github",
+      surface: "signature",
+      outcome: "legacy_signature_accepted",
+    });
+  }
+  return legacySignatureValid;
 }
 
 export async function linkGithubUser(


### PR DESCRIPTION
## Summary

- classify canonical, empty, legacy-only, matching-dual, and conflicting-dual integration identity inputs without exposing values
- emit production-visible structured compatibility events at every live Slack, Teams, and GitHub query/state reader, plus the pre-Switch GitHub signature fallback only after that fallback succeeds
- preserve all accepted and rejected behavior, including fail-closed conflicts, and add focused route-level coverage

Closes #27635
Relates to #27599

## Safe event schema

The compatibility payload is exactly:

- `provider`: `slack`, `teams`, or `github`
- `surface`: `query`, `state`, or `signature`
- `outcome`: `legacy_only_accepted`, `matching_dual_accepted`, `conflicting_dual_rejected`, or `legacy_signature_accepted`

Canonical-only and empty inputs emit nothing. The logger adds standard metadata only: `level=warn`, `message="Integration identity compatibility"`, `source=api`, and `fields.context="IntegrationIdentityCompatibility"` (plus normal timestamp/platform metadata). No user ID, legacy user ID, org ID, raw OAuth state, query string, signature, authorization code, or other request value is passed to the logger. Tests compare the complete logger payload.

## Production Axiom query and Contract gate

After the parent coordinator publishes this merge through `/release-production`, set the Axiom time range start to the exact production release timestamp and run against the full interval:

```apl
['vm0-web-logs-prod']
| where level == "warn"
| where message == "Integration identity compatibility"
| where ['fields.context'] == "IntegrationIdentityCompatibility"
| summarize compatibility_events=count()
```

If the count is non-zero, use this breakdown:

```apl
['vm0-web-logs-prod']
| where level == "warn"
| where message == "Integration identity compatibility"
| where ['fields.context'] == "IntegrationIdentityCompatibility"
| summarize compatibility_events=count() by ['fields.provider'], ['fields.surface'], ['fields.outcome']
| sort by compatibility_events desc
```

The Contract reader deletion in #27602 remains blocked until this instrumentation is in production and the complete continuous old web/app exposure window (at least approximately 48 hours from that release) returns `compatibility_events == 0`. Any event resets or extends the evidence window and must be investigated; elapsed time alone is not evidence. This PR does not start or authorize #27602.

## Fallback declaration

No behavioral fallback is introduced. The diff preserves the existing time-boxed `vm0UserId` query/state readers and pre-Switch GitHub state-signature fallback documented under `docs/fallback.md`; it only classifies and observes them. Their removal remains gated to #27602.

## Validation

- `pnpm exec prettier --check <9 changed files>`
- `pnpm --filter api run lint`
- `pnpm --filter api run check-types`
- changed-file Oxlint and ESLint with zero diagnostics
- `git diff --check`
- focused Vitest command attempted for `slack-oauth.test.ts`, `teams-oauth.test.ts`, and `integrations.bdd.test.ts`; local execution stopped before test bodies because this checkout has no PostgreSQL listener (`connect ECONNREFUSED ::1:5432` and `connect ECONNREFUSED 127.0.0.1:5432`). The PR pipeline owns the database-backed execution.
