### PR TITLE
feat(billing): grant redeem-code member usage packs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-redeem-code.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-redeem-code.test.ts
@@ -368,6 +368,7 @@ describe("POST /api/zero/billing/redeem-code", () => {
       code: "YUMA-123",
       email: fixture.email,
       org_id: fixture.orgId,
+      user_id: fixture.userId,
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
@@ -558,6 +558,7 @@ describe("usage pack subscription Stripe lifecycle", () => {
     const usagePackSubscriptionId = randomUUID();
     let cleanupUsagePackSubscriptionId: string = usagePackSubscriptionId;
     const grantedUserId = `user_${randomUUID()}`;
+    const delayedRedeemUserId = `user_${randomUUID()}`;
     const paidPeriod = period(0);
     const grantPeriod = {
       start: paidPeriod.start,
@@ -723,12 +724,46 @@ describe("usage pack subscription Stripe lifecycle", () => {
         ],
       },
     };
+    const delayedRedeemPlanInvoice = {
+      ...planInvoice,
+      id: `in_atom_usage_pack_plan_${randomUUID()}`,
+      metadata: {
+        ...metadata,
+        operationId: `sub_${randomUUID()}`,
+        userId: delayedRedeemUserId,
+      },
+      lines: {
+        has_more: false,
+        data: [
+          {
+            ...planInvoice.lines.data[0],
+            id: `il_${randomUUID()}`,
+          },
+        ],
+      },
+    };
     await postStripeEvent(stripeEvent("invoice.paid", renewedPlanInvoice), 200);
     await postStripeEvent(stripeEvent("invoice.paid", planInvoice), 200);
-    expect((await readUsagePackState(fixture)).org).toStrictEqual(
+    await postStripeEvent(
+      stripeEvent("invoice.paid", delayedRedeemPlanInvoice),
+      200,
+    );
+    await postStripeEvent(
+      stripeEvent("invoice.paid", delayedRedeemPlanInvoice),
+      200,
+    );
+    const renewedState = await readUsagePackState(fixture);
+    expect(renewedState.org).toStrictEqual(
       expect.objectContaining({
         currentPeriodEnd: new Date(renewedGrantPeriod.end * 1000).toISOString(),
       }),
+    );
+    expect(renewedState.grants).toHaveLength(2);
+    expect(renewedState.grants).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ userId: grantedUserId }),
+        expect.objectContaining({ userId: delayedRedeemUserId }),
+      ]),
     );
 
     await postStripeEvent(stripeEvent("invoice.paid", grantInvoice), 200);
@@ -736,11 +771,17 @@ describe("usage pack subscription Stripe lifecycle", () => {
 
     const grantedState = await readUsagePackState(fixture);
     expect(grantedState.allocations).toStrictEqual([]);
-    expect(grantedState.grants).toHaveLength(2);
+    expect(grantedState.grants).toHaveLength(3);
     expect(grantedState.grants).toStrictEqual(
       expect.arrayContaining([
         {
           userId: grantedUserId,
+          grantType: "bonus",
+          originalAmount: 20_000,
+          expiresAt: new Date(grantPeriod.end * 1000).toISOString(),
+        },
+        {
+          userId: delayedRedeemUserId,
           grantType: "bonus",
           originalAmount: 20_000,
           expiresAt: new Date(grantPeriod.end * 1000).toISOString(),

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
@@ -591,7 +591,7 @@ describe("usage pack subscription Stripe lifecycle", () => {
     const metadata = {
       type: "atom_grant",
       purpose: "atom_grant",
-      source: "atom_entitlement",
+      source: "atom_redeem_code",
       planVersion: "usagePack",
       operationId: `sub_${randomUUID()}`,
       orgId,
@@ -599,6 +599,9 @@ describe("usage pack subscription Stripe lifecycle", () => {
       planId: "pro",
       duration: "7d",
       atomGrantExpiresAt: new Date(grantPeriod.end * 1000).toISOString(),
+      userId: grantedUserId,
+      creditsAmount: "20000",
+      creditsExpiresAt: new Date(grantPeriod.end * 1000).toISOString(),
     };
     const planInvoice = {
       id: planInvoiceId,
@@ -660,6 +663,14 @@ describe("usage pack subscription Stripe lifecycle", () => {
     const planState = await readUsagePackState(fixture);
     expect(planState.subscription).toBeNull();
     expect(planState.allocations).toStrictEqual([]);
+    expect(planState.grants).toStrictEqual([
+      {
+        userId: grantedUserId,
+        grantType: "bonus",
+        originalAmount: 20_000,
+        expiresAt: new Date(grantPeriod.end * 1000).toISOString(),
+      },
+    ]);
     expect(planState.org).toStrictEqual(
       expect.objectContaining({
         tier: "pro",
@@ -688,7 +699,14 @@ describe("usage pack subscription Stripe lifecycle", () => {
       ...planInvoice,
       id: `in_atom_usage_pack_plan_${randomUUID()}`,
       metadata: {
-        ...metadata,
+        type: "atom_grant",
+        purpose: "atom_grant",
+        source: "atom_entitlement",
+        planVersion: "usagePack",
+        operationId: metadata.operationId,
+        orgId,
+        tier: "pro",
+        planId: "pro",
         duration: "14d",
         atomGrantExpiresAt: new Date(
           renewedGrantPeriod.end * 1000,
@@ -718,14 +736,23 @@ describe("usage pack subscription Stripe lifecycle", () => {
 
     const grantedState = await readUsagePackState(fixture);
     expect(grantedState.allocations).toStrictEqual([]);
-    expect(grantedState.grants).toStrictEqual([
-      {
-        userId: grantedUserId,
-        grantType: "bonus",
-        originalAmount: 6000,
-        expiresAt: new Date(creditPeriod.end * 1000).toISOString(),
-      },
-    ]);
+    expect(grantedState.grants).toHaveLength(2);
+    expect(grantedState.grants).toStrictEqual(
+      expect.arrayContaining([
+        {
+          userId: grantedUserId,
+          grantType: "bonus",
+          originalAmount: 20_000,
+          expiresAt: new Date(grantPeriod.end * 1000).toISOString(),
+        },
+        {
+          userId: grantedUserId,
+          grantType: "bonus",
+          originalAmount: 6000,
+          expiresAt: new Date(creditPeriod.end * 1000).toISOString(),
+        },
+      ]),
+    );
     expect(grantedState.org?.credits).toBe(0);
     expect(grantedState.legacyCredits).toStrictEqual([]);
     expect(grantedState.fulfillmentInvoiceIds).toStrictEqual([]);

--- a/turbo/apps/api/src/signals/routes/billing-redeem-code.ts
+++ b/turbo/apps/api/src/signals/routes/billing-redeem-code.ts
@@ -224,6 +224,7 @@ const redeemCodeAuthed$ = command(async ({ get }, signal: AbortSignal) => {
         code: bodyResult.data.code,
         email,
         org_id: auth.orgId,
+        user_id: auth.userId,
       }),
       signal,
     }),

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -235,6 +235,12 @@ interface PaidWebhookOutcome {
 
 type AtomGrantTier = Extract<OrgTier, "pro" | "team" | "custom">;
 
+interface AtomMemberUsagePackDetails {
+  readonly userId: string;
+  readonly credits: number;
+  readonly expiresAt: Date;
+}
+
 interface AtomPlanGrantInvoiceDetails {
   readonly kind: "plan";
   readonly orgId: string;
@@ -243,6 +249,7 @@ interface AtomPlanGrantInvoiceDetails {
   readonly creditExpiresAt: Date;
   readonly customerId: string | null;
   readonly credits: number;
+  readonly memberUsagePack: AtomMemberUsagePackDetails | null;
 }
 
 interface AtomCreditGrantInvoiceDetails {
@@ -757,6 +764,47 @@ function atomUsagePackCreditGrantInvoiceDetails(
   };
 }
 
+function atomPlanMemberUsagePackDetails(
+  invoice: InvoiceInput,
+  metadata: Readonly<Record<string, string>>,
+  line: InvoiceLineInput,
+):
+  | { readonly valid: true; readonly value: AtomMemberUsagePackDetails | null }
+  | { readonly valid: false } {
+  const hasMetadata =
+    metadata.userId !== undefined ||
+    metadata.creditsAmount !== undefined ||
+    metadata.creditsExpiresAt !== undefined;
+  if (!hasMetadata) {
+    return { valid: true, value: null };
+  }
+
+  const expiresAt = atomUsagePackGrantExpiresAt(metadata, line);
+  const credits = Number(metadata.creditsAmount);
+  if (
+    metadata.planVersion !== "usagePack" ||
+    metadata.source !== "atom_redeem_code" ||
+    !metadata.userId ||
+    !Number.isSafeInteger(credits) ||
+    credits <= 0 ||
+    !expiresAt
+  ) {
+    L.warn("atom redeem plan grant has invalid member usage pack metadata", {
+      invoiceId: invoice.id,
+      orgId: metadata.orgId ?? null,
+      hasUserId: Boolean(metadata.userId),
+      creditsAmount: metadata.creditsAmount ?? null,
+      creditsExpiresAt: metadata.creditsExpiresAt ?? null,
+    });
+    return { valid: false };
+  }
+
+  return {
+    valid: true,
+    value: { userId: metadata.userId, credits, expiresAt },
+  };
+}
+
 function atomCreditGrantInvoiceDetails(
   invoice: InvoiceInput,
   metadata: Readonly<Record<string, string>>,
@@ -840,6 +888,14 @@ function atomGrantInvoiceDetails(
     });
     return null;
   }
+  const memberUsagePack = atomPlanMemberUsagePackDetails(
+    invoice,
+    metadata,
+    line,
+  );
+  if (!memberUsagePack.valid) {
+    return null;
+  }
 
   return {
     kind: "plan",
@@ -850,6 +906,7 @@ function atomGrantInvoiceDetails(
     customerId,
     credits:
       metadata.planVersion === "usagePack" ? 0 : monthlyCreditsForTier(tier),
+    memberUsagePack: memberUsagePack.value,
   };
 }
 
@@ -1614,6 +1671,25 @@ function rejectAtomGrantTierReplacement(args: {
   });
 }
 
+async function grantAtomRedeemMemberUsagePack(
+  tx: WriteTx,
+  invoice: InvoiceInput,
+  details: AtomPlanGrantInvoiceDetails,
+): Promise<void> {
+  if (!details.memberUsagePack) {
+    return;
+  }
+
+  await createUsagePackCreditGrant(tx, {
+    orgId: details.orgId,
+    userId: details.memberUsagePack.userId,
+    grantType: "bonus",
+    idempotencyKey: `atom-redeem-usage-pack:${invoice.id}:${details.memberUsagePack.userId}`,
+    amount: details.memberUsagePack.credits,
+    expiresAt: details.memberUsagePack.expiresAt,
+  });
+}
+
 async function processAtomPlanGrantInvoicePaid(
   db: Db,
   invoice: InvoiceInput,
@@ -1640,6 +1716,7 @@ async function processAtomPlanGrantInvoicePaid(
       ) {
         await upsertAtomGrantPlanEntitlement(tx, invoice, details);
       }
+      await grantAtomRedeemMemberUsagePack(tx, invoice, details);
       await cancelReplacedSubscriptionsAfterAtomGrant({
         orgId: details.orgId,
         customerId: details.customerId,
@@ -1731,6 +1808,7 @@ async function processAtomPlanGrantInvoicePaid(
         await upsertAtomGrantPlanEntitlement(writeTx, invoice, details);
       },
     });
+    await grantAtomRedeemMemberUsagePack(tx, invoice, details);
     await cancelReplacedSubscriptionsAfterAtomGrant({
       orgId: details.orgId,
       customerId: details.customerId,
@@ -1813,6 +1891,8 @@ async function handleAtomGrantInvoicePaid(
     tier: details.tier,
     grantExpiresAt: details.grantExpiresAt?.toISOString() ?? null,
     creditExpiresAt: details.creditExpiresAt.toISOString(),
+    memberUsagePackCredits: details.memberUsagePack?.credits ?? 0,
+    memberUsagePackUserId: details.memberUsagePack?.userId ?? null,
   });
   return { handled: true, drainOrgId: details.orgId };
 }

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -1736,6 +1736,7 @@ async function processAtomPlanGrantInvoicePaid(
         lockedOrg,
       })
     ) {
+      await grantAtomRedeemMemberUsagePack(tx, invoice, details);
       return true;
     }
     if (


### PR DESCRIPTION
## Summary

- add the VM0 foundation for Atom-issued usage-pack plans and independent member credit grants
- pass the authenticated user ID when VM0 consumes an Atom redeem code
- grant the redeeming member the usage-pack credits embedded in a usage-pack plan invoice
- validate the member grant expiry against the plan invoice period and make webhook retries idempotent

## Test plan

- `pnpm -F api check-types`
- `pnpm -F api lint`
- `DATABASE_URL=postgresql://... pnpm -F api exec vitest run billing-redeem-code.test.ts usage-pack-subscription-lifecycle.test.ts --maxWorkers=1 --silent=passed-only`

Companion Atom change: vm0-ai/vm0-atom#9. This PR now targets `main` directly and includes the prerequisite work from #26948.