### PR TITLE
test(api): cover gmail renewal cron authorization

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/global-sweep-contracts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/global-sweep-contracts.test.ts
@@ -6,6 +6,7 @@ import { cronCleanupSandboxesRoutes } from "../cron-cleanup-sandboxes";
 import { cronConnectorOauthStateCleanupRoutes } from "../cron-connector-oauth-state-cleanup";
 import { cronDrainEmailOutboxRoutes } from "../cron-drain-email-outbox";
 import { cronExecuteWorkflowAutomationsRoutes } from "../cron-execute-workflow-automations";
+import { cronRenewGmailWatchesRoutes } from "../cron-renew-gmail-watches";
 import { modelStatsRoutes } from "../model-stats";
 import { cronReconcileBillingEntitlementsRoutes } from "../cron-reconcile-billing-entitlements";
 import { cronSyncSkillsRoutes } from "../cron-sync-skills";
@@ -83,6 +84,14 @@ describe("production-global sweep route contracts", () => {
       context,
       cronExecuteWorkflowAutomationsRoutes,
       "/api/cron/execute-workflow-automations",
+    );
+  });
+
+  it("rejects Gmail watch renewal without authorization", async () => {
+    await expectGlobalSweepMissingAuth(
+      context,
+      cronRenewGmailWatchesRoutes,
+      "/api/cron/renew-gmail-watches",
     );
   });
 


### PR DESCRIPTION
## Summary

- rebase onto the Gmail physical-scope isolation implemented by #27748
- add missing authorization contract coverage for the production-global Gmail renewal cron
- remove the duplicate org/user-scoped test route, contract, and service helper from this branch

## Conflict resolution

PR #27748 landed while this branch was open and implemented the same deterministic isolation fix for the flaky Gmail renewal test. This branch now keeps that upstream implementation as the canonical path and retains only the complementary global-sweep authorization coverage that #27748 did not add.

Together with #27748, this completes the acceptance criteria for #27746 without introducing a second test endpoint.

## Validation

- pnpm -F api lint
- targeted global-sweep contract test: 1 passed, 9 skipped
- git diff --check origin/main...HEAD

The full local Vitest suite was intentionally not run per repository guidance.

Closes #27746