### PR TITLE
fix(api): retry api release marker after github timeout

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed for #27796 on 2026-08-17)
+// (no-op API release retry marker for #27796 after a GitHub timeout)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary

- Refresh the existing no-op API release marker comment.
- Create a fresh main-push event after release-please refresh run #32039175537 exhausted its single bounded rerun on GitHub request timeouts.
- Preserve runtime behavior exactly.

## Validation

- `git diff --check` passed.
- The diff is exactly one TypeScript comment replacement.
- Local `pnpm format` could not start because this checkout has no `node_modules`; PR CI is authoritative for format, lint, types, and tests.

Tracking: #27796