### PR TITLE
test(api): seed runtime-sync batch grants through test route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -160,6 +160,7 @@ export async function seedCustomConnectorRuntimeConnectors(
   args: {
     readonly orgId: string;
     readonly userId: string;
+    readonly agentId?: string;
     readonly customConnectors: readonly {
       readonly id: string;
       readonly slug: string;
@@ -172,6 +173,7 @@ export async function seedCustomConnectorRuntimeConnectors(
     action: "seed-custom-runtime-connectors",
     org_id: args.orgId,
     user_id: args.userId,
+    ...(args.agentId === undefined ? {} : { agent_id: args.agentId }),
     custom_connectors: args.customConnectors.map((connector) => {
       return {
         id: connector.id,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9431,7 +9431,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
   it("hands off more than one runtime-sync batch without truncation", async () => {
     const api = createRunsApi(context);
-    const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     if (!actor.orgId) {
       throw new Error("Expected a custom connector actor with an organization");
@@ -9452,17 +9451,12 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await seedCustomConnectorRuntimeConnectors(context, {
       orgId: actor.orgId,
       userId: actor.userId,
+      agentId,
       customConnectors: runtimeConnectors,
     });
     const createdIds = runtimeConnectors.map((connector) => {
       return connector.id;
     });
-    const authorizedConnectorIds = await connectors.updateAgentCustomConnectors(
-      actor,
-      agentId,
-      createdIds,
-    );
-    expect(authorizedConnectorIds).toHaveLength(connectorCount);
 
     const run = await api.createRun(actor, {
       agentId,

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -7,6 +7,7 @@ import { connectors } from "@okouai/db/schema/connector";
 import { connectorOauthStates } from "@okouai/db/schema/connector-oauth-state";
 import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
 import { secrets } from "@okouai/db/schema/secret";
+import { userCustomConnectors } from "@okouai/db/schema/user-custom-connector";
 import { variables } from "@okouai/db/schema/variable";
 import { and, asc, eq, inArray } from "drizzle-orm";
 
@@ -379,6 +380,20 @@ async function seedCustomRuntimeConnectors(
         };
       }),
     );
+    const agentId = body.agent_id;
+    if (agentId) {
+      await tx.insert(userCustomConnectors).values(
+        body.custom_connectors.map((connector) => {
+          return {
+            orgId: body.org_id,
+            userId: body.user_id,
+            agentId,
+            customConnectorId: connector.id,
+            permissionNames: [] as string[],
+          };
+        }),
+      );
+    }
   });
   signal.throwIfAborted();
   return actionOk();

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -76,6 +76,7 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       action: z.literal("seed-custom-runtime-connectors"),
       org_id: z.string(),
       user_id: z.string(),
+      agent_id: z.uuid().optional(),
       custom_connectors: z
         .array(
           z.object({


### PR DESCRIPTION
## Problem

`RUN-02 > hands off more than one runtime-sync batch without truncation` intermittently times out at the 5000ms Vitest default. The test creates 257 connectors and then grants them through the production `updateAgentCustomConnectors` endpoint, whose bulk path takes one `SELECT ... FOR UPDATE` per connector to preserve deterministic lock ordering. A passing CI run measured the test at ~4.3s, close enough to the timeout that normal runner variance tips it over.

## Fix

The test's actual invariant is that a created run's claim returns all 257 authorized custom connector targets without truncation. It does not need to exercise the bulk grant endpoint. Extend the existing test-only `seed-custom-runtime-connectors` fixture route to optionally accept `agent_id` and insert matching `user_custom_connectors` grant rows in the same transaction. The test now seeds definitions and grants together and removes the slow production bulk update from its setup.

## Verification

- `prettier --check` and `git diff --check` pass on the changed files.
- `oxlint` reports no new errors.
- A targeted local Vitest run reached the previously slow setup in ~0.6s, though the sandbox does not reproduce the CI runner-job queue bootstrap, so the claim assertion could not complete locally; the PR pipeline runs the full API shard.
- The fixture route was confirmed against a migrated local Postgres instance to insert the expected `user_custom_connectors` rows.