### PR TITLE
fix(api): preserve model capabilities through custom gateways

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
@@ -322,6 +322,8 @@ describe("custom model provider gateway routes", () => {
               authHeaderTemplate: "{{secret}}",
               modelMappings: {
                 "gpt-5.6-sol": "company-gpt-production",
+                "deepseek-v4-flash": "deepseek-v4-flash-0731",
+                "deepseek-v4-pro": "company-deepseek-pro-production",
               },
             },
           ],
@@ -471,6 +473,7 @@ describe("custom model provider gateway routes", () => {
       requiresOpenaiAuth: false,
       wireApi: "responses",
     });
+    expect(codexClaim.codexRuntimeConfig?.modelCatalog).toBeUndefined();
     expect(codexClaim.environment?.OPENAI_API_KEY).toBe(
       MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
     );
@@ -501,5 +504,81 @@ describe("custom model provider gateway routes", () => {
     expect(codexClaim.secretValues).not.toContain("runtime-gateway-secret");
 
     await runs.requestCancelRun(actor, codexRunId, [200]);
+
+    const deepseekMappings = [
+      {
+        logicalModel: "deepseek-v4-flash",
+        upstreamModel: "deepseek-v4-flash-0731",
+      },
+      {
+        logicalModel: "deepseek-v4-pro",
+        upstreamModel: "company-deepseek-pro-production",
+      },
+    ] as const;
+    for (const { logicalModel, upstreamModel } of deepseekMappings) {
+      await runs.updateOrgModelPolicies(actor, [
+        {
+          model: logicalModel,
+          isDefault: true,
+          defaultProviderType: "vercel-ai-gateway-codex",
+          credentialScope: "org",
+          modelProviderId: null,
+          modelProviderSurfaceId: responsesSurface.id,
+        },
+      ]);
+      const deepseekSent = await chat.requestSendEvent(
+        actor,
+        {
+          clientEventId: randomUUID(),
+          agentId: agent.agentId,
+          prompt: `exercise the custom Responses gateway for ${logicalModel}`,
+          model: logicalModel,
+        },
+        [201],
+      );
+      if ("error" in deepseekSent.body) {
+        throw new Error(
+          `Expected the ${logicalModel} custom gateway chat send to succeed`,
+        );
+      }
+      const deepseekRunId = deepseekSent.body.runId;
+      if (!deepseekRunId) {
+        throw new Error(
+          `Expected the ${logicalModel} custom gateway chat send to create a run`,
+        );
+      }
+      await runs.heartbeatRunner(runnerGroup);
+      const deepseekClaim = await runs.claimRunnerJob(deepseekRunId);
+
+      expect(deepseekClaim.cliAgentType).toBe("codex");
+      expect(deepseekClaim.environment).toMatchObject({
+        OPENAI_BASE_URL: "https://gateway.example.com/openai/v1",
+        OPENAI_MODEL: upstreamModel,
+      });
+      const catalogModels =
+        deepseekClaim.codexRuntimeConfig?.modelCatalog?.models;
+      if (!Array.isArray(catalogModels) || catalogModels.length !== 1) {
+        throw new Error(`Expected one Codex catalog model for ${logicalModel}`);
+      }
+      const [catalogModel] = catalogModels;
+      if (!isRecord(catalogModel)) {
+        throw new Error(
+          `Expected a Codex catalog model record for ${logicalModel}`,
+        );
+      }
+      expect(catalogModel).toMatchObject({
+        slug: upstreamModel,
+        input_modalities: ["text"],
+        base_instructions: expect.stringContaining("You are Codex"),
+        model_messages: {
+          instructions_template: expect.stringContaining("You are Codex"),
+        },
+      });
+      expect(deepseekClaim.appendSystemPrompt).toContain(
+        'okou recognize --file <image-path> --prompt "<instruction>"',
+      );
+
+      await runs.requestCancelRun(actor, deepseekRunId, [200]);
+    }
   });
 });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -2280,6 +2280,7 @@ async function customGatewayModelProviderEnvironment(
     displayName: row.displayName,
     authHeaderName: row.authHeaderName,
     authHeaderTemplate: row.authHeaderTemplate,
+    logicalModel: args.selectedModelOverride,
     upstreamModel,
   });
   if (

--- a/turbo/apps/api/src/signals/services/model-provider-gateway-runtime.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-gateway-runtime.ts
@@ -1,4 +1,6 @@
 import {
+  getModelProviderCodexRuntimeConfig,
+  getVm0ConcreteProviderType,
   MODEL_PROVIDER_ENV_PLACEHOLDERS,
   type ModelProviderCodexRuntimeConfig,
   type ModelProviderType,
@@ -18,6 +20,7 @@ interface CompileModelProviderGatewayRuntimeArgs {
   readonly displayName: string;
   readonly authHeaderName: string;
   readonly authHeaderTemplate: string;
+  readonly logicalModel: string;
   readonly upstreamModel: string;
 }
 
@@ -78,6 +81,29 @@ export function compileModelProviderGatewayRuntime(
     };
   }
 
+  const sourceCatalog = getModelProviderCodexRuntimeConfig(
+    getVm0ConcreteProviderType(args.logicalModel),
+  )?.modelCatalog;
+  const sourceModels = sourceCatalog?.models;
+  const sourceModel = Array.isArray(sourceModels)
+    ? sourceModels.find((model: unknown): model is Record<string, unknown> => {
+        return (
+          typeof model === "object" &&
+          model !== null &&
+          !Array.isArray(model) &&
+          "slug" in model &&
+          model.slug === args.logicalModel
+        );
+      })
+    : undefined;
+  const modelCatalog =
+    sourceCatalog && sourceModel
+      ? {
+          ...sourceCatalog,
+          models: [{ ...sourceModel, slug: args.upstreamModel }],
+        }
+      : undefined;
+
   return {
     type,
     firewall,
@@ -95,6 +121,7 @@ export function compileModelProviderGatewayRuntime(
       requiresOpenaiAuth: false,
       wireApi: "responses",
       supportsWebsockets: false,
+      ...(modelCatalog ? { modelCatalog } : {}),
     },
   };
 }


### PR DESCRIPTION
## Summary

- preserve the selected logical model while compiling a custom provider gateway runtime
- project the authoritative VM0 Codex catalog record onto the gateway's upstream model alias
- keep custom Responses models without VM0-owned catalog metadata on the existing no-catalog fallback

## Compatibility

- uses the existing optional `modelCatalog` runner contract field
- leaves Anthropic Messages gateways and direct provider resolution unchanged
- sends only the selected catalog record, with its complete metadata and upstream slug

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/model-provider-gateways.test.ts --silent=passed-only`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts --silent=passed-only`
- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm knip --workspace @okouai/api-contracts --workspace api`
- `pnpm -F api build`
- `.git/hooks/pre-commit`

Closes #27737
