### PR TITLE
fix(guest-agent): preserve pi tool events

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -1390,7 +1390,9 @@ async fn execute_cli_inner(
                             // Extract tool info BEFORE masking (masker may replace tool names).
                             // Watchdog tracking is auxiliary state and must never make the
                             // ordinary event stream or the run fail.
-                            claude::track_claude_tool_events(&event, &mut stuck_tool_tracker);
+                            if matches!(runtime.framework, env::Framework::ClaudeCode) {
+                                claude::track_claude_tool_events(&event, &mut stuck_tool_tracker);
+                            }
                             termination_runtime.record_post_result_activity(
                                 post_result_cleanup_was_armed,
                                 termination_deadline.as_mut(),

--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -112,17 +112,17 @@ impl PiRpcProjection {
             ));
         };
         match message.get("role").and_then(Value::as_str) {
-            Some("assistant") => Ok(self.project_assistant_message(message)),
+            Some("assistant") => self.project_assistant_message(message),
             Some("toolResult") => self.project_tool_result_message(message).map(Some),
             _ => Ok(None),
         }
     }
 
-    fn project_assistant_message(&mut self, message: &Value) -> Option<Value> {
+    fn project_assistant_message(&mut self, message: &Value) -> Result<Option<Value>, AgentError> {
         self.final_assistant = Some(message.clone());
-        let content = assistant_content(message);
+        let content = assistant_content(message)?;
         if content.is_empty() {
-            return None;
+            return Ok(None);
         }
         let timestamp = message
             .get("timestamp")
@@ -137,7 +137,7 @@ impl PiRpcProjection {
             .and_then(Value::as_str)
             .map(ToString::to_string)
             .unwrap_or_else(|| format!("{}:{timestamp}:{model}", self.run_id));
-        Some(json!({
+        Ok(Some(json!({
             "type": "assistant",
             "message": {
                 "id": id,
@@ -151,13 +151,14 @@ impl PiRpcProjection {
                     "cache_creation_input_tokens": message.pointer("/usage/cacheWrite").and_then(Value::as_u64).unwrap_or(0),
                 },
             },
-        }))
+        })))
     }
 
     fn project_tool_result_message(&self, message: &Value) -> Result<Value, AgentError> {
         let tool_use_id = message
             .get("toolCallId")
             .and_then(Value::as_str)
+            .filter(|tool_use_id| !tool_use_id.is_empty())
             .ok_or_else(|| {
                 AgentError::Execution(
                     "Pi RPC toolResult message omitted its tool call id".to_string(),
@@ -170,8 +171,19 @@ impl PiRpcProjection {
                 AgentError::Execution("Pi RPC toolResult message omitted its content".to_string())
             })?
             .iter()
-            .filter_map(project_tool_result_content)
+            .map(project_tool_result_content)
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
             .collect::<Vec<_>>();
+        let is_error = message
+            .get("isError")
+            .and_then(Value::as_bool)
+            .ok_or_else(|| {
+                AgentError::Execution(
+                    "Pi RPC toolResult message omitted its error status".to_string(),
+                )
+            })?;
         Ok(json!({
             "type": "user",
             "session_id": self.session_id,
@@ -181,7 +193,7 @@ impl PiRpcProjection {
                     "type": "tool_result",
                     "tool_use_id": tool_use_id,
                     "content": content,
-                    "is_error": message.get("isError").and_then(Value::as_bool).unwrap_or(false),
+                    "is_error": is_error,
                 }],
             },
         }))
@@ -215,45 +227,91 @@ impl PiRpcProjection {
     }
 }
 
-fn assistant_content(message: &Value) -> Vec<Value> {
-    message
+fn assistant_content(message: &Value) -> Result<Vec<Value>, AgentError> {
+    let mut content = Vec::new();
+    for block in message
         .get("content")
         .and_then(Value::as_array)
         .into_iter()
         .flatten()
-        .filter_map(|block| match block.get("type").and_then(Value::as_str) {
-            Some("text") => block
-                .get("text")
-                .and_then(Value::as_str)
-                .map(str::trim)
-                .filter(|text| !text.is_empty())
-                .map(|text| json!({ "type": "text", "text": text })),
-            Some("toolCall") => Some(json!({
-                "type": "tool_use",
-                "id": block.get("id")?.as_str()?,
-                "name": block.get("name")?.as_str()?,
-                "input": block.get("arguments")?,
-            })),
-            _ => None,
-        })
-        .collect()
+    {
+        match block.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                if let Some(text) = block
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+                {
+                    content.push(json!({ "type": "text", "text": text }));
+                }
+            }
+            Some("toolCall") => content.push(project_tool_call(block)?),
+            _ => {}
+        }
+    }
+    Ok(content)
 }
 
-fn project_tool_result_content(block: &Value) -> Option<Value> {
+fn project_tool_call(block: &Value) -> Result<Value, AgentError> {
+    let id = block
+        .get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| {
+            AgentError::Execution("Pi RPC toolCall content omitted its id".to_string())
+        })?;
+    let name = block
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            AgentError::Execution("Pi RPC toolCall content omitted its name".to_string())
+        })?;
+    let arguments = block
+        .get("arguments")
+        .and_then(Value::as_object)
+        .ok_or_else(|| {
+            AgentError::Execution("Pi RPC toolCall content omitted its arguments".to_string())
+        })?;
+    Ok(json!({
+        "type": "tool_use",
+        "id": id,
+        "name": name,
+        "input": arguments,
+    }))
+}
+
+fn project_tool_result_content(block: &Value) -> Result<Option<Value>, AgentError> {
     match block.get("type").and_then(Value::as_str) {
-        Some("text") => Some(json!({
+        Some("text") => Ok(Some(json!({
             "type": "text",
-            "text": block.get("text")?.as_str()?,
-        })),
-        Some("image") => Some(json!({
+            "text": block
+                .get("text")
+                .and_then(Value::as_str)
+                .ok_or_else(|| AgentError::Execution(
+                    "Pi RPC toolResult text content omitted its text".to_string()
+                ))?,
+        }))),
+        Some("image") => Ok(Some(json!({
             "type": "image",
             "source": {
                 "type": "base64",
-                "media_type": block.get("mimeType")?.as_str()?,
-                "data": block.get("data")?.as_str()?,
+                "media_type": block
+                    .get("mimeType")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| AgentError::Execution(
+                        "Pi RPC toolResult image content omitted its media type".to_string()
+                    ))?,
+                "data": block
+                    .get("data")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| AgentError::Execution(
+                        "Pi RPC toolResult image content omitted its data".to_string()
+                    ))?,
             },
-        })),
-        _ => None,
+        }))),
+        _ => Ok(None),
     }
 }
 

--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -112,17 +112,17 @@ impl PiRpcProjection {
             ));
         };
         match message.get("role").and_then(Value::as_str) {
-            Some("assistant") => self.project_assistant_message(message),
-            Some("toolResult") => self.project_tool_result_message(message),
+            Some("assistant") => Ok(self.project_assistant_message(message)),
+            Some("toolResult") => self.project_tool_result_message(message).map(Some),
             _ => Ok(None),
         }
     }
 
-    fn project_assistant_message(&mut self, message: &Value) -> Result<Option<Value>, AgentError> {
+    fn project_assistant_message(&mut self, message: &Value) -> Option<Value> {
         self.final_assistant = Some(message.clone());
         let content = assistant_content(message);
         if content.is_empty() {
-            return Ok(None);
+            return None;
         }
         let timestamp = message
             .get("timestamp")
@@ -137,7 +137,7 @@ impl PiRpcProjection {
             .and_then(Value::as_str)
             .map(ToString::to_string)
             .unwrap_or_else(|| format!("{}:{timestamp}:{model}", self.run_id));
-        Ok(Some(json!({
+        Some(json!({
             "type": "assistant",
             "message": {
                 "id": id,
@@ -151,10 +151,10 @@ impl PiRpcProjection {
                     "cache_creation_input_tokens": message.pointer("/usage/cacheWrite").and_then(Value::as_u64).unwrap_or(0),
                 },
             },
-        })))
+        }))
     }
 
-    fn project_tool_result_message(&self, message: &Value) -> Result<Option<Value>, AgentError> {
+    fn project_tool_result_message(&self, message: &Value) -> Result<Value, AgentError> {
         let tool_use_id = message
             .get("toolCallId")
             .and_then(Value::as_str)
@@ -172,7 +172,7 @@ impl PiRpcProjection {
             .iter()
             .filter_map(project_tool_result_content)
             .collect::<Vec<_>>();
-        Ok(Some(json!({
+        Ok(json!({
             "type": "user",
             "session_id": self.session_id,
             "message": {
@@ -184,7 +184,7 @@ impl PiRpcProjection {
                     "is_error": message.get("isError").and_then(Value::as_bool).unwrap_or(false),
                 }],
             },
-        })))
+        }))
     }
 
     fn project_agent_settled(&mut self) -> Value {

--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -111,12 +111,17 @@ impl PiRpcProjection {
                 "Pi RPC message_end omitted its message".to_string(),
             ));
         };
-        if message.get("role").and_then(Value::as_str) != Some("assistant") {
-            return Ok(None);
+        match message.get("role").and_then(Value::as_str) {
+            Some("assistant") => self.project_assistant_message(message),
+            Some("toolResult") => self.project_tool_result_message(message),
+            _ => Ok(None),
         }
+    }
+
+    fn project_assistant_message(&mut self, message: &Value) -> Result<Option<Value>, AgentError> {
         self.final_assistant = Some(message.clone());
-        let text = assistant_text(message);
-        if text.is_empty() {
+        let content = assistant_content(message);
+        if content.is_empty() {
             return Ok(None);
         }
         let timestamp = message
@@ -137,7 +142,7 @@ impl PiRpcProjection {
             "message": {
                 "id": id,
                 "role": "assistant",
-                "content": [{ "type": "text", "text": text }],
+                "content": content,
                 "model": model,
                 "usage": {
                     "input_tokens": message.pointer("/usage/input").and_then(Value::as_u64).unwrap_or(0),
@@ -145,6 +150,39 @@ impl PiRpcProjection {
                     "cache_read_input_tokens": message.pointer("/usage/cacheRead").and_then(Value::as_u64).unwrap_or(0),
                     "cache_creation_input_tokens": message.pointer("/usage/cacheWrite").and_then(Value::as_u64).unwrap_or(0),
                 },
+            },
+        })))
+    }
+
+    fn project_tool_result_message(&self, message: &Value) -> Result<Option<Value>, AgentError> {
+        let tool_use_id = message
+            .get("toolCallId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                AgentError::Execution(
+                    "Pi RPC toolResult message omitted its tool call id".to_string(),
+                )
+            })?;
+        let content = message
+            .get("content")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                AgentError::Execution("Pi RPC toolResult message omitted its content".to_string())
+            })?
+            .iter()
+            .filter_map(project_tool_result_content)
+            .collect::<Vec<_>>();
+        Ok(Some(json!({
+            "type": "user",
+            "session_id": self.session_id,
+            "message": {
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": content,
+                    "is_error": message.get("isError").and_then(Value::as_bool).unwrap_or(false),
+                }],
             },
         })))
     }
@@ -174,6 +212,48 @@ impl PiRpcProjection {
             "session_id": self.session_id,
             "duration_ms": self.started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
         })
+    }
+}
+
+fn assistant_content(message: &Value) -> Vec<Value> {
+    message
+        .get("content")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|block| match block.get("type").and_then(Value::as_str) {
+            Some("text") => block
+                .get("text")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+                .map(|text| json!({ "type": "text", "text": text })),
+            Some("toolCall") => Some(json!({
+                "type": "tool_use",
+                "id": block.get("id")?.as_str()?,
+                "name": block.get("name")?.as_str()?,
+                "input": block.get("arguments")?,
+            })),
+            _ => None,
+        })
+        .collect()
+}
+
+fn project_tool_result_content(block: &Value) -> Option<Value> {
+    match block.get("type").and_then(Value::as_str) {
+        Some("text") => Some(json!({
+            "type": "text",
+            "text": block.get("text")?.as_str()?,
+        })),
+        Some("image") => Some(json!({
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": block.get("mimeType")?.as_str()?,
+                "data": block.get("data")?.as_str()?,
+            },
+        })),
+        _ => None,
     }
 }
 

--- a/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
+++ b/crates/guest-agent/tests/pi_cli_malformed_tool_event.rs
@@ -1,0 +1,122 @@
+//! Malformed final Pi tool events must fail visibly instead of being projected
+//! with invented success semantics.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
+use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+#[tokio::test]
+async fn missing_pi_tool_result_error_status_terminates_projection()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let server = common::RecordingServer::start(200, Duration::ZERO).await?;
+    let bin_dir = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin_dir)?;
+    let npx = bin_dir.join("npx");
+    std::fs::write(
+        &npx,
+        r#"#!/bin/sh
+set -eu
+IFS= read -r state_command
+case "$state_command" in
+  *'"type":"get_state"'*) ;;
+  *) exit 21 ;;
+esac
+printf '%s\n' '{"id":"00000000-0000-4000-8000-000000000124:pi:get-state","type":"response","command":"get_state","success":true,"data":{"sessionId":"11111111-1111-4111-8111-111111111112","sessionFile":"/home/user/.pi/agent/sessions/--home-user-workspace--/2026-08-14T00-00-00_11111111-1111-4111-8111-111111111112.jsonl"}}'
+IFS= read -r prompt_command
+case "$prompt_command" in
+  *'"type":"prompt"'*) ;;
+  *) exit 22 ;;
+esac
+printf '%s\n' '{"id":"00000000-0000-4000-8000-000000000124:pi:initial-prompt","type":"response","command":"prompt","success":true}'
+printf '%s\n' '{"type":"message_end","message":{"role":"toolResult","toolCallId":"tool-1","toolName":"web_search","content":[{"type":"text","text":"do-not-report-malformed-tool-result"}],"timestamp":2}}'
+while :; do
+  sleep 1
+done
+"#,
+    )?;
+    let mut permissions = std::fs::metadata(&npx)?.permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(&npx, permissions)?;
+
+    let run_id = "00000000-0000-4000-8000-000000000124";
+    let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), run_id)?;
+    unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
+        std::env::set_var(guest_contracts::env::CLI_AGENT_TYPE_ENV, "pi");
+        std::env::set_var(guest_contracts::env::RUN_ID_ENV, run_id);
+        std::env::set_var(guest_contracts::env::API_URL_ENV, &server.base_url);
+        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
+        std::env::set_var(
+            guest_contracts::env::SANDBOX_ID_ENV,
+            "00000000-0000-4000-8000-000000000abc",
+        );
+        std::env::set_var(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV, "reused");
+        std::env::set_var("HOME", tmp.path());
+        let mut paths = vec![bin_dir];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        std::env::set_var("PATH", std::env::join_paths(paths)?);
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: "reject malformed Pi tool result".to_string(),
+                pi_launch_config: r#"{"schemaVersion":2}"#.to_string(),
+                pi_model_config: "{}".to_string(),
+                pi_session_id: "11111111-1111-4111-8111-111111111112".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )?;
+        common::set_user_env_file_env_for_test(
+            &runtime_dir,
+            &HashMap::from([(
+                "CLI_PKG_URL".to_string(),
+                "https://example.invalid/current-okou-cli.tgz".to_string(),
+            )]),
+        )?;
+    }
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(tmp.path())?;
+
+    let runtime = common::guest_runtime_from_process_env()?;
+    let execution = tokio::time::timeout(
+        Duration::from_secs(10),
+        common::execute_cli_for_runtime(
+            &runtime,
+            &SecretMasker::from_raw(""),
+            common::spawn_dummy_heartbeat(),
+        ),
+    )
+    .await
+    .expect("malformed Pi tool result should terminate promptly")?;
+
+    let error = execution
+        .control_error
+        .expect("malformed Pi tool result should be a controlled execution error")
+        .to_string();
+    assert_eq!(
+        error,
+        "execution: Pi RPC toolResult message omitted its error status"
+    );
+    assert!(!error.contains("do-not-report-malformed-tool-result"));
+    let termination = execution
+        .cli_termination
+        .expect("malformed Pi event should record process-group termination");
+    assert_eq!(termination.reason, CliTerminationReason::StdoutIngestion);
+    assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
+    assert!(!termination.escalated);
+    assert_eq!(termination.observed_exit_code, Some(common::SIGTERM_EXIT));
+    assert!(
+        server
+            .requests()?
+            .iter()
+            .all(|request| !request.body.contains("do-not-report-malformed-tool-result"))
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/pi_cli_run_id_env.rs
+++ b/crates/guest-agent/tests/pi_cli_run_id_env.rs
@@ -10,7 +10,8 @@ use std::os::unix::fs::PermissionsExt;
 use std::time::Duration;
 
 #[tokio::test]
-async fn guest_exposes_canonical_run_id_to_pi_cli() -> Result<(), Box<dyn std::error::Error>> {
+async fn guest_projects_pi_rpc_events_and_exposes_canonical_run_id()
+-> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;
     let server = common::RecordingServer::start(200, Duration::ZERO).await?;
     let bin_dir = tmp.path().join("bin");
@@ -43,7 +44,12 @@ case "$prompt_command" in
   *) exit 24 ;;
 esac
 printf '%s\n' '{"id":"00000000-0000-4000-8000-000000000123:pi:initial-prompt","type":"response","command":"prompt","success":true}'
-printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"official rpc projection"}],"model":"deepseek-v4-flash","responseId":"response-1","usage":{"input":5,"output":3,"cacheRead":2,"cacheWrite":1},"stopReason":"stop","timestamp":1}}'
+printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"type":"toolCall","id":"tool-1","name":"web_search","arguments":{"query":"find supersecret"}}],"model":"deepseek-v4-flash","responseId":"response-1","usage":{"input":5,"output":3,"cacheRead":2,"cacheWrite":1},"stopReason":"toolUse","timestamp":1}}'
+printf '%s\n' '{"type":"message_end","message":{"role":"toolResult","toolCallId":"tool-1","toolName":"web_search","content":[{"type":"text","text":"result supersecret"}],"isError":false,"timestamp":2}}'
+printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"checking both"},{"type":"toolCall","id":"tool-2","name":"read_file","arguments":{"path":"README.md"}},{"type":"text","text":"and"},{"type":"toolCall","id":"tool-3","name":"render_image","arguments":{"format":"png"}}],"model":"deepseek-v4-flash","responseId":"response-2","usage":{"input":8,"output":5,"cacheRead":2,"cacheWrite":1},"stopReason":"toolUse","timestamp":3}}'
+printf '%s\n' '{"type":"message_end","message":{"role":"toolResult","toolCallId":"tool-2","toolName":"read_file","content":[{"type":"text","text":"file contents"}],"isError":false,"timestamp":4}}'
+printf '%s\n' '{"type":"message_end","message":{"role":"toolResult","toolCallId":"tool-3","toolName":"render_image","content":[{"type":"text","text":"render failed"},{"type":"image","data":"aW1hZ2U=","mimeType":"image/png"}],"isError":true,"timestamp":5}}'
+printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"official rpc projection"}],"model":"deepseek-v4-flash","responseId":"response-3","usage":{"input":13,"output":7,"cacheRead":2,"cacheWrite":1},"stopReason":"stop","timestamp":6}}'
 printf '%s\n' '{"type":"agent_settled"}'
 if IFS= read -r unexpected; then
   exit 23
@@ -110,7 +116,7 @@ fi
         Duration::from_secs(5),
         common::execute_cli_for_runtime(
             &runtime,
-            &SecretMasker::from_raw(""),
+            &SecretMasker::from_raw("c3VwZXJzZWNyZXQ="),
             common::spawn_dummy_heartbeat(),
         ),
     )
@@ -118,7 +124,7 @@ fi
     .expect("canonical Pi CLI process should finish")?;
 
     assert_eq!(result.exit_code, common::CLEAN_EXIT);
-    assert_eq!(result.last_event_sequence, Some(2));
+    assert_eq!(result.last_event_sequence, Some(7));
     assert_eq!(
         result.claude_result.map(|summary| summary.status),
         Some(guest_agent::cli::ClaudeResultStatus::Success)
@@ -142,7 +148,19 @@ fi
             .and_then(Value::as_u64)
             .unwrap_or(u64::MAX)
     });
-    assert_eq!(delivered_events.len(), 3);
+    assert_eq!(delivered_events.len(), 8);
+    assert_eq!(
+        delivered_events
+            .iter()
+            .map(|event| event["sequenceNumber"].as_u64())
+            .collect::<Vec<_>>(),
+        (0..8).map(Some).collect::<Vec<_>>()
+    );
+    assert!(
+        delivered_events
+            .iter()
+            .all(|event| !event.to_string().contains("supersecret"))
+    );
     assert_eq!(delivered_events[0]["type"], "system");
     assert_eq!(delivered_events[0]["subtype"], "init");
     assert_eq!(
@@ -151,12 +169,94 @@ fi
     );
     assert_eq!(delivered_events[1]["type"], "assistant");
     assert_eq!(
-        delivered_events[1].pointer("/message/content/0/text"),
+        delivered_events[1].pointer("/message/content/0/type"),
+        Some(&Value::String("tool_use".to_string()))
+    );
+    assert_eq!(delivered_events[1]["message"]["content"][0]["id"], "tool-1");
+    assert_eq!(
+        delivered_events[1]["message"]["content"][0]["name"],
+        "web_search"
+    );
+    assert_eq!(
+        delivered_events[1]["message"]["content"][0]["input"]["query"],
+        "find ***"
+    );
+
+    assert_eq!(delivered_events[2]["type"], "user");
+    assert_eq!(
+        delivered_events[2].pointer("/message/content/0/type"),
+        Some(&Value::String("tool_result".to_string()))
+    );
+    assert_eq!(
+        delivered_events[2]["message"]["content"][0]["tool_use_id"],
+        "tool-1"
+    );
+    assert_eq!(
+        delivered_events[2]["message"]["content"][0]["content"][0]["text"],
+        "result ***"
+    );
+    assert_eq!(
+        delivered_events[2]["message"]["content"][0]["is_error"],
+        false
+    );
+
+    assert_eq!(delivered_events[3]["type"], "assistant");
+    assert_eq!(
+        delivered_events[3]["message"]["content"],
+        serde_json::json!([
+            { "type": "text", "text": "checking both" },
+            {
+                "type": "tool_use",
+                "id": "tool-2",
+                "name": "read_file",
+                "input": { "path": "README.md" },
+            },
+            { "type": "text", "text": "and" },
+            {
+                "type": "tool_use",
+                "id": "tool-3",
+                "name": "render_image",
+                "input": { "format": "png" },
+            },
+        ])
+    );
+
+    assert_eq!(delivered_events[4]["type"], "user");
+    assert_eq!(
+        delivered_events[4]["message"]["content"][0]["tool_use_id"],
+        "tool-2"
+    );
+    assert_eq!(
+        delivered_events[4]["message"]["content"][0]["content"][0]["text"],
+        "file contents"
+    );
+
+    assert_eq!(delivered_events[5]["type"], "user");
+    assert_eq!(
+        delivered_events[5]["message"]["content"][0]["tool_use_id"],
+        "tool-3"
+    );
+    assert_eq!(
+        delivered_events[5]["message"]["content"][0]["is_error"],
+        true
+    );
+    assert_eq!(
+        delivered_events[5].pointer("/message/content/0/content/1/source"),
+        Some(&serde_json::json!({
+            "type": "base64",
+            "media_type": "image/png",
+            "data": "aW1hZ2U=",
+        }))
+    );
+
+    assert_eq!(delivered_events[6]["type"], "assistant");
+    assert_eq!(
+        delivered_events[6].pointer("/message/content/0/text"),
         Some(&Value::String("official rpc projection".to_string()))
     );
-    assert_eq!(delivered_events[2]["type"], "result");
-    assert_eq!(delivered_events[2]["subtype"], "success");
-    assert_eq!(delivered_events[2]["result"], "official rpc projection");
+    assert_eq!(delivered_events[7]["type"], "result");
+    assert_eq!(delivered_events[7]["subtype"], "success");
+    assert_eq!(delivered_events[7]["result"], "official rpc projection");
     assert_eq!(std::fs::read_to_string(capture_path)?, run_id);
 
     let payload_path = std::fs::read_to_string(payload_capture_path)?;


### PR DESCRIPTION
## Summary

- project final Pi assistant tool calls as ordered Claude-compatible `tool_use` blocks
- project Pi tool results as correlated `tool_result` user events, including error and image content
- keep the Claude-only stuck-tool watchdog from consuming newly projected Pi events
- verify tool-only, mixed, parallel, masking, ordering, and final-text behavior through the guest RPC/webhook boundary

## Scope

This change is limited to Pi public raw-event projection and the framework guard that prevents those events from changing Pi execution policy. It does not change API persistence, canonical chat events, frontend rendering, thinking output, transient progress events, or Claude/Codex projection behavior.

## Testing

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-agent --all-targets -- -D warnings`
- `cd crates && cargo doc -p guest-agent --no-deps`
- `cd crates && cargo test -p guest-agent --test pi_cli_run_id_env`
- `cd crates && cargo test -p guest-agent`

Closes #27784
