### PR TITLE
feat(core): add image model catalog and selection switch

### DIFF
--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -3,6 +3,11 @@ import { Buffer } from "node:buffer";
 import { command, computed, type Computed } from "ccstate";
 import { usageEvent } from "@okouai/db/schema/usage-event";
 import { usagePricing } from "@okouai/db/schema/usage-pricing";
+import {
+  DEFAULT_IMAGE_MODEL,
+  IMAGE_MODEL_ALIASES as SELECTABLE_IMAGE_MODEL_ALIASES,
+  type ImageModel as SelectableImageModel,
+} from "@okouai/core/image-model-catalog";
 import { r2ImageTransformUrl } from "@okouai/core/r2-image-transform";
 import { and, eq, inArray } from "drizzle-orm";
 
@@ -25,7 +30,6 @@ import {
 } from "./built-in-generation-usage-idempotency";
 
 const FAL_IMAGE_QUEUE_URL_PREFIX = "https://queue.fal.run";
-const IMAGE_IO_MODEL = "gpt-image-1";
 const IMAGE_IO_MAX_PROMPT_LENGTH = 32_000;
 const IMAGE_IO_MIN_PIXELS = 655_360;
 const IMAGE_IO_MAX_PIXELS = 8_294_400;
@@ -81,21 +85,12 @@ const FAL_IMAGE_ASPECT_RATIOS = [
 ] as const;
 
 const IMAGE_MODEL_ALIASES = {
-  "gpt-image-2": "gpt-image-2",
-  "gpt-image-1.5": "gpt-image-1.5",
-  "gpt-image-1": "gpt-image-1",
-  "gpt-image-1-mini": "gpt-image-1-mini",
-  "flux-pro-1.1": "fal-ai/flux-pro/v1.1",
-  "flux-pro-1.1-ultra": "fal-ai/flux-pro/v1.1-ultra",
-  "qwen-image": "fal-ai/qwen-image",
-  seedream4: "fal-ai/bytedance/seedream/v4/text-to-image",
-  "nano-banana-2": NANO_BANANA_2_MODEL,
-  "nano-banana2": NANO_BANANA_2_MODEL,
+  ...SELECTABLE_IMAGE_MODEL_ALIASES,
   birefnet: BIREFNET_MODEL,
   "clarity-upscaler": CLARITY_UPSCALER_MODEL,
 } as const;
 
-const IMAGE_MODEL_CONFIGS = {
+const IMAGE_GENERATION_MODEL_CONFIGS = {
   "gpt-image-2": {
     alias: "gpt-image-2",
     promptless: false,
@@ -321,6 +316,9 @@ const IMAGE_MODEL_CONFIGS = {
     supportsInputFidelity: false,
     supportsImagePromptStrength: false,
   },
+} as const satisfies Record<SelectableImageModel, unknown>;
+
+const IMAGE_TRANSFORM_MODEL_CONFIGS = {
   [BIREFNET_MODEL]: {
     alias: "birefnet",
     promptless: true,
@@ -371,6 +369,11 @@ const IMAGE_MODEL_CONFIGS = {
     supportsInputFidelity: false,
     supportsImagePromptStrength: false,
   },
+} as const;
+
+const IMAGE_MODEL_CONFIGS = {
+  ...IMAGE_GENERATION_MODEL_CONFIGS,
+  ...IMAGE_TRANSFORM_MODEL_CONFIGS,
 } as const;
 
 const IMAGE_MODELS = Object.keys(IMAGE_MODEL_CONFIGS) as ImageModel[];
@@ -765,7 +768,7 @@ function parsePrompt(
 function parseImageModel(
   body: Record<string, unknown>,
 ): ImageModel | ErrorResponse {
-  const rawModel = readString(body, "model", IMAGE_IO_MODEL);
+  const rawModel = readString(body, "model", DEFAULT_IMAGE_MODEL);
   const model = normalizeImageModel(rawModel);
   if (!model) {
     return badRequest(

--- a/turbo/packages/api-contracts/src/contracts/image-models.ts
+++ b/turbo/packages/api-contracts/src/contracts/image-models.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical IDs for prompt-based built-in image generation.
+ *
+ * Promptless transforms such as background removal and upscaling are not
+ * selectable defaults and remain private to the image generation service.
+ */
+import { z } from "zod";
+
+export const IMAGE_MODEL_IDS = [
+  "gpt-image-1",
+  "gpt-image-2",
+  "gpt-image-1.5",
+  "gpt-image-1-mini",
+  "fal-ai/flux-pro/v1.1",
+  "fal-ai/flux-pro/v1.1-ultra",
+  "fal-ai/qwen-image",
+  "fal-ai/bytedance/seedream/v4/text-to-image",
+  "fal-ai/nano-banana-2",
+] as const;
+
+export type ImageModelId = (typeof IMAGE_MODEL_IDS)[number];
+
+const IMAGE_MODEL_ID_SET: ReadonlySet<string> = new Set(IMAGE_MODEL_IDS);
+
+/** Returns whether a stored value still names a selectable image model. */
+export function isImageModelId(
+  model: string | null | undefined,
+): model is ImageModelId {
+  return typeof model === "string" && IMAGE_MODEL_ID_SET.has(model);
+}
+
+/** A canonical selectable image model id on the wire. */
+export const imageModelIdSchema = z.enum(IMAGE_MODEL_IDS);

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -106,6 +106,7 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ImageModelSelection]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       true,
     );
@@ -140,6 +141,7 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ImageModelSelection]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -75,6 +75,7 @@ export enum FeatureSwitchKey {
   PiLoop = "piLoop",
   VideoTemplateOptions = "videoTemplateOptions",
   VideoModelSelection = "videoModelSelection",
+  ImageModelSelection = "imageModelSelection",
   EmojiPickerCategoryRail = "emojiPickerCategoryRail",
   PresentationTemplates = "presentationTemplates",
   PresentationArtifactViewport = "presentationArtifactViewport",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -301,6 +301,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ImageModelSelection]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Let the chat composer model picker choose the default built-in image model for a chat thread.",
+    enabled: false,
+  },
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "ethan@vm0.ai",
     description:

--- a/turbo/packages/core/src/image-model-catalog.ts
+++ b/turbo/packages/core/src/image-model-catalog.ts
@@ -1,0 +1,81 @@
+/**
+ * Catalog of prompt-based built-in image generation models.
+ *
+ * Provider request shapes, pricing, and model-specific parameters stay in the
+ * API service. Promptless transforms are deliberately excluded because they
+ * cannot act as chat defaults.
+ */
+import {
+  IMAGE_MODEL_IDS,
+  type ImageModelId,
+} from "@okouai/api-contracts/contracts/image-models";
+
+interface ImageModelConfig {
+  /** Value accepted by the CLI's `--model` flag. */
+  readonly alias: string;
+  /** Human-facing name for pickers. */
+  readonly label: string;
+}
+
+export const IMAGE_MODEL_CONFIGS = {
+  "gpt-image-1": {
+    alias: "gpt-image-1",
+    label: "GPT Image 1",
+  },
+  "gpt-image-2": {
+    alias: "gpt-image-2",
+    label: "GPT Image 2",
+  },
+  "gpt-image-1.5": {
+    alias: "gpt-image-1.5",
+    label: "GPT Image 1.5",
+  },
+  "gpt-image-1-mini": {
+    alias: "gpt-image-1-mini",
+    label: "GPT Image 1 Mini",
+  },
+  "fal-ai/flux-pro/v1.1": {
+    alias: "flux-pro-1.1",
+    label: "Flux Pro v1.1",
+  },
+  "fal-ai/flux-pro/v1.1-ultra": {
+    alias: "flux-pro-1.1-ultra",
+    label: "Flux Pro v1.1 Ultra",
+  },
+  "fal-ai/qwen-image": {
+    alias: "qwen-image",
+    label: "Qwen Image",
+  },
+  "fal-ai/bytedance/seedream/v4/text-to-image": {
+    alias: "seedream4",
+    label: "Seedream 4",
+  },
+  "fal-ai/nano-banana-2": {
+    alias: "nano-banana-2",
+    label: "Nano Banana 2",
+  },
+} as const satisfies Record<ImageModelId, ImageModelConfig>;
+
+export type ImageModel = ImageModelId;
+
+/** All catalog models, in user-facing picker order. */
+export const IMAGE_MODELS: readonly ImageModel[] = IMAGE_MODEL_IDS;
+
+/** Every catalog model is currently available in the user-facing picker. */
+export const PUBLIC_IMAGE_MODELS: readonly ImageModel[] = IMAGE_MODEL_IDS;
+
+export const IMAGE_MODEL_ALIASES = {
+  "gpt-image-2": "gpt-image-2",
+  "gpt-image-1.5": "gpt-image-1.5",
+  "gpt-image-1": "gpt-image-1",
+  "gpt-image-1-mini": "gpt-image-1-mini",
+  "flux-pro-1.1": "fal-ai/flux-pro/v1.1",
+  "flux-pro-1.1-ultra": "fal-ai/flux-pro/v1.1-ultra",
+  "qwen-image": "fal-ai/qwen-image",
+  seedream4: "fal-ai/bytedance/seedream/v4/text-to-image",
+  "nano-banana-2": "fal-ai/nano-banana-2",
+  "nano-banana2": "fal-ai/nano-banana-2",
+} as const satisfies Readonly<Record<string, ImageModel>>;
+
+/** Global fallback when no more specific image model default exists. */
+export const DEFAULT_IMAGE_MODEL = "gpt-image-1" satisfies ImageModel;


### PR DESCRIPTION
## Summary

- define the nine prompt-based built-in image models as canonical contract IDs with a schema and type guard
- add a shared core catalog for picker order, labels, CLI aliases, and the global `gpt-image-1` default
- make the API's prompt-based generation configs exhaustively match that catalog while keeping `birefnet` and `clarity-upscaler` API-local
- register `ImageModelSelection` globally off, including for staff, with rollout-state coverage

## Behavior

This is PR 1 of the stack in #27688. It establishes shared types and the disabled rollout switch only. It does not add persistence, UI, CLI environment behavior, or image-generation precedence, and existing image API behavior remains unchanged.

After this merges, the DB/event protocol, dormant CLI/template support, and composer media-panel refactor can proceed in parallel.

## Verification

- changed-file Prettier check
- `@okouai/api-contracts` and `@okouai/core` lint and type checks
- changed-file API Oxlint, type-aware Oxlint, and ESLint
- API gateway and core TypeScript checks
- targeted Knip production scan for `api`, `@okouai/api-contracts`, and `@okouai/core`
- `feature-switch.test.ts` — 24 passed
- `image-io-generate.test.ts` — 20 passed
- `git diff --check`

Refs #27688
