### PR TITLE
fix(runner): reject expired post-claim idle reuse

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -35,7 +35,7 @@ use crate::guest_timezone::{GuestTimezoneAssumption, GuestTimezoneIntent};
 use crate::idle_pool::{
     DestroyOutcome, IdlePoolSnapshot, IdleUnparkResult, ReservedIdleSandbox,
     RestoreReservedIdleResult, ReusableIdleSandbox, SpeculativeIdleSandbox,
-    SpeculativeIdleUnparkResult, SpeculativeReparkResult,
+    SpeculativeIdleUnparkResult, SpeculativeReparkResult, TakenIdleEntryState,
 };
 use crate::ids::RunId;
 use crate::lifecycle::RunnerMode;
@@ -1915,8 +1915,8 @@ async fn try_reuse_from_pool(
     // so unpark does not block other take/park operations.
     let (taken, snapshot) = {
         let mut pool = ctx.idle_pool.lock().await;
-        let taken = pool.take(reuse_key);
-        let snapshot = taken.as_ref().map(|_| pool.status_snapshot());
+        let taken = pool.take_for_reuse(reuse_key);
+        let snapshot = taken.is_some().then(|| pool.status_snapshot());
         (taken, snapshot)
     };
     let took_idle_session = taken.is_some();
@@ -1931,7 +1931,28 @@ async fn try_reuse_from_pool(
         .record_phase_elapsed(RunnerPreSpawnPhase::WorkspaceCacheStateLookup, started_at);
     let needs_reuse_state_refresh = took_idle_session || claimed_workspace_cache_reuse_key;
     match taken {
-        Some(entry)
+        Some((TakenIdleEntryState::Expired, expired)) => {
+            info!(
+                run_id = %run_id,
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                reuse_key_kind = reuse_key_kind(reuse_key),
+                profile = %expired.profile_name(),
+                "expired idle VM found after claim, destroying and falling through to fresh create"
+            );
+            spawn_idle_destroy_job(
+                ctx.destroy_tasks,
+                expired.into_destroy_job(),
+                "reuse_expired",
+            );
+            (
+                None,
+                job_lease,
+                SandboxReuseResult::PoolMiss,
+                snapshot,
+                needs_reuse_state_refresh,
+            )
+        }
+        Some((TakenIdleEntryState::Available, entry))
             if entry.profile_name() == profile_name
                 && entry.device_rate_limits() == device_rate_limits =>
         {
@@ -2014,7 +2035,7 @@ async fn try_reuse_from_pool(
                 }
             }
         }
-        Some(stale) if stale.profile_name() == profile_name => {
+        Some((TakenIdleEntryState::Available, stale)) if stale.profile_name() == profile_name => {
             info!(
                 run_id = %run_id,
                 reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
@@ -2035,7 +2056,7 @@ async fn try_reuse_from_pool(
                 needs_reuse_state_refresh,
             )
         }
-        Some(stale) => {
+        Some((TakenIdleEntryState::Available, stale)) => {
             info!(
                 run_id = %run_id,
                 reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),

--- a/crates/runner/src/cmd/start/tests/idle_reuse/status.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/status.rs
@@ -1,9 +1,9 @@
 use super::super::super::*;
 use super::super::support::{
     context_with_session, mock_run_config, mock_run_config_with_overrides, publish_idle_status,
-    push_job, seed_idle_pool, seed_idle_pool_with_overrides, shutdown, status_idle_reuse_keys,
-    test_profiles, two_profiles, wait_discover_entered, wait_idle_pool_len,
-    wait_status_idle_empty_with_active_run,
+    push_job, seed_idle_pool, seed_idle_pool_expired_with_overrides, seed_idle_pool_with_overrides,
+    shutdown, status_idle_reuse_keys, test_profiles, two_profiles, wait_budget_count,
+    wait_discover_entered, wait_idle_pool_len, wait_status_idle_empty_with_active_run,
 };
 
 use crate::types::SandboxReuseResult;
@@ -126,6 +126,98 @@ async fn reuse_take_clears_idle_status_while_job_is_active() {
         completion.unwrap().reuse_result,
         Some(SandboxReuseResult::Reused),
     );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn expired_post_claim_idle_entry_falls_back_to_fresh() {
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 4, 8192, 2, Arc::clone(&overrides));
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let status = Arc::clone(&config.shared.status);
+    let status_path = env._temp_dir.path().join("status.json");
+    let reuse_key = "thread:expired-post-claim";
+
+    let expired_sandbox_id = seed_idle_pool_expired_with_overrides(
+        &idle_pool,
+        &budget,
+        &overrides,
+        reuse_key,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    publish_idle_status(&idle_pool, &status).await;
+    assert_eq!(
+        status_idle_reuse_keys(&status_path).await,
+        vec![reuse_key.to_string()],
+        "pre-run status should list the expired idle VM",
+    );
+
+    env.handle.block_claims();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    let run_id = RunId::new_v4();
+    let mut claimed_context = context_with_session(run_id, "provider-session-expired");
+    claimed_context.reuse_key = Some(reuse_key.to_string());
+    env.provider.set_claim_result(run_id, Some(claimed_context));
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+                .with_reuse_key(Some(reuse_key.to_string())),
+        )
+        .unwrap();
+    assert!(
+        env.handle
+            .wait_claim_in_flight(1, Duration::from_secs(5))
+            .await,
+        "claim should start with fresh capacity while the expired entry remains pooled",
+    );
+    assert_eq!(
+        idle_pool.lock().await.held_reuse_keys(),
+        vec![reuse_key.to_string()],
+        "pre-claim admission must leave the expired entry in the pool",
+    );
+    assert_eq!(
+        budget.allocated().2,
+        2,
+        "expired and fresh admission leases should both be held during claim",
+    );
+
+    env.handle.unblock_claims();
+    wait_status_idle_empty_with_active_run(&status_path, run_id, Duration::from_secs(5)).await;
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("fresh sandbox process should start");
+    wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
+    assert_eq!(overrides.unpark_call_count(), 0);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_eq!(
+        overrides.create_configs().len(),
+        2,
+        "the run should create a fresh sandbox after the seeded expired sandbox",
+    );
+
+    overrides.clear_wait_process_lifecycle_gate();
+    wait_gate.release_one();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("fresh fallback job should complete");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_ne!(completion.sandbox_id, Some(expired_sandbox_id));
+    wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated().2, 1);
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -352,6 +352,35 @@ pub(in super::super) async fn seed_idle_pool_expired(
     assert!(matches!(result, ParkResult::Parked));
 }
 
+pub(in super::super) async fn seed_idle_pool_expired_with_overrides(
+    pool: &SharedIdlePool,
+    budget: &Arc<ResourceBudget>,
+    overrides: &Arc<sandbox_mock::MockSandboxOverrides>,
+    reuse_key: &str,
+    profile_name: &str,
+    vcpu: u32,
+    memory_mb: u32,
+) -> SandboxId {
+    seed_idle_pool_with_overrides_and_generation(
+        pool,
+        budget,
+        overrides,
+        IdlePoolSeedSpec {
+            reuse_key,
+            profile_name,
+            vcpu,
+            memory_mb,
+            history_generation_run_id: None,
+            guest_timezone_intent: GuestTimezoneIntent::Unknown,
+            timing: Some((
+                std::time::Instant::now() - Duration::from_secs(400),
+                Duration::from_secs(300),
+            )),
+        },
+    )
+    .await
+}
+
 pub(in super::super) struct TestParkedIdleCandidateSpec<'a> {
     pub(in super::super) reuse_key: &'a str,
     pub(in super::super) profile_name: &'a str,

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -12,10 +12,10 @@ pub(super) use self::env::{
 };
 pub(super) use self::idle_pool::{
     SpeculativeIdleSeedSpec, TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec,
-    seed_idle_pool, seed_idle_pool_expired, seed_idle_pool_with_history_generation,
-    seed_idle_pool_with_overrides, seed_idle_pool_with_speculative_timezone,
-    seed_idle_pool_with_timing, seed_idle_pool_with_workspace_promotion,
-    seed_workspace_cache_state,
+    seed_idle_pool, seed_idle_pool_expired, seed_idle_pool_expired_with_overrides,
+    seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
+    seed_idle_pool_with_speculative_timezone, seed_idle_pool_with_timing,
+    seed_idle_pool_with_workspace_promotion, seed_workspace_cache_state,
 };
 pub(super) use self::jobs::{context_with_session, minimal_context, push_job, shutdown};
 pub(super) use self::status::{

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -63,6 +63,11 @@ pub struct IdlePoolSnapshot {
     pub idle_vms: Vec<IdleVm>,
 }
 
+pub(crate) enum TakenIdleEntryState {
+    Available,
+    Expired,
+}
+
 /// Pool of idle sandboxes keyed by reuse key.
 ///
 /// After a job reaches a terminal state that is proven reusable, its sandbox
@@ -141,6 +146,19 @@ impl IdlePool {
             self.bump_revision();
         }
         entry
+    }
+
+    pub(crate) fn take_for_reuse(
+        &mut self,
+        reuse_key: &str,
+    ) -> Option<(TakenIdleEntryState, IdleEntry)> {
+        let entry = self.take(reuse_key)?;
+        let state = if entry.is_expired_at(Instant::now()) {
+            TakenIdleEntryState::Expired
+        } else {
+            TakenIdleEntryState::Available
+        };
+        Some((state, entry))
     }
 
     pub fn has_reusable(


### PR DESCRIPTION
## Summary

- classify post-claim idle-pool takes as available or expired while holding the pool lock
- destroy expired idle sandboxes without unparking them, preserve the admitted fresh lease, and report `poolMiss`
- cover the race with a full runner integration test that verifies status, budget ownership, lifecycle calls, and fresh fallback identity

## Scope

- no API, wire-format, persisted-state, migration, or deployment-contract changes
- existing pre-claim reservation behavior is unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps --all-features`
- `cargo test -p runner expired_post_claim_idle_entry_falls_back_to_fresh`
- `cargo test -p runner`

Closes #27715
