### PR TITLE
fix(api): preserve public brand in run context

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -92,12 +92,14 @@ describe("auth tokens", () => {
       orgId: "org_zero",
       runId: "run_zero",
       capabilities: ["file:read"],
+      publicBrand: "vm0",
     });
     expect(verifyZeroToken(okouToken)).toStrictEqual({
       userId: "user_okou",
       orgId: "org_okou",
       runId: "run_okou",
       capabilities: ["file:write"],
+      publicBrand: "vm0",
     });
   });
 
@@ -115,9 +117,11 @@ describe("auth tokens", () => {
     expect(okouToken).toMatch(/^vm0_sandbox_/u);
     expect(decodeZeroTokenPayloadForTest(zeroToken)).toMatchObject({
       scope: "zero",
+      publicBrand: "vm0",
     });
     expect(decodeZeroTokenPayloadForTest(okouToken)).toMatchObject({
       scope: "okou",
+      publicBrand: "vm0",
     });
     expect(verifyZeroToken(okouToken)).toMatchObject({
       userId: "user_okou",
@@ -135,6 +139,7 @@ describe("auth tokens", () => {
       { [FeatureSwitchKey.Banking]: true },
       {
         scope: "okou",
+        publicBrand: "okou",
         computerUseHostId,
         cloudBrowserEnabled: true,
         imageRecognitionAvailable: true,
@@ -144,6 +149,7 @@ describe("auth tokens", () => {
     const okouPayload = decodeZeroTokenPayloadForTest(okouToken);
     expect(okouPayload).toMatchObject({
       scope: "okou",
+      publicBrand: "okou",
       userId: "user_shared",
       runId: "run_shared",
       orgId: "org_shared",
@@ -164,6 +170,7 @@ describe("auth tokens", () => {
       userId: "user_shared",
       runId: "run_shared",
       orgId: "org_shared",
+      publicBrand: "okou",
       computerUseHostId,
       cloudBrowserEnabled: true,
     });
@@ -186,6 +193,7 @@ describe("auth tokens", () => {
       orgId: "org_zero",
       runId: "run_zero",
       capabilities: ["file:read", "file:write"],
+      publicBrand: "vm0",
     });
   });
 

--- a/turbo/apps/api/src/signals/auth/auth-context.ts
+++ b/turbo/apps/api/src/signals/auth/auth-context.ts
@@ -146,6 +146,7 @@ const zeroAuth$ = command(
       orgId: zeroAuth.orgId,
       runId: zeroAuth.runId,
       capabilities: [...zeroAuth.capabilities],
+      publicBrand: zeroAuth.publicBrand,
       ...(zeroAuth.computerUseHostId
         ? { computerUseHostId: zeroAuth.computerUseHostId }
         : {}),
@@ -162,6 +163,7 @@ const zeroAuth$ = command(
         tokenType: "zero" as const,
         userId: result.userId,
         runId: result.runId,
+        publicBrand: result.publicBrand,
       };
     }
 

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -4,6 +4,10 @@ import {
   ZERO_CAPABILITIES,
   ZeroCapability,
 } from "@okouai/api-contracts/contracts/capabilities";
+import {
+  publicBrandSchema,
+  type PublicBrand,
+} from "@okouai/api-contracts/contracts/public-brand";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { z } from "zod";
@@ -35,6 +39,7 @@ const AGENT_EXCLUDED_CAPABILITIES = [
 
 interface ZeroTokenOptions {
   readonly scope?: "zero" | "okou";
+  readonly publicBrand?: PublicBrand;
   readonly computerUseHostId?: string;
   readonly cloudBrowserEnabled?: boolean;
   readonly imageRecognitionAvailable?: boolean;
@@ -74,6 +79,7 @@ const zeroTokenPayloadSchema = jwtBaseSchema.extend({
   runId: z.string().min(1),
   orgId: z.string().min(1),
   capabilities: zeroCapabilitiesSchema,
+  publicBrand: publicBrandSchema.optional(),
   computerUseHostId: z.string().uuid().optional(),
   cloudBrowserEnabled: z.literal(true).optional(),
 });
@@ -257,6 +263,7 @@ export function verifyZeroToken(token: string): ZeroAuth | null {
     runId: parsed.data.runId,
     orgId: parsed.data.orgId,
     capabilities: parsed.data.capabilities,
+    publicBrand: parsed.data.publicBrand ?? "vm0",
     ...(parsed.data.computerUseHostId
       ? { computerUseHostId: parsed.data.computerUseHostId }
       : {}),
@@ -350,6 +357,7 @@ function buildZeroTokenClaims(
     runId,
     orgId,
     capabilities,
+    publicBrand: options?.publicBrand ?? "vm0",
     ...(capabilities.includes("computer-use:write") &&
     options?.computerUseHostId
       ? { computerUseHostId: options.computerUseHostId }

--- a/turbo/apps/api/src/signals/auth/tokens.ts
+++ b/turbo/apps/api/src/signals/auth/tokens.ts
@@ -79,6 +79,8 @@ const zeroTokenPayloadSchema = jwtBaseSchema.extend({
   runId: z.string().min(1),
   orgId: z.string().min(1),
   capabilities: zeroCapabilitiesSchema,
+  // The public brand is presentation-only. Tokens from before this claim and
+  // intentionally unbranded callers keep the permanent VM0 presentation.
   publicBrand: publicBrandSchema.optional(),
   computerUseHostId: z.string().uuid().optional(),
   cloudBrowserEnabled: z.literal(true).optional(),

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { testBrowserReconcileContract } from "@okouai/api-contracts/contracts/test-browser-reconcile";
 import type { SupportedRunModel } from "@okouai/api-contracts/contracts/model-providers";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { CANCELLATION_RECOVERY_STALE_AFTER_MS } from "@okouai/api-contracts/contracts/runners";
 import { zeroGoalsContract } from "@okouai/api-contracts/contracts/zero-goals";
 import {
@@ -235,6 +236,7 @@ async function startChatRun(
   },
   options?: {
     readonly onMessageAccepted?: () => void;
+    readonly publicBrand?: PublicBrand;
   },
 ): Promise<{
   readonly runId: string;
@@ -258,7 +260,13 @@ async function startChatRun(
       : { revokesEventId: body.revokesEventId }),
     ...(selectedModel === undefined ? {} : { model: selectedModel }),
   };
-  const sent = await chat.requestSendEvent(actor, requestBody, [201]);
+  const sent = await chat.requestSendEvent(
+    actor,
+    requestBody,
+    [201],
+    undefined,
+    options?.publicBrand,
+  );
   if (sent.status !== 201) {
     throw new Error("Expected the entitled chat send to create a run");
   }
@@ -3908,6 +3916,7 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
 
 describe("CHAT-02: drain-time admission failure", () => {
   it("terminalizes a queued Web message when credits are lost before drain", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     if (!actor.orgId) {
       throw new Error("Expected an org-scoped Web chat actor");
@@ -3919,10 +3928,14 @@ describe("CHAT-02: drain-time admission failure", () => {
     });
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
-    const anchor = await startChatRun(actor, {
-      agentId,
-      prompt: "finish after queued Web credit loss",
-    });
+    const anchor = await startChatRun(
+      actor,
+      {
+        agentId,
+        prompt: "finish after queued Web credit loss",
+      },
+      { publicBrand: "okou" },
+    );
     const anchorHeaders = await claimChatRun(runnerGroup, anchor.runId);
     const queuedEventId = randomUUID();
     const queuedPrompt = "reject this queued Web message after credit loss";
@@ -3935,6 +3948,8 @@ describe("CHAT-02: drain-time admission failure", () => {
         clientEventId: queuedEventId,
       },
       [201],
+      undefined,
+      "okou",
     );
     if ("error" in queued.body) {
       throw new Error(queued.body.error.message);
@@ -4004,7 +4019,10 @@ describe("CHAT-02: drain-time admission failure", () => {
     });
     expect(errors).toHaveLength(1);
     expect(errors[0]?.content).toContain("Add credits");
-    expect(errors[0]?.content).toContain("settings=billing");
+    expect(errors[0]?.content).toContain(
+      "https://app.okou.ai/?settings=billing&billingView=credits",
+    );
+    expect(errors[0]?.content).not.toContain("https://app.vm0.ai");
     expect(
       (await api.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
         return run.prompt === queuedPrompt;
@@ -4234,6 +4252,7 @@ describe("CHAT-02: failed chat callbacks", () => {
   }, 90_000);
 
   it("shows Claude Code credential recovery guidance for upstream auth 401s", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const upstreamAuthError =
       "Failed to authenticate. API Error: 401 Invalid authentication credentials";
@@ -4242,6 +4261,7 @@ describe("CHAT-02: failed chat callbacks", () => {
       readonly prompt: string;
       readonly selectedModel?: SupportedRunModel;
       readonly orgRole?: TestOrgRole;
+      readonly publicBrand?: PublicBrand;
       readonly configureProvider?: (
         fixture: EntitledChatActor,
       ) => Promise<void>;
@@ -4251,13 +4271,17 @@ describe("CHAT-02: failed chat callbacks", () => {
           ? await entitledChatMemberActor()
           : await entitledChatActor();
       await params.configureProvider?.(fixture);
-      const run = await startChatRun(fixture.actor, {
-        agentId: fixture.agentId,
-        prompt: params.prompt,
-        ...(params.selectedModel === undefined
-          ? {}
-          : { selectedModel: params.selectedModel }),
-      });
+      const run = await startChatRun(
+        fixture.actor,
+        {
+          agentId: fixture.agentId,
+          prompt: params.prompt,
+          ...(params.selectedModel === undefined
+            ? {}
+            : { selectedModel: params.selectedModel }),
+        },
+        { publicBrand: params.publicBrand },
+      );
       const sandboxHeaders = await claimChatRun(fixture.runnerGroup, run.runId);
       if (params.orgRole !== undefined) {
         mockClerkMembership(
@@ -4292,6 +4316,7 @@ describe("CHAT-02: failed chat callbacks", () => {
       failAndReadError({
         prompt: "subscription credential failed",
         selectedModel: "claude-opus-4-8",
+        publicBrand: "okou",
         async configureProvider(fixture) {
           await misc.upsertPersonalModelProvider(
             fixture.actor,
@@ -4317,7 +4342,7 @@ describe("CHAT-02: failed chat callbacks", () => {
         },
       }),
     ).resolves.toBe(
-      "Claude Code subscription authentication failed. Reconnect Claude Code in Model Providers, then retry.\n\nReconnect Claude Code: http://localhost:3002/?settings=model",
+      "Claude Code subscription authentication failed. Reconnect Claude Code in Model Providers, then retry.\n\nReconnect Claude Code: https://app.okou.ai/?settings=model",
     );
     await expect(
       failAndReadError({
@@ -4325,7 +4350,7 @@ describe("CHAT-02: failed chat callbacks", () => {
         orgRole: "admin",
       }),
     ).resolves.toBe(
-      "Claude Code could not authenticate with the configured Anthropic API key. Update or replace the API key in Model Providers, then retry.\n\nOpen Model Providers: http://localhost:3002/?settings=model",
+      "Claude Code could not authenticate with the configured Anthropic API key. Update or replace the API key in Model Providers, then retry.\n\nOpen Model Providers: https://app.vm0.ai/?settings=model",
     );
     await expect(
       failAndReadError({
@@ -4333,7 +4358,7 @@ describe("CHAT-02: failed chat callbacks", () => {
         orgRole: "member",
       }),
     ).resolves.toBe(
-      "Claude Code could not authenticate with the configured Anthropic API key. Ask a workspace admin to update or replace the API key.\n\nShare with an admin: http://localhost:3002/?settings=model",
+      "Claude Code could not authenticate with the configured Anthropic API key. Ask a workspace admin to update or replace the API key.\n\nShare with an admin: https://app.vm0.ai/?settings=model",
     );
   }, 90_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -31,6 +31,7 @@ import {
   insertQueuedSlackMissingContextFixture,
   readChatEventContextFixture,
   removeAcknowledgedCancellationLifecycleFixture,
+  removeChatCallbackPublicBrandFixture,
 } from "../../../test-fixtures/chat-events";
 import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
@@ -4262,6 +4263,7 @@ describe("CHAT-02: failed chat callbacks", () => {
       readonly selectedModel?: SupportedRunModel;
       readonly orgRole?: TestOrgRole;
       readonly publicBrand?: PublicBrand;
+      readonly removeCallbackPublicBrand?: boolean;
       readonly configureProvider?: (
         fixture: EntitledChatActor,
       ) => Promise<void>;
@@ -4283,6 +4285,9 @@ describe("CHAT-02: failed chat callbacks", () => {
         { publicBrand: params.publicBrand },
       );
       const sandboxHeaders = await claimChatRun(fixture.runnerGroup, run.runId);
+      if (params.removeCallbackPublicBrand) {
+        await removeChatCallbackPublicBrandFixture(run.runId);
+      }
       if (params.orgRole !== undefined) {
         mockClerkMembership(
           context,
@@ -4346,8 +4351,10 @@ describe("CHAT-02: failed chat callbacks", () => {
     );
     await expect(
       failAndReadError({
-        prompt: "org key failed for admin",
+        prompt: "legacy callback without public brand failed for admin",
         orgRole: "admin",
+        publicBrand: "okou",
+        removeCallbackPublicBrand: true,
       }),
     ).resolves.toBe(
       "Claude Code could not authenticate with the configured Anthropic API key. Update or replace the API key in Model Providers, then retry.\n\nOpen Model Providers: https://app.vm0.ai/?settings=model",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -101,6 +101,7 @@ import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { overwriteModelProviderSecretForTests } from "./helpers/model-provider-state";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
+import { verifyZeroToken } from "../../auth/tokens";
 import {
   createUnassociatedThreadBoundAgentRunFixture,
   createUnassociatedThreadBoundZeroRunFixture,
@@ -518,6 +519,43 @@ async function claimChatRun(
     claim,
     sandboxHeaders,
   };
+}
+
+async function expectRunPublicBrandTransport(args: {
+  readonly actor: ApiTestUser;
+  readonly runId: string;
+  readonly claim: RunnerClaim;
+  readonly publicBrand: PublicBrand;
+  readonly appUrl: string;
+}): Promise<void> {
+  if (!args.actor.orgId) {
+    throw new Error("Expected an organization-scoped chat actor");
+  }
+  expect(args.claim.environment?.OKOU_APP_URL).toBe(args.appUrl);
+  const token = args.claim.environment?.OKOU_TOKEN;
+  if (!token) {
+    throw new Error("Expected the run context to contain an Okou token");
+  }
+  expect(verifyZeroToken(token)).toMatchObject({
+    runId: args.runId,
+    publicBrand: args.publicBrand,
+  });
+  const state = await runStateStore.set(
+    readAgentRunState$,
+    {
+      orgId: args.actor.orgId,
+      userId: args.actor.userId,
+      runId: args.runId,
+    },
+    context.signal,
+  );
+  expect(
+    state.callbacks.find((callback) => {
+      return callback.internalKind === "chat";
+    }),
+  ).toMatchObject({
+    payload: { publicBrand: args.publicBrand },
+  });
 }
 
 /**
@@ -8398,6 +8436,7 @@ describe("CHAT-02: queued attachments on auto-send", () => {
 
 describe("CHAT-02: public-brand default assistant identity", () => {
   it("uses the request brand for immediate and auto-sent runs without renaming custom agents", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
     const { actor, runnerGroup } = await entitledChatActor();
     bdd.acceptAgentStorageWrites();
     const onboarding = await bdd.readOnboardingStatus(actor);
@@ -8418,6 +8457,13 @@ describe("CHAT-02: public-brand default assistant identity", () => {
     );
 
     const anchorClaim = await claimChatRun(runnerGroup, okouAnchor.runId);
+    await expectRunPublicBrandTransport({
+      actor,
+      runId: okouAnchor.runId,
+      claim: anchorClaim.claim,
+      publicBrand: "okou",
+      appUrl: "https://app.okou.ai",
+    });
     const queuedEventId = randomUUID();
     const queued = await chat.requestSendEvent(
       actor,
@@ -8476,6 +8522,14 @@ describe("CHAT-02: public-brand default assistant identity", () => {
     const promotedRun = await api.readRun(actor, promoted.runId);
     expect(promotedRun.appendSystemPrompt).toContain("Your name is Okou.");
     expect(promotedRun.appendSystemPrompt).not.toContain("Your name is Zero.");
+    const promotedClaim = await claimChatRun(runnerGroup, promoted.runId);
+    await expectRunPublicBrandTransport({
+      actor,
+      runId: promoted.runId,
+      claim: promotedClaim.claim,
+      publicBrand: "okou",
+      appUrl: "https://app.okou.ai",
+    });
     await cancelChatRun(actor, promoted.runId);
 
     const vm0Run = await sendChatRun(actor, {
@@ -8485,7 +8539,16 @@ describe("CHAT-02: public-brand default assistant identity", () => {
     expect(
       (await api.readRun(actor, vm0Run.runId)).appendSystemPrompt,
     ).toContain("Your name is Zero.");
+    const vm0Claim = await claimChatRun(runnerGroup, vm0Run.runId);
+    await expectRunPublicBrandTransport({
+      actor,
+      runId: vm0Run.runId,
+      claim: vm0Claim.claim,
+      publicBrand: "vm0",
+      appUrl: "https://app.vm0.ai",
+    });
 
+    mockEnv("APP_URL", "https://preview.example.test");
     const customZero = await bdd.createAgent(actor, {
       displayName: "Zero",
       visibility: "private",
@@ -8499,6 +8562,14 @@ describe("CHAT-02: public-brand default assistant identity", () => {
       .appendSystemPrompt;
     expect(customPrompt).toContain("Your name is Zero.");
     expect(customPrompt).not.toContain("Your name is Okou.");
+    const customClaim = await claimChatRun(runnerGroup, customRun.runId);
+    await expectRunPublicBrandTransport({
+      actor,
+      runId: customRun.runId,
+      claim: customClaim.claim,
+      publicBrand: "okou",
+      appUrl: "https://preview.example.test",
+    });
 
     await cancelChatRun(actor, vm0Run.runId);
     await cancelChatRun(actor, customRun.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-user-config.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-user-config.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { initContract } from "@okouai/api-contracts/contracts/trpc-contract";
 import { authContract } from "@okouai/api-contracts/contracts/auth";
 import type { ZeroCapability } from "@okouai/api-contracts/contracts/capabilities";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { pushSubscriptionsContract } from "@okouai/api-contracts/contracts/push-subscriptions";
 import { zeroUserConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import {
@@ -196,6 +197,7 @@ export function createUserConfigBddApi(context: TestContext) {
     zeroBearer(
       actor: ApiTestUser,
       capabilities: readonly ZeroCapability[],
+      publicBrand?: PublicBrand,
     ): MintedBearer {
       const seconds = Math.floor(now() / 1000);
       const runId = `run_${randomUUID()}`;
@@ -205,6 +207,7 @@ export function createUserConfigBddApi(context: TestContext) {
         orgId: requireOrgId(actor),
         runId,
         capabilities: [...capabilities],
+        ...(publicBrand ? { publicBrand } : {}),
         iat: seconds,
         exp: seconds + 3600,
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -16,6 +16,7 @@ import {
   type Job as RunnerJob,
 } from "@okouai/api-contracts/contracts/runners";
 import type { CreateCustomConnectorBody } from "@okouai/api-contracts/contracts/zero-custom-connectors";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { testCustomConnectorSkillVersionAssociationContract } from "@okouai/api-contracts/contracts/test-custom-connector-skill-version-association";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV } from "@okouai/core/resource-registry";
@@ -759,6 +760,7 @@ function expectCanonicalOkouRunEnvironment(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly runId: string;
+  readonly publicBrand?: PublicBrand;
   readonly chatThreadId?: string;
 }): void {
   expect(args.environment?.OKOU_APP_URL).toBe(args.appUrl);
@@ -785,6 +787,7 @@ function expectCanonicalOkouRunEnvironment(args: {
     userId: args.userId,
     orgId: args.orgId,
     runId: args.runId,
+    publicBrand: args.publicBrand ?? "vm0",
     capabilities: expect.any(Array),
     iat: expect.any(Number),
     exp: expect.any(Number),

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -630,7 +630,7 @@ describe("AUTH-01 sandbox and zero bearers", () => {
       runId: sandbox.runId,
     });
 
-    const memberZero = cfg.zeroBearer(zeroMember, ["file:read"]);
+    const memberZero = cfg.zeroBearer(zeroMember, ["file:read"], "okou");
     cfg.mockMembership(zeroMember, "org:member");
     const memberProbe = await cfg.probeAuth(
       { authorization: `Bearer ${memberZero.token}` },
@@ -644,6 +644,7 @@ describe("AUTH-01 sandbox and zero bearers", () => {
       orgRole: "member",
       runId: memberZero.runId,
       capabilities: ["file:read"],
+      publicBrand: "okou",
     });
 
     const adminZero = cfg.zeroBearer(zeroAdmin, ["file:read", "file:write"]);
@@ -660,6 +661,7 @@ describe("AUTH-01 sandbox and zero bearers", () => {
       orgRole: "admin",
       runId: adminZero.runId,
       capabilities: ["file:read", "file:write"],
+      publicBrand: "vm0",
     });
 
     const orphanZero = cfg.zeroBearer(zeroOrphan, ["file:read"]);
@@ -673,6 +675,7 @@ describe("AUTH-01 sandbox and zero bearers", () => {
       tokenType: "zero",
       userId: zeroOrphan.userId,
       runId: orphanZero.runId,
+      publicBrand: "vm0",
     });
 
     const badSignature = await cfg.probeAuth(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -16,6 +16,7 @@ import {
 } from "@okouai/api-contracts/contracts/runners";
 import type { TriggerSource } from "@okouai/api-contracts/contracts/logs";
 import type { CodexServiceTier } from "@okouai/api-contracts/contracts/chat-threads";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import type { AgentCustomConnectorGrant } from "@okouai/api-contracts/contracts/zero-agent-custom-connectors";
 import { customConnectorSlugSchema } from "@okouai/api-contracts/contracts/zero-custom-connectors";
 import {
@@ -875,6 +876,7 @@ export interface CreateAgentRunArgs {
   readonly chatThreadId?: string;
   readonly threadSessionResolution?: ChatThreadSessionResolution;
   readonly includeZeroTokenSecret?: boolean;
+  readonly zeroTokenPublicBrand?: PublicBrand;
   readonly zeroTokenComputerUseHostId?: string;
   readonly zeroTokenCloudBrowserEnabled?: boolean;
   readonly extraEnvironment?: Record<string, string>;
@@ -6357,6 +6359,7 @@ interface BuildRunnerJobPayloadInput {
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly additionalVolumeSources: AdditionalVolumeSources;
   readonly includeZeroTokenSecret: boolean | undefined;
+  readonly zeroTokenPublicBrand: PublicBrand | undefined;
   readonly zeroTokenComputerUseHostId: string | undefined;
   readonly zeroTokenCloudBrowserEnabled: boolean | undefined;
   readonly imageRecognitionAvailable: boolean;
@@ -6455,6 +6458,7 @@ function preparedRunnerJobBody(
     args.featureSwitchContext.overrides,
     {
       scope: "okou",
+      publicBrand: args.zeroTokenPublicBrand ?? "vm0",
       ...(args.zeroTokenComputerUseHostId
         ? { computerUseHostId: args.zeroTokenComputerUseHostId }
         : {}),
@@ -7525,6 +7529,7 @@ function buildAtomicLaunchPayload(
     additionalVolumes: args.context.additionalVolumes,
     additionalVolumeSources: args.context.additionalVolumeSources,
     includeZeroTokenSecret: args.createArgs.includeZeroTokenSecret,
+    zeroTokenPublicBrand: args.createArgs.zeroTokenPublicBrand,
     zeroTokenComputerUseHostId: args.createArgs.zeroTokenComputerUseHostId,
     zeroTokenCloudBrowserEnabled: args.createArgs.zeroTokenCloudBrowserEnabled,
     imageRecognitionAvailable: args.context.imageRecognitionAvailable,

--- a/turbo/apps/api/src/signals/services/integration-run-errors.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-run-errors.service.ts
@@ -1,4 +1,6 @@
 import { formatRunErrorForExternalSurface } from "@okouai/api-contracts/contracts/errors";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { command } from "ccstate";
 
 import { env } from "../../lib/env";
@@ -6,13 +8,13 @@ import { db$ } from "../external/db";
 import { getMemberRoleAndUpdateCache$ } from "./auth.service";
 import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
 
-function addCreditsUrl(): string {
-  const appUrl = env("APP_URL").replace(/\/$/, "");
+function addCreditsUrl(publicBrand: PublicBrand): string {
+  const appUrl = appUrlForPublicBrand(env("APP_URL"), publicBrand);
   return `${appUrl}/?settings=billing&billingView=credits`;
 }
 
-function comparePlansUrl(): string {
-  const appUrl = env("APP_URL").replace(/\/$/, "");
+function comparePlansUrl(publicBrand: PublicBrand): string {
+  const appUrl = appUrlForPublicBrand(env("APP_URL"), publicBrand);
   return `${appUrl}/?settings=billing&billingView=plans`;
 }
 
@@ -24,6 +26,7 @@ export const formatIntegrationRunError$ = command(
       readonly userId: string;
       readonly code: string;
       readonly message: string;
+      readonly publicBrand: PublicBrand;
     },
     signal: AbortSignal,
   ): Promise<string> => {
@@ -48,8 +51,8 @@ export const formatIntegrationRunError$ = command(
       insufficientCredits: {
         canManageBilling: membership?.role === "admin",
         ...(canBuyCredits
-          ? { addCreditsUrl: addCreditsUrl() }
-          : { comparePlansUrl: comparePlansUrl() }),
+          ? { addCreditsUrl: addCreditsUrl(args.publicBrand) }
+          : { comparePlansUrl: comparePlansUrl(args.publicBrand) }),
       },
     });
   },

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -10,7 +10,10 @@ import {
   serializeChatFollowupsContent,
   type ChatRecommendedFollowup,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import {
+  publicBrandSchema,
+  type PublicBrand,
+} from "@okouai/api-contracts/contracts/public-brand";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
@@ -364,6 +367,7 @@ const chatCallbackPayloadSchema = z
   .object({
     threadId: z.string(),
     agentId: z.string(),
+    publicBrand: publicBrandSchema.optional(),
     slackDelivery: z
       .object({
         channelId: z.string(),
@@ -493,6 +497,7 @@ interface ChatCallbackDependencies {
       readonly chatThreadId: string;
       readonly runId: string;
       readonly errorMessage: string;
+      readonly publicBrand: PublicBrand;
     },
     signal: AbortSignal,
   ) => Promise<string>;
@@ -514,6 +519,7 @@ interface ChatCallbackDependencies {
       readonly userId: string;
       readonly code: string;
       readonly message: string;
+      readonly publicBrand: PublicBrand;
     },
     signal: AbortSignal,
   ) => Promise<string>;
@@ -697,6 +703,7 @@ interface SlackQueuedMessageAdmissionFailure {
   readonly agentId: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
+  readonly publicBrand: PublicBrand;
   readonly slackDelivery: {
     readonly channelId: string;
     readonly threadTs: string;
@@ -711,6 +718,7 @@ interface WebQueuedMessageAdmissionFailure {
   readonly userId: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
+  readonly publicBrand: PublicBrand;
   readonly error: QueuedMessageModelRouteError;
 }
 
@@ -720,6 +728,7 @@ interface FeishuQueuedMessageAdmissionFailure {
   readonly userId: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
+  readonly publicBrand: PublicBrand;
   readonly feishuDelivery: FeishuDeliveryTarget;
   readonly error: QueuedMessageModelRouteError;
 }
@@ -731,6 +740,7 @@ interface TeamsQueuedMessageAdmissionFailure {
   readonly agentId: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
+  readonly publicBrand: PublicBrand;
   readonly teamsDelivery: TeamsDeliveryTarget;
   readonly error: QueuedMessageModelRouteError;
 }
@@ -741,6 +751,7 @@ interface MorningBriefQueuedMessageAdmissionFailure {
   readonly userId: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
+  readonly publicBrand: PublicBrand;
   readonly morningBriefDelivery: NonNullable<
     CreateQueuedChatRunInput["morningBriefDelivery"]
   >;
@@ -754,6 +765,7 @@ interface TelegramQueuedMessageAdmissionFailure {
   readonly agentId: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
+  readonly publicBrand: PublicBrand;
   readonly telegramDelivery: TelegramDeliveryTarget;
   readonly error: QueuedMessageModelRouteError;
 }
@@ -765,6 +777,7 @@ interface AgentPhoneQueuedMessageAdmissionFailure {
   readonly agentId: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
+  readonly publicBrand: PublicBrand;
   readonly agentphoneDelivery: AgentPhoneDeliveryTarget;
   readonly error: QueuedMessageModelRouteError;
 }
@@ -776,6 +789,7 @@ interface GitHubQueuedMessageAdmissionFailure {
   readonly agentId: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
+  readonly publicBrand: PublicBrand;
   readonly githubDelivery: GitHubDeliveryTarget;
   readonly error: QueuedMessageModelRouteError;
 }
@@ -880,6 +894,7 @@ function buildQueuedCreateZeroRunArgs(
         payload: {
           threadId: input.threadId,
           agentId: input.agentId,
+          publicBrand: input.publicBrand ?? "vm0",
           queuedMessageId: input.queuedMessage.id,
           slackDelivery: input.slackDelivery,
           feishuDelivery: input.feishuDelivery,
@@ -2866,6 +2881,7 @@ function queuedMessageAdmissionFailure(
     agentId: args.agent.id,
     threadId: args.threadId,
     queuedMessage: args.queuedMessage,
+    publicBrand: launchMaterial.publicBrand ?? "vm0",
     error,
   };
   const contextType = args.queuedMessage.contextType;
@@ -3275,6 +3291,7 @@ async function handleWebQueuedMessageAdmissionFailure(
       userId: args.failure.userId,
       code: args.failure.error.code,
       message: args.failure.error.message,
+      publicBrand: args.failure.publicBrand,
     },
     signal,
   );
@@ -3317,6 +3334,7 @@ async function handleFeishuQueuedMessageAdmissionFailure(
       userId: args.failure.userId,
       code: args.failure.error.code,
       message: args.failure.error.message,
+      publicBrand: args.failure.publicBrand,
     },
     signal,
   );
@@ -3385,6 +3403,7 @@ async function handleSlackQueuedMessageAdmissionFailure(
       userId: args.failure.userId,
       code: args.failure.error.code,
       message: args.failure.error.message,
+      publicBrand: args.failure.publicBrand,
     },
     signal,
   );
@@ -3449,6 +3468,7 @@ async function handleTeamsQueuedMessageAdmissionFailure(
       userId: args.failure.userId,
       code: args.failure.error.code,
       message: args.failure.error.message,
+      publicBrand: args.failure.publicBrand,
     },
     signal,
   );
@@ -3509,6 +3529,7 @@ async function handleTelegramQueuedMessageAdmissionFailure(
       userId: args.failure.userId,
       code: args.failure.error.code,
       message: args.failure.error.message,
+      publicBrand: args.failure.publicBrand,
     },
     signal,
   );
@@ -3569,6 +3590,7 @@ async function handleAgentPhoneQueuedMessageAdmissionFailure(
       userId: args.failure.userId,
       code: args.failure.error.code,
       message: args.failure.error.message,
+      publicBrand: args.failure.publicBrand,
     },
     signal,
   );
@@ -3629,6 +3651,7 @@ async function handleGitHubQueuedMessageAdmissionFailure(
       userId: args.failure.userId,
       code: args.failure.error.code,
       message: args.failure.error.message,
+      publicBrand: args.failure.publicBrand,
     },
     signal,
   );
@@ -3688,6 +3711,7 @@ async function handleMorningBriefQueuedMessageAdmissionFailure(
       userId: args.failure.userId,
       code: args.failure.error.code,
       message: args.failure.error.message,
+      publicBrand: args.failure.publicBrand,
     },
     signal,
   );
@@ -4220,6 +4244,7 @@ async function prepareFailedTerminalChatCallbackWork(
     readonly chatThread: ChatThreadForRunRow;
     readonly suppressWebPushForActiveGoal: boolean;
     readonly errorMessage: string;
+    readonly publicBrand: PublicBrand;
     readonly dependencies: ChatCallbackDependencies;
     readonly timing: ChatCallbackPreCreateTimingCollector;
     readonly slackDelivery?: SlackDeliveryTarget;
@@ -4250,6 +4275,7 @@ async function prepareFailedTerminalChatCallbackWork(
               chatThreadId: args.chatThread.chatThreadId,
               runId: args.runId,
               errorMessage: args.errorMessage,
+              publicBrand: args.publicBrand,
             },
             signal,
           );
@@ -4669,6 +4695,7 @@ async function processTerminalChatCallback(
               args.callback.error,
               run.error,
             ),
+            publicBrand: args.payload.publicBrand ?? "vm0",
             dependencies: args.dependencies,
             timing,
             ...terminalIntegrationDeliveries(args.payload),

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -367,6 +367,8 @@ const chatCallbackPayloadSchema = z
   .object({
     threadId: z.string(),
     agentId: z.string(),
+    // Missing is the permanent VM0 presentation contract for callbacks
+    // persisted before branding and for current unbranded run producers.
     publicBrand: publicBrandSchema.optional(),
     slackDelivery: z
       .object({

--- a/turbo/apps/api/src/signals/services/internal-feishu-org-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-feishu-org-run-callback.service.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { formatRunErrorForExternalSurface } from "@okouai/api-contracts/contracts/errors";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentSessions } from "@okouai/db/schema/agent-session";
 import { feishuOrgConnections } from "@okouai/db/schema/feishu-org-connection";
@@ -53,6 +54,7 @@ interface HandleFeishuCallbackInput {
     readonly runId: string;
     readonly chatThreadId: string | null | undefined;
     readonly errorMessage: string;
+    readonly publicBrand: PublicBrand;
   }) => Promise<string>;
   readonly saveRunSummary: (
     runId: string,
@@ -227,6 +229,7 @@ async function handleFeishuCallback(
           runId: args.callback.runId,
           chatThreadId: run.chatThreadId,
           errorMessage: args.callback.error ?? "Agent execution failed.",
+          publicBrand: installation.publicBrand,
         })
       : undefined;
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/run-error-format.service.ts
+++ b/turbo/apps/api/src/signals/services/run-error-format.service.ts
@@ -9,6 +9,8 @@ import {
   type ModelProviderCredentialScope,
   type ModelProviderType,
 } from "@okouai/api-contracts/contracts/model-providers";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { eq } from "drizzle-orm";
 
@@ -31,23 +33,25 @@ interface FormatRunErrorLikeWebMessageParams {
   readonly chatThreadId?: string | null;
   readonly runId: string;
   readonly errorMessage: string;
+  readonly publicBrand: PublicBrand;
   readonly modelProviderType?: ModelProviderType | null;
   readonly modelProviderCredentialScope?: ModelProviderCredentialScope | null;
   readonly selectedModel?: string | null;
   readonly canManageOrgModelProviders?: boolean;
 }
 
-function buildModelProvidersUrl(): string {
-  const appUrl = env("APP_URL").replace(/\/$/u, "");
+function buildModelProvidersUrl(publicBrand: PublicBrand): string {
+  const appUrl = appUrlForPublicBrand(env("APP_URL"), publicBrand);
   return `${appUrl}/?settings=model`;
 }
 
-function buildPersonalModelProvidersUrl(): string {
-  const appUrl = env("APP_URL").replace(/\/$/u, "");
+function buildPersonalModelProvidersUrl(publicBrand: PublicBrand): string {
+  const appUrl = appUrlForPublicBrand(env("APP_URL"), publicBrand);
   return `${appUrl}/?settings=model`;
 }
 
 function buildClaudeCodeCredentialRecoveryUrl(params: {
+  readonly publicBrand: PublicBrand;
   readonly modelProviderType: ModelProviderType | null | undefined;
   readonly modelProviderCredentialScope:
     | ModelProviderCredentialScope
@@ -58,9 +62,9 @@ function buildClaudeCodeCredentialRecoveryUrl(params: {
     params.modelProviderType === "claude-code-oauth-token" &&
     params.modelProviderCredentialScope === "member"
   ) {
-    return buildPersonalModelProvidersUrl();
+    return buildPersonalModelProvidersUrl(params.publicBrand);
   }
-  return buildModelProvidersUrl();
+  return buildModelProvidersUrl(params.publicBrand);
 }
 
 function isProRequiredRunError(message: string): boolean {
@@ -166,6 +170,7 @@ function formatRunErrorLikeWebMessage(
         modelProviderCredentialScope,
         canManageOrgModelProviders: params.canManageOrgModelProviders ?? false,
         modelProvidersUrl: buildClaudeCodeCredentialRecoveryUrl({
+          publicBrand: params.publicBrand,
           modelProviderType,
           modelProviderCredentialScope,
         }),

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -2908,6 +2908,7 @@ function buildCreateZeroRunArgs(params: {
         payload: {
           threadId: prepared.thread.threadId,
           agentId: args.body.agentId,
+          publicBrand: args.publicBrand,
         },
       },
     ],

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -539,6 +539,8 @@ function buildZeroRunExtraEnvironment(args: {
   readonly publicBrand: PublicBrand | undefined;
 }): Record<string, string> {
   return {
+    // A run source that supplies no presentation brand is a VM0 run by
+    // contract; this does not derive brand identity from token scope.
     OKOU_APP_URL: appUrlForPublicBrand(
       env("APP_URL"),
       args.publicBrand ?? "vm0",

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -10,7 +10,10 @@ import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { permissionGrantsToFirewallPolicies } from "@okouai/connectors/firewall-metadata/policy";
 import type { FirewallPolicies } from "@okouai/connectors/firewall-types";
 import type { FeatureSwitchContext } from "@okouai/core/feature-switch";
-import { agentDisplayNameForPublicBrand } from "@okouai/core/public-brand";
+import {
+  agentDisplayNameForPublicBrand,
+  appUrlForPublicBrand,
+} from "@okouai/core/public-brand";
 import { agentSessions } from "@okouai/db/schema/agent-session";
 import {
   agentComposeVersions,
@@ -533,9 +536,13 @@ function buildZeroRunExtraEnvironment(args: {
   readonly agentId: string;
   readonly chatThreadId: string | undefined;
   readonly codexServiceTier: "fast" | undefined;
+  readonly publicBrand: PublicBrand | undefined;
 }): Record<string, string> {
   return {
-    OKOU_APP_URL: env("APP_URL"),
+    OKOU_APP_URL: appUrlForPublicBrand(
+      env("APP_URL"),
+      args.publicBrand ?? "vm0",
+    ),
     OKOU_AGENT_ID: args.agentId,
     // Chat-mode automation (and web) runs carry their thread id so the
     // in-sandbox CLI can bind a newly created automation to it (the create
@@ -856,9 +863,11 @@ function buildZeroCreateAgentRunArgs(args: {
       agentId: args.agent.id,
       chatThreadId: command.chatThreadId,
       codexServiceTier: command.codexServiceTier,
+      publicBrand: command.publicBrand,
     }),
     callbacks: command.callbacks,
     includeZeroTokenSecret: true,
+    zeroTokenPublicBrand: command.publicBrand,
     zeroTokenComputerUseHostId: command.computerUseHostId,
     zeroTokenCloudBrowserEnabled: args.cloudBrowserEnabled,
     enforceVm0Credits: true,

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -1273,6 +1273,46 @@ export async function invalidateChatCallbackPayloadFixture(
   }
 }
 
+/** Reproduce a pending chat callback persisted before publicBrand existed. */
+export async function removeChatCallbackPublicBrandFixture(
+  runId: string,
+): Promise<void> {
+  const [callback] = await db()
+    .select({
+      id: agentRunCallbacks.id,
+      payload: agentRunCallbacks.payload,
+    })
+    .from(agentRunCallbacks)
+    .where(
+      and(
+        eq(agentRunCallbacks.runId, runId),
+        eq(agentRunCallbacks.internalKind, "chat"),
+        eq(agentRunCallbacks.status, "pending"),
+      ),
+    )
+    .limit(1);
+  if (
+    !callback ||
+    typeof callback.payload !== "object" ||
+    callback.payload === null ||
+    Array.isArray(callback.payload) ||
+    !Object.hasOwn(callback.payload, "publicBrand")
+  ) {
+    throw new Error("Expected one branded pending canonical chat callback");
+  }
+
+  const legacyPayload: Record<string, unknown> = { ...callback.payload };
+  delete legacyPayload.publicBrand;
+  const callbacks = await db()
+    .update(agentRunCallbacks)
+    .set({ payload: legacyPayload })
+    .where(eq(agentRunCallbacks.id, callback.id))
+    .returning({ id: agentRunCallbacks.id });
+  if (callbacks.length !== 1) {
+    throw new Error("Expected one pending canonical chat callback");
+  }
+}
+
 async function transitiveBlockedWaiterCount(
   holderPid: number,
 ): Promise<number> {

--- a/turbo/apps/api/src/types/auth.ts
+++ b/turbo/apps/api/src/types/auth.ts
@@ -1,4 +1,5 @@
 import type { ZeroCapability } from "@okouai/api-contracts/contracts/capabilities";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 
 export type ApiOrgRole = "admin" | "member";
 
@@ -46,12 +47,14 @@ export type ZeroAuthContext =
       readonly orgRole?: ApiOrgRole;
       readonly runId: string;
       readonly capabilities: readonly ZeroCapability[];
+      readonly publicBrand: PublicBrand;
       readonly computerUseHostId?: string;
     }
   | {
       readonly tokenType: "zero";
       readonly userId: string;
       readonly runId: string;
+      readonly publicBrand: PublicBrand;
       readonly orgId?: undefined;
       readonly orgRole?: undefined;
       readonly capabilities?: undefined;
@@ -81,6 +84,7 @@ export interface ZeroAuth {
   readonly runId: string;
   readonly orgId: string;
   readonly capabilities: readonly ZeroCapability[];
+  readonly publicBrand: PublicBrand;
   readonly computerUseHostId?: string;
   readonly cloudBrowserEnabled?: true;
 }


### PR DESCRIPTION
## Summary

- add a presentation-only `publicBrand` claim to newly signed run tokens and expose it through `ZeroAuthContext`
- derive `OKOU_APP_URL` from the originating brand while preserving configured preview and local origins
- persist the brand in immediate and queued chat callback payloads so terminal failures, drain-time admission errors, and recovery CTAs use the originating App domain
- keep legacy token scope, prefix, protocol, and stored identifiers unchanged

## Fallbacks

- `turbo/apps/api/src/signals/auth/tokens.ts:zeroTokenPayloadSchema/verifyZeroToken` — a signed run token without `publicBrand` projects to `vm0`. Surface: signed run-token presentation for historical tokens and intentionally unbranded callers. This is a permanent presentation default rather than a bounded rollout bridge, so there is no removal window or follow-up while the missing-field contract remains supported.
- `turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts:chatCallbackPayloadSchema/processTerminalChatCallback` — a persisted chat callback without `publicBrand` formats VM0 recovery links. Surface: historical callback payloads and current unbranded run producers. This is a permanent presentation default rather than a bounded rollout bridge, so there is no removal window or follow-up while unbranded callback producers remain supported.
- `turbo/apps/api/src/signals/services/zero-runs-create.service.ts:buildZeroRunExtraEnvironment`, `turbo/apps/api/src/signals/services/agent-run-create.service.ts:preparedRunnerJobBody`, and the queued callback/admission defaults in `internal-chat-run-callback.service.ts` — a run source with no brand remains VM0 for `OKOU_APP_URL`, the signed claim, callback payloads, and billing/recovery links. Surface: current unbranded and legacy run sources. This is the permanent VM0 presentation contract; it has no version-skew removal window or cleanup follow-up.

## Compatibility

- tokens and callback payloads without `publicBrand` default to `vm0`
- VM0-origin runs continue to use `https://app.vm0.ai`
- Okou-origin runs use `https://app.okou.ai`, including when their run-scoped API calls reach `api.okou.ai`
- `scope: "okou"` and the `vm0_sandbox_` prefix remain technical authentication identifiers and are not treated as brand fields
- custom agent names and historical data are not renamed

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- auth token suite: 22 tests passed with the database-dependent global fixture excluded
- focused BDD coverage added for Okou/VM0 runtime URLs, token claims, callback persistence, queued billing CTAs, terminal recovery CTAs, legacy callback payloads, and preview-origin preservation; the PR pipeline will run these with Postgres
- `pnpm knip --workspace api` currently reports the pre-existing unused export `AgentComposeProvenanceSchemaUnavailable` in an untouched file

Refs #27750
