### PR TITLE
refactor(vsock-guest): share worker ownership guards

### DIFF
--- a/crates/vsock-guest/src/file_write_worker.rs
+++ b/crates/vsock-guest/src/file_write_worker.rs
@@ -10,6 +10,9 @@ use crate::handlers::{
 };
 use crate::log::log;
 use crate::quiesce::OperationGuard;
+use crate::worker_ownership::{
+    ShutdownConnectionOnDrop, SingleActiveAdmission, SingleActivePermit,
+};
 use crate::writer::GuestWriter;
 
 const THREAD_FILE_WRITE: &str = "vsock-file-write";
@@ -41,37 +44,19 @@ pub(crate) enum FileWriteSubmitError {
     Disconnected,
 }
 
-pub(crate) struct FileWriteAdmission {
-    active: Arc<AtomicBool>,
-}
-
-impl Drop for FileWriteAdmission {
-    fn drop(&mut self) {
-        self.active.store(false, Ordering::Release);
-    }
-}
-
 struct FileWriteRequest {
     kind: FileWriteKind,
     seq: u32,
     payload: Vec<u8>,
     operation_guard: OperationGuard,
-    admission: FileWriteAdmission,
+    admission: SingleActivePermit,
 }
 
 pub(crate) struct FileWriteWorker {
     sender: Option<SyncSender<FileWriteRequest>>,
     handle: Option<JoinHandle<()>>,
-    active: Arc<AtomicBool>,
+    admission: SingleActiveAdmission,
     connection_cancel: Arc<AtomicBool>,
-}
-
-struct ShutdownConnectionOnDrop(GuestWriter);
-
-impl Drop for ShutdownConnectionOnDrop {
-    fn drop(&mut self) {
-        self.0.shutdown();
-    }
 }
 
 impl FileWriteWorker {
@@ -90,7 +75,7 @@ impl FileWriteWorker {
                 // This worker exists for exactly one connection. Any exit,
                 // including an unwind, closes that connection so a pending
                 // host request cannot wait without a response producer.
-                let _shutdown_on_exit = ShutdownConnectionOnDrop(writer.clone());
+                let _shutdown_on_exit = ShutdownConnectionOnDrop::new(writer.clone());
                 while let Ok(request) = receiver.recv() {
                     if let Err(error) = handle_request(request, &writer, &worker_cancel) {
                         log("ERROR", &format!("file-write worker failed: {error}"));
@@ -102,18 +87,13 @@ impl FileWriteWorker {
         Ok(Self {
             sender: Some(sender),
             handle: Some(handle),
-            active: Arc::new(AtomicBool::new(false)),
+            admission: SingleActiveAdmission::new(),
             connection_cancel,
         })
     }
 
-    pub(crate) fn try_admit(&self) -> Option<FileWriteAdmission> {
-        self.active
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .ok()
-            .map(|_| FileWriteAdmission {
-                active: Arc::clone(&self.active),
-            })
+    pub(crate) fn try_admit(&self) -> Option<SingleActivePermit> {
+        self.admission.try_acquire()
     }
 
     pub(crate) fn submit(
@@ -122,7 +102,7 @@ impl FileWriteWorker {
         seq: u32,
         payload: &[u8],
         operation_guard: OperationGuard,
-        admission: FileWriteAdmission,
+        admission: SingleActivePermit,
     ) -> Result<(), FileWriteSubmitError> {
         let request = FileWriteRequest {
             kind,

--- a/crates/vsock-guest/src/guest_dns_readiness.rs
+++ b/crates/vsock-guest/src/guest_dns_readiness.rs
@@ -22,6 +22,9 @@ use crate::user::apply_command_identity;
 use crate::wait::{
     WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
 };
+use crate::worker_ownership::{
+    ShutdownConnectionOnDrop, SingleActiveAdmission, SingleActivePermit,
+};
 use crate::writer::GuestWriter;
 
 const PRODUCTION_PROGRAM: &str = "/usr/bin/getent";
@@ -61,43 +64,25 @@ pub(crate) enum GuestDnsReadinessSubmitError {
     Start(io::Error),
 }
 
-pub(crate) struct GuestDnsReadinessAdmission {
-    active: Arc<AtomicBool>,
-}
-
-impl Drop for GuestDnsReadinessAdmission {
-    fn drop(&mut self) {
-        self.active.store(false, Ordering::Release);
-    }
-}
-
 struct GuestDnsReadinessRequest {
     seq: u32,
     timeout_ms: u32,
     hostname: String,
     operation_guard: OperationGuard,
-    admission: GuestDnsReadinessAdmission,
+    admission: SingleActivePermit,
 }
 
 pub(crate) struct GuestDnsReadinessWorker {
     state: Mutex<GuestDnsReadinessWorkerState>,
     writer: GuestWriter,
     program: GuestDnsReadinessProgram,
-    active: Arc<AtomicBool>,
+    admission: SingleActiveAdmission,
     connection_cancel: Arc<AtomicBool>,
 }
 
 struct GuestDnsReadinessWorkerState {
     sender: Option<SyncSender<GuestDnsReadinessRequest>>,
     handle: Option<JoinHandle<()>>,
-}
-
-struct ShutdownConnectionOnDrop(GuestWriter);
-
-impl Drop for ShutdownConnectionOnDrop {
-    fn drop(&mut self) {
-        self.0.shutdown();
-    }
 }
 
 impl GuestDnsReadinessWorker {
@@ -113,18 +98,13 @@ impl GuestDnsReadinessWorker {
             }),
             writer,
             program,
-            active: Arc::new(AtomicBool::new(false)),
+            admission: SingleActiveAdmission::new(),
             connection_cancel,
         }
     }
 
-    pub(crate) fn try_admit(&self) -> Option<GuestDnsReadinessAdmission> {
-        self.active
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .ok()
-            .map(|_| GuestDnsReadinessAdmission {
-                active: Arc::clone(&self.active),
-            })
+    pub(crate) fn try_admit(&self) -> Option<SingleActivePermit> {
+        self.admission.try_acquire()
     }
 
     pub(crate) fn submit(
@@ -133,7 +113,7 @@ impl GuestDnsReadinessWorker {
         timeout_ms: u32,
         hostname: &str,
         operation_guard: OperationGuard,
-        admission: GuestDnsReadinessAdmission,
+        admission: SingleActivePermit,
     ) -> Result<(), GuestDnsReadinessSubmitError> {
         let sender = self.sender()?;
         let request = GuestDnsReadinessRequest {
@@ -163,7 +143,7 @@ impl GuestDnsReadinessWorker {
         let handle = thread::Builder::new()
             .name(THREAD_WORKER.to_string())
             .spawn(move || {
-                let _shutdown_on_exit = ShutdownConnectionOnDrop(writer.clone());
+                let _shutdown_on_exit = ShutdownConnectionOnDrop::new(writer.clone());
                 while let Ok(request) = receiver.recv() {
                     if let Err(error) = handle_request(request, &writer, &worker_cancel, &program) {
                         log(

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -26,6 +26,7 @@ mod test_support;
 mod threading;
 mod user;
 mod wait;
+mod worker_ownership;
 mod writer;
 
 pub use connection::handle_connection_with_test_dns_readiness_program;

--- a/crates/vsock-guest/src/worker_ownership.rs
+++ b/crates/vsock-guest/src/worker_ownership.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::writer::GuestWriter;
+
+pub(crate) struct SingleActiveAdmission {
+    active: Arc<AtomicBool>,
+}
+
+impl SingleActiveAdmission {
+    pub(crate) fn new() -> Self {
+        Self {
+            active: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub(crate) fn try_acquire(&self) -> Option<SingleActivePermit> {
+        self.active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| SingleActivePermit {
+                active: Arc::clone(&self.active),
+            })
+    }
+}
+
+pub(crate) struct SingleActivePermit {
+    active: Arc<AtomicBool>,
+}
+
+impl Drop for SingleActivePermit {
+    fn drop(&mut self) {
+        self.active.store(false, Ordering::Release);
+    }
+}
+
+pub(crate) struct ShutdownConnectionOnDrop(GuestWriter);
+
+impl ShutdownConnectionOnDrop {
+    pub(crate) fn new(writer: GuestWriter) -> Self {
+        Self(writer)
+    }
+}
+
+impl Drop for ShutdownConnectionOnDrop {
+    fn drop(&mut self) {
+        self.0.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary

- centralize the connection-worker single-active admission state and affine RAII permit in one private `vsock-guest` module
- share the shutdown-on-worker-exit guard between file-write and DNS-readiness workers
- preserve each worker's eager or lazy startup, request handling, cancellation, error mapping, sender closure, and join behavior

## Compatibility

- no wire protocol, public API, persisted state, configuration, or deployment contract changes
- preserve the existing `AcqRel`/`Acquire` acquisition and `Release` drop ordering
- keep the admission permit non-cloneable and at the existing request/writer-boundary lifetime

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-test`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-test --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-test --all-features --no-deps`
- `git diff --check`
- repository pre-commit Rust formatting, documentation, Clippy, file-size, and commit-message hooks

Closes #27668
