### PR TITLE
fix(platform): pass credential id for personal model reconnect

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -507,13 +507,18 @@ function createModelSelection(
       if (status === undefined || status.status === "connected") {
         return;
       }
-      const mode =
-        status.status === "needs_reconnect" ? "reconnect" : "connect";
+      const authArgs =
+        status.status === "needs_reconnect"
+          ? {
+              mode: "reconnect" as const,
+              modelProviderId: status.credentialId,
+            }
+          : { mode: "connect" as const };
       if (status.providerType === "claude-code-oauth-token") {
-        await set(openClaudeCodeDeviceAuthDialogPersonal$, mode, signal);
+        await set(openClaudeCodeDeviceAuthDialogPersonal$, authArgs, signal);
         return;
       }
-      await set(openCodexDeviceAuthDialogPersonal$, mode, signal);
+      await set(openCodexDeviceAuthDialogPersonal$, authArgs, signal);
     },
   );
 

--- a/turbo/apps/platform/src/signals/zero-page/model-first-personal-oauth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/model-first-personal-oauth.ts
@@ -33,6 +33,7 @@ type PersonalModelProviderStatus =
       status: "needs_reconnect";
       providerType: PersonalOauthProviderType;
       modelLabel: string;
+      credentialId: string;
     };
 
 type PersonalModelProviderStatusByModel = Readonly<
@@ -66,17 +67,26 @@ function personalStatusForPolicy(
   }
 
   const provider = personalProviders.find((candidate) => {
-    return candidate.type === policy.defaultProviderType;
+    return (
+      candidate.type === policy.defaultProviderType &&
+      candidate.isActive !== false
+    );
   });
-  return {
+  const providerDetails = {
     providerType: policy.defaultProviderType,
     modelLabel: policy.modelLabel,
-    status: !provider
-      ? "missing"
-      : provider.needsReconnect
-        ? "needs_reconnect"
-        : "connected",
   };
+  if (!provider) {
+    return { ...providerDetails, status: "missing" };
+  }
+  if (provider.needsReconnect) {
+    return {
+      ...providerDetails,
+      status: "needs_reconnect",
+      credentialId: provider.id,
+    };
+  }
+  return { ...providerDetails, status: "connected" };
 }
 
 export const personalModelProvider$ = computed(

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -29,6 +29,10 @@ type OpenClaudeCodeDeviceAuthArgs =
       readonly modelProviderId?: string;
     };
 
+type OpenPersonalClaudeCodeDeviceAuthArgs =
+  | { readonly mode: "connect" }
+  | { readonly mode: "reconnect"; readonly modelProviderId: string };
+
 type ActiveClaudeCodeDeviceAuthFlowState = {
   readonly status: "pending";
   readonly requestId: string;
@@ -434,15 +438,28 @@ export const {
   run$: runClaudeCodeDeviceAuth$,
 } = createClaudeCodeDeviceAuthSignals("org", reloadOrgModelProviders$);
 
-export const {
-  dialogState$: claudeCodeDeviceAuthDialogStatePersonal$,
-  flowState$: claudeCodeDeviceAuthFlowStatePersonal$,
-  open$: openClaudeCodeDeviceAuthDialogPersonal$,
-  openApprovalPage$: openClaudeCodeDeviceAuthApprovalPagePersonal$,
-  setAuthorizationCode$: setClaudeCodeDeviceAuthAuthorizationCodePersonal$,
-  submit$: submitClaudeCodeDeviceAuthPersonal$,
-  close$: closeClaudeCodeDeviceAuthDialogPersonal$,
-  run$: runClaudeCodeDeviceAuthPersonal$,
-} = createClaudeCodeDeviceAuthSignals("personal", reloadPersonalModelProvider$);
+const personalClaudeCodeDeviceAuthSignals = createClaudeCodeDeviceAuthSignals(
+  "personal",
+  reloadPersonalModelProvider$,
+);
+
+export const claudeCodeDeviceAuthDialogStatePersonal$ =
+  personalClaudeCodeDeviceAuthSignals.dialogState$;
+export const claudeCodeDeviceAuthFlowStatePersonal$ =
+  personalClaudeCodeDeviceAuthSignals.flowState$;
+export const openClaudeCodeDeviceAuthDialogPersonal$: Command<
+  Promise<boolean>,
+  [OpenPersonalClaudeCodeDeviceAuthArgs, AbortSignal]
+> = personalClaudeCodeDeviceAuthSignals.open$;
+export const openClaudeCodeDeviceAuthApprovalPagePersonal$ =
+  personalClaudeCodeDeviceAuthSignals.openApprovalPage$;
+export const setClaudeCodeDeviceAuthAuthorizationCodePersonal$ =
+  personalClaudeCodeDeviceAuthSignals.setAuthorizationCode$;
+export const submitClaudeCodeDeviceAuthPersonal$ =
+  personalClaudeCodeDeviceAuthSignals.submit$;
+export const closeClaudeCodeDeviceAuthDialogPersonal$ =
+  personalClaudeCodeDeviceAuthSignals.close$;
+export const runClaudeCodeDeviceAuthPersonal$ =
+  personalClaudeCodeDeviceAuthSignals.run$;
 
 export type { ClaudeCodeDeviceAuthFlowState };

--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -32,6 +32,10 @@ type OpenCodexDeviceAuthArgs =
       readonly modelProviderId?: string;
     };
 
+type OpenPersonalCodexDeviceAuthArgs =
+  | { readonly mode: "connect" }
+  | { readonly mode: "reconnect"; readonly modelProviderId: string };
+
 type ActiveCodexDeviceAuthFlowState = {
   readonly status: "pending" | "polling";
   readonly requestId: string;
@@ -517,13 +521,23 @@ export const {
   run$: runCodexDeviceAuth$,
 } = createCodexDeviceAuthSignals("org", reloadOrgModelProviders$);
 
-export const {
-  dialogState$: codexDeviceAuthDialogStatePersonal$,
-  flowState$: codexDeviceAuthFlowStatePersonal$,
-  open$: openCodexDeviceAuthDialogPersonal$,
-  openApprovalPage$: openCodexDeviceAuthApprovalPagePersonal$,
-  close$: closeCodexDeviceAuthDialogPersonal$,
-  run$: runCodexDeviceAuthPersonal$,
-} = createCodexDeviceAuthSignals("personal", reloadPersonalModelProvider$);
+const personalCodexDeviceAuthSignals = createCodexDeviceAuthSignals(
+  "personal",
+  reloadPersonalModelProvider$,
+);
+
+export const codexDeviceAuthDialogStatePersonal$ =
+  personalCodexDeviceAuthSignals.dialogState$;
+export const codexDeviceAuthFlowStatePersonal$ =
+  personalCodexDeviceAuthSignals.flowState$;
+export const openCodexDeviceAuthDialogPersonal$: Command<
+  Promise<boolean>,
+  [OpenPersonalCodexDeviceAuthArgs, AbortSignal]
+> = personalCodexDeviceAuthSignals.open$;
+export const openCodexDeviceAuthApprovalPagePersonal$ =
+  personalCodexDeviceAuthSignals.openApprovalPage$;
+export const closeCodexDeviceAuthDialogPersonal$ =
+  personalCodexDeviceAuthSignals.close$;
+export const runCodexDeviceAuthPersonal$ = personalCodexDeviceAuthSignals.run$;
 
 export type { CodexDeviceAuthFlowState };

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -116,12 +116,18 @@ export const configureChatPageSelectedModel$ = command(
     if (status === undefined || status.status === "connected") {
       return;
     }
-    const mode = status.status === "needs_reconnect" ? "reconnect" : "connect";
+    const authArgs =
+      status.status === "needs_reconnect"
+        ? {
+            mode: "reconnect" as const,
+            modelProviderId: status.credentialId,
+          }
+        : { mode: "connect" as const };
     if (status.providerType === "claude-code-oauth-token") {
-      await set(openClaudeCodeDeviceAuthDialogPersonal$, mode, signal);
+      await set(openClaudeCodeDeviceAuthDialogPersonal$, authArgs, signal);
       return;
     }
-    await set(openCodexDeviceAuthDialogPersonal$, mode, signal);
+    await set(openCodexDeviceAuthDialogPersonal$, authArgs, signal);
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -2410,8 +2410,9 @@ describe("chat composer models", () => {
     });
   });
 
-  it("opens reconnect login for a stale personal Codex routed model", async () => {
+  it("reconnects the active personal Codex account from a new chat", async () => {
     const user = userEvent.setup({ delay: null });
+    let startBody: unknown;
     mockBillingCapabilities(
       { supportByok: true, restrictedVm0Models: false },
       "limited-free-1",
@@ -2429,7 +2430,19 @@ describe("chat composer models", () => {
     ]);
     context.mocks.data.personalModelProviders([
       buildProvider({
+        id: "00000000-0000-4000-a000-000000000402",
+        modelProviderId: "00000000-0000-4000-a000-000000000400",
+        isActive: false,
+        type: "codex-oauth-token",
+        framework: "codex",
+        secretName: null,
+        authMethod: "auth_json",
+        secretNames: ["CODEX_AUTH_JSON"],
+      }),
+      buildProvider({
         id: "00000000-0000-4000-a000-000000000403",
+        modelProviderId: "00000000-0000-4000-a000-000000000400",
+        isActive: true,
         type: "codex-oauth-token",
         framework: "codex",
         secretName: null,
@@ -2440,7 +2453,8 @@ describe("chat composer models", () => {
       }),
     ]);
     mockAgent();
-    context.mocks.api(codexDeviceAuthContract.start, ({ respond }) => {
+    context.mocks.api(codexDeviceAuthContract.start, ({ body, respond }) => {
+      startBody = body;
       return respond(200, {
         sessionToken: "mock-stale-codex-device-session",
         type: "codex",
@@ -2476,6 +2490,67 @@ describe("chat composer models", () => {
       screen.findByTestId("codex-device-auth-code"),
     ).resolves.toHaveTextContent("RECO-NNECT");
     expect(screen.getByText("Re-connect Codex")).toBeInTheDocument();
+    expect(startBody).toStrictEqual({
+      scope: "personal",
+      mode: "reconnect",
+      modelProviderId: "00000000-0000-4000-a000-000000000403",
+    });
+  });
+
+  it("reconnects personal Claude Code from an existing chat", async () => {
+    const user = userEvent.setup({ delay: null });
+    let startBody: unknown;
+    context.mocks.data.orgModelPolicies([
+      buildModelPolicy({
+        model: "claude-opus-4-8",
+        modelLabel: "Claude Opus 4.8",
+        isDefault: true,
+        defaultProviderType: "claude-code-oauth-token",
+        credentialScope: "member",
+      }),
+    ]);
+    context.mocks.data.personalModelProviders([
+      buildProvider({
+        id: "00000000-0000-4000-a000-000000000404",
+        type: "claude-code-oauth-token",
+        framework: "claude-code",
+        secretName: "CLAUDE_CODE_OAUTH_TOKEN",
+        needsReconnect: true,
+        lastRefreshErrorCode: "refresh_token_expired",
+      }),
+    ]);
+    mockAgent();
+    mockThread({ selectedModel: "claude-opus-4-8" });
+    context.mocks.api(
+      claudeCodeDeviceAuthContract.start,
+      ({ body, respond }) => {
+        startBody = body;
+        return respond(200, {
+          sessionToken: "mock-stale-claude-code-device-session",
+          type: "claude-code",
+          status: "pending",
+          scope: "personal",
+          browserUrl: "https://claude.ai/oauth/authorize",
+          expiresIn: 30,
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+    await expectComposerModel("Claude Opus 4.8");
+
+    await screen.findByText("Configure model");
+    await user.click(buttonContainingText("Configure model"));
+
+    await expect(
+      screen.findByTestId("claude-code-device-auth-code"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByText("Re-connect Claude Code")).toBeInTheDocument();
+    expect(startBody).toStrictEqual({
+      scope: "personal",
+      mode: "reconnect",
+      modelProviderId: "00000000-0000-4000-a000-000000000404",
+    });
   });
 
   it("completes personal Claude Code auth from a routed model blocker", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -119,14 +119,18 @@ function connectedPersonalClaudeCodeProvider(): ModelProviderResponse {
   };
 }
 
-function mockPersonalProvidersStory(role: "admin" | "member" = "member"): void {
+function mockPersonalProvidersStory(
+  role: "admin" | "member" = "member",
+  onCodexStart?: (body: unknown) => void,
+): void {
   context.mocks.data.org({
     id: "org_1",
     name: "Test Org",
     role,
   });
   context.mocks.data.personalModelProviders([stalePersonalCodexProvider()]);
-  context.mocks.api(codexDeviceAuthContract.start, ({ respond }) => {
+  context.mocks.api(codexDeviceAuthContract.start, ({ body, respond }) => {
+    onCodexStart?.(body);
     return respond(200, {
       sessionToken: "mock-personal-codex-device-session",
       type: "codex",
@@ -815,7 +819,10 @@ describe("personal model providers settings", () => {
   });
 
   it("opens reconnect login from a stale personal Codex credential", async () => {
-    mockPersonalProvidersStory();
+    let startBody: unknown;
+    mockPersonalProvidersStory("member", (body) => {
+      startBody = body;
+    });
     await openModelSettings();
 
     const codexRow = await screen.findByTestId("oauth-card-codex-oauth-token");
@@ -832,6 +839,11 @@ describe("personal model providers settings", () => {
       for (const deviceAuthCode of deviceAuthCodes) {
         expect(deviceAuthCode).toHaveTextContent("PERS-1234");
       }
+    });
+    expect(startBody).toStrictEqual({
+      scope: "personal",
+      mode: "reconnect",
+      modelProviderId: "00000000-0000-4000-a000-000000000301",
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -537,9 +537,14 @@ function LegacyOAuthCredentialsSection() {
       openBillingPlans();
       return;
     }
-    const mode = claudeCode?.needsReconnect ? "reconnect" : "connect";
+    const args = claudeCode?.needsReconnect
+      ? {
+          mode: "reconnect" as const,
+          modelProviderId: claudeCode.id,
+        }
+      : { mode: "connect" as const };
     detach(
-      openClaudeCodeDeviceAuthDialog({ mode }, pageSignal),
+      openClaudeCodeDeviceAuthDialog(args, pageSignal),
       Reason.DomCallback,
     );
   };
@@ -548,8 +553,13 @@ function LegacyOAuthCredentialsSection() {
       openBillingPlans();
       return;
     }
-    const mode = openAI?.needsReconnect ? "reconnect" : "connect";
-    detach(openCodexDeviceAuthDialog({ mode }, pageSignal), Reason.DomCallback);
+    const args = openAI?.needsReconnect
+      ? {
+          mode: "reconnect" as const,
+          modelProviderId: openAI.id,
+        }
+      : { mode: "connect" as const };
+    detach(openCodexDeviceAuthDialog(args, pageSignal), Reason.DomCallback);
   };
 
   return (

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -44,6 +44,7 @@ overrides:
   '@types/node': 24.3.0
   axios: '>=1.18.0'
   brace-expansion: 5.0.9
+  deepmerge-ts@<8.0.0: '>=8.0.0'
   dompurify: 3.4.13
   esbuild: 0.28.1
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
@@ -6719,8 +6720,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   defaults@1.0.4:
@@ -17297,7 +17298,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   defaults@1.0.4:
     dependencies:
@@ -18516,7 +18517,7 @@ snapshots:
   html-to-text@10.0.0:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.12.0(selderee@0.12.0)
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       dom-serializer: 2.0.0
       htmlparser2: 10.1.0
       selderee: 0.12.0

--- a/turbo/pnpm-workspace.yaml
+++ b/turbo/pnpm-workspace.yaml
@@ -65,6 +65,7 @@ overrides:
   "@types/node": 24.3.0
   axios: ">=1.18.0"
   brace-expansion: 5.0.9
+  "deepmerge-ts@<8.0.0": ">=8.0.0"
   dompurify: 3.4.13
   esbuild: 0.28.1
   "esbuild@>=0.17.0 <0.28.1": ">=0.28.1"


### PR DESCRIPTION
## Summary

- pass the active personal credential ID when reconnecting Codex or Claude Code from new and existing chats
- require personal reconnect callers to provide the exact credential ID at compile time and fix the legacy Settings entry points
- cover active multi-account selection plus new-chat, existing-chat, and Settings reconnect request bodies
- override vulnerable `deepmerge-ts` versions to resolve the newly published high-severity SCA advisory

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm check-types`
- `pnpm audit --prod --ignore-registry-errors`
- `pnpm --filter api exec tsx -e '<html-to-text conversion smoke test>'`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx --reporter=dot`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/personal-providers-tab.test.tsx --reporter=dot`

Fixes #27809
