### PR TITLE
refactor(run): shadow compose-independent environment assembly

### DIFF
--- a/.github/workflows/agent-compose-consolidation-preflight.yml
+++ b/.github/workflows/agent-compose-consolidation-preflight.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: bash
     steps:
-      # transition-validator: #27613 + #27656 + #27671; removal-owner: #26938 Stage 8
+      # transition-validator: #27613 + #27656 + #27671 + #27792; removal-owner: #26938 Stage 8
       # The workflow definition and implementation always come from main.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -386,6 +386,10 @@ export default [
     // exceptions. Route tests cover constructible behavior, while these exact
     // transition inputs are not available through production APIs.
     files: [
+      // Exact pre-redaction classification and bucket boundaries are a finite,
+      // security-sensitive matrix that cannot be exhaustively observed through
+      // the product Run route without leaking the compared environment maps.
+      "src/signals/services/__tests__/agent-environment-shadow.test.ts",
       "src/signals/services/__tests__/connector-catalog-rejection-authority.test.ts",
       "src/signals/services/__tests__/connector-authorization-provider-state.test.ts",
       // A pre-migration schema cannot be constructed through a production API.

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7506,8 +7506,9 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const claim = await api.claimRunnerJob(run.runId);
 
     expect(claim.environment?.GH_TOKEN).toBe("legacy-authoritative-token");
-    expect(claim.environment?.GITHUB_TOKEN).toBe(
-      connectorPlaceholder("github", "GITHUB_TOKEN"),
+    expect(claim.environment?.GITHUB_TOKEN).toStrictEqual(expect.any(String));
+    expect(claim.environment?.GITHUB_TOKEN).not.toBe(
+      "github-shadow-unavailable",
     );
     expect(environmentShadowFieldsForRun(run.runId)).toStrictEqual({
       environmentShadowClassification: "shadow_unavailable",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -817,6 +817,14 @@ function runContextSnapshotForRun(runId: string): Record<string, unknown> {
   throw new Error(`Expected a run-context snapshot for ${runId}`);
 }
 
+function environmentShadowFieldsForRun(runId: string): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(runContextSnapshotForRun(runId)).filter(([key]) => {
+      return key.startsWith("environmentShadow");
+    }),
+  );
+}
+
 function sandboxOperationEventsForRun(
   runId: string,
 ): readonly Record<string, unknown>[] {
@@ -7460,6 +7468,55 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
+  it("keeps a product launch authoritative when its environment shadow is unavailable", async () => {
+    const api = createRunsApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await fw.seedTestConnector(actor, {
+      connectorSlug: "github",
+      authMethod: "oauth",
+      accessToken: "github-shadow-unavailable",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["github"]);
+    const canonicalCompose =
+      await readHistoricalAgentComposeHeadFixture(agentId);
+    await api.createHistoricalCompose(actor, {
+      version: "1",
+      agents: {
+        [canonicalCompose.name]: {
+          framework: "claude-code",
+          environment: {
+            OKOU_AGENT_ID: `\${{ vars.OKOU_AGENT_ID }}`,
+            OKOU_TOKEN: `\${{ secrets.OKOU_TOKEN }}`,
+            GH_TOKEN: "legacy-authoritative-token",
+          },
+        },
+      },
+    });
+    const kms = useSecretKmsProbe();
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "keep the real environment when the shadow is unavailable",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(kms.decryptCalls).toBe(0);
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.environment?.GH_TOKEN).toBe("legacy-authoritative-token");
+    expect(claim.environment?.GITHUB_TOKEN).toBe(
+      connectorPlaceholder("github", "GITHUB_TOKEN"),
+    );
+    expect(environmentShadowFieldsForRun(run.runId)).toStrictEqual({
+      environmentShadowClassification: "shadow_unavailable",
+    });
+    expect(JSON.stringify(claim)).not.toContain("environmentShadow");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
   it("maps stored connector variable sources to runtime aliases for permission manifests", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
@@ -12305,6 +12362,165 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 });
 
 describe("RUN-01: zero runner context, queue promotion, and skills", () => {
+  it("shadows the canonical environment without changing the Runner context", async () => {
+    const appUrl = "https://app.environment-shadow.example.test";
+    mockEnv("APP_URL", appUrl);
+    const api = createRunsApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error(
+        "The environment shadow fixture requires an organization",
+      );
+    }
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "compare the canonical application environment",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expectCanonicalOkouRunEnvironment({
+      environment: claim.environment,
+      secretValues: claim.secretValues,
+      appUrl,
+      agentId,
+      userId: actor.userId,
+      orgId: actor.orgId,
+      runId: run.runId,
+    });
+    const okouToken = claim.environment?.OKOU_TOKEN;
+    if (!okouToken) {
+      throw new Error(
+        "Expected the canonical environment to include its token",
+      );
+    }
+    expect(claim.environment).toStrictEqual({
+      ANTHROPIC_API_KEY: modelProviderPlaceholder(
+        "anthropic-api-key",
+        "ANTHROPIC_API_KEY",
+      ),
+      ANTHROPIC_MODEL: "claude-sonnet-5",
+      OKOU_AGENT_ID: agentId,
+      OKOU_TOKEN: okouToken,
+      OKOU_APP_URL: appUrl,
+      CLI_PKG_URL: "https://static.vm0.io/okou-cli/test-commit/package.tgz",
+      [WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV]: "previous",
+    });
+    expect(environmentShadowFieldsForRun(run.runId)).toStrictEqual({
+      environmentShadowClassification: "exact",
+      environmentShadowLegacyOnlyCountBucket: "0",
+      environmentShadowCandidateOnlyCountBucket: "0",
+      environmentShadowSharedValueDifferenceCountBucket: "0",
+    });
+    expect(JSON.stringify(claim)).not.toContain("environmentShadow");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("classifies active legacy environment value shapes without exposing them", async () => {
+    const api = createRunsApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("The legacy shadow fixture requires an organization");
+    }
+    const canonicalCompose =
+      await readHistoricalAgentComposeHeadFixture(agentId);
+    const legacyKey = "LEGACY_ENVIRONMENT_BINDING";
+    const userScope = { orgId: actor.orgId, userId: actor.userId };
+    await seedUserVariable(context, {
+      ...userScope,
+      name: "LEGACY_VARIABLE",
+      value: "legacy-variable-value",
+    });
+    await seedUserVariable(context, {
+      ...userScope,
+      name: "LEGACY_MIXED_VARIABLE",
+      value: "legacy-mixed-variable",
+    });
+    await seedUserSecret(context, {
+      ...userScope,
+      name: "LEGACY_SECRET",
+      value: "legacy-secret-value",
+    });
+    await seedUserSecret(context, {
+      ...userScope,
+      name: "LEGACY_MIXED_SECRET",
+      value: "legacy-mixed-secret",
+    });
+    const cases: readonly {
+      readonly name: string;
+      readonly value: string;
+      readonly expectedValue: string;
+    }[] = [
+      {
+        name: "variable reference",
+        value: `\${{ vars.LEGACY_VARIABLE }}`,
+        expectedValue: "legacy-variable-value",
+      },
+      {
+        name: "secret reference",
+        value: `\${{ secrets.LEGACY_SECRET }}`,
+        expectedValue: "legacy-secret-value",
+      },
+      {
+        name: "mixed references",
+        value: `\${{ vars.LEGACY_MIXED_VARIABLE }}:\${{ secrets.LEGACY_MIXED_SECRET }}`,
+        expectedValue: "legacy-mixed-variable:legacy-mixed-secret",
+      },
+      {
+        name: "literal value",
+        value: "legacy-literal-value",
+        expectedValue: "legacy-literal-value",
+      },
+    ];
+
+    for (const legacyCase of cases) {
+      await api.createHistoricalCompose(actor, {
+        version: "1",
+        agents: {
+          [canonicalCompose.name]: {
+            framework: "claude-code",
+            environment: {
+              OKOU_AGENT_ID: `\${{ vars.OKOU_AGENT_ID }}`,
+              OKOU_TOKEN: `\${{ secrets.OKOU_TOKEN }}`,
+              [legacyKey]: legacyCase.value,
+            },
+          },
+        },
+      });
+      const run = await api.createRun(actor, {
+        agentId,
+        prompt: `compare ${legacyCase.name}`,
+        modelProvider: "anthropic-api-key",
+      });
+      await api.heartbeatRunner(runnerGroup);
+      const claim = await api.claimRunnerJob(run.runId);
+      expect(claim.environment?.[legacyKey]).toBe(legacyCase.expectedValue);
+
+      const shadowFields = environmentShadowFieldsForRun(run.runId);
+      expect(shadowFields).toStrictEqual({
+        environmentShadowClassification: "legacy_only_bindings",
+        environmentShadowLegacyOnlyCountBucket: "1",
+        environmentShadowCandidateOnlyCountBucket: "0",
+        environmentShadowSharedValueDifferenceCountBucket: "0",
+      });
+      const serializedShadowFields = JSON.stringify(shadowFields);
+      for (const forbidden of [
+        legacyKey,
+        legacyCase.value,
+        legacyCase.expectedValue,
+        agentId,
+        run.runId,
+      ]) {
+        expect(serializedShadowFields).not.toContain(forbidden);
+      }
+      expect(JSON.stringify(claim)).not.toContain("environmentShadow");
+      await api.requestCancelRun(actor, run.runId, [200]);
+    }
+  });
+
   it("uses the commit-addressed R2 Okou CLI distribution", async () => {
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -2665,6 +2665,10 @@ describe("RUN-04: agent run telemetry families", () => {
             runId,
             cliAgentType: "claude-code",
             sessionId: "bdd-session-1",
+            environmentShadowClassification: "mixed_difference",
+            environmentShadowLegacyOnlyCountBucket: "2_4",
+            environmentShadowCandidateOnlyCountBucket: "1",
+            environmentShadowSharedValueDifferenceCountBucket: "5_8",
             environment: { LEGACY_IGNORED: "legacy-map" },
             environmentEntries: [
               { name: "NODE_ENV", value: "production" },
@@ -2822,6 +2826,9 @@ describe("RUN-04: agent run telemetry families", () => {
     expect(contextRead.body.environment).toStrictEqual({
       NODE_ENV: "production",
     });
+    expect(contextRead.body).not.toHaveProperty(
+      "environmentShadowClassification",
+    );
     expect(Object.keys(contextRead.body.networkPolicies ?? {})).toStrictEqual([
       "github",
     ]);

--- a/turbo/apps/api/src/signals/services/__tests__/agent-environment-shadow.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-environment-shadow.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildApplicationOwnedEnvironmentCandidate,
+  compareApplicationOwnedEnvironment,
+  type ApplicationOwnedEnvironmentCandidateInput,
+  type EnvironmentShadowObservation,
+} from "../agent-environment-shadow";
+
+function candidateInput(
+  overrides: Partial<ApplicationOwnedEnvironmentCandidateInput> = {},
+): ApplicationOwnedEnvironmentCandidateInput {
+  return {
+    modelProviderEnvironment: undefined,
+    storedConnectorEnvironment: undefined,
+    vars: undefined,
+    connectorVars: undefined,
+    secrets: undefined,
+    environmentSecretPlaceholders: undefined,
+    systemAndRunEnvironment: undefined,
+    runtimeOverrides: {},
+    ...overrides,
+  };
+}
+
+function bindings(count: number): Record<string, string> {
+  return Object.fromEntries(
+    Array.from({ length: count }, (_, index) => {
+      return [`BINDING_${index}`, `value-${index}`];
+    }),
+  );
+}
+
+interface EnvironmentComparisonCase {
+  readonly name: string;
+  readonly legacy: Readonly<Record<string, string>>;
+  readonly candidate: Readonly<Record<string, string>>;
+  readonly expected: EnvironmentShadowObservation;
+}
+
+describe("application-owned environment candidate", () => {
+  it("assembles code-owned identity and token without a legacy input", () => {
+    const candidate = buildApplicationOwnedEnvironmentCandidate(
+      candidateInput({
+        modelProviderEnvironment: {
+          MODEL_TOKEN: `\${{ secrets.MODEL_TOKEN }}`,
+        },
+        secrets: { MODEL_TOKEN: "resolved-model-token" },
+        systemAndRunEnvironment: {
+          OKOU_AGENT_ID: "agent-id",
+          OKOU_TOKEN: "okou-token",
+        },
+        runtimeOverrides: {
+          CLI_PKG_URL: "https://static.example.test/cli.tgz",
+          OKOU_WEBSITE_TEMPLATE_ARCHIVE_VERSION: "latest",
+        },
+      }),
+    );
+
+    expect(candidate).toStrictEqual({
+      MODEL_TOKEN: "resolved-model-token",
+      OKOU_AGENT_ID: "agent-id",
+      OKOU_TOKEN: "okou-token",
+      CLI_PKG_URL: "https://static.example.test/cli.tgz",
+      OKOU_WEBSITE_TEMPLATE_ARCHIVE_VERSION: "latest",
+    });
+  });
+
+  it("expands provider-only bindings from Run variables and secrets", () => {
+    expect(
+      buildApplicationOwnedEnvironmentCandidate(
+        candidateInput({
+          modelProviderEnvironment: {
+            PROVIDER_VARIABLE: `\${{ vars.PROVIDER_VARIABLE }}`,
+            PROVIDER_SECRET: `\${{ secrets.PROVIDER_SECRET }}`,
+          },
+          vars: { PROVIDER_VARIABLE: "provider-variable" },
+          secrets: { PROVIDER_SECRET: "provider-secret" },
+        }),
+      ),
+    ).toStrictEqual({
+      PROVIDER_VARIABLE: "provider-variable",
+      PROVIDER_SECRET: "provider-secret",
+    });
+  });
+
+  it("expands Connector-only bindings from Connector variables and secrets", () => {
+    expect(
+      buildApplicationOwnedEnvironmentCandidate(
+        candidateInput({
+          storedConnectorEnvironment: {
+            CONNECTOR_VARIABLE: `\${{ vars.CONNECTOR_VARIABLE }}`,
+            CONNECTOR_SECRET: `\${{ secrets.CONNECTOR_SECRET }}`,
+          },
+          connectorVars: { CONNECTOR_VARIABLE: "connector-variable" },
+          secrets: { CONNECTOR_SECRET: "connector-secret" },
+        }),
+      ),
+    ).toStrictEqual({
+      CONNECTOR_VARIABLE: "connector-variable",
+      CONNECTOR_SECRET: "connector-secret",
+    });
+  });
+
+  it("preserves provider, explicit Run/system, and runtime override precedence", () => {
+    const input = candidateInput({
+      modelProviderEnvironment: {
+        COLLISION: "provider",
+        RUN_OVERRIDE: "provider-run",
+      },
+      storedConnectorEnvironment: {
+        COLLISION: "connector",
+        CONNECTOR_ONLY: "connector-only",
+      },
+      systemAndRunEnvironment: {
+        RUN_OVERRIDE: "explicit-run",
+        CLI_PKG_URL: "run-cli",
+        ZERO_REMOVED: "legacy",
+      },
+      runtimeOverrides: {
+        CLI_PKG_URL: "runtime-cli",
+      },
+    });
+    const before = structuredClone(input);
+
+    expect(buildApplicationOwnedEnvironmentCandidate(input)).toStrictEqual({
+      COLLISION: "provider",
+      RUN_OVERRIDE: "explicit-run",
+      CONNECTOR_ONLY: "connector-only",
+      CLI_PKG_URL: "runtime-cli",
+    });
+    expect(input).toStrictEqual(before);
+  });
+});
+
+describe("exact environment shadow comparison", () => {
+  it.each([
+    {
+      name: "exact",
+      legacy: { SHARED: "same" },
+      candidate: { SHARED: "same" },
+      expected: {
+        classification: "exact",
+        legacyOnlyCountBucket: "0",
+        candidateOnlyCountBucket: "0",
+        sharedValueDifferenceCountBucket: "0",
+      },
+    },
+    {
+      name: "legacy-only bindings",
+      legacy: { LEGACY: "legacy" },
+      candidate: {},
+      expected: {
+        classification: "legacy_only_bindings",
+        legacyOnlyCountBucket: "1",
+        candidateOnlyCountBucket: "0",
+        sharedValueDifferenceCountBucket: "0",
+      },
+    },
+    {
+      name: "candidate-only bindings",
+      legacy: {},
+      candidate: { CANDIDATE: "candidate" },
+      expected: {
+        classification: "candidate_only_bindings",
+        legacyOnlyCountBucket: "0",
+        candidateOnlyCountBucket: "1",
+        sharedValueDifferenceCountBucket: "0",
+      },
+    },
+    {
+      name: "value override difference",
+      legacy: { SHARED: "legacy" },
+      candidate: { SHARED: "candidate" },
+      expected: {
+        classification: "value_override_difference",
+        legacyOnlyCountBucket: "0",
+        candidateOnlyCountBucket: "0",
+        sharedValueDifferenceCountBucket: "1",
+      },
+    },
+    {
+      name: "mixed difference",
+      legacy: { SHARED: "legacy", LEGACY: "legacy-only" },
+      candidate: {
+        SHARED: "candidate",
+        CANDIDATE: "candidate-only",
+      },
+      expected: {
+        classification: "mixed_difference",
+        legacyOnlyCountBucket: "1",
+        candidateOnlyCountBucket: "1",
+        sharedValueDifferenceCountBucket: "1",
+      },
+    },
+  ] as readonly EnvironmentComparisonCase[])(
+    "classifies $name",
+    ({ legacy, candidate, expected }) => {
+      expect(
+        compareApplicationOwnedEnvironment(legacy, candidate),
+      ).toStrictEqual(expected);
+    },
+  );
+
+  it.each([
+    [0, "0"],
+    [1, "1"],
+    [2, "2_4"],
+    [4, "2_4"],
+    [5, "5_8"],
+    [8, "5_8"],
+    [9, "9_16"],
+    [16, "9_16"],
+    [17, "17_plus"],
+  ] as const)("buckets %i bindings as %s", (count, expectedBucket) => {
+    expect(
+      compareApplicationOwnedEnvironment(bindings(count), {}),
+    ).toMatchObject({ legacyOnlyCountBucket: expectedBucket });
+  });
+
+  it("compares unequal secret values before identical redaction", () => {
+    const legacySecret = "legacy-secret-value";
+    const candidateSecret = "candidate-secret-value";
+    const redact = (
+      environment: Readonly<Record<string, string>>,
+      secret: string,
+    ): Record<string, string> => {
+      return Object.fromEntries(
+        Object.entries(environment).map(([key, value]) => {
+          return [key, value === secret ? "***" : value];
+        }),
+      );
+    };
+    const legacy = { TOKEN: legacySecret };
+    const candidate = { TOKEN: candidateSecret };
+
+    expect(redact(legacy, legacySecret)).toStrictEqual(
+      redact(candidate, candidateSecret),
+    );
+    expect(compareApplicationOwnedEnvironment(legacy, candidate)).toMatchObject(
+      {
+        classification: "value_override_difference",
+        sharedValueDifferenceCountBucket: "1",
+      },
+    );
+  });
+
+  it("fails with a fixed error when resolved candidate inputs are incomplete", () => {
+    expect(() => {
+      buildApplicationOwnedEnvironmentCandidate(
+        candidateInput({
+          modelProviderEnvironment: {
+            PRIVATE_PROVIDER_KEY: `\${{ secrets.PRIVATE_PROVIDER_REFERENCE }}`,
+          },
+        }),
+      );
+    }).toThrow("Application-owned environment candidate is unavailable");
+  });
+});

--- a/turbo/apps/api/src/signals/services/agent-environment-shadow.ts
+++ b/turbo/apps/api/src/signals/services/agent-environment-shadow.ts
@@ -1,0 +1,198 @@
+import {
+  expandVariables,
+  expandVariablesInString,
+} from "@okouai/core/variable-expander";
+
+import { APPLICATION_OWNED_AGENT_EXECUTION_PLAN } from "./agent-execution-plan";
+
+export const ENVIRONMENT_SHADOW_COUNT_BUCKETS = [
+  "0",
+  "1",
+  "2_4",
+  "5_8",
+  "9_16",
+  "17_plus",
+] as const;
+
+export type EnvironmentShadowCountBucket =
+  (typeof ENVIRONMENT_SHADOW_COUNT_BUCKETS)[number];
+
+export type EnvironmentShadowClassification =
+  | "exact"
+  | "legacy_only_bindings"
+  | "candidate_only_bindings"
+  | "value_override_difference"
+  | "mixed_difference"
+  | "shadow_unavailable";
+
+type AvailableEnvironmentShadowClassification = Exclude<
+  EnvironmentShadowClassification,
+  "shadow_unavailable"
+>;
+
+export type EnvironmentShadowObservation =
+  | {
+      readonly classification: AvailableEnvironmentShadowClassification;
+      readonly legacyOnlyCountBucket: EnvironmentShadowCountBucket;
+      readonly candidateOnlyCountBucket: EnvironmentShadowCountBucket;
+      readonly sharedValueDifferenceCountBucket: EnvironmentShadowCountBucket;
+    }
+  | {
+      readonly classification: "shadow_unavailable";
+    };
+
+export interface ApplicationOwnedEnvironmentCandidateInput {
+  readonly modelProviderEnvironment:
+    | Readonly<Record<string, string>>
+    | undefined;
+  readonly storedConnectorEnvironment:
+    | Readonly<Record<string, string>>
+    | undefined;
+  readonly vars: Readonly<Record<string, string>> | undefined;
+  readonly connectorVars: Readonly<Record<string, string>> | undefined;
+  readonly secrets: Readonly<Record<string, string>> | undefined;
+  readonly environmentSecretPlaceholders:
+    | Readonly<Record<string, string>>
+    | undefined;
+  readonly systemAndRunEnvironment:
+    | Readonly<Record<string, string>>
+    | undefined;
+  readonly runtimeOverrides: Readonly<Record<string, string>>;
+}
+
+/**
+ * Builds the application-owned environment without reading Compose content.
+ * All inputs are resolved by the existing launch path before this pure step.
+ */
+export function buildApplicationOwnedEnvironmentCandidate(
+  args: ApplicationOwnedEnvironmentCandidateInput,
+): Record<string, string> {
+  const providerEnvironment = { ...args.modelProviderEnvironment };
+  const variableSources = args.vars ? { ...args.vars } : undefined;
+  const connectorVariableSources = args.connectorVars
+    ? { ...args.connectorVars }
+    : undefined;
+  const secretSources = {
+    ...args.secrets,
+    ...args.environmentSecretPlaceholders,
+  };
+  const providerExpansion = expandVariables(providerEnvironment, {
+    vars: variableSources,
+    secrets: secretSources,
+  });
+  if (providerExpansion.missingVars.length > 0) {
+    throw new Error("Application-owned environment candidate is unavailable");
+  }
+
+  const acceptedStoredConnectorEntries = Object.entries(
+    args.storedConnectorEnvironment ?? {},
+  ).filter(([key]) => {
+    return !Object.hasOwn(providerEnvironment, key);
+  });
+  const expandedStoredConnectorEntries = acceptedStoredConnectorEntries.map(
+    ([key, value]) => {
+      const expansion = expandVariablesInString(value, {
+        vars: connectorVariableSources,
+        secrets: secretSources,
+      });
+      if (expansion.missingVars.length > 0) {
+        throw new Error(
+          "Application-owned environment candidate is unavailable",
+        );
+      }
+      return [key, expansion.result] as const;
+    },
+  );
+  const assembled = {
+    ...providerExpansion.result,
+    ...Object.fromEntries(expandedStoredConnectorEntries),
+    ...args.systemAndRunEnvironment,
+    ...args.runtimeOverrides,
+  };
+  return Object.fromEntries(
+    Object.entries(assembled).filter(([key]) => {
+      return !APPLICATION_OWNED_AGENT_EXECUTION_PLAN.environment.legacyRemovedPrefixes.some(
+        (prefix) => {
+          return key.startsWith(prefix);
+        },
+      );
+    }),
+  );
+}
+
+/** Compares exact, unredacted maps and immediately reduces them to buckets. */
+export function compareApplicationOwnedEnvironment(
+  legacyEnvironment: Readonly<Record<string, string>>,
+  candidateEnvironment: Readonly<Record<string, string>>,
+): EnvironmentShadowObservation {
+  let legacyOnlyCount = 0;
+  let candidateOnlyCount = 0;
+  let sharedValueDifferenceCount = 0;
+
+  for (const [key, legacyValue] of Object.entries(legacyEnvironment)) {
+    if (!Object.hasOwn(candidateEnvironment, key)) {
+      legacyOnlyCount += 1;
+    } else if (candidateEnvironment[key] !== legacyValue) {
+      sharedValueDifferenceCount += 1;
+    }
+  }
+  for (const key of Object.keys(candidateEnvironment)) {
+    if (!Object.hasOwn(legacyEnvironment, key)) {
+      candidateOnlyCount += 1;
+    }
+  }
+
+  let classification: AvailableEnvironmentShadowClassification;
+  if (
+    legacyOnlyCount === 0 &&
+    candidateOnlyCount === 0 &&
+    sharedValueDifferenceCount === 0
+  ) {
+    classification = "exact";
+  } else if (
+    legacyOnlyCount > 0 &&
+    candidateOnlyCount === 0 &&
+    sharedValueDifferenceCount === 0
+  ) {
+    classification = "legacy_only_bindings";
+  } else if (
+    legacyOnlyCount === 0 &&
+    candidateOnlyCount > 0 &&
+    sharedValueDifferenceCount === 0
+  ) {
+    classification = "candidate_only_bindings";
+  } else if (
+    legacyOnlyCount === 0 &&
+    candidateOnlyCount === 0 &&
+    sharedValueDifferenceCount > 0
+  ) {
+    classification = "value_override_difference";
+  } else {
+    classification = "mixed_difference";
+  }
+  const countBucket = (count: number): EnvironmentShadowCountBucket => {
+    if (count <= 0) {
+      return "0";
+    }
+    if (count === 1) {
+      return "1";
+    }
+    if (count <= 4) {
+      return "2_4";
+    }
+    if (count <= 8) {
+      return "5_8";
+    }
+    if (count <= 16) {
+      return "9_16";
+    }
+    return "17_plus";
+  };
+
+  return {
+    classification,
+    legacyOnlyCountBucket: countBucket(legacyOnlyCount),
+    candidateOnlyCountBucket: countBucket(candidateOnlyCount),
+    sharedValueDifferenceCountBucket: countBucket(sharedValueDifferenceCount),
+  };
+}

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -172,6 +172,11 @@ import {
   type RunContextAxiomSnapshot,
 } from "./run-context-snapshot.service";
 import {
+  buildApplicationOwnedEnvironmentCandidate,
+  compareApplicationOwnedEnvironment,
+  type EnvironmentShadowObservation,
+} from "./agent-environment-shadow";
+import {
   decryptStoredSecretValue,
   encryptPersistentSecretValue,
   encryptPersistentSecretsMap,
@@ -824,6 +829,7 @@ interface BuiltStoredExecutionContext {
   readonly secretNames: readonly string[];
   // Plain secret values used for run-context redaction; values, not names.
   readonly secretValues: readonly string[];
+  readonly environmentShadowObservation?: EnvironmentShadowObservation;
 }
 
 type BuiltStoredExecutionContextDraft = Omit<
@@ -5939,6 +5945,43 @@ function websiteTemplateArchiveVersionForRun(
     : "previous";
 }
 
+function applicationOwnedEnvironmentShadow(args: {
+  readonly eligible: boolean | undefined;
+  readonly actualEnvironment: Readonly<Record<string, string>>;
+  readonly launch: {
+    readonly modelProvider: ResolvedModelProviderEnvironment | null;
+    readonly connectorContext: ConnectorRuntimeContext;
+    readonly body: CreateRunBody;
+    readonly permissionManifest: PermissionManifest | undefined;
+    readonly extraEnvironment: Record<string, string> | undefined;
+  };
+  readonly executionSecrets: StoredExecutionSecrets;
+  readonly runtimeOverrides: Readonly<Record<string, string>>;
+}): EnvironmentShadowObservation | undefined {
+  if (!args.eligible) {
+    return undefined;
+  }
+  const result = safeSync(() => {
+    const candidateEnvironment = buildApplicationOwnedEnvironmentCandidate({
+      modelProviderEnvironment: args.launch.modelProvider?.environment,
+      storedConnectorEnvironment:
+        args.launch.connectorContext.storedEnvironment,
+      vars: args.launch.body.vars,
+      connectorVars: args.launch.connectorContext.vars,
+      secrets: args.executionSecrets.secrets,
+      environmentSecretPlaceholders:
+        args.launch.permissionManifest?.environmentSecretPlaceholders,
+      systemAndRunEnvironment: args.launch.extraEnvironment,
+      runtimeOverrides: args.runtimeOverrides,
+    });
+    return compareApplicationOwnedEnvironment(
+      args.actualEnvironment,
+      candidateEnvironment,
+    );
+  });
+  return "ok" in result ? result.ok : { classification: "shadow_unavailable" };
+}
+
 async function buildStoredExecutionContextDraft(args: {
   readonly runId: string;
   readonly userId: string;
@@ -5996,6 +6039,17 @@ async function buildStoredExecutionContextDraft(args: {
   const environment = args.includeZeroTokenSecret
     ? (withoutLegacyZeroEntries(expandedEnvironment) ?? {})
     : expandedEnvironment;
+  const environmentShadowObservation = applicationOwnedEnvironmentShadow({
+    eligible: args.includeZeroTokenSecret,
+    actualEnvironment: environment,
+    launch: args,
+    executionSecrets,
+    runtimeOverrides: {
+      CLI_PKG_URL: expandedEnvironment.CLI_PKG_URL,
+      [WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV]:
+        expandedEnvironment[WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV],
+    },
+  });
   const environmentKeyByValue = new Map<string, string>();
   for (const [key, value] of Object.entries(environment)) {
     if (!environmentKeyByValue.has(value)) {
@@ -6039,6 +6093,7 @@ async function buildStoredExecutionContextDraft(args: {
     },
     secretNames,
     secretValues,
+    environmentShadowObservation,
   };
 }
 
@@ -6095,6 +6150,31 @@ function buildRunContextSnapshot(args: {
   );
   const cliAgentSessionId =
     storedContext.piSessionId ?? storedContext.resumeSession?.sessionId ?? null;
+  const environmentShadow = args.builtContext.environmentShadowObservation;
+  let environmentShadowFields: Partial<
+    Pick<
+      RunContextAxiomSnapshot,
+      | "environmentShadowClassification"
+      | "environmentShadowLegacyOnlyCountBucket"
+      | "environmentShadowCandidateOnlyCountBucket"
+      | "environmentShadowSharedValueDifferenceCountBucket"
+    >
+  > = {};
+  if (environmentShadow?.classification === "shadow_unavailable") {
+    environmentShadowFields = {
+      environmentShadowClassification: environmentShadow.classification,
+    };
+  } else if (environmentShadow) {
+    environmentShadowFields = {
+      environmentShadowClassification: environmentShadow.classification,
+      environmentShadowLegacyOnlyCountBucket:
+        environmentShadow.legacyOnlyCountBucket,
+      environmentShadowCandidateOnlyCountBucket:
+        environmentShadow.candidateOnlyCountBucket,
+      environmentShadowSharedValueDifferenceCountBucket:
+        environmentShadow.sharedValueDifferenceCountBucket,
+    };
+  }
   const snapshot: RunContextAxiomSnapshot = {
     _time: nowDate().toISOString(),
     runId: args.runId,
@@ -6112,6 +6192,7 @@ function buildRunContextSnapshot(args: {
     volumes: args.builtContext.runContextStorage.volumes,
     artifact: args.builtContext.runContextStorage.artifact,
     featureFlagEntries: featureFlagsRecordToEntries(storedContext.featureFlags),
+    ...environmentShadowFields,
   };
   return snapshot;
 }

--- a/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
@@ -11,6 +11,11 @@ import {
 } from "@okouai/connectors/firewall-types";
 import { z } from "zod";
 
+import type {
+  EnvironmentShadowClassification,
+  EnvironmentShadowCountBucket,
+} from "./agent-environment-shadow";
+
 type UnknownRecord = Record<string, unknown>;
 type NetworkPolicy = NetworkPolicies[string];
 type NetworkPolicyValue = "allow" | "deny" | "ask";
@@ -94,6 +99,10 @@ export type RunContextAxiomSnapshot = Omit<
   readonly firewalls: readonly RunContextAxiomFirewall[];
   readonly networkPolicyEntries: readonly RunContextNetworkPolicyEntry[];
   readonly featureFlagEntries: readonly RunContextFeatureFlagEntry[];
+  readonly environmentShadowClassification?: EnvironmentShadowClassification;
+  readonly environmentShadowLegacyOnlyCountBucket?: EnvironmentShadowCountBucket;
+  readonly environmentShadowCandidateOnlyCountBucket?: EnvironmentShadowCountBucket;
+  readonly environmentShadowSharedValueDifferenceCountBucket?: EnvironmentShadowCountBucket;
 };
 
 interface NormalizedRunContextSnapshot {

--- a/turbo/packages/db/MIGRATIONS.md
+++ b/turbo/packages/db/MIGRATIONS.md
@@ -35,12 +35,12 @@ expired transition validator must be deleted.
 The repository inventory below is machine-checked. The removal owner must
 delete the workflow, probe, focused validator, and this entry together.
 
-| Issue                    | Validator                                         | Removal owner  |
-| ------------------------ | ------------------------------------------------- | -------------- |
-| #27613 / #27656 / #27671 | Agent/Compose consolidation production preflight  | #26938 Stage 8 |
-| #27665                   | Integration identity Contract readiness preflight | #27602         |
+| Issue                             | Validator                                         | Removal owner  |
+| --------------------------------- | ------------------------------------------------- | -------------- |
+| #27613 / #27656 / #27671 / #27792 | Agent/Compose consolidation production preflight  | #26938 Stage 8 |
+| #27665                            | Integration identity Contract readiness preflight | #27602         |
 
-<!-- vm0-transition-validator:#27613+#27656+#27671|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8 -->
+<!-- vm0-transition-validator:#27613+#27656+#27671+#27792|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8 -->
 <!-- vm0-transition-validator:#27665|integration-identity-contract-readiness-preflight|removal-owner:#27602 -->
 
 ## Migration patterns

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-consumers.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-consumers.ts
@@ -10,6 +10,7 @@ export interface RuntimeContentConsumerManifest {
 }
 
 type RuntimeContentConsumerMode =
+  | "compose-independent-environment-shadow"
   | "first-plural-schema-parse"
   | "first-plural-framework-display"
   | "head-content-selection-and-type-projection"
@@ -44,6 +45,17 @@ const REVIEWED_CONSUMERS: readonly ReviewedConsumer[] = [
   {
     relativePath: "turbo/apps/api/src/signals/routes/integrations-slack.ts",
     mode: "raw-recursive-variable-secret-scan",
+  },
+  {
+    relativePath:
+      "turbo/apps/api/src/signals/services/agent-environment-shadow.ts",
+    mode: "compose-independent-environment-shadow",
+    interfaces: ["ApplicationOwnedEnvironmentCandidateInput"],
+    functions: [
+      "buildApplicationOwnedEnvironmentCandidate",
+      "compareApplicationOwnedEnvironment",
+    ],
+    variables: ["ENVIRONMENT_SHADOW_COUNT_BUCKETS"],
   },
   {
     relativePath:
@@ -179,6 +191,7 @@ export const EXPECTED_RUNTIME_CONTENT_CONSUMER_MANIFEST: RuntimeContentConsumerM
     ],
     reviewedConsumers: [
       "turbo/apps/api/src/signals/routes/integrations-slack.ts|raw-recursive-variable-secret-scan|1|0357a0f694d2882516d811fff5f28d57abb01a6df4f2bdcb1f8435d0827ea17f",
+      "turbo/apps/api/src/signals/services/agent-environment-shadow.ts|compose-independent-environment-shadow|4|bb1c66722499e90deb9a6471567a6d374aefe0f68b878249d0fc4822ddaf3f13",
       "turbo/apps/api/src/signals/services/agent-instructions.service.ts|first-plural-schema-parse|2|5e0e03733f7327b9e719691adccd8ef9e643f7945e7a2011884b50c17cd0d5ca",
       "turbo/apps/api/src/signals/services/agent-run-create.service.ts|singular-or-first-plural-launch|18|eff82337ee0438f35a74d19fda0fbe828ab087c7f1c5078df06d677e782932d4",
       "turbo/apps/api/src/signals/services/agent-run-storage.service.ts|singular-or-first-plural-storage-and-volumes|8|f892995687452b9c164950e90aab24e9da198326187dea19b646864d71d35cf9",

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
@@ -396,7 +396,7 @@ export const EXPECTED_REPOSITORY_DEPENDENCIES = {
     "crates/api-contracts/src/generated/decode_paths.rs|agentComposeVersionId",
   ],
   transitionValidators: [
-    "#27613+#27656+#27671|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8",
+    "#27613+#27656+#27671+#27792|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8",
     "#27665|integration-identity-contract-readiness-preflight|removal-owner:#27602",
   ],
 } as const satisfies RepositoryDependencyManifest;

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -1860,6 +1860,29 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
       "turbo/apps/api/src/signals/services",
     );
     await fs.mkdir(runCreateDirectory, { recursive: true });
+    const environmentShadowConsumerPath = path.join(
+      runCreateDirectory,
+      "agent-environment-shadow.ts",
+    );
+    const environmentShadowConsumer = [
+      'const ENVIRONMENT_SHADOW_COUNT_BUCKETS = ["0", "1"] as const;',
+      "interface ApplicationOwnedEnvironmentCandidateInput {",
+      "  readonly runtimeOverrides: Readonly<Record<string, string>>;",
+      "}",
+      "function buildApplicationOwnedEnvironmentCandidate(",
+      "  args: ApplicationOwnedEnvironmentCandidateInput,",
+      ") {",
+      "  void args;",
+      "  return {};",
+      "}",
+      "function compareApplicationOwnedEnvironment() { return 'exact'; }",
+      "",
+    ].join("\n");
+    await fs.writeFile(
+      environmentShadowConsumerPath,
+      environmentShadowConsumer,
+      "utf8",
+    );
     const runCreateConsumerPath = path.join(
       runCreateDirectory,
       "agent-run-create.service.ts",
@@ -1924,6 +1947,29 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
 
     const semanticBaseline =
       await collectRuntimeContentConsumerManifest(fixtureRoot);
+
+    await fs.writeFile(
+      environmentShadowConsumerPath,
+      environmentShadowConsumer.replace(
+        "  return {};",
+        "  return firstAgent(args.content).environment;",
+      ),
+      "utf8",
+    );
+    const environmentShadowLegacyDrift =
+      await collectRuntimeContentConsumerManifest(fixtureRoot);
+    assert.equal(
+      runtimeContentConsumerManifestsEqual(
+        semanticBaseline,
+        environmentShadowLegacyDrift,
+      ),
+      false,
+    );
+    await fs.writeFile(
+      environmentShadowConsumerPath,
+      environmentShadowConsumer,
+      "utf8",
+    );
 
     const unrelatedZeroRunQueryChange = zeroRunConsumer
       .replace(
@@ -2129,7 +2175,7 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
       workflow.indexOf('>> "$GITHUB_OUTPUT"'),
   );
   assert.match(workflow, /scripts\/agent-compose-consolidation-preflight\.ts/u);
-  assert.match(workflow, /#27613 \+ #27656 \+ #27671/u);
+  assert.match(workflow, /#27613 \+ #27656 \+ #27671 \+ #27792/u);
   assert.match(workflow, /vm0\.agent-compose-consolidation-preflight\.v3/u);
   assert.equal(
     /vm0\.agent-compose-consolidation-preflight\.v[12]/u.test(workflow),


### PR DESCRIPTION
## Summary

- assemble a pure Compose-independent application-owned environment candidate from already-resolved launch inputs
- compare the exact unredacted candidate and authoritative legacy maps, then retain only a fixed classification and bounded count buckets
- attach the safe observation only to the existing Run-context snapshot and protect the temporary helper through the schema-v3 preflight manifests

## Runtime invariants

- the legacy environment remains the sole runtime authority; its assembly is unchanged
- the candidate never enters the Runner payload, stored execution context, Run row, launch snapshot, validation, or any behavior path
- shadow construction is synchronous and query-free; failures reduce only to `shadow_unavailable`
- no additional secret load, provider resolution, Connector resolution, data write, or side effect is introduced

## Safe telemetry schema

- `environmentShadowClassification`: `exact`, `legacy_only_bindings`, `candidate_only_bindings`, `value_override_difference`, `mixed_difference`, or `shadow_unavailable`
- `environmentShadowLegacyOnlyCountBucket`
- `environmentShadowCandidateOnlyCountBucket`
- `environmentShadowSharedValueDifferenceCountBucket`
- count buckets are fixed to `0`, `1`, `2_4`, `5_8`, `9_16`, or `17_plus`; unavailable observations omit all count fields
- exact maps are compared before redaction and are never serialized, hashed, logged, or retained

#26938 Stage 4/8 owns removal of the helper and fields after read cutover acceptance; the protected transition manifest keeps Stage 8 as the removal owner.

## Validation

- Prettier on changed files
- standard Oxlint, type-aware Oxlint, and ESLint on changed API and preflight files
- API TypeScript checks for dependencies, gateways, core, bootstrap, and tests
- DB package TypeScript check
- focused pure shadow test: 20 passed
- schema-v3 static preflight assertions passed; the local database-backed phase stopped at the expected `DATABASE_URL is required` boundary
- database-backed focused route tests are left to PR CI because no local PostgreSQL service is available

Closes #27792

Parent #26938