### PR TITLE
refactor(api): remove legacy-all connector scope

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -286,7 +286,6 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_prepare_context_load_persisted_environment",
   "api_dispatch_prepare_context_build_resolved_body",
   "api_dispatch_prepare_context_resolve_framework",
-  "api_dispatch_prepare_context_resolve_connector_scope",
   "api_dispatch_prepare_context_resolve_model_provider",
   "api_dispatch_prepare_context_load_connector_contexts",
   "api_dispatch_prepare_context_load_stored_connectors",
@@ -1234,35 +1233,6 @@ async function entitledRunActor(): Promise<{
   return { actor, agentId: agent.agentId, runnerGroup, granted };
 }
 
-async function zeroBackedDirectRunActor(args?: {
-  readonly visibility?: "private" | "public";
-}): Promise<{
-  readonly actor: ApiTestUser;
-  readonly orgId: string;
-  readonly agentId: string;
-  readonly runnerGroup: string;
-}> {
-  const bdd = createBddApi(context);
-  const api = createRunsApi(context);
-  const actor = bdd.user();
-  if (!actor.orgId) {
-    throw new Error("Zero-backed direct run tests require an org-scoped actor");
-  }
-  bdd.acceptAgentStorageWrites();
-  api.acceptStorageDownloads();
-  api.acceptTelemetryIngest();
-  const runnerGroup = api.configureRunnerGroup();
-  await api.grantProEntitlement(actor);
-  await api.ensureOrgModelProvider(actor);
-
-  const agent = await bdd.createAgent(actor, {
-    displayName: "BDD zero-backed direct agent",
-    visibility: args?.visibility ?? "private",
-  });
-
-  return { actor, orgId: actor.orgId, agentId: agent.agentId, runnerGroup };
-}
-
 function zeroBackedDirectRunBody(args: {
   readonly agentId: string;
   readonly agentComposeVersionId?: string;
@@ -2007,7 +1977,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expect(
       connectorCatalogLoadEvent.connector_catalog_requested_connector_count_bucket,
-    ).toBe("not_applicable");
+    ).toBe("0");
     expectApiDispatchActions(timingEvents, ["api_dispatch_check_org_tier"]);
     expectApiDispatchSpanKind(
       timingEvents,
@@ -7061,146 +7031,6 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("omits connected stored connectors when the Zero-backed direct run allowlist is empty", async () => {
-    const api = createRunsApi(context);
-    const fw = createFirewallApi(context);
-    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
-
-    await fw.seedTestConnector(actor, {
-      connectorSlug: "x",
-      authMethod: "oauth",
-      accessToken: "x-bdd-direct-unallowed-access",
-      refreshToken: "x-bdd-direct-unallowed-refresh",
-    });
-
-    const run = await api.createDirectRun(
-      actor,
-      zeroBackedDirectRunBody({
-        agentId,
-        prompt: "direct run without enabled stored connectors",
-      }),
-    );
-    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
-    expectNoApiDispatchActions(
-      timingEvents,
-      API_DISPATCH_STORED_CONNECTOR_SUBSTEP_ACTION_TYPES,
-    );
-    expectNoApiDispatchActions(
-      timingEvents,
-      API_DISPATCH_CUSTOM_CONNECTOR_TIMING_ACTION_TYPES,
-    );
-    await api.heartbeatRunner(runnerGroup);
-    const claim = await api.claimRunnerJob(run.runId);
-
-    expect(claim.environment ?? {}).not.toHaveProperty("X_TOKEN");
-    expect(claim.secretConnectorMap ?? {}).not.toHaveProperty("X_TOKEN");
-    expect(findFirewallEntry(claim.firewalls, "x")).toBeUndefined();
-    expect(claim.billableFirewalls).not.toContain("x");
-    expect(claim.networkPolicies ?? {}).not.toHaveProperty("x");
-
-    await api.requestCancelRun(actor, run.runId, [200]);
-    const cancelled = await api.readRun(actor, run.runId);
-    expect(cancelled.status).toBe("cancelled");
-  });
-
-  it("omits connected stored connectors for pinned Zero-backed direct run versions", async () => {
-    const api = createRunsApi(context);
-    const fw = createFirewallApi(context);
-    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
-    const compose = await readHistoricalAgentComposeHeadFixture(agentId);
-    const agentComposeVersionId = compose.headVersionId;
-    if (!agentComposeVersionId) {
-      throw new Error("Expected the Zero-backed agent compose to have a head");
-    }
-
-    await fw.seedTestConnector(actor, {
-      connectorSlug: "x",
-      authMethod: "oauth",
-      accessToken: "x-bdd-version-unallowed-access",
-      refreshToken: "x-bdd-version-unallowed-refresh",
-    });
-
-    const run = await api.createDirectRun(
-      actor,
-      zeroBackedDirectRunBody({
-        agentId,
-        agentComposeVersionId,
-        prompt: "direct run pinned to a zero agent version",
-      }),
-    );
-    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
-    expectNoApiDispatchActions(
-      timingEvents,
-      API_DISPATCH_STORED_CONNECTOR_SUBSTEP_ACTION_TYPES,
-    );
-    await api.heartbeatRunner(runnerGroup);
-    const claim = await api.claimRunnerJob(run.runId);
-
-    expect(claim.agentComposeVersionId).toBe(agentComposeVersionId);
-    expect(claim.environment ?? {}).not.toHaveProperty("X_TOKEN");
-    expect(findFirewallEntry(claim.firewalls, "x")).toBeUndefined();
-
-    await api.requestCancelRun(actor, run.runId, [200]);
-  });
-
-  it("rejects same-org non-owner Zero-backed direct runs for private agents", async () => {
-    const bdd = createBddApi(context);
-    const api = createRunsApi(context);
-    const { actor, agentId } = await zeroBackedDirectRunActor();
-    const member = bdd.user({ orgId: actor.orgId, orgRole: "org:member" });
-
-    const rejected = await api.requestDirectRun(
-      member,
-      zeroBackedDirectRunBody({
-        agentId,
-        prompt: "direct run someone else's private zero agent",
-      }),
-      [403],
-    );
-
-    expectApiError(rejected.body);
-    expect(rejected.body.error.message).toBe(
-      "Only the private agent owner can run this agent",
-    );
-  });
-
-  it("allows same-org non-owner Zero-backed direct runs for public agents without owner connector leakage", async () => {
-    const bdd = createBddApi(context);
-    const api = createRunsApi(context);
-    const fw = createFirewallApi(context);
-    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor({
-      visibility: "public",
-    });
-    const member = bdd.user({ orgId: actor.orgId, orgRole: "org:member" });
-
-    await fw.seedTestConnector(actor, {
-      connectorSlug: "x",
-      authMethod: "oauth",
-      accessToken: "x-bdd-public-owner-access",
-      refreshToken: "x-bdd-public-owner-refresh",
-    });
-    const enabled = await api.enableAgentConnectors(actor, agentId, ["x"]);
-    expect(enabled).toContain("x");
-
-    const run = await api.createDirectRun(
-      member,
-      zeroBackedDirectRunBody({
-        agentId,
-        prompt: "direct run someone else's public zero agent",
-      }),
-    );
-    await api.heartbeatRunner(runnerGroup);
-    const claim = await api.claimRunnerJob(run.runId);
-
-    expect(claim.environment ?? {}).not.toHaveProperty("X_TOKEN");
-    expect(claim.secretConnectorMap ?? {}).not.toHaveProperty("X_TOKEN");
-    expect(findFirewallEntry(claim.firewalls, "x")).toBeUndefined();
-    expect(claim.billableFirewalls).not.toContain("x");
-    expect(claim.networkPolicies ?? {}).not.toHaveProperty("x");
-
-    await api.requestCancelRun(member, run.runId, [200]);
-  });
-
   it("injects oauth connector tokens with billable firewalls and resolvable secrets", async () => {
     const api = createRunsApi(context);
     const fw = createFirewallApi(context);
@@ -7352,6 +7182,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       agentComposeId: compose.composeId,
       prompt: "use overridden x connector secret",
       secrets: { X_TOKEN: "body-x-token" },
+      connectorScope: {
+        allowedConnectorSlugs: ["x"],
+        allowedCustomConnectorIds: [],
+      },
     });
     expect(kms.decryptCalls).toBe(0);
 
@@ -7369,7 +7203,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     );
     expect(buildStoredConnectorStateEvent).toStrictEqual(
       expect.objectContaining({
-        connector_scope_source: "legacy_all",
+        connector_scope_source: "explicit",
         stored_connector_count_bucket: "1",
         stored_connector_secret_count_bucket: "0",
       }),
@@ -7453,6 +7287,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const run = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
       prompt: "use compose-overridden gitlab token",
+      connectorScope: {
+        allowedConnectorSlugs: ["gitlab"],
+        allowedCustomConnectorIds: [],
+      },
     });
     expect(kms.decryptCalls).toBe(0);
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
@@ -7499,6 +7337,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const run = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
       prompt: "use stored connector variable aliases",
+      connectorScope: {
+        allowedConnectorSlugs: ["test-oauth"],
+        allowedCustomConnectorIds: [],
+      },
     });
 
     await api.heartbeatRunner(runnerGroup);
@@ -7548,6 +7390,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const compatibleRun = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
       prompt: "materialize compatible connector state",
+      connectorScope: {
+        allowedConnectorSlugs: ["test-oauth"],
+        allowedCustomConnectorIds: [],
+      },
     });
     await api.heartbeatRunner(runnerGroup);
     const compatibleClaim = await api.claimRunnerJob(compatibleRun.runId);
@@ -7574,6 +7420,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const incompatibleRun = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
       prompt: "do not materialize incompatible connector state",
+      connectorScope: {
+        allowedConnectorSlugs: ["test-oauth"],
+        allowedCustomConnectorIds: [],
+      },
     });
     const timingEvents = apiDispatchTimingEventsForRun(incompatibleRun.runId);
     expectApiDispatchActions(timingEvents, [
@@ -7589,7 +7439,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     );
     expect(loadSnapshotEvent).toStrictEqual(
       expect.objectContaining({
-        connector_scope_source: "legacy_all",
+        connector_scope_source: "explicit",
         stored_connector_candidate_count_bucket: "1",
       }),
     );
@@ -7599,7 +7449,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     );
     expect(materializeSnapshotEvent).toStrictEqual(
       expect.objectContaining({
-        connector_scope_source: "legacy_all",
+        connector_scope_source: "explicit",
         stored_connector_candidate_count_bucket: "1",
         stored_connector_count_bucket: "0",
         stored_connector_secret_count_bucket: "0",
@@ -7615,62 +7465,6 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     );
 
     await api.requestCancelRun(actor, incompatibleRun.runId, [200]);
-  });
-
-  it("injects only enabled stored connectors for Zero-backed direct runs", async () => {
-    const api = createRunsApi(context);
-    const fw = createFirewallApi(context);
-    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
-
-    await fw.seedTestConnector(actor, {
-      connectorSlug: "x",
-      authMethod: "oauth",
-      accessToken: "x-bdd-direct-access",
-      refreshToken: "x-bdd-direct-refresh",
-    });
-    await fw.seedTestConnector(actor, {
-      connectorSlug: "slack",
-      authMethod: "oauth",
-      accessToken: "xoxb-bdd-direct-unenabled-access",
-    });
-    const enabled = await api.enableAgentConnectors(actor, agentId, ["x"]);
-    expect(enabled).toContain("x");
-
-    const run = await api.createDirectRun(
-      actor,
-      zeroBackedDirectRunBody({
-        agentId,
-        prompt: "direct run with the x connector",
-      }),
-    );
-    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
-    expectApiDispatchActions(
-      timingEvents,
-      API_DISPATCH_STORED_CONNECTOR_SNAPSHOT_ACTION_TYPES,
-    );
-    expectNoApiDispatchActions(timingEvents, [
-      "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
-    ]);
-    await api.heartbeatRunner(runnerGroup);
-    const claim = await api.claimRunnerJob(run.runId);
-
-    expect(claim.environment?.X_TOKEN).toBe(
-      connectorPlaceholder("x", "X_TOKEN"),
-    );
-    expect(claim.secretConnectorMap).toMatchObject({ X_TOKEN: "x" });
-    expect(findFirewallEntry(claim.firewalls, "x")).toStrictEqual({
-      kind: "builtin",
-      name: "x",
-    });
-    expect(claim.billableFirewalls).toContain("x");
-    expect(claim.networkPolicies?.x?.unknownPolicy).toBe("allow");
-    expect(claim.environment).not.toHaveProperty("SLACK_TOKEN");
-    expect(claim.secretConnectorMap).not.toHaveProperty("SLACK_TOKEN");
-    expect(findFirewallEntry(claim.firewalls, "slack")).toBeUndefined();
-    expect(claim.billableFirewalls).not.toContain("slack");
-    expect(claim.networkPolicies ?? {}).not.toHaveProperty("slack");
-
-    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("injects manual-grant api-token connectors and their optional variables", async () => {
@@ -7968,6 +7762,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
         agentId,
         prompt: "use google ads with explicit developer token",
       }),
+      connectorScope: {
+        allowedConnectorSlugs: ["google-ads"],
+        allowedCustomConnectorIds: [],
+      },
       secrets: {
         OKOU_TOKEN: "bdd-okou-direct-token",
         GOOGLE_ADS_DEVELOPER_TOKEN: "body-developer-token",
@@ -10262,83 +10060,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
-  it("injects only enabled custom connector firewalls for Zero-backed direct runs", async () => {
-    const api = createRunsApi(context);
-    const connectors = createConnectorBddApi(context);
-    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
-
-    const allowedSlug = `_bdd-direct-internal-${randomUUID().slice(0, 8)}`;
-    const allowed = await connectors.createCustomConnector(
-      actor,
-      manualHttpCustomConnectorCreateBody({
-        slug: allowedSlug,
-        displayName: "BDD Direct Internal API",
-        prefixTemplates: ["https://*.direct.internal.example.com/api/"],
-      }),
-    );
-    await connectors.setCustomConnectorSecret(
-      actor,
-      allowed.id,
-      "direct-custom-secret-value",
-    );
-
-    const blockedSlug = `_bdd-direct-blocked-${randomUUID().slice(0, 8)}`;
-    const blocked = await connectors.createCustomConnector(
-      actor,
-      manualHttpCustomConnectorCreateBody({
-        slug: blockedSlug,
-        displayName: "BDD Direct Blocked API",
-        prefixTemplates: ["https://*.blocked.internal.example.com/api/"],
-      }),
-    );
-    await connectors.setCustomConnectorSecret(
-      actor,
-      blocked.id,
-      "blocked-custom-secret-value",
-    );
-
-    await connectors.updateAgentCustomConnectors(actor, agentId, [allowed.id]);
-
-    const run = await api.createDirectRun(
-      actor,
-      zeroBackedDirectRunBody({
-        agentId,
-        prompt: "direct run with the custom connector",
-      }),
-    );
-    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
-    expectApiDispatchActions(
-      timingEvents,
-      API_DISPATCH_CUSTOM_CONNECTOR_TIMING_ACTION_TYPES,
-    );
-    expectCustomConnectorRuntimePhaseTimingEvents(timingEvents);
-    expectApiDispatchTimingEventsNotToLeak(timingEvents, [
-      allowed.id,
-      allowedSlug,
-      "direct-custom-secret-value",
-      blocked.id,
-      blockedSlug,
-      "blocked-custom-secret-value",
-    ]);
-    await api.heartbeatRunner(runnerGroup);
-    const claim = await api.claimRunnerJob(run.runId);
-
-    const allowedInternalName = `custom_connector_${allowed.id.replaceAll("-", "")}`;
-    const blockedInternalName = `custom_connector_${blocked.id.replaceAll("-", "")}`;
-    expect(
-      findFirewallEntry(claim.firewalls, allowedInternalName),
-    ).toBeDefined();
-    expect(
-      findFirewallEntry(claim.firewalls, blockedInternalName),
-    ).toBeUndefined();
-    expect(claim.networkPolicies?.[allowedInternalName]?.unknownPolicy).toBe(
-      "allow",
-    );
-    expect(claim.networkPolicies ?? {}).not.toHaveProperty(blockedInternalName);
-
-    await api.requestCancelRun(actor, run.runId, [200]);
-  });
-
   it("injects proposed custom connector fields into headers, query, and host templates", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
@@ -12284,6 +12005,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const run = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
       prompt: "direct run cloudflare defaults",
+      connectorScope: {
+        allowedConnectorSlugs: ["cloudflare"],
+        allowedCustomConnectorIds: [],
+      },
     });
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectApiDispatchActions(
@@ -12370,7 +12095,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     const appUrl = "https://app.writer-stop.example.test";
     mockEnv("APP_URL", appUrl);
     const api = createRunsApi(context);
-    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
     if (!actor.orgId) {
       throw new Error("The legacy compose fixture requires an organization");
     }

--- a/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
@@ -6,10 +6,6 @@ import type { AgentCustomConnectorGrant } from "@okouai/api-contracts/contracts/
 import { userCustomConnectors } from "@okouai/db/schema/user-custom-connector";
 import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
 import { userConnectors } from "@okouai/db/schema/user-connector";
-import {
-  zeroAgents,
-  type ZeroAgentVisibility,
-} from "@okouai/db/schema/zero-agent";
 import { and, eq } from "drizzle-orm";
 
 import type { ReadonlyDb } from "../external/db";
@@ -27,11 +23,6 @@ export interface AgentConnectorSlugRow {
 export interface AgentCustomConnectorRow {
   readonly customConnectorId: string;
   readonly permissionNames: readonly string[];
-}
-
-interface ZeroBackedComposeAgent {
-  readonly owner: string;
-  readonly visibility: ZeroAgentVisibility;
 }
 
 async function loadAgentAllowedConnectorSlugRows(
@@ -122,27 +113,4 @@ export async function loadAgentConnectorScope(
     loadAgentAllowedCustomConnectorRows(db, args),
   ]);
   return agentConnectorScopeFromRows({ connectorRows, customConnectorRows });
-}
-
-export async function loadZeroBackedComposeAgent(
-  db: ReadonlyDb,
-  args: {
-    readonly composeId: string;
-  },
-): Promise<ZeroBackedComposeAgent | null> {
-  // The caller must verify agent_composes.org_id first. zero_agents.org_id is
-  // denormalized and must not decide whether a resolved compose is Zero-backed.
-  const [agent] = await db
-    .select({
-      id: zeroAgents.id,
-      owner: zeroAgents.owner,
-      visibility: zeroAgents.visibility,
-    })
-    .from(zeroAgents)
-    .where(eq(zeroAgents.id, args.composeId))
-    .limit(1);
-  if (!agent) {
-    return null;
-  }
-  return { owner: agent.owner, visibility: agent.visibility };
 }

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -284,10 +284,6 @@ import {
   type ApiDispatchTimingDimensions,
 } from "./api-dispatch-timing.service";
 import {
-  loadAgentConnectorScope,
-  loadZeroBackedComposeAgent,
-} from "./agent-connector-scope.service";
-import {
   isCompressedSessionHistoryBlobEncoding,
   normalizeSessionHistoryBlobEncoding,
   type CompressedSessionHistoryBlobEncoding,
@@ -519,11 +515,11 @@ interface ResolvedCompose {
   readonly resumeSession?: StoredExecutionContext["resumeSession"];
 }
 
-type ConnectorScopeSource = "explicit" | "zero_agent" | "legacy_all" | "empty";
+type ConnectorScopeSource = "explicit" | "zero_agent" | "empty";
 
 interface EffectiveConnectorScope {
-  readonly allowedConnectorSlugs: readonly ConnectorSlug[] | undefined;
-  readonly allowedCustomConnectorIds: readonly string[] | undefined;
+  readonly allowedConnectorSlugs: readonly ConnectorSlug[];
+  readonly allowedCustomConnectorIds: readonly string[];
   readonly customConnectorGrants:
     | readonly AgentCustomConnectorGrant[]
     | undefined;
@@ -534,7 +530,7 @@ interface ExplicitConnectorScope {
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly customConnectorGrants?: readonly AgentCustomConnectorGrant[];
-  readonly source?: Exclude<ConnectorScopeSource, "legacy_all" | "empty">;
+  readonly source?: Exclude<ConnectorScopeSource, "empty">;
 }
 
 // Session naming in this service:
@@ -863,7 +859,7 @@ export interface CreateAgentRunArgs {
       readonly workflowId: string;
     }[];
   };
-  readonly connectorScope?: ExplicitConnectorScope;
+  readonly connectorScope: ExplicitConnectorScope;
   readonly validateEnvironmentReferences?: boolean;
   readonly zeroRunMetadata?: ZeroRunMetadata;
   readonly queueOnConcurrencyLimit?: boolean;
@@ -1112,7 +1108,7 @@ function buildCustomConnectorSkillVolumes(
 function buildInjectedSkillVolumes(
   args: {
     readonly injectSkillVolumes: CreateAgentRunArgs["injectSkillVolumes"];
-    readonly allowedConnectorSlugs: readonly ConnectorSlug[] | undefined;
+    readonly allowedConnectorSlugs: readonly ConnectorSlug[];
     readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   },
   skillsRoot: string,
@@ -1120,7 +1116,6 @@ function buildInjectedSkillVolumes(
   if (!args.injectSkillVolumes) {
     return undefined;
   }
-  const connectorSlugs = args.allowedConnectorSlugs ?? [];
   const seedSkillNames = [...SEED_SKILLS, GOAL_SKILL_NAME];
   // Connector rollout switches govern discovery only. Once a connector slug is
   // part of a run, its accepted catalog skill remains executable and mountable.
@@ -1130,7 +1125,7 @@ function buildInjectedSkillVolumes(
       "system_skill",
     ) ?? []),
     ...buildConnectorSkillVolumes(
-      connectorSlugs,
+      args.allowedConnectorSlugs,
       args.connectorCatalogSnapshot,
       skillsRoot,
     ),
@@ -2920,7 +2915,7 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
 
 function allowedStoredConnectorRows(
   rows: readonly StoredConnectorRuntimeRowCandidate[],
-  allowedConnectorSlugs: readonly ConnectorSlug[] | undefined,
+  allowedConnectorSlugs: readonly ConnectorSlug[],
   snapshot: ConnectorRuntimeSnapshot,
   now: Date,
 ): readonly StoredConnectorRuntimeRow[] {
@@ -2954,8 +2949,7 @@ function allowedStoredConnectorRows(
   });
   return validRows.filter((row) => {
     return (
-      (!allowedConnectorSlugs ||
-        allowedConnectorSlugs.includes(row.connectorSlug)) &&
+      allowedConnectorSlugs.includes(row.connectorSlug) &&
       storedConnectorRuntimeCredentialStatus(row, now) === "available"
     );
   });
@@ -3541,19 +3535,17 @@ async function loadStoredConnectorMaterializationPlan(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorSlugs: readonly ConnectorSlug[] | undefined;
+    readonly allowedConnectorSlugs: readonly ConnectorSlug[];
     readonly scopeSource: ConnectorScopeSource;
     readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   },
   timing?: ApiDispatchTimingCollector,
 ): Promise<StoredConnectorMaterializationSnapshot | null> {
-  if (args.allowedConnectorSlugs?.length === 0) {
+  if (args.allowedConnectorSlugs.length === 0) {
     return null;
   }
 
-  const allowedConnectorSlugs = args.allowedConnectorSlugs
-    ? [...new Set(args.allowedConnectorSlugs)]
-    : undefined;
+  const allowedConnectorSlugs = [...new Set(args.allowedConnectorSlugs)];
 
   const snapshot = await loadStoredConnectorMaterializationSnapshot(
     db,
@@ -3574,7 +3566,7 @@ function storedConnectorSnapshotQuery(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorSlugs: readonly ConnectorSlug[] | undefined;
+    readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   },
 ) {
   const selectedConnectors = db.$with("stored_connector_candidates").as(
@@ -3603,9 +3595,7 @@ function storedConnectorSnapshotQuery(
           eq(connectors.orgId, args.orgId),
           eq(connectors.userId, args.userId),
           isNotNull(connectors.connectorSlug),
-          args.allowedConnectorSlugs
-            ? inArray(connectors.connectorSlug, args.allowedConnectorSlugs)
-            : undefined,
+          inArray(connectors.connectorSlug, args.allowedConnectorSlugs),
         ),
       ),
   );
@@ -3684,7 +3674,7 @@ async function loadStoredConnectorSnapshotRows(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorSlugs: readonly ConnectorSlug[] | undefined;
+    readonly allowedConnectorSlugs: readonly ConnectorSlug[];
     readonly timingDimensions: ApiDispatchTimingDimensions;
   },
   timing?: ApiDispatchTimingCollector,
@@ -3714,7 +3704,7 @@ async function loadStoredConnectorSnapshotRows(
 
 function buildStoredConnectorMaterializationPlan(args: {
   readonly connectorRows: readonly StoredConnectorRuntimeRowCandidate[];
-  readonly allowedConnectorSlugs: readonly ConnectorSlug[] | undefined;
+  readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
 }): StoredConnectorMaterializationPlan | null {
   const allowedConnectorRows = allowedStoredConnectorRows(
@@ -3737,7 +3727,7 @@ function buildStoredConnectorMaterializationPlan(args: {
 function materializeStoredConnectorSnapshotRows(
   args: {
     readonly rows: readonly StoredConnectorMaterializationSnapshotRow[];
-    readonly allowedConnectorSlugs: readonly ConnectorSlug[] | undefined;
+    readonly allowedConnectorSlugs: readonly ConnectorSlug[];
     readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
     readonly timingDimensions: ApiDispatchTimingDimensions;
   },
@@ -3821,7 +3811,7 @@ async function loadStoredConnectorMaterializationSnapshot(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorSlugs: readonly ConnectorSlug[] | undefined;
+    readonly allowedConnectorSlugs: readonly ConnectorSlug[];
     readonly scopeSource: ConnectorScopeSource;
     readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
   },
@@ -4497,7 +4487,7 @@ async function loadCustomConnectorContext(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedCustomConnectorIds: readonly string[] | undefined;
+    readonly allowedCustomConnectorIds: readonly string[];
     readonly customConnectorGrants:
       | readonly AgentCustomConnectorGrant[]
       | undefined;
@@ -4507,7 +4497,7 @@ async function loadCustomConnectorContext(
   signal: AbortSignal,
   timing?: ApiDispatchTimingCollector,
 ): Promise<CustomConnectorRuntimeContext> {
-  if (args.allowedCustomConnectorIds?.length === 0) {
+  if (args.allowedCustomConnectorIds.length === 0) {
     return {
       firewalls: [],
       reservedSecretAliases: undefined,
@@ -7950,9 +7940,6 @@ function connectorScopeForRuntimeSnapshot(
   scope: EffectiveConnectorScope,
   snapshot: ConnectorRuntimeSnapshot,
 ): EffectiveConnectorScope {
-  if (scope.allowedConnectorSlugs === undefined) {
-    return scope;
-  }
   return {
     ...scope,
     allowedConnectorSlugs: scope.allowedConnectorSlugs.filter(
@@ -7971,10 +7958,7 @@ function connectorScopeForRuntimeSnapshot(
 
 function connectorScopeFromCreateArgs(
   args: CreateAgentRunArgs,
-): EffectiveConnectorScope | null {
-  if (!args.connectorScope) {
-    return null;
-  }
+): EffectiveConnectorScope {
   const source =
     args.connectorScope.allowedConnectorSlugs.length === 0 &&
     args.connectorScope.allowedCustomConnectorIds.length === 0
@@ -7985,53 +7969,6 @@ function connectorScopeFromCreateArgs(
     allowedCustomConnectorIds: args.connectorScope.allowedCustomConnectorIds,
     customConnectorGrants: args.connectorScope.customConnectorGrants,
     source,
-  };
-}
-
-async function resolveEffectiveConnectorScope(
-  args: {
-    readonly db: Db;
-    readonly createArgs: CreateAgentRunArgs;
-    readonly resolved: ResolvedCompose;
-  },
-  signal: AbortSignal,
-): Promise<EffectiveConnectorScope | CreateRunErrorResult> {
-  const createArgsScope = connectorScopeFromCreateArgs(args.createArgs);
-  if (createArgsScope) {
-    return createArgsScope;
-  }
-
-  const zeroBackedAgent = await loadZeroBackedComposeAgent(args.db, {
-    composeId: args.resolved.composeId,
-  });
-  signal.throwIfAborted();
-  if (zeroBackedAgent) {
-    if (
-      zeroBackedAgent.visibility === "private" &&
-      zeroBackedAgent.owner !== args.createArgs.userId
-    ) {
-      return forbidden("Only the private agent owner can run this agent");
-    }
-    const scope = await loadAgentConnectorScope(args.db, {
-      userId: args.createArgs.userId,
-      orgId: args.createArgs.orgId,
-      agentId: args.resolved.composeId,
-    });
-    return {
-      ...scope,
-      source:
-        scope.allowedConnectorSlugs.length === 0 &&
-        scope.allowedCustomConnectorIds.length === 0
-          ? "empty"
-          : "zero_agent",
-    };
-  }
-
-  return {
-    allowedConnectorSlugs: undefined,
-    allowedCustomConnectorIds: undefined,
-    customConnectorGrants: undefined,
-    source: "legacy_all",
   };
 }
 
@@ -8110,24 +8047,7 @@ async function prepareRunBodyContext(
   if (resolved.orgId !== args.createArgs.orgId) {
     return notFound("Resource not found");
   }
-  const connectorScope = await args.timing.measure(
-    "api_dispatch_prepare_context_resolve_connector_scope",
-    "nested",
-    async () => {
-      return await resolveEffectiveConnectorScope(
-        {
-          db: args.db,
-          createArgs: args.createArgs,
-          resolved,
-        },
-        signal,
-      );
-    },
-  );
-  signal.throwIfAborted();
-  if (isRouteError(connectorScope)) {
-    return connectorScope;
-  }
+  const connectorScope = connectorScopeFromCreateArgs(args.createArgs);
   const persistedEnvironment = await args.timing.measure(
     "api_dispatch_prepare_context_load_persisted_environment",
     "nested",
@@ -8388,8 +8308,7 @@ async function connectorCatalogSnapshotForRun(args: {
     args.preloadedConnectorCatalogSnapshot ??
     (await loadConnectorRuntimeSnapshot(args.db, {
       timing: args.timing,
-      requestedConnectorCount:
-        args.connectorScope.allowedConnectorSlugs?.length,
+      requestedConnectorCount: args.connectorScope.allowedConnectorSlugs.length,
     }))
   );
 }

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -105,7 +105,6 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_prepare_context_load_persisted_environment"
   | "api_dispatch_prepare_context_build_resolved_body"
   | "api_dispatch_prepare_context_resolve_framework"
-  | "api_dispatch_prepare_context_resolve_connector_scope"
   | "api_dispatch_prepare_context_resolve_model_provider"
   | "api_dispatch_prepare_context_load_connector_contexts"
   | "api_dispatch_prepare_context_load_stored_connectors"

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -28,6 +28,7 @@ export type DirectRunFixtureRequest = Omit<
   "triggerSource"
 > & {
   readonly triggerSource?: TriggerSource;
+  readonly connectorScope?: CreateAgentRunArgs["connectorScope"];
   readonly ownedSystemStorageMounts?: readonly {
     readonly storageId: string;
     readonly version?: string;
@@ -87,7 +88,7 @@ export async function createDirectRunFixture(args: {
   readonly body: DirectRunFixtureRequest;
   readonly signal: AbortSignal;
 }) {
-  const { ownedSystemStorageMounts, ...body } = args.body;
+  const { connectorScope, ownedSystemStorageMounts, ...body } = args.body;
   const resolvedOwnedSystemStorageMounts =
     await resolveOwnedSystemStorageMounts(
       ownedSystemStorageMounts,
@@ -101,6 +102,10 @@ export async function createDirectRunFixture(args: {
       orgId: args.orgId,
       apiStartTime: now(),
       modelProviderType: body.modelProviderType,
+      connectorScope: connectorScope ?? {
+        allowedConnectorSlugs: [],
+        allowedCustomConnectorIds: [],
+      },
       body: {
         ...body,
         ...(resolvedOwnedSystemStorageMounts.length === 0

--- a/turbo/apps/api/src/test-fixtures/thread-bound-run-admission.ts
+++ b/turbo/apps/api/src/test-fixtures/thread-bound-run-admission.ts
@@ -54,6 +54,10 @@ export async function createUnassociatedThreadBoundAgentRunFixture(
       },
       apiStartTime: now(),
       chatThreadId,
+      connectorScope: {
+        allowedConnectorSlugs: [],
+        allowedCustomConnectorIds: [],
+      },
     },
     new AbortController().signal,
   );


### PR DESCRIPTION
## Summary

- require every internal agent-run caller to provide a concrete connector scope
- remove the retired `legacy_all` fallback and its Zero-backed compose lookup
- make direct-run test fixtures fail closed by default and declare connector access explicitly where needed
- remove fallback-only tests and telemetry that no longer represent production behavior

## Why

Production Zero runs already resolve connector permissions before entering the lower agent-run service. The optional scope kept an obsolete direct-run compatibility path alive, where a missing scope meant access to every stored connector. Requiring a concrete scope removes that ambiguous and unsafe state.

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=4 --silent=passed-only` (153 tests)
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (3018 tests)
- `pnpm knip`
- pre-commit hooks

Closes #27645
