### PR TITLE
fix(platform): allow lab access before onboarding

### DIFF
--- a/turbo/apps/platform/src/signals/lab-page/lab-page-setup.ts
+++ b/turbo/apps/platform/src/signals/lab-page/lab-page-setup.ts
@@ -4,7 +4,6 @@ import { i18n } from "../../i18n/index.ts";
 import { LabPage } from "../../views/lab-page/lab-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 
 export const setupLabPage$ = command(async ({ set }, signal: AbortSignal) => {
@@ -16,8 +15,4 @@ export const setupLabPage$ = command(async ({ set }, signal: AbortSignal) => {
     }),
   );
   await set(hideAppSkeleton$, signal);
-
-  if (await set(onboardGuard$, signal)) {
-    return;
-  }
 });

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -8,6 +8,7 @@ import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -47,6 +48,29 @@ function maintainerFilterButton(label: string): HTMLElement {
 }
 
 describe("lab page", () => {
+  it("stays accessible when onboarding is required", async () => {
+    context.mocks.data.onboardingStatus({
+      needsOnboarding: true,
+      onboardingComplete: false,
+    });
+    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
+      const switches = { [FeatureSwitchKey.Banking]: true };
+      return respond(200, { switches, effectiveSwitches: switches });
+    });
+
+    detachedSetupPage({ context, path: "/_/lab" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Lab" })).toBeInTheDocument();
+      expect(featureSwitchControl(FeatureSwitchKey.Banking)).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+      expect(screen.getByTestId("pinned-agent-card")).toBeInTheDocument();
+      expect(pathname()).toBe("/_/lab");
+    });
+  });
+
   it("lets users toggle and reset feature switches", async () => {
     let switches: Partial<Record<FeatureSwitchKey, boolean>> = {
       [FeatureSwitchKey.Lab]: true,


### PR DESCRIPTION
## Summary

- remove the onboarding redirect guard from the `/_/lab` page setup while retaining authentication and organization selection checks
- add regression coverage confirming the Lab route remains active when onboarding is still required

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/lab-page/__tests__/lab-page.test.tsx`
