### PR TITLE
perf(python): share websocket server event parsing

### DIFF
--- a/crates/runner/mitm-addon/src/model_websocket_usage.py
+++ b/crates/runner/mitm-addon/src/model_websocket_usage.py
@@ -218,7 +218,6 @@ def feed_usage(
     if not is_enabled(flow):
         return
     prewarm_state = flow.metadata.get(_MODEL_WEBSOCKET_PREWARM_STATE)
-    lifecycle: usage.OpenAIResponsesServerLifecycle | None = None
     should_inspect_lifecycle = (
         isinstance(prewarm_state, _OpenAIResponsesPrewarmState)
         and not prewarm_state.ambiguous
@@ -230,11 +229,16 @@ def feed_usage(
             or event.event_type in _WEBSOCKET_LIFECYCLE_EVENT_TYPES
         )
     )
-    if should_inspect_lifecycle and isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
-        lifecycle = usage.inspect_openai_responses_server_lifecycle(event)
+    inspection = usage.inspect_openai_responses_server_event(
+        event,
+        include_lifecycle=should_inspect_lifecycle,
+    )
+    lifecycle = inspection.lifecycle
+    if lifecycle is not None and isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
         _observe_server_lifecycle(flow, prewarm_state, lifecycle)
 
-    usage_result, inspection_error = usage.extract_openai_responses_usage_from_event(event)
+    usage_result = inspection.usage
+    inspection_error = inspection.usage_error
     if inspection_error is not None:
         if isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
             _mark_correlation_ambiguous(flow, prewarm_state, "correlation_cap")

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -68,6 +68,7 @@ from .openai_chat_completions import (
 from .openai_responses import (
     OpenAIResponsesClientEvent,
     OpenAIResponsesEvent,
+    OpenAIResponsesServerEventInspection,
     OpenAIResponsesServerLifecycle,
     create_openai_responses_json_usage_extractor,
     create_openai_responses_sse_usage_extractor,
@@ -75,7 +76,7 @@ from .openai_responses import (
     extract_openai_responses_usage_with_error_from_json,
     inspect_openai_responses_client_event_json,
     inspect_openai_responses_event_json,
-    inspect_openai_responses_server_lifecycle,
+    inspect_openai_responses_server_event,
     merge_openai_responses_usage_result,
 )
 from .providers.connectors import (
@@ -101,6 +102,7 @@ __all__ = [
     "ModelUsageProtocol",
     "OpenAIResponsesClientEvent",
     "OpenAIResponsesEvent",
+    "OpenAIResponsesServerEventInspection",
     "OpenAIResponsesServerLifecycle",
     "admit_buffered_report",
     "buffer_model_usage_observations",
@@ -130,7 +132,7 @@ __all__ = [
     "increment_in_flight_flows",
     "inspect_openai_responses_client_event_json",
     "inspect_openai_responses_event_json",
-    "inspect_openai_responses_server_lifecycle",
+    "inspect_openai_responses_server_event",
     "is_model_provider_usage_observable",
     "log_ignored_model_provider_usage_source",
     "log_terminal_model_provider_usage_sources",

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -13,9 +13,10 @@ model-provider usage billing:
 - Single-frame WebSocket event JSON via
   ``inspect_openai_responses_client_event_json``,
   ``inspect_openai_responses_event_json``, and
-  ``extract_openai_responses_usage_from_event``, consumed by
-  ``mitm_addon.py`` and ``model_websocket_usage.py`` for client request intent,
-  event-type timing, and server usage events received over upgrades.
+  ``inspect_openai_responses_server_event``, consumed by ``mitm_addon.py`` and
+  ``model_websocket_usage.py`` for client request intent, event-type timing,
+  shared server lifecycle correlation, and usage received over upgrades.
+  ``extract_openai_responses_usage_from_event`` retains the usage-only facade.
 - Per-event usage aggregation via ``merge_openai_responses_usage_result``,
   used by ``response_streaming.py`` for terminal SSE events and
   ``model_websocket_usage.py`` for WebSocket events.
@@ -33,6 +34,7 @@ from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
 from .json_probe import TopLevelStringFieldProbeResult, probe_top_level_string_field
 from .json_selective import (
     JSON_WORK_LIMIT_EXCEEDED,
+    JsonExtractionResult,
     JsonSelectiveExtractor,
     ScalarField,
 )
@@ -140,6 +142,10 @@ _RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR = "work_limit_exceeded"
 _RESPONSES_CREATE_EVENT = "response.create"
 _RESPONSES_CREATED_EVENT = "response.created"
 _RESPONSES_ERROR_EVENT = "error"
+_RESPONSES_SERVER_LIFECYCLE_EVENTS = _RESPONSES_TERMINAL_USAGE_EVENTS | {
+    _RESPONSES_CREATED_EVENT,
+    _RESPONSES_ERROR_EVENT,
+}
 
 
 @dataclass(frozen=True)
@@ -172,6 +178,15 @@ class OpenAIResponsesServerLifecycle:
     @property
     def is_error(self) -> bool:
         return self.event_type == _RESPONSES_ERROR_EVENT
+
+
+@dataclass(frozen=True)
+class OpenAIResponsesServerEventInspection:
+    """Shared lifecycle and usage observations from one server frame."""
+
+    lifecycle: OpenAIResponsesServerLifecycle | None
+    usage: dict | None
+    usage_error: str | None
 
 
 @dataclass(frozen=True)
@@ -258,8 +273,9 @@ def inspect_openai_responses_event_json(body: bytes) -> OpenAIResponsesEvent:
 
     The returned ``event_type`` is only the bounded-prefix observation; this
     function does not fully parse or validate the frame. Pass the returned event
-    to ``extract_openai_responses_usage_from_event`` for selective full-frame
-    usage inspection.
+    to ``inspect_openai_responses_server_event`` for shared lifecycle and usage
+    inspection, or to ``extract_openai_responses_usage_from_event`` when only
+    usage is needed.
     """
     result = _probe_responses_event_type(body)
     return OpenAIResponsesEvent(
@@ -274,24 +290,11 @@ def _inspect_openai_responses_event_type_json(body: bytes) -> str | None:
     return _observed_responses_event_type(_probe_responses_event_type(body))
 
 
-def inspect_openai_responses_server_lifecycle(
+def _lifecycle_from_extraction(
     event: OpenAIResponsesEvent,
+    extractor: JsonSelectiveExtractor,
+    result: JsonExtractionResult,
 ) -> OpenAIResponsesServerLifecycle:
-    """Inspect a bounded lifecycle boundary for WebSocket correlation."""
-    relevant_event_types = _RESPONSES_TERMINAL_USAGE_EVENTS | {
-        _RESPONSES_CREATED_EVENT,
-        _RESPONSES_ERROR_EVENT,
-    }
-    if event.event_type is not None and event.event_type not in relevant_event_types:
-        return OpenAIResponsesServerLifecycle(event.event_type, None, True)
-
-    extractor = JsonSelectiveExtractor(
-        scalar_fields=_RESPONSES_LIFECYCLE_SCALAR_FIELDS,
-        scalar_consistency_paths={("type",), ("response", "id")},
-        max_work_units=_RESPONSES_MAX_WORK_UNITS,
-    )
-    extractor.feed(event._body)
-    result = extractor.finish()
     if not result.complete:
         return OpenAIResponsesServerLifecycle(
             event.event_type,
@@ -306,7 +309,7 @@ def inspect_openai_responses_server_lifecycle(
         return OpenAIResponsesServerLifecycle(event.event_type, None, False)
     if event_type == _RESPONSES_ERROR_EVENT:
         return OpenAIResponsesServerLifecycle(event_type, None, True)
-    if event_type not in relevant_event_types:
+    if event_type not in _RESPONSES_SERVER_LIFECYCLE_EVENTS:
         return OpenAIResponsesServerLifecycle(event_type, None, True)
     response_id = result.values.get(("response", "id"))
     if (
@@ -316,6 +319,77 @@ def inspect_openai_responses_server_lifecycle(
     ):
         return OpenAIResponsesServerLifecycle(event_type, None, False)
     return OpenAIResponsesServerLifecycle(event_type, response_id, True)
+
+
+def _usage_from_extraction(
+    result: JsonExtractionResult,
+    data_event_type: _ResponsesEventTypeClassification | None,
+) -> tuple[dict | None, str | None]:
+    if not result.complete:
+        error = (
+            _RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR
+            if result.error == JSON_WORK_LIMIT_EXCEEDED
+            else None
+        )
+        return None, error
+
+    extracted_usage: dict = {}
+    _store_sse_result_values(
+        result.values,
+        extracted_usage,
+        event_name=None,
+        data_event_type=data_event_type,
+    )
+    if not any(category in extracted_usage for category in MODEL_USAGE_CATEGORIES):
+        return None, None
+    return extracted_usage, None
+
+
+def inspect_openai_responses_server_event(
+    event: OpenAIResponsesEvent,
+    *,
+    include_lifecycle: bool,
+) -> OpenAIResponsesServerEventInspection:
+    """Inspect one server frame with at most one bounded full-body parse."""
+    lifecycle: OpenAIResponsesServerLifecycle | None = None
+    needs_lifecycle_parse = include_lifecycle
+    if (
+        include_lifecycle
+        and event.event_type is not None
+        and event.event_type not in _RESPONSES_SERVER_LIFECYCLE_EVENTS
+    ):
+        lifecycle = OpenAIResponsesServerLifecycle(event.event_type, None, True)
+        needs_lifecycle_parse = False
+
+    needs_usage_parse = event._classification != _RESPONSES_EVENT_KNOWN_NON_USAGE
+    if not needs_lifecycle_parse and not needs_usage_parse:
+        return OpenAIResponsesServerEventInspection(lifecycle, None, None)
+
+    data_event_type = _resolved_data_event_type(event._classification)
+    if needs_usage_parse:
+        scalar_fields = (
+            _RESPONSES_SSE_SCALAR_FIELDS
+            if data_event_type is None or needs_lifecycle_parse
+            else _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS
+        )
+    else:
+        scalar_fields = _RESPONSES_LIFECYCLE_SCALAR_FIELDS
+
+    consistency_paths = {("type",), ("response", "id")} if needs_lifecycle_parse else None
+    extractor = JsonSelectiveExtractor(
+        scalar_fields=scalar_fields,
+        scalar_consistency_paths=consistency_paths,
+        max_work_units=_RESPONSES_MAX_WORK_UNITS,
+    )
+    extractor.feed(event._body)
+    result = extractor.finish()
+
+    if needs_lifecycle_parse:
+        lifecycle = _lifecycle_from_extraction(event, extractor, result)
+    usage_result, usage_error = (
+        _usage_from_extraction(result, data_event_type) if needs_usage_parse else (None, None)
+    )
+    return OpenAIResponsesServerEventInspection(lifecycle, usage_result, usage_error)
 
 
 def _probe_responses_event_type(body: bytes) -> TopLevelStringFieldProbeResult:
@@ -914,37 +988,5 @@ def extract_openai_responses_usage_from_event(
     inspection failure is surfaced. Known non-usage events, other incomplete or
     malformed frames, and frames without extractable usage return ``(None, None)``.
     """
-    event_type = event._classification
-    if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
-        return None, None
-
-    data_event_type = _resolved_data_event_type(event_type)
-    scalar_fields = (
-        _RESPONSES_SSE_SCALAR_FIELDS
-        if data_event_type is None
-        else _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS
-    )
-    extractor = JsonSelectiveExtractor(
-        scalar_fields=scalar_fields,
-        max_work_units=_RESPONSES_MAX_WORK_UNITS,
-    )
-    extractor.feed(event._body)
-    result = extractor.finish()
-    if not result.complete:
-        error = (
-            _RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR
-            if result.error == JSON_WORK_LIMIT_EXCEEDED
-            else None
-        )
-        return None, error
-
-    usage: dict = {}
-    _store_sse_result_values(
-        result.values,
-        usage,
-        event_name=None,
-        data_event_type=data_event_type,
-    )
-    if not any(category in usage for category in MODEL_USAGE_CATEGORIES):
-        return None, None
-    return usage, None
+    inspection = inspect_openai_responses_server_event(event, include_lifecycle=False)
+    return inspection.usage, inspection.usage_error

--- a/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_websocket_helpers.py
@@ -10,6 +10,7 @@ from wsproto.frame_protocol import Opcode
 import deferred_callbacks
 import mitm_addon
 import model_websocket_usage
+from usage.json_selective import JsonSelectiveExtractor
 
 _WebSocketTrimCallback = Callable[[http.HTTPFlow], None]
 ScheduledWebSocketTrim = tuple[_WebSocketTrimCallback, http.HTTPFlow]
@@ -25,6 +26,21 @@ def capture_deferred_websocket_trims(
 
     monkeypatch.setattr(deferred_callbacks, "call_soon", call_soon)
     return scheduled
+
+
+def capture_openai_responses_extractor_feeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[bytes]:
+    """Record full-body extractor feeds while retaining the real parser."""
+    observed: list[bytes] = []
+    original_feed = JsonSelectiveExtractor.feed
+
+    def record_feed(extractor: JsonSelectiveExtractor, chunk: bytes) -> None:
+        observed.append(chunk)
+        original_feed(extractor, chunk)
+
+    monkeypatch.setattr(JsonSelectiveExtractor, "feed", record_feed)
+    return observed
 
 
 def run_deferred_websocket_trims(scheduled: list[ScheduledWebSocketTrim]) -> None:

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -19,6 +19,7 @@ from tests.model_provider_flow_helpers import (
 from tests.model_provider_websocket_helpers import (
     ScheduledWebSocketTrim,
     capture_deferred_websocket_trims,
+    capture_openai_responses_extractor_feeds,
     feed_websocket_client_message,
     feed_websocket_server_message,
     openai_websocket_usage_frame,
@@ -59,6 +60,48 @@ class TestModelProviderWebSocketPrewarmUsage:
     @pytest.fixture(autouse=True)
     def _sync_usage_delivery(self, sync_usage_executor, usage_webhook_api):
         self._usage_webhook_api = usage_webhook_api
+
+    def test_model_websocket_dense_terminal_uses_one_full_body_parse(
+        self,
+        tmp_path,
+        real_flow,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        full_body_feeds = capture_openai_responses_extractor_feeds(monkeypatch)
+        dense_terminal = (
+            b'{"type":"response.completed","padding":['
+            + b",".join([b"0"] * 20_000)
+            + b'],"response":{"id":"dense-prewarm","model":"gpt-5.5",'
+            b'"usage":{"input_tokens":9,"output_tokens":4}}}'
+        )
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(
+                flow,
+                _openai_websocket_created_frame("dense-prewarm"),
+            )
+            full_body_feeds.clear()
+            feed_websocket_server_message(flow, dense_terminal)
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert full_body_feeds.count(dense_terminal) == 1
+        assert webhook.usage_events() == []
+        assert webhook.model_usage_observation_events() == []
+        [ignored_entry] = [
+            entry
+            for entry in model_usage_source_entries(flow)
+            if entry.get("disposition") == "ignored"
+        ]
+        assert ignored_entry["provider_response_id"] == "dense-prewarm"
+        assert ignored_entry["reason"] == "responses_generate_false"
+        assert not _correlation_entries(flow)
 
     def test_model_websocket_ignores_bound_prewarm_and_reports_normal_input_only_turn(
         self,

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_source_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_source_reporting.py
@@ -18,6 +18,7 @@ from tests.model_provider_flow_helpers import (
 from tests.model_provider_websocket_helpers import (
     ScheduledWebSocketTrim,
     capture_deferred_websocket_trims,
+    capture_openai_responses_extractor_feeds,
     feed_websocket_server_message,
     feed_websocket_server_text_message,
     openai_websocket_usage_frame,
@@ -228,10 +229,12 @@ class TestModelProviderWebSocketSourceReporting:
         self,
         tmp_path,
         real_flow,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
         mitm_addon.responseheaders(flow)
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+        full_body_feeds = capture_openai_responses_extractor_feeds(monkeypatch)
         over_budget_frame = (
             b'{"type":"response.completed","response":{"id":"resp_partial",'
             b'"model":"gpt-5.5","usage":{"input_tokens":100,"output_tokens":40}},'
@@ -256,9 +259,11 @@ class TestModelProviderWebSocketSourceReporting:
             )
             usage.flush_usage_events(trigger="test")
 
+        assert full_body_feeds.count(over_budget_frame) == 1
+        proxy_entries = read_jsonl_entries_after_flush(proxy_log)
         warning_entries = [
             entry
-            for entry in read_jsonl_entries_after_flush(proxy_log)
+            for entry in proxy_entries
             if entry.get("message") == "Model provider WebSocket usage extraction failed"
         ]
         [warning] = warning_entries
@@ -266,6 +271,10 @@ class TestModelProviderWebSocketSourceReporting:
         assert warning["type"] == "usage_event"
         assert warning["usage_protocol"] == "openai_responses_websocket"
         assert warning["error"] == "work_limit_exceeded"
+        [correlation_entry] = [
+            entry for entry in proxy_entries if entry.get("type") == "model_usage_correlation"
+        ]
+        assert correlation_entry["reason"] == "correlation_cap"
         assert model_provider_usage_sources(flow) == {}
         expected_rows = [
             ("gpt-5.5", "tokens.input", 7),


### PR DESCRIPTION
## Summary

- replace separate OpenAI Responses WebSocket lifecycle and usage scans with one combined bounded server-event inspection
- preserve lifecycle duplicate-key validation, usage extraction semantics, prewarm fail-open behavior, diagnostics, and prefix/known-non-usage fast paths
- add hook-level regression coverage proving one target-body extractor feed for valid dense and work-limit-exhausted terminal frames

## Exclusions

- no change to the 65,536-unit parser budget or 4 KiB prefix probe
- no persisted state, runner protocol, API, database, or cross-version compatibility changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest -q tests/test_openai_responses_event_json.py tests/test_model_provider_websocket_prewarm.py tests/test_model_provider_websocket_source_reporting.py tests/test_model_provider_websocket_usage_aggregation.py tests/test_model_provider_websocket_lifecycle.py tests/test_model_provider_websocket_metadata.py tests/test_codex_output_timing.py tests/test_provider_output_timing.py` (111 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/` (5588 passed)

Closes #27720
