### PR TITLE
fix(python): retain prewarm ids across terminal frames

### DIFF
--- a/crates/runner/mitm-addon/src/model_websocket_usage.py
+++ b/crates/runner/mitm-addon/src/model_websocket_usage.py
@@ -272,22 +272,23 @@ def feed_usage(
                 and prewarm_state.active_intent == "prewarm"
                 and prewarm_state.active_response_id == message_id
             ):
-                if (
-                    not prewarm_state.ignored_diagnostic_emitted
-                    and usage.has_positive_model_provider_usage(usage_result)
-                ):
-                    usage.log_ignored_model_provider_usage_source(
-                        flow,
-                        flow_metadata.run_id(flow.metadata),
-                        message_id,
-                        usage_result,
-                        reason="responses_generate_false",
-                    )
-                    prewarm_state.ignored_diagnostic_emitted = True
                 prewarm_state.ignored_response_id = message_id
                 suppressed = True
             elif not prewarm_state.ambiguous and prewarm_state.ignored_response_id == message_id:
                 suppressed = True
+            if (
+                suppressed
+                and not prewarm_state.ignored_diagnostic_emitted
+                and usage.has_positive_model_provider_usage(usage_result)
+            ):
+                usage.log_ignored_model_provider_usage_source(
+                    flow,
+                    flow_metadata.run_id(flow.metadata),
+                    message_id,
+                    usage_result,
+                    reason="responses_generate_false",
+                )
+                prewarm_state.ignored_diagnostic_emitted = True
         if (
             not suppressed
             and usage_result is not None
@@ -351,5 +352,7 @@ def feed_usage(
         and not prewarm_state.ambiguous
         and prewarm_state.active_response_id == lifecycle.response_id
     ):
+        if prewarm_state.active_intent == "prewarm":
+            prewarm_state.ignored_response_id = lifecycle.response_id
         prewarm_state.active_intent = None
         prewarm_state.active_response_id = None

--- a/crates/runner/mitm-addon/src/model_websocket_usage.py
+++ b/crates/runner/mitm-addon/src/model_websocket_usage.py
@@ -73,6 +73,16 @@ def _clear_correlation_candidate(state: _OpenAIResponsesPrewarmState) -> None:
     state.active_response_id = None
 
 
+def _retain_ignored_response_id(
+    state: _OpenAIResponsesPrewarmState,
+    response_id: str,
+) -> None:
+    if state.ignored_response_id == response_id:
+        return
+    state.ignored_response_id = response_id
+    state.ignored_diagnostic_emitted = False
+
+
 def _lifecycle_ambiguity_reason(
     lifecycle: usage.OpenAIResponsesServerLifecycle,
 ) -> _WebSocketCorrelationReason:
@@ -130,8 +140,6 @@ def observe_client_event(
         _mark_correlation_ambiguous(flow, state, "overlapping_request")
         return
     state.pending_intent = "prewarm" if event.is_prewarm else "normal"
-    if event.is_prewarm:
-        state.ignored_diagnostic_emitted = False
 
 
 def _observe_server_lifecycle(
@@ -272,7 +280,7 @@ def feed_usage(
                 and prewarm_state.active_intent == "prewarm"
                 and prewarm_state.active_response_id == message_id
             ):
-                prewarm_state.ignored_response_id = message_id
+                _retain_ignored_response_id(prewarm_state, message_id)
                 suppressed = True
             elif not prewarm_state.ambiguous and prewarm_state.ignored_response_id == message_id:
                 suppressed = True
@@ -344,15 +352,18 @@ def feed_usage(
                 flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_target
             usage.merge_openai_responses_usage_result(usage_target, usage_result)
 
+    if not isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
+        return
+    active_response_id = prewarm_state.active_response_id
     if (
-        isinstance(prewarm_state, _OpenAIResponsesPrewarmState)
-        and lifecycle is not None
+        lifecycle is not None
         and lifecycle.is_terminal
         and lifecycle.is_valid
         and not prewarm_state.ambiguous
-        and prewarm_state.active_response_id == lifecycle.response_id
+        and active_response_id is not None
+        and active_response_id == lifecycle.response_id
     ):
         if prewarm_state.active_intent == "prewarm":
-            prewarm_state.ignored_response_id = lifecycle.response_id
+            _retain_ignored_response_id(prewarm_state, active_response_id)
         prewarm_state.active_intent = None
         prewarm_state.active_response_id = None

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -103,6 +103,44 @@ class TestModelProviderWebSocketPrewarmUsage:
         assert ignored_entry["reason"] == "responses_generate_false"
         assert not _correlation_entries(flow)
 
+    def test_model_websocket_ignores_late_usage_after_usage_free_terminal(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("warm-late"))
+            feed_websocket_server_message(
+                flow,
+                b'{"type":"response.completed","response":{"id":"warm-late"}}',
+            )
+            feed_websocket_server_message(
+                flow,
+                b'{"type":"response.done","response":{"id":"warm-late",'
+                b'"model":"gpt-5.5","usage":{"input_tokens":17,"output_tokens":0}}}',
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert webhook.usage_events() == []
+        assert webhook.model_usage_observation_events() == []
+        [ignored_entry] = [
+            entry
+            for entry in model_usage_source_entries(flow)
+            if entry.get("disposition") == "ignored"
+        ]
+        assert ignored_entry["provider_response_id"] == "warm-late"
+        assert ignored_entry["reason"] == "responses_generate_false"
+        assert ignored_entry["usage"] == {"tokens.input": 17}
+        assert not _correlation_entries(flow)
+
     def test_model_websocket_ignores_bound_prewarm_and_reports_normal_input_only_turn(
         self,
         tmp_path,

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_prewarm.py
@@ -141,6 +141,57 @@ class TestModelProviderWebSocketPrewarmUsage:
         assert ignored_entry["usage"] == {"tokens.input": 17}
         assert not _correlation_entries(flow)
 
+    def test_model_websocket_logs_each_prewarm_source_once_across_late_duplicate(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("warm-first"))
+            first_usage = openai_websocket_usage_frame(
+                "warm-first",
+                input_tokens=5,
+                output_tokens=0,
+            )
+            feed_websocket_server_message(flow, first_usage)
+
+            feed_websocket_client_message(
+                flow,
+                json.dumps({"type": "response.create", "generate": False}).encode(),
+            )
+            feed_websocket_server_message(flow, _openai_websocket_created_frame("warm-second"))
+            feed_websocket_server_message(flow, first_usage)
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "warm-second",
+                    input_tokens=7,
+                    output_tokens=0,
+                ),
+            )
+            mitm_addon.websocket_end(flow)
+            usage.flush_usage_events(trigger="test")
+
+        assert webhook.usage_events() == []
+        assert webhook.model_usage_observation_events() == []
+        ignored_entries = [
+            entry
+            for entry in model_usage_source_entries(flow)
+            if entry.get("disposition") == "ignored"
+        ]
+        assert [entry["provider_response_id"] for entry in ignored_entries] == [
+            "warm-first",
+            "warm-second",
+        ]
+        assert not _correlation_entries(flow)
+
     def test_model_websocket_ignores_bound_prewarm_and_reports_normal_input_only_turn(
         self,
         tmp_path,


### PR DESCRIPTION
## Summary

- retain proven `generate: false` response ownership when a valid terminal frame carries no usage
- suppress later same-response-ID terminal usage without changing ambiguity or ID-reuse fail-open behavior
- align the once-only ignored-source diagnostic with the retained response ID across sequential prewarm requests and late duplicates
- add entry-point WebSocket regressions covering billing, observations, and diagnostic ownership

## Scope

This change is local to the runner MITM addon's in-memory WebSocket lifecycle. It does not change JSON parsing, APIs, persisted state, queue payloads, migrations, or runner/guest compatibility contracts.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_websocket_prewarm.py` (26 passed)
- `uv run --no-sync python -m pytest tests/` (5,998 passed in 68.54 seconds)

Closes #27721
