### PR TITLE
fix(api): derive missing connector catalog compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-by-slug-delete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-by-slug-delete.test.ts
@@ -9,7 +9,7 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import {
-  deleteApiTestConnectorCatalogCompatibility,
+  invalidateApiTestConnectorCatalogCompatibility,
   installApiTestConnectorCatalog,
 } from "../../../test-fixtures/connector-catalog";
 import {
@@ -238,7 +238,7 @@ describe("DELETE /api/zero/connectors/:connectorSlug", () => {
     await connectOpenai(fixture);
     mockOptionalEnv("CLOSE_OAUTH_CLIENT_ID", undefined);
     await installApiTestConnectorCatalog();
-    await deleteApiTestConnectorCatalogCompatibility();
+    await invalidateApiTestConnectorCatalogCompatibility();
 
     const response = await deleteConnector(fixture, "openai", [204]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-by-slug-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-by-slug-get.test.ts
@@ -12,7 +12,7 @@ import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import {
-  deleteApiTestConnectorCatalogCompatibility,
+  invalidateApiTestConnectorCatalogCompatibility,
   installApiTestConnectorCatalog,
 } from "../../../test-fixtures/connector-catalog";
 import { signSandboxJwtForTests } from "../../auth/tokens";
@@ -202,7 +202,7 @@ describe("GET /api/zero/connectors/:connectorSlug", () => {
     await connectOpenai(fixture);
     mockOptionalEnv("DROPBOX_OAUTH_CLIENT_ID", undefined);
     await installApiTestConnectorCatalog();
-    await deleteApiTestConnectorCatalogCompatibility();
+    await invalidateApiTestConnectorCatalogCompatibility();
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context, routes: connectorsRoutes })(

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-list.test.ts
@@ -11,7 +11,7 @@ import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import {
-  deleteApiTestConnectorCatalogCompatibility,
+  invalidateApiTestConnectorCatalogCompatibility,
   installApiTestConnectorCatalog,
 } from "../../../test-fixtures/connector-catalog";
 import { seedConnectorStorageRow } from "./helpers/connector-credential-storage-state";
@@ -168,7 +168,7 @@ describe("GET /api/zero/connectors", () => {
     await connectGitlab(fixture);
     mockOptionalEnv("BOX_OAUTH_CLIENT_ID", undefined);
     await installApiTestConnectorCatalog();
-    await deleteApiTestConnectorCatalogCompatibility();
+    await invalidateApiTestConnectorCatalogCompatibility();
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
     const client = setupApp({ context, routes: connectorsRoutes })(

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -2101,7 +2101,7 @@ describe("connector catalog valid lifecycle", () => {
     expect(shapeResponse.body.error.code).toBe("PROVIDER_UNAVAILABLE");
   });
 
-  it("keeps stale semantic and compatibility corruption fail closed", async () => {
+  it("keeps corruption fail closed and derives missing compatibility", async () => {
     configureSource();
     const semanticRelease = buildRelease({
       version: "2026-07-27.stale-semantic-corruption",
@@ -2169,9 +2169,16 @@ describe("connector catalog valid lifecycle", () => {
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
-      [503],
+      [200],
     );
-    expect(missingResponse.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+    expect(missingResponse.body).toMatchObject({
+      connectors: [
+        expect.objectContaining({ slug: missingRelease.connectorSlug }),
+      ],
+    });
+    await expect(
+      readApiTestConnectorCatalogCompatibilityEvaluations(),
+    ).resolves.toHaveLength(0);
   });
 
   it("applies compatibility, authored visibility, and request rollout filters", async () => {
@@ -5250,7 +5257,7 @@ describe("connector catalog executable compatibility", () => {
     expect(wireMethods).toStrictEqual(expectedMethods);
   });
 
-  it("fails closed and reconciles a missing compatibility evaluation", async () => {
+  it("derives and reconciles a missing compatibility evaluation", async () => {
     configureSource();
     mockApiTestConnectorProviderConfiguration();
     const release = buildRelease({
@@ -5279,8 +5286,16 @@ describe("connector catalog executable compatibility", () => {
       context,
       routes: connectorCatalogRoutes,
     })(zeroConnectorCatalogContract);
-    const unavailable = await accept(catalogClient.list({ headers }), [503]);
-    expect(unavailable.body.error.code).toBe("PROVIDER_UNAVAILABLE");
+    const beforeReconciliation = await accept(
+      catalogClient.list({ headers }),
+      [200],
+    );
+    expect(beforeReconciliation.body).toMatchObject({
+      connectors: [expect.objectContaining({ slug: release.connectorSlug })],
+    });
+    await expect(
+      readApiTestConnectorCatalogCompatibilityEvaluations(),
+    ).resolves.toHaveLength(0);
 
     mockNow(new Date("2026-07-31T08:01:00.000Z"));
     const reconciled = await syncCatalog();
@@ -5827,14 +5842,11 @@ describe("connector catalog executable compatibility", () => {
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeStaleStatus);
     const stalePublicRead = await accept(
       catalogClient.list({ headers }),
-      [503],
+      [200],
     );
-    expect(stalePublicRead.body).toStrictEqual({
-      error: {
-        code: "PROVIDER_UNAVAILABLE",
-        message: "Connector catalog is temporarily unavailable",
-      },
-    });
+    expect(stalePublicRead.body.connectors).toStrictEqual([
+      expect.objectContaining({ slug: "steam" }),
+    ]);
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeStaleStatus);
 
     mockNow(new Date("2026-07-15T08:20:00.000Z"));
@@ -5903,6 +5915,30 @@ describe("connector catalog executable compatibility", () => {
       stale: true,
       filteredAuthMethods: [],
     });
+    expect(
+      (await accept(catalogClient.list({ headers }), [200])).body.connectors,
+    ).toStrictEqual([]);
+
+    mockNow(new Date("2026-07-15T08:40:00.000Z"));
+    const rolledBack = await syncCatalog();
+    expect(rolledBack.body).toMatchObject({
+      outcome: "unchanged",
+      filtering: {
+        capabilityDigest: firstDigest,
+        evaluatedAt: "2026-07-15T08:40:00.000Z",
+        stale: false,
+        filteredAuthMethods: [
+          {
+            connectorSlug: "steam",
+            authMethodId: "openid",
+            reasons: ["missing-platform-configuration"],
+          },
+        ],
+      },
+    });
+    expect(
+      (await accept(catalogClient.list({ headers }), [200])).body.connectors,
+    ).toStrictEqual([]);
   });
 
   it("reports a known provider contract mismatch without private details", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -55,7 +55,9 @@ import { createUniqueStaffOrgIdFixture } from "../../../test-fixtures/staff-org"
 import {
   API_TEST_CONNECTOR_FIREWALL_CONFIGS,
   apiTestConnectorCatalogValidationAuthority,
+  deleteApiTestConnectorCatalogCompatibility,
   installApiTestConnectorCatalog,
+  readApiTestConnectorCatalogCompatibilityEvaluations,
   readApiTestConnectorCatalogValidationAuthority,
   setApiTestConnectorCatalogValidationAuthority,
 } from "../../../test-fixtures/connector-catalog";
@@ -1042,7 +1044,10 @@ function expectConnectorCatalogLoadTiming(args: {
     | { readonly outcome: "attested" | "not_run" }
     | {
         readonly outcome: "full_fallback";
-        readonly fallbackReason: "missing_authority" | "different_authority";
+        readonly fallbackReason:
+          | "missing_authority"
+          | "different_authority"
+          | "missing_compatibility";
       };
 }): void {
   const event = singleApiDispatchEvent(
@@ -1768,6 +1773,61 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       missingCatalogVersion,
       missingAuthorityPrompt,
       missingAuthorityActor.agentId,
+      "test-oauth-secret",
+      "fixture-confidential-secret",
+    ]);
+  });
+
+  it("derives missing catalog compatibility without persisting it", async () => {
+    const api = createRunsApi(context);
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      "test-run-lifecycle-missing-catalog-compatibility",
+    );
+
+    const missingCompatibilityVersion = `api-test-missing-compatibility-${randomUUID()}`;
+    await installApiTestConnectorCatalog({
+      catalogVersion: missingCompatibilityVersion,
+    });
+    await deleteApiTestConnectorCatalogCompatibility();
+    await expect(
+      readApiTestConnectorCatalogCompatibilityEvaluations(),
+    ).resolves.toHaveLength(0);
+
+    const missingCompatibilityActor = await entitledRunActor();
+    const missingCompatibilityPrompt = "missing connector compatibility";
+    const missingCompatibilityRun = await api.createRun(
+      missingCompatibilityActor.actor,
+      {
+        agentId: missingCompatibilityActor.agentId,
+        prompt: missingCompatibilityPrompt,
+        modelProvider: "anthropic-api-key",
+      },
+    );
+    const missingCompatibilityEvents = apiDispatchTimingEventsForRun(
+      missingCompatibilityRun.runId,
+    );
+    expectApiDispatchActions(
+      missingCompatibilityEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_COMPLETE_VALIDATION_ACTION_TYPES,
+    );
+    expectConnectorCatalogLoadTiming({
+      events: missingCompatibilityEvents,
+      acceptedCacheOutcome: "miss",
+      runtimeCacheOutcome: "miss",
+      requestedConnectorCount: "known",
+      validation: {
+        outcome: "full_fallback",
+        fallbackReason: "missing_compatibility",
+      },
+    });
+    await expect(
+      readApiTestConnectorCatalogCompatibilityEvaluations(),
+    ).resolves.toHaveLength(0);
+    expectApiDispatchTimingEventsNotToLeak(missingCompatibilityEvents, [
+      missingCompatibilityVersion,
+      missingCompatibilityPrompt,
+      missingCompatibilityActor.agentId,
       "test-oauth-secret",
       "fixture-confidential-secret",
     ]);

--- a/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-compatibility.service.ts
@@ -293,7 +293,7 @@ function evaluateMethod(args: {
   });
 }
 
-function evaluateConnectorCatalogCompatibility(args: {
+export function evaluateConnectorCatalogCompatibility(args: {
   readonly artifact: ConnectorCatalogArtifact;
   readonly capability: ExecutableCapabilityState;
 }): readonly ConnectorCatalogCompatibilityFilteredAuthMethod[] {

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -40,7 +40,9 @@ import { connectorCatalogIconUrl } from "./connector-catalog-artifacts/icon";
 import { deriveConnectorCatalogFirewallPermissions } from "./connector-catalog-artifacts/relationships";
 import {
   connectorCatalogCompatibilityEvaluationSchema,
-  connectorCatalogExecutableCapabilityDigest,
+  connectorCatalogExecutableCapabilityState,
+  evaluateConnectorCatalogCompatibility,
+  type ExecutableCapabilityState,
 } from "./connector-catalog-compatibility.service";
 import type { ConnectorFeatureStates } from "./connector-catalog-feature-states";
 import type { ConnectorCatalogLoadTiming } from "./connector-catalog-load-timing.service";
@@ -236,7 +238,7 @@ function measureCatalogLoadSync<T>(
   return timing ? timing.measureSync(actionType, operation) : operation();
 }
 
-function externalCatalogJoin() {
+function externalCatalogJoin(capabilityDigest: string) {
   return and(
     eq(
       connectorCatalogCompatibilityEvaluation.sourceId,
@@ -253,6 +255,10 @@ function externalCatalogJoin() {
     eq(
       connectorCatalogCompatibilityEvaluation.catalogDigest,
       connectorCatalogActiveSnapshot.catalogDigest,
+    ),
+    eq(
+      connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
+      capabilityDigest,
     ),
   );
 }
@@ -274,20 +280,12 @@ async function readCurrentIdentity(args: {
           catalogDigest: connectorCatalogActiveSnapshot.catalogDigest,
         })
         .from(connectorCatalogActiveSnapshot)
-        .innerJoin(
-          connectorCatalogCompatibilityEvaluation,
-          externalCatalogJoin(),
-        )
         .where(
           and(
             eq(connectorCatalogActiveSnapshot.sourceId, args.sourceId),
             eq(
               connectorCatalogActiveSnapshot.schemaVersion,
               SUPPORTED_CONNECTOR_CATALOG_SCHEMA_VERSION,
-            ),
-            eq(
-              connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
-              args.capabilityDigest,
             ),
           ),
         )
@@ -305,11 +303,11 @@ async function readCurrentIdentity(args: {
     : undefined;
 }
 
-async function readCurrentCatalog(args: {
+async function readCurrentCatalogPayload(args: {
   readonly db: ReadonlyDb;
   readonly identity: ExternalCatalogIdentity;
   readonly timing?: ConnectorCatalogLoadTiming;
-}): Promise<AcceptedConnectorCatalogSnapshot | undefined> {
+}) {
   const [row] = await measureCatalogLoad(
     args.timing,
     "api_dispatch_connector_catalog_query_payload",
@@ -322,13 +320,15 @@ async function readCurrentCatalog(args: {
             connectorCatalogCompatibilityEvaluation.catalogValidationBackendVersion,
           catalogValidationBuildCommitSha:
             connectorCatalogCompatibilityEvaluation.catalogValidationBuildCommitSha,
+          executableCapabilityDigest:
+            connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
           filteredAuthMethods:
             connectorCatalogCompatibilityEvaluation.filteredAuthMethods,
         })
         .from(connectorCatalogActiveSnapshot)
-        .innerJoin(
+        .leftJoin(
           connectorCatalogCompatibilityEvaluation,
-          externalCatalogJoin(),
+          externalCatalogJoin(args.identity.capabilityDigest),
         )
         .where(
           and(
@@ -345,15 +345,21 @@ async function readCurrentCatalog(args: {
               connectorCatalogActiveSnapshot.catalogDigest,
               args.identity.catalogDigest,
             ),
-            eq(
-              connectorCatalogCompatibilityEvaluation.executableCapabilityDigest,
-              args.identity.capabilityDigest,
-            ),
           ),
         )
         .limit(1);
     },
   );
+  return row;
+}
+
+async function readCurrentCatalog(args: {
+  readonly db: ReadonlyDb;
+  readonly identity: ExternalCatalogIdentity;
+  readonly capability: ExecutableCapabilityState;
+  readonly timing?: ConnectorCatalogLoadTiming;
+}): Promise<AcceptedConnectorCatalogSnapshot | undefined> {
+  const row = await readCurrentCatalogPayload(args);
   if (!row) {
     return undefined;
   }
@@ -369,7 +375,9 @@ async function readCurrentCatalog(args: {
     backendVersion: row.catalogValidationBackendVersion,
     buildCommitSha: row.catalogValidationBuildCommitSha,
   });
+  const compatibilityEvaluationExists = row.executableCapabilityDigest !== null;
   const validationAuthorityIsCurrent =
+    compatibilityEvaluationExists &&
     validationAuthority !== null &&
     connectorCatalogValidationAuthorityIsCurrent({
       authority: validationAuthority,
@@ -380,8 +388,9 @@ async function readCurrentCatalog(args: {
   } else {
     args.timing?.recordValidationResult({
       outcome: "full_fallback",
-      fallbackReason:
-        validationAuthority === null
+      fallbackReason: !compatibilityEvaluationExists
+        ? "missing_compatibility"
+        : validationAuthority === null
           ? "missing_authority"
           : "different_authority",
     });
@@ -393,6 +402,12 @@ async function readCurrentCatalog(args: {
     args.timing,
     "api_dispatch_connector_catalog_validate_compatibility",
     () => {
+      if (!compatibilityEvaluationExists) {
+        return evaluateConnectorCatalogCompatibility({
+          artifact: decoded.artifact,
+          capability: args.capability,
+        });
+      }
       const parsed = connectorCatalogCompatibilityEvaluationSchema.safeParse(
         row.filteredAuthMethods,
       );
@@ -438,6 +453,7 @@ async function readCurrentCatalog(args: {
 async function loadCurrentCatalog(args: {
   readonly db: ReadonlyDb;
   readonly identity: ExternalCatalogIdentity;
+  readonly capability: ExecutableCapabilityState;
   readonly timing?: ConnectorCatalogLoadTiming;
 }): Promise<AcceptedConnectorCatalogSnapshot | undefined> {
   const result = await settle(readCurrentCatalog(args));
@@ -471,11 +487,11 @@ async function loadAcceptedConnectorCatalogSnapshotAttempt(
   timing: ConnectorCatalogLoadTiming | undefined,
 ): Promise<AcceptedConnectorCatalogSnapshot | undefined> {
   const sourceId = connectorCatalogSource().sourceId;
-  const capabilityDigest = connectorCatalogExecutableCapabilityDigest();
+  const capability = connectorCatalogExecutableCapabilityState();
   const currentIdentity = await readCurrentIdentity({
     db,
     sourceId,
-    capabilityDigest,
+    capabilityDigest: capability.digest,
     ...(timing === undefined ? {} : { timing }),
   });
   if (!currentIdentity) {
@@ -500,6 +516,7 @@ async function loadAcceptedConnectorCatalogSnapshotAttempt(
   const promise = loadCurrentCatalog({
     db,
     identity: currentIdentity,
+    capability,
     ...(timing === undefined ? {} : { timing }),
   });
   cache.inFlight.set(currentKey, promise);

--- a/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
@@ -10,7 +10,10 @@ type ConnectorCatalogValidationResult =
   | { readonly outcome: "attested" }
   | {
       readonly outcome: "full_fallback";
-      readonly fallbackReason: "missing_authority" | "different_authority";
+      readonly fallbackReason:
+        | "missing_authority"
+        | "different_authority"
+        | "missing_compatibility";
     }
   | { readonly outcome: "not_run" };
 


### PR DESCRIPTION
## Summary

- read the active connector catalog independently of whether the current API capability digest already has a persisted compatibility evaluation
- completely validate and derive exact current-capability filtering in memory when that evaluation is missing, while keeping Cron as the only persistence owner
- preserve fail-closed behavior for corrupt snapshots and invalid persisted evaluations, and add bounded `missing_compatibility` load telemetry
- cover pre-reconciliation reads, incompatible-method filtering, rolling/rollback capability isolation, later idempotent reconciliation, request non-persistence, and telemetry non-leakage

## Deployment compatibility

- no database migration or public API, runner, queue, or catalog publication contract change
- old, new, and rollback API revisions remain isolated by the existing catalog identity plus executable-capability digest keys
- the existing single retry still handles catalog activation between identity and payload reads

## Exclusions

- no production release sequencing or staged-deployment change
- no request-side compatibility persistence or database locking
- no weakening of complete catalog validation or provider/configuration filtering

## Fallbacks

- **Surface:** API catalog reads when the active catalog has no evaluation for the current executable-capability digest
- **Behavior:** complete current-code validation and deterministic current-capability filtering in memory; no stale evaluation, unfiltered catalog, fabricated default, or database write
- **Duration:** permanent while API deployment and catalog activation can expose reachable missing derived state
- **Removal condition:** every deployment and catalog activation atomically creates the exact evaluation before a matching reader can observe the active identity
- **Observability:** `connector_catalog_validation_outcome=full_fallback` with low-cardinality reason `missing_compatibility`, plus existing action duration and size/count buckets

## Validation

- `pnpm exec prettier --write <changed files>`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-connector-catalog.test.ts src/signals/routes/__tests__/connectors-list.test.ts src/signals/routes/__tests__/connectors-by-slug-get.test.ts src/signals/routes/__tests__/connectors-by-slug-delete.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=4 --silent=passed-only` (5 files, 288 tests)
- `pnpm knip`
- pre-commit hooks: Prettier, full-repository Knip, full Turbo type checking, file-size validation, and commitlint

Closes #27456

Parent context: #24203
