### PR TITLE
perf(python): bound connector-intent header work and retention

### DIFF
--- a/crates/runner/mitm-addon/src/connector_intent.py
+++ b/crates/runner/mitm-addon/src/connector_intent.py
@@ -7,6 +7,9 @@ from mitmproxy import http
 
 HEADER_NAME: Final = "X-VM0-Connector-Intent"
 
+_RAW_HEADER_NAME: Final = b"x-vm0-connector-intent"
+_MAX_CONNECTOR_INTENT_BYTES: Final = 64
+
 _VALUE_METADATA_KEY = "_connector_intent_value"
 _STATUS_METADATA_KEY = "_connector_intent_status"
 
@@ -33,21 +36,29 @@ MALFORMED = ConnectorIntent("malformed")
 def capture_and_strip(flow: http.HTTPFlow) -> None:
     """Capture connector intent once and always remove its private header."""
     if _STATUS_METADATA_KEY not in flow.metadata:
-        values = flow.request.headers.get_all(HEADER_NAME)
-        if not values:
+        raw_value: bytes | None = None
+        repeated = False
+        for name, value in flow.request.headers.fields:
+            if name.lower() != _RAW_HEADER_NAME:
+                continue
+            if raw_value is not None:
+                repeated = True
+                break
+            raw_value = value
+
+        if raw_value is None:
             flow.metadata[_STATUS_METADATA_KEY] = "absent"
-        elif len(values) != 1:
+        elif repeated or len(raw_value) > _MAX_CONNECTOR_INTENT_BYTES:
             flow.metadata[_STATUS_METADATA_KEY] = "malformed"
         else:
-            value = values[0].strip()
+            value = flow.request.headers.get_all(HEADER_NAME)[0].strip()
             if value == "" or "," in value:
                 flow.metadata[_STATUS_METADATA_KEY] = "malformed"
             else:
                 flow.metadata[_STATUS_METADATA_KEY] = "present"
                 flow.metadata[_VALUE_METADATA_KEY] = value
 
-    if HEADER_NAME in flow.request.headers:
-        del flow.request.headers[HEADER_NAME]
+    flow.request.headers.set_all(HEADER_NAME, [])
 
 
 def from_flow(flow: http.HTTPFlow) -> ConnectorIntent:

--- a/crates/runner/mitm-addon/tests/request_handler_helpers.py
+++ b/crates/runner/mitm-addon/tests/request_handler_helpers.py
@@ -54,7 +54,12 @@ def _single_firewall_vm(
     return vm_info
 
 
-def _shared_route_vm(tmp_path: Path, *, reverse: bool = False) -> dict[str, object]:
+def _shared_route_vm(
+    tmp_path: Path,
+    *,
+    reverse: bool = False,
+    primary_name: str = "primary",
+) -> dict[str, object]:
     """Build two credential owners for the same exact route."""
 
     def firewall(name: str, token: str, permission: str) -> dict[str, object]:
@@ -80,7 +85,7 @@ def _shared_route_vm(tmp_path: Path, *, reverse: bool = False) -> dict[str, obje
         }
 
     firewalls = [
-        firewall("primary", "PRIMARY_TOKEN", "items-read"),
+        firewall(primary_name, "PRIMARY_TOKEN", "items-read"),
         firewall("auditor", "AUDITOR_TOKEN", "audit-read"),
     ]
     if reverse:
@@ -96,7 +101,7 @@ def _shared_route_vm(tmp_path: Path, *, reverse: bool = False) -> dict[str, obje
         "captureNetworkBodies": True,
         "firewalls": firewalls,
         "networkPolicies": {
-            "primary": {
+            primary_name: {
                 "allow": ["items-read"],
                 "deny": [],
                 "ask": [],

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -23,6 +23,13 @@ from tests.request_handler_helpers import (
 )
 from tests.upstream_connection_helpers import seed_server_binding
 
+_MAX_CONNECTOR_INTENT_BYTES = 64
+
+
+class _DecodeGuardConnectorIntent(bytes):
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("oversized connector intent must not be decoded")
+
 
 @contextmanager
 def _observe_local_response_parser_inputs() -> Iterator[list[str]]:
@@ -67,13 +74,20 @@ async def test_firewall_match_calls_handler(
     assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "full-access"
 
 
+@pytest.mark.parametrize(
+    "primary_name",
+    [
+        pytest.param("primary", id="ordinary"),
+        pytest.param("p" * _MAX_CONNECTOR_INTENT_BYTES, id="at-limit"),
+    ],
+)
 @pytest.mark.parametrize("reverse", [False, True])
 async def test_connector_intent_selects_auth_template_in_both_firewall_orders(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, reverse
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, reverse, primary_name
 ):
     reg_path = _write_registry(
         tmp_path,
-        vm_info=_shared_route_vm(tmp_path, reverse=reverse),
+        vm_info=_shared_route_vm(tmp_path, reverse=reverse, primary_name=primary_name),
     )
     flow = real_flow(
         with_response=False,
@@ -82,7 +96,7 @@ async def test_connector_intent_selects_auth_template_in_both_firewall_orders(
         path="/items/123",
         request_headers=headers(
             ("Host", "shared.example.com"),
-            ("X-VM0-Connector-Intent", "primary"),
+            ("X-VM0-Connector-Intent", primary_name),
         ),
     )
 
@@ -98,7 +112,7 @@ async def test_connector_intent_selects_auth_template_in_both_firewall_orders(
     assert flow.response is None
     assert flow.request.headers["Authorization"] == "Bearer resolved-primary"
     assert "X-VM0-Connector-Intent" not in flow.request.headers
-    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "primary"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == primary_name
     assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "items-read"
 
 
@@ -229,6 +243,50 @@ async def test_ambiguous_connector_route_fails_before_auth_and_logs_candidates(
     assert network_log_entry["firewall_error"] == "ambiguous_connector_route"
     assert network_log_entry["connector_route_reason"] == reason
     assert network_log_entry["connector_route_candidates"] == ["auditor", "primary"]
+    assert "firewall_name" not in network_log_entry
+
+
+async def test_oversized_connector_intent_is_malformed_without_decoding_or_auth(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    reg_path = _write_registry(tmp_path, vm_info=_shared_route_vm(tmp_path))
+    oversized_intent = _DecodeGuardConnectorIntent(b"x" * (1024 * 1024))
+    request_headers = mitm_addon.http.Headers(
+        [
+            (b"Host", b"shared.example.com"),
+            (b"x-VM0-Connector-Intent", oversized_intent),
+        ]
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/items/123?sensitive=query",
+        request_headers=request_headers,
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+        mitm_addon.response(flow)
+
+    auth_fetch.assert_not_awaited()
+    assert flow.response is not None
+    assert flow.response.status_code == 409
+    assert all(name.lower() != b"x-vm0-connector-intent" for name, _ in flow.request.headers.fields)
+    assert connector_intent.from_flow(flow) == connector_intent.MALFORMED
+    assert connector_intent._VALUE_METADATA_KEY not in flow.metadata
+    body = json.loads(flow.response.content)
+    assert body["reason"] == "malformed_connector_intent"
+    proxy_log_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
+    assert "intent" not in proxy_log_entry
+    network_log_entry = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")[0]
+    assert network_log_entry["connector_route_reason"] == "malformed_connector_intent"
     assert "firewall_name" not in network_log_entry
 
 


### PR DESCRIPTION
## Summary

- preflight `X-VM0-Connector-Intent` against a 64-byte raw-field budget before mitmproxy decodes or normalizes it
- classify oversized values as malformed and strip every header occurrence through the raw-filtering multidict path
- preserve valid 64-byte built-in slugs, UUID custom connector IDs, and existing fail-closed malformed-input behavior
- cover the real ambiguous-route request hook with a 1 MiB decode guard, credential-fetch suppression, metadata bounds, and sanitized logs

## Compatibility

This is runner-local flow behavior with no API, queue, database, or persisted-state change. Valid connector identities behave identically across runner versions. During a rolling deployment, only invalid values over 64 raw bytes differ: new runners fail them closed without decoding or retaining them, while old runners may continue the prior behavior. Flows are owned by one runner and are not transferred.

This change intentionally does not bound mitmproxy's prior request-head buffering or work proportional to total header count/name size; those are separate parser/runtime concerns.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` — 0 errors, 0 warnings
- `uv run --no-sync python -m pytest tests/test_request_handler_firewall_dispatch.py tests/test_request_headers_firewall_auth.py tests/test_request_handler_catalog_removal.py` — 79 passed
- `uv run --no-sync python -m pytest tests/` — 5580 passed, 59 existing warnings

Local capture-plus-routing benchmark, with each flow built before timing/tracing:

| Oversized value | Median | Median traced peak |
| --- | ---: | ---: |
| 1 MiB | 0.003083 ms | 229 bytes |
| 16 MiB | 0.003333 ms | 229 bytes |
| 33 MiB | 0.003458 ms | 229 bytes |

All samples were malformed, removed from request headers, and left no connector-intent value metadata.

Closes #27630
