### PR TITLE
test(e2e): use sonnet 5 for real claude coverage

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 WORKFLOW="${REPO_ROOT}/.github/workflows/turbo.yml"
 RUNNER_START_HELPER="${REPO_ROOT}/.github/scripts/reconcile-and-start-runner-groups.sh"
 RUNNER_TESTS="${REPO_ROOT}/e2e/tests/03-runner"
+REAL_CLAUDE_TEST="${RUNNER_TESTS}/run-t10-real-claude-smoke.bats"
 RUNNER_HELPERS=(
   "${REPO_ROOT}/e2e/helpers/runner-api.bash"
   "${REPO_ROOT}/e2e/helpers/runner-chat.bash"
@@ -38,6 +39,14 @@ if grep -Fq 'playwright-staging' "$WORKFLOW"; then
 fi
 if grep -R -Fq '/api/test/' "$RUNNER_TESTS" "${RUNNER_HELPERS[@]}"; then
   fail "runner E2E coverage must use supported public APIs"
+fi
+grep -Fq 'REAL_CLAUDE_MODEL="claude-sonnet-5"' "$REAL_CLAUDE_TEST" ||
+  fail "real Claude E2E must select Sonnet 5"
+if [[ "$(grep -Fc '"$REAL_CLAUDE_MODEL"' "$REAL_CLAUDE_TEST")" -ne 3 ]]; then
+  fail "real Claude E2E must use its model pin for policy, smoke, and steer coverage"
+fi
+if grep -Fq 'claude-sonnet-4-6' "$REAL_CLAUDE_TEST"; then
+  fail "real Claude E2E must not retain the Sonnet 4.6 pin"
 fi
 grep -Fq 'startVideoOnboardingCheckout' "$RUNNER_TOKEN" ||
   fail "real runner accounts must upgrade through public paid onboarding"
@@ -338,12 +347,20 @@ claude_script = claude_step.fetch("run")
 %w[
   /api/okou/model-policies
   /api/okou/feature-switches
-  claude-sonnet-4-6
   realAgentInPreview
 ].each do |required_fragment|
   unless claude_script.include?(required_fragment)
     raise "real Claude bootstrap must include #{required_fragment}"
   end
+end
+unless claude_script.include?('claude_model="claude-sonnet-5"') &&
+    claude_script.include?('--arg model "$claude_model"') &&
+    claude_script.include?('select(.model != $model)') &&
+    claude_script.include?('model: $model')
+  raise "real Claude bootstrap must configure Sonnet 5 consistently"
+end
+if claude_script.include?("claude-sonnet-4-6")
+  raise "real Claude bootstrap must not retain the Sonnet 4.6 pin"
 end
 unless claude_script.include?('defaultProviderType: "vm0"') &&
     claude_script.include?("modelProviderId: null")

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2599,6 +2599,7 @@ jobs:
           token=$(jq -er '.token | select(type == "string" and length > 0)' /tmp/e2e-api-credentials-runner-real-claude.json)
           api_url=$(jq -er '.apiUrl | select(type == "string" and length > 0)' /tmp/e2e-api-credentials-runner-real-claude.json)
           echo "::add-mask::$token"
+          claude_model="claude-sonnet-5"
 
           headers=(-H "Authorization: Bearer ${token}" -H "Content-Type: application/json")
           if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
@@ -2606,11 +2607,11 @@ jobs:
           fi
 
           policies=$(curl -fsS "${headers[@]}" "${api_url}/api/okou/model-policies")
-          policy_payload=$(jq -c '
+          policy_payload=$(jq -c --arg model "$claude_model" '
             {
               policies: (
                 [.policies[] |
-                  select(.model != "claude-sonnet-4-6") |
+                  select(.model != $model) |
                   {
                     model,
                     isDefault,
@@ -2620,7 +2621,7 @@ jobs:
                   }
                 ] + [
                   {
-                    model: "claude-sonnet-4-6",
+                    model: $model,
                     isDefault: false,
                     defaultProviderType: "vm0",
                     credentialScope: "org",

--- a/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
@@ -7,6 +7,7 @@ load '../../helpers/runner-chat'
 load '../../helpers/runner-api'
 
 BATS_TEST_TIMEOUT=600
+REAL_CLAUDE_MODEL="claude-sonnet-5"
 
 setup_file() {
     local credentials="/tmp/e2e-api-credentials-runner-real-claude.json"
@@ -90,7 +91,7 @@ run_real_claude_steer() {
         "$RUNNER_AGENT_ID" \
         "$initial_prompt" \
         "$steer_prompt" \
-        "claude-sonnet-4-6" \
+        "$REAL_CLAUDE_MODEL" \
         "$expected_output" \
         150)" || return 1
     run_id="$(jq -er '.runId' <<< "$steer_result")" || return 1
@@ -128,9 +129,9 @@ run_real_claude_steer() {
 @test "vm0-managed real claude returns a successful answer" {
     run runner_api_curl "/api/okou/model-policies"
     assert_success
-    run jq -e '
+    run jq -e --arg model "$REAL_CLAUDE_MODEL" '
         any(.policies[]?;
-            .model == "claude-sonnet-4-6" and
+            .model == $model and
             .defaultProviderType == "vm0" and
             .credentialScope == "org" and
             .modelProviderId == null
@@ -141,7 +142,7 @@ run_real_claude_steer() {
     run run_real_chat \
         "123+456. Reply only RESULT=<answer>." \
         "RESULT=579" \
-        "claude-sonnet-4-6"
+        "$REAL_CLAUDE_MODEL"
 
     assert_success
     assert_output --partial '"status":"completed"'


### PR DESCRIPTION
## Summary

- switch the dedicated VM0-managed real Claude runner e2e from Sonnet 4.6 to the supported Sonnet 5 model
- keep workflow policy replacement, smoke selection, policy verification, and active-run steering aligned through boundary-local model constants
- extend the workflow regression script to reject a stale Sonnet 4.6 pin in the dedicated real-Claude paths while preserving independent mock and limited-free fixtures

## Scope and compatibility

- test and CI configuration only
- no product model catalog, provider routing, API, database, runner protocol, production default, or persisted-state changes
- mock Claude, limited-free, and Pi model selections remain unchanged
- the post-completion successor continues using the model selected on its existing thread

## Validation

- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/run-t10-real-claude-smoke.bats` (3 tests)
- `cd e2e && pnpm test` (35 passed)
- `cd e2e && pnpm check-types`
- `cd turbo && pnpm exec prettier --check ../.github/workflows/turbo.yml ../.github/scripts/tests/turbo-playwright-runner-workflow-test.sh ../e2e/tests/03-runner/run-t10-real-claude-smoke.bats --ignore-unknown`
- `git diff --check`
- validated the parameterized `jq` policy replacement against representative existing Sonnet policies

The full workflow regression script, ShellCheck, workflow shell-compatibility check, and Actionlint require tools not installed in the local container (`ruby`, `shellcheck`, `yq`, and `actionlint`) and remain CI validation. The deployed `03-runner` Bats suite is CI-only and is the authoritative Sonnet 5 smoke/steer gate.

Closes #27657
