### PR TITLE
fix(cli): ignore an explicit video model inside an agent run

### DIFF
--- a/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
@@ -34,6 +34,24 @@ const VIDEO_RESULT = {
   requestId: "video-request",
 };
 
+function buildRunToken(): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
+    "base64url",
+  );
+  const body = Buffer.from(
+    JSON.stringify({
+      userId: "user-video",
+      runId: "run-video",
+      orgId: "org-video",
+      scope: "okou",
+      capabilities: ["file:write", "billing:read"],
+      iat: 1000,
+      exp: 2000,
+    }),
+  ).toString("base64url");
+  return `vm0_sandbox_${header}.${body}.test-signature`;
+}
+
 function pngWithDimensions(width: number, height: number): Buffer {
   const buffer = Buffer.alloc(24);
   buffer.write("\x89PNG\r\n\x1a\n", 0, "latin1");
@@ -133,6 +151,32 @@ describe("okou generate video command", () => {
       autoFix: true,
       safetyTolerance: "4",
     });
+  });
+
+  it("should ignore an explicit model inside an agent run", async () => {
+    // The server generates with the model the run is set to and drops whatever
+    // the request names, so sending one would only misreport what was used.
+    vi.stubEnv("OKOU_TOKEN", buildRunToken());
+    let payload: unknown = null;
+    server.use(
+      http.post(VIDEO_URL, async ({ request }) => {
+        payload = await request.json();
+        return HttpResponse.json(VIDEO_RESULT);
+      }),
+    );
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "video",
+      "--prompt",
+      "A neon market tracking shot",
+      "--model",
+      "kling-v3-4k",
+    ]);
+
+    expect(payload).not.toHaveProperty("model");
+    expect(payload).toMatchObject({ prompt: "A neon market tracking shot" });
   });
 
   it("should generate a video and print the /f file URL", async () => {

--- a/turbo/apps/cli/src/commands/shared/video-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/video-generate.ts
@@ -14,6 +14,7 @@ import {
   currentPlanAllowsVideo,
   currentTokenCanReadBilling,
 } from "./billing-capabilities";
+import { decodeSandboxTokenPayload } from "../../lib/api/sandbox-token";
 import { dispatchGenerate } from "../generate/lib/dispatch";
 import type { GenerationType } from "../generate/lib/lister";
 
@@ -330,6 +331,14 @@ async function validateVideoOptions(options: VideoOptions): Promise<void> {
   ]);
 }
 
+/**
+ * An agent run authenticates with a run-scoped token, so the token payload
+ * itself says whether this process belongs to a run.
+ */
+function insideAgentRun(): boolean {
+  return decodeSandboxTokenPayload() !== undefined;
+}
+
 function formatOptionalVideoParameter(
   value: string | number | undefined,
   fallback = "none",
@@ -399,7 +408,7 @@ export function createVideoGenerateCommand(
     .option("--json", "Print the complete generation result as JSON")
     .option(
       "--model <model>",
-      "Model: dreamina-seedance-2.0-fast, dreamina-seedance-2.5, dreamina-seedance-2.0, dreamina-seedance-2.0-mini, seedance-1.5-pro, minimax-h3, veo3.1-fast, or kling-v3-4k; omit to use the model this run is set to",
+      "Model: dreamina-seedance-2.0-fast, dreamina-seedance-2.5, dreamina-seedance-2.0, dreamina-seedance-2.0-mini, seedance-1.5-pro, minimax-h3, veo3.1-fast, or kling-v3-4k; ignored inside an agent run, which generates with the model the run is set to",
     )
     .option(
       "--aspect-ratio <ratio>",
@@ -476,7 +485,14 @@ Models:
     4k output, negative prompts, and optional audio.`,
     )
     .action(
-      withErrorHandler(async (options: VideoOptions) => {
+      withErrorHandler(async (rawOptions: VideoOptions) => {
+        // Inside an agent run the server generates with the model the run is
+        // set to and ignores whatever the request names, so keep `--model` out
+        // of everything downstream rather than reporting a model that will not
+        // be used. Outside a run the flag is the only way to choose.
+        const options: VideoOptions = insideAgentRun()
+          ? { ...rawOptions, model: undefined }
+          : rawOptions;
         const dispatch = await dispatchGenerate({
           generationType: config.generationType,
           provider: options.provider,


### PR DESCRIPTION
Makes `okou generate video` stop sending `--model` when it runs inside an agent run, where the flag has no effect.

**Stacked on #27634** — base that PR first; this branch contains its commit. Review only `3c93e48`.

## Why

The endpoint replaces the request's model with the run's whenever the run has one, and it does not care whether the caller was explicit:

```ts
runVideoModel === null
  ? bodyResult.data
  : withEnforcedRunVideoModel(bodyResult.data, runVideoModel)
```

So inside a run, `--model kling-v3-4k --resolution 4k` against a MiniMax run produces MiniMax at 2k. The 4k is dropped by #27610's reconciliation, nothing is rejected, and the CLI exits 0. The agent has no way to distinguish "my model was used" from "my model was discarded", which is how it ended up telling a user the substitution was a routing fault.

Sending a flag the server is guaranteed to discard is the same defect #27634 removes for the default: the request states a choice that will not hold.

## What changes

The CLI already knows which case it is in. `decodeSandboxTokenPayload()` decodes `OKOU_TOKEN` locally — no round trip — and returns a payload carrying `runId` for a run-scoped token, `undefined` for a personal one. That is the same distinction the endpoint makes:

```ts
const runId =
  auth.tokenType === "zero" || auth.tokenType === "sandbox"
    ? auth.runId
    : undefined;
```

`billing-capabilities.ts:currentTokenCanReadBilling()` already branches on the same helper, on this same code path.

Inside a run the model is now cleared once, at the top of the action, so everything downstream agrees: the request body, the `--template` packet's "Requested Parameters", and the local frame-image validation. Outside a run nothing changes — `--model` is the only way to choose there, and it still works, including for models a run pin would otherwise override.

Ignoring is silent, matching what the endpoint already does. The flag is not rejected.

## Behavior

| Where | `--model kling-v3-4k` | Before | After |
| --- | --- | --- | --- |
| Agent run, run model applied | passed | discarded by the server, reported as a choice | dropped by the CLI, never claimed |
| Agent run, `VideoModelSelection` off | passed | honoured | **no longer honoured** — see below |
| Personal token, no run | passed | honoured | honoured |
| Anywhere | omitted | server resolves | server resolves |

## The one behavior change worth flagging

The CLI cannot read feature switches, so it branches on "is this a run", not on "will the server actually apply the run's model". When `VideoModelSelection` is off, the endpoint returns early and honours the request's model; today an explicit `--model` inside a run therefore works. After this change it does not — that path resolves to the run's model instead.

That is the intended end state and it is what the switch will do everywhere once it is on. But it arrives for the ignore half without the switch gating it. Three ways to handle it, in the order I would pick:

1. Merge as is, accepting that explicit `--model` stops working inside runs before the switch is fully on. The result is the same model the run resolves to, so nothing fails; callers that wanted a specific model inside a run silently get the run's.
2. Hold this PR until `VideoModelSelection` is on for everyone. #27634 stands on its own and does not need it.
3. Have the CLI read `effectiveSwitches` from `GET /api/okou/feature-switches` and branch on the real state, at the cost of a request before every generation.

## Testing

- New case: a run-scoped `OKOU_TOKEN` plus an explicit `--model kling-v3-4k` produces a request body with no `model`. Verified it fails without the change.
- The existing suite uses a non-run token, so it covers the outside-a-run half unchanged.
- `video.test.ts`: 12 passed
- `@okouai/cli` `check-types` and `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
