### PR TITLE
refactor(db): classify launch snapshot recoverability

### DIFF
--- a/.github/workflows/agent-compose-consolidation-preflight.yml
+++ b/.github/workflows/agent-compose-consolidation-preflight.yml
@@ -49,7 +49,7 @@ jobs:
               --ssl verify-full \
               2>/dev/null
           ); then
-            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v3","status":"failed","failureGates":["probe.database_resolution"]}'
+            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v4","status":"failed","failureGates":["probe.database_resolution"]}'
             exit 1
           fi
           if [[ -z "$database_url" ||
@@ -57,7 +57,7 @@ jobs:
                 "$database_url" == *$'\r'* ||
                 ( "$database_url" != postgres://* &&
                   "$database_url" != postgresql://* ) ]]; then
-            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v3","status":"failed","failureGates":["probe.database_resolution"]}'
+            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v4","status":"failed","failureGates":["probe.database_resolution"]}'
             exit 1
           fi
           WORKFLOW_COMMAND_DATA="${database_url//%/%25}"

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-fingerprint.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-fingerprint.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 
 export const PREFLIGHT_SCHEMA_VERSION =
-  "vm0.agent-compose-consolidation-preflight.v3";
+  "vm0.agent-compose-consolidation-preflight.v4";
 
 // Keep the accepted Stage 0 aggregate digests stable while the output schema
 // grows additively. New sets use their own domain strings at each call site.

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-launch-snapshots.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-launch-snapshots.ts
@@ -1,0 +1,1460 @@
+import { computeComposeVersionId } from "../../../apps/api/src/signals/services/agent-compose-content";
+import {
+  fingerprintSortedSet,
+  type SetFingerprint,
+} from "./agent-compose-consolidation-preflight-fingerprint";
+
+type HistoricalFramework = "claude-code" | "codex" | "pi";
+type BaseHistoricalFramework = Exclude<HistoricalFramework, "pi">;
+
+export const LAUNCH_SNAPSHOT_DISPOSITIONS = [
+  "already_valid",
+  "exactly_recoverable",
+  "historical_unknown",
+  "integrity_conflict",
+] as const;
+
+export type LaunchSnapshotDisposition =
+  (typeof LAUNCH_SNAPSHOT_DISPOSITIONS)[number];
+
+export const LAUNCH_SNAPSHOT_REASONS = [
+  "complete_exact_evidence",
+  "conversation_framework_conflict",
+  "conversation_framework_invalid",
+  "conversation_framework_missing",
+  "conversation_framework_valid",
+  "created_before_reviewed_history_boundary",
+  "evidence_conflict",
+  "existing_snapshot_invalid",
+  "existing_snapshot_valid",
+  "framework_evidence_conflict",
+  "framework_legacy_exact",
+  "framework_pi_state_unproven",
+  "framework_provider_exact",
+  "framework_provider_missing",
+  "framework_provider_precedence_inactive",
+  "framework_provider_retired",
+  "framework_provider_rollout_transition",
+  "framework_provider_unknown",
+  "framework_vm0_model_exact",
+  "framework_vm0_model_missing",
+  "framework_vm0_model_retired",
+  "framework_vm0_model_unknown",
+  "legacy_content_exact",
+  "legacy_content_hash_conflict",
+  "legacy_content_invalid",
+  "legacy_content_unsupported",
+  "legacy_first_agent_exact",
+  "no_version_reference",
+  "otherwise_unclassified_shape",
+  "checkpoint_snapshot_malformed",
+  "checkpoint_version_missing",
+  "checkpoint_version_reference_exact",
+  "run_checkpoint_version_conflict",
+  "run_checkpoint_version_reference_exact",
+  "run_version_missing",
+  "run_version_reference_exact",
+  "runner_profile_default_exact",
+  "runner_profile_default_unproven",
+  "runner_profile_explicit_exact",
+  "runner_profile_invalid",
+] as const;
+
+export type LaunchSnapshotReason = (typeof LAUNCH_SNAPSHOT_REASONS)[number];
+
+const ALL_DISPOSITIONS: readonly LaunchSnapshotDisposition[] =
+  LAUNCH_SNAPSHOT_DISPOSITIONS;
+const CONFLICT_ONLY = ["integrity_conflict"] as const;
+const VALID_OR_CONFLICT = ["already_valid", "integrity_conflict"] as const;
+const VALID_OR_UNKNOWN = ["already_valid", "historical_unknown"] as const;
+const NOT_RECOVERABLE = [
+  "already_valid",
+  "historical_unknown",
+  "integrity_conflict",
+] as const;
+
+// Informational reasons may overlap, but every overlap must be compatible with
+// the single disposition. This exhaustive table makes a newly added reason a
+// compile-time error and turns an unexpected combination into closure drift.
+const REASON_DISPOSITION_COMPATIBILITY = {
+  complete_exact_evidence: ["exactly_recoverable"],
+  conversation_framework_conflict: CONFLICT_ONLY,
+  conversation_framework_invalid: CONFLICT_ONLY,
+  conversation_framework_missing: ALL_DISPOSITIONS,
+  conversation_framework_valid: ALL_DISPOSITIONS,
+  created_before_reviewed_history_boundary: ALL_DISPOSITIONS,
+  evidence_conflict: CONFLICT_ONLY,
+  existing_snapshot_invalid: CONFLICT_ONLY,
+  existing_snapshot_valid: VALID_OR_CONFLICT,
+  framework_evidence_conflict: CONFLICT_ONLY,
+  framework_legacy_exact: ALL_DISPOSITIONS,
+  framework_pi_state_unproven: VALID_OR_UNKNOWN,
+  framework_provider_exact: ALL_DISPOSITIONS,
+  framework_provider_missing: ALL_DISPOSITIONS,
+  framework_provider_precedence_inactive: ALL_DISPOSITIONS,
+  framework_provider_retired: ALL_DISPOSITIONS,
+  framework_provider_rollout_transition: ALL_DISPOSITIONS,
+  framework_provider_unknown: ALL_DISPOSITIONS,
+  framework_vm0_model_exact: ALL_DISPOSITIONS,
+  framework_vm0_model_missing: ALL_DISPOSITIONS,
+  framework_vm0_model_retired: ALL_DISPOSITIONS,
+  framework_vm0_model_unknown: ALL_DISPOSITIONS,
+  legacy_content_exact: ALL_DISPOSITIONS,
+  legacy_content_hash_conflict: CONFLICT_ONLY,
+  legacy_content_invalid: NOT_RECOVERABLE,
+  legacy_content_unsupported: NOT_RECOVERABLE,
+  legacy_first_agent_exact: ALL_DISPOSITIONS,
+  no_version_reference: NOT_RECOVERABLE,
+  otherwise_unclassified_shape: CONFLICT_ONLY,
+  checkpoint_snapshot_malformed: CONFLICT_ONLY,
+  checkpoint_version_missing: CONFLICT_ONLY,
+  checkpoint_version_reference_exact: ALL_DISPOSITIONS,
+  run_checkpoint_version_conflict: CONFLICT_ONLY,
+  run_checkpoint_version_reference_exact: ALL_DISPOSITIONS,
+  run_version_missing: CONFLICT_ONLY,
+  run_version_reference_exact: ALL_DISPOSITIONS,
+  runner_profile_default_exact: ALL_DISPOSITIONS,
+  runner_profile_default_unproven: NOT_RECOVERABLE,
+  runner_profile_explicit_exact: ALL_DISPOSITIONS,
+  runner_profile_invalid: NOT_RECOVERABLE,
+} as const satisfies Readonly<
+  Record<LaunchSnapshotReason, readonly LaunchSnapshotDisposition[]>
+>;
+
+export interface LaunchSnapshotRunInventoryRow {
+  readonly id: string;
+  readonly versionId: string | null;
+  readonly createdAt: Date;
+  readonly launchSnapshot: unknown;
+  readonly modelProvider: string | null;
+  readonly selectedModel: string | null;
+  readonly triggerSource: string;
+  readonly chatThreadPresent: boolean;
+}
+
+export interface LaunchSnapshotVersionInventoryRow {
+  readonly id: string;
+  readonly content: unknown;
+}
+
+export interface LaunchSnapshotCheckpointInventoryRow {
+  readonly runId: string;
+  readonly snapshot: unknown;
+}
+
+export interface LaunchSnapshotConversationInventoryRow {
+  readonly runId: string;
+  readonly framework: string;
+}
+
+export interface ClosureComparison {
+  readonly expected: SetFingerprint;
+  readonly observed: SetFingerprint;
+  readonly classification: "exact" | "drift";
+}
+
+const REVIEWED_RUN_LOWER_BOUND_MS = Date.parse("2026-03-18T08:41:13.331Z");
+// The vm0/default profile constant and former Web persistence path shipped in
+// web-v12.119.0. Web completed at 2026-03-17T05:49:22Z and Runner at
+// 05:50:31Z, more than 26 hours before this reviewed live lower bound.
+
+// 4448bb2b2167 first threaded the former Web path's computed framework into
+// dispatch. The first carrying Web release was web-v12.330.3. GitHub Actions
+// run 25269380137 promoted it from 04:14:33 through 04:15:49 UTC, so neither
+// source-commit time nor any time inside the rolling deployment is authority.
+const PROVIDER_PRECEDENCE_ROLLOUT_START_MS = Date.parse(
+  "2026-05-03T04:14:33.000Z",
+);
+const PROVIDER_PRECEDENCE_ROLLOUT_END_MS = Date.parse(
+  "2026-05-03T04:15:49.000Z",
+);
+
+// Pi history is intentionally independent from today's feature switch and
+// model catalog. The transient-callback path first reached API production in
+// api-v1.396.0; subsequent boundaries use the complete successful production
+// promotion intervals supplied by the carrying releases. Before the Flash
+// restriction finishes rolling out, every compatible provider remains
+// potentially Pi because callback and feature state were not persisted.
+const PI_TRANSIENT_ROLLOUT_START_MS = Date.parse("2026-08-07T06:11:49.000Z");
+const PI_CALLBACK_REMOVAL_ROLLOUT_START_MS = Date.parse(
+  "2026-08-07T16:10:54.000Z",
+);
+const PI_CALLBACK_REMOVAL_ROLLOUT_END_MS = Date.parse(
+  "2026-08-07T16:12:19.000Z",
+);
+const PI_FLASH_ROLLOUT_START_MS = Date.parse("2026-08-10T03:38:03.000Z");
+const PI_FLASH_ROLLOUT_END_MS = Date.parse("2026-08-10T03:39:34.000Z");
+const PI_SANDBOX_ROLLOUT_START_MS = Date.parse("2026-08-12T16:42:28.000Z");
+const PI_SANDBOX_ROLLOUT_END_MS = Date.parse("2026-08-12T16:44:33.000Z");
+const PI_PRO_ROLLOUT_START_MS = Date.parse("2026-08-12T18:50:26.000Z");
+const PI_PRO_ROLLOUT_END_MS = Date.parse("2026-08-12T18:52:37.000Z");
+
+// c6ac8c8a49 changed the Flash label from Claude to Codex in api-v1.362.0;
+// its API promotion ran 2026-07-31T12:06:02Z through 12:08:52Z. c19ea0fa2d
+// retired the former Pro route in api-v1.373.1, promoted 2026-08-04T15:05:50Z
+// through 15:07:21Z. Pro did not become Codex evidence again until the
+// api-v1.440.0 expansion above finished. Every rollout overlap is unknown.
+const FLASH_CODEX_ROLLOUT_START_MS = Date.parse("2026-07-31T12:06:02.000Z");
+const FLASH_CODEX_ROLLOUT_END_MS = Date.parse("2026-07-31T12:08:52.000Z");
+const PRO_RETIREMENT_ROLLOUT_START_MS = Date.parse("2026-08-04T15:05:50.000Z");
+const PRO_RETIREMENT_ROLLOUT_END_MS = Date.parse("2026-08-04T15:07:21.000Z");
+const PRO_CODEX_ROLLOUT_END_MS = PI_PRO_ROLLOUT_END_MS;
+
+// These are reviewed historical facts, not imports from the live catalog.
+// Each label either predates the reviewed Run interval or carries the commit
+// time at which that exact persisted label acquired its unchanged framework.
+const HISTORICAL_PROVIDER_RULES = {
+  "anthropic-api-key": "claude-code",
+  "aws-bedrock": "claude-code",
+  "azure-foundry": "claude-code",
+  "claude-code-oauth-token": "claude-code",
+  "codex-oauth-token": "codex",
+  deepseek: "codex",
+  "openai-api-key": "codex",
+  "openrouter-api-key": "claude-code",
+  "openrouter-codex": "codex",
+  "vercel-ai-gateway": "claude-code",
+  "vercel-ai-gateway-codex": "codex",
+} as const satisfies Record<string, BaseHistoricalFramework>;
+
+const RETIRED_PROVIDER_TYPES: ReadonlySet<string> = new Set([
+  "deepseek-api-key",
+  "deepseek-codex",
+  "minimax-api-key",
+  "moonshot-api-key",
+  "zai-api-key",
+]);
+
+// Model labels in this map have one reviewed framework meaning over every
+// interval in which the exact label was launchable. Removed labels stay in the
+// retired set below even when their former concrete provider is knowable.
+const HISTORICAL_VM0_MODEL_RULES = {
+  "claude-fable-5": "claude-code",
+  "claude-opus-5": "claude-code",
+  "claude-opus-4-8": "claude-code",
+  "claude-sonnet-5": "claude-code",
+  "claude-sonnet-4-6": "claude-code",
+  "gpt-5.5": "codex",
+  "gpt-5.6-luna": "codex",
+  "gpt-5.6-sol": "codex",
+  "gpt-5.6-terra": "codex",
+} as const satisfies Record<string, BaseHistoricalFramework>;
+
+const RETIRED_VM0_MODELS: ReadonlySet<string> = new Set([
+  "MiniMax-M3",
+  "claude-opus-4-6",
+  "claude-opus-4-7",
+  "glm-5.1",
+  "glm-5.2",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "hy3-preview",
+  "kimi-k2.7-code",
+  "kimi-k3",
+  "mimo-v2.5",
+  "vm0-auto",
+  "vm0-model",
+]);
+
+const DEFAULT_RUNNER_PROFILE = "vm0/default";
+const VERSION_ID_PATTERN = /^[0-9a-f]{64}$/u;
+const WEB_CHAT_TRIGGER_SOURCES: ReadonlySet<string> = new Set(["agent", "web"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBaseFramework(value: unknown): value is BaseHistoricalFramework {
+  return value === "claude-code" || value === "codex";
+}
+
+function isFramework(value: unknown): value is HistoricalFramework {
+  return isBaseFramework(value) || value === "pi";
+}
+
+function isValidProfile(value: unknown): value is string {
+  return typeof value === "string" && value.length >= 1 && value.length <= 255;
+}
+
+function strictLaunchSnapshot(value: unknown): {
+  readonly framework: HistoricalFramework;
+  readonly runnerProfile: string;
+} | null {
+  if (!isRecord(value)) return null;
+  const keys = Object.keys(value).sort();
+  if (
+    keys.length !== 3 ||
+    keys[0] !== "framework" ||
+    keys[1] !== "runnerProfile" ||
+    keys[2] !== "schemaVersion" ||
+    value.schemaVersion !== 1 ||
+    !isFramework(value.framework) ||
+    !isValidProfile(value.runnerProfile)
+  ) {
+    return null;
+  }
+  return {
+    framework: value.framework,
+    runnerProfile: value.runnerProfile,
+  };
+}
+
+type CheckpointReference =
+  | { readonly classification: "absent" }
+  | { readonly classification: "invalid" }
+  | { readonly classification: "valid"; readonly versionId: string };
+
+function checkpointReference(snapshot: unknown): CheckpointReference {
+  if (!isRecord(snapshot)) return { classification: "invalid" };
+  const allowedKeys = new Set(["agentComposeVersionId", "secretNames", "vars"]);
+  if (
+    Object.keys(snapshot).some((key) => {
+      return !allowedKeys.has(key);
+    })
+  ) {
+    return { classification: "invalid" };
+  }
+  if (
+    "vars" in snapshot &&
+    (!isRecord(snapshot.vars) ||
+      Object.values(snapshot.vars).some((value) => {
+        return typeof value !== "string";
+      }))
+  ) {
+    return { classification: "invalid" };
+  }
+  if (
+    "secretNames" in snapshot &&
+    (!Array.isArray(snapshot.secretNames) ||
+      snapshot.secretNames.some((value) => {
+        return typeof value !== "string";
+      }))
+  ) {
+    return { classification: "invalid" };
+  }
+  if (!("agentComposeVersionId" in snapshot)) {
+    return { classification: "absent" };
+  }
+  if (
+    typeof snapshot.agentComposeVersionId !== "string" ||
+    !VERSION_ID_PATTERN.test(snapshot.agentComposeVersionId)
+  ) {
+    return { classification: "invalid" };
+  }
+  return {
+    classification: "valid",
+    versionId: snapshot.agentComposeVersionId,
+  };
+}
+
+interface HistoricalAgent {
+  readonly framework: unknown;
+  readonly profilePresent: boolean;
+  readonly profile: unknown;
+}
+
+type HistoricalContent =
+  | { readonly classification: "invalid" }
+  | { readonly classification: "unsupported" }
+  | { readonly classification: "exact"; readonly agent: HistoricalAgent };
+
+function historicalFirstAgent(content: unknown): HistoricalContent {
+  if (!isRecord(content)) return { classification: "invalid" };
+  const singularPresent = "agent" in content && Boolean(content.agent);
+  const pluralPresent = "agents" in content && content.agents !== undefined;
+  if (singularPresent && pluralPresent) {
+    return { classification: "unsupported" };
+  }
+
+  let value: unknown;
+  if (singularPresent) {
+    value = content.agent;
+  } else if (pluralPresent) {
+    if (!isRecord(content.agents)) return { classification: "invalid" };
+    const firstKey = Object.keys(content.agents)[0];
+    if (!firstKey) return { classification: "unsupported" };
+    value = content.agents[firstKey];
+  } else {
+    return { classification: "unsupported" };
+  }
+
+  if (!isRecord(value)) return { classification: "invalid" };
+  return {
+    classification: "exact",
+    agent: {
+      framework: value.framework,
+      profilePresent: "experimental_profile" in value,
+      profile: value.experimental_profile,
+    },
+  };
+}
+
+interface RunClassification {
+  readonly disposition: LaunchSnapshotDisposition;
+  readonly primaryReason: LaunchSnapshotReason;
+  readonly reasons: ReadonlySet<LaunchSnapshotReason>;
+}
+
+interface ResolvedVersionEvidence {
+  readonly content: unknown | undefined;
+  readonly conflictReason: LaunchSnapshotReason | undefined;
+  readonly unknownReason: LaunchSnapshotReason | undefined;
+}
+
+function addReason(
+  reasons: Set<LaunchSnapshotReason>,
+  reason: LaunchSnapshotReason,
+): void {
+  reasons.add(reason);
+}
+
+interface ReferenceEvidenceArgs {
+  readonly run: LaunchSnapshotRunInventoryRow;
+  readonly checkpoint: LaunchSnapshotCheckpointInventoryRow | undefined;
+  readonly duplicateCheckpoint: boolean;
+  readonly versions: ReadonlyMap<string, LaunchSnapshotVersionInventoryRow>;
+  readonly duplicateVersionIds: ReadonlySet<string>;
+  readonly reasons: Set<LaunchSnapshotReason>;
+}
+
+function referenceConflict(
+  reason: LaunchSnapshotReason,
+  reasons: Set<LaunchSnapshotReason>,
+): ResolvedVersionEvidence {
+  addReason(reasons, reason);
+  return {
+    content: undefined,
+    conflictReason: reason,
+    unknownReason: undefined,
+  };
+}
+
+function referenceUnknown(
+  reason: LaunchSnapshotReason,
+  reasons: Set<LaunchSnapshotReason>,
+  content?: unknown,
+): ResolvedVersionEvidence {
+  addReason(reasons, reason);
+  return {
+    content,
+    conflictReason: undefined,
+    unknownReason: reason,
+  };
+}
+
+function referenceShapeConflict(
+  args: ReferenceEvidenceArgs,
+): ResolvedVersionEvidence | undefined {
+  if (args.duplicateCheckpoint) {
+    return referenceConflict("otherwise_unclassified_shape", args.reasons);
+  }
+  if (
+    args.run.versionId !== null &&
+    (typeof args.run.versionId !== "string" ||
+      !VERSION_ID_PATTERN.test(args.run.versionId))
+  ) {
+    return referenceConflict("otherwise_unclassified_shape", args.reasons);
+  }
+  return undefined;
+}
+
+type ValidCheckpointReference = Exclude<
+  CheckpointReference,
+  { readonly classification: "invalid" }
+>;
+
+function resolveCheckpointReference(
+  args: ReferenceEvidenceArgs,
+):
+  | { readonly checkpoint: ValidCheckpointReference }
+  | { readonly terminal: ResolvedVersionEvidence } {
+  const checkpoint = args.checkpoint
+    ? checkpointReference(args.checkpoint.snapshot)
+    : ({ classification: "absent" } as const);
+  if (checkpoint.classification === "invalid") {
+    return {
+      terminal: referenceConflict(
+        "checkpoint_snapshot_malformed",
+        args.reasons,
+      ),
+    };
+  }
+  if (
+    args.run.versionId !== null &&
+    checkpoint.classification === "valid" &&
+    args.run.versionId !== checkpoint.versionId
+  ) {
+    return {
+      terminal: referenceConflict(
+        "run_checkpoint_version_conflict",
+        args.reasons,
+      ),
+    };
+  }
+  return { checkpoint };
+}
+
+function loadReferencedVersion(args: {
+  readonly referenceArgs: ReferenceEvidenceArgs;
+  readonly checkpoint: ValidCheckpointReference;
+  readonly effectiveVersionId: string;
+}): ResolvedVersionEvidence {
+  const { referenceArgs, checkpoint, effectiveVersionId } = args;
+  if (referenceArgs.duplicateVersionIds.has(effectiveVersionId)) {
+    return referenceConflict(
+      "otherwise_unclassified_shape",
+      referenceArgs.reasons,
+    );
+  }
+
+  const version = referenceArgs.versions.get(effectiveVersionId);
+  if (!version) {
+    if (referenceArgs.run.versionId !== null) {
+      addReason(referenceArgs.reasons, "run_version_missing");
+    }
+    if (checkpoint.classification === "valid") {
+      addReason(referenceArgs.reasons, "checkpoint_version_missing");
+    }
+    return {
+      content: undefined,
+      conflictReason:
+        referenceArgs.run.versionId !== null
+          ? "run_version_missing"
+          : "checkpoint_version_missing",
+      unknownReason: undefined,
+    };
+  }
+
+  if (
+    referenceArgs.run.versionId !== null &&
+    checkpoint.classification === "valid"
+  ) {
+    addReason(referenceArgs.reasons, "run_checkpoint_version_reference_exact");
+  } else if (referenceArgs.run.versionId !== null) {
+    addReason(referenceArgs.reasons, "run_version_reference_exact");
+  } else {
+    addReason(referenceArgs.reasons, "checkpoint_version_reference_exact");
+  }
+
+  if (!isRecord(version.content)) {
+    return referenceUnknown(
+      "legacy_content_invalid",
+      referenceArgs.reasons,
+      version.content,
+    );
+  }
+  let computedVersionId: string;
+  try {
+    computedVersionId = computeComposeVersionId(version.content);
+  } catch {
+    return referenceConflict(
+      "otherwise_unclassified_shape",
+      referenceArgs.reasons,
+    );
+  }
+  if (computedVersionId !== effectiveVersionId) {
+    addReason(referenceArgs.reasons, "legacy_content_hash_conflict");
+    addReason(referenceArgs.reasons, "evidence_conflict");
+    return {
+      content: undefined,
+      conflictReason: "legacy_content_hash_conflict",
+      unknownReason: undefined,
+    };
+  }
+  return {
+    content: version.content,
+    conflictReason: undefined,
+    unknownReason: undefined,
+  };
+}
+
+function classifyReferenceEvidence(
+  args: ReferenceEvidenceArgs,
+): ResolvedVersionEvidence {
+  const shapeConflict = referenceShapeConflict(args);
+  if (shapeConflict) return shapeConflict;
+
+  const checkpointResolution = resolveCheckpointReference(args);
+  if ("terminal" in checkpointResolution) {
+    return checkpointResolution.terminal;
+  }
+  const { checkpoint } = checkpointResolution;
+  const effectiveVersionId =
+    args.run.versionId ??
+    (checkpoint.classification === "valid" ? checkpoint.versionId : null);
+  if (effectiveVersionId === null) {
+    return referenceUnknown("no_version_reference", args.reasons);
+  }
+  return loadReferencedVersion({
+    referenceArgs: args,
+    checkpoint,
+    effectiveVersionId,
+  });
+}
+
+type ExactOrUnknown<Value> =
+  | { readonly classification: "exact"; readonly value: Value }
+  | {
+      readonly classification: "unknown";
+      readonly reason: LaunchSnapshotReason;
+    };
+
+function historicalRunnerProfile(args: {
+  readonly createdAtMs: number;
+  readonly content: HistoricalContent;
+  readonly reasons: Set<LaunchSnapshotReason>;
+}): ExactOrUnknown<string> {
+  if (args.content.classification === "invalid") {
+    addReason(args.reasons, "legacy_content_invalid");
+    return { classification: "unknown", reason: "legacy_content_invalid" };
+  }
+  if (args.content.classification === "unsupported") {
+    addReason(args.reasons, "legacy_content_unsupported");
+    return {
+      classification: "unknown",
+      reason: "legacy_content_unsupported",
+    };
+  }
+  if (args.content.agent.profilePresent) {
+    if (!isValidProfile(args.content.agent.profile)) {
+      addReason(args.reasons, "runner_profile_invalid");
+      return {
+        classification: "unknown",
+        reason: "runner_profile_invalid",
+      };
+    }
+    addReason(args.reasons, "runner_profile_explicit_exact");
+    return { classification: "exact", value: args.content.agent.profile };
+  }
+  if (args.createdAtMs < REVIEWED_RUN_LOWER_BOUND_MS) {
+    addReason(args.reasons, "runner_profile_default_unproven");
+    return {
+      classification: "unknown",
+      reason: "runner_profile_default_unproven",
+    };
+  }
+  addReason(args.reasons, "runner_profile_default_exact");
+  return { classification: "exact", value: DEFAULT_RUNNER_PROFILE };
+}
+
+function historicalVm0ModelFramework(args: {
+  readonly selectedModel: string;
+  readonly createdAtMs: number;
+  readonly reasons: Set<LaunchSnapshotReason>;
+}): ExactOrUnknown<BaseHistoricalFramework> {
+  const stableRule = Object.hasOwn(
+    HISTORICAL_VM0_MODEL_RULES,
+    args.selectedModel,
+  )
+    ? HISTORICAL_VM0_MODEL_RULES[
+        args.selectedModel as keyof typeof HISTORICAL_VM0_MODEL_RULES
+      ]
+    : undefined;
+  if (stableRule) {
+    addReason(args.reasons, "framework_vm0_model_exact");
+    return { classification: "exact", value: stableRule };
+  }
+  if (args.selectedModel === "deepseek-v4-flash") {
+    if (args.createdAtMs < FLASH_CODEX_ROLLOUT_START_MS) {
+      addReason(args.reasons, "framework_vm0_model_exact");
+      return { classification: "exact", value: "claude-code" };
+    }
+    if (args.createdAtMs <= FLASH_CODEX_ROLLOUT_END_MS) {
+      addReason(args.reasons, "framework_vm0_model_unknown");
+      return {
+        classification: "unknown",
+        reason: "framework_vm0_model_unknown",
+      };
+    }
+    addReason(args.reasons, "framework_vm0_model_exact");
+    return { classification: "exact", value: "codex" };
+  }
+  if (args.selectedModel === "deepseek-v4-pro") {
+    if (args.createdAtMs < PRO_RETIREMENT_ROLLOUT_START_MS) {
+      addReason(args.reasons, "framework_vm0_model_exact");
+      return { classification: "exact", value: "claude-code" };
+    }
+    if (args.createdAtMs <= PRO_RETIREMENT_ROLLOUT_END_MS) {
+      addReason(args.reasons, "framework_vm0_model_unknown");
+      return {
+        classification: "unknown",
+        reason: "framework_vm0_model_unknown",
+      };
+    }
+    if (args.createdAtMs < PI_PRO_ROLLOUT_START_MS) {
+      addReason(args.reasons, "framework_vm0_model_retired");
+      return {
+        classification: "unknown",
+        reason: "framework_vm0_model_retired",
+      };
+    }
+    if (args.createdAtMs <= PRO_CODEX_ROLLOUT_END_MS) {
+      addReason(args.reasons, "framework_vm0_model_unknown");
+      return {
+        classification: "unknown",
+        reason: "framework_vm0_model_unknown",
+      };
+    }
+    addReason(args.reasons, "framework_vm0_model_exact");
+    return { classification: "exact", value: "codex" };
+  }
+  if (RETIRED_VM0_MODELS.has(args.selectedModel)) {
+    addReason(args.reasons, "framework_vm0_model_retired");
+    return {
+      classification: "unknown",
+      reason: "framework_vm0_model_retired",
+    };
+  }
+  addReason(args.reasons, "framework_vm0_model_unknown");
+  return {
+    classification: "unknown",
+    reason: "framework_vm0_model_unknown",
+  };
+}
+
+function mappedProviderFramework(args: {
+  readonly run: LaunchSnapshotRunInventoryRow;
+  readonly createdAtMs: number;
+  readonly reasons: Set<LaunchSnapshotReason>;
+}): ExactOrUnknown<BaseHistoricalFramework> {
+  if (args.run.modelProvider === null) throw new Error("provider is required");
+  if (RETIRED_PROVIDER_TYPES.has(args.run.modelProvider)) {
+    addReason(args.reasons, "framework_provider_retired");
+    return {
+      classification: "unknown",
+      reason: "framework_provider_retired",
+    };
+  }
+  if (args.run.modelProvider === "vm0") {
+    if (
+      args.run.selectedModel === null ||
+      args.run.selectedModel.length === 0
+    ) {
+      addReason(args.reasons, "framework_vm0_model_missing");
+      return {
+        classification: "unknown",
+        reason: "framework_vm0_model_missing",
+      };
+    }
+    const modelFramework = historicalVm0ModelFramework({
+      selectedModel: args.run.selectedModel,
+      createdAtMs: args.createdAtMs,
+      reasons: args.reasons,
+    });
+    if (modelFramework.classification === "exact") {
+      addReason(args.reasons, "framework_provider_exact");
+    }
+    return modelFramework;
+  }
+
+  const rule = Object.hasOwn(HISTORICAL_PROVIDER_RULES, args.run.modelProvider)
+    ? HISTORICAL_PROVIDER_RULES[
+        args.run.modelProvider as keyof typeof HISTORICAL_PROVIDER_RULES
+      ]
+    : undefined;
+  if (!rule) {
+    addReason(args.reasons, "framework_provider_unknown");
+    return {
+      classification: "unknown",
+      reason: "framework_provider_unknown",
+    };
+  }
+  addReason(args.reasons, "framework_provider_exact");
+  return { classification: "exact", value: rule };
+}
+
+function providerFramework(args: {
+  readonly run: LaunchSnapshotRunInventoryRow;
+  readonly createdAtMs: number;
+  readonly legacyFramework: ExactOrUnknown<BaseHistoricalFramework>;
+  readonly reasons: Set<LaunchSnapshotReason>;
+}): ExactOrUnknown<BaseHistoricalFramework> {
+  if (args.run.modelProvider === null) {
+    addReason(args.reasons, "framework_provider_missing");
+    return args.legacyFramework;
+  }
+  if (args.createdAtMs < PROVIDER_PRECEDENCE_ROLLOUT_START_MS) {
+    addReason(args.reasons, "framework_provider_precedence_inactive");
+    return args.legacyFramework;
+  }
+  const mapped = mappedProviderFramework(args);
+  if (args.createdAtMs <= PROVIDER_PRECEDENCE_ROLLOUT_END_MS) {
+    if (
+      mapped.classification === "exact" &&
+      args.legacyFramework.classification === "exact" &&
+      mapped.value === args.legacyFramework.value
+    ) {
+      return mapped;
+    }
+    addReason(args.reasons, "framework_provider_rollout_transition");
+    return {
+      classification: "unknown",
+      reason: "framework_provider_rollout_transition",
+    };
+  }
+  return mapped;
+}
+
+type PiHistoricalWindow =
+  | "none"
+  | "transient_callback"
+  | "callback_removal_transition"
+  | "callback_removed"
+  | "flash_transition"
+  | "flash_only"
+  | "sandbox_transition"
+  | "pro_transition"
+  | "flash_and_pro";
+
+function piHistoricalWindow(createdAtMs: number): PiHistoricalWindow {
+  if (createdAtMs < PI_TRANSIENT_ROLLOUT_START_MS) return "none";
+  if (createdAtMs < PI_CALLBACK_REMOVAL_ROLLOUT_START_MS) {
+    return "transient_callback";
+  }
+  if (createdAtMs <= PI_CALLBACK_REMOVAL_ROLLOUT_END_MS) {
+    return "callback_removal_transition";
+  }
+  if (createdAtMs < PI_FLASH_ROLLOUT_START_MS) return "callback_removed";
+  if (createdAtMs <= PI_FLASH_ROLLOUT_END_MS) return "flash_transition";
+  if (createdAtMs < PI_SANDBOX_ROLLOUT_START_MS) return "flash_only";
+  if (createdAtMs <= PI_SANDBOX_ROLLOUT_END_MS) {
+    return "sandbox_transition";
+  }
+  if (createdAtMs < PI_PRO_ROLLOUT_START_MS) return "flash_only";
+  if (createdAtMs <= PI_PRO_ROLLOUT_END_MS) return "pro_transition";
+  return "flash_and_pro";
+}
+
+function potentiallyPiEligible(args: {
+  readonly run: LaunchSnapshotRunInventoryRow;
+  readonly createdAtMs: number;
+  readonly baseFramework: ExactOrUnknown<BaseHistoricalFramework>;
+}): boolean {
+  const window = piHistoricalWindow(args.createdAtMs);
+  if (
+    window === "none" ||
+    !args.run.chatThreadPresent ||
+    !WEB_CHAT_TRIGGER_SOURCES.has(args.run.triggerSource) ||
+    args.run.modelProvider === null ||
+    (args.baseFramework.classification === "exact" &&
+      args.baseFramework.value === "claude-code")
+  ) {
+    return false;
+  }
+  if (
+    window === "transient_callback" ||
+    window === "callback_removal_transition" ||
+    window === "callback_removed" ||
+    window === "flash_transition"
+  ) {
+    // Before the model predicate was persisted in code, provider config,
+    // credentials, the feature switch, and (initially) the kickoff callback
+    // were transient. A known Claude base is the only reviewed exclusion.
+    return true;
+  }
+  if (typeof args.run.selectedModel !== "string") return false;
+  if (args.run.selectedModel === "deepseek-v4-flash") return true;
+  return (
+    (window === "pro_transition" || window === "flash_and_pro") &&
+    args.run.selectedModel === "deepseek-v4-pro"
+  );
+}
+
+type FrameworkResolution =
+  | { readonly classification: "exact"; readonly value: HistoricalFramework }
+  | {
+      readonly classification: "unknown";
+      readonly reason: LaunchSnapshotReason;
+    }
+  | {
+      readonly classification: "conflict";
+      readonly reason: LaunchSnapshotReason;
+    };
+
+function historicalFramework(args: {
+  readonly run: LaunchSnapshotRunInventoryRow;
+  readonly createdAtMs: number;
+  readonly content: HistoricalContent;
+  readonly conversation: LaunchSnapshotConversationInventoryRow | undefined;
+  readonly duplicateConversation: boolean;
+  readonly reasons: Set<LaunchSnapshotReason>;
+}): FrameworkResolution {
+  let legacyFramework: ExactOrUnknown<BaseHistoricalFramework>;
+  if (args.content.classification === "exact") {
+    if (isBaseFramework(args.content.agent.framework)) {
+      addReason(args.reasons, "framework_legacy_exact");
+      legacyFramework = {
+        classification: "exact",
+        value: args.content.agent.framework,
+      };
+    } else {
+      addReason(args.reasons, "legacy_content_invalid");
+      legacyFramework = {
+        classification: "unknown",
+        reason: "legacy_content_invalid",
+      };
+    }
+  } else {
+    const reason =
+      args.content.classification === "invalid"
+        ? "legacy_content_invalid"
+        : "legacy_content_unsupported";
+    addReason(args.reasons, reason);
+    legacyFramework = { classification: "unknown", reason };
+  }
+
+  const baseFramework = providerFramework({
+    run: args.run,
+    createdAtMs: args.createdAtMs,
+    legacyFramework,
+    reasons: args.reasons,
+  });
+  if (
+    baseFramework.classification === "unknown" &&
+    baseFramework.reason === "otherwise_unclassified_shape"
+  ) {
+    return {
+      classification: "conflict",
+      reason: "otherwise_unclassified_shape",
+    };
+  }
+  const piEligible = potentiallyPiEligible({
+    run: args.run,
+    createdAtMs: args.createdAtMs,
+    baseFramework,
+  });
+
+  if (args.duplicateConversation) {
+    addReason(args.reasons, "otherwise_unclassified_shape");
+    return {
+      classification: "conflict",
+      reason: "otherwise_unclassified_shape",
+    };
+  }
+  if (!args.conversation) {
+    addReason(args.reasons, "conversation_framework_missing");
+    if (piEligible) {
+      addReason(args.reasons, "framework_pi_state_unproven");
+      return {
+        classification: "unknown",
+        reason: "framework_pi_state_unproven",
+      };
+    }
+    return baseFramework;
+  }
+  if (!isFramework(args.conversation.framework)) {
+    addReason(args.reasons, "conversation_framework_invalid");
+    return {
+      classification: "conflict",
+      reason: "conversation_framework_invalid",
+    };
+  }
+
+  addReason(args.reasons, "conversation_framework_valid");
+  const conversationFramework = args.conversation.framework;
+  if (conversationFramework === "pi") {
+    if (!piEligible) {
+      addReason(args.reasons, "conversation_framework_conflict");
+      addReason(args.reasons, "framework_evidence_conflict");
+      return {
+        classification: "conflict",
+        reason: "conversation_framework_conflict",
+      };
+    }
+    return { classification: "exact", value: "pi" };
+  }
+  if (
+    baseFramework.classification === "exact" &&
+    baseFramework.value !== conversationFramework
+  ) {
+    addReason(args.reasons, "conversation_framework_conflict");
+    addReason(args.reasons, "framework_evidence_conflict");
+    return {
+      classification: "conflict",
+      reason: "conversation_framework_conflict",
+    };
+  }
+  return { classification: "exact", value: conversationFramework };
+}
+
+function integrityConflict(
+  reason: LaunchSnapshotReason,
+  reasons: Set<LaunchSnapshotReason>,
+): RunClassification {
+  addReason(reasons, "evidence_conflict");
+  return {
+    disposition: "integrity_conflict",
+    primaryReason: reason,
+    reasons,
+  };
+}
+
+interface RunClassifierArgs {
+  readonly run: LaunchSnapshotRunInventoryRow;
+  readonly checkpoint: LaunchSnapshotCheckpointInventoryRow | undefined;
+  readonly duplicateCheckpoint: boolean;
+  readonly conversation: LaunchSnapshotConversationInventoryRow | undefined;
+  readonly duplicateConversation: boolean;
+  readonly versions: ReadonlyMap<string, LaunchSnapshotVersionInventoryRow>;
+  readonly duplicateVersionIds: ReadonlySet<string>;
+}
+
+interface RunClassifierContext extends RunClassifierArgs {
+  readonly createdAtMs: number;
+  readonly reasons: Set<LaunchSnapshotReason>;
+}
+
+function isValidRunInventory(run: LaunchSnapshotRunInventoryRow): boolean {
+  return (
+    run.createdAt instanceof Date &&
+    Number.isFinite(run.createdAt.getTime()) &&
+    (run.modelProvider === null || typeof run.modelProvider === "string") &&
+    (run.selectedModel === null || typeof run.selectedModel === "string") &&
+    typeof run.triggerSource === "string" &&
+    typeof run.chatThreadPresent === "boolean" &&
+    (run.launchSnapshot !== undefined || Object.hasOwn(run, "launchSnapshot"))
+  );
+}
+
+function referenceEvidenceForRun(
+  context: RunClassifierContext,
+): ResolvedVersionEvidence {
+  return classifyReferenceEvidence({
+    run: context.run,
+    checkpoint: context.checkpoint,
+    duplicateCheckpoint: context.duplicateCheckpoint,
+    versions: context.versions,
+    duplicateVersionIds: context.duplicateVersionIds,
+    reasons: context.reasons,
+  });
+}
+
+function recordExactHistoricalContent(
+  content: HistoricalContent,
+  reasons: Set<LaunchSnapshotReason>,
+): void {
+  if (content.classification !== "exact") return;
+  addReason(reasons, "legacy_content_exact");
+  addReason(reasons, "legacy_first_agent_exact");
+}
+
+function existingContentConflict(args: {
+  readonly context: RunClassifierContext;
+  readonly snapshot: {
+    readonly framework: HistoricalFramework;
+    readonly runnerProfile: string;
+  };
+  readonly content: unknown;
+}): LaunchSnapshotReason | undefined {
+  const { context, snapshot } = args;
+  const content = historicalFirstAgent(args.content);
+  recordExactHistoricalContent(content, context.reasons);
+  const profile = historicalRunnerProfile({
+    createdAtMs: context.createdAtMs,
+    content,
+    reasons: context.reasons,
+  });
+  if (
+    profile.classification === "exact" &&
+    profile.value !== snapshot.runnerProfile
+  ) {
+    addReason(context.reasons, "evidence_conflict");
+    return "evidence_conflict";
+  }
+
+  const framework = historicalFramework({
+    run: context.run,
+    createdAtMs: context.createdAtMs,
+    content,
+    conversation: context.conversation,
+    duplicateConversation: context.duplicateConversation,
+    reasons: context.reasons,
+  });
+  if (framework.classification === "conflict") {
+    addReason(context.reasons, "framework_evidence_conflict");
+    return framework.reason;
+  }
+  if (
+    framework.classification === "exact" &&
+    framework.value !== snapshot.framework
+  ) {
+    addReason(context.reasons, "framework_evidence_conflict");
+    return "framework_evidence_conflict";
+  }
+  return undefined;
+}
+
+function existingConversationConflict(args: {
+  readonly context: RunClassifierContext;
+  readonly snapshotFramework: HistoricalFramework;
+}): LaunchSnapshotReason | undefined {
+  const { context } = args;
+  if (context.duplicateConversation) {
+    addReason(context.reasons, "otherwise_unclassified_shape");
+    return "otherwise_unclassified_shape";
+  }
+  if (!context.conversation) return undefined;
+  if (!isFramework(context.conversation.framework)) {
+    addReason(context.reasons, "conversation_framework_invalid");
+    return "conversation_framework_invalid";
+  }
+  if (context.conversation.framework !== args.snapshotFramework) {
+    addReason(context.reasons, "conversation_framework_conflict");
+    return "conversation_framework_conflict";
+  }
+  return undefined;
+}
+
+function classifyExistingSnapshot(
+  context: RunClassifierContext,
+): RunClassification {
+  const snapshot = strictLaunchSnapshot(context.run.launchSnapshot);
+  if (!snapshot) {
+    addReason(context.reasons, "existing_snapshot_invalid");
+    return integrityConflict("existing_snapshot_invalid", context.reasons);
+  }
+  addReason(context.reasons, "existing_snapshot_valid");
+
+  const reference = referenceEvidenceForRun(context);
+  if (reference.conflictReason) {
+    return integrityConflict(reference.conflictReason, context.reasons);
+  }
+  const conflictReason =
+    reference.content === undefined
+      ? existingConversationConflict({
+          context,
+          snapshotFramework: snapshot.framework,
+        })
+      : existingContentConflict({
+          context,
+          snapshot,
+          content: reference.content,
+        });
+  if (conflictReason) {
+    return integrityConflict(conflictReason, context.reasons);
+  }
+  return {
+    disposition: "already_valid",
+    primaryReason: "existing_snapshot_valid",
+    reasons: context.reasons,
+  };
+}
+
+function classifyMissingSnapshot(
+  context: RunClassifierContext,
+): RunClassification {
+  const reference = referenceEvidenceForRun(context);
+  if (reference.conflictReason) {
+    return integrityConflict(reference.conflictReason, context.reasons);
+  }
+  if (reference.content === undefined) {
+    return {
+      disposition: "historical_unknown",
+      primaryReason: reference.unknownReason ?? "no_version_reference",
+      reasons: context.reasons,
+    };
+  }
+
+  const content = historicalFirstAgent(reference.content);
+  recordExactHistoricalContent(content, context.reasons);
+  const profile = historicalRunnerProfile({
+    createdAtMs: context.createdAtMs,
+    content,
+    reasons: context.reasons,
+  });
+  const framework = historicalFramework({
+    run: context.run,
+    createdAtMs: context.createdAtMs,
+    content,
+    conversation: context.conversation,
+    duplicateConversation: context.duplicateConversation,
+    reasons: context.reasons,
+  });
+  if (framework.classification === "conflict") {
+    return integrityConflict(framework.reason, context.reasons);
+  }
+  if (profile.classification === "unknown") {
+    return {
+      disposition: "historical_unknown",
+      primaryReason: profile.reason,
+      reasons: context.reasons,
+    };
+  }
+  if (framework.classification === "unknown") {
+    return {
+      disposition: "historical_unknown",
+      primaryReason: framework.reason,
+      reasons: context.reasons,
+    };
+  }
+
+  addReason(context.reasons, "complete_exact_evidence");
+  return {
+    disposition: "exactly_recoverable",
+    primaryReason: "complete_exact_evidence",
+    reasons: context.reasons,
+  };
+}
+
+function classifyRun(args: RunClassifierArgs): RunClassification {
+  const reasons = new Set<LaunchSnapshotReason>();
+  if (!isValidRunInventory(args.run)) {
+    addReason(reasons, "otherwise_unclassified_shape");
+    return integrityConflict("otherwise_unclassified_shape", reasons);
+  }
+  const createdAtMs = args.run.createdAt.getTime();
+  if (createdAtMs < REVIEWED_RUN_LOWER_BOUND_MS) {
+    addReason(reasons, "created_before_reviewed_history_boundary");
+  }
+
+  const context: RunClassifierContext = {
+    ...args,
+    createdAtMs,
+    reasons,
+  };
+  return args.run.launchSnapshot === null
+    ? classifyMissingSnapshot(context)
+    : classifyExistingSnapshot(context);
+}
+
+function closureComparison(
+  domain: string,
+  expected: readonly string[],
+  observed: readonly string[],
+  cardinalityAware = false,
+): ClosureComparison {
+  const expectedMetric = fingerprintSortedSet(`${domain}:expected`, expected);
+  const observedMetric = fingerprintSortedSet(`${domain}:expected`, observed);
+  const exactSet =
+    expectedMetric.count === observedMetric.count &&
+    expectedMetric.digest === observedMetric.digest;
+  const exactCardinality =
+    !cardinalityAware ||
+    (expected.length === expectedMetric.count &&
+      observed.length === observedMetric.count &&
+      expected.length === observed.length);
+  return {
+    expected: expectedMetric,
+    observed: observedMetric,
+    classification: exactSet && exactCardinality ? "exact" : "drift",
+  };
+}
+
+function groupedByRunId<Row extends { readonly runId: string }>(
+  rows: readonly Row[],
+): {
+  readonly first: ReadonlyMap<string, Row>;
+  readonly duplicates: ReadonlySet<string>;
+} {
+  const first = new Map<string, Row>();
+  const duplicates = new Set<string>();
+  for (const row of rows) {
+    if (first.has(row.runId)) duplicates.add(row.runId);
+    else first.set(row.runId, row);
+  }
+  return { first, duplicates };
+}
+
+function reasonsAreCompatible(classified: RunClassification): boolean {
+  if (!classified.reasons.has(classified.primaryReason)) return false;
+  return [...classified.reasons].every((reason) => {
+    return REASON_DISPOSITION_COMPATIBILITY[reason].some((disposition) => {
+      return disposition === classified.disposition;
+    });
+  });
+}
+
+export function classifyLaunchSnapshotRecoverability(args: {
+  readonly runs: readonly LaunchSnapshotRunInventoryRow[];
+  readonly versions: readonly LaunchSnapshotVersionInventoryRow[];
+  readonly checkpoints: readonly LaunchSnapshotCheckpointInventoryRow[];
+  readonly conversations: readonly LaunchSnapshotConversationInventoryRow[];
+}): {
+  readonly output: {
+    readonly total: number;
+    readonly population: SetFingerprint;
+    readonly dispositions: Readonly<
+      Record<LaunchSnapshotDisposition, SetFingerprint>
+    >;
+    readonly reasons: Readonly<Record<LaunchSnapshotReason, SetFingerprint>>;
+    readonly populationClosure: ClosureComparison;
+    readonly dispositionPartitionClosure: ClosureComparison;
+    readonly dispositionDisjointnessClosure: ClosureComparison;
+    readonly dispositionUnionClosure: ClosureComparison;
+    readonly reasonPartitionClosure: ClosureComparison;
+    readonly reasonUnionClosure: ClosureComparison;
+    readonly reasonCompatibilityClosure: ClosureComparison;
+  };
+  readonly failureGates: readonly string[];
+} {
+  const versions = new Map<string, LaunchSnapshotVersionInventoryRow>();
+  const duplicateVersionIds = new Set<string>();
+  for (const version of args.versions) {
+    if (versions.has(version.id)) duplicateVersionIds.add(version.id);
+    else versions.set(version.id, version);
+  }
+  const checkpoints = groupedByRunId(args.checkpoints);
+  const conversations = groupedByRunId(args.conversations);
+  const dispositionMembers = Object.fromEntries(
+    LAUNCH_SNAPSHOT_DISPOSITIONS.map((disposition) => {
+      return [disposition, [] as string[]];
+    }),
+  ) as Record<LaunchSnapshotDisposition, string[]>;
+  const reasonMembers = Object.fromEntries(
+    LAUNCH_SNAPSHOT_REASONS.map((reason) => {
+      return [reason, [] as string[]];
+    }),
+  ) as Record<LaunchSnapshotReason, string[]>;
+  const primaryReasonMembers: string[] = [];
+  const incompatibleReasonRunIds: string[] = [];
+
+  for (const run of args.runs) {
+    const classified = classifyRun({
+      run,
+      checkpoint: checkpoints.first.get(run.id),
+      duplicateCheckpoint: checkpoints.duplicates.has(run.id),
+      conversation: conversations.first.get(run.id),
+      duplicateConversation: conversations.duplicates.has(run.id),
+      versions,
+      duplicateVersionIds,
+    });
+    dispositionMembers[classified.disposition].push(run.id);
+    primaryReasonMembers.push(run.id);
+    if (!reasonsAreCompatible(classified)) {
+      incompatibleReasonRunIds.push(run.id);
+    }
+    for (const reason of classified.reasons) reasonMembers[reason].push(run.id);
+  }
+
+  const runIds = args.runs.map((run) => {
+    return run.id;
+  });
+  const uniqueRunIds = [...new Set(runIds)];
+  const dispositionAssignments = LAUNCH_SNAPSHOT_DISPOSITIONS.flatMap(
+    (disposition) => {
+      return dispositionMembers[disposition];
+    },
+  );
+  const dispositionCounts = new Map<string, number>();
+  for (const runId of dispositionAssignments) {
+    dispositionCounts.set(runId, (dispositionCounts.get(runId) ?? 0) + 1);
+  }
+  const duplicateDispositionRunIds = [...dispositionCounts]
+    .filter(([, count]) => {
+      return count > 1;
+    })
+    .map(([runId]) => {
+      return runId;
+    });
+  const reasonAssignments = LAUNCH_SNAPSHOT_REASONS.flatMap((reason) => {
+    return reasonMembers[reason];
+  });
+
+  const populationClosure = closureComparison(
+    "launch-snapshots:population-closure:v4",
+    runIds,
+    uniqueRunIds,
+    true,
+  );
+  const dispositionPartitionClosure = closureComparison(
+    "launch-snapshots:disposition-partition-closure:v4",
+    runIds,
+    dispositionAssignments,
+    true,
+  );
+  const dispositionDisjointnessClosure = closureComparison(
+    "launch-snapshots:disposition-disjointness-closure:v4",
+    [],
+    duplicateDispositionRunIds,
+  );
+  const dispositionUnionClosure = closureComparison(
+    "launch-snapshots:disposition-union-closure:v4",
+    runIds,
+    dispositionAssignments,
+  );
+  const reasonPartitionClosure = closureComparison(
+    "launch-snapshots:reason-partition-closure:v4",
+    runIds,
+    primaryReasonMembers,
+    true,
+  );
+  const reasonUnionClosure = closureComparison(
+    "launch-snapshots:reason-union-closure:v4",
+    runIds,
+    reasonAssignments,
+  );
+  const reasonCompatibilityClosure = closureComparison(
+    "launch-snapshots:reason-compatibility-closure:v4",
+    [],
+    incompatibleReasonRunIds,
+  );
+
+  const closureResults = [
+    populationClosure,
+    dispositionPartitionClosure,
+    dispositionDisjointnessClosure,
+    dispositionUnionClosure,
+    reasonPartitionClosure,
+    reasonUnionClosure,
+    reasonCompatibilityClosure,
+  ];
+  const failureGates = new Set<string>();
+  if (
+    dispositionMembers.integrity_conflict.length > 0 ||
+    duplicateVersionIds.size > 0 ||
+    checkpoints.duplicates.size > 0 ||
+    conversations.duplicates.size > 0
+  ) {
+    failureGates.add("launchSnapshots.integrity_conflict");
+  }
+  if (
+    closureResults.some((closure) => {
+      return closure.classification === "drift";
+    })
+  ) {
+    failureGates.add("launchSnapshots.closure");
+  }
+  if (reasonMembers.created_before_reviewed_history_boundary.length > 0) {
+    failureGates.add("launchSnapshots.history_boundary");
+  }
+
+  return {
+    output: {
+      total: args.runs.length,
+      population: fingerprintSortedSet(
+        "launch-snapshots:population-run-ids:v4",
+        runIds,
+      ),
+      dispositions: Object.fromEntries(
+        LAUNCH_SNAPSHOT_DISPOSITIONS.map((disposition) => {
+          return [
+            disposition,
+            fingerprintSortedSet(
+              `launch-snapshots:disposition:${disposition}:run-ids:v4`,
+              dispositionMembers[disposition],
+            ),
+          ];
+        }),
+      ) as Record<LaunchSnapshotDisposition, SetFingerprint>,
+      reasons: Object.fromEntries(
+        LAUNCH_SNAPSHOT_REASONS.map((reason) => {
+          return [
+            reason,
+            fingerprintSortedSet(
+              `launch-snapshots:reason:${reason}:run-ids:v4`,
+              reasonMembers[reason],
+            ),
+          ];
+        }),
+      ) as Record<LaunchSnapshotReason, SetFingerprint>,
+      populationClosure,
+      dispositionPartitionClosure,
+      dispositionDisjointnessClosure,
+      dispositionUnionClosure,
+      reasonPartitionClosure,
+      reasonUnionClosure,
+      reasonCompatibilityClosure,
+    },
+    failureGates: [...failureGates].sort(),
+  };
+}

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-launch-snapshots.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-launch-snapshots.ts
@@ -29,6 +29,8 @@ export const LAUNCH_SNAPSHOT_REASONS = [
   "existing_snapshot_valid",
   "framework_evidence_conflict",
   "framework_legacy_exact",
+  "framework_pi_model_missing",
+  "framework_pi_model_unknown",
   "framework_pi_state_unproven",
   "framework_provider_exact",
   "framework_provider_missing",
@@ -58,6 +60,7 @@ export const LAUNCH_SNAPSHOT_REASONS = [
   "runner_profile_default_unproven",
   "runner_profile_explicit_exact",
   "runner_profile_invalid",
+  "trigger_source_unrecognized",
 ] as const;
 
 export type LaunchSnapshotReason = (typeof LAUNCH_SNAPSHOT_REASONS)[number];
@@ -88,6 +91,8 @@ const REASON_DISPOSITION_COMPATIBILITY = {
   existing_snapshot_valid: VALID_OR_CONFLICT,
   framework_evidence_conflict: CONFLICT_ONLY,
   framework_legacy_exact: ALL_DISPOSITIONS,
+  framework_pi_model_missing: VALID_OR_UNKNOWN,
+  framework_pi_model_unknown: VALID_OR_UNKNOWN,
   framework_pi_state_unproven: VALID_OR_UNKNOWN,
   framework_provider_exact: ALL_DISPOSITIONS,
   framework_provider_missing: ALL_DISPOSITIONS,
@@ -117,6 +122,7 @@ const REASON_DISPOSITION_COMPATIBILITY = {
   runner_profile_default_unproven: NOT_RECOVERABLE,
   runner_profile_explicit_exact: ALL_DISPOSITIONS,
   runner_profile_invalid: NOT_RECOVERABLE,
+  trigger_source_unrecognized: CONFLICT_ONLY,
 } as const satisfies Readonly<
   Record<LaunchSnapshotReason, readonly LaunchSnapshotDisposition[]>
 >;
@@ -128,8 +134,9 @@ export interface LaunchSnapshotRunInventoryRow {
   readonly launchSnapshot: unknown;
   readonly modelProvider: string | null;
   readonly selectedModel: string | null;
-  readonly triggerSource: string;
+  readonly triggerSource: string | null;
   readonly chatThreadPresent: boolean;
+  readonly metadataShape: "lifecycle_only" | "product" | "partial";
 }
 
 export interface LaunchSnapshotVersionInventoryRow {
@@ -259,6 +266,34 @@ const RETIRED_VM0_MODELS: ReadonlySet<string> = new Set([
 const DEFAULT_RUNNER_PROFILE = "vm0/default";
 const VERSION_ID_PATTERN = /^[0-9a-f]{64}$/u;
 const WEB_CHAT_TRIGGER_SOURCES: ReadonlySet<string> = new Set(["agent", "web"]);
+// Fixed union of triggerSourceSchema values reviewed from 55fd4bf4209f
+// (the first agent_runs trigger column) through cd91f26cd599 (the last
+// retirement in the live Run interval). Retired persisted values stay valid;
+// this must not import the live contract or treat a future label as non-web.
+const HISTORICAL_TRIGGER_SOURCES: ReadonlySet<string> = new Set([
+  "agent",
+  "agentphone",
+  "automation",
+  "automation-event",
+  "automation-schedule",
+  "cli",
+  "email",
+  "feishu",
+  "github",
+  "goal",
+  "imessage",
+  "phone",
+  "schedule",
+  "slack",
+  "teams",
+  "telegram",
+  "test",
+  "voice-chat",
+  "web",
+  "webhook",
+  "workflow-event",
+  "workflow-schedule",
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -769,13 +804,19 @@ function providerFramework(args: {
   readonly legacyFramework: ExactOrUnknown<BaseHistoricalFramework>;
   readonly reasons: Set<LaunchSnapshotReason>;
 }): ExactOrUnknown<BaseHistoricalFramework> {
-  if (args.run.modelProvider === null) {
-    addReason(args.reasons, "framework_provider_missing");
-    return args.legacyFramework;
-  }
   if (args.createdAtMs < PROVIDER_PRECEDENCE_ROLLOUT_START_MS) {
     addReason(args.reasons, "framework_provider_precedence_inactive");
+    if (args.run.modelProvider === null) {
+      addReason(args.reasons, "framework_provider_missing");
+    }
     return args.legacyFramework;
+  }
+  if (args.run.modelProvider === null) {
+    addReason(args.reasons, "framework_provider_missing");
+    return {
+      classification: "unknown",
+      reason: "framework_provider_missing",
+    };
   }
   const mapped = mappedProviderFramework(args);
   if (args.createdAtMs <= PROVIDER_PRECEDENCE_ROLLOUT_END_MS) {
@@ -825,21 +866,64 @@ function piHistoricalWindow(createdAtMs: number): PiHistoricalWindow {
   return "flash_and_pro";
 }
 
-function potentiallyPiEligible(args: {
+type HistoricalPiEligibility =
+  | { readonly classification: "possible" }
+  | { readonly classification: "definitively_ineligible" }
+  | {
+      readonly classification: "unknown";
+      readonly reason:
+        | "framework_pi_model_missing"
+        | "framework_pi_model_unknown"
+        | "framework_provider_missing";
+    };
+
+function isReviewedHistoricalModel(value: string): boolean {
+  return (
+    value === "deepseek-v4-flash" ||
+    value === "deepseek-v4-pro" ||
+    Object.hasOwn(HISTORICAL_VM0_MODEL_RULES, value) ||
+    RETIRED_VM0_MODELS.has(value)
+  );
+}
+
+function historicalPiEligibility(args: {
   readonly run: LaunchSnapshotRunInventoryRow;
   readonly createdAtMs: number;
   readonly baseFramework: ExactOrUnknown<BaseHistoricalFramework>;
-}): boolean {
+}): HistoricalPiEligibility {
   const window = piHistoricalWindow(args.createdAtMs);
+  if (window === "none") {
+    return { classification: "definitively_ineligible" };
+  }
   if (
-    window === "none" ||
-    !args.run.chatThreadPresent ||
-    !WEB_CHAT_TRIGGER_SOURCES.has(args.run.triggerSource) ||
-    args.run.modelProvider === null ||
-    (args.baseFramework.classification === "exact" &&
-      args.baseFramework.value === "claude-code")
+    args.run.triggerSource !== null &&
+    !WEB_CHAT_TRIGGER_SOURCES.has(args.run.triggerSource)
   ) {
-    return false;
+    return { classification: "definitively_ineligible" };
+  }
+  if (!args.run.chatThreadPresent) {
+    return { classification: "definitively_ineligible" };
+  }
+  if (
+    args.baseFramework.classification === "exact" &&
+    args.baseFramework.value === "claude-code"
+  ) {
+    return { classification: "definitively_ineligible" };
+  }
+  if (args.run.triggerSource === null) {
+    return {
+      classification: "unknown",
+      // A schema-consistent NULL trigger also has NULL provider metadata.
+      // The no-chat case returned above is exact; any future reachable case
+      // still lacks provider authority and must remain unknown.
+      reason: "framework_provider_missing",
+    };
+  }
+  if (args.run.modelProvider === null) {
+    return {
+      classification: "unknown",
+      reason: "framework_provider_missing",
+    };
   }
   if (
     window === "transient_callback" ||
@@ -850,14 +934,28 @@ function potentiallyPiEligible(args: {
     // Before the model predicate was persisted in code, provider config,
     // credentials, the feature switch, and (initially) the kickoff callback
     // were transient. A known Claude base is the only reviewed exclusion.
-    return true;
+    return { classification: "possible" };
   }
-  if (typeof args.run.selectedModel !== "string") return false;
-  if (args.run.selectedModel === "deepseek-v4-flash") return true;
-  return (
+  if (typeof args.run.selectedModel !== "string") {
+    return {
+      classification: "unknown",
+      reason: "framework_pi_model_missing",
+    };
+  }
+  if (args.run.selectedModel === "deepseek-v4-flash") {
+    return { classification: "possible" };
+  }
+  const possible =
     (window === "pro_transition" || window === "flash_and_pro") &&
-    args.run.selectedModel === "deepseek-v4-pro"
-  );
+    args.run.selectedModel === "deepseek-v4-pro";
+  if (possible) return { classification: "possible" };
+  if (isReviewedHistoricalModel(args.run.selectedModel)) {
+    return { classification: "definitively_ineligible" };
+  }
+  return {
+    classification: "unknown",
+    reason: "framework_pi_model_unknown",
+  };
 }
 
 type FrameworkResolution =
@@ -918,7 +1016,7 @@ function historicalFramework(args: {
       reason: "otherwise_unclassified_shape",
     };
   }
-  const piEligible = potentiallyPiEligible({
+  const piEligibility = historicalPiEligibility({
     run: args.run,
     createdAtMs: args.createdAtMs,
     baseFramework,
@@ -933,11 +1031,18 @@ function historicalFramework(args: {
   }
   if (!args.conversation) {
     addReason(args.reasons, "conversation_framework_missing");
-    if (piEligible) {
+    if (piEligibility.classification === "possible") {
       addReason(args.reasons, "framework_pi_state_unproven");
       return {
         classification: "unknown",
         reason: "framework_pi_state_unproven",
+      };
+    }
+    if (piEligibility.classification === "unknown") {
+      addReason(args.reasons, piEligibility.reason);
+      return {
+        classification: "unknown",
+        reason: piEligibility.reason,
       };
     }
     return baseFramework;
@@ -953,7 +1058,7 @@ function historicalFramework(args: {
   addReason(args.reasons, "conversation_framework_valid");
   const conversationFramework = args.conversation.framework;
   if (conversationFramework === "pi") {
-    if (!piEligible) {
+    if (piEligibility.classification === "definitively_ineligible") {
       addReason(args.reasons, "conversation_framework_conflict");
       addReason(args.reasons, "framework_evidence_conflict");
       return {
@@ -1010,10 +1115,30 @@ function isValidRunInventory(run: LaunchSnapshotRunInventoryRow): boolean {
     Number.isFinite(run.createdAt.getTime()) &&
     (run.modelProvider === null || typeof run.modelProvider === "string") &&
     (run.selectedModel === null || typeof run.selectedModel === "string") &&
-    typeof run.triggerSource === "string" &&
+    (run.triggerSource === null || typeof run.triggerSource === "string") &&
     typeof run.chatThreadPresent === "boolean" &&
+    (run.metadataShape === "lifecycle_only" ||
+      run.metadataShape === "product" ||
+      run.metadataShape === "partial") &&
     (run.launchSnapshot !== undefined || Object.hasOwn(run, "launchSnapshot"))
   );
+}
+
+function hasConsistentRunMetadataShape(
+  run: LaunchSnapshotRunInventoryRow,
+): boolean {
+  if (run.metadataShape === "product") {
+    return typeof run.triggerSource === "string";
+  }
+  if (run.metadataShape === "lifecycle_only") {
+    return (
+      run.triggerSource === null &&
+      run.modelProvider === null &&
+      run.selectedModel === null &&
+      !run.chatThreadPresent
+    );
+  }
+  return false;
 }
 
 function referenceEvidenceForRun(
@@ -1201,6 +1326,17 @@ function classifyRun(args: RunClassifierArgs): RunClassification {
   if (!isValidRunInventory(args.run)) {
     addReason(reasons, "otherwise_unclassified_shape");
     return integrityConflict("otherwise_unclassified_shape", reasons);
+  }
+  if (!hasConsistentRunMetadataShape(args.run)) {
+    addReason(reasons, "otherwise_unclassified_shape");
+    return integrityConflict("otherwise_unclassified_shape", reasons);
+  }
+  if (
+    args.run.triggerSource !== null &&
+    !HISTORICAL_TRIGGER_SOURCES.has(args.run.triggerSource)
+  ) {
+    addReason(reasons, "trigger_source_unrecognized");
+    return integrityConflict("trigger_source_unrecognized", reasons);
   }
   const createdAtMs = args.run.createdAt.getTime();
   if (createdAtMs < REVIEWED_RUN_LOWER_BOUND_MS) {

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-launch-snapshots.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-launch-snapshots.ts
@@ -287,6 +287,9 @@ const HISTORICAL_TRIGGER_SOURCES: ReadonlySet<string> = new Set([
   "slack",
   "teams",
   "telegram",
+  // e785873209e4 introduced this persisted source and 54601f1aedeb
+  // retired it inside the reviewed live Run interval.
+  "template-import",
   "test",
   "voice-chat",
   "web",

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
@@ -2045,6 +2045,31 @@ async function collectDatabaseInventory(
        "run"."model_provider" AS "modelProvider",
        "run"."selected_model" AS "selectedModel",
        "run"."trigger_source" AS "triggerSource",
+       CASE
+         WHEN
+           "run"."trigger_source" IS NULL AND
+           "run"."autonomy_budget" IS NULL AND
+           "run"."workflow_automation_id" IS NULL AND
+           "run"."goal_id" IS NULL AND
+           "run"."model_provider" IS NULL AND
+           "run"."model_provider_id" IS NULL AND
+           "run"."model_provider_credential_scope" IS NULL AND
+           "run"."selected_model" IS NULL AND
+           "run"."codex_service_tier" IS NULL AND
+           "run"."selected_video_model" IS NULL AND
+           "run"."selected_image_model" IS NULL AND
+           "run"."chat_thread_id" IS NULL AND
+           "run"."api_started_at" IS NULL AND
+           "run"."first_assistant_event_acknowledged_at" IS NULL AND
+           "run"."summary" IS NULL AND
+           "run"."trigger_brief" IS NULL
+           THEN 'lifecycle_only'
+         WHEN
+           "run"."trigger_source" IS NOT NULL AND
+           "run"."autonomy_budget" IS NOT NULL
+           THEN 'product'
+         ELSE 'partial'
+       END AS "metadataShape",
        "run"."chat_thread_id" IS NOT NULL AS "chatThreadPresent"
      FROM "agent_runs" AS "run"
      LEFT JOIN "agent_compose_versions" AS "version"

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
@@ -27,6 +27,14 @@ import {
   type SetFingerprint,
 } from "./agent-compose-consolidation-preflight-fingerprint";
 import {
+  LAUNCH_SNAPSHOT_DISPOSITIONS,
+  LAUNCH_SNAPSHOT_REASONS,
+  classifyLaunchSnapshotRecoverability,
+  type LaunchSnapshotCheckpointInventoryRow,
+  type LaunchSnapshotConversationInventoryRow,
+  type LaunchSnapshotRunInventoryRow,
+} from "./agent-compose-consolidation-preflight-launch-snapshots";
+import {
   EXPECTED_RUNTIME_CONTENT_CONSUMER_MANIFEST,
   collectRuntimeContentConsumerManifest,
   type RuntimeContentConsumerManifest,
@@ -365,10 +373,29 @@ const PREFLIGHT_V3_OUTPUT_ALLOWLIST = [
   ),
 ];
 
-/** Every and only approved scalar/array path in a complete v3 result. */
+const PREFLIGHT_V4_OUTPUT_ALLOWLIST = [
+  "launchSnapshots.total",
+  ...setOutputPaths("launchSnapshots.population"),
+  ...LAUNCH_SNAPSHOT_DISPOSITIONS.flatMap((disposition) => {
+    return setOutputPaths(`launchSnapshots.dispositions.${disposition}`);
+  }),
+  ...LAUNCH_SNAPSHOT_REASONS.flatMap((reason) => {
+    return setOutputPaths(`launchSnapshots.reasons.${reason}`);
+  }),
+  ...comparisonOutputPaths("launchSnapshots.populationClosure"),
+  ...comparisonOutputPaths("launchSnapshots.dispositionPartitionClosure"),
+  ...comparisonOutputPaths("launchSnapshots.dispositionDisjointnessClosure"),
+  ...comparisonOutputPaths("launchSnapshots.dispositionUnionClosure"),
+  ...comparisonOutputPaths("launchSnapshots.reasonPartitionClosure"),
+  ...comparisonOutputPaths("launchSnapshots.reasonUnionClosure"),
+  ...comparisonOutputPaths("launchSnapshots.reasonCompatibilityClosure"),
+];
+
+/** Every and only approved scalar/array path in a complete v4 result. */
 export const PREFLIGHT_OUTPUT_ALLOWLIST = [
   ...PREFLIGHT_V2_OUTPUT_ALLOWLIST,
   ...PREFLIGHT_V3_OUTPUT_ALLOWLIST,
+  ...PREFLIGHT_V4_OUTPUT_ALLOWLIST,
 ].sort();
 
 export interface IdentityInventoryRow extends QueryResultRow {
@@ -397,16 +424,18 @@ export interface HeadInventoryRow extends QueryResultRow {
   readonly insertionComposeId: string | null;
 }
 
-export interface RunInventoryRow extends QueryResultRow {
-  readonly id: string;
-  readonly versionId: string | null;
+export interface RunInventoryRow
+  extends QueryResultRow, LaunchSnapshotRunInventoryRow {
   readonly versionPresent: boolean;
 }
 
-export interface CheckpointInventoryRow extends QueryResultRow {
+export interface CheckpointInventoryRow
+  extends QueryResultRow, LaunchSnapshotCheckpointInventoryRow {
   readonly id: string;
-  readonly snapshot: unknown;
 }
+
+export type ConversationInventoryRow = QueryResultRow &
+  LaunchSnapshotConversationInventoryRow;
 
 export interface DanglingInventoryRow extends QueryResultRow {
   readonly composeId: string;
@@ -434,6 +463,7 @@ export interface PreflightInventory {
   readonly heads: readonly HeadInventoryRow[];
   readonly runs: readonly RunInventoryRow[];
   readonly checkpoints: readonly CheckpointInventoryRow[];
+  readonly conversations: readonly ConversationInventoryRow[];
   readonly danglingStart: readonly DanglingInventoryRow[];
   readonly danglingEnd: readonly DanglingInventoryRow[];
   readonly agentExecutionPlans: readonly AgentExecutionPlanInventoryRow[];
@@ -479,6 +509,72 @@ export class SanitizedPreflightError extends Error {
   }
 }
 
+const SAFE_OUTPUT_LITERALS: ReadonlySet<string> = new Set([
+  PREFLIGHT_SCHEMA_VERSION,
+  "passed",
+  "failed",
+  "exact",
+  "drift",
+  "stable",
+  "supported",
+  "repeatable read",
+]);
+const SAFE_FAILURE_GATE_PATTERN = /^[A-Za-z]+(?:[._][A-Za-z]+)*$/u;
+const SAFE_DIGEST_PATTERN = /^[0-9a-f]{64}$/u;
+
+function aggregateOutputPaths(value: unknown, prefix = ""): string[] {
+  if (Array.isArray(value)) return [`${prefix}[]`];
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value)
+      .flatMap(([key, child]) => {
+        return aggregateOutputPaths(child, prefix ? `${prefix}.${key}` : key);
+      })
+      .sort();
+  }
+  return [prefix];
+}
+
+function hasSafeAggregateValues(value: unknown, pathPrefix = ""): boolean {
+  if (Array.isArray(value)) {
+    return (
+      pathPrefix === "failureGates" &&
+      value.every((gate) => {
+        return typeof gate === "string" && SAFE_FAILURE_GATE_PATTERN.test(gate);
+      })
+    );
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value).every(([key, child]) => {
+      return hasSafeAggregateValues(
+        child,
+        pathPrefix ? `${pathPrefix}.${key}` : key,
+      );
+    });
+  }
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0;
+  }
+  if (typeof value === "boolean") return true;
+  if (typeof value !== "string") return false;
+  if (pathPrefix.endsWith(".digest") || pathPrefix.endsWith("Digest")) {
+    return SAFE_DIGEST_PATTERN.test(value);
+  }
+  return SAFE_OUTPUT_LITERALS.has(value);
+}
+
+/** Fail closed before a dynamically constructed result reaches stdout. */
+export function assertPreflightOutputShape(value: unknown): void {
+  const paths = aggregateOutputPaths(value);
+  const exactPaths =
+    paths.length === PREFLIGHT_OUTPUT_ALLOWLIST.length &&
+    paths.every((path, index) => {
+      return path === PREFLIGHT_OUTPUT_ALLOWLIST[index];
+    });
+  if (!exactPaths || !hasSafeAggregateValues(value)) {
+    throw new SanitizedPreflightError("probe.output_shape");
+  }
+}
+
 function assertNotAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted) throw new SanitizedPreflightError("probe.cancelled");
 }
@@ -518,7 +614,7 @@ interface CapabilityRow extends QueryResultRow {
   readonly statementTimeoutMs: number;
 }
 
-export async function withReadOnlySnapshot<Value>(
+async function executeReadOnlySnapshotTransaction<Value>(
   client: Client,
   options: ReadOnlySnapshotOptions,
   body: (capabilities: PreflightCapabilities) => Promise<Value>,
@@ -587,13 +683,44 @@ export async function withReadOnlySnapshot<Value>(
     try {
       await client.query("ROLLBACK");
     } catch {
+      if (options.signal?.aborted) {
+        throw new SanitizedPreflightError("probe.cancelled");
+      }
       throw new SanitizedPreflightError("probe.transaction_cleanup");
     }
+  }
+  if (options.signal?.aborted) {
+    throw new SanitizedPreflightError("probe.cancelled");
   }
   if (bodyError !== undefined)
     classifyThrownError(bodyError, "probe.inventory");
   if (!result) throw new SanitizedPreflightError("probe.transaction_start");
   return result;
+}
+
+export async function withReadOnlySnapshot<Value>(
+  client: Client,
+  options: ReadOnlySnapshotOptions,
+  body: (capabilities: PreflightCapabilities) => Promise<Value>,
+): Promise<{
+  readonly capabilities: PreflightCapabilities;
+  readonly value: Value;
+}> {
+  // node-postgres 8 does not accept AbortSignal in QueryConfig. Closing this
+  // probe-owned connection interrupts an in-flight query and aborts its
+  // read-only transaction; callers receive only the fixed cancellation gate.
+  const cancelInFlightQuery = (): void => {
+    void client.end().catch(() => {});
+  };
+  options.signal?.addEventListener("abort", cancelInFlightQuery, {
+    once: true,
+  });
+  if (options.signal?.aborted) cancelInFlightQuery();
+  try {
+    return await executeReadOnlySnapshotTransaction(client, options, body);
+  } finally {
+    options.signal?.removeEventListener("abort", cancelInFlightQuery);
+  }
 }
 
 function frameTuple(parts: readonly string[]): string {
@@ -1736,9 +1863,16 @@ export function classifyPreflightInventory(
     observedRepository,
     failureGates,
   );
+  const launchSnapshots = classifyLaunchSnapshotRecoverability({
+    runs: inventory.runs,
+    versions: inventory.versions,
+    checkpoints: inventory.checkpoints,
+    conversations: inventory.conversations,
+  });
+  for (const gate of launchSnapshots.failureGates) failureGates.add(gate);
   const sortedFailureGates = [...failureGates].sort();
 
-  return {
+  const result = {
     schemaVersion: PREFLIGHT_SCHEMA_VERSION,
     status:
       sortedFailureGates.length === 0
@@ -1754,7 +1888,10 @@ export function classifyPreflightInventory(
     checkpoints,
     danglingHeads,
     dependencies,
+    launchSnapshots: launchSnapshots.output,
   };
+  assertPreflightOutputShape(result);
+  return result;
 }
 
 const DANGLING_QUERY = `
@@ -1902,7 +2039,13 @@ async function collectDatabaseInventory(
     `SELECT
        "run"."id"::text AS "id",
        "run"."agent_compose_version_id" AS "versionId",
-       "version"."id" IS NOT NULL AS "versionPresent"
+       "version"."id" IS NOT NULL AS "versionPresent",
+       "run"."created_at" AT TIME ZONE 'UTC' AS "createdAt",
+       "run"."launch_snapshot" AS "launchSnapshot",
+       "run"."model_provider" AS "modelProvider",
+       "run"."selected_model" AS "selectedModel",
+       "run"."trigger_source" AS "triggerSource",
+       "run"."chat_thread_id" IS NOT NULL AS "chatThreadPresent"
      FROM "agent_runs" AS "run"
      LEFT JOIN "agent_compose_versions" AS "version"
        ON "version"."id" = "run"."agent_compose_version_id"
@@ -1913,9 +2056,19 @@ async function collectDatabaseInventory(
     signal,
     `SELECT
        "checkpoint"."id"::text AS "id",
+       "checkpoint"."run_id"::text AS "runId",
        "checkpoint"."agent_compose_snapshot" AS "snapshot"
      FROM "checkpoints" AS "checkpoint"
      ORDER BY "checkpoint"."id"`,
+  );
+  const conversations = await safeQuery<ConversationInventoryRow>(
+    client,
+    signal,
+    `SELECT
+       "conversation"."run_id"::text AS "runId",
+       "conversation"."cli_agent_type" AS "framework"
+     FROM "conversations" AS "conversation"
+     ORDER BY "conversation"."run_id"`,
   );
   const catalogDependencies = await safeQuery<CatalogDependencyRow>(
     client,
@@ -1933,6 +2086,7 @@ async function collectDatabaseInventory(
     heads,
     runs,
     checkpoints,
+    conversations,
     danglingStart,
     danglingEnd,
     agentExecutionPlans,

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { computeComposeVersionId } from "../../../apps/api/src/signals/services/agent-compose-content";
 import {
+  LAUNCH_SNAPSHOT_DISPOSITIONS,
   LAUNCH_SNAPSHOT_REASONS,
   classifyLaunchSnapshotRecoverability,
   type LaunchSnapshotCheckpointInventoryRow,
   type LaunchSnapshotConversationInventoryRow,
+  type LaunchSnapshotDisposition,
   type LaunchSnapshotRunInventoryRow,
   type LaunchSnapshotVersionInventoryRow,
 } from "./agent-compose-consolidation-preflight-launch-snapshots";
@@ -50,10 +52,11 @@ function run(
     versionId,
     createdAt: new Date("2026-06-01T00:00:00.000Z"),
     launchSnapshot: null,
-    modelProvider: null,
+    modelProvider: "anthropic-api-key",
     selectedModel: null,
-    triggerSource: "api",
+    triggerSource: "slack",
     chatThreadPresent: false,
+    metadataShape: "product",
     ...overrides,
   };
 }
@@ -109,6 +112,20 @@ function assertAllClosuresExact(
     result.output.reasonCompatibilityClosure.classification,
     "exact",
   );
+}
+
+function assertSingleDisposition(
+  result: ReturnType<typeof classifyLaunchSnapshotRecoverability>,
+  expected: LaunchSnapshotDisposition,
+): void {
+  assert.equal(result.output.total, 1);
+  for (const disposition of LAUNCH_SNAPSHOT_DISPOSITIONS) {
+    assert.equal(
+      result.output.dispositions[disposition].count,
+      disposition === expected ? 1 : 0,
+    );
+  }
+  assertAllClosuresExact(result);
 }
 
 function testCompletePartitionAndStrictSnapshots(): void {
@@ -400,25 +417,43 @@ function testProviderAndProductionRolloutHistory(): void {
 function testExactProductionBoundaryEdges(): void {
   const claudeContent = agentContent({ framework: "claude-code" });
   const claudeVersion = version(claudeContent);
-  const providerBoundary = classify({
-    runs: [
-      run("provider-before", claudeVersion.id, {
+  const providerCases = [
+    {
+      row: run("provider-before", claudeVersion.id, {
         createdAt: new Date("2026-05-03T04:14:32.999Z"),
         modelProvider: "openai-api-key",
       }),
-      run("provider-start", claudeVersion.id, {
+      disposition: "exactly_recoverable",
+    },
+    {
+      row: run("provider-start", claudeVersion.id, {
         createdAt: new Date("2026-05-03T04:14:33.000Z"),
         modelProvider: "openai-api-key",
       }),
-      run("provider-end", claudeVersion.id, {
+      disposition: "historical_unknown",
+    },
+    {
+      row: run("provider-end", claudeVersion.id, {
         createdAt: new Date("2026-05-03T04:15:49.000Z"),
         modelProvider: "openai-api-key",
       }),
-      run("provider-after", claudeVersion.id, {
+      disposition: "historical_unknown",
+    },
+    {
+      row: run("provider-after", claudeVersion.id, {
         createdAt: new Date("2026-05-03T04:15:49.001Z"),
         modelProvider: "openai-api-key",
       }),
-    ],
+      disposition: "exactly_recoverable",
+    },
+  ] as const satisfies readonly {
+    readonly row: LaunchSnapshotRunInventoryRow;
+    readonly disposition: LaunchSnapshotDisposition;
+  }[];
+  const providerBoundary = classify({
+    runs: providerCases.map(({ row }) => {
+      return row;
+    }),
     versions: [claudeVersion],
   });
   assert.equal(
@@ -433,6 +468,97 @@ function testExactProductionBoundaryEdges(): void {
     providerBoundary.output.reasons.framework_provider_rollout_transition.count,
     2,
   );
+  for (const providerCase of providerCases) {
+    assertSingleDisposition(
+      classify({ runs: [providerCase.row], versions: [claudeVersion] }),
+      providerCase.disposition,
+    );
+  }
+
+  const missingProviderCases = [
+    {
+      row: run("missing-provider-before", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:14:32.999Z"),
+        modelProvider: null,
+      }),
+      conversation: undefined,
+      disposition: "exactly_recoverable",
+    },
+    {
+      row: run("missing-provider-start", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:14:33.000Z"),
+        modelProvider: null,
+      }),
+      conversation: undefined,
+      disposition: "historical_unknown",
+    },
+    {
+      row: run("missing-provider-end", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:15:49.000Z"),
+        modelProvider: null,
+      }),
+      conversation: undefined,
+      disposition: "historical_unknown",
+    },
+    {
+      row: run("missing-provider-after", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:15:49.001Z"),
+        modelProvider: null,
+      }),
+      conversation: undefined,
+      disposition: "historical_unknown",
+    },
+    {
+      row: run("missing-provider-conversation", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:15:49.001Z"),
+        modelProvider: null,
+      }),
+      conversation: conversation("missing-provider-conversation", "codex"),
+      disposition: "exactly_recoverable",
+    },
+  ] as const satisfies readonly {
+    readonly row: LaunchSnapshotRunInventoryRow;
+    readonly conversation: LaunchSnapshotConversationInventoryRow | undefined;
+    readonly disposition: LaunchSnapshotDisposition;
+  }[];
+  const missingProviderBoundary = classify({
+    runs: missingProviderCases.map(({ row }) => {
+      return row;
+    }),
+    versions: [claudeVersion],
+    conversations: missingProviderCases.flatMap(({ conversation }) => {
+      return conversation ? [conversation] : [];
+    }),
+  });
+  assert.equal(
+    missingProviderBoundary.output.dispositions.exactly_recoverable.count,
+    2,
+  );
+  assert.equal(
+    missingProviderBoundary.output.dispositions.historical_unknown.count,
+    3,
+  );
+  assert.equal(
+    missingProviderBoundary.output.reasons.framework_provider_missing.count,
+    5,
+  );
+  assert.equal(
+    missingProviderBoundary.output.reasons.conversation_framework_valid.count,
+    1,
+  );
+  assertAllClosuresExact(missingProviderBoundary);
+  for (const providerCase of missingProviderCases) {
+    assertSingleDisposition(
+      classify({
+        runs: [providerCase.row],
+        versions: [claudeVersion],
+        conversations: providerCase.conversation
+          ? [providerCase.conversation]
+          : [],
+      }),
+      providerCase.disposition,
+    );
+  }
 
   const profileBoundary = classify({
     runs: [
@@ -637,6 +763,149 @@ function testPiAndConversationEvidence(): void {
   assert.equal(result.output.reasons.conversation_framework_invalid.count, 1);
 }
 
+function testPiEligibilityTriState(): void {
+  const codexContent = agentContent({ framework: "codex" });
+  const codexVersion = version(codexContent);
+  const piWindow = new Date("2026-08-11T00:00:00.000Z");
+  const common = {
+    createdAt: piWindow,
+    modelProvider: "deepseek",
+    selectedModel: "deepseek-v4-flash",
+    triggerSource: "web",
+    chatThreadPresent: true,
+  } as const;
+  const cases = [
+    {
+      row: run("provider-missing-conversation", codexVersion.id, {
+        ...common,
+        modelProvider: null,
+      }),
+      conversation: conversation("provider-missing-conversation", "pi"),
+      disposition: "exactly_recoverable",
+    },
+    {
+      row: run("provider-missing-no-conversation", codexVersion.id, {
+        ...common,
+        modelProvider: null,
+      }),
+      conversation: undefined,
+      disposition: "historical_unknown",
+    },
+    {
+      row: run("model-missing-conversation", codexVersion.id, {
+        ...common,
+        selectedModel: null,
+      }),
+      conversation: conversation("model-missing-conversation", "pi"),
+      disposition: "exactly_recoverable",
+    },
+    {
+      row: run("model-missing-no-conversation", codexVersion.id, {
+        ...common,
+        selectedModel: null,
+      }),
+      conversation: undefined,
+      disposition: "historical_unknown",
+    },
+    {
+      row: run("model-unknown-conversation", codexVersion.id, {
+        ...common,
+        selectedModel: "future-model",
+      }),
+      conversation: conversation("model-unknown-conversation", "pi"),
+      disposition: "exactly_recoverable",
+    },
+    {
+      row: run("model-unknown-no-conversation", codexVersion.id, {
+        ...common,
+        selectedModel: "future-model",
+      }),
+      conversation: undefined,
+      disposition: "historical_unknown",
+    },
+    {
+      row: run("known-non-pi-model-conversation", codexVersion.id, {
+        ...common,
+        selectedModel: "gpt-5.5",
+      }),
+      conversation: conversation("known-non-pi-model-conversation", "pi"),
+      disposition: "integrity_conflict",
+    },
+    {
+      row: run("known-non-pi-model-no-conversation", codexVersion.id, {
+        ...common,
+        selectedModel: "gpt-5.5",
+      }),
+      conversation: undefined,
+      disposition: "exactly_recoverable",
+    },
+    {
+      row: run("non-web-pi-conversation", codexVersion.id, {
+        ...common,
+        triggerSource: "slack",
+      }),
+      conversation: conversation("non-web-pi-conversation", "pi"),
+      disposition: "integrity_conflict",
+    },
+    {
+      row: run("no-chat-pi-conversation", codexVersion.id, {
+        ...common,
+        chatThreadPresent: false,
+      }),
+      conversation: conversation("no-chat-pi-conversation", "pi"),
+      disposition: "integrity_conflict",
+    },
+    {
+      row: run("claude-base-pi-conversation", codexVersion.id, {
+        ...common,
+        modelProvider: "anthropic-api-key",
+      }),
+      conversation: conversation("claude-base-pi-conversation", "pi"),
+      disposition: "integrity_conflict",
+    },
+    {
+      row: run("before-pi-conversation", codexVersion.id, {
+        ...common,
+        createdAt: new Date("2026-08-07T06:11:48.999Z"),
+      }),
+      conversation: conversation("before-pi-conversation", "pi"),
+      disposition: "integrity_conflict",
+    },
+  ] as const satisfies readonly {
+    readonly row: LaunchSnapshotRunInventoryRow;
+    readonly conversation: LaunchSnapshotConversationInventoryRow | undefined;
+    readonly disposition: LaunchSnapshotDisposition;
+  }[];
+  const result = classify({
+    runs: cases.map(({ row }) => {
+      return row;
+    }),
+    versions: [codexVersion],
+    conversations: cases.flatMap(({ conversation }) => {
+      return conversation ? [conversation] : [];
+    }),
+  });
+  assert.equal(result.output.dispositions.exactly_recoverable.count, 4);
+  assert.equal(result.output.dispositions.historical_unknown.count, 3);
+  assert.equal(result.output.dispositions.integrity_conflict.count, 5);
+  assert.equal(result.output.reasons.framework_provider_missing.count, 2);
+  assert.equal(result.output.reasons.framework_pi_model_missing.count, 1);
+  assert.equal(result.output.reasons.framework_pi_model_unknown.count, 1);
+  assert.equal(result.output.reasons.conversation_framework_conflict.count, 5);
+  assert.deepEqual(result.failureGates, ["launchSnapshots.integrity_conflict"]);
+  assertAllClosuresExact(result);
+  for (const piCase of cases) {
+    assertSingleDisposition(
+      classify({
+        runs: [piCase.row],
+        versions: [codexVersion],
+        conversations: piCase.conversation ? [piCase.conversation] : [],
+      }),
+      piCase.disposition,
+    );
+  }
+}
+
 function testProfilesLegacyContentAndBoundary(): void {
   const explicitContent = agentContent({
     profile: "vm0/custom",
@@ -687,8 +956,13 @@ function testProfilesLegacyContentAndBoundary(): void {
         createdAt: new Date("2026-03-18T08:41:13.330Z"),
       }),
       run("unsupported-content", unsupportedVersion.id),
-      run("invalid-content", invalidFrameworkVersion.id),
-      run("multi-agent", multiAgentVersion.id),
+      run("invalid-content", invalidFrameworkVersion.id, {
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        modelProvider: null,
+      }),
+      run("multi-agent", multiAgentVersion.id, {
+        modelProvider: "openai-api-key",
+      }),
       run("conflicting-agent-shapes", conflictingShapesVersion.id),
     ],
     versions: [
@@ -719,6 +993,7 @@ function testProfilesLegacyContentAndBoundary(): void {
   const matchingFirstAgent = classify({
     runs: [
       run("multi-agent-match", multiAgentVersion.id, {
+        modelProvider: "openai-api-key",
         launchSnapshot: {
           schemaVersion: 1,
           framework: "codex",
@@ -733,6 +1008,7 @@ function testProfilesLegacyContentAndBoundary(): void {
   const conflictingSecondAgent = classify({
     runs: [
       run("multi-agent-conflict", multiAgentVersion.id, {
+        modelProvider: "openai-api-key",
         launchSnapshot: {
           schemaVersion: 1,
           framework: "claude-code",
@@ -776,11 +1052,19 @@ function testProfilesLegacyContentAndBoundary(): void {
   );
   assert.deepEqual(
     classify({
-      runs: [run("multi-agent", multiAgentVersion.id)],
+      runs: [
+        run("multi-agent", multiAgentVersion.id, {
+          modelProvider: "openai-api-key",
+        }),
+      ],
       versions: [multiAgentVersion],
     }).output,
     classify({
-      runs: [run("multi-agent", multiAgentVersion.id)],
+      runs: [
+        run("multi-agent", multiAgentVersion.id, {
+          modelProvider: "openai-api-key",
+        }),
+      ],
       versions: [multiAgentVersion],
     }).output,
   );
@@ -852,6 +1136,130 @@ function testShapeClosureRedactionAndDomainSeparation(): void {
   );
 }
 
+function testNullableLifecycleMetadataHistory(): void {
+  const content = agentContent();
+  const storedVersion = version(content);
+  // This models the complete accepted field shape of the observed
+  // lifecycle-only population without encoding its moving production count.
+  const prePiLifecycle = classify({
+    runs: [
+      run("pre-pi-lifecycle", storedVersion.id, {
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        launchSnapshot: null,
+        modelProvider: null,
+        selectedModel: null,
+        triggerSource: null,
+        chatThreadPresent: false,
+        metadataShape: "lifecycle_only",
+      }),
+    ],
+    versions: [storedVersion],
+  });
+  assert.equal(prePiLifecycle.output.dispositions.exactly_recoverable.count, 1);
+  assert.equal(prePiLifecycle.output.dispositions.integrity_conflict.count, 0);
+  assert.equal(prePiLifecycle.output.reasons.complete_exact_evidence.count, 1);
+  assert.deepEqual(prePiLifecycle.failureGates, []);
+  assertAllClosuresExact(prePiLifecycle);
+
+  const triggerDependentLifecycle = classify({
+    runs: [
+      run("pi-window-lifecycle", storedVersion.id, {
+        createdAt: new Date("2026-08-07T06:11:49.000Z"),
+        launchSnapshot: null,
+        modelProvider: null,
+        selectedModel: null,
+        triggerSource: null,
+        chatThreadPresent: false,
+        metadataShape: "lifecycle_only",
+      }),
+    ],
+    versions: [storedVersion],
+  });
+  assert.equal(
+    triggerDependentLifecycle.output.dispositions.historical_unknown.count,
+    1,
+  );
+  assert.equal(
+    triggerDependentLifecycle.output.reasons.framework_provider_missing.count,
+    1,
+  );
+  assert.equal(
+    triggerDependentLifecycle.output.reasons.complete_exact_evidence.count,
+    0,
+  );
+  assert.deepEqual(triggerDependentLifecycle.failureGates, []);
+  assertAllClosuresExact(triggerDependentLifecycle);
+
+  const partialMetadata = classify({
+    runs: [
+      run("partial-metadata", storedVersion.id, {
+        modelProvider: "vm0",
+        triggerSource: null,
+        metadataShape: "partial",
+      }),
+    ],
+    versions: [storedVersion],
+  });
+  assert.equal(partialMetadata.output.dispositions.integrity_conflict.count, 1);
+  assert.equal(
+    partialMetadata.output.reasons.otherwise_unclassified_shape.count,
+    1,
+  );
+  assert.deepEqual(partialMetadata.failureGates, [
+    "launchSnapshots.integrity_conflict",
+  ]);
+  assertAllClosuresExact(partialMetadata);
+
+  const reviewedTriggerSources = classify({
+    runs: [
+      run("historical-non-web-trigger", storedVersion.id, {
+        createdAt: new Date("2026-08-13T00:00:00.000Z"),
+        triggerSource: "slack",
+      }),
+      run("agent-trigger", storedVersion.id, {
+        createdAt: new Date("2026-08-13T00:00:00.000Z"),
+        triggerSource: "agent",
+      }),
+      run("web-trigger", storedVersion.id, {
+        createdAt: new Date("2026-08-13T00:00:00.000Z"),
+        triggerSource: "web",
+      }),
+    ],
+    versions: [storedVersion],
+  });
+  assert.equal(
+    reviewedTriggerSources.output.dispositions.exactly_recoverable.count,
+    3,
+  );
+  assert.equal(
+    reviewedTriggerSources.output.reasons.trigger_source_unrecognized.count,
+    0,
+  );
+  assertAllClosuresExact(reviewedTriggerSources);
+
+  const unrecognizedTriggerSource = classify({
+    runs: [
+      run("unrecognized-trigger", storedVersion.id, {
+        createdAt: new Date("2026-08-13T00:00:00.000Z"),
+        triggerSource: "future-trigger",
+      }),
+    ],
+    versions: [storedVersion],
+  });
+  assert.equal(
+    unrecognizedTriggerSource.output.dispositions.integrity_conflict.count,
+    1,
+  );
+  assert.equal(
+    unrecognizedTriggerSource.output.reasons.trigger_source_unrecognized.count,
+    1,
+  );
+  assert.deepEqual(unrecognizedTriggerSource.failureGates, [
+    "launchSnapshots.integrity_conflict",
+  ]);
+  assertAllClosuresExact(unrecognizedTriggerSource);
+}
+
 async function testClassifierHasNoCurrentAuthorityLookup(): Promise<void> {
   const dirname = path.dirname(fileURLToPath(import.meta.url));
   const source = await fs.readFile(
@@ -883,8 +1291,10 @@ export async function validateLaunchSnapshotRecoverabilityStatic(): Promise<void
   testProviderAndProductionRolloutHistory();
   testExactProductionBoundaryEdges();
   testPiAndConversationEvidence();
+  testPiEligibilityTriState();
   testProfilesLegacyContentAndBoundary();
   testShapeClosureRedactionAndDomainSeparation();
+  testNullableLifecycleMetadataHistory();
   await testClassifierHasNoCurrentAuthorityLookup();
   assert.deepEqual(
     [...observedReasons].sort(),

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts
@@ -1,0 +1,900 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { computeComposeVersionId } from "../../../apps/api/src/signals/services/agent-compose-content";
+import {
+  LAUNCH_SNAPSHOT_REASONS,
+  classifyLaunchSnapshotRecoverability,
+  type LaunchSnapshotCheckpointInventoryRow,
+  type LaunchSnapshotConversationInventoryRow,
+  type LaunchSnapshotRunInventoryRow,
+  type LaunchSnapshotVersionInventoryRow,
+} from "./agent-compose-consolidation-preflight-launch-snapshots";
+
+const observedReasons = new Set<string>();
+
+function agentContent(
+  args: {
+    readonly framework?: unknown;
+    readonly profile?: unknown;
+    readonly profilePresent?: boolean;
+    readonly name?: string;
+  } = {},
+): Record<string, unknown> {
+  const name = args.name ?? "agent";
+  return {
+    version: "1",
+    agents: {
+      [name]: {
+        framework: args.framework ?? "claude-code",
+        ...(args.profilePresent ? { experimental_profile: args.profile } : {}),
+      },
+    },
+  };
+}
+
+function version(
+  content: Record<string, unknown>,
+): LaunchSnapshotVersionInventoryRow {
+  return { id: computeComposeVersionId(content), content };
+}
+
+function run(
+  id: string,
+  versionId: string | null,
+  overrides: Partial<LaunchSnapshotRunInventoryRow> = {},
+): LaunchSnapshotRunInventoryRow {
+  return {
+    id,
+    versionId,
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    launchSnapshot: null,
+    modelProvider: null,
+    selectedModel: null,
+    triggerSource: "api",
+    chatThreadPresent: false,
+    ...overrides,
+  };
+}
+
+function checkpoint(
+  runId: string,
+  snapshot: unknown,
+): LaunchSnapshotCheckpointInventoryRow {
+  return { runId, snapshot };
+}
+
+function conversation(
+  runId: string,
+  framework: string,
+): LaunchSnapshotConversationInventoryRow {
+  return { runId, framework };
+}
+
+function classify(args: {
+  readonly runs: readonly LaunchSnapshotRunInventoryRow[];
+  readonly versions?: readonly LaunchSnapshotVersionInventoryRow[];
+  readonly checkpoints?: readonly LaunchSnapshotCheckpointInventoryRow[];
+  readonly conversations?: readonly LaunchSnapshotConversationInventoryRow[];
+}) {
+  const result = classifyLaunchSnapshotRecoverability({
+    runs: args.runs,
+    versions: args.versions ?? [],
+    checkpoints: args.checkpoints ?? [],
+    conversations: args.conversations ?? [],
+  });
+  for (const [reason, metric] of Object.entries(result.output.reasons)) {
+    if (metric.count > 0) observedReasons.add(reason);
+  }
+  return result;
+}
+
+function assertAllClosuresExact(
+  result: ReturnType<typeof classifyLaunchSnapshotRecoverability>,
+): void {
+  assert.equal(result.output.populationClosure.classification, "exact");
+  assert.equal(
+    result.output.dispositionPartitionClosure.classification,
+    "exact",
+  );
+  assert.equal(
+    result.output.dispositionDisjointnessClosure.classification,
+    "exact",
+  );
+  assert.equal(result.output.dispositionUnionClosure.classification, "exact");
+  assert.equal(result.output.reasonPartitionClosure.classification, "exact");
+  assert.equal(result.output.reasonUnionClosure.classification, "exact");
+  assert.equal(
+    result.output.reasonCompatibilityClosure.classification,
+    "exact",
+  );
+}
+
+function testCompletePartitionAndStrictSnapshots(): void {
+  const content = agentContent();
+  const storedVersion = version(content);
+  const result = classify({
+    runs: [
+      run("already", storedVersion.id, {
+        launchSnapshot: {
+          schemaVersion: 1,
+          framework: "claude-code",
+          runnerProfile: "vm0/default",
+        },
+      }),
+      run("recoverable", storedVersion.id),
+      run("unknown", null),
+      run("conflict", storedVersion.id, {
+        launchSnapshot: {
+          schemaVersion: 1,
+          framework: "claude-code",
+          runnerProfile: "vm0/default",
+          extra: true,
+        },
+      }),
+    ],
+    versions: [storedVersion],
+  });
+  assert.deepEqual(
+    Object.fromEntries(
+      Object.entries(result.output.dispositions).map(([key, metric]) => {
+        return [key, metric.count];
+      }),
+    ),
+    {
+      already_valid: 1,
+      exactly_recoverable: 1,
+      historical_unknown: 1,
+      integrity_conflict: 1,
+    },
+  );
+  assertAllClosuresExact(result);
+  assert.deepEqual(result.failureGates, ["launchSnapshots.integrity_conflict"]);
+
+  for (const launchSnapshot of [
+    null,
+    [],
+    "snapshot",
+    { schemaVersion: 1, framework: "claude-code", runnerProfile: "" },
+    { schemaVersion: 2, framework: "claude-code", runnerProfile: "profile" },
+    { schemaVersion: 1, framework: "other", runnerProfile: "profile" },
+  ]) {
+    const invalid = classify({
+      runs: [run("invalid-snapshot", storedVersion.id, { launchSnapshot })],
+      versions: [storedVersion],
+    });
+    if (launchSnapshot === null) {
+      assert.equal(invalid.output.dispositions.exactly_recoverable.count, 1);
+    } else {
+      assert.equal(invalid.output.dispositions.integrity_conflict.count, 1);
+    }
+  }
+}
+
+function testVersionAndCheckpointEvidence(): void {
+  const content = agentContent({ profile: "vm0/small", profilePresent: true });
+  const storedVersion = version(content);
+  const matching = classify({
+    runs: [
+      run("run-reference", storedVersion.id),
+      run("checkpoint-reference", null),
+      run("matching-references", storedVersion.id),
+      run("shared-reference", storedVersion.id),
+    ],
+    versions: [storedVersion],
+    checkpoints: [
+      checkpoint("checkpoint-reference", {
+        agentComposeVersionId: storedVersion.id,
+        vars: { SAFE: "value" },
+        secretNames: ["SECRET"],
+      }),
+      checkpoint("matching-references", {
+        agentComposeVersionId: storedVersion.id,
+      }),
+    ],
+  });
+  assert.equal(matching.output.dispositions.exactly_recoverable.count, 4);
+  assert.equal(matching.output.reasons.run_version_reference_exact.count, 2);
+  assert.equal(
+    matching.output.reasons.checkpoint_version_reference_exact.count,
+    1,
+  );
+  assert.equal(
+    matching.output.reasons.run_checkpoint_version_reference_exact.count,
+    1,
+  );
+  assertAllClosuresExact(matching);
+
+  const otherContent = agentContent({ framework: "codex" });
+  const otherVersion = version(otherContent);
+  const conflicts = classify({
+    runs: [
+      run("reference-conflict", storedVersion.id),
+      run("malformed-checkpoint", storedVersion.id),
+      run("missing-run-version", "a".repeat(64)),
+      run("missing-checkpoint-version", null),
+    ],
+    versions: [storedVersion, otherVersion],
+    checkpoints: [
+      checkpoint("reference-conflict", {
+        agentComposeVersionId: otherVersion.id,
+      }),
+      checkpoint("malformed-checkpoint", {
+        agentComposeVersionId: storedVersion.id,
+        unexpected: true,
+      }),
+      checkpoint("missing-checkpoint-version", {
+        agentComposeVersionId: "b".repeat(64),
+      }),
+    ],
+  });
+  assert.equal(conflicts.output.dispositions.integrity_conflict.count, 4);
+  assert.equal(
+    conflicts.output.reasons.run_checkpoint_version_conflict.count,
+    1,
+  );
+  assert.equal(conflicts.output.reasons.checkpoint_snapshot_malformed.count, 1);
+  assert.equal(conflicts.output.reasons.run_version_missing.count, 1);
+  assert.equal(conflicts.output.reasons.checkpoint_version_missing.count, 1);
+
+  const malformedVariants = [
+    null,
+    [],
+    { agentComposeVersionId: "invalid" },
+    { agentComposeVersionId: storedVersion.id, vars: { INVALID: 1 } },
+    { agentComposeVersionId: storedVersion.id, secretNames: [1] },
+  ];
+  for (const [index, snapshot] of malformedVariants.entries()) {
+    const malformed = classify({
+      runs: [run(`malformed-${index}`, storedVersion.id)],
+      versions: [storedVersion],
+      checkpoints: [checkpoint(`malformed-${index}`, snapshot)],
+    });
+    assert.equal(malformed.output.dispositions.integrity_conflict.count, 1);
+  }
+
+  const mismatchedHash = classify({
+    runs: [run("hash-conflict", "c".repeat(64))],
+    versions: [{ id: "c".repeat(64), content }],
+  });
+  assert.equal(mismatchedHash.output.dispositions.integrity_conflict.count, 1);
+  assert.equal(
+    mismatchedHash.output.reasons.legacy_content_hash_conflict.count,
+    1,
+  );
+}
+
+function testProviderAndProductionRolloutHistory(): void {
+  const claudeContent = agentContent({ framework: "claude-code" });
+  const claudeVersion = version(claudeContent);
+  const codexContent = agentContent({ framework: "codex" });
+  const codexVersion = version(codexContent);
+  const result = classify({
+    runs: [
+      run("before-provider-rollout", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:14:32.999Z"),
+        modelProvider: "openai-api-key",
+      }),
+      run("provider-rollout-transition", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:15:00.000Z"),
+        modelProvider: "openai-api-key",
+      }),
+      run("provider-rollout-same-framework", codexVersion.id, {
+        createdAt: new Date("2026-05-03T04:15:00.000Z"),
+        modelProvider: "openai-api-key",
+      }),
+      run("after-provider-rollout", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:15:49.001Z"),
+        modelProvider: "openai-api-key",
+      }),
+      run("claude-provider", codexVersion.id, {
+        modelProvider: "anthropic-api-key",
+      }),
+      run("vm0-codex", claudeVersion.id, {
+        modelProvider: "vm0",
+        selectedModel: "gpt-5.5",
+      }),
+      run("vm0-missing", claudeVersion.id, {
+        modelProvider: "vm0",
+      }),
+      run("vm0-retired", claudeVersion.id, {
+        modelProvider: "vm0",
+        selectedModel: "gpt-5.4",
+      }),
+      run("vm0-unknown", claudeVersion.id, {
+        modelProvider: "vm0",
+        selectedModel: "future-model",
+      }),
+      run("provider-retired", claudeVersion.id, {
+        modelProvider: "moonshot-api-key",
+      }),
+      run("provider-unknown", claudeVersion.id, {
+        modelProvider: "future-provider",
+      }),
+    ],
+    versions: [claudeVersion, codexVersion],
+  });
+  assert.equal(result.output.dispositions.exactly_recoverable.count, 5);
+  assert.equal(result.output.dispositions.historical_unknown.count, 6);
+  assert.equal(
+    result.output.reasons.framework_provider_precedence_inactive.count,
+    1,
+  );
+  assert.equal(
+    result.output.reasons.framework_provider_rollout_transition.count,
+    1,
+  );
+  assert.equal(result.output.reasons.framework_provider_exact.count, 5);
+  assert.equal(result.output.reasons.framework_vm0_model_exact.count, 1);
+  assert.equal(result.output.reasons.framework_vm0_model_missing.count, 1);
+  assert.equal(result.output.reasons.framework_vm0_model_retired.count, 1);
+  assert.equal(result.output.reasons.framework_vm0_model_unknown.count, 1);
+  assert.equal(result.output.reasons.framework_provider_retired.count, 1);
+  assert.equal(result.output.reasons.framework_provider_unknown.count, 1);
+
+  const flashHistory = classify({
+    runs: [
+      run("flash-before", claudeVersion.id, {
+        createdAt: new Date("2026-07-31T12:06:01.999Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-flash",
+      }),
+      run("flash-transition", claudeVersion.id, {
+        createdAt: new Date("2026-07-31T12:07:00.000Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-flash",
+      }),
+      run("flash-transition-start", claudeVersion.id, {
+        createdAt: new Date("2026-07-31T12:06:02.000Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-flash",
+      }),
+      run("flash-transition-end", claudeVersion.id, {
+        createdAt: new Date("2026-07-31T12:08:52.000Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-flash",
+      }),
+      run("flash-after", claudeVersion.id, {
+        createdAt: new Date("2026-07-31T12:08:52.001Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-flash",
+      }),
+      run("pro-before-retirement", claudeVersion.id, {
+        createdAt: new Date("2026-08-04T15:05:49.999Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-pro",
+      }),
+      run("pro-retirement-start", claudeVersion.id, {
+        createdAt: new Date("2026-08-04T15:05:50.000Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-pro",
+      }),
+      run("pro-retirement-end", claudeVersion.id, {
+        createdAt: new Date("2026-08-04T15:07:21.000Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-pro",
+      }),
+      run("pro-retired", claudeVersion.id, {
+        createdAt: new Date("2026-08-10T00:00:00.000Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-pro",
+      }),
+      run("pro-reintroduction", claudeVersion.id, {
+        createdAt: new Date("2026-08-12T18:51:00.000Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-pro",
+      }),
+      run("pro-after", claudeVersion.id, {
+        createdAt: new Date("2026-08-12T18:52:37.001Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-pro",
+      }),
+    ],
+    versions: [claudeVersion],
+  });
+  assert.equal(flashHistory.output.dispositions.exactly_recoverable.count, 4);
+  assert.equal(flashHistory.output.dispositions.historical_unknown.count, 7);
+}
+
+function testExactProductionBoundaryEdges(): void {
+  const claudeContent = agentContent({ framework: "claude-code" });
+  const claudeVersion = version(claudeContent);
+  const providerBoundary = classify({
+    runs: [
+      run("provider-before", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:14:32.999Z"),
+        modelProvider: "openai-api-key",
+      }),
+      run("provider-start", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:14:33.000Z"),
+        modelProvider: "openai-api-key",
+      }),
+      run("provider-end", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:15:49.000Z"),
+        modelProvider: "openai-api-key",
+      }),
+      run("provider-after", claudeVersion.id, {
+        createdAt: new Date("2026-05-03T04:15:49.001Z"),
+        modelProvider: "openai-api-key",
+      }),
+    ],
+    versions: [claudeVersion],
+  });
+  assert.equal(
+    providerBoundary.output.dispositions.exactly_recoverable.count,
+    2,
+  );
+  assert.equal(
+    providerBoundary.output.dispositions.historical_unknown.count,
+    2,
+  );
+  assert.equal(
+    providerBoundary.output.reasons.framework_provider_rollout_transition.count,
+    2,
+  );
+
+  const profileBoundary = classify({
+    runs: [
+      run("profile-before", claudeVersion.id, {
+        createdAt: new Date("2026-03-18T08:41:13.330Z"),
+      }),
+      run("profile-at-boundary", claudeVersion.id, {
+        createdAt: new Date("2026-03-18T08:41:13.331Z"),
+      }),
+    ],
+    versions: [claudeVersion],
+  });
+  assert.equal(profileBoundary.output.dispositions.historical_unknown.count, 1);
+  assert.equal(
+    profileBoundary.output.dispositions.exactly_recoverable.count,
+    1,
+  );
+  assert.deepEqual(profileBoundary.failureGates, [
+    "launchSnapshots.history_boundary",
+  ]);
+
+  const codexContent = agentContent({ framework: "codex" });
+  const codexVersion = version(codexContent);
+  const flashRestrictionBoundary = classify({
+    runs: [
+      run("flash-restriction-before", codexVersion.id, {
+        createdAt: new Date("2026-08-10T03:38:02.999Z"),
+        modelProvider: "deepseek",
+        selectedModel: "gpt-5.5",
+        triggerSource: "web",
+        chatThreadPresent: true,
+      }),
+      run("flash-restriction-start", codexVersion.id, {
+        createdAt: new Date("2026-08-10T03:38:03.000Z"),
+        modelProvider: "deepseek",
+        selectedModel: "gpt-5.5",
+        triggerSource: "web",
+        chatThreadPresent: true,
+      }),
+      run("flash-restriction-end", codexVersion.id, {
+        createdAt: new Date("2026-08-10T03:39:34.000Z"),
+        modelProvider: "deepseek",
+        selectedModel: "gpt-5.5",
+        triggerSource: "web",
+        chatThreadPresent: true,
+      }),
+      run("flash-restriction-after", codexVersion.id, {
+        createdAt: new Date("2026-08-10T03:39:34.001Z"),
+        modelProvider: "deepseek",
+        selectedModel: "gpt-5.5",
+        triggerSource: "web",
+        chatThreadPresent: true,
+      }),
+    ],
+    versions: [codexVersion],
+  });
+  assert.equal(
+    flashRestrictionBoundary.output.dispositions.historical_unknown.count,
+    3,
+  );
+  assert.equal(
+    flashRestrictionBoundary.output.dispositions.exactly_recoverable.count,
+    1,
+  );
+  assert.equal(
+    flashRestrictionBoundary.output.reasons.framework_pi_state_unproven.count,
+    3,
+  );
+
+  const proExpansionBoundary = classify({
+    runs: [
+      run("pro-expansion-before", codexVersion.id, {
+        createdAt: new Date("2026-08-12T18:50:25.999Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-pro",
+        triggerSource: "web",
+        chatThreadPresent: true,
+      }),
+      run("pro-expansion-start", codexVersion.id, {
+        createdAt: new Date("2026-08-12T18:50:26.000Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-pro",
+        triggerSource: "web",
+        chatThreadPresent: true,
+      }),
+      run("pro-expansion-end", codexVersion.id, {
+        createdAt: new Date("2026-08-12T18:52:37.000Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-pro",
+        triggerSource: "web",
+        chatThreadPresent: true,
+      }),
+      run("pro-expansion-after", codexVersion.id, {
+        createdAt: new Date("2026-08-12T18:52:37.001Z"),
+        modelProvider: "vm0",
+        selectedModel: "deepseek-v4-pro",
+        triggerSource: "web",
+        chatThreadPresent: true,
+      }),
+    ],
+    versions: [codexVersion],
+  });
+  assert.equal(
+    proExpansionBoundary.output.dispositions.historical_unknown.count,
+    4,
+  );
+  assert.equal(
+    proExpansionBoundary.output.reasons.framework_vm0_model_retired.count,
+    1,
+  );
+  assert.equal(
+    proExpansionBoundary.output.reasons.framework_pi_state_unproven.count,
+    3,
+  );
+}
+
+function testPiAndConversationEvidence(): void {
+  const codexContent = agentContent({ framework: "codex" });
+  const codexVersion = version(codexContent);
+  const commonPi = {
+    modelProvider: "deepseek",
+    selectedModel: "deepseek-v4-flash",
+    triggerSource: "web",
+    chatThreadPresent: true,
+  } as const;
+  const result = classify({
+    runs: [
+      run("before-pi", codexVersion.id, {
+        ...commonPi,
+        createdAt: new Date("2026-08-07T06:11:48.999Z"),
+      }),
+      run("initial-pi-transition", codexVersion.id, {
+        ...commonPi,
+        createdAt: new Date("2026-08-07T06:11:49.000Z"),
+      }),
+      run("callback-removal-transition", codexVersion.id, {
+        ...commonPi,
+        createdAt: new Date("2026-08-07T16:11:30.000Z"),
+      }),
+      run("flash-restriction-transition-other-model", codexVersion.id, {
+        ...commonPi,
+        selectedModel: "gpt-5.5",
+        createdAt: new Date("2026-08-10T03:39:00.000Z"),
+      }),
+      run("after-flash-restriction-other-model", codexVersion.id, {
+        ...commonPi,
+        selectedModel: "gpt-5.5",
+        createdAt: new Date("2026-08-10T03:39:34.001Z"),
+      }),
+      run("flash-eligible", codexVersion.id, {
+        ...commonPi,
+        createdAt: new Date("2026-08-11T00:00:00.000Z"),
+      }),
+      run("sandbox-transition", codexVersion.id, {
+        ...commonPi,
+        createdAt: new Date("2026-08-12T16:43:00.000Z"),
+      }),
+      run("pi-conversation", codexVersion.id, {
+        ...commonPi,
+        createdAt: new Date("2026-08-11T00:00:00.000Z"),
+      }),
+      run("pi-ineligible", codexVersion.id, {
+        ...commonPi,
+        chatThreadPresent: false,
+        createdAt: new Date("2026-08-11T00:00:00.000Z"),
+      }),
+      run("pro-transition", codexVersion.id, {
+        ...commonPi,
+        selectedModel: "deepseek-v4-pro",
+        createdAt: new Date("2026-08-12T18:51:00.000Z"),
+      }),
+      run("conversation-agreement", codexVersion.id, {
+        modelProvider: "openai-api-key",
+      }),
+      run("conversation-conflict", codexVersion.id, {
+        modelProvider: "openai-api-key",
+      }),
+      run("conversation-invalid", codexVersion.id, {
+        modelProvider: "openai-api-key",
+      }),
+      run("conversation-proves-unknown-provider", codexVersion.id, {
+        modelProvider: "future-provider",
+      }),
+    ],
+    versions: [codexVersion],
+    conversations: [
+      conversation("pi-conversation", "pi"),
+      conversation("pro-transition", "pi"),
+      conversation("conversation-agreement", "codex"),
+      conversation("conversation-conflict", "claude-code"),
+      conversation("conversation-invalid", "future-framework"),
+      conversation("conversation-proves-unknown-provider", "codex"),
+    ],
+  });
+  assert.equal(result.output.dispositions.exactly_recoverable.count, 7);
+  assert.equal(result.output.dispositions.historical_unknown.count, 5);
+  assert.equal(result.output.dispositions.integrity_conflict.count, 2);
+  assert.equal(result.output.reasons.framework_pi_state_unproven.count, 5);
+  assert.equal(result.output.reasons.conversation_framework_valid.count, 5);
+  assert.equal(result.output.reasons.conversation_framework_missing.count, 8);
+  assert.equal(result.output.reasons.conversation_framework_conflict.count, 1);
+  assert.equal(result.output.reasons.conversation_framework_invalid.count, 1);
+}
+
+function testProfilesLegacyContentAndBoundary(): void {
+  const explicitContent = agentContent({
+    profile: "vm0/custom",
+    profilePresent: true,
+  });
+  const explicitVersion = version(explicitContent);
+  const invalidProfileContent = agentContent({
+    profile: 1,
+    profilePresent: true,
+  });
+  const invalidProfileVersion = version(invalidProfileContent);
+  const defaultContent = agentContent();
+  const defaultVersion = version(defaultContent);
+  const unsupportedContent = { version: "1", future: true };
+  const unsupportedVersion = version(unsupportedContent);
+  const invalidFrameworkContent = agentContent({ framework: "future" });
+  const invalidFrameworkVersion = version(invalidFrameworkContent);
+  const multiAgentContent = {
+    version: "1",
+    agents: {
+      first: { framework: "codex", experimental_profile: "vm0/first" },
+      second: {
+        framework: "claude-code",
+        experimental_profile: "vm0/second",
+      },
+    },
+  };
+  const multiAgentVersion = version(multiAgentContent);
+  const conflictingShapes = {
+    version: "1",
+    agent: { framework: "claude-code" },
+    agents: { other: { framework: "codex" } },
+  };
+  const conflictingShapesVersion = version(conflictingShapes);
+  const result = classify({
+    runs: [
+      run("explicit-profile", explicitVersion.id),
+      run("invalid-profile", invalidProfileVersion.id),
+      run("proven-default", defaultVersion.id),
+      run("default-drift", defaultVersion.id, {
+        launchSnapshot: {
+          schemaVersion: 1,
+          framework: "claude-code",
+          runnerProfile: "vm0/drifted",
+        },
+      }),
+      run("unproven-default", defaultVersion.id, {
+        createdAt: new Date("2026-03-18T08:41:13.330Z"),
+      }),
+      run("unsupported-content", unsupportedVersion.id),
+      run("invalid-content", invalidFrameworkVersion.id),
+      run("multi-agent", multiAgentVersion.id),
+      run("conflicting-agent-shapes", conflictingShapesVersion.id),
+    ],
+    versions: [
+      explicitVersion,
+      invalidProfileVersion,
+      defaultVersion,
+      unsupportedVersion,
+      invalidFrameworkVersion,
+      multiAgentVersion,
+      conflictingShapesVersion,
+    ],
+  });
+  assert.equal(result.output.dispositions.exactly_recoverable.count, 3);
+  assert.equal(result.output.dispositions.historical_unknown.count, 5);
+  assert.equal(result.output.dispositions.integrity_conflict.count, 1);
+  assert.equal(result.output.reasons.runner_profile_explicit_exact.count, 2);
+  assert.equal(result.output.reasons.runner_profile_invalid.count, 1);
+  assert.equal(result.output.reasons.runner_profile_default_exact.count, 3);
+  assert.equal(result.output.reasons.runner_profile_default_unproven.count, 1);
+  assert.equal(
+    result.output.reasons.created_before_reviewed_history_boundary.count,
+    1,
+  );
+  assert.equal(result.output.reasons.legacy_content_unsupported.count, 2);
+  assert.equal(result.output.reasons.legacy_content_invalid.count, 1);
+  assert.ok(result.failureGates.includes("launchSnapshots.history_boundary"));
+
+  const matchingFirstAgent = classify({
+    runs: [
+      run("multi-agent-match", multiAgentVersion.id, {
+        launchSnapshot: {
+          schemaVersion: 1,
+          framework: "codex",
+          runnerProfile: "vm0/first",
+        },
+      }),
+    ],
+    versions: [multiAgentVersion],
+  });
+  assert.equal(matchingFirstAgent.output.dispositions.already_valid.count, 1);
+
+  const conflictingSecondAgent = classify({
+    runs: [
+      run("multi-agent-conflict", multiAgentVersion.id, {
+        launchSnapshot: {
+          schemaVersion: 1,
+          framework: "claude-code",
+          runnerProfile: "vm0/second",
+        },
+      }),
+    ],
+    versions: [multiAgentVersion],
+  });
+  assert.equal(
+    conflictingSecondAgent.output.dispositions.integrity_conflict.count,
+    1,
+  );
+
+  const reverseContent = {
+    version: "1",
+    agents: {
+      second: {
+        framework: "claude-code",
+        experimental_profile: "vm0/second",
+      },
+      first: { framework: "codex", experimental_profile: "vm0/first" },
+    },
+  };
+  const reverseVersion = version(reverseContent);
+  const matchingReversedFirstAgent = classify({
+    runs: [
+      run("multi-agent-reverse", reverseVersion.id, {
+        launchSnapshot: {
+          schemaVersion: 1,
+          framework: "claude-code",
+          runnerProfile: "vm0/second",
+        },
+      }),
+    ],
+    versions: [reverseVersion],
+  });
+  assert.equal(
+    matchingReversedFirstAgent.output.dispositions.already_valid.count,
+    1,
+  );
+  assert.deepEqual(
+    classify({
+      runs: [run("multi-agent", multiAgentVersion.id)],
+      versions: [multiAgentVersion],
+    }).output,
+    classify({
+      runs: [run("multi-agent", multiAgentVersion.id)],
+      versions: [multiAgentVersion],
+    }).output,
+  );
+}
+
+function testShapeClosureRedactionAndDomainSeparation(): void {
+  const content = agentContent({
+    framework: "codex",
+    profile: "private/profile",
+    profilePresent: true,
+  });
+  const storedVersion = version(content);
+  const result = classify({
+    runs: [
+      run("raw-run-id", storedVersion.id, {
+        modelProvider: "openai-api-key",
+        selectedModel: "private-model",
+        createdAt: new Date("2026-06-01T12:34:56.789Z"),
+      }),
+    ],
+    versions: [storedVersion],
+  });
+  const serialized = JSON.stringify(result.output);
+  for (const forbidden of [
+    "raw-run-id",
+    storedVersion.id,
+    "openai-api-key",
+    "private-model",
+    "private/profile",
+    "2026-06-01",
+  ]) {
+    assert.ok(!serialized.includes(forbidden), `leaked ${forbidden}`);
+  }
+  for (const metric of [
+    result.output.population,
+    ...Object.values(result.output.dispositions),
+    ...Object.values(result.output.reasons),
+  ]) {
+    assert.match(metric.digest, /^[0-9a-f]{64}$/u);
+  }
+  assert.notEqual(
+    result.output.dispositions.exactly_recoverable.digest,
+    result.output.reasons.complete_exact_evidence.digest,
+  );
+
+  const duplicatePopulation = classify({
+    runs: [run("duplicate", null), run("duplicate", null)],
+  });
+  assert.equal(
+    duplicatePopulation.output.populationClosure.classification,
+    "drift",
+  );
+  assert.ok(
+    duplicatePopulation.failureGates.includes("launchSnapshots.closure"),
+  );
+
+  const invalidShape = classify({
+    runs: [
+      run("invalid-shape", storedVersion.id, {
+        createdAt: new Date(Number.NaN),
+      }),
+    ],
+    versions: [storedVersion],
+  });
+  assert.equal(invalidShape.output.dispositions.integrity_conflict.count, 1);
+  assert.equal(
+    invalidShape.output.reasons.otherwise_unclassified_shape.count,
+    1,
+  );
+}
+
+async function testClassifierHasNoCurrentAuthorityLookup(): Promise<void> {
+  const dirname = path.dirname(fileURLToPath(import.meta.url));
+  const source = await fs.readFile(
+    path.join(
+      dirname,
+      "agent-compose-consolidation-preflight-launch-snapshots.ts",
+    ),
+    "utf8",
+  );
+  for (const forbidden of [
+    "MODEL_PROVIDER_TYPES",
+    "FeatureSwitch",
+    "DEFAULT_PROFILE",
+    "agent_composes",
+    "zero_agents",
+    "head_version_id",
+    "composeId",
+  ]) {
+    assert.ok(
+      !source.includes(forbidden),
+      `current authority lookup: ${forbidden}`,
+    );
+  }
+}
+
+export async function validateLaunchSnapshotRecoverabilityStatic(): Promise<void> {
+  testCompletePartitionAndStrictSnapshots();
+  testVersionAndCheckpointEvidence();
+  testProviderAndProductionRolloutHistory();
+  testExactProductionBoundaryEdges();
+  testPiAndConversationEvidence();
+  testProfilesLegacyContentAndBoundary();
+  testShapeClosureRedactionAndDomainSeparation();
+  await testClassifierHasNoCurrentAuthorityLookup();
+  assert.deepEqual(
+    [...observedReasons].sort(),
+    [...LAUNCH_SNAPSHOT_REASONS].sort(),
+  );
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) {
+  validateLaunchSnapshotRecoverabilityStatic().catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts
@@ -1237,6 +1237,22 @@ function testNullableLifecycleMetadataHistory(): void {
   );
   assertAllClosuresExact(reviewedTriggerSources);
 
+  const retiredTemplateImportTrigger = classify({
+    runs: [
+      run("retired-template-import-trigger", storedVersion.id, {
+        createdAt: new Date("2026-08-12T00:00:00.000Z"),
+        triggerSource: "template-import",
+      }),
+    ],
+    versions: [storedVersion],
+  });
+  assertSingleDisposition(retiredTemplateImportTrigger, "exactly_recoverable");
+  assert.equal(
+    retiredTemplateImportTrigger.output.reasons.trigger_source_unrecognized
+      .count,
+    0,
+  );
+
   const unrecognizedTriggerSource = classify({
     runs: [
       run("unrecognized-trigger", storedVersion.id, {

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -35,9 +35,11 @@ import {
   classifyExceptionRefinements,
   type UnclassifiedPrimaryClass,
 } from "./agent-compose-consolidation-preflight-refinements";
+import { validateLaunchSnapshotRecoverabilityStatic } from "./test-agent-compose-consolidation-preflight-launch-snapshots";
 import {
   PREFLIGHT_OUTPUT_ALLOWLIST,
   SanitizedPreflightError,
+  assertPreflightOutputShape,
   classifyPreflightInventory,
   executeAgentComposeConsolidationPreflight,
   sanitizedFailureResult,
@@ -49,6 +51,7 @@ import {
   type PreflightCapabilities,
   type PreflightClassificationOptions,
   type PreflightInventory,
+  type RunInventoryRow,
   type VersionInventoryRow,
 } from "./agent-compose-consolidation-preflight";
 
@@ -96,6 +99,7 @@ function emptyInventory(
     heads: [],
     runs: [],
     checkpoints: [],
+    conversations: [],
     danglingStart: [],
     danglingEnd: [],
     agentExecutionPlans: [],
@@ -441,6 +445,83 @@ function canonicalVersion(
   };
 }
 
+function runRow(
+  id: string,
+  versionId: string | null,
+  versionPresent: boolean,
+  overrides: Partial<RunInventoryRow> = {},
+): RunInventoryRow {
+  return {
+    id,
+    versionId,
+    versionPresent,
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    launchSnapshot: null,
+    modelProvider: null,
+    selectedModel: null,
+    triggerSource: "api",
+    chatThreadPresent: false,
+    ...overrides,
+  };
+}
+
+function acceptedV3DomainProjection(
+  result: ReturnType<typeof classifyPreflightInventory>,
+) {
+  return {
+    capabilities: result.capabilities,
+    agentExecutionPlans: result.agentExecutionPlans,
+    identity: result.identity,
+    versions: result.versions,
+    heads: result.heads,
+    runs: result.runs,
+    checkpoints: result.checkpoints,
+    danglingHeads: result.danglingHeads,
+    dependencies: result.dependencies,
+  };
+}
+
+function testSchemaV3DomainsRemainByteStable(): void {
+  const version = canonicalVersion("v3-stability", null, false);
+  const runId = "00000000-0000-4000-8000-000000000199";
+  const options = classificationOptions();
+  const withoutSnapshot = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      versions: [version],
+      runs: [runRow(runId, version.id, true)],
+    }),
+    options,
+  );
+  const withInvalidSnapshot = classifyPreflightInventory(
+    capabilities,
+    emptyInventory({
+      versions: [version],
+      runs: [
+        runRow(runId, version.id, true, {
+          launchSnapshot: {
+            schemaVersion: 1,
+            framework: "claude-code",
+            runnerProfile: "vm0/default",
+            unexpected: true,
+          },
+          modelProvider: "future-provider",
+          selectedModel: "future-model",
+        }),
+      ],
+    }),
+    options,
+  );
+  assert.notDeepEqual(
+    withInvalidSnapshot.launchSnapshots,
+    withoutSnapshot.launchSnapshots,
+  );
+  assert.equal(
+    JSON.stringify(acceptedV3DomainProjection(withInvalidSnapshot)),
+    JSON.stringify(acceptedV3DomainProjection(withoutSnapshot)),
+  );
+}
+
 function testVersionHeadRunAndCheckpointClassifications(): void {
   const firstAgent = "00000000-0000-4000-8000-000000000201";
   const secondAgent = "00000000-0000-4000-8000-000000000202";
@@ -476,24 +557,18 @@ function testVersionHeadRunAndCheckpointClassifications(): void {
         }),
       ],
       runs: [
-        {
-          id: "00000000-0000-4000-8000-000000000211",
-          versionId: version.id,
-          versionPresent: true,
-        },
-        {
-          id: "00000000-0000-4000-8000-000000000212",
-          versionId: version.id,
-          versionPresent: true,
-        },
+        runRow("00000000-0000-4000-8000-000000000211", version.id, true),
+        runRow("00000000-0000-4000-8000-000000000212", version.id, true),
       ],
       checkpoints: [
         {
           id: "00000000-0000-4000-8000-000000000221",
+          runId: "00000000-0000-4000-8000-000000000211",
           snapshot: { agentComposeVersionId: version.id },
         },
         {
           id: "00000000-0000-4000-8000-000000000222",
+          runId: "00000000-0000-4000-8000-000000000212",
           snapshot: { agentComposeVersionId: version.id },
         },
       ],
@@ -514,19 +589,17 @@ function testVersionHeadRunAndCheckpointClassifications(): void {
     capabilities,
     emptyInventory({
       runs: [
-        {
-          id: "00000000-0000-4000-8000-000000000231",
-          versionId: missingHash,
-          versionPresent: false,
-        },
+        runRow("00000000-0000-4000-8000-000000000231", missingHash, false),
       ],
       checkpoints: [
         {
           id: "00000000-0000-4000-8000-000000000232",
+          runId: "00000000-0000-4000-8000-000000000231",
           snapshot: { agentComposeVersionId: missingHash },
         },
         {
           id: "00000000-0000-4000-8000-000000000233",
+          runId: "00000000-0000-4000-8000-000000000233",
           snapshot: { agentComposeVersionId: "invalid" },
         },
       ],
@@ -1723,9 +1796,38 @@ function testOutputRedaction(): void {
     "checkpoints",
     "danglingHeads",
     "dependencies",
+    "launchSnapshots",
   ]);
   assert.deepEqual(outputPaths(result), [...PREFLIGHT_OUTPUT_ALLOWLIST]);
   assertSafeAggregateValues(result);
+
+  const invalidOutput = {
+    ...result,
+    launchSnapshots: {
+      ...result.launchSnapshots,
+      unexpected: "never-emit-invalid-output-value",
+    },
+  };
+  assert.throws(
+    () => {
+      assertPreflightOutputShape(invalidOutput);
+    },
+    (error: unknown) => {
+      assert.ok(error instanceof SanitizedPreflightError);
+      assert.deepEqual(sanitizedFailureResult(error), {
+        schemaVersion: "vm0.agent-compose-consolidation-preflight.v4",
+        status: "failed",
+        failureGates: ["probe.output_shape"],
+      });
+      assert.equal(
+        JSON.stringify(sanitizedFailureResult(error)).includes(
+          "never-emit-invalid-output-value",
+        ),
+        false,
+      );
+      return true;
+    },
+  );
 }
 
 function assertSafeAggregateValues(value: unknown, pathPrefix = ""): void {
@@ -1756,7 +1858,7 @@ function assertSafeAggregateValues(value: unknown, pathPrefix = ""): void {
     return;
   }
   const allowedClassifications = new Set([
-    "vm0.agent-compose-consolidation-preflight.v3",
+    "vm0.agent-compose-consolidation-preflight.v4",
     "passed",
     "failed",
     "exact",
@@ -2176,9 +2278,9 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
   );
   assert.match(workflow, /scripts\/agent-compose-consolidation-preflight\.ts/u);
   assert.match(workflow, /#27613 \+ #27656 \+ #27671 \+ #27792/u);
-  assert.match(workflow, /vm0\.agent-compose-consolidation-preflight\.v3/u);
+  assert.match(workflow, /vm0\.agent-compose-consolidation-preflight\.v4/u);
   assert.equal(
-    /vm0\.agent-compose-consolidation-preflight\.v[12]/u.test(workflow),
+    /vm0\.agent-compose-consolidation-preflight\.v[123]/u.test(workflow),
     false,
   );
   assert.equal(
@@ -2186,6 +2288,29 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
     false,
   );
   assert.equal(/--apply|fallback|REPORT_PATH/iu.test(workflow), false);
+
+  const preflightSource = await fs.readFile(
+    path.join(
+      repositoryRoot,
+      "turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts",
+    ),
+    "utf8",
+  );
+  assert.match(
+    preflightSource,
+    /BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY/u,
+  );
+  assert.match(preflightSource, /const DEFAULT_LOCK_TIMEOUT_MS = 1000;/u);
+  assert.match(
+    preflightSource,
+    /const DEFAULT_STATEMENT_TIMEOUT_MS = 30_000;/u,
+  );
+  assert.equal(
+    /\b(?:UPDATE|INSERT|DELETE|CREATE|ALTER|DROP|TRUNCATE|LOCK TABLE|pg_advisory_)\b/iu.test(
+      preflightSource,
+    ),
+    false,
+  );
 
   const service = await fs.readFile(
     path.join(
@@ -2230,6 +2355,21 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
   assert.equal(
     contentOwner.includes("APPLICATION_OWNED_AGENT_EXECUTION_PLAN"),
     true,
+  );
+}
+
+async function testConnectionFailureIsSanitized(): Promise<void> {
+  await assert.rejects(
+    executeAgentComposeConsolidationPreflight({
+      connectionString: "postgresql://127.0.0.1:1/preflight",
+      repositoryRoot,
+    }),
+    (error: unknown) => {
+      return (
+        error instanceof SanitizedPreflightError &&
+        error.gate === "probe.database_connection"
+      );
+    },
   );
 }
 
@@ -2343,23 +2483,30 @@ async function testDatabaseBoundariesForTimeZone(
         },
       );
 
+      const cancellationClient = new Client({ connectionString: testUrl });
+      await cancellationClient.connect();
       const abortController = new AbortController();
-      abortController.abort();
-      await assert.rejects(
-        withReadOnlySnapshot(
-          client,
-          { signal: abortController.signal },
-          async () => {
-            return undefined;
-          },
-        ),
-        (error: unknown) => {
-          return (
-            error instanceof SanitizedPreflightError &&
-            error.gate === "probe.cancelled"
-          );
+      let signalQueryStarted = (): void => {};
+      const queryStarted = new Promise<void>((resolve) => {
+        signalQueryStarted = resolve;
+      });
+      const cancelledQuery = withReadOnlySnapshot(
+        cancellationClient,
+        { signal: abortController.signal },
+        async () => {
+          signalQueryStarted();
+          await cancellationClient.query("SELECT pg_sleep(30)");
         },
       );
+      await queryStarted;
+      abortController.abort();
+      await assert.rejects(cancelledQuery, (error: unknown) => {
+        return (
+          error instanceof SanitizedPreflightError &&
+          error.gate === "probe.cancelled"
+        );
+      });
+      await cancellationClient.end().catch(() => {});
 
       const concurrentAgentId = "00000000-0000-4000-8000-000000027613";
       const firstHead = "a".repeat(64);
@@ -2736,6 +2883,8 @@ async function testDatabaseBoundaries(databaseUrl: string): Promise<void> {
 }
 
 export async function validateAgentComposeConsolidationPreflightStatic(): Promise<void> {
+  await validateLaunchSnapshotRecoverabilityStatic();
+  testSchemaV3DomainsRemainByteStable();
   testApplicationOwnedPlanAndCanonicalCompatibility();
   testIdentityAndApprovedArtifacts();
   testVersionHeadRunAndCheckpointClassifications();
@@ -2748,6 +2897,7 @@ export async function validateAgentComposeConsolidationPreflightStatic(): Promis
   testDependencyDriftAndDeterminism();
   testOutputRedaction();
   await testRepositoryAndWorkflowValidators();
+  await testConnectionFailureIsSanitized();
 }
 
 export async function validateAgentComposeConsolidationPreflight(): Promise<void> {

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -459,8 +459,9 @@ function runRow(
     launchSnapshot: null,
     modelProvider: null,
     selectedModel: null,
-    triggerSource: "api",
+    triggerSource: "slack",
     chatThreadPresent: false,
+    metadataShape: "product",
     ...overrides,
   };
 }
@@ -2673,6 +2674,18 @@ async function testDatabaseBoundariesForTimeZone(
           expectedDanglingHeadCount: 1,
         },
       });
+      assert.equal(
+        attributed.launchSnapshots.dispositions.historical_unknown.count,
+        1,
+      );
+      assert.equal(
+        attributed.launchSnapshots.dispositions.integrity_conflict.count,
+        0,
+      );
+      assert.equal(
+        attributed.launchSnapshots.reasons.framework_provider_missing.count,
+        1,
+      );
       const activity =
         attributed.agentExecutionPlans.refinements.systemEnvironmentDifferences
           .activity.parent;


### PR DESCRIPTION
## Summary

- extend the protected Agent/Compose consolidation preflight additively from schema v3 to strict schema v4
- partition every Run into `already_valid`, `exactly_recoverable`, `historical_unknown`, or `integrity_conflict` using only immutable same-Run evidence
- add fixed reason aggregates, population/partition/disjointness/union/reason closures, runtime output-shape validation, and sanitized fail-closed gates
- preserve all accepted schema-v3 domains and digest semantics byte-for-byte while adding only bounded v4 aggregates

## Historical evidence boundaries

- use the reviewed live Run lower bound to prove the unchanged `vm0/default` profile rule and fail closed if an earlier Run appears
- treat the complete Web production rollout of provider-overrides-Compose dispatch as transition/unknown unless both possible frameworks agree or a same-Run conversation proves the result
- isolate provider/model history from the live catalog, including the Flash/Pro framework rollout and retirement intervals
- treat every potentially eligible Pi interval from the first transient-callback rollout onward as historical unknown without same-Run conversation evidence, using production promotion boundaries rather than commit timestamps
- parse checkpoint version references strictly, require Run/checkpoint agreement, verify referenced content hashes, and never infer ownership from shared version insertion provenance

## Safe v4 output

- fixed schema keys only: total, population count/digest, four disposition count/digests, forty-three fixed reason count/digests, and seven closure comparisons
- no row-level identifiers, content, hashes, provider/model/profile labels, timestamps, samples, or other reversible values
- fixed failure gates for integrity conflicts, closure drift, reviewed-history boundary drift, invalid output shape, cancellation, and existing probe failures
- repeatable-read read-only transaction, 1-second lock timeout, 30-second statement timeout, and in-flight query cancellation by terminating the probe-owned connection

## Verification

- `pnpm exec prettier --check packages/db/scripts/agent-compose-consolidation-preflight-launch-snapshots.ts packages/db/scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts packages/db/scripts/agent-compose-consolidation-preflight-fingerprint.ts packages/db/scripts/agent-compose-consolidation-preflight.ts packages/db/scripts/test-agent-compose-consolidation-preflight.ts ../.github/workflows/agent-compose-consolidation-preflight.yml`
- `pnpm --filter @okouai/db lint`
- `pnpm --filter @okouai/db check-types`
- `pnpm --filter @okouai/db exec tsx scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts`
- no-DB static execution of `validateAgentComposeConsolidationPreflightStatic()`
- `PATH="/usr/lib/postgresql/18/bin:$PATH" DATABASE_URL="postgresql://postgres@127.0.0.1:55440/postgres" pnpm --filter @okouai/db test:migration-consistency` against a fresh mktemp-owned isolated PostgreSQL 18 cluster (exit 0; read-only, timeout, cancellation, and migration/schema checks passed)

## Publication baseline

- merged latest `main` at `a1721545aff43ebc73d0e9d048a512d8777a36b8`
- reviewed head: `bff1443a791e1b5e57d255a711c007c6b066c9ba`
- the post-merge PR patch ID remains `c6646ab1e3d074b6b10b359d3ca38e750d8d51ad`, identical to the previously reviewed patch; the six preflight/workflow files have no branch-only delta from the prior reviewed head
- the publication-time paginated inventory at the prior baseline covered 26 open PRs and 379 files, including both pages of the 185-file #25722; no external PR overlapped the dedicated workflow or preflight script paths
- no migration, schema, writer, runtime, dependency, lockfile, or product-behavior change

Closes #27802

Parent #26938
