### PR TITLE
feat(composer): offer new-chat video model as an explicit default

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1342,6 +1342,7 @@
       "temporaryFastModeDisabledNotice": "Der Fast-Modus ist für diesen Lauf vorübergehend deaktiviert",
       "temporaryFastModeEnabledNotice": "Der Fast-Modus ist für diesen Lauf vorübergehend aktiviert",
       "temporaryModelNotice": "Vorübergehend zu {{model}} gewechselt",
+      "temporaryVideoModelNotice": "Für Videos vorübergehend zu {{model}} gewechselt",
       "threadSuggestions": "Chat-Threads",
       "visualAttachmentsUnsupported": "{{modelName}} kann Bilder oder Videos nicht erkennen. Wechseln Sie vor dem Anhängen zu einem visionsfähigen Modell.",
       "workflows": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1342,6 +1342,7 @@
       "temporaryFastModeDisabledNotice": "Fast mode is temporarily disabled for this run",
       "temporaryFastModeEnabledNotice": "Fast mode is temporarily enabled for this run",
       "temporaryModelNotice": "Temporarily switched to {{model}}",
+      "temporaryVideoModelNotice": "Temporarily switched to {{model}} for video",
       "threadSuggestions": "Chat threads",
       "visualAttachmentsUnsupported": "{{modelName}} cannot recognize images or videos. Switch to a vision-capable model to attach them.",
       "workflows": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1368,6 +1368,7 @@
       "temporaryFastModeDisabledNotice": "El modo rápido está desactivado temporalmente para esta ejecución",
       "temporaryFastModeEnabledNotice": "El modo rápido está activado temporalmente para esta ejecución",
       "temporaryModelNotice": "Cambio temporal a {{model}}",
+      "temporaryVideoModelNotice": "Cambio temporal a {{model}} para vídeo",
       "threadSuggestions": "Conversaciones",
       "visualAttachmentsUnsupported": "{{modelName}} no reconoce imágenes ni vídeos. Cambia a un modelo con capacidad visual para adjuntarlos.",
       "workflows": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1368,6 +1368,7 @@
       "temporaryFastModeDisabledNotice": "Le mode rapide est temporairement désactivé pour cette exécution",
       "temporaryFastModeEnabledNotice": "Le mode rapide est temporairement activé pour cette exécution",
       "temporaryModelNotice": "Passage temporaire à {{model}}",
+      "temporaryVideoModelNotice": "Passage temporaire à {{model}} pour la vidéo",
       "threadSuggestions": "Conversations",
       "visualAttachmentsUnsupported": "{{modelName}} ne peut pas reconnaître les images ou les vidéos. Passez à un modèle capable de vision pour les joindre.",
       "workflows": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1342,6 +1342,7 @@
       "temporaryFastModeDisabledNotice": "इस रन के लिए फ़ास्ट मोड अस्थायी रूप से बंद है",
       "temporaryFastModeEnabledNotice": "इस रन के लिए फ़ास्ट मोड अस्थायी रूप से चालू है",
       "temporaryModelNotice": "अस्थायी रूप से {{model}} पर स्विच किया गया",
+      "temporaryVideoModelNotice": "वीडियो के लिए अस्थायी रूप से {{model}} पर स्विच किया गया",
       "threadSuggestions": "चैट थ्रेड",
       "visualAttachmentsUnsupported": "{{modelName}} छवियों या वीडियो को नहीं पहचान सकता। उन्हें संलग्न करने के लिए दृष्टि-सक्षम मॉडल पर स्विच करें।",
       "workflows": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1342,6 +1342,7 @@
       "temporaryFastModeDisabledNotice": "Mode Cepat dinonaktifkan sementara untuk proses ini",
       "temporaryFastModeEnabledNotice": "Mode Cepat diaktifkan sementara untuk proses ini",
       "temporaryModelNotice": "Sementara beralih ke {{model}}",
+      "temporaryVideoModelNotice": "Sementara beralih ke {{model}} untuk video",
       "threadSuggestions": "Thread chat",
       "visualAttachmentsUnsupported": "{{modelName}} tidak dapat mengenali gambar atau video. Ganti ke model yang mendukung visi untuk melampirkannya.",
       "workflows": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1368,6 +1368,7 @@
       "temporaryFastModeDisabledNotice": "La modalità Fast è temporaneamente disattivata per questa esecuzione",
       "temporaryFastModeEnabledNotice": "La modalità Fast è temporaneamente attivata per questa esecuzione",
       "temporaryModelNotice": "Passaggio temporaneo a {{model}}",
+      "temporaryVideoModelNotice": "Passaggio temporaneo a {{model}} per i video",
       "threadSuggestions": "Thread di chat",
       "visualAttachmentsUnsupported": "{{modelName}} non supporta immagini o video. Passa a un modello con capacità visive per allegarli.",
       "workflows": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1342,6 +1342,7 @@
       "temporaryFastModeDisabledNotice": "この実行では一時的に高速モードが無効です",
       "temporaryFastModeEnabledNotice": "この実行では一時的に高速モードが有効です",
       "temporaryModelNotice": "一時的に {{model}} に切り替えました",
+      "temporaryVideoModelNotice": "動画モデルを一時的に {{model}} に切り替えました",
       "threadSuggestions": "チャットスレッド",
       "visualAttachmentsUnsupported": "{{modelName}} は画像またはビデオを認識できません。ビジョン対応モデルに切り替えて取り付けてください。",
       "workflows": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1342,6 +1342,7 @@
       "temporaryFastModeDisabledNotice": "이 실행에서는 빠른 모드가 일시적으로 비활성화되었습니다",
       "temporaryFastModeEnabledNotice": "이 실행에서는 빠른 모드가 일시적으로 활성화되었습니다",
       "temporaryModelNotice": "일시적으로 {{model}}(으)로 전환됨",
+      "temporaryVideoModelNotice": "동영상 모델을 일시적으로 {{model}}(으)로 전환함",
       "threadSuggestions": "채팅 스레드",
       "visualAttachmentsUnsupported": "{{modelName}}은 이미지나 비디오를 인식할 수 없습니다. 첨부하려면 비전 기능이 있는 모델로 전환하세요.",
       "workflows": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1368,6 +1368,7 @@
       "temporaryFastModeDisabledNotice": "O modo rápido está temporariamente desativado para esta execução",
       "temporaryFastModeEnabledNotice": "O modo rápido está temporariamente ativado para esta execução",
       "temporaryModelNotice": "Alternado temporariamente para {{model}}",
+      "temporaryVideoModelNotice": "Alternado temporariamente para {{model}} em vídeo",
       "threadSuggestions": "Conversas",
       "visualAttachmentsUnsupported": "{{modelName}} não reconhece imagens nem vídeos. Troque para um modelo com visão para anexá-los.",
       "workflows": {

--- a/turbo/apps/platform/src/signals/external/user-model-preference.ts
+++ b/turbo/apps/platform/src/signals/external/user-model-preference.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import type { VideoModel } from "@okouai/core/video-model-catalog";
 import {
   type UserPreferenceChangedPayload,
   userPreferenceChangedPayloadSchema,
@@ -52,6 +53,36 @@ export const updateUserModelPreference$ = command(
     // `userPreferenceChanged` realtime topic; do not reload the local cache
     // here (the initiating session receives the push like any other).
     return result.body;
+  },
+);
+
+/**
+ * Makes a video model the member default without disturbing the run model.
+ *
+ * The request must carry the run model, so this reads the stored one back
+ * instead of echoing the cached copy: the sibling run-model notice writes
+ * through the same resource, and `updateUserModelPreference$` leaves the cache
+ * to the `userPreferenceChanged` push rather than refreshing it. Echoing the
+ * cache would resend a run model that a moments-old write already replaced.
+ */
+export const updateDefaultVideoModel$ = command(
+  async (
+    { get, set },
+    videoModel: VideoModel,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    set(reloadUserModelPreference$);
+    const preference = await get(userModelPreference$);
+    signal.throwIfAborted();
+    await set(
+      updateUserModelPreference$,
+      {
+        selectedModel: preference.selectedModel,
+        serviceTier: preference.serviceTier,
+        selectedVideoModel: videoModel,
+      },
+      signal,
+    );
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
@@ -92,6 +92,13 @@ const setVideoModel$ = command(
       return;
     }
     set(setChatPageVideoModelSelection$, videoModel);
+    const explicitDefaultActionEnabled =
+      get(featureSwitch$)[FeatureSwitchKey.NewChatDefaultModelAction] ?? false;
+    if (explicitDefaultActionEnabled) {
+      // The composer notice carries an explicit "Set as default" instead, so
+      // picking a video model only scopes the next new chat.
+      return;
+    }
     const userPreference = await get(userModelPreference$);
     signal.throwIfAborted();
     await set(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -29,6 +29,7 @@ import { zeroModelPoliciesMainContract } from "@okouai/api-contracts/contracts/z
 import { zeroBillingStatusContract } from "@okouai/api-contracts/contracts/zero-billing";
 import {
   userModelPreferenceContract,
+  type UpdateUserModelPreferenceRequest,
   type UserModelPreferenceResponse,
 } from "@okouai/api-contracts/contracts/user-model-preference";
 import { zeroWorkflowsCollectionContract } from "@okouai/api-contracts/contracts/zero-workflows";
@@ -3804,5 +3805,175 @@ describe("chat composer video model", () => {
     expect(
       within(resolutions).queryByRole("radio", { name: "720p" }),
     ).not.toBeInTheDocument();
+  });
+
+  function mockNewChatVideoDefaultAction(
+    preference: UserModelPreferenceResponse,
+  ): {
+    readonly updates: UpdateUserModelPreferenceRequest[];
+  } {
+    const updates: UpdateUserModelPreferenceRequest[] = [];
+    let stored = preference;
+    context.mocks.browser.matchMedia(true);
+    mockOrgModelRoutes("claude-fable-5");
+    context.mocks.api(userModelPreferenceContract.get, ({ respond }) => {
+      return respond(200, stored);
+    });
+    context.mocks.api(
+      userModelPreferenceContract.update,
+      ({ body, respond }) => {
+        updates.push(body);
+        stored = { ...stored, ...body, updatedAt: "2026-08-14T00:01:00Z" };
+        return respond(200, stored);
+      },
+    );
+    mockAgent();
+    return { updates };
+  }
+
+  function noticeText(text: string): HTMLElement | null {
+    return screen.queryByText(text);
+  }
+
+  it("keeps a new-chat video pick temporary and offers it as the default", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { updates } = mockNewChatVideoDefaultAction({
+      selectedModel: null,
+      serviceTier: null,
+      selectedVideoModel: "MiniMax-H3",
+      updatedAt: "2026-08-14T00:00:00Z",
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.VideoModelSelection]: true,
+        [FeatureSwitchKey.NewChatDefaultModelAction]: true,
+      },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    // Entering video mode with the member default still selected says nothing.
+    await user.click(await findDesktopVideoModelButton());
+    expect(
+      noticeText("Temporarily switched to MiniMax H3 for video"),
+    ).toBeNull();
+
+    await user.click(await findDesktopVideoModelButton());
+    await user.click(await findVideoPanelButton("Veo 3.1 fast"));
+
+    await waitFor(() => {
+      expect(
+        noticeText("Temporarily switched to Veo 3.1 Fast for video"),
+      ).toBeInTheDocument();
+    });
+    // Picking alone must not touch the member default any more.
+    expect(updates).toStrictEqual([]);
+
+    await user.click(buttonContainingText("Set as default", document.body));
+
+    await waitFor(() => {
+      expect(updates).toStrictEqual([
+        {
+          // The run model is untouched, so the stored null is repeated rather
+          // than pinning the workspace default onto the member.
+          selectedModel: null,
+          serviceTier: null,
+          selectedVideoModel: "fal-ai/veo3.1/fast",
+        },
+      ]);
+    });
+
+    // The write is reflected through the realtime topic, like the run model.
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("userPreferenceChanged"),
+      ).toBeTruthy();
+    });
+    act(() => {
+      triggerAblyEvent("userPreferenceChanged", {
+        kinds: ["defaultVideoModel"],
+      });
+    });
+    await waitFor(() => {
+      expect(
+        noticeText("Temporarily switched to Veo 3.1 Fast for video"),
+      ).toBeNull();
+    });
+  });
+
+  it("shows only the notice for the model mode the composer is in", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { updates } = mockNewChatVideoDefaultAction({
+      selectedModel: "claude-fable-5",
+      serviceTier: null,
+      selectedVideoModel: "MiniMax-H3",
+      updatedAt: "2026-08-14T00:00:00Z",
+    });
+    const chatNotice = "Temporarily switched to Claude Sonnet 4.6";
+    const videoNotice = "Temporarily switched to Veo 3.1 Fast for video";
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.VideoModelSelection]: true,
+        [FeatureSwitchKey.NewChatDefaultModelAction]: true,
+      },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await user.click(await findComposerModel("Claude Fable 5"));
+    await user.click(
+      await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    );
+    await waitFor(() => {
+      expect(noticeText(chatNotice)).toBeInTheDocument();
+    });
+
+    // Video mode, video model still on the member default: nothing pending.
+    const videoModelButton = await findDesktopVideoModelButton();
+    await user.click(videoModelButton);
+    expect(videoModelButton).toHaveAttribute("aria-pressed", "true");
+    await waitFor(() => {
+      expect(noticeText(chatNotice)).toBeNull();
+    });
+    expect(noticeText(videoNotice)).toBeNull();
+
+    await user.click(videoModelButton);
+    await user.click(await findVideoPanelButton("Veo 3.1 fast"));
+    await waitFor(() => {
+      expect(noticeText(videoNotice)).toBeInTheDocument();
+    });
+    expect(noticeText(chatNotice)).toBeNull();
+
+    // Back to chat mode: the run-model notice returns, the video one leaves.
+    const chatModelButton = await findComposerModel("Claude Sonnet 4.6");
+    chatModelButton.focus();
+    await user.keyboard("{Enter}");
+    expect(videoModelButton).toHaveAttribute("aria-pressed", "false");
+    await waitFor(() => {
+      expect(noticeText(chatNotice)).toBeInTheDocument();
+    });
+    expect(noticeText(videoNotice)).toBeNull();
+
+    // And back again — still one at a time, still the current mode's.
+    await user.click(videoModelButton);
+    await waitFor(() => {
+      expect(noticeText(videoNotice)).toBeInTheDocument();
+    });
+    expect(noticeText(chatNotice)).toBeNull();
+
+    // Setting the default in video mode writes the video model only.
+    await user.click(buttonContainingText("Set as default", document.body));
+
+    await waitFor(() => {
+      expect(updates).toStrictEqual([
+        {
+          selectedModel: "claude-fable-5",
+          serviceTier: null,
+          selectedVideoModel: "fal-ai/veo3.1/fast",
+        },
+      ]);
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3976,4 +3976,61 @@ describe("chat composer video model", () => {
       ]);
     });
   });
+
+  it("keeps a just-written run model when the video default follows it", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { updates } = mockNewChatVideoDefaultAction({
+      selectedModel: "claude-fable-5",
+      serviceTier: null,
+      selectedVideoModel: "MiniMax-H3",
+      updatedAt: "2026-08-14T00:00:00Z",
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.VideoModelSelection]: true,
+        [FeatureSwitchKey.NewChatDefaultModelAction]: true,
+      },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await user.click(await findComposerModel("Claude Fable 5"));
+    await user.click(
+      await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    );
+    await waitFor(() => {
+      expect(
+        noticeText("Temporarily switched to Claude Sonnet 4.6"),
+      ).toBeInTheDocument();
+    });
+    await user.click(buttonContainingText("Set as default", document.body));
+    await waitFor(() => {
+      expect(updates).toHaveLength(1);
+    });
+
+    // No `userPreferenceChanged` push is delivered, so the cached preference
+    // still holds the pre-write run model. The video write must not resend it.
+    const videoModelButton = await findDesktopVideoModelButton();
+    await user.click(videoModelButton);
+    await user.click(videoModelButton);
+    await user.click(await findVideoPanelButton("Veo 3.1 fast"));
+    await waitFor(() => {
+      expect(
+        noticeText("Temporarily switched to Veo 3.1 Fast for video"),
+      ).toBeInTheDocument();
+    });
+    await user.click(buttonContainingText("Set as default", document.body));
+
+    await waitFor(() => {
+      expect(updates).toStrictEqual([
+        { selectedModel: "claude-sonnet-4-6", serviceTier: null },
+        {
+          selectedModel: "claude-sonnet-4-6",
+          serviceTier: null,
+          selectedVideoModel: "fal-ai/veo3.1/fast",
+        },
+      ]);
+    });
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -7745,6 +7745,41 @@ function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
   );
 }
 
+function ComposerTemporaryModelNoticeRow({
+  notice,
+  updating,
+  onSetAsDefault,
+}: {
+  notice: string;
+  updating: boolean;
+  onSetAsDefault: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div
+      className="mt-1.5 flex flex-wrap items-center justify-end gap-x-1.5 gap-y-1 px-3 text-xs leading-5 text-muted-foreground sm:px-4"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <span>{notice}</span>
+      <button
+        type="button"
+        className="inline-flex items-center gap-1 rounded-sm font-medium text-foreground underline-offset-2 transition-colors hover:text-foreground/70 hover:underline focus-visible:text-foreground/70 focus-visible:underline disabled:pointer-events-none disabled:opacity-70"
+        disabled={updating}
+        aria-busy={updating}
+        onClick={onSetAsDefault}
+      >
+        {updating && (
+          <Loader2 size={12} className="animate-spin" aria-hidden="true" />
+        )}
+        {t(($) => {
+          return $.chat.composer.setAsDefault;
+        })}
+      </button>
+    </div>
+  );
+}
+
 function ComposerTemporaryModelNotice({
   signals,
 }: {
@@ -7817,27 +7852,67 @@ function ComposerTemporaryModelNotice({
     );
   };
   return (
-    <div
-      className="mt-1.5 flex flex-wrap items-center justify-end gap-x-1.5 gap-y-1 px-3 text-xs leading-5 text-muted-foreground sm:px-4"
-      aria-live="polite"
-      aria-atomic="true"
-    >
-      <span>{notice}</span>
-      <button
-        type="button"
-        className="inline-flex items-center gap-1 rounded-sm font-medium text-foreground underline-offset-2 transition-colors hover:text-foreground/70 hover:underline focus-visible:text-foreground/70 focus-visible:underline disabled:pointer-events-none disabled:opacity-70"
-        disabled={updating}
-        aria-busy={updating}
-        onClick={setAsDefault}
-      >
-        {updating && (
-          <Loader2 size={12} className="animate-spin" aria-hidden="true" />
-        )}
-        {t(($) => {
-          return $.chat.composer.setAsDefault;
-        })}
-      </button>
-    </div>
+    <ComposerTemporaryModelNoticeRow
+      notice={notice}
+      updating={updating}
+      onSetAsDefault={setAsDefault}
+    />
+  );
+}
+
+function ComposerTemporaryVideoModelNotice({
+  videoModelSignals,
+}: {
+  videoModelSignals: ComposerVideoModelSignals;
+}) {
+  const { t } = useTranslation();
+  // The effective model, not the pin: the notice names the model a run would
+  // actually use, which is what the member default is being compared against.
+  const selection = useLastResolved(videoModelSignals.effectiveVideoModel$);
+  const userPreference = useLastResolved(userModelPreference$);
+  const [updateLoadable, updatePreference] = useLoadableSet(
+    updateUserModelPreference$,
+  );
+  const pageSignal = useGet(pageSignal$);
+  if (!userPreference) {
+    return null;
+  }
+  const defaultVideoModel =
+    userPreference.selectedVideoModel ?? DEFAULT_VIDEO_MODEL;
+  if (!selection || selection === defaultVideoModel) {
+    return null;
+  }
+  const updating = updateLoadable.state === "loading";
+  const setAsDefault = () => {
+    if (updating) {
+      return;
+    }
+    detach(
+      updatePreference(
+        {
+          // The run model is required by the request, so repeat what is already
+          // stored. Sending the resolved selection instead would pin the
+          // workspace default onto the member whose run model is still unset.
+          selectedModel: userPreference.selectedModel,
+          serviceTier: userPreference.serviceTier,
+          selectedVideoModel: selection,
+        },
+        pageSignal,
+      ),
+      Reason.DomCallback,
+    );
+  };
+  return (
+    <ComposerTemporaryModelNoticeRow
+      notice={t(
+        ($) => {
+          return $.chat.composer.temporaryVideoModelNotice;
+        },
+        { model: getModelDisplayName(selection) },
+      )}
+      updating={updating}
+      onSetAsDefault={setAsDefault}
+    />
   );
 }
 
@@ -7847,7 +7922,23 @@ function ComposerTemporaryModelNoticeSlot({
   signals: ComposerSignals;
 }) {
   const enabled = useGet(signals.model.temporaryModelNoticeEnabled$);
-  return enabled ? <ComposerTemporaryModelNotice signals={signals} /> : null;
+  const videoModelEnabled = useGet(videoModelSelectionEnabled$);
+  const desktopLayout = useGet(signals.model.desktopModelPickerLayout$);
+  const desktopModelMode = useGet(signals.model.desktopModelMode$);
+  const videoModelSignals = signals.videoModel;
+  if (!enabled) {
+    return null;
+  }
+  // One notice at a time: it belongs to whichever model the composer is
+  // currently pointed at, matching the pressed state of the two mode chips.
+  return videoModelEnabled &&
+    videoModelSignals &&
+    desktopLayout &&
+    desktopModelMode === "video" ? (
+    <ComposerTemporaryVideoModelNotice videoModelSignals={videoModelSignals} />
+  ) : (
+    <ComposerTemporaryModelNotice signals={signals} />
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -177,6 +177,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { orgModelPolicies$ } from "../../signals/external/org-model-policies.ts";
 import {
+  updateDefaultVideoModel$,
   updateUserModelPreference$,
   userModelPreference$,
 } from "../../signals/external/user-model-preference.ts";
@@ -7870,8 +7871,8 @@ function ComposerTemporaryVideoModelNotice({
   // actually use, which is what the member default is being compared against.
   const selection = useLastResolved(videoModelSignals.effectiveVideoModel$);
   const userPreference = useLastResolved(userModelPreference$);
-  const [updateLoadable, updatePreference] = useLoadableSet(
-    updateUserModelPreference$,
+  const [updateLoadable, updateDefaultVideoModel] = useLoadableSet(
+    updateDefaultVideoModel$,
   );
   const pageSignal = useGet(pageSignal$);
   if (!userPreference) {
@@ -7887,20 +7888,7 @@ function ComposerTemporaryVideoModelNotice({
     if (updating) {
       return;
     }
-    detach(
-      updatePreference(
-        {
-          // The run model is required by the request, so repeat what is already
-          // stored. Sending the resolved selection instead would pin the
-          // workspace default onto the member whose run model is still unset.
-          selectedModel: userPreference.selectedModel,
-          serviceTier: userPreference.serviceTier,
-          selectedVideoModel: selection,
-        },
-        pageSignal,
-      ),
-      Reason.DomCallback,
-    );
+    detach(updateDefaultVideoModel(selection, pageSignal), Reason.DomCallback);
   };
   return (
     <ComposerTemporaryModelNoticeRow


### PR DESCRIPTION
## Problem

On the new-chat composer, picking a video model wrote it straight into the member default (`org_members_metadata.selected_video_model`). Picking a run model has not behaved that way since `NewChatDefaultModelAction` shipped — under that switch the pick only scopes the next new chat, and a notice under the composer offers **Set as default**.

This aligns the video model with the run model.

## Changes

- `setVideoModel$` (`agent-composer-signals.ts`) now mirrors `setModelSelection$`: when `NewChatDefaultModelAction` is on it only sets the session selection and never writes the member default. With the switch off, the previous silent write is unchanged.
- `ComposerTemporaryModelNoticeSlot` picks the notice for the composer's **current model mode**. The shared row markup moved into `ComposerTemporaryModelNoticeRow`; the run-model notice is otherwise untouched.
- New `chat.composer.temporaryVideoModelNotice` string in all 10 locales.

## Design decision: both models changed at once

One notice at a time, scoped to the mode the composer is in — not a merged row, not two stacked rows.

- Chat mode pressed → the run-model notice, and **Set as default** writes only the run model.
- Video mode pressed → the video-model notice, and **Set as default** writes only the video model.
- Nothing pending in the current mode → no row, even if the other mode has a pending change.

Rationale: the two mode chips (`Chat · <model>` / the video chip, both carrying `aria-pressed`) already tell the user which model they are editing. Tying the notice to that pressed state means the row always answers "the thing I just changed", one click sets exactly what the user is looking at, and the combinatorial notice strings — run model × service tier × video model — never have to exist in 10 languages.

## Preserving the run model on a video-only write

`PUT /api/okou/user-model-preference` requires `selectedModel`/`serviceTier`, so a video-only write has to send them. It sends **the stored preference**, not the resolved composer selection: those differ when the member's own run model is unset and the selection resolved to the workspace default. Sending the resolved value would silently pin that workspace default onto the member and stop them following future workspace changes.

`selectedVideoModel` is only sent when the video model is what changed — the field's own-property semantics mean "absent = leave alone", so the run-model notice cannot blank a stored video default.

## Known gap: mobile

Mode is a desktop concept — the video chip is `sm:`-only and `desktopModelMode$` stays `"chat"` below 640px, where video models are reached through a transient nested panel. So on mobile, with `NewChatDefaultModelAction` on, a video pick is temporary and there is no composer affordance to persist it (there is no settings surface for the video default either). Reusing the nested panel's open state would make the row flicker in and out with the popup, so I left it out rather than guess. Flagging it as a follow-up rather than folding a mobile mode model into this PR.

## Tests

`chat-composer-model-selection-and-providers.test.tsx`, 2 new cases (62 pass):

- a new-chat video pick writes nothing, shows `Temporarily switched to Veo 3.1 Fast for video`, and **Set as default** sends exactly `{selectedModel: null, serviceTier: null, selectedVideoModel: "fal-ai/veo3.1/fast"}` — the null run model proves the workspace default is not pinned.
- both models changed, then toggling Chat ↔ Video repeatedly: exactly one row each time, always the pressed mode's; and none at all while video mode is on its member default.

The existing "writes a landing selection to the member default and new thread" case still passes and now covers the switch-off path.

## Checks

`pnpm -F @okouai/app lint` (exit 0, no new warnings), `check-types` (production + tests), and the 4 composer/sidebar test files that touch this area (160 tests) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
