### PR TITLE
test(runner): make finalizing deadline tests deterministic

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -18,6 +18,7 @@ use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::WorkspaceImageCache;
 
 const NON_SELECTED_RUNNER_ID: u128 = 1;
+const FINALIZING_TEST_PREFERENCE_LIFETIME: Duration = Duration::from_secs(30);
 
 fn ranked_candidate(
     run_id: RunId,
@@ -783,7 +784,7 @@ async fn selected_ranked_finalizing_candidate_falls_back_at_deadline() {
     let run_id = RunId::new_v4();
     env.provider
         .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
-    let deadline = std::time::Instant::now() + Duration::from_millis(100);
+    let deadline = std::time::Instant::now() + FINALIZING_TEST_PREFERENCE_LIFETIME;
     env.handle
         .discover_tx
         .send(
@@ -814,7 +815,7 @@ async fn selected_ranked_finalizing_candidate_falls_back_at_deadline() {
     );
     assert_eq!(preference.deadline(), deadline);
 
-    tokio::time::advance(Duration::from_millis(101)).await;
+    tokio::time::advance(FINALIZING_TEST_PREFERENCE_LIFETIME + Duration::from_millis(1)).await;
     let completion = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
@@ -965,7 +966,7 @@ async fn published_exact_remains_reusable_past_preference_deadline() {
                 RunnerPreferenceTier::FinalizingPredecessor,
                 TEST_RUNNER_ID,
                 TEST_HEARTBEAT_GENERATION,
-                std::time::Instant::now() + Duration::from_millis(100),
+                std::time::Instant::now() + FINALIZING_TEST_PREFERENCE_LIFETIME,
             )
             .with_history_generation_run_id(Some(history_generation_run_id)),
         )
@@ -993,7 +994,7 @@ async fn published_exact_remains_reusable_past_preference_deadline() {
         .await
         .expect("published exact sandbox should start before predecessor release");
 
-    tokio::time::advance(Duration::from_millis(101)).await;
+    tokio::time::advance(FINALIZING_TEST_PREFERENCE_LIFETIME + Duration::from_millis(1)).await;
     successor_gate.release_one();
     let completion = env
         .handle
@@ -1390,7 +1391,7 @@ async fn same_run_duplicate_does_not_renew_claimed_finalizing_deadline() {
     let run_id = RunId::new_v4();
     env.provider
         .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
-    let original_deadline = std::time::Instant::now() + Duration::from_millis(100);
+    let original_deadline = std::time::Instant::now() + FINALIZING_TEST_PREFERENCE_LIFETIME;
     env.handle
         .discover_tx
         .send(finalizing_candidate_until(
@@ -1421,7 +1422,7 @@ async fn same_run_duplicate_does_not_renew_claimed_finalizing_deadline() {
             history_generation_run_id,
             TEST_RUNNER_ID,
             TEST_HEARTBEAT_GENERATION,
-            std::time::Instant::now() + Duration::from_secs(30),
+            original_deadline + FINALIZING_TEST_PREFERENCE_LIFETIME,
         ))
         .unwrap();
     wait_discover_entered(&env, Duration::from_secs(2)).await;
@@ -1454,7 +1455,7 @@ async fn same_run_duplicate_does_not_renew_claimed_finalizing_deadline() {
         "a duplicate discovery must not renew the claimed finalizing deadline"
     );
 
-    tokio::time::advance(Duration::from_millis(101)).await;
+    tokio::time::advance(FINALIZING_TEST_PREFERENCE_LIFETIME + Duration::from_millis(1)).await;
     let completion = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -799,13 +799,20 @@ async fn selected_ranked_finalizing_candidate_falls_back_at_deadline() {
         )
         .unwrap();
     wait_discover_entered(&env, Duration::from_secs(2)).await;
-    assert!(
-        env.handle
-            .claim_candidates()
-            .iter()
-            .any(|candidate| candidate.run_id() == run_id),
-        "selected finalizing candidate should be claimed before its deadline"
+    let claimed = env
+        .handle
+        .claim_candidates()
+        .into_iter()
+        .find(|candidate| candidate.run_id() == run_id)
+        .expect("selected finalizing candidate should be claimed before its deadline");
+    let preference = claimed
+        .runner_preference()
+        .expect("claimed finalizing candidate should retain its preference");
+    assert_eq!(
+        preference.tier(),
+        RunnerPreferenceTier::FinalizingPredecessor
     );
+    assert_eq!(preference.deadline(), deadline);
 
     tokio::time::advance(Duration::from_millis(101)).await;
     let completion = env
@@ -814,23 +821,6 @@ async fn selected_ranked_finalizing_candidate_falls_back_at_deadline() {
         .await
         .expect("expired finalizing preference should enter ordinary admission");
     assert_ne!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    let claimed = env
-        .handle
-        .claim_candidates()
-        .into_iter()
-        .find(|candidate| candidate.run_id() == run_id)
-        .expect("expired candidate should reach claim");
-    let telemetry = claimed
-        .runner_preference_claim_telemetry()
-        .expect("decision observation should survive expiry");
-    assert!(matches!(
-        telemetry.runner_preference,
-        RunnerPreference::Preference {
-            tier: RunnerPreferenceTier::FinalizingPredecessor,
-            ..
-        }
-    ));
-    assert_eq!(telemetry.state, Some(RunnerPreferenceClaimState::Active));
 
     drop(predecessor_guard);
     shutdown(&env, run_handle).await;
@@ -1445,6 +1435,24 @@ async fn same_run_duplicate_does_not_renew_claimed_finalizing_deadline() {
         "a duplicate discovery must not claim the same run again"
     );
     assert!(env.handle.deferred_poll_deadlines().is_empty());
+    let claimed = env
+        .handle
+        .claim_candidates()
+        .into_iter()
+        .find(|candidate| candidate.run_id() == run_id)
+        .expect("claimed finalizing candidate should retain the first decision");
+    let preference = claimed
+        .runner_preference()
+        .expect("claimed finalizing candidate should retain its preference");
+    assert_eq!(
+        preference.tier(),
+        RunnerPreferenceTier::FinalizingPredecessor
+    );
+    assert_eq!(
+        preference.deadline(),
+        original_deadline,
+        "a duplicate discovery must not renew the claimed finalizing deadline"
+    );
 
     tokio::time::advance(Duration::from_millis(101)).await;
     let completion = env
@@ -1454,26 +1462,6 @@ async fn same_run_duplicate_does_not_renew_claimed_finalizing_deadline() {
     assert!(
         completion.is_some(),
         "the original deadline should start fallback despite a later duplicate"
-    );
-    let claimed = env
-        .handle
-        .claim_candidates()
-        .into_iter()
-        .find(|candidate| candidate.run_id() == run_id)
-        .expect("expired pending candidate should reach claim");
-    let preference_telemetry = claimed
-        .runner_preference_claim_telemetry()
-        .expect("finalizing observation should survive expiry");
-    assert!(matches!(
-        preference_telemetry.runner_preference,
-        RunnerPreference::Preference {
-            tier: RunnerPreferenceTier::FinalizingPredecessor,
-            ..
-        }
-    ));
-    assert_eq!(
-        preference_telemetry.state,
-        Some(RunnerPreferenceClaimState::Active)
     );
 
     drop(predecessor_guard);


### PR DESCRIPTION
## Summary

- assert the exact finalizing preference deadline retained by the candidate recorded during claim
- replace sub-100-ms real scheduling windows with a shared 30-second lifetime crossed immediately by paused Tokio time
- cover all three admission tests with the same short standard-library deadline and virtual-time transition

Production admission, deadline, provider, and telemetry behavior is unchanged. The longer value is test scenario input, not a wall-clock wait or diagnostic timeout.

## Validation

- `cargo fmt --all -- --check`
- duplicate-deadline target repeated 20 times
- selected-finalizing and published-exact tests repeated 10 times each
- `cargo llvm-cov -p runner --all-targets --all-features --no-report -- cmd::start::tests::main_loop::admission::same_run_duplicate_does_not_renew_claimed_finalizing_deadline --exact`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps --all-features`
- `cargo test -p runner -- --quiet` passed on the initial implementation (3,159 passed, 20 ignored); two later final-revision attempts passed all changed tests but separately reproduced unrelated full-suite flakes in #27765 and `dns::port::tests::find_available_port_retries_when_udp_candidate_is_in_use`, both of which passed immediately in isolation
- repository pre-commit and commit-message hooks
- after rebasing onto current `main`, all three exact tests and the coverage-instrumented target passed again

Closes #27722

Parent context: #27738
