### PR TITLE
fix(api): refresh api release marker comment

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed again on 2026-07-31)
+// (no-op API release marker refreshed for #27796 on 2026-08-17)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary

- refresh the existing no-op API release marker comment
- create a fresh push to `main` after release-please refresh run #32037010757 timed out internally on all three bounded attempts
- trigger release-please to rebuild the canonical API release PR from scratch

## Runtime impact

None. This PR changes only one explanatory comment in `turbo/apps/api/src/index.ts`.

## Validation

- `git diff --check`: passed
- local `pnpm format`: unavailable because this checkout has no `node_modules`; rely on the PR pipeline for authoritative validation
- no Vitest run, per the comment-only release-trigger workflow

## Release context

Required to continue production verification for #27796 and EPIC #27599.
