### PR TITLE
refactor(run): shadow application-owned agent execution plans

### DIFF
--- a/.github/workflows/agent-compose-consolidation-preflight.yml
+++ b/.github/workflows/agent-compose-consolidation-preflight.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: bash
     steps:
-      # transition-validator: #27613; removal-owner: #26938 Stage 8
+      # transition-validator: #27613 + #27656; removal-owner: #26938 Stage 8
       # The workflow definition and implementation always come from main.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -48,7 +48,7 @@ jobs:
               --pooled \
               2>/dev/null
           ); then
-            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v1","status":"failed","failureGates":["probe.database_resolution"]}'
+            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v2","status":"failed","failureGates":["probe.database_resolution"]}'
             exit 1
           fi
           if [[ -z "$database_url" ||
@@ -56,7 +56,7 @@ jobs:
                 "$database_url" == *$'\r'* ||
                 ( "$database_url" != postgres://* &&
                   "$database_url" != postgresql://* ) ]]; then
-            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v1","status":"failed","failureGates":["probe.database_resolution"]}'
+            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v2","status":"failed","failureGates":["probe.database_resolution"]}'
             exit 1
           fi
           echo "::add-mask::$database_url"

--- a/turbo/apps/api/src/signals/services/agent-compose-content.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose-content.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { getInstructionsFilename } from "@okouai/core/frameworks";
+import { APPLICATION_OWNED_AGENT_EXECUTION_PLAN } from "./agent-execution-plan";
 
 /**
  * Canonical application-owned content for a Zero Agent compose.
@@ -11,14 +12,17 @@ import { getInstructionsFilename } from "@okouai/core/frameworks";
 export function buildZeroAgentComposeContent(
   agentName: string,
 ): Record<string, unknown> {
+  const plan = APPLICATION_OWNED_AGENT_EXECUTION_PLAN;
   const environment: Record<string, string> = {
-    OKOU_AGENT_ID: `\${{ vars.OKOU_AGENT_ID }}`,
-    OKOU_TOKEN: `\${{ secrets.OKOU_TOKEN }}`,
+    [plan.environment.legacySerializedBindings.agentId]:
+      `\${{ vars.OKOU_AGENT_ID }}`,
+    [plan.environment.legacySerializedBindings.token]:
+      `\${{ secrets.OKOU_TOKEN }}`,
   };
 
   const agentDef: Record<string, unknown> = {
-    framework: "claude-code",
-    instructions: getInstructionsFilename("claude-code"),
+    framework: plan.framework.fallback,
+    instructions: getInstructionsFilename(plan.framework.fallback),
     environment,
   };
 

--- a/turbo/apps/api/src/signals/services/agent-execution-plan.ts
+++ b/turbo/apps/api/src/signals/services/agent-execution-plan.ts
@@ -1,0 +1,54 @@
+import { DEFAULT_PROFILE } from "@okouai/api-contracts/contracts/runners";
+
+/**
+ * Application-owned baseline for launching a product Agent.
+ *
+ * This definition intentionally contains ownership and defaults only. Dynamic
+ * provider, Connector, Workflow, request, continuation, Storage, and routing
+ * inputs stay at their existing service boundaries.
+ */
+export const APPLICATION_OWNED_AGENT_EXECUTION_PLAN = {
+  framework: {
+    owner: "model-provider",
+    fallback: "claude-code",
+  },
+  environment: {
+    owners: ["system-identity", "model-provider", "connector", "run"],
+    legacyRemovedPrefixes: ["ZERO_"],
+    runtimeOverrideKeys: [
+      "CLI_PKG_URL",
+      "OKOU_AGENT_ID",
+      "OKOU_APP_URL",
+      "OKOU_TOKEN",
+      "OKOU_WEBSITE_TEMPLATE_ARCHIVE_VERSION",
+    ],
+    legacySerializedBindings: {
+      agentId: "OKOU_AGENT_ID",
+      token: "OKOU_TOKEN",
+    },
+  },
+  runner: {
+    group: {
+      owner: "execution-routing-policy",
+      fallback: null,
+    },
+    profile: {
+      owner: "resource-policy",
+      fallback: DEFAULT_PROFILE,
+    },
+  },
+  instructions: {
+    owner: "agent-storage",
+    enabled: true,
+  },
+  storage: {
+    owners: [
+      "system",
+      "connector",
+      "workflow",
+      "request",
+      "continuation",
+      "session-storage",
+    ],
+  },
+} as const;

--- a/turbo/packages/db/MIGRATIONS.md
+++ b/turbo/packages/db/MIGRATIONS.md
@@ -35,11 +35,11 @@ expired transition validator must be deleted.
 The repository inventory below is machine-checked. The removal owner must
 delete the workflow, probe, focused validator, and this entry together.
 
-| Issue  | Validator                                        | Removal owner  |
-| ------ | ------------------------------------------------ | -------------- |
-| #27613 | Agent/Compose consolidation production preflight | #26938 Stage 8 |
+| Issue           | Validator                                        | Removal owner  |
+| --------------- | ------------------------------------------------ | -------------- |
+| #27613 / #27656 | Agent/Compose consolidation production preflight | #26938 Stage 8 |
 
-<!-- vm0-transition-validator:#27613|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8 -->
+<!-- vm0-transition-validator:#27613+#27656|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8 -->
 
 ## Migration patterns
 

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-fingerprint.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-fingerprint.ts
@@ -1,8 +1,10 @@
 import { createHash } from "node:crypto";
 
 export const PREFLIGHT_SCHEMA_VERSION =
-  "vm0.agent-compose-consolidation-preflight.v1";
+  "vm0.agent-compose-consolidation-preflight.v2";
 
+// Keep the accepted Stage 0 aggregate digests stable while the output schema
+// grows additively. New sets use their own domain strings at each call site.
 const FINGERPRINT_DOMAIN = "vm0:agent-compose-consolidation-preflight:v1";
 
 export interface SetFingerprint {

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
@@ -165,7 +165,6 @@ export const EXPECTED_REPOSITORY_DEPENDENCIES = {
     "turbo/apps/api/src/signals/routes/workflows.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
     "turbo/apps/api/src/signals/services/agent-compose-provenance-lifecycle.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
     "turbo/apps/api/src/signals/services/agent-compose.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
-    "turbo/apps/api/src/signals/services/agent-connector-scope.service.ts|@okouai/db/schema/zero-agent|type:ZeroAgentVisibility:ZeroAgentVisibility,zeroAgents:zeroAgents",
     "turbo/apps/api/src/signals/services/agent-data.service.ts|@okouai/db/schema/agent-compose|agentComposes:agentComposes",
     "turbo/apps/api/src/signals/services/agent-data.service.ts|@okouai/db/schema/zero-agent|zeroAgents:zeroAgents",
     "turbo/apps/api/src/signals/services/agent-instructions.service.ts|@okouai/db/schema/agent-compose|agentComposeVersions:agentComposeVersions,agentComposes:agentComposes",
@@ -273,7 +272,6 @@ export const EXPECTED_REPOSITORY_DEPENDENCIES = {
     "turbo/apps/api/src/signals/routes/workflows.ts|agentComposeId,zeroAgents",
     "turbo/apps/api/src/signals/services/agent-compose-provenance-lifecycle.service.ts|agentComposes",
     "turbo/apps/api/src/signals/services/agent-compose.service.ts|agentComposeId,agentComposeVersions,agentComposes,headVersionId",
-    "turbo/apps/api/src/signals/services/agent-connector-scope.service.ts|zeroAgents",
     "turbo/apps/api/src/signals/services/agent-data.service.ts|agentComposes,headVersionId,zeroAgents",
     "turbo/apps/api/src/signals/services/agent-instructions.service.ts|agentComposeVersions,agentComposes,headVersionId,zeroAgents",
     "turbo/apps/api/src/signals/services/agent-run-create.service.ts|agentComposeId,agentComposeVersionId,agentComposeVersions,agentComposes,headVersionId",
@@ -397,7 +395,7 @@ export const EXPECTED_REPOSITORY_DEPENDENCIES = {
     "crates/api-contracts/src/generated/decode_paths.rs|agentComposeVersionId",
   ],
   transitionValidators: [
-    "#27613|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8",
+    "#27613+#27656|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8",
   ],
 } as const satisfies RepositoryDependencyManifest;
 

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
@@ -8,6 +8,7 @@ import {
   buildZeroAgentComposeContent,
   computeComposeVersionId,
 } from "../../../apps/api/src/signals/services/agent-compose-content";
+import { APPLICATION_OWNED_AGENT_EXECUTION_PLAN } from "../../../apps/api/src/signals/services/agent-execution-plan";
 import {
   CATALOG_DEPENDENCY_KINDS,
   CATALOG_DEPENDENCY_QUERY,
@@ -45,6 +46,49 @@ export const APPROVED_ARTIFACT_SET_DIGEST =
 
 /** Exact scalar/array paths permitted in a complete production result. */
 export const PREFLIGHT_OUTPUT_ALLOWLIST = [
+  "agentExecutionPlans.agentInstructionsMarkerOrMountDifferences.count",
+  "agentExecutionPlans.agentInstructionsMarkerOrMountDifferences.digest",
+  "agentExecutionPlans.completeSemanticParity.count",
+  "agentExecutionPlans.completeSemanticParity.digest",
+  "agentExecutionPlans.composeArtifactOrVolumeDifferences.count",
+  "agentExecutionPlans.composeArtifactOrVolumeDifferences.digest",
+  "agentExecutionPlans.danglingOrMissingHeadVersion.count",
+  "agentExecutionPlans.danglingOrMissingHeadVersion.digest",
+  "agentExecutionPlans.dimensionUnionClosure.classification",
+  "agentExecutionPlans.dimensionUnionClosure.expected.count",
+  "agentExecutionPlans.dimensionUnionClosure.expected.digest",
+  "agentExecutionPlans.dimensionUnionClosure.observed.count",
+  "agentExecutionPlans.dimensionUnionClosure.observed.digest",
+  "agentExecutionPlans.exceptions.count",
+  "agentExecutionPlans.exceptions.digest",
+  "agentExecutionPlans.frameworkOrFallbackDifferences.count",
+  "agentExecutionPlans.frameworkOrFallbackDifferences.digest",
+  "agentExecutionPlans.inventoryClosure.classification",
+  "agentExecutionPlans.inventoryClosure.expected.count",
+  "agentExecutionPlans.inventoryClosure.expected.digest",
+  "agentExecutionPlans.inventoryClosure.observed.count",
+  "agentExecutionPlans.inventoryClosure.observed.digest",
+  "agentExecutionPlans.matched.count",
+  "agentExecutionPlans.matched.digest",
+  "agentExecutionPlans.multiDimensionExceptions.count",
+  "agentExecutionPlans.multiDimensionExceptions.digest",
+  "agentExecutionPlans.otherLaunchAffectingLegacyFields.count",
+  "agentExecutionPlans.otherLaunchAffectingLegacyFields.digest",
+  "agentExecutionPlans.partitionClosure.classification",
+  "agentExecutionPlans.partitionClosure.expected.count",
+  "agentExecutionPlans.partitionClosure.expected.digest",
+  "agentExecutionPlans.partitionClosure.observed.count",
+  "agentExecutionPlans.partitionClosure.observed.digest",
+  "agentExecutionPlans.runnerGroupPolicyDifferences.count",
+  "agentExecutionPlans.runnerGroupPolicyDifferences.digest",
+  "agentExecutionPlans.runnerProfilePolicyDifferences.count",
+  "agentExecutionPlans.runnerProfilePolicyDifferences.digest",
+  "agentExecutionPlans.systemEnvironmentDifferences.count",
+  "agentExecutionPlans.systemEnvironmentDifferences.digest",
+  "agentExecutionPlans.unclassifiedContent.count",
+  "agentExecutionPlans.unclassifiedContent.digest",
+  "agentExecutionPlans.unsupportedOrInvalidContent.count",
+  "agentExecutionPlans.unsupportedOrInvalidContent.digest",
   "capabilities.isolationLevel",
   "capabilities.lockTimeoutMs",
   "capabilities.requiredExtensionCount",
@@ -280,6 +324,15 @@ export interface DanglingInventoryRow extends QueryResultRow {
   readonly agentName: string | null;
 }
 
+export interface AgentExecutionPlanInventoryRow extends QueryResultRow {
+  readonly id: string;
+  readonly agentName: string;
+  readonly headVersionId: string | null;
+  readonly versionId: string | null;
+  readonly insertionComposeId: string | null;
+  readonly content: unknown;
+}
+
 export interface PreflightInventory {
   readonly identity: readonly IdentityInventoryRow[];
   readonly versions: readonly VersionInventoryRow[];
@@ -288,6 +341,7 @@ export interface PreflightInventory {
   readonly checkpoints: readonly CheckpointInventoryRow[];
   readonly danglingStart: readonly DanglingInventoryRow[];
   readonly danglingEnd: readonly DanglingInventoryRow[];
+  readonly agentExecutionPlans: readonly AgentExecutionPlanInventoryRow[];
   readonly catalogDependencies: readonly CatalogDependencyRow[];
 }
 
@@ -672,6 +726,354 @@ function classifyIdentity(
       ),
       classification: approvedClassification,
     },
+  };
+}
+
+const AGENT_EXECUTION_PLAN_DIMENSIONS = [
+  "danglingOrMissingHeadVersion",
+  "unsupportedOrInvalidContent",
+  "frameworkOrFallbackDifferences",
+  "systemEnvironmentDifferences",
+  "runnerGroupPolicyDifferences",
+  "runnerProfilePolicyDifferences",
+  "agentInstructionsMarkerOrMountDifferences",
+  "composeArtifactOrVolumeDifferences",
+  "otherLaunchAffectingLegacyFields",
+  "unclassifiedContent",
+] as const;
+
+type AgentExecutionPlanDimension =
+  (typeof AGENT_EXECUTION_PLAN_DIMENSIONS)[number];
+
+function cardinalityAwareComparison(
+  domain: string,
+  expected: readonly string[],
+  observed: readonly string[],
+): ReturnType<typeof comparison> {
+  const result = comparison(domain, expected, observed);
+  return {
+    ...result,
+    classification:
+      expected.length === result.expected.count &&
+      observed.length === result.observed.count &&
+      expected.length === observed.length &&
+      result.classification === "exact"
+        ? "exact"
+        : "drift",
+  };
+}
+
+function hasInvalidActiveVolumeReference(args: {
+  readonly declarations: readonly string[] | undefined;
+  readonly volumeNames: ReadonlySet<string>;
+}): boolean {
+  return (args.declarations ?? []).some((declaration) => {
+    const [name, mountPath, extra] = declaration.split(":");
+    return (
+      extra !== undefined ||
+      !name?.trim() ||
+      !mountPath?.trim() ||
+      !args.volumeNames.has(name.trim())
+    );
+  });
+}
+
+function hasLegacyEnvironmentInfluence(
+  environment: Readonly<Record<string, string>> | undefined,
+): boolean {
+  if (!environment) return false;
+  const plan = APPLICATION_OWNED_AGENT_EXECUTION_PLAN.environment;
+  const runtimeOverrideKeys = new Set<string>(plan.runtimeOverrideKeys);
+  return Object.keys(environment).some((key) => {
+    return (
+      !runtimeOverrideKeys.has(key) &&
+      !plan.legacyRemovedPrefixes.some((prefix) => {
+        return key.startsWith(prefix);
+      })
+    );
+  });
+}
+
+type ParsedAgentComposeContent = ReturnType<
+  typeof agentComposeApiContentSchema.parse
+>;
+type ParsedAgentDefinition = ParsedAgentComposeContent["agents"][string];
+
+type ValidatedAgentExecutionPlan =
+  | {
+      readonly classification: "exception";
+      readonly dimension: AgentExecutionPlanDimension;
+    }
+  | {
+      readonly classification: "supported";
+      readonly content: ParsedAgentComposeContent;
+      readonly activeAgentName: string;
+      readonly activeAgent: ParsedAgentDefinition;
+    };
+
+function isMissingCurrentPlanHead(
+  row: AgentExecutionPlanInventoryRow,
+): boolean {
+  return (
+    row.headVersionId === null || row.versionId === null || row.content === null
+  );
+}
+
+function hasValidCurrentPlanHash(
+  row: AgentExecutionPlanInventoryRow,
+): row is AgentExecutionPlanInventoryRow & {
+  readonly headVersionId: string;
+  readonly versionId: string;
+  readonly content: Record<string, unknown>;
+} {
+  return (
+    row.versionId !== null &&
+    row.versionId === row.headVersionId &&
+    typeof row.content === "object" &&
+    row.content !== null &&
+    !Array.isArray(row.content) &&
+    computeComposeVersionId(row.content as Record<string, unknown>) ===
+      row.versionId
+  );
+}
+
+function validateAgentExecutionPlanRow(
+  row: AgentExecutionPlanInventoryRow,
+): ValidatedAgentExecutionPlan {
+  if (isMissingCurrentPlanHead(row)) {
+    return {
+      classification: "exception",
+      dimension: "danglingOrMissingHeadVersion",
+    };
+  }
+  if (!hasValidCurrentPlanHash(row)) {
+    return {
+      classification: "exception",
+      dimension: "unsupportedOrInvalidContent",
+    };
+  }
+  const parsed = agentComposeApiContentSchema.safeParse(row.content);
+  if (!parsed.success) {
+    return {
+      classification: "exception",
+      dimension: "unsupportedOrInvalidContent",
+    };
+  }
+  if (!isDeepStrictEqual(row.content, parsed.data)) {
+    // Zod strips unknown object keys. Any such key could acquire runtime
+    // meaning later, so the shadow must not silently call it parity.
+    return { classification: "exception", dimension: "unclassifiedContent" };
+  }
+  const firstEntry = Object.entries(parsed.data.agents)[0];
+  const activeAgentName = firstEntry?.[0];
+  const activeAgent = firstEntry?.[1];
+  if (!activeAgentName || !activeAgent) {
+    return {
+      classification: "exception",
+      dimension: "unsupportedOrInvalidContent",
+    };
+  }
+  if (
+    hasInvalidActiveVolumeReference({
+      declarations: activeAgent.volumes,
+      volumeNames: new Set(Object.keys(parsed.data.volumes ?? {})),
+    })
+  ) {
+    return {
+      classification: "exception",
+      dimension: "unsupportedOrInvalidContent",
+    };
+  }
+  return {
+    classification: "supported",
+    content: parsed.data,
+    activeAgentName,
+    activeAgent,
+  };
+}
+
+function semanticAgentExecutionPlanDimensions(
+  row: AgentExecutionPlanInventoryRow,
+  validated: Extract<
+    ValidatedAgentExecutionPlan,
+    { readonly classification: "supported" }
+  >,
+): Set<AgentExecutionPlanDimension> {
+  const dimensions = new Set<AgentExecutionPlanDimension>();
+  const plan = APPLICATION_OWNED_AGENT_EXECUTION_PLAN;
+  const { activeAgent, activeAgentName, content } = validated;
+  // Selected providers supply the same effective framework to both plans.
+  // Compare only the legacy value that remains capable of acting as fallback.
+  if (activeAgent.framework !== plan.framework.fallback) {
+    dimensions.add("frameworkOrFallbackDifferences");
+  }
+  if (hasLegacyEnvironmentInfluence(activeAgent.environment)) {
+    dimensions.add("systemEnvironmentDifferences");
+  }
+  if (activeAgent.experimental_runner !== undefined) {
+    dimensions.add("runnerGroupPolicyDifferences");
+  }
+  if (
+    activeAgent.experimental_profile !== undefined &&
+    activeAgent.experimental_profile !== plan.runner.profile.fallback
+  ) {
+    dimensions.add("runnerProfilePolicyDifferences");
+  }
+  if (
+    plan.instructions.enabled &&
+    (activeAgent.instructions === undefined ||
+      activeAgentName !== row.agentName)
+  ) {
+    dimensions.add("agentInstructionsMarkerOrMountDifferences");
+  }
+  if (
+    (content.artifacts?.length ?? 0) > 0 ||
+    (activeAgent.volumes?.length ?? 0) > 0
+  ) {
+    dimensions.add("composeArtifactOrVolumeDifferences");
+  }
+  if (activeAgentName !== row.agentName) {
+    dimensions.add("otherLaunchAffectingLegacyFields");
+  }
+  return dimensions;
+}
+
+function dimensionsForAgentExecutionPlanRows(
+  rows: readonly AgentExecutionPlanInventoryRow[],
+): Set<AgentExecutionPlanDimension> {
+  if (rows.length === 0) {
+    return new Set(["danglingOrMissingHeadVersion"]);
+  }
+  const row = rows[0];
+  if (rows.length !== 1 || !row) {
+    return new Set(["unclassifiedContent"]);
+  }
+  const validated = validateAgentExecutionPlanRow(row);
+  if (validated.classification === "exception") {
+    return new Set([validated.dimension]);
+  }
+  return semanticAgentExecutionPlanDimensions(row, validated);
+}
+
+function classifyAgentExecutionPlans(
+  identityRows: readonly IdentityInventoryRow[],
+  rows: readonly AgentExecutionPlanInventoryRow[],
+  failureGates: Set<string>,
+) {
+  const expectedMatchedIds = identityRows
+    .filter((row) => {
+      return row.composePresent && row.zeroPresent;
+    })
+    .map((row) => {
+      return row.id;
+    });
+  const observedMatchedIds = rows.map((row) => {
+    return row.id;
+  });
+  const rowsById = new Map<string, AgentExecutionPlanInventoryRow[]>();
+  for (const row of rows) {
+    const existing = rowsById.get(row.id);
+    if (existing) existing.push(row);
+    else rowsById.set(row.id, [row]);
+  }
+
+  const dimensionIds = Object.fromEntries(
+    AGENT_EXECUTION_PLAN_DIMENSIONS.map((dimension) => {
+      return [dimension, new Set<string>()];
+    }),
+  ) as Record<AgentExecutionPlanDimension, Set<string>>;
+  const parityIds: string[] = [];
+  const exceptionIds: string[] = [];
+  const multiDimensionIds: string[] = [];
+
+  for (const id of expectedMatchedIds) {
+    const matches = rowsById.get(id) ?? [];
+    const dimensions = dimensionsForAgentExecutionPlanRows(matches);
+
+    if (dimensions.size === 0) {
+      parityIds.push(id);
+      continue;
+    }
+    exceptionIds.push(id);
+    if (dimensions.size > 1) multiDimensionIds.push(id);
+    for (const dimension of dimensions) {
+      dimensionIds[dimension].add(id);
+    }
+  }
+
+  const inventoryClosure = cardinalityAwareComparison(
+    "agent-execution-plans:inventory-closure",
+    expectedMatchedIds,
+    observedMatchedIds,
+  );
+  const partitionClosure = cardinalityAwareComparison(
+    "agent-execution-plans:partition-closure",
+    expectedMatchedIds,
+    [...parityIds, ...exceptionIds],
+  );
+  const dimensionUnionIds = [
+    ...new Set(
+      AGENT_EXECUTION_PLAN_DIMENSIONS.flatMap((dimension) => {
+        return [...dimensionIds[dimension]];
+      }),
+    ),
+  ];
+  const dimensionUnionClosure = cardinalityAwareComparison(
+    "agent-execution-plans:dimension-union-closure",
+    exceptionIds,
+    dimensionUnionIds,
+  );
+
+  for (const [name, closure] of [
+    ["inventoryClosure", inventoryClosure],
+    ["partitionClosure", partitionClosure],
+    ["dimensionUnionClosure", dimensionUnionClosure],
+  ] as const) {
+    if (closure.classification === "drift") {
+      failureGates.add(`agentExecutionPlans.${name}`);
+    }
+  }
+  for (const dimension of AGENT_EXECUTION_PLAN_DIMENSIONS) {
+    if (dimensionIds[dimension].size > 0) {
+      failureGates.add(`agentExecutionPlans.${dimension}`);
+    }
+  }
+  if (multiDimensionIds.length > 0) {
+    failureGates.add("agentExecutionPlans.multiDimensionExceptions");
+  }
+
+  const dimensionOutput = Object.fromEntries(
+    AGENT_EXECUTION_PLAN_DIMENSIONS.map((dimension) => {
+      return [
+        dimension,
+        fingerprintSortedSet(`agent-execution-plans:${dimension}:agent-ids`, [
+          ...dimensionIds[dimension],
+        ]),
+      ];
+    }),
+  ) as Record<AgentExecutionPlanDimension, SetFingerprint>;
+
+  return {
+    matched: fingerprintSortedSet(
+      "agent-execution-plans:matched-agent-ids",
+      expectedMatchedIds,
+    ),
+    completeSemanticParity: fingerprintSortedSet(
+      "agent-execution-plans:complete-semantic-parity-agent-ids",
+      parityIds,
+    ),
+    exceptions: fingerprintSortedSet(
+      "agent-execution-plans:exception-agent-ids",
+      exceptionIds,
+    ),
+    ...dimensionOutput,
+    multiDimensionExceptions: fingerprintSortedSet(
+      "agent-execution-plans:multi-dimension-exception-agent-ids",
+      multiDimensionIds,
+    ),
+    inventoryClosure,
+    partitionClosure,
+    dimensionUnionClosure,
   };
 }
 
@@ -1167,6 +1569,11 @@ export function classifyPreflightInventory(
     },
     failureGates,
   );
+  const agentExecutionPlans = classifyAgentExecutionPlans(
+    inventory.identity,
+    inventory.agentExecutionPlans,
+    failureGates,
+  );
   const versions = classifyVersions(inventory.versions, failureGates);
   const heads = classifyHeads(inventory.heads);
   const headHashSet = new Set(heads.distinctHashes);
@@ -1205,6 +1612,7 @@ export function classifyPreflightInventory(
         : ("failed" as const),
     failureGates: sortedFailureGates,
     capabilities,
+    agentExecutionPlans,
     identity,
     versions,
     heads: heads.output,
@@ -1267,6 +1675,23 @@ async function collectDatabaseInventory(
      FULL OUTER JOIN "zero_agents" AS "agent"
        ON "agent"."id" = "compose"."id"
      ORDER BY coalesce("compose"."id", "agent"."id")`,
+  );
+  const agentExecutionPlans = await safeQuery<AgentExecutionPlanInventoryRow>(
+    client,
+    signal,
+    `SELECT
+         "compose"."id"::text AS "id",
+         "agent"."name" AS "agentName",
+         "compose"."head_version_id" AS "headVersionId",
+         "version"."id" AS "versionId",
+         "version"."compose_id"::text AS "insertionComposeId",
+         "version"."content"
+       FROM "agent_composes" AS "compose"
+       INNER JOIN "zero_agents" AS "agent"
+         ON "agent"."id" = "compose"."id"
+       LEFT JOIN "agent_compose_versions" AS "version"
+         ON "version"."id" = "compose"."head_version_id"
+       ORDER BY "compose"."id"`,
   );
   const versions = await safeQuery<VersionInventoryRow>(
     client,
@@ -1335,6 +1760,7 @@ async function collectDatabaseInventory(
     checkpoints,
     danglingStart,
     danglingEnd,
+    agentExecutionPlans,
     catalogDependencies,
   };
 }

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -10,6 +10,7 @@ import {
   buildZeroAgentComposeContent,
   computeComposeVersionId,
 } from "../../../apps/api/src/signals/services/agent-compose-content";
+import { APPLICATION_OWNED_AGENT_EXECUTION_PLAN } from "../../../apps/api/src/signals/services/agent-execution-plan";
 import {
   CATALOG_DEPENDENCY_KINDS,
   CATALOG_DEPENDENCY_QUERY,
@@ -32,6 +33,7 @@ import {
   executeAgentComposeConsolidationPreflight,
   sanitizedFailureResult,
   withReadOnlySnapshot,
+  type AgentExecutionPlanInventoryRow,
   type DanglingInventoryRow,
   type HeadInventoryRow,
   type IdentityInventoryRow,
@@ -86,6 +88,7 @@ function emptyInventory(
     checkpoints: [],
     danglingStart: [],
     danglingEnd: [],
+    agentExecutionPlans: [],
     catalogDependencies: [],
     ...overrides,
   };
@@ -131,6 +134,85 @@ function identityRow(
   };
 }
 
+interface MutableAgentDefinition {
+  description?: string;
+  framework: "claude-code" | "codex";
+  volumes?: string[];
+  environment?: Record<string, string>;
+  instructions?: string;
+  skills?: string[];
+  experimental_runner?: { group: string };
+  experimental_profile?: string;
+  firewalls?: unknown;
+  futureField?: unknown;
+}
+
+interface MutableAgentContent extends Record<string, unknown> {
+  version: string;
+  agents: Record<string, MutableAgentDefinition>;
+  volumes?: Record<
+    string,
+    { name: string; version: string; optional?: boolean }
+  >;
+  artifacts?: { name: string; version?: string; mount_path?: string }[];
+  futureField?: unknown;
+}
+
+function mutableAgentContent(name: string): MutableAgentContent {
+  return structuredClone(
+    buildZeroAgentComposeContent(name),
+  ) as MutableAgentContent;
+}
+
+function executionPlanRow(args: {
+  readonly id: string;
+  readonly agentName: string;
+  readonly content?: unknown;
+  readonly headVersionId?: string | null;
+  readonly versionId?: string | null;
+  readonly insertionComposeId?: string | null;
+}): AgentExecutionPlanInventoryRow {
+  const content = Object.hasOwn(args, "content")
+    ? args.content
+    : buildZeroAgentComposeContent(args.agentName);
+  const computedVersionId =
+    content !== null && typeof content === "object" && !Array.isArray(content)
+      ? computeComposeVersionId(content as Record<string, unknown>)
+      : "f".repeat(64);
+  return {
+    id: args.id,
+    agentName: args.agentName,
+    headVersionId: Object.hasOwn(args, "headVersionId")
+      ? (args.headVersionId ?? null)
+      : computedVersionId,
+    versionId: Object.hasOwn(args, "versionId")
+      ? (args.versionId ?? null)
+      : computedVersionId,
+    insertionComposeId: Object.hasOwn(args, "insertionComposeId")
+      ? (args.insertionComposeId ?? null)
+      : args.id,
+    content,
+  };
+}
+
+function classifyPlanRows(
+  rows: readonly AgentExecutionPlanInventoryRow[],
+  identityIds: readonly string[] = rows.map((row) => {
+    return row.id;
+  }),
+) {
+  return classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      identity: [...new Set(identityIds)].map((id) => {
+        return identityRow(id);
+      }),
+      agentExecutionPlans: rows,
+    }),
+    classificationOptions(),
+  );
+}
+
 function gatePresent(
   result: { readonly failureGates: readonly string[] },
   gate: string,
@@ -138,11 +220,80 @@ function gatePresent(
   assert.ok(result.failureGates.includes(gate), `missing gate ${gate}`);
 }
 
+function testApplicationOwnedPlanAndCanonicalCompatibility(): void {
+  assert.deepEqual(APPLICATION_OWNED_AGENT_EXECUTION_PLAN, {
+    framework: { owner: "model-provider", fallback: "claude-code" },
+    environment: {
+      owners: ["system-identity", "model-provider", "connector", "run"],
+      legacyRemovedPrefixes: ["ZERO_"],
+      runtimeOverrideKeys: [
+        "CLI_PKG_URL",
+        "OKOU_AGENT_ID",
+        "OKOU_APP_URL",
+        "OKOU_TOKEN",
+        "OKOU_WEBSITE_TEMPLATE_ARCHIVE_VERSION",
+      ],
+      legacySerializedBindings: {
+        agentId: "OKOU_AGENT_ID",
+        token: "OKOU_TOKEN",
+      },
+    },
+    runner: {
+      group: {
+        owner: "execution-routing-policy",
+        fallback: null,
+      },
+      profile: {
+        owner: "resource-policy",
+        fallback: "vm0/default",
+      },
+    },
+    instructions: { owner: "agent-storage", enabled: true },
+    storage: {
+      owners: [
+        "system",
+        "connector",
+        "workflow",
+        "request",
+        "continuation",
+        "session-storage",
+      ],
+    },
+  });
+
+  const exact = buildZeroAgentComposeContent("agent-one");
+  assert.equal(
+    JSON.stringify(exact),
+    '{"version":"1","agents":{"agent-one":{"framework":"claude-code","instructions":"CLAUDE.md","environment":{"OKOU_AGENT_ID":"${{ vars.OKOU_AGENT_ID }}","OKOU_TOKEN":"${{ secrets.OKOU_TOKEN }}"}}}}',
+  );
+  for (const [name, hash] of [
+    ["abc", "95d80f7ce931ac6a5e34b5eb8929dee3244522bf859ac5f4c53e91e3cc3f6c6e"],
+    [
+      "agent-one",
+      "02345310e6913e03cb82d4c68a59f09a335ecd1bb2bf11b9ac4615eeac80ad53",
+    ],
+    [
+      "a".repeat(64),
+      "0c0c0c71cca0b457af4182ce1c1db5eab7289eb59e6135b90e46bb42412913bc",
+    ],
+  ] as const) {
+    assert.equal(
+      computeComposeVersionId(buildZeroAgentComposeContent(name)),
+      hash,
+    );
+  }
+}
+
 function testIdentityAndApprovedArtifacts(): void {
   const matched = identityRow("00000000-0000-4000-8000-000000000001");
   const exact = classifyPreflightInventory(
     capabilities,
-    emptyInventory({ identity: [matched] }),
+    emptyInventory({
+      identity: [matched],
+      agentExecutionPlans: [
+        executionPlanRow({ id: matched.id, agentName: "matched-agent" }),
+      ],
+    }),
     classificationOptions(),
   );
   assert.equal(exact.status, "passed");
@@ -287,6 +438,20 @@ function testVersionHeadRunAndCheckpointClassifications(): void {
       identity: [identityRow(firstAgent), identityRow(secondAgent)],
       versions: [version],
       heads,
+      agentExecutionPlans: [
+        executionPlanRow({
+          id: firstAgent,
+          agentName: "shared-agent",
+          content: version.content,
+          insertionComposeId: firstAgent,
+        }),
+        executionPlanRow({
+          id: secondAgent,
+          agentName: "shared-agent",
+          content: version.content,
+          insertionComposeId: firstAgent,
+        }),
+      ],
       runs: [
         {
           id: "00000000-0000-4000-8000-000000000211",
@@ -453,13 +618,23 @@ function testDanglingClassifications(): void {
     emptyInventory({
       identity: [identityRow(composeId)],
       heads: [head],
+      agentExecutionPlans: [
+        executionPlanRow({
+          id: composeId,
+          agentName: "dangling-agent",
+          content: null,
+          headVersionId: exactRow.recordedHash,
+          versionId: null,
+        }),
+      ],
       danglingStart: [exactRow],
       danglingEnd: [exactRow],
     }),
     classificationOptions({ expectedDanglingHeadCount: 1 }),
   );
-  assert.equal(exact.status, "passed");
+  assert.equal(exact.status, "failed");
   assert.equal(exact.danglingHeads.exact.count, 1);
+  assert.equal(exact.agentExecutionPlans.danglingOrMissingHeadVersion.count, 1);
 
   const nonExactRow = danglingRow({
     composeId,
@@ -497,6 +672,382 @@ function testDanglingClassifications(): void {
     classificationOptions({ expectedDanglingHeadCount: 1 }),
   );
   gatePresent(drift, "dangling.snapshot_drift");
+}
+
+function testAgentExecutionPlanClassifications(): void {
+  const id = (suffix: number): string => {
+    return `00000000-0000-4000-8000-${suffix.toString().padStart(12, "0")}`;
+  };
+
+  const canonical = classifyPlanRows([
+    executionPlanRow({ id: id(601), agentName: "canonical-agent" }),
+  ]);
+  assert.equal(canonical.status, "passed");
+  assert.equal(canonical.agentExecutionPlans.completeSemanticParity.count, 1);
+  assert.equal(canonical.agentExecutionPlans.exceptions.count, 0);
+  assert.equal(
+    canonical.agentExecutionPlans.inventoryClosure.classification,
+    "exact",
+  );
+  assert.equal(
+    canonical.agentExecutionPlans.partitionClosure.classification,
+    "exact",
+  );
+  assert.equal(
+    canonical.agentExecutionPlans.dimensionUnionClosure.classification,
+    "exact",
+  );
+
+  const injected = mutableAgentContent("injected-agent");
+  injected.agents["injected-agent"]!.environment = {
+    ZERO_AGENT_ID: "legacy-agent-id",
+    ZERO_TOKEN: "legacy-token",
+    CLI_PKG_URL: "legacy-cli-package",
+    OKOU_AGENT_ID: "legacy-okou-agent-id",
+    OKOU_APP_URL: "legacy-app-url",
+    OKOU_TOKEN: "legacy-okou-token",
+    OKOU_WEBSITE_TEMPLATE_ARCHIVE_VERSION: "legacy-template-version",
+  };
+  const injectedResult = classifyPlanRows([
+    executionPlanRow({
+      id: id(602),
+      agentName: "injected-agent",
+      content: injected,
+    }),
+  ]);
+  assert.equal(injectedResult.status, "passed");
+  assert.equal(
+    injectedResult.agentExecutionPlans.completeSemanticParity.count,
+    1,
+  );
+
+  const ignoredLegacyFields = mutableAgentContent("ignored-fields-agent");
+  ignoredLegacyFields.version = "legacy-version";
+  Object.assign(ignoredLegacyFields.agents["ignored-fields-agent"]!, {
+    description: "not used to launch",
+    skills: ["retired-skill"],
+    firewalls: { retired: { permissions: "all" } },
+  });
+  assert.equal(
+    classifyPlanRows([
+      executionPlanRow({
+        id: id(603),
+        agentName: "ignored-fields-agent",
+        content: ignoredLegacyFields,
+      }),
+    ]).status,
+    "passed",
+  );
+
+  const environment = mutableAgentContent("environment-agent");
+  environment.agents["environment-agent"]!.environment = {
+    CUSTOM_RUNTIME_VALUE: "raw-secret-value",
+  };
+  const environmentResult = classifyPlanRows([
+    executionPlanRow({
+      id: id(604),
+      agentName: "environment-agent",
+      content: environment,
+    }),
+  ]);
+  assert.equal(
+    environmentResult.agentExecutionPlans.systemEnvironmentDifferences.count,
+    1,
+  );
+
+  const framework = mutableAgentContent("framework-agent");
+  framework.agents["framework-agent"]!.framework = "codex";
+  const frameworkResult = classifyPlanRows([
+    executionPlanRow({
+      id: id(605),
+      agentName: "framework-agent",
+      content: framework,
+    }),
+  ]);
+  assert.equal(
+    frameworkResult.agentExecutionPlans.frameworkOrFallbackDifferences.count,
+    1,
+  );
+  assert.equal(
+    APPLICATION_OWNED_AGENT_EXECUTION_PLAN.framework.owner,
+    "model-provider",
+  );
+  assert.equal(
+    APPLICATION_OWNED_AGENT_EXECUTION_PLAN.framework.fallback,
+    "claude-code",
+  );
+
+  const explicitGroup = mutableAgentContent("runner-group-agent");
+  explicitGroup.agents["runner-group-agent"]!.experimental_runner = {
+    group: "vm0/default",
+  };
+  const explicitGroupResult = classifyPlanRows([
+    executionPlanRow({
+      id: id(606),
+      agentName: "runner-group-agent",
+      content: explicitGroup,
+    }),
+  ]);
+  assert.equal(
+    explicitGroupResult.agentExecutionPlans.runnerGroupPolicyDifferences.count,
+    1,
+  );
+
+  const explicitDefaultProfile = mutableAgentContent("default-profile-agent");
+  explicitDefaultProfile.agents["default-profile-agent"]!.experimental_profile =
+    "vm0/default";
+  assert.equal(
+    classifyPlanRows([
+      executionPlanRow({
+        id: id(607),
+        agentName: "default-profile-agent",
+        content: explicitDefaultProfile,
+      }),
+    ]).status,
+    "passed",
+  );
+  const customProfile = mutableAgentContent("custom-profile-agent");
+  customProfile.agents["custom-profile-agent"]!.experimental_profile =
+    "vm0/large";
+  assert.equal(
+    classifyPlanRows([
+      executionPlanRow({
+        id: id(608),
+        agentName: "custom-profile-agent",
+        content: customProfile,
+      }),
+    ]).agentExecutionPlans.runnerProfilePolicyDifferences.count,
+    1,
+  );
+
+  const alternateInstructionMarker = mutableAgentContent(
+    "instruction-marker-agent",
+  );
+  alternateInstructionMarker.agents["instruction-marker-agent"]!.instructions =
+    "AGENTS.md";
+  assert.equal(
+    classifyPlanRows([
+      executionPlanRow({
+        id: id(609),
+        agentName: "instruction-marker-agent",
+        content: alternateInstructionMarker,
+      }),
+    ]).status,
+    "passed",
+  );
+  const missingInstructions = mutableAgentContent("missing-instructions-agent");
+  delete missingInstructions.agents["missing-instructions-agent"]!.instructions;
+  assert.equal(
+    classifyPlanRows([
+      executionPlanRow({
+        id: id(610),
+        agentName: "missing-instructions-agent",
+        content: missingInstructions,
+      }),
+    ]).agentExecutionPlans.agentInstructionsMarkerOrMountDifferences.count,
+    1,
+  );
+
+  const artifact = mutableAgentContent("artifact-agent");
+  artifact.artifacts = [{ name: "legacy-artifact" }];
+  assert.equal(
+    classifyPlanRows([
+      executionPlanRow({
+        id: id(611),
+        agentName: "artifact-agent",
+        content: artifact,
+      }),
+    ]).agentExecutionPlans.composeArtifactOrVolumeDifferences.count,
+    1,
+  );
+  const volume = mutableAgentContent("volume-agent");
+  volume.agents["volume-agent"]!.volumes = ["legacy-volume:/data"];
+  volume.volumes = {
+    "legacy-volume": { name: "legacy-storage", version: "latest" },
+  };
+  assert.equal(
+    classifyPlanRows([
+      executionPlanRow({
+        id: id(612),
+        agentName: "volume-agent",
+        content: volume,
+      }),
+    ]).agentExecutionPlans.composeArtifactOrVolumeDifferences.count,
+    1,
+  );
+  const unreferencedVolume = mutableAgentContent("unreferenced-volume-agent");
+  unreferencedVolume.volumes = {
+    unused: { name: "legacy-storage", version: "latest" },
+  };
+  assert.equal(
+    classifyPlanRows([
+      executionPlanRow({
+        id: id(613),
+        agentName: "unreferenced-volume-agent",
+        content: unreferencedVolume,
+      }),
+    ]).status,
+    "passed",
+  );
+  const invalidVolume = mutableAgentContent("invalid-volume-agent");
+  invalidVolume.agents["invalid-volume-agent"]!.volumes = [
+    "missing-volume:/data",
+  ];
+  assert.equal(
+    classifyPlanRows([
+      executionPlanRow({
+        id: id(614),
+        agentName: "invalid-volume-agent",
+        content: invalidVolume,
+      }),
+    ]).agentExecutionPlans.unsupportedOrInvalidContent.count,
+    1,
+  );
+
+  const unknown = mutableAgentContent("unknown-agent");
+  unknown.futureField = { payload: "never-emit-unknown-payload" };
+  const unknownResult = classifyPlanRows([
+    executionPlanRow({
+      id: id(615),
+      agentName: "unknown-agent",
+      content: unknown,
+    }),
+  ]);
+  assert.equal(unknownResult.agentExecutionPlans.unclassifiedContent.count, 1);
+
+  const dangling = classifyPlanRows([
+    executionPlanRow({
+      id: id(616),
+      agentName: "dangling-plan-agent",
+      content: null,
+      headVersionId: "a".repeat(64),
+      versionId: null,
+    }),
+  ]);
+  assert.equal(
+    dangling.agentExecutionPlans.danglingOrMissingHeadVersion.count,
+    1,
+  );
+  const absent = classifyPlanRows([], [id(617)]);
+  assert.equal(
+    absent.agentExecutionPlans.danglingOrMissingHeadVersion.count,
+    1,
+  );
+  assert.equal(
+    absent.agentExecutionPlans.inventoryClosure.classification,
+    "drift",
+  );
+
+  const unsupported = executionPlanRow({
+    id: id(618),
+    agentName: "unsupported-agent",
+    content: { version: "1", agents: {} },
+  });
+  const hashMismatch = executionPlanRow({
+    id: id(619),
+    agentName: "hash-mismatch-agent",
+    headVersionId: "e".repeat(64),
+    versionId: "e".repeat(64),
+  });
+  const invalid = executionPlanRow({
+    id: id(620),
+    agentName: "invalid-agent",
+    content: "raw-invalid-payload",
+  });
+  const invalidResult = classifyPlanRows([unsupported, hashMismatch, invalid]);
+  assert.equal(
+    invalidResult.agentExecutionPlans.unsupportedOrInvalidContent.count,
+    3,
+  );
+
+  const crossProvenance = executionPlanRow({
+    id: id(621),
+    agentName: "cross-provenance-agent",
+    insertionComposeId: id(999),
+  });
+  assert.equal(classifyPlanRows([crossProvenance]).status, "passed");
+  const crossNameContent = mutableAgentContent("other-agent-name");
+  const crossName = classifyPlanRows([
+    executionPlanRow({
+      id: id(622),
+      agentName: "product-agent-name",
+      content: crossNameContent,
+      insertionComposeId: id(998),
+    }),
+  ]);
+  assert.equal(
+    crossName.agentExecutionPlans.otherLaunchAffectingLegacyFields.count,
+    1,
+  );
+  assert.equal(
+    crossName.agentExecutionPlans.agentInstructionsMarkerOrMountDifferences
+      .count,
+    1,
+  );
+  assert.equal(crossName.agentExecutionPlans.multiDimensionExceptions.count, 1);
+
+  const combined = mutableAgentContent("combined-agent");
+  const combinedAgent = combined.agents["combined-agent"]!;
+  combinedAgent.framework = "codex";
+  combinedAgent.environment = { CUSTOM_VALUE: "combined-sensitive-value" };
+  combinedAgent.experimental_runner = { group: "vm0/custom" };
+  combinedAgent.experimental_profile = "vm0/large";
+  delete combinedAgent.instructions;
+  combined.artifacts = [{ name: "combined-artifact" }];
+  const combinedResult = classifyPlanRows([
+    executionPlanRow({
+      id: id(623),
+      agentName: "combined-agent",
+      content: combined,
+    }),
+  ]);
+  assert.equal(combinedResult.agentExecutionPlans.exceptions.count, 1);
+  assert.equal(
+    combinedResult.agentExecutionPlans.multiDimensionExceptions.count,
+    1,
+  );
+  assert.equal(
+    combinedResult.agentExecutionPlans.dimensionUnionClosure.classification,
+    "exact",
+  );
+
+  const orderedRows = [
+    executionPlanRow({ id: id(624), agentName: "order-one" }),
+    executionPlanRow({ id: id(625), agentName: "order-two" }),
+  ];
+  assert.deepEqual(
+    classifyPlanRows([...orderedRows].reverse()),
+    classifyPlanRows(orderedRows),
+  );
+  const duplicate = classifyPlanRows([orderedRows[0]!, orderedRows[0]!]);
+  assert.equal(
+    duplicate.agentExecutionPlans.inventoryClosure.classification,
+    "drift",
+  );
+  assert.equal(duplicate.agentExecutionPlans.unclassifiedContent.count, 1);
+  const duplicateIdentity = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      identity: [identityRow(id(626)), identityRow(id(626))],
+      agentExecutionPlans: [
+        executionPlanRow({ id: id(626), agentName: "duplicate-identity" }),
+        executionPlanRow({ id: id(626), agentName: "duplicate-identity" }),
+      ],
+    }),
+    classificationOptions(),
+  );
+  assert.equal(
+    duplicateIdentity.agentExecutionPlans.inventoryClosure.classification,
+    "drift",
+  );
+  assert.equal(
+    duplicateIdentity.agentExecutionPlans.partitionClosure.classification,
+    "drift",
+  );
+  assert.equal(
+    duplicateIdentity.agentExecutionPlans.dimensionUnionClosure.classification,
+    "drift",
+  );
 }
 
 function testDependencyDriftAndDeterminism(): void {
@@ -548,9 +1099,21 @@ function testOutputRedaction(): void {
   const rawId = "00000000-0000-4000-8000-000000000501";
   const rawName = "never-emit-agent-name";
   const dangling = danglingRow({ composeId: rawId, name: rawName });
+  const rawPlanContent = mutableAgentContent(rawName);
+  rawPlanContent.agents[rawName]!.environment = {
+    RAW_SECRET_KEY: "never-emit-environment-value",
+  };
   const result = classifyPreflightInventory(
     capabilities,
     emptyInventory({
+      identity: [identityRow(rawId)],
+      agentExecutionPlans: [
+        executionPlanRow({
+          id: rawId,
+          agentName: rawName,
+          content: rawPlanContent,
+        }),
+      ],
       versions: [
         {
           id: "d".repeat(64),
@@ -570,6 +1133,8 @@ function testOutputRedaction(): void {
     rawId,
     rawName,
     "never-emit-version-content",
+    "never-emit-environment-value",
+    "RAW_SECRET_KEY",
     "OKOU_TOKEN",
     "user_clerk_fixture",
     "postgresql://user:secret@host/database",
@@ -588,6 +1153,7 @@ function testOutputRedaction(): void {
     "status",
     "failureGates",
     "capabilities",
+    "agentExecutionPlans",
     "identity",
     "versions",
     "heads",
@@ -628,7 +1194,7 @@ function assertSafeAggregateValues(value: unknown, pathPrefix = ""): void {
     return;
   }
   const allowedClassifications = new Set([
-    "vm0.agent-compose-consolidation-preflight.v1",
+    "vm0.agent-compose-consolidation-preflight.v2",
     "passed",
     "failed",
     "exact",
@@ -730,6 +1296,12 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
       workflow.indexOf('>> "$GITHUB_OUTPUT"'),
   );
   assert.match(workflow, /scripts\/agent-compose-consolidation-preflight\.ts/u);
+  assert.match(workflow, /#27613 \+ #27656/u);
+  assert.match(workflow, /vm0\.agent-compose-consolidation-preflight\.v2/u);
+  assert.equal(
+    workflow.includes("vm0.agent-compose-consolidation-preflight.v1"),
+    false,
+  );
   assert.equal(
     /pull_request:|schedule:|actions\/upload-artifact/iu.test(workflow),
     false,
@@ -750,6 +1322,13 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
     ),
     "utf8",
   );
+  const executionPlanOwner = await fs.readFile(
+    path.join(
+      repositoryRoot,
+      "turbo/apps/api/src/signals/services/agent-execution-plan.ts",
+    ),
+    "utf8",
+  );
   assert.equal(
     service.includes("function buildZeroAgentComposeContent"),
     false,
@@ -762,6 +1341,16 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
   assert.equal(
     contentOwner.match(/function computeComposeVersionId/gu)?.length,
     1,
+  );
+  assert.equal(
+    executionPlanOwner.match(/const APPLICATION_OWNED_AGENT_EXECUTION_PLAN/gu)
+      ?.length,
+    1,
+  );
+  assert.equal(executionPlanOwner.includes("agent-compose"), false);
+  assert.equal(
+    contentOwner.includes("APPLICATION_OWNED_AGENT_EXECUTION_PLAN"),
+    true,
   );
 }
 
@@ -1083,9 +1672,11 @@ async function testDatabaseBoundaries(databaseUrl: string): Promise<void> {
 }
 
 export async function validateAgentComposeConsolidationPreflightStatic(): Promise<void> {
+  testApplicationOwnedPlanAndCanonicalCompatibility();
   testIdentityAndApprovedArtifacts();
   testVersionHeadRunAndCheckpointClassifications();
   testDanglingClassifications();
+  testAgentExecutionPlanClassifications();
   testDependencyDriftAndDeterminism();
   testOutputRedaction();
   await testRepositoryAndWorkflowValidators();


### PR DESCRIPTION
## Summary

- define one pure application-owned Agent execution-plan baseline while keeping provider, Connector, Workflow, request, continuation, Storage, and routing inputs at their existing boundaries
- make `buildZeroAgentComposeContent` a transitional adapter over that baseline without changing canonical JSON ordering or content-addressed hashes
- extend the existing read-only production preflight with aggregate-only current-head semantic shadow classifications and exact closure checks
- advance the reviewed output schema to v2 and retain #26938 Stage 8 as the transition-validator removal owner

## Shadow contract

- partitions every matched `agent_composes` + `zero_agents` identity exactly once into complete semantic parity or exceptions
- emits domain-separated count/digest sets for dangling or missing heads, unsupported or invalid content, framework fallback, system environment, runner group/profile policy, Agent instructions, Compose artifact/volume, other launch influence, multi-dimension, and unclassified exceptions
- closes the plan inventory against the matched identity inventory, the top-level partition against matched Agents, and the dimension union against all exceptions
- normalizes always-overridden Okou system environment keys and runtime-removed `ZERO_` branding while classifying every remaining environment influence
- treats provider-selected effective framework as an external owner and compares the legacy Compose value only as a possible fallback
- excludes the six approved Compose-only artifacts through the matched-identity join and classifies the known dangling heads without repair
- permits only the existing aggregate output plus the reviewed `agentExecutionPlans` count/digest and closure leaves; raw names, content, values, IDs, secrets, payloads, and connection material remain prohibited

## Inventory and safety

- rebased onto exact `main` `57f9504c4bd1b596dcc4b6b6fba97d5e5f3186d4`, which contains #27655 at `4618ea5631eebb765cccbd09d6e1ccd008640a52`
- paginated all 23 open PR changed-file inventories after rebase; only #25722 and #26947 touch `agent-run-create.service.ts`, and none touch this PR target files
- refreshed the repository dependency manifest for the two Connector-scope entries retired by #27655
- does not edit `agent-run-create.service.ts`, restore or model `legacy_all`, change launch selection, add telemetry, mutate data, add a migration or route, or change a runtime contract

## Validation

- focused static Agent/Compose consolidation preflight tests
- `pnpm check-types` in `turbo/packages/db`
- `pnpm check-types` in `turbo/apps/api`
- targeted Oxlint, type-aware Oxlint, and ESLint for changed TypeScript files
- Prettier check for all changed files
- database-backed read-only, timeout, cancellation, repeatable-read, and idempotency coverage remains in the focused script for PR CI; no local `DATABASE_URL` was available

Closes #27656

Parent #26938