### PR TITLE
feat(api): snapshot the default image model on runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -11,6 +11,7 @@ import {
 import { replayChatThreadEvents } from "@okouai/core/chat-thread-event-replay";
 import { avatarTemplateStylePresetId } from "@okouai/core/avatar-template";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { DEFAULT_IMAGE_MODEL } from "@okouai/core/image-model-catalog";
 import { DEFAULT_VIDEO_MODEL } from "@okouai/core/video-model-catalog";
 import {
   chatEventsContract,
@@ -64,6 +65,12 @@ import {
   readRunVideoModelFixture,
   setOrgMemberVideoModelFixture,
 } from "../../../test-fixtures/run-video-model";
+import {
+  readImageModelRunChatThreadIdFixture,
+  readRunImageModelFixture,
+  setChatThreadImageModelFixture,
+  setOrgMemberImageModelFixture,
+} from "../../../test-fixtures/run-image-model";
 import {
   createBddApi,
   expectApiError,
@@ -10962,5 +10969,266 @@ describe("CHAT-02: run video model snapshot", () => {
       readRunVideoModelFixture(withMemberDefault.runId),
     ).resolves.toBe("MiniMax-H3");
     await cancelChatRun(actor, withMemberDefault.runId);
+  }, 90_000);
+});
+
+async function imageModelSnapshotActor(args: {
+  readonly selectionEnabled: boolean;
+}): Promise<{
+  readonly actor: ApiTestUser;
+  readonly agentId: string;
+  readonly orgId: string;
+}> {
+  const { actor, agentId } = await entitledChatActor();
+  const orgId = actor.orgId;
+  if (!orgId) {
+    throw new Error("Expected an entitled chat actor to own an org");
+  }
+  await updateFeatureSwitchesForUser(
+    context,
+    { ...actor, orgId },
+    { [FeatureSwitchKey.ImageModelSelection]: args.selectionEnabled },
+  );
+  return { actor, agentId, orgId };
+}
+
+describe("CHAT-02: run image model snapshot", () => {
+  it("keeps the run snapshot null while image model selection is disabled", async () => {
+    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+      selectionEnabled: false,
+    });
+
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "image snapshot stays dormant for a new thread",
+    });
+    await expect(readRunImageModelFixture(anchor.runId)).resolves.toBeNull();
+    await cancelChatRun(actor, anchor.runId);
+
+    await setOrgMemberImageModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedImageModel: "gpt-image-2",
+    });
+    await setChatThreadImageModelFixture(anchor.threadId, "fal-ai/qwen-image");
+    const continued = await sendChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "image snapshot stays dormant for a continued thread",
+    });
+    await expect(readRunImageModelFixture(continued.runId)).resolves.toBeNull();
+    await cancelChatRun(actor, continued.runId);
+  }, 90_000);
+
+  it("resolves thread, member, and global image defaults into stable snapshots", async () => {
+    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+      selectionEnabled: true,
+    });
+
+    const globalDefault = await sendChatRun(actor, {
+      agentId,
+      prompt: "image model comes from the vm0 global default",
+    });
+    await expect(readRunImageModelFixture(globalDefault.runId)).resolves.toBe(
+      DEFAULT_IMAGE_MODEL,
+    );
+    await cancelChatRun(actor, globalDefault.runId);
+
+    await setOrgMemberImageModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedImageModel: "fal-ai/qwen-image",
+    });
+    const memberDefault = await sendChatRun(actor, {
+      agentId,
+      threadId: globalDefault.threadId,
+      prompt: "image model comes from the member default",
+    });
+    await expect(readRunImageModelFixture(memberDefault.runId)).resolves.toBe(
+      "fal-ai/qwen-image",
+    );
+    await cancelChatRun(actor, memberDefault.runId);
+
+    const initialThreadPin = "fal-ai/bytedance/seedream/v4/text-to-image";
+    await setChatThreadImageModelFixture(
+      globalDefault.threadId,
+      initialThreadPin,
+    );
+    const threadPinned = await sendChatRun(actor, {
+      agentId,
+      threadId: globalDefault.threadId,
+      prompt: "image model comes from the thread pin",
+    });
+    await expect(readRunImageModelFixture(threadPinned.runId)).resolves.toBe(
+      initialThreadPin,
+    );
+
+    const nextThreadPin = "fal-ai/nano-banana-2";
+    await setChatThreadImageModelFixture(globalDefault.threadId, nextThreadPin);
+    await expect(readRunImageModelFixture(threadPinned.runId)).resolves.toBe(
+      initialThreadPin,
+    );
+    await cancelChatRun(actor, threadPinned.runId);
+
+    const rePinned = await sendChatRun(actor, {
+      agentId,
+      threadId: globalDefault.threadId,
+      prompt: "the next run sees the updated image model pin",
+    });
+    await expect(readRunImageModelFixture(rePinned.runId)).resolves.toBe(
+      nextThreadPin,
+    );
+    await cancelChatRun(actor, rePinned.runId);
+  }, 90_000);
+
+  it("falls through image model IDs that the catalog no longer supports", async () => {
+    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+      selectionEnabled: true,
+    });
+    const retiredImageModel = "fal-ai/retired-image-model";
+
+    const anchor = await sendChatRun(actor, {
+      agentId,
+      prompt: "anchor run for retired image model storage",
+    });
+    await cancelChatRun(actor, anchor.runId);
+
+    await setOrgMemberImageModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedImageModel: "gpt-image-2",
+    });
+    await setChatThreadImageModelFixture(anchor.threadId, retiredImageModel);
+    const retiredThreadPin = await sendChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "retired thread image model falls through to the member",
+    });
+    await expect(
+      readRunImageModelFixture(retiredThreadPin.runId),
+    ).resolves.toBe("gpt-image-2");
+    await cancelChatRun(actor, retiredThreadPin.runId);
+
+    await setOrgMemberImageModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedImageModel: retiredImageModel,
+    });
+    const retiredEverywhere = await sendChatRun(actor, {
+      agentId,
+      threadId: anchor.threadId,
+      prompt: "retired image defaults fall through to the vm0 default",
+    });
+    await expect(
+      readRunImageModelFixture(retiredEverywhere.runId),
+    ).resolves.toBe(DEFAULT_IMAGE_MODEL);
+    await cancelChatRun(actor, retiredEverywhere.runId);
+  }, 90_000);
+
+  it("persists the image snapshot when dispatch fails before runner start", async () => {
+    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+      selectionEnabled: true,
+    });
+    await setOrgMemberImageModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedImageModel: "gpt-image-2",
+    });
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", undefined);
+
+    const sent = await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        prompt: "image snapshot survives pre-runner dispatch failure",
+        clientEventId: randomUUID(),
+      },
+      [201],
+    );
+    if (sent.status !== 201 || sent.body.runId === null) {
+      throw new Error("Expected the failed dispatch to create a run");
+    }
+    expect(sent.body.status).toBe("failed");
+    await expect(readRunImageModelFixture(sent.body.runId)).resolves.toBe(
+      "gpt-image-2",
+    );
+  }, 90_000);
+
+  it("persists the resolved image model on a queued run", async () => {
+    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+      selectionEnabled: true,
+    });
+    await setOrgMemberImageModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedImageModel: "fal-ai/qwen-image",
+    });
+    mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+
+    const blocker = await chat.requestSendEvent(
+      actor,
+      { agentId, prompt: "occupy image snapshot concurrency" },
+      [201],
+    );
+    if (blocker.status !== 201 || blocker.body.runId === null) {
+      throw new Error("Expected the blocking send to create a run");
+    }
+    expect(blocker.body.status).toBe("pending");
+
+    const queued = await chat.requestSendEvent(
+      actor,
+      { agentId, prompt: "queue an image model snapshot" },
+      [201],
+    );
+    if (queued.status !== 201 || queued.body.runId === null) {
+      throw new Error("Expected the second send to create a queued run");
+    }
+    expect(queued.body.status).toBe("queued");
+    await expect(readRunImageModelFixture(queued.body.runId)).resolves.toBe(
+      "fal-ai/qwen-image",
+    );
+
+    await cancelChatRun(actor, queued.body.runId);
+    await cancelChatRun(actor, blocker.body.runId);
+  }, 90_000);
+
+  it("snapshots direct runs and re-resolves on session continuation", async () => {
+    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+      selectionEnabled: true,
+    });
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "direct image model snapshot",
+      modelProvider: "anthropic-api-key",
+    });
+    await expect(
+      readImageModelRunChatThreadIdFixture(first.runId),
+    ).resolves.toBeNull();
+    await expect(readRunImageModelFixture(first.runId)).resolves.toBe(
+      DEFAULT_IMAGE_MODEL,
+    );
+
+    await setOrgMemberImageModelFixture({
+      orgId,
+      userId: actor.userId,
+      selectedImageModel: "fal-ai/flux-pro/v1.1",
+    });
+    const resumed = await api.createRun(actor, {
+      agentId,
+      sessionId: first.sessionId,
+      prompt: "continued session image model snapshot",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(resumed.sessionId).toBe(first.sessionId);
+    await expect(readRunImageModelFixture(resumed.runId)).resolves.toBe(
+      "fal-ai/flux-pro/v1.1",
+    );
+    await expect(readRunImageModelFixture(first.runId)).resolves.toBe(
+      DEFAULT_IMAGE_MODEL,
+    );
+
+    await cancelChatRun(actor, first.runId);
+    await cancelChatRun(actor, resumed.runId);
   }, 90_000);
 });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -262,6 +262,7 @@ import {
 } from "./chat-queued-event.service";
 import { recordFirstAssistantEventEligibility } from "./zero-chat-first-assistant-event-metric.service";
 import { isWebChatTriggerSource } from "./chat-trigger-source.service";
+import { resolveImageModelForRun } from "./image-model.service";
 import { resolveVideoModelForRun } from "./video-model.service";
 import {
   cappedBaseConcurrencyLimit,
@@ -5760,6 +5761,7 @@ interface LaunchRunRowsArgs {
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly zeroRunModelPin: ZeroRunModelPin | undefined;
   readonly selectedVideoModel: string;
+  readonly selectedImageModel: string | null;
   readonly callbackRows: readonly AgentRunCallbackInsert[];
   readonly chatThreadId: string | undefined;
   readonly zeroRunMetadata: ZeroRunMetadata | undefined;
@@ -5827,6 +5829,7 @@ function launchRunMetadataValues(args: LaunchRunRowsArgs): RunMetadataValues {
     selectedModel: modelPin.selectedModel,
     codexServiceTier: metadata.codexServiceTier ?? null,
     selectedVideoModel: args.selectedVideoModel,
+    selectedImageModel: args.selectedImageModel,
     chatThreadId: args.chatThreadId ?? null,
     apiStartedAt: args.status === "queued" ? null : new Date(args.apiStartTime),
     firstAssistantEventAcknowledgedAt: null,
@@ -6586,6 +6589,7 @@ function preparedLaunchRowsArgs(args: {
     modelProvider: args.commit.context.modelProvider,
     zeroRunModelPin: args.commit.createArgs.zeroRunModelPin,
     selectedVideoModel: args.commit.context.selectedVideoModel,
+    selectedImageModel: args.commit.context.selectedImageModel,
     callbackRows: args.commit.callbackRows,
     chatThreadId: args.commit.createArgs.chatThreadId,
     zeroRunMetadata: args.commit.createArgs.zeroRunMetadata,
@@ -7029,6 +7033,7 @@ async function commitFailedLaunch(args: {
         modelProvider: args.context.modelProvider,
         zeroRunModelPin: args.createArgs.zeroRunModelPin,
         selectedVideoModel: args.context.selectedVideoModel,
+        selectedImageModel: args.context.selectedImageModel,
         callbackRows: args.callbackRows,
         chatThreadId: args.createArgs.chatThreadId,
         zeroRunMetadata: args.createArgs.zeroRunMetadata,
@@ -7591,6 +7596,8 @@ interface PreparedRunContext {
   readonly imageRecognitionAvailable: boolean;
   /** Snapshotted onto the run row; see `resolveVideoModelForRun`. */
   readonly selectedVideoModel: string;
+  /** Resolved once at run start and persisted without affecting generation. */
+  readonly selectedImageModel: string | null;
 }
 
 interface FinalizedPreparedRunContext extends PreparedRunContext {
@@ -8561,6 +8568,15 @@ function prepareRunContext(
       });
       signal.throwIfAborted();
 
+      const selectedImageModel = await resolveImageModelForRun({
+        db,
+        orgId: args.orgId,
+        userId: args.userId,
+        chatThreadId: args.chatThreadId,
+        featureSwitchContext: bodyContext.featureSwitchContext,
+      });
+      signal.throwIfAborted();
+
       const outputMetadata = await timing.measure(
         "api_dispatch_prepare_context_prepare_output_metadata",
         "nested",
@@ -8599,6 +8615,7 @@ function prepareRunContext(
         userTimezone,
         featureSwitchContext: bodyContext.featureSwitchContext,
         selectedVideoModel,
+        selectedImageModel,
         imageRecognitionAvailable: isImageRecognitionAvailableForRun({
           includeZeroTokenSecret: args.includeZeroTokenSecret,
           selectedModel:

--- a/turbo/apps/api/src/signals/services/image-model.service.ts
+++ b/turbo/apps/api/src/signals/services/image-model.service.ts
@@ -1,0 +1,90 @@
+/**
+ * Resolves the built-in image model default snapshotted onto a run.
+ *
+ * Image model selection is dormant while its feature switch is disabled. Once
+ * enabled, the chain is thread pin, then member default, then the catalog
+ * default. The run row owns the result so later preference changes cannot
+ * affect an in-flight run.
+ */
+import { isImageModelId } from "@okouai/api-contracts/contracts/image-models";
+import {
+  isFeatureEnabled,
+  type FeatureSwitchContext,
+} from "@okouai/core/feature-switch";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import {
+  DEFAULT_IMAGE_MODEL,
+  type ImageModel,
+} from "@okouai/core/image-model-catalog";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { orgMembersMetadata } from "@okouai/db/schema/org-members-metadata";
+import { and, eq } from "drizzle-orm";
+
+import type { ReadonlyDb } from "../external/db";
+
+function catalogedImageModel(
+  value: string | null | undefined,
+): ImageModel | null {
+  return isImageModelId(value) ? value : null;
+}
+
+async function threadImageModel(
+  db: ReadonlyDb,
+  chatThreadId: string,
+): Promise<ImageModel | null> {
+  const [thread] = await db
+    .select({ selectedImageModel: chatThreads.selectedImageModel })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, chatThreadId))
+    .limit(1);
+  return catalogedImageModel(thread?.selectedImageModel);
+}
+
+async function memberImageModel(
+  db: ReadonlyDb,
+  orgId: string,
+  userId: string,
+): Promise<ImageModel | null> {
+  const [member] = await db
+    .select({ selectedImageModel: orgMembersMetadata.selectedImageModel })
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, orgId),
+        eq(orgMembersMetadata.userId, userId),
+      ),
+    )
+    .limit(1);
+  return catalogedImageModel(member?.selectedImageModel);
+}
+
+export async function resolveImageModelForRun(args: {
+  readonly db: ReadonlyDb;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly chatThreadId: string | undefined;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): Promise<ImageModel | null> {
+  if (
+    !isFeatureEnabled(
+      FeatureSwitchKey.ImageModelSelection,
+      args.featureSwitchContext,
+    )
+  ) {
+    return null;
+  }
+
+  if (args.chatThreadId !== undefined) {
+    const threadPin = await threadImageModel(args.db, args.chatThreadId);
+    if (threadPin !== null) {
+      return threadPin;
+    }
+  }
+
+  const memberDefault = await memberImageModel(
+    args.db,
+    args.orgId,
+    args.userId,
+  );
+  return memberDefault ?? DEFAULT_IMAGE_MODEL;
+}

--- a/turbo/apps/api/src/test-fixtures/run-image-model.ts
+++ b/turbo/apps/api/src/test-fixtures/run-image-model.ts
@@ -1,0 +1,74 @@
+/**
+ * Test fixtures for the dormant run image-model snapshot.
+ *
+ * PR6 intentionally ships before the preference writers and generation reader.
+ * Retired stored IDs and the write-only run output therefore need controlled
+ * direct database access in integration tests.
+ */
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { orgMembersMetadata } from "@okouai/db/schema/org-members-metadata";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
+
+import { db } from "../lib/db";
+
+export async function setOrgMemberImageModelFixture(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly selectedImageModel: string;
+}): Promise<void> {
+  await db()
+    .insert(orgMembersMetadata)
+    .values({
+      orgId: args.orgId,
+      userId: args.userId,
+      selectedImageModel: args.selectedImageModel,
+    })
+    .onConflictDoUpdate({
+      target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+      set: {
+        selectedImageModel: args.selectedImageModel,
+        updatedAt: sql`now()`,
+      },
+    });
+}
+
+export async function setChatThreadImageModelFixture(
+  chatThreadId: string,
+  selectedImageModel: string,
+): Promise<void> {
+  await db()
+    .update(chatThreads)
+    .set({ selectedImageModel })
+    .where(eq(chatThreads.id, chatThreadId));
+}
+
+export async function readRunImageModelFixture(
+  runId: string,
+): Promise<string | null> {
+  return (await readRunRow(runId)).selectedImageModel;
+}
+
+export async function readImageModelRunChatThreadIdFixture(
+  runId: string,
+): Promise<string | null> {
+  return (await readRunRow(runId)).chatThreadId;
+}
+
+async function readRunRow(runId: string): Promise<{
+  readonly selectedImageModel: string | null;
+  readonly chatThreadId: string | null;
+}> {
+  const [run] = await db()
+    .select({
+      selectedImageModel: agentRuns.selectedImageModel,
+      chatThreadId: agentRuns.chatThreadId,
+    })
+    .from(agentRuns)
+    .where(and(eq(agentRuns.id, runId), isNotNull(agentRuns.triggerSource)))
+    .limit(1);
+  if (!run) {
+    throw new Error("Expected a product run row for the image model snapshot");
+  }
+  return run;
+}


### PR DESCRIPTION
## Summary

- Resolve the run image-model snapshot once from cataloged thread selection, cataloged member selection, then `DEFAULT_IMAGE_MODEL`.
- Persist the canonical ID across pending, queued, failed, direct, and continued-session run creation paths; keep it null while `ImageModelSelection` is disabled.
- Keep the snapshot write-only: image generation, prompts, CLI, environment, preference writers, thread-creation APIs, and telemetry are unchanged.

## Fallbacks

- `image-model.service.ts:catalogedImageModel` treats a stored thread/member ID absent from the current catalog as unset and continues to the next precedence layer. Surface: persisted state; none — non-GA feature switch. Remove only after a migration and enforced writer/schema invariant guarantee that every stored non-null ID belongs to the current catalog; tracked by #27688.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check` on all four changed files
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_image_model_pr6_test pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "CHAT-02: run image model snapshot" --reporter=dot` (6 passed)
- `pnpm knip --workspace api` reports the existing unrelated unused `AgentComposeProvenanceSchemaUnavailable` export in `agent-compose-provenance-lifecycle.service.ts`; this diff adds no Knip finding.

Refs #27688
