### PR TITLE
refactor(cli): prepare default image model precedence

### DIFF
--- a/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
@@ -33,6 +33,24 @@ const IMAGE_RESULT = {
   moderation: "auto",
 };
 
+function buildRunToken(): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
+    "base64url",
+  );
+  const body = Buffer.from(
+    JSON.stringify({
+      userId: "user-image",
+      runId: "run-image",
+      orgId: "org-image",
+      scope: "okou",
+      capabilities: ["file:write"],
+      iat: 1000,
+      exp: 2000,
+    }),
+  ).toString("base64url");
+  return `vm0_sandbox_${header}.${body}.test-signature`;
+}
+
 describe("okou generate image command", () => {
   vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -115,6 +133,71 @@ describe("okou generate image command", () => {
     expect(stdout).toContain("Model: gpt-image-1");
     expect(stdout).toContain("Provider: fal");
   });
+
+  it.each([
+    {
+      name: "outside a run with an implicit model",
+      insideRun: false,
+      modelArguments: [],
+      expectedModel: "gpt-image-1",
+    },
+    {
+      name: "outside a run with an explicit model",
+      insideRun: false,
+      modelArguments: ["--model", "qwen-image"],
+      expectedModel: "qwen-image",
+    },
+    {
+      name: "inside a run with an implicit model",
+      insideRun: true,
+      modelArguments: [],
+      expectedModel: undefined,
+    },
+    {
+      name: "inside a run with an explicit model",
+      insideRun: true,
+      modelArguments: ["--model", "qwen-image"],
+      expectedModel: "qwen-image",
+    },
+    {
+      name: "inside a run with an explicit value equal to the CLI default",
+      insideRun: true,
+      modelArguments: ["--model", "gpt-image-1"],
+      expectedModel: "gpt-image-1",
+    },
+  ])(
+    "should serialize image model precedence for $name",
+    async ({ insideRun, modelArguments, expectedModel }) => {
+      vi.stubEnv("OKOU_TOKEN", insideRun ? buildRunToken() : "test-token");
+      let capturedBody: unknown;
+      server.use(
+        http.post(IMAGE_URL, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(IMAGE_RESULT);
+        }),
+      );
+
+      await generateCommand.parseAsync([
+        "node",
+        "cli",
+        "image",
+        "--raw-prompt",
+        "Model precedence",
+        ...modelArguments,
+      ]);
+
+      expect(capturedBody).toEqual({
+        prompt: "Model precedence",
+        ...(expectedModel === undefined ? {} : { model: expectedModel }),
+        size: "1024x1024",
+        quality: "medium",
+        background: "auto",
+        outputFormat: "png",
+        moderation: "auto",
+        safetyTolerance: "4",
+      });
+    },
+  );
 
   it("should surface the CDN embed URL when it differs from the file URL", async () => {
     const embedUrl =

--- a/turbo/apps/cli/src/commands/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/image-generate.ts
@@ -1,12 +1,17 @@
 import { Command, InvalidArgumentError } from "commander";
 import chalk from "chalk";
 import { generateWebImage } from "../../lib/api/domains/web";
+import { decodeSandboxTokenPayload } from "../../lib/api/sandbox-token";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { createStyledImageCompilationPacket } from "./image-style-authoring";
 import {
   findImageStyle,
   listImageStyles,
 } from "@okouai/core/resource-registry";
+import {
+  DEFAULT_IMAGE_MODEL,
+  IMAGE_MODEL_CONFIGS,
+} from "@okouai/core/image-model-catalog";
 import { formatRegistryListing } from "./resource-listing";
 import { dispatchGenerate } from "../generate/lib/dispatch";
 import type { GenerationType } from "../generate/lib/lister";
@@ -135,6 +140,15 @@ function resolvePromptInput(options: ImageOptions): string | undefined {
   return options.compiledPrompt ?? options.rawPrompt ?? options.prompt;
 }
 
+function resolveImageRequestModel(
+  command: Command,
+  model: string,
+): string | undefined {
+  const hasRunScopedToken = decodeSandboxTokenPayload() !== undefined;
+  const modelSource = command.getOptionValueSource("model");
+  return hasRunScopedToken && modelSource === "default" ? undefined : model;
+}
+
 function hasImagePromptModeRequest(options: ImageOptions): boolean {
   return (
     options.style !== undefined ||
@@ -213,7 +227,7 @@ export function createImageGenerateCommand(
     .option(
       "--model <model>",
       "Model: gpt-image-1 (default), gpt-image-2, gpt-image-1.5, gpt-image-1-mini, flux-pro-1.1, flux-pro-1.1-ultra, qwen-image, seedream4, or nano-banana-2",
-      "gpt-image-1",
+      IMAGE_MODEL_CONFIGS[DEFAULT_IMAGE_MODEL].alias,
     )
     .option(
       "--size <size>",
@@ -393,7 +407,7 @@ ${formatRegistryListing(styles, "image styles")}`;
             : options.size;
         const result = await generateWebImage({
           prompt: resolvedPrompt,
-          model: options.model,
+          model: resolveImageRequestModel(command, options.model),
           size,
           quality: options.quality,
           background: options.background,


### PR DESCRIPTION
## Summary

- distinguish the implicit Commander `--model` default from an explicit value for direct built-in image generation
- when a run-scoped sandbox token is present, omit `model` only when Commander reports the option source as `default`
- preserve every explicit direct-image `--model B` value exactly, including explicit `gpt-image-1`
- outside a run, preserve the existing implicit `gpt-image-1` and explicit-model request shapes
- reuse `DEFAULT_IMAGE_MODEL` and its CLI alias from the shared image model catalog added by merged PR #27710

## Behavior matrix

| Context | CLI input | Commander source | Serialized `model` |
| --- | --- | --- | --- |
| Outside run | implicit | `default` | `gpt-image-1` |
| Outside run | explicit B | `cli` | B |
| Run | implicit | `default` | omitted |
| Run | explicit B | `cli` | B |
| Run | explicit `gpt-image-1` | `cli` | `gpt-image-1` |

The CLI does not read or duplicate the run snapshot model. Before run-snapshot resolution lands, an omitted model still reaches the existing API fallback of `gpt-image-1`; once that later server work applies the snapshot, the missing field allows the run default to take effect.

## Scope guards

- Sprite is unchanged and retains its implicit `gpt-image-2` recommendation
- Website and image compile-prompt guidance are unchanged
- no `OKOU_DEFAULT_IMAGE_MODEL` or other environment injection
- no image endpoint, server defaulting, run snapshot, database, composer UI, or feature-switch changes
- final diff contains only direct image serialization and its CLI integration tests
- single commit rebased directly on current `origin/main` (`508b6a701d6f6303c0925be6a48c67793bb162bd`)

## Verification

- `pnpm exec prettier --write apps/cli/src/commands/generate/__tests__/image.test.ts apps/cli/src/commands/shared/image-generate.ts`
- `pnpm exec prettier --check apps/cli/src/commands/generate/__tests__/image.test.ts apps/cli/src/commands/shared/image-generate.ts`
- `pnpm --filter @okouai/cli run lint`
- `pnpm exec knip --workspace @okouai/cli`
- `pnpm --filter @okouai/cli run check-types`
- `pnpm --filter @okouai/cli exec vitest run src/commands/generate/__tests__/image.test.ts` (24 tests)
- committed-diff whitespace, two-file scope, forbidden environment/server change, Sprite zero-diff, and current-main ancestry review

## Deferred external template companion

`template:image-poster` is sourced outside this repository from `nexu-io/open-design@3fb620af423534643677c7c6fae76be088fa770a`, at `design-templates/image-poster/SKILL.md`. Its frontmatter still defaults to `gpt-image-2`, and its dispatch instructions pass that model. Any change to make that externally authored implicit recommendation yield to a run default requires a focused companion change in `nexu-io/open-design`, followed by advancing the pinned registry source in vm0. That work is intentionally deferred.

Depends only on merged PR #27710.

Refs #27688