### PR TITLE
perf(sandbox-fc): reduce balloon settle polling latency

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3322,7 +3322,7 @@ const BALLOON_SETTLE_FAST_POLL_INTERVALS: [Duration; 7] = [
     Duration::from_millis(200),
 ];
 /// Maximum poll interval while waiting for balloon inflation.
-const BALLOON_SETTLE_MAX_POLL: Duration = Duration::from_millis(500);
+const BALLOON_SETTLE_MAX_POLL: Duration = Duration::from_millis(200);
 /// Upper bound for accepting residual differences between requested and
 /// reported balloon size. Current 4 GiB production profiles commonly settle
 /// with low-hundreds MiB residuals when the guest reports little available

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -4563,6 +4563,8 @@ async fn wait_for_balloon_follows_exact_bounded_poll_schedule() {
     let wait = wait_for_balloon_with_outcome(&client, target_mib, "bounded-schedule");
     tokio::pin!(wait);
 
+    // Exercise through 4,775 ms. A 4,975 ms sample is not guaranteed because
+    // each interval starts after the previous Unix-socket response completes.
     for (index, delay_ms) in std::iter::once(0_u64)
         .chain([25, 50, 100, 100, 100, 200, 200])
         .chain(std::iter::repeat_n(200, 20))

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -4551,7 +4551,7 @@ async fn wait_for_balloon_follows_exact_bounded_poll_schedule() {
             release: Arc::clone(&response_release),
             stats: MockBalloonStats::new(target_mib, 0),
         })
-        .take(16)
+        .take(28)
         .chain(std::iter::once(MockBalloonStatsReply::Status(500)))
         .collect(),
     );
@@ -4563,11 +4563,10 @@ async fn wait_for_balloon_follows_exact_bounded_poll_schedule() {
     let wait = wait_for_balloon_with_outcome(&client, target_mib, "bounded-schedule");
     tokio::pin!(wait);
 
-    for (index, delay_ms) in [
-        0_u64, 25, 50, 100, 100, 100, 200, 200, 500, 500, 500, 500, 500, 500, 500, 500,
-    ]
-    .into_iter()
-    .enumerate()
+    for (index, delay_ms) in std::iter::once(0_u64)
+        .chain([25, 50, 100, 100, 100, 200, 200])
+        .chain(std::iter::repeat_n(200, 20))
+        .enumerate()
     {
         if delay_ms > 0 {
             tokio::time::advance(Duration::from_millis(delay_ms - 1)).await;
@@ -4631,7 +4630,7 @@ async fn wait_for_balloon_follows_exact_bounded_poll_schedule() {
             .iter()
             .filter(|request| request.method == "GET" && request.path == "/balloon/statistics")
             .count(),
-        16
+        28
     );
 }
 


### PR DESCRIPTION
## Summary

- cap the post-ramp balloon settle polling interval at 200 ms instead of 500 ms
- update the bounded schedule regression test to cover 28 guaranteed statistics samples through 4.775 seconds

## Scope

- keep the 5-second settle timeout and progress grace unchanged
- keep target, tolerance, pressure, pause, and lifecycle behavior unchanged
- add no configuration, API, protocol, or persisted-state changes

## Validation

- `cargo test -p sandbox-fc --lib wait_for_balloon_follows_exact_bounded_poll_schedule`
- `cargo test -p sandbox-fc --lib`
- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `cargo doc -p sandbox-fc --all-features --no-deps`
- repository pre-commit and commit-message hooks

Closes #27643

Parent context: #27451
