### PR TITLE
test(api): isolate runtime sync batch boundary

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9290,10 +9290,90 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, genericDirectRun.runId, [200]);
   });
 
-  it("hands off more than one runtime-sync batch without truncation", async () => {
+  it("reads a seeded canonical connector through runtime auth", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Expected a custom connector actor with an organization");
+    }
+    const suffix = randomUUID().slice(0, 8);
+    const runtimeConnector = {
+      id: randomUUID(),
+      slug: `_bdd-canonical-${suffix}`,
+      displayName: "BDD Canonical Runtime",
+      prefixTemplate: `https://canonical-${suffix}.example.test/api/`,
+    };
+    await seedCustomConnectorRuntimeConnectors(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectors: [runtimeConnector],
+    });
+    const listedRuntimeConnectors =
+      await connectors.listCustomConnectors(actor);
+    expect(
+      listedRuntimeConnectors.find((connector) => {
+        return connector.id === runtimeConnector.id;
+      }),
+    ).toMatchObject({
+      prefixTemplates: [runtimeConnector.prefixTemplate],
+      headerInjections: [
+        {
+          name: "X-Connector",
+          valueTemplate: "runtime-batch {{secrets.optional_secret}}",
+        },
+      ],
+    });
+    await connectors.updateAgentCustomConnectors(actor, agentId, [
+      runtimeConnector.id,
+    ]);
+    await connectors.setCustomConnectorValues(actor, runtimeConnector.id, [
+      {
+        key: "optional_secret",
+        kind: "secret",
+        value: "canonical-runtime-secret",
+      },
+    ]);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use the seeded canonical connector",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [
+        {
+          kind: "custom",
+          customConnectorId: runtimeConnector.id,
+          baseUrlVars: {},
+        },
+      ],
+    });
+    const runtime = availableCustomConnectorRuntime(runtimeResult);
+    const { body: authBody } = customConnectorRuntimeAuthBody(
+      runtime,
+      fw.encryptedSecretsBody({}),
+    );
+    const auth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      authBody,
+      [200],
+    );
+    expect(auth.body).toMatchObject({
+      headers: {
+        "X-Connector": "runtime-batch canonical-runtime-secret",
+      },
+    });
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("hands off more than one runtime-sync batch without truncation", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     if (!actor.orgId) {
       throw new Error("Expected a custom connector actor with an organization");
@@ -9316,25 +9396,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       userId: actor.userId,
       customConnectors: runtimeConnectors,
     });
-    const listedRuntimeConnectors =
-      await connectors.listCustomConnectors(actor);
-    const firstRuntimeConnector = runtimeConnectors[0];
-    if (!firstRuntimeConnector) {
-      throw new Error("Expected a canonical runtime connector fixture");
-    }
-    expect(
-      listedRuntimeConnectors.find((connector) => {
-        return connector.id === firstRuntimeConnector.id;
-      }),
-    ).toMatchObject({
-      prefixTemplates: [firstRuntimeConnector.prefixTemplate],
-      headerInjections: [
-        {
-          name: "X-Connector",
-          valueTemplate: "runtime-batch {{secrets.optional_secret}}",
-        },
-      ],
-    });
     const createdIds = runtimeConnectors.map((connector) => {
       return connector.id;
     });
@@ -9344,13 +9405,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       createdIds,
     );
     expect(authorizedConnectorIds).toHaveLength(connectorCount);
-    await connectors.setCustomConnectorValues(actor, firstRuntimeConnector.id, [
-      {
-        key: "optional_secret",
-        kind: "secret",
-        value: "canonical-runtime-secret",
-      },
-    ]);
 
     const run = await api.createRun(actor, {
       agentId,
@@ -9367,31 +9421,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         })
         .sort(),
     ).toStrictEqual(expectedIds);
-
-    const [firstRuntime] = await api.syncConnectorRuntime(run.runId, {
-      targets: [
-        {
-          kind: "custom",
-          customConnectorId: firstRuntimeConnector.id,
-          baseUrlVars: {},
-        },
-      ],
-    });
-    const availableFirstRuntime = availableCustomConnectorRuntime(firstRuntime);
-    const { body: firstAuthBody } = customConnectorRuntimeAuthBody(
-      availableFirstRuntime,
-      fw.encryptedSecretsBody({}),
-    );
-    const firstAuth = await fw.requestFirewallAuth(
-      { authorization: `Bearer ${claim.sandboxToken}` },
-      firstAuthBody,
-      [200],
-    );
-    expect(firstAuth.body).toMatchObject({
-      headers: {
-        "X-Connector": "runtime-batch canonical-runtime-secret",
-      },
-    });
 
     await api.requestCancelRun(actor, run.runId, [200]);
   });


### PR DESCRIPTION
## Summary

- keep the 257-target claim assertion focused on the runtime-sync batch boundary
- move the independent seeded canonical connector list, credential, sync, and firewall-auth contract into a single-target test
- preserve every business assertion without retries, sleeps, timeout changes, skipped tests, or production changes

## Failure evidence

- [main run 32027207007](https://github.com/vm0-ai/vm0/actions/runs/32027207007), [`test-api (7)`](https://github.com/vm0-ai/vm0/actions/runs/32027207007/job/95380874298): the test timed out at 5005 ms
- [main run 32028220996](https://github.com/vm0-ai/vm0/actions/runs/32028220996), [`test-api (7)`](https://github.com/vm0-ai/vm0/actions/runs/32028220996/job/95382634755): the same test timed out at 5009 ms on the next unrelated main SHA
- [merge-group run 32030465848](https://github.com/vm0-ai/vm0/actions/runs/32030465848), [`test-api (7)`](https://github.com/vm0-ai/vm0/actions/runs/32030465848/job/95389189367): the same test timed out at 5021 ms while queueing #27780, whose changes do not touch this test or the connector batch path
- [merge-group run 32032282196](https://github.com/vm0-ai/vm0/actions/runs/32032282196), [`test-api (7)`](https://github.com/vm0-ai/vm0/actions/runs/32032282196/job/95394830160): the same test timed out at 5105 ms on a fresh merge-group head after #27780 was requeued
- comparison passes completed in [4617 ms](https://github.com/vm0-ai/vm0/actions/runs/32027182719/job/95379015524), [1042 ms](https://github.com/vm0-ai/vm0/actions/runs/32025353894/job/95374127878), and [1191 ms](https://github.com/vm0-ai/vm0/actions/runs/32024968403/job/95372428609)

The first causal failure in all four occurrences is the per-test 5000 ms timeout. `test-api (5)` in the fourth run is cancellation noise, and `ci-gate-turbo` is only the downstream aggregate failure; no teardown or unhandled-rejection failure precedes the timeout.

## Diagnosis

The batch invariant intentionally creates `CONNECTOR_RUNTIME_SYNC_TARGETS_MAX + 1` (257) persisted custom connectors and verifies that the runner claim contains every target. Its wall-clock pass/fail outcome varies with the real API and PostgreSQL work under CI scheduling.

PR #26176 already replaced 257 per-connector route and encryption setup calls with a bulk fixture after the original form timed out. PR #26246 later added an independent canonical seeded-connector contract—list projection, secret write, runtime sync, and firewall auth—to the same 5-second test. Four identical boundary failures across two main SHAs and two merge-group SHAs for the same unrelated PR establish that the combined workload, rather than a change-owned product regression, is crossing the budget.

This change separates those independent contracts. The boundary test still seeds 257 connectors, grants all 257, and requires the claimed target IDs to equal all 257 IDs. The canonical fixture test retains the list projection, secret resolution, runtime sync, and firewall header assertion with one connector.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`

The focused Vitest test requires PostgreSQL. It was not run locally because this repair explicitly prohibits starting a local service; the PR's `test-api (7)` job provides the applicable integration validation.

## Preview

Not applicable. This is a test-only API integration change with no browser-visible or deployable product behavior change.
