### PR TITLE
refactor(runner): centralize raw http test fixture

### DIFF
--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
-
 use crate::active_input::{
     API_ACTIVE_INPUT_RECHECK_INTERVAL, ActiveInputNotifications, ActiveInputSource,
     local_active_input_delivery_id,
@@ -15,106 +12,21 @@ use crate::executor::tests::support::{
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
 use crate::provider::ApiClient;
+use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, json_response};
 use crate::types::SandboxReuseResult;
 
 const DELIVERY_ID: &str = "b1e2ad6d-930a-4d51-aa40-7952d54f978b";
 const EVENT_ID: &str = "e6bc287d-8c08-464e-831a-cad771610157";
 
-async fn read_http_request(socket: &mut TcpStream) -> String {
-    let mut request = Vec::new();
-    let mut buffer = [0_u8; 1024];
-    let header_end = loop {
-        let read = socket.read(&mut buffer).await.unwrap();
-        assert!(read > 0, "connection closed before HTTP headers completed");
-        request.extend_from_slice(&buffer[..read]);
-        if let Some(header_end) = request
-            .windows(4)
-            .position(|window| window == b"\r\n\r\n")
-            .map(|position| position + 4)
-        {
-            break header_end;
-        }
-    };
-    let headers = String::from_utf8_lossy(&request[..header_end]);
-    let body_len = headers
-        .lines()
-        .find_map(|line| {
-            let (name, value) = line.split_once(':')?;
-            name.eq_ignore_ascii_case("content-length")
-                .then(|| value.trim().parse::<usize>().unwrap())
-        })
-        .unwrap_or(0);
-    while request.len() < header_end + body_len {
-        let read = socket.read(&mut buffer).await.unwrap();
-        assert!(read > 0, "connection closed before HTTP body completed");
-        request.extend_from_slice(&buffer[..read]);
-    }
-    String::from_utf8(request).unwrap()
-}
-
-fn http_response(status: &str, body: &str) -> String {
-    format!(
-        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        body.len()
-    )
-}
-
-enum HttpServerAction {
-    Respond(String),
-    Disconnect,
-}
-
-async fn spawn_http_server(
-    responses: Vec<String>,
-) -> (
-    String,
-    tokio::sync::mpsc::UnboundedReceiver<String>,
-    tokio::task::JoinHandle<()>,
-) {
-    spawn_http_server_with_actions(
-        responses
-            .into_iter()
-            .map(HttpServerAction::Respond)
-            .collect(),
-    )
-    .await
-}
-
-async fn spawn_http_server_with_actions(
-    actions: Vec<HttpServerAction>,
-) -> (
-    String,
-    tokio::sync::mpsc::UnboundedReceiver<String>,
-    tokio::task::JoinHandle<()>,
-) {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let api_url = format!("http://{}", listener.local_addr().unwrap());
-    let (request_tx, request_rx) = tokio::sync::mpsc::unbounded_channel();
-    let server = tokio::spawn(async move {
-        for action in actions {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            if let HttpServerAction::Respond(response) = action {
-                socket.write_all(response.as_bytes()).await.unwrap();
-                socket.shutdown().await.unwrap();
-                let mut closed = [0_u8; 1];
-                assert_eq!(socket.read(&mut closed).await.unwrap(), 0);
-            }
-            request_tx.send(request).unwrap();
-        }
-    });
-    (api_url, request_rx, server)
-}
-
 async fn receive_http_request_before(
     deadline: tokio::time::Instant,
-    request_rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
+    server: &mut RawHttpTestServer,
     description: &str,
 ) -> Result<String, String> {
-    match tokio::time::timeout_at(deadline, request_rx.recv()).await {
-        Ok(Some(request)) => Ok(request),
-        Ok(None) => Err(format!(
-            "active-input request channel closed before {description}"
+    match tokio::time::timeout_at(deadline, server.receive_request_text()).await {
+        Ok(Ok(request)) => Ok(request),
+        Ok(Err(error)) => Err(format!(
+            "active-input request capture failed before {description}: {error}"
         )),
         Err(_) => Err(format!("timed out waiting for {description}")),
     }
@@ -272,17 +184,22 @@ async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() 
     let run_id = ctx.run_id;
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
 
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("200 OK", r#"{"outcome":"empty"}"#),
-        http_response("503 Service Unavailable", r#"{"error":"transient"}"#),
-        http_response(
+    let mut server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(json_response("200 OK", br#"{"outcome":"empty"}"#)),
+        RawHttpAction::Respond(json_response(
+            "503 Service Unavailable",
+            br#"{"error":"transient"}"#,
+        )),
+        RawHttpAction::Respond(json_response(
             "200 OK",
-            &format!(
+            format!(
                 r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retry delivered"}}"#,
-            ),
-        ),
+            )
+            .as_bytes(),
+        )),
     ])
     .await;
+    let api_url = server.url();
 
     let notifications = ActiveInputNotifications::new();
     let source =
@@ -306,10 +223,11 @@ async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() 
         .await
     });
 
-    let initial_reserve = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_rx.recv())
-        .await
-        .expect("initial active-input reserve request should reach the server")
-        .expect("active-input request channel should remain open");
+    let initial_reserve =
+        tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server.receive_request_text())
+            .await
+            .expect("initial active-input reserve request should reach the server")
+            .expect("active-input request capture should succeed");
     assert!(initial_reserve.starts_with(&format!("POST {reserve_path} ")));
     notifications.notify(run_id);
 
@@ -327,15 +245,11 @@ async fn run_in_sandbox_retries_api_active_input_after_transient_read_failure() 
         .unwrap();
     assert!(result.failure.is_none());
 
-    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
-        .await
-        .expect("active-input server should finish")
-        .unwrap();
-    let mut remaining_requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        remaining_requests.push(request);
-    }
-    assert_eq!(remaining_requests.len(), 2);
+    server.assert_complete().await;
+    let remaining_requests = [
+        server.receive_request_text().await.unwrap(),
+        server.receive_request_text().await.unwrap(),
+    ];
     assert!(remaining_requests[0].starts_with(&format!("POST {reserve_path} ")));
     assert!(remaining_requests[1].starts_with(&format!("POST {reserve_path} ")));
 
@@ -360,16 +274,18 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
     let run_id = ctx.run_id;
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
 
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("200 OK", r#"{"outcome":"empty"}"#),
-        http_response(
+    let mut server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(json_response("200 OK", br#"{"outcome":"empty"}"#)),
+        RawHttpAction::Respond(json_response(
             "200 OK",
-            &format!(
+            format!(
                 r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"recheck delivered"}}"#,
-            ),
-        ),
+            )
+            .as_bytes(),
+        )),
     ])
     .await;
+    let api_url = server.url();
 
     let notifications = ActiveInputNotifications::new();
     let source =
@@ -393,10 +309,11 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
         .await
     });
 
-    let initial_reserve = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_rx.recv())
-        .await
-        .expect("initial active-input reserve request should reach the server")
-        .expect("active-input request channel should remain open");
+    let initial_reserve =
+        tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server.receive_request_text())
+            .await
+            .expect("initial active-input reserve request should reach the server")
+            .expect("active-input request capture should succeed");
     assert!(initial_reserve.starts_with(&format!("POST {reserve_path} ")));
 
     tokio::time::pause();
@@ -418,15 +335,8 @@ async fn run_in_sandbox_rechecks_api_active_input_without_notification() {
         .unwrap();
     assert!(result.failure.is_none());
 
-    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
-        .await
-        .expect("active-input server should finish")
-        .unwrap();
-    let mut remaining_requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        remaining_requests.push(request);
-    }
-    assert_eq!(remaining_requests.len(), 1);
+    server.assert_complete().await;
+    let remaining_requests = [server.receive_request_text().await.unwrap()];
     assert!(remaining_requests[0].starts_with(&format!("POST {reserve_path} ")));
 
     let calls = overrides.process_control_calls();
@@ -528,16 +438,21 @@ async fn run_in_sandbox_retries_reserve_when_first_request_is_not_found() {
     let ctx = minimal_context();
     let run_id = ctx.run_id;
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("404 Not Found", r#"{"error":"not found"}"#),
-        http_response(
+    let mut server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(json_response(
+            "404 Not Found",
+            br#"{"error":"not found"}"#,
+        )),
+        RawHttpAction::Respond(json_response(
             "200 OK",
-            &format!(
+            format!(
                 r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"reserve delivered"}}"#,
-            ),
-        ),
+            )
+            .as_bytes(),
+        )),
     ])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -577,16 +492,11 @@ async fn run_in_sandbox_retries_reserve_when_first_request_is_not_found() {
         .unwrap()
         .unwrap();
     assert!(result.failure.is_none());
-    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
-        .await
-        .unwrap()
-        .unwrap();
-
-    let mut requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        requests.push(request);
-    }
-    assert_eq!(requests.len(), 2);
+    server.assert_complete().await;
+    let requests = [
+        server.receive_request_text().await.unwrap(),
+        server.receive_request_text().await.unwrap(),
+    ];
     assert!(
         requests
             .iter()
@@ -612,17 +522,19 @@ async fn run_in_sandbox_retrieves_reservation_after_lost_first_response() {
     let ctx = minimal_context();
     let run_id = ctx.run_id;
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
-    let reserved = http_response(
+    let reserved = json_response(
         "200 OK",
-        &format!(
+        format!(
             r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retrieved delivery"}}"#,
-        ),
+        )
+        .as_bytes(),
     );
-    let (api_url, mut request_rx, server) = spawn_http_server_with_actions(vec![
-        HttpServerAction::Disconnect,
-        HttpServerAction::Respond(reserved),
+    let mut server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Disconnect,
+        RawHttpAction::Respond(reserved),
     ])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -662,13 +574,11 @@ async fn run_in_sandbox_retrieves_reservation_after_lost_first_response() {
         .unwrap()
         .unwrap();
     assert!(result.failure.is_none());
-    server.await.unwrap();
-
-    let mut requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        requests.push(request);
-    }
-    assert_eq!(requests.len(), 2);
+    server.assert_complete().await;
+    let requests = [
+        server.receive_request_text().await.unwrap(),
+        server.receive_request_text().await.unwrap(),
+    ];
     assert!(
         requests
             .iter()
@@ -691,11 +601,15 @@ async fn run_in_sandbox_keeps_using_reserve_after_ambiguous_failure() {
     let ctx = minimal_context();
     let run_id = ctx.run_id;
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response("503 Service Unavailable", r#"{"error":"transient"}"#),
-        http_response("404 Not Found", r#"{"error":"not found"}"#),
+    let mut server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(json_response(
+            "503 Service Unavailable",
+            br#"{"error":"transient"}"#,
+        )),
+        RawHttpAction::Respond(json_response("404 Not Found", br#"{"error":"not found"}"#)),
     ])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -723,15 +637,11 @@ async fn run_in_sandbox_keeps_using_reserve_after_ambiguous_failure() {
         .await
     });
 
-    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, server)
-        .await
-        .unwrap()
-        .unwrap();
-    let mut requests = Vec::new();
-    while let Some(request) = request_rx.recv().await {
-        requests.push(request);
-    }
-    assert_eq!(requests.len(), 2);
+    server.assert_complete().await;
+    let requests = [
+        server.receive_request_text().await.unwrap(),
+        server.receive_request_text().await.unwrap(),
+    ];
     assert!(
         requests
             .iter()
@@ -758,8 +668,12 @@ async fn run_in_sandbox_stops_when_reserve_reports_terminal() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let (api_url, _request_rx, server) =
-        spawn_http_server(vec![http_response("200 OK", r#"{"outcome":"terminal"}"#)]).await;
+    let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
+        "200 OK",
+        br#"{"outcome":"terminal"}"#,
+    ))])
+    .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -787,7 +701,7 @@ async fn run_in_sandbox_stops_when_reserve_reports_terminal() {
         .await
     });
 
-    server.await.unwrap();
+    server.assert_complete().await;
     wait_gate.notify_one();
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
         .await
@@ -814,13 +728,15 @@ async fn run_in_sandbox_retries_not_written_delivery_with_same_id() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let (api_url, _request_rx, server) = spawn_http_server(vec![http_response(
+    let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
         "200 OK",
-        &format!(
+        format!(
             r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retry exact delivery"}}"#,
-        ),
-    )])
+        )
+        .as_bytes(),
+    ))])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -860,7 +776,7 @@ async fn run_in_sandbox_retries_not_written_delivery_with_same_id() {
         .unwrap()
         .unwrap();
     assert!(result.failure.is_none());
-    server.await.unwrap();
+    server.assert_complete().await;
     let calls = overrides.process_control_calls();
     assert_eq!(calls.len(), 2);
     assert!(calls.iter().all(|call| call.message_id == DELIVERY_ID));
@@ -887,13 +803,15 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let (api_url, _request_rx, server) = spawn_http_server(vec![http_response(
+    let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
         "200 OK",
-        &format!(
+        format!(
             r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retry guest backpressure"}}"#,
-        ),
-    )])
+        )
+        .as_bytes(),
+    ))])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -933,7 +851,7 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
         .unwrap()
         .unwrap();
     assert!(result.failure.is_none());
-    server.await.unwrap();
+    server.assert_complete().await;
     let calls = overrides.process_control_calls();
     assert_eq!(calls.len(), 3);
     assert!(calls.iter().all(|call| call.message_id == DELIVERY_ID));
@@ -959,18 +877,20 @@ async fn run_in_sandbox_suppresses_possibly_written_delivery() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
-    let reserve = http_response(
+    let reserve = json_response(
         "200 OK",
-        &format!(
+        format!(
             r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"uncertain delivery"}}"#,
-        ),
+        )
+        .as_bytes(),
     );
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        reserve.clone(),
-        reserve,
-        http_response("200 OK", r#"{"outcome":"empty"}"#),
+    let mut server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(reserve.clone()),
+        RawHttpAction::Respond(reserve),
+        RawHttpAction::Respond(json_response("200 OK", br#"{"outcome":"empty"}"#)),
     ])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -998,7 +918,6 @@ async fn run_in_sandbox_suppresses_possibly_written_delivery() {
         )
         .await
     }));
-    let mut server = Some(server);
     let deadline = tokio::time::Instant::now() + RUN_IN_SANDBOX_TEST_TIMEOUT;
 
     let scenario = async {
@@ -1013,18 +932,18 @@ async fn run_in_sandbox_suppresses_possibly_written_delivery() {
         if !process_control_observed {
             return Err("timed out waiting for the first process-control delivery attempt".into());
         }
-        receive_http_request_before(deadline, &mut request_rx, "the first reserve request").await?;
+        receive_http_request_before(deadline, &mut server, "the first reserve request").await?;
         notifications.notify(run_id);
         receive_http_request_before(
             deadline,
-            &mut request_rx,
+            &mut server,
             "the second reserve request after the first notification",
         )
         .await?;
         notifications.notify(run_id);
         receive_http_request_before(
             deadline,
-            &mut request_rx,
+            &mut server,
             "the third reserve request after the second notification",
         )
         .await?;
@@ -1041,16 +960,6 @@ async fn run_in_sandbox_suppresses_possibly_written_delivery() {
             .map_err(|error| format!("runner task failed: {error}"))?
             .map_err(|error| format!("run_in_sandbox failed: {error}"))?;
 
-        let Some(server_handle) = server.as_mut() else {
-            return Err("active-input server task ownership was lost before completion".into());
-        };
-        let server_outcome = tokio::time::timeout_at(deadline, server_handle)
-            .await
-            .map_err(|_| {
-                "timed out waiting for the active-input server task to finish".to_string()
-            })?;
-        server.take();
-        server_outcome.map_err(|error| format!("active-input server task failed: {error}"))?;
         Ok::<_, String>(result)
     }
     .await;
@@ -1060,14 +969,8 @@ async fn run_in_sandbox_suppresses_possibly_written_delivery() {
         Err(error) => {
             cancel.cancel();
             wait_gate.notify_one();
-            if let Some(server) = server.as_ref() {
-                server.abort();
-            }
-            let (run_cleanup, server_cleanup) = tokio::join!(
-                reap_spawned_test_task(run_task.take(), "runner"),
-                reap_spawned_test_task(server.take(), "active-input server"),
-            );
-            let cleanup_errors = [run_cleanup, server_cleanup]
+            server.cancel().await;
+            let cleanup_errors = [reap_spawned_test_task(run_task.take(), "runner").await]
                 .into_iter()
                 .flatten()
                 .collect::<Vec<_>>();
@@ -1077,6 +980,7 @@ async fn run_in_sandbox_suppresses_possibly_written_delivery() {
             panic!("{error}; cleanup errors: {}", cleanup_errors.join("; "));
         }
     };
+    server.assert_complete().await;
     assert!(result.failure.is_none());
     let calls = overrides.process_control_calls();
     assert_eq!(calls.len(), 1);
@@ -1103,16 +1007,21 @@ async fn run_in_sandbox_carries_failed_journal_receipt_to_completion() {
     let reserve_path = format!("/api/runners/runs/{run_id}/active-inputs/reserve");
     let receipt_path =
         format!("/api/runners/runs/{run_id}/active-inputs/deliveries/{DELIVERY_ID}/receipt");
-    let (api_url, mut request_rx, server) = spawn_http_server(vec![
-        http_response(
+    let mut server = RawHttpTestServer::spawn(vec![
+        RawHttpAction::Respond(json_response(
             "200 OK",
-            &format!(
+            format!(
                 r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"recover receipt"}}"#,
-            ),
-        ),
-        http_response("503 Service Unavailable", r#"{"error":"transient"}"#),
+            )
+            .as_bytes(),
+        )),
+        RawHttpAction::Respond(json_response(
+            "503 Service Unavailable",
+            br#"{"error":"transient"}"#,
+        )),
     ])
     .await;
+    let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
         api_url,
@@ -1156,9 +1065,9 @@ async fn run_in_sandbox_carries_failed_journal_receipt_to_completion() {
         result.active_input_delivery_ids,
         vec![DELIVERY_ID.to_string()]
     );
-    server.await.unwrap();
-    let first_request = request_rx.recv().await.unwrap();
-    let second_request = request_rx.recv().await.unwrap();
+    server.assert_complete().await;
+    let first_request = server.receive_request_text().await.unwrap();
+    let second_request = server.receive_request_text().await.unwrap();
     assert!(first_request.starts_with(&format!("POST {reserve_path} ")));
     assert!(second_request.starts_with(&format!("POST {receipt_path} ")));
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1481,10 +1481,7 @@ mod tests {
     use super::*;
     use httpmock::Method::POST;
     use httpmock::MockServer;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
-    use tokio::sync::mpsc;
-    use tokio::task::JoinHandle;
     use tracing::{Level, instrument::WithSubscriber};
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
@@ -1494,6 +1491,10 @@ mod tests {
     use crate::provider::{
         ActiveRunnerPreference, RunnerNoPreferenceReason, RunnerPreference,
         RunnerPreferenceRemovalReason, RunnerPreferenceTier,
+    };
+    use crate::test_fixtures::raw_http::{
+        RawHttpAction, RawHttpTestServer, accept_raw_http_request_text, json_response,
+        status_response, write_raw_http_response,
     };
 
     const RUNNER_CLAIM_RESPONSE_FIXTURE: &str = include_str!(
@@ -1829,101 +1830,6 @@ mod tests {
         provider.direct_candidates.push(candidate).await;
     }
 
-    async fn read_http_request(socket: &mut tokio::net::TcpStream) {
-        let _ = read_http_request_text(socket).await;
-    }
-
-    async fn read_http_request_text(socket: &mut tokio::net::TcpStream) -> String {
-        let mut request = Vec::new();
-        let mut buf = [0_u8; 1024];
-        let header_end = loop {
-            let n = socket.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break request.len();
-            }
-            request.extend_from_slice(&buf[..n]);
-            if let Some(header_end) = request
-                .windows(4)
-                .position(|window| window == b"\r\n\r\n")
-                .map(|position| position + 4)
-            {
-                break header_end;
-            }
-        };
-        let headers = String::from_utf8_lossy(&request[..header_end]);
-        let content_length = headers
-            .lines()
-            .find_map(|line| {
-                let (name, value) = line.split_once(':')?;
-                if name.eq_ignore_ascii_case("content-length") {
-                    value.trim().parse::<usize>().ok()
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(0);
-        let request_len = header_end + content_length;
-        loop {
-            if request.len() >= request_len {
-                break;
-            }
-            let n = socket.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break;
-            }
-            request.extend_from_slice(&buf[..n]);
-        }
-        String::from_utf8_lossy(&request).into_owned()
-    }
-
-    async fn write_http_status_response(socket: &mut tokio::net::TcpStream, status: u16) {
-        let reason = match status {
-            200 => "OK",
-            500 => "Internal Server Error",
-            _ => "Unknown",
-        };
-        let body = if status == 200 { "ok" } else { "failed" };
-        let response = format!(
-            "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        socket.write_all(response.as_bytes()).await.unwrap();
-    }
-
-    async fn write_json_response(socket: &mut tokio::net::TcpStream, body: &str) {
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        socket.write_all(response.as_bytes()).await.unwrap();
-    }
-
-    async fn complete_sequence_server(
-        statuses: Vec<u16>,
-    ) -> (String, mpsc::UnboundedReceiver<String>, JoinHandle<()>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let (request_tx, request_rx) = mpsc::unbounded_channel();
-        let server_task = tokio::spawn(async move {
-            for status in statuses {
-                let (mut socket, _) = listener.accept().await.unwrap();
-                let request = read_http_request_text(&mut socket).await;
-                write_http_status_response(&mut socket, status).await;
-                request_tx.send(request).unwrap();
-            }
-        });
-        (api_url, request_rx, server_task)
-    }
-
-    async fn next_request(requests: &mut mpsc::UnboundedReceiver<String>) -> String {
-        requests
-            .recv()
-            .await
-            .expect("complete request should reach the server")
-    }
-
     fn assert_complete_authorization(request: &str, token: &str) {
         let expected = format!("authorization: Bearer {token}");
         assert!(
@@ -1948,11 +1854,8 @@ mod tests {
 
     #[tokio::test]
     async fn heartbeat_send_failure_logs_transport_and_state_context_without_secrets() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let server_task = tokio::spawn(async move {
-            let (_socket, _) = listener.accept().await.unwrap();
-        });
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+        let api_url = server.url();
         let provider = api_provider_for_test(
             api_url.clone(),
             CancellationToken::new(),
@@ -1961,8 +1864,7 @@ mod tests {
         let state = heartbeat_state_for_test();
 
         let (_, events) = capture_api_provider_events(provider.heartbeat(&state)).await;
-        server_task.abort();
-        let _ = server_task.await;
+        server.assert_complete().await;
         let event = captured_event(&events, "heartbeat failed");
 
         assert_eq!(event.level, Level::WARN);
@@ -2008,22 +1910,19 @@ mod tests {
 
     #[tokio::test]
     async fn heartbeat_status_failure_logs_held_state_counts_without_body() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let server_task = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut socket).await;
-            write_http_status_response(&mut socket, 500).await;
-        });
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(status_response(
+            "500 Internal Server Error",
+        ))])
+        .await;
         let provider = api_provider_for_test(
-            api_url,
+            server.url(),
             CancellationToken::new(),
             Arc::new(PollWakeups::new(false)),
         );
         let state = heartbeat_state_for_test();
 
         let (_, events) = capture_api_provider_events(provider.heartbeat(&state)).await;
-        server_task.await.unwrap();
+        server.assert_complete().await;
         let event = captured_event(&events, "heartbeat failed");
 
         assert_eq!(event.level, Level::WARN);
@@ -2331,7 +2230,7 @@ mod tests {
         assert!(body["telemetry"].get("pollReason").is_none());
     }
 
-    async fn write_poll_job_response(socket: &mut tokio::net::TcpStream, run_id: RunId) {
+    fn poll_job_response(run_id: RunId) -> Vec<u8> {
         let body = serde_json::json!({
             "job": {
                 "runId": run_id,
@@ -2339,38 +2238,33 @@ mod tests {
             }
         })
         .to_string();
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        socket.write_all(response.as_bytes()).await.unwrap();
+        json_response("200 OK", body.as_bytes())
+    }
+
+    async fn write_poll_job_response(socket: &mut tokio::net::TcpStream, run_id: RunId) {
+        write_raw_http_response(socket, &poll_job_response(run_id))
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
     async fn discover_cancel_aborts_in_flight_poll() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
-        let server_task = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let mut buf = [0_u8; 1024];
-            let _ = socket.read(&mut buf).await;
-            let _ = accepted_tx.send(());
-            std::future::pending::<()>().await;
-        });
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Stall]).await;
 
         let cancel = CancellationToken::new();
-        let provider =
-            api_provider_for_test(api_url, cancel.clone(), Arc::new(PollWakeups::new(false)));
+        let provider = api_provider_for_test(
+            server.url(),
+            cancel.clone(),
+            Arc::new(PollWakeups::new(false)),
+        );
 
         let provider_for_discover = Arc::clone(&provider);
         let discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
 
-        tokio::time::timeout(Duration::from_secs(1), accepted_rx)
+        tokio::time::timeout(Duration::from_secs(1), server.receive_request())
             .await
             .expect("poll request should reach the server")
-            .unwrap();
+            .expect("poll request should be captured");
 
         cancel.cancel();
 
@@ -2380,8 +2274,7 @@ mod tests {
             .unwrap();
         assert!(result.is_none());
 
-        server_task.abort();
-        let _ = server_task.await;
+        server.cancel().await;
     }
 
     #[tokio::test]
@@ -2903,32 +2796,21 @@ mod tests {
 
     #[tokio::test]
     async fn transient_claim_failure_repolls_when_cooldown_expires_during_excluded_poll() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
         let run_id: RunId = RUNNER_CLAIM_RESPONSE_FIXTURE_RUN_ID.parse().unwrap();
-        let (request_tx, mut requests) = mpsc::unbounded_channel();
-        let server_task = tokio::spawn(async move {
-            let (mut first_claim, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut first_claim).await;
-            write_http_status_response(&mut first_claim, 503).await;
-            request_tx.send(request).unwrap();
-
-            let (mut excluded_poll, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut excluded_poll).await;
-            request_tx.send(request).unwrap();
-            tokio::time::sleep(CLAIM_TRANSIENT_COOLDOWN + Duration::from_millis(50)).await;
-            write_json_response(&mut excluded_poll, r#"{"job":null}"#).await;
-
-            let (mut retry_poll, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut retry_poll).await;
-            write_poll_job_response(&mut retry_poll, run_id).await;
-            request_tx.send(request).unwrap();
-
-            let (mut second_claim, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut second_claim).await;
-            write_json_response(&mut second_claim, RUNNER_CLAIM_RESPONSE_FIXTURE).await;
-            request_tx.send(request).unwrap();
-        });
+        let release_excluded_poll = Arc::new(tokio::sync::Notify::new());
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Respond(status_response("503 Service Unavailable")),
+            RawHttpAction::WaitThenRespond {
+                release: Arc::clone(&release_excluded_poll),
+                response: json_response("200 OK", br#"{"job":null}"#),
+            },
+            RawHttpAction::Respond(poll_job_response(run_id)),
+            RawHttpAction::Respond(json_response(
+                "200 OK",
+                RUNNER_CLAIM_RESPONSE_FIXTURE.as_bytes(),
+            )),
+        ])
+        .await;
         let wakeups = Arc::new(PollWakeups::new(true));
         let initial_poll = wakeups
             .wait_for_poll_due(&CancellationToken::new(), POLL_SLOW, POLL_FAST)
@@ -2938,7 +2820,7 @@ mod tests {
             .record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY)
             .await;
         let provider =
-            api_provider_for_test(api_url, CancellationToken::new(), Arc::clone(&wakeups));
+            api_provider_for_test(server.url(), CancellationToken::new(), Arc::clone(&wakeups));
         push_direct_candidate_for_test(
             &provider,
             DirectJobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string()),
@@ -2947,29 +2829,31 @@ mod tests {
 
         let direct = provider.discover().await.unwrap();
         assert!(provider.claim(direct).await.is_none());
-        let first_claim_request = next_request(&mut requests).await;
+        let first_claim_request = server.receive_request_text().await.unwrap();
         assert!(first_claim_request.contains(&format!("/api/runners/jobs/{run_id}/claim")));
 
         let provider_for_discover = Arc::clone(&provider);
         let discover_task =
             tokio::spawn(async move { provider_for_discover.discover().await.unwrap() });
-        let excluded_poll_request = next_request(&mut requests).await;
+        let excluded_poll_request = server.receive_request_text().await.unwrap();
         assert!(excluded_poll_request.contains(r#""excludedRunIds":["#));
         assert!(excluded_poll_request.contains(&run_id.to_string()));
         assert!(
-            tokio::time::timeout(Duration::from_millis(100), requests.recv())
+            tokio::time::timeout(Duration::from_millis(100), server.receive_request_text())
                 .await
                 .is_err(),
             "claim retry must wait for its transient cooldown"
         );
+        tokio::time::sleep(CLAIM_TRANSIENT_COOLDOWN + Duration::from_millis(50)).await;
+        release_excluded_poll.notify_one();
 
         let retry_poll_request = tokio::time::timeout(
             CLAIM_TRANSIENT_COOLDOWN + Duration::from_secs(1),
-            requests.recv(),
+            server.receive_request_text(),
         )
         .await
         .expect("runner should poll after the transient cooldown")
-        .expect("request channel should remain open");
+        .expect("retry poll should be captured");
         assert!(!retry_poll_request.contains(r#""excludedRunIds""#));
         let retry_candidate = tokio::time::timeout(Duration::from_secs(1), discover_task)
             .await
@@ -2982,36 +2866,24 @@ mod tests {
                 .expect("retry claim should receive its response")
                 .is_some()
         );
-        let second_claim_request = tokio::time::timeout(Duration::from_secs(1), requests.recv())
-            .await
-            .expect("retry claim request should reach the server")
-            .expect("request channel should remain open");
+        let second_claim_request =
+            tokio::time::timeout(Duration::from_secs(1), server.receive_request_text())
+                .await
+                .expect("retry claim request should reach the server")
+                .expect("retry claim should be captured");
         assert!(second_claim_request.contains(&format!("/api/runners/jobs/{run_id}/claim")));
 
-        tokio::time::timeout(Duration::from_secs(1), server_task)
-            .await
-            .expect("transient sequence server should finish")
-            .unwrap();
-        assert!(requests.recv().await.is_none());
+        server.assert_complete().await;
     }
 
     #[tokio::test]
     async fn old_api_returning_excluded_run_does_not_rediscover_it() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
         let run_id: RunId = "00000000-0000-0000-0000-00000000001a".parse().unwrap();
-        let (request_tx, mut requests) = mpsc::unbounded_channel();
-        let server_task = tokio::spawn(async move {
-            let (mut claim, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut claim).await;
-            write_http_status_response(&mut claim, 400).await;
-            request_tx.send(request).unwrap();
-
-            let (mut ignored_exclusion_poll, _) = listener.accept().await.unwrap();
-            let request = read_http_request_text(&mut ignored_exclusion_poll).await;
-            write_poll_job_response(&mut ignored_exclusion_poll, run_id).await;
-            request_tx.send(request).unwrap();
-        });
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Respond(status_response("400 Bad Request")),
+            RawHttpAction::Respond(poll_job_response(run_id)),
+        ])
+        .await;
         let wakeups = Arc::new(PollWakeups::new(true));
         let initial_poll = wakeups
             .wait_for_poll_due(&CancellationToken::new(), POLL_SLOW, POLL_FAST)
@@ -3021,7 +2893,7 @@ mod tests {
             .record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY)
             .await;
         let cancel = CancellationToken::new();
-        let provider = api_provider_for_test(api_url, cancel.clone(), Arc::clone(&wakeups));
+        let provider = api_provider_for_test(server.url(), cancel.clone(), Arc::clone(&wakeups));
         push_direct_candidate_for_test(
             &provider,
             DirectJobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string()),
@@ -3030,12 +2902,12 @@ mod tests {
 
         let direct = provider.discover().await.unwrap();
         assert!(provider.claim(direct).await.is_none());
-        let claim_request = next_request(&mut requests).await;
+        let claim_request = server.receive_request_text().await.unwrap();
         assert!(claim_request.contains(&format!("/api/runners/jobs/{run_id}/claim")));
 
         let provider_for_discover = Arc::clone(&provider);
         let mut discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
-        let ignored_exclusion_request = next_request(&mut requests).await;
+        let ignored_exclusion_request = server.receive_request_text().await.unwrap();
         assert!(ignored_exclusion_request.contains(r#""excludedRunIds":["#));
         assert!(ignored_exclusion_request.contains(&run_id.to_string()));
         assert!(
@@ -3044,12 +2916,10 @@ mod tests {
                 .is_err(),
             "an excluded run returned by an old API must not be rediscovered"
         );
-        assert!(requests.try_recv().is_err());
+        server.assert_complete().await;
 
         cancel.cancel();
         assert!(discover_task.await.unwrap().is_none());
-        server_task.await.unwrap();
-        assert!(requests.recv().await.is_none());
     }
 
     #[tokio::test]
@@ -3190,14 +3060,12 @@ mod tests {
         let (poll_accepted_tx, poll_accepted_rx) = tokio::sync::oneshot::channel();
         let (release_first_poll_tx, release_first_poll_rx) = tokio::sync::oneshot::channel();
         let server_task = tokio::spawn(async move {
-            let (mut first_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut first_socket).await;
+            let (first_socket, _) = accept_raw_http_request_text(&listener).await;
             let _ = poll_accepted_tx.send(());
             release_first_poll_rx.await.unwrap();
             drop(first_socket);
 
-            let (mut second_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut second_socket).await;
+            let (mut second_socket, _) = accept_raw_http_request_text(&listener).await;
             write_poll_job_response(&mut second_socket, poll_run_id).await;
         });
         let provider = api_provider_for_test(
@@ -3244,38 +3112,31 @@ mod tests {
 
     #[tokio::test]
     async fn discover_defers_job_return_when_deferred_poll_arrives_during_poll() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
         let first_run_id: RunId = "00000000-0000-0000-0000-000000000004".parse().unwrap();
         let second_run_id: RunId = "00000000-0000-0000-0000-000000000005".parse().unwrap();
-        let (first_accepted_tx, first_accepted_rx) = tokio::sync::oneshot::channel();
-        let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
-        let server_task = tokio::spawn(async move {
-            let (mut first_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut first_socket).await;
-            let _ = first_accepted_tx.send(());
-            release_first_rx.await.unwrap();
-            write_poll_job_response(&mut first_socket, first_run_id).await;
-            drop(first_socket);
-
-            let (mut second_socket, _) = listener.accept().await.unwrap();
-            read_http_request(&mut second_socket).await;
-            write_poll_job_response(&mut second_socket, second_run_id).await;
-        });
+        let release_first = Arc::new(tokio::sync::Notify::new());
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::WaitThenRespond {
+                release: Arc::clone(&release_first),
+                response: poll_job_response(first_run_id),
+            },
+            RawHttpAction::Respond(poll_job_response(second_run_id)),
+        ])
+        .await;
         let wakeups = Arc::new(PollWakeups::new(false));
         let provider =
-            api_provider_for_test(api_url, CancellationToken::new(), Arc::clone(&wakeups));
+            api_provider_for_test(server.url(), CancellationToken::new(), Arc::clone(&wakeups));
         let provider_for_discover = Arc::clone(&provider);
         let discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
 
-        tokio::time::timeout(Duration::from_secs(1), first_accepted_rx)
+        tokio::time::timeout(Duration::from_secs(1), server.receive_request())
             .await
             .expect("first poll should reach the server")
-            .unwrap();
+            .expect("first poll should be captured");
         wakeups
             .request_deferred_poll_after_for_test(Duration::ZERO)
             .await;
-        release_first_tx.send(()).unwrap();
+        release_first.notify_one();
 
         let discovered = tokio::time::timeout(Duration::from_secs(1), discover_task)
             .await
@@ -3285,7 +3146,7 @@ mod tests {
 
         assert_eq!(discovered.run_id(), second_run_id);
         assert_eq!(discovered.profile_name(), "vm0/default");
-        server_task.await.unwrap();
+        server.assert_complete().await;
     }
 
     #[tokio::test]
@@ -4498,10 +4359,13 @@ mod tests {
 
     #[tokio::test]
     async fn api_provider_complete_does_not_retry_permanent_http_failure() {
-        let (api_url, mut requests, server_task) = complete_sequence_server(vec![400]).await;
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(status_response(
+            "400 Bad Request",
+        ))])
+        .await;
         let run_id = RunId::nil();
         let provider = api_provider_for_test(
-            api_url,
+            server.url(),
             CancellationToken::new(),
             Arc::new(PollWakeups::new(false)),
         );
@@ -4519,13 +4383,9 @@ mod tests {
         .await
         .expect("permanent completion failure should not wait for the retry delay");
 
-        let request = next_request(&mut requests).await;
+        let request = server.receive_request_text().await.unwrap();
         assert_complete_authorization(&request, "sandbox-token");
-        server_task.await.unwrap();
-        assert!(
-            requests.recv().await.is_none(),
-            "permanent completion failure should send one request"
-        );
+        server.assert_complete().await;
 
         let run_id = run_id.to_string();
         assert_eq!(
@@ -4554,11 +4414,14 @@ mod tests {
             StatusCode::TOO_MANY_REQUESTS,
             StatusCode::INTERNAL_SERVER_ERROR,
         ] {
-            let (api_url, mut requests, server_task) =
-                complete_sequence_server(vec![status.as_u16(), 200]).await;
+            let mut server = RawHttpTestServer::spawn(vec![
+                RawHttpAction::Respond(status_response(&status.to_string())),
+                RawHttpAction::Respond(status_response("200 OK")),
+            ])
+            .await;
             let run_id = RunId::nil();
             let provider = api_provider_for_test(
-                api_url,
+                server.url(),
                 CancellationToken::new(),
                 Arc::new(PollWakeups::new(false)),
             );
@@ -4571,41 +4434,32 @@ mod tests {
                     .await;
             });
 
-            let first_request = next_request(&mut requests).await;
+            let first_request = server.receive_request_text().await.unwrap();
             assert_complete_authorization(&first_request, "sandbox-token");
             tokio::task::yield_now().await;
             assert!(
-                requests.try_recv().is_err(),
+                server.try_receive_request_text().unwrap().is_none(),
                 "status {status} should wait before the retry"
             );
             tokio::time::advance(Duration::from_secs(2)).await;
-            let second_request = next_request(&mut requests).await;
+            let second_request = server.receive_request_text().await.unwrap();
             assert_complete_authorization(&second_request, "sandbox-token");
 
             complete_task.await.unwrap();
-            server_task.await.unwrap();
+            server.assert_complete().await;
         }
     }
 
     #[tokio::test(start_paused = true)]
     async fn api_provider_complete_retries_transport_failure() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let (request_tx, mut requests) = mpsc::unbounded_channel();
-        let server_task = tokio::spawn(async move {
-            let (mut first_socket, _) = listener.accept().await.unwrap();
-            let first_request = read_http_request_text(&mut first_socket).await;
-            drop(first_socket);
-            request_tx.send(first_request).unwrap();
-
-            let (mut second_socket, _) = listener.accept().await.unwrap();
-            let second_request = read_http_request_text(&mut second_socket).await;
-            write_http_status_response(&mut second_socket, 200).await;
-            request_tx.send(second_request).unwrap();
-        });
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Disconnect,
+            RawHttpAction::Respond(status_response("200 OK")),
+        ])
+        .await;
         let run_id = RunId::nil();
         let provider = api_provider_for_test(
-            api_url,
+            server.url(),
             CancellationToken::new(),
             Arc::new(PollWakeups::new(false)),
         );
@@ -4618,19 +4472,19 @@ mod tests {
                 .await;
         });
 
-        let first_request = next_request(&mut requests).await;
+        let first_request = server.receive_request_text().await.unwrap();
         assert_complete_authorization(&first_request, "sandbox-token");
         tokio::task::yield_now().await;
         assert!(
-            requests.try_recv().is_err(),
+            server.try_receive_request_text().unwrap().is_none(),
             "transport failure should wait before the retry"
         );
         tokio::time::advance(Duration::from_secs(2)).await;
-        let second_request = next_request(&mut requests).await;
+        let second_request = server.receive_request_text().await.unwrap();
         assert_complete_authorization(&second_request, "sandbox-token");
 
         complete_task.await.unwrap();
-        server_task.await.unwrap();
+        server.assert_complete().await;
     }
 
     #[tokio::test(start_paused = true)]
@@ -4661,10 +4515,14 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn api_provider_complete_stops_after_two_transient_failures() {
-        let (api_url, mut requests, server_task) = complete_sequence_server(vec![500, 500]).await;
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Respond(status_response("500 Internal Server Error")),
+            RawHttpAction::Respond(status_response("500 Internal Server Error")),
+        ])
+        .await;
         let run_id = RunId::nil();
         let provider = api_provider_for_test(
-            api_url,
+            server.url(),
             CancellationToken::new(),
             Arc::new(PollWakeups::new(false)),
         );
@@ -4685,7 +4543,7 @@ mod tests {
 
         let first_request = tokio::select! {
             () = &mut completion => panic!("completion should wait before the retry"),
-            request = next_request(&mut requests) => request,
+            request = server.receive_request_text() => request.unwrap(),
         };
         assert_complete_authorization(&first_request, "sandbox-token");
         // Establish the retry timer before advancing paused time.
@@ -4707,18 +4565,15 @@ mod tests {
         })
         .await;
         assert!(
-            requests.try_recv().is_err(),
+            server.try_receive_request_text().unwrap().is_none(),
             "completion should wait before the retry"
         );
 
         tokio::time::advance(Duration::from_secs(2)).await;
-        let ((), second_request) = tokio::join!(&mut completion, next_request(&mut requests));
+        let ((), second_request) = tokio::join!(&mut completion, server.receive_request_text());
+        let second_request = second_request.unwrap();
         assert_complete_authorization(&second_request, "sandbox-token");
-        server_task.await.unwrap();
-        assert!(
-            requests.recv().await.is_none(),
-            "completion should stop after the retry"
-        );
+        server.assert_complete().await;
 
         let events = captured.entries();
         let run_id = run_id.to_string();

--- a/crates/runner/src/provider/connector_runtime_sync.rs
+++ b/crates/runner/src/provider/connector_runtime_sync.rs
@@ -1680,7 +1680,7 @@ mod tests {
 
     use httpmock::{Method::POST, MockServer};
     use serde_json::json;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::io::AsyncReadExt;
     use tokio::net::TcpListener;
     use tracing::instrument::WithSubscriber;
     use tracing_subscriber::prelude::*;
@@ -1688,6 +1688,10 @@ mod tests {
 
     use crate::http::{HttpClient, HttpClientConfig};
     use crate::proxy::{ProxyRegistryHandle, VmRegistration};
+    use crate::test_fixtures::raw_http::{
+        RawHttpAction, RawHttpTestServer, accept_raw_http_request_text, json_response,
+        write_raw_http_response,
+    };
     use crate::types::{Firewall, FirewallApi, FirewallAuth, FirewallEntry};
 
     fn api_client_for_url(api_url: String) -> ApiClient {
@@ -1759,47 +1763,6 @@ mod tests {
 
     fn api_client_for_server(server: &MockServer) -> ApiClient {
         api_client_for_url(server.base_url())
-    }
-
-    async fn accept_http_request(listener: &TcpListener) -> (tokio::net::TcpStream, String) {
-        let (mut socket, _) = listener.accept().await.unwrap();
-        let mut request = Vec::new();
-        let mut buf = [0_u8; 1024];
-        let header_end = loop {
-            let n = socket.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break request.len();
-            }
-            request.extend_from_slice(&buf[..n]);
-            if let Some(header_end) = request
-                .windows(4)
-                .position(|window| window == b"\r\n\r\n")
-                .map(|position| position + 4)
-            {
-                break header_end;
-            }
-        };
-        let headers = String::from_utf8_lossy(&request[..header_end]);
-        let content_length = headers
-            .lines()
-            .find_map(|line| {
-                let (name, value) = line.split_once(':')?;
-                if name.eq_ignore_ascii_case("content-length") {
-                    value.trim().parse::<usize>().ok()
-                } else {
-                    None
-                }
-            })
-            .expect("request should include a valid Content-Length header");
-        let request_len = header_end + content_length;
-        while request.len() < request_len {
-            let n = socket.read(&mut buf).await.unwrap();
-            if n == 0 {
-                break;
-            }
-            request.extend_from_slice(&buf[..n]);
-        }
-        (socket, String::from_utf8_lossy(&request).into_owned())
     }
 
     fn assert_connector_runtime_sync_request(request: &str, run_id: &RunId) {
@@ -2429,13 +2392,7 @@ mod tests {
             }],
         })
         .to_string();
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        socket
-            .write_all(response.as_bytes())
+        write_raw_http_response(socket, &json_response("200 OK", body.as_bytes()))
             .await
             .expect("connector runtime sync response should be written");
     }
@@ -2448,13 +2405,7 @@ mod tests {
             },
         })
         .to_string();
-        let response = format!(
-            "HTTP/1.1 409 Conflict\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        socket
-            .write_all(response.as_bytes())
+        write_raw_http_response(socket, &json_response("409 Conflict", body.as_bytes()))
             .await
             .expect("terminal connector runtime response should be written");
     }
@@ -2492,7 +2443,7 @@ mod tests {
         let (verify_shutdown_tx, verify_shutdown_rx) = tokio::sync::oneshot::channel();
         let mut server_tasks = tokio::task::JoinSet::new();
         server_tasks.spawn(async move {
-            let (mut socket, request) = accept_http_request(&listener).await;
+            let (mut socket, request) = accept_raw_http_request_text(&listener).await;
             request_received_tx
                 .send(())
                 .expect("request receiver should remain available");
@@ -2503,12 +2454,9 @@ mod tests {
                     "connectorSlug": "slack",
                 }))
                 .to_string();
-                let response = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                    body.len(),
-                    body
-                );
-                let _ = socket.write_all(response.as_bytes()).await;
+                let _ =
+                    write_raw_http_response(&mut socket, &json_response("200 OK", body.as_bytes()))
+                        .await;
                 return (request, None);
             }
 
@@ -2612,10 +2560,12 @@ mod tests {
         handle
             .notify_connector_runtime_sync(run_a, builtin_target("slack"))
             .await;
-        let (mut run_a_socket, run_a_request) =
-            tokio::time::timeout(Duration::from_secs(1), accept_http_request(&listener))
-                .await
-                .expect("run A should reach the API");
+        let (mut run_a_socket, run_a_request) = tokio::time::timeout(
+            Duration::from_secs(1),
+            accept_raw_http_request_text(&listener),
+        )
+        .await
+        .expect("run A should reach the API");
         assert_connector_runtime_sync_request(&run_a_request, &run_a);
 
         handle
@@ -2628,10 +2578,12 @@ mod tests {
             .notify_connector_runtime_sync(run_b, builtin_target("slack"))
             .await;
 
-        let (mut run_b_socket, run_b_request) =
-            tokio::time::timeout(Duration::from_secs(1), accept_http_request(&listener))
-                .await
-                .expect("run B should bypass stalled run A");
+        let (mut run_b_socket, run_b_request) = tokio::time::timeout(
+            Duration::from_secs(1),
+            accept_raw_http_request_text(&listener),
+        )
+        .await
+        .expect("run B should bypass stalled run A");
         assert_connector_runtime_sync_request(&run_b_request, &run_b);
         write_connector_runtime_sync_response(&mut run_b_socket, &["run-b:read"]).await;
         drop(run_b_socket);
@@ -2650,10 +2602,12 @@ mod tests {
 
         write_connector_runtime_sync_response(&mut run_a_socket, &["stale:read"]).await;
         drop(run_a_socket);
-        let (mut run_a_follow_up_socket, run_a_follow_up_request) =
-            tokio::time::timeout(Duration::from_secs(1), accept_http_request(&listener))
-                .await
-                .expect("run A follow-up should start after its first request completes");
+        let (mut run_a_follow_up_socket, run_a_follow_up_request) = tokio::time::timeout(
+            Duration::from_secs(1),
+            accept_raw_http_request_text(&listener),
+        )
+        .await
+        .expect("run A follow-up should start after its first request completes");
         assert_connector_runtime_sync_request(&run_a_follow_up_request, &run_a);
         write_connector_runtime_sync_response(&mut run_a_follow_up_socket, &["new:read"]).await;
         drop(run_a_follow_up_socket);
@@ -2684,10 +2638,12 @@ mod tests {
         let mut stalled = Vec::new();
         let mut accepted_runs = HashSet::new();
         for _ in 0..SYNC_REQUEST_CONCURRENCY {
-            let (socket, request) =
-                tokio::time::timeout(Duration::from_secs(1), accept_http_request(&listener))
-                    .await
-                    .expect("an admitted run should reach the API");
+            let (socket, request) = tokio::time::timeout(
+                Duration::from_secs(1),
+                accept_raw_http_request_text(&listener),
+            )
+            .await
+            .expect("an admitted run should reach the API");
             let run_id = *run_ids
                 .iter()
                 .find(|run_id| {
@@ -2713,10 +2669,12 @@ mod tests {
         let (mut released_socket, _released_request) = stalled.remove(0);
         write_connector_runtime_sync_response(&mut released_socket, &["released:read"]).await;
         drop(released_socket);
-        let (fifth_socket, fifth_request) =
-            tokio::time::timeout(Duration::from_secs(1), accept_http_request(&listener))
-                .await
-                .expect("a waiting run should start after a slot is released");
+        let (fifth_socket, fifth_request) = tokio::time::timeout(
+            Duration::from_secs(1),
+            accept_raw_http_request_text(&listener),
+        )
+        .await
+        .expect("a waiting run should start after a slot is released");
         let fifth_run = *run_ids
             .iter()
             .find(|run_id| {
@@ -2761,10 +2719,12 @@ mod tests {
         handle
             .notify_connector_runtime_sync(run_id, builtin_target("slack"))
             .await;
-        let (mut old_socket, old_request) =
-            tokio::time::timeout(Duration::from_secs(1), accept_http_request(&listener))
-                .await
-                .expect("old registration should reach the API");
+        let (mut old_socket, old_request) = tokio::time::timeout(
+            Duration::from_secs(1),
+            accept_raw_http_request_text(&listener),
+        )
+        .await
+        .expect("old registration should reach the API");
         assert_connector_runtime_sync_request(&old_request, &run_id);
 
         handle
@@ -2782,10 +2742,12 @@ mod tests {
             .expect("old request socket should remain readable");
         assert_eq!(old_closed, 0);
 
-        let (mut new_socket, new_request) =
-            tokio::time::timeout(Duration::from_secs(1), accept_http_request(&listener))
-                .await
-                .expect("new registration should not wait for the old request timeout");
+        let (mut new_socket, new_request) = tokio::time::timeout(
+            Duration::from_secs(1),
+            accept_raw_http_request_text(&listener),
+        )
+        .await
+        .expect("new registration should not wait for the old request timeout");
         assert_connector_runtime_sync_request(&new_request, &run_id);
         write_connector_runtime_sync_response(&mut new_socket, &["new-registration:read"]).await;
         drop(new_socket);
@@ -2822,10 +2784,12 @@ mod tests {
         handle
             .notify_connector_runtime_sync(run_id, builtin_target("slack"))
             .await;
-        let (mut socket, request) =
-            tokio::time::timeout(Duration::from_secs(1), accept_http_request(&listener))
-                .await
-                .expect("terminal sync should reach the API");
+        let (mut socket, request) = tokio::time::timeout(
+            Duration::from_secs(1),
+            accept_raw_http_request_text(&listener),
+        )
+        .await
+        .expect("terminal sync should reach the API");
         assert_connector_runtime_sync_request(&request, &run_id);
         write_terminal_connector_runtime_sync_response(&mut socket).await;
         drop(socket);
@@ -2883,10 +2847,12 @@ mod tests {
                 .await
             })
         };
-        let (mut old_socket, old_request) =
-            tokio::time::timeout(Duration::from_secs(1), accept_http_request(&listener))
-                .await
-                .expect("old registration should reach the API");
+        let (mut old_socket, old_request) = tokio::time::timeout(
+            Duration::from_secs(1),
+            accept_raw_http_request_text(&listener),
+        )
+        .await
+        .expect("old registration should reach the API");
         assert_connector_runtime_sync_request(&old_request, &run_id);
 
         let (_new_dir, new_registry) = register_slack_run(&handle, run_id).await;
@@ -2949,10 +2915,12 @@ mod tests {
                 .await
             })
         };
-        let (mut old_socket, old_request) =
-            tokio::time::timeout(Duration::from_secs(1), accept_http_request(&listener))
-                .await
-                .expect("old registration should reach the API");
+        let (mut old_socket, old_request) = tokio::time::timeout(
+            Duration::from_secs(1),
+            accept_raw_http_request_text(&listener),
+        )
+        .await
+        .expect("old registration should reach the API");
         assert_connector_runtime_sync_request(&old_request, &run_id);
 
         let (_new_dir, new_registry) = register_slack_run(&handle, run_id).await;
@@ -4748,82 +4716,58 @@ mod tests {
 
     #[tokio::test]
     async fn newer_notification_survives_older_in_flight_sync() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
         let run_id = RunId::nil();
+        let release_first = Arc::new(tokio::sync::Notify::new());
+        let first_body = json!({
+            "results": [{
+                "target": { "kind": "builtin", "connectorSlug": "slack" },
+                "state": "available",
+                "networkPolicy": {
+                    "allow": ["old:read"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                },
+            }],
+        })
+        .to_string();
+        let second_body = json!({
+            "results": [{
+                "target": { "kind": "builtin", "connectorSlug": "slack" },
+                "state": "available",
+                "networkPolicy": {
+                    "allow": ["new:read"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                },
+            }],
+        })
+        .to_string();
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::WaitThenRespond {
+                release: Arc::clone(&release_first),
+                response: json_response("200 OK", first_body.as_bytes()),
+            },
+            RawHttpAction::Respond(json_response("200 OK", second_body.as_bytes())),
+        ])
+        .await;
         let harness = ConnectorRuntimeSyncHarness::new_with_api(
-            api_client_for_url(api_url),
+            api_client_for_url(server.url()),
             run_id,
             &["slack"],
         )
         .await;
-        let (first_received_tx, first_received_rx) = tokio::sync::oneshot::channel();
-        let (release_first_tx, release_first_rx) = tokio::sync::oneshot::channel();
-        let server_task = tokio::spawn(async move {
-            let (mut first_socket, first_request) = accept_http_request(&listener).await;
-            first_received_tx
-                .send(())
-                .expect("first request receiver should remain available");
-            release_first_rx
-                .await
-                .expect("first response should be released");
-            let first_body = json!({
-                "results": [{
-                    "target": { "kind": "builtin", "connectorSlug": "slack" },
-                    "state": "available",
-                    "networkPolicy": {
-                        "allow": ["old:read"],
-                        "deny": [],
-                        "ask": [],
-                        "unknownPolicy": "allow",
-                    },
-                }],
-            })
-            .to_string();
-            let first_response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                first_body.len(),
-                first_body
-            );
-            first_socket
-                .write_all(first_response.as_bytes())
-                .await
-                .unwrap();
-
-            let (mut second_socket, second_request) = accept_http_request(&listener).await;
-            let second_body = json!({
-                "results": [{
-                    "target": { "kind": "builtin", "connectorSlug": "slack" },
-                    "state": "available",
-                    "networkPolicy": {
-                        "allow": ["new:read"],
-                        "deny": [],
-                        "ask": [],
-                        "unknownPolicy": "allow",
-                    },
-                }],
-            })
-            .to_string();
-            let second_response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                second_body.len(),
-                second_body
-            );
-            second_socket
-                .write_all(second_response.as_bytes())
-                .await
-                .unwrap();
-            [first_request, second_request]
-        });
 
         harness
             .handle
             .notify_connector_runtime_sync(run_id, builtin_target("slack"))
             .await;
-        tokio::time::timeout(Duration::from_secs(1), first_received_rx)
-            .await
-            .expect("first refresh should reach the API")
-            .expect("first request sender should remain available");
+        let first_request =
+            tokio::time::timeout(Duration::from_secs(1), server.receive_request_text())
+                .await
+                .expect("first refresh should reach the API")
+                .expect("first request should be captured");
 
         harness
             .handle
@@ -4835,20 +4779,19 @@ mod tests {
                 .generation,
             2
         );
-        release_first_tx
-            .send(())
-            .expect("first response receiver should remain available");
+        release_first.notify_one();
 
+        let second_request = server
+            .receive_request_text()
+            .await
+            .expect("second request should be captured");
         let policy = wait_until_slack_policy(&harness.registry_path, |policy| {
             policy["allow"] == json!(["new:read"])
         })
         .await;
         assert_eq!(policy["unknownPolicy"], json!("allow"));
-        let requests = tokio::time::timeout(Duration::from_secs(1), server_task)
-            .await
-            .expect("both generations should reach the API")
-            .expect("API task should succeed");
-        for request in &requests {
+        server.assert_complete().await;
+        for request in [&first_request, &second_request] {
             assert_connector_runtime_sync_request(request, &run_id);
         }
         let active_runs = harness.handle.core.inner.active_runs.lock().await;
@@ -4867,17 +4810,7 @@ mod tests {
 
     #[tokio::test]
     async fn transport_connector_runtime_sync_error_retries_and_recovers() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
         let run_id = RunId::nil();
-        let harness = ConnectorRuntimeSyncHarness::new_with_api(
-            api_client_for_url(api_url),
-            run_id,
-            &["slack"],
-        )
-        .await;
-        let registry_path = harness.registry_path.clone();
-        let source_ip = harness.source_ip.clone();
         let response_body = json!({
             "results": [{
                 "target": { "kind": "builtin", "connectorSlug": "slack" },
@@ -4892,11 +4825,32 @@ mod tests {
             }],
         })
         .to_string();
-        let server_task = tokio::spawn(async move {
-            let (first_socket, first_request) = accept_http_request(&listener).await;
-            drop(first_socket);
-
-            let (mut second_socket, second_request) = accept_http_request(&listener).await;
+        let release_response = Arc::new(tokio::sync::Notify::new());
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Disconnect,
+            RawHttpAction::WaitThenRespond {
+                release: Arc::clone(&release_response),
+                response: json_response("200 OK", response_body.as_bytes()),
+            },
+        ])
+        .await;
+        let harness = ConnectorRuntimeSyncHarness::new_with_api(
+            api_client_for_url(server.url()),
+            run_id,
+            &["slack"],
+        )
+        .await;
+        let registry_path = harness.registry_path.clone();
+        let source_ip = harness.source_ip.clone();
+        let server_flow = async {
+            let first_request = server
+                .receive_request_text()
+                .await
+                .expect("first request should be captured");
+            let second_request = server
+                .receive_request_text()
+                .await
+                .expect("second request should be captured");
             let registry_json: serde_json::Value = serde_json::from_str(
                 &tokio::fs::read_to_string(&registry_path)
                     .await
@@ -4905,26 +4859,17 @@ mod tests {
             .expect("registry should be valid JSON before retry response");
             let policy_before_retry_response =
                 registry_json["vms"][&source_ip]["networkPolicies"]["slack"].clone();
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                response_body.len(),
-                response_body
-            );
-            second_socket.write_all(response.as_bytes()).await.unwrap();
+            release_response.notify_one();
+            server.assert_complete().await;
             (first_request, second_request, policy_before_retry_response)
-        });
+        };
 
-        let (_, events) = tokio::time::timeout(
-            Duration::from_secs(1),
-            capture_sync_events(harness.sync_slack()),
-        )
-        .await
-        .expect("connector runtime sync retry should complete");
-        let (first_request, second_request, policy_before_retry_response) =
-            tokio::time::timeout(Duration::from_secs(1), server_task)
-                .await
-                .expect("connector runtime sync server should finish")
-                .expect("connector runtime sync server task should succeed");
+        let ((_, events), (first_request, second_request, policy_before_retry_response)) =
+            tokio::time::timeout(Duration::from_secs(1), async {
+                tokio::join!(capture_sync_events(harness.sync_slack()), server_flow)
+            })
+            .await
+            .expect("connector runtime sync retry and server should complete");
 
         assert_connector_runtime_sync_request(&first_request, &run_id);
         assert_connector_runtime_sync_request(&second_request, &run_id);
@@ -4982,34 +4927,24 @@ mod tests {
 
     #[tokio::test]
     async fn persistent_transport_failure_retains_policy_and_scheduled_retry_recovers() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
         let run_id = RunId::nil();
-        let harness = ConnectorRuntimeSyncHarness::new_with_api(
-            api_client_for_url(api_url),
-            run_id,
-            &["slack"],
-        )
-        .await;
         let response_body = connector_runtime_sync_response(json!({
             "kind": "builtin",
             "connectorSlug": "slack",
         }))
         .to_string();
-        let server_task = tokio::spawn(async move {
-            let (first_socket, first_request) = accept_http_request(&listener).await;
-            drop(first_socket);
-            let (second_socket, second_request) = accept_http_request(&listener).await;
-            drop(second_socket);
-            let (mut third_socket, third_request) = accept_http_request(&listener).await;
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                response_body.len(),
-                response_body
-            );
-            third_socket.write_all(response.as_bytes()).await.unwrap();
-            [first_request, second_request, third_request]
-        });
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Disconnect,
+            RawHttpAction::Disconnect,
+            RawHttpAction::Respond(json_response("200 OK", response_body.as_bytes())),
+        ])
+        .await;
+        let harness = ConnectorRuntimeSyncHarness::new_with_api(
+            api_client_for_url(server.url()),
+            run_id,
+            &["slack"],
+        )
+        .await;
 
         let (_, events) = tokio::time::timeout(
             Duration::from_secs(1),
@@ -5055,11 +4990,12 @@ mod tests {
         })
         .await;
         assert_eq!(recovered_policy["unknownPolicy"], json!("allow"));
-        let [first_request, second_request, third_request] =
-            tokio::time::timeout(Duration::from_secs(1), server_task)
-                .await
-                .expect("connector runtime sync server should finish after scheduled retry")
-                .expect("connector runtime sync server task should succeed");
+        server.assert_complete().await;
+        let [first_request, second_request, third_request] = [
+            server.receive_request_text().await.unwrap(),
+            server.receive_request_text().await.unwrap(),
+            server.receive_request_text().await.unwrap(),
+        ];
         for request in [&first_request, &second_request, &third_request] {
             assert_connector_runtime_sync_request(request, &run_id);
         }

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3395,6 +3395,10 @@ mod tests {
     use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
     use crate::storage_manifest::{ArtifactEntry, StorageEntry, StorageManifest};
     use crate::storage_plan::build_storage_plan;
+    use crate::test_fixtures::raw_http::{
+        RawHttpAction, RawHttpTestServer, accept_raw_http_request_text, json_response,
+        raw_http_response, status_response, write_raw_http_response,
+    };
 
     const CACHE_TEST_RUNTIME_DIR: &str = "/tmp/storage-cache-test-runtime";
 
@@ -3871,38 +3875,6 @@ mod tests {
         }
     }
 
-    async fn raw_http_url(
-        response: Vec<u8>,
-    ) -> (String, tokio::task::JoinHandle<std::io::Result<()>>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let handle = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await?;
-            let mut request = [0u8; 1024];
-            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
-            socket.write_all(&response).await?;
-            Ok(())
-        });
-        (format!("http://{addr}/archive.tar.gz"), handle)
-    }
-
-    async fn raw_http_sequence_url(
-        responses: Vec<Vec<u8>>,
-    ) -> (String, tokio::task::JoinHandle<std::io::Result<()>>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let handle = tokio::spawn(async move {
-            for response in responses {
-                let (mut socket, _) = listener.accept().await?;
-                let mut request = [0u8; 1024];
-                let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
-                socket.write_all(&response).await?;
-            }
-            Ok(())
-        });
-        (format!("http://{addr}/archive.tar.gz"), handle)
-    }
-
     struct GatedArchiveServer {
         url: String,
         requests: tokio::sync::mpsc::Receiver<usize>,
@@ -3924,14 +3896,13 @@ mod tests {
         let task = tokio::spawn(async move {
             let mut handlers = JoinSet::new();
             for index in 0..connections {
-                let (mut socket, _) = listener.accept().await?;
+                let (mut socket, _) = accept_raw_http_request_text(&listener).await;
                 let body = body.clone();
                 let request_tx = request_tx.clone();
                 let release = Arc::clone(&task_release);
                 let active = Arc::clone(&task_active);
                 let max_active = Arc::clone(&task_max_active);
                 handlers.spawn(async move {
-                    let _ = read_http_request(&mut socket).await;
                     let current = active.fetch_add(1, Ordering::SeqCst) + 1;
                     max_active.fetch_max(current, Ordering::SeqCst);
                     request_tx.send(index).await.map_err(|_| {
@@ -3940,7 +3911,8 @@ mod tests {
                     let permit = release.acquire_owned().await.map_err(|_| {
                         io::Error::new(io::ErrorKind::BrokenPipe, "release semaphore closed")
                     })?;
-                    socket.write_all(&ok_response(&body)).await?;
+                    write_raw_http_response(&mut socket, &raw_http_response("200 OK", &body))
+                        .await?;
                     drop(permit);
                     active.fetch_sub(1, Ordering::SeqCst);
                     Ok::<(), io::Error>(())
@@ -3960,88 +3932,6 @@ mod tests {
         }
     }
 
-    async fn telemetry_capture_server(
-        expected_requests: usize,
-    ) -> (String, tokio::task::JoinHandle<Vec<String>>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let task = tokio::spawn(async move {
-            let mut requests = Vec::with_capacity(expected_requests);
-            for _ in 0..expected_requests {
-                let (mut socket, _) = listener.accept().await.unwrap();
-                requests.push(read_http_request(&mut socket).await);
-                socket
-                    .write_all(
-                        concat!(
-                            "HTTP/1.1 200 OK\r\n",
-                            "content-length: 16\r\n",
-                            "content-type: application/json\r\n",
-                            "connection: close\r\n",
-                            "\r\n",
-                            r#"{"success":true}"#
-                        )
-                        .as_bytes(),
-                    )
-                    .await
-                    .unwrap();
-            }
-            requests
-        });
-        (format!("http://{addr}"), task)
-    }
-
-    async fn await_raw_http_sequence(handle: tokio::task::JoinHandle<std::io::Result<()>>) {
-        tokio::time::timeout(Duration::from_secs(5), handle)
-            .await
-            .expect("raw HTTP sequence server should finish")
-            .expect("raw HTTP sequence server task should not panic")
-            .expect("raw HTTP sequence server should not fail");
-    }
-
-    fn http_headers_end(buf: &[u8]) -> Option<usize> {
-        buf.windows(4)
-            .position(|window| window == b"\r\n\r\n")
-            .map(|index| index + 4)
-    }
-
-    fn content_length(headers: &str) -> usize {
-        headers
-            .lines()
-            .filter_map(|line| line.split_once(':'))
-            .find_map(|(name, value)| {
-                name.eq_ignore_ascii_case("content-length")
-                    .then(|| value.trim().parse::<usize>().unwrap())
-            })
-            .unwrap_or(0)
-    }
-
-    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
-        use tokio::io::AsyncReadExt as _;
-
-        let mut buf = Vec::new();
-        let header_end = loop {
-            let mut chunk = [0; 1024];
-            let len = socket.read(&mut chunk).await.unwrap();
-            assert!(len > 0, "connection closed before HTTP headers completed");
-            buf.extend_from_slice(&chunk[..len]);
-
-            if let Some(header_end) = http_headers_end(&buf) {
-                break header_end;
-            }
-        };
-
-        let headers = String::from_utf8_lossy(&buf[..header_end]);
-        let body_len = content_length(&headers);
-        while buf.len() < header_end + body_len {
-            let mut chunk = [0; 1024];
-            let len = socket.read(&mut chunk).await.unwrap();
-            assert!(len > 0, "connection closed before HTTP body completed");
-            buf.extend_from_slice(&chunk[..len]);
-        }
-
-        String::from_utf8(buf).unwrap()
-    }
-
     async fn wait_cached_archive(home: &HomePaths, name: &str, version: &str) -> Vec<u8> {
         let lock_path = home.storage_lock(name, version);
         let path = home.storage_cache_dir(name, version).join("archive.tar.gz");
@@ -4054,22 +3944,11 @@ mod tests {
             .unwrap_or_else(|e| panic!("failed to read cached archive {}: {e}", path.display()))
     }
 
-    fn status_response(status: &str) -> Vec<u8> {
-        format!("HTTP/1.1 {status}\r\nContent-Length: 0\r\n\r\n").into_bytes()
-    }
-
     fn partial_content_response(total: usize) -> Vec<u8> {
         format!(
             "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{total}\r\nContent-Length: 1\r\n\r\nx"
         )
         .into_bytes()
-    }
-
-    fn ok_response(body: &[u8]) -> Vec<u8> {
-        let mut response =
-            format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", body.len()).into_bytes();
-        response.extend_from_slice(body);
-        response
     }
 
     fn background_fill_group(
@@ -4409,7 +4288,8 @@ mod tests {
         response.extend_from_slice(format!("{:x}\r\n", body.len()).as_bytes());
         response.extend_from_slice(&body);
         response.extend_from_slice(b"\r\n0\r\n\r\n");
-        let (url, server_task) = raw_http_url(response).await;
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(response)]).await;
+        let url = format!("{}/archive.tar.gz", server.url());
         let name = "fresh-no-size";
         let version = "v1";
         let mut plan = fresh_storage_plan(url.clone(), name, version);
@@ -4419,7 +4299,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        server_task.await.unwrap().unwrap();
+        server.assert_complete().await;
         assert!(deferred.is_none());
         assert_eq!(storage_archive_url(&plan, 0), Some(url.as_str()));
         assert!(sandbox.write_files_calls().is_empty());
@@ -4657,7 +4537,8 @@ mod tests {
             response.extend_from_slice(format!("{:x}\r\n", delivered.len()).as_bytes());
             response.extend_from_slice(delivered);
             response.extend_from_slice(b"\r\n0\r\n\r\n");
-            let (url, server_task) = raw_http_url(response).await;
+            let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(response)]).await;
+            let url = format!("{}/archive.tar.gz", server.url());
             let mut plan = fresh_storage_plan_with_archive_size(
                 url.clone(),
                 &format!("fresh-{case}"),
@@ -4670,7 +4551,7 @@ mod tests {
                     .await
                     .unwrap();
 
-            server_task.await.unwrap().unwrap();
+            server.assert_complete().await;
             assert!(deferred.is_none(), "case {case}");
             assert_eq!(storage_archive_url(&plan, 0), Some(url.as_str()));
             let ops = telemetry.pending_ops_snapshot();
@@ -5682,20 +5563,10 @@ mod tests {
         let home = home_at(&temp);
         let sandbox = MockSandbox::new("test");
         let mut telemetry = new_telemetry();
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (hit_tx, mut hit_rx) = tokio::sync::oneshot::channel();
-        let server_task = tokio::spawn(async move {
-            if let Ok((mut socket, _)) = listener.accept().await {
-                let _ = hit_tx.send(());
-                let _ = socket
-                    .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n")
-                    .await;
-            }
-        });
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Stall]).await;
         let name = "guarded-miss";
         let version = "v1";
-        let original = format!("http://{addr}/archive.tar.gz");
+        let original = format!("{}/archive.tar.gz", server.url());
         let mut manifest = fresh_storage_plan(original.clone(), name, version);
 
         let deferred = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -5706,11 +5577,10 @@ mod tests {
 
         assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
         assert!(
-            hit_rx.try_recv().is_err(),
+            server.try_receive_request_text().unwrap().is_none(),
             "guarded miss should not contact the archive URL"
         );
-        server_task.abort();
-        let _ = server_task.await;
+        server.cancel().await;
         assert!(!home.storage_cache_dir(name, version).exists());
         assert!(!home.storage_lock(name, version).exists());
         assert!(sandbox.write_file_calls().is_empty());
@@ -5730,30 +5600,18 @@ mod tests {
         let mut telemetry = new_telemetry();
         let body = tarball_bytes();
         let expected_body = body.clone();
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (allow_tx, allow_rx) = tokio::sync::oneshot::channel();
-        let (request_tx, mut request_rx) = tokio::sync::oneshot::channel();
-        let server_task = tokio::spawn(async move {
-            let mut allow_rx = Some(allow_rx);
-            let mut request_tx = Some(request_tx);
-            for response in [partial_content_response(body.len()), ok_response(&body)] {
-                let (mut socket, _) = listener.accept().await?;
-                let mut request = [0u8; 1024];
-                let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
-                if let Some(request_tx) = request_tx.take() {
-                    let _ = request_tx.send(());
-                }
-                if let Some(allow_rx) = allow_rx.take() {
-                    let _ = allow_rx.await;
-                }
-                socket.write_all(&response).await?;
-            }
-            Ok::<(), std::io::Error>(())
-        });
+        let release = Arc::new(tokio::sync::Notify::new());
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::WaitThenRespond {
+                release: Arc::clone(&release),
+                response: partial_content_response(body.len()),
+            },
+            RawHttpAction::Respond(raw_http_response("200 OK", &body)),
+        ])
+        .await;
         let name = "background-miss";
         let version = "v1";
-        let original = format!("http://{addr}/archive.tar.gz");
+        let original = format!("{}/archive.tar.gz", server.url());
         let mut manifest = fresh_storage_plan(original.clone(), name, version);
 
         let deferred = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -5762,10 +5620,7 @@ mod tests {
             .expect("cold miss should return deferred cache fill");
 
         assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
-        assert!(matches!(
-            request_rx.try_recv(),
-            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
-        ));
+        assert!(server.try_receive_request_text().unwrap().is_none());
         assert!(
             !home
                 .storage_cache_dir(name, version)
@@ -5783,12 +5638,12 @@ mod tests {
 
         let coordinator = StorageCacheBackgroundFillCoordinator::new().unwrap();
         deferred.start(&coordinator, &mut telemetry);
-        tokio::time::timeout(Duration::from_secs(5), &mut request_rx)
+        tokio::time::timeout(Duration::from_secs(5), server.receive_request())
             .await
             .expect("started background fill should contact archive server")
-            .expect("archive request sender should remain available");
-        allow_tx.send(()).unwrap();
-        await_raw_http_sequence(server_task).await;
+            .expect("archive request should be captured");
+        release.notify_one();
+        server.assert_complete().await;
         assert_eq!(
             wait_cached_archive(&home, name, version).await,
             expected_body
@@ -5810,20 +5665,10 @@ mod tests {
         let home = home_at(&temp);
         let sandbox = MockSandbox::new("test");
         let mut telemetry = new_telemetry();
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let (request_tx, mut request_rx) = tokio::sync::oneshot::channel();
-        let server_task = tokio::spawn(async move {
-            if let Ok((mut socket, _)) = listener.accept().await {
-                let _ = request_tx.send(());
-                let _ = socket
-                    .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n")
-                    .await;
-            }
-        });
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Stall]).await;
         let name = "dropped-background-miss";
         let version = "v1";
-        let original = format!("http://{addr}/archive.tar.gz");
+        let original = format!("{}/archive.tar.gz", server.url());
         let mut manifest = fresh_storage_plan(original.clone(), name, version);
 
         let deferred = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -5834,10 +5679,7 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
-        assert!(matches!(
-            request_rx.try_recv(),
-            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
-        ));
+        assert!(server.try_receive_request_text().unwrap().is_none());
         assert!(!home.storage_cache_dir(name, version).exists());
         assert!(!home.storage_lock(name, version).exists());
         let ops = telemetry.pending_ops_snapshot();
@@ -5845,8 +5687,7 @@ mod tests {
         assert_no_op(&ops, "storage_cache_background_fill_scheduled_count_1");
         assert_no_op(&ops, STORAGE_CACHE_BACKGROUND_FILL_DEFERRED_DELAY);
 
-        server_task.abort();
-        let _ = server_task.await;
+        server.cancel().await;
     }
 
     #[tokio::test]
@@ -5854,34 +5695,18 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let body = tarball_bytes();
-        let (archive_url, archive_server) = raw_http_sequence_url(vec![
-            partial_content_response(body.len()),
-            ok_response(&body),
+        let mut archive_server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Respond(partial_content_response(body.len())),
+            RawHttpAction::Respond(raw_http_response("200 OK", &body)),
         ])
         .await;
-        let telemetry_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let telemetry_api_url = format!("http://{}", telemetry_listener.local_addr().unwrap());
-        let telemetry_server = tokio::spawn(async move {
-            let (mut socket, _) = telemetry_listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            socket
-                .write_all(
-                    concat!(
-                        "HTTP/1.1 200 OK\r\n",
-                        "content-length: 16\r\n",
-                        "content-type: application/json\r\n",
-                        "connection: close\r\n",
-                        "\r\n",
-                        r#"{"success":true}"#
-                    )
-                    .as_bytes(),
-                )
-                .await
-                .unwrap();
-            request
-        });
+        let archive_url = format!("{}/archive.tar.gz", archive_server.url());
+        let mut telemetry_server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(
+            json_response("200 OK", br#"{"success":true}"#),
+        )])
+        .await;
         let sandbox = MockSandbox::new("test");
-        let mut telemetry = new_telemetry_for_api_url(&telemetry_api_url);
+        let mut telemetry = new_telemetry_for_api_url(&telemetry_server.url());
         let name = "background-report";
         let version = "v1";
         let mut plan = fresh_storage_plan(archive_url, name, version);
@@ -5891,12 +5716,16 @@ mod tests {
             .await
             .start(&coordinator, &mut telemetry);
 
-        await_raw_http_sequence(archive_server).await;
+        archive_server.assert_complete().await;
         assert_eq!(wait_cached_archive(&home, name, version).await, body);
-        let request = tokio::time::timeout(Duration::from_secs(1), telemetry_server)
-            .await
-            .expect("telemetry server should receive background fill payload")
-            .unwrap();
+        let request = tokio::time::timeout(
+            Duration::from_secs(1),
+            telemetry_server.receive_request_text(),
+        )
+        .await
+        .expect("telemetry server should receive background fill payload")
+        .expect("background fill telemetry should be captured");
+        telemetry_server.assert_complete().await;
         assert!(request.contains(r#""action_type":"storage_cache_background_fill_filled""#));
         assert!(
             request.contains(r#""action_type":"storage_cache_background_fill_size_lt_64_kib""#)
@@ -5958,11 +5787,20 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let body = tarball_bytes();
-        let (archive_url, archive_server) = raw_http_sequence_url(vec![ok_response(&body)]).await;
-        let (telemetry_url, telemetry_server) = telemetry_capture_server(2).await;
+        let mut archive_server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(
+            raw_http_response("200 OK", &body),
+        )])
+        .await;
+        let archive_url = format!("{}/archive.tar.gz", archive_server.url());
+        let telemetry_response = json_response("200 OK", br#"{"success":true}"#);
+        let mut telemetry_server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Respond(telemetry_response.clone()),
+            RawHttpAction::Respond(telemetry_response),
+        ])
+        .await;
         let coordinator = StorageCacheBackgroundFillCoordinator::new_with_limits(1, 4).unwrap();
-        let first_reporter = new_telemetry_for_api_url(&telemetry_url).reporter();
-        let second_reporter = new_telemetry_for_api_url(&telemetry_url).reporter();
+        let first_reporter = new_telemetry_for_api_url(&telemetry_server.url()).reporter();
+        let second_reporter = new_telemetry_for_api_url(&telemetry_server.url()).reporter();
         let group =
             background_fill_group(archive_url, "deduplicated", "v1", Some(body.len() as u64));
 
@@ -5975,15 +5813,15 @@ mod tests {
             BackgroundFillAdmission::Deduplicated
         );
 
-        await_raw_http_sequence(archive_server).await;
+        archive_server.assert_complete().await;
         assert_eq!(wait_cached_archive(&home, "deduplicated", "v1").await, body);
         coordinator.shutdown().await;
 
-        let reports = tokio::time::timeout(Duration::from_secs(5), telemetry_server)
-            .await
-            .expect("both deduplicated subscribers should receive terminal telemetry")
-            .expect("telemetry server task should not panic");
-        assert_eq!(reports.len(), 2);
+        telemetry_server.assert_complete().await;
+        let reports = [
+            telemetry_server.receive_request_text().await.unwrap(),
+            telemetry_server.receive_request_text().await.unwrap(),
+        ];
         assert!(reports.iter().all(|request| {
             request.contains(r#""action_type":"storage_cache_background_fill_filled""#)
         }));
@@ -6067,9 +5905,14 @@ mod tests {
         let home = home_at(&temp);
         let body = tarball_bytes();
         let mut server = gated_archive_server(body.clone(), 1).await;
-        let (telemetry_url, telemetry_server) = telemetry_capture_server(2).await;
+        let telemetry_response = json_response("200 OK", br#"{"success":true}"#);
+        let mut telemetry_server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Respond(telemetry_response.clone()),
+            RawHttpAction::Respond(telemetry_response),
+        ])
+        .await;
         let coordinator = StorageCacheBackgroundFillCoordinator::new_with_limits(1, 1).unwrap();
-        let reporter = new_telemetry_for_api_url(&telemetry_url).reporter();
+        let reporter = new_telemetry_for_api_url(&telemetry_server.url()).reporter();
 
         assert_eq!(
             coordinator.submit(
@@ -6126,10 +5969,11 @@ mod tests {
         );
         assert!(!home.storage_cache_dir("shutdown-queued", "v1").exists());
 
-        let reports = tokio::time::timeout(Duration::from_secs(5), telemetry_server)
-            .await
-            .expect("active and queued shutdown outcomes should be reported")
-            .expect("telemetry server task should not panic");
+        telemetry_server.assert_complete().await;
+        let reports = [
+            telemetry_server.receive_request_text().await.unwrap(),
+            telemetry_server.receive_request_text().await.unwrap(),
+        ];
         assert!(reports.iter().any(|request| {
             request.contains(r#""action_type":"storage_cache_background_fill_filled""#)
         }));
@@ -6705,9 +6549,12 @@ mod tests {
         let responses = vec![
             status_response("500 Internal Server Error"),
             partial_content_response(body.len()),
-            ok_response(&body),
+            raw_http_response("200 OK", &body),
         ];
-        let (url, handle) = raw_http_sequence_url(responses).await;
+        let mut server =
+            RawHttpTestServer::spawn(responses.into_iter().map(RawHttpAction::Respond).collect())
+                .await;
+        let url = format!("{}/archive.tar.gz", server.url());
         let name = "probe-retry-success";
         let version = "v1";
         let mut manifest = fresh_storage_plan(url, name, version);
@@ -6716,7 +6563,7 @@ mod tests {
             populate_cache_through_background(&mut manifest, &sandbox, &home, &mut telemetry)
                 .await
                 .unwrap();
-        await_raw_http_sequence(handle).await;
+        server.assert_complete().await;
 
         assert_eq!(
             storage_archive_url(&manifest, 0),
@@ -6812,9 +6659,12 @@ mod tests {
         let responses = vec![
             partial_content_response(body.len()),
             status_response("503 Service Unavailable"),
-            ok_response(&body),
+            raw_http_response("200 OK", &body),
         ];
-        let (url, handle) = raw_http_sequence_url(responses).await;
+        let mut server =
+            RawHttpTestServer::spawn(responses.into_iter().map(RawHttpAction::Respond).collect())
+                .await;
+        let url = format!("{}/archive.tar.gz", server.url());
         let name = "download-retry-success";
         let version = "v1";
         let mut manifest = fresh_storage_plan(url, name, version);
@@ -6823,7 +6673,7 @@ mod tests {
             populate_cache_through_background(&mut manifest, &sandbox, &home, &mut telemetry)
                 .await
                 .unwrap();
-        await_raw_http_sequence(handle).await;
+        server.assert_complete().await;
 
         assert_eq!(
             storage_archive_url(&manifest, 0),
@@ -6847,9 +6697,12 @@ mod tests {
         let responses = vec![
             partial_content_response(body.len()),
             truncated_ok_response(&body),
-            ok_response(&body),
+            raw_http_response("200 OK", &body),
         ];
-        let (url, handle) = raw_http_sequence_url(responses).await;
+        let mut server =
+            RawHttpTestServer::spawn(responses.into_iter().map(RawHttpAction::Respond).collect())
+                .await;
+        let url = format!("{}/archive.tar.gz", server.url());
         let name = "download-body-retry-success";
         let version = "v1";
         let mut manifest = fresh_storage_plan(url, name, version);
@@ -6858,7 +6711,7 @@ mod tests {
             populate_cache_through_background(&mut manifest, &sandbox, &home, &mut telemetry)
                 .await
                 .unwrap();
-        await_raw_http_sequence(handle).await;
+        server.assert_complete().await;
 
         assert_eq!(
             storage_archive_url(&manifest, 0),
@@ -7832,7 +7685,10 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let mut telemetry = new_telemetry();
         let responses = vec![Vec::new(); OBJECT_DOWNLOAD_MAX_ATTEMPTS * 2];
-        let (url, handle) = raw_http_sequence_url(responses).await;
+        let mut server =
+            RawHttpTestServer::spawn(responses.into_iter().map(RawHttpAction::Respond).collect())
+                .await;
+        let url = format!("{}/archive.tar.gz", server.url());
 
         let original = format!("{url}?X-Amz-Signature=secret&X-Amz-Credential=credential");
         let name = "transport-retry-exhausted";
@@ -7848,7 +7704,7 @@ mod tests {
             .await
             .unwrap_err()
             .to_string();
-        await_raw_http_sequence(handle).await;
+        server.assert_complete().await;
 
         assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
         assert!(sandbox.write_file_calls().is_empty());
@@ -7878,9 +7734,7 @@ mod tests {
         let advertised_size = CACHE_MAX_SIZE + 1;
 
         let server_task = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await?;
-            let mut request = [0u8; 1024];
-            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
+            let (mut socket, _) = accept_raw_http_request_text(&listener).await;
             socket
                 .write_all(
                     format!("HTTP/1.1 200 OK\r\nContent-Length: {advertised_size}\r\n\r\n")
@@ -7908,12 +7762,13 @@ mod tests {
     #[tokio::test]
     async fn probe_200_rejects_malformed_content_length() {
         let response = b"HTTP/1.1 200 OK\r\nContent-Length: +7\r\n\r\n".to_vec();
-        let (url, handle) = raw_http_url(response).await;
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(response)]).await;
+        let url = format!("{}/archive.tar.gz", server.url());
 
         let http = Client::builder().build().unwrap();
         let result = probe_size(&http, &url).await;
 
-        handle.await.unwrap().unwrap();
+        server.assert_complete().await;
         match result {
             Ok(SizeProbe::Unknown(SizeProbeUnknown::InvalidSizeHeader)) => {}
             Err(err) => assert!(err.to_string().contains("probe GET"), "got: {err}"),
@@ -7928,7 +7783,8 @@ mod tests {
         let sandbox = MockSandbox::new("test");
         let mut telemetry = new_telemetry();
         let response = b"HTTP/1.1 200 OK\r\nContent-Length: +7\r\n\r\n".to_vec();
-        let (original, handle) = raw_http_url(response).await;
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(response)]).await;
+        let original = format!("{}/archive.tar.gz", server.url());
         let name = "malformed-length";
         let version = "v1";
         let mut manifest = fresh_storage_plan(original.clone(), name, version);
@@ -7938,7 +7794,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        handle.await.unwrap().unwrap();
+        server.assert_complete().await;
         assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
         assert!(
             !home
@@ -8064,9 +7920,7 @@ mod tests {
         let total_size = CACHE_MAX_SIZE;
 
         let server_task = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await?;
-            let mut request = [0u8; 1024];
-            let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
+            let (mut socket, _) = accept_raw_http_request_text(&listener).await;
             socket
                 .write_all(
                     format!(
@@ -8197,15 +8051,14 @@ mod tests {
 
     #[tokio::test]
     async fn download_rejects_stream_without_content_length_over_limit() {
-        let (url, server_task) = raw_http_url(
-            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n4\r\nabcd\r\n3\r\nefg\r\n0\r\n\r\n"
-                .to_vec(),
-        )
-        .await;
+        let response = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n4\r\nabcd\r\n3\r\nefg\r\n0\r\n\r\n"
+            .to_vec();
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(response)]).await;
+        let url = format!("{}/archive.tar.gz", server.url());
         let http = Client::builder().build().unwrap();
 
         let result = download_tarball(&http, &url, Some(6), 6).await.unwrap();
-        server_task.await.unwrap().unwrap();
+        server.assert_complete().await;
 
         match result {
             DownloadBody::Complete(bytes) => {
@@ -8324,22 +8177,6 @@ mod tests {
 
     #[tokio::test]
     async fn multi_group_background_fill_precedes_later_warm_staging() {
-        async fn read_request(socket: &mut tokio::net::TcpStream) -> std::io::Result<String> {
-            let mut request = Vec::new();
-            let mut buf = [0u8; 1024];
-            loop {
-                let n = socket.read(&mut buf).await?;
-                if n == 0 {
-                    break;
-                }
-                request.extend_from_slice(&buf[..n]);
-                if request.windows(4).any(|window| window == b"\r\n\r\n") {
-                    break;
-                }
-            }
-            Ok(String::from_utf8_lossy(&request).into_owned())
-        }
-
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let sandbox = Arc::new(MockSandbox::new("test"));
@@ -8362,8 +8199,8 @@ mod tests {
         let (cold_full_seen_tx, cold_full_seen_rx) = tokio::sync::oneshot::channel::<()>();
 
         let ready_server_task = tokio::spawn(async move {
-            let (mut probe_socket, _) = ready_listener.accept().await?;
-            let probe_request = read_request(&mut probe_socket).await?;
+            let (mut probe_socket, probe_request) =
+                accept_raw_http_request_text(&ready_listener).await;
             assert!(
                 probe_request
                     .to_ascii_lowercase()
@@ -8371,41 +8208,28 @@ mod tests {
                 "expected range probe, got {probe_request:?}"
             );
             let _ = allow_ready_rx.await;
-            probe_socket
-                .write_all(
-                    format!(
-                        "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{}\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
-                        ready_body.len()
-                    )
-                    .as_bytes(),
-                )
-                .await?;
-            drop(probe_socket);
+            write_raw_http_response(
+                &mut probe_socket,
+                &partial_content_response(ready_body.len()),
+            )
+            .await?;
 
-            let (mut full_socket, _) = ready_listener.accept().await?;
-            let full_request = read_request(&mut full_socket).await?;
+            let (mut full_socket, full_request) =
+                accept_raw_http_request_text(&ready_listener).await;
             assert!(
                 !full_request
                     .to_ascii_lowercase()
                     .contains("range: bytes=0-0"),
                 "expected full download, got {full_request:?}"
             );
-            full_socket
-                .write_all(
-                    format!(
-                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                        ready_body.len()
-                    )
-                    .as_bytes(),
-                )
+            write_raw_http_response(&mut full_socket, &raw_http_response("200 OK", &ready_body))
                 .await?;
-            full_socket.write_all(&ready_body).await?;
             Ok::<(), std::io::Error>(())
         });
 
         let cold_server_task = tokio::spawn(async move {
-            let (mut probe_socket, _) = cold_listener.accept().await?;
-            let probe_request = read_request(&mut probe_socket).await?;
+            let (mut probe_socket, probe_request) =
+                accept_raw_http_request_text(&cold_listener).await;
             assert!(
                 probe_request
                     .to_ascii_lowercase()
@@ -8414,35 +8238,22 @@ mod tests {
             );
             let _ = cold_probe_seen_tx.send(());
             let _ = release_cold_probe_rx.await;
-            probe_socket
-                .write_all(
-                    format!(
-                        "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{}\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
-                        cold_body.len()
-                    )
-                    .as_bytes(),
-                )
-                .await?;
-            drop(probe_socket);
+            write_raw_http_response(
+                &mut probe_socket,
+                &partial_content_response(cold_body.len()),
+            )
+            .await?;
 
-            let (mut full_socket, _) = cold_listener.accept().await?;
-            let full_request = read_request(&mut full_socket).await?;
+            let (mut full_socket, full_request) =
+                accept_raw_http_request_text(&cold_listener).await;
             assert!(
                 !full_request
                     .to_ascii_lowercase()
                     .contains("range: bytes=0-0"),
                 "expected full download, got {full_request:?}"
             );
-            full_socket
-                .write_all(
-                    format!(
-                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                        cold_body.len()
-                    )
-                    .as_bytes(),
-                )
+            write_raw_http_response(&mut full_socket, &raw_http_response("200 OK", &cold_body))
                 .await?;
-            full_socket.write_all(&cold_body).await?;
             let _ = cold_full_seen_tx.send(());
             Ok::<(), std::io::Error>(())
         });

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -504,8 +504,11 @@ async fn send_telemetry(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::http::HttpClientConfig;
+    use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, json_response};
     use crate::types::{
         ResumeSessionHistoryDownloadSource, ResumeSessionHistoryEncoding, ResumeSessionHistoryRef,
         ResumeSessionHistoryRefKind,
@@ -534,50 +537,6 @@ mod tests {
             encoded_size: 16 * 1024,
             download_source: Some(ResumeSessionHistoryDownloadSource::ConfiguredPublicEndpoint),
         })
-    }
-
-    fn http_headers_end(buf: &[u8]) -> Option<usize> {
-        buf.windows(4)
-            .position(|window| window == b"\r\n\r\n")
-            .map(|index| index + 4)
-    }
-
-    fn content_length(headers: &str) -> usize {
-        headers
-            .lines()
-            .filter_map(|line| line.split_once(':'))
-            .find_map(|(name, value)| {
-                name.eq_ignore_ascii_case("content-length")
-                    .then(|| value.trim().parse::<usize>().unwrap())
-            })
-            .unwrap_or(0)
-    }
-
-    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
-        use tokio::io::AsyncReadExt;
-
-        let mut buf = Vec::new();
-        let header_end = loop {
-            let mut chunk = [0; 1024];
-            let len = socket.read(&mut chunk).await.unwrap();
-            assert!(len > 0, "connection closed before HTTP headers completed");
-            buf.extend_from_slice(&chunk[..len]);
-
-            if let Some(header_end) = http_headers_end(&buf) {
-                break header_end;
-            }
-        };
-
-        let headers = String::from_utf8_lossy(&buf[..header_end]);
-        let body_len = content_length(&headers);
-        while buf.len() < header_end + body_len {
-            let mut chunk = [0; 1024];
-            let len = socket.read(&mut chunk).await.unwrap();
-            assert!(len > 0, "connection closed before HTTP body completed");
-            buf.extend_from_slice(&chunk[..len]);
-        }
-
-        String::from_utf8(buf).unwrap()
     }
 
     #[test]
@@ -951,34 +910,15 @@ mod tests {
     #[tokio::test]
     async fn flush_waits_for_in_flight_auto_flush_after_buffer_is_drained() {
         use futures_util::FutureExt;
-        use tokio::io::AsyncWriteExt;
 
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let (request_tx, request_rx) = tokio::sync::oneshot::channel();
-        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
-        let server = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            request_tx.send(request).unwrap();
-            release_rx.await.unwrap();
-            socket
-                .write_all(
-                    concat!(
-                        "HTTP/1.1 200 OK\r\n",
-                        "content-length: 16\r\n",
-                        "content-type: application/json\r\n",
-                        "connection: close\r\n",
-                        "\r\n",
-                        r#"{"success":true}"#
-                    )
-                    .as_bytes(),
-                )
-                .await
-                .unwrap();
-        });
+        let release = Arc::new(tokio::sync::Notify::new());
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::WaitThenRespond {
+            release: Arc::clone(&release),
+            response: json_response("200 OK", br#"{"success":true}"#),
+        }])
+        .await;
 
-        let http = http_client_for_api_url(&api_url);
+        let http = http_client_for_api_url(&server.url());
         let mut telemetry = JobTelemetry::new(
             http,
             RunId::nil(),
@@ -993,10 +933,10 @@ mod tests {
         assert!(telemetry.pending_ops_snapshot().is_empty());
         assert_eq!(telemetry.in_flight_flushes.len(), 1);
 
-        let request = tokio::time::timeout(Duration::from_secs(1), request_rx)
+        let request = tokio::time::timeout(Duration::from_secs(1), server.receive_request_text())
             .await
             .expect("auto flush request should reach the server")
-            .unwrap();
+            .expect("auto flush request should be captured");
         assert!(request.starts_with("POST /api/webhooks/agent/telemetry "));
         assert!(
             request
@@ -1013,44 +953,23 @@ mod tests {
             "flush returned before the held auto-flush response completed"
         );
 
-        release_tx.send(()).unwrap();
+        release.notify_one();
         tokio::time::timeout(Duration::from_secs(1), flush)
             .await
             .expect("flush should complete after the response is released");
-        tokio::time::timeout(Duration::from_secs(1), server)
-            .await
-            .expect("server should exit")
-            .unwrap();
+        server.assert_complete().await;
     }
 
     #[tokio::test]
     async fn detached_reporter_sends_sandbox_operations_payload() {
-        use tokio::io::AsyncWriteExt;
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let server = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            socket
-                .write_all(
-                    concat!(
-                        "HTTP/1.1 200 OK\r\n",
-                        "content-length: 16\r\n",
-                        "content-type: application/json\r\n",
-                        "connection: close\r\n",
-                        "\r\n",
-                        r#"{"success":true}"#
-                    )
-                    .as_bytes(),
-                )
-                .await
-                .unwrap();
-            request
-        });
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
+            "200 OK",
+            br#"{"success":true}"#,
+        ))])
+        .await;
 
         let telemetry = JobTelemetry::new(
-            http_client_for_api_url(&api_url),
+            http_client_for_api_url(&server.url()),
             RunId::nil(),
             "tok".to_string(),
             "test-runner".to_string(),
@@ -1066,10 +985,11 @@ mod tests {
             )])
             .await;
 
-        let request = tokio::time::timeout(Duration::from_secs(1), server)
+        let request = tokio::time::timeout(Duration::from_secs(1), server.receive_request_text())
             .await
             .expect("server should receive reporter request")
-            .unwrap();
+            .expect("reporter request should be captured");
+        server.assert_complete().await;
         assert!(request.starts_with("POST /api/webhooks/agent/telemetry "));
         assert!(
             request
@@ -1084,32 +1004,14 @@ mod tests {
 
     #[tokio::test]
     async fn required_runner_name_is_sent_by_direct_reporter() {
-        use tokio::io::AsyncWriteExt;
-
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        let server = tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let request = read_http_request(&mut socket).await;
-            socket
-                .write_all(
-                    concat!(
-                        "HTTP/1.1 200 OK\r\n",
-                        "content-length: 16\r\n",
-                        "content-type: application/json\r\n",
-                        "connection: close\r\n",
-                        "\r\n",
-                        r#"{"success":true}"#
-                    )
-                    .as_bytes(),
-                )
-                .await
-                .unwrap();
-            request
-        });
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
+            "200 OK",
+            br#"{"success":true}"#,
+        ))])
+        .await;
 
         let telemetry = JobTelemetry::new(
-            http_client_for_api_url(&api_url),
+            http_client_for_api_url(&server.url()),
             RunId::nil(),
             "tok".to_string(),
             "v0.168.14".to_string(),
@@ -1124,10 +1026,11 @@ mod tests {
             )])
             .await;
 
-        let request = tokio::time::timeout(Duration::from_secs(1), server)
+        let request = tokio::time::timeout(Duration::from_secs(1), server.receive_request_text())
             .await
             .expect("server should receive configured reporter request")
-            .unwrap();
+            .expect("configured reporter request should be captured");
+        server.assert_complete().await;
         assert!(request.contains(r#""runnerName":"v0.168.14"#));
     }
 }

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -2,4 +2,5 @@ pub(crate) mod execution_context;
 pub(crate) mod firewall_base_url_contract;
 pub(crate) mod http_body;
 pub(crate) mod ignored_child;
+pub(crate) mod raw_http;
 pub(crate) mod session_history;

--- a/crates/runner/src/test_fixtures/raw_http.rs
+++ b/crates/runner/src/test_fixtures/raw_http.rs
@@ -1,0 +1,509 @@
+use std::future::{Future, pending};
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Notify, mpsc};
+use tokio::task::JoinHandle;
+
+const RAW_HTTP_FIXTURE_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_RAW_HTTP_REQUEST_BYTES: usize = 1024 * 1024;
+
+pub(crate) enum RawHttpAction {
+    Respond(Vec<u8>),
+    Disconnect,
+    WaitThenRespond {
+        release: Arc<Notify>,
+        response: Vec<u8>,
+    },
+    Stall,
+}
+
+pub(crate) struct RawHttpTestServer {
+    url: String,
+    requests: mpsc::Receiver<Vec<u8>>,
+    task: Option<JoinHandle<io::Result<()>>>,
+}
+
+impl RawHttpTestServer {
+    pub(crate) async fn spawn(actions: Vec<RawHttpAction>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("raw HTTP fixture should bind a loopback listener");
+        let address = listener
+            .local_addr()
+            .expect("raw HTTP fixture should have a local address");
+        let (request_tx, request_rx) = mpsc::channel(actions.len().max(1));
+        let task = tokio::spawn(serve_actions(listener, actions, request_tx));
+
+        Self {
+            url: format!("http://{address}"),
+            requests: request_rx,
+            task: Some(task),
+        }
+    }
+
+    pub(crate) fn url(&self) -> String {
+        self.url.clone()
+    }
+
+    pub(crate) async fn receive_request(&mut self) -> io::Result<Vec<u8>> {
+        match tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, self.requests.recv()).await {
+            Ok(Some(request)) => Ok(request),
+            Ok(None) => Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "raw HTTP fixture request channel closed",
+            )),
+            Err(_) => Err(timeout_error("receiving a captured raw HTTP request")),
+        }
+    }
+
+    pub(crate) async fn receive_request_text(&mut self) -> io::Result<String> {
+        String::from_utf8(self.receive_request().await?)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    }
+
+    pub(crate) fn try_receive_request_text(&mut self) -> io::Result<Option<String>> {
+        match self.requests.try_recv() {
+            Ok(request) => String::from_utf8(request)
+                .map(Some)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error)),
+            Err(mpsc::error::TryRecvError::Empty) => Ok(None),
+            Err(mpsc::error::TryRecvError::Disconnected) => Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "raw HTTP fixture request channel closed",
+            )),
+        }
+    }
+
+    pub(crate) async fn assert_complete(&mut self) {
+        let mut task = self
+            .task
+            .take()
+            .expect("raw HTTP fixture task should be present");
+        match tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, &mut task).await {
+            Ok(result) => assert_task_succeeded(result),
+            Err(_) => {
+                task.abort();
+                reap_aborted_task(task).await;
+                panic!("raw HTTP fixture should finish within five seconds");
+            }
+        }
+    }
+
+    pub(crate) async fn cancel(&mut self) {
+        let task = self
+            .task
+            .take()
+            .expect("raw HTTP fixture task should be present");
+        task.abort();
+        reap_aborted_task(task).await;
+    }
+}
+
+impl Drop for RawHttpTestServer {
+    fn drop(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+pub(crate) async fn read_raw_http_request(socket: &mut TcpStream) -> io::Result<Vec<u8>> {
+    with_io_timeout(
+        "reading a complete raw HTTP request",
+        read_raw_http_request_inner(socket),
+    )
+    .await
+}
+
+pub(crate) async fn read_raw_http_request_text(socket: &mut TcpStream) -> io::Result<String> {
+    String::from_utf8(read_raw_http_request(socket).await?)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+pub(crate) async fn accept_raw_http_request(
+    listener: &TcpListener,
+) -> io::Result<(TcpStream, Vec<u8>)> {
+    with_io_timeout("accepting a complete raw HTTP request", async {
+        let (mut socket, _) = listener.accept().await?;
+        let request = read_raw_http_request_inner(&mut socket).await?;
+        Ok((socket, request))
+    })
+    .await
+}
+
+pub(crate) async fn accept_raw_http_request_text(listener: &TcpListener) -> (TcpStream, String) {
+    let (socket, request) = accept_raw_http_request(listener)
+        .await
+        .expect("raw HTTP fixture should accept a complete request");
+    let request = String::from_utf8(request).expect("raw HTTP fixture request should be UTF-8");
+    (socket, request)
+}
+
+pub(crate) fn raw_http_response(status: &str, body: &[u8]) -> Vec<u8> {
+    response_bytes(status, None, body)
+}
+
+pub(crate) fn json_response(status: &str, body: &[u8]) -> Vec<u8> {
+    response_bytes(status, Some("application/json"), body)
+}
+
+pub(crate) fn status_response(status: &str) -> Vec<u8> {
+    raw_http_response(status, &[])
+}
+
+pub(crate) async fn write_raw_http_response(
+    socket: &mut TcpStream,
+    response: &[u8],
+) -> io::Result<()> {
+    with_io_timeout(
+        "writing a raw HTTP response",
+        write_raw_http_response_inner(socket, response),
+    )
+    .await
+}
+
+async fn serve_actions(
+    listener: TcpListener,
+    actions: Vec<RawHttpAction>,
+    request_tx: mpsc::Sender<Vec<u8>>,
+) -> io::Result<()> {
+    for action in actions {
+        let (mut socket, _) = listener.accept().await?;
+        let request = read_raw_http_request_inner(&mut socket).await?;
+        request_tx.send(request).await.map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "raw HTTP fixture request receiver was dropped",
+            )
+        })?;
+
+        match action {
+            RawHttpAction::Respond(response) => {
+                write_raw_http_response_inner(&mut socket, &response).await?
+            }
+            RawHttpAction::Disconnect => {}
+            RawHttpAction::WaitThenRespond { release, response } => {
+                release.notified().await;
+                write_raw_http_response_inner(&mut socket, &response).await?;
+            }
+            RawHttpAction::Stall => pending::<()>().await,
+        }
+    }
+    Ok(())
+}
+
+async fn write_raw_http_response_inner(socket: &mut TcpStream, response: &[u8]) -> io::Result<()> {
+    socket.write_all(response).await?;
+    socket.shutdown().await
+}
+
+async fn read_raw_http_request_inner(socket: &mut TcpStream) -> io::Result<Vec<u8>> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    let header_end = loop {
+        let read = socket.read(&mut buffer).await?;
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "connection closed before raw HTTP headers completed",
+            ));
+        }
+        request.extend_from_slice(&buffer[..read]);
+        if request.len() > MAX_RAW_HTTP_REQUEST_BYTES {
+            return Err(request_too_large_error());
+        }
+        if let Some(header_end) = request
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|position| position + 4)
+        {
+            break header_end;
+        }
+    };
+
+    let body_length = content_length(&request[..header_end])?;
+    let request_length = header_end
+        .checked_add(body_length)
+        .ok_or_else(request_too_large_error)?;
+    if request_length > MAX_RAW_HTTP_REQUEST_BYTES {
+        return Err(request_too_large_error());
+    }
+    while request.len() < request_length {
+        let read = socket.read(&mut buffer).await?;
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "connection closed before raw HTTP body completed",
+            ));
+        }
+        request.extend_from_slice(&buffer[..read]);
+        if request.len() > MAX_RAW_HTTP_REQUEST_BYTES {
+            return Err(request_too_large_error());
+        }
+    }
+    request.truncate(request_length);
+    Ok(request)
+}
+
+fn content_length(headers: &[u8]) -> io::Result<usize> {
+    let headers = std::str::from_utf8(headers)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    for line in headers.lines() {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.eq_ignore_ascii_case("content-length") {
+            let value = value.trim();
+            if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "raw HTTP Content-Length must contain only decimal digits",
+                ));
+            }
+            return value
+                .parse::<usize>()
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
+        }
+    }
+    Ok(0)
+}
+
+fn response_bytes(status: &str, content_type: Option<&str>, body: &[u8]) -> Vec<u8> {
+    let content_type = content_type
+        .map(|value| format!("Content-Type: {value}\r\n"))
+        .unwrap_or_default();
+    let mut response = format!(
+        "HTTP/1.1 {status}\r\n{content_type}Content-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    response.extend_from_slice(body);
+    response
+}
+
+async fn with_io_timeout<T>(
+    context: &'static str,
+    future: impl Future<Output = io::Result<T>>,
+) -> io::Result<T> {
+    tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, future)
+        .await
+        .map_err(|_| timeout_error(context))?
+}
+
+fn timeout_error(context: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!("timed out while {context}"),
+    )
+}
+
+fn request_too_large_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("raw HTTP request exceeds {MAX_RAW_HTTP_REQUEST_BYTES} bytes"),
+    )
+}
+
+fn assert_task_succeeded(result: Result<io::Result<()>, tokio::task::JoinError>) {
+    result
+        .expect("raw HTTP fixture task should not panic")
+        .expect("raw HTTP fixture should not fail");
+}
+
+async fn reap_aborted_task(task: JoinHandle<io::Result<()>>) {
+    match tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, task).await {
+        Ok(Err(error)) if error.is_cancelled() => {}
+        Ok(result) => assert_task_succeeded(result),
+        Err(_) => panic!("raw HTTP fixture task should be reaped after cancellation"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn connected_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let client = TcpStream::connect(address);
+        let server = listener.accept();
+        let (client, server) = tokio::join!(client, server);
+        let (server, _) = server.unwrap();
+        (client.unwrap(), server)
+    }
+
+    async fn connect_fixture(server: &RawHttpTestServer) -> TcpStream {
+        let url = server.url();
+        TcpStream::connect(url.trim_start_matches("http://"))
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn captures_complete_request_and_responds() {
+        let response = json_response("200 OK", br#"{"ok":true}"#);
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(response)]).await;
+        let mut client = connect_fixture(&server).await;
+        let request = b"POST /events HTTP/1.1\r\nContent-Length: 4\r\n\r\ntest";
+        client.write_all(request).await.unwrap();
+
+        assert_eq!(
+            server.receive_request_text().await.unwrap(),
+            String::from_utf8(request.to_vec()).unwrap()
+        );
+        let mut received_response = Vec::new();
+        client.read_to_end(&mut received_response).await.unwrap();
+        assert_eq!(
+            received_response,
+            json_response("200 OK", br#"{"ok":true}"#)
+        );
+        server.assert_complete().await;
+    }
+
+    #[tokio::test]
+    async fn rejects_premature_header_eof() {
+        let (mut client, mut server) = connected_pair().await;
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: test")
+            .await
+            .unwrap();
+        client.shutdown().await.unwrap();
+
+        let error = read_raw_http_request_text(&mut server).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(error.to_string().contains("headers"));
+    }
+
+    #[tokio::test]
+    async fn rejects_premature_body_eof() {
+        let (mut client, mut server) = connected_pair().await;
+        client
+            .write_all(b"POST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nabc")
+            .await
+            .unwrap();
+        client.shutdown().await.unwrap();
+
+        let error = read_raw_http_request(&mut server).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(error.to_string().contains("body"));
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_and_oversized_content_lengths() {
+        for (content_length, expected_message) in [
+            ("+4".to_string(), "decimal digits"),
+            ((MAX_RAW_HTTP_REQUEST_BYTES + 1).to_string(), "exceeds"),
+        ] {
+            let (mut client, mut server) = connected_pair().await;
+            client
+                .write_all(
+                    format!("POST / HTTP/1.1\r\nContent-Length: {content_length}\r\n\r\n")
+                        .as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            let error = read_raw_http_request(&mut server).await.unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+            assert!(error.to_string().contains(expected_message));
+        }
+    }
+
+    #[tokio::test]
+    async fn disconnects_after_publishing_request() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+        let mut client = connect_fixture(&server).await;
+        let request = b"GET / HTTP/1.1\r\n\r\n";
+        client.write_all(request).await.unwrap();
+
+        assert_eq!(server.receive_request().await.unwrap(), request);
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).await.unwrap();
+        assert!(response.is_empty());
+        server.assert_complete().await;
+    }
+
+    #[tokio::test]
+    async fn publishes_request_before_waiting_for_release() {
+        let release = Arc::new(Notify::new());
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::WaitThenRespond {
+            release: Arc::clone(&release),
+            response: status_response("204 No Content"),
+        }])
+        .await;
+        let address = server.url().trim_start_matches("http://").to_string();
+        let client_task = tokio::spawn(async move {
+            let mut client = TcpStream::connect(address).await.unwrap();
+            client.write_all(b"GET / HTTP/1.1\r\n\r\n").await.unwrap();
+            let mut response = Vec::new();
+            client.read_to_end(&mut response).await.unwrap();
+            response
+        });
+
+        assert_eq!(
+            server.receive_request().await.unwrap(),
+            b"GET / HTTP/1.1\r\n\r\n"
+        );
+        assert!(!client_task.is_finished());
+        release.notify_one();
+        assert_eq!(
+            client_task.await.unwrap(),
+            status_response("204 No Content")
+        );
+        server.assert_complete().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn remains_available_across_virtual_time_advance_between_actions() {
+        let response = status_response("204 No Content");
+        let mut server = RawHttpTestServer::spawn(vec![
+            RawHttpAction::Respond(response.clone()),
+            RawHttpAction::Respond(response.clone()),
+        ])
+        .await;
+
+        for request in [
+            &b"GET /first HTTP/1.1\r\n\r\n"[..],
+            &b"GET /second HTTP/1.1\r\n\r\n"[..],
+        ] {
+            let mut client = connect_fixture(&server).await;
+            client.write_all(request).await.unwrap();
+            assert_eq!(server.receive_request().await.unwrap(), request);
+            let mut received_response = Vec::new();
+            client.read_to_end(&mut received_response).await.unwrap();
+            assert_eq!(received_response, response);
+            tokio::time::advance(RAW_HTTP_FIXTURE_TIMEOUT + Duration::from_secs(1)).await;
+        }
+
+        server.assert_complete().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn assert_complete_aborts_and_reaps_timed_out_task() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Stall]).await;
+        let assertion = tokio::spawn(async move {
+            server.assert_complete().await;
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(RAW_HTTP_FIXTURE_TIMEOUT).await;
+
+        assert!(assertion.await.unwrap_err().is_panic());
+    }
+
+    #[tokio::test]
+    async fn cancellation_reaps_stalled_task() {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::Stall]).await;
+        let mut client = connect_fixture(&server).await;
+        client.write_all(b"GET / HTTP/1.1\r\n\r\n").await.unwrap();
+        assert_eq!(
+            server.receive_request().await.unwrap(),
+            b"GET / HTTP/1.1\r\n\r\n"
+        );
+
+        server.cancel().await;
+    }
+}


### PR DESCRIPTION
## Summary

- add a lifecycle-owned raw HTTP test fixture with complete request capture, scripted response/disconnect/gate/stall actions, and explicit completion or cancellation
- centralize bounded request parsing and raw response framing for runner tests
- migrate active-input, connector-runtime-sync, provider API, telemetry, and storage-cache tests while retaining specialized domain orchestration locally
- cover strict request parsing, action ordering, timeout cleanup, task reaping, and virtual-time behavior at the fixture boundary

## Scope

This is test-only runner infrastructure. It does not change production behavior, public APIs, persistence, queue payloads, deployment compatibility, or rollout behavior. Specialized multi-listener, concurrency, and malformed-response scenarios remain with their existing test owners.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner`
- focused fixture and affected-module tests for active-input, connector-runtime-sync, provider API, telemetry, and storage-cache

Closes #27667
