### PR TITLE
fix(ci): require verify-full for neon database urls

### DIFF
--- a/.github/actions/neon-branch/action.yml
+++ b/.github/actions/neon-branch/action.yml
@@ -97,11 +97,11 @@ runs:
           exit 1
         fi
 
-        DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME" --pooled)
+        DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME" --pooled --ssl verify-full)
         if [ -z "$DATABASE_URL" ]; then
           echo "Error: Failed to get database URL from neonctl"
           echo "Attempting without --pooled flag..."
-          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME")
+          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME" --ssl verify-full)
         fi
         echo "DATABASE_URL value: $DATABASE_URL"
         echo "database-url=$DATABASE_URL" >> $GITHUB_OUTPUT

--- a/.github/actions/production-migration-smoke/action.yml
+++ b/.github/actions/production-migration-smoke/action.yml
@@ -58,7 +58,7 @@ runs:
           exit 1
         fi
 
-        DATABASE_URL=$(neonctl connection-string "$BRANCH_ID" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
+        DATABASE_URL=$(neonctl connection-string "$BRANCH_ID" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled --ssl verify-full)
         echo "::add-mask::$DATABASE_URL"
         echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
 

--- a/.github/scripts/tests/neon-connection-string-ssl-test.sh
+++ b/.github/scripts/tests/neon-connection-string-ssl-test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+mapfile -t invocations < <(
+  rg \
+    --line-number \
+    --no-heading \
+    --fixed-strings \
+    --glob '*.yml' \
+    --glob '*.yaml' \
+    'neonctl connection-string' \
+    "${repo_root}/.github/actions" \
+    "${repo_root}/.github/workflows"
+)
+
+if [[ ${#invocations[@]} -eq 0 ]]; then
+  fail "no neonctl connection-string invocations found"
+fi
+
+checked=0
+for invocation in "${invocations[@]}"; do
+  IFS=: read -r file line_number command <<< "$invocation"
+  if [[ "$command" =~ ^[[:space:]]*# ]]; then
+    continue
+  fi
+
+  next_line="$line_number"
+  while [[ "$command" =~ \\[[:space:]]*$ ]]; do
+    next_line=$((next_line + 1))
+    continuation=$(sed -n "${next_line}p" "$file")
+    if [[ -z "$continuation" ]]; then
+      fail "unterminated neonctl command at ${file}:${line_number}"
+    fi
+    command+=" ${continuation}"
+  done
+
+  if [[ ! "$command" =~ (^|[[:space:]])--ssl[[:space:]]+verify-full([^[:alnum:]_-]|$) ]]; then
+    fail "neonctl connection-string must specify --ssl verify-full at ${file}:${line_number}"
+  fi
+  checked=$((checked + 1))
+done
+
+if [[ $checked -eq 0 ]]; then
+  fail "no executable neonctl connection-string invocations found"
+fi
+
+echo "neon connection-string SSL checks passed (${checked} invocations)"

--- a/.github/workflows/agent-compose-consolidation-preflight.yml
+++ b/.github/workflows/agent-compose-consolidation-preflight.yml
@@ -46,6 +46,7 @@ jobs:
               --database-name neondb \
               --role-name neondb_owner \
               --pooled \
+              --ssl verify-full \
               2>/dev/null
           ); then
             echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v2","status":"failed","failureGates":["probe.database_resolution"]}'

--- a/.github/workflows/backfill-acquisition-attribution.yml
+++ b/.github/workflows/backfill-acquisition-attribution.yml
@@ -72,7 +72,8 @@ jobs:
               --project-id "$NEON_PROJECT_ID" \
               --database-name neondb \
               --role-name neondb_owner \
-              --pooled
+              --pooled \
+              --ssl verify-full
           )
           echo "::add-mask::$database_url"
           echo "database_url=$database_url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1058,7 +1058,7 @@ jobs:
       - name: Get Production Database URL
         id: get-db-url
         run: |
-          DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --role-name neondb_owner --pooled)
+          DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --role-name neondb_owner --pooled --ssl verify-full)
           echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
         env:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -273,6 +273,7 @@ jobs:
             .github/scripts/tests/download-verified-test.sh \
             .github/scripts/tests/fetch-okou-desktop-artifact-test.sh \
             .github/scripts/tests/list-okou-pages-preview-pr-numbers-test.sh \
+            .github/scripts/tests/neon-connection-string-ssl-test.sh \
             .github/scripts/tests/okou-desktop-artifact-test.sh \
             .github/scripts/tests/provision-runner-kvm-test.sh \
             .github/scripts/tests/release-tool-downloads-test.sh \

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -988,9 +988,9 @@ jobs:
           # NEON_PROJECT_ID resolves to the Neon TEST project, never production.
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "main push: pre-migrating test project default (parent) branch"
-            PARENT_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
+            PARENT_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled --ssl verify-full)
             if [ -z "$PARENT_DATABASE_URL" ]; then
-              PARENT_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner)
+              PARENT_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --ssl verify-full)
             fi
             (cd turbo && DATABASE_URL="$PARENT_DATABASE_URL" pnpm -F @okouai/db db:migrate)
           fi
@@ -1010,9 +1010,9 @@ jobs:
             neonctl branches create --name "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID"
           fi
 
-          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled)
+          DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --pooled --ssl verify-full)
           if [ -z "$DATABASE_URL" ]; then
-            DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner)
+            DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --ssl verify-full)
           fi
 
           cd turbo


### PR DESCRIPTION
## Summary

- explicitly request `sslmode=verify-full` from every repository-owned `neonctl connection-string` invocation
- cover production, preview, pooled, non-pooled fallback, migration smoke, preflight, and backfill paths
- add a workflow invariant test that rejects future implicit Neon SSL-mode invocations

## Behavior

Generated Neon URLs now contain `sslmode=verify-full&channel_binding=require`. This preserves the certificate and hostname verification currently applied by node-postgres while preventing a future `pg` major upgrade from adopting weaker libpq `require` semantics.

The change does not upgrade `neonctl`, rewrite URLs in consumers, alter pooling or fallback behavior, or change API, database schema, persisted data, frontend, or runner contracts.

## Validation

- `bash .github/scripts/tests/neon-connection-string-ssl-test.sh`
- `bash -n .github/scripts/tests/neon-connection-string-ssl-test.sh`
- `shellcheck .github/scripts/tests/neon-connection-string-ssl-test.sh` (ShellCheck 0.11.0)
- YAML parse of all changed workflows and composite actions with `yq 4.47.2`
- `.github/scripts/check-workflow-shell-compatibility.sh` for all changed workflows
- `actionlint` 1.7.12
- `git diff --check`
- repository pre-commit and commit-message hooks

Live privileged Neon workflow execution remains delegated to CI and deployment.

Closes #27697
