### PR TITLE
docs(python): correct connector module ownership guidance

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/__init__.py
@@ -2,7 +2,8 @@
 
 Model-provider responses route through :mod:`.model_provider` after a
 provider-specific extractor normalizes API usage fields into shared
-``usage_event`` categories.  Connector billing routes through the
-per-connector modules under :mod:`.connectors` — one file per billable
-connector so that each connector's domain quirks stay isolated.
+``usage_event`` categories. Connector billing routes through per-connector
+registrations under :mod:`.connectors`. Each registration combines a reporter
+with optional focused response-inspection behavior; those capabilities may be
+implemented in separate modules.
 """

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -1,17 +1,19 @@
 """Per-connector billing and response parser dispatch.
 
-One file per billable connector under this package owns the connector's
-domain-specific request / response parsing.  :func:`report_connector_usage`
-is the single entry point called by the addon response / error handlers;
-it applies the universal gates (``run_id`` present, firewall flagged
-billable by the web layer, firewall has a registered handler) and
-delegates to the matching per-connector ``report_usage`` function.
+Each billable connector has one coherent registration under this package. The
+registration combines a required usage reporter with optional focused
+response-inspection behavior. The capability implementations may live in
+separate modules. :func:`report_connector_usage` is the single entry point
+called by the addon response / error handlers; it applies the universal gates
+(``run_id`` present, firewall flagged billable by the web layer, firewall has a
+registered handler) and delegates to the matching per-connector ``report_usage``
+function.
 
 Billable connector metadata comes from the accepted connector catalog and
 reaches the runner through the claim's ``billableFirewalls`` list. Adding a new
-billable connector means marking its catalog firewall billable, adding its
-reporter and any focused response-inspection owner here, and registering those
-capabilities in :data:`_REGISTRATIONS`.
+billable connector means marking its catalog firewall billable, adding a
+reporter and any focused response-inspection implementation under this package,
+and composing those capabilities in :data:`_REGISTRATIONS`.
 Response inspection owns both parser creation and buffered-fallback selection,
 so those decisions cannot drift across independent registries.
 """

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -1,8 +1,8 @@
 """Per-connector billing and response parser dispatch.
 
-Each billable connector has one coherent registration under this package. The
-registration combines a required usage reporter with optional focused
-response-inspection behavior. The capability implementations may live in
+Each supported billable connector has one coherent registration under this
+package. The registration combines a required usage reporter with optional
+focused response-inspection behavior. The capability implementations may live in
 separate modules. :func:`report_connector_usage` is the single entry point
 called by the addon response / error handlers; it applies the universal gates
 (``run_id`` present, firewall flagged billable by the web layer, firewall has a


### PR DESCRIPTION
## Summary

- replace stale one-file-per-connector guidance with the coherent registration and capability model
- document that a required reporter and optional focused response-inspection implementation may live in separate modules
- align the parent provider overview and connector contributor guidance with `_REGISTRATIONS` and the current X split

## Scope

Documentation-only change to two package docstrings. No runtime behavior, tests, generated files, dependencies, or lockfiles are changed.

## Validation

- Ruff 0.16.0: `python3 -m ruff check src/usage/providers/__init__.py src/usage/providers/connectors/__init__.py`
- Ruff 0.16.0: `python3 -m ruff format --check src/usage/providers/__init__.py src/usage/providers/connectors/__init__.py`
- `git diff --check`
- searched `crates/runner/mitm-addon/src/usage` for residual one-file-per-connector ownership claims (no matches)

Closes #27708
