### PR TITLE
fix(python): bound request host authority work

### DIFF
--- a/crates/runner/mitm-addon/src/request_authority.py
+++ b/crates/runner/mitm-addon/src/request_authority.py
@@ -9,7 +9,7 @@ for firewall matching or credential injection.
 
 import ipaddress
 from dataclasses import dataclass
-from typing import Literal
+from typing import Final, Literal
 
 from mitmproxy import http
 
@@ -24,6 +24,9 @@ from host_normalization import normalize_hostname
 
 _FORBIDDEN_HOST_CHARS = frozenset("#%*,/<>?@[\\]^|{}")
 _DEFAULT_HTTPS_PORT = 443
+_RAW_HOST_HEADER_NAME: Final = b"host"
+_HOST_HEADER_FOLD_SEPARATOR_BYTES: Final = len(b", ")
+_MAX_HOST_HEADER_BYTES: Final = 4096
 
 
 @dataclass(frozen=True)
@@ -102,6 +105,27 @@ def _build_url(scheme: str, host: str, port: int, path: str) -> str:
     return f"{scheme}://{_host_with_port(scheme, host, port)}{uri_path}"
 
 
+def _host_headers_within_budget(headers: http.Headers) -> bool:
+    """Bound addon Host value work before dependency string access.
+
+    This is not a proxy request-head limit: mitmproxy has already buffered the
+    fields before addon hooks run. Separators match ``Headers`` folding so a
+    bounded result also bounds duplicate-field decoding and diagnostics.
+    """
+    host_header_bytes = 0
+    has_host_header = False
+    for name, value in headers.fields:
+        if name.lower() != _RAW_HOST_HEADER_NAME:
+            continue
+        if has_host_header:
+            host_header_bytes += _HOST_HEADER_FOLD_SEPARATOR_BYTES
+        host_header_bytes += len(value)
+        if host_header_bytes > _MAX_HOST_HEADER_BYTES:
+            return False
+        has_host_header = True
+    return True
+
+
 def _parse_host_authority(authority: str) -> tuple[str, int | None]:
     if not authority or has_ascii_space_or_control(authority):
         raise ValueError("invalid authority")
@@ -155,7 +179,6 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
     scheme = flow.request.scheme
     port = flow.request.port
     path = flow.request.path
-    host_header = flow.request.host_header
     request_host = flow.request.host
 
     if scheme != "https":
@@ -165,7 +188,13 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
             url=_build_url(scheme, request_host, port, path),
         )
 
-    raw_host_headers = flow.request.headers.get_all("Host")
+    host_headers_within_budget = _host_headers_within_budget(flow.request.headers)
+    if host_headers_within_budget:
+        host_header = flow.request.host_header
+        raw_host_headers = flow.request.headers.get_all("Host")
+    else:
+        host_header = None
+        raw_host_headers = []
     raw_sni = getattr(flow.client_conn, "sni", None)
     sni = raw_sni.strip() if isinstance(raw_sni, str) else None
 
@@ -202,6 +231,13 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
         ) from None
 
     trusted_url = _build_url(scheme, normalized_sni, port, path)
+    if not host_headers_within_budget:
+        raise _authority_validation_error(
+            "invalid_authority",
+            message="Request blocked: HTTPS request has invalid Host authority",
+            fallback_url=trusted_url,
+        )
+
     if len(raw_host_headers) > 1:
         raise _authority_validation_error(
             "invalid_authority",
@@ -217,14 +253,15 @@ def get_trusted_authority(flow: http.HTTPFlow) -> TrustedAuthority:
         )
 
     authority_assertions: list[tuple[str, int | None]] = [(host_header, None)]
-    if flow.request.authority:
+    request_authority = flow.request.authority
+    if request_authority:
         if flow.request.is_http2 or flow.request.is_http3:
             if raw_host_headers:
                 authority_assertions.append((raw_host_headers[0], None))
         else:
             # Unlike a Host field, an absolute HTTPS URI with no explicit port
             # identifies the default 443 origin.
-            authority_assertions.append((flow.request.authority, _DEFAULT_HTTPS_PORT))
+            authority_assertions.append((request_authority, _DEFAULT_HTTPS_PORT))
 
     for authority, implicit_port in authority_assertions:
         try:

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_authority_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_authority_framing.py
@@ -56,33 +56,6 @@ def _start_transparent_http1_absolute_request(
     return http_layer, request_headers_hook
 
 
-def _start_transparent_http1_origin_request(
-    addon_context: taddons.context,
-    *,
-    host_header: bytes,
-) -> tuple[HttpLayer, HttpRequestHeadersHook]:
-    client, http_layer = start_http_layer(
-        addon_context,
-        alpn=b"http/1.1",
-        host="api.github.com",
-        server_host="203.0.113.10",
-        mode=HTTPMode.transparent,
-    )
-
-    commands = list(
-        http_layer.handle_event(
-            events.DataReceived(
-                client,
-                b"GET /repos HTTP/1.1\r\nHost: " + host_header + b"\r\n\r\n",
-            )
-        )
-    )
-    request_headers_hook = next(
-        command for command in commands if isinstance(command, HttpRequestHeadersHook)
-    )
-    return http_layer, request_headers_hook
-
-
 async def test_over_budget_http1_host_is_rejected_in_both_hooks_without_string_access(
     tmp_path: Path,
     fake_firewall_headers,
@@ -103,9 +76,23 @@ async def test_over_budget_http1_host_is_rejected_in_both_hooks_without_string_a
             vm0_api_url="https://api.vm0.ai",
             vm0_proxy_registry_path=str(registry_path),
         )
-        http_layer, request_headers_hook = _start_transparent_http1_origin_request(
+        client, http_layer = start_http_layer(
             addon_context,
-            host_header=oversized_host,
+            alpn=b"http/1.1",
+            host="api.github.com",
+            server_host="203.0.113.10",
+            mode=HTTPMode.transparent,
+        )
+        initial_commands = list(
+            http_layer.handle_event(
+                events.DataReceived(
+                    client,
+                    b"GET /repos HTTP/1.1\r\nHost: " + oversized_host + b"\r\n\r\n",
+                )
+            )
+        )
+        request_headers_hook = next(
+            command for command in initial_commands if isinstance(command, HttpRequestHeadersHook)
         )
         flow = request_headers_hook.flow
         original_headers = tuple(flow.request.headers.fields)

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_authority_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_authority_framing.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from mitmproxy import connection
+from mitmproxy import connection, http
 from mitmproxy.addons.proxyserver import Proxyserver
 from mitmproxy.net.http import http1
 from mitmproxy.proxy import commands, events
@@ -15,6 +15,7 @@ from mitmproxy.test import taddons
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import request_authority
 from tests.mitmproxy_http_framing_helpers import (
     PLACEHOLDER_HOST,
     start_http2_request,
@@ -53,6 +54,123 @@ def _start_transparent_http1_absolute_request(
         command for command in commands if isinstance(command, HttpRequestHeadersHook)
     )
     return http_layer, request_headers_hook
+
+
+def _start_transparent_http1_origin_request(
+    addon_context: taddons.context,
+    *,
+    host_header: bytes,
+) -> tuple[HttpLayer, HttpRequestHeadersHook]:
+    client, http_layer = start_http_layer(
+        addon_context,
+        alpn=b"http/1.1",
+        host="api.github.com",
+        server_host="203.0.113.10",
+        mode=HTTPMode.transparent,
+    )
+
+    commands = list(
+        http_layer.handle_event(
+            events.DataReceived(
+                client,
+                b"GET /repos HTTP/1.1\r\nHost: " + host_header + b"\r\n\r\n",
+            )
+        )
+    )
+    request_headers_hook = next(
+        command for command in commands if isinstance(command, HttpRequestHeadersHook)
+    )
+    return http_layer, request_headers_hook
+
+
+async def test_over_budget_http1_host_is_rejected_in_both_hooks_without_string_access(
+    tmp_path: Path,
+    fake_firewall_headers,
+) -> None:
+    registry_path = _write_github_firewall_registry(
+        tmp_path,
+        vm_fields={"captureNetworkBodies": True},
+    )
+    oversized_host = (b"a." * 2048) + b"a"
+    assert len(oversized_host) == 4097
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+        fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}) as get_headers,
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai",
+            vm0_proxy_registry_path=str(registry_path),
+        )
+        http_layer, request_headers_hook = _start_transparent_http1_origin_request(
+            addon_context,
+            host_header=oversized_host,
+        )
+        flow = request_headers_hook.flow
+        original_headers = tuple(flow.request.headers.fields)
+        original_head = http1.assemble_request_head(flow.request)
+        assert flow.request.host == "203.0.113.10"
+        assert flow.request.port == 443
+        assert flow.client_conn.sni == "api.github.com"
+        assert [
+            value for name, value in flow.request.headers.fields if name.lower() == b"host"
+        ] == [oversized_host]
+
+        real_get_all = http.Headers.get_all
+        real_normalize_hostname = request_authority.normalize_hostname
+
+        def reject_host_string_access(headers: http.Headers, name: str) -> list[str]:
+            if name.lower() == "host":
+                raise AssertionError("over-budget Host must not reach string access")
+            return real_get_all(headers, name)
+
+        def normalize_trusted_sni(host: str) -> str:
+            assert host == "api.github.com"
+            return real_normalize_hostname(host)
+
+        with (
+            patch.object(http.Headers, "get_all", reject_host_string_access),
+            patch.object(
+                request_authority,
+                "normalize_hostname",
+                side_effect=normalize_trusted_sni,
+            ),
+        ):
+            await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
+            get_headers.assert_not_awaited()
+            assert flow.response is None
+            assert tuple(flow.request.headers.fields) == original_headers
+            assert http1.assemble_request_head(flow.request) == original_head
+
+            header_commands = list(
+                http_layer.handle_event(events.HookCompleted(request_headers_hook, None))
+            )
+            request_hook = next(
+                command for command in header_commands if isinstance(command, HttpRequestHook)
+            )
+            await addon_context.master.addons.invoke_addon(mitm_addon, request_hook)
+            request_commands = list(
+                http_layer.handle_event(events.HookCompleted(request_hook, None))
+            )
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.response.content is not None
+    body = json.loads(flow.response.content)
+    assert body["error"] == "invalid_authority"
+    assert body["host_header"] is None
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_authority"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
+    assert tuple(flow.request.headers.fields) == original_headers
+    assert http1.assemble_request_head(flow.request) == original_head
+    assert "Authorization" not in flow.request.headers
+    get_headers.assert_not_awaited()
+    assert not any(
+        isinstance(command, (commands.OpenConnection, commands.SendData))
+        and isinstance(command.connection, connection.Server)
+        for command in request_commands
+    )
 
 
 async def test_http2_duplicate_host_is_rejected_before_auth_or_http1_downgrade(

--- a/crates/runner/mitm-addon/tests/test_request_authority.py
+++ b/crates/runner/mitm-addon/tests/test_request_authority.py
@@ -1,8 +1,16 @@
 """Trusted request authority URL utility tests."""
 
 import pytest
+from mitmproxy import http
 
 from request_authority import get_trusted_authority
+
+_MAX_HOST_HEADER_BYTES = 4096
+
+
+class _DecodeGuardHost(bytes):
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("untrusted Host must not be decoded")
 
 
 class TestTrustedAuthorityUrl:
@@ -109,6 +117,24 @@ class TestTrustedAuthorityUrl:
         assert trusted.port == 80
         assert trusted.url == "http://203.0.113.10/v1/data"
 
+    def test_http_does_not_decode_host_header(self, real_flow):
+        request_headers = http.Headers(
+            [(b"Host", _DecodeGuardHost(b"x" * (_MAX_HOST_HEADER_BYTES + 1)))]
+        )
+        flow = real_flow(
+            scheme="http",
+            host="203.0.113.10",
+            port=80,
+            path="/v1/data",
+            request_headers=request_headers,
+        )
+
+        trusted = get_trusted_authority(flow)
+
+        assert trusted.host == "203.0.113.10"
+        assert trusted.port == 80
+        assert trusted.url == "http://203.0.113.10/v1/data"
+
     def test_http_brackets_ipv6_request_host(self, real_flow, headers):
         flow = real_flow(
             scheme="http",
@@ -137,6 +163,28 @@ class TestTrustedAuthorityUrl:
 
 
 class TestTrustedAuthoritySuccess:
+    def test_accepts_exact_raw_host_header_byte_budget(self, real_flow, headers):
+        host_prefix = "bücher.example:"
+        host_suffix = "443"
+        zero_padding = "0" * (
+            _MAX_HOST_HEADER_BYTES - len(host_prefix.encode()) - len(host_suffix.encode())
+        )
+        host_header = f"{host_prefix}{zero_padding}{host_suffix}"
+        assert len(host_header.encode()) == _MAX_HOST_HEADER_BYTES
+        flow = real_flow(
+            with_response=False,
+            host="203.0.113.10",
+            sni="xn--bcher-kva.example",
+            path="/repos",
+            request_headers=headers(("Host", host_header)),
+        )
+
+        trusted = get_trusted_authority(flow)
+
+        assert trusted.host == "xn--bcher-kva.example"
+        assert trusted.port == 443
+        assert trusted.url == "https://xn--bcher-kva.example/repos"
+
     @pytest.mark.parametrize(
         "host_header",
         [

--- a/crates/runner/mitm-addon/tests/test_request_authority_rejection.py
+++ b/crates/runner/mitm-addon/tests/test_request_authority_rejection.py
@@ -1,6 +1,7 @@
 """Trusted request authority rejection URL utility tests."""
 
 import pytest
+from mitmproxy import http
 
 from request_authority import AuthorityValidationError, get_trusted_authority
 from tests.host_normalization_cases import (
@@ -13,6 +14,12 @@ _INVALID_TRUSTED_HOSTNAME_CASES = (
     pytest.param("*.github.com", id="wildcard-label"),
     pytest.param("api*.github.com", id="mixed-wildcard-label"),
 )
+_MAX_HOST_HEADER_BYTES = 4096
+
+
+class _DecodeGuardHost(bytes):
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("over-budget Host must not be decoded")
 
 
 def _request_headers(headers, host_header):
@@ -39,6 +46,65 @@ def _assert_authority_error(
 
 
 class TestTrustedAuthorityRejection:
+    def test_rejects_first_over_budget_host_byte_without_decoding(self, real_flow):
+        guarded_host = _DecodeGuardHost(b"a" * (_MAX_HOST_HEADER_BYTES + 1))
+        flow = real_flow(
+            with_response=False,
+            host="203.0.113.10",
+            sni="api.github.com",
+            path="/repos",
+            request_headers=http.Headers([(b"hOsT", guarded_host)]),
+        )
+
+        with pytest.raises(AuthorityValidationError) as exc_info:
+            get_trusted_authority(flow)
+
+        _assert_authority_error(
+            exc_info,
+            reason="invalid_authority",
+            sni="api.github.com",
+            request_host="203.0.113.10",
+            host_header=None,
+            request_port=443,
+            fallback_url="https://api.github.com/repos",
+        )
+
+    @pytest.mark.parametrize(
+        ("raw_sni", "expected_reason", "expected_sni"),
+        [
+            pytest.param(None, "missing_sni", None, id="missing"),
+            pytest.param("...", "invalid_sni", "...", id="invalid"),
+        ],
+    )
+    def test_oversized_host_preserves_sni_error_precedence_without_decoding(
+        self,
+        real_flow,
+        raw_sni,
+        expected_reason,
+        expected_sni,
+    ):
+        guarded_host = _DecodeGuardHost(b"a" * (_MAX_HOST_HEADER_BYTES + 1))
+        flow = real_flow(
+            with_response=False,
+            host="203.0.113.10",
+            path="/repos",
+            request_headers=http.Headers([(b"Host", guarded_host)]),
+        )
+        flow.client_conn.sni = raw_sni
+
+        with pytest.raises(AuthorityValidationError) as exc_info:
+            get_trusted_authority(flow)
+
+        _assert_authority_error(
+            exc_info,
+            reason=expected_reason,
+            sni=expected_sni,
+            request_host="203.0.113.10",
+            host_header=None,
+            request_port=443,
+            fallback_url="https://203.0.113.10/repos",
+        )
+
     def test_https_rejects_host_sni_mismatch(self, real_flow, headers):
         flow = real_flow(
             host="203.0.113.10",

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -539,7 +539,7 @@ async def test_rejects_duplicate_host_authority_before_firewall_auth(
         ),
     ],
 )
-async def test_rejects_over_budget_host_without_decoding_logging_or_auth(
+async def test_rejects_over_budget_host_without_decoding_or_auth(
     tmp_path,
     real_flow,
     mitm_ctx,
@@ -548,10 +548,7 @@ async def test_rejects_over_budget_host_without_decoding_logging_or_auth(
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
     request_headers = mitm_addon.http.Headers(
-        [
-            *((b"Host", value) for value in host_values),
-            (b"Authorization", b"Bearer sandbox-token"),
-        ]
+        [(b"Host", value) for value in host_values] + [(b"Authorization", b"Bearer sandbox-token")]
     )
     flow = real_flow(
         with_response=False,

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -1,11 +1,13 @@
 """Authority validation request hook integration tests."""
 
 import json
+from unittest.mock import patch
 
 import pytest
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import request_authority
 import upstream_destination_binding
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import _write_github_firewall_registry
@@ -15,6 +17,12 @@ _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) HeadlessChrome/126.0.0.0 Safari/537.36"
 )
+_MAX_HOST_HEADER_BYTES = 4096
+
+
+class _DecodeGuardHost(bytes):
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("over-budget Host must not be decoded")
 
 
 @pytest.mark.parametrize(
@@ -513,6 +521,134 @@ async def test_rejects_duplicate_host_authority_before_firewall_auth(
     assert flow.request.path == original_path
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
+
+
+@pytest.mark.parametrize(
+    "host_values",
+    [
+        pytest.param(
+            (_DecodeGuardHost(b"a" * (_MAX_HOST_HEADER_BYTES + 1)),),
+            id="single-field",
+        ),
+        pytest.param(
+            (
+                _DecodeGuardHost(b"a" * 2048),
+                _DecodeGuardHost(b"b" * 2047),
+            ),
+            id="folded-duplicate-fields",
+        ),
+    ],
+)
+async def test_rejects_over_budget_host_without_decoding_logging_or_auth(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    host_values,
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    request_headers = mitm_addon.http.Headers(
+        [
+            *((b"Host", value) for value in host_values),
+            (b"Authorization", b"Bearer sandbox-token"),
+        ]
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        sni="api.github.com",
+        path="/repos",
+        request_headers=request_headers,
+    )
+    original_headers = tuple(flow.request.headers.fields)
+    real_normalize_hostname = request_authority.normalize_hostname
+
+    def normalize_trusted_sni(host: str) -> str:
+        assert host == "api.github.com"
+        return real_normalize_hostname(host)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+        patch.object(
+            request_authority,
+            "normalize_hostname",
+            side_effect=normalize_trusted_sni,
+        ),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["error"] == "invalid_authority"
+    assert body["sni"] == "api.github.com"
+    assert body["host_header"] is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_authority"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
+    assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET] == {
+        "url": "https://api.github.com/repos",
+        "host": "api.github.com",
+        "port": 443,
+    }
+    assert tuple(flow.request.headers.fields) == original_headers
+    assert flow.request.headers["Authorization"] == "Bearer sandbox-token"
+    auth_fetch.assert_not_called()
+
+    [proxy_log_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert proxy_log_entry["type"] == "authority_validation"
+    assert proxy_log_entry["reason"] == "invalid_authority"
+    assert proxy_log_entry["host_header"] is None
+
+
+async def test_redacts_over_budget_host_from_network_log(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    reg_path = _write_github_firewall_registry(
+        tmp_path,
+        vm_fields={"captureNetworkBodies": True},
+    )
+    oversized_host = b"a" * (_MAX_HOST_HEADER_BYTES + 1)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        sni="api.github.com",
+        path="/repos",
+        request_headers=mitm_addon.http.Headers(
+            [
+                (b"Host", oversized_host),
+                (b"Authorization", b"Bearer sandbox-token"),
+            ]
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert json.loads(flow.response.content)["host_header"] is None
+    auth_fetch.assert_not_called()
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    [network_log_entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert network_log_entry["action"] == "DENY"
+    assert network_log_entry["firewall_error"] == "invalid_authority"
+    assert network_log_entry["request_headers"] == {
+        "Host": "***",
+        "Authorization": "***",
+    }
+    assert "a" * 256 not in json.dumps(network_log_entry)
 
 
 async def test_rejects_host_authority_port_mismatch_before_firewall_auth(


### PR DESCRIPTION
## Summary

- enforce an inclusive 4,096-byte aggregate budget for regular `Host` fields before mitmproxy string access, folding, diagnostic retention, or project hostname normalization
- return from non-HTTPS authority resolution before reading unused Host text
- preserve SNI error precedence, bounded duplicate diagnostics, parser-owned request authority behavior, and existing accepted hostname/port identities
- reject over-budget Host input through the existing `invalid_authority` path with `host_header: null`, before firewall matching, credential lookup, or forwarding

## Behavior and compatibility

The aggregate counts every raw regular Host value plus the `", "` separators used by mitmproxy when folding duplicates. Exactly 4,096 raw bytes remain accepted; the 4,097th byte is rejected. Tests cover multibyte IDNA input, extreme but valid zero-padded ports, single and duplicate crossings, missing/invalid SNI precedence, request-hook logging/auth behavior, and both real mitmproxy request hooks.

The intentional compatibility change is limited to regular Host aggregates above 4,096 raw bytes. Old and new runners may differ for those invalid oversized requests during rollout, but no flow, persisted state, API, queue, or protocol contract crosses runner versions.

## Explicit exclusions

- no new addon limit is applied to parser-validated HTTP/1 request-target authority, HTTP/2/3 `:authority`, or TLS SNI
- shared hostname normalization and bounded ordinary duplicate diagnostics are unchanged
- this does not solve mitmproxy's pre-hook request-head buffering or total header field-count/name work; proxy-wide head limits remain separate hardening

## Benchmark

The same real pinned `Headers`/`HTTPFlow` reproduction was run with input construction outside measurement. Timings are one untraced call; allocation is one separately traced call.

| Raw Host bytes | Before elapsed | After elapsed | Before peak | After peak |
| ---: | ---: | ---: | ---: | ---: |
| 65,535 | 15.2 ms | 0.067 ms | 2.0 MiB | 2.6 KiB |
| 1,048,575 | 631.1 ms | 0.052 ms | 33.0 MiB | 2.6 KiB |
| 8,388,607 | 4,737.3 ms | 0.059 ms | 258.3 MiB | 2.6 KiB |

Absolute timings are host-dependent; the result demonstrates that addon work and new allocation no longer scale materially with oversized Host value length.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- focused authority/request/framing pytest: 215 passed
- `uv run --no-sync python -m pytest tests/`: 5,596 passed

Closes #27713
