### PR TITLE
feat(core): enable video model selection for staff

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -105,7 +105,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       true,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -299,6 +299,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Let the chat composer model picker pin the video model a chat thread generates with.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

- enable `VideoModelSelection` for staff organizations while keeping it disabled globally
- update the rollout matrix regression test to keep non-staff organizations disabled

## Verification

- `pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13)
- `pnpm knip`
- staged TypeScript checks for non-App/API packages, App, and API
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (24/24)
