### PR TITLE
fix(python): bound codex prefetch marker parsing

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -103,6 +103,7 @@ _FLOW_STATE = "_codex_model_catalog_cache_state"
 _FLOW_TELEMETRY = "_codex_model_catalog_cache_telemetry"
 _PREFETCH_REQUEST = "_codex_model_catalog_prefetch_request"
 _PREFETCH_HEADER = "X-VM0-Codex-Model-Catalog-Prefetch"
+_RAW_PREFETCH_HEADER = b"x-vm0-codex-model-catalog-prefetch"
 _BROTLI_ENCODING = "br"
 _IDENTITY_ENCODING = "identity"
 _REQUEST_CONDITIONAL_HEADERS = (
@@ -549,11 +550,20 @@ def _request_bypass_reason(
 
 def capture_and_strip_prefetch_marker(flow: http.HTTPFlow) -> None:
     """Capture the runner-only prefetch marker without forwarding it upstream."""
-    values = flow.request.headers.get_all(_PREFETCH_HEADER)
-    if not values:
+    raw_value: bytes | None = None
+    repeated = False
+    for name, value in flow.request.headers.fields:
+        if name.lower() != _RAW_PREFETCH_HEADER:
+            continue
+        if raw_value is not None:
+            repeated = True
+            break
+        raw_value = value
+
+    if raw_value is None:
         return
-    flow.request.headers.pop(_PREFETCH_HEADER, None)
-    if values == ["1"]:
+    flow.request.headers.set_all(_PREFETCH_HEADER, [])
+    if not repeated and len(raw_value) == 1 and raw_value == b"1":
         flow.metadata[_PREFETCH_REQUEST] = True
 
 

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -8,7 +8,7 @@ from typing import Literal
 from unittest.mock import patch
 
 import pytest
-from mitmproxy import connection
+from mitmproxy import connection, http
 from mitmproxy.flow import Error
 
 import codex_model_catalog_cache as catalog_cache
@@ -33,6 +33,11 @@ from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 from tests.requestheaders_helpers import await_requestheaders_result
 from tests.upstream_connection_helpers import mark_connected_tls_upstream
+
+
+class _DecodeGuardPrefetchMarker(bytes):
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("Codex prefetch marker must not be decoded")
 
 
 async def test_request_bypasses_do_not_touch_unrelated_traffic(real_flow):
@@ -271,6 +276,84 @@ async def test_both_firewall_auth_paths_prepare_catalog_cache(
     assert header_flow.response.content == CATALOG_BODY
     assert header_flow.response.stream is False
     assert "X-VM0-Codex-Model-Catalog-Prefetch" not in header_flow.request.headers
+
+
+@pytest.mark.parametrize(
+    ("marker_values", "expected_prefetch"),
+    [
+        pytest.param((_DecodeGuardPrefetchMarker(b"1"),), True, id="exact"),
+        pytest.param(
+            (
+                _DecodeGuardPrefetchMarker(b"1"),
+                _DecodeGuardPrefetchMarker(b"1"),
+            ),
+            False,
+            id="repeated",
+        ),
+        pytest.param((_DecodeGuardPrefetchMarker(b""),), False, id="empty"),
+        pytest.param((_DecodeGuardPrefetchMarker(b"\xff"),), False, id="non-ascii"),
+        pytest.param(
+            (_DecodeGuardPrefetchMarker(b"x" * (1024 * 1024)),),
+            False,
+            id="oversized",
+        ),
+    ],
+)
+async def test_prefetch_marker_requires_one_exact_raw_value_across_request_hooks(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    marker_values: tuple[bytes, ...],
+    expected_prefetch: bool,
+):
+    registry_path = _write_codex_registry(tmp_path, capture=False)
+    request_headers = http.Headers(
+        [
+            (b"Host", b"chatgpt.com"),
+            (b"Accept-Encoding", b"identity"),
+            (b"Content-Length", b"0"),
+            *((b"x-VM0-Codex-Model-Catalog-Prefetch", value) for value in marker_values),
+        ]
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="chatgpt.com",
+        method="GET",
+        path="/backend-api/codex/models?client_version=0.145.0",
+        request_headers=request_headers,
+    )
+    flow.metadata["_vm0_request_end_stream"] = True
+
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(
+            headers={
+                "Authorization": "Bearer resolved-token",
+                "ChatGPT-Account-ID": "resolved-account",
+            }
+        ),
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        assert requestheaders_result is None
+        assert all(
+            name.lower() != b"x-vm0-codex-model-catalog-prefetch"
+            for name, _ in flow.request.headers.fields
+        )
+        assert (
+            flow.metadata.get("_codex_model_catalog_prefetch_request") is True
+        ) is expected_prefetch
+
+        await mitm_addon.request(flow)
+
+    assert all(
+        name.lower() != b"x-vm0-codex-model-catalog-prefetch"
+        for name, _ in flow.request.headers.fields
+    )
+    assert (flow.metadata.get("_codex_model_catalog_prefetch_request") is True) is expected_prefetch
+    assert flow.request.headers["Accept-Encoding"] == ("br" if expected_prefetch else "identity")
+    catalog_cache.release_flow_state(flow)
 
 
 @pytest.mark.parametrize("entry_point", ["request", "requestheaders"])


### PR DESCRIPTION
## Summary

- inspect the runner-private Codex catalog prefetch marker through raw mitmproxy header fields
- accept only one exact `b"1"` value and strip every marker occurrence without decoded access
- preserve prefetch metadata across the normal `requestheaders()` to `request()` lifecycle
- structurally cover exact, repeated, empty, non-ASCII, and 1 MiB marker values through real hook integration

## Security and compatibility

This removes request-sized UTF-8 decoding, list construction, and the additional decoded lookup/folding previously performed by `Headers.pop()` on the shared proxy event loop. Valid runner-generated traffic is unchanged; invalid marker forms remain stripped, non-fatal, and ordinary identity requests.

The marker and cache metadata are runner-local, so old and new runners can overlap without a cross-version protocol or persisted-state change. This PR intentionally does not introduce a proxy-wide request-head limit or address work proportional to aggregate header count, unrelated fields, or mitmproxy's prior parser buffering.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` — 0 errors, 0 warnings
- `uv run --no-sync python -m pytest tests/test_codex_model_catalog_cache_hooks.py` — 24 passed
- `uv run --no-sync python -m pytest tests/` — 5,587 passed, 59 existing warnings
- `git diff --check`
- staged-file pre-commit hook — Ruff and file-size checks passed
- commit message hook — commitlint passed

Closes #27717
