### PR TITLE
perf(api): bypass catalog for empty run scopes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1755,12 +1755,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     const missingCompatibilityActor = await entitledRunActor();
     const missingCompatibilityPrompt = "missing connector compatibility";
-    const missingCompatibilityRun = await api.createRun(
+    const missingCompatibilityRun = await api.createDirectRun(
       missingCompatibilityActor.actor,
       {
-        agentId: missingCompatibilityActor.agentId,
-        prompt: missingCompatibilityPrompt,
-        modelProvider: "anthropic-api-key",
+        ...zeroBackedDirectRunBody({
+          agentId: missingCompatibilityActor.agentId,
+          prompt: missingCompatibilityPrompt,
+        }),
+        connectorScope: {
+          allowedConnectorSlugs: ["x"],
+          allowedCustomConnectorIds: [],
+        },
       },
     );
     const missingCompatibilityEvents = apiDispatchTimingEventsForRun(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -56,10 +56,10 @@ import {
   API_TEST_CONNECTOR_FIREWALL_CONFIGS,
   apiTestConnectorCatalogValidationAuthority,
   deleteApiTestConnectorCatalogCompatibility,
-  deleteApiTestConnectorCatalogCompatibilityEvaluation,
   installApiTestConnectorCatalog,
   readApiTestConnectorCatalogCompatibilityEvaluations,
   readApiTestConnectorCatalogValidationAuthority,
+  replaceApiTestConnectorCatalogStoredBytes,
   setApiTestConnectorCatalogValidationAuthority,
 } from "../../../test-fixtures/connector-catalog";
 import { readStorageS3PrefixFixture } from "../../../test-fixtures/storage";
@@ -2013,15 +2013,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     await api.requestCancelRun(actor, warmed.runId, [200]);
 
-    const evaluations =
-      await readApiTestConnectorCatalogCompatibilityEvaluations();
-    const matchingEvaluations = evaluations.filter((evaluation) => {
-      return evaluation.catalogVersion === catalogVersion;
+    await replaceApiTestConnectorCatalogStoredBytes({
+      catalogVersion: `${catalogVersion}-unavailable`,
+      rawBytes: Buffer.from("{"),
+      catalogValidationAuthority: apiTestConnectorCatalogValidationAuthority(),
     });
-    expect(matchingEvaluations).toHaveLength(1);
-    await deleteApiTestConnectorCatalogCompatibilityEvaluation(
-      matchingEvaluations[0]!.capabilityDigest,
-    );
 
     const emptyRun = await api.createRun(actor, {
       agentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -33,7 +33,7 @@ import { HttpResponse, http } from "msw";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { v5 as uuidv5 } from "uuid";
 
-import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { env, mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now, nowDate } from "../../../lib/time";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -56,6 +56,7 @@ import {
   API_TEST_CONNECTOR_FIREWALL_CONFIGS,
   apiTestConnectorCatalogValidationAuthority,
   deleteApiTestConnectorCatalogCompatibility,
+  deleteApiTestConnectorCatalogCompatibilityEvaluation,
   installApiTestConnectorCatalog,
   readApiTestConnectorCatalogCompatibilityEvaluations,
   readApiTestConnectorCatalogValidationAuthority,
@@ -987,6 +988,7 @@ function expectClaimNetworkPolicyRefreshPath(
   path:
     | "baseline"
     | "baseline_empty"
+    | "no_builtin_targets"
     | "full_missing_baseline"
     | "full_invalid_baseline"
     | "full_incompatible_baseline",
@@ -1430,7 +1432,7 @@ async function setupSameThreadReuseScenario(sourceRunnerIdentity?: {
 }
 
 describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks", () => {
-  it("emits api dispatch timing for direct dispatch runs", async () => {
+  it("emits api dispatch timing for exact-empty direct dispatch runs", async () => {
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     const prompt = "api dispatch timing should not leak prompt";
@@ -1476,33 +1478,25 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect(finishedAt - Number(event.duration_ms)).toBe(previousBoundaryAt);
       previousBoundaryAt = finishedAt;
     }
-    expectApiDispatchActions(
+    expectNoApiDispatchActions(
       timingEvents,
       API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES,
     );
-    expectApiDispatchSpanKind(
+    expectNoApiDispatchActions(
       timingEvents,
-      API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES,
-      "nested",
+      API_DISPATCH_STORED_CONNECTOR_SUBSTEP_ACTION_TYPES,
     );
-    expectConnectorCatalogLoadTiming({
-      events: timingEvents,
-      acceptedCacheOutcome: "miss",
-      runtimeCacheOutcome: "miss",
-      requestedConnectorCount: "known",
-      validation: {
-        outcome: "full_fallback",
-        fallbackReason: "different_authority",
-      },
-    });
-    expectApiDispatchActions(
+    expectNoApiDispatchActions(
       timingEvents,
-      API_DISPATCH_CONNECTOR_CATALOG_COMPLETE_VALIDATION_ACTION_TYPES,
+      API_DISPATCH_CUSTOM_CONNECTOR_TIMING_ACTION_TYPES,
     );
-    expectApiDispatchSpanKind(
-      timingEvents,
-      API_DISPATCH_CONNECTOR_CATALOG_COMPLETE_VALIDATION_ACTION_TYPES,
-      "nested",
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_prepare_context_load_connector_contexts",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({ connector_scope_source: "empty" }),
     );
     expectNoApiDispatchActions(timingEvents, ["api_dispatch_check_org_tier"]);
     expectApiDispatchActions(
@@ -1646,39 +1640,29 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const claim = await api.claimRunnerJob(created.runId);
     expect(claim.appendSystemPrompt ?? "").toContain("Timezone: UTC");
     expect(claim.userTimezone).toBeUndefined();
+    expect(claim.networkPolicies).toHaveProperty(
+      "model-provider:anthropic-api-key",
+    );
+    expect(claim.connectorRuntimeTargets).toStrictEqual([]);
+    expect(claim).not.toHaveProperty("connectorPermissionBaseline");
+    expectClaimNetworkPolicyRefreshPath(created.runId, "no_builtin_targets");
 
     const {
       actor: warmActor,
       agentId: warmAgentId,
       runnerGroup: warmRunnerGroup,
     } = await entitledRunActor();
-    const warmPrompt = "warm catalog timing should not leak prompt";
+    const warmPrompt = "repeated empty timing should not leak prompt";
     const warmCreated = await api.createRun(warmActor, {
       agentId: warmAgentId,
       prompt: warmPrompt,
       modelProvider: "anthropic-api-key",
     });
     const warmTimingEvents = apiDispatchTimingEventsForRun(warmCreated.runId);
-    expectApiDispatchActions(
-      warmTimingEvents,
-      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
-    );
     expectNoApiDispatchActions(
       warmTimingEvents,
-      API_DISPATCH_CONNECTOR_CATALOG_MISS_ACTION_TYPES,
+      API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES,
     );
-    expectApiDispatchSpanKind(
-      warmTimingEvents,
-      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
-      "nested",
-    );
-    expectConnectorCatalogLoadTiming({
-      events: warmTimingEvents,
-      acceptedCacheOutcome: "hit",
-      runtimeCacheOutcome: "hit",
-      requestedConnectorCount: "known",
-      validation: { outcome: "not_run" },
-    });
     for (const event of warmTimingEvents) {
       expect(event).toStrictEqual(
         expect.objectContaining({
@@ -1711,12 +1695,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const missingAuthorityActor = await entitledRunActor();
     const missingAuthorityPrompt =
       "legacy connector catalog validation authority";
-    const missingAuthorityRun = await api.createRun(
+    const missingAuthorityRun = await api.createDirectRun(
       missingAuthorityActor.actor,
       {
-        agentId: missingAuthorityActor.agentId,
-        prompt: missingAuthorityPrompt,
-        modelProvider: "anthropic-api-key",
+        ...zeroBackedDirectRunBody({
+          agentId: missingAuthorityActor.agentId,
+          prompt: missingAuthorityPrompt,
+        }),
+        connectorScope: {
+          allowedConnectorSlugs: ["x"],
+          allowedCustomConnectorIds: [],
+        },
       },
     );
     const missingAuthorityEvents = apiDispatchTimingEventsForRun(
@@ -1824,12 +1813,17 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const differentAuthorityActor = await entitledRunActor();
     const differentAuthorityPrompt =
       "different connector catalog validation authority";
-    const differentAuthorityRun = await api.createRun(
+    const differentAuthorityRun = await api.createDirectRun(
       differentAuthorityActor.actor,
       {
-        agentId: differentAuthorityActor.agentId,
-        prompt: differentAuthorityPrompt,
-        modelProvider: "anthropic-api-key",
+        ...zeroBackedDirectRunBody({
+          agentId: differentAuthorityActor.agentId,
+          prompt: differentAuthorityPrompt,
+        }),
+        connectorScope: {
+          allowedConnectorSlugs: ["x"],
+          allowedCustomConnectorIds: [],
+        },
       },
     );
     const differentAuthorityEvents = apiDispatchTimingEventsForRun(
@@ -1863,10 +1857,15 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     const cachedActor = await entitledRunActor();
     const cachedPrompt = "cached connector catalog fallback";
-    const cachedRun = await api.createRun(cachedActor.actor, {
-      agentId: cachedActor.agentId,
-      prompt: cachedPrompt,
-      modelProvider: "anthropic-api-key",
+    const cachedRun = await api.createDirectRun(cachedActor.actor, {
+      ...zeroBackedDirectRunBody({
+        agentId: cachedActor.agentId,
+        prompt: cachedPrompt,
+      }),
+      connectorScope: {
+        allowedConnectorSlugs: ["x"],
+        allowedCustomConnectorIds: [],
+      },
     });
     const cachedEvents = apiDispatchTimingEventsForRun(cachedRun.runId);
     expectApiDispatchActions(
@@ -1913,15 +1912,25 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const firstConcurrentPrompt = "first concurrent attested catalog load";
     const secondConcurrentPrompt = "second concurrent attested catalog load";
     const [firstConcurrentRun, secondConcurrentRun] = await Promise.all([
-      api.createRun(concurrentActor.actor, {
-        agentId: concurrentActor.agentId,
-        prompt: firstConcurrentPrompt,
-        modelProvider: "anthropic-api-key",
+      api.createDirectRun(concurrentActor.actor, {
+        ...zeroBackedDirectRunBody({
+          agentId: concurrentActor.agentId,
+          prompt: firstConcurrentPrompt,
+        }),
+        connectorScope: {
+          allowedConnectorSlugs: ["x"],
+          allowedCustomConnectorIds: [],
+        },
       }),
-      api.createRun(concurrentActor.actor, {
-        agentId: concurrentActor.agentId,
-        prompt: secondConcurrentPrompt,
-        modelProvider: "anthropic-api-key",
+      api.createDirectRun(concurrentActor.actor, {
+        ...zeroBackedDirectRunBody({
+          agentId: concurrentActor.agentId,
+          prompt: secondConcurrentPrompt,
+        }),
+        connectorScope: {
+          allowedConnectorSlugs: ["x"],
+          allowedCustomConnectorIds: [],
+        },
       }),
     ]);
     const concurrentEvents = [
@@ -1975,6 +1984,84 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     }
   });
 
+  it("keeps exact-empty create and claim independent from catalog availability", async () => {
+    const api = createRunsApi(context);
+    const originalCatalogBucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const isolatedCatalogBucket = `test-run-lifecycle-empty-catalog-${randomUUID()}`;
+    mockEnv("R2_USER_STORAGES_BUCKET_NAME", isolatedCatalogBucket);
+    const catalogVersion = `api-test-empty-unavailable-${randomUUID()}`;
+    await installApiTestConnectorCatalog({ catalogVersion });
+    const restoreCatalogs = async (): Promise<void> => {
+      mockEnv("R2_USER_STORAGES_BUCKET_NAME", isolatedCatalogBucket);
+      await installApiTestConnectorCatalog({ catalogVersion });
+      mockEnv("R2_USER_STORAGES_BUCKET_NAME", originalCatalogBucket);
+      await installApiTestConnectorCatalog();
+    };
+    onTestFinished(restoreCatalogs);
+
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const catalogBackedScope = {
+      allowedConnectorSlugs: ["x"],
+      allowedCustomConnectorIds: [],
+    } as const;
+    const warmed = await api.createDirectRun(actor, {
+      ...zeroBackedDirectRunBody({
+        agentId,
+        prompt: "warm the exact catalog identity before deletion",
+      }),
+      connectorScope: catalogBackedScope,
+    });
+    await api.requestCancelRun(actor, warmed.runId, [200]);
+
+    const evaluations =
+      await readApiTestConnectorCatalogCompatibilityEvaluations();
+    const matchingEvaluations = evaluations.filter((evaluation) => {
+      return evaluation.catalogVersion === catalogVersion;
+    });
+    expect(matchingEvaluations).toHaveLength(1);
+    await deleteApiTestConnectorCatalogCompatibilityEvaluation(
+      matchingEvaluations[0]!.capabilityDigest,
+    );
+
+    const emptyRun = await api.createRun(actor, {
+      agentId,
+      prompt: "run without connectors while the catalog is unavailable",
+      modelProvider: "anthropic-api-key",
+    });
+    expectNoApiDispatchActions(
+      apiDispatchTimingEventsForRun(emptyRun.runId),
+      API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES,
+    );
+    await api.heartbeatRunner(runnerGroup);
+    const emptyClaim = await api.claimRunnerJob(emptyRun.runId);
+    expect(emptyClaim.networkPolicies).toHaveProperty(
+      "model-provider:anthropic-api-key",
+    );
+    expect(emptyClaim).not.toHaveProperty("connectorPermissionBaseline");
+    expectClaimNetworkPolicyRefreshPath(emptyRun.runId, "no_builtin_targets");
+
+    const rejectedPrompt =
+      "reject catalog-backed creation while the catalog is unavailable";
+    await expect(
+      api.createDirectRun(actor, {
+        ...zeroBackedDirectRunBody({ agentId, prompt: rejectedPrompt }),
+        connectorScope: catalogBackedScope,
+      }),
+    ).rejects.toThrow("Accepted external connector catalog is unavailable");
+    const runs = await api.listAgentRuns(actor, {
+      status: "queued,pending,running,completed,failed,timeout,cancelled",
+      limit: 100,
+    });
+    expect(
+      runs.runs.filter((run) => {
+        return run.prompt === rejectedPrompt;
+      }),
+    ).toHaveLength(0);
+
+    await restoreCatalogs();
+    await api.requestCancelRun(actor, emptyRun.runId, [200]);
+  });
+
   it("retains direct plan admission and emits create timing", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
@@ -2001,43 +2088,26 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
     expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
-    expectApiDispatchActions(
+    expectNoApiDispatchActions(
       timingEvents,
-      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
+      API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES,
     );
-    expectApiDispatchSpanKind(
+    expectNoApiDispatchActions(
       timingEvents,
-      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
-      "nested",
+      API_DISPATCH_STORED_CONNECTOR_SUBSTEP_ACTION_TYPES,
     );
-    const connectorCatalogLoadEvent = singleApiDispatchEvent(
+    expectNoApiDispatchActions(
       timingEvents,
-      "api_dispatch_connector_catalog_load_runtime_snapshot",
-    );
-    expect(["hit", "miss", "in_flight"]).toContain(
-      connectorCatalogLoadEvent.connector_catalog_accepted_cache_outcome,
-    );
-    expect(["hit", "miss"]).toContain(
-      connectorCatalogLoadEvent.connector_catalog_runtime_cache_outcome,
-    );
-    expect(connectorCatalogLoadEvent.connector_catalog_validation_outcome).toBe(
-      connectorCatalogLoadEvent.connector_catalog_accepted_cache_outcome ===
-        "miss"
-        ? "attested"
-        : "not_run",
-    );
-    expect(connectorCatalogLoadEvent).not.toHaveProperty(
-      "connector_catalog_validation_fallback_reason",
-    );
-    expect(CONNECTOR_CATALOG_RAW_SIZE_BUCKETS).toContain(
-      connectorCatalogLoadEvent.connector_catalog_raw_size_bucket,
-    );
-    expect(CONNECTOR_CATALOG_COUNT_BUCKETS).toContain(
-      connectorCatalogLoadEvent.connector_catalog_connector_count_bucket,
+      API_DISPATCH_CUSTOM_CONNECTOR_TIMING_ACTION_TYPES,
     );
     expect(
-      connectorCatalogLoadEvent.connector_catalog_requested_connector_count_bucket,
-    ).toBe("0");
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_prepare_context_load_connector_contexts",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({ connector_scope_source: "empty" }),
+    );
     expectApiDispatchActions(timingEvents, ["api_dispatch_check_org_tier"]);
     expectApiDispatchSpanKind(
       timingEvents,
@@ -2100,6 +2170,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(created.runId);
     expect(claim.userTimezone).toBe("Asia/Shanghai");
+    expect(claim.connectorRuntimeTargets).toStrictEqual([]);
     await api.requestCancelRun(actor, created.runId, [200]);
 
     if (!actor.orgId) {
@@ -3342,7 +3413,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         resumedClaim.sandboxToken,
       ],
     });
-    expectClaimNetworkPolicyRefreshPath(resumed.runId, "baseline_empty");
+    expectClaimNetworkPolicyRefreshPath(resumed.runId, "no_builtin_targets");
 
     await api.requestCancelRun(actor, resumed.runId, [200]);
   });
@@ -5615,7 +5686,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(thirdClaim.environment ?? {}).not.toHaveProperty("ZERO_TOKEN");
     expect(thirdClaim).not.toHaveProperty("secretValueEnvironmentKeys");
     expect(thirdClaim).not.toHaveProperty("runContextStorage");
-    expectClaimNetworkPolicyRefreshPath(third.runId, "baseline_empty");
+    expectClaimNetworkPolicyRefreshPath(third.runId, "no_builtin_targets");
     const apiToRunnerQueueMs = sandboxOperationDurationForRun(
       third.runId,
       "api_to_runner_queue",
@@ -7071,6 +7142,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectNoApiDispatchActions(
       timingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_ACTION_TYPES,
+    );
+    expectNoApiDispatchActions(
+      timingEvents,
       API_DISPATCH_STORED_CONNECTOR_SUBSTEP_ACTION_TYPES,
     );
     expectNoApiDispatchActions(
@@ -7085,6 +7160,8 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(findFirewallEntry(claim.firewalls, "x")).toBeUndefined();
     expect(claim.billableFirewalls).not.toContain("x");
     expect(claim.networkPolicies ?? {}).not.toHaveProperty("x");
+    expect(claim).not.toHaveProperty("connectorPermissionBaseline");
+    expectClaimNetworkPolicyRefreshPath(run.runId, "no_builtin_targets");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
@@ -7116,6 +7193,10 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       modelProvider: "anthropic-api-key",
     });
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
+    );
     expectApiDispatchActions(
       timingEvents,
       API_DISPATCH_STORED_CONNECTOR_SNAPSHOT_ACTION_TYPES,
@@ -7181,6 +7262,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(findFirewallEntry(claim.firewalls, "slack")).toBeUndefined();
     expect(claim.billableFirewalls).not.toContain("slack");
     expect(claim.networkPolicies ?? {}).not.toHaveProperty("slack");
+    expectClaimNetworkPolicyRefreshPath(run.runId, "baseline");
 
     // The stored access token is only readable through the firewall-auth
     // webhook with the claimed run's sandbox token.
@@ -9338,6 +9420,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       prompt: "use the reconnected custom connector",
       modelProvider: "anthropic-api-key",
     });
+    expectApiDispatchActions(
+      apiDispatchTimingEventsForRun(restoredRun.runId),
+      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
+    );
     const restoredClaim = await api.claimRunnerJob(restoredRun.runId);
     const customApis = inlineFirewallApis(
       restoredClaim.firewalls,
@@ -9366,6 +9452,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       customConnectorId: custom.id,
       baseUrlVars: { workspace: "restored" },
     });
+    expect(restoredClaim).not.toHaveProperty("connectorPermissionBaseline");
+    expectClaimNetworkPolicyRefreshPath(
+      restoredRun.runId,
+      "no_builtin_targets",
+    );
     const restoredSkillMount = expectCanonicalStorageManifest(
       restoredClaim.storageManifest,
     )?.storageMounts.find((storage) => {
@@ -10201,7 +10292,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     ]);
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
-    expectClaimNetworkPolicyRefreshPath(run.runId, "baseline_empty");
+    expectClaimNetworkPolicyRefreshPath(run.runId, "no_builtin_targets");
 
     const idPart = saved.connector.id.replaceAll("-", "");
     const internalName = `custom_connector_${idPart}`;
@@ -11233,7 +11324,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       "model-provider:anthropic-api-key",
     );
     expect(claim).not.toHaveProperty("connectorPermissionBaseline");
-    expectClaimNetworkPolicyRefreshPath(run.runId, "baseline_empty");
+    expectClaimNetworkPolicyRefreshPath(run.runId, "no_builtin_targets");
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
@@ -13095,7 +13186,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       expectedActionTypes: ["claim_route_response_network_policy_refresh"],
       forbiddenValues: [firstPrompt, claimed.body.sandboxToken, apiKey.token],
     });
-    expectClaimNetworkPolicyRefreshPath(first.runId, "baseline_empty");
+    expectClaimNetworkPolicyRefreshPath(first.runId, "no_builtin_targets");
     const claimRouteTimingEvents = claimRouteTimingEventsForRun(first.runId);
     expect(claimRouteTimingEvents).toHaveLength(
       CLAIM_ROUTE_TIMING_ACTION_TYPES.length + 1,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2007,7 +2007,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const warmed = await api.createDirectRun(actor, {
       ...zeroBackedDirectRunBody({
         agentId,
-        prompt: "warm the exact catalog identity before deletion",
+        prompt: "warm the exact catalog identity before corruption",
       }),
       connectorScope: catalogBackedScope,
     });

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -176,6 +176,7 @@ type ClaimRouteTimingSpanKind = "parent" | "top_level" | "nested";
 type ClaimNetworkPolicyRefreshPath =
   | "baseline"
   | "baseline_empty"
+  | "no_builtin_targets"
   | "full_missing_baseline"
   | "full_invalid_baseline"
   | "full_incompatible_baseline";
@@ -1325,15 +1326,32 @@ async function refreshClaimNetworkPolicies(args: {
   Pick<StoredExecutionContext, "networkPolicies" | "networkPolicyRefreshes">
 > {
   const storedNetworkPolicies = args.storedContext.networkPolicies ?? {};
-  const networkPolicyConnectorSlugs = Object.keys(storedNetworkPolicies);
-  if (networkPolicyConnectorSlugs.length === 0) {
+  if (Object.keys(storedNetworkPolicies).length === 0) {
     return {
       networkPolicies: args.storedContext.networkPolicies,
       networkPolicyRefreshes: undefined,
     };
   }
 
+  const builtinConnectorSlugs = [
+    ...new Set(
+      args.storedContext.connectorRuntimeTargets.flatMap((target) => {
+        return target.kind === "builtin" ? [target.connectorSlug] : [];
+      }),
+    ),
+  ];
+
   return await args.timing.measureNetworkPolicyRefresh(async () => {
+    if (builtinConnectorSlugs.length === 0) {
+      return {
+        value: {
+          networkPolicies: args.storedContext.networkPolicies,
+          networkPolicyRefreshes: undefined,
+        },
+        path: "no_builtin_targets",
+      };
+    }
+
     const scope = {
       orgId: args.run.orgId,
       userId: args.run.userId,
@@ -1347,7 +1365,7 @@ async function refreshClaimNetworkPolicies(args: {
       );
       const connectorSlugs = networkPolicyRefreshConnectorSlugs(
         connectorCatalogSnapshot.serverFirewalls,
-        networkPolicyConnectorSlugs,
+        builtinConnectorSlugs,
       );
       const refreshes =
         connectorSlugs.length === 0

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -538,6 +538,23 @@ interface EffectiveConnectorScope {
   readonly source: ConnectorScopeSource;
 }
 
+export type RunConnectorCatalogSelection =
+  | { readonly kind: "empty" }
+  | {
+      readonly kind: "complete";
+      readonly snapshot: ConnectorRuntimeSnapshot;
+    };
+
+export function isEmptyRunConnectorScope(scope: {
+  readonly allowedConnectorSlugs: readonly ConnectorSlug[];
+  readonly allowedCustomConnectorIds: readonly string[];
+}): boolean {
+  return (
+    scope.allowedConnectorSlugs.length === 0 &&
+    scope.allowedCustomConnectorIds.length === 0
+  );
+}
+
 interface ExplicitConnectorScope {
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   readonly allowedCustomConnectorIds: readonly string[];
@@ -947,6 +964,18 @@ interface CustomConnectorRuntimeContext {
   }[];
 }
 
+function emptyCustomConnectorRuntimeContext(): CustomConnectorRuntimeContext {
+  return {
+    firewalls: [],
+    reservedSecretAliases: undefined,
+    permissionPolicies: undefined,
+    targets: [],
+    customConnectorIdByFirewallName: {},
+    mcpConnectorSlugs: [],
+    skills: [],
+  };
+}
+
 function forbidden(message: string): ApiErrorResponse<403, "FORBIDDEN"> {
   return {
     status: 403,
@@ -1121,7 +1150,7 @@ function buildInjectedSkillVolumes(
   args: {
     readonly injectSkillVolumes: CreateAgentRunArgs["injectSkillVolumes"];
     readonly allowedConnectorSlugs: readonly ConnectorSlug[];
-    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+    readonly connectorCatalogSelection: RunConnectorCatalogSelection;
   },
   skillsRoot: string,
 ): readonly PreparedAdditionalVolume[] | undefined {
@@ -1136,11 +1165,13 @@ function buildInjectedSkillVolumes(
       buildLegacySystemSkillVolumes(seedSkillNames, skillsRoot),
       "system_skill",
     ) ?? []),
-    ...buildConnectorSkillVolumes(
-      args.allowedConnectorSlugs,
-      args.connectorCatalogSnapshot,
-      skillsRoot,
-    ),
+    ...(args.connectorCatalogSelection.kind === "complete"
+      ? buildConnectorSkillVolumes(
+          args.allowedConnectorSlugs,
+          args.connectorCatalogSelection.snapshot,
+          skillsRoot,
+        )
+      : []),
   ];
   return [
     ...systemSkillVolumes,
@@ -4510,15 +4541,7 @@ async function loadCustomConnectorContext(
   timing?: ApiDispatchTimingCollector,
 ): Promise<CustomConnectorRuntimeContext> {
   if (args.allowedCustomConnectorIds.length === 0) {
-    return {
-      firewalls: [],
-      reservedSecretAliases: undefined,
-      permissionPolicies: undefined,
-      targets: [],
-      customConnectorIdByFirewallName: {},
-      mcpConnectorSlugs: [],
-      skills: [],
-    };
+    return emptyCustomConnectorRuntimeContext();
   }
 
   const rows = await loadCustomConnectorRuntimeData(db, {
@@ -4539,15 +4562,7 @@ async function loadCustomConnectorContext(
     },
   });
   if (rows.length === 0) {
-    return {
-      firewalls: [],
-      reservedSecretAliases: undefined,
-      permissionPolicies: undefined,
-      targets: [],
-      customConnectorIdByFirewallName: {},
-      mcpConnectorSlugs: [],
-      skills: [],
-    };
+    return emptyCustomConnectorRuntimeContext();
   }
   signal.throwIfAborted();
   const newRunRows = rows.filter((row) => {
@@ -4941,7 +4956,7 @@ function builtinRuntimeTargetRegistration(
 }
 
 function mergePermissionManifests(args: {
-  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly connectorCatalogSelection: RunConnectorCatalogSelection;
   readonly builtinSources: readonly BuiltinConnectorManifestSource[];
   readonly connectorManifest: PermissionManifest;
   readonly customConnectorManifest: Pick<
@@ -4964,13 +4979,23 @@ function mergePermissionManifests(args: {
     return undefined;
   }
 
+  const connectorPermissionBaseline = (() => {
+    if (args.builtinSources.length === 0) {
+      return undefined;
+    }
+    if (args.connectorCatalogSelection.kind === "empty") {
+      throw new Error("Builtin connector sources require a complete catalog");
+    }
+    return buildConnectorPermissionBaseline(
+      args.connectorCatalogSelection.snapshot,
+      args.builtinSources,
+    );
+  })();
+
   return {
     firewalls,
     builtinRuntimeTargets,
-    connectorPermissionBaseline: buildConnectorPermissionBaseline(
-      args.connectorCatalogSnapshot,
-      args.builtinSources,
-    ),
+    ...(connectorPermissionBaseline ? { connectorPermissionBaseline } : {}),
     environmentSecretPlaceholders: mergeRecords(
       args.providerManifest?.environmentSecretPlaceholders,
       args.connectorManifest.environmentSecretPlaceholders,
@@ -4989,7 +5014,7 @@ function mergePermissionManifests(args: {
 }
 
 interface BuildPermissionManifestArgs {
-  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly connectorCatalogSelection: RunConnectorCatalogSelection;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly permissionPolicies: FirewallPolicies | undefined;
   readonly vars: Record<string, string> | undefined;
@@ -5004,30 +5029,34 @@ interface BuildPermissionManifestArgs {
 async function buildPermissionManifest(
   args: BuildPermissionManifestArgs,
 ): Promise<PermissionManifest | undefined> {
-  const connectorSlugs =
-    args.connectorSlugs ??
-    Object.keys(args.permissionPolicies ?? {}).filter((connectorSlug) => {
-      return args.connectorCatalogSnapshot.serverFirewalls.has(connectorSlug);
-    });
   const connectorBaseUrlVars = mergeRecords(args.vars, args.connectorVars);
   const customConnectorFirewalls = args.customConnectorFirewalls ?? [];
-  const builtinConnectorSlugs = connectorSlugs.filter((connectorSlug) => {
-    return args.connectorCatalogSnapshot.serverFirewalls.has(connectorSlug);
-  });
 
   const builtinSources = await measureApiDispatchTiming(
     args.timing,
     "api_dispatch_prepare_context_load_builtin_permission_indexes",
     "nested",
     async () => {
+      if (args.connectorCatalogSelection.kind === "empty") {
+        return [];
+      }
+      const snapshot = args.connectorCatalogSelection.snapshot;
+      const connectorSlugs =
+        args.connectorSlugs ??
+        Object.keys(args.permissionPolicies ?? {}).filter((connectorSlug) => {
+          return snapshot.serverFirewalls.has(connectorSlug);
+        });
+      const builtinConnectorSlugs = connectorSlugs.filter((connectorSlug) => {
+        return snapshot.serverFirewalls.has(connectorSlug);
+      });
       return await Promise.all(
         builtinConnectorSlugs.map(async (connectorSlug) => {
           const metadata = getRequiredFirewallExecutionMetadata(
-            args.connectorCatalogSnapshot,
+            snapshot,
             connectorSlug,
           );
           const permissionIndex = await loadRequiredFirewallPermissionIndex({
-            snapshot: args.connectorCatalogSnapshot,
+            snapshot,
             connectorSlug,
           });
           return { metadata, permissionIndex };
@@ -5093,7 +5122,7 @@ async function buildPermissionManifest(
     () => {
       return Promise.resolve(
         mergePermissionManifests({
-          connectorCatalogSnapshot: args.connectorCatalogSnapshot,
+          connectorCatalogSelection: args.connectorCatalogSelection,
           builtinSources,
           connectorManifest,
           customConnectorManifest,
@@ -7860,7 +7889,7 @@ function validateRunEnvironmentReferences(args: {
 }
 
 async function buildPreparedPermissionManifest(args: {
-  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly connectorCatalogSelection: RunConnectorCatalogSelection;
   readonly body: CreateRunBody;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly storedConnectorMetadataContext: ConnectorRuntimeContext;
@@ -7869,7 +7898,7 @@ async function buildPreparedPermissionManifest(args: {
 }): Promise<PermissionManifest | undefined | CreateRunErrorResult> {
   const result = await settle(
     buildPermissionManifest({
-      connectorCatalogSnapshot: args.connectorCatalogSnapshot,
+      connectorCatalogSelection: args.connectorCatalogSelection,
       modelProvider: args.modelProvider,
       permissionPolicies: args.body.permissionPolicies,
       vars: args.body.vars,
@@ -7895,7 +7924,7 @@ async function buildPreparedPermissionManifest(args: {
 function preparedRunAdditionalVolumes(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly connectorScope: EffectiveConnectorScope;
-  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly connectorCatalogSelection: RunConnectorCatalogSelection;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
   readonly skillsRoot: string;
   readonly featureSwitchContext: FeatureSwitchContext;
@@ -7907,7 +7936,7 @@ function preparedRunAdditionalVolumes(args: {
     {
       injectSkillVolumes: args.createArgs.injectSkillVolumes,
       allowedConnectorSlugs: args.connectorScope.allowedConnectorSlugs,
-      connectorCatalogSnapshot: args.connectorCatalogSnapshot,
+      connectorCatalogSelection: args.connectorCatalogSelection,
     },
     args.skillsRoot,
   );
@@ -7945,7 +7974,7 @@ interface PreparedRuntimeContext {
   readonly billableFirewalls: readonly string[];
   readonly modelUsageProvider: SupportedRunModel | undefined;
   readonly connectorScope: EffectiveConnectorScope;
-  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly connectorCatalogSelection: RunConnectorCatalogSelection;
 }
 
 function connectorScopeForRuntimeSnapshot(
@@ -7971,11 +8000,9 @@ function connectorScopeForRuntimeSnapshot(
 function connectorScopeFromCreateArgs(
   args: CreateAgentRunArgs,
 ): EffectiveConnectorScope {
-  const source =
-    args.connectorScope.allowedConnectorSlugs.length === 0 &&
-    args.connectorScope.allowedCustomConnectorIds.length === 0
-      ? "empty"
-      : (args.connectorScope.source ?? "explicit");
+  const source = isEmptyRunConnectorScope(args.connectorScope)
+    ? "empty"
+    : (args.connectorScope.source ?? "explicit");
   return {
     allowedConnectorSlugs: args.connectorScope.allowedConnectorSlugs,
     allowedCustomConnectorIds: args.connectorScope.allowedCustomConnectorIds,
@@ -8123,7 +8150,7 @@ async function prepareRunConnectorContexts(
     readonly createArgs: CreateAgentRunArgs;
     readonly connectorScope: EffectiveConnectorScope;
     readonly featureSwitchContext: FeatureSwitchContext;
-    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+    readonly connectorCatalogSelection: RunConnectorCatalogSelection;
     readonly timing: ApiDispatchTimingCollector;
   },
   signal: AbortSignal,
@@ -8135,13 +8162,42 @@ async function prepareRunConnectorContexts(
       "api_dispatch_prepare_context_load_connector_contexts",
       "nested",
       async () => {
+        if (args.connectorCatalogSelection.kind === "empty") {
+          const [storedConnectorSnapshot, customConnectorContext] =
+            await Promise.all([
+              measureApiDispatchTiming(
+                args.timing,
+                "api_dispatch_prepare_context_load_stored_connectors",
+                "nested",
+                () => {
+                  return null;
+                },
+                storedConnectorTimingDimensions({
+                  scopeSource: args.connectorScope.source,
+                }),
+              ),
+              measureApiDispatchTiming(
+                args.timing,
+                "api_dispatch_prepare_context_load_custom_connectors",
+                "nested",
+                () => {
+                  return emptyCustomConnectorRuntimeContext();
+                },
+              ),
+            ]);
+          return {
+            storedConnectorSnapshot,
+            storedConnectorMetadataContext: emptyConnectorRuntimeContext(),
+            customConnectorContext,
+          };
+        }
         return await loadRunConnectorContexts(
           args.db,
           {
             orgId: args.createArgs.orgId,
             userId: args.createArgs.userId,
             connectorScope: args.connectorScope,
-            connectorCatalogSnapshot: args.connectorCatalogSnapshot,
+            connectorCatalogSnapshot: args.connectorCatalogSelection.snapshot,
             featureSwitchContext: args.featureSwitchContext,
             timing: args.timing,
           },
@@ -8201,12 +8257,15 @@ async function prepareRunRuntimeContext(
 ): Promise<PreparedRuntimeContext | CreateRunErrorResult> {
   const { body, resolved, requestedFramework, featureSwitchContext } =
     args.bodyContext;
-  const connectorCatalogSnapshot = await connectorCatalogSnapshotForRun(args);
+  const connectorCatalogSelection = await connectorCatalogSelectionForRun(args);
   signal.throwIfAborted();
-  const connectorScope = connectorScopeForRuntimeSnapshot(
-    args.connectorScope,
-    connectorCatalogSnapshot,
-  );
+  const connectorScope =
+    connectorCatalogSelection.kind === "complete"
+      ? connectorScopeForRuntimeSnapshot(
+          args.connectorScope,
+          connectorCatalogSelection.snapshot,
+        )
+      : args.connectorScope;
   const modelProvider = await resolvePreparedRunModelProvider(args, signal);
   if (isRouteError(modelProvider)) {
     return modelProvider;
@@ -8219,7 +8278,7 @@ async function prepareRunRuntimeContext(
       ...args,
       connectorScope,
       featureSwitchContext,
-      connectorCatalogSnapshot,
+      connectorCatalogSelection,
     },
     signal,
   );
@@ -8255,7 +8314,7 @@ async function prepareRunRuntimeContext(
     "nested",
     async () => {
       return await buildPreparedPermissionManifest({
-        connectorCatalogSnapshot,
+        connectorCatalogSelection,
         body,
         modelProvider,
         storedConnectorMetadataContext,
@@ -8306,29 +8365,32 @@ async function prepareRunRuntimeContext(
     billableFirewalls: modelUsageContext.billableFirewalls,
     modelUsageProvider: modelUsageContext.modelUsageProvider,
     connectorScope,
-    connectorCatalogSnapshot,
+    connectorCatalogSelection,
   };
 }
 
-async function connectorCatalogSnapshotForRun(args: {
+async function connectorCatalogSelectionForRun(args: {
   readonly db: Db;
   readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
   readonly connectorScope: EffectiveConnectorScope;
   readonly timing: ApiDispatchTimingCollector;
-}): Promise<ConnectorRuntimeSnapshot> {
-  return (
+}): Promise<RunConnectorCatalogSelection> {
+  if (isEmptyRunConnectorScope(args.connectorScope)) {
+    return { kind: "empty" };
+  }
+  const snapshot =
     args.preloadedConnectorCatalogSnapshot ??
     (await loadConnectorRuntimeSnapshot(args.db, {
       timing: args.timing,
       requestedConnectorCount: args.connectorScope.allowedConnectorSlugs.length,
-    }))
-  );
+    }));
+  return { kind: "complete", snapshot };
 }
 
 function prepareRunOutputMetadata(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly connectorScope: EffectiveConnectorScope;
-  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly connectorCatalogSelection: RunConnectorCatalogSelection;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
   readonly framework: SupportedFramework;
   readonly piSandbox: PiModelConfig | undefined;
@@ -8343,7 +8405,7 @@ function prepareRunOutputMetadata(args: {
   const additionalVolumes = preparedRunAdditionalVolumes({
     createArgs: args.createArgs,
     connectorScope: args.connectorScope,
-    connectorCatalogSnapshot: args.connectorCatalogSnapshot,
+    connectorCatalogSelection: args.connectorCatalogSelection,
     customConnectorContext: args.customConnectorContext,
     skillsRoot:
       args.piSandbox === undefined
@@ -8506,7 +8568,8 @@ function prepareRunContext(
             prepareRunOutputMetadata({
               createArgs: args,
               connectorScope: runtimeContext.connectorScope,
-              connectorCatalogSnapshot: runtimeContext.connectorCatalogSnapshot,
+              connectorCatalogSelection:
+                runtimeContext.connectorCatalogSelection,
               customConnectorContext: runtimeContext.customConnectorContext,
               framework: runtimeContext.framework,
               piSandbox,

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -26,6 +26,7 @@ import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import {
   completeAgentRun$,
+  isEmptyRunConnectorScope,
   isQueueFirstRunClaimLost,
   isThreadSessionSnapshotStale,
   prepareAgentRun$,
@@ -33,6 +34,7 @@ import {
   type CreateAgentRunArgs,
   type DispatchFailedRunCallbacks,
   type QueueFirstRunClaimLost,
+  type RunConnectorCatalogSelection,
   type ZeroRunModelPin,
 } from "./agent-run-create.service";
 import {
@@ -57,10 +59,7 @@ import {
   type ZeroRunBootstrapSnapshotRows,
 } from "./zero-run-bootstrap-context.service";
 import type { RunWorkflowRef } from "./workflow-data.service";
-import {
-  loadConnectorRuntimeSnapshot,
-  type ConnectorRuntimeSnapshot,
-} from "./connector-catalog-runtime.service";
+import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
 import { expandConnectorServerFirewallPolicies } from "./connector-server-firewall-catalog.service";
 import type { QueueFirstRunAssociation } from "./chat-queued-event.service";
 import {
@@ -753,20 +752,31 @@ async function loadZeroRunPostAuthorizationContext(
   );
   signal.throwIfAborted();
 
-  const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(db, {
-    timing: args.timing,
-    requestedConnectorCount: bootstrapContext.allowedConnectorSlugs.length,
-  });
+  const connectorCatalogSelection: RunConnectorCatalogSelection =
+    isEmptyRunConnectorScope(bootstrapContext)
+      ? { kind: "empty" }
+      : {
+          kind: "complete",
+          snapshot: await loadConnectorRuntimeSnapshot(db, {
+            timing: args.timing,
+            requestedConnectorCount:
+              bootstrapContext.allowedConnectorSlugs.length,
+          }),
+        };
   signal.throwIfAborted();
+  const storedPermissionPolicies = permissionGrantsToFirewallPolicies(
+    bootstrapContext.permissionGrants,
+  );
   const runPermissionPolicies = await measureZeroPreCreate(
     args.timing,
     "api_dispatch_pre_create_zero_resolve_firewall_metadata",
     async () => {
+      if (connectorCatalogSelection.kind === "empty") {
+        return storedPermissionPolicies;
+      }
       return await expandConnectorServerFirewallPolicies({
-        catalog: connectorCatalogSnapshot.serverFirewalls,
-        stored: permissionGrantsToFirewallPolicies(
-          bootstrapContext.permissionGrants,
-        ),
+        catalog: connectorCatalogSelection.snapshot.serverFirewalls,
+        stored: storedPermissionPolicies,
         connectorSlugs: [...bootstrapContext.allowedConnectorSlugs],
       });
     },
@@ -775,7 +785,7 @@ async function loadZeroRunPostAuthorizationContext(
 
   return {
     ...bootstrapContext,
-    connectorCatalogSnapshot,
+    connectorCatalogSelection,
     runPermissionPolicies,
   };
 }
@@ -866,7 +876,7 @@ interface ZeroRunAfterPreCreate {
   readonly userInfo: UserInfo;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
-  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly connectorCatalogSelection: RunConnectorCatalogSelection;
   readonly workflows: readonly RunWorkflowRef[];
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];
   readonly allowedCustomConnectorIds: readonly string[];
@@ -977,7 +987,12 @@ const createAgentRunAfterZeroPreCreate$ = command(
           checkOrgPlanStatusBeforeContext: false,
           preloadedFeatureSwitchContext: input.featureSwitchContext,
           preloadedUserTimezone: input.userInfo.timezone,
-          preloadedConnectorCatalogSnapshot: input.connectorCatalogSnapshot,
+          ...(input.connectorCatalogSelection.kind === "complete"
+            ? {
+                preloadedConnectorCatalogSnapshot:
+                  input.connectorCatalogSelection.snapshot,
+              }
+            : {}),
         },
         signal,
       );
@@ -1052,7 +1067,7 @@ const createZeroRunInternal$ = command(
       customConnectorGrants,
       workflows,
       runPermissionPolicies,
-      connectorCatalogSnapshot,
+      connectorCatalogSelection,
     } = await loadZeroRunPostAuthorizationContext(
       db,
       {
@@ -1073,7 +1088,7 @@ const createZeroRunInternal$ = command(
         userInfo,
         featureSwitchContext,
         runPermissionPolicies,
-        connectorCatalogSnapshot,
+        connectorCatalogSelection,
         workflows,
         allowedConnectorSlugs,
         allowedCustomConnectorIds,

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -764,13 +764,13 @@ async function loadZeroRunPostAuthorizationContext(
           }),
         };
   signal.throwIfAborted();
-  const storedPermissionPolicies = permissionGrantsToFirewallPolicies(
-    bootstrapContext.permissionGrants,
-  );
   const runPermissionPolicies = await measureZeroPreCreate(
     args.timing,
     "api_dispatch_pre_create_zero_resolve_firewall_metadata",
     async () => {
+      const storedPermissionPolicies = permissionGrantsToFirewallPolicies(
+        bootstrapContext.permissionGrants,
+      );
       if (connectorCatalogSelection.kind === "empty") {
         return storedPermissionPolicies;
       }


### PR DESCRIPTION
## Summary

- skip connector catalog loading and catalog-derived context when a run has no built-in or custom connector scope
- preserve connector-independent permissions, workflow/goal context, timing, and queue semantics on the empty-scope path
- make runner claim refresh depend on persisted built-in targets, while retaining complete catalog validation for selected built-ins and custom connectors
- add integration coverage for direct dispatch, Zero create/claim, provider-only and custom-skill-only scopes, and unavailable catalog behavior

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 -t 'exact-empty direct dispatch|fully validates a missing catalog authority|fully validates a different catalog authority|deduplicates concurrent attested catalog loads|keeps exact-empty create and claim independent|retains direct plan admission|omits connected stored connectors|injects oauth connector tokens|keeps a granted custom skill|injects proposed custom connector fields|skips connector catalog work for a current writer without built-ins|handles missing, invalid, and incompatible permission baselines|creates, dispatches, claims, reports, and completes|queues runs over the concurrency limit|dispatches, scopes, and claims runs through CLI PATs'`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit: Prettier, repository Knip, repository type checks, commitlint

No database migration, HTTP contract, queue payload, or runner protocol change is included.

Closes #27454

Parent: #24203
