### PR TITLE
fix(onboarding): use usage pack checkout when enabled

### DIFF
--- a/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
@@ -3,14 +3,18 @@ import { onboardingCompleteContract } from "@okouai/api-contracts/contracts/onbo
 import {
   zeroBillingCheckoutContract,
   zeroBillingRedeemCodeContract,
+  zeroBillingUsagePackCheckoutContract,
 } from "@okouai/api-contracts/contracts/zero-billing";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
 import { IN_VITEST } from "../../env.ts";
 import { zeroClient$ } from "../api-client.ts";
+import { authenticatedIdentity$ } from "../auth.ts";
 import { ROUTES } from "../route-paths.ts";
 import { setLoop } from "../utils.ts";
 import { billingStatusAsync$ } from "../zero-page/billing.ts";
 import { readStoredAdAttributionMetadata$ } from "../bootstrap/ad-attribution.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import { reloadOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 import {
   ONBOARDING_CHECKOUT_STATE_PARAM,
@@ -106,24 +110,49 @@ export const prepareOnboardingVideoRun$ = command(
       prompt: input.prompt,
       note: input.note,
     });
-    const client = get(zeroClient$)(zeroBillingCheckoutContract);
     const adAttribution = set(readStoredAdAttributionMetadata$);
-    const result = await accept(
-      client.create({
-        body: {
-          tier: "pro",
-          successUrl: checkoutReturnUrl(input, "pro", checkoutState),
-          cancelUrl: checkoutReturnUrl(input, "canceled", checkoutState),
-          ...(adAttribution === undefined ? {} : { adAttribution }),
-        },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
+    const successUrl = checkoutReturnUrl(input, "pro", checkoutState);
+    const cancelUrl = checkoutReturnUrl(input, "canceled", checkoutState);
+    let checkoutUrl: string;
+    if (get(featureSwitch$)[FeatureSwitchKey.UsagePackPlans]) {
+      const { userId } = await get(authenticatedIdentity$);
+      signal.throwIfAborted();
+      const client = get(zeroClient$)(zeroBillingUsagePackCheckoutContract);
+      const result = await accept(
+        client.create({
+          body: {
+            tier: "pro",
+            memberUsagePacks: [{ memberId: userId, usagePackUsd: 20 }],
+            successUrl,
+            cancelUrl,
+            ...(adAttribution === undefined ? {} : { adAttribution }),
+          },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      checkoutUrl = result.body.url;
+    } else {
+      const client = get(zeroClient$)(zeroBillingCheckoutContract);
+      const result = await accept(
+        client.create({
+          body: {
+            tier: "pro",
+            successUrl,
+            cancelUrl,
+            ...(adAttribution === undefined ? {} : { adAttribution }),
+          },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      checkoutUrl = result.body.url;
+    }
     set(capturePaidOnboardingCheckoutCreated$, "onboarding_video");
     set(capturePaidOnboardingRedirectToStripe$, "onboarding_video");
-    window.location.href = result.body.url;
+    window.location.href = checkoutUrl;
     return "checkout";
   },
 );

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -6,7 +6,11 @@ import {
   VIDEO_TEMPLATE_ITEMS,
   WEBSITE_TEMPLATE_ITEMS,
 } from "@okouai/core";
-import { zeroBillingCheckoutContract } from "@okouai/api-contracts/contracts/zero-billing";
+import {
+  zeroBillingCheckoutContract,
+  zeroBillingUsagePackCheckoutContract,
+} from "@okouai/api-contracts/contracts/zero-billing";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type { UserMessageDocument } from "@okouai/api-contracts/contracts/chat-threads";
 import {
   zeroConnectorCatalogContract,
@@ -954,6 +958,73 @@ describe("onboarding flow", () => {
       expect(runPrompt).toContain(videoBrief);
       expect(generationType).toBe("video");
       expect(pathname()).toMatch(/^\/chats\//u);
+    });
+  });
+
+  it("uses the new Pro plan with a $20 usage pack when enabled", async () => {
+    const template = firstItem(VIDEO_TEMPLATE_ITEMS);
+    let legacyCheckoutCalled = false;
+    let usagePackCheckoutBody:
+      | {
+          readonly tier: "pro" | "team";
+          readonly memberUsagePacks: readonly {
+            readonly memberId: string;
+            readonly usagePackUsd: 20 | 50 | 100 | 200;
+          }[];
+        }
+      | undefined;
+    context.mocks.api(zeroBillingCheckoutContract.create, ({ respond }) => {
+      legacyCheckoutCalled = true;
+      return respond(200, {
+        url: "https://checkout.stripe.com/test/legacy-onboarding-video",
+      });
+    });
+    context.mocks.api(
+      zeroBillingUsagePackCheckoutContract.create,
+      ({ body, respond }) => {
+        usagePackCheckoutBody = body;
+        return respond(200, {
+          url: "https://checkout.stripe.com/test/usage-pack-onboarding-video",
+        });
+      },
+    );
+
+    mockOnboardingNeeded();
+    detachedSetupPage({
+      context,
+      path: "/onboarding",
+      featureSwitches: { [FeatureSwitchKey.UsagePackPlans]: true },
+    });
+    await expect(
+      screen.findByRole("heading", {
+        name: "What do you want to make first",
+      }),
+    ).resolves.toBeInTheDocument();
+    chooseMakeOption("Video production");
+    await expect(
+      screen.findByRole("heading", {
+        name: "Pick a video template to start from",
+      }),
+    ).resolves.toBeInTheDocument();
+    chooseTemplate(template.title, "video");
+    await expect(
+      screen.findByRole("heading", { name: "Customize your video" }),
+    ).resolves.toBeInTheDocument();
+    await fill(
+      screen.getByLabelText("Custom video prompt"),
+      "A product launch video with a fast-paced opening.",
+    );
+    click(buttonByText("Upgrade Pro to run"));
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(
+        "https://checkout.stripe.com/test/usage-pack-onboarding-video",
+      );
+    });
+    expect(legacyCheckoutCalled).toBeFalsy();
+    expect(usagePackCheckoutBody).toMatchObject({
+      tier: "pro",
+      memberUsagePacks: [{ memberId: "test-user-123", usagePackUsd: 20 }],
     });
   });
 


### PR DESCRIPTION
## Summary

- route paid video onboarding through the usage-pack checkout when `UsagePackPlans` is enabled
- include the new Pro plan and a $20 monthly usage pack for the onboarding user
- preserve the legacy Pro checkout while the switch is disabled
- cover both checkout paths with the page-level onboarding flow test

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/onboarding/__tests__/onboarding-flow.test.tsx --maxWorkers=1 --silent=passed-only` (24 tests passed)
