### PR TITLE
fix(ui): stabilize pinned agent loading layout

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { localStorageSignals } from "../external/local-storage.ts";
+import { onRef } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Chat list dialog search query
@@ -179,6 +180,28 @@ export const setAgentCardCollapsed$ = command(({ set }, collapsed: boolean) => {
     set(clearAgentCardCollapsed$);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Pinned agent grid rows (three-column sidebar) — persisted in localStorage
+// ---------------------------------------------------------------------------
+const { get$: pinnedAgentGridRowsRaw$, set$: setPinnedAgentGridRowsRaw$ } =
+  localStorageSignals("pinnedAgentGridRows");
+export const pinnedAgentGridRows$ = computed((get) => {
+  const rows = Number(get(pinnedAgentGridRowsRaw$));
+  return Number.isSafeInteger(rows) && rows > 0 ? rows : 1;
+});
+export const setPinnedAgentGridRows$ = command(({ get, set }, rows: number) => {
+  const next = String(rows);
+  if (get(pinnedAgentGridRowsRaw$) === next) {
+    return;
+  }
+  set(setPinnedAgentGridRowsRaw$, next);
+});
+export const cachePinnedAgentGridRowsRef$ = onRef(
+  command(({ set }, element: HTMLSpanElement, _signal: AbortSignal) => {
+    set(setPinnedAgentGridRows$, Number(element.dataset.pinnedAgentGridRows));
+  }),
+);
 
 // ---------------------------------------------------------------------------
 // Custom scrollbar thumb style (OverlayScrollArea)

--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -1,6 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { localStorageSignals } from "../external/local-storage.ts";
-import { onRef } from "../utils.ts";
+import { onDomEventFn, onRef } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Chat list dialog search query
@@ -184,22 +184,43 @@ export const setAgentCardCollapsed$ = command(({ set }, collapsed: boolean) => {
 // ---------------------------------------------------------------------------
 // Pinned agent grid rows (three-column sidebar) — persisted in localStorage
 // ---------------------------------------------------------------------------
+export const PINNED_AGENT_GRID_COLUMNS = 4;
+
 const { get$: pinnedAgentGridRowsRaw$, set$: setPinnedAgentGridRowsRaw$ } =
   localStorageSignals("pinnedAgentGridRows");
 export const pinnedAgentGridRows$ = computed((get) => {
   const rows = Number(get(pinnedAgentGridRowsRaw$));
   return Number.isSafeInteger(rows) && rows > 0 ? rows : 1;
 });
-export const setPinnedAgentGridRows$ = command(({ get, set }, rows: number) => {
-  const next = String(rows);
-  if (get(pinnedAgentGridRowsRaw$) === next) {
-    return;
-  }
-  set(setPinnedAgentGridRowsRaw$, next);
-});
+const cachePinnedAgentGridRowsFromElement$ = command(
+  ({ get, set }, element: HTMLDivElement) => {
+    const rows = Math.max(
+      1,
+      Math.ceil(element.childElementCount / PINNED_AGENT_GRID_COLUMNS),
+    );
+    const next = String(rows);
+    if (get(pinnedAgentGridRowsRaw$) === next) {
+      return;
+    }
+    set(setPinnedAgentGridRowsRaw$, next);
+  },
+);
 export const cachePinnedAgentGridRowsRef$ = onRef(
-  command(({ set }, element: HTMLSpanElement, _signal: AbortSignal) => {
-    set(setPinnedAgentGridRows$, Number(element.dataset.pinnedAgentGridRows));
+  command(({ set }, element: HTMLDivElement, signal: AbortSignal) => {
+    set(cachePinnedAgentGridRowsFromElement$, element);
+    const observer = new MutationObserver(
+      onDomEventFn(() => {
+        set(cachePinnedAgentGridRowsFromElement$, element);
+      }),
+    );
+    observer.observe(element, { childList: true });
+    signal.addEventListener(
+      "abort",
+      () => {
+        observer.disconnect();
+      },
+      { once: true },
+    );
   }),
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -36,8 +42,6 @@ import { pathname } from "../../../signals/location.ts";
 import {
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
   getChatThreadVirtualListScrollMargin,
-  pinnedAgentGridRows$,
-  setPinnedAgentGridRows$,
 } from "../../../signals/zero-page/zero-sidebar-state.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
 import { mockChatEventRows } from "./chat-event-test-helpers.ts";
@@ -56,6 +60,7 @@ function mountedComposer(): HTMLElement {
 }
 
 const context = testContext();
+const refreshContext = testContext();
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const RESEARCH_AGENT_ID = "c0000000-0000-4000-a000-000000000002";
@@ -92,7 +97,7 @@ function prepareDefaultAgent(): void {
   ]);
 }
 
-function prepareAgentTeam(): TeamComposeItem[] {
+function prepareAgentTeam(targetContext = context): TeamComposeItem[] {
   const team: TeamComposeItem[] = [
     {
       id: AGENT_ID,
@@ -128,8 +133,8 @@ function prepareAgentTeam(): TeamComposeItem[] {
       updatedAt: "2024-01-01T00:00:00Z",
     },
   ];
-  context.mocks.data.team(team);
-  context.mocks.api(zeroAgentsByIdContract.get, ({ params, respond }) => {
+  targetContext.mocks.data.team(team);
+  targetContext.mocks.api(zeroAgentsByIdContract.get, ({ params, respond }) => {
     const displayNameById: Record<string, string> = {
       [AGENT_ID]: "Zero",
       [RESEARCH_AGENT_ID]: "Research Agent",
@@ -2865,7 +2870,7 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("reserves cached pinned agent rows while preferences load", async () => {
+  it("preserves pinned agent rows across a loading refresh", async () => {
     const team = prepareAgentTeam();
     const operationsAgentId = "c0000000-0000-4000-a000-000000000004";
     context.mocks.data.team([
@@ -2877,39 +2882,72 @@ describe("zero sidebar", () => {
         headVersionId: "version_4",
       },
     ]);
-    const preferencesGate = context.mocks.deferred<void>();
-    context.mocks.api(userPreferencesContract.get, async ({ respond }) => {
-      await preferencesGate.promise;
-      return respond(200, {
-        timezone: null,
-        locale: null,
-        supportedLocales: [
-          "en-US",
-          "pt-BR",
-          "ja-JP",
-          "ko-KR",
-          "id-ID",
-          "de-DE",
-          "es-ES",
-          "it-IT",
-          "fr-FR",
-          "hi-IN",
-        ],
-        pinnedAgentIds: [
-          RESEARCH_AGENT_ID,
-          SUPPORT_AGENT_ID,
-          operationsAgentId,
-        ],
-        sendMode: "enter",
-        morningBriefEnabled: false,
-        morningBriefNextRunAt: null,
-        captureNetworkBodiesRemaining: 0,
-      });
+    context.mocks.data.userPreferences({
+      pinnedAgentIds: [RESEARCH_AGENT_ID, SUPPORT_AGENT_ID, operationsAgentId],
     });
-    context.store.set(setPinnedAgentGridRows$, 2);
 
     setupSidebarPage({
       context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+      },
+    });
+
+    const initialGrid = await screen.findByTestId("pinned-agents-grid");
+    await waitFor(() => {
+      expect(
+        within(initialGrid).getAllByTestId("pinned-agent-card"),
+      ).toHaveLength(4);
+    });
+
+    cleanup();
+
+    const refreshTeam = prepareAgentTeam(refreshContext);
+    refreshContext.mocks.data.team([
+      ...refreshTeam,
+      {
+        ...refreshTeam[1]!,
+        id: operationsAgentId,
+        displayName: "Operations Agent",
+        headVersionId: "version_4",
+      },
+    ]);
+    const preferencesGate = refreshContext.mocks.deferred<void>();
+    refreshContext.mocks.api(
+      userPreferencesContract.get,
+      async ({ respond }) => {
+        await preferencesGate.promise;
+        return respond(200, {
+          timezone: null,
+          locale: null,
+          supportedLocales: [
+            "en-US",
+            "pt-BR",
+            "ja-JP",
+            "ko-KR",
+            "id-ID",
+            "de-DE",
+            "es-ES",
+            "it-IT",
+            "fr-FR",
+            "hi-IN",
+          ],
+          pinnedAgentIds: [
+            RESEARCH_AGENT_ID,
+            SUPPORT_AGENT_ID,
+            operationsAgentId,
+          ],
+          sendMode: "enter",
+          morningBriefEnabled: false,
+          morningBriefNextRunAt: null,
+          captureNetworkBodiesRemaining: 0,
+        });
+      },
+    );
+
+    setupSidebarPage({
+      context: refreshContext,
       path: `/agents/${AGENT_ID}/chat`,
       featureSwitches: {
         [FeatureSwitchKey.ThreeColumnNav]: true,
@@ -2926,7 +2964,6 @@ describe("zero sidebar", () => {
     await waitFor(() => {
       expect(within(grid).queryByTestId("pinned-agent-skeleton")).toBeNull();
       expect(within(grid).getAllByTestId("pinned-agent-card")).toHaveLength(4);
-      expect(context.store.get(pinnedAgentGridRows$)).toBe(2);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { zeroAgentsByIdContract } from "@okouai/api-contracts/contracts/zero-agents";
+import { userPreferencesContract } from "@okouai/api-contracts/contracts/user-preferences";
 import {
   zeroTeamContract,
   type TeamComposeItem,
@@ -35,6 +36,8 @@ import { pathname } from "../../../signals/location.ts";
 import {
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
   getChatThreadVirtualListScrollMargin,
+  pinnedAgentGridRows$,
+  setPinnedAgentGridRows$,
 } from "../../../signals/zero-page/zero-sidebar-state.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
 import { mockChatEventRows } from "./chat-event-test-helpers.ts";
@@ -2859,6 +2862,71 @@ describe("zero sidebar", () => {
       expect(createdThreadId).toBeDefined();
       expect(pathname()).toBe(`/chats/${createdThreadId}`);
       expect(within(list).getByText("New chat")).toBeInTheDocument();
+    });
+  });
+
+  it("reserves cached pinned agent rows while preferences load", async () => {
+    const team = prepareAgentTeam();
+    const operationsAgentId = "c0000000-0000-4000-a000-000000000004";
+    context.mocks.data.team([
+      ...team,
+      {
+        ...team[1]!,
+        id: operationsAgentId,
+        displayName: "Operations Agent",
+        headVersionId: "version_4",
+      },
+    ]);
+    const preferencesGate = context.mocks.deferred<void>();
+    context.mocks.api(userPreferencesContract.get, async ({ respond }) => {
+      await preferencesGate.promise;
+      return respond(200, {
+        timezone: null,
+        locale: null,
+        supportedLocales: [
+          "en-US",
+          "pt-BR",
+          "ja-JP",
+          "ko-KR",
+          "id-ID",
+          "de-DE",
+          "es-ES",
+          "it-IT",
+          "fr-FR",
+          "hi-IN",
+        ],
+        pinnedAgentIds: [
+          RESEARCH_AGENT_ID,
+          SUPPORT_AGENT_ID,
+          operationsAgentId,
+        ],
+        sendMode: "enter",
+        morningBriefEnabled: false,
+        morningBriefNextRunAt: null,
+        captureNetworkBodiesRemaining: 0,
+      });
+    });
+    context.store.set(setPinnedAgentGridRows$, 2);
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+      },
+    });
+
+    const grid = await screen.findByTestId("pinned-agents-grid");
+    expect(within(grid).getAllByTestId("pinned-agent-skeleton")).toHaveLength(
+      7,
+    );
+
+    preferencesGate.resolve();
+
+    await waitFor(() => {
+      expect(within(grid).queryByTestId("pinned-agent-skeleton")).toBeNull();
+      expect(within(grid).getAllByTestId("pinned-agent-card")).toHaveLength(4);
+      expect(context.store.get(pinnedAgentGridRows$)).toBe(2);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -68,7 +68,7 @@ function PinnedAgentGridSkeletonCard() {
       className="flex w-full min-w-0 flex-col items-center gap-1.5 rounded-lg p-1.5"
     >
       <Skeleton className="h-9 w-9 shrink-0 rounded-full" />
-      <Skeleton className="h-3.5 w-10" />
+      <Skeleton className="h-[13.75px] w-10" />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -31,6 +31,7 @@ import {
   setAgentCardCollapsed$,
   pinnedAgentGridRows$,
   cachePinnedAgentGridRowsRef$,
+  PINNED_AGENT_GRID_COLUMNS,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 import {
   subagents$,
@@ -52,13 +53,6 @@ import { Link } from "../router/link.tsx";
 import { assistantName$ } from "../../signals/branding.ts";
 import { AgentListDialog } from "./zero-sidebar-dialogs.tsx";
 import { AgentRowSideActions } from "./zero-sidebar-agent-row-actions.tsx";
-
-const PINNED_AGENT_GRID_COLUMNS = 4;
-
-function pinnedAgentGridRows(agentCount: number): number {
-  // The New button always occupies the fourth slot in the first row.
-  return Math.max(1, Math.ceil((agentCount + 1) / PINNED_AGENT_GRID_COLUMNS));
-}
 
 function PinnedAgentGridSkeletonCard() {
   return (
@@ -254,10 +248,6 @@ export function PinnedAgentListSection({
     displayedPinnedAgentsLoadable.state === "hasData"
       ? displayedPinnedAgentsLoadable.data
       : pinnedAgents;
-  const displayedPinnedAgentCount =
-    displayedPinnedAgentsLoadable.state === "hasData"
-      ? displayedPinnedAgentsLoadable.data.length
-      : null;
 
   const selectedAgentId =
     routeAgentId ?? (routeThreadId ? null : sidebarAgentId);
@@ -318,6 +308,7 @@ export function PinnedAgentListSection({
           })}
         </span>
         <div
+          ref={cachePinnedAgentGridRowsRef}
           className="grid min-w-0 grid-cols-4 items-start gap-1 pb-1"
           data-testid="pinned-agents-grid"
         >
@@ -343,16 +334,6 @@ export function PinnedAgentListSection({
           </button>
           {pinnedAgentCards.slice(3)}
         </div>
-        {displayedPinnedAgentCount !== null && (
-          <span
-            key={pinnedAgentGridRows(displayedPinnedAgentCount)}
-            ref={cachePinnedAgentGridRowsRef}
-            data-pinned-agent-grid-rows={pinnedAgentGridRows(
-              displayedPinnedAgentCount,
-            )}
-            hidden
-          />
-        )}
         <AgentListDialogContainer />
       </div>
     );

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -13,6 +13,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  Skeleton,
 } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
 import {
@@ -28,6 +29,8 @@ import {
   openAgentListDialog$,
   agentCardCollapsed$,
   setAgentCardCollapsed$,
+  pinnedAgentGridRows$,
+  cachePinnedAgentGridRowsRef$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 import {
   subagents$,
@@ -49,6 +52,26 @@ import { Link } from "../router/link.tsx";
 import { assistantName$ } from "../../signals/branding.ts";
 import { AgentListDialog } from "./zero-sidebar-dialogs.tsx";
 import { AgentRowSideActions } from "./zero-sidebar-agent-row-actions.tsx";
+
+const PINNED_AGENT_GRID_COLUMNS = 4;
+
+function pinnedAgentGridRows(agentCount: number): number {
+  // The New button always occupies the fourth slot in the first row.
+  return Math.max(1, Math.ceil((agentCount + 1) / PINNED_AGENT_GRID_COLUMNS));
+}
+
+function PinnedAgentGridSkeletonCard() {
+  return (
+    <div
+      aria-hidden="true"
+      data-testid="pinned-agent-skeleton"
+      className="flex w-full min-w-0 flex-col items-center gap-1.5 rounded-lg p-1.5"
+    >
+      <Skeleton className="h-9 w-9 shrink-0 rounded-full" />
+      <Skeleton className="h-3.5 w-10" />
+    </div>
+  );
+}
 
 function PinnedAgentSideDecorator({
   agentId,
@@ -208,7 +231,7 @@ export function PinnedAgentListSection({
     typeof pathParams?.threadId === "string" ? pathParams.threadId : null;
   const sidebarAgentId = useLastResolved(currentChatAgentId$) ?? null;
   const pinnedAgentsLoadable = useLastLoadable(pinnedAgents$);
-  const displayedPinnedAgentsResolved = useLastResolved(displayedPinnedAgents$);
+  const displayedPinnedAgentsLoadable = useLastLoadable(displayedPinnedAgents$);
   const unreadAgentIds = useLastResolved(unreadAgentIds$, {
     equalityFn: equalSets,
   });
@@ -217,6 +240,8 @@ export function PinnedAgentListSection({
   const setExpanded = useSet(setSidebarExpanded$);
   const collapsed = useGet(agentCardCollapsed$);
   const setCollapsed = useSet(setAgentCardCollapsed$);
+  const cachedPinnedAgentGridRows = useGet(pinnedAgentGridRows$);
+  const cachePinnedAgentGridRowsRef = useSet(cachePinnedAgentGridRowsRef$);
   const defaultAgentId = useLastResolved(defaultAgentId$);
   const pinnedAgents =
     pinnedAgentsLoadable.state === "hasData" ? pinnedAgentsLoadable.data : [];
@@ -225,15 +250,34 @@ export function PinnedAgentListSection({
       return agent.id;
     }),
   );
-  const displayedPinnedAgents = displayedPinnedAgentsResolved ?? pinnedAgents;
+  const displayedPinnedAgents =
+    displayedPinnedAgentsLoadable.state === "hasData"
+      ? displayedPinnedAgentsLoadable.data
+      : pinnedAgents;
+  const displayedPinnedAgentCount =
+    displayedPinnedAgentsLoadable.state === "hasData"
+      ? displayedPinnedAgentsLoadable.data.length
+      : null;
 
   const selectedAgentId =
     routeAgentId ?? (routeThreadId ? null : sidebarAgentId);
 
   if (layout === "horizontal") {
+    const horizontalPinnedAgents =
+      displayedPinnedAgentsLoadable.state === "loading"
+        ? null
+        : displayedPinnedAgents;
     const pinnedAgentCards =
-      pinnedAgentsLoadable.state === "hasData"
-        ? displayedPinnedAgents.map((agent) => {
+      horizontalPinnedAgents === null
+        ? Array.from(
+            {
+              length: cachedPinnedAgentGridRows * PINNED_AGENT_GRID_COLUMNS - 1,
+            },
+            (_, index) => {
+              return <PinnedAgentGridSkeletonCard key={index} />;
+            },
+          )
+        : horizontalPinnedAgents.map((agent) => {
             const isPrimarySelected =
               isChatRoute(activeRoute) && selectedAgentId === agent.id;
             const hasUnread = unreadAgentIds?.has(agent.id) ?? false;
@@ -264,8 +308,7 @@ export function PinnedAgentListSection({
                 </span>
               </Link>
             );
-          })
-        : [];
+          });
 
     return (
       <div className="shrink-0" data-testid="pinned-agents-horizontal">
@@ -300,6 +343,16 @@ export function PinnedAgentListSection({
           </button>
           {pinnedAgentCards.slice(3)}
         </div>
+        {displayedPinnedAgentCount !== null && (
+          <span
+            key={pinnedAgentGridRows(displayedPinnedAgentCount)}
+            ref={cachePinnedAgentGridRowsRef}
+            data-pinned-agent-grid-rows={pinnedAgentGridRows(
+              displayedPinnedAgentCount,
+            )}
+            hidden
+          />
+        )}
         <AgentListDialogContainer />
       </div>
     );


### PR DESCRIPTION
## Summary\n\n- cache the resolved pinned-agent grid row count for refreshes\n- render equal-height skeleton cards until pinned and unread agent data resolves\n- keep the New action in the fourth slot while preserving the cached grid height\n- cover the delayed-preferences loading transition with an integration test\n\n## Verification\n\n- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx --maxWorkers=1 --silent=passed-only\n- pnpm -F @okouai/app lint\n- pnpm -F @okouai/app check-types\n- pnpm knip --workspace @okouai/app\n- pnpm exec prettier --write on changed files