### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/scripts/dev-bench-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-bench-seed.ts
@@ -24,6 +24,7 @@ import { zeroAgents } from "@okouai/db/schema/zero-agent";
 import { closeDbPool, db } from "../lib/db";
 import { optionalEnv } from "../lib/env";
 import { normalizeRunMetadata } from "../signals/services/agent-run-metadata-write.service";
+import { webChatPublicBrandContextId } from "../signals/services/web-chat-public-brand-context.service";
 import { onRejection } from "../signals/utils";
 
 const BULK_INSERT_CHUNK = 500;
@@ -877,6 +878,7 @@ function appendNullRunControlRows(args: {
       ...(isInputPrompt
         ? {
             contextType: "web",
+            contextId: webChatPublicBrandContextId("vm0"),
             payload: { userMessage },
           }
         : {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -124,7 +124,6 @@ import {
   holdThreadSessionBindingClearFixture,
   holdThreadSessionConversationChangesFixture,
   holdThreadSessionConversationClearFixture,
-  insertLegacyWebChatQueueEventFixture,
   readCanonicalChatEventStorageFixture,
   releaseBddVm0ApiKey,
   replayPendingChatInputQueueEventFixture,
@@ -8611,64 +8610,6 @@ describe("CHAT-02: public-brand default assistant identity", () => {
 
     await cancelChatRun(actor, vm0Run.runId);
     await cancelChatRun(actor, customRun.runId);
-  }, 90_000);
-
-  it("keeps a pre-rollout queued Web event on the legacy Zero identity", async () => {
-    const { actor, runnerGroup } = await entitledChatActor();
-    bdd.acceptAgentStorageWrites();
-    const onboarding = await bdd.readOnboardingStatus(actor);
-    const defaultAgentId = onboarding.defaultAgentId;
-    if (!defaultAgentId) {
-      throw new Error("Expected the system default agent to exist");
-    }
-
-    const anchor = await sendChatRun(
-      actor,
-      { agentId: defaultAgentId, prompt: "start legacy queue coverage" },
-      "okou",
-    );
-    const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
-    // Current routes cannot create the historical missing-context shape.
-    const queuedEventId = randomUUID();
-    await insertLegacyWebChatQueueEventFixture({
-      eventId: queuedEventId,
-      threadId: anchor.threadId,
-      prompt: "promote a pre-rollout Web event",
-    });
-    const rawQueuedEvent = (
-      await chat.listThreadEventRows(actor, anchor.threadId)
-    ).find((event) => {
-      return event.id === queuedEventId;
-    });
-    expect(rawQueuedEvent).toMatchObject({
-      contextType: "web",
-      contextId: null,
-    });
-    chatCallbacks.mockChatOutputEvents([]);
-    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
-    await flushWaitUntilForTest();
-    const promotedMessages = await waitForThreadMessages(
-      actor,
-      anchor.threadId,
-      (items) => {
-        return userMessages(items).some((message) => {
-          return (
-            message.revokesEventId === queuedEventId &&
-            message.runId !== undefined
-          );
-        });
-      },
-    );
-    const promoted = userMessages(promotedMessages.events).find((message) => {
-      return message.revokesEventId === queuedEventId;
-    });
-    if (!promoted?.runId) {
-      throw new Error("Expected the pre-rollout Web event to auto-send");
-    }
-    const promotedRun = await api.readRun(actor, promoted.runId);
-    expect(promotedRun.appendSystemPrompt).toContain("Your name is Zero.");
-    expect(promotedRun.appendSystemPrompt).not.toContain("Your name is Okou.");
-    await cancelChatRun(actor, promoted.runId);
   }, 90_000);
 });
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2681,21 +2681,6 @@ type LaunchLoader = (
   args: QueuedLaunchLoaderArgs,
 ) => Promise<QueuedLaunchMaterial | null>;
 
-function queuedWebPublicBrand(
-  args: QueuedLaunchLoaderArgs,
-): PublicBrand | undefined {
-  if (args.contextType !== "web") {
-    return args.publicBrand ?? undefined;
-  }
-  if (args.publicBrand !== null) {
-    return args.publicBrand;
-  }
-  // Queued Web events written before this API release have no brand context.
-  // Preserve their legacy VM0 identity while old runner/sandbox work drains
-  // (up to 2 hours). Remove after that rollout window; follow-up #27744.
-  return "vm0";
-}
-
 /**
  * Web is the only trigger source with no context table: the user typed the
  * message, so `chat_events.payload.userMessage` is the durable original fact
@@ -2703,7 +2688,7 @@ function queuedWebPublicBrand(
  * place a launch loader reads it, and it is deliberate.
  */
 const loadWebQueuedLaunchMaterial: LaunchLoader = (_db, args) => {
-  const publicBrand = queuedWebPublicBrand(args);
+  const publicBrand = args.publicBrand ?? undefined;
   return Promise.resolve({
     prompt: args.userMessageProjection.agentPrompt,
     appendSystemPrompt: buildWebChatAppendSystemPrompt({

--- a/turbo/apps/api/src/signals/services/web-chat-public-brand-context.service.ts
+++ b/turbo/apps/api/src/signals/services/web-chat-public-brand-context.service.ts
@@ -12,13 +12,10 @@ export function webChatPublicBrandContextId(publicBrand: PublicBrand): string {
   return WEB_PUBLIC_BRAND_CONTEXT_IDS[publicBrand];
 }
 
-/** Decode current Web context while preserving null for pre-rollout events. */
+/** Decode Web launch identity; every Web input event carries this context. */
 export function webChatPublicBrandFromContextId(
   contextId: string | null,
-): PublicBrand | null {
-  if (contextId === null) {
-    return null;
-  }
+): PublicBrand {
   if (contextId === WEB_PUBLIC_BRAND_CONTEXT_IDS.vm0) {
     return "vm0";
   }

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -822,31 +822,6 @@ export async function replayPendingChatInputQueueEventFixture(args: {
 }
 
 /**
- * Reproduce a queued Web row written before public-brand context existed.
- * Current production APIs always write the context, so this historical rollout
- * shape cannot be constructed through the current external route.
- */
-export async function insertLegacyWebChatQueueEventFixture(args: {
-  readonly eventId: string;
-  readonly threadId: string;
-  readonly prompt: string;
-}): Promise<void> {
-  const inserted = await db().transaction(async (tx) => {
-    return await insertChatEvent(tx, {
-      id: args.eventId,
-      chatThreadId: args.threadId,
-      eventType: "input.prompt",
-      userMessage: createUserMessageDocument({ text: args.prompt }),
-      runId: null,
-      contextType: "web",
-    });
-  });
-  if (!inserted) {
-    throw new Error("Expected one pre-rollout queued Web event");
-  }
-}
-
-/**
  * Move one exact automation event into historical state without waiting for real
  * time to pass. A string preserves PostgreSQL precision beyond JavaScript
  * milliseconds. Product APIs cannot construct an already-stale queue item.

--- a/turbo/apps/api/src/test-fixtures/morning-brief.ts
+++ b/turbo/apps/api/src/test-fixtures/morning-brief.ts
@@ -8,6 +8,7 @@ import { db } from "../lib/db";
 import { insertChatEvent } from "../signals/services/chat-event.service";
 import { touchChatThreadLastMessageAt } from "../signals/services/chat-event-shared.service";
 import { createUserMessageDocument } from "../signals/services/chat-user-message.service";
+import { webChatPublicBrandContextId } from "../signals/services/web-chat-public-brand-context.service";
 
 export async function readMorningBriefDeliveryFixture(args: {
   readonly orgId: string;
@@ -52,7 +53,8 @@ export async function setMorningBriefTriggeredAtFixture(args: {
 
 /**
  * Appends a normal web user message without invoking a drain. Product sends
- * persist this same event before draining, but cannot pause at that boundary.
+ * persist this same event, including its public-brand launch context, before
+ * draining, but cannot pause at that boundary.
  */
 export async function insertQueuedWebUserMessageFixture(args: {
   readonly threadId: string;
@@ -65,6 +67,7 @@ export async function insertQueuedWebUserMessageFixture(args: {
       id: messageId,
       chatThreadId: args.threadId,
       contextType: "web",
+      contextId: webChatPublicBrandContextId("vm0"),
       eventType: "input.prompt",
       userMessage: createUserMessageDocument({ text: args.content }),
       runId: null,


### PR DESCRIPTION
Daily deployment-compatibility cleanup. One cohort survived evidence collection; everything else is inside its window, gated on a product decision, or blocked, and is listed at the bottom rather than split into a second PR.

## Cohort — remove the legacy Web queue public-brand fallback (#27744)

**Old → new boundary.** [PR #27716](https://github.com/vm0-ai/vm0/pull/27716) started encoding Web launch identity in `chat_events.context_id` using two reserved UUIDs. Queued Web events written by the previous API carry no such context, so two things tolerated it: `webChatPublicBrandFromContextId` returned `null` for a `null` context, and `queuedWebPublicBrand` in the run-callback loader mapped that to the legacy `"vm0"` identity.

**Window.** Existing runs and their queued follow-ups can stay on the old launch path for up to **2 hours** after #27716's API promotion. #27744's gate is that drain window closing.

**Rollout evidence, corrected against production rather than assumed.** #27716 merged 2026-08-17T10:25:50Z (`423fb0ae0d3e`) and the next `api/production` promotion was `15ea3d684149` at 10:34:18Z, which does contain that commit. But measuring the window from there would have been wrong: production kept writing context-less Web events for another 45 minutes. The **observed** writer cutover is **2026-08-17T11:19:55.033Z**, coinciding with the `5c2f6f138c85` promotion at 11:19:54Z. That observed timestamp — not the merge or the first promotion — is the baseline used below.

**MaskDB evidence** (`vm0-prod-ro`, read-only aggregates):

| measurement | result |
|---|---|
| Web `input.prompt` events written at/after the 10:34:18Z promotion | 1 057, of which **154** had `context_id IS NULL` |
| Newest Web `input.prompt` with `context_id IS NULL` | **2026-08-17T11:19:55.033Z** |
| Web `input.prompt` events after that instant | **903** |
| …of those, with `context_id IS NULL` | **0** |
| Oldest run in `running`/`pending`/`queued`/`starting` | **2026-08-17T20:22:44Z** |

Every Web input event written since the cutover carries the encoded context — 903 of 903. The oldest active run in production started **9 hours after** the cutover, so no thread has been blocked since before it and no pre-cutover queued Web event can still be waiting for admission. Elapsed since the cutover at this run: **9.7 hours** against a 2-hour window, with five further `api/production` promotions in between.

**Axiom coverage** (`vm0-request-log-prod`, explicit bounds `2026-08-17T11:19:55Z → 2026-08-17T21:30:00Z`, `_time` predicate applied before the path filter): the Web chat surface is live and healthy through the window — `/api/okou/chat-threads` 1 089 POSTs, `mark-read` 1 201, `model-selection` 734, all with **0** responses ≥ 500. Stated plainly: this shows the surface is serving, not that the context field is populated; the field-population proof is the MaskDB counts above.

**Removed.** The `null` branch of `webChatPublicBrandFromContextId` (its return type is now `PublicBrand`, and an unrecognised context still throws as before); the `queuedWebPublicBrand` helper with its `"vm0"` fallback, inlined at its single call site to `args.publicBrand ?? undefined` since both of its branches collapsed to that expression; the `keeps a pre-rollout queued Web event on the legacy Zero identity` integration test; and the `insertLegacyWebChatQueueEventFixture` helper that existed only to build the historical missing-context shape.

**Persisted-data reasoning.** This touches only the *queue admission* path, which reads events that are still awaiting a run. It does not re-read historical rows: events already admitted keep whatever brand their run recorded, and nothing in this diff parses `context_id` for completed events. The 154 context-less rows written before the cutover remain in the table and are simply never re-admitted, which the oldest-active-run measurement establishes.

## Checks

Run once against the combined diff, with a local PostgreSQL 18 cluster created for this run and set to `UTC`:

- `pnpm format`; `pnpm check-types` (all tasks, no errors); `pnpm -F api lint` (exit 0); `pnpm knip` (exit 0)
- `pnpm -F api exec vitest run chat-events.bdd.test.ts` → **104 passed** (the suite that owned the deleted test)
- `pnpm -F api exec vitest run chat-callbacks.bdd.test.ts` → **48 passed** (the public-brand transport assertions)

Per repo guidance the full local Vitest suite was not run and no dev server was started.

## Open-PR overlap

File-level only, checked hunk by hunk with no line contention:

- **#27810** touches `internal-chat-run-callback.service.ts` at lines 2990–3104 (this PR edits ~2684) and `chat-events.bdd.test.ts` at 11, 7885–7918 and 11109+ (this PR deletes 8616–8672 and one import at 127).
- **#27791** touches `chat-events.bdd.test.ts` at 3296–3421 only.

Deferred this run, with the exact blocker:

- **#27356** zero-agent default-avatar bridge — the window is long closed, but its acceptance criterion "no supported API writer can insert a NULL avatar when `avatarUrl` is omitted" is **still false on main**: `apps/api/src/signals/routes/agents.ts:322` remains `avatarUrl: args.body.avatarUrl ?? null`, and only the create path at line 399 uses `randomPresetAvatar()`. That upsert runs from the PUT route and hits its INSERT branch for a compose-backed agent with no `zero_agents` row yet, so the trigger is compensating a live writer rather than a drained one. This is the third consecutive run reporting it; the unblocking change is one line.
- **#26152** concurrency billing fallbacks and **#26842** saved-billing credit purchase — both still contended by **#27128**, which was active again on 2026-08-17T11:21Z and still edits `reduceConcurrencySubscription$` and the reduce request schema. #26842 additionally needs the CLI hosted-checkout contract split first.
- **#27602 / #27796** integration identity contraction, **#27660** public-brand OAuth defaults, **#27688** chat-thread-event, **#26938** agent/compose consolidation — all recent or multi-stage programs with their own removal owners and open windows.
- **#26672 / #26519** Website template archive pins — `LatestWebsiteTemplates` is still `enabled: false`; the gate is a product decision.
- `PersonalModelProviderAccounts` fallbacks — switch still `enabled: false`.
- **#26487** route-entry Phase A, **#25620** avatar flat-field read fallback (needs a jsonb backfill), and the `browser_*` identity contraction (MaskDB still exposes no `browser_*` table, so `chat_thread_id` uniqueness across retained rows cannot be proven).
