### PR TITLE
fix(guest-download): preserve normalized cleanup paths

### DIFF
--- a/crates/guest-download/src/archive.rs
+++ b/crates/guest-download/src/archive.rs
@@ -1,9 +1,10 @@
 use crate::LOG_TAG;
 use crate::error::DownloadError;
+use crate::path::normalize_path;
 use crate::source::{ArchiveSource, HttpBodyReadFailure};
 use guest_common::log_warn;
 use std::io;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
 /// Extract a gzip-compressed tar archive into an existing target directory.
 ///
@@ -161,25 +162,6 @@ fn archive_error(
     }
 }
 
-/// Lexically normalize a path by collapsing `.` and `..` components.
-/// Unlike `canonicalize()`, this does not touch the filesystem.
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut components: Vec<Component> = Vec::new();
-    for component in path.components() {
-        match component {
-            Component::ParentDir => {
-                // Only pop Normal components; don't pop RootDir or Prefix
-                if matches!(components.last(), Some(Component::Normal(_))) {
-                    components.pop();
-                }
-            }
-            Component::CurDir => {}
-            c => components.push(c),
-        }
-    }
-    components.iter().collect()
-}
-
 /// Check whether `path` stays within `target` after lexical normalization.
 fn is_within(path: &Path, target: &Path) -> bool {
     normalize_path(path).starts_with(target)
@@ -219,6 +201,7 @@ mod tests {
     use flate2::Compression;
     use flate2::write::GzEncoder;
     use std::io::{Cursor, Write};
+    use std::path::PathBuf;
 
     enum TarEntry<'a> {
         File(&'a str, &'a [u8]),

--- a/crates/guest-download/src/cleanup.rs
+++ b/crates/guest-download/src/cleanup.rs
@@ -1,4 +1,5 @@
 use crate::LOG_TAG;
+use crate::path::normalize_path;
 use guest_common::{log_info, log_warn};
 use std::cell::OnceCell;
 use std::collections::HashSet;
@@ -14,6 +15,7 @@ use std::path::{Component, Path, PathBuf};
 /// to unchanged storages.
 ///
 /// For each path in `cleanup_paths`:
+/// - If the path is at or below a preserved path: skip it.
 /// - If a preserved path is a child: remove only top-level entries that don't
 ///   overlap with any preserved child path.
 /// - If no `preserved` path is a child and the path is a mountpoint: preserve
@@ -57,55 +59,97 @@ fn cleanup_stale_paths_with_options<M, R>(
     M: Fn(&Path) -> bool,
     R: Fn(&fs::DirEntry) -> io::Result<()>,
 {
-    // Sort cleanup paths shortest-first so parents are cleaned before children.
-    let mut sorted: Vec<&str> = cleanup_paths.iter().map(|s| s.as_str()).collect();
-    sorted.sort_by_key(|p| p.len());
+    let preserved = preserved
+        .iter()
+        .map(|path| normalize_path(Path::new(path)))
+        .collect::<HashSet<_>>();
+    let mut sorted = cleanup_paths
+        .iter()
+        .map(|path| {
+            let original = Path::new(path);
+            CleanupPath {
+                original,
+                logical: normalize_path(original),
+            }
+        })
+        .collect::<Vec<_>>();
+    sorted.sort_by_key(|path| path.logical.components().count());
 
     for path in sorted {
-        let cleanup_path = Path::new(path);
-        let preserved_child_count = count_preserved_children(cleanup_path, preserved);
+        if is_preserved_or_descendant(&path.logical, &preserved) {
+            continue;
+        }
+
+        let preserved_child_count = count_preserved_children(&path.logical, &preserved);
 
         if preserved_child_count > 0 {
-            if let Err(e) = clean_directory_contents(cleanup_path, preserved, &remove_entry) {
-                log_warn!(LOG_TAG, "Failed to safely clean {path}: {e}");
+            if let Err(e) =
+                clean_directory_contents(path.original, &path.logical, &preserved, &remove_entry)
+            {
+                log_warn!(
+                    LOG_TAG,
+                    "Failed to safely clean {}: {e}",
+                    path.original.display()
+                );
                 continue;
             }
             log_info!(
                 LOG_TAG,
-                "Selectively cleaned {path} (preserved {} children)",
+                "Selectively cleaned {} (preserved {} children)",
+                path.original.display(),
                 preserved_child_count
             );
-        } else if is_mount_point(cleanup_path) {
+        } else if is_mount_point(&path.logical) {
             // Removing a mounted filesystem root can fail on filesystem metadata
             // such as ext4 lost+found. Keep the mountpoint and remove entries.
-            if let Err(e) = clean_directory_contents(cleanup_path, preserved, &remove_entry) {
-                log_warn!(LOG_TAG, "Failed to safely clean {path}: {e}");
+            if let Err(e) =
+                clean_directory_contents(path.original, &path.logical, &preserved, &remove_entry)
+            {
+                log_warn!(
+                    LOG_TAG,
+                    "Failed to safely clean {}: {e}",
+                    path.original.display()
+                );
                 continue;
             }
-            log_info!(LOG_TAG, "Cleaned mountpoint contents: {path}");
+            log_info!(
+                LOG_TAG,
+                "Cleaned mountpoint contents: {}",
+                path.original.display()
+            );
         } else {
-            match remove_directory_tree(cleanup_path) {
+            match remove_directory_tree(path.original) {
                 Ok(RemoveOutcome::Removed) => {
-                    log_info!(LOG_TAG, "Cleaned stale path: {path}");
+                    log_info!(LOG_TAG, "Cleaned stale path: {}", path.original.display());
                 }
                 Ok(RemoveOutcome::Missing) => {}
                 Err(e) => {
-                    log_warn!(LOG_TAG, "Failed to safely clean {path}: {e}");
+                    log_warn!(
+                        LOG_TAG,
+                        "Failed to safely clean {}: {e}",
+                        path.original.display()
+                    );
                 }
             }
         }
     }
 }
 
+struct CleanupPath<'a> {
+    original: &'a Path,
+    logical: PathBuf,
+}
+
 fn clean_directory_contents<R>(
-    path: &Path,
-    preserved: &[String],
+    original_path: &Path,
+    logical_path: &Path,
+    preserved: &HashSet<PathBuf>,
     remove_entry: &R,
 ) -> io::Result<()>
 where
     R: Fn(&fs::DirEntry) -> io::Result<()>,
 {
-    let directory = match CleanupDirectory::open(path) {
+    let directory = match CleanupDirectory::open(original_path) {
         Ok(directory) => directory,
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(e) => return Err(e),
@@ -116,13 +160,18 @@ where
         let entry = match entry {
             Ok(entry) => entry,
             Err(e) => {
-                log_warn!(LOG_TAG, "Failed to read entry in {}: {e}", path.display());
+                log_warn!(
+                    LOG_TAG,
+                    "Failed to read entry in {}: {e}",
+                    original_path.display()
+                );
                 continue;
             }
         };
-        let entry_path = path.join(entry.file_name());
+        let entry_path = original_path.join(entry.file_name());
+        let logical_entry_path = logical_path.join(entry.file_name());
 
-        if entry_overlaps_preserved_path(&entry_path, preserved) {
+        if entry_overlaps_preserved_path(&logical_entry_path, preserved) {
             continue;
         }
 
@@ -245,19 +294,23 @@ impl CleanupDirectory {
     }
 }
 
-fn count_preserved_children(path: &Path, preserved: &[String]) -> usize {
+fn is_preserved_or_descendant(path: &Path, preserved: &HashSet<PathBuf>) -> bool {
+    preserved
+        .iter()
+        .any(|preserved_path| path.starts_with(preserved_path))
+}
+
+fn count_preserved_children(path: &Path, preserved: &HashSet<PathBuf>) -> usize {
     preserved
         .iter()
         .filter(|preserved_path| {
-            let preserved_path = Path::new(preserved_path);
-            preserved_path != path && preserved_path.starts_with(path)
+            preserved_path.as_path() != path && preserved_path.starts_with(path)
         })
         .count()
 }
 
-fn entry_overlaps_preserved_path(entry_path: &Path, preserved: &[String]) -> bool {
+fn entry_overlaps_preserved_path(entry_path: &Path, preserved: &HashSet<PathBuf>) -> bool {
     preserved.iter().any(|preserved_path| {
-        let preserved_path = Path::new(preserved_path);
         preserved_path == entry_path || preserved_path.starts_with(entry_path)
     })
 }
@@ -317,11 +370,12 @@ fn cleanup_mountinfo() -> io::Result<String> {
 }
 
 fn absolute_path_without_following_final_symlink(path: &Path) -> io::Result<PathBuf> {
-    if path.is_absolute() {
-        Ok(path.to_path_buf())
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
     } else {
-        Ok(std::env::current_dir()?.join(path))
-    }
+        std::env::current_dir()?.join(path)
+    };
+    Ok(normalize_path(&absolute))
 }
 
 fn mount_points_from_mountinfo(mountinfo: &str) -> HashSet<PathBuf> {
@@ -383,7 +437,7 @@ fn is_octal_digit(byte: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
     use std::ffi::OsStr;
 
     fn disable_system_log() {
@@ -572,11 +626,14 @@ mod tests {
         disable_system_log();
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("workspace");
+        let alias = dir.path().join("alias");
+        let cleanup_path = alias.join("..").join("workspace");
+        fs::create_dir_all(&alias).unwrap();
         fs::create_dir_all(path.join("old-dir")).unwrap();
         fs::write(path.join("old-dir").join("nested.txt"), "old").unwrap();
         fs::write(path.join("agent.txt"), "old").unwrap();
 
-        cleanup_stale_paths_with_mount_detector(&[path_string(&path)], &[], |candidate| {
+        cleanup_stale_paths_with_mount_detector(&[path_string(&cleanup_path)], &[], |candidate| {
             candidate == path
         });
 
@@ -672,16 +729,24 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let parent = dir.path().join("workspace");
         let child = parent.join("child");
+        let alias = dir.path().join("alias");
+        let parent_cleanup = alias.join("..").join("workspace");
+        let observed = RefCell::new(Vec::new());
+        fs::create_dir_all(&alias).unwrap();
         fs::create_dir_all(&child).unwrap();
         fs::write(child.join("stale.txt"), "old").unwrap();
         fs::write(parent.join("agent.txt"), "old").unwrap();
 
         cleanup_stale_paths_with_mount_detector(
-            &[path_string(&child), path_string(&parent)],
+            &[path_string(&child), path_string(&parent_cleanup)],
             &[],
-            |candidate| candidate == parent,
+            |candidate| {
+                observed.borrow_mut().push(candidate.to_path_buf());
+                candidate == parent
+            },
         );
 
+        assert_eq!(*observed.borrow(), [parent.clone(), child.clone()]);
         assert!(parent.exists());
         assert!(!parent.join("agent.txt").exists());
         assert!(!child.exists());

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -1,13 +1,14 @@
 use crate::LOG_TAG;
 use crate::archive;
 use crate::error::DownloadError;
+use crate::path::normalize_path;
 use crate::source;
 use crate::telemetry::{DownloadRunTelemetry, DownloadTaskTelemetry, RemoteArchiveTaskMetrics};
 use guest_common::{log_error, log_info, log_warn};
 use std::any::Any;
 use std::collections::VecDeque;
 use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -33,7 +34,7 @@ impl DownloadTask {
         mount_path: String,
         has_instructions_target: bool,
     ) -> Self {
-        let normalized_mount_path = normalize_mount_path(&mount_path);
+        let normalized_mount_path = normalize_path(Path::new(&mount_path));
         let telemetry =
             DownloadTaskTelemetry::storage(&url, &normalized_mount_path, has_instructions_target);
         Self {
@@ -46,7 +47,7 @@ impl DownloadTask {
     }
 
     pub(crate) fn artifact(label: String, url: String, mount_path: String) -> Self {
-        let normalized_mount_path = normalize_mount_path(&mount_path);
+        let normalized_mount_path = normalize_path(Path::new(&mount_path));
         let telemetry = DownloadTaskTelemetry::artifact(&url, &normalized_mount_path);
         Self {
             label,
@@ -295,30 +296,6 @@ fn conflicting_mount_paths<'pending, 'active>(
     None
 }
 
-fn normalize_mount_path(path: &str) -> PathBuf {
-    let mut components = Vec::new();
-
-    for component in Path::new(path).components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => match components.last() {
-                Some(Component::Normal(_)) => {
-                    components.pop();
-                }
-                Some(Component::RootDir | Component::Prefix(_)) => {}
-                _ => components.push(component),
-            },
-            _ => components.push(component),
-        }
-    }
-
-    let mut normalized = PathBuf::new();
-    for component in components {
-        normalized.push(component.as_os_str());
-    }
-    normalized
-}
-
 fn mount_paths_conflict(left: &Path, right: &Path) -> bool {
     left.starts_with(right) || right.starts_with(left)
 }
@@ -450,6 +427,10 @@ fn download_and_extract(
 mod tests {
     use super::*;
 
+    fn normalized_path(path: &str) -> PathBuf {
+        normalize_path(Path::new(path))
+    }
+
     fn task_at(path: &str) -> DownloadTask {
         DownloadTask::storage(
             format!("task {path}"),
@@ -462,7 +443,7 @@ mod tests {
     fn prepared_task_at(path: &str) -> PreparedDownloadTask {
         PreparedDownloadTask {
             task: task_at(path),
-            effective_mount_path: normalize_mount_path(path),
+            effective_mount_path: normalized_path(path),
         }
     }
 
@@ -473,40 +454,40 @@ mod tests {
     #[test]
     fn mount_paths_conflict_for_exact_and_parent_child_paths() {
         assert!(mount_paths_conflict(
-            &normalize_mount_path("/tmp/mount"),
-            &normalize_mount_path("/tmp/mount")
+            &normalized_path("/tmp/mount"),
+            &normalized_path("/tmp/mount")
         ));
         assert!(mount_paths_conflict(
-            &normalize_mount_path("/tmp/mount"),
-            &normalize_mount_path("/tmp/mount/child")
+            &normalized_path("/tmp/mount"),
+            &normalized_path("/tmp/mount/child")
         ));
         assert!(mount_paths_conflict(
-            &normalize_mount_path("/tmp/mount/child"),
-            &normalize_mount_path("/tmp/mount")
+            &normalized_path("/tmp/mount/child"),
+            &normalized_path("/tmp/mount")
         ));
     }
 
     #[test]
     fn mount_paths_do_not_conflict_for_siblings_or_prefix_traps() {
         assert!(!mount_paths_conflict(
-            &normalize_mount_path("/tmp/mount-a"),
-            &normalize_mount_path("/tmp/mount-b")
+            &normalized_path("/tmp/mount-a"),
+            &normalized_path("/tmp/mount-b")
         ));
         assert!(!mount_paths_conflict(
-            &normalize_mount_path("/tmp/foo/bar"),
-            &normalize_mount_path("/tmp/foo/barista")
+            &normalized_path("/tmp/foo/bar"),
+            &normalized_path("/tmp/foo/barista")
         ));
     }
 
     #[test]
     fn mount_path_conflicts_use_lexical_normalization() {
         assert!(mount_paths_conflict(
-            &normalize_mount_path("/tmp//foo/./bar/baz/.."),
-            &normalize_mount_path("/tmp/foo/bar")
+            &normalized_path("/tmp//foo/./bar/baz/.."),
+            &normalized_path("/tmp/foo/bar")
         ));
         assert!(!mount_paths_conflict(
-            &normalize_mount_path("/tmp/foo/bar/../barista"),
-            &normalize_mount_path("/tmp/foo/bar")
+            &normalized_path("/tmp/foo/bar/../barista"),
+            &normalized_path("/tmp/foo/bar")
         ));
     }
 
@@ -558,8 +539,8 @@ mod tests {
         ]);
         let active = vec![ActiveDownload {
             id: 2,
-            logical_mount_path: normalize_mount_path("/tmp/mount"),
-            effective_mount_path: normalize_mount_path("/tmp/mount"),
+            logical_mount_path: normalized_path("/tmp/mount"),
+            effective_mount_path: normalized_path("/tmp/mount"),
         }];
         let mut conflicts = Vec::new();
 
@@ -578,13 +559,13 @@ mod tests {
         let active = vec![
             ActiveDownload {
                 id: 2,
-                logical_mount_path: normalize_mount_path("/tmp/mount"),
-                effective_mount_path: normalize_mount_path("/tmp/mount"),
+                logical_mount_path: normalized_path("/tmp/mount"),
+                effective_mount_path: normalized_path("/tmp/mount"),
             },
             ActiveDownload {
                 id: 3,
-                logical_mount_path: normalize_mount_path("/tmp/mount/child"),
-                effective_mount_path: normalize_mount_path("/tmp/mount/child"),
+                logical_mount_path: normalized_path("/tmp/mount/child"),
+                effective_mount_path: normalized_path("/tmp/mount/child"),
             },
         ];
         let mut conflicts = Vec::new();

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -32,6 +32,7 @@ mod download;
 mod error;
 mod instructions;
 mod manifest;
+mod path;
 mod plan;
 mod source;
 mod telemetry;

--- a/crates/guest-download/src/path.rs
+++ b/crates/guest-download/src/path.rs
@@ -1,0 +1,26 @@
+use std::path::{Component, Path, PathBuf};
+
+/// Collapse `.` and resolvable `..` components without accessing the filesystem.
+pub(crate) fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => match components.last() {
+                Some(Component::Normal(_)) => {
+                    components.pop();
+                }
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                _ => components.push(component),
+            },
+            _ => components.push(component),
+        }
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in components {
+        normalized.push(component.as_os_str());
+    }
+    normalized
+}

--- a/crates/guest-download/tests/integration/cleanup.rs
+++ b/crates/guest-download/tests/integration/cleanup.rs
@@ -140,3 +140,69 @@ fn selective_cleanup_preserves_cached_child_in_real_directory() {
     assert!(!cleanup_root.join("stale").exists());
     assert!(!cleanup_root.join("stale.txt").exists());
 }
+
+#[test]
+fn cleanup_preserves_cached_path_across_equivalent_manifest_spellings() {
+    let dir = tempfile::tempdir().unwrap();
+    let alias = dir.path().join("alias");
+    let cached = dir.path().join("cache");
+    let cleanup_path = alias.join("..").join("cache");
+
+    fs::create_dir_all(&alias).unwrap();
+    fs::create_dir_all(&cached).unwrap();
+    fs::write(cached.join("content.txt"), "keep").unwrap();
+
+    let manifest = cleanup_manifest(&[&cleanup_path], Some(&cached)).unwrap();
+    let success = run_guest_download_manifest_json(&manifest);
+
+    assert!(success);
+    assert_eq!(
+        fs::read_to_string(cached.join("content.txt")).unwrap(),
+        "keep"
+    );
+}
+
+#[test]
+fn cleanup_preserves_path_nested_below_cached_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let alias = dir.path().join("alias");
+    let cached = dir.path().join("cache");
+    let nested = cached.join("nested");
+    let cleanup_path = alias.join("..").join("cache").join("nested");
+
+    fs::create_dir_all(&alias).unwrap();
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("content.txt"), "keep").unwrap();
+
+    let manifest = cleanup_manifest(&[&cleanup_path], Some(&cached)).unwrap();
+    let success = run_guest_download_manifest_json(&manifest);
+
+    assert!(success);
+    assert_eq!(
+        fs::read_to_string(nested.join("content.txt")).unwrap(),
+        "keep"
+    );
+}
+
+#[test]
+fn cleanup_normalization_does_not_bypass_intermediate_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+    let alias = dir.path().join("alias");
+    let target = dir.path().join("target");
+    let cache = dir.path().join("cache");
+    let cleanup_path = alias.join("..").join("cache");
+
+    fs::create_dir_all(&target).unwrap();
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("content.txt"), "keep").unwrap();
+    symlink(&target, &alias).unwrap();
+
+    let manifest = cleanup_manifest(&[&cleanup_path], None).unwrap();
+    let success = run_guest_download_manifest_json(&manifest);
+
+    assert!(success);
+    assert_eq!(
+        fs::read_to_string(cache.join("content.txt")).unwrap(),
+        "keep"
+    );
+}

--- a/crates/guest-download/tests/integration/cleanup.rs
+++ b/crates/guest-download/tests/integration/cleanup.rs
@@ -185,6 +185,31 @@ fn cleanup_preserves_path_nested_below_cached_root() {
 }
 
 #[test]
+fn selective_cleanup_preserves_cached_child_across_equivalent_parent_spelling() {
+    let dir = tempfile::tempdir().unwrap();
+    let alias = dir.path().join("alias");
+    let cleanup_root = dir.path().join("workspace");
+    let cleanup_path = alias.join("..").join("workspace");
+    let preserved = cleanup_root.join("keep");
+
+    fs::create_dir_all(&alias).unwrap();
+    fs::create_dir_all(&preserved).unwrap();
+    fs::create_dir_all(cleanup_root.join("stale")).unwrap();
+    fs::write(preserved.join("content.txt"), "keep").unwrap();
+    fs::write(cleanup_root.join("stale/content.txt"), "remove").unwrap();
+
+    let manifest = cleanup_manifest(&[&cleanup_path], Some(&preserved)).unwrap();
+    let success = run_guest_download_manifest_json(&manifest);
+
+    assert!(success);
+    assert_eq!(
+        fs::read_to_string(preserved.join("content.txt")).unwrap(),
+        "keep"
+    );
+    assert!(!cleanup_root.join("stale").exists());
+}
+
+#[test]
 fn cleanup_normalization_does_not_bypass_intermediate_symlink() {
     let dir = tempfile::tempdir().unwrap();
     let alias = dir.path().join("alias");


### PR DESCRIPTION
## Summary

- share one filesystem-independent lexical path normalizer across archive extraction, download scheduling, and cleanup
- compare, order, and classify cleanup requests using normalized logical identities while retaining the original path for descriptor-anchored `O_NOFOLLOW` traversal
- preserve cleanup targets that are equivalent to or nested below cached paths, with regressions covering manifest aliases and intermediate symlinks

## Compatibility

- no API, schema, database, runner protocol, or persisted-state changes
- existing best-effort cleanup behavior and symlink traversal protections remain unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-download --all-targets --all-features`
- `cargo doc -p guest-download --all-features --no-deps`
- `cargo test -p guest-download`
- pre-commit Rust workspace formatting, documentation, and Clippy checks

Closes #27666
