### PR TITLE
fix(platform): create chat from three-column header

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -21,7 +21,7 @@ export const navigateToChat$ = command(({ set }, chatThreadId: string) => {
   });
 });
 
-const navigateToNewChat$ = command(
+export const navigateToNewChat$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const agentId = await get(currentChatAgentId$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -21,7 +21,7 @@ export const navigateToChat$ = command(({ set }, chatThreadId: string) => {
   });
 });
 
-export const navigateToNewChat$ = command(
+const navigateToNewChat$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const agentId = await get(currentChatAgentId$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2819,6 +2819,29 @@ describe("zero sidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens a new chat from the three-column header without visiting home", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Existing conversation"),
+    ]);
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+      },
+    });
+
+    const list = await screen.findByTestId("chat-list-column");
+    click(within(list).getByLabelText("New chat"));
+
+    expect(pathname()).not.toBe("/");
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
+    });
+  });
+
   it("keeps New fourth in the pinned agent navigation order", async () => {
     const team = prepareAgentTeam();
     const operationsAgentId = "c0000000-0000-4000-a000-000000000004";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2819,11 +2819,24 @@ describe("zero sidebar", () => {
     ).toBeInTheDocument();
   });
 
-  it("opens a new chat from the three-column header without visiting home", async () => {
+  it("creates a new chat thread from the three-column header", async () => {
     prepareDefaultAgent();
     mockSidebarThreadStory([
       createThread(EXISTING_THREAD_ID, "Existing conversation"),
     ]);
+    let createdThreadId: string | undefined;
+    let createdAgentId: string | undefined;
+    context.mocks.api(chatThreadsContract.create, ({ body, respond }) => {
+      createdThreadId = body.clientThreadId ?? "created-thread-id";
+      createdAgentId = body.agentId;
+      return respond(201, {
+        id: createdThreadId,
+        title: null,
+        createdAt: "2026-03-10T00:00:00Z",
+        selectedModel: body.model ?? "claude-sonnet-4-6",
+        serviceTier: body.serviceTier ?? null,
+      });
+    });
 
     setupSidebarPage({
       context,
@@ -2834,11 +2847,18 @@ describe("zero sidebar", () => {
     });
 
     const list = await screen.findByTestId("chat-list-column");
-    click(within(list).getByLabelText("New chat"));
+    const newChatButton = within(list).getByLabelText("New chat");
+    await waitFor(() => {
+      expect(newChatButton).toBeEnabled();
+    });
+    click(newChatButton);
 
     expect(pathname()).not.toBe("/");
     await waitFor(() => {
-      expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
+      expect(createdAgentId).toBe(AGENT_ID);
+      expect(createdThreadId).toBeDefined();
+      expect(pathname()).toBe(`/chats/${createdThreadId}`);
+      expect(within(list).getByText("New chat")).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -29,6 +29,7 @@ import {
   setSidebarExpanded$,
   handleZeroNavSelect$,
   handleZeroAccountAction$,
+  navigateToNewChat$,
   type SidebarNavId,
 } from "../../signals/zero-page/zero-nav.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
@@ -51,6 +52,8 @@ import { AccountDropdown } from "./zero-sidebar-account.tsx";
 import { ChatThreadsSection } from "./sidebar-threads.tsx";
 import { PinnedAgentListSection } from "./zero-sidebar-pinned.tsx";
 import { SidebarUpgradeCard } from "./zero-sidebar-upgrade.tsx";
+import { rootSignal$ } from "../../signals/root-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 
@@ -730,7 +733,8 @@ function LabeledNavRail() {
 }
 
 function ChatListColumn() {
-  const onSelect = useNavSelect();
+  const navigateToNewChat = useSet(navigateToNewChat$);
+  const rootSignal = useGet(rootSignal$);
   const openAgentList = useSet(openAgentListDialog$);
   const activeId = useGet(activeRoute$);
   const { t } = useTranslation();
@@ -784,7 +788,7 @@ function ChatListColumn() {
                     return;
                   }
                   e.preventDefault();
-                  onSelect("chat");
+                  detach(navigateToNewChat(rootSignal), Reason.DomCallback);
                 }}
                 aria-label={newChatLabel}
                 aria-current={isNewChatActive ? "page" : undefined}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -29,7 +29,6 @@ import {
   setSidebarExpanded$,
   handleZeroNavSelect$,
   handleZeroAccountAction$,
-  navigateToNewChat$,
   type SidebarNavId,
 } from "../../signals/zero-page/zero-nav.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
@@ -54,6 +53,11 @@ import { PinnedAgentListSection } from "./zero-sidebar-pinned.tsx";
 import { SidebarUpgradeCard } from "./zero-sidebar-upgrade.tsx";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
+import {
+  createNewChatThread$,
+  newChatThreadDisabled$,
+} from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 
@@ -733,10 +737,11 @@ function LabeledNavRail() {
 }
 
 function ChatListColumn() {
-  const navigateToNewChat = useSet(navigateToNewChat$);
+  const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;
+  const createNewChat = useSet(createNewChatThread$);
+  const newChatDisabled = useGet(newChatThreadDisabled$);
   const rootSignal = useGet(rootSignal$);
   const openAgentList = useSet(openAgentListDialog$);
-  const activeId = useGet(activeRoute$);
   const { t } = useTranslation();
   const searchLabel = t(($) => {
     return $.appShell.sidebar.searchConversations;
@@ -744,11 +749,15 @@ function ChatListColumn() {
   const newChatLabel = t(($) => {
     return $.appShell.sidebar.navigation.newChat;
   });
-  const isNewChatActive =
-    activeId !== null &&
-    (["home", "agentChat", "agentIdeas", "chat"] as RouteKey[]).includes(
-      activeId,
+  const onNewChat = () => {
+    if (!currentChatAgentId) {
+      return;
+    }
+    detach(
+      createNewChat(currentChatAgentId, "main", rootSignal),
+      Reason.DomCallback,
     );
+  };
   return (
     <aside
       data-testid="chat-list-column"
@@ -781,21 +790,16 @@ function ChatListColumn() {
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Link
-                pathname="/"
-                onClick={(e) => {
-                  if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                    return;
-                  }
-                  e.preventDefault();
-                  detach(navigateToNewChat(rootSignal), Reason.DomCallback);
-                }}
+              <Button
+                type="button"
+                onClick={onNewChat}
+                disabled={!currentChatAgentId || newChatDisabled}
                 aria-label={newChatLabel}
-                aria-current={isNewChatActive ? "page" : undefined}
-                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground no-underline transition-colors hover:bg-state-hover hover:text-sidebar-foreground"
+                variant="quiet"
+                size="icon-sm"
               >
                 <Edit className="opacity-50" size={17} />
-              </Link>
+              </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
               <p className="text-xs">{newChatLabel}</p>


### PR DESCRIPTION
## Summary

- make the three-column chat header's New chat button use the same `createNewChatThread$` action as the agent chat-list menu
- create an optimistic thread for the current agent and navigate directly to `/chats/:threadId`, without visiting the bare Home route
- use the existing quiet icon button pattern and keep the action disabled until the current agent context is available
- add integration coverage for the create request, optimistic list entry, and direct thread destination

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx --maxWorkers=1`

## Preview QA

- verified the three-column header creates a new chat thread with a `201` response and routes directly to `/chats/:threadId`
- verified the optimistic `New chat` row appears beside the existing conversation and the new composer remains editable
- [Staging browser recording](https://cdn.vm0.io/artifacts/52nvu2d42z.mp4)
