### PR TITLE
fix(api): contextualize axiom log delivery failures

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -18,6 +18,9 @@ type AbortSignalTimeoutMock = Mock<
 >;
 type SyncMock = Mock<(...args: unknown[]) => void>;
 type UnknownMock = Mock<(...args: unknown[]) => unknown>;
+interface AxiomClientOptions {
+  readonly onError?: (error: Error) => void;
+}
 interface BrowserUseCdpCommand {
   readonly id: number;
   readonly method: string;
@@ -47,6 +50,7 @@ export interface ApiTestMocks {
     readonly timeout: AbortSignalTimeoutMock;
   };
   readonly axiom: {
+    readonly clientError: Mock<(error: Error) => void>;
     readonly flush: AsyncMock;
     readonly ingest: BooleanMock;
     readonly query: AsyncMock;
@@ -58,6 +62,11 @@ export interface ApiTestMocks {
     readonly warn: SyncMock;
     readonly error: SyncMock;
     readonly flush: AsyncMock;
+  };
+  readonly console: {
+    readonly capture: () => () => void;
+    readonly error: SyncMock;
+    readonly warn: SyncMock;
   };
   readonly ably: {
     readonly channelGet: Mock<(channelName: string) => void>;
@@ -261,10 +270,26 @@ export interface ApiTestMocks {
 
 const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const axiom = {
+    clientError: vi.fn<(error: Error) => void>(),
     flush: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     ingest: vi.fn<(...args: unknown[]) => boolean>(),
     query: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     sdkIngest: vi.fn<(...args: unknown[]) => unknown>(),
+  };
+
+  const consoleWarn = vi.fn<(...args: unknown[]) => void>();
+  const consoleError = vi.fn<(...args: unknown[]) => void>();
+  const consoleOutput = {
+    capture: (): (() => void) => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(consoleWarn);
+      const error = vi.spyOn(console, "error").mockImplementation(consoleError);
+      return () => {
+        warn.mockRestore();
+        error.mockRestore();
+      };
+    },
+    error: consoleError,
+    warn: consoleWarn,
   };
 
   const clerk = {
@@ -444,6 +469,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
     },
     axiom,
     axiomLogging,
+    console: consoleOutput,
     browserUseCdp: {
       connect: vi.fn<(url: string) => void>(),
       command: vi.fn<(command: BrowserUseCdpCommand) => unknown>(),
@@ -1085,7 +1111,12 @@ vi.mock("../signals/external/axiom", async () => {
 
 vi.mock("@axiomhq/js", () => {
   return {
-    Axiom: vi.fn(function () {
+    Axiom: vi.fn<(options: AxiomClientOptions) => unknown>(function (
+      options: AxiomClientOptions,
+    ) {
+      apiTestMocks.axiom.clientError.mockImplementation((error: Error) => {
+        options.onError?.(error);
+      });
       return {
         flush: apiTestMocks.axiom.flush,
         ingest: apiTestMocks.axiom.sdkIngest,
@@ -1127,6 +1158,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.ably.requestToken.mockResolvedValue({
     token: "test-ably-token",
   });
+  apiTestMocks.axiom.clientError.mockReset();
   apiTestMocks.axiom.flush.mockReset();
   apiTestMocks.axiom.ingest.mockReset();
   apiTestMocks.axiom.ingest.mockReturnValue(true);
@@ -1137,6 +1169,8 @@ export function resetApiTestMocks(): void {
   apiTestMocks.axiomLogging.warn.mockReset();
   apiTestMocks.axiomLogging.error.mockReset();
   apiTestMocks.axiomLogging.flush.mockReset();
+  apiTestMocks.console.error.mockReset();
+  apiTestMocks.console.warn.mockReset();
   apiTestMocks.browserUseCdp.connect.mockReset();
   apiTestMocks.browserUseCdp.command.mockReset();
   apiTestMocks.clerk.authenticateRequest.mockReset();

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, onTestFinished } from "vitest";
 import { EVENT } from "@axiomhq/logging";
 import { flushLogs, logger, __resetForTest } from "../log";
 import { testContext } from "../../__tests__/test-context";
 
-const { axiomLogging } = testContext().mocks;
+const { axiom, axiomLogging, console: consoleOutput } = testContext().mocks;
 
 beforeEach(() => {
   __resetForTest();
@@ -256,6 +256,55 @@ describe("flushLogs", () => {
     __resetForTest();
     // flushLogs calls getAxiomLogger()?.flush() — optional chain handles null
     await expect(flushLogs()).resolves.toBeUndefined();
+  });
+
+  it("reports Axiom transport timeouts as contextual warnings", async () => {
+    const restoreConsole = consoleOutput.capture();
+    onTestFinished(restoreConsole);
+    await flushLogs();
+    const error = new Error("The operation was aborted due to timeout");
+    error.name = "TimeoutError";
+
+    expect(() => {
+      axiom.clientError(error);
+    }).not.toThrow();
+
+    expect(consoleOutput.warn).toHaveBeenCalledWith(
+      "Axiom application log delivery timed out",
+      {
+        client: "telemetry",
+        dataset: "vm0-web-logs-dev",
+        failureKind: "timeout",
+        error,
+      },
+    );
+    expect(consoleOutput.error).not.toHaveBeenCalled();
+    expect(axiomLogging.warn).not.toHaveBeenCalled();
+    expect(axiomLogging.error).not.toHaveBeenCalled();
+  });
+
+  it("reports other Axiom transport failures as contextual errors", async () => {
+    const restoreConsole = consoleOutput.capture();
+    onTestFinished(restoreConsole);
+    await flushLogs();
+    const error = new Error("connection refused");
+
+    expect(() => {
+      axiom.clientError(error);
+    }).not.toThrow();
+
+    expect(consoleOutput.error).toHaveBeenCalledWith(
+      "Axiom application log delivery failed",
+      {
+        client: "telemetry",
+        dataset: "vm0-web-logs-dev",
+        failureKind: "transport_error",
+        error,
+      },
+    );
+    expect(consoleOutput.warn).not.toHaveBeenCalled();
+    expect(axiomLogging.warn).not.toHaveBeenCalled();
+    expect(axiomLogging.error).not.toHaveBeenCalled();
   });
 });
 

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -119,18 +119,43 @@ function writeError(...args: unknown[]): void {
 
 // ── Axiom integration ────────────────────────────────────────────────────
 
+function reportAxiomLogDeliveryError(dataset: string, error: Error): void {
+  if (error.name === "TimeoutError") {
+    console.warn("Axiom application log delivery timed out", {
+      client: "telemetry",
+      dataset,
+      failureKind: "timeout",
+      error,
+    });
+    return;
+  }
+
+  writeError("Axiom application log delivery failed", {
+    client: "telemetry",
+    dataset,
+    failureKind: "transport_error",
+    error,
+  });
+}
+
 const getAxiomLogger = singleton((): AxiomLogger | null => {
   const token = env("AXIOM_TOKEN_TELEMETRY");
   if (!token) {
     return null;
   }
 
-  const axiom = new Axiom({ token });
+  const dataset = `vm0-web-logs-${env("AXIOM_DATASET_SUFFIX")}`;
+  const axiom = new Axiom({
+    token,
+    onError: (error) => {
+      reportAxiomLogDeliveryError(dataset, error);
+    },
+  });
   return new AxiomLogger({
     transports: [
       new AxiomJSTransport({
         axiom,
-        dataset: `vm0-web-logs-${env("AXIOM_DATASET_SUFFIX")}`,
+        dataset,
       }),
     ],
   });


### PR DESCRIPTION
## Summary

- configure the Axiom application-log client with an explicit delivery error callback
- report SDK timeouts as contextual warnings and preserve error severity for other transport failures
- write delivery diagnostics directly to the console sink so reporting cannot recurse through Axiom
- cover both timeout and non-timeout callbacks without timers, network access, or artificial delays

## Scope

This change only affects diagnostics emitted after Axiom application-log delivery failures. It does not change the SDK timeout, add retries, change batching, or alter API response behavior. Axiom delivery remains best-effort.

## Validation

- `pnpm -F api exec vitest run src/lib/__tests__/log.test.ts` (37 tests passed)
- `pnpm exec prettier --check apps/api/src/lib/log.ts apps/api/src/__tests__/mocks.ts apps/api/src/lib/__tests__/log.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- pre-commit hooks: Prettier, Knip, repository type checks, file-size check, and commitlint

## Compatibility

No API, queue payload, persisted state, frontend/backend contract, or runner protocol changes.

Closes #27779
