### PR TITLE
perf(runner): make idle vm reclamation capacity-driven

### DIFF
--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -26,7 +26,7 @@ serde_path_to_error = { workspace = true }
 serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs", "net", "io-util"] }
-tokio-util = { workspace = true, features = ["io", "io-util"] }
+tokio-util = { workspace = true, features = ["io", "io-util", "rt"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/runner/src/cmd/start/active_runs.rs
+++ b/crates/runner/src/cmd/start/active_runs.rs
@@ -8,7 +8,6 @@ use crate::ids::RunId;
 #[derive(Clone)]
 pub(super) struct ActiveRuns {
     entries: Arc<Mutex<HashMap<RunId, ActiveRunEntry>>>,
-    changes: watch::Sender<u64>,
     reuse_state_notify: Arc<Notify>,
 }
 
@@ -46,7 +45,6 @@ impl ActiveRunReuseProof {
 #[derive(Clone)]
 pub(super) struct ActiveRunReusePublisher {
     reuse_state: watch::Sender<ActiveRunReuseState>,
-    changes: watch::Sender<u64>,
 }
 
 impl ActiveRunReusePublisher {
@@ -59,27 +57,19 @@ impl ActiveRunReusePublisher {
     }
 
     fn resolve_pending(&self, next: ActiveRunReuseState) -> bool {
-        let changed = self.reuse_state.send_if_modified(|state| {
+        self.reuse_state.send_if_modified(|state| {
             if *state != ActiveRunReuseState::Pending {
                 return false;
             }
             *state = next;
             true
-        });
-        if changed {
-            bump_changes(&self.changes);
-        }
-        changed
+        })
     }
 
     #[cfg(test)]
     pub(super) fn detached() -> Self {
         let (reuse_state, _reuse_state_rx) = watch::channel(ActiveRunReuseState::Pending);
-        let (changes, _changes_rx) = watch::channel(0);
-        Self {
-            reuse_state,
-            changes,
-        }
+        Self { reuse_state }
     }
 }
 
@@ -92,10 +82,8 @@ pub(super) struct ActiveRunGuard {
 
 impl ActiveRuns {
     pub(super) fn new(reuse_state_notify: Arc<Notify>) -> Self {
-        let (changes, _changes_rx) = watch::channel(0);
         Self {
             entries: Arc::new(Mutex::new(HashMap::new())),
-            changes,
             reuse_state_notify,
         }
     }
@@ -122,7 +110,6 @@ impl ActiveRuns {
             });
         }
         drop(entries);
-        bump_changes(&self.changes);
         ActiveRunGuard {
             active_runs: self.clone(),
             run_id: Some(run_id),
@@ -166,17 +153,12 @@ impl ActiveRuns {
     pub(super) fn contains(&self, run_id: RunId) -> bool {
         lock_entries(&self.entries).contains_key(&run_id)
     }
-
-    pub(super) fn subscribe_changes(&self) -> watch::Receiver<u64> {
-        self.changes.subscribe()
-    }
 }
 
 impl ActiveRunGuard {
     pub(super) fn reuse_publisher(&self) -> ActiveRunReusePublisher {
         ActiveRunReusePublisher {
             reuse_state: self.reuse_state.clone(),
-            changes: self.active_runs.changes.clone(),
         }
     }
 
@@ -191,7 +173,6 @@ impl ActiveRunGuard {
         lock_entries(&self.active_runs.entries).remove(&run_id);
         let was_pending = self.reuse_state.send_replace(ActiveRunReuseState::Released)
             == ActiveRunReuseState::Pending;
-        bump_changes(&self.active_runs.changes);
         if self.has_reuse_key && was_pending {
             self.active_runs.reuse_state_notify.notify_one();
         }
@@ -203,10 +184,6 @@ impl Drop for ActiveRunGuard {
     fn drop(&mut self) {
         self.release_inner();
     }
-}
-
-fn bump_changes(changes: &watch::Sender<u64>) {
-    changes.send_modify(|revision| *revision = revision.wrapping_add(1));
 }
 
 fn lock_entries(

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -9,7 +9,9 @@ use tracing::info;
 
 use super::active_runs::ActiveRunReuseState;
 use super::factory_lifecycle::SharedFactory;
-use super::idle_lifecycle::retire_oldest_idle_entry;
+use super::idle_lifecycle::{
+    IdlePressureRequest, IdlePressureSelection, select_idle_entry_for_pressure,
+};
 use super::job_discovery::{
     ClaimedJobSetup, FinalizingAdmission, ReadyClaimedResource, ReservedActivation,
     ReservedActivationRequest, activate_reserved_idle, build_spawn_job_request,
@@ -389,7 +391,7 @@ async fn acquire_fallback_resource(
         )
         .await?
         {
-            return Ok(FinalizingResource::Exact(Box::new(reservation)));
+            return Ok(FinalizingResource::Exact(reservation));
         }
         match ResourceBudget::try_substitute_leases(
             &ctx.budget,
@@ -409,28 +411,41 @@ async fn acquire_fallback_resource(
                 .await?
                 {
                     drop(lease);
-                    return Ok(FinalizingResource::Exact(Box::new(reservation)));
+                    return Ok(FinalizingResource::Exact(reservation));
                 }
                 return Ok(FinalizingResource::Fresh(lease));
             }
             Err(retained) => retiring_leases = retained,
         }
-        if let Some(retiring) = retire_oldest_idle_entry(
+        match select_idle_entry_for_pressure(
             &ctx.idle_pool,
             &ctx.status,
             &ctx.idle_destroy_tracker,
-            "finalizing_fallback_oldest",
+            IdlePressureRequest {
+                reuse_key: Some(reuse_key),
+                profile_name,
+                device_rate_limits,
+                history_generation_run_id: Some(history_generation_run_id),
+                context: "finalizing_fallback_oldest",
+            },
         )
         .await
         {
-            info!(
-                run_id = %run_id,
-                profile = %retiring.profile_name(),
-                "evicting idle VM for finalizing fallback"
-            );
-            retiring_leases.push(retiring.into_budget_lease());
-            ctx.reuse_state_notify.notify_one();
-            continue;
+            IdlePressureSelection::Reusable(reservation) => {
+                let reservation = accept_fallback_exact(cancellation, reservation, ctx).await?;
+                return Ok(FinalizingResource::Exact(reservation));
+            }
+            IdlePressureSelection::Retiring(retiring) => {
+                info!(
+                    run_id = %run_id,
+                    profile = %retiring.profile_name(),
+                    "evicting idle VM for finalizing fallback"
+                );
+                retiring_leases.push(retiring.into_budget_lease());
+                ctx.reuse_state_notify.notify_one();
+                continue;
+            }
+            IdlePressureSelection::Empty => {}
         }
 
         info!(run_id = %run_id, "finalizing fallback waiting for fresh capacity");
@@ -457,7 +472,7 @@ async fn acquire_fallback_resource(
                     ctx,
                 ).await? {
                     drop(lease);
-                    return Ok(FinalizingResource::Exact(Box::new(reservation)));
+                    return Ok(FinalizingResource::Exact(reservation));
                 }
                 return Ok(FinalizingResource::Fresh(lease));
             }
@@ -473,7 +488,7 @@ async fn reserve_fallback_exact(
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     history_generation_run_id: RunId,
     ctx: &SpawnContext,
-) -> Result<Option<ReservedIdleSandbox>, ExecutionFailure> {
+) -> Result<Option<Box<ReservedIdleSandbox>>, ExecutionFailure> {
     let Some(reservation) = reserve_reusable_idle_for_spawn(
         reuse_key,
         profile_name,
@@ -485,12 +500,22 @@ async fn reserve_fallback_exact(
     else {
         return Ok(None);
     };
+    accept_fallback_exact(cancellation, Box::new(reservation), ctx)
+        .await
+        .map(Some)
+}
+
+async fn accept_fallback_exact(
+    cancellation: &RunCancellationRegistration,
+    reservation: Box<ReservedIdleSandbox>,
+    ctx: &SpawnContext,
+) -> Result<Box<ReservedIdleSandbox>, ExecutionFailure> {
     if cancellation.token().is_cancelled() {
-        rollback_reserved_idle_for_spawn(reservation, ctx).await;
+        rollback_reserved_idle_for_spawn(*reservation, ctx).await;
         ctx.reuse_state_notify.notify_one();
         return Err(ExecutionFailure::cancelled());
     }
-    Ok(Some(reservation))
+    Ok(reservation)
 }
 
 async fn complete_claimed_without_sandbox(

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -9,7 +9,7 @@ use tracing::info;
 
 use super::active_runs::ActiveRunReuseState;
 use super::factory_lifecycle::SharedFactory;
-use super::idle_lifecycle::{evict_oldest_idle_entry, spawn_idle_destroy_job_retaining_lease};
+use super::idle_lifecycle::retire_oldest_idle_entry;
 use super::job_discovery::{
     ClaimedJobSetup, FinalizingAdmission, ReadyClaimedResource, ReservedActivation,
     ReservedActivationRequest, activate_reserved_idle, build_spawn_job_request,
@@ -347,6 +347,7 @@ async fn acquire_fresh_capacity(
     memory_mb: u32,
     ctx: &SpawnContext,
 ) -> Result<BudgetLease, ExecutionFailure> {
+    let mut idle_pool_changes = ctx.idle_pool.lock().await.subscribe_changes();
     let cancel = cancellation.token();
     let mut retiring_leases = Vec::new();
     loop {
@@ -359,22 +360,28 @@ async fn acquire_fresh_capacity(
             Ok(lease) => return Ok(lease),
             Err(retained) => retiring_leases = retained,
         }
-        if let Some(evicted) = evict_oldest_idle_entry(&ctx.idle_pool, &ctx.status).await {
+        if let Some(retiring) = retire_oldest_idle_entry(
+            &ctx.idle_pool,
+            &ctx.status,
+            &ctx.idle_destroy_tracker,
+            "finalizing_fallback_oldest",
+        )
+        .await
+        {
             info!(
                 run_id = %run_id,
-                profile = %evicted.profile_name(),
+                profile = %retiring.profile_name(),
                 "evicting idle VM for finalizing fallback"
             );
-            retiring_leases.push(spawn_idle_destroy_job_retaining_lease(
-                &ctx.idle_destroy_tracker,
-                evicted,
-                "finalizing_fallback_oldest",
-            ));
+            retiring_leases.push(retiring.into_budget_lease());
             ctx.reuse_state_notify.notify_one();
             continue;
         }
 
         info!(run_id = %run_id, "finalizing fallback waiting for fresh capacity");
+        #[cfg(test)]
+        ctx.test_observer
+            .notify_finalizing_capacity_wait_entered(run_id);
         tokio::select! {
             biased;
             () = cancel.cancelled() => {
@@ -382,12 +389,13 @@ async fn acquire_fresh_capacity(
             }
             lease = ResourceBudget::substitute_leases_when_available(
                 &ctx.budget,
-                retiring_leases,
+                &mut retiring_leases,
                 vcpu,
                 memory_mb,
             ) => {
                 return Ok(lease);
             }
+            _ = idle_pool_changes.changed() => {}
         }
     }
 }

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -64,6 +64,18 @@ struct FinalizingPreparation<'a> {
     ctx: &'a SpawnContext,
 }
 
+struct FinalizingFallback<'a> {
+    run_id: RunId,
+    cancellation: &'a RunCancellationRegistration,
+    reuse_key: &'a str,
+    history_generation_run_id: RunId,
+    profile_name: &'a str,
+    vcpu: u32,
+    memory_mb: u32,
+    device_rate_limits: &'a Option<sandbox::DeviceRateLimits>,
+    ctx: &'a SpawnContext,
+}
+
 pub(super) fn spawn_finalizing_claim(
     request: FinalizingClaimRequest,
     ctx: &SpawnContext,
@@ -265,9 +277,18 @@ async fn prepare_finalizing_resource(
                 finalizing_fallback_reason = reason,
                 "finalizing successor entering workspace or cold fallback"
             );
-            acquire_fresh_capacity(run_id, cancellation, vcpu, memory_mb, ctx)
-                .await
-                .map(FinalizingResource::Fresh)
+            acquire_fallback_resource(FinalizingFallback {
+                run_id,
+                cancellation,
+                reuse_key: &admission.reuse_key,
+                history_generation_run_id: admission.history_generation_run_id,
+                profile_name,
+                vcpu,
+                memory_mb,
+                device_rate_limits,
+                ctx,
+            })
+            .await
         }
         FinalizingWaitOutcome::Cancelled => Err(ExecutionFailure::cancelled()),
     }
@@ -340,24 +361,58 @@ async fn wait_for_finalizing_resource(
     }
 }
 
-async fn acquire_fresh_capacity(
-    run_id: RunId,
-    cancellation: &RunCancellationRegistration,
-    vcpu: u32,
-    memory_mb: u32,
-    ctx: &SpawnContext,
-) -> Result<BudgetLease, ExecutionFailure> {
+async fn acquire_fallback_resource(
+    request: FinalizingFallback<'_>,
+) -> Result<FinalizingResource, ExecutionFailure> {
+    let FinalizingFallback {
+        run_id,
+        cancellation,
+        reuse_key,
+        history_generation_run_id,
+        profile_name,
+        vcpu,
+        memory_mb,
+        device_rate_limits,
+        ctx,
+    } = request;
     let mut idle_pool_changes = ctx.idle_pool.lock().await.subscribe_changes();
     let cancel = cancellation.token();
     let mut retiring_leases = Vec::new();
     loop {
+        if let Some(reservation) = reserve_fallback_exact(
+            cancellation,
+            reuse_key,
+            profile_name,
+            device_rate_limits,
+            history_generation_run_id,
+            ctx,
+        )
+        .await?
+        {
+            return Ok(FinalizingResource::Exact(Box::new(reservation)));
+        }
         match ResourceBudget::try_substitute_leases(
             &ctx.budget,
             std::mem::take(&mut retiring_leases),
             vcpu,
             memory_mb,
         ) {
-            Ok(lease) => return Ok(lease),
+            Ok(lease) => {
+                if let Some(reservation) = reserve_fallback_exact(
+                    cancellation,
+                    reuse_key,
+                    profile_name,
+                    device_rate_limits,
+                    history_generation_run_id,
+                    ctx,
+                )
+                .await?
+                {
+                    drop(lease);
+                    return Ok(FinalizingResource::Exact(Box::new(reservation)));
+                }
+                return Ok(FinalizingResource::Fresh(lease));
+            }
             Err(retained) => retiring_leases = retained,
         }
         if let Some(retiring) = retire_oldest_idle_entry(
@@ -393,11 +448,49 @@ async fn acquire_fresh_capacity(
                 vcpu,
                 memory_mb,
             ) => {
-                return Ok(lease);
+                if let Some(reservation) = reserve_fallback_exact(
+                    cancellation,
+                    reuse_key,
+                    profile_name,
+                    device_rate_limits,
+                    history_generation_run_id,
+                    ctx,
+                ).await? {
+                    drop(lease);
+                    return Ok(FinalizingResource::Exact(Box::new(reservation)));
+                }
+                return Ok(FinalizingResource::Fresh(lease));
             }
             _ = idle_pool_changes.changed() => {}
         }
     }
+}
+
+async fn reserve_fallback_exact(
+    cancellation: &RunCancellationRegistration,
+    reuse_key: &str,
+    profile_name: &str,
+    device_rate_limits: &Option<sandbox::DeviceRateLimits>,
+    history_generation_run_id: RunId,
+    ctx: &SpawnContext,
+) -> Result<Option<ReservedIdleSandbox>, ExecutionFailure> {
+    let Some(reservation) = reserve_reusable_idle_for_spawn(
+        reuse_key,
+        profile_name,
+        device_rate_limits,
+        Some(history_generation_run_id),
+        ctx,
+    )
+    .await
+    else {
+        return Ok(None);
+    };
+    if cancellation.token().is_cancelled() {
+        rollback_reserved_idle_for_spawn(reservation, ctx).await;
+        ctx.reuse_state_notify.notify_one();
+        return Err(ExecutionFailure::cancelled());
+    }
+    Ok(Some(reservation))
 }
 
 async fn complete_claimed_without_sandbox(

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -5,13 +5,11 @@ use std::time::Instant;
 
 use futures_util::FutureExt;
 use tokio::task::JoinSet;
-use tracing::{info, warn};
+use tracing::info;
 
 use super::active_runs::ActiveRunReuseState;
 use super::factory_lifecycle::SharedFactory;
-use super::idle_lifecycle::{
-    destroy_idle_jobs_and_wait, evict_expired_idle_entries, evict_oldest_idle_entry,
-};
+use super::idle_lifecycle::{evict_oldest_idle_entry, spawn_idle_destroy_job_retaining_lease};
 use super::job_discovery::{
     ClaimedJobSetup, FinalizingAdmission, ReadyClaimedResource, ReservedActivation,
     ReservedActivationRequest, activate_reserved_idle, build_spawn_job_request,
@@ -349,22 +347,17 @@ async fn acquire_fresh_capacity(
     memory_mb: u32,
     ctx: &SpawnContext,
 ) -> Result<BudgetLease, ExecutionFailure> {
-    let mut active_run_changes = ctx.active_runs.subscribe_changes();
     let cancel = cancellation.token();
+    let mut retiring_leases = Vec::new();
     loop {
-        if let Some(lease) = ResourceBudget::try_reserve_lease(&ctx.budget, vcpu, memory_mb) {
-            return Ok(lease);
-        }
-        let expired = evict_expired_idle_entries(&ctx.idle_pool, &ctx.status).await;
-        if !expired.is_empty() {
-            info!(
-                run_id = %run_id,
-                count = expired.len(),
-                "reclaiming expired idle VMs for finalizing fallback"
-            );
-            destroy_idle_jobs_and_wait(expired, "finalizing_fallback_expired").await;
-            ctx.reuse_state_notify.notify_one();
-            continue;
+        match ResourceBudget::try_substitute_leases(
+            &ctx.budget,
+            std::mem::take(&mut retiring_leases),
+            vcpu,
+            memory_mb,
+        ) {
+            Ok(lease) => return Ok(lease),
+            Err(retained) => retiring_leases = retained,
         }
         if let Some(evicted) = evict_oldest_idle_entry(&ctx.idle_pool, &ctx.status).await {
             info!(
@@ -372,7 +365,11 @@ async fn acquire_fresh_capacity(
                 profile = %evicted.profile_name(),
                 "evicting idle VM for finalizing fallback"
             );
-            destroy_idle_jobs_and_wait(vec![evicted], "finalizing_fallback_oldest").await;
+            retiring_leases.push(spawn_idle_destroy_job_retaining_lease(
+                &ctx.idle_destroy_tracker,
+                evicted,
+                "finalizing_fallback_oldest",
+            ));
             ctx.reuse_state_notify.notify_one();
             continue;
         }
@@ -383,13 +380,13 @@ async fn acquire_fresh_capacity(
             () = cancel.cancelled() => {
                 return Err(ExecutionFailure::cancelled());
             }
-            lease = ResourceBudget::reserve_lease_when_available(&ctx.budget, vcpu, memory_mb) => {
+            lease = ResourceBudget::substitute_leases_when_available(
+                &ctx.budget,
+                retiring_leases,
+                vcpu,
+                memory_mb,
+            ) => {
                 return Ok(lease);
-            }
-            changed = active_run_changes.changed() => {
-                if changed.is_err() {
-                    warn!(run_id = %run_id, "active-run change channel closed");
-                }
             }
         }
     }

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -997,10 +997,7 @@ mod tests {
             ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
             ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
         ];
-        let pool = IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
-            max_idle: 0,
-        });
+        let pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
         let profiles = test_profiles();
 
         let state = collect_heartbeat_state(
@@ -1029,10 +1026,7 @@ mod tests {
                 workspace_disk_mb: 10240,
             },
         );
-        let pool = IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
-            max_idle: 0,
-        });
+        let pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
 
         let state = collect_heartbeat_state(
             test_snapshot_metadata(),
@@ -1048,10 +1042,7 @@ mod tests {
     #[test]
     fn heartbeat_admittable_profiles_exclude_unaffordable_parked_profiles() {
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 1));
-        let mut pool = IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
-            max_idle: 0,
-        });
+        let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
         let candidate = ParkedIdleCandidateBuilder::new(
             "sess-idle",
             ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
@@ -1075,10 +1066,7 @@ mod tests {
     #[test]
     fn heartbeat_admittable_profiles_empty_when_not_running() {
         let budget = ResourceBudget::new(8, 32768, 1.0, 4);
-        let pool = IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
-            max_idle: 0,
-        });
+        let pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
         let profiles = test_profiles();
 
         let state = collect_heartbeat_state(
@@ -1095,10 +1083,7 @@ mod tests {
     #[test]
     fn heartbeat_starting_reports_no_admittable_profiles() {
         let budget = ResourceBudget::new(8, 32768, 1.0, 4);
-        let pool = IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
-            max_idle: 0,
-        });
+        let pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
         let profiles = test_profiles();
 
         let state = collect_heartbeat_state(
@@ -1117,7 +1102,6 @@ mod tests {
     async fn send_heartbeat_logs_state_counts_without_raw_reuse_state() {
         let reuse_key = "thread:sensitive-heartbeat-17975";
         let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
             max_idle: 1,
         })));
         let dir = tempfile::tempdir().unwrap();
@@ -1189,7 +1173,6 @@ mod tests {
     async fn initial_workspace_cache_heartbeat_uses_loaded_snapshot() {
         let reuse_key = "thread:loaded-initial-snapshot";
         let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
             max_idle: 1,
         })));
         let dir = tempfile::tempdir().unwrap();
@@ -1491,10 +1474,7 @@ mod tests {
             ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
             ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
         ];
-        let mut pool = IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
-            max_idle: 0,
-        });
+        let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
         assert!(matches!(
             pool.park(make_synthetic_parked_candidate("sess-1")),
             ParkResult::Parked,
@@ -1519,10 +1499,7 @@ mod tests {
             ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
             ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
         ];
-        let mut pool = IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
-            max_idle: 0,
-        });
+        let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
         assert!(matches!(
             pool.park(make_synthetic_parked_candidate("sess-1")),
             ParkResult::Parked,
@@ -1546,10 +1523,7 @@ mod tests {
     #[test]
     fn heartbeat_running_count_saturates_on_transient_inconsistency() {
         let budget = ResourceBudget::new(8, 32768, 1.0, 4);
-        let mut pool = IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
-            max_idle: 0,
-        });
+        let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
         assert!(matches!(
             pool.park(make_synthetic_parked_candidate("sess-1")),
             ParkResult::Parked,

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use sandbox::SandboxId;
+use tokio::sync::Notify;
 use tokio::task::JoinSet;
+use tokio_util::task::TaskTracker;
 use tracing::{info, warn};
 
 use crate::idle_pool::{
@@ -11,9 +13,51 @@ use crate::idle_pool::{
     IdlePoolSnapshot,
 };
 use crate::ids::RunId;
+use crate::resource_budget::BudgetLease;
 use crate::status::StatusTracker;
 
 pub(super) type SharedIdlePool = Arc<tokio::sync::Mutex<IdlePool>>;
+
+#[derive(Clone)]
+pub(super) struct IdleDestroyTracker {
+    tasks: TaskTracker,
+    reuse_state_notify: Arc<Notify>,
+}
+
+impl IdleDestroyTracker {
+    pub(super) fn new(reuse_state_notify: Arc<Notify>) -> Self {
+        Self {
+            tasks: TaskTracker::new(),
+            reuse_state_notify,
+        }
+    }
+
+    fn spawn_job(&self, job: IdleDestroyJob, context: &'static str) {
+        let reuse_state_notify = Arc::clone(&self.reuse_state_notify);
+        drop(self.tasks.spawn(async move {
+            match tokio::spawn(destroy_idle_job(job, context)).await {
+                Ok(true) => reuse_state_notify.notify_one(),
+                Ok(false) => {}
+                Err(error) => warn!(context, %error, "idle entry destroy task panicked"),
+            }
+        }));
+    }
+
+    fn spawn_payload(&self, payload: IdleDestroyPayload, context: &'static str) {
+        let reuse_state_notify = Arc::clone(&self.reuse_state_notify);
+        drop(self.tasks.spawn(async move {
+            let result = destroy_idle_payload_and_wait(payload, context).await;
+            if result.workspace_cache_promoted {
+                reuse_state_notify.notify_one();
+            }
+        }));
+    }
+
+    pub(super) async fn close_and_wait(&self) {
+        let _ = self.tasks.close();
+        self.tasks.wait().await;
+    }
+}
 
 /// Drain the idle pool: destroy every entry captured at drain start in parallel
 /// and wait for all destroys to complete before returning (budgets released).
@@ -37,47 +81,6 @@ pub(super) async fn drain_idle_pool(
     }
     let snapshot = idle_pool.lock().await.status_snapshot();
     set_idle_status_snapshot(status, snapshot).await;
-}
-
-/// Remove expired idle entries and update status to match the new pool state.
-pub(super) async fn evict_expired_idle_entries(
-    idle_pool: &SharedIdlePool,
-    status: &StatusTracker,
-) -> Vec<IdleDestroyJob> {
-    let mut pool = idle_pool.lock().await;
-    let expired = pool.evict_expired();
-    if expired.is_empty() {
-        return expired;
-    }
-    let snapshot = pool.status_snapshot();
-    drop(pool);
-    set_idle_status_snapshot(status, snapshot).await;
-    expired
-}
-
-/// Remove expired idle entries during the periodic cleanup tick.
-///
-/// Unlike budget-pressure eviction, the periodic tick refreshes status even
-/// when no entries expired. Preserve that behavior so status.json can be
-/// reconciled from the current pool snapshot on every cleanup pass.
-pub(super) async fn cleanup_expired_idle_entries(
-    idle_pool: &SharedIdlePool,
-    status: &StatusTracker,
-) -> Vec<IdleDestroyJob> {
-    let mut pool = idle_pool.lock().await;
-    let (expired, mut snapshot) = pool.evict_expired_with_snapshot();
-    drop(pool);
-    if snapshot.idle_vms.len() < snapshot.idle_vms.capacity() / 2 {
-        snapshot.idle_vms.shrink_to_fit();
-    }
-    for entry in &expired {
-        info!(
-            profile = %entry.profile_name(),
-            "idle VM expired, destroying"
-        );
-    }
-    set_idle_status_snapshot(status, snapshot).await;
-    expired
 }
 
 /// Remove the oldest idle entry and update status to match the new pool state.
@@ -150,11 +153,21 @@ pub(super) async fn add_preparing_run_with_idle_status_snapshot(
 }
 
 pub(super) fn spawn_idle_destroy_job(
-    destroy_tasks: &mut JoinSet<bool>,
+    tracker: &IdleDestroyTracker,
     job: IdleDestroyJob,
     context: &'static str,
 ) {
-    destroy_tasks.spawn(destroy_idle_job(job, context));
+    tracker.spawn_job(job, context);
+}
+
+pub(super) fn spawn_idle_destroy_job_retaining_lease(
+    tracker: &IdleDestroyTracker,
+    job: IdleDestroyJob,
+    context: &'static str,
+) -> BudgetLease {
+    let (payload, budget_lease) = job.into_retiring_parts();
+    tracker.spawn_payload(payload, context);
+    budget_lease
 }
 
 /// Destroy idle entries in parallel and wait until their leases are dropped.
@@ -204,8 +217,6 @@ pub(super) async fn destroy_idle_payload_and_wait(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use std::time::Duration;
 
     use sandbox::{ResourceLimits, SandboxConfig, SandboxFactory};
     use sandbox_mock::MockSandboxFactory;
@@ -267,10 +278,7 @@ mod tests {
                 .with_last_completed_at(TEST_COMPLETED_AT.into()),
             Err(_) => panic!("park should succeed"),
         };
-        let mut pool = IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
-            max_idle: 0,
-        });
+        let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
         assert!(matches!(pool.park(candidate), ParkResult::Parked));
 
         let promoted = destroy_idle_jobs_and_wait(pool.drain(), "test_idle_destroy_cache").await;

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -83,17 +83,57 @@ pub(super) async fn drain_idle_pool(
     set_idle_status_snapshot(status, snapshot).await;
 }
 
-/// Remove the oldest idle entry and update status to match the new pool state.
-pub(super) async fn evict_oldest_idle_entry(
+pub(super) struct RetiringIdleEntry {
+    budget_lease: BudgetLease,
+    reuse_key: String,
+    profile_name: String,
+}
+
+impl RetiringIdleEntry {
+    pub(super) fn reuse_key(&self) -> &str {
+        &self.reuse_key
+    }
+
+    pub(super) fn profile_name(&self) -> &str {
+        &self.profile_name
+    }
+
+    pub(super) fn budget_vcpu(&self) -> u32 {
+        self.budget_lease.vcpu()
+    }
+
+    pub(super) fn budget_memory_mb(&self) -> u32 {
+        self.budget_lease.memory_mb()
+    }
+
+    pub(super) fn into_budget_lease(self) -> BudgetLease {
+        self.budget_lease
+    }
+}
+
+/// Remove the oldest idle entry, durably own its physical cleanup, and update
+/// status to match the new pool state before returning its retiring lease.
+pub(super) async fn retire_oldest_idle_entry(
     idle_pool: &SharedIdlePool,
     status: &StatusTracker,
-) -> Option<IdleDestroyJob> {
-    let mut pool = idle_pool.lock().await;
-    let evicted = pool.evict_oldest()?;
-    let snapshot = pool.status_snapshot();
-    drop(pool);
+    tracker: &IdleDestroyTracker,
+    context: &'static str,
+) -> Option<RetiringIdleEntry> {
+    let (job, snapshot) = {
+        let mut pool = idle_pool.lock().await;
+        let job = pool.evict_oldest()?;
+        let snapshot = pool.status_snapshot();
+        (job, snapshot)
+    };
+    let reuse_key = job.reuse_key().to_owned();
+    let profile_name = job.profile_name().to_owned();
+    let budget_lease = spawn_idle_destroy_job_retaining_lease(tracker, job, context);
     set_idle_status_snapshot(status, snapshot).await;
-    Some(evicted)
+    Some(RetiringIdleEntry {
+        budget_lease,
+        reuse_key,
+        profile_name,
+    })
 }
 
 pub(super) async fn set_idle_status_snapshot(status: &StatusTracker, snapshot: IdlePoolSnapshot) {
@@ -160,7 +200,7 @@ pub(super) fn spawn_idle_destroy_job(
     tracker.spawn_job(job, context);
 }
 
-pub(super) fn spawn_idle_destroy_job_retaining_lease(
+fn spawn_idle_destroy_job_retaining_lease(
     tracker: &IdleDestroyTracker,
     job: IdleDestroyJob,
     context: &'static str,

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use sandbox::SandboxId;
+use sandbox::{DeviceRateLimits, SandboxId};
 use tokio::sync::Notify;
 use tokio::task::JoinSet;
 use tokio_util::task::TaskTracker;
@@ -10,7 +10,7 @@ use tracing::{info, warn};
 
 use crate::idle_pool::{
     DestroyOutcome, IdleDestroyJob, IdleDestroyPayload, IdleDestroyResult, IdlePool,
-    IdlePoolSnapshot,
+    IdlePoolPressureSelection, IdlePoolSnapshot, ReservedIdleSandbox,
 };
 use crate::ids::RunId;
 use crate::resource_budget::BudgetLease;
@@ -89,6 +89,20 @@ pub(super) struct RetiringIdleEntry {
     profile_name: String,
 }
 
+pub(super) struct IdlePressureRequest<'a> {
+    pub(super) reuse_key: Option<&'a str>,
+    pub(super) profile_name: &'a str,
+    pub(super) device_rate_limits: &'a Option<DeviceRateLimits>,
+    pub(super) history_generation_run_id: Option<RunId>,
+    pub(super) context: &'static str,
+}
+
+pub(super) enum IdlePressureSelection {
+    Reusable(Box<ReservedIdleSandbox>),
+    Retiring(RetiringIdleEntry),
+    Empty,
+}
+
 impl RetiringIdleEntry {
     pub(super) fn reuse_key(&self) -> &str {
         &self.reuse_key
@@ -111,29 +125,45 @@ impl RetiringIdleEntry {
     }
 }
 
-/// Remove the oldest idle entry, durably own its physical cleanup, and update
-/// status to match the new pool state before returning its retiring lease.
-pub(super) async fn retire_oldest_idle_entry(
+/// Prefer a matching reusable entry; otherwise remove the oldest idle entry.
+/// The pool decision is atomic, and an evicted payload obtains durable cleanup
+/// ownership before the status write yields or its lease can be handed off.
+pub(super) async fn select_idle_entry_for_pressure(
     idle_pool: &SharedIdlePool,
     status: &StatusTracker,
     tracker: &IdleDestroyTracker,
-    context: &'static str,
-) -> Option<RetiringIdleEntry> {
-    let (job, snapshot) = {
+    request: IdlePressureRequest<'_>,
+) -> IdlePressureSelection {
+    let (selection, snapshot) = {
         let mut pool = idle_pool.lock().await;
-        let job = pool.evict_oldest()?;
+        let selection = pool.reserve_reusable_or_evict_oldest(
+            request.reuse_key,
+            request.profile_name,
+            request.device_rate_limits,
+            request.history_generation_run_id,
+        );
         let snapshot = pool.status_snapshot();
-        (job, snapshot)
+        (selection, snapshot)
     };
-    let reuse_key = job.reuse_key().to_owned();
-    let profile_name = job.profile_name().to_owned();
-    let budget_lease = spawn_idle_destroy_job_retaining_lease(tracker, job, context);
+    let selection = match selection {
+        IdlePoolPressureSelection::Reusable(reservation) => {
+            IdlePressureSelection::Reusable(reservation)
+        }
+        IdlePoolPressureSelection::Evicted(job) => {
+            let reuse_key = job.reuse_key().to_owned();
+            let profile_name = job.profile_name().to_owned();
+            let budget_lease =
+                spawn_idle_destroy_job_retaining_lease(tracker, *job, request.context);
+            IdlePressureSelection::Retiring(RetiringIdleEntry {
+                budget_lease,
+                reuse_key,
+                profile_name,
+            })
+        }
+        IdlePoolPressureSelection::Empty => return IdlePressureSelection::Empty,
+    };
     set_idle_status_snapshot(status, snapshot).await;
-    Some(RetiringIdleEntry {
-        budget_lease,
-        reuse_key,
-        profile_name,
-    })
+    selection
 }
 
 pub(super) async fn set_idle_status_snapshot(status: &StatusTracker, snapshot: IdlePoolSnapshot) {

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -20,8 +20,8 @@ use super::factory_lifecycle::SharedFactory;
 use super::finalizing_claim::{FinalizingClaimRequest, spawn_finalizing_claim};
 use super::idle_lifecycle::{
     SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
-    add_running_run_with_idle_status_snapshot, destroy_idle_jobs_and_wait, evict_oldest_idle_entry,
-    set_idle_status_snapshot, spawn_idle_destroy_job, spawn_idle_destroy_job_retaining_lease,
+    add_running_run_with_idle_status_snapshot, destroy_idle_jobs_and_wait,
+    retire_oldest_idle_entry, set_idle_status_snapshot, spawn_idle_destroy_job,
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
@@ -1145,21 +1145,23 @@ async fn acquire_local_admission_resource(
             }
         }
 
-        let evicted = evict_oldest_idle_entry(ctx.idle_pool, ctx.status).await?;
+        let retiring = retire_oldest_idle_entry(
+            ctx.idle_pool,
+            ctx.status,
+            &ctx.spawn_ctx.idle_destroy_tracker,
+            "candidate_admission_oldest",
+        )
+        .await?;
         info!(
             run_id = %candidate.run_id(),
-            reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(evicted.reuse_key()),
-            reuse_key_kind = reuse_key_kind(evicted.reuse_key()),
-            profile = %evicted.profile_name(),
-            vcpu = evicted.budget_vcpu(),
-            memory_mb = evicted.budget_memory_mb(),
+            reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(retiring.reuse_key()),
+            reuse_key_kind = reuse_key_kind(retiring.reuse_key()),
+            profile = %retiring.profile_name(),
+            vcpu = retiring.budget_vcpu(),
+            memory_mb = retiring.budget_memory_mb(),
             "evicting idle VM for candidate admission"
         );
-        retiring_leases.push(spawn_idle_destroy_job_retaining_lease(
-            &ctx.spawn_ctx.idle_destroy_tracker,
-            evicted,
-            "candidate_admission_oldest",
-        ));
+        retiring_leases.push(retiring.into_budget_lease());
         ctx.spawn_ctx.reuse_state_notify.notify_one();
     }
 }

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -20,9 +20,8 @@ use super::factory_lifecycle::SharedFactory;
 use super::finalizing_claim::{FinalizingClaimRequest, spawn_finalizing_claim};
 use super::idle_lifecycle::{
     SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
-    add_running_run_with_idle_status_snapshot, destroy_idle_jobs_and_wait,
-    evict_expired_idle_entries, evict_oldest_idle_entry, set_idle_status_snapshot,
-    spawn_idle_destroy_job,
+    add_running_run_with_idle_status_snapshot, destroy_idle_jobs_and_wait, evict_oldest_idle_entry,
+    set_idle_status_snapshot, spawn_idle_destroy_job, spawn_idle_destroy_job_retaining_lease,
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
@@ -68,7 +67,6 @@ pub(super) struct DiscoveredJobContext<'a> {
     pub(super) mode_rx: &'a tokio::sync::watch::Receiver<RunnerMode>,
     pub(super) cancel_tokens: &'a RunCancellationRegistry,
     pub(super) spawn_ctx: &'a SpawnContext,
-    pub(super) destroy_tasks: &'a mut JoinSet<bool>,
     pub(super) jobs: &'a mut JoinSet<RunCancellationRegistration>,
 }
 
@@ -1121,6 +1119,7 @@ async fn acquire_local_admission_resource(
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     ctx: &mut DiscoveredJobContext<'_>,
 ) -> Option<LocalAdmissionResource> {
+    let mut retiring_leases = Vec::new();
     loop {
         if let Some(reuse_key) = candidate.reuse_key()
             && let Some(reservation) =
@@ -1129,20 +1128,21 @@ async fn acquire_local_admission_resource(
             return Some(LocalAdmissionResource::Reusable(Box::new(reservation)));
         }
 
-        if let Some(lease) = ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory) {
-            return Some(LocalAdmissionResource::Fresh(lease));
-        }
-
-        let expired = evict_expired_idle_entries(ctx.idle_pool, ctx.status).await;
-        if !expired.is_empty() {
-            info!(
-                run_id = %candidate.run_id(),
-                count = expired.len(),
-                "reclaiming expired idle VMs for candidate admission"
-            );
-            destroy_idle_jobs_and_wait(expired, "candidate_admission_expired").await;
-            ctx.spawn_ctx.reuse_state_notify.notify_one();
-            continue;
+        if retiring_leases.is_empty() {
+            if let Some(lease) = ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)
+            {
+                return Some(LocalAdmissionResource::Fresh(lease));
+            }
+        } else {
+            match ResourceBudget::try_substitute_leases(
+                ctx.budget,
+                std::mem::take(&mut retiring_leases),
+                job_vcpu,
+                job_memory,
+            ) {
+                Ok(lease) => return Some(LocalAdmissionResource::Fresh(lease)),
+                Err(retained) => retiring_leases = retained,
+            }
         }
 
         let evicted = evict_oldest_idle_entry(ctx.idle_pool, ctx.status).await?;
@@ -1155,7 +1155,11 @@ async fn acquire_local_admission_resource(
             memory_mb = evicted.budget_memory_mb(),
             "evicting idle VM for candidate admission"
         );
-        destroy_idle_jobs_and_wait(vec![evicted], "candidate_admission_oldest").await;
+        retiring_leases.push(spawn_idle_destroy_job_retaining_lease(
+            &ctx.spawn_ctx.idle_destroy_tracker,
+            evicted,
+            "candidate_admission_oldest",
+        ));
         ctx.spawn_ctx.reuse_state_notify.notify_one();
     }
 }
@@ -1241,7 +1245,7 @@ async fn rollback_untracked_resource(
             set_idle_status_snapshot(ctx.status, snapshot).await;
             if let RestoreReservedIdleResult::Rejected(destroy_job) = restore_result {
                 spawn_idle_destroy_job(
-                    ctx.destroy_tasks,
+                    &ctx.spawn_ctx.idle_destroy_tracker,
                     *destroy_job,
                     "reserved_idle_rollback_rejected",
                 );
@@ -1956,7 +1960,7 @@ async fn try_reuse_from_pool(
                         "workspace promotion identity mismatch, destroying idle VM and falling through to fresh create"
                     );
                     spawn_idle_destroy_job(
-                        ctx.destroy_tasks,
+                        &ctx.spawn_ctx.idle_destroy_tracker,
                         entry.into_destroy_job_without_workspace_promotion_for_mismatch(),
                         "reuse_workspace_promotion_mismatch",
                     );
@@ -2003,7 +2007,11 @@ async fn try_reuse_from_pool(
                         error = %error,
                         "unpark failed, destroying idle VM and falling through to fresh create"
                     );
-                    spawn_idle_destroy_job(ctx.destroy_tasks, *destroy_job, "reuse_unpark_failed");
+                    spawn_idle_destroy_job(
+                        &ctx.spawn_ctx.idle_destroy_tracker,
+                        *destroy_job,
+                        "reuse_unpark_failed",
+                    );
                     (
                         None,
                         job_lease,
@@ -2023,7 +2031,7 @@ async fn try_reuse_from_pool(
                 "idle VM device rate limiter mismatch, destroying"
             );
             spawn_idle_destroy_job(
-                ctx.destroy_tasks,
+                &ctx.spawn_ctx.idle_destroy_tracker,
                 stale.into_destroy_job(),
                 "reuse_device_limit_mismatch",
             );
@@ -2045,7 +2053,7 @@ async fn try_reuse_from_pool(
                 "idle VM profile mismatch, destroying"
             );
             spawn_idle_destroy_job(
-                ctx.destroy_tasks,
+                &ctx.spawn_ctx.idle_destroy_tracker,
                 stale.into_destroy_job(),
                 "reuse_profile_mismatch",
             );

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -19,9 +19,10 @@ use super::active_runs::{ActiveRunGuard, ActiveRunReuseProof};
 use super::factory_lifecycle::SharedFactory;
 use super::finalizing_claim::{FinalizingClaimRequest, spawn_finalizing_claim};
 use super::idle_lifecycle::{
-    SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
-    add_running_run_with_idle_status_snapshot, destroy_idle_jobs_and_wait,
-    retire_oldest_idle_entry, set_idle_status_snapshot, spawn_idle_destroy_job,
+    IdlePressureRequest, IdlePressureSelection, SharedIdlePool,
+    add_preparing_run_with_idle_status_snapshot, add_running_run_with_idle_status_snapshot,
+    destroy_idle_jobs_and_wait, select_idle_entry_for_pressure, set_idle_status_snapshot,
+    spawn_idle_destroy_job,
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
@@ -1145,13 +1146,26 @@ async fn acquire_local_admission_resource(
             }
         }
 
-        let retiring = retire_oldest_idle_entry(
+        let pressure_selection = select_idle_entry_for_pressure(
             ctx.idle_pool,
             ctx.status,
             &ctx.spawn_ctx.idle_destroy_tracker,
-            "candidate_admission_oldest",
+            IdlePressureRequest {
+                reuse_key: candidate.reuse_key(),
+                profile_name,
+                device_rate_limits,
+                history_generation_run_id: None,
+                context: "candidate_admission_oldest",
+            },
         )
-        .await?;
+        .await;
+        let retiring = match pressure_selection {
+            IdlePressureSelection::Reusable(reservation) => {
+                return Some(LocalAdmissionResource::Reusable(reservation));
+            }
+            IdlePressureSelection::Retiring(retiring) => retiring,
+            IdlePressureSelection::Empty => return None,
+        };
         info!(
             run_id = %candidate.run_id(),
             reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(retiring.reuse_key()),

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -17,7 +17,7 @@ use tracing::{error, warn};
 use super::active_runs::{ActiveRunGuard, ActiveRunReusePublisher, ActiveRuns};
 use super::factory_lifecycle::SharedFactory;
 use super::heartbeat::WorkspaceCacheStateSnapshot;
-use super::idle_lifecycle::SharedIdlePool;
+use super::idle_lifecycle::{IdleDestroyTracker, SharedIdlePool};
 use super::job_lifecycle::{
     ActiveBudgetLease, CompletionPayload, FinalizationReady, RunCleanupDisposition, RunCleanupState,
 };
@@ -73,6 +73,7 @@ pub(super) struct SpawnContext {
     /// completion so soft-drain/resume races do not depend on a stale
     /// spawn-time mode snapshot.
     pub(super) parking_gate: ParkingGate,
+    pub(super) idle_destroy_tracker: IdleDestroyTracker,
     /// Notifies the main loop to send an immediate heartbeat after reusable
     /// state changes. This eliminates the up-to-10s blind spot where
     /// the server does not know which runner holds a reusable sandbox or
@@ -943,10 +944,7 @@ mod tests {
             status.write_initial().await;
             let parking_gate = ParkingGate::new_open();
             let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
-                IdlePoolConfig {
-                    default_timeout: Duration::from_secs(300),
-                    max_idle: 10,
-                },
+                IdlePoolConfig { max_idle: 10 },
                 parking_gate.clone(),
             )));
 
@@ -1491,7 +1489,6 @@ mod tests {
             let status = Arc::new(StatusTracker::new(status_path.clone(), 4, None, None));
             let idle_pool: SharedIdlePool =
                 Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-                    default_timeout: Duration::from_secs(300),
                     max_idle: 10,
                 })));
             let tokens = RunCancellationRegistry::new();

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -385,7 +385,6 @@ async fn run_start_with_home(
     let config::SandboxConfig {
         max_concurrent,
         concurrency_factor: yaml_concurrency_factor,
-        idle_timeout_secs: _,
         max_idle,
     } = runner_config.sandbox;
     let (concurrency_factor, concurrency_factor_source) =

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -103,10 +103,7 @@ use heartbeat::{
     refresh_initial_workspace_cache_snapshot,
 };
 use identity::load_runner_process_identity;
-use idle_lifecycle::{
-    SharedIdlePool, cleanup_expired_idle_entries, destroy_idle_jobs_and_wait, drain_idle_pool,
-    evict_expired_idle_entries, spawn_idle_destroy_job,
-};
+use idle_lifecycle::{IdleDestroyTracker, SharedIdlePool, drain_idle_pool};
 use job_discovery::{DiscoveredJob, DiscoveredJobContext, handle_discovered_job};
 use job_spawn::{SpawnContext, handle_job_result};
 use mitm_restart::{
@@ -388,7 +385,7 @@ async fn run_start_with_home(
     let config::SandboxConfig {
         max_concurrent,
         concurrency_factor: yaml_concurrency_factor,
-        idle_timeout_secs,
+        idle_timeout_secs: _,
         max_idle,
     } = runner_config.sandbox;
     let (concurrency_factor, concurrency_factor_source) =
@@ -593,10 +590,7 @@ async fn run_start_with_home(
     // Idle sandbox pool for VM reuse across conversation turns.
     let parking_gate = ParkingGate::new_open();
     let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
-        IdlePoolConfig {
-            default_timeout: Duration::from_secs(idle_timeout_secs),
-            max_idle,
-        },
+        IdlePoolConfig { max_idle },
         parking_gate.clone(),
     )));
 
@@ -967,7 +961,6 @@ enum SignalSource {
 enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
     WorkspaceCacheChangeObserved,
-    IdleCleanupProcessed { expired_count: usize },
     ActiveRunStatusPublished { run_id: RunId },
     BeforeIdlePoolOwnershipTransfer { run_id: RunId },
     VmParkedForReuse { run_id: RunId, reuse_key: String },
@@ -1153,20 +1146,6 @@ impl StartLoopTestObserver {
         cursor
     }
 
-    async fn wait_idle_cleanup_processed_with_expired_entries(&self, timeout: Duration) -> usize {
-        self.wait_for(
-            timeout,
-            "idle cleanup processing expired entries",
-            |event| match event {
-                StartLoopEvent::IdleCleanupProcessed { expired_count } if *expired_count > 0 => {
-                    Some(*expired_count)
-                }
-                _ => None,
-            },
-        )
-        .await
-    }
-
     async fn wait_before_idle_pool_ownership_transfer(&self, run_id: RunId, timeout: Duration) {
         self.wait_for(
             timeout,
@@ -1204,9 +1183,9 @@ impl StartLoopTestObserver {
 mod start_loop_observer_tests {
     use super::*;
 
-    fn idle_cleanup_expired_count(event: &StartLoopEvent) -> Option<usize> {
+    fn ownership_transfer_run_id(event: &StartLoopEvent) -> Option<RunId> {
         match event {
-            StartLoopEvent::IdleCleanupProcessed { expired_count } => Some(*expired_count),
+            StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id } => Some(*run_id),
             _ => None,
         }
     }
@@ -1214,35 +1193,38 @@ mod start_loop_observer_tests {
     #[tokio::test]
     async fn start_loop_observer_wait_after_ignores_events_before_cursor() {
         let observer = StartLoopTestObserver::default();
+        let first = RunId::new_v4();
+        let second = RunId::new_v4();
+        let third = RunId::new_v4();
 
-        observer.record(StartLoopEvent::IdleCleanupProcessed { expired_count: 1 });
+        observer.record(StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id: first });
         let cursor = observer.cursor();
-        observer.record(StartLoopEvent::IdleCleanupProcessed { expired_count: 2 });
+        observer.record(StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id: second });
 
-        let (expired_count, cursor) = observer
+        let (observed_run_id, cursor) = observer
             .wait_after(
                 cursor,
                 Duration::from_secs(1),
-                "second idle cleanup",
-                idle_cleanup_expired_count,
+                "second ownership transfer",
+                ownership_transfer_run_id,
             )
             .await;
         assert_eq!(
-            expired_count, 2,
+            observed_run_id, second,
             "wait_after should ignore stale events before the cursor"
         );
 
-        observer.record(StartLoopEvent::IdleCleanupProcessed { expired_count: 3 });
-        let (expired_count, _) = observer
+        observer.record(StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id: third });
+        let (observed_run_id, _) = observer
             .wait_after(
                 cursor,
                 Duration::from_secs(1),
-                "third idle cleanup",
-                idle_cleanup_expired_count,
+                "third ownership transfer",
+                ownership_transfer_run_id,
             )
             .await;
         assert_eq!(
-            expired_count, 3,
+            observed_run_id, third,
             "next cursor should advance past the matched event"
         );
     }
@@ -1504,10 +1486,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     shared.status.set_mode(startup_mode).await;
 
     let mut jobs: JoinSet<RunCancellationRegistration> = JoinSet::new();
-    // Tracked destroy tasks — JoinSet ensures we can await all in-flight
-    // destroys at shutdown so their factory Arcs are released before the
-    // exclusive ownership preflight.
-    let mut destroy_tasks: JoinSet<bool> = JoinSet::new();
 
     if startup_mode == RunnerMode::Running {
         info!(
@@ -1537,26 +1515,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     );
 
     // -----------------------------------------------------------------------
-    // Idle pool cleanup interval (every 10 seconds)
-    // -----------------------------------------------------------------------
-    // `interval` fires its first tick immediately. In the main-loop
-    // `tokio::select!` this can pre-empt `discover_fut` on its very first
-    // poll — the discover future parks on `rx.recv()` (Pending) while the
-    // interval tick is Ready, so select deterministically picks the tick.
-    // Inside the tick arm any silent watch flip (`send_if_modified(.., false)`)
-    // lands before the loop returns to the discover arm, and the top-of-loop
-    // `borrow_and_update()` then breaks out before the pending job is ever
-    // claimed. Delaying the first tick by one period keeps both arms Pending
-    // on entry, so `discover_fut` wins the first wake. No observable prod
-    // effect: idle cleanup on an empty pool and the first heartbeat were
-    // both fine to happen ~10s later.
-    let mut idle_cleanup = tokio::time::interval_at(
-        tokio::time::Instant::now() + Duration::from_secs(10),
-        Duration::from_secs(10),
-    );
-    idle_cleanup.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-    // -----------------------------------------------------------------------
     // Heartbeat interval — same first-tick delay as above.
     // -----------------------------------------------------------------------
     let mut heartbeat_tick = tokio::time::interval_at(
@@ -1573,6 +1531,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // learns about a held reusable sandbox or workspace image cache without
     // waiting for the next 10-second tick.
     let reuse_state_notify = Arc::clone(&shared.reuse_state_notify);
+    let idle_destroy_tracker = IdleDestroyTracker::new(Arc::clone(&reuse_state_notify));
     let orphaned_active_runs = OrphanedActiveRuns::new();
     let active_runs = shared.active_runs.clone();
     let workspace_cache_snapshot = WorkspaceCacheStateSnapshot::new();
@@ -1664,7 +1623,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     }
 
     // Pin the discover future so it survives cancellation by other select!
-    // branches (heartbeat, idle cleanup, etc.). Without pinning, heartbeat
+    // branches (heartbeat, lifecycle changes, etc.). Without pinning, heartbeat
     // (10s) cancels discover() on every tick, restarting its internal poll
     // sleep (30s) from scratch — so poll never fires. See #8747.
     let mut discover_fut = Box::pin(provider_state.provider.discover());
@@ -1678,6 +1637,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         status: Arc::clone(&shared.status),
         orphaned_active_runs: orphaned_active_runs.clone(),
         parking_gate: shared.parking_gate.clone(),
+        idle_destroy_tracker: idle_destroy_tracker.clone(),
         reuse_state_notify: Arc::clone(&reuse_state_notify),
         usage_flush_tx,
         active_runs: active_runs.clone(),
@@ -1741,22 +1701,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         maybe_spawn_mitm_restart(&mut mitm, &mut mitm_crash_rx, &mut mitm_retry).await;
 
         let can_discover = if matches!(mode, RunnerMode::Running) {
-            if !capacity
-                .budget
-                .can_afford(capacity.min_vcpu, capacity.min_memory_mb)
-            {
-                let expired = evict_expired_idle_entries(&shared.idle_pool, &shared.status).await;
-                if !expired.is_empty() {
-                    info!(
-                        count = expired.len(),
-                        "reclaiming expired idle VMs for resource pressure"
-                    );
-                    if destroy_idle_jobs_and_wait(expired, "budget_pressure_expired").await {
-                        reuse_state_notify.notify_one();
-                    }
-                    continue;
-                }
-            }
             // A selected finalizing successor can claim against an exact
             // in-process predecessor without reserving fresh capacity.
             capacity
@@ -1800,7 +1744,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         mode_rx: &mode_rx,
                         cancel_tokens: &provider_state.cancel_tokens,
                         spawn_ctx: &spawn_ctx,
-                        destroy_tasks: &mut destroy_tasks,
                         jobs: &mut jobs,
                     },
                 ).await;
@@ -1845,7 +1788,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                             mode_rx: &mode_rx,
                             cancel_tokens: &provider_state.cancel_tokens,
                             spawn_ctx: &spawn_ctx,
-                            destroy_tasks: &mut destroy_tasks,
                             jobs: &mut jobs,
                         },
                     ).await;
@@ -1968,14 +1910,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     orphan_reap.process_discovery.as_ref(),
                 ).await;
             }
-            // Reap completed destroy tasks
-            Some(result) = destroy_tasks.join_next(), if !destroy_tasks.is_empty() => {
-                match result {
-                    Ok(true) => reuse_state_notify.notify_one(),
-                    Ok(false) => {}
-                    Err(e) => warn!(error = %e, "destroy task panicked"),
-                }
-            }
             // Mitmproxy crash detection
             _ = mitm_crash_rx.recv() => {
                 error!(
@@ -1993,19 +1927,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             }
             // Mitmproxy restart timer
             () = sleep_until_retry(&mitm_retry.restart_at) => {}
-            // Idle pool cleanup: evict expired VMs and update status
-            _ = idle_cleanup.tick(), if can_discover => {
-                let expired = cleanup_expired_idle_entries(&shared.idle_pool, &shared.status).await;
-                #[cfg(test)]
-                let expired_count = expired.len();
-                for entry in expired {
-                    spawn_idle_destroy_job(&mut destroy_tasks, entry, "idle_expired");
-                }
-                #[cfg(test)]
-                test_hooks
-                    .test_observer
-                    .record(StartLoopEvent::IdleCleanupProcessed { expired_count });
-            }
             // Heartbeat: report runner state to the server
             _ = heartbeat_tick.tick() => {
                 let live_mode = *mode_rx.borrow();
@@ -2031,7 +1952,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         mode_rx: &mode_rx,
                         cancel_tokens: &provider_state.cancel_tokens,
                         spawn_ctx: &spawn_ctx,
-                        destroy_tasks: &mut destroy_tasks,
                         jobs: &mut jobs,
                     },
                 ).await;
@@ -2064,7 +1984,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                             mode_rx: &mode_rx,
                             cancel_tokens: &provider_state.cancel_tokens,
                             spawn_ctx: &spawn_ctx,
-                            destroy_tasks: &mut destroy_tasks,
                             jobs: &mut jobs,
                         },
                     ).await;
@@ -2169,12 +2088,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     test_hooks.test_observer.notify_usage_flush_requested();
                     mitm.request_usage_flush();
                 }
-                Some(result) = destroy_tasks.join_next() => {
-                    match result {
-                        Ok(_) => {}
-                        Err(e) => warn!(error = %e, "destroy task panicked"),
-                    }
-                }
                 _ = mitm_crash_rx.recv() => {
                     error!(
                         r#type = "usage_underbilling",
@@ -2205,18 +2118,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         .await;
         teardown.phase_complete("orphan_reap_shutdown_final", phase);
     }
-    // Wait for any in-flight destroy tasks (from cleanup tick, profile
-    // mismatch eviction, etc.) so their factory Arcs are dropped before the
+    // Wait for any in-flight destroy tasks (from capacity or profile-mismatch
+    // eviction) so their factory Arcs are dropped before the
     // factory shutdown ownership preflight.
     let phase = teardown.phase_start("destroy_tasks_drain");
-    while let Some(result) = destroy_tasks.join_next().await {
-        match result {
-            Ok(_) => {}
-            Err(e) => {
-                warn!(error = %e, "destroy task panicked during shutdown");
-            }
-        }
-    }
+    idle_destroy_tracker.close_and_wait().await;
     teardown.phase_complete("destroy_tasks_drain", phase);
     let phase = teardown.phase_start("background_fill_shutdown");
     exec_config.background_fill.shutdown().await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -960,6 +960,7 @@ enum SignalSource {
 enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
     WorkspaceCacheChangeObserved,
+    DestroyTasksDrainEntered,
     FinalizingCapacityWaitEntered { run_id: RunId },
     ActiveRunStatusPublished { run_id: RunId },
     BeforeIdlePoolOwnershipTransfer { run_id: RunId },
@@ -1094,6 +1095,10 @@ impl StartLoopTestObserver {
         self.record(StartLoopEvent::WorkspaceCacheChangeObserved);
     }
 
+    fn notify_destroy_tasks_drain_entered(&self) {
+        self.record(StartLoopEvent::DestroyTasksDrainEntered);
+    }
+
     fn notify_finalizing_capacity_wait_entered(&self, run_id: RunId) {
         self.record(StartLoopEvent::FinalizingCapacityWaitEntered { run_id });
     }
@@ -1148,6 +1153,13 @@ impl StartLoopTestObserver {
             })
             .await;
         cursor
+    }
+
+    async fn wait_destroy_tasks_drain_entered(&self, timeout: Duration) {
+        self.wait_for(timeout, "destroy-task drain", |event| {
+            matches!(event, StartLoopEvent::DestroyTasksDrainEntered).then_some(())
+        })
+        .await;
     }
 
     async fn wait_finalizing_capacity_wait_entered(&self, run_id: RunId, timeout: Duration) {
@@ -2136,6 +2148,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // eviction) so their factory Arcs are dropped before the
     // factory shutdown ownership preflight.
     let phase = teardown.phase_start("destroy_tasks_drain");
+    #[cfg(test)]
+    test_hooks
+        .test_observer
+        .notify_destroy_tasks_drain_entered();
     idle_destroy_tracker.close_and_wait().await;
     teardown.phase_complete("destroy_tasks_drain", phase);
     let phase = teardown.phase_start("background_fill_shutdown");

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -23,13 +23,13 @@
 //! Important invariants:
 //! - one process owns the canonical `base_dir` lock;
 //! - lifecycle signals are registered before slow startup work;
-//! - discovery is pinned across `select!` ticks so heartbeat and cleanup
+//! - discovery is pinned across `select!` ticks so heartbeat and lifecycle
 //!   branches do not restart polling;
 //! - heartbeat work is pinned and single-flight so its I/O does not stall the
 //!   main reactor or overlap a newer snapshot;
 //! - workspace-cache watcher work is pinned across reactor turns so async
 //!   metadata classification cannot lose already-drained kernel events;
-//! - the first routine heartbeat and idle-cleanup ticks are deferred;
+//! - the first routine heartbeat tick is deferred;
 //! - teardown drains heartbeat work and drops discovery before provider
 //!   shutdown.
 
@@ -1722,8 +1722,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             .map(crate::provider::ActiveRunnerPreference::deadline);
         tokio::select! {
             // Job discovery via provider (Ably wakeups + HTTP poll).
-            // The future is pinned outside the loop so heartbeat/cleanup
-            // ticks don't cancel and restart its internal poll timer. See #8747.
+            // The future is pinned outside the loop so other reactor branches
+            // do not cancel and restart its internal poll timer. See #8747.
             discovered = &mut discover_fut, if can_discover => {
                 let Some(candidate) = discovered else { break };
                 // Future completed — create a new one for the next discovery.

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -961,6 +961,7 @@ enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
     WorkspaceCacheChangeObserved,
     DestroyTasksDrainEntered,
+    DestroyTasksDrainCompleted,
     FinalizingCapacityWaitEntered { run_id: RunId },
     ActiveRunStatusPublished { run_id: RunId },
     BeforeIdlePoolOwnershipTransfer { run_id: RunId },
@@ -1099,6 +1100,19 @@ impl StartLoopTestObserver {
         self.record(StartLoopEvent::DestroyTasksDrainEntered);
     }
 
+    fn notify_destroy_tasks_drain_completed(&self) {
+        self.record(StartLoopEvent::DestroyTasksDrainCompleted);
+    }
+
+    fn destroy_tasks_drain_was_completed(&self) -> bool {
+        self.inner
+            .events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .any(|event| matches!(event, StartLoopEvent::DestroyTasksDrainCompleted))
+    }
+
     fn notify_finalizing_capacity_wait_entered(&self, run_id: RunId) {
         self.record(StartLoopEvent::FinalizingCapacityWaitEntered { run_id });
     }
@@ -1158,6 +1172,13 @@ impl StartLoopTestObserver {
     async fn wait_destroy_tasks_drain_entered(&self, timeout: Duration) {
         self.wait_for(timeout, "destroy-task drain", |event| {
             matches!(event, StartLoopEvent::DestroyTasksDrainEntered).then_some(())
+        })
+        .await;
+    }
+
+    async fn wait_destroy_tasks_drain_completed(&self, timeout: Duration) {
+        self.wait_for(timeout, "destroy-task drain completion", |event| {
+            matches!(event, StartLoopEvent::DestroyTasksDrainCompleted).then_some(())
         })
         .await;
     }
@@ -2153,6 +2174,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         .test_observer
         .notify_destroy_tasks_drain_entered();
     idle_destroy_tracker.close_and_wait().await;
+    #[cfg(test)]
+    test_hooks
+        .test_observer
+        .notify_destroy_tasks_drain_completed();
     teardown.phase_complete("destroy_tasks_drain", phase);
     let phase = teardown.phase_start("background_fill_shutdown");
     exec_config.background_fill.shutdown().await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -960,6 +960,7 @@ enum SignalSource {
 enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
     WorkspaceCacheChangeObserved,
+    FinalizingCapacityWaitEntered { run_id: RunId },
     ActiveRunStatusPublished { run_id: RunId },
     BeforeIdlePoolOwnershipTransfer { run_id: RunId },
     VmParkedForReuse { run_id: RunId, reuse_key: String },
@@ -1093,6 +1094,10 @@ impl StartLoopTestObserver {
         self.record(StartLoopEvent::WorkspaceCacheChangeObserved);
     }
 
+    fn notify_finalizing_capacity_wait_entered(&self, run_id: RunId) {
+        self.record(StartLoopEvent::FinalizingCapacityWaitEntered { run_id });
+    }
+
     fn notify_before_idle_pool_ownership_transfer(&self, run_id: RunId) {
         self.record(StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id });
     }
@@ -1143,6 +1148,16 @@ impl StartLoopTestObserver {
             })
             .await;
         cursor
+    }
+
+    async fn wait_finalizing_capacity_wait_entered(&self, run_id: RunId, timeout: Duration) {
+        self.wait_for(timeout, "finalizing capacity wait", |event| match event {
+            StartLoopEvent::FinalizingCapacityWaitEntered {
+                run_id: observed_run_id,
+            } if *observed_run_id == run_id => Some(()),
+            _ => None,
+        })
+        .await
     }
 
     async fn wait_before_idle_pool_ownership_transfer(&self, run_id: RunId, timeout: Duration) {

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -325,8 +325,6 @@ mod tests {
         IdlePool, IdlePoolConfig, ParkResult, test_support::ParkedIdleCandidateBuilder,
     };
     use crate::resource_budget::ResourceBudget;
-    use std::time::Duration;
-
     struct OrphanReapFixture {
         _dir: tempfile::TempDir,
         status_path: std::path::PathBuf,
@@ -342,7 +340,6 @@ mod tests {
             let status = StatusTracker::new(status_path.clone(), 4, None, None);
             let idle_pool: SharedIdlePool =
                 Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-                    default_timeout: Duration::from_secs(300),
                     max_idle: 10,
                 })));
             Self {

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -698,8 +698,7 @@ async fn finalize_sandbox_for_completion_inner(
                         // conditional active-run removal (below) clears the run_id
                         // from active_runs. Without this, doctor would
                         // briefly see the FC as unknown (neither active
-                        // nor idle) until the next idle_cleanup tick
-                        // (~10s), producing transient false-positive
+                        // nor idle), producing transient false-positive
                         // FirecrackerNotInStatus warnings.
                         let snapshot = pool.status_snapshot();
                         drop(transfer_guard);
@@ -1168,14 +1167,9 @@ mod tests {
             ));
             status.write_initial().await;
             let parking_gate = ParkingGate::new_open();
-            let idle_pool: SharedIdlePool =
-                Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
-                    IdlePoolConfig {
-                        default_timeout: Duration::from_secs(300),
-                        max_idle,
-                    },
-                    parking_gate.clone(),
-                )));
+            let idle_pool: SharedIdlePool = Arc::new(tokio::sync::Mutex::new(
+                IdlePool::new_with_parking_gate(IdlePoolConfig { max_idle }, parking_gate.clone()),
+            ));
             let network_log_manager = NetworkLogManager::new();
 
             Self {

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -217,7 +217,7 @@ async fn budget_pressure_starts_fresh_vm_before_idle_destroy_finishes() {
         "budget should be exhausted after seeding"
     );
 
-    let mut run_handle = tokio::spawn(run(config));
+    let run_handle = tokio::spawn(run(config));
 
     // Push new job — budget is full, but idle pool has an entry to evict.
     let run_id = RunId::new_v4();
@@ -248,10 +248,11 @@ async fn budget_pressure_starts_fresh_vm_before_idle_destroy_finishes() {
 
     env.drain();
     env.cancel.cancel();
+    env.start_observer
+        .wait_destroy_tasks_drain_entered(Duration::from_secs(5))
+        .await;
     assert!(
-        tokio::time::timeout(Duration::from_millis(100), &mut run_handle)
-            .await
-            .is_err(),
+        !run_handle.is_finished(),
         "shutdown must wait for the tracked retired idle destroy"
     );
     destroy_gate.release_one();

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -263,6 +263,58 @@ async fn budget_pressure_starts_fresh_vm_before_idle_destroy_finishes() {
 }
 
 #[tokio::test]
+async fn fresh_create_failure_does_not_cancel_retired_idle_destroy() {
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    let idle_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    idle_overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let fresh_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    fresh_overrides.push_create_result(Err(sandbox::SandboxError::Initialization {
+        phase: sandbox::SandboxInitializationPhase::SandboxAllocation,
+        message: "create failed after idle retirement".into(),
+    }));
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, fresh_overrides);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    seed_idle_pool_with_overrides(
+        &idle_pool,
+        &budget,
+        &idle_overrides,
+        "sess-create-failure-retirement",
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("idle destroy should remain tracked before fresh creation");
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("fresh create failure should report completion without waiting for old destroy");
+    assert_eq!(completion.exit_code, 1);
+    assert!(
+        completion
+            .error
+            .is_some_and(|error| error.contains("create failed after idle retirement"))
+    );
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert_eq!(idle_pool.lock().await.len(), 0);
+    assert_eq!(destroy_gate.entered_count(), 1);
+
+    destroy_gate.release_one();
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
 async fn smaller_fresh_profile_releases_only_net_idle_capacity() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let wait_gate = sandbox_mock::MockLifecycleGate::new();

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -6,8 +6,6 @@ use super::support::{
     wait_budget_count, wait_cancel_token, wait_discover_entered,
     wait_status_idle_reuse_keys_and_active_runs,
 };
-use crate::types::SandboxReuseResult;
-
 // -----------------------------------------------------------------------
 // Test 11: Budget full → job skipped (not claimed) → budget freed → next job succeeds
 //
@@ -128,11 +126,11 @@ async fn budget_exhausted_buffers_discovery_until_budget_frees() {
 }
 
 // -----------------------------------------------------------------------
-// Test 15: Legacy timeout does not affect idle lifetime or reuse
+// Test 15: Idle VMs remain reusable until capacity is needed
 // -----------------------------------------------------------------------
 
 #[tokio::test(start_paused = true)]
-async fn legacy_idle_timeout_does_not_affect_retention_or_reuse() {
+async fn idle_vm_remains_reusable_until_capacity_is_needed() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
@@ -177,7 +175,10 @@ async fn legacy_idle_timeout_does_not_affect_retention_or_reuse() {
         .wait_completion(run_id, Duration::from_secs(5))
         .await
         .expect("aged idle VM should remain reusable");
-    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(
+        completion.reuse_result,
+        Some(crate::types::SandboxReuseResult::Reused)
+    );
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -187,7 +187,7 @@ async fn idle_vm_remains_reusable_until_capacity_is_needed() {
 // Test 16: Budget exhausted → evict idle VM → admit new job
 // -----------------------------------------------------------------------
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn budget_pressure_starts_fresh_vm_before_idle_destroy_finishes() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let wait_gate = sandbox_mock::MockLifecycleGate::new();
@@ -252,10 +252,13 @@ async fn budget_pressure_starts_fresh_vm_before_idle_destroy_finishes() {
         .wait_destroy_tasks_drain_entered(Duration::from_secs(5))
         .await;
     assert!(
-        !run_handle.is_finished(),
+        !env.start_observer.destroy_tasks_drain_was_completed(),
         "shutdown must wait for the tracked retired idle destroy"
     );
     destroy_gate.release_one();
+    env.start_observer
+        .wait_destroy_tasks_drain_completed(Duration::from_secs(5))
+        .await;
     assert_run_exits_within(
         run_handle,
         Duration::from_secs(5),

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -1,11 +1,12 @@
 use super::super::*;
 use super::support::{
-    TestParkedIdleCandidateSpec, context_with_session, minimal_context, mock_run_config,
-    mock_run_config_with_overrides, push_job, seed_idle_pool, seed_idle_pool_expired,
+    TestParkedIdleCandidateSpec, assert_run_exits_within, context_with_session, minimal_context,
+    mock_run_config, mock_run_config_with_overrides, push_job, seed_idle_pool_with_overrides,
     seed_idle_pool_with_timing, shutdown, status_idle_reuse_keys, test_profiles, two_profiles,
     wait_budget_count, wait_cancel_token, wait_discover_entered,
-    wait_idle_cleanup_processed_with_expired_entries, wait_status_idle_reuse_keys_and_active_runs,
+    wait_status_idle_reuse_keys_and_active_runs,
 };
+use crate::types::SandboxReuseResult;
 
 // -----------------------------------------------------------------------
 // Test 11: Budget full → job skipped (not claimed) → budget freed → next job succeeds
@@ -127,17 +128,29 @@ async fn budget_exhausted_buffers_discovery_until_budget_frees() {
 }
 
 // -----------------------------------------------------------------------
-// Test 15: Cleanup tick evicts expired idle entries
+// Test 15: Legacy timeout does not affect idle lifetime or reuse
 // -----------------------------------------------------------------------
 
 #[tokio::test(start_paused = true)]
-async fn cleanup_tick_evicts_expired_entries() {
+async fn legacy_idle_timeout_does_not_affect_retention_or_reuse() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
+    let now = std::time::Instant::now();
 
-    // Pre-seed: park an entry that is already expired (400s old, 300s timeout).
-    seed_idle_pool_expired(&idle_pool, &budget, "sess-exp", "vm0/default", 2, 4096).await;
+    seed_idle_pool_with_timing(
+        &idle_pool,
+        &budget,
+        TestParkedIdleCandidateSpec {
+            reuse_key: "sess-old",
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: None,
+            parked_at: now - Duration::from_secs(3600),
+        },
+    )
+    .await;
     assert_eq!(
         idle_pool.lock().await.len(),
         1,
@@ -148,19 +161,23 @@ async fn cleanup_tick_evicts_expired_entries() {
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(5)).await;
 
-    // Advance to the first cleanup tick, then synchronize on the loop's
-    // cleanup event instead of using the fixed sleep as the assertion gate.
-    tokio::time::advance(Duration::from_secs(11)).await;
-    let expired_count =
-        wait_idle_cleanup_processed_with_expired_entries(&env, Duration::from_secs(5)).await;
-    assert_eq!(expired_count, 1, "cleanup should process the expired entry");
+    tokio::time::advance(Duration::from_secs(3600)).await;
+    assert_eq!(idle_pool.lock().await.len(), 1, "idle age must not evict");
+    assert_eq!(budget.allocated().2, 1, "aged idle VM keeps its lease");
 
-    // Eviction spawns a destroy_task that releases the idle entry lease.
-    // Poll until it completes.
-    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
-
-    let pool_len = idle_pool.lock().await.len();
-    assert_eq!(pool_len, 0, "expired entry should be evicted");
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, "sess-old")),
+    );
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("aged idle VM should remain reusable");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
 
     shutdown(&env, run_handle).await;
 }
@@ -169,41 +186,141 @@ async fn cleanup_tick_evicts_expired_entries() {
 // Test 16: Budget exhausted → evict idle VM → admit new job
 // -----------------------------------------------------------------------
 
-#[tokio::test(start_paused = true)]
-async fn budget_exhausted_evicts_idle_and_admits_job() {
+#[tokio::test]
+async fn budget_pressure_starts_fresh_vm_before_idle_destroy_finishes() {
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let idle_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    idle_overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let fresh_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    fresh_overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     // Budget: exactly 1 default job (2 vcpu, 4096 MB).
-    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 2);
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 2, Arc::clone(&fresh_overrides));
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
 
     // Pre-seed: idle VM fills the entire budget.
-    seed_idle_pool(&idle_pool, &budget, "sess-evict", "vm0/default", 2, 4096).await;
+    seed_idle_pool_with_overrides(
+        &idle_pool,
+        &budget,
+        &idle_overrides,
+        "sess-evict",
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
     assert!(
         !budget.can_afford(2, 4096),
         "budget should be exhausted after seeding"
     );
 
-    let run_handle = tokio::spawn(run(config));
+    let mut run_handle = tokio::spawn(run(config));
 
     // Push new job — budget is full, but idle pool has an entry to evict.
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
 
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("idle VM should enter tracked destroy");
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("fresh VM should activate while idle destroy is blocked");
+    assert_eq!(
+        budget.allocated(),
+        (2, 4096, 1),
+        "incoming lease should atomically replace the idle lease"
+    );
+    assert_eq!(idle_pool.lock().await.len(), 0);
+
+    wait_gate.release_one();
     let completion = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
-        .await;
+        .await
+        .expect("fresh job should complete while retired idle cleanup remains blocked");
+    assert_eq!(completion.exit_code, 0);
+
+    env.drain();
+    env.cancel.cancel();
     assert!(
-        completion.is_some(),
-        "job should complete after idle VM eviction frees budget"
+        tokio::time::timeout(Duration::from_millis(100), &mut run_handle)
+            .await
+            .is_err(),
+        "shutdown must wait for the tracked retired idle destroy"
     );
-    assert_eq!(completion.unwrap().exit_code, 0);
+    destroy_gate.release_one();
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "shutdown should finish after retired idle destroy completes",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn smaller_fresh_profile_releases_only_net_idle_capacity() {
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) =
+        mock_run_config_with_overrides(two_profiles(), 4, 8192, 2, Arc::clone(&overrides));
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    seed_idle_pool_with_overrides(
+        &idle_pool,
+        &budget,
+        &overrides,
+        "sess-large-idle",
+        "vm0/large",
+        4,
+        8192,
+    )
+    .await;
+
+    let run_handle = tokio::spawn(run(config));
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("large idle VM should enter tracked destroy");
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("smaller fresh VM should activate before destroy completes");
+    assert_eq!(budget.allocated(), (2, 4096, 1));
+    assert!(
+        budget.can_afford(2, 4096),
+        "unused half of the retired large lease should remain admittable"
+    );
+
+    destroy_gate.release_one();
+    wait_gate.release_one();
+    destroy_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("fresh VM should enter normal active cleanup");
+    destroy_gate.release_one();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("smaller fresh job should complete");
+    assert_eq!(completion.exit_code, 0);
 
     shutdown(&env, run_handle).await;
 }
 
 #[tokio::test(start_paused = true)]
-async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
+async fn budget_pressure_evicts_oldest_idle_regardless_of_age() {
     let (config, env) = mock_run_config(two_profiles(), 6, 12288, 3);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
@@ -220,7 +337,6 @@ async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
             memory_mb: 4096,
             history_generation_run_id: None,
             parked_at: now - Duration::from_secs(100),
-            idle_timeout: Duration::from_secs(300),
         },
     )
     .await;
@@ -228,13 +344,12 @@ async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
         &idle_pool,
         &budget,
         TestParkedIdleCandidateSpec {
-            reuse_key: "sess-expired-newer",
+            reuse_key: "sess-newer-large",
             profile_name: "vm0/large",
             vcpu: 4,
             memory_mb: 8192,
             history_generation_run_id: None,
             parked_at: now - Duration::from_secs(10),
-            idle_timeout: Duration::from_secs(1),
         },
     )
     .await;
@@ -254,7 +369,7 @@ async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
         .await;
     assert!(
         completion.is_some(),
-        "job should complete after expired idle reclaim frees budget"
+        "job should complete after oldest idle capacity is reclaimed"
     );
     assert_eq!(completion.unwrap().exit_code, 0);
 
@@ -263,12 +378,12 @@ async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
     let reuse_keys = idle_pool.lock().await.held_reuse_keys();
     assert_eq!(
         reuse_keys,
-        vec!["sess-old-active".to_string()],
-        "expired idle entry should be reclaimed before oldest active entry"
+        vec!["sess-newer-large".to_string()],
+        "oldest idle entry should be reclaimed regardless of age"
     );
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,
-        vec!["sess-old-active".to_string()],
+        vec!["sess-newer-large".to_string()],
         "status.json should reflect the remaining idle VM"
     );
 
@@ -276,8 +391,8 @@ async fn budget_exhausted_reclaims_expired_before_oldest_idle() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
-    let (config, env) = mock_run_config(two_profiles(), 7, 13312, 3);
+async fn larger_profile_retires_only_the_required_oldest_idle_entries() {
+    let (config, env) = mock_run_config(two_profiles(), 6, 12288, 4);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
     let status_path = env._temp_dir.path().join("status.json");
@@ -287,13 +402,12 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
         &idle_pool,
         &budget,
         TestParkedIdleCandidateSpec {
-            reuse_key: "sess-old-active",
-            profile_name: "vm0/large",
-            vcpu: 4,
-            memory_mb: 8192,
+            reuse_key: "sess-oldest",
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
             history_generation_run_id: None,
             parked_at: now - Duration::from_secs(100),
-            idle_timeout: Duration::from_secs(300),
         },
     )
     .await;
@@ -301,13 +415,12 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
         &idle_pool,
         &budget,
         TestParkedIdleCandidateSpec {
-            reuse_key: "sess-new-active",
+            reuse_key: "sess-middle",
             profile_name: "vm0/default",
             vcpu: 2,
             memory_mb: 4096,
             history_generation_run_id: None,
             parked_at: now - Duration::from_secs(50),
-            idle_timeout: Duration::from_secs(300),
         },
     )
     .await;
@@ -315,29 +428,24 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
         &idle_pool,
         &budget,
         TestParkedIdleCandidateSpec {
-            reuse_key: "sess-expired-small",
+            reuse_key: "sess-newest",
             profile_name: "vm0/default",
-            // Intentionally smaller than the current min profile. With
-            // only profile-sized entries, releasing one expired VM is
-            // already enough to admit the min profile; this pins the
-            // fallback loop for stale/non-current idle footprints.
-            vcpu: 1,
-            memory_mb: 1024,
+            vcpu: 2,
+            memory_mb: 4096,
             history_generation_run_id: None,
             parked_at: now - Duration::from_secs(10),
-            idle_timeout: Duration::from_secs(1),
         },
     )
     .await;
     assert!(
-        !budget.can_afford(2, 4096),
+        !budget.can_afford(4, 8192),
         "seeded idle entries should exhaust budget"
     );
 
     let run_handle = tokio::spawn(run(config));
 
     let run_id = RunId::new_v4();
-    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    push_job(&env, run_id, "vm0/large", Some(minimal_context(run_id)));
 
     let completion = env
         .handle
@@ -345,7 +453,7 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
         .await;
     assert!(
         completion.is_some(),
-        "job should complete after expired reclaim plus oldest eviction"
+        "large job should complete after two oldest idle entries retire"
     );
     assert_eq!(completion.unwrap().exit_code, 0);
 
@@ -354,12 +462,12 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
     let reuse_keys = idle_pool.lock().await.held_reuse_keys();
     assert_eq!(
         reuse_keys,
-        vec!["sess-new-active".to_string()],
-        "expired entry and oldest active entry should be reclaimed"
+        vec!["sess-newest".to_string()],
+        "only the newest unneeded idle entry should remain"
     );
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,
-        vec!["sess-new-active".to_string()],
+        vec!["sess-newest".to_string()],
         "status.json should reflect only the remaining idle VM"
     );
 

--- a/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/parking_cleanup.rs
@@ -542,10 +542,7 @@ async fn pool_full_rejected_vm_keeps_budget_until_destroy_and_completion() {
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     {
         let mut pool = idle_pool.lock().await;
-        *pool = IdlePool::new(IdlePoolConfig {
-            default_timeout: Duration::from_secs(300),
-            max_idle: 1,
-        });
+        *pool = IdlePool::new(IdlePoolConfig { max_idle: 1 });
     }
     seed_idle_pool(&idle_pool, &budget, "sess-existing", "vm0/default", 2, 4096).await;
     assert_eq!(budget.allocated().2, 1, "seeded idle entry holds budget");

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -947,6 +947,99 @@ async fn finalizing_capacity_wait_rechecks_when_an_active_vm_parks_idle() {
     shutdown(&env, run_handle).await;
 }
 
+#[tokio::test(start_paused = true)]
+async fn finalizing_capacity_wait_reuses_matching_vm_parked_after_deadline() {
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let reuse_key = "thread:matching-after-finalizing-deadline";
+    let predecessor_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        predecessor_run_id,
+        "vm0/default",
+        Some(context_with_reuse_key(predecessor_run_id, reuse_key)),
+    );
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("predecessor should hold the full budget while running");
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    let successor_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        successor_run_id,
+        Some(context_with_reuse_key(successor_run_id, reuse_key)),
+    );
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate_until(
+            successor_run_id,
+            reuse_key,
+            predecessor_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+            std::time::Instant::now() + Duration::from_millis(100),
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle
+            .claim_candidates()
+            .iter()
+            .any(|candidate| candidate.run_id() == successor_run_id),
+        "finalizing successor should be claimed before its preference deadline"
+    );
+
+    tokio::time::advance(Duration::from_millis(101)).await;
+    env.start_observer
+        .wait_finalizing_capacity_wait_entered(successor_run_id, Duration::from_secs(5))
+        .await;
+
+    wait_gate.release_one();
+    let parked_reuse_key = env
+        .start_observer
+        .wait_vm_parked_for_reuse(predecessor_run_id, Duration::from_secs(5))
+        .await;
+    assert_eq!(parked_reuse_key, reuse_key);
+    wait_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("matching idle publication should activate the successor");
+    assert_eq!(destroy_gate.entered_count(), 0);
+    assert_eq!(budget.allocated(), (2, 4096, 1));
+
+    wait_gate.release_one();
+    let predecessor_completion = env
+        .handle
+        .wait_completion(predecessor_run_id, Duration::from_secs(5))
+        .await
+        .expect("predecessor should complete after publishing its sandbox");
+    let successor_completion = env
+        .handle
+        .wait_completion(successor_run_id, Duration::from_secs(5))
+        .await
+        .expect("successor should complete with the matching sandbox");
+    assert_eq!(
+        successor_completion.reuse_result,
+        Some(SandboxReuseResult::Reused)
+    );
+    assert_eq!(
+        successor_completion.sandbox_id, predecessor_completion.sandbox_id,
+        "successor should reuse the predecessor sandbox after the deadline"
+    );
+
+    destroy_gate.release_one();
+    shutdown(&env, run_handle).await;
+}
+
 #[tokio::test]
 async fn ordinary_and_finalizing_pressure_admission_do_not_double_spend_idle_capacity() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -849,6 +849,103 @@ async fn finalizing_fallback_starts_fresh_vm_before_idle_destroy_finishes() {
 }
 
 #[tokio::test]
+async fn ordinary_and_finalizing_pressure_admission_do_not_double_spend_idle_capacity() {
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let idle_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    idle_overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let fresh_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    fresh_overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 4, 8192, 2, fresh_overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    for reuse_key in ["thread:pressure-idle-first", "thread:pressure-idle-second"] {
+        seed_idle_pool_with_overrides(
+            &env.idle_pool,
+            &budget,
+            &idle_overrides,
+            reuse_key,
+            "vm0/default",
+            2,
+            4096,
+        )
+        .await;
+    }
+
+    let finalizing_reuse_key = "thread:concurrent-finalizing-pressure";
+    let history_generation_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        history_generation_run_id,
+        Some(finalizing_reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let finalizing_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        finalizing_run_id,
+        Some(context_with_reuse_key(
+            finalizing_run_id,
+            finalizing_reuse_key,
+        )),
+    );
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            finalizing_run_id,
+            finalizing_reuse_key,
+            history_generation_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle
+            .claim_candidates()
+            .iter()
+            .any(|candidate| candidate.run_id() == finalizing_run_id)
+    );
+
+    let ordinary_run_id = RunId::new_v4();
+    drop(predecessor_guard);
+    push_job(
+        &env,
+        ordinary_run_id,
+        "vm0/default",
+        Some(minimal_context(ordinary_run_id)),
+    );
+
+    destroy_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("ordinary and finalizing admission should each retire one idle VM");
+    wait_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("both fresh runs should activate while old destroys remain blocked");
+    assert_eq!(budget.allocated(), (4, 8192, 2));
+    assert_eq!(env.idle_pool.lock().await.len(), 0);
+
+    wait_gate.release_one();
+    wait_gate.release_one();
+    for run_id in [ordinary_run_id, finalizing_run_id] {
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .expect("both admitted runs should complete before old idle teardown");
+        assert_eq!(completion.exit_code, 0);
+    }
+    assert_eq!(destroy_gate.entered_count(), 2);
+
+    destroy_gate.release_one();
+    destroy_gate.release_one();
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
 async fn cancelled_finalizing_capacity_wait_releases_retiring_leases_but_keeps_cleanup_owned() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let idle_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -849,6 +849,105 @@ async fn finalizing_fallback_starts_fresh_vm_before_idle_destroy_finishes() {
 }
 
 #[tokio::test]
+async fn finalizing_capacity_wait_rechecks_when_an_active_vm_parks_idle() {
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let capacity_source_run_id = RunId::new_v4();
+    let capacity_source_reuse_key = "thread:capacity-source";
+    push_job(
+        &env,
+        capacity_source_run_id,
+        "vm0/default",
+        Some(context_with_reuse_key(
+            capacity_source_run_id,
+            capacity_source_reuse_key,
+        )),
+    );
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("capacity source should hold the full budget while running");
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert_eq!(budget.allocated(), (2, 4096, 1));
+    assert_eq!(env.idle_pool.lock().await.len(), 0);
+
+    let finalizing_reuse_key = "thread:waiting-finalizing-capacity";
+    let history_generation_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        history_generation_run_id,
+        Some(finalizing_reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    let finalizing_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        finalizing_run_id,
+        Some(context_with_reuse_key(
+            finalizing_run_id,
+            finalizing_reuse_key,
+        )),
+    );
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            finalizing_run_id,
+            finalizing_reuse_key,
+            history_generation_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle
+            .claim_candidates()
+            .iter()
+            .any(|candidate| candidate.run_id() == finalizing_run_id),
+        "finalizing successor should be claimed before waiting for capacity"
+    );
+
+    drop(predecessor_guard);
+    env.start_observer
+        .wait_finalizing_capacity_wait_entered(finalizing_run_id, Duration::from_secs(5))
+        .await;
+
+    wait_gate.release_one();
+    let parked_reuse_key = env
+        .start_observer
+        .wait_vm_parked_for_reuse(capacity_source_run_id, Duration::from_secs(5))
+        .await;
+    assert_eq!(parked_reuse_key, capacity_source_reuse_key);
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("newly idle capacity should be retired without waiting for lease release");
+    wait_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("finalizing fallback should start after the active VM becomes idle");
+    assert_eq!(budget.allocated(), (2, 4096, 1));
+    assert_eq!(env.idle_pool.lock().await.len(), 0);
+
+    wait_gate.release_one();
+    let completion = env
+        .handle
+        .wait_completion(finalizing_run_id, Duration::from_secs(5))
+        .await
+        .expect("finalizing fallback should complete while retired cleanup is blocked");
+    assert_eq!(completion.exit_code, 0);
+
+    destroy_gate.release_many(2);
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
 async fn ordinary_and_finalizing_pressure_admission_do_not_double_spend_idle_capacity() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let wait_gate = sandbox_mock::MockLifecycleGate::new();

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -4,8 +4,9 @@ use super::super::support::{
     context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
     push_job, seed_idle_pool, seed_idle_pool_with_history_generation,
     seed_idle_pool_with_overrides, seed_idle_pool_with_speculative_timezone,
-    seed_workspace_cache_state, shutdown, test_profiles, wait_budget_count, wait_cancel_token,
-    wait_cancel_token_removed, wait_discover_entered, wait_status_idle_reuse_keys_and_active_runs,
+    seed_workspace_cache_state, shutdown, test_profiles, two_profiles, wait_budget_count,
+    wait_cancel_handle, wait_cancel_token, wait_cancel_token_removed, wait_discover_entered,
+    wait_status_idle_reuse_keys_and_active_runs,
 };
 use std::sync::Arc;
 
@@ -765,6 +766,160 @@ async fn selected_finalizing_candidate_claims_while_predecessor_is_running() {
         Some(RunnerPreferenceClaimState::Active)
     );
 
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn finalizing_fallback_starts_fresh_vm_before_idle_destroy_finishes() {
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let idle_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    idle_overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let fresh_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    fresh_overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, fresh_overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = "thread:finalizing-pressure-overlap";
+    let history_generation_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        history_generation_run_id,
+        Some(reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    seed_idle_pool_with_overrides(
+        &env.idle_pool,
+        &budget,
+        &idle_overrides,
+        "thread:unrelated-idle-capacity",
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            run_id,
+            reuse_key,
+            history_generation_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle
+            .claim_candidates()
+            .iter()
+            .any(|candidate| candidate.run_id() == run_id),
+        "finalizing successor should be claimed before fallback"
+    );
+
+    drop(predecessor_guard);
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("finalizing fallback should retire unrelated idle capacity");
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("finalizing fallback should activate fresh VM before destroy completes");
+    assert_eq!(budget.allocated(), (2, 4096, 1));
+    assert_eq!(env.idle_pool.lock().await.len(), 0);
+
+    wait_gate.release_one();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("finalizing fallback should complete while old destroy remains blocked");
+    assert_eq!(completion.exit_code, 0);
+    assert_ne!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(destroy_gate.entered_count(), 1);
+
+    destroy_gate.release_one();
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn cancelled_finalizing_capacity_wait_releases_retiring_leases_but_keeps_cleanup_owned() {
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    let idle_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    idle_overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let fresh_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let (config, env) = mock_run_config_with_overrides(two_profiles(), 4, 8192, 2, fresh_overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let occupied = ResourceBudget::try_reserve_lease(&budget, 2, 4096)
+        .expect("active work should reserve half the budget");
+    seed_idle_pool_with_overrides(
+        &env.idle_pool,
+        &budget,
+        &idle_overrides,
+        "thread:retiring-idle-capacity",
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let reuse_key = "thread:cancelled-finalizing-capacity";
+    let history_generation_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        history_generation_run_id,
+        Some(reuse_key.to_owned()),
+        "vm0/large".into(),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(run_id, "vm0/large".into())
+                .with_reuse_key(Some(reuse_key.to_owned()))
+                .with_history_generation_run_id(Some(history_generation_run_id))
+                .with_runner_preference_for_test(ActiveRunnerPreference::ranked_for_test(
+                    RunnerProcessIdentity::new(
+                        TEST_RUNNER_ID.parse().unwrap(),
+                        TEST_HEARTBEAT_GENERATION,
+                    )
+                    .unwrap(),
+                    RunnerPreferenceTier::FinalizingPredecessor,
+                    std::time::Instant::now() + Duration::from_secs(30),
+                )),
+        )
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+
+    drop(predecessor_guard);
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("finalizing fallback should retire idle capacity before waiting");
+    assert_eq!(budget.allocated(), (4, 8192, 2));
+    cancellation.request_hard_cancellation().await;
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("cancelled finalizing fallback should report completion");
+    assert_eq!(completion.exit_code, 137);
+    wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
+    assert_eq!(destroy_gate.entered_count(), 1);
+
+    destroy_gate.release_one();
+    drop(occupied);
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
     shutdown(&env, run_handle).await;
 }
 

--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -484,10 +484,10 @@ async fn heartbeat_tick_uses_live_mode_after_silent_mode_flip() {
     .await;
 }
 
-/// Regression for #10146 / #10223: the main-loop `idle_cleanup` and
-/// `heartbeat_tick` intervals must defer their first tick past the
-/// configured period, so neither tick branch is Ready on the first `select!`
-/// poll. Otherwise they pre-empt `discover_fut` (which parks on
+/// Regression for #10146 / #10223: the main-loop `heartbeat_tick` interval
+/// must defer its first tick past the configured period, so the tick branch
+/// is not Ready on the first `select!` poll. Otherwise it pre-empts
+/// `discover_fut` (which parks on
 /// `rx.recv()` → Pending) and any silent `mode_tx` flip during the
 /// tick body breaks the loop before the pending job is ever claimed.
 ///

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -199,14 +199,9 @@ fn build_mock_run_config_with_runtime(
     let (usage_flush_tx, usage_flush_rx) = mpsc::channel(1);
     let min_vcpu = profiles_min_vcpu(&profiles);
     let min_memory_mb = profiles_min_memory(&profiles);
-    let idle_pool: SharedIdlePool =
-        Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
-            IdlePoolConfig {
-                default_timeout: Duration::from_secs(300),
-                max_idle: 10,
-            },
-            parking_gate.clone(),
-        )));
+    let idle_pool: SharedIdlePool = Arc::new(tokio::sync::Mutex::new(
+        IdlePool::new_with_parking_gate(IdlePoolConfig { max_idle: 10 }, parking_gate.clone()),
+    ));
     let reuse_state_notify = Arc::new(tokio::sync::Notify::new());
     let active_runs = ActiveRuns::new(Arc::clone(&reuse_state_notify));
 

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -1,11 +1,10 @@
 use super::super::super::*;
 
 use crate::guest_timezone::GuestTimezoneIntent;
-use crate::idle_pool::{ParkResult, ParkedIdleCandidate, test_support::ParkedIdleCandidateBuilder};
+use crate::idle_pool::{ParkResult, test_support::ParkedIdleCandidateBuilder};
 use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
 use crate::ids::RunId;
 use crate::paths::RunnerPaths;
-use crate::resource_budget::BudgetLease;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::workspace_image_cache::{
     WorkspaceCacheTerminalStatus, WorkspaceImageCache, WorkspaceImageLeaseIdentity,
@@ -16,17 +15,6 @@ use sandbox::SandboxId;
 
 const TEST_LAST_COMPLETED_AT: &str = "2026-05-28T00:00:00.000Z";
 
-fn make_synthetic_parked_candidate(
-    reuse_key: &str,
-    profile_name: &str,
-    budget_lease: BudgetLease,
-) -> ParkedIdleCandidate {
-    ParkedIdleCandidateBuilder::new(reuse_key, budget_lease)
-        .with_profile_name(profile_name)
-        .with_guest_timezone_intent(GuestTimezoneIntent::Unknown)
-        .build()
-}
-
 struct IdlePoolSeedSpec<'a> {
     reuse_key: &'a str,
     profile_name: &'a str,
@@ -34,7 +22,7 @@ struct IdlePoolSeedSpec<'a> {
     memory_mb: u32,
     history_generation_run_id: Option<RunId>,
     guest_timezone_intent: GuestTimezoneIntent,
-    timing: Option<(std::time::Instant, Duration)>,
+    timing: Option<std::time::Instant>,
 }
 
 pub(in super::super) struct SpeculativeIdleSeedSpec<'a> {
@@ -44,7 +32,7 @@ pub(in super::super) struct SpeculativeIdleSeedSpec<'a> {
     pub(in super::super) memory_mb: u32,
     pub(in super::super) history_generation_run_id: RunId,
     pub(in super::super) guest_timezone_intent: GuestTimezoneIntent,
-    pub(in super::super) timing: Option<(std::time::Instant, Duration)>,
+    pub(in super::super) timing: Option<std::time::Instant>,
 }
 
 /// Pre-populate idle pool with an entry and reserve its budget. Returns
@@ -220,9 +208,7 @@ async fn seed_idle_pool_with_overrides_and_generation(
     };
     let mut guard = pool.lock().await;
     let result = match timing {
-        Some((parked_at, idle_timeout)) => {
-            guard.park_at_for_test(candidate, parked_at, idle_timeout)
-        }
+        Some(parked_at) => guard.park_at_for_test(candidate, parked_at),
         None => guard.park(candidate),
     };
     assert!(matches!(result, ParkResult::Parked));
@@ -333,25 +319,6 @@ pub(in super::super) async fn seed_workspace_cache_state(
     );
 }
 
-pub(in super::super) async fn seed_idle_pool_expired(
-    pool: &SharedIdlePool,
-    budget: &Arc<ResourceBudget>,
-    reuse_key: &str,
-    profile_name: &str,
-    vcpu: u32,
-    memory_mb: u32,
-) {
-    let budget_lease = ResourceBudget::try_reserve_lease(budget, vcpu, memory_mb).unwrap();
-    let candidate = make_synthetic_parked_candidate(reuse_key, profile_name, budget_lease);
-    let mut guard = pool.lock().await;
-    let result = guard.park_at_for_test(
-        candidate,
-        std::time::Instant::now() - Duration::from_secs(400),
-        Duration::from_secs(300),
-    );
-    assert!(matches!(result, ParkResult::Parked));
-}
-
 pub(in super::super) struct TestParkedIdleCandidateSpec<'a> {
     pub(in super::super) reuse_key: &'a str,
     pub(in super::super) profile_name: &'a str,
@@ -359,7 +326,6 @@ pub(in super::super) struct TestParkedIdleCandidateSpec<'a> {
     pub(in super::super) memory_mb: u32,
     pub(in super::super) history_generation_run_id: Option<RunId>,
     pub(in super::super) parked_at: std::time::Instant,
-    pub(in super::super) idle_timeout: Duration,
 }
 
 pub(in super::super) async fn seed_idle_pool_with_timing(
@@ -376,6 +342,6 @@ pub(in super::super) async fn seed_idle_pool_with_timing(
         None => builder.build(),
     };
     let mut guard = pool.lock().await;
-    let result = guard.park_at_for_test(candidate, spec.parked_at, spec.idle_timeout);
+    let result = guard.park_at_for_test(candidate, spec.parked_at);
     assert!(matches!(result, ParkResult::Parked));
 }

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -12,10 +12,9 @@ pub(super) use self::env::{
 };
 pub(super) use self::idle_pool::{
     SpeculativeIdleSeedSpec, TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec,
-    seed_idle_pool, seed_idle_pool_expired, seed_idle_pool_with_history_generation,
-    seed_idle_pool_with_overrides, seed_idle_pool_with_speculative_timezone,
-    seed_idle_pool_with_timing, seed_idle_pool_with_workspace_promotion,
-    seed_workspace_cache_state,
+    seed_idle_pool, seed_idle_pool_with_history_generation, seed_idle_pool_with_overrides,
+    seed_idle_pool_with_speculative_timezone, seed_idle_pool_with_timing,
+    seed_idle_pool_with_workspace_promotion, seed_workspace_cache_state,
 };
 pub(super) use self::jobs::{context_with_session, minimal_context, push_job, shutdown};
 pub(super) use self::status::{
@@ -25,8 +24,7 @@ pub(super) use self::status::{
 };
 pub(super) use self::wait::{
     assert_run_exits_within, wait_budget_count, wait_budget_exhausted_reactor, wait_cancel_handle,
-    wait_cancel_token, wait_cancel_token_removed, wait_discover_entered,
-    wait_idle_cleanup_processed_with_expired_entries, wait_idle_pool_len,
+    wait_cancel_token, wait_cancel_token_removed, wait_discover_entered, wait_idle_pool_len,
     wait_idle_pool_reuse_keys, wait_parking_state, wait_sandbox_lifecycle_counts,
     wait_usage_flush_requested, wait_workspace_cache_reuse_keys,
 };

--- a/crates/runner/src/cmd/start/tests/support/wait.rs
+++ b/crates/runner/src/cmd/start/tests/support/wait.rs
@@ -306,15 +306,6 @@ pub(in super::super) async fn wait_budget_exhausted_reactor(env: &MockRunEnv, ti
         .await;
 }
 
-pub(in super::super) async fn wait_idle_cleanup_processed_with_expired_entries(
-    env: &MockRunEnv,
-    timeout: Duration,
-) -> usize {
-    env.start_observer
-        .wait_idle_cleanup_processed_with_expired_entries(timeout)
-        .await
-}
-
 pub(in super::super) async fn wait_usage_flush_requested(env: &MockRunEnv, timeout: Duration) {
     env.start_observer.wait_usage_flush_requested(timeout).await;
 }

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -146,8 +146,10 @@ pub struct SandboxConfig {
     pub max_concurrent: usize,
     /// Overcommit factor applied to both CPU and memory budgets (default: 1.0).
     pub concurrency_factor: f64,
-    /// Idle timeout in seconds for reusable VMs
-    /// (default: [`DEFAULT_IDLE_TIMEOUT_SECS`]).
+    /// Legacy idle timeout retained for runner YAML compatibility.
+    ///
+    /// Idle VM lifetime is capacity-driven, so this value has no runtime
+    /// effect (default: [`DEFAULT_IDLE_TIMEOUT_SECS`]).
     pub idle_timeout_secs: u64,
     /// Maximum number of idle VMs to keep (0 = no limit, default: 0).
     pub max_idle: usize,

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -52,7 +52,6 @@ use guest_contracts::process_containment::{
 };
 
 use crate::error::{RunnerError, RunnerResult};
-use crate::idle_pool::DEFAULT_IDLE_TIMEOUT_SECS;
 use crate::paths::{HomePaths, RootfsPaths, SnapshotPaths};
 use crate::profile;
 
@@ -146,11 +145,6 @@ pub struct SandboxConfig {
     pub max_concurrent: usize,
     /// Overcommit factor applied to both CPU and memory budgets (default: 1.0).
     pub concurrency_factor: f64,
-    /// Legacy idle timeout retained for runner YAML compatibility.
-    ///
-    /// Idle VM lifetime is capacity-driven, so this value has no runtime
-    /// effect (default: [`DEFAULT_IDLE_TIMEOUT_SECS`]).
-    pub idle_timeout_secs: u64,
     /// Maximum number of idle VMs to keep (0 = no limit, default: 0).
     pub max_idle: usize,
 }
@@ -160,7 +154,6 @@ impl Default for SandboxConfig {
         Self {
             max_concurrent: DEFAULT_MAX_CONCURRENT,
             concurrency_factor: DEFAULT_CONCURRENCY_FACTOR,
-            idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_idle: 0,
         }
     }

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -1270,7 +1270,6 @@ async fn idle_pool_config_round_trip() {
         sandbox: SandboxConfig {
             max_concurrent: 4,
             concurrency_factor: 1.5,
-            idle_timeout_secs: 600,
             max_idle: 10,
         },
         server: None,
@@ -1281,7 +1280,6 @@ async fn idle_pool_config_round_trip() {
     let loaded = load_with_home(&runner_dir.join("runner.yaml"), &fixture.home, true)
         .await
         .unwrap();
-    assert_eq!(loaded.sandbox.idle_timeout_secs, 600);
     assert_eq!(loaded.sandbox.max_idle, 10);
     assert_eq!(loaded, config);
 }
@@ -1293,6 +1291,5 @@ async fn idle_pool_defaults_when_omitted() {
     let yaml = fixture.yaml_with_default_profile("");
 
     let config = fixture.load_config(&yaml, true).await.unwrap();
-    assert_eq!(config.sandbox.idle_timeout_secs, DEFAULT_IDLE_TIMEOUT_SECS);
     assert_eq!(config.sandbox.max_idle, 0);
 }

--- a/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
@@ -32,10 +32,7 @@ async fn idle_pool_park_and_reuse_cycle() {
     );
 
     // Park in idle pool
-    let mut pool = IdlePool::new(IdlePoolConfig {
-        default_timeout: std::time::Duration::from_secs(300),
-        max_idle: 0,
-    });
+    let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
 
     let entry = ParkedIdleCandidateBuilder::new("test-session", test_budget_lease())
         .with_sandbox(sandbox)

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -1672,10 +1672,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
     .expect_reusable()
     .with_last_completed_at("2026-06-01T00:00:01.000Z".into());
 
-    let mut pool = IdlePool::new(IdlePoolConfig {
-        default_timeout: std::time::Duration::from_secs(300),
-        max_idle: 0,
-    });
+    let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
     let entry = pool.take(&reuse_key).expect("idle entry should exist");
     let idle_sandbox = match entry.try_unpark_for_run(crate::ids::RunId::new_v4()).await {
@@ -1784,10 +1781,7 @@ async fn reusable_idle_sandbox_with_fresh_workspace_promotion(
     .expect_reusable()
     .with_last_completed_at("2026-06-01T00:00:01.000Z".into());
 
-    let mut pool = IdlePool::new(IdlePoolConfig {
-        default_timeout: std::time::Duration::from_secs(300),
-        max_idle: 0,
-    });
+    let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
     let entry = pool.take(&reuse_key).expect("idle entry should exist");
     let idle_sandbox = match entry.try_unpark_for_run(crate::ids::RunId::new_v4()).await {

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -91,10 +91,7 @@ pub(in crate::executor::tests) async fn make_reusable_idle_sandbox(
         sandbox.park().await.unwrap(),
         sandbox::SandboxParkOutcome::Reusable
     );
-    let mut pool = IdlePool::new(IdlePoolConfig {
-        default_timeout: std::time::Duration::from_secs(300),
-        max_idle: 0,
-    });
+    let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
     let candidate = ParkedIdleCandidateBuilder::new(session_id, test_budget_lease())
         .with_sandbox(sandbox)
         .with_source_ip(source_ip)

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -170,6 +170,38 @@ impl IdlePool {
         Some(ReservedIdleSandbox { entry })
     }
 
+    /// Reserve a matching idle entry or select the oldest entry for pressure
+    /// eviction in one pool transition.
+    ///
+    /// Keeping both decisions under the caller's exclusive `&mut` access
+    /// prevents an entry parked between a match check and eviction from being
+    /// destroyed instead of reused.
+    pub(crate) fn reserve_reusable_or_evict_oldest(
+        &mut self,
+        reuse_key: Option<&str>,
+        profile_name: &str,
+        device_rate_limits: &Option<DeviceRateLimits>,
+        history_generation_run_id: Option<RunId>,
+    ) -> IdlePoolPressureSelection {
+        let reservation = reuse_key.and_then(|reuse_key| match history_generation_run_id {
+            Some(history_generation_run_id) => self.reserve_reusable_generation(
+                reuse_key,
+                profile_name,
+                device_rate_limits,
+                history_generation_run_id,
+            ),
+            None => self.reserve_reusable(reuse_key, profile_name, device_rate_limits),
+        });
+        if let Some(reservation) = reservation {
+            return IdlePoolPressureSelection::Reusable(Box::new(reservation));
+        }
+
+        match self.evict_oldest() {
+            Some(job) => IdlePoolPressureSelection::Evicted(Box::new(job)),
+            None => IdlePoolPressureSelection::Empty,
+        }
+    }
+
     pub fn restore_reserved(
         &mut self,
         reservation: ReservedIdleSandbox,
@@ -332,6 +364,13 @@ pub enum ParkResult {
     Replaced(IdleDestroyJob),
     /// Parking is closed/soft-draining or at capacity; the entry could not be parked.
     Rejected(RejectedParkedIdleCandidate),
+}
+
+#[must_use = "pressure selection must reserve, track, or explicitly handle idle ownership"]
+pub(crate) enum IdlePoolPressureSelection {
+    Reusable(Box<ReservedIdleSandbox>),
+    Evicted(Box<IdleDestroyJob>),
+    Empty,
 }
 
 #[cfg(test)]

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use sandbox::{DeviceRateLimits, SandboxId};
+use tokio::sync::watch;
 
 use crate::ids::RunId;
 use crate::status::IdleVm;
@@ -55,6 +56,7 @@ pub struct IdlePool {
     entries: HashMap<String, IdleEntry>,
     config: IdlePoolConfig,
     revision: u64,
+    changes: watch::Sender<u64>,
     /// Shared lifecycle gate. The signal/main-loop lifecycle controller updates
     /// this before publishing externally visible mode transitions.
     parking_gate: ParkingGate,
@@ -67,10 +69,12 @@ impl IdlePool {
     }
 
     pub(crate) fn new_with_parking_gate(config: IdlePoolConfig, parking_gate: ParkingGate) -> Self {
+        let (changes, _changes_rx) = watch::channel(0);
         Self {
             entries: HashMap::new(),
             config,
             revision: 0,
+            changes,
             parking_gate,
         }
     }
@@ -188,7 +192,11 @@ impl IdlePool {
         let oldest_key = self
             .entries
             .iter()
-            .min_by_key(|(_, e)| e.parked_at)
+            .min_by(|(left_key, left), (right_key, right)| {
+                left.parked_at
+                    .cmp(&right.parked_at)
+                    .then_with(|| left_key.cmp(right_key))
+            })
             .map(|(k, _)| k.clone())?;
         let job = self
             .entries
@@ -268,6 +276,13 @@ impl IdlePool {
         self.entries.len()
     }
 
+    /// Subscribe to pool ownership mutations. The revision is durable for each
+    /// receiver, so capacity waiters cannot miss an entry parked or restored
+    /// between checking the pool and waiting for its next change.
+    pub(crate) fn subscribe_changes(&self) -> watch::Receiver<u64> {
+        self.changes.subscribe()
+    }
+
     /// Current lifecycle parking state.
     #[cfg(test)]
     pub fn parking_state(&self) -> ParkingState {
@@ -297,6 +312,7 @@ impl IdlePool {
 
     fn bump_revision(&mut self) {
         self.revision = self.revision.saturating_add(1);
+        self.changes.send_replace(self.revision);
     }
 }
 

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use sandbox::{DeviceRateLimits, SandboxId};
 
@@ -28,28 +28,17 @@ pub(crate) use parking_gate::ParkingState;
 #[cfg(test)]
 pub(crate) mod test_support;
 
-/// Default idle timeout for kept-alive VMs (30 minutes).
+/// Compatibility default for the legacy `idle_timeout_secs` config field.
 ///
-/// Re-exported via `SandboxConfig::default()` so the YAML default and
-/// the in-process fallback stay locked together.
+/// Idle lifetime is capacity-driven; the field remains only so existing
+/// runner YAML continues to deserialize and round-trip during deployment.
 pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 1800;
 
 /// Configuration for the idle sandbox pool.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct IdlePoolConfig {
-    /// Default idle timeout for parked VMs.
-    pub default_timeout: Duration,
     /// Maximum number of idle VMs (0 = unlimited).
     pub max_idle: usize,
-}
-
-impl Default for IdlePoolConfig {
-    fn default() -> Self {
-        Self {
-            default_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
-            max_idle: 0,
-        }
-    }
 }
 
 /// Idle pool status snapshot paired with a monotonic mutation revision.
@@ -97,7 +86,7 @@ impl IdlePool {
     ///
     /// Returns `Rejected(candidate)` if parking is closed/soft-draining or at capacity.
     pub fn park(&mut self, candidate: ParkedIdleCandidate) -> ParkResult {
-        self.park_at(candidate, Instant::now(), self.config.default_timeout)
+        self.park_at(candidate, Instant::now())
     }
 
     #[cfg(test)]
@@ -105,17 +94,11 @@ impl IdlePool {
         &mut self,
         candidate: ParkedIdleCandidate,
         parked_at: Instant,
-        idle_timeout: Duration,
     ) -> ParkResult {
-        self.park_at(candidate, parked_at, idle_timeout)
+        self.park_at(candidate, parked_at)
     }
 
-    fn park_at(
-        &mut self,
-        candidate: ParkedIdleCandidate,
-        parked_at: Instant,
-        idle_timeout: Duration,
-    ) -> ParkResult {
+    fn park_at(&mut self, candidate: ParkedIdleCandidate, parked_at: Instant) -> ParkResult {
         let reuse_key = candidate.reuse_key().to_string();
         if !self.parking_gate.is_open() {
             return ParkResult::Rejected(candidate.into_rejected());
@@ -126,7 +109,7 @@ impl IdlePool {
                 return ParkResult::Rejected(candidate.into_rejected());
             }
         }
-        let entry = candidate.into_idle_entry(parked_at, idle_timeout);
+        let entry = candidate.into_idle_entry(parked_at);
         let result = match self.entries.insert(reuse_key, entry) {
             Some(evicted) => ParkResult::Replaced(evicted.into_destroy_job()),
             None => ParkResult::Parked,
@@ -150,9 +133,7 @@ impl IdlePool {
         device_rate_limits: &Option<DeviceRateLimits>,
     ) -> bool {
         self.entries.get(reuse_key).is_some_and(|entry| {
-            !entry.is_expired_at(Instant::now())
-                && entry.profile_name() == profile_name
-                && entry.device_rate_limits() == device_rate_limits
+            entry.profile_name() == profile_name && entry.device_rate_limits() == device_rate_limits
         })
     }
 
@@ -198,38 +179,13 @@ impl IdlePool {
         let entry = reservation.entry;
         let reuse_key = entry.reuse_key().to_owned();
         let has_capacity = self.config.max_idle == 0 || self.entries.len() < self.config.max_idle;
-        if !self.parking_gate.is_open()
-            || entry.is_expired_at(Instant::now())
-            || !has_capacity
-            || self.entries.contains_key(&reuse_key)
-        {
+        if !self.parking_gate.is_open() || !has_capacity || self.entries.contains_key(&reuse_key) {
             return RestoreReservedIdleResult::Rejected(Box::new(entry.into_destroy_job()));
         }
 
         self.entries.insert(reuse_key, entry);
         self.bump_revision();
         RestoreReservedIdleResult::Restored
-    }
-
-    /// Remove and return all entries that have exceeded their idle timeout.
-    pub fn evict_expired(&mut self) -> Vec<IdleDestroyJob> {
-        let now = Instant::now();
-        let expired: Vec<IdleDestroyJob> = self
-            .entries
-            .extract_if(|_, entry| entry.is_expired_at(now))
-            .map(|(_, entry)| entry.into_destroy_job())
-            .collect();
-        if !expired.is_empty() {
-            self.bump_revision();
-        }
-        expired
-    }
-
-    /// Remove expired entries and return the post-eviction idle status snapshot.
-    pub fn evict_expired_with_snapshot(&mut self) -> (Vec<IdleDestroyJob>, IdlePoolSnapshot) {
-        let expired = self.evict_expired();
-        let snapshot = self.status_snapshot();
-        (expired, snapshot)
     }
 
     /// Evict the oldest idle entry (by park time). Used for resource

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -28,12 +28,6 @@ pub(crate) use parking_gate::ParkingState;
 #[cfg(test)]
 pub(crate) mod test_support;
 
-/// Compatibility default for the legacy `idle_timeout_secs` config field.
-///
-/// Idle lifetime is capacity-driven; the field remains only so existing
-/// runner YAML continues to deserialize and round-trip during deployment.
-pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 1800;
-
 /// Configuration for the idle sandbox pool.
 #[derive(Debug, Clone, Default)]
 pub struct IdlePoolConfig {

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -414,10 +414,12 @@ impl IdleDestroyJob {
         &self.profile_name
     }
 
+    #[cfg(test)]
     pub fn budget_vcpu(&self) -> u32 {
         self.budget_lease.vcpu()
     }
 
+    #[cfg(test)]
     pub fn budget_memory_mb(&self) -> u32 {
         self.budget_lease.memory_mb()
     }

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -1,6 +1,6 @@
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use futures_util::FutureExt;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
@@ -114,7 +114,7 @@ impl ParkedIdleCandidate {
         self
     }
 
-    pub(super) fn into_idle_entry(self, parked_at: Instant, idle_timeout: Duration) -> IdleEntry {
+    pub(super) fn into_idle_entry(self, parked_at: Instant) -> IdleEntry {
         let Self {
             resources,
             metadata,
@@ -126,7 +126,6 @@ impl ParkedIdleCandidate {
             metadata,
             budget_lease,
             parked_at,
-            idle_timeout,
         }
     }
 
@@ -165,7 +164,6 @@ pub struct IdleEntry {
     pub(super) metadata: IdleSandboxMetadata,
     pub(super) budget_lease: BudgetLease,
     pub(super) parked_at: Instant,
-    pub(super) idle_timeout: Duration,
 }
 
 #[must_use = "reserved idle sandboxes must be activated, restored, or destroyed"]
@@ -398,6 +396,16 @@ impl IdleDestroyJob {
         }
     }
 
+    pub(crate) fn into_retiring_parts(self) -> (IdleDestroyPayload, BudgetLease) {
+        let Self {
+            payload,
+            budget_lease,
+            reuse_key: _,
+            profile_name: _,
+        } = self;
+        (payload, budget_lease)
+    }
+
     pub fn reuse_key(&self) -> &str {
         &self.reuse_key
     }
@@ -467,10 +475,6 @@ impl IdleEntry {
     #[cfg(test)]
     pub fn budget_memory_mb(&self) -> u32 {
         self.budget_lease.memory_mb()
-    }
-
-    pub(super) fn is_expired_at(&self, now: Instant) -> bool {
-        now.duration_since(self.parked_at) >= self.idle_timeout
     }
 
     /// Bind the next run identity while parked, then unpark and consume this

--- a/crates/runner/src/idle_pool/park_transition.rs
+++ b/crates/runner/src/idle_pool/park_transition.rs
@@ -373,7 +373,6 @@ impl SpeculativeIdleSandbox {
             metadata,
             budget_lease,
             parked_at,
-            idle_timeout,
         } = entry;
         let reuse_key = metadata.reuse_key.clone();
         let profile_name = metadata.profile_name.clone();
@@ -392,7 +391,7 @@ impl SpeculativeIdleSandbox {
         {
             Ok(IdleParkOutcome::Reusable(candidate)) => {
                 SpeculativeReparkResult::Reparked(Box::new(ReservedIdleSandbox {
-                    entry: candidate.into_idle_entry(parked_at, idle_timeout),
+                    entry: candidate.into_idle_entry(parked_at),
                 }))
             }
             Ok(IdleParkOutcome::NonReusable {

--- a/crates/runner/src/idle_pool/park_transition_tests.rs
+++ b/crates/runner/src/idle_pool/park_transition_tests.rs
@@ -25,10 +25,7 @@ fn make_budget_lease(vcpu: u32, memory_mb: u32) -> BudgetLease {
 }
 
 fn pool_config(max_idle: usize) -> IdlePoolConfig {
-    IdlePoolConfig {
-        default_timeout: Duration::from_secs(300),
-        max_idle,
-    }
+    IdlePoolConfig { max_idle }
 }
 
 async fn make_idle_park_request(
@@ -333,9 +330,8 @@ async fn speculative_repark_preserves_original_idle_age_and_metadata() {
     };
 
     let original_parked_at = Instant::now() - Duration::from_secs(120);
-    let original_timeout = Duration::from_secs(300);
     let reservation = ReservedIdleSandbox {
-        entry: candidate.into_idle_entry(original_parked_at, original_timeout),
+        entry: candidate.into_idle_entry(original_parked_at),
     };
     let SpeculativeIdleUnparkResult::Ready(speculative) = reservation
         .try_unpark_for_speculation(RunId::new_v4())
@@ -352,7 +348,6 @@ async fn speculative_repark_preserves_original_idle_age_and_metadata() {
     };
 
     assert_eq!(restored.entry.parked_at, original_parked_at);
-    assert_eq!(restored.entry.idle_timeout, original_timeout);
     assert_eq!(restored.entry.reuse_key(), reuse_key);
     assert_eq!(restored.entry.profile_name(), profile_name);
     assert_eq!(
@@ -409,7 +404,7 @@ async fn speculative_repark_without_history_generation_returns_owned_destroy_job
         Err(_) => panic!("initial park should succeed"),
     };
     let reservation = ReservedIdleSandbox {
-        entry: candidate.into_idle_entry(Instant::now(), Duration::from_secs(300)),
+        entry: candidate.into_idle_entry(Instant::now()),
     };
     let SpeculativeIdleUnparkResult::Ready(speculative) = reservation
         .try_unpark_for_speculation(RunId::new_v4())

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -300,6 +300,23 @@ fn evict_oldest() {
 }
 
 #[test]
+fn evict_oldest_breaks_equal_park_time_by_reuse_key() {
+    let mut pool = IdlePool::new(pool_config(0));
+    let parked_at = Instant::now();
+    for reuse_key in ["session-z", "session-a", "session-m"] {
+        let _ = park_at(
+            &mut pool,
+            reuse_key,
+            make_candidate_for(reuse_key, 2, 2048),
+            parked_at,
+        );
+    }
+
+    let evicted = pool.evict_oldest().unwrap();
+    assert_eq!(evicted.reuse_key(), "session-a");
+}
+
+#[test]
 fn evict_oldest_empty_returns_none() {
     let mut pool = IdlePool::new(pool_config(0));
     assert!(pool.evict_oldest().is_none());

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -173,18 +173,18 @@ async fn reserved_restore_rejects_after_parking_closes() {
 fn reserved_restore_accepts_an_entry_regardless_of_original_age() {
     let mut pool = IdlePool::new(pool_config(0));
     let now = Instant::now();
-    let candidate = make_candidate_for("session-expired-reservation", 2, 2048);
+    let candidate = make_candidate_for("session-aged-reservation", 2, 2048);
     assert!(matches!(
         park_at(
             &mut pool,
-            "session-expired-reservation",
+            "session-aged-reservation",
             candidate,
             now - Duration::from_secs(301),
         ),
         ParkResult::Parked
     ));
     let reservation = pool
-        .reserve_reusable("session-expired-reservation", "vm0/default", &None)
+        .reserve_reusable("session-aged-reservation", "vm0/default", &None)
         .expect("idle age must not prevent reservation");
 
     assert!(matches!(

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -31,17 +31,13 @@ fn park_at(
     reuse_key: &str,
     candidate: ParkedIdleCandidate,
     parked_at: Instant,
-    idle_timeout: Duration,
 ) -> ParkResult {
     assert_eq!(candidate.reuse_key(), reuse_key);
-    pool.park_at_for_test(candidate, parked_at, idle_timeout)
+    pool.park_at_for_test(candidate, parked_at)
 }
 
 fn pool_config(max_idle: usize) -> IdlePoolConfig {
-    IdlePoolConfig {
-        default_timeout: Duration::from_secs(300),
-        max_idle,
-    }
+    IdlePoolConfig { max_idle }
 }
 
 #[test]
@@ -173,8 +169,8 @@ async fn reserved_restore_rejects_after_parking_closes() {
     assert_eq!(pool.len(), 0);
 }
 
-#[tokio::test]
-async fn reserved_restore_rejects_an_entry_with_expired_original_age() {
+#[test]
+fn reserved_restore_accepts_an_entry_regardless_of_original_age() {
     let mut pool = IdlePool::new(pool_config(0));
     let now = Instant::now();
     let candidate = make_candidate_for("session-expired-reservation", 2, 2048);
@@ -184,21 +180,18 @@ async fn reserved_restore_rejects_an_entry_with_expired_original_age() {
             "session-expired-reservation",
             candidate,
             now - Duration::from_secs(301),
-            Duration::from_secs(300),
         ),
         ParkResult::Parked
     ));
-    let reservation = ReservedIdleSandbox {
-        entry: pool
-            .take("session-expired-reservation")
-            .expect("expired entry should still be available for ownership testing"),
-    };
+    let reservation = pool
+        .reserve_reusable("session-expired-reservation", "vm0/default", &None)
+        .expect("idle age must not prevent reservation");
 
-    let RestoreReservedIdleResult::Rejected(rejected) = pool.restore_reserved(reservation) else {
-        panic!("originally expired reservation must not be restored");
-    };
-    rejected.run().await;
-    assert_eq!(pool.len(), 0);
+    assert!(matches!(
+        pool.restore_reserved(reservation),
+        RestoreReservedIdleResult::Restored
+    ));
+    assert_eq!(pool.len(), 1);
 }
 
 #[test]
@@ -288,127 +281,6 @@ async fn rejected_parked_idle_candidate_returns_active_owned_lease() {
 }
 
 #[test]
-fn evict_expired() {
-    let mut pool = IdlePool::new(pool_config(0));
-    let now = Instant::now();
-
-    // Entry expired 10s ago
-    let _ = park_at(
-        &mut pool,
-        "expired",
-        make_candidate_for("expired", 2, 2048),
-        now - Duration::from_secs(310),
-        Duration::from_secs(300),
-    );
-    // Entry still fresh
-    let _ = park_at(
-        &mut pool,
-        "fresh",
-        make_candidate_for("fresh", 2, 2048),
-        now,
-        Duration::from_secs(300),
-    );
-
-    let evicted = pool.evict_expired();
-    assert_eq!(evicted.len(), 1);
-    assert_eq!(pool.len(), 1);
-    assert!(pool.take("fresh").is_some());
-}
-
-#[test]
-fn evict_expired_with_snapshot_none_expired_keeps_revision() {
-    let mut pool = IdlePool::new(pool_config(0));
-    let now = Instant::now();
-    let fresh = make_candidate_for("fresh", 2, 2048);
-    let fresh_sandbox_id = fresh.sandbox_id();
-    let _ = park_at(&mut pool, "fresh", fresh, now, Duration::from_secs(300));
-    let before_revision = pool.status_snapshot().revision;
-
-    let (evicted, snapshot) = pool.evict_expired_with_snapshot();
-
-    assert!(evicted.is_empty());
-    assert_eq!(pool.len(), 1);
-    assert_eq!(snapshot.revision, before_revision);
-    assert_eq!(snapshot.idle_vms.len(), 1);
-    assert_eq!(snapshot.idle_vms[0].reuse_key, "fresh");
-    assert_eq!(snapshot.idle_vms[0].sandbox_id, fresh_sandbox_id);
-}
-
-#[test]
-fn evict_expired_with_snapshot_returns_retained_entries_sorted() {
-    let mut pool = IdlePool::new(pool_config(0));
-    let now = Instant::now();
-
-    let expired = make_candidate_for("expired", 2, 2048);
-    let _ = park_at(
-        &mut pool,
-        "expired",
-        expired,
-        now - Duration::from_secs(310),
-        Duration::from_secs(300),
-    );
-    let retained_b = make_candidate_for("sess-b", 4, 4096);
-    let retained_b_sandbox_id = retained_b.sandbox_id();
-    let _ = park_at(
-        &mut pool,
-        "sess-b",
-        retained_b,
-        now,
-        Duration::from_secs(300),
-    );
-    let retained_a = make_candidate_for("sess-a", 1, 1024);
-    let retained_a_sandbox_id = retained_a.sandbox_id();
-    let _ = park_at(
-        &mut pool,
-        "sess-a",
-        retained_a,
-        now,
-        Duration::from_secs(300),
-    );
-    let before_revision = pool.status_snapshot().revision;
-
-    let (evicted, snapshot) = pool.evict_expired_with_snapshot();
-
-    assert_eq!(evicted.len(), 1);
-    assert_eq!(pool.len(), 2);
-    assert_eq!(snapshot.revision, before_revision + 1);
-    assert_eq!(snapshot.idle_vms.len(), 2);
-    assert_eq!(snapshot.idle_vms[0].reuse_key, "sess-a");
-    assert_eq!(snapshot.idle_vms[0].sandbox_id, retained_a_sandbox_id);
-    assert_eq!(snapshot.idle_vms[1].reuse_key, "sess-b");
-    assert_eq!(snapshot.idle_vms[1].sandbox_id, retained_b_sandbox_id);
-}
-
-#[test]
-fn evict_expired_with_snapshot_all_expired_returns_empty_snapshot() {
-    let mut pool = IdlePool::new(pool_config(0));
-    let now = Instant::now();
-
-    let _ = park_at(
-        &mut pool,
-        "s1",
-        make_candidate_for("s1", 2, 2048),
-        now - Duration::from_secs(400),
-        Duration::from_secs(300),
-    );
-    let _ = park_at(
-        &mut pool,
-        "s2",
-        make_candidate_for("s2", 4, 4096),
-        now - Duration::from_secs(310),
-        Duration::from_secs(300),
-    );
-    let before_revision = pool.status_snapshot().revision;
-
-    let (evicted, snapshot) = pool.evict_expired_with_snapshot();
-
-    assert_eq!(evicted.len(), 2);
-    assert_eq!(pool.len(), 0);
-    assert_eq!(snapshot.revision, before_revision + 1);
-    assert!(snapshot.idle_vms.is_empty());
-}
-
-#[test]
 fn evict_oldest() {
     let mut pool = IdlePool::new(pool_config(0));
     let now = Instant::now();
@@ -418,15 +290,8 @@ fn evict_oldest() {
         "old",
         make_candidate_for("old", 2, 2048),
         now - Duration::from_secs(100),
-        Duration::from_secs(300),
     );
-    let _ = park_at(
-        &mut pool,
-        "new",
-        make_candidate_for("new", 4, 4096),
-        now,
-        Duration::from_secs(300),
-    );
+    let _ = park_at(&mut pool, "new", make_candidate_for("new", 4, 4096), now);
 
     let evicted = pool.evict_oldest().unwrap();
     assert_eq!(evicted.budget_vcpu(), 2); // the old one
@@ -609,84 +474,11 @@ fn soft_drain_can_reopen_parking() {
 }
 
 #[test]
-fn evict_expired_none_expired() {
-    let mut pool = IdlePool::new(pool_config(0));
-    let now = Instant::now();
-    let _ = park_at(
-        &mut pool,
-        "fresh",
-        make_candidate_for("fresh", 2, 2048),
-        now,
-        Duration::from_secs(300),
-    );
-    let evicted = pool.evict_expired();
-    assert!(evicted.is_empty());
-    assert_eq!(pool.len(), 1);
-    assert_eq!(pool.status_snapshot().revision, 1);
-}
-
-#[test]
 fn drain_empty_pool() {
     let mut pool = IdlePool::new(pool_config(0));
     let drained = pool.drain();
     assert!(drained.is_empty());
     assert_eq!(pool.parking_state(), ParkingState::Open);
-}
-
-#[test]
-fn evict_expired_all_entries() {
-    let mut pool = IdlePool::new(pool_config(0));
-    let now = Instant::now();
-
-    let _ = park_at(
-        &mut pool,
-        "s1",
-        make_candidate_for("s1", 2, 2048),
-        now - Duration::from_secs(400),
-        Duration::from_secs(300),
-    );
-    let _ = park_at(
-        &mut pool,
-        "s2",
-        make_candidate_for("s2", 4, 4096),
-        now - Duration::from_secs(310),
-        Duration::from_secs(300),
-    );
-    assert_eq!(pool.len(), 2);
-
-    let evicted = pool.evict_expired();
-    assert_eq!(evicted.len(), 2);
-    assert_eq!(pool.len(), 0);
-    assert_eq!(pool.status_snapshot().revision, 3);
-}
-
-#[test]
-fn evict_expired_respects_per_entry_timeout() {
-    let mut pool = IdlePool::new(pool_config(0));
-    let now = Instant::now();
-
-    // Short timeout (60s), parked 70s ago → expired
-    let _ = park_at(
-        &mut pool,
-        "short",
-        make_candidate_for("short", 2, 2048),
-        now - Duration::from_secs(70),
-        Duration::from_secs(60),
-    );
-    // Long timeout (300s), parked 70s ago → NOT expired
-    let _ = park_at(
-        &mut pool,
-        "long",
-        make_candidate_for("long", 4, 4096),
-        now - Duration::from_secs(70),
-        Duration::from_secs(300),
-    );
-
-    let evicted = pool.evict_expired();
-    assert_eq!(evicted.len(), 1);
-    assert_eq!(evicted[0].budget_vcpu(), 2); // only the short-timeout entry
-    assert_eq!(pool.len(), 1);
-    assert!(pool.take("long").is_some());
 }
 
 #[test]

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -317,6 +317,44 @@ fn evict_oldest_breaks_equal_park_time_by_reuse_key() {
 }
 
 #[test]
+fn pressure_selection_reserves_exact_match_before_oldest_eviction() {
+    let mut pool = IdlePool::new(pool_config(0));
+    let parked_at = Instant::now();
+    let history_generation_run_id = RunId::new_v4();
+    let matching = ParkedIdleCandidateBuilder::new("session-matching", make_budget_lease(2, 2048))
+        .with_history_generation_run_id(history_generation_run_id)
+        .build();
+    let _ = park_at(
+        &mut pool,
+        "session-matching",
+        matching,
+        parked_at - Duration::from_secs(1),
+    );
+    let _ = park_at(
+        &mut pool,
+        "session-unrelated",
+        make_candidate_for("session-unrelated", 2, 2048),
+        parked_at,
+    );
+
+    let selection = pool.reserve_reusable_or_evict_oldest(
+        Some("session-matching"),
+        "vm0/default",
+        &None,
+        Some(history_generation_run_id),
+    );
+
+    let IdlePoolPressureSelection::Reusable(reservation) = selection else {
+        panic!("matching entry must be reserved before pressure eviction");
+    };
+    assert_eq!(pool.held_reuse_keys(), vec!["session-unrelated"]);
+    assert!(matches!(
+        pool.restore_reserved(*reservation),
+        RestoreReservedIdleResult::Restored
+    ));
+}
+
+#[test]
 fn evict_oldest_empty_returns_none() {
     let mut pool = IdlePool::new(pool_config(0));
     assert!(pool.evict_oldest().is_none());

--- a/crates/runner/src/resource_budget.rs
+++ b/crates/runner/src/resource_budget.rs
@@ -145,10 +145,83 @@ impl ResourceBudget {
         }
     }
 
-    /// Wait until resources can be reserved, without losing a release that
-    /// races the capacity check.
-    pub async fn reserve_lease_when_available(
+    /// Atomically substitute existing leases for one incoming reservation.
+    ///
+    /// The supplied leases remain intact when the virtual post-release state
+    /// cannot admit the incoming shape. On success their reservations are
+    /// consumed under the same lock that installs the incoming reservation,
+    /// so concurrent admission cannot observe or steal intermediate capacity.
+    pub fn try_substitute_leases(
         budget: &Arc<Self>,
+        mut leases: Vec<BudgetLease>,
+        vcpu: u32,
+        memory_mb: u32,
+    ) -> Result<BudgetLease, Vec<BudgetLease>> {
+        assert!(
+            leases.iter().all(|lease| {
+                lease
+                    .budget
+                    .as_ref()
+                    .is_some_and(|owner| Arc::ptr_eq(owner, budget))
+            }),
+            "substituted leases must belong to the target resource budget"
+        );
+
+        let mut state = budget.lock();
+        let before = (
+            state.running_vcpu,
+            state.running_memory_mb,
+            state.running_count,
+        );
+        let mut virtual_state = BudgetState {
+            running_vcpu: state.running_vcpu,
+            running_memory_mb: state.running_memory_mb,
+            running_count: state.running_count,
+        };
+        for lease in &leases {
+            assert!(
+                virtual_state.running_vcpu >= lease.vcpu,
+                "substituted vCPU exceeds resource budget allocation"
+            );
+            assert!(
+                virtual_state.running_memory_mb >= lease.memory_mb,
+                "substituted memory exceeds resource budget allocation"
+            );
+            assert!(
+                virtual_state.running_count > 0,
+                "substituted lease count exceeds resource budget allocation"
+            );
+            virtual_state.running_vcpu -= lease.vcpu;
+            virtual_state.running_memory_mb -= lease.memory_mb;
+            virtual_state.running_count -= 1;
+        }
+
+        if !budget.can_admit_locked(&virtual_state, vcpu, memory_mb) {
+            return Err(leases);
+        }
+
+        *state = virtual_state;
+        Self::reserve_locked(&mut state, vcpu, memory_mb);
+        for lease in &mut leases {
+            lease.budget = None;
+        }
+        let released_capacity = state.running_vcpu < before.0
+            || state.running_memory_mb < before.1
+            || state.running_count < before.2;
+        drop(state);
+
+        if released_capacity {
+            budget.availability.notify_waiters();
+        }
+
+        Ok(BudgetLease::new(Arc::clone(budget), vcpu, memory_mb))
+    }
+
+    /// Wait until selected leases can be atomically substituted for one
+    /// incoming reservation without losing a concurrent release notification.
+    pub async fn substitute_leases_when_available(
+        budget: &Arc<Self>,
+        mut leases: Vec<BudgetLease>,
         vcpu: u32,
         memory_mb: u32,
     ) -> BudgetLease {
@@ -156,8 +229,9 @@ impl ResourceBudget {
             let notified = budget.availability.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            if let Some(lease) = Self::try_reserve_lease(budget, vcpu, memory_mb) {
-                return lease;
+            match Self::try_substitute_leases(budget, leases, vcpu, memory_mb) {
+                Ok(lease) => return lease,
+                Err(retained) => leases = retained,
             }
             notified.await;
         }
@@ -408,28 +482,6 @@ mod tests {
         assert_eq!(budget.allocated(), (2, 2048, 1));
 
         drop(lease);
-        assert_eq!(budget.allocated(), (0, 0, 0));
-    }
-
-    #[tokio::test]
-    async fn waiting_reservation_wakes_when_a_lease_is_released() {
-        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 1));
-        let occupied = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-        let waiting_budget = Arc::clone(&budget);
-        let waiter = tokio::spawn(async move {
-            ResourceBudget::reserve_lease_when_available(&waiting_budget, 2, 4096).await
-        });
-
-        tokio::task::yield_now().await;
-        assert!(!waiter.is_finished());
-        drop(occupied);
-
-        let replacement = tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
-            .await
-            .expect("released capacity should wake the waiter")
-            .expect("capacity waiter should not panic");
-        assert_eq!(budget.allocated(), (2, 4096, 1));
-        drop(replacement);
         assert_eq!(budget.allocated(), (0, 0, 0));
     }
 

--- a/crates/runner/src/resource_budget.rs
+++ b/crates/runner/src/resource_budget.rs
@@ -219,9 +219,11 @@ impl ResourceBudget {
 
     /// Wait until selected leases can be atomically substituted for one
     /// incoming reservation without losing a concurrent release notification.
+    /// The leases remain in the caller-owned vector whenever this future is
+    /// waiting, so cancelling the wait preserves normal lease-drop accounting.
     pub async fn substitute_leases_when_available(
         budget: &Arc<Self>,
-        mut leases: Vec<BudgetLease>,
+        leases: &mut Vec<BudgetLease>,
         vcpu: u32,
         memory_mb: u32,
     ) -> BudgetLease {
@@ -229,9 +231,9 @@ impl ResourceBudget {
             let notified = budget.availability.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            match Self::try_substitute_leases(budget, leases, vcpu, memory_mb) {
+            match Self::try_substitute_leases(budget, std::mem::take(leases), vcpu, memory_mb) {
                 Ok(lease) => return lease,
-                Err(retained) => leases = retained,
+                Err(retained) => *leases = retained,
             }
             notified.await;
         }


### PR DESCRIPTION
## Summary

- manage idle VM lifetime through capacity pressure
- atomically prefer a matching reusable idle VM before selecting the oldest idle VM for pressure eviction, including exact-generation finalizing fallback
- atomically replace retired idle budget leases with the incoming fresh reservation, allowing physical teardown and fresh VM activation to overlap
- wake blocked finalizing admission on every idle-pool ownership change, including active VM parking and claim rollback
- preserve exact-generation reuse when a matching predecessor VM parks while finalizing fallback is waiting for capacity
- register asynchronous teardown ownership before any post-removal await so cancellation, failures, and shutdown preserve physical cleanup

## Scope and compatibility

- capacity pressure evicts only as many oldest idle VMs as the incoming profile requires, with deterministic ordering for equal park times
- `max_idle`, drain, and shutdown cleanup behavior remains in effect
- no API, queue, runner protocol, or persisted-state schema changes
- transient physical resource overlap during teardown and fresh activation is intentional; logical CPU, memory, and concurrency accounting remains bounded

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner idle_pool::pool_tests -- --nocapture` (27 passed)
- `cargo test -p runner cmd::start::tests::main_loop::admission -- --nocapture` (42 passed)
- `cargo test -p runner cmd::start::tests::budget -- --nocapture` (9 passed)
- `cargo test -p runner --quiet` (3,161 passed, 20 ignored; guest inventory 1 passed)

Closes #27761
