### PR TITLE
fix(api): project first-party app urls by public brand

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-downgrade.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-downgrade.test.ts
@@ -489,7 +489,8 @@ describe("POST /api/zero/billing/downgrade", () => {
     const periodStart = 1_782_809_751;
     const periodEnd = 1_785_401_751;
     const checkoutUrl = "https://checkout.stripe.com/setup/downgrade";
-    const returnUrl = "https://app.vm0.ai/settings?settings=billing";
+    const fallbackReturnUrl = "https://app.okou.ai";
+    const explicitReturnUrl = "https://app.vm0.ai/settings?settings=billing";
     const fixture = await track(
       store.set(
         seedInvoicesOrg$,
@@ -502,6 +503,7 @@ describe("POST /api/zero/billing/downgrade", () => {
         context.signal,
       ),
     );
+    mockEnv("APP_URL", "https://app.vm0.ai");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
@@ -540,8 +542,9 @@ describe("POST /api/zero/billing/downgrade", () => {
     );
     const response = await accept(
       client.create({
-        body: { targetTier: "pro", returnUrl },
+        body: { targetTier: "pro" },
         headers: { authorization: "Bearer clerk-session" },
+        extraHeaders: { origin: "https://app.okou.ai" },
       }),
       [200],
     );
@@ -554,8 +557,8 @@ describe("POST /api/zero/billing/downgrade", () => {
       mode: "setup",
       customer: customerId,
       currency: "usd",
-      success_url: returnUrl,
-      cancel_url: returnUrl,
+      success_url: fallbackReturnUrl,
+      cancel_url: fallbackReturnUrl,
       metadata: {
         purpose: "billing_downgrade",
         orgId: fixture.orgId,
@@ -571,6 +574,22 @@ describe("POST /api/zero/billing/downgrade", () => {
         },
       },
     });
+    context.mocks.stripe.checkout.sessions.create.mockClear();
+    const explicitResponse = await accept(
+      client.create({
+        body: { targetTier: "pro", returnUrl: explicitReturnUrl },
+        headers: { authorization: "Bearer clerk-session" },
+        extraHeaders: { origin: "https://app.okou.ai" },
+      }),
+      [200],
+    );
+    expect(explicitResponse.body).toStrictEqual(response.body);
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url: explicitReturnUrl,
+        cancel_url: explicitReturnUrl,
+      }),
+    );
     expect(
       context.mocks.stripe.subscriptionSchedules.create,
     ).not.toHaveBeenCalled();

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-restore.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-restore.test.ts
@@ -24,7 +24,6 @@ import { billingStatusRoutes } from "../billing-status";
 const context = testContext();
 const store = createStore();
 const mocks = createZeroRouteMocks(context);
-const APP_ORIGIN = "http://app.localhost:3002";
 
 function mockSubscriptionWithPaymentMethod(
   subId: string,
@@ -271,10 +270,11 @@ describe("POST /api/zero/billing/restore", () => {
     expect(status.body.scheduledChange).toBeNull();
   });
 
-  it("returns setup checkout URL when restore requires a payment method", async () => {
+  it("uses the request brand fallback and preserves an explicit return URL when restore requires a payment method", async () => {
     const subId = `sub-restore-card-${randomUUID().slice(0, 8)}`;
     const customerId = `cus-restore-card-${randomUUID().slice(0, 8)}`;
-    const returnUrl = `${APP_ORIGIN}/settings/billing`;
+    const fallbackReturnUrl = "https://app.okou.ai";
+    const explicitReturnUrl = "https://app.vm0.ai/settings/billing";
     const checkoutUrl = "https://checkout.stripe.com/setup/restore";
     const fixture = await track(
       store.set(
@@ -289,7 +289,7 @@ describe("POST /api/zero/billing/restore", () => {
         context.signal,
       ),
     );
-    mockEnv("APP_URL", APP_ORIGIN);
+    mockEnv("APP_URL", "https://app.vm0.ai");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
       id: subId,
@@ -312,8 +312,9 @@ describe("POST /api/zero/billing/restore", () => {
     );
     const response = await accept(
       client.create({
-        body: { returnUrl },
+        body: {},
         headers: { authorization: "Bearer clerk-session" },
+        extraHeaders: { origin: "https://app.okou.ai" },
       }),
       [200],
     );
@@ -326,8 +327,8 @@ describe("POST /api/zero/billing/restore", () => {
       mode: "setup",
       customer: customerId,
       currency: "usd",
-      success_url: returnUrl,
-      cancel_url: returnUrl,
+      success_url: fallbackReturnUrl,
+      cancel_url: fallbackReturnUrl,
       metadata: {
         purpose: "billing_restore",
         orgId: fixture.orgId,
@@ -341,6 +342,22 @@ describe("POST /api/zero/billing/restore", () => {
         },
       },
     });
+    context.mocks.stripe.checkout.sessions.create.mockClear();
+    const explicitResponse = await accept(
+      client.create({
+        body: { returnUrl: explicitReturnUrl },
+        headers: { authorization: "Bearer clerk-session" },
+        extraHeaders: { origin: "https://app.okou.ai" },
+      }),
+      [200],
+    );
+    expect(explicitResponse.body).toStrictEqual(response.body);
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url: explicitReturnUrl,
+        cancel_url: explicitReturnUrl,
+      }),
+    );
     expect(context.mocks.stripe.subscriptions.update).not.toHaveBeenCalled();
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 
 import { testBrowserReconcileContract } from "@okouai/api-contracts/contracts/test-browser-reconcile";
 import {
@@ -182,6 +183,21 @@ function acceptBrowserUseCdpSessions(
   }
 }
 
+function browserHeadersForRun(
+  runs: ReturnType<typeof createRunsApi>,
+  actor: ApiTestUser,
+  runId: string,
+  publicBrand?: PublicBrand,
+): { readonly authorization: string } {
+  const browserToken = runs.zeroTokenForRunWithCapabilities(
+    actor,
+    runId,
+    ["browser:read", "browser:write"],
+    publicBrand,
+  );
+  return { authorization: `Bearer ${browserToken}` };
+}
+
 async function claimChatRun(
   runs: ReturnType<typeof createRunsApi>,
   actor: ApiTestUser,
@@ -193,12 +209,8 @@ async function claimChatRun(
   if (!okouToken) {
     throw new Error("Expected the runner claim to include OKOU_TOKEN");
   }
-  const browserToken = runs.zeroTokenForRunWithCapabilities(actor, runId, [
-    "browser:read",
-    "browser:write",
-  ]);
   return {
-    browserHeaders: { authorization: `Bearer ${browserToken}` },
+    browserHeaders: browserHeadersForRun(runs, actor, runId),
     sandboxHeaders: {
       authorization: `Bearer ${claim.sandboxToken}`,
     },
@@ -411,10 +423,22 @@ describe("okou browser route", () => {
     if (sent.status !== 201 || sent.body.runId === null) {
       throw new Error("Expected a chat run");
     }
+    const legacySandboxToken = runs.sandboxTokenForRun(actor, sent.body.runId);
+    const legacyCreated = await accept(
+      authorizationClient().create({
+        headers: { authorization: `Bearer ${legacySandboxToken}` },
+        body: {},
+      }),
+      [200],
+    );
+    expect(new URL(legacyCreated.body.authorizationUrl).origin).toBe(
+      "https://app.vm0.ai",
+    );
     const runToken = runs.zeroTokenForRunWithCapabilities(
       actor,
       sent.body.runId,
       [],
+      "okou",
     );
     const created = await accept(
       authorizationClient().create({
@@ -422,6 +446,9 @@ describe("okou browser route", () => {
         body: {},
       }),
       [200],
+    );
+    expect(new URL(created.body.authorizationUrl).origin).toBe(
+      "https://app.okou.ai",
     );
     const requestToken = decodeURIComponent(
       new URL(created.body.authorizationUrl).pathname.split("/").at(-1) ?? "",
@@ -479,6 +506,12 @@ describe("okou browser route", () => {
       actor,
       agent.agentId,
       "Open a managed browser",
+    );
+    const firstBrowserHeaders = browserHeadersForRun(
+      runs,
+      actor,
+      first.runId,
+      "okou",
     );
     const other = await createClaimedChatRun(
       chat,
@@ -569,7 +602,7 @@ describe("okou browser route", () => {
     );
 
     const firstCreateRequest = client().create({
-      headers: first.claim.browserHeaders,
+      headers: firstBrowserHeaders,
       body: {
         name: "booking",
         proxyCountryCode: null,
@@ -593,7 +626,7 @@ describe("okou browser route", () => {
       // reclamation through the idle lease instead.
       timeoutMinutes: 240,
       idleExpiresAt: isoAt(10 * MINUTE_MS),
-      viewerUrl: `https://app.vm0.ai/browsers/${created.body.browser.threadId}`,
+      viewerUrl: `https://app.okou.ai/browsers/${created.body.browser.threadId}`,
       screen: {
         width: 1440,
         height: 900,
@@ -606,6 +639,7 @@ describe("okou browser route", () => {
     expect(createdInOtherThread.body.browser).toMatchObject({
       name: "research",
       status: "active",
+      viewerUrl: `https://app.vm0.ai/browsers/${createdInOtherThread.body.browser.threadId}`,
       screen: {
         width: 1440,
         height: 900,
@@ -646,7 +680,7 @@ describe("okou browser route", () => {
       {
         method: "POST",
         headers: {
-          ...first.claim.browserHeaders,
+          ...firstBrowserHeaders,
           "content-type": "application/json",
         },
         body: JSON.stringify({ aspectRatio: 0.75 }),
@@ -725,6 +759,7 @@ describe("okou browser route", () => {
     const restoredForAnotherViewer = await accept(
       client().get({
         headers: { authorization: "Bearer clerk-session" },
+        extraHeaders: { origin: "https://app.okou.ai" },
         params: { threadId: created.body.browser.threadId },
       }),
       [200],
@@ -734,6 +769,9 @@ describe("okou browser route", () => {
       height: 1920,
       resizable: true,
     });
+    expect(restoredForAnotherViewer.body.browser.viewerUrl).toBe(
+      `https://app.okou.ai/browsers/${created.body.browser.threadId}`,
+    );
 
     context.mocks.browserUseCdp.command.mockClear();
     const clampedTall = await accept(
@@ -786,13 +824,13 @@ describe("okou browser route", () => {
       signal: context.signal,
       routes: TEST_APP_ROUTES,
     }).request(`/api/zero/chat-threads/${randomUUID()}/browser`, {
-      headers: first.claim.browserHeaders,
+      headers: firstBrowserHeaders,
     });
     expect(copiedToAnotherThread.status).toBe(404);
 
     const duplicateNew = await accept(
       client().create({
-        headers: first.claim.browserHeaders,
+        headers: firstBrowserHeaders,
         body: {
           name: "another",
           proxyCountryCode: null,
@@ -833,7 +871,7 @@ describe("okou browser route", () => {
     expect(providerStops()).toBe(0);
     const stillLive = await accept(
       client().get({
-        headers: first.claim.browserHeaders,
+        headers: firstBrowserHeaders,
         params: { threadId: created.body.browser.threadId },
       }),
       [200],

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -3296,6 +3296,7 @@ describe("CHAT-02: dispatch failure", () => {
 
 describe("CHAT-02: admission without spendable credits", () => {
   it("blocks admission for model-first sends through visible chat messages", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
     const completed = await bdd.completeOnboarding(actor);
@@ -3333,7 +3334,13 @@ describe("CHAT-02: admission without spendable credits", () => {
       model: "claude-sonnet-5",
       clientEventId,
     };
-    const sent = await chat.requestSendEvent(actor, sendBody, [201]);
+    const sent = await chat.requestSendEvent(
+      actor,
+      sendBody,
+      [201],
+      undefined,
+      "okou",
+    );
     if (sent.status !== 201) {
       throw new Error("Expected the blocked send to return 201 without a run");
     }
@@ -3378,6 +3385,8 @@ describe("CHAT-02: admission without spendable credits", () => {
       throw new Error("Expected insufficient-credits assistant guidance");
     }
     expect(guidance.content).toContain("Buy more credits");
+    expect(guidance.content).toContain("https://app.okou.ai/?settings=usage");
+    expect(guidance.content).not.toContain("https://app.vm0.ai");
     expect(guidance.error).toBe("insufficient_credits");
 
     const appended = await chat.listThreadEvents(actor, sent.body.threadId, {
@@ -3404,6 +3413,8 @@ describe("CHAT-02: admission without spendable credits", () => {
       actor,
       { ...sendBody, threadId: sent.body.threadId },
       [201],
+      undefined,
+      "okou",
     );
     expect(retry.body).toStrictEqual(sent.body);
     const afterRetry = await chat.listThreadEvents(actor, sent.body.threadId);

--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -15,7 +15,9 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
+import { mockEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
+import { generateSandboxToken } from "../../auth/tokens";
 import { testContext } from "../../../__tests__/test-context";
 import { testComputerUseStateRoutes } from "../test-computer-use-state";
 import {
@@ -164,6 +166,7 @@ function requestTokenFromUrl(authorizationUrl: string): string {
 
 describe("FILE-03 desktop computer-use runtime", () => {
   it("creates a delegated authorization link and applies the selected host to the chat thread", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
     const orgId = `org_${randomUUID()}`;
     const actor = bdd.user({ orgId });
     const run = await seedZeroRun({ actor, triggerSource: "web" });
@@ -181,11 +184,19 @@ describe("FILE-03 desktop computer-use runtime", () => {
       hostName: "Studio Mac",
     });
     mockClerkMembership(context, actor, "org:admin");
+    const legacyToken = generateSandboxToken(actor.userId, run.runId, orgId);
+    const legacyCreated = await api.createComputerUseAuthorizationRequest({
+      bearer: legacyToken,
+    });
+    expect(new URL(legacyCreated.authorizationUrl).origin).toBe(
+      "https://app.vm0.ai",
+    );
     const token = zeroComputerUseToken({
       userId: actor.userId,
       orgId,
       runId: run.runId,
       capabilities: ["connector:read"],
+      publicBrand: "okou",
     }).token;
 
     const created = await api.createComputerUseAuthorizationRequest({
@@ -195,6 +206,9 @@ describe("FILE-03 desktop computer-use runtime", () => {
       source: "chat",
     });
     expect(created.authorizationUrl).toContain("/computer-use/authorize/");
+    expect(new URL(created.authorizationUrl).origin).toBe(
+      "https://app.okou.ai",
+    );
 
     const requestToken = requestTokenFromUrl(created.authorizationUrl);
     const readable = await api.readComputerUseAuthorizationRequest(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -5,6 +5,7 @@ import {
   type DesktopProduct,
 } from "@okouai/api-contracts/contracts/client-headers";
 import type { ZeroCapability } from "@okouai/api-contracts/contracts/capabilities";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { cronComputerUseScreenshotCleanupContract } from "@okouai/api-contracts/contracts/cron";
 import {
   zeroComputerUseAuthorizationRequestsContract,
@@ -322,6 +323,7 @@ export function zeroComputerUseToken(args: {
   readonly capabilities: readonly ZeroCapability[];
   readonly runId?: string;
   readonly computerUseHostId?: string;
+  readonly publicBrand?: PublicBrand;
 }): { readonly token: string; readonly runId: string } {
   const seconds = Math.floor(now() / 1000);
   const runId = args.runId ?? `run_${randomUUID()}`;
@@ -331,6 +333,9 @@ export function zeroComputerUseToken(args: {
     orgId: args.orgId,
     runId,
     capabilities: [...args.capabilities],
+    ...(args.publicBrand === undefined
+      ? {}
+      : { publicBrand: args.publicBrand }),
     ...(args.computerUseHostId
       ? { computerUseHostId: args.computerUseHostId }
       : {}),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -4,6 +4,7 @@ import {
 } from "@okouai/api-contracts/contracts/logs";
 import type { z } from "zod";
 import { emailUnsubscribeContract } from "@okouai/api-contracts/contracts/email-unsubscribe";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { pushSubscriptionsContract } from "@okouai/api-contracts/contracts/push-subscriptions";
 import { userExportContract } from "@okouai/api-contracts/contracts/user-export";
 import type {
@@ -298,12 +299,16 @@ export function createMiscRoutesApi(context: TestContext) {
     async requestEmailUnsubscribePage(
       token: string | undefined,
       statuses: readonly (302 | 400)[],
+      publicBrand: PublicBrand = "vm0",
     ) {
       return await accept(
         setupApp({ context, routes: emailUnsubscribeRoutes })(
           emailUnsubscribeContract,
         ).get({
           query: { token },
+          ...(publicBrand === "okou"
+            ? { extraHeaders: { origin: "https://app.okou.ai" } }
+            : {}),
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -8,6 +8,7 @@ import {
   cliAuthTokenContract,
 } from "@okouai/api-contracts/contracts/cli-auth";
 import type { ZeroCapability } from "@okouai/api-contracts/contracts/capabilities";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { agentComposeApiContentSchema } from "@okouai/api-contracts/contracts/composes";
 import { webhookStripeContract } from "@okouai/api-contracts/contracts/webhooks";
 import { zeroBillingStatusContract } from "@okouai/api-contracts/contracts/zero-billing";
@@ -687,6 +688,7 @@ export function createRunsApi(context: TestContext) {
       actor: ApiTestUser,
       runId: string,
       capabilities: readonly ZeroCapability[],
+      publicBrand?: PublicBrand,
     ): string {
       if (!actor.orgId) {
         throw new Error("Zero run tokens require an org-scoped actor");
@@ -698,6 +700,7 @@ export function createRunsApi(context: TestContext) {
         orgId: actor.orgId,
         runId,
         capabilities: [...capabilities],
+        ...(publicBrand === undefined ? {} : { publicBrand }),
         iat: seconds,
         exp: seconds + 3600,
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
 
 import { testMailDraftStateContract } from "@okouai/api-contracts/contracts/test-mail-draft-state";
 import { zeroMailContract } from "@okouai/api-contracts/contracts/zero-mail";
@@ -7,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { testMailDraftStateRoutes } from "../test-mail-draft-state";
 import { createBddApi } from "./helpers/api-bdd";
@@ -290,10 +292,11 @@ function authHeaders() {
 
 async function linkDraft(
   fixture: Awaited<ReturnType<typeof seedGmailMailCardFixture>>,
+  headers = authHeaders(),
 ) {
   return await accept(
     client().linkDraft({
-      headers: authHeaders(),
+      headers,
       body: {
         threadId: fixture.thread.id,
         agentId: fixture.agent.agentId,
@@ -306,16 +309,28 @@ async function linkDraft(
 
 describe("POST /api/zero/mail/drafts/link", () => {
   it("links without injecting a duplicate card and sends without rebuilding MIME", async () => {
+    mockEnv("APP_URL", "https://app.vm0.ai");
     const fixture = await seedGmailMailCardFixture();
     const gmail = mockGmailDraftApi();
 
-    const linked = await linkDraft(fixture);
+    const okouToken = runs.zeroTokenForRunWithCapabilities(
+      fixture.actor,
+      randomUUID(),
+      ["connector:read"],
+      "okou",
+    );
+    const linked = await linkDraft(fixture, {
+      authorization: `Bearer ${okouToken}`,
+    });
     expect(linked.body.mailDraftUrl).toBe(
-      `http://localhost:3002/mail/drafts/${linked.body.mailDraftId}`,
+      `https://app.okou.ai/mail/drafts/${linked.body.mailDraftId}`,
     );
 
     const duplicateLink = await linkDraft(fixture);
-    expect(duplicateLink.body).toStrictEqual(linked.body);
+    expect(duplicateLink.body).toStrictEqual({
+      mailDraftId: linked.body.mailDraftId,
+      mailDraftUrl: `https://app.vm0.ai/mail/drafts/${linked.body.mailDraftId}`,
+    });
 
     const loaded = await accept(
       client().getDraft({
@@ -323,6 +338,9 @@ describe("POST /api/zero/mail/drafts/link", () => {
         params: { mailDraftId: linked.body.mailDraftId },
       }),
       [200],
+    );
+    expect(loaded.body.mailDraftUrl).toBe(
+      `https://app.vm0.ai/mail/drafts/${linked.body.mailDraftId}`,
     );
     expect(loaded.body.mailDraft).toMatchObject({
       version: 3,

--- a/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
@@ -2,7 +2,7 @@ import { createHmac, randomUUID } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
 
-import { env } from "../../../lib/env";
+import { env, mockEnv } from "../../../lib/env";
 import { testContext } from "../../../__tests__/test-context";
 import { createBddApi, expectApiError } from "./helpers/api-bdd";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
@@ -158,12 +158,21 @@ describe("MISC-02: preferences, push subscription, user export, and empty logs",
     });
 
     const validToken = unsubscribeToken(`user_${randomUUID()}`);
+    mockEnv("APP_URL", "https://app.vm0.ai");
     const unsubscribePage = await api.requestEmailUnsubscribePage(
       validToken,
       [302],
     );
     expect(unsubscribePage.headers.get("Location")).toBe(
-      `http://localhost:3002/email/unsubscribe?token=${validToken}`,
+      `https://app.vm0.ai/email/unsubscribe?token=${validToken}`,
+    );
+    const okouUnsubscribePage = await api.requestEmailUnsubscribePage(
+      validToken,
+      [302],
+      "okou",
+    );
+    expect(okouUnsubscribePage.headers.get("Location")).toBe(
+      `https://app.okou.ai/email/unsubscribe?token=${validToken}`,
     );
 
     const unsubscribed = await api.requestEmailUnsubscribe(validToken, [200]);

--- a/turbo/apps/api/src/signals/routes/billing-downgrade.ts
+++ b/turbo/apps/api/src/signals/routes/billing-downgrade.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { zeroBillingDowngradeContract } from "@okouai/api-contracts/contracts/zero-billing";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 
 import { env, optionalEnv } from "../../lib/env";
 import { billingRedirectAllowed } from "../../lib/billing-redirect";
@@ -10,6 +11,7 @@ import {
 } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { publicBrand$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { downgradeSubscription$ } from "../services/zero-billing-downgrade.service";
 import type { RouteEntry } from "../route-entry";
@@ -39,7 +41,9 @@ const downgradeAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
     return bodyResult.response;
   }
   const { targetTier } = bodyResult.data;
-  const returnUrl = bodyResult.data.returnUrl ?? env("APP_URL");
+  const returnUrl =
+    bodyResult.data.returnUrl ??
+    appUrlForPublicBrand(env("APP_URL"), get(publicBrand$));
   if (!billingRedirectAllowed(returnUrl)) {
     return badRequestMessage("returnUrl must match the platform origin");
   }

--- a/turbo/apps/api/src/signals/routes/billing-restore.ts
+++ b/turbo/apps/api/src/signals/routes/billing-restore.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { zeroBillingRestoreContract } from "@okouai/api-contracts/contracts/zero-billing";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 
 import { env, optionalEnv } from "../../lib/env";
 import { billingRedirectAllowed } from "../../lib/billing-redirect";
@@ -10,6 +11,7 @@ import {
 } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { publicBrand$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { restoreSubscription$ } from "../services/zero-billing-restore.service";
 import type { RouteEntry } from "../route-entry";
@@ -36,7 +38,9 @@ const restoreAuthed$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (!bodyResult.ok) {
     return bodyResult.response;
   }
-  const returnUrl = bodyResult.data.returnUrl ?? env("APP_URL");
+  const returnUrl =
+    bodyResult.data.returnUrl ??
+    appUrlForPublicBrand(env("APP_URL"), get(publicBrand$));
   if (!billingRedirectAllowed(returnUrl)) {
     return badRequestMessage("returnUrl must match the platform origin");
   }

--- a/turbo/apps/api/src/signals/routes/browser-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/browser-authorization.ts
@@ -61,10 +61,17 @@ const createAuthorizationRequestInner$ = command(
         "Cloud browser authorization requires a run token",
       );
     }
+    // Legacy sandbox tokens do not carry presentation context and remain VM0.
+    const publicBrand = auth.tokenType === "zero" ? auth.publicBrand : "vm0";
 
     const result = await set(
       createBrowserAuthorizationRequest$,
-      { orgId: auth.orgId, userId: auth.userId, runId: auth.runId },
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        runId: auth.runId,
+        publicBrand,
+      },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/browser.ts
+++ b/turbo/apps/api/src/signals/routes/browser.ts
@@ -4,6 +4,7 @@ import { command } from "ccstate";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
+import { publicBrand$ } from "../context/hono";
 import type { RouteEntry } from "../route-entry";
 import {
   createZeroBrowser$,
@@ -39,12 +40,15 @@ const createBrowserInner$ = command(
       return body.response;
     }
     const auth = get(organizationAuthContext$);
+    const publicBrand =
+      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       createZeroBrowser$,
       {
         actor: {
           orgId: auth.orgId,
           userId: auth.userId,
+          publicBrand,
           ...("runId" in auth ? { runId: auth.runId } : {}),
         },
         input: body.data,
@@ -65,11 +69,14 @@ const useBrowserInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return body.response;
   }
   const auth = get(organizationAuthContext$);
+  const publicBrand =
+    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
   const result = await set(
     useZeroBrowser$,
     {
       orgId: auth.orgId,
       userId: auth.userId,
+      publicBrand,
       ...("runId" in auth ? { runId: auth.runId } : {}),
     },
     signal,
@@ -88,11 +95,14 @@ const leaseBrowserInner$ = command(
       return body.response;
     }
     const auth = get(organizationAuthContext$);
+    const publicBrand =
+      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       leaseCurrentZeroBrowser$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
+        publicBrand,
         ...("runId" in auth ? { runId: auth.runId } : {}),
       },
       signal,
@@ -113,11 +123,14 @@ const leaseBrowserByThreadInner$ = command(
       return body.response;
     }
     const auth = get(organizationAuthContext$);
+    const publicBrand =
+      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       leaseZeroBrowserByThread$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
+        publicBrand,
         chatThreadId: get(leaseByThreadParams$).threadId,
         ...("runId" in auth ? { runId: auth.runId } : {}),
       },
@@ -138,11 +151,14 @@ const openBrowserInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return body.response;
   }
   const auth = get(organizationAuthContext$);
+  const publicBrand =
+    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
   const result = await set(
     openZeroBrowserForThread$,
     {
       orgId: auth.orgId,
       userId: auth.userId,
+      publicBrand,
       chatThreadId: get(openParams$).threadId,
       lifecycleEventId: body.data.eventId,
       ...("runId" in auth ? { runId: auth.runId } : {}),
@@ -164,11 +180,14 @@ const closeBrowserInner$ = command(
       return body.response;
     }
     const auth = get(organizationAuthContext$);
+    const publicBrand =
+      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       closeZeroBrowserForThread$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
+        publicBrand,
         chatThreadId: get(closeParams$).threadId,
         lifecycleEventId: body.data.eventId,
         ...("runId" in auth ? { runId: auth.runId } : {}),
@@ -191,11 +210,14 @@ const resizeBrowserByThreadInner$ = command(
       return body.response;
     }
     const auth = get(organizationAuthContext$);
+    const publicBrand =
+      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       resizeZeroBrowserByThread$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
+        publicBrand,
         chatThreadId: get(resizeByThreadParams$).threadId,
         aspectRatio: body.data.aspectRatio,
         ...("runId" in auth ? { runId: auth.runId } : {}),
@@ -211,11 +233,14 @@ const resizeBrowserByThreadInner$ = command(
 const currentBrowserInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
+    const publicBrand =
+      auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
     const result = await set(
       getCurrentZeroBrowser$,
       {
         orgId: auth.orgId,
         userId: auth.userId,
+        publicBrand,
         ...("runId" in auth ? { runId: auth.runId } : {}),
       },
       signal,
@@ -229,11 +254,14 @@ const currentBrowserInner$ = command(
 const getParams$ = pathParamsOf(zeroBrowserContract.get);
 const getBrowserInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
+  const publicBrand =
+    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
   const result = await set(
     getZeroBrowser$,
     {
       orgId: auth.orgId,
       userId: auth.userId,
+      publicBrand,
       chatThreadId: get(getParams$).threadId,
       ...("runId" in auth ? { runId: auth.runId } : {}),
     },

--- a/turbo/apps/api/src/signals/routes/computer-use-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/computer-use-authorization.ts
@@ -66,10 +66,17 @@ const createAuthorizationRequestInner$ = command(
         "Computer Use authorization requires a run token",
       );
     }
+    // Legacy sandbox tokens do not carry presentation context and remain VM0.
+    const publicBrand = auth.tokenType === "zero" ? auth.publicBrand : "vm0";
 
     const result = await set(
       createComputerUseAuthorizationRequest$,
-      { orgId: auth.orgId, userId: auth.userId, runId: auth.runId },
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        runId: auth.runId,
+        publicBrand,
+      },
       signal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/email-unsubscribe.ts
+++ b/turbo/apps/api/src/signals/routes/email-unsubscribe.ts
@@ -1,7 +1,9 @@
 import { command } from "ccstate";
 import { emailUnsubscribeContract } from "@okouai/api-contracts/contracts/email-unsubscribe";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 
 import { env } from "../../lib/env";
+import { publicBrand$ } from "../context/hono";
 import { queryOf } from "../context/request";
 import {
   unsubscribeEmailUser$,
@@ -31,7 +33,7 @@ const getEmailUnsubscribe$ = command(async ({ get }, signal: AbortSignal) => {
     return invalidTokenResponse();
   }
 
-  const appUrl = env("APP_URL");
+  const appUrl = appUrlForPublicBrand(env("APP_URL"), get(publicBrand$));
   return new Response(null, {
     status: 302,
     headers: {

--- a/turbo/apps/api/src/signals/routes/mail.ts
+++ b/turbo/apps/api/src/signals/routes/mail.ts
@@ -1,9 +1,13 @@
 import { command } from "ccstate";
 import { zeroMailContract } from "@okouai/api-contracts/contracts/zero-mail";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 
 import { conflict, notFound } from "../../lib/error";
+import { env } from "../../lib/env";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { publicBrand$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import {
@@ -16,14 +20,21 @@ import {
   type MailDraftMutationResult,
 } from "../services/mail-draft.service";
 
-function mutationResponse(result: MailDraftMutationResult) {
+function mailDraftUrl(mailDraftId: string, publicBrand: PublicBrand): string {
+  return `${appUrlForPublicBrand(env("APP_URL"), publicBrand)}/mail/drafts/${mailDraftId}`;
+}
+
+function mutationResponse(
+  result: MailDraftMutationResult,
+  publicBrand: PublicBrand,
+) {
   switch (result.kind) {
     case "ok": {
       return {
         status: 200 as const,
         body: {
           mailDraftId: result.mailDraftId,
-          mailDraftUrl: result.mailDraftUrl,
+          mailDraftUrl: mailDraftUrl(result.mailDraftId, publicBrand),
           mailDraft: result.mailDraft,
         },
       };
@@ -37,14 +48,17 @@ function mutationResponse(result: MailDraftMutationResult) {
   }
 }
 
-function linkMutationResponse(result: MailDraftLinkMutationResult) {
+function linkMutationResponse(
+  result: MailDraftLinkMutationResult,
+  publicBrand: PublicBrand,
+) {
   switch (result.kind) {
     case "ok": {
       return {
         status: 200 as const,
         body: {
           mailDraftId: result.mailDraftId,
-          mailDraftUrl: result.mailDraftUrl,
+          mailDraftUrl: mailDraftUrl(result.mailDraftId, publicBrand),
         },
       };
     }
@@ -60,6 +74,8 @@ function linkMutationResponse(result: MailDraftLinkMutationResult) {
 const linkDraftBody$ = bodyResultOf(zeroMailContract.linkDraft);
 const linkDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
+  const publicBrand =
+    auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$);
   const bodyResult = await get(linkDraftBody$);
   signal.throwIfAborted();
   if (!bodyResult.ok) {
@@ -74,12 +90,13 @@ const linkDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     },
     signal,
   );
-  return linkMutationResponse(result);
+  return linkMutationResponse(result, publicBrand);
 });
 
 const getDraftParams$ = pathParamsOf(zeroMailContract.getDraft);
 const getDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
+  const publicBrand = get(publicBrand$);
   return mutationResponse(
     await set(
       getMailDraft$,
@@ -90,6 +107,7 @@ const getDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       },
       signal,
     ),
+    publicBrand,
   );
 });
 
@@ -150,6 +168,7 @@ const getAttachmentInner$ = command(
 const deleteDraftParams$ = pathParamsOf(zeroMailContract.deleteDraft);
 const deleteDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
+  const publicBrand = get(publicBrand$);
   const result = await set(
     deleteMailDraft$,
     {
@@ -160,7 +179,7 @@ const deleteDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     signal,
   );
   if (result.kind !== "ok") {
-    return mutationResponse(result);
+    return mutationResponse(result, publicBrand);
   }
   return { status: 204 as const, body: undefined };
 });
@@ -168,6 +187,7 @@ const deleteDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 const sendDraftParams$ = pathParamsOf(zeroMailContract.sendDraft);
 const sendDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
+  const publicBrand = get(publicBrand$);
   return mutationResponse(
     await set(
       sendMailDraft$,
@@ -178,6 +198,7 @@ const sendDraftInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       },
       signal,
     ),
+    publicBrand,
   );
 });
 

--- a/turbo/apps/api/src/signals/services/browser-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/browser-authorization.service.ts
@@ -4,6 +4,8 @@ import { and, eq, isNotNull } from "drizzle-orm";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { browserAuthorizationRequests } from "@okouai/db/schema/browser-session";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { env } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
@@ -55,8 +57,11 @@ function isUuid(value: string): boolean {
   );
 }
 
-function authorizationUrl(requestToken: string): string {
-  return `${env("APP_URL")}/browser/authorize/${encodeURIComponent(
+function authorizationUrl(
+  requestToken: string,
+  publicBrand: PublicBrand,
+): string {
+  return `${appUrlForPublicBrand(env("APP_URL"), publicBrand)}/browser/authorize/${encodeURIComponent(
     requestToken,
   )}`;
 }
@@ -132,6 +137,7 @@ export const createBrowserAuthorizationRequest$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly runId: string;
+      readonly publicBrand: PublicBrand;
     },
     signal: AbortSignal,
   ): Promise<CreateBrowserAuthorizationRequestResult> => {
@@ -164,7 +170,7 @@ export const createBrowserAuthorizationRequest$ = command(
 
     return {
       status: "created",
-      authorizationUrl: authorizationUrl(requestToken),
+      authorizationUrl: authorizationUrl(requestToken, args.publicBrand),
       expiresAt: expiresAt.toISOString(),
     };
   },

--- a/turbo/apps/api/src/signals/services/computer-use-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/computer-use-authorization.service.ts
@@ -6,6 +6,8 @@ import type {
   ComputerUseAuthorizationSource,
   ComputerUseHostListResponse,
 } from "@okouai/api-contracts/contracts/zero-computer-use";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import {
@@ -94,8 +96,11 @@ function isUuid(value: string): boolean {
   );
 }
 
-function authorizationUrl(requestToken: string): string {
-  return `${env("APP_URL")}/computer-use/authorize/${encodeURIComponent(
+function authorizationUrl(
+  requestToken: string,
+  publicBrand: PublicBrand,
+): string {
+  return `${appUrlForPublicBrand(env("APP_URL"), publicBrand)}/computer-use/authorize/${encodeURIComponent(
     requestToken,
   )}`;
 }
@@ -416,6 +421,7 @@ export const createComputerUseAuthorizationRequest$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly runId: string;
+      readonly publicBrand: PublicBrand;
     },
     signal: AbortSignal,
   ): Promise<CreateComputerUseAuthorizationRequestResult> => {
@@ -454,7 +460,7 @@ export const createComputerUseAuthorizationRequest$ = command(
 
     return {
       status: "created",
-      authorizationUrl: authorizationUrl(requestToken),
+      authorizationUrl: authorizationUrl(requestToken, args.publicBrand),
       source: scope.source,
       expiresAt: expiresAt.toISOString(),
     };

--- a/turbo/apps/api/src/signals/services/mail-draft.service.ts
+++ b/turbo/apps/api/src/signals/services/mail-draft.service.ts
@@ -20,7 +20,6 @@ import { convert } from "html-to-text";
 import { z } from "zod";
 
 import { pgTextDecoder } from "../../lib/db-structured-result";
-import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../../lib/time";
@@ -113,14 +112,12 @@ interface MailConnection extends ConnectorCredentialConnection {
 interface MailDraftResult {
   readonly kind: "ok";
   readonly mailDraftId: string;
-  readonly mailDraftUrl: string;
   readonly mailDraft: ZeroMailDraft;
 }
 
 interface MailDraftLinkResult {
   readonly kind: "ok";
   readonly mailDraftId: string;
-  readonly mailDraftUrl: string;
 }
 
 interface MailDraftAttachmentSuccess {
@@ -240,15 +237,10 @@ interface MailAccess {
   readonly connection: MailConnection;
 }
 
-function mailDraftUrl(mailDraftId: string): string {
-  return `${env("APP_URL").replace(/\/+$/u, "")}/mail/drafts/${mailDraftId}`;
-}
-
 function linkResult(mailDraftId: string): MailDraftLinkResult {
   return {
     kind: "ok",
     mailDraftId,
-    mailDraftUrl: mailDraftUrl(mailDraftId),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-browser.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-browser.service.ts
@@ -21,6 +21,8 @@ import {
 } from "@okouai/db/schema/browser-session";
 import { agentComposes } from "@okouai/db/schema/agent-compose";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { command } from "ccstate";
 import {
   and,
@@ -146,6 +148,7 @@ interface BrowserScreen {
 interface BrowserActor {
   readonly orgId: string;
   readonly userId: string;
+  readonly publicBrand: PublicBrand;
   readonly runId?: string;
 }
 
@@ -156,6 +159,7 @@ interface BrowserRunContext {
   // calling run; for viewer requests it is the thread's most recent run.
   readonly runId: string;
   readonly chatThreadId: string;
+  readonly publicBrand: PublicBrand;
   // Viewer requests may start a browser while no run is alive, so only run
   // tokens assert that their own run is still running.
   readonly requireLiveRun: boolean;
@@ -169,6 +173,7 @@ interface BrowserCreateInput {
 interface BrowserOwnerAccess {
   readonly orgId: string;
   readonly userId: string;
+  readonly publicBrand: PublicBrand;
   readonly runId?: string;
 }
 
@@ -256,28 +261,34 @@ async function providerCall<T>(
     : providerFailure(result.error);
 }
 
-function browserViewerUrl(chatThreadId: string): string {
-  return `${env("APP_URL").replace(/\/+$/u, "")}/browsers/${chatThreadId}`;
+function browserViewerUrl(
+  chatThreadId: string,
+  publicBrand: PublicBrand,
+): string {
+  return `${appUrlForPublicBrand(env("APP_URL"), publicBrand)}/browsers/${chatThreadId}`;
 }
 
 function publicBrowser(
   row: BrowserSessionRow,
-  liveUrl: string | null,
-  screenshotUrl: string | null,
-  idleExpiresAt: Date | null = null,
-  screen: BrowserScreen | null = null,
+  presentation: {
+    readonly publicBrand: PublicBrand;
+    readonly liveUrl: string | null;
+    readonly screenshotUrl: string | null;
+    readonly idleExpiresAt?: Date | null;
+    readonly screen?: BrowserScreen | null;
+  },
 ): ZeroBrowserSession {
   return {
     threadId: row.chatThreadId,
     name: row.name,
     status: row.status,
-    viewerUrl: browserViewerUrl(row.chatThreadId),
-    liveUrl,
-    screenshotUrl,
+    viewerUrl: browserViewerUrl(row.chatThreadId, presentation.publicBrand),
+    liveUrl: presentation.liveUrl,
+    screenshotUrl: presentation.screenshotUrl,
     proxyCountryCode: row.proxyCountryCode,
     timeoutMinutes: row.timeoutMinutes,
-    ...(screen ? { screen } : {}),
-    idleExpiresAt: idleExpiresAt?.toISOString() ?? null,
+    ...(presentation.screen ? { screen: presentation.screen } : {}),
+    idleExpiresAt: presentation.idleExpiresAt?.toISOString() ?? null,
     suspendedAt: row.suspendedAt?.toISOString() ?? null,
     suspensionReason: row.suspensionReason,
     createdAt: row.createdAt.toISOString(),
@@ -992,6 +1003,7 @@ async function resolveRunContext(
       userId: actor.userId,
       runId: actor.runId,
       chatThreadId: run.chatThreadId,
+      publicBrand: actor.publicBrand,
       requireLiveRun: true,
     },
   };
@@ -1044,6 +1056,7 @@ async function resolveViewerStartContext(
       userId: access.userId,
       runId: latestRunId,
       chatThreadId: access.chatThreadId,
+      publicBrand: access.publicBrand,
       requireLiveRun: false,
     },
   };
@@ -1674,13 +1687,13 @@ const startProviderInstance$ = command(
     return {
       kind: "ok",
       value: {
-        browser: publicBrowser(
-          claimed.browser,
-          started.liveUrl,
+        browser: publicBrowser(claimed.browser, {
+          publicBrand: args.context.publicBrand,
+          liveUrl: started.liveUrl,
           screenshotUrl,
-          claimed.instance.idleExpiresAt,
-          claimed.screen,
-        ),
+          idleExpiresAt: claimed.instance.idleExpiresAt,
+          screen: claimed.screen,
+        }),
         cdpUrl: started.cdpUrl,
         lifecycleEventId: null,
       },
@@ -1899,13 +1912,13 @@ const inspectActiveConnection$ = command(
       return {
         kind: "ok",
         value: {
-          browser: publicBrowser(
-            owner ?? browser,
+          browser: publicBrowser(owner ?? browser, {
+            publicBrand: args.context.publicBrand,
             liveUrl,
             screenshotUrl,
-            leased?.idleExpiresAt ?? instance.idleExpiresAt,
+            idleExpiresAt: leased?.idleExpiresAt ?? instance.idleExpiresAt,
             screen,
-          ),
+          }),
           cdpUrl,
           lifecycleEventId: null,
         },
@@ -2306,6 +2319,7 @@ const leaseInstanceForBrowser$ = command(
   async (
     { set },
     browser: BrowserSessionRow,
+    publicBrand: PublicBrand,
     signal: AbortSignal,
   ): Promise<BrowserServiceResult<ZeroBrowserSession>> => {
     const db = set(writeDb$);
@@ -2327,13 +2341,13 @@ const leaseInstanceForBrowser$ = command(
     signal.throwIfAborted();
     return {
       kind: "ok",
-      value: publicBrowser(
-        browser,
-        null,
+      value: publicBrowser(browser, {
+        publicBrand,
+        liveUrl: null,
         screenshotUrl,
-        leased.idleExpiresAt,
+        idleExpiresAt: leased.idleExpiresAt,
         screen,
-      ),
+      }),
     };
   },
 );
@@ -2355,7 +2369,12 @@ export const leaseCurrentZeroBrowser$ = command(
     if (!browser) {
       return notFound();
     }
-    return await set(leaseInstanceForBrowser$, browser, signal);
+    return await set(
+      leaseInstanceForBrowser$,
+      browser,
+      context.value.publicBrand,
+      signal,
+    );
   },
 );
 
@@ -2376,7 +2395,12 @@ export const leaseZeroBrowserByThread$ = command(
     if (accessError) {
       return accessError;
     }
-    return await set(leaseInstanceForBrowser$, browser, signal);
+    return await set(
+      leaseInstanceForBrowser$,
+      browser,
+      access.publicBrand,
+      signal,
+    );
   },
 );
 
@@ -2479,13 +2503,13 @@ export const resizeZeroBrowserByThread$ = command(
     );
     return {
       kind: "ok",
-      value: publicBrowser(
-        browser,
-        provider.value.liveUrl,
+      value: publicBrowser(browser, {
+        publicBrand: access.publicBrand,
+        liveUrl: provider.value.liveUrl,
         screenshotUrl,
-        persisted.value.instance.idleExpiresAt,
-        persisted.value.screen,
-      ),
+        idleExpiresAt: persisted.value.instance.idleExpiresAt,
+        screen: persisted.value.screen,
+      }),
     };
   },
 );
@@ -2538,7 +2562,13 @@ export const getZeroBrowser$ = command(
     }
     return {
       kind: "ok",
-      value: publicBrowser(row, liveUrl, screenshotUrl, idleExpiresAt, screen),
+      value: publicBrowser(row, {
+        publicBrand: access.publicBrand,
+        liveUrl,
+        screenshotUrl,
+        idleExpiresAt,
+        screen,
+      }),
     };
   },
 );
@@ -2566,6 +2596,7 @@ export const getCurrentZeroBrowser$ = command(
         orgId: actor.orgId,
         userId: actor.userId,
         chatThreadId: context.value.chatThreadId,
+        publicBrand: actor.publicBrand,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -13,6 +13,7 @@ import {
 } from "@okouai/api-contracts/contracts/chat-threads";
 import type { SupportedRunModel } from "@okouai/api-contracts/contracts/model-providers";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import {
   chatEvents,
@@ -2624,9 +2625,10 @@ function scheduleClaimedQueueFirstEventSideEffects(params: {
 async function buildInsufficientCreditsAssistantMessage(params: {
   readonly db: Db;
   readonly orgId: string;
+  readonly publicBrand: PublicBrand;
 }): Promise<string> {
   const capabilities = await loadOrgPlanCapabilities(params.db, params.orgId);
-  const appUrl = env("APP_URL").replace(/\/$/, "");
+  const appUrl = appUrlForPublicBrand(env("APP_URL"), params.publicBrand);
   const usageUrl = `${appUrl}/?settings=usage`;
   const billingUrl = `${appUrl}/?settings=billing&billingView=plans`;
   if (capabilities?.canBuyCredits !== true) {
@@ -2728,12 +2730,14 @@ async function appendInsufficientCreditsEvents(params: {
   readonly body: RuntimeNormalSendBody;
   readonly userId: string;
   readonly orgId: string;
+  readonly publicBrand: PublicBrand;
   readonly touchThreadSort: boolean;
   readonly queueFirstEventId?: string;
 }): Promise<CreatedChatEventResponse> {
   const assistantContent = await buildInsufficientCreditsAssistantMessage({
     db: params.prepared.db,
     orgId: params.orgId,
+    publicBrand: params.publicBrand,
   });
   if (params.queueFirstEventId) {
     return appendQueueFirstInsufficientCreditsEvents({
@@ -3065,6 +3069,7 @@ const createNormalChatRun$ = command(
         body: prepared.body,
         userId: args.userId,
         orgId: args.orgId,
+        publicBrand: args.publicBrand,
         touchThreadSort: shouldTouchThreadSortFromNormalSend(
           args.zeroPreCreateSource,
           prepared.thread.isNewThread,


### PR DESCRIPTION
## Summary

- project managed-browser viewer URLs, browser and Computer Use authorization links, and mail-draft links from the authenticated run or request public brand
- brand immediate insufficient-credit CTAs, email-unsubscribe redirects, and Billing downgrade/restore fallback URLs while preserving explicit client return URLs
- generate mail-draft presentation URLs at the route boundary so stored drafts and historical data remain brand-neutral
- reuse `appUrlForPublicBrand` so VM0 remains unchanged and configured preview, local, and custom App origins are preserved

## Fallbacks

- `turbo/apps/api/src/signals/routes/browser-authorization.ts:createAuthorizationRequestInner$` and `turbo/apps/api/src/signals/routes/computer-use-authorization.ts:createAuthorizationRequestInner$` — accepted legacy sandbox tokens do not carry presentation context and therefore continue to generate VM0 authorization links. Surface: the technical sandbox authorization contract, not a rollout compatibility bridge. This is permanent VM0 presentation behavior with no removal condition while these endpoints accept sandbox tokens.

## Compatibility

- Zero run-token calls use the signed `publicBrand`; signed-in browser and mail calls use request-scoped brand context
- VM0 and unbranded legacy calls continue to use `https://app.vm0.ai`
- Okou calls use `https://app.okou.ai`
- preview, local, and custom configured App origins are not rewritten
- explicit Billing `returnUrl` values remain authoritative and are still validated by the existing first-party allowlist
- no database fields, API paths, token scopes, prefixes, stored drafts, custom agent names, or historical data are renamed

## Validation

- `pnpm -F api check-types`
- `pnpm -F api check-types:tests`
- Prettier check for all changed files
- ESLint with zero warnings for all changed files
- focused BDD coverage added for Okou and VM0 browser URLs, legacy sandbox authorization, Computer Use authorization, mail-draft projection, immediate credit CTAs, unsubscribe redirects, and Billing fallback/explicit return URLs
- route BDD execution requires PostgreSQL; the local `localhost:5432` service is unavailable, so the PR pipeline will execute those tests
- full API lint is currently blocked locally by the pre-existing unused `mockEnv` import in untouched `webhooks-notion.test.ts`
- `pnpm knip --workspace api` currently reports the pre-existing unused export `AgentComposeProvenanceSchemaUnavailable` in an untouched file

Refs #27750