### PR TITLE
fix(api): patch transitive deepmerge-ts dependency

### DIFF
--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -56,6 +56,7 @@ overrides:
   form-data: '>=4.0.6'
   glob: '>=10.5.0'
   hono: 4.13.0
+  html-to-text>deepmerge-ts: 8.0.1
   ip-address: 10.4.0
   jayson>uuid: 11.1.1
   js-cookie: '>=3.0.7'
@@ -6719,8 +6720,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   defaults@1.0.4:
@@ -17297,7 +17298,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   defaults@1.0.4:
     dependencies:
@@ -18516,7 +18517,7 @@ snapshots:
   html-to-text@10.0.0:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.12.0(selderee@0.12.0)
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       dom-serializer: 2.0.0
       htmlparser2: 10.1.0
       selderee: 0.12.0

--- a/turbo/pnpm-workspace.yaml
+++ b/turbo/pnpm-workspace.yaml
@@ -77,6 +77,7 @@ overrides:
   form-data: ">=4.0.6"
   glob: ">=10.5.0"
   hono: 4.13.0
+  "html-to-text>deepmerge-ts": 8.0.1
   ip-address: 10.4.0
   "jayson>uuid": 11.1.1
   js-cookie: ">=3.0.7"


### PR DESCRIPTION
## Summary

- add a parent-scoped pnpm override for `html-to-text > deepmerge-ts` at `8.0.1`
- regenerate the lockfile so the API production edge resolves only the patched release
- keep the mail draft and Teams HTML conversion source unchanged after compatibility validation

## Security result

- `api -> html-to-text@10.0.0 -> deepmerge-ts@8.0.1`
- no `deepmerge-ts` version below `8.0.0` remains in `turbo/pnpm-lock.yaml`
- the production pnpm audit reports no known vulnerabilities

## Verification

- `pnpm audit --prod --ignore-registry-errors` — passed (`No known vulnerabilities found`)
- `pnpm --filter api why deepmerge-ts` — one version: `deepmerge-ts@8.0.1` under `html-to-text@10.0.0`
- `pnpm format` — passed
- `pnpm turbo run lint --concurrency=1 --log-order grouped` — 13/13 tasks passed
- `pnpm knip` — passed (46 existing configuration hints)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` — 12/12 tasks passed
- `pnpm --filter @okouai/app run check-types` — passed
- `pnpm --filter api run check-types` — passed, including API boundary and test graph checks
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/mail.test.ts -t "links without injecting a duplicate card and sends without rebuilding MIME"` — 1 passed, 11 skipped
- direct `html-to-text` runtime probe — ordinary conversion and custom `img` formatter/selectors both passed
- `git diff --check` — passed

## Baseline test note

The additional Teams history test `includes recent Teams personal messages in the run context` stops before its text assertions because runner claim returns `404 Job not found in queue`. The exact invocation fails identically in a detached, unmodified `origin/main` worktree using the original `deepmerge-ts@7.1.5`, so this is not introduced by the dependency override.

Closes #27804

Unblocks #27805. Part of #27599.
