### PR TITLE
fix(deps): override deepmerge-ts to >=8.0.0

### DIFF
--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -44,6 +44,7 @@ overrides:
   '@types/node': 24.3.0
   axios: '>=1.18.0'
   brace-expansion: 5.0.9
+  deepmerge-ts: '>=8.0.0'
   dompurify: 3.4.13
   esbuild: 0.28.1
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
@@ -6719,8 +6720,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   defaults@1.0.4:
@@ -10807,7 +10808,7 @@ packages:
     peerDependencies:
       '@types/node': 24.3.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: 0.28.1
+      esbuild: '>=0.28.1'
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -17297,7 +17298,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   defaults@1.0.4:
     dependencies:
@@ -18516,7 +18517,7 @@ snapshots:
   html-to-text@10.0.0:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.12.0(selderee@0.12.0)
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       dom-serializer: 2.0.0
       htmlparser2: 10.1.0
       selderee: 0.12.0

--- a/turbo/pnpm-workspace.yaml
+++ b/turbo/pnpm-workspace.yaml
@@ -65,6 +65,7 @@ overrides:
   "@types/node": 24.3.0
   axios: ">=1.18.0"
   brace-expansion: 5.0.9
+  deepmerge-ts: ">=8.0.0"
   dompurify: 3.4.13
   esbuild: 0.28.1
   "esbuild@>=0.17.0 <0.28.1": ">=0.28.1"


### PR DESCRIPTION
## What

Resolve `GHSA-ggr8-5vv4-36mx` by adding a pnpm override for `deepmerge-ts` to
`>=8.0.0`. `html-to-text@10.0.0` still depends on `deepmerge-ts@^7.1.5`, so this
bumps the transitive dependency to `8.0.1`.

## Why

`pnpm audit --prod` reports a high-severity vulnerability:

> DeepmergeTS has stack exhaustion when merging recursive object graphs

The vulnerable path is `apps/api > html-to-text > deepmerge-ts`.

## Changes

- `turbo/pnpm-workspace.yaml`: add `deepmerge-ts: ">=8.0.0"` to `pnpm.overrides`.
- `turbo/pnpm-lock.yaml`: regenerate the lockfile, resolving `deepmerge-ts@8.0.1`.

## Validation

```text
pnpm install --lockfile-only --frozen-lockfile --ignore-scripts
pnpm audit --prod --audit-level high
```

The production audit now reports:

```text
No known vulnerabilities found
```

## Out of scope

- No application code or `html-to-text` version changes.
- Advisories outside the reported `html-to-text > deepmerge-ts` path are not
  addressed here.
