### PR TITLE
fix(platform): brand standalone surfaces by hostname

### DIFF
--- a/turbo/apps/platform/src/views/browser-authorization/__tests__/browser-authorization-page.test.tsx
+++ b/turbo/apps/platform/src/views/browser-authorization/__tests__/browser-authorization-page.test.tsx
@@ -26,6 +26,10 @@ describe("browser authorization page", () => {
     const user = userEvent.setup({ delay: null });
     let enabled = false;
 
+    context.mocks.browser.url(
+      "https://app.vm0.ai/browser/authorize/vm0_browser_authorization_request_test",
+    );
+
     context.mocks.api(
       zeroBrowserAuthorizationRequestsContract.get,
       ({ respond }) => {
@@ -53,6 +57,9 @@ describe("browser authorization page", () => {
       screen.findByRole("heading", { name: "Enable cloud browser" }),
     ).resolves.toBeInTheDocument();
     expect(
+      screen.getByRole("img", { name: "VM0" }).closest("a"),
+    ).toBeInTheDocument();
+    expect(
       screen.getByText(
         "Zero will use an isolated cloud browser profile for this chat thread. Enabling it disconnects Computer Use for the thread.",
       ),
@@ -64,5 +71,32 @@ describe("browser authorization page", () => {
       expect(enabled).toBeTruthy();
       expect(getButtonByText("Cloud browser enabled")).toBeDisabled();
     });
+  });
+
+  it("shows the Okou brand on the Okou app host", async () => {
+    context.mocks.browser.url(
+      "https://app.okou.ai/browser/authorize/vm0_browser_authorization_request_test",
+    );
+    context.mocks.api(
+      zeroBrowserAuthorizationRequestsContract.get,
+      ({ respond }) => {
+        return respond(200, {
+          expiresAt: "2026-07-27T12:00:00Z",
+          completedAt: null,
+          cloudBrowserEnabled: false,
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/browser/authorize/vm0_browser_authorization_request_test",
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Enable cloud browser" }),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("Okou").closest("a")).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: "VM0" })).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/browser-authorization/browser-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/browser-authorization/browser-authorization-page.tsx
@@ -11,7 +11,7 @@ import {
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { locale$ } from "../../signals/locale.ts";
-import { Vm0LogoLink } from "../zero-page/zero-directed-shared.tsx";
+import { ProductBrandMarkLink } from "../zero-page/zero-directed-shared.tsx";
 
 function formatTime(value: string, locale: string): string {
   return new Date(value).toLocaleString(locale, {
@@ -25,7 +25,7 @@ function ErrorState() {
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center px-4">
       <div className="flex w-[430px] max-w-full flex-col items-center gap-6 rounded-xl border border-border bg-background px-6 py-10 text-center">
-        <Vm0LogoLink />
+        <ProductBrandMarkLink />
         <div className="flex flex-col gap-2">
           <h1 className="text-lg font-medium text-foreground">
             {t(($) => {
@@ -75,7 +75,7 @@ export function BrowserAuthorizationPage() {
     <div className="fixed inset-0 z-10 flex items-center justify-center overflow-y-auto px-4 py-8">
       <div className="flex w-[500px] max-w-full flex-col gap-6 rounded-xl border border-border bg-background px-6 py-8">
         <div className="flex flex-col items-center gap-5 text-center">
-          <Vm0LogoLink />
+          <ProductBrandMarkLink />
           <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-muted">
             <Globe size={22} />
           </div>

--- a/turbo/apps/platform/src/views/components/product-brand-mark.tsx
+++ b/turbo/apps/platform/src/views/components/product-brand-mark.tsx
@@ -1,12 +1,33 @@
-export function VM0Logo() {
+import { useGet } from "ccstate-react";
+
+import { brandName$ } from "../../signals/branding.ts";
+
+type ProductBrandMarkSize = "default" | "compact" | "small";
+
+function Vm0BrandMark({
+  size,
+  label,
+}: {
+  size: ProductBrandMarkSize;
+  label: string;
+}) {
+  const dimensions =
+    size === "default"
+      ? { width: 80, height: 24 }
+      : size === "compact"
+        ? { width: 82, height: 20 }
+        : { width: 53, height: 16 };
+
   return (
     <svg
-      width="80"
-      height="24"
+      width={dimensions.width}
+      height={dimensions.height}
       viewBox="0 0 100 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className="text-foreground"
+      role="img"
+      aria-label={label}
     >
       <path
         d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"
@@ -41,5 +62,32 @@ export function VM0Logo() {
         fill="currentColor"
       />
     </svg>
+  );
+}
+
+export function ProductBrandMark({
+  size = "default",
+}: {
+  size?: ProductBrandMarkSize;
+}) {
+  const brandName = useGet(brandName$);
+
+  if (brandName === "VM0") {
+    return <Vm0BrandMark size={size} label={brandName} />;
+  }
+
+  const sizeClassName =
+    size === "default"
+      ? "text-xl leading-6"
+      : size === "compact"
+        ? "text-xl leading-5"
+        : "text-base leading-4";
+
+  return (
+    <span
+      className={`${sizeClassName} font-semibold tracking-tight text-foreground`}
+    >
+      {brandName}
+    </span>
   );
 }

--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -20,7 +20,7 @@ import { computerUseProductName$ } from "../../signals/branding.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { computerUseIllustrationImg } from "../zero-page/platform-assets.ts";
-import { Vm0LogoLink } from "../zero-page/zero-directed-shared.tsx";
+import { ProductBrandMarkLink } from "../zero-page/zero-directed-shared.tsx";
 import { locale$ } from "../../signals/locale.ts";
 import { i18n } from "../../i18n/index.ts";
 import { desktopProductDisplayName } from "../../i18n/desktop-product.ts";
@@ -191,7 +191,7 @@ function ErrorState() {
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center px-4">
       <div className="flex w-[430px] max-w-full flex-col items-center gap-6 rounded-xl border border-border bg-background px-6 py-10 text-center">
-        <Vm0LogoLink />
+        <ProductBrandMarkLink />
         <div className="flex flex-col gap-2">
           <h1 className="text-lg font-medium text-foreground">
             {t(($) => {
@@ -246,7 +246,7 @@ export function ComputerUseAuthorizationPage() {
     <div className="fixed inset-0 z-10 flex items-center justify-center overflow-y-auto px-4 py-8">
       <div className="flex w-[520px] max-w-full flex-col gap-6 rounded-xl border border-border bg-background px-6 py-8">
         <div className="flex flex-col items-center gap-5 text-center">
-          <Vm0LogoLink />
+          <ProductBrandMarkLink />
           <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-muted">
             <Monitor size={22} />
           </div>

--- a/turbo/apps/platform/src/views/email-unsubscribe/email-unsubscribe-page.tsx
+++ b/turbo/apps/platform/src/views/email-unsubscribe/email-unsubscribe-page.tsx
@@ -10,7 +10,7 @@ import {
   emailUnsubscribeToken$,
 } from "../../signals/email-unsubscribe/email-unsubscribe-signals.ts";
 import { detach, Reason } from "../../signals/utils.ts";
-import { VM0Logo } from "../components/vm0-logo.tsx";
+import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 
 export function EmailUnsubscribePage() {
   const { t } = useTranslation();
@@ -23,7 +23,7 @@ export function EmailUnsubscribePage() {
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center bg-background">
       <div className="flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-8 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
-        <VM0Logo />
+        <ProductBrandMark />
         {status === "done" ? (
           <div className="flex flex-col items-center gap-2.5">
             <Check size={20} className="" />

--- a/turbo/apps/platform/src/views/export-page/export-page.tsx
+++ b/turbo/apps/platform/src/views/export-page/export-page.tsx
@@ -12,10 +12,6 @@ import {
 import type { UserExportStatusResponse } from "@okouai/api-contracts/contracts/user-export";
 import { Button } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
-import {
-  platformVm0LogoDarkImg,
-  platformVm0LogoImg,
-} from "../../lib/static-assets.ts";
 import { now } from "../../lib/time.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
@@ -25,6 +21,7 @@ import {
   userExportStatusPollingRef$,
 } from "../../signals/export-page/export-page-signals.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 import { Link } from "../router/link.tsx";
 
 type ExportViewState =
@@ -447,20 +444,7 @@ export function ExportPage() {
                 return $.settings.export.backToZero;
               })}
             </Link>
-            <img
-              src={platformVm0LogoDarkImg}
-              alt={t(($) => {
-                return $.appShell.logoAlt;
-              })}
-              className="h-4 w-auto dark:hidden"
-            />
-            <img
-              src={platformVm0LogoImg}
-              alt={t(($) => {
-                return $.appShell.logoAlt;
-              })}
-              className="hidden h-4 w-auto dark:block"
-            />
+            <ProductBrandMark size="small" />
           </div>
 
           <div className="space-y-6">

--- a/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx
+++ b/turbo/apps/platform/src/views/morning-brief-unsubscribe-page/morning-brief-unsubscribe-page.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../signals/morning-brief-unsubscribe/morning-brief-unsubscribe-signals.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { Link } from "../router/link.tsx";
-import { VM0Logo } from "../components/vm0-logo.tsx";
+import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 
 interface CardInfo {
   title: string;
@@ -74,7 +74,7 @@ export function MorningBriefUnsubscribePage() {
   return (
     <div className="flex min-h-0 flex-1 items-center justify-center px-6">
       <div className="flex w-[500px] max-w-full flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-[50px] py-12">
-        <VM0Logo />
+        <ProductBrandMark />
         <div className="flex flex-col items-center gap-4">
           <CardIcon status={status} />
           <p className="text-center text-lg font-medium leading-7 text-foreground">

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -34,7 +34,7 @@ import {
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
 import { isActiveUserPermissionGrant } from "../../signals/user-permission-grants.ts";
 import { detach, Reason } from "../../signals/utils.ts";
-import { VM0Logo } from "../components/vm0-logo.tsx";
+import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 import { PermissionGrantDurationSelect } from "../components/permission-grant-duration-select.tsx";
 import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
@@ -144,7 +144,7 @@ function LoadingCard() {
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12">
-        <VM0Logo />
+        <ProductBrandMark />
         <Loader2 size={20} className="animate-spin text-muted-foreground" />
       </div>
     </div>
@@ -200,7 +200,7 @@ function ResultCard({
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-[50px] py-12">
-        <VM0Logo />
+        <ProductBrandMark />
         <div className="flex flex-col items-center gap-4">
           {allowed ? (
             <Check size={40} className="text-green-600 opacity-70" />
@@ -439,7 +439,7 @@ function ConfirmGrantCard({
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12">
-        <VM0Logo />
+        <ProductBrandMark />
 
         <div className="flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-4 px-[26px]">
           <p className="text-center text-lg font-medium leading-7 text-foreground">

--- a/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
+++ b/turbo/apps/platform/src/views/redeem-campaign-page/redeem-campaign-page.tsx
@@ -13,7 +13,7 @@ import { ROUTES } from "../../signals/route-paths.ts";
 import { clerk$ } from "../../signals/auth.ts";
 import { brandName$ } from "../../signals/branding.ts";
 import { Link } from "../router/link.tsx";
-import { VM0Logo } from "../components/vm0-logo.tsx";
+import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 
 type CardKind = "ready" | "granted" | "processing" | "auth" | "broken";
 
@@ -219,7 +219,7 @@ export function RedeemCampaignPage() {
   return (
     <div className="flex min-h-0 flex-1 items-center justify-center px-6 md:-translate-x-[128px]">
       <div className="flex w-[500px] max-w-full flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-[50px] py-12">
-        <VM0Logo />
+        <ProductBrandMark />
         <div className="flex flex-col items-center gap-4">
           <CardIcon kind={info.kind} />
           <p className="text-center text-lg font-medium leading-7 text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-flow-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-flow-card.tsx
@@ -1,7 +1,7 @@
 import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/zero-connector-catalog";
 import type { ReactNode } from "react";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
-import { Vm0LogoLink } from "./zero-directed-shared.tsx";
+import { ProductBrandMarkLink } from "./zero-directed-shared.tsx";
 
 export function ZeroConnectorFlowCard({
   connectorIcon,
@@ -17,7 +17,7 @@ export function ZeroConnectorFlowCard({
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center bg-background pointer-events-none">
       <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
-        <Vm0LogoLink />
+        <ProductBrandMarkLink />
         <div
           className="flex w-full flex-col items-center gap-4"
           aria-live="polite"

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -38,7 +38,7 @@ import {
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { reloadAgentConnectorAuthorizations$ } from "../../signals/zero-page/agent-connector-authorizations.ts";
 import { Check, Loader2 } from "lucide-react";
-import { Vm0LogoLink } from "./zero-directed-shared.tsx";
+import { ProductBrandMarkLink } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { useTranslation } from "react-i18next";
 
@@ -224,7 +224,7 @@ function DirectedAuthorizeCardContent({
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
-        <Vm0LogoLink />
+        <ProductBrandMarkLink />
         <div className="flex w-full flex-col gap-4">
           <div className="flex flex-col items-center gap-2.5">
             {isLoading ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -62,7 +62,7 @@ import {
 } from "../../signals/connectors-page/directed-connect-slug.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { Check, Loader2 } from "lucide-react";
-import { Vm0LogoLink } from "./zero-directed-shared.tsx";
+import { ProductBrandMarkLink } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import type { FormEvent, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -570,7 +570,7 @@ function DirectedConnectCardContent({
   return (
     <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
-        <Vm0LogoLink />
+        <ProductBrandMarkLink />
         <div className="flex w-full flex-col gap-4">
           <div className="flex flex-col items-center gap-2.5">
             {isLoading ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -1,15 +1,15 @@
 import type { ReactNode } from "react";
 import { useGet, useSet } from "ccstate-react";
-import { useTranslation } from "react-i18next";
 import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
 import {
   closeSettingsModal$,
   settingsDialogOpen$,
 } from "../../signals/zero-page/settings/settings-dialog.ts";
-import { SettingsDialog } from "./components/settings/settings-dialog.tsx";
-import { AccountDropdown } from "./zero-sidebar-account";
+import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 import { Link } from "../router/link.tsx";
 import { CreditPurchaseConfirmDialog } from "./components/org-manage/credit-purchase-confirm-dialog.tsx";
+import { SettingsDialog } from "./components/settings/settings-dialog.tsx";
+import { AccountDropdown } from "./zero-sidebar-account";
 
 export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
   const onAccountAction = useSet(handleZeroAccountAction$);
@@ -43,53 +43,10 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
   );
 }
 
-export function Vm0LogoLink() {
-  const { t } = useTranslation();
+export function ProductBrandMarkLink() {
   return (
     <Link pathname="/connectors" className="no-underline text-foreground">
-      <svg
-        width="82"
-        height="20"
-        viewBox="0 0 100 30"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        aria-label={t(($) => {
-          return $.appShell.logoAlt;
-        })}
-      >
-        <path
-          d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"
-          fill="#ED4E01"
-        />
-        <path
-          d="M0.710495 8.33374L12.6479 15.2595C12.7944 15.3445 12.8846 15.5015 12.8846 15.6715L12.8843 29.5237C12.8843 29.8899 12.4897 30.1187 12.1741 29.9356L0.236691 23.0096C0.0902206 22.9246 -3.46036e-06 22.7676 0 22.5977L0.00028208 8.74568C0.000289537 8.37949 0.394855 8.15064 0.710495 8.33374Z"
-          fill="#ED4E01"
-        />
-        <path
-          d="M24.947 21.6772C24.947 21.9507 24.8017 22.2036 24.5655 22.3415L16.2103 27.219C15.6975 27.5184 15.0533 27.1485 15.0533 26.5547L15.0531 16.7842C15.0531 16.5107 15.1983 16.2578 15.4345 16.1199L23.7897 11.2425C24.3025 10.9431 24.9468 11.313 24.9468 11.9068L24.947 21.6772ZM13.6541 16.3426V29.5279C13.6541 29.8852 14.0308 30.1106 14.3391 29.9444L14.3538 29.9362L25.5769 23.3654C26.25 22.9808 26.3462 22.6924 26.3459 22.1188L26.3459 8.93378C26.3459 8.57084 25.9572 8.344 25.6462 8.52548L14.4231 15.0001C14.0385 15.2885 13.6539 15.577 13.6541 16.3426Z"
-          fill="#ED4E01"
-        />
-        <path
-          d="M25.9616 10.58L15.2113 28.4616L14.2308 27.8817L24.981 10.0001L25.9616 10.58Z"
-          fill="#ED4E01"
-        />
-        <path
-          d="M42.1865 25L34.3459 5H37.4651L43.7887 21.4575L50.1264 5H53.2315L45.3908 25H42.1865Z"
-          fill="currentColor"
-        />
-        <path
-          d="M66.9877 25L59.4023 10.3417V25H56.4957V5H59.6716L67.413 20.0628L75.1686 5H78.3304V25H75.438V10.3417L67.8526 25H66.9877Z"
-          fill="currentColor"
-        />
-        <path
-          d="M99.3459 22.1409C99.3459 22.5314 99.2703 22.9033 99.1191 23.2566C98.9678 23.6007 98.7599 23.9028 98.4952 24.1632C98.2305 24.4235 97.9186 24.6281 97.5594 24.7768C97.2097 24.9256 96.8363 25 96.4393 25H86.2735C85.8765 25 85.4984 24.9256 85.1392 24.7768C84.7894 24.6281 84.4822 24.4235 84.2176 24.1632C83.9529 23.9028 83.745 23.6007 83.5937 23.2566C83.4425 22.9033 83.3669 22.5314 83.3669 22.1409V7.85914C83.3669 7.46862 83.4425 7.10135 83.5937 6.75732C83.745 6.404 83.9529 6.10181 84.2176 5.85077C84.4822 5.59042 84.7894 5.38587 85.1392 5.2371C85.4984 5.07903 85.8765 5 86.2735 5H96.4393C96.8363 5 97.2097 5.07903 97.5594 5.2371C97.9186 5.38587 98.2305 5.59042 98.4952 5.85077C98.7599 6.10181 98.9678 6.404 99.1191 6.75732C99.2703 7.10135 99.3459 7.46862 99.3459 7.85914V22.1409ZM86.2735 7.85914V22.1409H96.4393V7.85914H86.2735Z"
-          fill="currentColor"
-        />
-        <path
-          d="M94.8994 6.79107L97.1494 8.06891L87.8973 23.8325L85.6473 22.5547L94.8994 6.79107Z"
-          fill="currentColor"
-        />
-      </svg>
+      <ProductBrandMark size="compact" />
     </Link>
   );
 }


### PR DESCRIPTION
## Summary

- introduce one hostname-aware product brand mark for standalone Platform surfaces
- render the approved typographic `Okou` mark on Okou hosts while preserving the existing VM0 SVG on VM0 hosts
- apply the shared mark to browser and Computer Use authorization, connector flows, permission approval, redemption, unsubscribe, and export pages
- cover both `app.okou.ai` and `app.vm0.ai` behavior through the browser authorization page bootstrap

## Brand isolation

- `app.okou.ai` and Okou preview hosts render `Okou`
- `app.vm0.ai` and other VM0 hosts keep the existing VM0 mark and behavior
- no user data, API contracts, routes, product identifiers, favicon, PWA, or Open Graph assets change

## Verification

- `pnpm exec prettier --write <changed Platform files>`
- `pnpm --filter @okouai/app run lint`
- `pnpm --filter @okouai/app run check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm --filter @okouai/app exec vitest run src/views/browser-authorization/__tests__/browser-authorization-page.test.tsx`
