### PR TITLE
refactor(rust): centralize workload cgroup events

### DIFF
--- a/crates/guest-agent/src/workload_containment.rs
+++ b/crates/guest-agent/src/workload_containment.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 
 use guest_contracts::diagnostics::WorkloadResourceLimitDiagnostic;
 use guest_contracts::process_containment::{
-    CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, EXEC_CGROUP_NAME_PREFIX,
-    MATERIAL_CPU_THROTTLED_USEC, WORKLOAD_CGROUP_NAME, WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
+    CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, EXEC_CGROUP_NAME_PREFIX, WORKLOAD_CGROUP_NAME,
+    WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV, WorkloadResourceEvents,
 };
 
 const CGROUP_PROCS_FILE: &str = "cgroup.procs";
@@ -110,30 +110,16 @@ impl WorkloadContainment {
 
     /// Read workload resource counters after CLI execution.
     pub fn resource_diagnostics(&self) -> io::Result<WorkloadResourceDiagnostics> {
-        let cpu = read_key_values(&self.workload_path.join("cpu.stat"))?;
-        let memory = read_key_values(&self.workload_path.join("memory.events"))?;
-        let pids = read_key_values(&self.workload_path.join("pids.events"))?;
-        let memory_max = value_or_zero(&memory, "max");
-        let memory_oom = value_or_zero(&memory, "oom");
-        let memory_oom_kill = value_or_zero(&memory, "oom_kill");
-        let memory_oom_group_kill = value_or_zero(&memory, "oom_group_kill");
-        let pids_max = value_or_zero(&pids, "max");
-        let cpu_nr_throttled = value_or_zero(&cpu, "nr_throttled");
-        let cpu_throttled_usec = value_or_zero(&cpu, "throttled_usec");
-        let memory_high = value_or_zero(&memory, "high");
+        let cpu = fs::read_to_string(self.workload_path.join("cpu.stat"))?;
+        let memory = fs::read_to_string(self.workload_path.join("memory.events"))?;
+        let pids = fs::read_to_string(self.workload_path.join("pids.events"))?;
+        let events = WorkloadResourceEvents::from_file_contents(&cpu, &memory, &pids)?;
 
-        let hard_limit = WorkloadResourceLimitDiagnostic {
-            memory_max_events: memory_max,
-            memory_oom_events: memory_oom,
-            memory_oom_kill_events: memory_oom_kill,
-            memory_oom_group_kill_events: memory_oom_group_kill,
-            pids_max_events: pids_max,
-        };
-        let hard_limit = hard_limit.has_events().then_some(hard_limit);
-        let pressure =
-            (cpu_throttled_usec >= MATERIAL_CPU_THROTTLED_USEC || memory_high > 0).then(|| {
+        let hard_limit = events.hard_limit_diagnostic();
+        let pressure = events.has_material_pressure().then(|| {
             format!(
-                "workload resource pressure observed (cpu_nr_throttled={cpu_nr_throttled}, cpu_throttled_usec={cpu_throttled_usec}, memory_high={memory_high})"
+                "workload resource pressure observed (cpu_nr_throttled={}, cpu_throttled_usec={}, memory_high={})",
+                events.cpu_nr_throttled, events.cpu_throttled_usec, events.memory_high
             )
         });
         Ok(WorkloadResourceDiagnostics {
@@ -235,36 +221,6 @@ fn validate_descriptor(placement: &OwnedFd) -> io::Result<PathBuf> {
         .ok_or_else(|| io::Error::other("workload cgroup.procs path has no parent"))
 }
 
-fn read_key_values(path: &Path) -> io::Result<std::collections::HashMap<String, u64>> {
-    fs::read_to_string(path)?
-        .lines()
-        .map(|line| {
-            let mut fields = line.split_ascii_whitespace();
-            let key = fields.next().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "missing cgroup counter name")
-            })?;
-            let value = fields
-                .next()
-                .ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::InvalidData, "missing cgroup counter value")
-                })?
-                .parse::<u64>()
-                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-            if fields.next().is_some() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "unexpected cgroup counter field",
-                ));
-            }
-            Ok((key.to_string(), value))
-        })
-        .collect()
-}
-
-fn value_or_zero(values: &std::collections::HashMap<String, u64>, key: &str) -> u64 {
-    values.get(key).copied().unwrap_or(0)
-}
-
 fn expected_workload_procs_path() -> io::Result<PathBuf> {
     let content = fs::read_to_string(PROC_SELF_CGROUP)?;
     let relative = content
@@ -340,6 +296,8 @@ mod tests {
     use super::*;
     use std::io::{Read, Seek, SeekFrom};
     use std::process::Stdio;
+
+    use guest_contracts::process_containment::MATERIAL_CPU_THROTTLED_USEC;
 
     #[test]
     fn pre_exec_places_child_without_inheriting_descriptor() {

--- a/crates/guest-contracts/src/process_containment.rs
+++ b/crates/guest-contracts/src/process_containment.rs
@@ -6,6 +6,11 @@
 //! empty so it can distribute cgroup v2 controllers and act as the recursive
 //! cleanup boundary.
 
+use std::collections::HashMap;
+use std::io;
+
+use crate::diagnostics::WorkloadResourceLimitDiagnostic;
+
 /// Canonical cgroup v2 mount inside the guest.
 pub const CGROUP_V2_MOUNT_PATH: &str = "/sys/fs/cgroup";
 
@@ -88,6 +93,103 @@ pub const WORKLOAD_PIDS_MAX: &str = "max";
 /// Highest cgroup v2 CPU weight, assigned to a controlled operation and its
 /// Guest Agent leaf so concurrent ordinary execs cannot dominate it.
 pub const CONTROL_CPU_WEIGHT: u64 = 10_000;
+
+/// Workload cgroup-v2 resource events shared by guest consumers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WorkloadResourceEvents {
+    /// Number of workload CPU periods that contained throttling.
+    pub cpu_nr_throttled: u64,
+    /// Total workload CPU time throttled, in microseconds.
+    pub cpu_throttled_usec: u64,
+    /// Number of workload `memory.high` events.
+    pub memory_high: u64,
+    /// Number of workload `memory.max` events.
+    pub memory_max: u64,
+    /// Number of workload OOM events.
+    pub memory_oom: u64,
+    /// Number of workload processes killed by the OOM killer.
+    pub memory_oom_kill: u64,
+    /// Number of workload cgroups killed as an OOM group.
+    pub memory_oom_group_kill: u64,
+    /// Number of workload forks or clones rejected by `pids.max`.
+    pub pids_max: u64,
+}
+
+impl WorkloadResourceEvents {
+    /// Parse the flat-keyed contents of `cpu.stat`, `memory.events`, and
+    /// `pids.events` for one workload cgroup.
+    ///
+    /// Missing known counters default to zero and unknown numeric counters are
+    /// ignored. Malformed lines return [`io::ErrorKind::InvalidData`].
+    pub fn from_file_contents(
+        cpu_stat: &str,
+        memory_events: &str,
+        pids_events: &str,
+    ) -> io::Result<Self> {
+        let cpu = parse_key_values(cpu_stat)?;
+        let memory = parse_key_values(memory_events)?;
+        let pids = parse_key_values(pids_events)?;
+        Ok(Self {
+            cpu_nr_throttled: value_or_zero(&cpu, "nr_throttled"),
+            cpu_throttled_usec: value_or_zero(&cpu, "throttled_usec"),
+            memory_high: value_or_zero(&memory, "high"),
+            memory_max: value_or_zero(&memory, "max"),
+            memory_oom: value_or_zero(&memory, "oom"),
+            memory_oom_kill: value_or_zero(&memory, "oom_kill"),
+            memory_oom_group_kill: value_or_zero(&memory, "oom_group_kill"),
+            pids_max: value_or_zero(&pids, "max"),
+        })
+    }
+
+    /// Build the canonical hard-limit diagnostic when any such event occurred.
+    #[must_use]
+    pub fn hard_limit_diagnostic(self) -> Option<WorkloadResourceLimitDiagnostic> {
+        let diagnostic = WorkloadResourceLimitDiagnostic {
+            memory_max_events: self.memory_max,
+            memory_oom_events: self.memory_oom,
+            memory_oom_kill_events: self.memory_oom_kill,
+            memory_oom_group_kill_events: self.memory_oom_group_kill,
+            pids_max_events: self.pids_max,
+        };
+        diagnostic.has_events().then_some(diagnostic)
+    }
+
+    /// Whether the snapshot contains material CPU or memory pressure.
+    #[must_use]
+    pub const fn has_material_pressure(self) -> bool {
+        self.cpu_throttled_usec >= MATERIAL_CPU_THROTTLED_USEC || self.memory_high > 0
+    }
+}
+
+fn parse_key_values(contents: &str) -> io::Result<HashMap<&str, u64>> {
+    contents
+        .lines()
+        .map(|line| {
+            let mut fields = line.split_ascii_whitespace();
+            let key = fields.next().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "missing cgroup counter name")
+            })?;
+            let value = fields
+                .next()
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "missing cgroup counter value")
+                })?
+                .parse::<u64>()
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+            if fields.next().is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "unexpected cgroup counter field",
+                ));
+            }
+            Ok((key, value))
+        })
+        .collect()
+}
+
+fn value_or_zero(values: &HashMap<&str, u64>, key: &str) -> u64 {
+    values.get(key).copied().unwrap_or(0)
+}
 
 /// Calibrated cgroup v2 resource policy for one workload leaf.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/guest-contracts/tests/workload_resource_events.rs
+++ b/crates/guest-contracts/tests/workload_resource_events.rs
@@ -40,23 +40,40 @@ fn parses_one_snapshot_for_both_guest_consumers() {
 
 #[test]
 fn missing_counters_default_to_no_resource_events() {
-    let events = WorkloadResourceEvents::from_file_contents(
-        &format!(
-            "nr_throttled 2\nthrottled_usec {}\n",
-            MATERIAL_CPU_THROTTLED_USEC - 1
-        ),
-        "high 0\n",
-        "",
-    )
-    .unwrap();
+    let events = WorkloadResourceEvents::from_file_contents("", "", "").unwrap();
 
-    assert_eq!(events.memory_max, 0);
-    assert_eq!(events.memory_oom, 0);
-    assert_eq!(events.memory_oom_kill, 0);
-    assert_eq!(events.memory_oom_group_kill, 0);
-    assert_eq!(events.pids_max, 0);
+    assert_eq!(
+        events,
+        WorkloadResourceEvents {
+            cpu_nr_throttled: 0,
+            cpu_throttled_usec: 0,
+            memory_high: 0,
+            memory_max: 0,
+            memory_oom: 0,
+            memory_oom_kill: 0,
+            memory_oom_group_kill: 0,
+            pids_max: 0,
+        }
+    );
     assert_eq!(events.hard_limit_diagnostic(), None);
     assert!(!events.has_material_pressure());
+}
+
+#[test]
+fn material_cpu_pressure_starts_at_threshold() {
+    for (throttled_usec, expected) in [
+        (MATERIAL_CPU_THROTTLED_USEC - 1, false),
+        (MATERIAL_CPU_THROTTLED_USEC, true),
+    ] {
+        let events = WorkloadResourceEvents::from_file_contents(
+            &format!("throttled_usec {throttled_usec}\n"),
+            "high 0\n",
+            "",
+        )
+        .unwrap();
+
+        assert_eq!(events.has_material_pressure(), expected);
+    }
 }
 
 #[test]
@@ -65,6 +82,7 @@ fn rejects_malformed_flat_keyed_contents() {
         ("\n", "", ""),
         ("nr_throttled", "", ""),
         ("nr_throttled 1 extra", "", ""),
+        ("nr_throttled -1", "", ""),
         ("", "max invalid", ""),
         ("", "", "max 18446744073709551616"),
     ] {

--- a/crates/guest-contracts/tests/workload_resource_events.rs
+++ b/crates/guest-contracts/tests/workload_resource_events.rs
@@ -1,0 +1,77 @@
+use std::io;
+
+use guest_contracts::diagnostics::WorkloadResourceLimitDiagnostic;
+use guest_contracts::process_containment::{MATERIAL_CPU_THROTTLED_USEC, WorkloadResourceEvents};
+
+#[test]
+fn parses_one_snapshot_for_both_guest_consumers() {
+    let events = WorkloadResourceEvents::from_file_contents(
+        " usage_usec 10\nnr_throttled\t2\nthrottled_usec 3\nthrottled_usec   1000000 \nnice_usec 4\n",
+        "low 0\n high\t4\nmax 5\noom 1\noom_kill 2\noom_group_kill 3\nsock_throttled 6\n",
+        "max 7\nfuture_counter 8\n",
+    )
+    .unwrap();
+
+    assert_eq!(
+        events,
+        WorkloadResourceEvents {
+            cpu_nr_throttled: 2,
+            cpu_throttled_usec: MATERIAL_CPU_THROTTLED_USEC,
+            memory_high: 4,
+            memory_max: 5,
+            memory_oom: 1,
+            memory_oom_kill: 2,
+            memory_oom_group_kill: 3,
+            pids_max: 7,
+        }
+    );
+    assert_eq!(
+        events.hard_limit_diagnostic(),
+        Some(WorkloadResourceLimitDiagnostic {
+            memory_max_events: 5,
+            memory_oom_events: 1,
+            memory_oom_kill_events: 2,
+            memory_oom_group_kill_events: 3,
+            pids_max_events: 7,
+        })
+    );
+    assert!(events.has_material_pressure());
+}
+
+#[test]
+fn missing_counters_default_to_no_resource_events() {
+    let events = WorkloadResourceEvents::from_file_contents(
+        &format!(
+            "nr_throttled 2\nthrottled_usec {}\n",
+            MATERIAL_CPU_THROTTLED_USEC - 1
+        ),
+        "high 0\n",
+        "",
+    )
+    .unwrap();
+
+    assert_eq!(events.memory_max, 0);
+    assert_eq!(events.memory_oom, 0);
+    assert_eq!(events.memory_oom_kill, 0);
+    assert_eq!(events.memory_oom_group_kill, 0);
+    assert_eq!(events.pids_max, 0);
+    assert_eq!(events.hard_limit_diagnostic(), None);
+    assert!(!events.has_material_pressure());
+}
+
+#[test]
+fn rejects_malformed_flat_keyed_contents() {
+    for (cpu_stat, memory_events, pids_events) in [
+        ("\n", "", ""),
+        ("nr_throttled", "", ""),
+        ("nr_throttled 1 extra", "", ""),
+        ("", "max invalid", ""),
+        ("", "", "max 18446744073709551616"),
+    ] {
+        let error =
+            WorkloadResourceEvents::from_file_contents(cpu_stat, memory_events, pids_events)
+                .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/vsock-guest/src/process_containment.rs
+++ b/crates/vsock-guest/src/process_containment.rs
@@ -17,8 +17,8 @@ use guest_contracts::exec_terminal::{
 };
 use guest_contracts::process_containment::{
     CGROUP_V2_MOUNT_PATH, CONTROL_CGROUP_NAME, CONTROL_CPU_WEIGHT, EXEC_CGROUP_BASE_PATH,
-    EXEC_CGROUP_NAME_PREFIX, MATERIAL_CPU_THROTTLED_USEC, REQUIRED_CGROUP_CONTROLLERS,
-    REQUIRED_CGROUP_SUBTREE_CONTROL, WORKLOAD_CGROUP_NAME, WorkloadResourcePolicy,
+    EXEC_CGROUP_NAME_PREFIX, REQUIRED_CGROUP_CONTROLLERS, REQUIRED_CGROUP_SUBTREE_CONTROL,
+    WORKLOAD_CGROUP_NAME, WorkloadResourceEvents, WorkloadResourcePolicy,
 };
 
 use crate::log::log;
@@ -568,18 +568,6 @@ fn open_placement(
         .map_err(|error| ProcessContainmentError::new(stage, error))
 }
 
-#[derive(Debug, Default)]
-struct ResourceEvents {
-    cpu_nr_throttled: u64,
-    cpu_throttled_usec: u64,
-    memory_high: u64,
-    memory_max: u64,
-    memory_oom: u64,
-    memory_oom_kill: u64,
-    memory_oom_group_kill: u64,
-    pids_max: u64,
-}
-
 fn log_resource_events(group_name: &str, workload_path: &Path) {
     let events = match read_resource_events(workload_path) {
         Ok(events) => events,
@@ -593,25 +581,20 @@ fn log_resource_events(group_name: &str, workload_path: &Path) {
             return;
         }
     };
-    if events.memory_max > 0
-        || events.memory_oom > 0
-        || events.memory_oom_kill > 0
-        || events.memory_oom_group_kill > 0
-        || events.pids_max > 0
-    {
+    if let Some(hard_limit) = events.hard_limit_diagnostic() {
         log(
             "WARN",
             &format!(
                 "exec workload hard resource limit reached group={group_name} memory_max={} memory_oom={} memory_oom_kill={} memory_oom_group_kill={} pids_max={}",
-                events.memory_max,
-                events.memory_oom,
-                events.memory_oom_kill,
-                events.memory_oom_group_kill,
-                events.pids_max
+                hard_limit.memory_max_events,
+                hard_limit.memory_oom_events,
+                hard_limit.memory_oom_kill_events,
+                hard_limit.memory_oom_group_kill_events,
+                hard_limit.pids_max_events
             ),
         );
     }
-    if events.cpu_throttled_usec >= MATERIAL_CPU_THROTTLED_USEC || events.memory_high > 0 {
+    if events.has_material_pressure() {
         log(
             "INFO",
             &format!(
@@ -622,39 +605,11 @@ fn log_resource_events(group_name: &str, workload_path: &Path) {
     }
 }
 
-fn read_resource_events(workload_path: &Path) -> io::Result<ResourceEvents> {
-    let cpu = read_key_value_file(&workload_path.join(CPU_STAT_FILE))?;
-    let memory = read_key_value_file(&workload_path.join(MEMORY_EVENTS_FILE))?;
-    let pids = read_key_value_file(&workload_path.join(PIDS_EVENTS_FILE))?;
-    Ok(ResourceEvents {
-        cpu_nr_throttled: value_or_zero(&cpu, "nr_throttled"),
-        cpu_throttled_usec: value_or_zero(&cpu, "throttled_usec"),
-        memory_high: value_or_zero(&memory, "high"),
-        memory_max: value_or_zero(&memory, "max"),
-        memory_oom: value_or_zero(&memory, "oom"),
-        memory_oom_kill: value_or_zero(&memory, "oom_kill"),
-        memory_oom_group_kill: value_or_zero(&memory, "oom_group_kill"),
-        pids_max: value_or_zero(&pids, "max"),
-    })
-}
-
-fn read_key_value_file(path: &Path) -> io::Result<std::collections::HashMap<String, u64>> {
-    fs::read_to_string(path)?
-        .lines()
-        .map(|line| {
-            let (key, value) = line.split_once(' ').ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "invalid cgroup event line")
-            })?;
-            let value = value
-                .parse::<u64>()
-                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-            Ok((key.to_string(), value))
-        })
-        .collect()
-}
-
-fn value_or_zero(values: &std::collections::HashMap<String, u64>, key: &str) -> u64 {
-    values.get(key).copied().unwrap_or(0)
+fn read_resource_events(workload_path: &Path) -> io::Result<WorkloadResourceEvents> {
+    let cpu = fs::read_to_string(workload_path.join(CPU_STAT_FILE))?;
+    let memory = fs::read_to_string(workload_path.join(MEMORY_EVENTS_FILE))?;
+    let pids = fs::read_to_string(workload_path.join(PIDS_EVENTS_FILE))?;
+    WorkloadResourceEvents::from_file_contents(&cpu, &memory, &pids)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

- add one typed `WorkloadResourceEvents` parser and classifier in `guest-contracts`
- migrate Guest Agent and `vsock-guest` to the shared eight-counter interpretation
- cover whitespace, duplicate, unknown, missing, malformed, hard-limit, and pressure behavior through the public contract

## Behavior and scope

The shared parser accepts exactly two ASCII-whitespace-separated fields per present line, keeps the last duplicate value, validates unknown numeric counters, and defaults missing known counters to zero. This intentionally makes `vsock-guest` accept the same valid whitespace forms as Guest Agent.

Filesystem reads, lifecycle timing, local error handling, cleanup behavior, log levels and text, pressure thresholds, and the serialized failure-diagnostic schema remain with their existing owners and are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo clippy -p vsock-guest --release --no-default-features --all-targets`
- release/no-default-features `vsock-guest` library test binary under the CI-equivalent root and production-user setup: 154 passed
- production identity tests under the CI-equivalent setup: 3 passed

Closes #27712
