### PR TITLE
fix(platform): reduce chat mode icon size

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3601,12 +3601,12 @@ describe("chat composer video model", () => {
     const videoModelButton = await findDesktopVideoModelButton();
     expect(chatModelButton).toHaveAttribute("aria-expanded", "false");
     expect(videoModelButton).toHaveAttribute("aria-expanded", "false");
-    const chatModeIcon = chatModelButton.querySelector(
+    const expandedChatModeIcon = chatModelButton.querySelector(
       ".lucide-message-circle",
     );
-    expect(chatModeIcon).toBeInTheDocument();
-    expect(chatModeIcon).toHaveAttribute("width", "16");
-    expect(chatModeIcon).toHaveAttribute("height", "16");
+    expect(expandedChatModeIcon).toBeInTheDocument();
+    expect(expandedChatModeIcon).toHaveAttribute("width", "16");
+    expect(expandedChatModeIcon).toHaveAttribute("height", "16");
     expect(chatModelButton).toHaveTextContent(/·\s*Claude Fable 5/);
     expect(chatModelButton).not.toHaveTextContent("Chat");
 
@@ -3617,6 +3617,16 @@ describe("chat composer video model", () => {
     expect(videoModelButton).toHaveAttribute("aria-pressed", "true");
     expect(chatModelButton).toHaveAttribute("aria-expanded", "false");
     expect(videoModelButton).toHaveAttribute("aria-expanded", "false");
+    const collapsedChatModeIcon = Array.from(
+      chatModelButton.parentElement?.querySelectorAll(
+        ".lucide-message-circle",
+      ) ?? [],
+    ).find((icon) => {
+      return !chatModelButton.contains(icon);
+    });
+    expect(collapsedChatModeIcon).toBeInTheDocument();
+    expect(collapsedChatModeIcon).toHaveAttribute("width", "16");
+    expect(collapsedChatModeIcon).toHaveAttribute("height", "16");
 
     chatModelButton.focus();
     await user.keyboard("{Enter}");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3601,9 +3601,12 @@ describe("chat composer video model", () => {
     const videoModelButton = await findDesktopVideoModelButton();
     expect(chatModelButton).toHaveAttribute("aria-expanded", "false");
     expect(videoModelButton).toHaveAttribute("aria-expanded", "false");
-    expect(
-      chatModelButton.querySelector(".lucide-message-circle"),
-    ).toBeInTheDocument();
+    const chatModeIcon = chatModelButton.querySelector(
+      ".lucide-message-circle",
+    );
+    expect(chatModeIcon).toBeInTheDocument();
+    expect(chatModeIcon).toHaveAttribute("width", "16");
+    expect(chatModeIcon).toHaveAttribute("height", "16");
     expect(chatModelButton).toHaveTextContent(/·\s*Claude Fable 5/);
     expect(chatModelButton).not.toHaveTextContent("Chat");
 

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -411,7 +411,7 @@ function ModelFirstTriggerContent({
     <span className="flex min-w-0 items-center gap-1.5">
       {desktopModeLabel && (
         <span className="hidden shrink-0 sm:inline-flex sm:items-center sm:gap-1.5">
-          <MessageCircle size={18} aria-hidden="true" />
+          <MessageCircle size={16} aria-hidden="true" />
           <span aria-hidden="true">·</span>
         </span>
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -7492,7 +7492,7 @@ function ComposerRunModelPickerControl({
       />
       {pickerVideoModel && (
         <MessageCircle
-          size={18}
+          size={16}
           aria-hidden="true"
           className={cn(
             "pointer-events-none absolute inset-0 m-auto hidden opacity-0 transition-opacity duration-150 sm:block",


### PR DESCRIPTION
## Summary

- reduce the desktop chat mode icon from 18px to 16px when video model selection is enabled
- keep the icon size consistent across expanded and collapsed chat mode states
- add an integration assertion for the 16px dimensions

## Preview

![Chat mode icon at 16px](https://cdn.vm0.io/artifacts/b01skj6pk7.png)

## Testing

- `pnpm exec prettier --check apps/platform/src/views/zero-page/components/model-provider-picker.tsx apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx -t "preserves the shared popup state while switching desktop model modes"`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`