### PR TITLE
fix(ci): mask neon branch database credentials

### DIFF
--- a/.github/actions/neon-branch/action.yml
+++ b/.github/actions/neon-branch/action.yml
@@ -103,7 +103,10 @@ runs:
           echo "Attempting without --pooled flag..."
           DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME" --ssl verify-full)
         fi
-        echo "::add-mask::$DATABASE_URL"
+        WORKFLOW_COMMAND_DATA="${DATABASE_URL//%/%25}"
+        WORKFLOW_COMMAND_DATA="${WORKFLOW_COMMAND_DATA//$'\r'/%0D}"
+        WORKFLOW_COMMAND_DATA="${WORKFLOW_COMMAND_DATA//$'\n'/%0A}"
+        printf '::add-mask::%s\n' "$WORKFLOW_COMMAND_DATA"
         echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
         echo "Neon branch ready: $BRANCH_NAME"
 

--- a/.github/actions/neon-branch/action.yml
+++ b/.github/actions/neon-branch/action.yml
@@ -103,8 +103,8 @@ runs:
           echo "Attempting without --pooled flag..."
           DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name "$INPUT_DATABASE_NAME" --role-name "$INPUT_ROLE_NAME" --ssl verify-full)
         fi
-        echo "DATABASE_URL value: $DATABASE_URL"
-        echo "database-url=$DATABASE_URL" >> $GITHUB_OUTPUT
+        echo "::add-mask::$DATABASE_URL"
+        echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
         echo "Neon branch ready: $BRANCH_NAME"
 
         # Get branch ID for console URL

--- a/.github/scripts/tests/neon-branch-credential-mask-test.sh
+++ b/.github/scripts/tests/neon-branch-credential-mask-test.sh
@@ -13,7 +13,7 @@ if grep -Fq 'DATABASE_URL value:' "$action"; then
   fail "Neon branch action logs the generated database URL"
 fi
 
-mapfile -t database_url_emissions < <(
+mapfile -t raw_database_url_emissions < <(
   awk '
     /^[[:space:]]*(echo|printf)[[:space:]]/ && index($0, "$DATABASE_URL") > 0 {
       sub(/^[[:space:]]+/, "")
@@ -22,18 +22,43 @@ mapfile -t database_url_emissions < <(
   ' "$action"
 )
 
-expected_emissions=(
-  "echo \"::add-mask::\$DATABASE_URL\""
+expected_raw_database_url_emissions=(
   "echo \"database-url=\$DATABASE_URL\" >> \"\$GITHUB_OUTPUT\""
 )
 
-if [[ ${#database_url_emissions[@]} -ne ${#expected_emissions[@]} ]]; then
-  fail "expected only mask and output commands for the generated database URL"
+if [[ ${#raw_database_url_emissions[@]} -ne ${#expected_raw_database_url_emissions[@]} ]]; then
+  fail "expected only the existing output command to emit the raw database URL"
 fi
 
-for index in "${!expected_emissions[@]}"; do
-  if [[ "${database_url_emissions[$index]}" != "${expected_emissions[$index]}" ]]; then
-    fail "generated database URL must be masked before the existing output is written"
+for index in "${!expected_raw_database_url_emissions[@]}"; do
+  if [[ "${raw_database_url_emissions[$index]}" != "${expected_raw_database_url_emissions[$index]}" ]]; then
+    fail "raw database URL must only be written to the existing output"
+  fi
+done
+
+mapfile -t mask_commands < <(
+  awk '
+    index($0, "WORKFLOW_COMMAND_DATA=") > 0 || index($0, "::add-mask::") > 0 {
+      sub(/^[[:space:]]+/, "")
+      print
+    }
+  ' "$action"
+)
+
+mapfile -t expected_mask_commands <<'EXPECTED'
+WORKFLOW_COMMAND_DATA="${DATABASE_URL//%/%25}"
+WORKFLOW_COMMAND_DATA="${WORKFLOW_COMMAND_DATA//$'\r'/%0D}"
+WORKFLOW_COMMAND_DATA="${WORKFLOW_COMMAND_DATA//$'\n'/%0A}"
+printf '::add-mask::%s\n' "$WORKFLOW_COMMAND_DATA"
+EXPECTED
+
+if [[ ${#mask_commands[@]} -ne ${#expected_mask_commands[@]} ]]; then
+  fail "expected workflow-command escaping before the generated database URL is masked"
+fi
+
+for index in "${!expected_mask_commands[@]}"; do
+  if [[ "${mask_commands[$index]}" != "${expected_mask_commands[$index]}" ]]; then
+    fail "database URL mask must escape percent, carriage return, and newline in order"
   fi
 done
 

--- a/.github/scripts/tests/neon-branch-credential-mask-test.sh
+++ b/.github/scripts/tests/neon-branch-credential-mask-test.sh
@@ -15,7 +15,8 @@ fi
 
 mapfile -t raw_database_url_emissions < <(
   awk '
-    /^[[:space:]]*(echo|printf)[[:space:]]/ && index($0, "$DATABASE_URL") > 0 {
+    /^[[:space:]]*(echo|printf)[[:space:]]/ &&
+    (index($0, "$DATABASE_URL") > 0 || index($0, "${DATABASE_URL}") > 0) {
       sub(/^[[:space:]]+/, "")
       print
     }

--- a/.github/scripts/tests/neon-branch-credential-mask-test.sh
+++ b/.github/scripts/tests/neon-branch-credential-mask-test.sh
@@ -36,29 +36,32 @@ for index in "${!expected_raw_database_url_emissions[@]}"; do
   fi
 done
 
-mapfile -t mask_commands < <(
+mapfile -t mask_and_output_commands < <(
   awk '
-    index($0, "WORKFLOW_COMMAND_DATA=") > 0 || index($0, "::add-mask::") > 0 {
+    index($0, "WORKFLOW_COMMAND_DATA=") > 0 ||
+    index($0, "::add-mask::") > 0 ||
+    index($0, "database-url=$DATABASE_URL") > 0 {
       sub(/^[[:space:]]+/, "")
       print
     }
   ' "$action"
 )
 
-mapfile -t expected_mask_commands <<'EXPECTED'
+mapfile -t expected_mask_and_output_commands <<'EXPECTED'
 WORKFLOW_COMMAND_DATA="${DATABASE_URL//%/%25}"
 WORKFLOW_COMMAND_DATA="${WORKFLOW_COMMAND_DATA//$'\r'/%0D}"
 WORKFLOW_COMMAND_DATA="${WORKFLOW_COMMAND_DATA//$'\n'/%0A}"
 printf '::add-mask::%s\n' "$WORKFLOW_COMMAND_DATA"
+echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
 EXPECTED
 
-if [[ ${#mask_commands[@]} -ne ${#expected_mask_commands[@]} ]]; then
-  fail "expected workflow-command escaping before the generated database URL is masked"
+if [[ ${#mask_and_output_commands[@]} -ne ${#expected_mask_and_output_commands[@]} ]]; then
+  fail "expected workflow-command escaping and masking before the database URL output"
 fi
 
-for index in "${!expected_mask_commands[@]}"; do
-  if [[ "${mask_commands[$index]}" != "${expected_mask_commands[$index]}" ]]; then
-    fail "database URL mask must escape percent, carriage return, and newline in order"
+for index in "${!expected_mask_and_output_commands[@]}"; do
+  if [[ "${mask_and_output_commands[$index]}" != "${expected_mask_and_output_commands[$index]}" ]]; then
+    fail "database URL must be escaped, masked, and output in order"
   fi
 done
 

--- a/.github/scripts/tests/neon-branch-credential-mask-test.sh
+++ b/.github/scripts/tests/neon-branch-credential-mask-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+action="${repo_root}/.github/actions/neon-branch/action.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+if grep -Fq 'DATABASE_URL value:' "$action"; then
+  fail "Neon branch action logs the generated database URL"
+fi
+
+mapfile -t database_url_emissions < <(
+  awk '
+    /^[[:space:]]*(echo|printf)[[:space:]]/ && index($0, "$DATABASE_URL") > 0 {
+      sub(/^[[:space:]]+/, "")
+      print
+    }
+  ' "$action"
+)
+
+expected_emissions=(
+  "echo \"::add-mask::\$DATABASE_URL\""
+  "echo \"database-url=\$DATABASE_URL\" >> \"\$GITHUB_OUTPUT\""
+)
+
+if [[ ${#database_url_emissions[@]} -ne ${#expected_emissions[@]} ]]; then
+  fail "expected only mask and output commands for the generated database URL"
+fi
+
+for index in "${!expected_emissions[@]}"; do
+  if [[ "${database_url_emissions[$index]}" != "${expected_emissions[$index]}" ]]; then
+    fail "generated database URL must be masked before the existing output is written"
+  fi
+done
+
+echo "neon branch credential masking checks passed"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -273,6 +273,7 @@ jobs:
             .github/scripts/tests/download-verified-test.sh \
             .github/scripts/tests/fetch-okou-desktop-artifact-test.sh \
             .github/scripts/tests/list-okou-pages-preview-pr-numbers-test.sh \
+            .github/scripts/tests/neon-branch-credential-mask-test.sh \
             .github/scripts/tests/neon-connection-string-ssl-test.sh \
             .github/scripts/tests/okou-desktop-artifact-test.sh \
             .github/scripts/tests/provision-runner-kvm-test.sh \


### PR DESCRIPTION
## Summary

- remove the Neon branch action's generated database URL diagnostic
- escape the URL for GitHub's workflow-command data protocol, then register the exact original value for masking before preserving the existing output
- add a focused Security workflow contract test for raw credential emission, command-data escaping, and mask-before-output ordering

## Behavior

The composite action still resolves the same pooled or fallback URL, writes the unchanged `database-url` output, exposes the same `console-url`, and retains its existing branch, migration, and deployment behavior. The generated database URL is now explicitly masked before it can reach later same-job logs.

Before issuing `add-mask`, the action escapes percent, carriage-return, and newline characters in the command payload using GitHub Actions' workflow-command protocol. This ensures a percent-encoded database URL is decoded by the runner back to the exact original value registered for masking. The regression test permits only the existing raw URL output command, rejects direct or braced raw URL logging, and requires command-data escaping, masking, and output in that order.

## Scope

- no Neon connection routing, pooling, TLS, branch retention, or credential rotation changes
- no API, schema, persisted data, runner, frontend, or deployment payload changes
- no historical incident conclusion; this is preventive hardening of the supported `create` path

## Validation

- `bash .github/scripts/tests/neon-branch-credential-mask-test.sh`
- `bash -n .github/scripts/tests/neon-branch-credential-mask-test.sh`
- `shellcheck .github/scripts/tests/neon-branch-credential-mask-test.sh` (ShellCheck 0.9.0)
- `bash .github/scripts/tests/neon-connection-string-ssl-test.sh`
- synthetic Bash assertion for `%25`, carriage-return, and newline command-data escaping
- `yq 4.47.2 eval '.' .github/actions/neon-branch/action.yml .github/workflows/security.yml`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/security.yml`
- Actionlint 1.7.12
- `git diff --check`, including the new file
- repository pre-commit and commit-message hooks

Privileged live Neon execution was not run locally because no checked-in workflow currently invokes the action's `create` path.

Closes #27701
