### PR TITLE
test(api): isolate gmail watch renewal scopes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import {
-  cronRenewGmailWatchesContract,
   cronRenewGoogleCalendarWatchesContract,
   cronRenewGoogleFormsWatchesContract,
 } from "@okouai/api-contracts/contracts/cron";
+import { testGmailWatchRenewalContract } from "@okouai/api-contracts/contracts/test-gmail-watch-renewal";
 import {
   zeroWorkflowAutomationsContract,
   zeroWorkflowsDetailContract,
@@ -49,6 +49,7 @@ import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { cronRenewGmailWatchesRoutes } from "../cron-renew-gmail-watches";
 import { cronRenewGoogleCalendarWatchesRoutes } from "../cron-renew-google-calendar-watches";
 import { cronRenewGoogleFormsWatchesRoutes } from "../cron-renew-google-forms-watches";
+import { testGmailWatchRenewalRoutes } from "../test-gmail-watch-renewal";
 import { workflowAutomationsRoutes } from "../workflow-automations";
 import { workflowsRoutes } from "../workflows";
 import { webhooksGoogleCalendarRoutes } from "../webhooks-google-calendar";
@@ -87,9 +88,9 @@ function detailClient() {
   );
 }
 
-function renewGmailWatchesClient() {
-  return setupApp({ context, routes: cronRenewGmailWatchesRoutes })(
-    cronRenewGmailWatchesContract,
+function renewGmailWatchScopeClient() {
+  return setupApp({ context, routes: testGmailWatchRenewalRoutes })(
+    testGmailWatchRenewalContract,
   );
 }
 
@@ -2693,7 +2694,6 @@ describe("okou workflow automations", () => {
   });
 
   it("renews a shared Gmail mailbox through another healthy identity", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     const startedAt = Date.parse("2026-08-05T08:00:00.000Z");
     mockNow(startedAt);
     const first = await setupFixture();
@@ -2756,8 +2756,11 @@ describe("okou workflow automations", () => {
     mockNow(startedAt + 6 * 24 * 60 * 60 * 1000 + 2000);
 
     const renewed = await accept(
-      renewGmailWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      renewGmailWatchScopeClient().renew({
+        body: {
+          email_address: sharedEmail,
+          topic_name: GMAIL_TOPIC_NAME,
+        },
       }),
       [200],
     );
@@ -3001,12 +3004,9 @@ describe("okou workflow automations", () => {
   });
 
   it("keeps a failed Gmail stop retryable and repairs it in the renewal pass", async () => {
-    mockEnv("CRON_SECRET", CRON_SECRET);
     const scenario = await setupFixture();
-    await connectGmail(
-      scenario,
-      `retry-stop-${scenario.fixture.userId}@example.com`,
-    );
+    const email = `retry-stop-${scenario.fixture.userId}@example.com`;
+    await connectGmail(scenario, email);
     const watch = configureGmailWatchMock(["history-1", "history-2"]);
     const stop = configureGmailStopMock([500, 500, 204]);
 
@@ -3050,8 +3050,11 @@ describe("okou workflow automations", () => {
     expect(stop.calls).toBe(2);
 
     const reconciled = await accept(
-      renewGmailWatchesClient().renew({
-        headers: { authorization: `Bearer ${CRON_SECRET}` },
+      renewGmailWatchScopeClient().renew({
+        body: {
+          email_address: email,
+          topic_name: GMAIL_TOPIC_NAME,
+        },
       }),
       [200],
     );

--- a/turbo/apps/api/src/signals/routes/test-gmail-watch-renewal.ts
+++ b/turbo/apps/api/src/signals/routes/test-gmail-watch-renewal.ts
@@ -1,0 +1,49 @@
+import { testGmailWatchRenewalContract } from "@okouai/api-contracts/contracts/test-gmail-watch-renewal";
+import { command } from "ccstate";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { renewGmailWatchScope$ } from "../services/gmail-automation-event.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const body$ = bodyResultOf(testGmailWatchRenewalContract.renew);
+
+const renewGmailWatchScopeRoute$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+
+    const bodyResult = await get(body$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      renewGmailWatchScope$,
+      bodyResult.data.email_address,
+      bodyResult.data.topic_name,
+      signal,
+    );
+    return {
+      status: 200 as const,
+      body: {
+        success: true as const,
+        renewed: result.renewed,
+        failed: result.failed,
+      },
+    };
+  },
+);
+
+export const testGmailWatchRenewalRoutes: readonly RouteEntry[] = [
+  {
+    route: testGmailWatchRenewalContract.renew,
+    handler: renewGmailWatchScopeRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/gmail-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-automation-event.service.ts
@@ -1192,6 +1192,35 @@ function gmailPhysicalScopes(states: readonly GmailWatchStateRow[]): readonly {
   return [...scopes.values()];
 }
 
+async function renewGmailPhysicalScopes(
+  args: {
+    readonly db: Db;
+    readonly scopes: readonly {
+      readonly emailAddress: string;
+      readonly topicName: string;
+    }[];
+    readonly renewBefore: Date;
+  },
+  signal: AbortSignal,
+): Promise<{ readonly renewed: number; readonly failed: number }> {
+  let renewed = 0;
+  let failed = 0;
+  for (const scope of args.scopes) {
+    const result = await reconcileGmailPhysicalScope(
+      {
+        db: args.db,
+        ...scope,
+        renewBefore: args.renewBefore,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    renewed += result.kind === "renewed" ? 1 : 0;
+    failed += result.kind === "failed" ? 1 : 0;
+  }
+  return { renewed, failed };
+}
+
 export async function reconcileGmailWatchesForUser(
   args: {
     readonly db: Db;
@@ -2565,23 +2594,28 @@ export const renewGmailWatches$ = command(
     );
     const states = await db.select().from(gmailWatchStates);
     signal.throwIfAborted();
+    return await renewGmailPhysicalScopes(
+      { db, scopes: gmailPhysicalScopes(states), renewBefore },
+      signal,
+    );
+  },
+);
 
-    let renewed = 0;
-    let failed = 0;
-    for (const scope of gmailPhysicalScopes(states)) {
-      const result = await reconcileGmailPhysicalScope(
-        {
-          db,
-          ...scope,
-          renewBefore,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-      renewed += result.kind === "renewed" ? 1 : 0;
-      failed += result.kind === "failed" ? 1 : 0;
-    }
-
-    return { renewed, failed };
+export const renewGmailWatchScope$ = command(
+  async (
+    { set },
+    emailAddress: string,
+    topicName: string,
+    signal: AbortSignal,
+  ) => {
+    const currentTime = nowDate();
+    return await renewGmailPhysicalScopes(
+      {
+        db: set(writeDb$),
+        scopes: [{ emailAddress, topicName }],
+        renewBefore: new Date(currentTime.getTime() + WATCH_RENEWAL_WINDOW_MS),
+      },
+      signal,
+    );
   },
 );

--- a/turbo/packages/api-contracts/src/contracts/test-gmail-watch-renewal.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-gmail-watch-renewal.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const testGmailWatchRenewalContract = c.router({
+  renew: {
+    method: "POST",
+    path: "/api/test/gmail-watch-renewal/renew",
+    body: z.object({
+      email_address: z.string().min(1),
+      topic_name: z.string().min(1),
+    }),
+    responses: {
+      200: z.object({
+        success: z.literal(true),
+        renewed: z.number(),
+        failed: z.number(),
+      }),
+      400: apiErrorSchema,
+      404: z.string(),
+    },
+    summary: "Renew one Gmail watch scope in API tests",
+  },
+});
+
+export type TestGmailWatchRenewalContract =
+  typeof testGmailWatchRenewalContract;


### PR DESCRIPTION
## Summary

- keep the production Gmail renewal cron global while extracting its per-physical-scope reconciliation path
- add a test-only route that renews the Gmail scope owned by the calling integration test
- update the two Gmail renewal integration cases to use their exact email/topic scope without changing their business assertions

## Root cause

API Vitest workers share a database, while their mocked clocks and OAuth handlers are worker-local. An earlier case in `workflow-automations.test.ts` fixes time at `2026-08-05T08:00:00Z`, advances it to `2026-08-11T08:00:02Z`, and leaves an enabled Gmail watch expiring at `2026-08-18T08:00:02Z` with a short-lived access token.

The affected test called the production-wide renewal cron. Once real time crossed the 24-hour renewal threshold at `2026-08-17T08:00:02Z`, that call also selected the unrelated persisted scope. The current worker's Gmail OAuth fixture rejects refresh-token grants, so the unrelated scope produced `invalid_grant`, then `renew/access_unavailable`, and incorrectly contributed `failed: 1` to this test's response.

The focused route calls the same reconciliation implementation for only the physical Gmail scope created by the test. Production cron selection and behavior are unchanged.

## Failure evidence

- main push [32008248029](https://github.com/vm0-ai/vm0/actions/runs/32008248029), job [95322180006](https://github.com/vm0-ai/vm0/actions/runs/32008248029/job/95322180006)
- merge queue [32008449544](https://github.com/vm0-ai/vm0/actions/runs/32008449544), job [95322763742](https://github.com/vm0-ai/vm0/actions/runs/32008449544/job/95322763742)
- main push [32008689972](https://github.com/vm0-ai/vm0/actions/runs/32008689972), job [95323485357](https://github.com/vm0-ai/vm0/actions/runs/32008689972/job/95323485357)
- main push [32008803734](https://github.com/vm0-ai/vm0/actions/runs/32008803734), job [95325028497](https://github.com/vm0-ai/vm0/actions/runs/32008803734/job/95325028497)
- re-enqueued merge queue [32010516281](https://github.com/vm0-ai/vm0/actions/runs/32010516281), job [95328943683](https://github.com/vm0-ai/vm0/actions/runs/32010516281/job/95328943683)
- merge queue [32011452421](https://github.com/vm0-ai/vm0/actions/runs/32011452421), job [95331789583](https://github.com/vm0-ai/vm0/actions/runs/32011452421/job/95331789583)
- main push [32011755314](https://github.com/vm0-ai/vm0/actions/runs/32011755314), job [95332708900](https://github.com/vm0-ai/vm0/actions/runs/32011755314/job/95332708900)
- main push [32011939987](https://github.com/vm0-ai/vm0/actions/runs/32011939987), job [95333738057](https://github.com/vm0-ai/vm0/actions/runs/32011939987/job/95333738057)

All eight failures occurred after the fixed threshold and had the same sequence: two expected `stop/provider_error/500` results, an unrelated Gmail credential refresh rejected with `invalid_grant`, and `renew/access_unavailable` before the `failed: 1` assertion mismatch. Canceled API shards were fail-fast fallout, and `ci-gate-turbo` was only the aggregate gate.

Runs 32008449544, 32010516281, and 32011452421 were three separate merge-group attempts for PR #27709 with different temporary head SHAs. Re-enqueueing did not remove the time/shared-state failure. The third attempt logged the identical chain at approximately `08:41:42Z` and finished with 1 failed / 373 passed. PR #27709 changes only the Neon branch action, its shell test, and the security workflow; it does not touch the API, Gmail automation, or this test.

Main-push run 32011755314 on SHA `ac3ba26944f5d66bc7f17ae8d73f5ccf0ac1c8fb` logged the identical chain at approximately `08:45:33Z`; the shard finished with 1 failed / 373 passed. The code-identical merge-group run [32011199513](https://github.com/vm0-ai/vm0/actions/runs/32011199513) succeeded overall but skipped `test-api`, so it is not an A/B pass. That SHA changes only Python runner WebSocket usage parsing and related Python tests; it does not touch the API, Gmail automation, or this test.

The immediately following main-push run 32011939987 on SHA `4a0fa5a1d52257110430027a42996d7af08748a4` logged the same sequence at approximately `08:49:53Z` and also finished with 1 failed / 373 passed. Its direct parent is `ac3ba26944f5d66bc7f17ae8d73f5ccf0ac1c8fb`; the commit changes only Python runner request-authority code and related Python tests. Merge-group SHA `7a2b1ff730b40a696be90fc8071948b30b3a35f8` from run 32011452421 has `4a0fa5a1d52257110430027a42996d7af08748a4` as its parent, so both the base and the queue overlay failed identically. This further excludes PR #27709 as a deterministic cause.

The strongest code-identical control is SHA `5221f393c5fc221c8b794948578a674a1b5144bf`: merge-group run [32007741033](https://github.com/vm0-ai/vm0/actions/runs/32007741033), job [95320675961](https://github.com/vm0-ai/vm0/actions/runs/32007741033/job/95320675961), ran the same shard before the threshold and passed without the extra refresh. The triggering Python, billing, documentation, and Neon CI changes did not touch this API path.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order=stream --output-logs=full`
- `pnpm knip`
- `pnpm --filter @okouai/api-contracts check-types`
- `pnpm --filter api check-types`
- `workflow-automations.test.ts`: 73/73 passed on a fresh local PostgreSQL database
- affected Gmail test: 5/5 passed while reusing the same accumulated database; this included two full-file executions and three focused executions
- `git diff --check`

The second same-database full-file stress execution exposed an equivalent pre-existing global-sweep isolation issue in an adjacent Google Calendar test; the Gmail target still passed. This PR deliberately remains scoped to the reported Gmail flake.

## Preview

Not applicable. The new route is mounted only by the integration test, the production cron contract is unchanged, and there is no browser-visible behavior to validate on a deployed preview.
