### PR TITLE
feat(platform): attribute telemetry by public brand

### DIFF
--- a/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-runtime-environment.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserOptions } from "@sentry/browser";
+import type { PostHogConfig } from "posthog-js";
 import { isOkouProductionHostname } from "../lib/platform-host.ts";
 import { sentryLogContext } from "../lib/sentry-config.ts";
 import { initSharedDatabaseWorkerSentry } from "../shared-database/worker-sentry.ts";
@@ -27,7 +28,8 @@ const {
     browserSentryCaptureException: vi.fn(),
     browserSentryCaptureMessage: vi.fn(),
     browserSentryInit: vi.fn<(options: BrowserOptions) => void>(),
-    posthogInit: vi.fn(),
+    posthogInit:
+      vi.fn<(key: string, config?: Partial<PostHogConfig>) => void>(),
     sentryInit: vi.fn<(options: BrowserOptions) => void>(),
   };
 });
@@ -173,10 +175,33 @@ describe("portable platform runtime environment", () => {
     expect(isOkouProductionHostname("okou.ai.evil.example")).toBeFalsy();
     expect(runtime.platformHost.resolvePlatformRuntimeConfig()).toMatchObject({
       environment: "production",
+      publicBrand: "okou",
       clerkPublishableKey: PRODUCTION_CLERK_KEY,
       sentryDsn: SENTRY_DSN,
       vapidPublicKey: PRODUCTION_VAPID_KEY,
     });
+
+    const plausibleController = new AbortController();
+    await runtime.plausible.initPlausible(plausibleController.signal);
+    plausibleController.abort();
+    runtime.plausible.capturePlausibleEvent("runtime_environment_test");
+    runtime.posthog.initPostHog();
+    runtime.sentry.initSentry();
+
+    expect(window.plausible?.q).toStrictEqual([
+      ["runtime_environment_test", { props: { public_brand: "okou" } }],
+    ]);
+    const [, posthogConfig] = posthogInit.mock.lastCall ?? [];
+    expect(posthogConfig?.sanitize_properties?.({}, "$pageview")).toStrictEqual(
+      { public_brand: "okou" },
+    );
+    expect(sentryInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialScope: {
+          tags: { app: "platform", public_brand: "okou" },
+        },
+      }),
+    );
   });
 
   it("selects canonical services and production telemetry on an alternate production host", async () => {
@@ -186,6 +211,7 @@ describe("portable platform runtime environment", () => {
     expect(runtime.apiBase.resolveApiBase()).toBe("https://api.vm0.ai");
     expect(runtime.auth.resolveWebOrigin()).toBe("https://www.vm0.ai");
     expect(runtime.platformHost.resolvePlatformRuntimeConfig()).toMatchObject({
+      publicBrand: "vm0",
       clerkPublishableKey: PRODUCTION_CLERK_KEY,
       vapidPublicKey: PRODUCTION_VAPID_KEY,
     });
@@ -204,18 +230,34 @@ describe("portable platform runtime environment", () => {
 
     expect(plausibleScriptSources()).toStrictEqual([PRODUCTION_PLAUSIBLE_URL]);
     expect(window.plausible?.q).toStrictEqual([
-      ["runtime_environment_test", undefined],
+      ["runtime_environment_test", { props: { public_brand: "vm0" } }],
     ]);
     expect(posthogInit).toHaveBeenCalledWith(
       POSTHOG_KEY,
       expect.objectContaining({ api_host: "https://j.vm0.ai" }),
     );
+    const [, posthogConfig] = posthogInit.mock.lastCall ?? [];
+    expect(
+      posthogConfig?.sanitize_properties?.(
+        {
+          $current_url:
+            "https://app.vm0.ai/agents/00000000-0000-0000-0000-000000000000",
+        },
+        "$pageview",
+      ),
+    ).toStrictEqual({
+      $current_url: "https://app.vm0.ai/agents/:id",
+      public_brand: "vm0",
+    });
     expect(sentryInit).toHaveBeenCalledWith(
       expect.objectContaining({
         dsn: SENTRY_DSN,
         enabled: true,
         enhanceFetchErrorMessages: false,
         environment: "production",
+        initialScope: {
+          tags: { app: "platform", public_brand: "vm0" },
+        },
       }),
     );
     const [pageSentryOptions] = sentryInit.mock.lastCall ?? [];
@@ -237,6 +279,7 @@ describe("portable platform runtime environment", () => {
     );
     expect(runtime.platformHost.resolvePlatformRuntimeConfig()).toMatchObject({
       environment: "preview",
+      publicBrand: "okou",
       clerkPublishableKey: PREVIEW_CLERK_KEY,
       vapidPublicKey: PREVIEW_VAPID_KEY,
     });
@@ -249,16 +292,28 @@ describe("portable platform runtime environment", () => {
     const plausibleController = new AbortController();
     await runtime.plausible.initPlausible(plausibleController.signal);
     plausibleController.abort();
+    runtime.plausible.capturePlausibleEvent("runtime_environment_test", {
+      props: { surface: "preview" },
+    });
     runtime.posthog.initPostHog();
     runtime.sentry.initSentry();
 
     expect(plausibleScriptSources()).toStrictEqual([PREVIEW_PLAUSIBLE_URL]);
+    expect(window.plausible?.q).toStrictEqual([
+      [
+        "runtime_environment_test",
+        { props: { public_brand: "okou", surface: "preview" } },
+      ],
+    ]);
     expect(posthogInit).not.toHaveBeenCalled();
     expect(sentryInit).toHaveBeenCalledWith(
       expect.objectContaining({
         dsn: undefined,
         enabled: false,
         environment: "preview",
+        initialScope: {
+          tags: { app: "platform", public_brand: "okou" },
+        },
       }),
     );
   });
@@ -277,6 +332,7 @@ describe("portable platform runtime environment", () => {
         initialScope: {
           tags: {
             app: "platform",
+            public_brand: "okou",
             runtime: "shared-worker",
             worker: "shared-database",
           },
@@ -370,6 +426,9 @@ describe("portable platform runtime environment", () => {
     expect(runtime.apiBase.resolveOAuthApiBase()).toBe(
       "https://pr-23364-api.vm6.ai",
     );
+    expect(runtime.platformHost.resolvePlatformRuntimeConfig()).toMatchObject({
+      publicBrand: "okou",
+    });
   });
 
   it("rejects an invalid API origin on an immutable Pages deployment", async () => {

--- a/turbo/apps/platform/src/lib/platform-host.ts
+++ b/turbo/apps/platform/src/lib/platform-host.ts
@@ -1,9 +1,11 @@
 type PlatformEnvironment = "development" | "preview" | "production";
+type PlatformPublicBrand = "vm0" | "okou";
 
 export type PlatformService = "api" | "www" | "app" | "platform";
 
 interface PlatformRuntimeConfig {
   readonly environment: PlatformEnvironment;
+  readonly publicBrand: PlatformPublicBrand;
   readonly clerkPublishableKey: string;
   readonly publicArtifactsBaseUrl: "https://cdn.vm0.io" | "https://cdn.vm7.io";
   readonly zeroHostDomain: "sites.vm0.io" | "sites.vm7.io";
@@ -16,6 +18,12 @@ interface PlatformRuntimeConfig {
 const PRODUCTION_DOMAIN = "vm0.ai";
 const OKOU_PRODUCTION_DOMAIN = "okou.ai";
 const OKOU_PREVIEW_DOMAIN = "omby.ai";
+const OKOU_PAGES_DOMAIN = "okou-app.pages.dev";
+const OKOU_ROOT_DOMAINS = [
+  OKOU_PRODUCTION_DOMAIN,
+  OKOU_PREVIEW_DOMAIN,
+  OKOU_PAGES_DOMAIN,
+] as const;
 const PREVIEW_API_DOMAIN = "vm6.ai";
 export const PRODUCTION_SATELLITE_HOSTNAME = "app.okou.ai";
 const PLATFORM_SERVICE_LABELS = ["platform", "app", "www", "api"] as const;
@@ -27,12 +35,29 @@ function browserHostname(): string | null {
   return location.hostname.toLowerCase();
 }
 
+function isDomainOrSubdomain(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+export function isOkouHostname(hostname: string): boolean {
+  const normalizedHostname = hostname.toLowerCase().replace(/:\d+$/u, "");
+  return OKOU_ROOT_DOMAINS.some((domain) => {
+    return isDomainOrSubdomain(normalizedHostname, domain);
+  });
+}
+
+function resolvePlatformPublicBrand(
+  hostname: string | null,
+): PlatformPublicBrand {
+  if (!hostname) {
+    return "vm0";
+  }
+  return isOkouHostname(hostname) ? "okou" : "vm0";
+}
+
 export function isOkouProductionHostname(hostname: string): boolean {
   const normalizedHostname = hostname.toLowerCase();
-  return (
-    normalizedHostname === OKOU_PRODUCTION_DOMAIN ||
-    normalizedHostname.endsWith(`.${OKOU_PRODUCTION_DOMAIN}`)
-  );
+  return isDomainOrSubdomain(normalizedHostname, OKOU_PRODUCTION_DOMAIN);
 }
 
 export function isProductionSatelliteHostname(hostname: string): boolean {
@@ -146,10 +171,12 @@ function requiredBuildValue(value: unknown, name: string): string {
 
 export function resolvePlatformRuntimeConfig(): PlatformRuntimeConfig {
   const environment = resolvePlatformEnvironment();
+  const publicBrand = resolvePlatformPublicBrand(browserHostname());
 
   if (environment === "production") {
     return {
       environment,
+      publicBrand,
       clerkPublishableKey: requiredBuildValue(
         import.meta.env.VITE_CLERK_PUBLISHABLE_KEY_PROD,
         "VITE_CLERK_PUBLISHABLE_KEY_PROD",
@@ -169,6 +196,7 @@ export function resolvePlatformRuntimeConfig(): PlatformRuntimeConfig {
 
   return {
     environment,
+    publicBrand,
     clerkPublishableKey: requiredBuildValue(
       import.meta.env.VITE_CLERK_PUBLISHABLE_KEY_PREVIEW,
       "VITE_CLERK_PUBLISHABLE_KEY_PREVIEW",

--- a/turbo/apps/platform/src/lib/plausible.ts
+++ b/turbo/apps/platform/src/lib/plausible.ts
@@ -110,5 +110,11 @@ export function capturePlausibleEvent(
   options?: PlausibleEventOptions,
 ): void {
   const plausible = getPlausible();
-  plausible?.(eventName, options);
+  plausible?.(eventName, {
+    ...options,
+    props: {
+      ...options?.props,
+      public_brand: resolvePlatformRuntimeConfig().publicBrand,
+    },
+  });
 }

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -2,7 +2,8 @@ import { command, state } from "ccstate";
 import { posthog } from "posthog-js";
 import { resolvePlatformRuntimeConfig } from "./platform-host.ts";
 
-const POSTHOG_KEY = resolvePlatformRuntimeConfig().postHogKey;
+const RUNTIME_CONFIG = resolvePlatformRuntimeConfig();
+const POSTHOG_KEY = RUNTIME_CONFIG.postHogKey;
 
 function runPostHog(action: (key: string) => void): void {
   if (!POSTHOG_KEY) {
@@ -34,7 +35,7 @@ export function initPostHog(): void {
             "/:id",
           );
         }
-        return properties;
+        return { ...properties, public_brand: RUNTIME_CONFIG.publicBrand };
       },
     });
   });

--- a/turbo/apps/platform/src/lib/sentry-config.ts
+++ b/turbo/apps/platform/src/lib/sentry-config.ts
@@ -52,6 +52,7 @@ export function createPlatformSentryOptions(
     initialScope: {
       tags: {
         app: "platform",
+        public_brand: runtimeConfig.publicBrand,
         ...(runtime === "shared-worker"
           ? { runtime: "shared-worker", worker: "shared-database" }
           : {}),

--- a/turbo/apps/platform/src/signals/branding.ts
+++ b/turbo/apps/platform/src/signals/branding.ts
@@ -1,20 +1,12 @@
 import { computed } from "ccstate";
+import { isOkouHostname } from "../lib/platform-host.ts";
 
 type Branding = "vm0" | "okou";
 export type BrandName = "VM0" | "Okou";
 export type AssistantName = "Zero" | "Okou";
 
-const OKOU_ROOT_DOMAINS = ["okou.ai", "omby.ai", "okou-app.pages.dev"] as const;
-
 export function resolveBrandNameForHostname(hostname: string): BrandName {
-  const normalizedHostname = hostname.toLowerCase().replace(/:\d+$/u, "");
-  const isOkou = OKOU_ROOT_DOMAINS.some((domain) => {
-    return (
-      normalizedHostname === domain || normalizedHostname.endsWith(`.${domain}`)
-    );
-  });
-
-  return isOkou ? "Okou" : "VM0";
+  return isOkouHostname(hostname) ? "Okou" : "VM0";
 }
 
 export function resolveAssistantNameForHostname(


### PR DESCRIPTION
## Summary

- centralize Okou hostname classification in the Platform runtime boundary
- attach a trusted `public_brand` value to PostHog events and Plausible custom events
- tag Sentry page and shared-worker events with the same brand dimension
- preserve existing event names, telemetry projects, ingest hosts, URL sanitization, and VM0 behavior

## Brand behavior

- Okou production, `omby.ai` previews, and immutable Okou Pages hosts emit `public_brand=okou`
- VM0 production and unrecognized hosts emit `public_brand=vm0`
- callers cannot override the hostname-derived value in PostHog or Plausible payloads

## Verification

- `pnpm --filter @okouai/app run lint`
- `pnpm knip`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter @okouai/app exec vitest run src/__tests__/platform-runtime-environment.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/views/agents-page/__tests__/document-title-branding.test.tsx`

## Deferred

External PostHog dashboards, Sentry views, ad accounts, consent configuration, status/support destinations, and Okou favicon/PWA/OG assets are outside this code-only PR.