### PR TITLE
fix(billing): restore cancellation before scheduling downgrade

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-downgrade.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-downgrade.test.ts
@@ -297,6 +297,109 @@ describe("POST /api/zero/billing/downgrade", () => {
     });
   });
 
+  it("restores a direct cancellation before scheduling team to pro", async () => {
+    const subId = `sub-team-cancel-pro-${randomUUID().slice(0, 8)}`;
+    const periodStart = 1_782_809_751;
+    const periodEnd = 1_785_401_751;
+    const scheduleId = `sched-team-cancel-pro-${randomUUID().slice(0, 8)}`;
+    const effectiveDate = new Date(periodEnd * 1000);
+    const fixture = await track(
+      store.set(
+        seedInvoicesOrg$,
+        {
+          stripeSubscriptionId: subId,
+          subscriptionStatus: "active",
+          tier: "team",
+          currentPeriodEnd: effectiveDate,
+          cancelAtPeriodEnd: true,
+          pendingSubscriptionTargetTier: "limited-free-1",
+          pendingSubscriptionChangeAt: effectiveDate,
+        },
+        context.signal,
+      ),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      id: subId,
+      cancel_at_period_end: true,
+      default_payment_method: "pm_card",
+      schedule: null,
+      items: {
+        data: [
+          {
+            id: "si_item_1",
+            current_period_start: periodStart,
+            current_period_end: periodEnd,
+            quantity: 1,
+            price: {
+              id: TEST_PRICE_TEAM,
+              recurring: { interval: "month", interval_count: 1 },
+            },
+          },
+        ],
+      },
+    });
+    context.mocks.stripe.subscriptions.update.mockResolvedValue({ id: subId });
+    context.mocks.stripe.subscriptionSchedules.create.mockResolvedValue({
+      id: scheduleId,
+      current_phase: {
+        start_date: periodStart,
+        end_date: periodEnd,
+      },
+    });
+    context.mocks.stripe.subscriptionSchedules.update.mockResolvedValue({
+      id: scheduleId,
+    });
+
+    const client = setupApp({ context, routes: billingDowngradeRoutes })(
+      zeroBillingDowngradeContract,
+    );
+    const response = await accept(
+      client.create({
+        body: { targetTier: "pro" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      success: true,
+      effectiveDate: effectiveDate.toISOString(),
+    });
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledWith(
+      subId,
+      { cancel_at_period_end: false },
+    );
+    const restoreCall =
+      context.mocks.stripe.subscriptions.update.mock.invocationCallOrder[0];
+    const createScheduleCall =
+      context.mocks.stripe.subscriptionSchedules.create.mock
+        .invocationCallOrder[0];
+    const updateScheduleCall =
+      context.mocks.stripe.subscriptionSchedules.update.mock
+        .invocationCallOrder[0];
+    if (
+      restoreCall === undefined ||
+      createScheduleCall === undefined ||
+      updateScheduleCall === undefined
+    ) {
+      throw new Error(
+        "Expected cancellation restore and schedule update calls",
+      );
+    }
+    expect(restoreCall).toBeLessThan(createScheduleCall);
+    expect(createScheduleCall).toBeLessThan(updateScheduleCall);
+
+    const status = await readBillingStatus();
+    expect(status.body.cancelAtPeriodEnd).toBeFalsy();
+    expect(status.body.scheduledChange).toStrictEqual({
+      type: "downgrade",
+      targetTier: "pro",
+      effectiveDate: effectiveDate.toISOString(),
+    });
+  });
+
   it("preserves usage packs when scheduling team to pro", async () => {
     mockEnv("ZERO_PRICE_USAGE_PACK_PLAN_PRO", TEST_USAGE_PACK_PLAN_PRO);
     mockEnv("ZERO_PRICE_USAGE_PACK_PLAN_TEAM", TEST_USAGE_PACK_PLAN_TEAM);

--- a/turbo/apps/api/src/signals/services/zero-billing-downgrade.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-downgrade.service.ts
@@ -332,9 +332,19 @@ async function scheduleDowngradeToPro(
     throw new Error("Pro plan price ID not configured");
   }
 
+  const attachedScheduleId = subscriptionScheduleId(subscription);
+  // Restore a direct cancellation before attaching a schedule so concurrent
+  // subscription.updated handlers re-read a non-canceling Stripe state.
+  if (subscription.cancel_at_period_end && !attachedScheduleId) {
+    await context.stripe.subscriptions.update(
+      context.org.stripeSubscriptionId,
+      { cancel_at_period_end: false },
+    );
+    signal?.throwIfAborted();
+  }
+
   const existingScheduleId =
-    context.org.pendingSubscriptionScheduleId ??
-    subscriptionScheduleId(subscription);
+    context.org.pendingSubscriptionScheduleId ?? attachedScheduleId;
   const createdSchedule = existingScheduleId
     ? null
     : await context.stripe.subscriptionSchedules.create({


### PR DESCRIPTION
## Summary

- clear a direct Stripe period-end cancellation before attaching and updating the Pro downgrade schedule
- preserve the Team to Pro scheduled intent when concurrent `subscription.updated` handlers re-read Stripe state
- cover the cancellation-to-schedule call order and persisted billing status with a focused route regression test

## Failure evidence

Trigger: [Turbo run 31996360681](https://github.com/vm0-ai/vm0/actions/runs/31996360681), `cli-e2e-02-playwright` job [95289049158](https://github.com/vm0-ai/vm0/actions/runs/31996360681/job/95289049158), test `usage-pack and Plan transitions preserve scheduled intent`.

The failed run kept returning authenticated billing status responses through 05:06:30.576Z, then the fixed Clerk token expired and polling returned 401 from 05:06:31.661Z onward. The 60-second timeout, aggregate gate failure, and later Clerk `Test ended` warning were downstream or post-failure effects.

The state diverged earlier at the cancellation-to-schedule boundary:

- the downgrade route created and updated the Stripe schedule, then persisted the Pro target at 05:05:44.682Z
- a concurrent `subscription.updated` handler re-retrieved the subscription while Stripe still exposed `cancel_at_period_end=true`, then persisted the old cancellation target at 05:05:44.726Z after the route write
- the error artifact consequently showed Team still scheduled for Limited free rather than Pro
- in the passing exact-SHA merge-group run [31995976519](https://github.com/vm0-ai/vm0/actions/runs/31995976519), the equivalent stale webhook write landed before the route's Pro write, so the intended state won

The pass/fail outcome therefore depended on the ordering of the route's local intent write and a webhook re-read during the two-call schedule attachment/update window. This change first awaits Stripe confirmation that the direct cancellation is cleared, so webhook re-reads at the schedule boundary observe a non-canceling subscription before the schedule is attached and updated.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (passes; existing repository warnings remain)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- targeted Prettier, Oxlint, and ESLint checks for the changed files
- `git diff --check origin/main...HEAD`

The focused Vitest command collected all 17 route tests but skipped them before their bodies because PostgreSQL was unavailable at both `::1:5432` and `127.0.0.1:5432`. Per the repair constraints, no local database or service was started, so the five-run repetition was not performed locally.

## Preview validation

Deployment succeeded for head `60eebbb57a197e065e720d0e7680be3e2af58445`:

- App: https://pr-27672-app.omby.ai from [deploy-app](https://github.com/vm0-ai/vm0/actions/runs/31999573869/job/95297255633)
- API: https://pr-27672-api.vm6.ai from [deploy-api](https://github.com/vm0-ai/vm0/actions/runs/31999573869/job/95297340001), backed by immutable deployment https://vm0-kenywujc9.vm6.ai

Authenticated billing-state validation, five narrow repetitions where feasible, and screenshots are pending browser authorization. The PR remains Draft until that validation succeeds.

## Recurrence evidence: main run 32019977498

[Turbo run 32019977498](https://github.com/vm0-ai/vm0/actions/runs/32019977498) reproduced the same failure on main SHA `1161535ac5bfc6b767a70eb1b745d81c3ec51ae9`. The only substantive failure was [`cli-e2e-02-playwright`](https://github.com/vm0-ai/vm0/actions/runs/32019977498/job/95358533993): the same `usage-pack and Plan transitions preserve scheduled intent` test failed while 24 other tests passed. The aggregate `ci-gate-turbo` failure was downstream.

The Playwright artifact again preserved the earlier business-state divergence: the signed-in Billing page still showed **Team plan → Limited free** with **Restore plan**, rather than the requested scheduled downgrade to Pro. Bounded Axiom queries over `2026-08-17T10:29:30Z`–`10:33:40Z` then proved the same cancellation-to-schedule overwrite:

- the final downgrade route started at `10:31:36.020Z`, created the schedule at `10:31:36.066Z`, updated it at `10:31:36.444Z`, and persisted the Pro intent at `10:31:37.203Z` (trace `1c13a5cae5efb9003c486d8b435e3535`)
- a subsequent `customer.subscription.updated` handler re-retrieved the subscription at `10:31:37.474Z`, read the attached schedule at `10:31:37.608Z`, and updated `org_metadata` at `10:31:37.690Z` after the route write (trace `72977e2e94c279baca0cec58cff8bd22`)
- at this exact SHA, the legacy handler maps `periodEnd + pendingScheduleId` to the canceled target while the direct `cancel_at_period_end` flag remains set, so the later webhook write replaces Pro with Limited free

Authentication loss was again downstream of the state divergence. The owning poll returned HTTP 200 through `10:32:22.153Z`, then returned 14 consecutive 401 responses from `10:32:23.242Z` through `10:32:37.240Z`. The test recorded `F` at `10:32:38.707Z`; the Clerk Testing `route.fetch: Test ended` warning arrived later at `10:32:53.049Z`, so it was not causal. The same warning also occurred in the passing exact-SHA merge-group job [95354133821](https://github.com/vm0-ai/vm0/actions/runs/32018659588/job/95354133821).

PR #27749 changed only the agent-compose consolidation preflight workflow, database scripts, and their tests. It did not change this billing route, Playwright test, or Clerk ownership path. This recurrence therefore reinforces the existing fix boundary: await removal of direct period-end cancellation before attaching/updating the schedule, so later webhook re-reads cannot reconstruct the stale Limited free intent.
