### PR TITLE
fix(ui): tighten segment control track padding to 2px

### DIFF
--- a/turbo/packages/ui/src/components/ui/segment-control.tsx
+++ b/turbo/packages/ui/src/components/ui/segment-control.tsx
@@ -23,7 +23,7 @@ const SegmentControlSizeContext =
  * step under the selected segment in both themes.
  */
 const segmentControlVariants = cva(
-  "inline-flex items-center gap-0.5 rounded-lg bg-muted p-[3px]",
+  "inline-flex items-center gap-0.5 rounded-lg bg-muted p-0.5",
   {
     variants: {
       size: {
@@ -40,18 +40,18 @@ const segmentControlVariants = cva(
 );
 
 /**
- * `rounded-[5px]` keeps the segment concentric with the track: the 8px outer
- * radius minus the 3px of track padding it sits inside.
+ * `rounded-md` keeps the segment concentric with the track: the 8px outer
+ * radius minus the 2px of track padding it sits inside.
  *
  * The selected segment carries an opaque fill, so it must not take the
  * translucent `state-hover` layer -- the layer replaces a fill instead of
  * sitting on it, which would drop the segment back to the track colour.
  */
 const segmentControlItemVariants = cva(
-  "inline-flex h-full shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-[5px] font-medium whitespace-nowrap text-muted-foreground outline-none transition-colors select-none not-data-checked:hover:bg-state-hover not-data-checked:hover:text-foreground data-checked:bg-segment-selected data-checked:text-foreground data-checked:shadow-segment-selected data-disabled:pointer-events-none data-disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex h-full shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-md font-medium whitespace-nowrap text-muted-foreground outline-none transition-colors select-none not-data-checked:hover:bg-state-hover not-data-checked:hover:text-foreground data-checked:bg-segment-selected data-checked:text-foreground data-checked:shadow-segment-selected data-disabled:pointer-events-none data-disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     // Segment padding runs one step tighter than the matching button size,
-    // because the segment already sits inside the track's 3px inset -- that
+    // because the segment already sits inside the track's 2px inset -- that
     // puts the label the same optical distance from the outer edge as a
     // button of the same size. `xs` drops to `text-xs`: 14px text in a 22px
     // segment leaves a 1px line box gap, which reads as clipped.

--- a/turbo/packages/ui/src/components/ui/segment-control.tsx
+++ b/turbo/packages/ui/src/components/ui/segment-control.tsx
@@ -53,8 +53,9 @@ const segmentControlItemVariants = cva(
     // Segment padding runs one step tighter than the matching button size,
     // because the segment already sits inside the track's 2px inset -- that
     // puts the label the same optical distance from the outer edge as a
-    // button of the same size. `xs` drops to `text-xs`: 14px text in a 22px
-    // segment leaves a 1px line box gap, which reads as clipped.
+    // button of the same size. `xs` drops to `text-xs`: the h-7 track leaves a
+    // 24px segment, where `text-sm`'s 20px line box would clear only 2px a
+    // side against the 4px an h-7 button gives it.
     variants: {
       size: {
         xs: "px-2 text-xs",

--- a/turbo/packages/ui/src/components/ui/tabs.tsx
+++ b/turbo/packages/ui/src/components/ui/tabs.tsx
@@ -31,7 +31,7 @@ const TabsList = React.forwardRef<HTMLDivElement, TabsPrimitive.List.Props>(
           // Geometry is shared with SegmentControl: the two patterns differ in
           // semantics (navigating panels vs picking a value), not in looks, and
           // letting them drift is what left the product with two skins.
-          "inline-flex h-9 items-center justify-center gap-0.5 rounded-lg bg-muted p-[3px] text-muted-foreground",
+          "inline-flex h-9 items-center justify-center gap-0.5 rounded-lg bg-muted p-0.5 text-muted-foreground",
           className,
         )}
         {...props}
@@ -48,7 +48,7 @@ const TabsTrigger = React.forwardRef<HTMLElement, TabsPrimitive.Tab.Props>(
         ref={ref}
         data-slot="tabs-trigger"
         className={cn(
-          "inline-flex h-full shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-[5px] px-3 text-sm font-medium text-muted-foreground outline-none transition-colors not-data-active:hover:bg-state-hover not-data-active:hover:text-foreground data-active:bg-segment-selected data-active:text-foreground data-active:shadow-segment-selected disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+          "inline-flex h-full shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-3 text-sm font-medium text-muted-foreground outline-none transition-colors not-data-active:hover:bg-state-hover not-data-active:hover:text-foreground data-active:bg-segment-selected data-active:text-foreground data-active:shadow-segment-selected disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
           className,
         )}
         {...props}


### PR DESCRIPTION
## What

The segment control track inset was 3px, which left the selected segment sitting too far from the track edge. Drop it to 2px.

- `SegmentControl` track: `p-[3px]` → `p-0.5` (2px)
- Segment radius: `rounded-[5px]` → `rounded-md` (6px), keeping the segment concentric with the 8px track (8 − 2 = 6)
- Same change applied to `TabsList` / `TabsTrigger`, which share this geometry by design — the comment in `tabs.tsx` explicitly calls out that letting the two drift is what left the product with two skins

## Verification

Rendered a static 3px vs 2px comparison at 3× and confirmed the tighter inset and the concentric radius. Relying on the PR pipeline for lint, type-check, and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)