### PR TITLE
feat(image): apply the run image model as a default

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -11,7 +11,10 @@ import {
 import { replayChatThreadEvents } from "@okouai/core/chat-thread-event-replay";
 import { avatarTemplateStylePresetId } from "@okouai/core/avatar-template";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { DEFAULT_IMAGE_MODEL } from "@okouai/core/image-model-catalog";
+import {
+  DEFAULT_IMAGE_MODEL,
+  DEFAULT_IMAGE_MODEL_ENV,
+} from "@okouai/core/image-model-catalog";
 import { DEFAULT_VIDEO_MODEL } from "@okouai/core/video-model-catalog";
 import {
   chatEventsContract,
@@ -11049,8 +11052,9 @@ async function imageModelSnapshotActor(args: {
   readonly actor: ApiTestUser;
   readonly agentId: string;
   readonly orgId: string;
+  readonly runnerGroup: string;
 }> {
-  const { actor, agentId } = await entitledChatActor();
+  const { actor, agentId, runnerGroup } = await entitledChatActor();
   const orgId = actor.orgId;
   if (!orgId) {
     throw new Error("Expected an entitled chat actor to own an org");
@@ -11060,12 +11064,12 @@ async function imageModelSnapshotActor(args: {
     { ...actor, orgId },
     { [FeatureSwitchKey.ImageModelSelection]: args.selectionEnabled },
   );
-  return { actor, agentId, orgId };
+  return { actor, agentId, orgId, runnerGroup };
 }
 
 describe("CHAT-02: run image model snapshot", () => {
   it("keeps the run snapshot null while image model selection is disabled", async () => {
-    const { actor, agentId } = await imageModelSnapshotActor({
+    const { actor, agentId, runnerGroup } = await imageModelSnapshotActor({
       selectionEnabled: false,
     });
 
@@ -11076,6 +11080,9 @@ describe("CHAT-02: run image model snapshot", () => {
     await expect(
       readRunImageModelSnapshotFixture(anchor.runId),
     ).resolves.toBeNull();
+    expect(
+      (await api.readRun(actor, anchor.runId)).appendSystemPrompt ?? "",
+    ).not.toContain("# Default built-in image model");
     await cancelChatRun(actor, anchor.runId);
 
     await chat.updateUserModelPreference(actor, null, "gpt-image-2");
@@ -11092,11 +11099,18 @@ describe("CHAT-02: run image model snapshot", () => {
     await expect(
       readRunImageModelSnapshotFixture(continued.runId),
     ).resolves.toBeNull();
+    const { claim: disabledClaim } = await claimChatRun(
+      runnerGroup,
+      continued.runId,
+    );
+    expect(
+      claimEnvironment(disabledClaim)[DEFAULT_IMAGE_MODEL_ENV],
+    ).toBeUndefined();
     await cancelChatRun(actor, continued.runId);
   }, 90_000);
 
   it("resolves thread, member, and global image defaults into stable snapshots", async () => {
-    const { actor, agentId } = await imageModelSnapshotActor({
+    const { actor, agentId, runnerGroup } = await imageModelSnapshotActor({
       selectionEnabled: true,
     });
 
@@ -11144,6 +11158,21 @@ describe("CHAT-02: run image model snapshot", () => {
     await expect(
       readRunImageModelSnapshotFixture(threadPinned.runId),
     ).resolves.toBe(initialThreadPin);
+    const threadPinnedPrompt =
+      (await api.readRun(actor, threadPinned.runId)).appendSystemPrompt ?? "";
+    expect(threadPinnedPrompt).toContain("# Default built-in image model");
+    expect(threadPinnedPrompt).toContain(
+      "This run's default built-in image model is `seedream4`.",
+    );
+    expect(threadPinnedPrompt).toContain(
+      "Only when the current user request explicitly names another supported built-in image model, pass `--model <model>`.",
+    );
+    expect(threadPinnedPrompt).toContain(
+      "Otherwise omit `--model`; the server applies `seedream4`.",
+    );
+    expect(threadPinnedPrompt).toContain(
+      "Image generation through a connected third-party service chooses its model separately; this default does not apply to that path.\n\n# Restricted Explicit Content",
+    );
     await cancelChatRun(actor, threadPinned.runId);
 
     const rePinned = await sendChatRun(actor, {
@@ -11154,6 +11183,13 @@ describe("CHAT-02: run image model snapshot", () => {
     await expect(
       readRunImageModelSnapshotFixture(rePinned.runId),
     ).resolves.toBe(nextThreadPin);
+    const { claim: rePinnedClaim } = await claimChatRun(
+      runnerGroup,
+      rePinned.runId,
+    );
+    expect(claimEnvironment(rePinnedClaim)[DEFAULT_IMAGE_MODEL_ENV]).toBe(
+      "nano-banana-2",
+    );
     await cancelChatRun(actor, rePinned.runId);
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -8,6 +8,7 @@ import {
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { testContext } from "../../../__tests__/test-context";
@@ -30,12 +31,14 @@ import {
 } from "../../../test-fixtures/system-config-seeds";
 import { seedOrgMembership$ } from "./helpers/org-membership";
 import { seedCompose$, seedRun$ } from "./helpers/usage-state";
+import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import {
   generatedStripeCustomerId,
   postUsageAllowanceInvoicePaid,
 } from "./helpers/stripe-billing-webhook";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import { setRunImageModelFixture } from "../../../test-fixtures/run-image-model";
 
 const context = testContext();
 const store = createStore();
@@ -493,6 +496,35 @@ async function seedImageFixture(options: {
   return fixture;
 }
 
+async function seedImageRun(
+  fixture: ImageFixture,
+  options: {
+    readonly imageModelSelectionEnabled: boolean;
+    readonly selectedImageModel: string | null;
+  },
+): Promise<{ readonly runId: string }> {
+  const { composeId } = await store.set(
+    seedCompose$,
+    { orgId: fixture.orgId, userId: fixture.userId },
+    context.signal,
+  );
+  const { runId } = await store.set(
+    seedRun$,
+    {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      composeId,
+      triggerSource: "web",
+    },
+    context.signal,
+  );
+  await setRunImageModelFixture(runId, options.selectedImageModel);
+  await updateFeatureSwitchesForUser(context, fixture, {
+    [FeatureSwitchKey.ImageModelSelection]: options.imageModelSelectionEnabled,
+  });
+  return { runId };
+}
+
 describe("POST /api/zero/image-io/generate", () => {
   let releasePendingFalResponse: (() => void) | null = null;
 
@@ -614,6 +646,176 @@ describe("POST /api/zero/image-io/generate", () => {
       },
     });
     expect(calledFal).toBeFalsy();
+  });
+
+  it("uses the stable run snapshot for omitted and blank models", async () => {
+    const fixture = await seedImageFixture({});
+    const pricingFixture = await createScopedImagePricing({
+      configured: QWEN_IMAGE_PRICING,
+    });
+    const { runId } = await seedImageRun(fixture, {
+      imageModelSelectionEnabled: true,
+      selectedImageModel: "fal-ai/qwen-image",
+    });
+
+    let falCalls = 0;
+    server.use(
+      http.post(FAL_QWEN_IMAGE_URL, () => {
+        falCalls += 1;
+        return HttpResponse.json(falQueueHandle(`run-default-${falCalls}`));
+      }),
+    );
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId,
+    });
+    const app = createImageIoTestApp(pricingFixture.resolution);
+    const prompts = ["omitted model prompt", "blank model prompt"];
+
+    for (const [index, prompt] of prompts.entries()) {
+      const response = await app.request("/api/zero/image-io/generate", {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          prompt,
+          ...(index === 0 ? {} : { model: "   " }),
+        }),
+      });
+      expect(response.status).toBe(202);
+    }
+
+    expect(falCalls).toBe(2);
+  });
+
+  it("preserves a valid explicit model and rejects an invalid explicit model", async () => {
+    const fixture = await seedImageFixture({});
+    const pricingFixture = await createScopedImagePricing({
+      configured: [...GPT_IMAGE_1_PRICING, ...QWEN_IMAGE_PRICING],
+    });
+    const { runId } = await seedImageRun(fixture, {
+      imageModelSelectionEnabled: true,
+      selectedImageModel: "fal-ai/qwen-image",
+    });
+    let gptCalls = 0;
+    let qwenCalls = 0;
+    server.use(
+      http.post(FAL_GPT_IMAGE_1_URL, () => {
+        gptCalls += 1;
+        return HttpResponse.json(falQueueHandle("explicit-gpt-image-1"));
+      }),
+      http.post(FAL_QWEN_IMAGE_URL, () => {
+        qwenCalls += 1;
+        return HttpResponse.json(falQueueHandle("unexpected-qwen"));
+      }),
+    );
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      runId,
+    });
+    const app = createImageIoTestApp(pricingFixture.resolution);
+
+    const explicitResponse = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        prompt: "explicit model parameters use the explicit model",
+        model: "gpt-image-1",
+        background: "transparent",
+        outputFormat: "webp",
+      }),
+    });
+    expect(explicitResponse.status).toBe(202);
+    expect(gptCalls).toBe(1);
+    expect(qwenCalls).toBe(0);
+
+    const invalidResponse = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        prompt: "invalid explicit model must not fall back",
+        model: "not-a-real-image-model",
+      }),
+    });
+    expect(invalidResponse.status).toBe(400);
+    await expect(invalidResponse.json()).resolves.toMatchObject({
+      error: {
+        message: expect.stringContaining(
+          "Unsupported image model: not-a-real-image-model",
+        ),
+        code: "BAD_REQUEST",
+      },
+    });
+    expect(gptCalls).toBe(1);
+    expect(qwenCalls).toBe(0);
+  });
+
+  it("keeps the global default for disabled, null, old, and session paths", async () => {
+    const pricingFixture = await createScopedImagePricing({
+      configured: GPT_IMAGE_1_PRICING,
+    });
+    let gptCalls = 0;
+    let qwenCalls = 0;
+    server.use(
+      http.post(FAL_GPT_IMAGE_1_URL, () => {
+        gptCalls += 1;
+        return HttpResponse.json(falQueueHandle(`global-default-${gptCalls}`));
+      }),
+      http.post(FAL_QWEN_IMAGE_URL, () => {
+        qwenCalls += 1;
+        return HttpResponse.json(falQueueHandle("unexpected-run-default"));
+      }),
+    );
+    const app = createImageIoTestApp(pricingFixture.resolution);
+
+    const runCases = [
+      {
+        imageModelSelectionEnabled: false,
+        selectedImageModel: "fal-ai/qwen-image",
+        prompt: "disabled switch",
+      },
+      {
+        imageModelSelectionEnabled: true,
+        selectedImageModel: null,
+        prompt: "null snapshot",
+      },
+      {
+        imageModelSelectionEnabled: true,
+        selectedImageModel: "fal-ai/retired-image-model",
+        prompt: "old snapshot",
+      },
+    ] as const;
+    for (const runCase of runCases) {
+      const fixture = await seedImageFixture({});
+      const { runId } = await seedImageRun(fixture, runCase);
+      const token = zeroToken({
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        runId,
+      });
+      const response = await app.request("/api/zero/image-io/generate", {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` },
+        body: JSON.stringify({ prompt: runCase.prompt }),
+      });
+      expect(response.status).toBe(202);
+    }
+
+    const sessionFixture = await seedImageFixture({});
+    await updateFeatureSwitchesForUser(context, sessionFixture, {
+      [FeatureSwitchKey.ImageModelSelection]: true,
+    });
+    mocks.clerk.session(sessionFixture.userId, sessionFixture.orgId);
+    const sessionResponse = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ prompt: "session request without a run" }),
+    });
+    expect(sessionResponse.status).toBe(202);
+
+    expect(gptCalls).toBe(4);
+    expect(qwenCalls).toBe(0);
   });
 
   it("returns 402 when the org has no spendable credits", async () => {

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -3,6 +3,15 @@ import { randomUUID } from "node:crypto";
 import { command } from "ccstate";
 import { zeroImageIoGenerateContract } from "@okouai/api-contracts/contracts/zero-image-io-generate";
 import type { BuiltInGenerationRealtimeSubscription } from "@okouai/api-contracts/contracts/built-in-generation";
+import { isImageModelId } from "@okouai/api-contracts/contracts/image-models";
+import { isFeatureEnabled } from "@okouai/core/feature-switch";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import {
+  DEFAULT_IMAGE_MODEL,
+  type ImageModel,
+} from "@okouai/core/image-model-catalog";
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { and, eq, isNotNull } from "drizzle-orm";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -10,6 +19,7 @@ import { bodyResultOf } from "../context/request";
 import { logger } from "../../lib/log";
 import type { RouteEntry } from "../route-entry";
 import { env } from "../../lib/env";
+import { db$, type ReadonlyDb } from "../external/db";
 import { createBuiltInGenerationRealtimeSubscription } from "../external/realtime";
 import {
   checkImageCredits$,
@@ -36,6 +46,7 @@ import {
   startRunBuiltInAdmission$,
   type RunBuiltInAdmission,
 } from "../services/run-built-in-admission.service";
+import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 
 const L = logger("ImageGeneration");
 const imageBody$ = bodyResultOf(zeroImageIoGenerateContract.post);
@@ -60,6 +71,50 @@ interface ImageJobArgs {
   readonly admission: RunBuiltInAdmission | null;
   readonly options: ImageOptions;
   readonly pricing: ImagePricing;
+}
+
+async function loadRunImageModelDefault(
+  db: ReadonlyDb,
+  orgId: string,
+  userId: string,
+  runId: string | undefined,
+  signal: AbortSignal,
+): Promise<ImageModel | null> {
+  if (!runId) {
+    return null;
+  }
+
+  const [run] = await db
+    .select({ selectedImageModel: agentRuns.selectedImageModel })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        eq(agentRuns.orgId, orgId),
+        eq(agentRuns.userId, userId),
+        isNotNull(agentRuns.triggerSource),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  if (!run) {
+    return null;
+  }
+  const featureSwitchContext = await loadUserFeatureSwitchContext(
+    db,
+    orgId,
+    userId,
+  );
+  signal.throwIfAborted();
+  if (
+    !isFeatureEnabled(
+      FeatureSwitchKey.ImageModelSelection,
+      featureSwitchContext,
+    )
+  ) {
+    return null;
+  }
+  return isImageModelId(run.selectedImageModel) ? run.selectedImageModel : null;
 }
 
 function isGenerationError(value: unknown): value is GenerationError {
@@ -172,13 +227,27 @@ const submitImageProviderWebhookJob$ = command(
 
 const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
+  const db = get(db$);
   const bodyResult = await get(imageBody$);
   signal.throwIfAborted();
   if (!bodyResult.ok) {
     return bodyResult.response;
   }
 
-  const options = parseImageOptions(bodyResult.data);
+  const runId =
+    auth.tokenType === "zero" || auth.tokenType === "sandbox"
+      ? auth.runId
+      : undefined;
+  const runImageModelDefault = await loadRunImageModelDefault(
+    db,
+    auth.orgId,
+    auth.userId,
+    runId,
+    signal,
+  );
+  const options = parseImageOptions(bodyResult.data, {
+    defaultModel: runImageModelDefault ?? DEFAULT_IMAGE_MODEL,
+  });
   if ("status" in options) {
     return options;
   }
@@ -219,10 +288,6 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     generationId,
   );
   signal.throwIfAborted();
-  const runId =
-    auth.tokenType === "zero" || auth.tokenType === "sandbox"
-      ? auth.runId
-      : undefined;
   const admission = await set(
     startRunBuiltInAdmission$,
     { runId, kind: "image" },

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -85,6 +85,11 @@ import {
   isFeatureEnabled,
   type FeatureSwitchContext,
 } from "@okouai/core/feature-switch";
+import {
+  DEFAULT_IMAGE_MODEL_ENV,
+  IMAGE_MODEL_CONFIGS,
+  type ImageModel,
+} from "@okouai/core/image-model-catalog";
 import { resolveSkillRef, parseGitHubTreeUrl } from "@okouai/core/github-url";
 import {
   getCustomConnectorSkillName,
@@ -420,12 +425,38 @@ function withPendingZeroTokenSecret(body: CreateRunBody): CreateRunBody {
   return withOkouTokenSecret(body, "__pending_okou_token__");
 }
 
+function defaultImageModelPrompt(model: ImageModel): string {
+  const alias = IMAGE_MODEL_CONFIGS[model].alias;
+  return [
+    "# Default built-in image model",
+    "",
+    `This run's default built-in image model is \`${alias}\`.`,
+    "- Only when the current user request explicitly names another supported built-in image model, pass `--model <model>`.",
+    `- Otherwise omit \`--model\`; the server applies \`${alias}\`.`,
+    "- Image generation through a connected third-party service chooses its model separately; this default does not apply to that path.",
+  ].join("\n");
+}
+
+function withDefaultImageModelEnvironment(
+  environment: Record<string, string> | undefined,
+  model: ImageModel | null,
+): Record<string, string> | undefined {
+  if (model === null) {
+    return environment;
+  }
+  return {
+    ...environment,
+    [DEFAULT_IMAGE_MODEL_ENV]: IMAGE_MODEL_CONFIGS[model].alias,
+  };
+}
+
 function withFinalRunAppendSystemPrompt(args: {
   readonly body: CreateRunBody;
   readonly framework: SupportedFramework;
   readonly chatThreadId: string | undefined;
   readonly imageRecognitionAvailable: boolean;
   readonly mcpConnectorSlugs: readonly string[];
+  readonly selectedImageModel: ImageModel | null;
   readonly zeroCliAvailable: boolean;
 }): CreateRunBody {
   const appendedParts: string[] = [];
@@ -444,6 +475,9 @@ function withFinalRunAppendSystemPrompt(args: {
     args.chatThreadId
   ) {
     appendedParts.push(CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT);
+  }
+  if (args.selectedImageModel !== null) {
+    appendedParts.push(defaultImageModelPrompt(args.selectedImageModel));
   }
   // Keep this policy last so custom and integration prompts cannot override it.
   appendedParts.push(RESTRICTED_EXPLICIT_CONTENT_PROMPT);
@@ -5828,7 +5862,7 @@ interface LaunchRunRowsArgs {
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly zeroRunModelPin: ZeroRunModelPin | undefined;
   readonly selectedVideoModel: string;
-  readonly selectedImageModel: string | null;
+  readonly selectedImageModel: ImageModel | null;
   readonly callbackRows: readonly AgentRunCallbackInsert[];
   readonly chatThreadId: string | undefined;
   readonly zeroRunMetadata: ZeroRunMetadata | undefined;
@@ -7679,7 +7713,10 @@ function buildAtomicLaunchPayload(
     zeroTokenCloudBrowserEnabled: args.createArgs.zeroTokenCloudBrowserEnabled,
     imageRecognitionAvailable: args.context.imageRecognitionAvailable,
     chatThreadId: args.createArgs.chatThreadId,
-    extraEnvironment: args.createArgs.extraEnvironment,
+    extraEnvironment: withDefaultImageModelEnvironment(
+      args.createArgs.extraEnvironment,
+      args.context.selectedImageModel,
+    ),
     userTimezone: args.context.userTimezone,
     featureSwitchContext: args.context.featureSwitchContext,
     timing: args.timing,
@@ -7741,8 +7778,8 @@ interface PreparedRunContext {
   readonly imageRecognitionAvailable: boolean;
   /** Snapshotted onto the run row; see `resolveVideoModelForRun`. */
   readonly selectedVideoModel: string;
-  /** Resolved once at run start and persisted without affecting generation. */
-  readonly selectedImageModel: string | null;
+  /** Resolved once at run start and used as the run's built-in image default. */
+  readonly selectedImageModel: ImageModel | null;
 }
 
 interface FinalizedPreparedRunContext extends PreparedRunContext {
@@ -9172,6 +9209,7 @@ function finalizePreparedRunContext(
       imageRecognitionAvailable: prepared.context.imageRecognitionAvailable,
       mcpConnectorSlugs:
         prepared.context.customConnectorContext.mcpConnectorSlugs,
+      selectedImageModel: prepared.context.selectedImageModel,
       zeroCliAvailable: prepared.args.includeZeroTokenSecret === true,
     }),
   };

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -767,8 +767,9 @@ function parsePrompt(
 
 function parseImageModel(
   body: Record<string, unknown>,
+  defaultModel: ImageModel,
 ): ImageModel | ErrorResponse {
-  const rawModel = readString(body, "model", DEFAULT_IMAGE_MODEL);
+  const rawModel = readString(body, "model", defaultModel);
   const model = normalizeImageModel(rawModel);
   if (!model) {
     return badRequest(
@@ -1064,12 +1065,21 @@ function parseImagePromptStrength(
   return undefined;
 }
 
-export function parseImageOptions(body: unknown): ImageOptions | ErrorResponse {
+function requestedDefaultImageModel(
+  options: { readonly defaultModel?: ImageModel } | undefined,
+): ImageModel {
+  return options?.defaultModel ?? DEFAULT_IMAGE_MODEL;
+}
+
+export function parseImageOptions(
+  body: unknown,
+  options?: { readonly defaultModel?: ImageModel },
+): ImageOptions | ErrorResponse {
   if (!isRecord(body)) {
     return badRequest("Invalid JSON body");
   }
 
-  const model = parseImageModel(body);
+  const model = parseImageModel(body, requestedDefaultImageModel(options));
   if (typeof model === "object") {
     return model;
   }

--- a/turbo/apps/api/src/test-fixtures/run-image-model.ts
+++ b/turbo/apps/api/src/test-fixtures/run-image-model.ts
@@ -2,9 +2,9 @@
  * Test fixtures for image-model states that production APIs cannot expose.
  *
  * Canonical member defaults and thread pins must use their production routes.
- * The routes intentionally reject retired IDs, while the run snapshot remains
- * write-only until its generation reader ships, so only those two transition
- * cases use controlled direct database access.
+ * The routes intentionally reject retired IDs, and endpoint fallback tests
+ * need run snapshot states without a public setter. Only those transition and
+ * endpoint cases use controlled direct database access.
  */
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
@@ -56,4 +56,14 @@ export async function readRunImageModelSnapshotFixture(
     throw new Error("Expected a product run row for the image model snapshot");
   }
   return run.selectedImageModel;
+}
+
+export async function setRunImageModelFixture(
+  runId: string,
+  selectedImageModel: string | null,
+): Promise<void> {
+  await db()
+    .update(agentRuns)
+    .set({ selectedImageModel })
+    .where(and(eq(agentRuns.id, runId), isNotNull(agentRuns.triggerSource)));
 }

--- a/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/image.test.ts
@@ -13,6 +13,7 @@ import chalk from "chalk";
 import { server } from "../../../mocks/server";
 import { generateCommand } from "../index";
 import { imageCommand } from "../image";
+import { DEFAULT_IMAGE_MODEL_ENV } from "@okouai/core/image-model-catalog";
 
 const IMAGE_URL = "http://localhost:3000/api/okou/image-io/generate";
 const IMAGE_GENERATION_ID = "00000000-0000-4000-8000-000000000001";
@@ -138,37 +139,57 @@ describe("okou generate image command", () => {
     {
       name: "outside a run with an implicit model",
       insideRun: false,
+      runDefaultImageModel: undefined,
       modelArguments: [],
       expectedModel: "gpt-image-1",
     },
     {
       name: "outside a run with an explicit model",
       insideRun: false,
+      runDefaultImageModel: undefined,
       modelArguments: ["--model", "qwen-image"],
       expectedModel: "qwen-image",
     },
     {
       name: "inside a run with an implicit model",
       insideRun: true,
+      runDefaultImageModel: undefined,
       modelArguments: [],
       expectedModel: undefined,
     },
     {
-      name: "inside a run with an explicit model",
+      name: "inside a gated run with an implicit model",
       insideRun: true,
+      runDefaultImageModel: "qwen-image",
+      modelArguments: [],
+      expectedModel: undefined,
+    },
+    {
+      name: "inside a gated run with an explicit model",
+      insideRun: true,
+      runDefaultImageModel: "seedream4",
       modelArguments: ["--model", "qwen-image"],
       expectedModel: "qwen-image",
     },
     {
-      name: "inside a run with an explicit value equal to the CLI default",
+      name: "inside a gated run with an explicit value equal to the CLI default",
       insideRun: true,
+      runDefaultImageModel: "qwen-image",
       modelArguments: ["--model", "gpt-image-1"],
       expectedModel: "gpt-image-1",
     },
   ])(
     "should serialize image model precedence for $name",
-    async ({ insideRun, modelArguments, expectedModel }) => {
+    async ({
+      insideRun,
+      runDefaultImageModel,
+      modelArguments,
+      expectedModel,
+    }) => {
       vi.stubEnv("OKOU_TOKEN", insideRun ? buildRunToken() : "test-token");
+      if (runDefaultImageModel !== undefined) {
+        vi.stubEnv(DEFAULT_IMAGE_MODEL_ENV, runDefaultImageModel);
+      }
       let capturedBody: unknown;
       server.use(
         http.post(IMAGE_URL, async ({ request }) => {
@@ -499,6 +520,50 @@ describe("okou generate image command", () => {
       "`--background` accepts only `auto`, `opaque`, or `transparent`",
     );
     expect(stdout).toContain("--compiled-prompt");
+  });
+
+  it("should keep style compilation on the run default unless a model is explicit", async () => {
+    vi.stubEnv(DEFAULT_IMAGE_MODEL_ENV, "seedream4");
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "image",
+      "--style",
+      "image-style:ink-storefront",
+      "--prompt",
+      "A florist named Luna Floral",
+      "--compile",
+    ]);
+
+    const implicitStdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(implicitStdout).toContain(
+      "Run default model if direct image generation is used: seedream4; omit --model so the server applies it",
+    );
+    expect(implicitStdout).not.toContain(
+      "Model preference if direct image generation is used: gpt-image-1",
+    );
+
+    mockConsoleLog.mockClear();
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "image",
+      "--style",
+      "image-style:ink-storefront",
+      "--prompt",
+      "A florist named Luna Floral",
+      "--compile",
+      "--model",
+      "qwen-image",
+    ]);
+
+    const explicitStdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(explicitStdout).toContain(
+      "Explicit model if direct image generation is used: qwen-image",
+    );
+    expect(explicitStdout).not.toContain(
+      "Run default model if direct image generation is used",
+    );
   });
 
   it("should print an R2-backed style packet when --style-source r2 is selected", async () => {

--- a/turbo/apps/cli/src/commands/generate/__tests__/sprite.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/sprite.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import chalk from "chalk";
+import { DEFAULT_IMAGE_MODEL_ENV } from "@okouai/core/image-model-catalog";
 import { generateCommand } from "../index";
 import { spriteCommand } from "../sprite";
 
@@ -77,6 +78,44 @@ describe("okou generate sprite command", () => {
     expect(stdout).toContain("- Asset type: agent decides");
     expect(stdout).toContain("- Sheet / grid: auto");
     expect(stdout).toContain("Use `gpt-image-2`");
+    expect(stdout).toContain("--model gpt-image-2 --raw-prompt");
+  });
+
+  it("should keep Sprite's implicit model inside a run with a default image model", async () => {
+    vi.stubEnv(DEFAULT_IMAGE_MODEL_ENV, "qwen-image");
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "sprite",
+      "--prompt",
+      "A fireball projectile",
+    ]);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain("Use `gpt-image-2`");
+    expect(stdout).toContain("--model gpt-image-2 --raw-prompt");
+    expect(stdout).not.toContain("Use the run default");
+    expect(stdout).not.toContain("--model qwen-image --raw-prompt");
+  });
+
+  it("should preserve Sprite's explicit model inside a gated run", async () => {
+    vi.stubEnv(DEFAULT_IMAGE_MODEL_ENV, "qwen-image");
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "sprite",
+      "--prompt",
+      "A fireball projectile",
+      "--model",
+      "seedream4",
+    ]);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain("Use `seedream4`");
+    expect(stdout).toContain("--model seedream4 --raw-prompt");
+    expect(stdout).not.toContain("Use the run default `qwen-image`");
   });
 
   it("should reject an unknown asset type", async () => {

--- a/turbo/apps/cli/src/commands/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/website.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import chalk from "chalk";
+import { DEFAULT_IMAGE_MODEL_ENV } from "@okouai/core/image-model-catalog";
 import { WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV } from "@okouai/core/resource-registry";
 import { generateCommand } from "../index";
 import { websiteCommand } from "../website";
@@ -118,6 +119,26 @@ describe("okou generate website command", () => {
     expect(stdout).toContain(
       "Embed the `Embed this URL in HTML` value returned by the generator",
     );
+  });
+
+  it("should keep seedream4 inside a run with a default image model", async () => {
+    vi.stubEnv(WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV, "latest");
+    vi.stubEnv(DEFAULT_IMAGE_MODEL_ENV, "qwen-image");
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "website",
+      "--prompt",
+      "observability launch site",
+    ]);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain(
+      "use `seedream4` by default unless the user specifies another image model",
+    );
+    expect(stdout).not.toContain("use `qwen-image` by default");
+    expect(stdout).not.toContain("run default image model");
   });
 
   it("should use the generated base slug when no stable site slug is provided", async () => {

--- a/turbo/apps/cli/src/commands/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/image-generate.ts
@@ -4,6 +4,7 @@ import { generateWebImage } from "../../lib/api/domains/web";
 import { decodeSandboxTokenPayload } from "../../lib/api/sandbox-token";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { createStyledImageCompilationPacket } from "./image-style-authoring";
+import { runDefaultImageModelFromEnvironment } from "./run-default-image-model";
 import {
   findImageStyle,
   listImageStyles,
@@ -144,9 +145,22 @@ function resolveImageRequestModel(
   command: Command,
   model: string,
 ): string | undefined {
-  const hasRunScopedToken = decodeSandboxTokenPayload() !== undefined;
   const modelSource = command.getOptionValueSource("model");
-  return hasRunScopedToken && modelSource === "default" ? undefined : model;
+  const hasRunDefault =
+    runDefaultImageModelFromEnvironment() !== undefined ||
+    decodeSandboxTokenPayload() !== undefined;
+  return hasRunDefault && modelSource === "default" ? undefined : model;
+}
+
+function imageModelPreferenceDetail(command: Command, model: string): string {
+  const runDefaultModel = runDefaultImageModelFromEnvironment();
+  if (runDefaultModel === undefined) {
+    return `Model preference if direct image generation is used: ${model}`;
+  }
+  if (command.getOptionValueSource("model") === "default") {
+    return `Run default model if direct image generation is used: ${runDefaultModel}; omit --model so the server applies it`;
+  }
+  return `Explicit model if direct image generation is used: ${model}`;
 }
 
 function hasImagePromptModeRequest(options: ImageOptions): boolean {
@@ -377,7 +391,7 @@ ${formatRegistryListing(styles, "image styles")}`;
             style,
             sourceMode: options.styleSource,
             details: [
-              `Model preference if direct image generation is used: ${options.model}`,
+              imageModelPreferenceDetail(command, options.model),
               `Requested size: ${options.size}`,
               `Requested quality: ${options.quality}`,
               `Requested background: ${options.background}`,

--- a/turbo/apps/cli/src/commands/shared/run-default-image-model.ts
+++ b/turbo/apps/cli/src/commands/shared/run-default-image-model.ts
@@ -1,0 +1,6 @@
+import { DEFAULT_IMAGE_MODEL_ENV } from "@okouai/core/image-model-catalog";
+
+export function runDefaultImageModelFromEnvironment(): string | undefined {
+  const model = process.env[DEFAULT_IMAGE_MODEL_ENV]?.trim();
+  return model ? model : undefined;
+}

--- a/turbo/packages/core/src/image-model-catalog.ts
+++ b/turbo/packages/core/src/image-model-catalog.ts
@@ -58,6 +58,9 @@ export const IMAGE_MODEL_CONFIGS = {
 
 export type ImageModel = ImageModelId;
 
+/** Reserved run environment key carrying the built-in image default alias. */
+export const DEFAULT_IMAGE_MODEL_ENV = "OKOU_DEFAULT_IMAGE_MODEL";
+
 /** All catalog models, in user-facing picker order. */
 export const IMAGE_MODELS: readonly ImageModel[] = IMAGE_MODEL_IDS;
 


### PR DESCRIPTION
## Summary

- Resolve the built-in image model with the authoritative order: a non-blank explicit request, then the current run's valid `selected_image_model` snapshot when `ImageModelSelection` is enabled, then `gpt-image-1`. Blank requests are treated as omitted, invalid explicit models still return HTTP 400, and model-specific options are validated against the effective model.
- Inject the reserved non-secret `OKOU_DEFAULT_IMAGE_MODEL` environment value and run-specific guidance for enabled runs. Direct `okou generate image` omits only Commander's implicit model while preserving explicit overrides; Website keeps `seedream4`, and Sprite keeps `gpt-image-2`.
- Keep `ImageModelSelection` globally disabled. Do not emit endpoint-resolution telemetry and do not restore run-snapshot telemetry.

## Test plan

- [x] `env -u OKOU_WEBSITE_TEMPLATE_ARCHIVE_VERSION pnpm exec vitest run apps/cli/src/commands/generate/__tests__/image.test.ts apps/cli/src/commands/generate/__tests__/website.test.ts apps/cli/src/commands/generate/__tests__/sprite.test.ts` — 44 passed
- [x] `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/image-io-generate.test.ts` — 23 passed
- [x] `env -u OKOU_WEBSITE_TEMPLATE_ARCHIVE_VERSION DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts -t "run image model snapshot|renders generation template guidance"` — 7 passed, 97 skipped by filter
- [x] `env -u OKOU_WEBSITE_TEMPLATE_ARCHIVE_VERSION DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts` — 14 passed
- [x] `pnpm --dir packages/core run check-types`
- [x] `pnpm --dir apps/cli run check-types`
- [x] `pnpm --dir apps/api run check-types`
- [x] `pnpm --dir packages/core run lint`
- [x] `pnpm --dir apps/cli run lint`
- [x] `pnpm --dir apps/api run lint` — exit 0; existing unrelated test warnings remain
- [x] Prettier write for every changed file, followed by `pnpm exec prettier --check <all changed files>`

## Fallback plan

`ImageModelSelection` remains globally disabled, so the new run-default path has no rollout until a later change enables it. If a regression is found, revert this PR to remove the endpoint, environment, prompt, and direct-image CLI changes together.

Compatibility fallbacks remain unchanged: disabled selection, null or retired snapshots, and PAT/session/no-run requests use `gpt-image-1`; missing `OKOU_DEFAULT_IMAGE_MODEL` preserves non-run CLI behavior; explicit invalid models still fail with HTTP 400. Website and Sprite retain their existing model defaults regardless of the run default.

Refs #27688
