### PR TITLE
refactor(db): add integration identity contract readiness preflight

### DIFF
--- a/.github/workflows/integration-identity-contract-readiness-preflight.yml
+++ b/.github/workflows/integration-identity-contract-readiness-preflight.yml
@@ -1,0 +1,74 @@
+name: Integration Identity Contract Readiness Preflight
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-integration-identity-contract-readiness-preflight
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
+    environment: production
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # transition-validator: #27665; removal-owner: #27602
+      # The workflow definition and implementation always come from main.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
+      - name: Initialize toolchain
+        uses: ./.github/actions/toolchain-init
+
+      - name: Install neonctl
+        run: npm install -g neonctl@2.15.0
+
+      - name: Resolve production database
+        id: database
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if ! database_url=$(
+            neonctl connection-string production \
+              --project-id "$NEON_PROJECT_ID" \
+              --database-name neondb \
+              --role-name neondb_owner \
+              --pooled \
+              --ssl verify-full \
+              2>/dev/null
+          ); then
+            echo '{"schemaVersion":"vm0.integration-identity-contract-readiness-preflight.v1","status":"failed","failureGates":["probe.database_resolution"]}'
+            exit 1
+          fi
+          if [[ -z "$database_url" ||
+                "$database_url" == *$'\n'* ||
+                "$database_url" == *$'\r'* ||
+                ( "$database_url" != postgres://* &&
+                  "$database_url" != postgresql://* ) ]]; then
+            echo '{"schemaVersion":"vm0.integration-identity-contract-readiness-preflight.v1","status":"failed","failureGates":["probe.database_resolution"]}'
+            exit 1
+          fi
+          echo "::add-mask::$database_url"
+          echo "database-url=$database_url" >> "$GITHUB_OUTPUT"
+
+      - name: Run aggregate-only preflight
+        env:
+          DATABASE_URL: ${{ steps.database.outputs.database-url }}
+        working-directory: turbo
+        run: |
+          set -euo pipefail
+          pnpm --filter @okouai/db exec tsx \
+            scripts/integration-identity-contract-readiness-preflight.ts

--- a/turbo/packages/db/MIGRATIONS.md
+++ b/turbo/packages/db/MIGRATIONS.md
@@ -35,11 +35,13 @@ expired transition validator must be deleted.
 The repository inventory below is machine-checked. The removal owner must
 delete the workflow, probe, focused validator, and this entry together.
 
-| Issue           | Validator                                        | Removal owner  |
-| --------------- | ------------------------------------------------ | -------------- |
-| #27613 / #27656 | Agent/Compose consolidation production preflight | #26938 Stage 8 |
+| Issue           | Validator                                         | Removal owner  |
+| --------------- | ------------------------------------------------- | -------------- |
+| #27613 / #27656 | Agent/Compose consolidation production preflight  | #26938 Stage 8 |
+| #27665          | Integration identity Contract readiness preflight | #27602         |
 
 <!-- vm0-transition-validator:#27613+#27656|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8 -->
+<!-- vm0-transition-validator:#27665|integration-identity-contract-readiness-preflight|removal-owner:#27602 -->
 
 ## Migration patterns
 

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
@@ -396,6 +396,7 @@ export const EXPECTED_REPOSITORY_DEPENDENCIES = {
   ],
   transitionValidators: [
     "#27613+#27656|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8",
+    "#27665|integration-identity-contract-readiness-preflight|removal-owner:#27602",
   ],
 } as const satisfies RepositoryDependencyManifest;
 

--- a/turbo/packages/db/scripts/integration-identity-contract-readiness-preflight-manifest.ts
+++ b/turbo/packages/db/scripts/integration-identity-contract-readiness-preflight-manifest.ts
@@ -1,0 +1,612 @@
+import { createHash } from "node:crypto";
+
+export const INTEGRATION_IDENTITY_TABLES = [
+  {
+    tableName: "agentphone_user_agent_preferences",
+    triggerName: "sync_agentphone_user_agent_preferences_identity_0930",
+  },
+  {
+    tableName: "agentphone_user_links",
+    triggerName: "sync_agentphone_user_links_identity_0930",
+  },
+  {
+    tableName: "feishu_org_connections",
+    triggerName: "sync_feishu_org_connections_identity_0930",
+  },
+  {
+    tableName: "feishu_user_agent_preferences",
+    triggerName: "sync_feishu_user_agent_preferences_identity_0930",
+  },
+  {
+    tableName: "github_user_links",
+    triggerName: "sync_github_user_links_identity_0930",
+  },
+  {
+    tableName: "slack_org_connections",
+    triggerName: "sync_slack_org_connections_identity_0930",
+  },
+  {
+    tableName: "slack_user_agent_preferences",
+    triggerName: "sync_slack_user_agent_preferences_identity_0930",
+  },
+  {
+    tableName: "teams_org_connections",
+    triggerName: "sync_teams_org_connections_identity_0930",
+  },
+  {
+    tableName: "teams_user_agent_preferences",
+    triggerName: "sync_teams_user_agent_preferences_identity_0930",
+  },
+  {
+    tableName: "telegram_official_user_links",
+    triggerName: "sync_telegram_official_user_links_identity_0930",
+  },
+  {
+    tableName: "telegram_user_agent_preferences",
+    triggerName: "sync_telegram_user_agent_preferences_identity_0930",
+  },
+  {
+    tableName: "telegram_user_links",
+    triggerName: "sync_telegram_user_links_identity_0930",
+  },
+] as const;
+
+export type IntegrationIdentityTableName =
+  (typeof INTEGRATION_IDENTITY_TABLES)[number]["tableName"];
+
+export const CATALOG_DEPENDENCY_KINDS = [
+  "columns",
+  "primaryKeys",
+  "constraints",
+  "defaultsAndGenerated",
+  "indexes",
+  "triggers",
+  "functions",
+  "rewriteDependents",
+  "otherDependents",
+] as const;
+
+export type CatalogDependencyKind = (typeof CATALOG_DEPENDENCY_KINDS)[number];
+
+export interface CatalogDependencySourceRow {
+  readonly kind: string;
+  readonly identity: string;
+  readonly definition: string;
+}
+
+const CATALOG_DEFINITION_DOMAIN =
+  "vm0:integration-identity-contract-readiness-preflight:catalog-definition:v1";
+
+function hashDefinition(definition: string): string {
+  return createHash("sha256")
+    .update(CATALOG_DEFINITION_DOMAIN)
+    .update("\0")
+    .update(definition)
+    .digest("hex");
+}
+
+export function catalogManifestEntry(
+  identity: string,
+  definition: string,
+): string {
+  return `${identity}|definition_sha256=${hashDefinition(definition)}`;
+}
+
+function catalogManifestDigestEntry(
+  identity: string,
+  definitionDigest: string,
+): string {
+  return `${identity}|definition_sha256=${definitionDigest}`;
+}
+
+export function normalizeCatalogDependencyRow(
+  row: CatalogDependencySourceRow,
+): { kind: CatalogDependencyKind; entry: string } {
+  if (
+    !CATALOG_DEPENDENCY_KINDS.some((kind) => {
+      return kind === row.kind;
+    })
+  ) {
+    throw new Error("unknown catalog dependency kind");
+  }
+  if (row.identity.length === 0 || row.definition.length === 0) {
+    throw new Error("incomplete catalog dependency row");
+  }
+  return {
+    kind: row.kind as CatalogDependencyKind,
+    entry: catalogManifestEntry(row.identity, row.definition),
+  };
+}
+
+const COLUMN_DEFINITION = "type=text|not_null=true|identity=|generated=";
+
+const expectedColumns = INTEGRATION_IDENTITY_TABLES.flatMap(({ tableName }) => {
+  return ["user_id", "vm0_user_id"].map((columnName) => {
+    return catalogManifestEntry(
+      `public.${tableName}|${columnName}`,
+      COLUMN_DEFINITION,
+    );
+  });
+});
+
+const expectedPrimaryKeys = [
+  catalogManifestEntry(
+    "public.agentphone_user_agent_preferences|agentphone_user_agent_preferences_pkey",
+    "PRIMARY KEY (vm0_user_id, org_id)|validated=true|deferrable=false|initially_deferred=false",
+  ),
+  catalogManifestEntry(
+    "public.feishu_user_agent_preferences|feishu_user_agent_preferences_pkey",
+    "PRIMARY KEY (vm0_user_id, org_id)|validated=true|deferrable=false|initially_deferred=false",
+  ),
+  catalogManifestEntry(
+    "public.slack_user_agent_preferences|slack_user_agent_preferences_pkey",
+    "PRIMARY KEY (vm0_user_id, org_id)|validated=true|deferrable=false|initially_deferred=false",
+  ),
+  catalogManifestEntry(
+    "public.teams_user_agent_preferences|teams_user_agent_preferences_pkey",
+    "PRIMARY KEY (vm0_user_id, org_id)|validated=true|deferrable=false|initially_deferred=false",
+  ),
+  catalogManifestEntry(
+    "public.telegram_user_agent_preferences|telegram_user_agent_preferences_pkey",
+    "PRIMARY KEY (vm0_user_id, org_id)|validated=true|deferrable=false|initially_deferred=false",
+  ),
+];
+
+const expectedIndexDefinitions: readonly (readonly [string, string])[] = [
+  [
+    "public.agentphone_user_agent_preferences|agentphone_user_agent_preferences_pkey",
+    "CREATE UNIQUE INDEX agentphone_user_agent_preferences_pkey ON public.agentphone_user_agent_preferences USING btree (vm0_user_id, org_id)|valid=true|ready=true|unique=true|primary=true",
+  ],
+  [
+    "public.agentphone_user_agent_preferences|idx_agentphone_user_agent_preferences_user_org",
+    "CREATE UNIQUE INDEX idx_agentphone_user_agent_preferences_user_org ON public.agentphone_user_agent_preferences USING btree (user_id, org_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+  [
+    "public.agentphone_user_links|idx_agentphone_user_links_user_org",
+    "CREATE UNIQUE INDEX idx_agentphone_user_links_user_org ON public.agentphone_user_links USING btree (user_id, org_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+  [
+    "public.agentphone_user_links|idx_agentphone_user_links_vm0_org",
+    "CREATE UNIQUE INDEX idx_agentphone_user_links_vm0_org ON public.agentphone_user_links USING btree (vm0_user_id, org_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+  [
+    "public.feishu_org_connections|idx_feishu_org_connections_user_id_installation",
+    "CREATE INDEX idx_feishu_org_connections_user_id_installation ON public.feishu_org_connections USING btree (user_id, installation_id)|valid=true|ready=true|unique=false|primary=false",
+  ],
+  [
+    "public.feishu_org_connections|idx_feishu_org_connections_vm0_installation",
+    "CREATE INDEX idx_feishu_org_connections_vm0_installation ON public.feishu_org_connections USING btree (vm0_user_id, installation_id)|valid=true|ready=true|unique=false|primary=false",
+  ],
+  [
+    "public.feishu_user_agent_preferences|feishu_user_agent_preferences_pkey",
+    "CREATE UNIQUE INDEX feishu_user_agent_preferences_pkey ON public.feishu_user_agent_preferences USING btree (vm0_user_id, org_id)|valid=true|ready=true|unique=true|primary=true",
+  ],
+  [
+    "public.feishu_user_agent_preferences|idx_feishu_user_agent_preferences_user_org",
+    "CREATE UNIQUE INDEX idx_feishu_user_agent_preferences_user_org ON public.feishu_user_agent_preferences USING btree (user_id, org_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+  [
+    "public.slack_org_connections|idx_slack_org_connections_user_id_workspace",
+    "CREATE INDEX idx_slack_org_connections_user_id_workspace ON public.slack_org_connections USING btree (user_id, slack_workspace_id)|valid=true|ready=true|unique=false|primary=false",
+  ],
+  [
+    "public.slack_org_connections|idx_slack_org_connections_vm0_user_workspace",
+    "CREATE INDEX idx_slack_org_connections_vm0_user_workspace ON public.slack_org_connections USING btree (vm0_user_id, slack_workspace_id)|valid=true|ready=true|unique=false|primary=false",
+  ],
+  [
+    "public.slack_user_agent_preferences|idx_slack_user_agent_preferences_user_org",
+    "CREATE UNIQUE INDEX idx_slack_user_agent_preferences_user_org ON public.slack_user_agent_preferences USING btree (user_id, org_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+  [
+    "public.slack_user_agent_preferences|slack_user_agent_preferences_pkey",
+    "CREATE UNIQUE INDEX slack_user_agent_preferences_pkey ON public.slack_user_agent_preferences USING btree (vm0_user_id, org_id)|valid=true|ready=true|unique=true|primary=true",
+  ],
+  [
+    "public.teams_org_connections|idx_teams_org_connections_user_id_tenant",
+    "CREATE INDEX idx_teams_org_connections_user_id_tenant ON public.teams_org_connections USING btree (user_id, teams_tenant_id)|valid=true|ready=true|unique=false|primary=false",
+  ],
+  [
+    "public.teams_org_connections|idx_teams_org_connections_vm0_tenant",
+    "CREATE INDEX idx_teams_org_connections_vm0_tenant ON public.teams_org_connections USING btree (vm0_user_id, teams_tenant_id)|valid=true|ready=true|unique=false|primary=false",
+  ],
+  [
+    "public.teams_user_agent_preferences|idx_teams_user_agent_preferences_user_org",
+    "CREATE UNIQUE INDEX idx_teams_user_agent_preferences_user_org ON public.teams_user_agent_preferences USING btree (user_id, org_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+  [
+    "public.teams_user_agent_preferences|teams_user_agent_preferences_pkey",
+    "CREATE UNIQUE INDEX teams_user_agent_preferences_pkey ON public.teams_user_agent_preferences USING btree (vm0_user_id, org_id)|valid=true|ready=true|unique=true|primary=true",
+  ],
+  [
+    "public.telegram_official_user_links|idx_telegram_official_user_links_user_org",
+    "CREATE UNIQUE INDEX idx_telegram_official_user_links_user_org ON public.telegram_official_user_links USING btree (user_id, org_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+  [
+    "public.telegram_official_user_links|idx_telegram_official_user_links_vm0_org",
+    "CREATE UNIQUE INDEX idx_telegram_official_user_links_vm0_org ON public.telegram_official_user_links USING btree (vm0_user_id, org_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+  [
+    "public.telegram_user_agent_preferences|idx_telegram_user_agent_preferences_user_org",
+    "CREATE UNIQUE INDEX idx_telegram_user_agent_preferences_user_org ON public.telegram_user_agent_preferences USING btree (user_id, org_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+  [
+    "public.telegram_user_agent_preferences|telegram_user_agent_preferences_pkey",
+    "CREATE UNIQUE INDEX telegram_user_agent_preferences_pkey ON public.telegram_user_agent_preferences USING btree (vm0_user_id, org_id)|valid=true|ready=true|unique=true|primary=true",
+  ],
+  [
+    "public.telegram_user_links|idx_telegram_user_links_user_id_installation",
+    "CREATE UNIQUE INDEX idx_telegram_user_links_user_id_installation ON public.telegram_user_links USING btree (user_id, installation_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+  [
+    "public.telegram_user_links|idx_telegram_user_links_vm0_installation",
+    "CREATE UNIQUE INDEX idx_telegram_user_links_vm0_installation ON public.telegram_user_links USING btree (vm0_user_id, installation_id)|valid=true|ready=true|unique=true|primary=false",
+  ],
+];
+
+const expectedIndexes = expectedIndexDefinitions.map(
+  ([identity, definition]) => {
+    return catalogManifestEntry(identity, definition);
+  },
+);
+
+const expectedTriggers = INTEGRATION_IDENTITY_TABLES.map(
+  ({ tableName, triggerName }) => {
+    return catalogManifestEntry(
+      `public.${tableName}|${triggerName}`,
+      `CREATE TRIGGER ${triggerName} BEFORE INSERT OR UPDATE OF vm0_user_id, user_id ON public.${tableName} FOR EACH ROW EXECUTE FUNCTION sync_integration_user_identity_0930()|enabled=O`,
+    );
+  },
+);
+
+const expectedFunctions = [
+  // Domain-separated SHA-256 of the exact prosrc installed by 0930_past_jetstream.
+  catalogManifestDigestEntry(
+    "public.sync_integration_user_identity_0930()|kind=f|result=trigger|language=plpgsql|volatility=v|security_definer=false",
+    "50622a23cb618306571dbed28ec66a1c1ea5afd72b929c0292ac93342a455cee",
+  ),
+];
+
+export const EXPECTED_CATALOG_DEPENDENCIES = {
+  columns: expectedColumns,
+  primaryKeys: expectedPrimaryKeys,
+  constraints: [],
+  defaultsAndGenerated: [],
+  indexes: expectedIndexes,
+  triggers: expectedTriggers,
+  functions: expectedFunctions,
+  rewriteDependents: [],
+  otherDependents: [],
+} as const satisfies Record<CatalogDependencyKind, readonly string[]>;
+
+/**
+ * Discover every Contract-relevant dependency on the two integration identity
+ * columns. Definitions are returned only to the in-process SHA-256 normalizer;
+ * no raw definition is part of the result schema or workflow output.
+ */
+export const CATALOG_DEPENDENCY_QUERY = `
+WITH RECURSIVE target_table_names("table_name") AS (
+  VALUES
+    ('agentphone_user_agent_preferences'),
+    ('agentphone_user_links'),
+    ('feishu_org_connections'),
+    ('feishu_user_agent_preferences'),
+    ('github_user_links'),
+    ('slack_org_connections'),
+    ('slack_user_agent_preferences'),
+    ('teams_org_connections'),
+    ('teams_user_agent_preferences'),
+    ('telegram_official_user_links'),
+    ('telegram_user_agent_preferences'),
+    ('telegram_user_links')
+),
+target_relations AS (
+  SELECT "relation"."oid", "relation"."relname"
+  FROM "pg_class" AS "relation"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  INNER JOIN target_table_names AS "target"
+    ON "target"."table_name" = "relation"."relname"
+  WHERE "namespace"."nspname" = 'public'
+    AND "relation"."relkind" IN ('r', 'p')
+),
+identity_columns AS (
+  SELECT
+    "attribute"."attrelid" AS "relid",
+    "attribute"."attnum" AS "attnum",
+    "attribute"."attname" AS "attname"
+  FROM "pg_attribute" AS "attribute"
+  INNER JOIN target_relations AS "target"
+    ON "target"."oid" = "attribute"."attrelid"
+  WHERE "attribute"."attname" IN ('user_id', 'vm0_user_id')
+    AND "attribute"."attnum" > 0
+    AND NOT "attribute"."attisdropped"
+),
+rewrite_relation_closure("oid") AS (
+  SELECT DISTINCT "rewrite"."ev_class"
+  FROM "pg_depend" AS "dependency"
+  INNER JOIN identity_columns AS "column"
+    ON "dependency"."refclassid" = 'pg_class'::regclass
+    AND "dependency"."refobjid" = "column"."relid"
+    AND "dependency"."refobjsubid" = "column"."attnum"
+  INNER JOIN "pg_rewrite" AS "rewrite"
+    ON "dependency"."classid" = 'pg_rewrite'::regclass
+    AND "dependency"."objid" = "rewrite"."oid"
+  WHERE "dependency"."deptype" = 'n'
+  UNION
+  SELECT DISTINCT "rewrite"."ev_class"
+  FROM rewrite_relation_closure AS "referenced"
+  INNER JOIN "pg_depend" AS "dependency"
+    ON "dependency"."refclassid" = 'pg_class'::regclass
+    AND "dependency"."refobjid" = "referenced"."oid"
+    AND "dependency"."classid" = 'pg_rewrite'::regclass
+    AND "dependency"."deptype" = 'n'
+  INNER JOIN "pg_rewrite" AS "rewrite"
+    ON "rewrite"."oid" = "dependency"."objid"
+),
+columns AS (
+  SELECT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+      "attribute"."attname" AS "identity",
+    'type=' || format_type("attribute"."atttypid", "attribute"."atttypmod") ||
+      '|not_null=' || "attribute"."attnotnull"::text ||
+      '|identity=' || "attribute"."attidentity"::text ||
+      '|generated=' || "attribute"."attgenerated"::text AS "definition"
+  FROM identity_columns AS "column"
+  INNER JOIN "pg_attribute" AS "attribute"
+    ON "attribute"."attrelid" = "column"."relid"
+    AND "attribute"."attnum" = "column"."attnum"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "attribute"."attrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+),
+primary_keys AS (
+  SELECT DISTINCT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+      "constraint"."conname" AS "identity",
+    pg_get_constraintdef("constraint"."oid", false) ||
+      '|validated=' || "constraint"."convalidated"::text ||
+      '|deferrable=' || "constraint"."condeferrable"::text ||
+      '|initially_deferred=' || "constraint"."condeferred"::text AS "definition"
+  FROM "pg_constraint" AS "constraint"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "constraint"."conrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  WHERE "constraint"."contype" = 'p'
+    AND EXISTS (
+      SELECT 1
+      FROM unnest("constraint"."conkey") AS "key"("attnum")
+      INNER JOIN identity_columns AS "column"
+        ON "column"."relid" = "constraint"."conrelid"
+        AND "column"."attnum" = "key"."attnum"
+    )
+),
+constraints AS (
+  SELECT DISTINCT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+      "constraint"."conname" AS "identity",
+    'type=' || "constraint"."contype"::text || '|' ||
+      pg_get_constraintdef("constraint"."oid", false) ||
+      '|validated=' || "constraint"."convalidated"::text ||
+      '|deferrable=' || "constraint"."condeferrable"::text ||
+      '|initially_deferred=' || "constraint"."condeferred"::text AS "definition"
+  FROM "pg_constraint" AS "constraint"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "constraint"."conrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  WHERE "constraint"."contype" NOT IN ('p', 'n')
+    AND (
+      EXISTS (
+        SELECT 1
+        FROM unnest("constraint"."conkey") AS "key"("attnum")
+        INNER JOIN identity_columns AS "column"
+          ON "column"."relid" = "constraint"."conrelid"
+          AND "column"."attnum" = "key"."attnum"
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM "pg_depend" AS "dependency"
+        INNER JOIN identity_columns AS "column"
+          ON "dependency"."refclassid" = 'pg_class'::regclass
+          AND "dependency"."refobjid" = "column"."relid"
+          AND "dependency"."refobjsubid" = "column"."attnum"
+        WHERE "dependency"."classid" = 'pg_constraint'::regclass
+          AND "dependency"."objid" = "constraint"."oid"
+      )
+    )
+),
+defaults_and_generated AS (
+  SELECT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+      "attribute"."attname" AS "identity",
+    'generated=' || "attribute"."attgenerated"::text || '|' ||
+      pg_get_expr("default"."adbin", "default"."adrelid", false) AS "definition"
+  FROM "pg_attrdef" AS "default"
+  INNER JOIN "pg_attribute" AS "attribute"
+    ON "attribute"."attrelid" = "default"."adrelid"
+    AND "attribute"."attnum" = "default"."adnum"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "default"."adrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  WHERE EXISTS (
+      SELECT 1
+      FROM identity_columns AS "column"
+      WHERE "column"."relid" = "default"."adrelid"
+        AND "column"."attnum" = "default"."adnum"
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM "pg_depend" AS "dependency"
+      INNER JOIN identity_columns AS "column"
+        ON "dependency"."refclassid" = 'pg_class'::regclass
+        AND "dependency"."refobjid" = "column"."relid"
+        AND "dependency"."refobjsubid" = "column"."attnum"
+      WHERE "dependency"."classid" = 'pg_attrdef'::regclass
+        AND "dependency"."objid" = "default"."oid"
+    )
+),
+indexes AS (
+  SELECT DISTINCT
+    "namespace"."nspname" || '.' || "table"."relname" || '|' ||
+      "index_relation"."relname" AS "identity",
+    pg_get_indexdef("index"."indexrelid", 0, false) ||
+      '|valid=' || "index"."indisvalid"::text ||
+      '|ready=' || "index"."indisready"::text ||
+      '|unique=' || "index"."indisunique"::text ||
+      '|primary=' || "index"."indisprimary"::text AS "definition"
+  FROM "pg_index" AS "index"
+  INNER JOIN "pg_class" AS "index_relation"
+    ON "index_relation"."oid" = "index"."indexrelid"
+  INNER JOIN "pg_class" AS "table"
+    ON "table"."oid" = "index"."indrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "table"."relnamespace"
+  WHERE EXISTS (
+      SELECT 1
+      FROM unnest("index"."indkey") AS "key"("attnum")
+      INNER JOIN identity_columns AS "column"
+        ON "column"."relid" = "index"."indrelid"
+        AND "column"."attnum" = "key"."attnum"
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM "pg_depend" AS "dependency"
+      INNER JOIN identity_columns AS "column"
+        ON "dependency"."refclassid" = 'pg_class'::regclass
+        AND "dependency"."refobjid" = "column"."relid"
+        AND "dependency"."refobjsubid" = "column"."attnum"
+      WHERE "dependency"."classid" = 'pg_class'::regclass
+        AND "dependency"."objid" = "index"."indexrelid"
+    )
+),
+triggers AS (
+  SELECT DISTINCT
+    "namespace"."nspname" || '.' || "relation"."relname" || '|' ||
+      "trigger"."tgname" AS "identity",
+    pg_get_triggerdef("trigger"."oid", false) ||
+      '|enabled=' || "trigger"."tgenabled"::text AS "definition",
+    "trigger"."tgfoid" AS "function_oid"
+  FROM "pg_trigger" AS "trigger"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "trigger"."tgrelid"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  INNER JOIN "pg_proc" AS "function"
+    ON "function"."oid" = "trigger"."tgfoid"
+  WHERE NOT "trigger"."tgisinternal"
+    AND (
+      "function"."proname" = 'sync_integration_user_identity_0930'
+      OR lower("function"."prosrc") LIKE '%vm0_user_id%'
+      OR EXISTS (
+        SELECT 1
+        FROM "pg_depend" AS "dependency"
+        INNER JOIN identity_columns AS "column"
+          ON "dependency"."refclassid" = 'pg_class'::regclass
+          AND "dependency"."refobjid" = "column"."relid"
+          AND "dependency"."refobjsubid" = "column"."attnum"
+        WHERE "dependency"."classid" = 'pg_trigger'::regclass
+          AND "dependency"."objid" = "trigger"."oid"
+      )
+    )
+),
+functions AS (
+  SELECT DISTINCT
+    "namespace"."nspname" || '.' || "function"."proname" || '(' ||
+      pg_get_function_identity_arguments("function"."oid") || ')|' ||
+      'kind=' || "function"."prokind"::text ||
+      '|result=' || pg_get_function_result("function"."oid") ||
+      '|language=' || "language"."lanname" ||
+      '|volatility=' || "function"."provolatile"::text ||
+      '|security_definer=' || "function"."prosecdef"::text AS "identity",
+    "function"."prosrc" AS "definition"
+  FROM "pg_proc" AS "function"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "function"."pronamespace"
+  INNER JOIN "pg_language" AS "language"
+    ON "language"."oid" = "function"."prolang"
+  WHERE "function"."oid" IN (SELECT "function_oid" FROM triggers)
+    OR (
+      "namespace"."nspname" = 'public'
+      AND lower("function"."prosrc") LIKE '%vm0_user_id%'
+    )
+),
+rewrite_dependents AS (
+  SELECT DISTINCT
+    "namespace"."nspname" || '.' || "relation"."relname" ||
+      '|relation_kind=' ||
+      CASE "relation"."relkind"
+        WHEN 'v' THEN 'view'
+        WHEN 'm' THEN 'materialized_view'
+        ELSE 'relation'
+      END ||
+      '|rule=' || "rewrite"."rulename" ||
+      '|event=' || "rewrite"."ev_type"::text ||
+      '|instead=' || "rewrite"."is_instead"::text AS "identity",
+    pg_get_ruledef("rewrite"."oid", false) AS "definition"
+  FROM "pg_rewrite" AS "rewrite"
+  INNER JOIN "pg_class" AS "relation"
+    ON "relation"."oid" = "rewrite"."ev_class"
+  INNER JOIN "pg_namespace" AS "namespace"
+    ON "namespace"."oid" = "relation"."relnamespace"
+  WHERE "rewrite"."ev_class" IN (SELECT "oid" FROM rewrite_relation_closure)
+),
+other_dependents AS (
+  SELECT DISTINCT
+    "dependency"."classid"::regclass::text ||
+      '|dependency_type=' || "dependency"."deptype"::text ||
+      '|object=' || pg_describe_object(
+        "dependency"."classid",
+        "dependency"."objid",
+        "dependency"."objsubid"
+      ) ||
+      '|referenced=' || pg_describe_object(
+        "dependency"."refclassid",
+        "dependency"."refobjid",
+        "dependency"."refobjsubid"
+      ) AS "identity",
+    'structural-dependency' AS "definition"
+  FROM "pg_depend" AS "dependency"
+  LEFT JOIN "pg_class" AS "dependent_relation"
+    ON "dependency"."classid" = 'pg_class'::regclass
+    AND "dependent_relation"."oid" = "dependency"."objid"
+  WHERE (
+      EXISTS (
+        SELECT 1
+        FROM identity_columns AS "column"
+        WHERE "dependency"."refclassid" = 'pg_class'::regclass
+          AND "dependency"."refobjid" = "column"."relid"
+          AND "dependency"."refobjsubid" = "column"."attnum"
+      )
+      OR (
+        "dependency"."refclassid" = 'pg_proc'::regclass
+        AND "dependency"."refobjid" IN (
+          SELECT "function_oid" FROM triggers
+        )
+      )
+    )
+    AND "dependency"."deptype" <> 'i'
+    AND "dependency"."classid" NOT IN (
+      'pg_attrdef'::regclass,
+      'pg_constraint'::regclass,
+      'pg_rewrite'::regclass,
+      'pg_trigger'::regclass
+    )
+    AND NOT (
+      "dependency"."classid" = 'pg_class'::regclass
+      AND "dependent_relation"."relkind" IN ('i', 'I')
+    )
+)
+SELECT 'columns' AS "kind", "identity", "definition" FROM columns
+UNION ALL SELECT 'primaryKeys', "identity", "definition" FROM primary_keys
+UNION ALL SELECT 'constraints', "identity", "definition" FROM constraints
+UNION ALL SELECT 'defaultsAndGenerated', "identity", "definition" FROM defaults_and_generated
+UNION ALL SELECT 'indexes', "identity", "definition" FROM indexes
+UNION ALL SELECT 'triggers', "identity", "definition" FROM triggers
+UNION ALL SELECT 'functions', "identity", "definition" FROM functions
+UNION ALL SELECT 'rewriteDependents', "identity", "definition" FROM rewrite_dependents
+UNION ALL SELECT 'otherDependents', "identity", "definition" FROM other_dependents
+ORDER BY "kind", "identity"
+`;

--- a/turbo/packages/db/scripts/integration-identity-contract-readiness-preflight.ts
+++ b/turbo/packages/db/scripts/integration-identity-contract-readiness-preflight.ts
@@ -1,0 +1,583 @@
+#!/usr/bin/env tsx
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client, type QueryResultRow } from "pg";
+import {
+  CATALOG_DEPENDENCY_KINDS,
+  CATALOG_DEPENDENCY_QUERY,
+  EXPECTED_CATALOG_DEPENDENCIES,
+  INTEGRATION_IDENTITY_TABLES,
+  normalizeCatalogDependencyRow,
+  type CatalogDependencyKind,
+  type CatalogDependencySourceRow,
+  type IntegrationIdentityTableName,
+} from "./integration-identity-contract-readiness-preflight-manifest";
+
+export const PREFLIGHT_SCHEMA_VERSION =
+  "vm0.integration-identity-contract-readiness-preflight.v1";
+
+const MINIMUM_SERVER_VERSION = 170000;
+const DEFAULT_LOCK_TIMEOUT_MS = 1000;
+const DEFAULT_STATEMENT_TIMEOUT_MS = 30_000;
+const SET_FINGERPRINT_DOMAIN =
+  "vm0:integration-identity-contract-readiness-preflight:set:v1";
+
+const SANITIZED_PROBE_FAILURE_GATES = [
+  "probe.aggregate_contract",
+  "probe.cancelled",
+  "probe.capability_gate",
+  "probe.configuration",
+  "probe.database_connection",
+  "probe.database_resolution",
+  "probe.inventory",
+  "probe.lock_timeout",
+  "probe.output_contract",
+  "probe.row_inventory",
+  "probe.statement_timeout",
+  "probe.transaction_cleanup",
+  "probe.transaction_start",
+  "probe.unexpected",
+] as const;
+
+type SanitizedFailureGate = (typeof SANITIZED_PROBE_FAILURE_GATES)[number];
+
+const ROW_INVENTORY_QUERY = INTEGRATION_IDENTITY_TABLES.map(({ tableName }) => {
+  return `
+SELECT
+  '${tableName}'::text AS "tableName",
+  COUNT(*)::text AS "totalCount",
+  COUNT(*) FILTER (
+    WHERE "user_id" IS NULL
+      OR "vm0_user_id" IS NULL
+      OR "user_id" IS DISTINCT FROM "vm0_user_id"
+  )::text AS "invalidCount"
+FROM "public"."${tableName}"`;
+}).join("\nUNION ALL\n");
+
+interface SetFingerprint {
+  readonly count: number;
+  readonly digest: string;
+}
+
+interface DependencyComparison {
+  readonly classification: "exact" | "drift";
+  readonly expected: SetFingerprint;
+  readonly observed: SetFingerprint;
+}
+
+export interface PreflightCapabilities {
+  readonly serverVersionClassification: "supported";
+  readonly transactionReadOnly: true;
+  readonly isolationLevel: "repeatable read";
+  readonly lockTimeoutMs: number;
+  readonly statementTimeoutMs: number;
+}
+
+interface RowAggregate {
+  readonly total_count: number;
+  readonly invalid_count: number;
+}
+
+export interface PreflightInventory {
+  readonly rows: readonly RowInventoryRow[];
+  readonly catalogDependencies: readonly CatalogDependencySourceRow[];
+}
+
+export interface SuccessfulPreflightResult {
+  readonly schemaVersion: typeof PREFLIGHT_SCHEMA_VERSION;
+  readonly status: "passed" | "failed";
+  readonly failureGates: readonly string[];
+  readonly capabilities: PreflightCapabilities;
+  readonly rows: {
+    readonly total_count: number;
+    readonly invalid_count: number;
+    readonly tables: Readonly<
+      Record<IntegrationIdentityTableName, RowAggregate>
+    >;
+  };
+  readonly dependencies: Readonly<
+    Record<CatalogDependencyKind, DependencyComparison>
+  >;
+}
+
+export interface ReadOnlySnapshotOptions {
+  readonly signal?: AbortSignal;
+  readonly lockTimeoutMs?: number;
+  readonly statementTimeoutMs?: number;
+}
+
+export interface RowInventoryRow extends QueryResultRow {
+  readonly tableName: string;
+  readonly totalCount: string;
+  readonly invalidCount: string;
+}
+
+interface CapabilityRow extends QueryResultRow {
+  readonly serverVersion: number;
+  readonly readOnly: boolean;
+  readonly isolationLevel: string;
+  readonly lockTimeoutMs: number;
+  readonly statementTimeoutMs: number;
+}
+
+export const PREFLIGHT_OUTPUT_ALLOWLIST = [
+  "capabilities.isolationLevel",
+  "capabilities.lockTimeoutMs",
+  "capabilities.serverVersionClassification",
+  "capabilities.statementTimeoutMs",
+  "capabilities.transactionReadOnly",
+  ...CATALOG_DEPENDENCY_KINDS.flatMap((kind) => {
+    return [
+      `dependencies.${kind}.classification`,
+      `dependencies.${kind}.expected.count`,
+      `dependencies.${kind}.expected.digest`,
+      `dependencies.${kind}.observed.count`,
+      `dependencies.${kind}.observed.digest`,
+    ];
+  }),
+  "failureGates",
+  "rows.invalid_count",
+  ...INTEGRATION_IDENTITY_TABLES.flatMap(({ tableName }) => {
+    return [
+      `rows.tables.${tableName}.invalid_count`,
+      `rows.tables.${tableName}.total_count`,
+    ];
+  }),
+  "rows.total_count",
+  "schemaVersion",
+  "status",
+].sort();
+
+export class SanitizedPreflightError extends Error {
+  readonly gate: SanitizedFailureGate;
+
+  constructor(gate: SanitizedFailureGate) {
+    super(gate);
+    this.name = "SanitizedPreflightError";
+    this.gate = gate;
+  }
+}
+
+function assertNotAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw new SanitizedPreflightError("probe.cancelled");
+}
+
+function classifyThrownError(
+  error: unknown,
+  fallbackGate: SanitizedFailureGate,
+): never {
+  if (error instanceof SanitizedPreflightError) throw error;
+  if (error instanceof DOMException && error.name === "AbortError") {
+    throw new SanitizedPreflightError("probe.cancelled");
+  }
+  const code = (error as { readonly code?: unknown } | null)?.code;
+  if (code === "57014") {
+    throw new SanitizedPreflightError("probe.statement_timeout");
+  }
+  if (code === "55P03") {
+    throw new SanitizedPreflightError("probe.lock_timeout");
+  }
+  throw new SanitizedPreflightError(fallbackGate);
+}
+
+async function safeQuery<Row extends QueryResultRow>(
+  client: Client,
+  signal: AbortSignal | undefined,
+  text: string,
+  values?: readonly unknown[],
+): Promise<readonly Row[]> {
+  assertNotAborted(signal);
+  const result = await client.query<Row>(text, values as unknown[] | undefined);
+  assertNotAborted(signal);
+  return result.rows;
+}
+
+function fingerprintSortedSet(
+  domain: string,
+  members: readonly string[],
+): SetFingerprint {
+  const uniqueMembers = [...new Set(members)].sort();
+  const hash = createHash("sha256");
+  hash.update(SET_FINGERPRINT_DOMAIN);
+  hash.update("\0");
+  hash.update(domain);
+  hash.update("\0");
+  for (const member of uniqueMembers) {
+    hash.update(Buffer.byteLength(member, "utf8").toString());
+    hash.update(":");
+    hash.update(member);
+    hash.update("\0");
+  }
+  return { count: uniqueMembers.length, digest: hash.digest("hex") };
+}
+
+function compareDependencies(
+  kind: CatalogDependencyKind,
+  expectedMembers: readonly string[],
+  observedMembers: readonly string[],
+): DependencyComparison {
+  const expected = fingerprintSortedSet(kind, expectedMembers);
+  const observed = fingerprintSortedSet(kind, observedMembers);
+  return {
+    classification:
+      expected.count === observed.count && expected.digest === observed.digest
+        ? "exact"
+        : "drift",
+    expected,
+    observed,
+  };
+}
+
+function parseCount(value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new SanitizedPreflightError("probe.aggregate_contract");
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new SanitizedPreflightError("probe.aggregate_contract");
+  }
+  return parsed;
+}
+
+function outputLeafPaths(value: unknown, prefix = ""): string[] {
+  if (Array.isArray(value)) return [prefix];
+  if (value === null || typeof value !== "object") return [prefix];
+  return Object.entries(value).flatMap(([key, child]) => {
+    return outputLeafPaths(
+      child,
+      prefix.length === 0 ? key : `${prefix}.${key}`,
+    );
+  });
+}
+
+function assertAllowedOutputPaths(value: unknown): void {
+  const allowlist = new Set(PREFLIGHT_OUTPUT_ALLOWLIST);
+  if (
+    outputLeafPaths(value).some((path) => {
+      return !allowlist.has(path);
+    })
+  ) {
+    throw new SanitizedPreflightError("probe.output_contract");
+  }
+  const failureGates = (value as { readonly failureGates?: unknown } | null)
+    ?.failureGates;
+  if (
+    !Array.isArray(failureGates) ||
+    failureGates.some((gate) => {
+      return (
+        typeof gate !== "string" ||
+        (!SANITIZED_PROBE_FAILURE_GATES.some((known) => {
+          return known === gate;
+        }) &&
+          !INTEGRATION_IDENTITY_TABLES.some(({ tableName }) => {
+            return gate === `rows.${tableName}.invalid`;
+          }) &&
+          !CATALOG_DEPENDENCY_KINDS.some((kind) => {
+            return gate === `dependencies.${kind}`;
+          }))
+      );
+    })
+  ) {
+    throw new SanitizedPreflightError("probe.output_contract");
+  }
+}
+
+export function assertOutputAllowlist(value: unknown): void {
+  assertAllowedOutputPaths(value);
+  const observed = outputLeafPaths(value).sort();
+  if (
+    observed.length !== PREFLIGHT_OUTPUT_ALLOWLIST.length ||
+    observed.some((path, index) => {
+      return path !== PREFLIGHT_OUTPUT_ALLOWLIST[index];
+    })
+  ) {
+    throw new SanitizedPreflightError("probe.output_contract");
+  }
+}
+
+export function classifyPreflightInventory(
+  capabilities: PreflightCapabilities,
+  inventory: PreflightInventory,
+  expectedCatalogDependencies: Readonly<
+    Record<CatalogDependencyKind, readonly string[]>
+  > = EXPECTED_CATALOG_DEPENDENCIES,
+): SuccessfulPreflightResult {
+  const expectedTables = new Set<string>(
+    INTEGRATION_IDENTITY_TABLES.map(({ tableName }) => {
+      return tableName;
+    }),
+  );
+  const observedTables = new Set<string>();
+  const tableAggregates = {} as Record<
+    IntegrationIdentityTableName,
+    RowAggregate
+  >;
+  let totalCount = 0;
+  let invalidCount = 0;
+  const failureGates: string[] = [];
+
+  for (const row of inventory.rows) {
+    if (
+      !expectedTables.has(row.tableName) ||
+      observedTables.has(row.tableName)
+    ) {
+      throw new SanitizedPreflightError("probe.row_inventory");
+    }
+    observedTables.add(row.tableName);
+    const aggregate = {
+      total_count: parseCount(row.totalCount),
+      invalid_count: parseCount(row.invalidCount),
+    };
+    if (aggregate.invalid_count > aggregate.total_count) {
+      throw new SanitizedPreflightError("probe.aggregate_contract");
+    }
+    tableAggregates[row.tableName as IntegrationIdentityTableName] = aggregate;
+    totalCount += aggregate.total_count;
+    invalidCount += aggregate.invalid_count;
+    if (aggregate.invalid_count > 0) {
+      failureGates.push(`rows.${row.tableName}.invalid`);
+    }
+  }
+  if (observedTables.size !== expectedTables.size) {
+    throw new SanitizedPreflightError("probe.row_inventory");
+  }
+  if (
+    !Number.isSafeInteger(totalCount) ||
+    !Number.isSafeInteger(invalidCount)
+  ) {
+    throw new SanitizedPreflightError("probe.aggregate_contract");
+  }
+
+  const observedCatalogDependencies = Object.fromEntries(
+    CATALOG_DEPENDENCY_KINDS.map((kind) => {
+      return [kind, [] as string[]];
+    }),
+  ) as Record<CatalogDependencyKind, string[]>;
+  for (const sourceRow of inventory.catalogDependencies) {
+    const normalized = normalizeCatalogDependencyRow(sourceRow);
+    observedCatalogDependencies[normalized.kind].push(normalized.entry);
+  }
+
+  const dependencies = Object.fromEntries(
+    CATALOG_DEPENDENCY_KINDS.map((kind) => {
+      const comparison = compareDependencies(
+        kind,
+        expectedCatalogDependencies[kind],
+        observedCatalogDependencies[kind],
+      );
+      if (comparison.classification !== "exact") {
+        failureGates.push(`dependencies.${kind}`);
+      }
+      return [kind, comparison];
+    }),
+  ) as Record<CatalogDependencyKind, DependencyComparison>;
+
+  failureGates.sort();
+  const result: SuccessfulPreflightResult = {
+    schemaVersion: PREFLIGHT_SCHEMA_VERSION,
+    status: failureGates.length === 0 ? "passed" : "failed",
+    failureGates,
+    capabilities,
+    rows: {
+      total_count: totalCount,
+      invalid_count: invalidCount,
+      tables: Object.fromEntries(
+        INTEGRATION_IDENTITY_TABLES.map(({ tableName }) => {
+          return [tableName, tableAggregates[tableName]];
+        }),
+      ) as Record<IntegrationIdentityTableName, RowAggregate>,
+    },
+    dependencies,
+  };
+  assertOutputAllowlist(result);
+  return result;
+}
+
+export async function withReadOnlySnapshot<Value>(
+  client: Client,
+  options: ReadOnlySnapshotOptions,
+  body: (capabilities: PreflightCapabilities) => Promise<Value>,
+): Promise<{
+  readonly capabilities: PreflightCapabilities;
+  readonly value: Value;
+}> {
+  const lockTimeoutMs = options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+  const statementTimeoutMs =
+    options.statementTimeoutMs ?? DEFAULT_STATEMENT_TIMEOUT_MS;
+  let transactionStarted = false;
+  let bodyError: unknown;
+  let result:
+    | { readonly capabilities: PreflightCapabilities; readonly value: Value }
+    | undefined;
+
+  try {
+    assertNotAborted(options.signal);
+    await client.query(
+      "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+    );
+    transactionStarted = true;
+    await client.query(
+      `SELECT
+         set_config('lock_timeout', $1, true),
+         set_config('statement_timeout', $2, true)`,
+      [`${lockTimeoutMs}ms`, `${statementTimeoutMs}ms`],
+    );
+    const capabilityRows = await safeQuery<CapabilityRow>(
+      client,
+      options.signal,
+      `SELECT
+         current_setting('server_version_num')::integer AS "serverVersion",
+         current_setting('transaction_read_only') = 'on' AS "readOnly",
+         current_setting('transaction_isolation') AS "isolationLevel",
+         (SELECT "setting"::integer FROM "pg_settings"
+          WHERE "name" = 'lock_timeout') AS "lockTimeoutMs",
+         (SELECT "setting"::integer FROM "pg_settings"
+          WHERE "name" = 'statement_timeout') AS "statementTimeoutMs"`,
+    );
+    const capability = capabilityRows[0];
+    if (
+      !capability ||
+      capability.serverVersion < MINIMUM_SERVER_VERSION ||
+      !capability.readOnly ||
+      capability.isolationLevel !== "repeatable read" ||
+      capability.lockTimeoutMs !== lockTimeoutMs ||
+      capability.statementTimeoutMs !== statementTimeoutMs
+    ) {
+      throw new SanitizedPreflightError("probe.capability_gate");
+    }
+    const capabilities: PreflightCapabilities = {
+      serverVersionClassification: "supported",
+      transactionReadOnly: true,
+      isolationLevel: "repeatable read",
+      lockTimeoutMs,
+      statementTimeoutMs,
+    };
+    result = { capabilities, value: await body(capabilities) };
+  } catch (error) {
+    bodyError = error;
+  }
+
+  if (transactionStarted) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      throw new SanitizedPreflightError("probe.transaction_cleanup");
+    }
+  }
+  if (bodyError !== undefined) {
+    classifyThrownError(bodyError, "probe.inventory");
+  }
+  if (!result) throw new SanitizedPreflightError("probe.transaction_start");
+  return result;
+}
+
+async function collectDatabaseInventory(
+  client: Client,
+  signal: AbortSignal | undefined,
+): Promise<PreflightInventory> {
+  const catalogDependencies = await safeQuery<CatalogDependencySourceRow>(
+    client,
+    signal,
+    CATALOG_DEPENDENCY_QUERY,
+  );
+  const rows = await safeQuery<RowInventoryRow>(
+    client,
+    signal,
+    ROW_INVENTORY_QUERY,
+  );
+  return { rows, catalogDependencies };
+}
+
+export async function executeIntegrationIdentityContractReadinessPreflight(args: {
+  readonly connectionString: string;
+  readonly signal?: AbortSignal;
+  readonly lockTimeoutMs?: number;
+  readonly statementTimeoutMs?: number;
+}): Promise<SuccessfulPreflightResult> {
+  const client = new Client({ connectionString: args.connectionString });
+  client.on("error", () => {});
+  try {
+    await client.connect();
+  } catch (error) {
+    classifyThrownError(error, "probe.database_connection");
+  }
+
+  try {
+    const snapshot = await withReadOnlySnapshot(
+      client,
+      {
+        signal: args.signal,
+        lockTimeoutMs: args.lockTimeoutMs,
+        statementTimeoutMs: args.statementTimeoutMs,
+      },
+      async () => {
+        return collectDatabaseInventory(client, args.signal);
+      },
+    );
+    return classifyPreflightInventory(snapshot.capabilities, snapshot.value);
+  } catch (error) {
+    classifyThrownError(error, "probe.inventory");
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+export function sanitizedFailureResult(error: unknown): {
+  readonly schemaVersion: string;
+  readonly status: "failed";
+  readonly failureGates: readonly string[];
+} {
+  const result = {
+    schemaVersion: PREFLIGHT_SCHEMA_VERSION,
+    status: "failed" as const,
+    failureGates: [
+      error instanceof SanitizedPreflightError
+        ? error.gate
+        : "probe.unexpected",
+    ],
+  };
+  assertAllowedOutputPaths(result);
+  return result;
+}
+
+async function runCli(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    process.stdout.write(
+      `${JSON.stringify(sanitizedFailureResult(new SanitizedPreflightError("probe.configuration")))}\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const abortController = new AbortController();
+  const abort = (): void => {
+    return abortController.abort();
+  };
+  process.once("SIGINT", abort);
+  process.once("SIGTERM", abort);
+  try {
+    const result = await executeIntegrationIdentityContractReadinessPreflight({
+      connectionString: databaseUrl,
+      signal: abortController.signal,
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    if (result.status !== "passed") process.exitCode = 1;
+  } catch (error) {
+    const result = sanitizedFailureResult(error);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    process.exitCode = 1;
+  } finally {
+    process.removeListener("SIGINT", abort);
+    process.removeListener("SIGTERM", abort);
+  }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  runCli().catch((error: unknown) => {
+    process.stdout.write(`${JSON.stringify(sanitizedFailureResult(error))}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/turbo/packages/db/scripts/test-integration-identity-contract-readiness-preflight.ts
+++ b/turbo/packages/db/scripts/test-integration-identity-contract-readiness-preflight.ts
@@ -227,6 +227,28 @@ function databaseUrlFor(baseUrl: URL, database: string): string {
   return result.toString();
 }
 
+async function waitForApplicationLockWait(
+  observer: Client,
+  applicationName: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 1000; attempt += 1) {
+    const result = await observer.query<{ blocked: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1
+         FROM "pg_stat_activity"
+         WHERE "application_name" = $1
+           AND "wait_event_type" = 'Lock'
+       ) AS "blocked"`,
+      [applicationName],
+    );
+    if (result.rows[0]?.blocked) return;
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+  throw new Error("preflight query did not reach the expected lock wait");
+}
+
 async function insertValidRows(client: Client): Promise<void> {
   await client.query(`
     SET session_replication_role = replica;
@@ -388,35 +410,40 @@ async function testDatabaseBoundaries(databaseUrl: string): Promise<void> {
         `LOCK TABLE "agentphone_user_links" IN ACCESS EXCLUSIVE MODE`,
       );
       const activeCancellation = new AbortController();
-      const abortTimer = setTimeout(() => {
-        activeCancellation.abort();
-      }, 25);
-      const releaseWriter = new Promise<void>((resolve, reject) => {
-        setTimeout(() => {
-          writer.query("ROLLBACK").then(() => {
-            resolve();
-          }, reject);
-        }, 125);
-      });
+      const cancellationApplicationName =
+        "integration-identity-preflight-cancellation-test";
+      const cancellationUrl = new URL(testUrl);
+      cancellationUrl.searchParams.set(
+        "application_name",
+        cancellationApplicationName,
+      );
+      const activePreflight =
+        executeIntegrationIdentityContractReadinessPreflight({
+          connectionString: cancellationUrl.toString(),
+          signal: activeCancellation.signal,
+          lockTimeoutMs: 1000,
+          statementTimeoutMs: 2000,
+        });
+      let synchronizationError: unknown;
       try {
-        await assert.rejects(
-          executeIntegrationIdentityContractReadinessPreflight({
-            connectionString: testUrl,
-            signal: activeCancellation.signal,
-            lockTimeoutMs: 1000,
-            statementTimeoutMs: 2000,
-          }),
-          (error: unknown) => {
-            return (
-              error instanceof SanitizedPreflightError &&
-              error.gate === "probe.cancelled"
-            );
-          },
-        );
-      } finally {
-        clearTimeout(abortTimer);
-        await releaseWriter;
+        await waitForApplicationLockWait(client, cancellationApplicationName);
+      } catch (error) {
+        synchronizationError = error;
       }
+      activeCancellation.abort();
+      await writer.query("ROLLBACK");
+      if (synchronizationError !== undefined) {
+        await activePreflight.catch(() => {
+          return undefined;
+        });
+        throw synchronizationError;
+      }
+      await assert.rejects(activePreflight, (error: unknown) => {
+        return (
+          error instanceof SanitizedPreflightError &&
+          error.gate === "probe.cancelled"
+        );
+      });
 
       await withReadOnlySnapshot(client, {}, async () => {
         const before = await client.query<{ count: string }>(

--- a/turbo/packages/db/scripts/test-integration-identity-contract-readiness-preflight.ts
+++ b/turbo/packages/db/scripts/test-integration-identity-contract-readiness-preflight.ts
@@ -1,0 +1,654 @@
+#!/usr/bin/env tsx
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+import {
+  CATALOG_DEPENDENCY_QUERY,
+  INTEGRATION_IDENTITY_TABLES,
+  type CatalogDependencyKind,
+  type CatalogDependencySourceRow,
+} from "./integration-identity-contract-readiness-preflight-manifest";
+import {
+  PREFLIGHT_OUTPUT_ALLOWLIST,
+  SanitizedPreflightError,
+  assertOutputAllowlist,
+  classifyPreflightInventory,
+  executeIntegrationIdentityContractReadinessPreflight,
+  sanitizedFailureResult,
+  withReadOnlySnapshot,
+  type PreflightCapabilities,
+  type PreflightInventory,
+  type RowInventoryRow,
+} from "./integration-identity-contract-readiness-preflight";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageDirectory = path.resolve(dirname, "..");
+const repositoryRoot = path.resolve(dirname, "../../../..");
+const testDatabase = "integration_identity_contract_readiness_preflight_test";
+
+const capabilities: PreflightCapabilities = {
+  serverVersionClassification: "supported",
+  transactionReadOnly: true,
+  isolationLevel: "repeatable read",
+  lockTimeoutMs: 1000,
+  statementTimeoutMs: 30_000,
+};
+
+const emptyCatalog: Record<CatalogDependencyKind, readonly string[]> = {
+  columns: [],
+  primaryKeys: [],
+  constraints: [],
+  defaultsAndGenerated: [],
+  indexes: [],
+  triggers: [],
+  functions: [],
+  rewriteDependents: [],
+  otherDependents: [],
+};
+
+function rowInventory(invalidTable?: string): readonly RowInventoryRow[] {
+  return INTEGRATION_IDENTITY_TABLES.map(({ tableName }) => {
+    return {
+      tableName,
+      totalCount: "1",
+      invalidCount: tableName === invalidTable ? "1" : "0",
+    };
+  });
+}
+
+function inventory(
+  rows: readonly RowInventoryRow[],
+  catalogDependencies: readonly CatalogDependencySourceRow[] = [],
+): PreflightInventory {
+  return { rows, catalogDependencies };
+}
+
+function gatePresent(
+  result: { readonly failureGates: readonly string[] },
+  gate: string,
+): void {
+  assert.ok(result.failureGates.includes(gate), `missing gate ${gate}`);
+}
+
+function testStaticClassification(): void {
+  const valid = classifyPreflightInventory(
+    capabilities,
+    inventory(rowInventory()),
+    emptyCatalog,
+  );
+  assert.equal(valid.status, "passed");
+  assert.equal(valid.rows.total_count, 12);
+  assert.equal(valid.rows.invalid_count, 0);
+  assertOutputAllowlist(valid);
+  assert.deepEqual(
+    PREFLIGHT_OUTPUT_ALLOWLIST,
+    [...new Set(PREFLIGHT_OUTPUT_ALLOWLIST)].sort(),
+  );
+
+  const nullPair = classifyPreflightInventory(
+    capabilities,
+    inventory(rowInventory("agentphone_user_links")),
+    emptyCatalog,
+  );
+  assert.equal(nullPair.rows.invalid_count, 1);
+  gatePresent(nullPair, "rows.agentphone_user_links.invalid");
+
+  const mismatchedPair = classifyPreflightInventory(
+    capabilities,
+    inventory(rowInventory("telegram_user_links")),
+    emptyCatalog,
+  );
+  assert.equal(mismatchedPair.rows.invalid_count, 1);
+  gatePresent(mismatchedPair, "rows.telegram_user_links.invalid");
+
+  const rawIdentity = "never-emit-provider-row-or-org-identifier";
+  const rawDefinition = "never-emit-raw-catalog-definition";
+  const driftRows: CatalogDependencySourceRow[] = [
+    {
+      kind: "constraints",
+      identity: rawIdentity,
+      definition: rawDefinition,
+    },
+    {
+      kind: "constraints",
+      identity: "never-emit-second-catalog-identity",
+      definition: "never-emit-second-catalog-definition",
+    },
+  ];
+  const forward = classifyPreflightInventory(
+    capabilities,
+    inventory(rowInventory(), driftRows),
+    emptyCatalog,
+  );
+  const reverse = classifyPreflightInventory(
+    capabilities,
+    inventory([...rowInventory()].reverse(), [...driftRows].reverse()),
+    emptyCatalog,
+  );
+  assert.deepEqual(reverse, forward);
+  gatePresent(forward, "dependencies.constraints");
+  const serialized = JSON.stringify(forward);
+  assert.equal(serialized.includes(rawIdentity), false);
+  assert.equal(serialized.includes(rawDefinition), false);
+
+  const failure = sanitizedFailureResult(
+    new Error("never-emit-unhandled-error-detail"),
+  );
+  const failureJson = JSON.stringify(failure);
+  assert.equal(
+    failureJson.includes("never-emit-unhandled-error-detail"),
+    false,
+  );
+  assert.deepEqual(failure.failureGates, ["probe.unexpected"]);
+  assert.deepEqual(
+    sanitizedFailureResult(
+      new SanitizedPreflightError("probe.database_resolution"),
+    ).failureGates,
+    ["probe.database_resolution"],
+  );
+  assert.throws(
+    () => {
+      assertOutputAllowlist({
+        ...valid,
+        failureGates: ["never-emit-raw-failure-gate"],
+      });
+    },
+    (error: unknown) => {
+      return (
+        error instanceof SanitizedPreflightError &&
+        error.gate === "probe.output_contract"
+      );
+    },
+  );
+}
+
+async function testRepositoryContracts(): Promise<void> {
+  const workflow = await fs.readFile(
+    path.join(
+      repositoryRoot,
+      ".github/workflows/integration-identity-contract-readiness-preflight.yml",
+    ),
+    "utf8",
+  );
+  assert.match(workflow, /^on:\n {2}workflow_dispatch:\s*$/mu);
+  assert.match(workflow, /^ {4}environment: production$/mu);
+  assert.match(workflow, /^ {4}if: github\.ref == 'refs\/heads\/main'$/mu);
+  assert.match(workflow, /^ {10}ref: main$/mu);
+  assert.match(
+    workflow,
+    /actions\/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1/u,
+  );
+  assert.match(workflow, /#27665; removal-owner: #27602/u);
+  assert.match(
+    workflow,
+    /scripts\/integration-identity-contract-readiness-preflight\.ts/u,
+  );
+  assert.match(workflow, /--ssl verify-full \\/u);
+  assert.equal(
+    /pull_request:|schedule:|actions\/upload-artifact/iu.test(workflow),
+    false,
+  );
+
+  const migrationGuide = await fs.readFile(
+    path.join(repositoryRoot, "turbo/packages/db/MIGRATIONS.md"),
+    "utf8",
+  );
+  assert.match(
+    migrationGuide,
+    /vm0-transition-validator:#27665\|integration-identity-contract-readiness-preflight\|removal-owner:#27602/u,
+  );
+
+  const probe = await fs.readFile(
+    path.join(
+      repositoryRoot,
+      "turbo/packages/db/scripts/integration-identity-contract-readiness-preflight.ts",
+    ),
+    "utf8",
+  );
+  assert.match(
+    probe,
+    /BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY/u,
+  );
+  assert.match(probe, /current_setting\('transaction_read_only'\)/u);
+  assert.match(probe, /set_config\('lock_timeout'/u);
+  assert.match(probe, /set_config\('statement_timeout'/u);
+  assert.equal(
+    /FOR UPDATE|FOR SHARE|LOCK TABLE|pg_advisory/iu.test(probe),
+    false,
+  );
+}
+
+function databaseUrlFor(baseUrl: URL, database: string): string {
+  const result = new URL(baseUrl);
+  result.pathname = `/${database}`;
+  return result.toString();
+}
+
+async function insertValidRows(client: Client): Promise<void> {
+  await client.query(`
+    SET session_replication_role = replica;
+    INSERT INTO "agentphone_user_agent_preferences"
+      ("user_id", "vm0_user_id", "org_id")
+      VALUES ('never-emit-user-01', 'never-emit-user-01', 'never-emit-org-01');
+    INSERT INTO "agentphone_user_links"
+      ("phone_handle", "user_id", "vm0_user_id", "org_id")
+      VALUES ('never-emit-phone-02', 'never-emit-user-02', 'never-emit-user-02', 'never-emit-org-02');
+    INSERT INTO "feishu_org_connections"
+      ("installation_id", "feishu_open_id", "user_id", "vm0_user_id")
+      VALUES ('10000000-0000-4000-8000-000000000003', 'never-emit-feishu-03', 'never-emit-user-03', 'never-emit-user-03');
+    INSERT INTO "feishu_user_agent_preferences"
+      ("user_id", "vm0_user_id", "org_id")
+      VALUES ('never-emit-user-04', 'never-emit-user-04', 'never-emit-org-04');
+    INSERT INTO "github_user_links"
+      ("github_user_id", "installation_id", "user_id", "vm0_user_id")
+      VALUES ('never-emit-github-05', '10000000-0000-4000-8000-000000000005', 'never-emit-user-05', 'never-emit-user-05');
+    INSERT INTO "slack_org_connections"
+      ("slack_user_id", "slack_workspace_id", "user_id", "vm0_user_id")
+      VALUES ('never-emit-slack-06', 'never-emit-workspace-06', 'never-emit-user-06', 'never-emit-user-06');
+    INSERT INTO "slack_user_agent_preferences"
+      ("user_id", "vm0_user_id", "org_id")
+      VALUES ('never-emit-user-07', 'never-emit-user-07', 'never-emit-org-07');
+    INSERT INTO "teams_org_connections"
+      ("teams_tenant_id", "user_id", "vm0_user_id")
+      VALUES ('never-emit-tenant-08', 'never-emit-user-08', 'never-emit-user-08');
+    INSERT INTO "teams_user_agent_preferences"
+      ("user_id", "vm0_user_id", "org_id")
+      VALUES ('never-emit-user-09', 'never-emit-user-09', 'never-emit-org-09');
+    INSERT INTO "telegram_official_user_links"
+      ("telegram_user_id", "user_id", "vm0_user_id", "org_id")
+      VALUES ('never-emit-telegram-10', 'never-emit-user-10', 'never-emit-user-10', 'never-emit-org-10');
+    INSERT INTO "telegram_user_agent_preferences"
+      ("user_id", "vm0_user_id", "org_id")
+      VALUES ('never-emit-user-11', 'never-emit-user-11', 'never-emit-org-11');
+    INSERT INTO "telegram_user_links"
+      ("telegram_user_id", "installation_id", "user_id", "vm0_user_id")
+      VALUES ('never-emit-telegram-12', 'never-emit-installation-12', 'never-emit-user-12', 'never-emit-user-12');
+    SET session_replication_role = origin;
+  `);
+}
+
+async function executeAndExpectDependencyDrift(
+  connectionString: string,
+  kind: CatalogDependencyKind,
+): Promise<string> {
+  const result = await executeIntegrationIdentityContractReadinessPreflight({
+    connectionString,
+  });
+  assert.equal(result.status, "failed");
+  gatePresent(result, `dependencies.${kind}`);
+  return JSON.stringify(result);
+}
+
+async function restoreSyncTrigger(
+  client: Client,
+  tableName: string,
+  triggerName: string,
+): Promise<void> {
+  await client.query(`
+    CREATE TRIGGER "${triggerName}"
+    BEFORE INSERT OR UPDATE OF "vm0_user_id", "user_id"
+    ON "${tableName}"
+    FOR EACH ROW EXECUTE FUNCTION "sync_integration_user_identity_0930"()
+  `);
+}
+
+async function testDatabaseBoundaries(databaseUrl: string): Promise<void> {
+  const sourceUrl = new URL(databaseUrl);
+  const admin = new Client({
+    connectionString: databaseUrlFor(sourceUrl, "postgres"),
+  });
+  await admin.connect();
+  await admin.query(`DROP DATABASE IF EXISTS "${testDatabase}" WITH (FORCE)`);
+  await admin.query(`CREATE DATABASE "${testDatabase}"`);
+  const testUrl = databaseUrlFor(sourceUrl, testDatabase);
+
+  try {
+    execFileSync("tsx", [path.join(dirname, "migrate.ts")], {
+      cwd: packageDirectory,
+      env: { ...process.env, DATABASE_URL: testUrl },
+      stdio: "pipe",
+    });
+    const client = new Client({ connectionString: testUrl });
+    const writer = new Client({ connectionString: testUrl });
+    await client.connect();
+    await writer.connect();
+    try {
+      await insertValidRows(client);
+      const allValid =
+        await executeIntegrationIdentityContractReadinessPreflight({
+          connectionString: testUrl,
+        });
+      assert.equal(allValid.status, "passed");
+      assert.equal(allValid.rows.total_count, 12);
+      assert.equal(allValid.rows.invalid_count, 0);
+      assert.equal(JSON.stringify(allValid).includes("never-emit"), false);
+
+      await withReadOnlySnapshot(client, {}, async () => {
+        await assert.rejects(
+          client.query(`INSERT INTO "agentphone_user_links"
+            ("phone_handle", "user_id", "vm0_user_id", "org_id")
+            VALUES ('readonly-phone', 'readonly-user', 'readonly-user', 'readonly-org')`),
+          (error: unknown) => {
+            return (error as { readonly code?: unknown }).code === "25006";
+          },
+        );
+      });
+
+      await assert.rejects(
+        withReadOnlySnapshot(client, { statementTimeoutMs: 25 }, async () => {
+          await client.query("SELECT pg_sleep(0.2)");
+        }),
+        (error: unknown) => {
+          return (
+            error instanceof SanitizedPreflightError &&
+            error.gate === "probe.statement_timeout"
+          );
+        },
+      );
+
+      await writer.query("BEGIN");
+      try {
+        await writer.query(
+          `LOCK TABLE "agentphone_user_links" IN ACCESS EXCLUSIVE MODE`,
+        );
+        await assert.rejects(
+          withReadOnlySnapshot(client, { lockTimeoutMs: 25 }, async () => {
+            await client.query(`SELECT count(*) FROM "agentphone_user_links"`);
+          }),
+          (error: unknown) => {
+            return (
+              error instanceof SanitizedPreflightError &&
+              error.gate === "probe.lock_timeout"
+            );
+          },
+        );
+      } finally {
+        await writer.query("ROLLBACK");
+      }
+
+      const cancelled = new AbortController();
+      cancelled.abort();
+      await assert.rejects(
+        withReadOnlySnapshot(client, { signal: cancelled.signal }, async () => {
+          return undefined;
+        }),
+        (error: unknown) => {
+          return (
+            error instanceof SanitizedPreflightError &&
+            error.gate === "probe.cancelled"
+          );
+        },
+      );
+
+      await writer.query("BEGIN");
+      await writer.query(
+        `LOCK TABLE "agentphone_user_links" IN ACCESS EXCLUSIVE MODE`,
+      );
+      const activeCancellation = new AbortController();
+      const abortTimer = setTimeout(() => {
+        activeCancellation.abort();
+      }, 25);
+      const releaseWriter = new Promise<void>((resolve, reject) => {
+        setTimeout(() => {
+          writer.query("ROLLBACK").then(() => {
+            resolve();
+          }, reject);
+        }, 125);
+      });
+      try {
+        await assert.rejects(
+          executeIntegrationIdentityContractReadinessPreflight({
+            connectionString: testUrl,
+            signal: activeCancellation.signal,
+            lockTimeoutMs: 1000,
+            statementTimeoutMs: 2000,
+          }),
+          (error: unknown) => {
+            return (
+              error instanceof SanitizedPreflightError &&
+              error.gate === "probe.cancelled"
+            );
+          },
+        );
+      } finally {
+        clearTimeout(abortTimer);
+        await releaseWriter;
+      }
+
+      await withReadOnlySnapshot(client, {}, async () => {
+        const before = await client.query<{ count: string }>(
+          `SELECT count(*)::text AS "count" FROM "agentphone_user_links"`,
+        );
+        await writer.query(`INSERT INTO "agentphone_user_links"
+          ("phone_handle", "user_id", "vm0_user_id", "org_id")
+          VALUES ('never-emit-phone-snapshot', 'never-emit-user-snapshot', 'never-emit-user-snapshot', 'never-emit-org-snapshot')`);
+        const after = await client.query<{ count: string }>(
+          `SELECT count(*)::text AS "count" FROM "agentphone_user_links"`,
+        );
+        assert.equal(before.rows[0]?.count, "1");
+        assert.equal(after.rows[0]?.count, "1");
+      });
+
+      const firstRerun =
+        await executeIntegrationIdentityContractReadinessPreflight({
+          connectionString: testUrl,
+        });
+      const secondRerun =
+        await executeIntegrationIdentityContractReadinessPreflight({
+          connectionString: testUrl,
+        });
+      assert.deepEqual(secondRerun, firstRerun);
+      assert.equal(firstRerun.rows.total_count, 13);
+
+      const triggerTable = "agentphone_user_links";
+      const triggerName = "sync_agentphone_user_links_identity_0930";
+      await client.query(
+        `ALTER TABLE "${triggerTable}" DISABLE TRIGGER "${triggerName}"`,
+      );
+      await client.query(
+        `ALTER TABLE "${triggerTable}" ALTER COLUMN "vm0_user_id" DROP NOT NULL`,
+      );
+      await client.query(`UPDATE "${triggerTable}"
+        SET "vm0_user_id" = NULL
+        WHERE "phone_handle" = 'never-emit-phone-02'`);
+      const nullPair =
+        await executeIntegrationIdentityContractReadinessPreflight({
+          connectionString: testUrl,
+        });
+      assert.equal(nullPair.rows.tables.agentphone_user_links.invalid_count, 1);
+      gatePresent(nullPair, "rows.agentphone_user_links.invalid");
+      gatePresent(nullPair, "dependencies.columns");
+      await client.query(`UPDATE "${triggerTable}"
+        SET "vm0_user_id" = "user_id"
+        WHERE "phone_handle" = 'never-emit-phone-02'`);
+      await client.query(
+        `ALTER TABLE "${triggerTable}" ALTER COLUMN "vm0_user_id" SET NOT NULL`,
+      );
+
+      await client.query(`UPDATE "${triggerTable}"
+        SET "vm0_user_id" = 'never-emit-mismatched-identity'
+        WHERE "phone_handle" = 'never-emit-phone-02'`);
+      const mismatchedPair =
+        await executeIntegrationIdentityContractReadinessPreflight({
+          connectionString: testUrl,
+        });
+      assert.equal(
+        mismatchedPair.rows.tables.agentphone_user_links.invalid_count,
+        1,
+      );
+      gatePresent(mismatchedPair, "rows.agentphone_user_links.invalid");
+      await client.query(`UPDATE "${triggerTable}"
+        SET "vm0_user_id" = "user_id"
+        WHERE "phone_handle" = 'never-emit-phone-02'`);
+      await client.query(
+        `ALTER TABLE "${triggerTable}" ENABLE TRIGGER "${triggerName}"`,
+      );
+
+      await client.query(`DROP TRIGGER "${triggerName}" ON "${triggerTable}"`);
+      await executeAndExpectDependencyDrift(testUrl, "triggers");
+      await restoreSyncTrigger(client, triggerTable, triggerName);
+
+      await client.query(
+        `ALTER TABLE "${triggerTable}" DISABLE TRIGGER "${triggerName}"`,
+      );
+      await executeAndExpectDependencyDrift(testUrl, "triggers");
+      await client.query(
+        `ALTER TABLE "${triggerTable}" ENABLE TRIGGER "${triggerName}"`,
+      );
+
+      await client.query(`DROP TRIGGER "${triggerName}" ON "${triggerTable}"`);
+      await client.query(`
+        CREATE TRIGGER "${triggerName}"
+        BEFORE INSERT ON "${triggerTable}"
+        FOR EACH ROW EXECUTE FUNCTION "sync_integration_user_identity_0930"()
+      `);
+      await executeAndExpectDependencyDrift(testUrl, "triggers");
+      await client.query(`DROP TRIGGER "${triggerName}" ON "${triggerTable}"`);
+      await restoreSyncTrigger(client, triggerTable, triggerName);
+
+      const functionDefinition = await client.query<{ definition: string }>(`
+        SELECT pg_get_functiondef("function"."oid") AS "definition"
+        FROM "pg_proc" AS "function"
+        INNER JOIN "pg_namespace" AS "namespace"
+          ON "namespace"."oid" = "function"."pronamespace"
+        WHERE "namespace"."nspname" = 'public'
+          AND "function"."proname" = 'sync_integration_user_identity_0930'
+      `);
+      const originalFunctionDefinition = functionDefinition.rows[0]?.definition;
+      assert.ok(originalFunctionDefinition);
+      await client.query(`
+        CREATE OR REPLACE FUNCTION "sync_integration_user_identity_0930"()
+        RETURNS trigger LANGUAGE plpgsql AS $body$
+        BEGIN
+          RETURN NEW;
+        END;
+        $body$
+      `);
+      await executeAndExpectDependencyDrift(testUrl, "functions");
+      await client.query(originalFunctionDefinition);
+
+      await client.query(`ALTER TABLE "agentphone_user_agent_preferences"
+        DROP CONSTRAINT "agentphone_user_agent_preferences_pkey"`);
+      await executeAndExpectDependencyDrift(testUrl, "primaryKeys");
+      await client.query(`ALTER TABLE "agentphone_user_agent_preferences"
+        ADD CONSTRAINT "agentphone_user_agent_preferences_pkey"
+        PRIMARY KEY ("vm0_user_id", "org_id")`);
+
+      await client.query(`ALTER TABLE "agentphone_user_links"
+        ADD CONSTRAINT "preflight_unexpected_identity_check"
+        CHECK ("vm0_user_id" <> 'never-emit-constraint-value')`);
+      const constraintJson = await executeAndExpectDependencyDrift(
+        testUrl,
+        "constraints",
+      );
+      assert.equal(
+        constraintJson.includes("never-emit-constraint-value"),
+        false,
+      );
+      await client.query(`ALTER TABLE "agentphone_user_links"
+        DROP CONSTRAINT "preflight_unexpected_identity_check"`);
+
+      await client.query(`CREATE TABLE "preflight_identity_reference" (
+        "vm0_user_id" text NOT NULL,
+        "org_id" text NOT NULL,
+        CONSTRAINT "preflight_unexpected_identity_foreign_key"
+          FOREIGN KEY ("vm0_user_id", "org_id")
+          REFERENCES "agentphone_user_agent_preferences" ("vm0_user_id", "org_id")
+      )`);
+      await executeAndExpectDependencyDrift(testUrl, "constraints");
+      await client.query(`DROP TABLE "preflight_identity_reference"`);
+
+      await client.query(`ALTER TABLE "agentphone_user_links"
+        ALTER COLUMN "vm0_user_id" SET DEFAULT 'never-emit-default-value'`);
+      const defaultJson = await executeAndExpectDependencyDrift(
+        testUrl,
+        "defaultsAndGenerated",
+      );
+      assert.equal(defaultJson.includes("never-emit-default-value"), false);
+      await client.query(`ALTER TABLE "agentphone_user_links"
+        ALTER COLUMN "vm0_user_id" DROP DEFAULT`);
+
+      await client.query(`ALTER TABLE "agentphone_user_links"
+        ADD COLUMN "preflight_generated_identity" text
+        GENERATED ALWAYS AS ("vm0_user_id") STORED`);
+      await executeAndExpectDependencyDrift(testUrl, "defaultsAndGenerated");
+      await client.query(`ALTER TABLE "agentphone_user_links"
+        DROP COLUMN "preflight_generated_identity"`);
+
+      await client.query(`CREATE INDEX "preflight_unexpected_identity_index"
+        ON "agentphone_user_links" ((lower("vm0_user_id")))`);
+      await executeAndExpectDependencyDrift(testUrl, "indexes");
+      await client.query(`DROP INDEX "preflight_unexpected_identity_index"`);
+
+      await client.query(`CREATE VIEW "preflight_identity_view" AS
+        SELECT "vm0_user_id" FROM "agentphone_user_links"`);
+      await executeAndExpectDependencyDrift(testUrl, "rewriteDependents");
+      await client.query(`DROP VIEW "preflight_identity_view"`);
+
+      await client.query(`CREATE MATERIALIZED VIEW "preflight_identity_matview" AS
+        SELECT "vm0_user_id" FROM "agentphone_user_links" WITH NO DATA`);
+      await executeAndExpectDependencyDrift(testUrl, "rewriteDependents");
+      await client.query(`DROP MATERIALIZED VIEW "preflight_identity_matview"`);
+
+      await client.query(`CREATE RULE "preflight_identity_rule" AS
+        ON UPDATE TO "agentphone_user_links"
+        WHERE OLD."vm0_user_id" IS NOT NULL DO ALSO NOTHING`);
+      await executeAndExpectDependencyDrift(testUrl, "rewriteDependents");
+      await client.query(
+        `DROP RULE "preflight_identity_rule" ON "agentphone_user_links"`,
+      );
+
+      await client.query(`CREATE SEQUENCE "preflight_identity_sequence"
+        OWNED BY "agentphone_user_links"."vm0_user_id"`);
+      await executeAndExpectDependencyDrift(testUrl, "otherDependents");
+      await client.query(`DROP SEQUENCE "preflight_identity_sequence"`);
+
+      const catalog = await client.query<CatalogDependencySourceRow>(
+        CATALOG_DEPENDENCY_QUERY,
+      );
+      assert.equal(
+        catalog.rows.filter((row) => {
+          return row.kind === "columns";
+        }).length,
+        24,
+      );
+      const finalResult =
+        await executeIntegrationIdentityContractReadinessPreflight({
+          connectionString: testUrl,
+        });
+      assert.equal(finalResult.status, "passed");
+      assert.equal(JSON.stringify(finalResult).includes("never-emit"), false);
+    } finally {
+      await client.end();
+      await writer.end();
+    }
+  } finally {
+    await admin.query(`DROP DATABASE IF EXISTS "${testDatabase}" WITH (FORCE)`);
+    await admin.end();
+  }
+}
+
+export async function validateIntegrationIdentityContractReadinessPreflightStatic(): Promise<void> {
+  testStaticClassification();
+  await testRepositoryContracts();
+}
+
+export async function validateIntegrationIdentityContractReadinessPreflight(): Promise<void> {
+  await validateIntegrationIdentityContractReadinessPreflightStatic();
+  const databaseUrl = process.env.DATABASE_URL;
+  assert.ok(databaseUrl, "DATABASE_URL is required");
+  await testDatabaseBoundaries(databaseUrl);
+  console.log("integration identity Contract readiness preflight passed");
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) {
+  validateIntegrationIdentityContractReadinessPreflight().catch(
+    (error: unknown) => {
+      console.error(error);
+      process.exitCode = 1;
+    },
+  );
+}

--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -53,6 +53,7 @@ import {
   validateAgentRunLaunchSnapshotSchema,
 } from "./test-agent-run-launch-snapshot";
 import { validateAgentComposeConsolidationPreflight } from "./test-agent-compose-consolidation-preflight";
+import { validateIntegrationIdentityContractReadinessPreflight } from "./test-integration-identity-contract-readiness-preflight";
 import {
   AgentComposeProvenanceSchemaUnavailableError,
   deleteClerkAgentLifecycleData,
@@ -11654,6 +11655,7 @@ async function main(): Promise<void> {
     await validateChatEventSnapshotContraction();
     await validateAgentComposeProvenanceMigration();
     await validateAgentComposeConsolidationPreflight();
+    await validateIntegrationIdentityContractReadinessPreflight();
     await validateAgentRunMetadataStage2Preflight();
     await validateAgentRunMetadataStage2Lock();
     await validateAgentRunMetadataStage2Index();


### PR DESCRIPTION
## Summary

- add a temporary, manually dispatched, production-environment-gated, main-only integration identity Contract readiness workflow
- run the reviewed probe in `REPEATABLE READ READ ONLY`, verify read-only/isolation capabilities, and enforce bounded lock and statement timeouts
- compare aggregate row invariants for exactly the 12 reviewed identity tables and fingerprint the reviewed PostgreSQL catalog dependency manifest
- register the transition validator with #27602 as the removal owner

## Contract and safety

- resolves the Neon production connection with `--ssl verify-full`
- reports only deterministic v1 aggregate/catalog JSON on success and sanitized failure JSON on failure
- fails closed for null or mismatched identity pairs and for missing, changed, disabled, or unexpected catalog dependencies
- covers columns, primary keys, constraints (including external foreign-key consumers), defaults/generated expressions, indexes, triggers, functions, views, materialized views, rewrite rules, and other `pg_depend` consumers
- adds no migration, Drizzle schema change, historical migration/snapshot/journal edit, API route, scheduled path, production write, DDL, or raw-result artifact
- does not invoke or approve the production preflight, change release/rollback policy, or start Contract #27602

## Validation

- `pnpm exec prettier --check` on all changed files
- repository lint and Knip
- segmented type-checks for all non-API packages (12/12), `@okouai/app`, and `api`
- `DATABASE_URL=... pnpm --filter @okouai/db exec tsx scripts/test-integration-identity-contract-readiness-preflight.ts`
- `DATABASE_URL=... pnpm --filter @okouai/db test:migration-consistency` (128 migrations/snapshots, fresh/existing replay, normalized schema, and both transition validators)
- `actionlint 1.7.12` on the dedicated workflow and all repository workflows
- repository Neon connection-string SSL invariant: 11/11 invocations use `--ssl verify-full`
- the in-flight cancellation fixture waits for the probe's observed PostgreSQL `Lock` wait before aborting, without fixed timing assumptions
- final open-PR inventory before push found one exact-file overlap: #27736 also changes `test-migration-consistency-schema.ts`, only at its permanent agent-run metadata inventory; this PR changes only the top-level import and terminal transition-validator invocation, with no shared symbol or hunk

Validated after rebasing to exact base `508b6a701d6f6303c0925be6a48c67793bb162bd`.

Closes #27665

Parent #27599