### PR TITLE
fix(api): bound oversized axiom agent event data

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1357,21 +1357,45 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     expect(redirectTargetRequests).toBe(0);
   });
 
-  it("bounds oversized event data only in the optional Axiom trace", async () => {
+  it("preserves display fields while bounding oversized Axiom traces", async () => {
     const { actor, runId, headers } = await createEventWebhookRun(
       "oversized optional Axiom trace",
     );
-    const oversizedContent = "界".repeat(300_000);
-    const event = {
-      type: "result",
+    const oversizedAssistantContent = "助".repeat(300_000);
+    const assistantEvent = {
+      type: "assistant",
       sequenceNumber: 0,
-      result: oversizedContent,
+      message: {
+        content: [
+          { type: "text", text: oversizedAssistantContent },
+          {
+            type: "tool_use",
+            id: "tool_1",
+            name: "Bash",
+            input: { command: "pwd" },
+          },
+        ],
+      },
+    };
+    const oversizedResultContent = "界".repeat(300_000);
+    const resultEvent = {
+      type: "result",
+      sequenceNumber: 1,
+      result: oversizedResultContent,
       duration_ms: 123,
       num_turns: 4,
       modelUsage: { inputTokens: 100, outputTokens: 200 },
     };
-    const originalBytes = Buffer.byteLength(JSON.stringify(event), "utf8");
-    expect(originalBytes).toBeGreaterThan(900_000);
+    const assistantOriginalBytes = Buffer.byteLength(
+      JSON.stringify(assistantEvent),
+      "utf8",
+    );
+    const resultOriginalBytes = Buffer.byteLength(
+      JSON.stringify(resultEvent),
+      "utf8",
+    );
+    expect(assistantOriginalBytes).toBeGreaterThan(900_000);
+    expect(resultOriginalBytes).toBeGreaterThan(900_000);
 
     const requests: unknown[] = [];
     server.use(
@@ -1379,20 +1403,20 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
         "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
         async ({ request }) => {
           requests.push(await request.json());
-          return HttpResponse.json(successfulAxiomIngestStatus(1));
+          return HttpResponse.json(successfulAxiomIngestStatus(2));
         },
       ),
     );
 
     const response = await api.requestAgentEvents(
-      { runId, events: [event] },
+      { runId, events: [assistantEvent, resultEvent] },
       headers,
       [200],
     );
     expect(response.body).toStrictEqual({
-      received: 1,
+      received: 2,
       firstSequence: 0,
-      lastSequence: 0,
+      lastSequence: 1,
     });
     await flushWaitUntilForTest();
 
@@ -1401,67 +1425,147 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     if (!Array.isArray(requestBatch)) {
       throw new Error("Expected an Axiom request batch");
     }
-    const requestEvent: unknown = requestBatch[0];
-    expect(requestEvent).toStrictEqual(
+    expect(requestBatch).toHaveLength(2);
+
+    const assistantRequestEvent: unknown = requestBatch[0];
+    expect(assistantRequestEvent).toStrictEqual(
       expect.objectContaining({
         runId,
         userId: actor.userId,
-        sequenceNumber: event.sequenceNumber,
-        eventType: event.type,
+        sequenceNumber: assistantEvent.sequenceNumber,
+        eventType: assistantEvent.type,
       }),
     );
-    if (!isUnknownRecord(requestEvent)) {
-      throw new Error("Expected an Axiom request event");
+    if (!isUnknownRecord(assistantRequestEvent)) {
+      throw new Error("Expected an assistant Axiom request event");
     }
-    const eventData = requestEvent.eventData;
-    expect(eventData).toStrictEqual(
+    const assistantEventData = assistantRequestEvent.eventData;
+    expect(assistantEventData).toStrictEqual(
       expect.objectContaining({
-        type: event.type,
-        sequenceNumber: event.sequenceNumber,
-        duration_ms: event.duration_ms,
-        num_turns: event.num_turns,
-        modelUsage: event.modelUsage,
+        type: assistantEvent.type,
+        sequenceNumber: assistantEvent.sequenceNumber,
         axiomReduction: {
           reason: "field_size_limit",
-          originalBytes,
+          originalBytes: assistantOriginalBytes,
           budgetBytes: 900_000,
         },
       }),
     );
-    if (!isUnknownRecord(eventData)) {
-      throw new Error("Expected Axiom event data");
+    if (!isUnknownRecord(assistantEventData)) {
+      throw new Error("Expected assistant Axiom event data");
     }
-    const reducedResult = eventData.result;
+    const assistantMessage = assistantEventData.message;
+    if (!isUnknownRecord(assistantMessage)) {
+      throw new Error("Expected a retained assistant message");
+    }
+    const assistantMessageContent = assistantMessage.content;
+    if (!Array.isArray(assistantMessageContent)) {
+      throw new Error("Expected retained assistant message content");
+    }
+    expect(assistantMessageContent).toHaveLength(2);
+    const reducedTextBlock: unknown = assistantMessageContent[0];
+    if (!isUnknownRecord(reducedTextBlock)) {
+      throw new Error("Expected a retained assistant text block");
+    }
+    expect(reducedTextBlock.type).toBe("text");
+    const reducedAssistantText = reducedTextBlock.text;
+    if (typeof reducedAssistantText !== "string") {
+      throw new Error("Expected retained assistant text");
+    }
+    expect(reducedAssistantText).not.toBe(oversizedAssistantContent);
+    expect(reducedAssistantText.startsWith("助")).toBeTruthy();
+    expect(reducedAssistantText.endsWith("[truncated]")).toBeTruthy();
+    expect(assistantMessageContent[1]).toStrictEqual(
+      assistantEvent.message.content[1],
+    );
+    const assistantDeliveredBytes = Buffer.byteLength(
+      JSON.stringify(assistantEventData),
+      "utf8",
+    );
+    expect(assistantDeliveredBytes).toBeLessThanOrEqual(900_000);
+
+    const resultRequestEvent: unknown = requestBatch[1];
+    expect(resultRequestEvent).toStrictEqual(
+      expect.objectContaining({
+        runId,
+        userId: actor.userId,
+        sequenceNumber: resultEvent.sequenceNumber,
+        eventType: resultEvent.type,
+      }),
+    );
+    if (!isUnknownRecord(resultRequestEvent)) {
+      throw new Error("Expected a result Axiom request event");
+    }
+    const resultEventData = resultRequestEvent.eventData;
+    expect(resultEventData).toStrictEqual(
+      expect.objectContaining({
+        type: resultEvent.type,
+        sequenceNumber: resultEvent.sequenceNumber,
+        duration_ms: resultEvent.duration_ms,
+        num_turns: resultEvent.num_turns,
+        modelUsage: resultEvent.modelUsage,
+        axiomReduction: {
+          reason: "field_size_limit",
+          originalBytes: resultOriginalBytes,
+          budgetBytes: 900_000,
+        },
+      }),
+    );
+    if (!isUnknownRecord(resultEventData)) {
+      throw new Error("Expected result Axiom event data");
+    }
+    const reducedResult = resultEventData.result;
     if (typeof reducedResult !== "string") {
       throw new Error("Expected a retained result prefix");
     }
-    expect(reducedResult).not.toBe(oversizedContent);
+    expect(reducedResult).not.toBe(oversizedResultContent);
     expect(reducedResult.startsWith("界")).toBeTruthy();
     expect(reducedResult.endsWith("[truncated]")).toBeTruthy();
-
-    const deliveredBytes = Buffer.byteLength(JSON.stringify(eventData), "utf8");
-    expect(deliveredBytes).toBeLessThanOrEqual(900_000);
+    const resultDeliveredBytes = Buffer.byteLength(
+      JSON.stringify(resultEventData),
+      "utf8",
+    );
+    expect(resultDeliveredBytes).toBeLessThanOrEqual(900_000);
 
     const reductionLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
       ([message]) => {
         return message === "Reduced oversized agent event for Axiom";
       },
     );
-    expect(reductionLogs).toHaveLength(1);
-    const fields = reductionLogs[0]?.[1];
-    expect(fields).toStrictEqual(
+    expect(reductionLogs).toHaveLength(2);
+    const assistantFields = reductionLogs[0]?.[1];
+    expect(assistantFields).toStrictEqual(
       expect.objectContaining({
         context: "agent-event-consumer:axiom",
         runId,
-        sequenceNumber: event.sequenceNumber,
-        eventType: event.type,
-        originalBytes,
-        deliveredBytes,
+        sequenceNumber: assistantEvent.sequenceNumber,
+        eventType: assistantEvent.type,
+        originalBytes: assistantOriginalBytes,
+        deliveredBytes: assistantDeliveredBytes,
         budgetBytes: 900_000,
       }),
     );
-    expect(fields).not.toHaveProperty("eventData");
-    expect(JSON.stringify(fields)).not.toContain(oversizedContent.slice(0, 64));
+    const resultFields = reductionLogs[1]?.[1];
+    expect(resultFields).toStrictEqual(
+      expect.objectContaining({
+        context: "agent-event-consumer:axiom",
+        runId,
+        sequenceNumber: resultEvent.sequenceNumber,
+        eventType: resultEvent.type,
+        originalBytes: resultOriginalBytes,
+        deliveredBytes: resultDeliveredBytes,
+        budgetBytes: 900_000,
+      }),
+    );
+    for (const fields of [assistantFields, resultFields]) {
+      expect(fields).not.toHaveProperty("eventData");
+      expect(JSON.stringify(fields)).not.toContain(
+        oversizedAssistantContent.slice(0, 64),
+      );
+      expect(JSON.stringify(fields)).not.toContain(
+        oversizedResultContent.slice(0, 64),
+      );
+    }
   });
 
   it("acknowledges an event batch when its required DB run is missing", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1353,6 +1353,90 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     expect(redirectTargetRequests).toBe(0);
   });
 
+  it("bounds oversized event data only in the optional Axiom trace", async () => {
+    const { actor, runId, headers } = await createEventWebhookRun(
+      "oversized optional Axiom trace",
+    );
+    const oversizedContent = "界".repeat(300_000);
+    const event = {
+      type: "result",
+      sequenceNumber: 0,
+      result: oversizedContent,
+    };
+    const originalBytes = Buffer.byteLength(JSON.stringify(event), "utf8");
+    expect(originalBytes).toBeGreaterThan(900_000);
+
+    const requests: unknown[] = [];
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
+        async ({ request }) => {
+          requests.push(await request.json());
+          return HttpResponse.json(successfulAxiomIngestStatus(1));
+        },
+      ),
+    );
+
+    const response = await api.requestAgentEvents(
+      { runId, events: [event] },
+      headers,
+      [200],
+    );
+    expect(response.body).toStrictEqual({
+      received: 1,
+      firstSequence: 0,
+      lastSequence: 0,
+    });
+    await flushWaitUntilForTest();
+
+    const reducedEventData = {
+      type: event.type,
+      sequenceNumber: event.sequenceNumber,
+      vm0AxiomReduction: {
+        reason: "field_size_limit",
+        originalBytes,
+        budgetBytes: 900_000,
+      },
+    };
+    const deliveredBytes = Buffer.byteLength(
+      JSON.stringify(reducedEventData),
+      "utf8",
+    );
+    expect(deliveredBytes).toBeLessThanOrEqual(900_000);
+    expect(requests).toStrictEqual([
+      [
+        {
+          runId,
+          userId: actor.userId,
+          sequenceNumber: event.sequenceNumber,
+          eventType: event.type,
+          eventData: reducedEventData,
+        },
+      ],
+    ]);
+
+    const reductionLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
+      ([message]) => {
+        return message === "Reduced oversized agent event for Axiom";
+      },
+    );
+    expect(reductionLogs).toHaveLength(1);
+    const fields = reductionLogs[0]?.[1];
+    expect(fields).toStrictEqual(
+      expect.objectContaining({
+        context: "agent-event-consumer:axiom",
+        runId,
+        sequenceNumber: event.sequenceNumber,
+        eventType: event.type,
+        originalBytes,
+        deliveredBytes,
+        budgetBytes: 900_000,
+      }),
+    );
+    expect(fields).not.toHaveProperty("eventData");
+    expect(JSON.stringify(fields)).not.toContain(oversizedContent.slice(0, 64));
+  });
+
   it("acknowledges an event batch when its required DB run is missing", async () => {
     const runId = randomUUID();
     const headers = api.sandboxWebhookHeaders({ runId });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -60,6 +60,10 @@ const store = createStore();
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const DEFAULT_AGENT_AVATAR_URL = "svg:r1s0h1c5f4h";
 
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function successfulAxiomIngestStatus(ingested: number) {
   return {
     ingested,
@@ -1362,6 +1366,9 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
       type: "result",
       sequenceNumber: 0,
       result: oversizedContent,
+      duration_ms: 123,
+      num_turns: 4,
+      modelUsage: { inputTokens: 100, outputTokens: 200 },
     };
     const originalBytes = Buffer.byteLength(JSON.stringify(event), "utf8");
     expect(originalBytes).toBeGreaterThan(900_000);
@@ -1389,31 +1396,51 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     });
     await flushWaitUntilForTest();
 
-    const reducedEventData = {
-      type: event.type,
-      sequenceNumber: event.sequenceNumber,
-      vm0AxiomReduction: {
-        reason: "field_size_limit",
-        originalBytes,
-        budgetBytes: 900_000,
-      },
-    };
-    const deliveredBytes = Buffer.byteLength(
-      JSON.stringify(reducedEventData),
-      "utf8",
+    expect(requests).toHaveLength(1);
+    const requestBatch = requests[0];
+    if (!Array.isArray(requestBatch)) {
+      throw new Error("Expected an Axiom request batch");
+    }
+    const requestEvent: unknown = requestBatch[0];
+    expect(requestEvent).toStrictEqual(
+      expect.objectContaining({
+        runId,
+        userId: actor.userId,
+        sequenceNumber: event.sequenceNumber,
+        eventType: event.type,
+      }),
     );
-    expect(deliveredBytes).toBeLessThanOrEqual(900_000);
-    expect(requests).toStrictEqual([
-      [
-        {
-          runId,
-          userId: actor.userId,
-          sequenceNumber: event.sequenceNumber,
-          eventType: event.type,
-          eventData: reducedEventData,
+    if (!isUnknownRecord(requestEvent)) {
+      throw new Error("Expected an Axiom request event");
+    }
+    const eventData = requestEvent.eventData;
+    expect(eventData).toStrictEqual(
+      expect.objectContaining({
+        type: event.type,
+        sequenceNumber: event.sequenceNumber,
+        duration_ms: event.duration_ms,
+        num_turns: event.num_turns,
+        modelUsage: event.modelUsage,
+        axiomReduction: {
+          reason: "field_size_limit",
+          originalBytes,
+          budgetBytes: 900_000,
         },
-      ],
-    ]);
+      }),
+    );
+    if (!isUnknownRecord(eventData)) {
+      throw new Error("Expected Axiom event data");
+    }
+    const reducedResult = eventData.result;
+    if (typeof reducedResult !== "string") {
+      throw new Error("Expected a retained result prefix");
+    }
+    expect(reducedResult).not.toBe(oversizedContent);
+    expect(reducedResult.startsWith("界")).toBeTruthy();
+    expect(reducedResult.endsWith("[truncated]")).toBeTruthy();
+
+    const deliveredBytes = Buffer.byteLength(JSON.stringify(eventData), "utf8");
+    expect(deliveredBytes).toBeLessThanOrEqual(900_000);
 
     const reductionLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
       ([message]) => {

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -8,11 +8,12 @@ import { getDatasetName, ingestAxiomDirect } from "../external/axiom";
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const AXIOM_EVENT_INGEST_TIMEOUT_MS = 10_000;
 const AXIOM_EVENT_DATA_MAX_BYTES = 900_000;
+const AXIOM_TRUNCATED_STRING_SUFFIX = "\n\n[truncated]";
 
 const L = logger("agent-event-consumer:axiom");
 
 function serializedUtf8Bytes(
-  value: Record<string, unknown>,
+  value: unknown,
   encoder: InstanceType<typeof TextEncoder>,
 ): number {
   const serialized = JSON.stringify(value);
@@ -22,25 +23,205 @@ function serializedUtf8Bytes(
   return encoder.encode(serialized).byteLength;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type MutableStringSlot =
+  | {
+      readonly kind: "array";
+      readonly container: unknown[];
+      readonly key: number;
+      readonly original: string;
+      readonly serializedBytes: number;
+    }
+  | {
+      readonly kind: "object";
+      readonly container: Record<string, unknown>;
+      readonly key: string;
+      readonly original: string;
+      readonly serializedBytes: number;
+    };
+
+function collectMutableStringSlots(
+  value: unknown,
+  encoder: InstanceType<typeof TextEncoder>,
+): MutableStringSlot[] {
+  const slots: MutableStringSlot[] = [];
+  const pending: unknown[] = [value];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (Array.isArray(current)) {
+      for (const [key, item] of current.entries()) {
+        if (typeof item === "string") {
+          slots.push({
+            kind: "array",
+            container: current,
+            key,
+            original: item,
+            serializedBytes: serializedUtf8Bytes(item, encoder),
+          });
+        } else if (typeof item === "object" && item !== null) {
+          pending.push(item);
+        }
+      }
+      continue;
+    }
+
+    if (!isRecord(current)) {
+      continue;
+    }
+    for (const [key, item] of Object.entries(current)) {
+      if (current === value && key === "axiomReduction") {
+        continue;
+      }
+      if (typeof item === "string") {
+        slots.push({
+          kind: "object",
+          container: current,
+          key,
+          original: item,
+          serializedBytes: serializedUtf8Bytes(item, encoder),
+        });
+      } else if (typeof item === "object" && item !== null) {
+        pending.push(item);
+      }
+    }
+  }
+
+  return slots.sort((left, right) => {
+    return right.serializedBytes - left.serializedBytes;
+  });
+}
+
+function setStringSlot(slot: MutableStringSlot, value: string): void {
+  if (slot.kind === "array") {
+    slot.container[slot.key] = value;
+  } else {
+    slot.container[slot.key] = value;
+  }
+}
+
+function truncatedStringPrefix(value: string, end: number): string {
+  let safeEnd = end;
+  const boundaryCodePoint = value.codePointAt(end - 1);
+  if (boundaryCodePoint !== undefined && boundaryCodePoint > 65_535) {
+    safeEnd -= 1;
+  }
+  return `${value.slice(0, safeEnd)}${AXIOM_TRUNCATED_STRING_SUFFIX}`;
+}
+
+interface StringTruncationResult {
+  readonly bytes: number;
+  readonly fits: boolean;
+}
+
+function truncateStringSlotToFit(
+  slot: MutableStringSlot,
+  currentBytes: number,
+  encoder: InstanceType<typeof TextEncoder>,
+): StringTruncationResult {
+  const minimumValue = AXIOM_TRUNCATED_STRING_SUFFIX.trimStart();
+  const minimumSerializedBytes = serializedUtf8Bytes(minimumValue, encoder);
+  const surroundingBytes = currentBytes - slot.serializedBytes;
+  setStringSlot(slot, minimumValue);
+  if (surroundingBytes + minimumSerializedBytes > AXIOM_EVENT_DATA_MAX_BYTES) {
+    return {
+      bytes: surroundingBytes + minimumSerializedBytes,
+      fits: false,
+    };
+  }
+
+  let lower = 0;
+  let upper = slot.original.length;
+  let best = 0;
+  let bestSerializedBytes = minimumSerializedBytes;
+  while (lower <= upper) {
+    const middle = Math.floor((lower + upper) / 2);
+    const candidate = truncatedStringPrefix(slot.original, middle);
+    const candidateBytes = serializedUtf8Bytes(candidate, encoder);
+    if (surroundingBytes + candidateBytes <= AXIOM_EVENT_DATA_MAX_BYTES) {
+      best = middle;
+      bestSerializedBytes = candidateBytes;
+      lower = middle + 1;
+    } else {
+      upper = middle - 1;
+    }
+  }
+  setStringSlot(slot, truncatedStringPrefix(slot.original, best));
+  return {
+    bytes: surroundingBytes + bestSerializedBytes,
+    fits: true,
+  };
+}
+
+function reducedEventData(
+  event: AgentEvent,
+  serialized: string,
+  originalBytes: number,
+  encoder: InstanceType<typeof TextEncoder>,
+): AgentEvent {
+  const parsed: unknown = JSON.parse(serialized);
+  if (!isRecord(parsed)) {
+    throw new Error("Axiom event data must be a JSON object");
+  }
+  const axiomReduction = {
+    reason: "field_size_limit",
+    originalBytes,
+    budgetBytes: AXIOM_EVENT_DATA_MAX_BYTES,
+  };
+  const reducedEvent: AgentEvent = {
+    ...parsed,
+    type: event.type,
+    sequenceNumber: event.sequenceNumber,
+    axiomReduction,
+  };
+  const stringSlots = collectMutableStringSlots(reducedEvent, encoder);
+
+  const suffixBytes = serializedUtf8Bytes(
+    AXIOM_TRUNCATED_STRING_SUFFIX,
+    encoder,
+  );
+  let currentBytes = serializedUtf8Bytes(reducedEvent, encoder);
+  for (const slot of stringSlots) {
+    if (slot.serializedBytes <= suffixBytes) {
+      continue;
+    }
+    const truncation = truncateStringSlotToFit(slot, currentBytes, encoder);
+    currentBytes = truncation.bytes;
+    if (truncation.fits) {
+      return reducedEvent;
+    }
+  }
+
+  return {
+    type: event.type,
+    sequenceNumber: event.sequenceNumber,
+    axiomReduction,
+  };
+}
+
 function eventDataForAxiom(
   runId: string,
   event: AgentEvent,
   encoder: InstanceType<typeof TextEncoder>,
 ): AgentEvent {
-  const originalBytes = serializedUtf8Bytes(event, encoder);
+  const serialized = JSON.stringify(event);
+  if (serialized === undefined) {
+    throw new Error("Axiom event data must be JSON serializable");
+  }
+  const originalBytes = encoder.encode(serialized).byteLength;
   if (originalBytes <= AXIOM_EVENT_DATA_MAX_BYTES) {
     return event;
   }
 
-  const reducedEvent = {
-    type: event.type,
-    sequenceNumber: event.sequenceNumber,
-    vm0AxiomReduction: {
-      reason: "field_size_limit",
-      originalBytes,
-      budgetBytes: AXIOM_EVENT_DATA_MAX_BYTES,
-    },
-  };
+  const reducedEvent = reducedEventData(
+    event,
+    serialized,
+    originalBytes,
+    encoder,
+  );
   const deliveredBytes = serializedUtf8Bytes(reducedEvent, encoder);
   L.warn("Reduced oversized agent event for Axiom", {
     runId,

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -11,16 +11,23 @@ const AXIOM_EVENT_DATA_MAX_BYTES = 900_000;
 
 const L = logger("agent-event-consumer:axiom");
 
-function serializedUtf8Bytes(value: Record<string, unknown>): number {
+function serializedUtf8Bytes(
+  value: Record<string, unknown>,
+  encoder: InstanceType<typeof TextEncoder>,
+): number {
   const serialized = JSON.stringify(value);
   if (serialized === undefined) {
     throw new Error("Axiom event data must be JSON serializable");
   }
-  return new TextEncoder().encode(serialized).byteLength;
+  return encoder.encode(serialized).byteLength;
 }
 
-function eventDataForAxiom(runId: string, event: AgentEvent): AgentEvent {
-  const originalBytes = serializedUtf8Bytes(event);
+function eventDataForAxiom(
+  runId: string,
+  event: AgentEvent,
+  encoder: InstanceType<typeof TextEncoder>,
+): AgentEvent {
+  const originalBytes = serializedUtf8Bytes(event, encoder);
   if (originalBytes <= AXIOM_EVENT_DATA_MAX_BYTES) {
     return event;
   }
@@ -34,7 +41,7 @@ function eventDataForAxiom(runId: string, event: AgentEvent): AgentEvent {
       budgetBytes: AXIOM_EVENT_DATA_MAX_BYTES,
     },
   };
-  const deliveredBytes = serializedUtf8Bytes(reducedEvent);
+  const deliveredBytes = serializedUtf8Bytes(reducedEvent, encoder);
   L.warn("Reduced oversized agent event for Axiom", {
     runId,
     sequenceNumber: event.sequenceNumber,
@@ -51,13 +58,14 @@ export async function ingestAxiomEvents(
   signal: AbortSignal,
 ): Promise<void> {
   signal.throwIfAborted();
+  const encoder = new TextEncoder();
   const axiomEvents = payload.events.map((event) => {
     return {
       runId: payload.runId,
       userId: payload.context.userId,
       sequenceNumber: event.sequenceNumber,
       eventType: event.type,
-      eventData: eventDataForAxiom(payload.runId, event),
+      eventData: eventDataForAxiom(payload.runId, event, encoder),
     };
   });
   const ingestSignal = AbortSignal.any([

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -1,8 +1,50 @@
-import type { EventConsumerPayload } from "../../lib/event-consumer/verify";
+import type {
+  AgentEvent,
+  EventConsumerPayload,
+} from "../../lib/event-consumer/verify";
+import { logger } from "../../lib/log";
 import { getDatasetName, ingestAxiomDirect } from "../external/axiom";
 
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const AXIOM_EVENT_INGEST_TIMEOUT_MS = 10_000;
+const AXIOM_EVENT_DATA_MAX_BYTES = 900_000;
+
+const L = logger("agent-event-consumer:axiom");
+
+function serializedUtf8Bytes(value: Record<string, unknown>): number {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new Error("Axiom event data must be JSON serializable");
+  }
+  return new TextEncoder().encode(serialized).byteLength;
+}
+
+function eventDataForAxiom(runId: string, event: AgentEvent): AgentEvent {
+  const originalBytes = serializedUtf8Bytes(event);
+  if (originalBytes <= AXIOM_EVENT_DATA_MAX_BYTES) {
+    return event;
+  }
+
+  const reducedEvent = {
+    type: event.type,
+    sequenceNumber: event.sequenceNumber,
+    vm0AxiomReduction: {
+      reason: "field_size_limit",
+      originalBytes,
+      budgetBytes: AXIOM_EVENT_DATA_MAX_BYTES,
+    },
+  };
+  const deliveredBytes = serializedUtf8Bytes(reducedEvent);
+  L.warn("Reduced oversized agent event for Axiom", {
+    runId,
+    sequenceNumber: event.sequenceNumber,
+    eventType: event.type,
+    originalBytes,
+    deliveredBytes,
+    budgetBytes: AXIOM_EVENT_DATA_MAX_BYTES,
+  });
+  return reducedEvent;
+}
 
 export async function ingestAxiomEvents(
   payload: EventConsumerPayload,
@@ -15,7 +57,7 @@ export async function ingestAxiomEvents(
       userId: payload.context.userId,
       sequenceNumber: event.sequenceNumber,
       eventType: event.type,
-      eventData: event,
+      eventData: eventDataForAxiom(payload.runId, event),
     };
   });
   const ingestSignal = AbortSignal.any([

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -8,7 +8,8 @@ import { getDatasetName, ingestAxiomDirect } from "../external/axiom";
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const AXIOM_EVENT_INGEST_TIMEOUT_MS = 10_000;
 const AXIOM_EVENT_DATA_MAX_BYTES = 900_000;
-const AXIOM_TRUNCATED_STRING_SUFFIX = "\n\n[truncated]";
+const AXIOM_TRUNCATED_STRING_VALUE = "[truncated]";
+const AXIOM_TRUNCATED_STRING_SUFFIX = `\n\n${AXIOM_TRUNCATED_STRING_VALUE}`;
 
 const L = logger("agent-event-consumer:axiom");
 
@@ -109,6 +110,9 @@ function truncatedStringPrefix(value: string, end: number): string {
   if (boundaryCodePoint !== undefined && boundaryCodePoint > 65_535) {
     safeEnd -= 1;
   }
+  if (safeEnd === 0) {
+    return AXIOM_TRUNCATED_STRING_VALUE;
+  }
   return `${value.slice(0, safeEnd)}${AXIOM_TRUNCATED_STRING_SUFFIX}`;
 }
 
@@ -122,10 +126,12 @@ function truncateStringSlotToFit(
   currentBytes: number,
   encoder: InstanceType<typeof TextEncoder>,
 ): StringTruncationResult {
-  const minimumValue = AXIOM_TRUNCATED_STRING_SUFFIX.trimStart();
-  const minimumSerializedBytes = serializedUtf8Bytes(minimumValue, encoder);
+  const minimumSerializedBytes = serializedUtf8Bytes(
+    AXIOM_TRUNCATED_STRING_VALUE,
+    encoder,
+  );
   const surroundingBytes = currentBytes - slot.serializedBytes;
-  setStringSlot(slot, minimumValue);
+  setStringSlot(slot, AXIOM_TRUNCATED_STRING_VALUE);
   if (surroundingBytes + minimumSerializedBytes > AXIOM_EVENT_DATA_MAX_BYTES) {
     return {
       bytes: surroundingBytes + minimumSerializedBytes,
@@ -179,13 +185,13 @@ function reducedEventData(
   };
   const stringSlots = collectMutableStringSlots(reducedEvent, encoder);
 
-  const suffixBytes = serializedUtf8Bytes(
-    AXIOM_TRUNCATED_STRING_SUFFIX,
+  const minimumReplacementBytes = serializedUtf8Bytes(
+    AXIOM_TRUNCATED_STRING_VALUE,
     encoder,
   );
   let currentBytes = serializedUtf8Bytes(reducedEvent, encoder);
   for (const slot of stringSlots) {
-    if (slot.serializedBytes <= suffixBytes) {
+    if (slot.serializedBytes <= minimumReplacementBytes) {
       continue;
     }
     const truncation = truncateStringSlotToFit(slot, currentBytes, encoder);


### PR DESCRIPTION
## Summary

- measure each agent event's serialized UTF-8 size before constructing the optional Axiom trace
- keep the original event shape and metadata while reducing the largest string values until oversized `eventData` fits the conservative 900,000-byte budget
- retain the displayable string prefix with a visible `[truncated]` suffix and record `axiomReduction` metadata without copying event content into logs
- fall back to a minimal reduction marker only when non-string JSON structure cannot fit after reducible strings are exhausted
- cover the oversized multibyte path through the real webhook/Axiom integration boundary while retaining the existing exact normal-event assertion

## Behavior and compatibility

- The Activity reader can still render retained result text, duration, turn count, model usage, assistant content, and tool data from the preserved event structure.
- The complete inbound event still reaches the required PostgreSQL projection before optional consumers run.
- Normal Axiom event values remain unchanged.
- The webhook contract, acknowledgement, sequence allocation, runner protocol, public API schema, and Axiom dataset field type are unchanged.
- Oversized activity rows contain explicit reduction metadata and a displayable content prefix instead of being absent after an Axiom HTTP 400.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --silent=passed-only` (48 passed)
- `pnpm knip`
- pre-commit full Turbo type checking (14 tasks passed)

Closes #27773
