### PR TITLE
refactor(runner): centralize raw http test fixture

### DIFF
--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
-
 use crate::active_input::{
     API_ACTIVE_INPUT_RECHECK_INTERVAL, ActiveInputNotifications, ActiveInputSource,
     local_active_input_delivery_id,
@@ -15,109 +12,18 @@ use crate::executor::tests::support::{
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
 use crate::provider::ApiClient;
+use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, json_response};
 use crate::types::SandboxReuseResult;
 
 const DELIVERY_ID: &str = "b1e2ad6d-930a-4d51-aa40-7952d54f978b";
 const EVENT_ID: &str = "e6bc287d-8c08-464e-831a-cad771610157";
 
-async fn read_http_request(socket: &mut TcpStream) -> String {
-    let mut request = Vec::new();
-    let mut buffer = [0_u8; 1024];
-    let header_end = loop {
-        let read = socket.read(&mut buffer).await.unwrap();
-        assert!(read > 0, "connection closed before HTTP headers completed");
-        request.extend_from_slice(&buffer[..read]);
-        if let Some(header_end) = request
-            .windows(4)
-            .position(|window| window == b"\r\n\r\n")
-            .map(|position| position + 4)
-        {
-            break header_end;
-        }
-    };
-    let headers = String::from_utf8_lossy(&request[..header_end]);
-    let body_len = headers
-        .lines()
-        .find_map(|line| {
-            let (name, value) = line.split_once(':')?;
-            name.eq_ignore_ascii_case("content-length")
-                .then(|| value.trim().parse::<usize>().unwrap())
-        })
-        .unwrap_or(0);
-    while request.len() < header_end + body_len {
-        let read = socket.read(&mut buffer).await.unwrap();
-        assert!(read > 0, "connection closed before HTTP body completed");
-        request.extend_from_slice(&buffer[..read]);
-    }
-    String::from_utf8(request).unwrap()
-}
-
-fn http_response(status: &str, body: &str) -> String {
-    format!(
-        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        body.len()
-    )
-}
-
-enum HttpServerAction {
-    Respond(String),
-    Disconnect,
-}
-
-async fn spawn_http_server(
-    responses: Vec<String>,
-) -> (
-    String,
-    tokio::sync::mpsc::UnboundedReceiver<String>,
-    tokio::task::JoinHandle<()>,
-) {
-    spawn_http_server_with_actions(
-        responses
-            .into_iter()
-            .map(HttpServerAction::Respond)
-            .collect(),
-    )
-    .await
-}
-
-async fn spawn_http_server_with_actions(
-    actions: Vec<HttpServerAction>,
-) -> (
-    String,
-    tokio::sync::mpsc::UnboundedReceiver<String>,
-    tokio::task::JoinHandle<()>,
-) {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let api_url = format!("http://{}", listener.local_addr().unwrap());
-    let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
-    let server = tokio::spawn(async move {
-        for action in actions {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            if let HttpServerAction::Respond(response) = action {
-                socket.write_all(response.as_bytes()).await.unwrap();
-                socket.shutdown().await.unwrap();
-                let mut closed = [0_u8; 1];
-                assert_eq!(socket.read(&mut closed).await.unwrap(), 0);
-            }
-            request_tx.send(request).unwrap();
-        }
-    });
-    (api_url, request_rx, server)
-}
-
 async fn receive_http_request_before(
     deadline: tokio::time::Instant,
-    request_rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+    server: &mut RawHttpTestServer,
     description: &str,
 ) -> Result<String, String> {
-    match tokio::time::timeout_at(deadline, request_rx.recv()).await {
-        Ok(Some(request)) => Ok(request),
-        Ok(None) => Err(format!(
-            "active-input request channel closed before {description}"
-        )),
-        Err(_) => Err(format!("timed out waiting for {description}")),
-    }
+    server.next_request_before(deadline, description).await
 }
 
 async fn reap_spawned_test_task<T>(
@@ -272,17 +178,21 @@ async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() 
     let run_id = ctx.run_id;
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
 
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("200 OK", r#"{"outcome":"empty"}"#),
-        http_response("503 Service Unavailable", r#"{"error":"transient"}"#),
-        http_response(
+    let mut server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(json_response("200 OK", r#"{"outcome":"empty"}"#)),
+        RawHttpAction::Respond(json_response(
+            "503 Service Unavailable",
+            r#"{"error":"transient"}"#,
+        )),
+        RawHttpAction::Respond(json_response(
             "200 OK",
             &format!(
                 r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retry delivered"}}"#,
             ),
-        ),
+        )),
     ])
     .await;
+    let api_url = server.url();
 
     let notifications = ActiveInputNotifications::new();
     let source =
@@ -306,10 +216,9 @@ async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() 
         .await
     });
 
-    let initial_reserve = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_rx.recv())
-        .await
-        .expect("initial active-input reserve request should reach the server")
-        .expect("active-input request channel should remain open");
+    let initial_reserve = server
+        .next_request("initial active-input reserve request")
+        .await;
     assert!(initial_reserve.starts_with(&format!("POST {reserve_path} ")));
     notifications.notify(run_id);
 
@@ -327,14 +236,7 @@ async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() 
         .unwrap();
     assert!(result.failure.is_none());
 
-    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
-        .await
-        .expect("active-input server should finish")
-        .unwrap();
-    let mut remaining_requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        remaining_requests.push(request);
-    }
+    let remaining_requests = server.assert_finished_with_requests().await;
     assert_eq!(remaining_requests.len(), 2);
     assert!(remaining_requests[0].starts_with(&format!("POST {reserve_path} ")));
     assert!(remaining_requests[1].starts_with(&format!("POST {reserve_path} ")));
@@ -360,16 +262,17 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
     let run_id = ctx.run_id;
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
 
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("200 OK", r#"{"outcome":"empty"}"#),
-        http_response(
+    let mut server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(json_response("200 OK", r#"{"outcome":"empty"}"#)),
+        RawHttpAction::Respond(json_response(
             "200 OK",
             &format!(
                 r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"recheck delivered"}}"#,
             ),
-        ),
+        )),
     ])
     .await;
+    let api_url = server.url();
 
     let notifications = ActiveInputNotifications::new();
     let source =
@@ -393,10 +296,9 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
         .await
     });
 
-    let initial_reserve = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_rx.recv())
-        .await
-        .expect("initial active-input reserve request should reach the server")
-        .expect("active-input request channel should remain open");
+    let initial_reserve = server
+        .next_request("initial active-input reserve request")
+        .await;
     assert!(initial_reserve.starts_with(&format!("POST {reserve_path} ")));
 
     tokio::time::pause();
@@ -418,14 +320,7 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
         .unwrap();
     assert!(result.failure.is_none());
 
-    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
-        .await
-        .expect("active-input server should finish")
-        .unwrap();
-    let mut remaining_requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        remaining_requests.push(request);
-    }
+    let remaining_requests = server.assert_finished_with_requests().await;
     assert_eq!(remaining_requests.len(), 1);
     assert!(remaining_requests[0].starts_with(&format!("POST {reserve_path} ")));
 
@@ -528,16 +423,17 @@ async fn run_in_sandbox_retries_reserve_when_first_request_is_not_found() {
     let ctx = minimal_context();
     let run_id = ctx.run_id;
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("404 Not Found", r#"{"error":"not found"}"#),
-        http_response(
+    let server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(json_response("404 Not Found", r#"{"error":"not found"}"#)),
+        RawHttpAction::Respond(json_response(
             "200 OK",
             &format!(
                 r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"reserve delivered"}}"#,
             ),
-        ),
+        )),
     ])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -577,15 +473,7 @@ async fn run_in_sandbox_retries_reserve_when_first_request_is_not_found() {
         .unwrap()
         .unwrap();
     assert!(result.failure.is_none());
-    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
-        .await
-        .unwrap()
-        .unwrap();
-
-    let mut requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        requests.push(request);
-    }
+    let requests = server.assert_finished_with_requests().await;
     assert_eq!(requests.len(), 2);
     assert!(
         requests
@@ -612,17 +500,18 @@ async fn run_in_sandbox_retrieves_reservation_after_lost_first_response() {
     let ctx = minimal_context();
     let run_id = ctx.run_id;
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
-    let reserved = http_response(
+    let reserved = json_response(
         "200 OK",
         &format!(
             r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retrieved delivery"}}"#,
         ),
     );
-    let (api_url, mut request_rx, server) = spawn_http_server_with_actions(vec![
-        HttpServerAction::Disconnect,
-        HttpServerAction::Respond(reserved),
+    let server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Disconnect,
+        RawHttpAction::Respond(reserved),
     ])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -662,12 +551,7 @@ async fn run_in_sandbox_retrieves_reservation_after_lost_first_response() {
         .unwrap()
         .unwrap();
     assert!(result.failure.is_none());
-    server.await.unwrap();
-
-    let mut requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        requests.push(request);
-    }
+    let requests = server.assert_finished_with_requests().await;
     assert_eq!(requests.len(), 2);
     assert!(
         requests
@@ -691,11 +575,15 @@ async fn run_in_sandbox_keeps_using_reserve_after_ambiguous_failure() {
     let ctx = minimal_context();
     let run_id = ctx.run_id;
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("503 Service Unavailable", r#"{"error":"transient"}"#),
-        http_response("404 Not Found", r#"{"error":"not found"}"#),
+    let server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(json_response(
+            "503 Service Unavailable",
+            r#"{"error":"transient"}"#,
+        )),
+        RawHttpAction::Respond(json_response("404 Not Found", r#"{"error":"not found"}"#)),
     ])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -723,14 +611,7 @@ async fn run_in_sandbox_keeps_using_reserve_after_ambiguous_failure() {
         .await
     });
 
-    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
-        .await
-        .unwrap()
-        .unwrap();
-    let mut requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        requests.push(request);
-    }
+    let requests = server.assert_finished_with_requests().await;
     assert_eq!(requests.len(), 2);
     assert!(
         requests
@@ -758,8 +639,12 @@ async fn run_in_sandbox_stops_when_reserve_reports_terminal() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let (api_url, _request_rx, server) =
-        spawn_http_server(vec![http_response("200 OK", r#"{"outcome":"terminal"}"#)]).await;
+    let server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
+        "200 OK",
+        r#"{"outcome":"terminal"}"#,
+    ))])
+    .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -787,7 +672,7 @@ async fn run_in_sandbox_stops_when_reserve_reports_terminal() {
         .await
     });
 
-    server.await.unwrap();
+    server.assert_finished().await;
     wait_gate.notify_one();
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
         .await
@@ -814,13 +699,14 @@ async fn run_in_sandbox_retries_not_written_delivery_with_same_id() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let (api_url, _request_rx, server) = spawn_http_server(vec![http_response(
+    let server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
         "200 OK",
         &format!(
             r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retry exact delivery"}}"#,
         ),
-    )])
+    ))])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -860,7 +746,7 @@ async fn run_in_sandbox_retries_not_written_delivery_with_same_id() {
         .unwrap()
         .unwrap();
     assert!(result.failure.is_none());
-    server.await.unwrap();
+    server.assert_finished().await;
     let calls = overrides.process_control_calls();
     assert_eq!(calls.len(), 2);
     assert!(calls.iter().all(|call| call.message_id == DELIVERY_ID));
@@ -887,13 +773,14 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let (api_url, _request_rx, server) = spawn_http_server(vec![http_response(
+    let server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
         "200 OK",
         &format!(
             r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retry guest backpressure"}}"#,
         ),
-    )])
+    ))])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -933,7 +820,7 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
         .unwrap()
         .unwrap();
     assert!(result.failure.is_none());
-    server.await.unwrap();
+    server.assert_finished().await;
     let calls = overrides.process_control_calls();
     assert_eq!(calls.len(), 3);
     assert!(calls.iter().all(|call| call.message_id == DELIVERY_ID));
@@ -959,18 +846,19 @@ async fn run_in_sandbox_suppresses_possibly_written_delivery() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let reserve = http_response(
+    let reserve = json_response(
         "200 OK",
         &format!(
             r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"uncertain delivery"}}"#,
         ),
     );
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        reserve.clone(),
-        reserve,
-        http_response("200 OK", r#"{"outcome":"empty"}"#),
+    let server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(reserve.clone()),
+        RawHttpAction::Respond(reserve),
+        RawHttpAction::Respond(json_response("200 OK", r#"{"outcome":"empty"}"#)),
     ])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -1013,18 +901,27 @@ async fn run_in_sandbox_suppresses_possibly_written_delivery() {
         if !process_control_observed {
             return Err("timed out waiting for the first process-control delivery attempt".into());
         }
-        receive_http_request_before(deadline, &mut request_rx, "the first reserve request").await?;
+        let Some(server_fixture) = server.as_mut() else {
+            return Err("active-input server ownership was lost before the first request".into());
+        };
+        receive_http_request_before(deadline, server_fixture, "the first reserve request").await?;
         notifications.notify(run_id);
+        let Some(server_fixture) = server.as_mut() else {
+            return Err("active-input server ownership was lost before the second request".into());
+        };
         receive_http_request_before(
             deadline,
-            &mut request_rx,
+            server_fixture,
             "the second reserve request after the first notification",
         )
         .await?;
         notifications.notify(run_id);
+        let Some(server_fixture) = server.as_mut() else {
+            return Err("active-input server ownership was lost before the third request".into());
+        };
         receive_http_request_before(
             deadline,
-            &mut request_rx,
+            server_fixture,
             "the third reserve request after the second notification",
         )
         .await?;
@@ -1041,16 +938,10 @@ async fn run_in_sandbox_suppresses_possibly_written_delivery() {
             .map_err(|error| format!("runner task failed: {error}"))?
             .map_err(|error| format!("run_in_sandbox failed: {error}"))?;
 
-        let Some(server_handle) = server.as_mut() else {
+        let Some(server_fixture) = server.take() else {
             return Err("active-input server task ownership was lost before completion".into());
         };
-        let server_outcome = tokio::time::timeout_at(deadline, server_handle)
-            .await
-            .map_err(|_| {
-                "timed out waiting for the active-input server task to finish".to_string()
-            })?;
-        server.take();
-        server_outcome.map_err(|error| format!("active-input server task failed: {error}"))?;
+        server_fixture.assert_finished().await;
         Ok::<_, String>(result)
     }
     .await;
@@ -1060,16 +951,12 @@ async fn run_in_sandbox_suppresses_possibly_written_delivery() {
         Err(error) => {
             cancel.cancel();
             wait_gate.notify_one();
-            if let Some(server) = server.as_ref() {
-                server.abort();
+            if let Some(server_fixture) = server.take() {
+                server_fixture.cancel_and_reap().await;
             }
-            let (run_cleanup, server_cleanup) = tokio::join!(
-                reap_spawned_test_task(run_task.take(), "runner"),
-                reap_spawned_test_task(server.take(), "active-input server"),
-            );
-            let cleanup_errors = [run_cleanup, server_cleanup]
+            let cleanup_errors = reap_spawned_test_task(run_task.take(), "runner")
+                .await
                 .into_iter()
-                .flatten()
                 .collect::<Vec<_>>();
             if cleanup_errors.is_empty() {
                 panic!("{error}");
@@ -1103,16 +990,20 @@ async fn run_in_sandbox_carries_failed_journal_receipt_to_completion() {
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
     let receipt_path =
         format!("/api/runners/runs/{run_id}/active-inputs/deliveries/{DELIVERY_ID}/receipt");
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response(
+    let server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(json_response(
             "200 OK",
             &format!(
                 r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"recover receipt"}}"#,
             ),
-        ),
-        http_response("503 Service Unavailable", r#"{"error":"transient"}"#),
+        )),
+        RawHttpAction::Respond(json_response(
+            "503 Service Unavailable",
+            r#"{"error":"transient"}"#,
+        )),
     ])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -1156,9 +1047,9 @@ async fn run_in_sandbox_carries_failed_journal_receipt_to_completion() {
         result.active_input_delivery_ids,
         vec![DELIVERY_ID.to_string()]
     );
-    server.await.unwrap();
-    let first_request = request_rx.recv().await.unwrap();
-    let second_request = request_rx.recv().await.unwrap();
+    let requests = server.assert_finished_with_requests().await;
+    let first_request = &requests[0];
+    let second_request = &requests[1];
     assert!(first_request.starts_with(&format!("POST {reserve_path} ")));
     assert!(second_request.starts_with(&format!("POST {receipt_path} ")));
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1495,7 +1495,8 @@ mod tests {
         RunnerPreferenceRemovalReason, RunnerPreferenceTier,
     };
     use crate::test_fixtures::raw_http::{
-        RawHttpAction, RawHttpTestServer, http_response, json_response, read_http_request,
+        RawHttpAction, RawHttpTestServer, http_response, join_raw_http_task, json_response,
+        read_http_request,
     };
 
     const RUNNER_CLAIM_RESPONSE_FIXTURE: &str = include_str!(
@@ -2907,10 +2908,7 @@ mod tests {
             .expect("request channel should remain open");
         assert!(second_claim_request.contains(&format!("/api/runners/jobs/{run_id}/claim")));
 
-        tokio::time::timeout(Duration::from_secs(1), server_task)
-            .await
-            .expect("transient sequence server should finish")
-            .unwrap();
+        join_raw_http_task(server_task, "transient sequence server").await;
         assert!(requests.recv().await.is_none());
     }
 
@@ -3149,7 +3147,7 @@ mod tests {
             rediscovered.discovery_source(),
             Some(JobDiscoverySource::Poll)
         );
-        server_task.await.unwrap();
+        join_raw_http_task(server_task, "direct candidate sequence server").await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1481,7 +1481,7 @@ mod tests {
     use super::*;
     use httpmock::Method::POST;
     use httpmock::MockServer;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::io::AsyncWriteExt;
     use tokio::net::TcpListener;
     use tokio::sync::mpsc;
     use tracing::{Level, instrument::WithSubscriber};
@@ -1882,11 +1882,8 @@ mod tests {
 
     #[tokio::test]
     async fn heartbeat_send_failure_logs_transport_and_state_context_without_secrets() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let server_task = tokio::spawn(async move {
-            let (_socket, _) = listener.accept().await.unwrap();
-        });
+        let server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+        let api_url = server.url();
         let provider = api_provider_for_test(
             api_url.clone(),
             CancellationToken::new(),
@@ -1895,8 +1892,7 @@ mod tests {
         let state = heartbeat_state_for_test();
 
         let (_, events) = capture_api_provider_events(provider.heartbeat(&state)).await;
-        server_task.abort();
-        let _ = server_task.await;
+        server.assert_finished().await;
         let event = captured_event(&events, "heartbeat failed");
 
         assert_eq!(event.level, Level::WARN);
@@ -1942,13 +1938,9 @@ mod tests {
 
     #[tokio::test]
     async fn heartbeat_status_failure_logs_held_state_counts_without_body() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let server_task = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut socket).await.unwrap();
-            socket.write_all(&status_response(500)).await.unwrap();
-        });
+        let server =
+            RawHttpTestServer::spawn(vec![RawHttpAction::Respond(status_response(500))]).await;
+        let api_url = server.url();
         let provider = api_provider_for_test(
             api_url,
             CancellationToken::new(),
@@ -1957,7 +1949,7 @@ mod tests {
         let state = heartbeat_state_for_test();
 
         let (_, events) = capture_api_provider_events(provider.heartbeat(&state)).await;
-        server_task.await.unwrap();
+        server.assert_finished().await;
         let event = captured_event(&events, "heartbeat failed");
 
         assert_eq!(event.level, Level::WARN);
@@ -2265,7 +2257,7 @@ mod tests {
         assert!(body["telemetry"].get("pollReason").is_none());
     }
 
-    async fn write_poll_job_response(socket: &mut tokio::net::TcpStream, run_id: RunId) {
+    fn poll_job_response(run_id: RunId) -> Vec<u8> {
         let body = serde_json::json!({
             "job": {
                 "runId": run_id,
@@ -2273,24 +2265,17 @@ mod tests {
             }
         })
         .to_string();
-        socket
-            .write_all(&json_response("200 OK", &body))
-            .await
-            .unwrap();
+        json_response("200 OK", &body)
+    }
+
+    async fn write_poll_job_response(socket: &mut tokio::net::TcpStream, run_id: RunId) {
+        socket.write_all(&poll_job_response(run_id)).await.unwrap();
     }
 
     #[tokio::test]
     async fn discover_cancel_aborts_in_flight_poll() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
-        let server_task = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let mut buf = [0_u8; 1024];
-            let _ = socket.read(&mut buf).await;
-            let _ = accepted_tx.send(());
-            std::future::pending::<()>().await;
-        });
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Stall]).await;
+        let api_url = server.url();
 
         let cancel = CancellationToken::new();
         let provider =
@@ -2299,10 +2284,7 @@ mod tests {
         let provider_for_discover = Arc::clone(&provider);
         let discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
 
-        tokio::time::timeout(Duration::from_secs(1), accepted_rx)
-            .await
-            .expect("poll request should reach the server")
-            .unwrap();
+        server.next_request("in-flight poll request").await;
 
         cancel.cancel();
 
@@ -2312,8 +2294,7 @@ mod tests {
             .unwrap();
         assert!(result.is_none());
 
-        server_task.abort();
-        let _ = server_task.await;
+        server.cancel_and_reap().await;
     }
 
     #[tokio::test]
@@ -2935,23 +2916,13 @@ mod tests {
 
     #[tokio::test]
     async fn old_api_returning_excluded_run_does_not_rediscover_it() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
         let run_id: RunId = "00000000-0000-0000-0000-00000000001a".parse().unwrap();
-        let (request_tx, mut requests) = mpsc::unbounded_channel();
-        let server_task = tokio::spawn(async move {
-            let (mut claim, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut claim).await.unwrap();
-            claim.write_all(&status_response(400)).await.unwrap();
-            request_tx.send(request).unwrap();
-
-            let (mut ignored_exclusion_poll, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut ignored_exclusion_poll)
-                .await
-                .unwrap();
-            write_poll_job_response(&mut ignored_exclusion_poll, run_id).await;
-            request_tx.send(request).unwrap();
-        });
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Respond(status_response(400)),
+            RawHttpAction::Respond(poll_job_response(run_id)),
+        ])
+        .await;
+        let api_url = server.url();
         let wakeups = Arc::new(PollWakeups::new(true));
         let initial_poll = wakeups
             .wait_for_poll_due(&CancellationToken::new(), POLL_SLOW, POLL_FAST)
@@ -2970,12 +2941,12 @@ mod tests {
 
         let direct = provider.discover().await.unwrap();
         assert!(provider.claim(direct).await.is_none());
-        let claim_request = next_request(&mut requests).await;
+        let claim_request = server.next_request("old API claim request").await;
         assert!(claim_request.contains(&format!("/api/runners/jobs/{run_id}/claim")));
 
         let provider_for_discover = Arc::clone(&provider);
         let mut discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
-        let ignored_exclusion_request = next_request(&mut requests).await;
+        let ignored_exclusion_request = server.next_request("old API poll request").await;
         assert!(ignored_exclusion_request.contains(r#""excludedRunIds":["#));
         assert!(ignored_exclusion_request.contains(&run_id.to_string()));
         assert!(
@@ -2984,12 +2955,11 @@ mod tests {
                 .is_err(),
             "an excluded run returned by an old API must not be rediscovered"
         );
-        assert!(requests.try_recv().is_err());
+        assert!(server.try_next_request().is_err());
 
         cancel.cancel();
         assert!(discover_task.await.unwrap().is_none());
-        server_task.await.unwrap();
-        assert!(requests.recv().await.is_none());
+        server.assert_finished().await;
     }
 
     #[tokio::test]
@@ -3184,34 +3154,25 @@ mod tests {
 
     #[tokio::test]
     async fn discover_defers_job_return_when_deferred_poll_arrives_during_poll() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
         let first_run_id: RunId = "00000000-0000-0000-0000-000000000004".parse().unwrap();
         let second_run_id: RunId = "00000000-0000-0000-0000-000000000005".parse().unwrap();
-        let (first_accepted_tx, first_accepted_rx) = tokio::sync::oneshot::channel();
         let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
-        let server_task = tokio::spawn(async move {
-            let (mut first_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut first_socket).await.unwrap();
-            let _ = first_accepted_tx.send(());
-            release_first_rx.await.unwrap();
-            write_poll_job_response(&mut first_socket, first_run_id).await;
-            drop(first_socket);
-
-            let (mut second_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut second_socket).await.unwrap();
-            write_poll_job_response(&mut second_socket, second_run_id).await;
-        });
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::WaitThenRespond {
+                release: release_first_rx,
+                response: poll_job_response(first_run_id),
+            },
+            RawHttpAction::Respond(poll_job_response(second_run_id)),
+        ])
+        .await;
+        let api_url = server.url();
         let wakeups = Arc::new(PollWakeups::new(false));
         let provider =
             api_provider_for_test(api_url, CancellationToken::new(), Arc::clone(&wakeups));
         let provider_for_discover = Arc::clone(&provider);
         let discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
 
-        tokio::time::timeout(Duration::from_secs(1), first_accepted_rx)
-            .await
-            .expect("first poll should reach the server")
-            .unwrap();
+        server.next_request("first deferred poll request").await;
         wakeups
             .request_deferred_poll_after_for_test(Duration::ZERO)
             .await;
@@ -3225,7 +3186,7 @@ mod tests {
 
         assert_eq!(discovered.run_id(), second_run_id);
         assert_eq!(discovered.profile_name(), "vm0/default");
-        server_task.await.unwrap();
+        server.assert_finished().await;
     }
 
     #[tokio::test]
@@ -4530,23 +4491,12 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn api_provider_complete_retries_transport_failure() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let (request_tx, mut requests) = mpsc::unbounded_channel();
-        let server_task = tokio::spawn(async move {
-            let (mut first_socket, _) = listener.accept().await.unwrap();
-            let first_request = read_http_request(&mut first_socket).await.unwrap();
-            drop(first_socket);
-            request_tx.send(first_request).unwrap();
-
-            let (mut second_socket, _) = listener.accept().await.unwrap();
-            let second_request = read_http_request(&mut second_socket).await.unwrap();
-            second_socket
-                .write_all(&status_response(200))
-                .await
-                .unwrap();
-            request_tx.send(second_request).unwrap();
-        });
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Disconnect,
+            RawHttpAction::Respond(status_response(200)),
+        ])
+        .await;
+        let api_url = server.url();
         let run_id = RunId::nil();
         let provider = api_provider_for_test(
             api_url,
@@ -4562,19 +4512,19 @@ mod tests {
                 .await;
         });
 
-        let first_request = next_request(&mut requests).await;
+        let first_request = server.next_request("first completion request").await;
         assert_complete_authorization(&first_request, "sandbox-token");
         tokio::task::yield_now().await;
         assert!(
-            requests.try_recv().is_err(),
+            server.try_next_request().is_err(),
             "transport failure should wait before the retry"
         );
         tokio::time::advance(Duration::from_secs(2)).await;
-        let second_request = next_request(&mut requests).await;
+        let second_request = server.next_request("retried completion request").await;
         assert_complete_authorization(&second_request, "sandbox-token");
 
         complete_task.await.unwrap();
-        server_task.await.unwrap();
+        server.assert_finished().await;
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1484,7 +1484,6 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::sync::mpsc;
-    use tokio::task::JoinHandle;
     use tracing::{Level, instrument::WithSubscriber};
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
@@ -1494,6 +1493,9 @@ mod tests {
     use crate::provider::{
         ActiveRunnerPreference, RunnerNoPreferenceReason, RunnerPreference,
         RunnerPreferenceRemovalReason, RunnerPreferenceTier,
+    };
+    use crate::test_fixtures::raw_http::{
+        RawHttpAction, RawHttpTestServer, http_response, json_response, read_http_request,
     };
 
     const RUNNER_CLAIM_RESPONSE_FIXTURE: &str = include_str!(
@@ -1829,92 +1831,24 @@ mod tests {
         provider.direct_candidates.push(candidate).await;
     }
 
-    async fn read_http_request(socket: &mut tokio::net::TcpStream) {
-        let _ = read_http_request_text(socket).await;
-    }
-
-    async fn read_http_request_text(socket: &mut tokio::net::TcpStream) -> String {
-        let mut request = Vec::new();
-        let mut buf = [0_u8; 1024];
-        let header_end = loop {
-            let n = socket.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break request.len();
-            }
-            request.extend_from_slice(&buf[..n]);
-            if let Some(header_end) = request
-                .windows(4)
-                .position(|window| window == b"\r\n\r\n")
-                .map(|position| position + 4)
-            {
-                break header_end;
-            }
-        };
-        let headers = String::from_utf8_lossy(&request[..header_end]);
-        let content_length = headers
-            .lines()
-            .find_map(|line| {
-                let (name, value) = line.split_once(':')?;
-                if name.eq_ignore_ascii_case("content-length") {
-                    value.trim().parse::<usize>().ok()
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(0);
-        let request_len = header_end + content_length;
-        loop {
-            if request.len() >= request_len {
-                break;
-            }
-            let n = socket.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break;
-            }
-            request.extend_from_slice(&buf[..n]);
-        }
-        String::from_utf8_lossy(&request).into_owned()
-    }
-
-    async fn write_http_status_response(socket: &mut tokio::net::TcpStream, status: u16) {
+    fn status_response(status: u16) -> Vec<u8> {
         let reason = match status {
             200 => "OK",
             500 => "Internal Server Error",
             _ => "Unknown",
         };
         let body = if status == 200 { "ok" } else { "failed" };
-        let response = format!(
-            "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        socket.write_all(response.as_bytes()).await.unwrap();
+        http_response(&format!("{status} {reason}"), body.as_bytes())
     }
 
-    async fn write_json_response(socket: &mut tokio::net::TcpStream, body: &str) {
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        socket.write_all(response.as_bytes()).await.unwrap();
-    }
-
-    async fn complete_sequence_server(
-        statuses: Vec<u16>,
-    ) -> (String, mpsc::UnboundedReceiver<String>, JoinHandle<()>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let (request_tx, request_rx) = mpsc::unbounded_channel();
-        let server_task = tokio::spawn(async move {
-            for status in statuses {
-                let (mut socket, _) = listener.accept().await.unwrap();
-                let request = read_http_request_text(&mut socket).await;
-                write_http_status_response(&mut socket, status).await;
-                request_tx.send(request).unwrap();
-            }
-        });
-        (api_url, request_rx, server_task)
+    async fn complete_sequence_server(statuses: Vec<u16>) -> RawHttpTestServer {
+        RawHttpTestServer::spawn(
+            statuses
+                .into_iter()
+                .map(|status| RawHttpAction::Respond(status_response(status)))
+                .collect(),
+        )
+        .await
     }
 
     async fn next_request(requests: &mut mpsc::UnboundedReceiver<String>) -> String {
@@ -2012,8 +1946,8 @@ mod tests {
         let api_url = format!("http://{}", listener.local_addr().unwrap());
         let server_task = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut socket).await;
-            write_http_status_response(&mut socket, 500).await;
+            read_http_request(&mut socket).await.unwrap();
+            socket.write_all(&status_response(500)).await.unwrap();
         });
         let provider = api_provider_for_test(
             api_url,
@@ -2339,12 +2273,10 @@ mod tests {
             }
         })
         .to_string();
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        socket.write_all(response.as_bytes()).await.unwrap();
+        socket
+            .write_all(&json_response("200 OK", &body))
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -2909,24 +2841,30 @@ mod tests {
         let (request_tx, mut requests) = mpsc::unbounded_channel();
         let server_task = tokio::spawn(async move {
             let (mut first_claim, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut first_claim).await;
-            write_http_status_response(&mut first_claim, 503).await;
+            let request = read_http_request(&mut first_claim).await.unwrap();
+            first_claim.write_all(&status_response(503)).await.unwrap();
             request_tx.send(request).unwrap();
 
             let (mut excluded_poll, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut excluded_poll).await;
+            let request = read_http_request(&mut excluded_poll).await.unwrap();
             request_tx.send(request).unwrap();
             tokio::time::sleep(CLAIM_TRANSIENT_COOLDOWN + Duration::from_millis(50)).await;
-            write_json_response(&mut excluded_poll, r#"{"job":null}"#).await;
+            excluded_poll
+                .write_all(&json_response("200 OK", r#"{"job":null}"#))
+                .await
+                .unwrap();
 
             let (mut retry_poll, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut retry_poll).await;
+            let request = read_http_request(&mut retry_poll).await.unwrap();
             write_poll_job_response(&mut retry_poll, run_id).await;
             request_tx.send(request).unwrap();
 
             let (mut second_claim, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut second_claim).await;
-            write_json_response(&mut second_claim, RUNNER_CLAIM_RESPONSE_FIXTURE).await;
+            let request = read_http_request(&mut second_claim).await.unwrap();
+            second_claim
+                .write_all(&json_response("200 OK", RUNNER_CLAIM_RESPONSE_FIXTURE))
+                .await
+                .unwrap();
             request_tx.send(request).unwrap();
         });
         let wakeups = Arc::new(PollWakeups::new(true));
@@ -3003,12 +2941,14 @@ mod tests {
         let (request_tx, mut requests) = mpsc::unbounded_channel();
         let server_task = tokio::spawn(async move {
             let (mut claim, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut claim).await;
-            write_http_status_response(&mut claim, 400).await;
+            let request = read_http_request(&mut claim).await.unwrap();
+            claim.write_all(&status_response(400)).await.unwrap();
             request_tx.send(request).unwrap();
 
             let (mut ignored_exclusion_poll, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut ignored_exclusion_poll).await;
+            let request = read_http_request(&mut ignored_exclusion_poll)
+                .await
+                .unwrap();
             write_poll_job_response(&mut ignored_exclusion_poll, run_id).await;
             request_tx.send(request).unwrap();
         });
@@ -3191,13 +3131,13 @@ mod tests {
         let (release_first_poll_tx, release_first_poll_rx) = tokio::sync::oneshot::channel();
         let server_task = tokio::spawn(async move {
             let (mut first_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut first_socket).await;
+            read_http_request(&mut first_socket).await.unwrap();
             let _ = poll_accepted_tx.send(());
             release_first_poll_rx.await.unwrap();
             drop(first_socket);
 
             let (mut second_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut second_socket).await;
+            read_http_request(&mut second_socket).await.unwrap();
             write_poll_job_response(&mut second_socket, poll_run_id).await;
         });
         let provider = api_provider_for_test(
@@ -3252,14 +3192,14 @@ mod tests {
         let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
         let server_task = tokio::spawn(async move {
             let (mut first_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut first_socket).await;
+            read_http_request(&mut first_socket).await.unwrap();
             let _ = first_accepted_tx.send(());
             release_first_rx.await.unwrap();
             write_poll_job_response(&mut first_socket, first_run_id).await;
             drop(first_socket);
 
             let (mut second_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut second_socket).await;
+            read_http_request(&mut second_socket).await.unwrap();
             write_poll_job_response(&mut second_socket, second_run_id).await;
         });
         let wakeups = Arc::new(PollWakeups::new(false));
@@ -4498,7 +4438,8 @@ mod tests {
 
     #[tokio::test]
     async fn api_provider_complete_does_not_retry_permanent_http_failure() {
-        let (api_url, mut requests, server_task) = complete_sequence_server(vec![400]).await;
+        let mut server = complete_sequence_server(vec![400]).await;
+        let api_url = server.url();
         let run_id = RunId::nil();
         let provider = api_provider_for_test(
             api_url,
@@ -4519,13 +4460,9 @@ mod tests {
         .await
         .expect("permanent completion failure should not wait for the retry delay");
 
-        let request = next_request(&mut requests).await;
+        let request = server.next_request("permanent completion request").await;
         assert_complete_authorization(&request, "sandbox-token");
-        server_task.await.unwrap();
-        assert!(
-            requests.recv().await.is_none(),
-            "permanent completion failure should send one request"
-        );
+        server.assert_finished().await;
 
         let run_id = run_id.to_string();
         assert_eq!(
@@ -4554,8 +4491,8 @@ mod tests {
             StatusCode::TOO_MANY_REQUESTS,
             StatusCode::INTERNAL_SERVER_ERROR,
         ] {
-            let (api_url, mut requests, server_task) =
-                complete_sequence_server(vec![status.as_u16(), 200]).await;
+            let mut server = complete_sequence_server(vec![status.as_u16(), 200]).await;
+            let api_url = server.url();
             let run_id = RunId::nil();
             let provider = api_provider_for_test(
                 api_url,
@@ -4571,19 +4508,23 @@ mod tests {
                     .await;
             });
 
-            let first_request = next_request(&mut requests).await;
+            let first_request = server
+                .next_request("first transient completion request")
+                .await;
             assert_complete_authorization(&first_request, "sandbox-token");
             tokio::task::yield_now().await;
             assert!(
-                requests.try_recv().is_err(),
+                server.try_next_request().is_err(),
                 "status {status} should wait before the retry"
             );
             tokio::time::advance(Duration::from_secs(2)).await;
-            let second_request = next_request(&mut requests).await;
+            let second_request = server
+                .next_request("retried transient completion request")
+                .await;
             assert_complete_authorization(&second_request, "sandbox-token");
 
             complete_task.await.unwrap();
-            server_task.await.unwrap();
+            server.assert_finished().await;
         }
     }
 
@@ -4594,13 +4535,16 @@ mod tests {
         let (request_tx, mut requests) = mpsc::unbounded_channel();
         let server_task = tokio::spawn(async move {
             let (mut first_socket, _) = listener.accept().await.unwrap();
-            let first_request = read_http_request_text(&mut first_socket).await;
+            let first_request = read_http_request(&mut first_socket).await.unwrap();
             drop(first_socket);
             request_tx.send(first_request).unwrap();
 
             let (mut second_socket, _) = listener.accept().await.unwrap();
-            let second_request = read_http_request_text(&mut second_socket).await;
-            write_http_status_response(&mut second_socket, 200).await;
+            let second_request = read_http_request(&mut second_socket).await.unwrap();
+            second_socket
+                .write_all(&status_response(200))
+                .await
+                .unwrap();
             request_tx.send(second_request).unwrap();
         });
         let run_id = RunId::nil();
@@ -4661,7 +4605,8 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn api_provider_complete_stops_after_two_transient_failures() {
-        let (api_url, mut requests, server_task) = complete_sequence_server(vec![500, 500]).await;
+        let mut server = complete_sequence_server(vec![500, 500]).await;
+        let api_url = server.url();
         let run_id = RunId::nil();
         let provider = api_provider_for_test(
             api_url,
@@ -4685,7 +4630,7 @@ mod tests {
 
         let first_request = tokio::select! {
             () = &mut completion => panic!("completion should wait before the retry"),
-            request = next_request(&mut requests) => request,
+            request = server.next_request("first failed completion request") => request,
         };
         assert_complete_authorization(&first_request, "sandbox-token");
         // Establish the retry timer before advancing paused time.
@@ -4707,18 +4652,16 @@ mod tests {
         })
         .await;
         assert!(
-            requests.try_recv().is_err(),
+            server.try_next_request().is_err(),
             "completion should wait before the retry"
         );
-
         tokio::time::advance(Duration::from_secs(2)).await;
-        let ((), second_request) = tokio::join!(&mut completion, next_request(&mut requests));
-        assert_complete_authorization(&second_request, "sandbox-token");
-        server_task.await.unwrap();
-        assert!(
-            requests.recv().await.is_none(),
-            "completion should stop after the retry"
+        let ((), second_request) = tokio::join!(
+            &mut completion,
+            server.next_request("second failed completion request")
         );
+        assert_complete_authorization(&second_request, "sandbox-token");
+        server.assert_finished().await;
 
         let events = captured.entries();
         let run_id = run_id.to_string();

--- a/crates/runner/src/provider/connector_runtime_sync.rs
+++ b/crates/runner/src/provider/connector_runtime_sync.rs
@@ -1688,6 +1688,7 @@ mod tests {
 
     use crate::http::{HttpClient, HttpClientConfig};
     use crate::proxy::{ProxyRegistryHandle, VmRegistration};
+    use crate::test_fixtures::raw_http::{json_response, read_http_request};
     use crate::types::{Firewall, FirewallApi, FirewallAuth, FirewallEntry};
 
     fn api_client_for_url(api_url: String) -> ApiClient {
@@ -1763,43 +1764,8 @@ mod tests {
 
     async fn accept_http_request(listener: &TcpListener) -> (tokio::net::TcpStream, String) {
         let (mut socket, _) = listener.accept().await.unwrap();
-        let mut request = Vec::new();
-        let mut buf = [0_u8; 1024];
-        let header_end = loop {
-            let n = socket.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break request.len();
-            }
-            request.extend_from_slice(&buf[..n]);
-            if let Some(header_end) = request
-                .windows(4)
-                .position(|window| window == b"\r\n\r\n")
-                .map(|position| position + 4)
-            {
-                break header_end;
-            }
-        };
-        let headers = String::from_utf8_lossy(&request[..header_end]);
-        let content_length = headers
-            .lines()
-            .find_map(|line| {
-                let (name, value) = line.split_once(':')?;
-                if name.eq_ignore_ascii_case("content-length") {
-                    value.trim().parse::<usize>().ok()
-                } else {
-                    None
-                }
-            })
-            .expect("request should include a valid Content-Length header");
-        let request_len = header_end + content_length;
-        while request.len() < request_len {
-            let n = socket.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break;
-            }
-            request.extend_from_slice(&buf[..n]);
-        }
-        (socket, String::from_utf8_lossy(&request).into_owned())
+        let request = read_http_request(&mut socket).await.unwrap();
+        (socket, request)
     }
 
     fn assert_connector_runtime_sync_request(request: &str, run_id: &RunId) {
@@ -2429,13 +2395,8 @@ mod tests {
             }],
         })
         .to_string();
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
         socket
-            .write_all(response.as_bytes())
+            .write_all(&json_response("200 OK", &body))
             .await
             .expect("connector runtime sync response should be written");
     }
@@ -2448,13 +2409,8 @@ mod tests {
             },
         })
         .to_string();
-        let response = format!(
-            "HTTP/1.1 409 Conflict\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
         socket
-            .write_all(response.as_bytes())
+            .write_all(&json_response("409 Conflict", &body))
             .await
             .expect("terminal connector runtime response should be written");
     }
@@ -2503,12 +2459,7 @@ mod tests {
                     "connectorSlug": "slack",
                 }))
                 .to_string();
-                let response = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                    body.len(),
-                    body
-                );
-                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.write_all(&json_response("200 OK", &body)).await;
                 return (request, None);
             }
 
@@ -4780,13 +4731,8 @@ mod tests {
                 }],
             })
             .to_string();
-            let first_response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                first_body.len(),
-                first_body
-            );
             first_socket
-                .write_all(first_response.as_bytes())
+                .write_all(&json_response("200 OK", &first_body))
                 .await
                 .unwrap();
 
@@ -4804,13 +4750,8 @@ mod tests {
                 }],
             })
             .to_string();
-            let second_response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                second_body.len(),
-                second_body
-            );
             second_socket
-                .write_all(second_response.as_bytes())
+                .write_all(&json_response("200 OK", &second_body))
                 .await
                 .unwrap();
             [first_request, second_request]
@@ -4905,12 +4846,10 @@ mod tests {
             .expect("registry should be valid JSON before retry response");
             let policy_before_retry_response =
                 registry_json["vms"][&source_ip]["networkPolicies"]["slack"].clone();
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                response_body.len(),
-                response_body
-            );
-            second_socket.write_all(response.as_bytes()).await.unwrap();
+            second_socket
+                .write_all(&json_response("200 OK", &response_body))
+                .await
+                .unwrap();
             (first_request, second_request, policy_before_retry_response)
         });
 
@@ -5002,12 +4941,10 @@ mod tests {
             let (second_socket, second_request) = accept_http_request(&listener).await;
             drop(second_socket);
             let (mut third_socket, third_request) = accept_http_request(&listener).await;
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                response_body.len(),
-                response_body
-            );
-            third_socket.write_all(response.as_bytes()).await.unwrap();
+            third_socket
+                .write_all(&json_response("200 OK", &response_body))
+                .await
+                .unwrap();
             [first_request, second_request, third_request]
         });
 

--- a/crates/runner/src/provider/connector_runtime_sync.rs
+++ b/crates/runner/src/provider/connector_runtime_sync.rs
@@ -1688,7 +1688,9 @@ mod tests {
 
     use crate::http::{HttpClient, HttpClientConfig};
     use crate::proxy::{ProxyRegistryHandle, VmRegistration};
-    use crate::test_fixtures::raw_http::{json_response, read_http_request};
+    use crate::test_fixtures::raw_http::{
+        RawHttpAction, RawHttpTestServer, json_response, read_http_request,
+    };
     use crate::types::{Firewall, FirewallApi, FirewallAuth, FirewallEntry};
 
     fn api_client_for_url(api_url: String) -> ApiClient {
@@ -4699,72 +4701,54 @@ mod tests {
 
     #[tokio::test]
     async fn newer_notification_survives_older_in_flight_sync() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
         let run_id = RunId::nil();
+        let first_body = json!({
+            "results": [{
+                "target": { "kind": "builtin", "connectorSlug": "slack" },
+                "state": "available",
+                "networkPolicy": {
+                    "allow": ["old:read"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                },
+            }],
+        })
+        .to_string();
+        let second_body = json!({
+            "results": [{
+                "target": { "kind": "builtin", "connectorSlug": "slack" },
+                "state": "available",
+                "networkPolicy": {
+                    "allow": ["new:read"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                },
+            }],
+        })
+        .to_string();
+        let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::WaitThenRespond {
+                release: release_first_rx,
+                response: json_response("200 OK", &first_body),
+            },
+            RawHttpAction::Respond(json_response("200 OK", &second_body)),
+        ])
+        .await;
         let harness = ConnectorRuntimeSyncHarness::new_with_api(
-            api_client_for_url(api_url),
+            api_client_for_url(server.url()),
             run_id,
             &["slack"],
         )
         .await;
-        let (first_received_tx, first_received_rx) = tokio::sync::oneshot::channel();
-        let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
-        let server_task = tokio::spawn(async move {
-            let (mut first_socket, first_request) = accept_http_request(&listener).await;
-            first_received_tx
-                .send(())
-                .expect("first request receiver should remain available");
-            release_first_rx
-                .await
-                .expect("first response should be released");
-            let first_body = json!({
-                "results": [{
-                    "target": { "kind": "builtin", "connectorSlug": "slack" },
-                    "state": "available",
-                    "networkPolicy": {
-                        "allow": ["old:read"],
-                        "deny": [],
-                        "ask": [],
-                        "unknownPolicy": "allow",
-                    },
-                }],
-            })
-            .to_string();
-            first_socket
-                .write_all(&json_response("200 OK", &first_body))
-                .await
-                .unwrap();
-
-            let (mut second_socket, second_request) = accept_http_request(&listener).await;
-            let second_body = json!({
-                "results": [{
-                    "target": { "kind": "builtin", "connectorSlug": "slack" },
-                    "state": "available",
-                    "networkPolicy": {
-                        "allow": ["new:read"],
-                        "deny": [],
-                        "ask": [],
-                        "unknownPolicy": "allow",
-                    },
-                }],
-            })
-            .to_string();
-            second_socket
-                .write_all(&json_response("200 OK", &second_body))
-                .await
-                .unwrap();
-            [first_request, second_request]
-        });
 
         harness
             .handle
             .notify_connector_runtime_sync(run_id, builtin_target("slack"))
             .await;
-        tokio::time::timeout(Duration::from_secs(1), first_received_rx)
-            .await
-            .expect("first refresh should reach the API")
-            .expect("first request sender should remain available");
+        server.next_request("older generation sync request").await;
 
         harness
             .handle
@@ -4785,10 +4769,7 @@ mod tests {
         })
         .await;
         assert_eq!(policy["unknownPolicy"], json!("allow"));
-        let requests = tokio::time::timeout(Duration::from_secs(1), server_task)
-            .await
-            .expect("both generations should reach the API")
-            .expect("API task should succeed");
+        let requests = server.assert_finished_with_requests().await;
         for request in &requests {
             assert_connector_runtime_sync_request(request, &run_id);
         }
@@ -4921,32 +4902,24 @@ mod tests {
 
     #[tokio::test]
     async fn persistent_transport_failure_retains_policy_and_scheduled_retry_recovers() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
         let run_id = RunId::nil();
-        let harness = ConnectorRuntimeSyncHarness::new_with_api(
-            api_client_for_url(api_url),
-            run_id,
-            &["slack"],
-        )
-        .await;
         let response_body = connector_runtime_sync_response(json!({
             "kind": "builtin",
             "connectorSlug": "slack",
         }))
         .to_string();
-        let server_task = tokio::spawn(async move {
-            let (first_socket, first_request) = accept_http_request(&listener).await;
-            drop(first_socket);
-            let (second_socket, second_request) = accept_http_request(&listener).await;
-            drop(second_socket);
-            let (mut third_socket, third_request) = accept_http_request(&listener).await;
-            third_socket
-                .write_all(&json_response("200 OK", &response_body))
-                .await
-                .unwrap();
-            [first_request, second_request, third_request]
-        });
+        let server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Disconnect,
+            RawHttpAction::Disconnect,
+            RawHttpAction::Respond(json_response("200 OK", &response_body)),
+        ])
+        .await;
+        let harness = ConnectorRuntimeSyncHarness::new_with_api(
+            api_client_for_url(server.url()),
+            run_id,
+            &["slack"],
+        )
+        .await;
 
         let (_, events) = tokio::time::timeout(
             Duration::from_secs(1),
@@ -4992,11 +4965,11 @@ mod tests {
         })
         .await;
         assert_eq!(recovered_policy["unknownPolicy"], json!("allow"));
-        let [first_request, second_request, third_request] =
-            tokio::time::timeout(Duration::from_secs(1), server_task)
-                .await
-                .expect("connector runtime sync server should finish after scheduled retry")
-                .expect("connector runtime sync server task should succeed");
+        let [first_request, second_request, third_request] = server
+            .assert_finished_with_requests()
+            .await
+            .try_into()
+            .expect("connector runtime sync server should capture three requests");
         for request in [&first_request, &second_request, &third_request] {
             assert_connector_runtime_sync_request(request, &run_id);
         }

--- a/crates/runner/src/provider/connector_runtime_sync.rs
+++ b/crates/runner/src/provider/connector_runtime_sync.rs
@@ -1689,7 +1689,7 @@ mod tests {
     use crate::http::{HttpClient, HttpClientConfig};
     use crate::proxy::{ProxyRegistryHandle, VmRegistration};
     use crate::test_fixtures::raw_http::{
-        RawHttpAction, RawHttpTestServer, json_response, read_http_request,
+        RawHttpAction, RawHttpTestServer, join_raw_http_task, json_response, read_http_request,
     };
     use crate::types::{Firewall, FirewallApi, FirewallAuth, FirewallEntry};
 
@@ -4841,10 +4841,7 @@ mod tests {
         .await
         .expect("connector runtime sync retry should complete");
         let (first_request, second_request, policy_before_retry_response) =
-            tokio::time::timeout(Duration::from_secs(1), server_task)
-                .await
-                .expect("connector runtime sync server should finish")
-                .expect("connector runtime sync server task should succeed");
+            join_raw_http_task(server_task, "connector runtime sync retry server").await;
 
         assert_connector_runtime_sync_request(&first_request, &run_id);
         assert_connector_runtime_sync_request(&second_request, &run_id);

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -8266,15 +8266,8 @@ mod tests {
                 "expected full download, got {full_request:?}"
             );
             full_socket
-                .write_all(
-                    format!(
-                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                        ready_body.len()
-                    )
-                    .as_bytes(),
-                )
+                .write_all(&http_response("200 OK", &ready_body))
                 .await?;
-            full_socket.write_all(&ready_body).await?;
             Ok::<(), std::io::Error>(())
         });
 
@@ -8309,15 +8302,8 @@ mod tests {
                 "expected full download, got {full_request:?}"
             );
             full_socket
-                .write_all(
-                    format!(
-                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                        cold_body.len()
-                    )
-                    .as_bytes(),
-                )
+                .write_all(&http_response("200 OK", &cold_body))
                 .await?;
-            full_socket.write_all(&cold_body).await?;
             let _ = cold_full_seen_tx.send(());
             Ok::<(), std::io::Error>(())
         });

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3956,14 +3956,6 @@ mod tests {
         server.assert_finished().await;
     }
 
-    async fn await_raw_http_task(handle: tokio::task::JoinHandle<std::io::Result<()>>) {
-        tokio::time::timeout(Duration::from_secs(5), handle)
-            .await
-            .expect("raw HTTP server should finish")
-            .expect("raw HTTP server task should not panic")
-            .expect("raw HTTP server should not fail");
-    }
-
     async fn wait_cached_archive(home: &HomePaths, name: &str, version: &str) -> Vec<u8> {
         let lock_path = home.storage_lock(name, version);
         let path = home.storage_cache_dir(name, version).join("archive.tar.gz");
@@ -5641,33 +5633,18 @@ mod tests {
         let mut telemetry = new_telemetry();
         let body = tarball_bytes();
         let expected_body = body.clone();
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
         let (allow_tx, allow_rx) = tokio::sync::oneshot::channel();
-        let (request_tx, mut request_rx) = tokio::sync::oneshot::channel();
-        let server_task = tokio::spawn(async move {
-            let mut allow_rx = Some(allow_rx);
-            let mut request_tx = Some(request_tx);
-            for response in [
-                partial_content_response(body.len()),
-                http_response("200 OK", &body),
-            ] {
-                let (mut socket, _) = listener.accept().await?;
-                let mut request = [0u8; 1024];
-                let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
-                if let Some(request_tx) = request_tx.take() {
-                    let _ = request_tx.send(());
-                }
-                if let Some(allow_rx) = allow_rx.take() {
-                    let _ = allow_rx.await;
-                }
-                socket.write_all(&response).await?;
-            }
-            Ok::<(), std::io::Error>(())
-        });
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::WaitThenRespond {
+                release: allow_rx,
+                response: partial_content_response(body.len()),
+            },
+            RawHttpAction::Respond(http_response("200 OK", &body)),
+        ])
+        .await;
+        let original = format!("{}/archive.tar.gz", server.url());
         let name = "background-miss";
         let version = "v1";
-        let original = format!("http://{addr}/archive.tar.gz");
         let mut manifest = fresh_storage_plan(original.clone(), name, version);
 
         let deferred = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -5677,8 +5654,8 @@ mod tests {
 
         assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
         assert!(matches!(
-            request_rx.try_recv(),
-            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+            server.try_next_request(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
         ));
         assert!(
             !home
@@ -5697,12 +5674,11 @@ mod tests {
 
         let coordinator = StorageCacheBackgroundFillCoordinator::new().unwrap();
         deferred.start(&coordinator, &mut telemetry);
-        tokio::time::timeout(Duration::from_secs(5), &mut request_rx)
-            .await
-            .expect("started background fill should contact archive server")
-            .expect("archive request sender should remain available");
+        server
+            .next_request("started background fill archive request")
+            .await;
         allow_tx.send(()).unwrap();
-        await_raw_http_task(server_task).await;
+        server.assert_finished().await;
         assert_eq!(
             wait_cached_archive(&home, name, version).await,
             expected_body

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3395,6 +3395,9 @@ mod tests {
     use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
     use crate::storage_manifest::{ArtifactEntry, StorageEntry, StorageManifest};
     use crate::storage_plan::build_storage_plan;
+    use crate::test_fixtures::raw_http::{
+        RawHttpAction, RawHttpTestServer, http_response, json_response, read_http_request,
+    };
 
     const CACHE_TEST_RUNTIME_DIR: &str = "/tmp/storage-cache-test-runtime";
 
@@ -3871,36 +3874,15 @@ mod tests {
         }
     }
 
-    async fn raw_http_url(
-        response: Vec<u8>,
-    ) -> (String, tokio::task::JoinHandle<std::io::Result<()>>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let handle = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await?;
-            let mut request = [0u8; 1024];
-            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
-            socket.write_all(&response).await?;
-            Ok(())
-        });
-        (format!("http://{addr}/archive.tar.gz"), handle)
+    async fn raw_http_url(response: Vec<u8>) -> (String, RawHttpTestServer) {
+        raw_http_sequence_url(vec![response]).await
     }
 
-    async fn raw_http_sequence_url(
-        responses: Vec<Vec<u8>>,
-    ) -> (String, tokio::task::JoinHandle<std::io::Result<()>>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let handle = tokio::spawn(async move {
-            for response in responses {
-                let (mut socket, _) = listener.accept().await?;
-                let mut request = [0u8; 1024];
-                let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
-                socket.write_all(&response).await?;
-            }
-            Ok(())
-        });
-        (format!("http://{addr}/archive.tar.gz"), handle)
+    async fn raw_http_sequence_url(responses: Vec<Vec<u8>>) -> (String, RawHttpTestServer) {
+        let server =
+            RawHttpTestServer::spawn(responses.into_iter().map(RawHttpAction::Respond).collect())
+                .await;
+        (format!("{}/archive.tar.gz", server.url()), server)
     }
 
     struct GatedArchiveServer {
@@ -3931,7 +3913,7 @@ mod tests {
                 let active = Arc::clone(&task_active);
                 let max_active = Arc::clone(&task_max_active);
                 handlers.spawn(async move {
-                    let _ = read_http_request(&mut socket).await;
+                    read_http_request(&mut socket).await?;
                     let current = active.fetch_add(1, Ordering::SeqCst) + 1;
                     max_active.fetch_max(current, Ordering::SeqCst);
                     request_tx.send(index).await.map_err(|_| {
@@ -3940,7 +3922,7 @@ mod tests {
                     let permit = release.acquire_owned().await.map_err(|_| {
                         io::Error::new(io::ErrorKind::BrokenPipe, "release semaphore closed")
                     })?;
-                    socket.write_all(&ok_response(&body)).await?;
+                    socket.write_all(&http_response("200 OK", &body)).await?;
                     drop(permit);
                     active.fetch_sub(1, Ordering::SeqCst);
                     Ok::<(), io::Error>(())
@@ -3960,86 +3942,26 @@ mod tests {
         }
     }
 
-    async fn telemetry_capture_server(
-        expected_requests: usize,
-    ) -> (String, tokio::task::JoinHandle<Vec<String>>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let task = tokio::spawn(async move {
-            let mut requests = Vec::with_capacity(expected_requests);
-            for _ in 0..expected_requests {
-                let (mut socket, _) = listener.accept().await.unwrap();
-                requests.push(read_http_request(&mut socket).await);
-                socket
-                    .write_all(
-                        concat!(
-                            "HTTP/1.1 200 OK\r\n",
-                            "content-length: 16\r\n",
-                            "content-type: application/json\r\n",
-                            "connection: close\r\n",
-                            "\r\n",
-                            r#"{"success":true}"#
-                        )
-                        .as_bytes(),
-                    )
-                    .await
-                    .unwrap();
-            }
-            requests
-        });
-        (format!("http://{addr}"), task)
+    async fn telemetry_capture_server(expected_requests: usize) -> (String, RawHttpTestServer) {
+        let server = RawHttpTestServer::spawn(
+            (0..expected_requests)
+                .map(|_| RawHttpAction::Respond(json_response("200 OK", r#"{"success":true}"#)))
+                .collect(),
+        )
+        .await;
+        (server.url(), server)
     }
 
-    async fn await_raw_http_sequence(handle: tokio::task::JoinHandle<std::io::Result<()>>) {
+    async fn await_raw_http_sequence(server: RawHttpTestServer) {
+        server.assert_finished().await;
+    }
+
+    async fn await_raw_http_task(handle: tokio::task::JoinHandle<std::io::Result<()>>) {
         tokio::time::timeout(Duration::from_secs(5), handle)
             .await
-            .expect("raw HTTP sequence server should finish")
-            .expect("raw HTTP sequence server task should not panic")
-            .expect("raw HTTP sequence server should not fail");
-    }
-
-    fn http_headers_end(buf: &[u8]) -> Option<usize> {
-        buf.windows(4)
-            .position(|window| window == b"\r\n\r\n")
-            .map(|index| index + 4)
-    }
-
-    fn content_length(headers: &str) -> usize {
-        headers
-            .lines()
-            .filter_map(|line| line.split_once(':'))
-            .find_map(|(name, value)| {
-                name.eq_ignore_ascii_case("content-length")
-                    .then(|| value.trim().parse::<usize>().unwrap())
-            })
-            .unwrap_or(0)
-    }
-
-    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
-        use tokio::io::AsyncReadExt as _;
-
-        let mut buf = Vec::new();
-        let header_end = loop {
-            let mut chunk = [0; 1024];
-            let len = socket.read(&mut chunk).await.unwrap();
-            assert!(len > 0, "connection closed before HTTP headers completed");
-            buf.extend_from_slice(&chunk[..len]);
-
-            if let Some(header_end) = http_headers_end(&buf) {
-                break header_end;
-            }
-        };
-
-        let headers = String::from_utf8_lossy(&buf[..header_end]);
-        let body_len = content_length(&headers);
-        while buf.len() < header_end + body_len {
-            let mut chunk = [0; 1024];
-            let len = socket.read(&mut chunk).await.unwrap();
-            assert!(len > 0, "connection closed before HTTP body completed");
-            buf.extend_from_slice(&chunk[..len]);
-        }
-
-        String::from_utf8(buf).unwrap()
+            .expect("raw HTTP server should finish")
+            .expect("raw HTTP server task should not panic")
+            .expect("raw HTTP server should not fail");
     }
 
     async fn wait_cached_archive(home: &HomePaths, name: &str, version: &str) -> Vec<u8> {
@@ -4054,22 +3976,11 @@ mod tests {
             .unwrap_or_else(|e| panic!("failed to read cached archive {}: {e}", path.display()))
     }
 
-    fn status_response(status: &str) -> Vec<u8> {
-        format!("HTTP/1.1 {status}\r\nContent-Length: 0\r\n\r\n").into_bytes()
-    }
-
     fn partial_content_response(total: usize) -> Vec<u8> {
         format!(
             "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{total}\r\nContent-Length: 1\r\n\r\nx"
         )
         .into_bytes()
-    }
-
-    fn ok_response(body: &[u8]) -> Vec<u8> {
-        let mut response =
-            format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", body.len()).into_bytes();
-        response.extend_from_slice(body);
-        response
     }
 
     fn background_fill_group(
@@ -4419,7 +4330,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        server_task.await.unwrap().unwrap();
+        server_task.assert_finished().await;
         assert!(deferred.is_none());
         assert_eq!(storage_archive_url(&plan, 0), Some(url.as_str()));
         assert!(sandbox.write_files_calls().is_empty());
@@ -4670,7 +4581,7 @@ mod tests {
                     .await
                     .unwrap();
 
-            server_task.await.unwrap().unwrap();
+            server_task.assert_finished().await;
             assert!(deferred.is_none(), "case {case}");
             assert_eq!(storage_archive_url(&plan, 0), Some(url.as_str()));
             let ops = telemetry.pending_ops_snapshot();
@@ -5689,7 +5600,7 @@ mod tests {
             if let Ok((mut socket, _)) = listener.accept().await {
                 let _ = hit_tx.send(());
                 let _ = socket
-                    .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n")
+                    .write_all(&http_response("500 Internal Server Error", b""))
                     .await;
             }
         });
@@ -5737,7 +5648,10 @@ mod tests {
         let server_task = tokio::spawn(async move {
             let mut allow_rx = Some(allow_rx);
             let mut request_tx = Some(request_tx);
-            for response in [partial_content_response(body.len()), ok_response(&body)] {
+            for response in [
+                partial_content_response(body.len()),
+                http_response("200 OK", &body),
+            ] {
                 let (mut socket, _) = listener.accept().await?;
                 let mut request = [0u8; 1024];
                 let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
@@ -5788,7 +5702,7 @@ mod tests {
             .expect("started background fill should contact archive server")
             .expect("archive request sender should remain available");
         allow_tx.send(()).unwrap();
-        await_raw_http_sequence(server_task).await;
+        await_raw_http_task(server_task).await;
         assert_eq!(
             wait_cached_archive(&home, name, version).await,
             expected_body
@@ -5817,7 +5731,7 @@ mod tests {
             if let Ok((mut socket, _)) = listener.accept().await {
                 let _ = request_tx.send(());
                 let _ = socket
-                    .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n")
+                    .write_all(&http_response("500 Internal Server Error", b""))
                     .await;
             }
         });
@@ -5856,30 +5770,14 @@ mod tests {
         let body = tarball_bytes();
         let (archive_url, archive_server) = raw_http_sequence_url(vec![
             partial_content_response(body.len()),
-            ok_response(&body),
+            http_response("200 OK", &body),
         ])
         .await;
-        let telemetry_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let telemetry_api_url = format!("http://{}", telemetry_listener.local_addr().unwrap());
-        let telemetry_server = tokio::spawn(async move {
-            let (mut socket, _) = telemetry_listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            socket
-                .write_all(
-                    concat!(
-                        "HTTP/1.1 200 OK\r\n",
-                        "content-length: 16\r\n",
-                        "content-type: application/json\r\n",
-                        "connection: close\r\n",
-                        "\r\n",
-                        r#"{"success":true}"#
-                    )
-                    .as_bytes(),
-                )
-                .await
-                .unwrap();
-            request
-        });
+        let telemetry_server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(
+            json_response("200 OK", r#"{"success":true}"#),
+        )])
+        .await;
+        let telemetry_api_url = telemetry_server.url();
         let sandbox = MockSandbox::new("test");
         let mut telemetry = new_telemetry_for_api_url(&telemetry_api_url);
         let name = "background-report";
@@ -5893,10 +5791,8 @@ mod tests {
 
         await_raw_http_sequence(archive_server).await;
         assert_eq!(wait_cached_archive(&home, name, version).await, body);
-        let request = tokio::time::timeout(Duration::from_secs(1), telemetry_server)
-            .await
-            .expect("telemetry server should receive background fill payload")
-            .unwrap();
+        let requests = telemetry_server.assert_finished_with_requests().await;
+        let request = &requests[0];
         assert!(request.contains(r#""action_type":"storage_cache_background_fill_filled""#));
         assert!(
             request.contains(r#""action_type":"storage_cache_background_fill_size_lt_64_kib""#)
@@ -5958,7 +5854,8 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let body = tarball_bytes();
-        let (archive_url, archive_server) = raw_http_sequence_url(vec![ok_response(&body)]).await;
+        let (archive_url, archive_server) =
+            raw_http_sequence_url(vec![http_response("200 OK", &body)]).await;
         let (telemetry_url, telemetry_server) = telemetry_capture_server(2).await;
         let coordinator = StorageCacheBackgroundFillCoordinator::new_with_limits(1, 4).unwrap();
         let first_reporter = new_telemetry_for_api_url(&telemetry_url).reporter();
@@ -5979,10 +5876,7 @@ mod tests {
         assert_eq!(wait_cached_archive(&home, "deduplicated", "v1").await, body);
         coordinator.shutdown().await;
 
-        let reports = tokio::time::timeout(Duration::from_secs(5), telemetry_server)
-            .await
-            .expect("both deduplicated subscribers should receive terminal telemetry")
-            .expect("telemetry server task should not panic");
+        let reports = telemetry_server.assert_finished_with_requests().await;
         assert_eq!(reports.len(), 2);
         assert!(reports.iter().all(|request| {
             request.contains(r#""action_type":"storage_cache_background_fill_filled""#)
@@ -6126,10 +6020,7 @@ mod tests {
         );
         assert!(!home.storage_cache_dir("shutdown-queued", "v1").exists());
 
-        let reports = tokio::time::timeout(Duration::from_secs(5), telemetry_server)
-            .await
-            .expect("active and queued shutdown outcomes should be reported")
-            .expect("telemetry server task should not panic");
+        let reports = telemetry_server.assert_finished_with_requests().await;
         assert!(reports.iter().any(|request| {
             request.contains(r#""action_type":"storage_cache_background_fill_filled""#)
         }));
@@ -6703,9 +6594,9 @@ mod tests {
         let mut telemetry = new_telemetry();
         let body = tarball_bytes();
         let responses = vec![
-            status_response("500 Internal Server Error"),
+            http_response("500 Internal Server Error", b""),
             partial_content_response(body.len()),
-            ok_response(&body),
+            http_response("200 OK", &body),
         ];
         let (url, handle) = raw_http_sequence_url(responses).await;
         let name = "probe-retry-success";
@@ -6811,8 +6702,8 @@ mod tests {
         let body = tarball_bytes();
         let responses = vec![
             partial_content_response(body.len()),
-            status_response("503 Service Unavailable"),
-            ok_response(&body),
+            http_response("503 Service Unavailable", b""),
+            http_response("200 OK", &body),
         ];
         let (url, handle) = raw_http_sequence_url(responses).await;
         let name = "download-retry-success";
@@ -6847,7 +6738,7 @@ mod tests {
         let responses = vec![
             partial_content_response(body.len()),
             truncated_ok_response(&body),
-            ok_response(&body),
+            http_response("200 OK", &body),
         ];
         let (url, handle) = raw_http_sequence_url(responses).await;
         let name = "download-body-retry-success";
@@ -7913,7 +7804,7 @@ mod tests {
         let http = Client::builder().build().unwrap();
         let result = probe_size(&http, &url).await;
 
-        handle.await.unwrap().unwrap();
+        handle.assert_finished().await;
         match result {
             Ok(SizeProbe::Unknown(SizeProbeUnknown::InvalidSizeHeader)) => {}
             Err(err) => assert!(err.to_string().contains("probe GET"), "got: {err}"),
@@ -7938,7 +7829,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        handle.await.unwrap().unwrap();
+        handle.assert_finished().await;
         assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
         assert!(
             !home
@@ -8205,7 +8096,7 @@ mod tests {
         let http = Client::builder().build().unwrap();
 
         let result = download_tarball(&http, &url, Some(6), 6).await.unwrap();
-        server_task.await.unwrap().unwrap();
+        server_task.assert_finished().await;
 
         match result {
             DownloadBody::Complete(bytes) => {
@@ -8324,22 +8215,6 @@ mod tests {
 
     #[tokio::test]
     async fn multi_group_background_fill_precedes_later_warm_staging() {
-        async fn read_request(socket: &mut tokio::net::TcpStream) -> std::io::Result<String> {
-            let mut request = Vec::new();
-            let mut buf = [0u8; 1024];
-            loop {
-                let n = socket.read(&mut buf).await?;
-                if n == 0 {
-                    break;
-                }
-                request.extend_from_slice(&buf[..n]);
-                if request.windows(4).any(|window| window == b"\r\n\r\n") {
-                    break;
-                }
-            }
-            Ok(String::from_utf8_lossy(&request).into_owned())
-        }
-
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let sandbox = Arc::new(MockSandbox::new("test"));
@@ -8363,7 +8238,7 @@ mod tests {
 
         let ready_server_task = tokio::spawn(async move {
             let (mut probe_socket, _) = ready_listener.accept().await?;
-            let probe_request = read_request(&mut probe_socket).await?;
+            let probe_request = read_http_request(&mut probe_socket).await?;
             assert!(
                 probe_request
                     .to_ascii_lowercase()
@@ -8383,7 +8258,7 @@ mod tests {
             drop(probe_socket);
 
             let (mut full_socket, _) = ready_listener.accept().await?;
-            let full_request = read_request(&mut full_socket).await?;
+            let full_request = read_http_request(&mut full_socket).await?;
             assert!(
                 !full_request
                     .to_ascii_lowercase()
@@ -8405,7 +8280,7 @@ mod tests {
 
         let cold_server_task = tokio::spawn(async move {
             let (mut probe_socket, _) = cold_listener.accept().await?;
-            let probe_request = read_request(&mut probe_socket).await?;
+            let probe_request = read_http_request(&mut probe_socket).await?;
             assert!(
                 probe_request
                     .to_ascii_lowercase()
@@ -8426,7 +8301,7 @@ mod tests {
             drop(probe_socket);
 
             let (mut full_socket, _) = cold_listener.accept().await?;
-            let full_request = read_request(&mut full_socket).await?;
+            let full_request = read_http_request(&mut full_socket).await?;
             assert!(
                 !full_request
                     .to_ascii_lowercase()

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3396,7 +3396,8 @@ mod tests {
     use crate::storage_manifest::{ArtifactEntry, StorageEntry, StorageManifest};
     use crate::storage_plan::build_storage_plan;
     use crate::test_fixtures::raw_http::{
-        RawHttpAction, RawHttpTestServer, http_response, json_response, read_http_request,
+        RawHttpAction, RawHttpTestServer, http_response, join_raw_http_task, json_response,
+        read_http_request,
     };
 
     const CACHE_TEST_RUNTIME_DIR: &str = "/tmp/storage-cache-test-runtime";
@@ -5817,10 +5818,8 @@ mod tests {
         assert_eq!(server.max_active.load(Ordering::SeqCst), 2);
 
         server.release.add_permits(3);
-        tokio::time::timeout(Duration::from_secs(5), server.task)
+        join_raw_http_task(server.task, "archive server after all workers are released")
             .await
-            .expect("archive server should finish after all workers are released")
-            .expect("archive server task should not panic")
             .expect("archive server should not fail");
         coordinator.shutdown().await;
     }
@@ -5985,10 +5984,8 @@ mod tests {
         .expect("shutdown should close admissions before draining workers");
         server.release.add_permits(1);
         shutdown_task.await.expect("shutdown task should not panic");
-        tokio::time::timeout(Duration::from_secs(5), server.task)
+        join_raw_http_task(server.task, "active archive server during shutdown")
             .await
-            .expect("active archive server should finish during shutdown")
-            .expect("archive server task should not panic")
             .expect("archive server should not fail");
         assert_eq!(
             wait_cached_archive(&home, "shutdown-active", "v1").await,
@@ -7768,7 +7765,9 @@ mod tests {
         .unwrap();
 
         let _ = release_tx.send(());
-        server_task.await.unwrap().unwrap();
+        join_raw_http_task(server_task, "ignored range probe server")
+            .await
+            .unwrap();
         assert_eq!(result, SizeProbe::Known(advertised_size));
     }
 
@@ -7957,7 +7956,9 @@ mod tests {
         .unwrap();
 
         let _ = release_tx.send(());
-        server_task.await.unwrap().unwrap();
+        join_raw_http_task(server_task, "partial content probe server")
+            .await
+            .unwrap();
         assert_eq!(result, SizeProbe::Known(total_size));
     }
 
@@ -8332,8 +8333,12 @@ mod tests {
         gate.wait_entered(1, Duration::from_secs(5)).await.unwrap();
         gate.release_one();
         let manifest = task.await.unwrap().unwrap();
-        ready_server_task.await.unwrap().unwrap();
-        cold_server_task.await.unwrap().unwrap();
+        join_raw_http_task(ready_server_task, "ready storage archive server")
+            .await
+            .unwrap();
+        join_raw_http_task(cold_server_task, "cold storage archive server")
+            .await
+            .unwrap();
 
         let batches = sandbox.write_files_calls();
         assert_eq!(batches.len(), 1);

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -506,6 +506,7 @@ async fn send_telemetry(
 mod tests {
     use super::*;
     use crate::http::HttpClientConfig;
+    use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, json_response};
     use crate::types::{
         ResumeSessionHistoryDownloadSource, ResumeSessionHistoryEncoding, ResumeSessionHistoryRef,
         ResumeSessionHistoryRefKind,
@@ -534,50 +535,6 @@ mod tests {
             encoded_size: 16 * 1024,
             download_source: Some(ResumeSessionHistoryDownloadSource::ConfiguredPublicEndpoint),
         })
-    }
-
-    fn http_headers_end(buf: &[u8]) -> Option<usize> {
-        buf.windows(4)
-            .position(|window| window == b"\r\n\r\n")
-            .map(|index| index + 4)
-    }
-
-    fn content_length(headers: &str) -> usize {
-        headers
-            .lines()
-            .filter_map(|line| line.split_once(':'))
-            .find_map(|(name, value)| {
-                name.eq_ignore_ascii_case("content-length")
-                    .then(|| value.trim().parse::<usize>().unwrap())
-            })
-            .unwrap_or(0)
-    }
-
-    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
-        use tokio::io::AsyncReadExt;
-
-        let mut buf = Vec::new();
-        let header_end = loop {
-            let mut chunk = [0; 1024];
-            let len = socket.read(&mut chunk).await.unwrap();
-            assert!(len > 0, "connection closed before HTTP headers completed");
-            buf.extend_from_slice(&chunk[..len]);
-
-            if let Some(header_end) = http_headers_end(&buf) {
-                break header_end;
-            }
-        };
-
-        let headers = String::from_utf8_lossy(&buf[..header_end]);
-        let body_len = content_length(&headers);
-        while buf.len() < header_end + body_len {
-            let mut chunk = [0; 1024];
-            let len = socket.read(&mut chunk).await.unwrap();
-            assert!(len > 0, "connection closed before HTTP body completed");
-            buf.extend_from_slice(&chunk[..len]);
-        }
-
-        String::from_utf8(buf).unwrap()
     }
 
     #[test]
@@ -951,32 +908,14 @@ mod tests {
     #[tokio::test]
     async fn flush_waits_for_in_flight_auto_flush_after_buffer_is_drained() {
         use futures_util::FutureExt;
-        use tokio::io::AsyncWriteExt;
 
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let (request_tx, request_rx) = tokio::sync::oneshot::channel();
         let (release_tx, release_rx) = tokio::sync::oneshot::channel();
-        let server = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            request_tx.send(request).unwrap();
-            release_rx.await.unwrap();
-            socket
-                .write_all(
-                    concat!(
-                        "HTTP/1.1 200 OK\r\n",
-                        "content-length: 16\r\n",
-                        "content-type: application/json\r\n",
-                        "connection: close\r\n",
-                        "\r\n",
-                        r#"{"success":true}"#
-                    )
-                    .as_bytes(),
-                )
-                .await
-                .unwrap();
-        });
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::WaitThenRespond {
+            release: release_rx,
+            response: json_response("200 OK", r#"{"success":true}"#),
+        }])
+        .await;
+        let api_url = server.url();
 
         let http = http_client_for_api_url(&api_url);
         let mut telemetry = JobTelemetry::new(
@@ -993,10 +932,7 @@ mod tests {
         assert!(telemetry.pending_ops_snapshot().is_empty());
         assert_eq!(telemetry.in_flight_flushes.len(), 1);
 
-        let request = tokio::time::timeout(Duration::from_secs(1), request_rx)
-            .await
-            .expect("auto flush request should reach the server")
-            .unwrap();
+        let request = server.next_request("auto flush request").await;
         assert!(request.starts_with("POST /api/webhooks/agent/telemetry "));
         assert!(
             request
@@ -1017,37 +953,17 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), flush)
             .await
             .expect("flush should complete after the response is released");
-        tokio::time::timeout(Duration::from_secs(1), server)
-            .await
-            .expect("server should exit")
-            .unwrap();
+        server.assert_finished().await;
     }
 
     #[tokio::test]
     async fn detached_reporter_sends_sandbox_operations_payload() {
-        use tokio::io::AsyncWriteExt;
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let server = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            socket
-                .write_all(
-                    concat!(
-                        "HTTP/1.1 200 OK\r\n",
-                        "content-length: 16\r\n",
-                        "content-type: application/json\r\n",
-                        "connection: close\r\n",
-                        "\r\n",
-                        r#"{"success":true}"#
-                    )
-                    .as_bytes(),
-                )
-                .await
-                .unwrap();
-            request
-        });
+        let server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
+            "200 OK",
+            r#"{"success":true}"#,
+        ))])
+        .await;
+        let api_url = server.url();
 
         let telemetry = JobTelemetry::new(
             http_client_for_api_url(&api_url),
@@ -1066,10 +982,8 @@ mod tests {
             )])
             .await;
 
-        let request = tokio::time::timeout(Duration::from_secs(1), server)
-            .await
-            .expect("server should receive reporter request")
-            .unwrap();
+        let requests = server.assert_finished_with_requests().await;
+        let request = &requests[0];
         assert!(request.starts_with("POST /api/webhooks/agent/telemetry "));
         assert!(
             request
@@ -1084,29 +998,12 @@ mod tests {
 
     #[tokio::test]
     async fn required_runner_name_is_sent_by_direct_reporter() {
-        use tokio::io::AsyncWriteExt;
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let server = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            socket
-                .write_all(
-                    concat!(
-                        "HTTP/1.1 200 OK\r\n",
-                        "content-length: 16\r\n",
-                        "content-type: application/json\r\n",
-                        "connection: close\r\n",
-                        "\r\n",
-                        r#"{"success":true}"#
-                    )
-                    .as_bytes(),
-                )
-                .await
-                .unwrap();
-            request
-        });
+        let server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
+            "200 OK",
+            r#"{"success":true}"#,
+        ))])
+        .await;
+        let api_url = server.url();
 
         let telemetry = JobTelemetry::new(
             http_client_for_api_url(&api_url),
@@ -1124,10 +1021,8 @@ mod tests {
             )])
             .await;
 
-        let request = tokio::time::timeout(Duration::from_secs(1), server)
-            .await
-            .expect("server should receive configured reporter request")
-            .unwrap();
+        let requests = server.assert_finished_with_requests().await;
+        let request = &requests[0];
         assert!(request.contains(r#""runnerName":"v0.168.14"#));
     }
 }

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -2,4 +2,5 @@ pub(crate) mod execution_context;
 pub(crate) mod firewall_base_url_contract;
 pub(crate) mod http_body;
 pub(crate) mod ignored_child;
+pub(crate) mod raw_http;
 pub(crate) mod session_history;

--- a/crates/runner/src/test_fixtures/raw_http.rs
+++ b/crates/runner/src/test_fixtures/raw_http.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, oneshot};
-use tokio::task::{JoinError, JoinHandle};
+use tokio::task::JoinHandle;
 
 const RAW_HTTP_FIXTURE_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_REQUEST_HEADER_BYTES: usize = 64 * 1024;
@@ -104,26 +104,13 @@ impl RawHttpTestServer {
     }
 
     async fn finish_with_timeout(&mut self, timeout: Duration) -> Result<(), String> {
-        let mut task = self
+        let task = self
             .task
             .take()
             .expect("raw HTTP fixture task should be present");
-        match tokio::time::timeout(timeout, &mut task).await {
-            Ok(result) => flatten_task_result(result),
-            Err(_) => {
-                task.abort();
-                let reap_result = tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, task).await;
-                match reap_result {
-                    Ok(Err(error)) if error.is_cancelled() => {
-                        Err("timed out; task reaped after abort".to_string())
-                    }
-                    Ok(result) => Err(format!(
-                        "timed out; unexpected task result while reaping after abort: {result:?}"
-                    )),
-                    Err(_) => Err("timed out reaping task after abort".to_string()),
-                }
-            }
-        }
+        finish_task_with_timeout(task, timeout)
+            .await?
+            .map_err(|error| format!("server failed: {error}"))
     }
 }
 
@@ -137,6 +124,36 @@ impl Drop for RawHttpTestServer {
 
 pub(crate) async fn read_http_request(socket: &mut TcpStream) -> io::Result<String> {
     read_http_request_with_timeout(socket, RAW_HTTP_FIXTURE_TIMEOUT).await
+}
+
+pub(crate) async fn join_raw_http_task<T>(task: JoinHandle<T>, description: &str) -> T {
+    finish_task_with_timeout(task, RAW_HTTP_FIXTURE_TIMEOUT)
+        .await
+        .unwrap_or_else(|error| panic!("{description} should finish: {error}"))
+}
+
+async fn finish_task_with_timeout<T>(
+    mut task: JoinHandle<T>,
+    timeout: Duration,
+) -> Result<T, String> {
+    match tokio::time::timeout(timeout, &mut task).await {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(error)) if error.is_cancelled() => Err("server task was cancelled".to_string()),
+        Ok(Err(error)) => Err(format!("server task failed: {error}")),
+        Err(_) => {
+            task.abort();
+            match tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, task).await {
+                Ok(Err(error)) if error.is_cancelled() => {
+                    Err("timed out; task reaped after abort".to_string())
+                }
+                Ok(Ok(_)) => Err("timed out; task completed while reaping after abort".to_string()),
+                Ok(Err(error)) => Err(format!(
+                    "timed out; task cleanup failed while reaping after abort: {error}"
+                )),
+                Err(_) => Err("timed out reaping task after abort".to_string()),
+            }
+        }
+    }
 }
 
 async fn read_http_request_with_timeout(
@@ -333,15 +350,6 @@ fn fixture_timeout(index: usize, stage: &str) -> io::Error {
         io::ErrorKind::TimedOut,
         format!("timed out {stage} for raw HTTP action {}", index + 1),
     )
-}
-
-fn flatten_task_result(result: Result<io::Result<()>, JoinError>) -> Result<(), String> {
-    match result {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(error)) => Err(format!("server failed: {error}")),
-        Err(error) if error.is_cancelled() => Err("server task was cancelled".to_string()),
-        Err(error) => Err(format!("server task failed: {error}")),
-    }
 }
 
 #[cfg(test)]

--- a/crates/runner/src/test_fixtures/raw_http.rs
+++ b/crates/runner/src/test_fixtures/raw_http.rs
@@ -225,7 +225,14 @@ fn content_length(headers: &str) -> io::Result<usize> {
             continue;
         };
         if name.eq_ignore_ascii_case("content-length") {
-            let parsed = value.trim().parse::<usize>().map_err(|error| {
+            let value = value.trim();
+            if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid HTTP Content-Length: expected decimal digits",
+                ));
+            }
+            let parsed = value.parse::<usize>().map_err(|error| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("invalid HTTP Content-Length: {error}"),
@@ -392,7 +399,7 @@ mod tests {
         let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
         let mut socket = connect(&server).await;
         socket
-            .write_all(b"POST / HTTP/1.1\r\nContent-Length: invalid\r\n\r\n")
+            .write_all(b"POST / HTTP/1.1\r\nContent-Length: +7\r\n\r\n")
             .await
             .unwrap();
         drop(socket);

--- a/crates/runner/src/test_fixtures/raw_http.rs
+++ b/crates/runner/src/test_fixtures/raw_http.rs
@@ -136,6 +136,24 @@ impl Drop for RawHttpTestServer {
 }
 
 pub(crate) async fn read_http_request(socket: &mut TcpStream) -> io::Result<String> {
+    read_http_request_with_timeout(socket, RAW_HTTP_FIXTURE_TIMEOUT).await
+}
+
+async fn read_http_request_with_timeout(
+    socket: &mut TcpStream,
+    timeout: Duration,
+) -> io::Result<String> {
+    tokio::time::timeout(timeout, read_http_request_inner(socket))
+        .await
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out reading raw HTTP request",
+            )
+        })?
+}
+
+async fn read_http_request_inner(socket: &mut TcpStream) -> io::Result<String> {
     let mut request = Vec::new();
     let mut buffer = [0_u8; 1024];
     let header_end = loop {
@@ -269,10 +287,13 @@ async fn serve(
 ) -> io::Result<()> {
     for (index, action) in actions.into_iter().enumerate() {
         let (mut socket, _) = listener.accept().await?;
-        let request =
-            tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, read_http_request(&mut socket))
-                .await
-                .map_err(|_| fixture_timeout(index, "reading request"))??;
+        let request = read_http_request(&mut socket).await.map_err(|error| {
+            if error.kind() == io::ErrorKind::TimedOut {
+                fixture_timeout(index, "reading request")
+            } else {
+                error
+            }
+        })?;
         request_tx.send(request).await.map_err(|_| {
             io::Error::new(
                 io::ErrorKind::BrokenPipe,
@@ -392,6 +413,22 @@ mod tests {
             .await
             .unwrap_err();
         assert!(error.contains("connection closed before HTTP body completed"));
+    }
+
+    #[tokio::test]
+    async fn direct_reader_times_out_incomplete_request() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let mut client = TcpStream::connect(address).await.unwrap();
+        let (mut socket, _) = listener.accept().await.unwrap();
+        client.write_all(b"GET / HTTP/1.1\r\n").await.unwrap();
+
+        let error = read_http_request_with_timeout(&mut socket, Duration::from_millis(10))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(error.to_string(), "timed out reading raw HTTP request");
     }
 
     #[tokio::test]

--- a/crates/runner/src/test_fixtures/raw_http.rs
+++ b/crates/runner/src/test_fixtures/raw_http.rs
@@ -1,0 +1,502 @@
+use std::future::pending;
+use std::io;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::{JoinError, JoinHandle};
+
+const RAW_HTTP_FIXTURE_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_REQUEST_HEADER_BYTES: usize = 64 * 1024;
+const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
+
+pub(crate) enum RawHttpAction {
+    Respond(Vec<u8>),
+    Disconnect,
+    WaitThenRespond {
+        release: oneshot::Receiver<()>,
+        response: Vec<u8>,
+    },
+    Stall,
+}
+
+pub(crate) struct RawHttpTestServer {
+    address: SocketAddr,
+    requests: mpsc::Receiver<String>,
+    task: Option<JoinHandle<io::Result<()>>>,
+}
+
+impl RawHttpTestServer {
+    pub(crate) async fn spawn(actions: Vec<RawHttpAction>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, requests) = mpsc::channel(actions.len().max(1));
+        let task = tokio::spawn(serve(listener, actions, request_tx));
+
+        Self {
+            address,
+            requests,
+            task: Some(task),
+        }
+    }
+
+    pub(crate) fn url(&self) -> String {
+        format!("http://{}", self.address)
+    }
+
+    pub(crate) async fn next_request(&mut self, description: &str) -> String {
+        let deadline = tokio::time::Instant::now() + RAW_HTTP_FIXTURE_TIMEOUT;
+        self.next_request_before(deadline, description)
+            .await
+            .unwrap_or_else(|error| panic!("{error}"))
+    }
+
+    pub(crate) fn try_next_request(&mut self) -> Result<String, mpsc::error::TryRecvError> {
+        self.requests.try_recv()
+    }
+
+    pub(crate) async fn next_request_before(
+        &mut self,
+        deadline: tokio::time::Instant,
+        description: &str,
+    ) -> Result<String, String> {
+        match tokio::time::timeout_at(deadline, self.requests.recv()).await {
+            Ok(Some(request)) => Ok(request),
+            Ok(None) => Err(format!(
+                "raw HTTP request channel closed before {description}"
+            )),
+            Err(_) => Err(format!("timed out waiting for {description}")),
+        }
+    }
+
+    pub(crate) async fn assert_finished(mut self) {
+        if let Err(error) = self.finish_with_timeout(RAW_HTTP_FIXTURE_TIMEOUT).await {
+            panic!("raw HTTP fixture should finish: {error}");
+        }
+    }
+
+    pub(crate) async fn assert_finished_with_requests(mut self) -> Vec<String> {
+        if let Err(error) = self.finish_with_timeout(RAW_HTTP_FIXTURE_TIMEOUT).await {
+            panic!("raw HTTP fixture should finish: {error}");
+        }
+        let mut requests = Vec::new();
+        while let Some(request) = self.requests.recv().await {
+            requests.push(request);
+        }
+        requests
+    }
+
+    pub(crate) async fn cancel_and_reap(mut self) {
+        let task = self
+            .task
+            .take()
+            .expect("raw HTTP fixture task should be present");
+        task.abort();
+        match tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, task).await {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(error))) => panic!("raw HTTP fixture failed before cancellation: {error}"),
+            Ok(Err(error)) if error.is_cancelled() => {}
+            Ok(Err(error)) => panic!("raw HTTP fixture task cleanup failed: {error}"),
+            Err(_) => panic!("timed out reaping raw HTTP fixture task after cancellation"),
+        }
+    }
+
+    async fn finish_with_timeout(&mut self, timeout: Duration) -> Result<(), String> {
+        let mut task = self
+            .task
+            .take()
+            .expect("raw HTTP fixture task should be present");
+        match tokio::time::timeout(timeout, &mut task).await {
+            Ok(result) => flatten_task_result(result),
+            Err(_) => {
+                task.abort();
+                let reap_result = tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, task).await;
+                match reap_result {
+                    Ok(Err(error)) if error.is_cancelled() => {
+                        Err("timed out; task reaped after abort".to_string())
+                    }
+                    Ok(result) => Err(format!(
+                        "timed out; unexpected task result while reaping after abort: {result:?}"
+                    )),
+                    Err(_) => Err("timed out reaping task after abort".to_string()),
+                }
+            }
+        }
+    }
+}
+
+impl Drop for RawHttpTestServer {
+    fn drop(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+pub(crate) async fn read_http_request(socket: &mut TcpStream) -> io::Result<String> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    let header_end = loop {
+        let read = socket.read(&mut buffer).await?;
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "connection closed before HTTP headers completed",
+            ));
+        }
+        request.extend_from_slice(&buffer[..read]);
+        if let Some(header_end) = request
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|position| position + 4)
+        {
+            if header_end > MAX_REQUEST_HEADER_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "HTTP request headers exceed fixture limit",
+                ));
+            }
+            break header_end;
+        }
+        if request.len() >= MAX_REQUEST_HEADER_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "HTTP request headers exceed fixture limit",
+            ));
+        }
+    };
+
+    let headers = std::str::from_utf8(&request[..header_end]).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("HTTP request headers are not UTF-8: {error}"),
+        )
+    })?;
+    let body_len = content_length(headers)?;
+    if body_len > MAX_REQUEST_BODY_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "HTTP request body exceeds fixture limit",
+        ));
+    }
+    let request_len = header_end.checked_add(body_len).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "HTTP request length exceeds fixture limit",
+        )
+    })?;
+
+    while request.len() < request_len {
+        let remaining = request_len - request.len();
+        let read_len = remaining.min(buffer.len());
+        let read = socket.read(&mut buffer[..read_len]).await?;
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "connection closed before HTTP body completed",
+            ));
+        }
+        request.extend_from_slice(&buffer[..read]);
+    }
+    request.truncate(request_len);
+
+    String::from_utf8(request).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("HTTP request is not UTF-8: {error}"),
+        )
+    })
+}
+
+pub(crate) fn http_response(status: &str, body: &[u8]) -> Vec<u8> {
+    response(status, None, body)
+}
+
+pub(crate) fn json_response(status: &str, body: &str) -> Vec<u8> {
+    response(status, Some("application/json"), body.as_bytes())
+}
+
+fn content_length(headers: &str) -> io::Result<usize> {
+    let mut content_length = None;
+    for line in headers.lines() {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.eq_ignore_ascii_case("content-length") {
+            let parsed = value.trim().parse::<usize>().map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid HTTP Content-Length: {error}"),
+                )
+            })?;
+            if content_length.replace(parsed).is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "duplicate HTTP Content-Length header",
+                ));
+            }
+        }
+    }
+    Ok(content_length.unwrap_or(0))
+}
+
+fn response(status: &str, content_type: Option<&str>, body: &[u8]) -> Vec<u8> {
+    let content_type = content_type
+        .map(|value| format!("Content-Type: {value}\r\n"))
+        .unwrap_or_default();
+    let mut response = format!(
+        "HTTP/1.1 {status}\r\n{content_type}Content-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    response.extend_from_slice(body);
+    response
+}
+
+async fn serve(
+    listener: TcpListener,
+    actions: Vec<RawHttpAction>,
+    request_tx: mpsc::Sender<String>,
+) -> io::Result<()> {
+    for (index, action) in actions.into_iter().enumerate() {
+        let (mut socket, _) = listener.accept().await?;
+        let request =
+            tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, read_http_request(&mut socket))
+                .await
+                .map_err(|_| fixture_timeout(index, "reading request"))??;
+        request_tx.send(request).await.map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                format!("raw HTTP request receiver closed for action {}", index + 1),
+            )
+        })?;
+
+        match action {
+            RawHttpAction::Respond(response) => {
+                write_response(index, &mut socket, &response).await?;
+            }
+            RawHttpAction::Disconnect => {}
+            RawHttpAction::WaitThenRespond { release, response } => {
+                release.await.map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        format!("raw HTTP response release dropped for action {}", index + 1),
+                    )
+                })?;
+                write_response(index, &mut socket, &response).await?;
+            }
+            RawHttpAction::Stall => pending::<()>().await,
+        }
+    }
+    Ok(())
+}
+
+async fn write_response(index: usize, socket: &mut TcpStream, response: &[u8]) -> io::Result<()> {
+    tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, socket.write_all(response))
+        .await
+        .map_err(|_| fixture_timeout(index, "writing response"))??;
+    Ok(())
+}
+
+fn fixture_timeout(index: usize, stage: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("timed out {stage} for raw HTTP action {}", index + 1),
+    )
+}
+
+fn flatten_task_result(result: Result<io::Result<()>, JoinError>) -> Result<(), String> {
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(format!("server failed: {error}")),
+        Err(error) if error.is_cancelled() => Err("server task was cancelled".to_string()),
+        Err(error) => Err(format!("server task failed: {error}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn connect(server: &RawHttpTestServer) -> TcpStream {
+        let url = server.url();
+        TcpStream::connect(url.strip_prefix("http://").unwrap())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn captures_complete_request_and_responds() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
+            "200 OK",
+            r#"{"success":true}"#,
+        ))])
+        .await;
+        let mut socket = connect(&server).await;
+        socket
+            .write_all(b"POST /test HTTP/1.1\r\nContent-Length: 4\r\n\r\nbody")
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        socket.read_to_end(&mut response).await.unwrap();
+
+        assert_eq!(
+            server.next_request("complete fixture request").await,
+            "POST /test HTTP/1.1\r\nContent-Length: 4\r\n\r\nbody"
+        );
+        assert!(
+            String::from_utf8(response)
+                .unwrap()
+                .ends_with(r#"{"success":true}"#)
+        );
+        server.assert_finished().await;
+    }
+
+    #[tokio::test]
+    async fn rejects_premature_header_eof() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+        let mut socket = connect(&server).await;
+        socket.write_all(b"GET / HTTP/1.1\r\n").await.unwrap();
+        socket.shutdown().await.unwrap();
+        drop(socket);
+
+        let error = server
+            .finish_with_timeout(RAW_HTTP_FIXTURE_TIMEOUT)
+            .await
+            .unwrap_err();
+        assert!(error.contains("connection closed before HTTP headers completed"));
+    }
+
+    #[tokio::test]
+    async fn rejects_premature_body_eof() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+        let mut socket = connect(&server).await;
+        socket
+            .write_all(b"POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nab")
+            .await
+            .unwrap();
+        socket.shutdown().await.unwrap();
+        drop(socket);
+
+        let error = server
+            .finish_with_timeout(RAW_HTTP_FIXTURE_TIMEOUT)
+            .await
+            .unwrap_err();
+        assert!(error.contains("connection closed before HTTP body completed"));
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_content_length() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+        let mut socket = connect(&server).await;
+        socket
+            .write_all(b"POST / HTTP/1.1\r\nContent-Length: invalid\r\n\r\n")
+            .await
+            .unwrap();
+        drop(socket);
+
+        let error = server
+            .finish_with_timeout(RAW_HTTP_FIXTURE_TIMEOUT)
+            .await
+            .unwrap_err();
+        assert!(error.contains("invalid HTTP Content-Length"));
+    }
+
+    #[tokio::test]
+    async fn rejects_body_over_fixture_limit() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+        let mut socket = connect(&server).await;
+        socket
+            .write_all(
+                format!(
+                    "POST / HTTP/1.1\r\nContent-Length: {}\r\n\r\n",
+                    MAX_REQUEST_BODY_BYTES + 1
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        drop(socket);
+
+        let error = server
+            .finish_with_timeout(RAW_HTTP_FIXTURE_TIMEOUT)
+            .await
+            .unwrap_err();
+        assert!(error.contains("HTTP request body exceeds fixture limit"));
+    }
+
+    #[tokio::test]
+    async fn disconnects_after_capturing_request() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+        let mut socket = connect(&server).await;
+        socket.write_all(b"GET / HTTP/1.1\r\n\r\n").await.unwrap();
+        let mut response = Vec::new();
+        socket.read_to_end(&mut response).await.unwrap();
+
+        assert!(response.is_empty());
+        assert_eq!(
+            server.next_request("disconnect request").await,
+            "GET / HTTP/1.1\r\n\r\n"
+        );
+        server.assert_finished().await;
+    }
+
+    #[tokio::test]
+    async fn captures_request_before_delayed_response_is_released() {
+        let (release_tx, release_rx) = oneshot::channel();
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::WaitThenRespond {
+            release: release_rx,
+            response: http_response("204 No Content", b""),
+        }])
+        .await;
+        let address = server.address;
+        let client = tokio::spawn(async move {
+            let mut socket = TcpStream::connect(address).await.unwrap();
+            socket.write_all(b"GET / HTTP/1.1\r\n\r\n").await.unwrap();
+            let mut response = Vec::new();
+            socket.read_to_end(&mut response).await.unwrap();
+            response
+        });
+
+        assert_eq!(
+            server.next_request("delayed response request").await,
+            "GET / HTTP/1.1\r\n\r\n"
+        );
+        assert!(!client.is_finished());
+        release_tx.send(()).unwrap();
+        let response = client.await.unwrap();
+        assert!(
+            String::from_utf8(response)
+                .unwrap()
+                .starts_with("HTTP/1.1 204 No Content")
+        );
+        server.assert_finished().await;
+    }
+
+    #[tokio::test]
+    async fn timeout_aborts_and_reaps_unfinished_accept() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+
+        let error = server
+            .finish_with_timeout(Duration::from_millis(10))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error, "timed out; task reaped after abort");
+    }
+
+    #[tokio::test]
+    async fn explicit_cancellation_reaps_stalled_action() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Stall]).await;
+        let mut socket = connect(&server).await;
+        socket.write_all(b"GET / HTTP/1.1\r\n\r\n").await.unwrap();
+        assert_eq!(
+            server.next_request("stalled request").await,
+            "GET / HTTP/1.1\r\n\r\n"
+        );
+
+        server.cancel_and_reap().await;
+    }
+}


### PR DESCRIPTION
## Summary

- add a lifecycle-owned, bounded raw HTTP runner test fixture with canonical `Content-Length` request capture
- support scripted responses, disconnects, delayed responses, and stalls while explicitly reaping server tasks
- migrate active-input, provider API, connector runtime sync, telemetry, and storage cache tests away from duplicated transport helpers
- bound and reap the specialized raw HTTP server tasks that retain local domain orchestration
- cover complete requests, malformed and incomplete input, size limits, delayed actions, timeouts, disconnects, and cancellation

## Scope

- test-only; no production behavior, API, persistence, or deployment changes
- retain session-history's separate fixture and domain-specific storage, concurrency, and malformed-response orchestration

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner -- --test-threads=1` (3,158 passed, 20 ignored)
- focused raw HTTP fixture (10 tests), active-input, telemetry, provider API, connector-runtime-sync, and storage-cache tests

Closes #27667
