### PR TITLE
test(runner): separate bounded signal scenario budgets

### DIFF
--- a/crates/runner/src/cmd/service/signal.rs
+++ b/crates/runner/src/cmd/service/signal.rs
@@ -141,6 +141,8 @@ mod tests {
     const SIGNAL_ENV: &str = "VM0_RUN_SERVICE_SIGNAL_NAME";
     const INVOCATIONS_ENV: &str = "VM0_RUN_SERVICE_SIGNAL_INVOCATIONS";
     const CHILD_TEST: &str = "cmd::service::signal::tests::signal_service_main_systemctl_child";
+    const BOUNDED_OUTCOME_SCENARIO_BUDGET: Duration = Duration::from_secs(5);
+    const BOUNDED_TIMEOUT_SCENARIO_BUDGET: Duration = Duration::from_millis(100);
     const FAKE_SYSTEMCTL: &str = r#"#!/bin/sh
 printf '%s\n' "$*" >> "$VM0_RUN_SERVICE_SIGNAL_INVOCATIONS"
 
@@ -304,10 +306,14 @@ exit 2
             value => panic!("unexpected signal scenario value: {value:?}"),
         };
         let unit = RunnerServiceUnit::from_suffix("test").unwrap();
-        let result = if scenario.starts_with("bounded-") {
-            signal_service_main_bounded(&unit, signal, Duration::from_millis(100)).await
-        } else {
-            signal_service_main(&unit, signal).await
+        let result = match scenario.as_str() {
+            "bounded-success" | "bounded-absent" => {
+                signal_service_main_bounded(&unit, signal, BOUNDED_OUTCOME_SCENARIO_BUDGET).await
+            }
+            "bounded-timeout" => {
+                signal_service_main_bounded(&unit, signal, BOUNDED_TIMEOUT_SCENARIO_BUDGET).await
+            }
+            _ => signal_service_main(&unit, signal).await,
         };
 
         match scenario.as_str() {
@@ -334,7 +340,10 @@ exit 2
             "bounded-timeout" => {
                 let error = result.unwrap_err().to_string();
                 assert!(
-                    error.contains("systemctl timed out after 100ms"),
+                    error.contains(&format!(
+                        "systemctl timed out after {}ms",
+                        BOUNDED_TIMEOUT_SCENARIO_BUDGET.as_millis()
+                    )),
                     "unexpected error: {error}"
                 );
             }


### PR DESCRIPTION
## Summary

- separate normally completing bounded signal scenarios from the deliberate timeout probe
- give `Sent` and `AlreadyGone` subprocess integration paths a 5-second fixture watchdog
- retain the 100 ms timeout scenario and existing bounded child kill-and-reap coverage

## Scope

- changes only `#[cfg(test)]` scenario selection in `crates/runner/src/cmd/service/signal.rs`
- does not change production service signaling, deadline accounting, error precedence, or cleanup
- does not address the independent full-suite flakes tracked by #27722 and #27765

## Validation

Passed:

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service::signal::tests`
- bounded outcome target repeated 20 consecutive times
- `cargo test --manifest-path crates/Cargo.toml -p runner bounded_command::tests`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `git diff --check`
- repository pre-commit Rust formatting, workspace rustdoc, and workspace Clippy hooks
- post-rebase database migration and focused signal/cleanup tests

Complete default-concurrency runner attempts were not counted as passing:

- attempt 1: 3,158 passed, 1 failed, 20 ignored; `execute_inner_waits_for_transient_workspace_cache_lock` failed and then passed alone; tracked by #27765
- attempt 2: 3,158 passed, 1 failed, 20 ignored; `same_run_duplicate_does_not_renew_claimed_finalizing_deadline` failed; tracked by #27722
- the bounded signal target passed in both complete-suite attempts

Closes #27757
Parent context: #27738
