### PR TITLE
test(api): enforce external behavior test boundary

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -66,10 +66,9 @@ import {
   setOrgMemberVideoModelFixture,
 } from "../../../test-fixtures/run-video-model";
 import {
-  readImageModelRunChatThreadIdFixture,
-  readRunImageModelFixture,
-  setChatThreadImageModelFixture,
-  setOrgMemberImageModelFixture,
+  readRunImageModelSnapshotFixture,
+  setRetiredChatThreadImageModelFixture,
+  setRetiredOrgMemberImageModelFixture,
 } from "../../../test-fixtures/run-image-model";
 import {
   createBddApi,
@@ -11125,7 +11124,7 @@ async function imageModelSnapshotActor(args: {
 
 describe("CHAT-02: run image model snapshot", () => {
   it("keeps the run snapshot null while image model selection is disabled", async () => {
-    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+    const { actor, agentId } = await imageModelSnapshotActor({
       selectionEnabled: false,
     });
 
@@ -11133,26 +11132,30 @@ describe("CHAT-02: run image model snapshot", () => {
       agentId,
       prompt: "image snapshot stays dormant for a new thread",
     });
-    await expect(readRunImageModelFixture(anchor.runId)).resolves.toBeNull();
+    await expect(
+      readRunImageModelSnapshotFixture(anchor.runId),
+    ).resolves.toBeNull();
     await cancelChatRun(actor, anchor.runId);
 
-    await setOrgMemberImageModelFixture({
-      orgId,
-      userId: actor.userId,
-      selectedImageModel: "gpt-image-2",
-    });
-    await setChatThreadImageModelFixture(anchor.threadId, "fal-ai/qwen-image");
+    await chat.updateUserModelPreference(actor, null, "gpt-image-2");
+    await chat.updateThreadImageModel(
+      actor,
+      anchor.threadId,
+      "fal-ai/qwen-image",
+    );
     const continued = await sendChatRun(actor, {
       agentId,
       threadId: anchor.threadId,
       prompt: "image snapshot stays dormant for a continued thread",
     });
-    await expect(readRunImageModelFixture(continued.runId)).resolves.toBeNull();
+    await expect(
+      readRunImageModelSnapshotFixture(continued.runId),
+    ).resolves.toBeNull();
     await cancelChatRun(actor, continued.runId);
   }, 90_000);
 
   it("resolves thread, member, and global image defaults into stable snapshots", async () => {
-    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+    const { actor, agentId } = await imageModelSnapshotActor({
       selectionEnabled: true,
     });
 
@@ -11160,28 +11163,25 @@ describe("CHAT-02: run image model snapshot", () => {
       agentId,
       prompt: "image model comes from the vm0 global default",
     });
-    await expect(readRunImageModelFixture(globalDefault.runId)).resolves.toBe(
-      DEFAULT_IMAGE_MODEL,
-    );
+    await expect(
+      readRunImageModelSnapshotFixture(globalDefault.runId),
+    ).resolves.toBe(DEFAULT_IMAGE_MODEL);
     await cancelChatRun(actor, globalDefault.runId);
 
-    await setOrgMemberImageModelFixture({
-      orgId,
-      userId: actor.userId,
-      selectedImageModel: "fal-ai/qwen-image",
-    });
+    await chat.updateUserModelPreference(actor, null, "fal-ai/qwen-image");
     const memberDefault = await sendChatRun(actor, {
       agentId,
       threadId: globalDefault.threadId,
       prompt: "image model comes from the member default",
     });
-    await expect(readRunImageModelFixture(memberDefault.runId)).resolves.toBe(
-      "fal-ai/qwen-image",
-    );
+    await expect(
+      readRunImageModelSnapshotFixture(memberDefault.runId),
+    ).resolves.toBe("fal-ai/qwen-image");
     await cancelChatRun(actor, memberDefault.runId);
 
     const initialThreadPin = "fal-ai/bytedance/seedream/v4/text-to-image";
-    await setChatThreadImageModelFixture(
+    await chat.updateThreadImageModel(
+      actor,
       globalDefault.threadId,
       initialThreadPin,
     );
@@ -11190,15 +11190,19 @@ describe("CHAT-02: run image model snapshot", () => {
       threadId: globalDefault.threadId,
       prompt: "image model comes from the thread pin",
     });
-    await expect(readRunImageModelFixture(threadPinned.runId)).resolves.toBe(
-      initialThreadPin,
-    );
+    await expect(
+      readRunImageModelSnapshotFixture(threadPinned.runId),
+    ).resolves.toBe(initialThreadPin);
 
     const nextThreadPin = "fal-ai/nano-banana-2";
-    await setChatThreadImageModelFixture(globalDefault.threadId, nextThreadPin);
-    await expect(readRunImageModelFixture(threadPinned.runId)).resolves.toBe(
-      initialThreadPin,
+    await chat.updateThreadImageModel(
+      actor,
+      globalDefault.threadId,
+      nextThreadPin,
     );
+    await expect(
+      readRunImageModelSnapshotFixture(threadPinned.runId),
+    ).resolves.toBe(initialThreadPin);
     await cancelChatRun(actor, threadPinned.runId);
 
     const rePinned = await sendChatRun(actor, {
@@ -11206,9 +11210,9 @@ describe("CHAT-02: run image model snapshot", () => {
       threadId: globalDefault.threadId,
       prompt: "the next run sees the updated image model pin",
     });
-    await expect(readRunImageModelFixture(rePinned.runId)).resolves.toBe(
-      nextThreadPin,
-    );
+    await expect(
+      readRunImageModelSnapshotFixture(rePinned.runId),
+    ).resolves.toBe(nextThreadPin);
     await cancelChatRun(actor, rePinned.runId);
   }, 90_000);
 
@@ -11224,26 +11228,27 @@ describe("CHAT-02: run image model snapshot", () => {
     });
     await cancelChatRun(actor, anchor.runId);
 
-    await setOrgMemberImageModelFixture({
-      orgId,
-      userId: actor.userId,
-      selectedImageModel: "gpt-image-2",
-    });
-    await setChatThreadImageModelFixture(anchor.threadId, retiredImageModel);
+    await chat.updateUserModelPreference(actor, null, "gpt-image-2");
+    // Current preference routes reject retired IDs, so this test alone injects
+    // the historical stored values whose fallback behavior it exercises.
+    await setRetiredChatThreadImageModelFixture(
+      anchor.threadId,
+      retiredImageModel,
+    );
     const retiredThreadPin = await sendChatRun(actor, {
       agentId,
       threadId: anchor.threadId,
       prompt: "retired thread image model falls through to the member",
     });
     await expect(
-      readRunImageModelFixture(retiredThreadPin.runId),
+      readRunImageModelSnapshotFixture(retiredThreadPin.runId),
     ).resolves.toBe("gpt-image-2");
     await cancelChatRun(actor, retiredThreadPin.runId);
 
-    await setOrgMemberImageModelFixture({
+    await setRetiredOrgMemberImageModelFixture({
       orgId,
       userId: actor.userId,
-      selectedImageModel: retiredImageModel,
+      retiredImageModel,
     });
     const retiredEverywhere = await sendChatRun(actor, {
       agentId,
@@ -11251,20 +11256,16 @@ describe("CHAT-02: run image model snapshot", () => {
       prompt: "retired image defaults fall through to the vm0 default",
     });
     await expect(
-      readRunImageModelFixture(retiredEverywhere.runId),
+      readRunImageModelSnapshotFixture(retiredEverywhere.runId),
     ).resolves.toBe(DEFAULT_IMAGE_MODEL);
     await cancelChatRun(actor, retiredEverywhere.runId);
   }, 90_000);
 
   it("persists the image snapshot when dispatch fails before runner start", async () => {
-    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+    const { actor, agentId } = await imageModelSnapshotActor({
       selectionEnabled: true,
     });
-    await setOrgMemberImageModelFixture({
-      orgId,
-      userId: actor.userId,
-      selectedImageModel: "gpt-image-2",
-    });
+    await chat.updateUserModelPreference(actor, null, "gpt-image-2");
     mockOptionalEnv("RUNNER_DEFAULT_GROUP", undefined);
 
     const sent = await chat.requestSendEvent(
@@ -11280,20 +11281,16 @@ describe("CHAT-02: run image model snapshot", () => {
       throw new Error("Expected the failed dispatch to create a run");
     }
     expect(sent.body.status).toBe("failed");
-    await expect(readRunImageModelFixture(sent.body.runId)).resolves.toBe(
-      "gpt-image-2",
-    );
+    await expect(
+      readRunImageModelSnapshotFixture(sent.body.runId),
+    ).resolves.toBe("gpt-image-2");
   }, 90_000);
 
   it("persists the resolved image model on a queued run", async () => {
-    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+    const { actor, agentId } = await imageModelSnapshotActor({
       selectionEnabled: true,
     });
-    await setOrgMemberImageModelFixture({
-      orgId,
-      userId: actor.userId,
-      selectedImageModel: "fal-ai/qwen-image",
-    });
+    await chat.updateUserModelPreference(actor, null, "fal-ai/qwen-image");
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
 
     const blocker = await chat.requestSendEvent(
@@ -11315,16 +11312,16 @@ describe("CHAT-02: run image model snapshot", () => {
       throw new Error("Expected the second send to create a queued run");
     }
     expect(queued.body.status).toBe("queued");
-    await expect(readRunImageModelFixture(queued.body.runId)).resolves.toBe(
-      "fal-ai/qwen-image",
-    );
+    await expect(
+      readRunImageModelSnapshotFixture(queued.body.runId),
+    ).resolves.toBe("fal-ai/qwen-image");
 
     await cancelChatRun(actor, queued.body.runId);
     await cancelChatRun(actor, blocker.body.runId);
   }, 90_000);
 
   it("snapshots direct runs and re-resolves on session continuation", async () => {
-    const { actor, agentId, orgId } = await imageModelSnapshotActor({
+    const { actor, agentId } = await imageModelSnapshotActor({
       selectionEnabled: true,
     });
 
@@ -11333,18 +11330,11 @@ describe("CHAT-02: run image model snapshot", () => {
       prompt: "direct image model snapshot",
       modelProvider: "anthropic-api-key",
     });
-    await expect(
-      readImageModelRunChatThreadIdFixture(first.runId),
-    ).resolves.toBeNull();
-    await expect(readRunImageModelFixture(first.runId)).resolves.toBe(
+    await expect(readRunImageModelSnapshotFixture(first.runId)).resolves.toBe(
       DEFAULT_IMAGE_MODEL,
     );
 
-    await setOrgMemberImageModelFixture({
-      orgId,
-      userId: actor.userId,
-      selectedImageModel: "fal-ai/flux-pro/v1.1",
-    });
+    await chat.updateUserModelPreference(actor, null, "fal-ai/flux-pro/v1.1");
     const resumed = await api.createRun(actor, {
       agentId,
       sessionId: first.sessionId,
@@ -11352,10 +11342,10 @@ describe("CHAT-02: run image model snapshot", () => {
       modelProvider: "anthropic-api-key",
     });
     expect(resumed.sessionId).toBe(first.sessionId);
-    await expect(readRunImageModelFixture(resumed.runId)).resolves.toBe(
+    await expect(readRunImageModelSnapshotFixture(resumed.runId)).resolves.toBe(
       "fal-ai/flux-pro/v1.1",
     );
-    await expect(readRunImageModelFixture(first.runId)).resolves.toBe(
+    await expect(readRunImageModelSnapshotFixture(first.runId)).resolves.toBe(
       DEFAULT_IMAGE_MODEL,
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -44,7 +44,6 @@ import {
 import {
   holdChatThreadEventInsertTransactionFixture,
   insertChatThreadEventTransactionFixture,
-  setChatThreadImageModelFixture,
   setChatThreadVideoModelFixture,
 } from "../../../test-fixtures/chat-thread-events";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
@@ -1022,7 +1021,11 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       { eventId: modelSelectionEventId },
     );
     await setChatThreadVideoModelFixture(liveThread.id, "fal-ai/veo3.1/fast");
-    await setChatThreadImageModelFixture(liveThread.id, "fal-ai/qwen-image");
+    await chat.updateThreadImageModel(
+      actor,
+      liveThread.id,
+      "fal-ai/qwen-image",
+    );
 
     const incrementalSnapshotAt = initialSnapshotAt + 1000;
     mockNow(incrementalSnapshotAt);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -7,6 +7,7 @@ import {
   chatThreadComputerUseHostContract,
   chatThreadDraftContract,
   chatThreadEventsContract,
+  chatThreadImageModelContract,
   chatThreadMarkAgentReadContract,
   chatThreadMarkReadContract,
   chatThreadMetadataContract,
@@ -29,6 +30,7 @@ import {
   type UserMessageInputDocument,
   type ZeroIndicators,
 } from "@okouai/api-contracts/contracts/chat-threads";
+import type { ImageModelId } from "@okouai/api-contracts/contracts/image-models";
 import {
   CHAT_EVENT_SCHEMA_VERSION_HEADER,
   CURRENT_CHAT_EVENT_SCHEMA_VERSION,
@@ -77,6 +79,7 @@ import { artifactCatalogRoutes } from "../../artifact-catalog";
 import { chatThreadComputerUseHostRoutes } from "../../chat-threads-computer-use-host";
 import { chatThreadCreateRoutes } from "../../chat-threads-create";
 import { chatThreadDeleteRoutes } from "../../chat-threads-delete";
+import { chatThreadImageModelRoutes } from "../../chat-threads-image-model";
 import { chatThreadMarkReadRoutes } from "../../chat-threads-mark-read";
 import { chatThreadModelSelectionRoutes } from "../../chat-threads-model-selection";
 import { chatThreadPatchRoutes } from "../../chat-threads-patch";
@@ -198,6 +201,7 @@ const chatFilesRoutes = [
   ...chatThreadPinRoutes,
   ...chatThreadUnpinRoutes,
   ...chatThreadRenameRoutes,
+  ...chatThreadImageModelRoutes,
   ...chatThreadModelSelectionRoutes,
   ...chatThreadComputerUseHostRoutes,
   ...chatThreadsArtifactsSyncRoutes,
@@ -326,6 +330,10 @@ export function createChatFilesBddApi(context: TestContext) {
 
   function threadModelSelectionClient() {
     return chatFilesApp(context)(chatThreadModelSelectionContract);
+  }
+
+  function threadImageModelClient() {
+    return chatFilesApp(context)(chatThreadImageModelContract);
   }
 
   function userModelPreferenceClient() {
@@ -879,14 +887,34 @@ export function createChatFilesBddApi(context: TestContext) {
       );
     },
 
+    async updateThreadImageModel(
+      actor: ApiTestUser,
+      threadId: string,
+      imageModel: ImageModelId | null,
+    ): Promise<void> {
+      await accept(
+        threadImageModelClient().update({
+          headers: authenticate(context, actor),
+          params: { id: threadId },
+          body: { model: imageModel },
+        }),
+        [204],
+      );
+    },
+
     async updateUserModelPreference(
       actor: ApiTestUser,
       selectedModel: SupportedRunModel | null,
+      selectedImageModel?: ImageModelId | null,
     ): Promise<void> {
       await accept(
         userModelPreferenceClient().update({
           headers: authenticate(context, actor),
-          body: { selectedModel, serviceTier: null },
+          body: {
+            selectedModel,
+            serviceTier: null,
+            ...(selectedImageModel === undefined ? {} : { selectedImageModel }),
+          },
         }),
         [200],
       );

--- a/turbo/apps/api/src/test-fixtures/chat-thread-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-thread-events.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 
-import type { ImageModelId } from "@okouai/api-contracts/contracts/image-models";
 import { chatThreadEvents } from "@okouai/db/schema/chat-thread-event";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { count, eq, sql } from "drizzle-orm";
@@ -160,20 +159,5 @@ export async function setChatThreadVideoModelFixture(
   await db()
     .update(chatThreads)
     .set({ selectedVideoModel })
-    .where(eq(chatThreads.id, chatThreadId));
-}
-
-/**
- * Pins a thread's image model without adding a product writer. The compaction
- * test uses a non-null value so a missing hand-written projection cannot be
- * normalized into a false-positive null result.
- */
-export async function setChatThreadImageModelFixture(
-  chatThreadId: string,
-  selectedImageModel: ImageModelId,
-): Promise<void> {
-  await db()
-    .update(chatThreads)
-    .set({ selectedImageModel })
     .where(eq(chatThreads.id, chatThreadId));
 }

--- a/turbo/apps/api/src/test-fixtures/run-image-model.ts
+++ b/turbo/apps/api/src/test-fixtures/run-image-model.ts
@@ -1,9 +1,10 @@
 /**
- * Test fixtures for the dormant run image-model snapshot.
+ * Test fixtures for image-model states that production APIs cannot expose.
  *
- * PR6 intentionally ships before the preference writers and generation reader.
- * Retired stored IDs and the write-only run output therefore need controlled
- * direct database access in integration tests.
+ * Canonical member defaults and thread pins must use their production routes.
+ * The routes intentionally reject retired IDs, while the run snapshot remains
+ * write-only until its generation reader ships, so only those two transition
+ * cases use controlled direct database access.
  */
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
@@ -12,63 +13,47 @@ import { and, eq, isNotNull, sql } from "drizzle-orm";
 
 import { db } from "../lib/db";
 
-export async function setOrgMemberImageModelFixture(args: {
+export async function setRetiredOrgMemberImageModelFixture(args: {
   readonly orgId: string;
   readonly userId: string;
-  readonly selectedImageModel: string;
+  readonly retiredImageModel: string;
 }): Promise<void> {
   await db()
     .insert(orgMembersMetadata)
     .values({
       orgId: args.orgId,
       userId: args.userId,
-      selectedImageModel: args.selectedImageModel,
+      selectedImageModel: args.retiredImageModel,
     })
     .onConflictDoUpdate({
       target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
       set: {
-        selectedImageModel: args.selectedImageModel,
+        selectedImageModel: args.retiredImageModel,
         updatedAt: sql`now()`,
       },
     });
 }
 
-export async function setChatThreadImageModelFixture(
+export async function setRetiredChatThreadImageModelFixture(
   chatThreadId: string,
-  selectedImageModel: string,
+  retiredImageModel: string,
 ): Promise<void> {
   await db()
     .update(chatThreads)
-    .set({ selectedImageModel })
+    .set({ selectedImageModel: retiredImageModel })
     .where(eq(chatThreads.id, chatThreadId));
 }
 
-export async function readRunImageModelFixture(
+export async function readRunImageModelSnapshotFixture(
   runId: string,
 ): Promise<string | null> {
-  return (await readRunRow(runId)).selectedImageModel;
-}
-
-export async function readImageModelRunChatThreadIdFixture(
-  runId: string,
-): Promise<string | null> {
-  return (await readRunRow(runId)).chatThreadId;
-}
-
-async function readRunRow(runId: string): Promise<{
-  readonly selectedImageModel: string | null;
-  readonly chatThreadId: string | null;
-}> {
   const [run] = await db()
-    .select({
-      selectedImageModel: agentRuns.selectedImageModel,
-      chatThreadId: agentRuns.chatThreadId,
-    })
+    .select({ selectedImageModel: agentRuns.selectedImageModel })
     .from(agentRuns)
     .where(and(eq(agentRuns.id, runId), isNotNull(agentRuns.triggerSource)))
     .limit(1);
   if (!run) {
     throw new Error("Expected a product run row for the image model snapshot");
   }
-  return run;
+  return run.selectedImageModel;
 }


### PR DESCRIPTION
## Scan

- Timestamp: 2026-08-18 05:00 Asia/Shanghai
- Base commit: `96f5b357f69f091645a5ca7eb391773caa1becff`
- Primary ESLint scan: 1,091 API files, 0 restricted-import findings

## Violations fixed

- Supported member image-model defaults and thread pins were still injected through direct database fixtures after production preference endpoints shipped.
- A direct-run case asserted the internal `chatThreadId` column even though that relationship was not part of the behavior under test.

## Changes

- `chat-events.bdd.test.ts` now configures supported member defaults and thread pins through the production user-model-preference and chat-thread image-model endpoints.
- `chat-threads.bdd.test.ts` now configures the compaction image-model pin through the production endpoint.
- The shared BDD client mounts those production contracts/routes and exposes their typed update calls.
- Generic direct-write fixtures and the unrelated internal `chatThreadId` assertion were removed.

## Intentionally remaining exceptions

- Retired image-model IDs still use narrowly named direct database fixtures because production request schemas correctly reject IDs outside the current catalog; those historical stored states cannot be constructed externally.
- The run `selectedImageModel` snapshot remains a direct database read because no API response, runner claim, or generation contract exposes that write-only transition field yet. The fixture is named and documented accordingly.
- Existing finite persisted/security-sensitive service-matrix exceptions remain unchanged.

## Verification

- `pnpm exec prettier --check` on all five changed files
- `git diff --check`
- Full API ESLint: 1,091 files, 0 errors, 0 warnings
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run check-types`
- `chat-events.bdd.test.ts -t "CHAT-02: run image model snapshot"`: 6 passed
- `chat-threads.bdd.test.ts -t "preserves UTC snapshot and event cutoff boundaries outside UTC"`: 1 passed

A broader local CHAT-01 filter also ran: 10 passed and 2 existing runner-queue cases failed while claiming an already-missing job with `404 Job not found in queue`. The modified compaction case passes in isolation. A temporary baseline-worktree comparison could not complete because dependency installation exhausted the runtime root disk; PR CI remains the full-suite check.