### PR TITLE
feat(db): backfill exact launch snapshots

### DIFF
--- a/.github/scripts/tests/neon-credential-mask-test.sh
+++ b/.github/scripts/tests/neon-credential-mask-test.sh
@@ -25,6 +25,7 @@ expected_generator_files=(
   .github/actions/neon-branch/action.yml
   .github/actions/production-migration-smoke/action.yml
   .github/workflows/agent-compose-consolidation-preflight.yml
+  .github/workflows/agent-run-launch-snapshot-backfill.yml
   .github/workflows/backfill-acquisition-attribution.yml
   .github/workflows/integration-identity-contract-readiness-preflight.yml
   .github/workflows/release-please.yml
@@ -50,8 +51,8 @@ mapfile -t invocations < <(
     "${generator_files[@]}"
 )
 
-if [[ ${#invocations[@]} -ne 11 ]]; then
-  fail "expected eleven reviewed Neon connection-string invocations"
+if [[ ${#invocations[@]} -ne 12 ]]; then
+  fail "expected twelve reviewed Neon connection-string invocations"
 fi
 
 mapfile -t raw_mask_variables <<'VARIABLES'
@@ -94,6 +95,7 @@ mapfile -t expected_raw_database_url_emissions <<'EMISSIONS'
 .github/actions/neon-branch/action.yml:echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
 .github/actions/production-migration-smoke/action.yml:echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
 .github/workflows/agent-compose-consolidation-preflight.yml:echo "database-url=$database_url" >> "$GITHUB_OUTPUT"
+.github/workflows/agent-run-launch-snapshot-backfill.yml:echo "database-url=$database_url" >> "$GITHUB_OUTPUT"
 .github/workflows/backfill-acquisition-attribution.yml:echo "database_url=$database_url" >> "$GITHUB_OUTPUT"
 .github/workflows/integration-identity-contract-readiness-preflight.yml:echo "database-url=$database_url" >> "$GITHUB_OUTPUT"
 .github/workflows/release-please.yml:echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
@@ -161,6 +163,7 @@ done <<'BOUNDARIES'
 .github/actions/production-migration-smoke/action.yml|Production migration smoke action|DATABASE_URL|DATABASE_URL=$(neonctl connection-string "$BRANCH_ID"|echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
 .github/workflows/backfill-acquisition-attribution.yml|Acquisition backfill workflow|database_url|database_url=$(|echo "database_url=$database_url" >> "$GITHUB_OUTPUT"
 .github/workflows/agent-compose-consolidation-preflight.yml|Agent-compose preflight workflow|database_url|if ! database_url=$(|echo "database-url=$database_url" >> "$GITHUB_OUTPUT"
+.github/workflows/agent-run-launch-snapshot-backfill.yml|Agent-run launch snapshot backfill workflow|database_url|if ! database_url=$(|echo "database-url=$database_url" >> "$GITHUB_OUTPUT"
 .github/workflows/integration-identity-contract-readiness-preflight.yml|Integration identity readiness preflight|database_url|if ! database_url=$(|echo "database-url=$database_url" >> "$GITHUB_OUTPUT"
 .github/workflows/turbo.yml|Turbo parent database|PARENT_DATABASE_URL|PARENT_DATABASE_URL=$(neonctl connection-string --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --ssl verify-full)|(cd turbo && DATABASE_URL="$PARENT_DATABASE_URL" pnpm -F @okouai/db db:migrate)
 .github/workflows/turbo.yml|Turbo preview database|DATABASE_URL|DATABASE_URL=$(neonctl connection-string "$BRANCH_NAME" --project-id "$NEON_PROJECT_ID" --database-name neondb --role-name neondb_owner --ssl verify-full)|DATABASE_URL="$DATABASE_URL" pnpm -F @okouai/db db:migrate
@@ -177,4 +180,4 @@ assert_ordered \
   'Production release database shell' \
   "${release_shell_patterns[@]}"
 
-echo "Neon credential masking checks passed (11 invocations, 8 resolved values)"
+echo "Neon credential masking checks passed (12 invocations, 9 resolved values)"

--- a/.github/workflows/agent-run-launch-snapshot-backfill.yml
+++ b/.github/workflows/agent-run-launch-snapshot-backfill.yml
@@ -1,0 +1,130 @@
+name: Agent Run Launch Snapshot Backfill
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Dry-run proves eligibility; apply writes re-proven null snapshots"
+        required: true
+        type: choice
+        options:
+          - dry-run
+          - apply
+        default: dry-run
+      batch_size:
+        description: "Maximum rows in each independently committed transaction"
+        required: true
+        type: choice
+        options:
+          - "1"
+          - "100"
+          - "500"
+        default: "500"
+      max_batches:
+        description: "Maximum independently committed batches in this invocation"
+        required: true
+        type: choice
+        options:
+          - "1"
+          - "20"
+          - "300"
+        default: "1"
+      confirmed_apply:
+        description: "I reviewed a dry-run and authorize this bounded production write"
+        required: true
+        type: choice
+        options:
+          - "no"
+          - "yes"
+        default: "no"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-agent-run-launch-snapshot-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
+    environment: production
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Gate production apply
+        if: inputs.mode == 'apply' && inputs.confirmed_apply != 'yes'
+        run: |
+          echo "::error::confirmed_apply must be yes before applying production writes."
+          exit 1
+
+      # transition-validator: #27820; removal-owner: #26938 Stage 8
+      # The workflow definition and implementation always come from main.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
+      - name: Initialize toolchain
+        uses: ./.github/actions/toolchain-init
+
+      - name: Install neonctl
+        run: npm install -g neonctl@2.15.0
+
+      - name: Resolve production database
+        id: database
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if ! database_url=$(
+            neonctl connection-string production \
+              --project-id "$NEON_PROJECT_ID" \
+              --database-name neondb \
+              --role-name neondb_owner \
+              --pooled \
+              --ssl verify-full \
+              2>/dev/null
+          ); then
+            echo "::error::unable to resolve the production database."
+            exit 1
+          fi
+          if [[ -z "$database_url" ||
+                "$database_url" == *$'\n'* ||
+                "$database_url" == *$'\r'* ||
+                ( "$database_url" != postgres://* &&
+                  "$database_url" != postgresql://* ) ]]; then
+            echo "::error::resolved production database value is invalid."
+            exit 1
+          fi
+          WORKFLOW_COMMAND_DATA="${database_url//%/%25}"
+          WORKFLOW_COMMAND_DATA="${WORKFLOW_COMMAND_DATA//$'\r'/%0D}"
+          WORKFLOW_COMMAND_DATA="${WORKFLOW_COMMAND_DATA//$'\n'/%0A}"
+          printf '::add-mask::%s\n' "$WORKFLOW_COMMAND_DATA"
+          echo "database-url=$database_url" >> "$GITHUB_OUTPUT"
+
+      - name: Run aggregate-only launch snapshot backfill
+        env:
+          BACKFILL_BATCH_SIZE: ${{ inputs.batch_size }}
+          BACKFILL_MAX_BATCHES: ${{ inputs.max_batches }}
+          BACKFILL_MODE: ${{ inputs.mode }}
+          CONFIRMED_APPLY: ${{ inputs.confirmed_apply }}
+          DATABASE_URL: ${{ steps.database.outputs.database-url }}
+        working-directory: turbo
+        run: |
+          set -euo pipefail
+          args=(
+            --mode "$BACKFILL_MODE"
+            --batch-size "$BACKFILL_BATCH_SIZE"
+            --max-batches "$BACKFILL_MAX_BATCHES"
+          )
+          if [[ "$BACKFILL_MODE" == "apply" && "$CONFIRMED_APPLY" == "yes" ]]; then
+            args+=(--confirm-apply apply-agent-run-launch-snapshot-backfill)
+          fi
+          pnpm --filter @okouai/db exec tsx \
+            scripts/agent-run-launch-snapshot-backfill.ts \
+            "${args[@]}"

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-launch-snapshots.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-launch-snapshots.ts
@@ -4,8 +4,15 @@ import {
   type SetFingerprint,
 } from "./agent-compose-consolidation-preflight-fingerprint";
 
-type HistoricalFramework = "claude-code" | "codex" | "pi";
+export type LaunchSnapshotFramework = "claude-code" | "codex" | "pi";
+type HistoricalFramework = LaunchSnapshotFramework;
 type BaseHistoricalFramework = Exclude<HistoricalFramework, "pi">;
+
+export interface ExactLaunchSnapshotValue {
+  readonly schemaVersion: 1;
+  readonly framework: LaunchSnapshotFramework;
+  readonly runnerProfile: string;
+}
 
 export const LAUNCH_SNAPSHOT_DISPOSITIONS = [
   "already_valid",
@@ -427,10 +434,34 @@ function historicalFirstAgent(content: unknown): HistoricalContent {
   };
 }
 
-interface RunClassification {
-  readonly disposition: LaunchSnapshotDisposition;
+interface RunClassificationBase {
   readonly primaryReason: LaunchSnapshotReason;
   readonly reasons: ReadonlySet<LaunchSnapshotReason>;
+}
+
+type RunClassification =
+  | (RunClassificationBase & {
+      readonly disposition: "exactly_recoverable";
+      readonly snapshot: ExactLaunchSnapshotValue;
+    })
+  | (RunClassificationBase & {
+      readonly disposition: Exclude<
+        LaunchSnapshotDisposition,
+        "exactly_recoverable"
+      >;
+    });
+
+type WithRunId<Classification> = Classification extends RunClassification
+  ? Classification & { readonly runId: string }
+  : never;
+
+export type LaunchSnapshotRunClassification = WithRunId<RunClassification>;
+
+function includeRunId(
+  runId: string,
+  classification: RunClassification,
+): LaunchSnapshotRunClassification {
+  return { runId, ...classification };
 }
 
 interface ResolvedVersionEvidence {
@@ -1321,6 +1352,11 @@ function classifyMissingSnapshot(
     disposition: "exactly_recoverable",
     primaryReason: "complete_exact_evidence",
     reasons: context.reasons,
+    snapshot: {
+      schemaVersion: 1,
+      framework: framework.value,
+      runnerProfile: profile.value,
+    },
   };
 }
 
@@ -1425,6 +1461,7 @@ export function classifyLaunchSnapshotRecoverability(args: {
     readonly reasonCompatibilityClosure: ClosureComparison;
   };
   readonly failureGates: readonly string[];
+  readonly classifications: readonly LaunchSnapshotRunClassification[];
 } {
   const versions = new Map<string, LaunchSnapshotVersionInventoryRow>();
   const duplicateVersionIds = new Set<string>();
@@ -1446,6 +1483,7 @@ export function classifyLaunchSnapshotRecoverability(args: {
   ) as Record<LaunchSnapshotReason, string[]>;
   const primaryReasonMembers: string[] = [];
   const incompatibleReasonRunIds: string[] = [];
+  const classifications: LaunchSnapshotRunClassification[] = [];
 
   for (const run of args.runs) {
     const classified = classifyRun({
@@ -1457,6 +1495,7 @@ export function classifyLaunchSnapshotRecoverability(args: {
       versions,
       duplicateVersionIds,
     });
+    classifications.push(includeRunId(run.id, classified));
     dispositionMembers[classified.disposition].push(run.id);
     primaryReasonMembers.push(run.id);
     if (!reasonsAreCompatible(classified)) {
@@ -1595,5 +1634,6 @@ export function classifyLaunchSnapshotRecoverability(args: {
       reasonCompatibilityClosure,
     },
     failureGates: [...failureGates].sort(),
+    classifications,
   };
 }

--- a/turbo/packages/db/scripts/agent-run-launch-snapshot-backfill.ts
+++ b/turbo/packages/db/scripts/agent-run-launch-snapshot-backfill.ts
@@ -1,0 +1,1708 @@
+#!/usr/bin/env tsx
+
+import process from "node:process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual, parseArgs } from "node:util";
+import { Client, type QueryResultRow } from "pg";
+import {
+  fingerprintSortedSet,
+  type SetFingerprint,
+} from "./agent-compose-consolidation-preflight-fingerprint";
+import {
+  LAUNCH_SNAPSHOT_DISPOSITIONS,
+  classifyLaunchSnapshotRecoverability,
+  type ExactLaunchSnapshotValue,
+  type LaunchSnapshotCheckpointInventoryRow,
+  type LaunchSnapshotConversationInventoryRow,
+  type LaunchSnapshotReason,
+  type LaunchSnapshotRunClassification,
+  type LaunchSnapshotRunInventoryRow,
+  type LaunchSnapshotVersionInventoryRow,
+} from "./agent-compose-consolidation-preflight-launch-snapshots";
+
+export const LAUNCH_SNAPSHOT_BACKFILL_SCHEMA_VERSION =
+  "vm0.agent-run-launch-snapshot-backfill.v1";
+export const LAUNCH_SNAPSHOT_BACKFILL_MAX_BATCH_SIZE = 500;
+export const LAUNCH_SNAPSHOT_BACKFILL_MAX_BATCH_CHOICES = [1, 20, 300] as const;
+export const LAUNCH_SNAPSHOT_BACKFILL_APPLY_CONFIRMATION =
+  "apply-agent-run-launch-snapshot-backfill";
+
+const PRODUCTION_LOCK_TIMEOUT_MS = 1000;
+const PRODUCTION_STATEMENT_TIMEOUT_MS = 30_000;
+const FROZEN_HISTORICAL_UNKNOWN: SetFingerprint = {
+  count: 2627,
+  digest: "314360539273450908d01e647338c39ee30c12e131bcddf67c54023c57bad94c",
+};
+const FROZEN_INTEGRITY_CONFLICT: SetFingerprint = {
+  count: 9,
+  digest: "c74f9a7cbeba3d52589f7b7bfb569ca7ecc25b7fa00e4a88ab728df7d22e2159",
+};
+
+const ACTIVE_RUN_STATUSES: ReadonlySet<string> = new Set([
+  "queued",
+  "pending",
+  "running",
+]);
+const TERMINAL_RUN_STATUSES: ReadonlySet<string> = new Set([
+  "completed",
+  "failed",
+  "timeout",
+  "cancelled",
+]);
+const SUPPORTED_RUN_STATUSES: ReadonlySet<string> = new Set([
+  ...ACTIVE_RUN_STATUSES,
+  ...TERMINAL_RUN_STATUSES,
+]);
+const CRITICAL_REASONS: ReadonlySet<LaunchSnapshotReason> = new Set([
+  "checkpoint_snapshot_malformed",
+  "checkpoint_version_missing",
+  "conversation_framework_invalid",
+  "created_before_reviewed_history_boundary",
+  "existing_snapshot_invalid",
+  "legacy_content_hash_conflict",
+  "legacy_content_invalid",
+  "legacy_content_unsupported",
+  "otherwise_unclassified_shape",
+  "run_checkpoint_version_conflict",
+  "run_version_missing",
+  "runner_profile_invalid",
+  "trigger_source_unrecognized",
+]);
+
+const FAILURE_GATES = [
+  "none",
+  "configuration",
+  "input",
+  "database.connection",
+  "database.query",
+  "transaction.cleanup",
+  "inventory.shape",
+  "inventory.closure",
+  "inventory.classifier",
+  "inventory.duplicate_evidence",
+  "inventory.critical_reason",
+  "inventory.active_null",
+  "inventory.unsupported_status",
+  "inventory.frozen_historical_unknown",
+  "inventory.frozen_integrity_conflict",
+  "batch.size",
+  "batch.contention",
+  "batch.drift",
+  "batch.affected_rows",
+  "batch.read_back",
+  "proof.drift",
+  "lock_timeout",
+  "statement_timeout",
+  "cancelled",
+  "output.shape",
+  "unexpected",
+] as const;
+
+export type LaunchSnapshotBackfillFailureGate = (typeof FAILURE_GATES)[number];
+export type LaunchSnapshotBackfillMode = "dry-run" | "apply";
+export type LaunchSnapshotBackfillStatus =
+  | "dry-run"
+  | "no-op"
+  | "partial"
+  | "complete"
+  | "failed";
+
+export interface LaunchSnapshotBackfillPolicy {
+  readonly frozenHistoricalUnknown: SetFingerprint;
+  readonly frozenIntegrityConflict: SetFingerprint;
+  readonly lockTimeoutMs: number;
+  readonly statementTimeoutMs: number;
+}
+
+export const PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY: LaunchSnapshotBackfillPolicy =
+  {
+    frozenHistoricalUnknown: FROZEN_HISTORICAL_UNKNOWN,
+    frozenIntegrityConflict: FROZEN_INTEGRITY_CONFLICT,
+    lockTimeoutMs: PRODUCTION_LOCK_TIMEOUT_MS,
+    statementTimeoutMs: PRODUCTION_STATEMENT_TIMEOUT_MS,
+  };
+
+export interface LaunchSnapshotBackfillInput {
+  readonly connectionString: string;
+  readonly mode: LaunchSnapshotBackfillMode;
+  readonly batchSize: number;
+  readonly maxBatches: number;
+  readonly applyConfirmation?: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface LaunchSnapshotBackfillRunInventoryRow extends LaunchSnapshotRunInventoryRow {
+  readonly status: string;
+}
+
+export interface LaunchSnapshotBackfillInventory {
+  readonly runs: readonly LaunchSnapshotBackfillRunInventoryRow[];
+  readonly versions: readonly LaunchSnapshotVersionInventoryRow[];
+  readonly checkpoints: readonly LaunchSnapshotCheckpointInventoryRow[];
+  readonly conversations: readonly LaunchSnapshotConversationInventoryRow[];
+}
+
+export interface LaunchSnapshotBackfillCandidate {
+  readonly runId: string;
+  readonly snapshot: ExactLaunchSnapshotValue;
+}
+
+interface LaunchSnapshotBackfillInventorySummary {
+  readonly total: number;
+  readonly population: SetFingerprint;
+  readonly dispositions: Readonly<
+    Record<(typeof LAUNCH_SNAPSHOT_DISPOSITIONS)[number], SetFingerprint>
+  >;
+  readonly closures: "exact" | "drift";
+  readonly frozenHistoricalUnknown: "exact" | "drift";
+  readonly frozenIntegrityConflict: "exact" | "drift";
+  readonly criticalReasons: SetFingerprint;
+  readonly duplicateEvidence: SetFingerprint;
+  readonly activeNull: SetFingerprint;
+  readonly unsupportedStatus: SetFingerprint;
+  readonly existingSnapshots: SetFingerprint;
+}
+
+export interface LaunchSnapshotBackfillOutput {
+  readonly schemaVersion: typeof LAUNCH_SNAPSHOT_BACKFILL_SCHEMA_VERSION;
+  readonly mode: LaunchSnapshotBackfillMode;
+  readonly status: LaunchSnapshotBackfillStatus;
+  readonly failureGate: LaunchSnapshotBackfillFailureGate;
+  readonly parameters: {
+    readonly batchSize: number;
+    readonly maxBatches: number;
+  };
+  readonly progress: {
+    readonly candidateRows: number;
+    readonly attemptedBatches: number;
+    readonly committedBatches: number;
+    readonly committedRows: number;
+  };
+  readonly before: LaunchSnapshotBackfillInventorySummary;
+  readonly after: LaunchSnapshotBackfillInventorySummary;
+  readonly proof: "exact" | "drift" | "not_run";
+}
+
+export class SanitizedLaunchSnapshotBackfillError extends Error {
+  readonly gate: LaunchSnapshotBackfillFailureGate;
+
+  constructor(gate: LaunchSnapshotBackfillFailureGate) {
+    super(gate);
+    this.name = "SanitizedLaunchSnapshotBackfillError";
+    this.gate = gate;
+  }
+}
+
+interface LaunchSnapshotBackfillAnalysis {
+  readonly inventory: LaunchSnapshotBackfillInventory;
+  readonly classifications: readonly LaunchSnapshotRunClassification[];
+  readonly candidates: readonly LaunchSnapshotBackfillCandidate[];
+  readonly summary: LaunchSnapshotBackfillInventorySummary;
+  readonly runById: ReadonlyMap<string, LaunchSnapshotBackfillRunInventoryRow>;
+  readonly classificationById: ReadonlyMap<
+    string,
+    LaunchSnapshotRunClassification
+  >;
+  readonly failureGates: readonly string[];
+}
+
+interface RawRunInventoryRow extends QueryResultRow {
+  readonly id: unknown;
+  readonly versionId: unknown;
+  readonly createdAt: unknown;
+  readonly launchSnapshot: unknown;
+  readonly modelProvider: unknown;
+  readonly selectedModel: unknown;
+  readonly triggerSource: unknown;
+  readonly chatThreadPresent: unknown;
+  readonly metadataShape: unknown;
+  readonly status: unknown;
+}
+
+interface RawVersionInventoryRow extends QueryResultRow {
+  readonly id: unknown;
+  readonly content: unknown;
+}
+
+interface RawCheckpointInventoryRow extends QueryResultRow {
+  readonly runId: unknown;
+  readonly snapshot: unknown;
+}
+
+interface RawConversationInventoryRow extends QueryResultRow {
+  readonly runId: unknown;
+  readonly framework: unknown;
+}
+
+interface RawCapabilityRow extends QueryResultRow {
+  readonly readOnly: unknown;
+  readonly isolationLevel: unknown;
+  readonly lockTimeoutMs: unknown;
+  readonly statementTimeoutMs: unknown;
+}
+
+interface RawSnapshotRow extends QueryResultRow {
+  readonly id: unknown;
+  readonly launchSnapshot: unknown;
+}
+
+const RUN_INVENTORY_PROJECTION = `
+  "run"."id"::text AS "id",
+  "run"."agent_compose_version_id" AS "versionId",
+  "run"."created_at" AT TIME ZONE 'UTC' AS "createdAt",
+  "run"."launch_snapshot" AS "launchSnapshot",
+  "run"."model_provider" AS "modelProvider",
+  "run"."selected_model" AS "selectedModel",
+  "run"."trigger_source" AS "triggerSource",
+  "run"."chat_thread_id" IS NOT NULL AS "chatThreadPresent",
+  CASE
+    WHEN
+      "run"."trigger_source" IS NULL AND
+      "run"."autonomy_budget" IS NULL AND
+      "run"."workflow_automation_id" IS NULL AND
+      "run"."goal_id" IS NULL AND
+      "run"."model_provider" IS NULL AND
+      "run"."model_provider_id" IS NULL AND
+      "run"."model_provider_credential_scope" IS NULL AND
+      "run"."selected_model" IS NULL AND
+      "run"."codex_service_tier" IS NULL AND
+      "run"."selected_video_model" IS NULL AND
+      "run"."selected_image_model" IS NULL AND
+      "run"."chat_thread_id" IS NULL AND
+      "run"."api_started_at" IS NULL AND
+      "run"."first_assistant_event_acknowledged_at" IS NULL AND
+      "run"."summary" IS NULL AND
+      "run"."trigger_brief" IS NULL
+      THEN 'lifecycle_only'
+    WHEN
+      "run"."trigger_source" IS NOT NULL AND
+      "run"."autonomy_budget" IS NOT NULL
+      THEN 'product'
+    ELSE 'partial'
+  END AS "metadataShape",
+  "run"."status" AS "status"
+`;
+
+const ALL_RUNS_QUERY = `
+SELECT ${RUN_INVENTORY_PROJECTION}
+FROM "agent_runs" AS "run"
+ORDER BY "run"."id"
+`;
+
+const TARGET_RUNS_QUERY = `
+SELECT ${RUN_INVENTORY_PROJECTION}
+FROM "agent_runs" AS "run"
+WHERE "run"."id" = ANY($1::uuid[])
+ORDER BY "run"."id"
+`;
+
+const LOCKED_TARGET_RUNS_QUERY = `
+SELECT ${RUN_INVENTORY_PROJECTION}
+FROM "agent_runs" AS "run"
+WHERE "run"."id" = ANY($1::uuid[])
+  AND "run"."launch_snapshot" IS NULL
+ORDER BY "run"."id"
+FOR UPDATE OF "run" SKIP LOCKED
+`;
+
+const ALL_VERSIONS_QUERY = `
+SELECT "version"."id", "version"."content"
+FROM "agent_compose_versions" AS "version"
+ORDER BY "version"."id"
+`;
+
+const TARGET_VERSIONS_QUERY = `
+SELECT "version"."id", "version"."content"
+FROM "agent_compose_versions" AS "version"
+WHERE "version"."id" IN (
+  SELECT "run"."agent_compose_version_id"
+  FROM "agent_runs" AS "run"
+  WHERE "run"."id" = ANY($1::uuid[])
+  UNION
+  SELECT "checkpoint"."agent_compose_snapshot" ->> 'agentComposeVersionId'
+  FROM "checkpoints" AS "checkpoint"
+  WHERE "checkpoint"."run_id" = ANY($1::uuid[])
+)
+ORDER BY "version"."id"
+`;
+
+const ALL_CHECKPOINTS_QUERY = `
+SELECT
+  "checkpoint"."run_id"::text AS "runId",
+  "checkpoint"."agent_compose_snapshot" AS "snapshot"
+FROM "checkpoints" AS "checkpoint"
+ORDER BY "checkpoint"."id"
+`;
+
+const TARGET_CHECKPOINTS_QUERY = `
+SELECT
+  "checkpoint"."run_id"::text AS "runId",
+  "checkpoint"."agent_compose_snapshot" AS "snapshot"
+FROM "checkpoints" AS "checkpoint"
+WHERE "checkpoint"."run_id" = ANY($1::uuid[])
+ORDER BY "checkpoint"."id"
+`;
+
+const ALL_CONVERSATIONS_QUERY = `
+SELECT
+  "conversation"."run_id"::text AS "runId",
+  "conversation"."cli_agent_type" AS "framework"
+FROM "conversations" AS "conversation"
+ORDER BY "conversation"."run_id"
+`;
+
+const TARGET_CONVERSATIONS_QUERY = `
+SELECT
+  "conversation"."run_id"::text AS "runId",
+  "conversation"."cli_agent_type" AS "framework"
+FROM "conversations" AS "conversation"
+WHERE "conversation"."run_id" = ANY($1::uuid[])
+ORDER BY "conversation"."run_id"
+`;
+
+const UPDATE_SNAPSHOTS_QUERY = `
+WITH "payload" AS (
+  SELECT "value"."id", "value"."snapshot"
+  FROM jsonb_to_recordset($1::jsonb)
+    AS "value"("id" uuid, "snapshot" jsonb)
+)
+UPDATE "agent_runs" AS "run"
+SET "launch_snapshot" = "payload"."snapshot"
+FROM "payload"
+WHERE "run"."id" = "payload"."id"
+  AND "run"."launch_snapshot" IS NULL
+RETURNING
+  "run"."id"::text AS "id",
+  "run"."launch_snapshot" AS "launchSnapshot"
+`;
+
+const READ_BACK_SNAPSHOTS_QUERY = `
+SELECT
+  "run"."id"::text AS "id",
+  "run"."launch_snapshot" AS "launchSnapshot"
+FROM "agent_runs" AS "run"
+WHERE "run"."id" = ANY($1::uuid[])
+ORDER BY "run"."id"
+`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new SanitizedLaunchSnapshotBackfillError("inventory.shape");
+  }
+  return value;
+}
+
+function nullableString(value: unknown): string | null {
+  if (value === null) return null;
+  return requiredString(value);
+}
+
+function parseRunInventoryRow(
+  row: RawRunInventoryRow,
+): LaunchSnapshotBackfillRunInventoryRow {
+  if (
+    !(row.createdAt instanceof Date) ||
+    !Number.isFinite(row.createdAt.getTime()) ||
+    typeof row.chatThreadPresent !== "boolean" ||
+    (row.metadataShape !== "lifecycle_only" &&
+      row.metadataShape !== "product" &&
+      row.metadataShape !== "partial")
+  ) {
+    throw new SanitizedLaunchSnapshotBackfillError("inventory.shape");
+  }
+  return {
+    id: requiredString(row.id),
+    versionId: nullableString(row.versionId),
+    createdAt: row.createdAt,
+    launchSnapshot: row.launchSnapshot,
+    modelProvider: nullableString(row.modelProvider),
+    selectedModel: nullableString(row.selectedModel),
+    triggerSource: nullableString(row.triggerSource),
+    chatThreadPresent: row.chatThreadPresent,
+    metadataShape: row.metadataShape,
+    status: requiredString(row.status),
+  };
+}
+
+function parseVersionInventoryRow(
+  row: RawVersionInventoryRow,
+): LaunchSnapshotVersionInventoryRow {
+  return { id: requiredString(row.id), content: row.content };
+}
+
+function parseCheckpointInventoryRow(
+  row: RawCheckpointInventoryRow,
+): LaunchSnapshotCheckpointInventoryRow {
+  return { runId: requiredString(row.runId), snapshot: row.snapshot };
+}
+
+function parseConversationInventoryRow(
+  row: RawConversationInventoryRow,
+): LaunchSnapshotConversationInventoryRow {
+  return {
+    runId: requiredString(row.runId),
+    framework: requiredString(row.framework),
+  };
+}
+
+function parseSnapshotRow(row: RawSnapshotRow): {
+  readonly id: string;
+  readonly launchSnapshot: unknown;
+} {
+  return { id: requiredString(row.id), launchSnapshot: row.launchSnapshot };
+}
+
+function assertNotAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new SanitizedLaunchSnapshotBackfillError("cancelled");
+  }
+}
+
+function databaseErrorCode(error: unknown): string | undefined {
+  if (!isRecord(error)) return undefined;
+  if (typeof error.code === "string") return error.code;
+  return databaseErrorCode(error.cause);
+}
+
+function sanitizeError(
+  error: unknown,
+  fallback: LaunchSnapshotBackfillFailureGate,
+  signal?: AbortSignal,
+): SanitizedLaunchSnapshotBackfillError {
+  if (error instanceof SanitizedLaunchSnapshotBackfillError) return error;
+  if (signal?.aborted) {
+    return new SanitizedLaunchSnapshotBackfillError("cancelled");
+  }
+  const code = databaseErrorCode(error);
+  if (code === "57014") {
+    return new SanitizedLaunchSnapshotBackfillError("statement_timeout");
+  }
+  if (code === "55P03") {
+    return new SanitizedLaunchSnapshotBackfillError("lock_timeout");
+  }
+  if (code === "40001") {
+    return new SanitizedLaunchSnapshotBackfillError("batch.drift");
+  }
+  if (
+    code?.startsWith("08") ||
+    code === "57P01" ||
+    code === "ECONNREFUSED" ||
+    code === "ECONNRESET" ||
+    code === "EPIPE"
+  ) {
+    return new SanitizedLaunchSnapshotBackfillError("database.connection");
+  }
+  return new SanitizedLaunchSnapshotBackfillError(fallback);
+}
+
+function fingerprintsEqual(
+  left: SetFingerprint,
+  right: SetFingerprint,
+): boolean {
+  return left.count === right.count && left.digest === right.digest;
+}
+
+function compareRunIds(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function framedSnapshotMember(runId: string, snapshot: unknown): string {
+  const serialized = JSON.stringify(snapshot);
+  if (serialized === undefined) {
+    throw new SanitizedLaunchSnapshotBackfillError("inventory.shape");
+  }
+  return `${Buffer.byteLength(runId, "utf8")}:${runId}|${Buffer.byteLength(serialized, "utf8")}:${serialized}`;
+}
+
+function allClosuresExact(
+  output: ReturnType<typeof classifyLaunchSnapshotRecoverability>["output"],
+): boolean {
+  return [
+    output.populationClosure,
+    output.dispositionPartitionClosure,
+    output.dispositionDisjointnessClosure,
+    output.dispositionUnionClosure,
+    output.reasonPartitionClosure,
+    output.reasonUnionClosure,
+    output.reasonCompatibilityClosure,
+  ].every((closure) => {
+    return closure.classification === "exact";
+  });
+}
+
+export function validateLaunchSnapshotBackfillInput(
+  input: Omit<LaunchSnapshotBackfillInput, "connectionString" | "signal">,
+): void {
+  if (
+    (input.mode !== "dry-run" && input.mode !== "apply") ||
+    !Number.isSafeInteger(input.batchSize) ||
+    input.batchSize < 1 ||
+    input.batchSize > LAUNCH_SNAPSHOT_BACKFILL_MAX_BATCH_SIZE ||
+    !LAUNCH_SNAPSHOT_BACKFILL_MAX_BATCH_CHOICES.some((choice) => {
+      return choice === input.maxBatches;
+    }) ||
+    (input.mode === "apply" &&
+      input.applyConfirmation !== LAUNCH_SNAPSHOT_BACKFILL_APPLY_CONFIRMATION)
+  ) {
+    throw new SanitizedLaunchSnapshotBackfillError("input");
+  }
+}
+
+async function configureTransaction(
+  client: Client,
+  readOnly: boolean,
+  policy: LaunchSnapshotBackfillPolicy,
+): Promise<void> {
+  await client.query(
+    `SELECT
+       set_config('lock_timeout', $1, true),
+       set_config('statement_timeout', $2, true)`,
+    [`${policy.lockTimeoutMs}ms`, `${policy.statementTimeoutMs}ms`],
+  );
+  const capabilityResult = await client.query<RawCapabilityRow>(`
+    SELECT
+      current_setting('transaction_read_only') = 'on' AS "readOnly",
+      current_setting('transaction_isolation') AS "isolationLevel",
+      (SELECT "setting"::integer FROM "pg_settings"
+       WHERE "name" = 'lock_timeout') AS "lockTimeoutMs",
+      (SELECT "setting"::integer FROM "pg_settings"
+       WHERE "name" = 'statement_timeout') AS "statementTimeoutMs"
+  `);
+  const capability = capabilityResult.rows[0];
+  if (
+    !capability ||
+    capability.readOnly !== readOnly ||
+    capability.isolationLevel !== "repeatable read" ||
+    capability.lockTimeoutMs !== policy.lockTimeoutMs ||
+    capability.statementTimeoutMs !== policy.statementTimeoutMs
+  ) {
+    throw new SanitizedLaunchSnapshotBackfillError("database.query");
+  }
+}
+
+async function inTransaction<Value>(args: {
+  readonly client: Client;
+  readonly readOnly: boolean;
+  readonly policy: LaunchSnapshotBackfillPolicy;
+  readonly signal?: AbortSignal;
+  readonly fallbackGate: LaunchSnapshotBackfillFailureGate;
+  readonly body: () => Promise<Value>;
+}): Promise<Value> {
+  let started = false;
+  try {
+    assertNotAborted(args.signal);
+    await args.client.query(
+      args.readOnly
+        ? "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY"
+        : "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+    );
+    started = true;
+    await configureTransaction(args.client, args.readOnly, args.policy);
+    const value = await args.body();
+    assertNotAborted(args.signal);
+    await args.client.query(args.readOnly ? "ROLLBACK" : "COMMIT");
+    started = false;
+    return value;
+  } catch (error) {
+    if (started) {
+      try {
+        await args.client.query("ROLLBACK");
+      } catch {
+        throw sanitizeError(error, "transaction.cleanup", args.signal);
+      }
+    }
+    throw sanitizeError(error, args.fallbackGate, args.signal);
+  }
+}
+
+async function queryRuns(
+  client: Client,
+  query: string,
+  signal: AbortSignal | undefined,
+  runIds?: readonly string[],
+): Promise<readonly LaunchSnapshotBackfillRunInventoryRow[]> {
+  assertNotAborted(signal);
+  const result = await client.query<RawRunInventoryRow>(
+    query,
+    runIds ? [[...runIds]] : undefined,
+  );
+  assertNotAborted(signal);
+  return result.rows.map(parseRunInventoryRow);
+}
+
+async function queryVersions(
+  client: Client,
+  signal: AbortSignal | undefined,
+  runIds?: readonly string[],
+): Promise<readonly LaunchSnapshotVersionInventoryRow[]> {
+  assertNotAborted(signal);
+  const result = await client.query<RawVersionInventoryRow>(
+    runIds ? TARGET_VERSIONS_QUERY : ALL_VERSIONS_QUERY,
+    runIds ? [[...runIds]] : undefined,
+  );
+  assertNotAborted(signal);
+  return result.rows.map(parseVersionInventoryRow);
+}
+
+async function queryCheckpoints(
+  client: Client,
+  signal: AbortSignal | undefined,
+  runIds?: readonly string[],
+): Promise<readonly LaunchSnapshotCheckpointInventoryRow[]> {
+  assertNotAborted(signal);
+  const result = await client.query<RawCheckpointInventoryRow>(
+    runIds ? TARGET_CHECKPOINTS_QUERY : ALL_CHECKPOINTS_QUERY,
+    runIds ? [[...runIds]] : undefined,
+  );
+  assertNotAborted(signal);
+  return result.rows.map(parseCheckpointInventoryRow);
+}
+
+async function queryConversations(
+  client: Client,
+  signal: AbortSignal | undefined,
+  runIds?: readonly string[],
+): Promise<readonly LaunchSnapshotConversationInventoryRow[]> {
+  assertNotAborted(signal);
+  const result = await client.query<RawConversationInventoryRow>(
+    runIds ? TARGET_CONVERSATIONS_QUERY : ALL_CONVERSATIONS_QUERY,
+    runIds ? [[...runIds]] : undefined,
+  );
+  assertNotAborted(signal);
+  return result.rows.map(parseConversationInventoryRow);
+}
+
+export async function collectLaunchSnapshotBackfillInventory(args: {
+  readonly client: Client;
+  readonly policy: LaunchSnapshotBackfillPolicy;
+  readonly signal?: AbortSignal;
+}): Promise<LaunchSnapshotBackfillInventory> {
+  return inTransaction({
+    client: args.client,
+    readOnly: true,
+    policy: args.policy,
+    signal: args.signal,
+    fallbackGate: "database.query",
+    body: async () => {
+      const runs = await queryRuns(args.client, ALL_RUNS_QUERY, args.signal);
+      const versions = await queryVersions(args.client, args.signal);
+      const checkpoints = await queryCheckpoints(args.client, args.signal);
+      const conversations = await queryConversations(args.client, args.signal);
+      return { runs, versions, checkpoints, conversations };
+    },
+  });
+}
+
+function matchingRunFingerprint(
+  domain: string,
+  runs: readonly LaunchSnapshotBackfillRunInventoryRow[],
+  predicate: (run: LaunchSnapshotBackfillRunInventoryRow) => boolean,
+): SetFingerprint {
+  return fingerprintSortedSet(
+    domain,
+    runs.filter(predicate).map((run) => {
+      return run.id;
+    }),
+  );
+}
+
+function summarizeLaunchSnapshotBackfillInventory(args: {
+  readonly classified: ReturnType<typeof classifyLaunchSnapshotRecoverability>;
+  readonly inventory: LaunchSnapshotBackfillInventory;
+  readonly policy: LaunchSnapshotBackfillPolicy;
+}): LaunchSnapshotBackfillInventorySummary {
+  const criticalRunIds = args.classified.classifications
+    .filter((classification) => {
+      return [...classification.reasons].some((reason) => {
+        return CRITICAL_REASONS.has(reason);
+      });
+    })
+    .map((classification) => {
+      return classification.runId;
+    });
+  const duplicateEvidenceMembers = [
+    ...duplicateMembers(
+      args.inventory.versions.map((version) => {
+        return version.id;
+      }),
+    ).map((versionId) => {
+      return `version:${versionId}`;
+    }),
+    ...duplicateMembers(
+      args.inventory.checkpoints.map((checkpoint) => {
+        return checkpoint.runId;
+      }),
+    ).map((runId) => {
+      return `checkpoint:${runId}`;
+    }),
+    ...duplicateMembers(
+      args.inventory.conversations.map((conversation) => {
+        return conversation.runId;
+      }),
+    ).map((runId) => {
+      return `conversation:${runId}`;
+    }),
+  ];
+  const existingSnapshotMembers = args.inventory.runs
+    .filter((run) => {
+      return run.launchSnapshot !== null;
+    })
+    .map((run) => {
+      return framedSnapshotMember(run.id, run.launchSnapshot);
+    });
+  return {
+    total: args.classified.output.total,
+    population: args.classified.output.population,
+    dispositions: args.classified.output.dispositions,
+    closures: allClosuresExact(args.classified.output) ? "exact" : "drift",
+    frozenHistoricalUnknown: fingerprintsEqual(
+      args.classified.output.dispositions.historical_unknown,
+      args.policy.frozenHistoricalUnknown,
+    )
+      ? "exact"
+      : "drift",
+    frozenIntegrityConflict: fingerprintsEqual(
+      args.classified.output.dispositions.integrity_conflict,
+      args.policy.frozenIntegrityConflict,
+    )
+      ? "exact"
+      : "drift",
+    criticalReasons: fingerprintSortedSet(
+      "launch-snapshot-backfill:critical-reason-run-ids:v1",
+      criticalRunIds,
+    ),
+    duplicateEvidence: fingerprintSortedSet(
+      "launch-snapshot-backfill:duplicate-evidence:v1",
+      duplicateEvidenceMembers,
+    ),
+    activeNull: matchingRunFingerprint(
+      "launch-snapshot-backfill:active-null-run-ids:v1",
+      args.inventory.runs,
+      (run) => {
+        return (
+          run.launchSnapshot === null && ACTIVE_RUN_STATUSES.has(run.status)
+        );
+      },
+    ),
+    unsupportedStatus: matchingRunFingerprint(
+      "launch-snapshot-backfill:unsupported-status-run-ids:v1",
+      args.inventory.runs,
+      (run) => {
+        return !SUPPORTED_RUN_STATUSES.has(run.status);
+      },
+    ),
+    existingSnapshots: fingerprintSortedSet(
+      "launch-snapshot-backfill:existing-snapshots:v1",
+      existingSnapshotMembers,
+    ),
+  };
+}
+
+export function analyzeLaunchSnapshotBackfillInventory(
+  inventory: LaunchSnapshotBackfillInventory,
+  policy: LaunchSnapshotBackfillPolicy,
+): LaunchSnapshotBackfillAnalysis {
+  const classified = classifyLaunchSnapshotRecoverability(inventory);
+  const runById = new Map(
+    inventory.runs.map((run) => {
+      return [run.id, run] as const;
+    }),
+  );
+  const classificationById = new Map(
+    classified.classifications.map((classification) => {
+      return [classification.runId, classification] as const;
+    }),
+  );
+  const summary = summarizeLaunchSnapshotBackfillInventory({
+    classified,
+    inventory,
+    policy,
+  });
+  const candidates = classified.classifications
+    .flatMap((classification): readonly LaunchSnapshotBackfillCandidate[] => {
+      return classification.disposition === "exactly_recoverable"
+        ? [{ runId: classification.runId, snapshot: classification.snapshot }]
+        : [];
+    })
+    .sort((left, right) => {
+      return compareRunIds(left.runId, right.runId);
+    });
+  return {
+    inventory,
+    classifications: classified.classifications,
+    candidates,
+    summary,
+    runById,
+    classificationById,
+    failureGates: classified.failureGates,
+  };
+}
+
+function duplicateMembers(values: readonly string[]): string[] {
+  const observed = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (observed.has(value)) duplicates.add(value);
+    observed.add(value);
+  }
+  return [...duplicates];
+}
+
+export function assertLaunchSnapshotBackfillInventorySafe(
+  analysis: LaunchSnapshotBackfillAnalysis,
+): void {
+  if (analysis.summary.closures !== "exact") {
+    throw new SanitizedLaunchSnapshotBackfillError("inventory.closure");
+  }
+  if (
+    analysis.failureGates.some((gate) => {
+      return gate !== "launchSnapshots.integrity_conflict";
+    })
+  ) {
+    throw new SanitizedLaunchSnapshotBackfillError("inventory.classifier");
+  }
+  if (analysis.summary.duplicateEvidence.count !== 0) {
+    throw new SanitizedLaunchSnapshotBackfillError(
+      "inventory.duplicate_evidence",
+    );
+  }
+  if (analysis.summary.frozenHistoricalUnknown !== "exact") {
+    throw new SanitizedLaunchSnapshotBackfillError(
+      "inventory.frozen_historical_unknown",
+    );
+  }
+  if (analysis.summary.frozenIntegrityConflict !== "exact") {
+    throw new SanitizedLaunchSnapshotBackfillError(
+      "inventory.frozen_integrity_conflict",
+    );
+  }
+  if (analysis.summary.criticalReasons.count !== 0) {
+    throw new SanitizedLaunchSnapshotBackfillError("inventory.critical_reason");
+  }
+  if (analysis.summary.activeNull.count !== 0) {
+    throw new SanitizedLaunchSnapshotBackfillError("inventory.active_null");
+  }
+  if (analysis.summary.unsupportedStatus.count !== 0) {
+    throw new SanitizedLaunchSnapshotBackfillError(
+      "inventory.unsupported_status",
+    );
+  }
+  for (const candidate of analysis.candidates) {
+    const run = analysis.runById.get(candidate.runId);
+    if (!run || !TERMINAL_RUN_STATUSES.has(run.status)) {
+      throw new SanitizedLaunchSnapshotBackfillError("inventory.active_null");
+    }
+  }
+}
+
+function sameRunIds(
+  rows: readonly { readonly id: string }[],
+  expected: readonly string[],
+): boolean {
+  return (
+    rows.length === expected.length &&
+    rows.every((row, index) => {
+      return row.id === expected[index];
+    })
+  );
+}
+
+function exactClassification(
+  classifications: readonly LaunchSnapshotRunClassification[],
+  runId: string,
+): LaunchSnapshotRunClassification | undefined {
+  return classifications.find((classification) => {
+    return classification.runId === runId;
+  });
+}
+
+async function reproveLaunchSnapshotBackfillBatch(args: {
+  readonly candidateIds: readonly string[];
+  readonly candidates: readonly LaunchSnapshotBackfillCandidate[];
+  readonly client: Client;
+  readonly signal?: AbortSignal;
+}): Promise<void> {
+  const lockedRuns = await queryRuns(
+    args.client,
+    LOCKED_TARGET_RUNS_QUERY,
+    args.signal,
+    args.candidateIds,
+  );
+  if (!sameRunIds(lockedRuns, args.candidateIds)) {
+    const currentRuns = await queryRuns(
+      args.client,
+      TARGET_RUNS_QUERY,
+      args.signal,
+      args.candidateIds,
+    );
+    const currentById = new Map(
+      currentRuns.map((run) => {
+        return [run.id, run] as const;
+      }),
+    );
+    const contentionOnly = args.candidateIds.every((runId) => {
+      return currentById.get(runId)?.launchSnapshot === null;
+    });
+    throw new SanitizedLaunchSnapshotBackfillError(
+      contentionOnly ? "batch.contention" : "batch.drift",
+    );
+  }
+
+  const versions = await queryVersions(
+    args.client,
+    args.signal,
+    args.candidateIds,
+  );
+  const checkpoints = await queryCheckpoints(
+    args.client,
+    args.signal,
+    args.candidateIds,
+  );
+  const conversations = await queryConversations(
+    args.client,
+    args.signal,
+    args.candidateIds,
+  );
+  const classified = classifyLaunchSnapshotRecoverability({
+    runs: lockedRuns,
+    versions,
+    checkpoints,
+    conversations,
+  });
+  if (
+    !allClosuresExact(classified.output) ||
+    classified.classifications.length !== args.candidates.length
+  ) {
+    throw new SanitizedLaunchSnapshotBackfillError("batch.drift");
+  }
+  for (const candidate of args.candidates) {
+    const run = lockedRuns.find((item) => {
+      return item.id === candidate.runId;
+    });
+    const classification = exactClassification(
+      classified.classifications,
+      candidate.runId,
+    );
+    if (
+      !run ||
+      run.launchSnapshot !== null ||
+      !TERMINAL_RUN_STATUSES.has(run.status) ||
+      classification?.disposition !== "exactly_recoverable" ||
+      !isDeepStrictEqual(classification.snapshot, candidate.snapshot)
+    ) {
+      throw new SanitizedLaunchSnapshotBackfillError("batch.drift");
+    }
+  }
+}
+
+async function writeAndReadBackLaunchSnapshots(args: {
+  readonly candidateIds: readonly string[];
+  readonly candidates: readonly LaunchSnapshotBackfillCandidate[];
+  readonly client: Client;
+}): Promise<void> {
+  const payload = args.candidates.map((candidate) => {
+    return { id: candidate.runId, snapshot: candidate.snapshot };
+  });
+  const update = await args.client.query<RawSnapshotRow>(
+    UPDATE_SNAPSHOTS_QUERY,
+    [JSON.stringify(payload)],
+  );
+  const updatedRows = update.rows.map(parseSnapshotRow).sort((left, right) => {
+    return compareRunIds(left.id, right.id);
+  });
+  if (
+    update.rowCount !== args.candidates.length ||
+    !sameRunIds(updatedRows, args.candidateIds)
+  ) {
+    throw new SanitizedLaunchSnapshotBackfillError("batch.affected_rows");
+  }
+  assertSnapshotRowsMatch(updatedRows, args.candidates);
+
+  const readBack = await args.client.query<RawSnapshotRow>(
+    READ_BACK_SNAPSHOTS_QUERY,
+    [[...args.candidateIds]],
+  );
+  const readBackRows = readBack.rows
+    .map(parseSnapshotRow)
+    .sort((left, right) => {
+      return compareRunIds(left.id, right.id);
+    });
+  if (!sameRunIds(readBackRows, args.candidateIds)) {
+    throw new SanitizedLaunchSnapshotBackfillError("batch.read_back");
+  }
+  assertSnapshotRowsMatch(readBackRows, args.candidates);
+}
+
+function assertSnapshotRowsMatch(
+  rows: readonly { readonly launchSnapshot: unknown }[],
+  candidates: readonly LaunchSnapshotBackfillCandidate[],
+): void {
+  for (const [index, row] of rows.entries()) {
+    if (!isDeepStrictEqual(row.launchSnapshot, candidates[index]!.snapshot)) {
+      throw new SanitizedLaunchSnapshotBackfillError("batch.read_back");
+    }
+  }
+}
+
+export async function applyLaunchSnapshotBackfillBatch(args: {
+  readonly client: Client;
+  readonly candidates: readonly LaunchSnapshotBackfillCandidate[];
+  readonly policy: LaunchSnapshotBackfillPolicy;
+  readonly signal?: AbortSignal;
+}): Promise<number> {
+  if (
+    args.candidates.length < 1 ||
+    args.candidates.length > LAUNCH_SNAPSHOT_BACKFILL_MAX_BATCH_SIZE
+  ) {
+    throw new SanitizedLaunchSnapshotBackfillError("batch.size");
+  }
+  const candidates = [...args.candidates].sort((left, right) => {
+    return compareRunIds(left.runId, right.runId);
+  });
+  const candidateIds = candidates.map((candidate) => {
+    return candidate.runId;
+  });
+
+  return inTransaction({
+    client: args.client,
+    readOnly: false,
+    policy: args.policy,
+    signal: args.signal,
+    fallbackGate: "database.query",
+    body: async () => {
+      await reproveLaunchSnapshotBackfillBatch({
+        candidateIds,
+        candidates,
+        client: args.client,
+        signal: args.signal,
+      });
+      await writeAndReadBackLaunchSnapshots({
+        candidateIds,
+        candidates,
+        client: args.client,
+      });
+      return candidates.length;
+    },
+  });
+}
+
+function setsEqual(
+  left: ReadonlySet<string>,
+  right: ReadonlySet<string>,
+): boolean {
+  return (
+    left.size === right.size &&
+    [...left].every((value) => {
+      return right.has(value);
+    })
+  );
+}
+
+export function proveLaunchSnapshotBackfill(args: {
+  readonly before: LaunchSnapshotBackfillAnalysis;
+  readonly after: LaunchSnapshotBackfillAnalysis;
+  readonly committed: ReadonlyMap<string, ExactLaunchSnapshotValue>;
+}): void {
+  assertLaunchSnapshotBackfillInventorySafe(args.after);
+  const expectedRemaining = new Set(
+    args.before.candidates
+      .map((candidate) => {
+        return candidate.runId;
+      })
+      .filter((runId) => {
+        return !args.committed.has(runId);
+      }),
+  );
+  const observedRemaining = new Set(
+    args.after.candidates.map((candidate) => {
+      return candidate.runId;
+    }),
+  );
+  if (!setsEqual(expectedRemaining, observedRemaining)) {
+    throw new SanitizedLaunchSnapshotBackfillError("proof.drift");
+  }
+
+  for (const [runId, snapshot] of args.committed) {
+    const run = args.after.runById.get(runId);
+    const classification = args.after.classificationById.get(runId);
+    if (
+      !run ||
+      classification?.disposition !== "already_valid" ||
+      !isDeepStrictEqual(run.launchSnapshot, snapshot)
+    ) {
+      throw new SanitizedLaunchSnapshotBackfillError("proof.drift");
+    }
+  }
+
+  for (const run of args.before.inventory.runs) {
+    if (run.launchSnapshot === null) continue;
+    const after = args.after.runById.get(run.id);
+    if (
+      !after ||
+      !isDeepStrictEqual(after.launchSnapshot, run.launchSnapshot)
+    ) {
+      throw new SanitizedLaunchSnapshotBackfillError("proof.drift");
+    }
+  }
+}
+
+function emptySummary(
+  policy: LaunchSnapshotBackfillPolicy,
+): LaunchSnapshotBackfillInventorySummary {
+  const dispositions = Object.fromEntries(
+    LAUNCH_SNAPSHOT_DISPOSITIONS.map((disposition) => {
+      return [
+        disposition,
+        fingerprintSortedSet(
+          `launch-snapshot-backfill:empty:${disposition}:v1`,
+          [],
+        ),
+      ];
+    }),
+  ) as Record<(typeof LAUNCH_SNAPSHOT_DISPOSITIONS)[number], SetFingerprint>;
+  return {
+    total: 0,
+    population: fingerprintSortedSet(
+      "launch-snapshot-backfill:empty:population:v1",
+      [],
+    ),
+    dispositions,
+    closures: "drift",
+    frozenHistoricalUnknown: fingerprintsEqual(
+      dispositions.historical_unknown,
+      policy.frozenHistoricalUnknown,
+    )
+      ? "exact"
+      : "drift",
+    frozenIntegrityConflict: fingerprintsEqual(
+      dispositions.integrity_conflict,
+      policy.frozenIntegrityConflict,
+    )
+      ? "exact"
+      : "drift",
+    criticalReasons: fingerprintSortedSet(
+      "launch-snapshot-backfill:empty:critical:v1",
+      [],
+    ),
+    duplicateEvidence: fingerprintSortedSet(
+      "launch-snapshot-backfill:empty:duplicate-evidence:v1",
+      [],
+    ),
+    activeNull: fingerprintSortedSet(
+      "launch-snapshot-backfill:empty:active-null:v1",
+      [],
+    ),
+    unsupportedStatus: fingerprintSortedSet(
+      "launch-snapshot-backfill:empty:unsupported-status:v1",
+      [],
+    ),
+    existingSnapshots: fingerprintSortedSet(
+      "launch-snapshot-backfill:empty:existing-snapshots:v1",
+      [],
+    ),
+  };
+}
+
+function safeOutputInteger(value: number): number {
+  return Number.isSafeInteger(value) && value >= 0 ? value : 0;
+}
+
+function buildOutput(args: {
+  readonly input: Pick<
+    LaunchSnapshotBackfillInput,
+    "mode" | "batchSize" | "maxBatches"
+  >;
+  readonly policy: LaunchSnapshotBackfillPolicy;
+  readonly status: LaunchSnapshotBackfillStatus;
+  readonly failureGate: LaunchSnapshotBackfillFailureGate;
+  readonly candidateRows: number;
+  readonly attemptedBatches: number;
+  readonly committedBatches: number;
+  readonly committedRows: number;
+  readonly before?: LaunchSnapshotBackfillInventorySummary;
+  readonly after?: LaunchSnapshotBackfillInventorySummary;
+  readonly proof: "exact" | "drift" | "not_run";
+}): LaunchSnapshotBackfillOutput {
+  const empty = emptySummary(args.policy);
+  return {
+    schemaVersion: LAUNCH_SNAPSHOT_BACKFILL_SCHEMA_VERSION,
+    mode: args.input.mode,
+    status: args.status,
+    failureGate: args.failureGate,
+    parameters: {
+      batchSize: safeOutputInteger(args.input.batchSize),
+      maxBatches: safeOutputInteger(args.input.maxBatches),
+    },
+    progress: {
+      candidateRows: safeOutputInteger(args.candidateRows),
+      attemptedBatches: safeOutputInteger(args.attemptedBatches),
+      committedBatches: safeOutputInteger(args.committedBatches),
+      committedRows: safeOutputInteger(args.committedRows),
+    },
+    before: args.before ?? empty,
+    after: args.after ?? empty,
+    proof: args.proof,
+  };
+}
+
+function summaryOutputPaths(prefix: string): string[] {
+  return [
+    `${prefix}.total`,
+    `${prefix}.population.count`,
+    `${prefix}.population.digest`,
+    ...LAUNCH_SNAPSHOT_DISPOSITIONS.flatMap((disposition) => {
+      return [
+        `${prefix}.dispositions.${disposition}.count`,
+        `${prefix}.dispositions.${disposition}.digest`,
+      ];
+    }),
+    `${prefix}.closures`,
+    `${prefix}.frozenHistoricalUnknown`,
+    `${prefix}.frozenIntegrityConflict`,
+    `${prefix}.criticalReasons.count`,
+    `${prefix}.criticalReasons.digest`,
+    `${prefix}.duplicateEvidence.count`,
+    `${prefix}.duplicateEvidence.digest`,
+    `${prefix}.activeNull.count`,
+    `${prefix}.activeNull.digest`,
+    `${prefix}.unsupportedStatus.count`,
+    `${prefix}.unsupportedStatus.digest`,
+    `${prefix}.existingSnapshots.count`,
+    `${prefix}.existingSnapshots.digest`,
+  ];
+}
+
+export const LAUNCH_SNAPSHOT_BACKFILL_OUTPUT_ALLOWLIST = [
+  "schemaVersion",
+  "mode",
+  "status",
+  "failureGate",
+  "parameters.batchSize",
+  "parameters.maxBatches",
+  "progress.candidateRows",
+  "progress.attemptedBatches",
+  "progress.committedBatches",
+  "progress.committedRows",
+  ...summaryOutputPaths("before"),
+  ...summaryOutputPaths("after"),
+  "proof",
+].sort();
+
+function outputPaths(value: unknown, prefix = ""): string[] {
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value)
+      .flatMap(([key, child]) => {
+        return outputPaths(child, prefix ? `${prefix}.${key}` : key);
+      })
+      .sort();
+  }
+  return [prefix];
+}
+
+const SAFE_OUTPUT_STRINGS: ReadonlySet<string> = new Set([
+  LAUNCH_SNAPSHOT_BACKFILL_SCHEMA_VERSION,
+  "dry-run",
+  "apply",
+  "no-op",
+  "partial",
+  "complete",
+  "failed",
+  "exact",
+  "drift",
+  "not_run",
+  ...FAILURE_GATES,
+]);
+
+function hasSafeOutputValues(value: unknown, prefix = ""): boolean {
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value).every(([key, child]) => {
+      return hasSafeOutputValues(child, prefix ? `${prefix}.${key}` : key);
+    });
+  }
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0;
+  }
+  if (typeof value !== "string") return false;
+  if (prefix.endsWith(".digest")) return /^[0-9a-f]{64}$/u.test(value);
+  return SAFE_OUTPUT_STRINGS.has(value);
+}
+
+export function assertLaunchSnapshotBackfillOutputShape(value: unknown): void {
+  const paths = outputPaths(value);
+  if (
+    paths.length !== LAUNCH_SNAPSHOT_BACKFILL_OUTPUT_ALLOWLIST.length ||
+    !paths.every((path, index) => {
+      return path === LAUNCH_SNAPSHOT_BACKFILL_OUTPUT_ALLOWLIST[index];
+    }) ||
+    !hasSafeOutputValues(value)
+  ) {
+    throw new SanitizedLaunchSnapshotBackfillError("output.shape");
+  }
+}
+
+interface MutableLaunchSnapshotBackfillProgress {
+  attemptedBatches: number;
+  committedBatches: number;
+  committedRows: number;
+  readonly committed: Map<string, ExactLaunchSnapshotValue>;
+}
+
+interface MutableLaunchSnapshotBackfillExecution {
+  after?: LaunchSnapshotBackfillAnalysis;
+  before?: LaunchSnapshotBackfillAnalysis;
+  candidateRows: number;
+  proof: "exact" | "drift" | "not_run";
+  readonly progress: MutableLaunchSnapshotBackfillProgress;
+}
+
+async function connectLaunchSnapshotBackfillClient(
+  input: LaunchSnapshotBackfillInput,
+): Promise<Client> {
+  const client = new Client({ connectionString: input.connectionString });
+  client.on("error", () => {});
+  try {
+    await client.connect();
+    return client;
+  } catch (error) {
+    throw sanitizeError(error, "database.connection", input.signal);
+  }
+}
+
+async function applyDiscoveredLaunchSnapshotBatches(args: {
+  readonly before: LaunchSnapshotBackfillAnalysis;
+  readonly client: Client;
+  readonly input: LaunchSnapshotBackfillInput;
+  readonly policy: LaunchSnapshotBackfillPolicy;
+  readonly progress: MutableLaunchSnapshotBackfillProgress;
+}): Promise<void> {
+  let offset = 0;
+  while (
+    offset < args.before.candidates.length &&
+    args.progress.committedBatches < args.input.maxBatches
+  ) {
+    const batch = args.before.candidates.slice(
+      offset,
+      offset + args.input.batchSize,
+    );
+    args.progress.attemptedBatches++;
+    const updated = await applyLaunchSnapshotBackfillBatch({
+      client: args.client,
+      candidates: batch,
+      policy: args.policy,
+      signal: args.input.signal,
+    });
+    args.progress.committedBatches++;
+    args.progress.committedRows += updated;
+    offset += updated;
+    for (const candidate of batch) {
+      args.progress.committed.set(candidate.runId, candidate.snapshot);
+    }
+  }
+}
+
+function completedApplyStatus(
+  candidateRows: number,
+  remainingCandidates: number,
+): LaunchSnapshotBackfillStatus {
+  if (candidateRows === 0) return "no-op";
+  return remainingCandidates === 0 ? "complete" : "partial";
+}
+
+async function attemptLaunchSnapshotBackfillFailureProof(args: {
+  readonly before: LaunchSnapshotBackfillAnalysis | undefined;
+  readonly client: Client | undefined;
+  readonly failureGate: LaunchSnapshotBackfillFailureGate;
+  readonly input: LaunchSnapshotBackfillInput;
+  readonly policy: LaunchSnapshotBackfillPolicy;
+  readonly committed: ReadonlyMap<string, ExactLaunchSnapshotValue>;
+}): Promise<{
+  readonly after?: LaunchSnapshotBackfillAnalysis;
+  readonly proof: "exact" | "drift" | "not_run";
+}> {
+  if (
+    args.input.mode !== "apply" ||
+    !args.client ||
+    !args.before ||
+    args.failureGate === "cancelled" ||
+    args.failureGate === "database.connection"
+  ) {
+    return { proof: "not_run" };
+  }
+  let after: LaunchSnapshotBackfillAnalysis | undefined;
+  try {
+    const inventory = await collectLaunchSnapshotBackfillInventory({
+      client: args.client,
+      policy: args.policy,
+    });
+    after = analyzeLaunchSnapshotBackfillInventory(inventory, args.policy);
+    proveLaunchSnapshotBackfill({
+      before: args.before,
+      after,
+      committed: args.committed,
+    });
+    return { after, proof: "exact" };
+  } catch {
+    return { after, proof: "drift" };
+  }
+}
+
+async function executeConnectedLaunchSnapshotBackfill(args: {
+  readonly client: Client;
+  readonly input: LaunchSnapshotBackfillInput;
+  readonly policy: LaunchSnapshotBackfillPolicy;
+  readonly state: MutableLaunchSnapshotBackfillExecution;
+}): Promise<LaunchSnapshotBackfillOutput> {
+  const beforeInventory = await collectLaunchSnapshotBackfillInventory({
+    client: args.client,
+    policy: args.policy,
+    signal: args.input.signal,
+  });
+  const before = analyzeLaunchSnapshotBackfillInventory(
+    beforeInventory,
+    args.policy,
+  );
+  args.state.before = before;
+  assertLaunchSnapshotBackfillInventorySafe(before);
+  args.state.candidateRows = before.candidates.length;
+
+  if (args.input.mode === "dry-run") {
+    return buildOutput({
+      input: args.input,
+      policy: args.policy,
+      status: args.state.candidateRows === 0 ? "no-op" : "dry-run",
+      failureGate: "none",
+      candidateRows: args.state.candidateRows,
+      attemptedBatches: args.state.progress.attemptedBatches,
+      committedBatches: args.state.progress.committedBatches,
+      committedRows: args.state.progress.committedRows,
+      before: before.summary,
+      after: before.summary,
+      proof: args.state.proof,
+    });
+  }
+
+  await applyDiscoveredLaunchSnapshotBatches({
+    before,
+    client: args.client,
+    input: args.input,
+    policy: args.policy,
+    progress: args.state.progress,
+  });
+  const afterInventory = await collectLaunchSnapshotBackfillInventory({
+    client: args.client,
+    policy: args.policy,
+    signal: args.input.signal,
+  });
+  const after = analyzeLaunchSnapshotBackfillInventory(
+    afterInventory,
+    args.policy,
+  );
+  args.state.after = after;
+  proveLaunchSnapshotBackfill({
+    before,
+    after,
+    committed: args.state.progress.committed,
+  });
+  args.state.proof = "exact";
+  return buildOutput({
+    input: args.input,
+    policy: args.policy,
+    status: completedApplyStatus(
+      args.state.candidateRows,
+      after.candidates.length,
+    ),
+    failureGate: "none",
+    candidateRows: args.state.candidateRows,
+    attemptedBatches: args.state.progress.attemptedBatches,
+    committedBatches: args.state.progress.committedBatches,
+    committedRows: args.state.progress.committedRows,
+    before: before.summary,
+    after: after.summary,
+    proof: args.state.proof,
+  });
+}
+
+export async function executeLaunchSnapshotBackfill(
+  input: LaunchSnapshotBackfillInput,
+  policy: LaunchSnapshotBackfillPolicy = PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY,
+): Promise<LaunchSnapshotBackfillOutput> {
+  let client: Client | undefined;
+  const state: MutableLaunchSnapshotBackfillExecution = {
+    candidateRows: 0,
+    proof: "not_run",
+    progress: {
+      attemptedBatches: 0,
+      committedBatches: 0,
+      committedRows: 0,
+      committed: new Map(),
+    },
+  };
+
+  try {
+    validateLaunchSnapshotBackfillInput(input);
+    if (!input.connectionString.trim()) {
+      throw new SanitizedLaunchSnapshotBackfillError("configuration");
+    }
+    client = await connectLaunchSnapshotBackfillClient(input);
+    const connectedClient = client;
+    const cancelInFlight = (): void => {
+      void connectedClient.end().catch(() => {});
+    };
+    input.signal?.addEventListener("abort", cancelInFlight, { once: true });
+    if (input.signal?.aborted) cancelInFlight();
+    try {
+      const output = await executeConnectedLaunchSnapshotBackfill({
+        client: connectedClient,
+        input,
+        policy,
+        state,
+      });
+      assertLaunchSnapshotBackfillOutputShape(output);
+      return output;
+    } finally {
+      input.signal?.removeEventListener("abort", cancelInFlight);
+    }
+  } catch (error) {
+    const sanitized = sanitizeError(error, "unexpected", input.signal);
+    const failureProof = await attemptLaunchSnapshotBackfillFailureProof({
+      before: state.before,
+      client,
+      failureGate: sanitized.gate,
+      input,
+      policy,
+      committed: state.progress.committed,
+    });
+    state.after = failureProof.after;
+    state.proof = failureProof.proof;
+    const output = buildOutput({
+      input,
+      policy,
+      status: "failed",
+      failureGate: sanitized.gate,
+      candidateRows: state.candidateRows,
+      attemptedBatches: state.progress.attemptedBatches,
+      committedBatches: state.progress.committedBatches,
+      committedRows: state.progress.committedRows,
+      before: state.before?.summary,
+      after: state.after?.summary,
+      proof: state.proof,
+    });
+    assertLaunchSnapshotBackfillOutputShape(output);
+    return output;
+  } finally {
+    await client?.end().catch(() => {});
+  }
+}
+
+function parseIntegerInput(value: string | undefined): number {
+  if (!value || !/^[0-9]+$/u.test(value)) {
+    throw new SanitizedLaunchSnapshotBackfillError("input");
+  }
+  return Number(value);
+}
+
+function fallbackInput(): LaunchSnapshotBackfillInput {
+  return {
+    connectionString: "",
+    mode: "dry-run",
+    batchSize: LAUNCH_SNAPSHOT_BACKFILL_MAX_BATCH_SIZE,
+    maxBatches: 1,
+  };
+}
+
+async function runCli(): Promise<void> {
+  let input = fallbackInput();
+  let output: LaunchSnapshotBackfillOutput;
+  const controller = new AbortController();
+  const abort = (): void => {
+    controller.abort();
+  };
+  const timeout = setTimeout(abort, 55 * 60 * 1000);
+  timeout.unref();
+  process.once("SIGINT", abort);
+  process.once("SIGTERM", abort);
+  try {
+    const { values } = parseArgs({
+      options: {
+        mode: { type: "string", default: "dry-run" },
+        "batch-size": {
+          type: "string",
+          default: String(LAUNCH_SNAPSHOT_BACKFILL_MAX_BATCH_SIZE),
+        },
+        "max-batches": { type: "string", default: "1" },
+        "confirm-apply": { type: "string" },
+      },
+      strict: true,
+    });
+    if (values.mode !== "dry-run" && values.mode !== "apply") {
+      throw new SanitizedLaunchSnapshotBackfillError("input");
+    }
+    input = {
+      connectionString: process.env.DATABASE_URL ?? "",
+      mode: values.mode,
+      batchSize: parseIntegerInput(values["batch-size"]),
+      maxBatches: parseIntegerInput(values["max-batches"]),
+      applyConfirmation: values["confirm-apply"],
+      signal: controller.signal,
+    };
+    output = await executeLaunchSnapshotBackfill(input);
+  } catch (error) {
+    const sanitized = sanitizeError(error, "unexpected");
+    output = buildOutput({
+      input,
+      policy: PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY,
+      status: "failed",
+      failureGate: sanitized.gate,
+      candidateRows: 0,
+      attemptedBatches: 0,
+      committedBatches: 0,
+      committedRows: 0,
+      proof: "not_run",
+    });
+  } finally {
+    clearTimeout(timeout);
+    process.off("SIGINT", abort);
+    process.off("SIGTERM", abort);
+  }
+  try {
+    assertLaunchSnapshotBackfillOutputShape(output);
+  } catch {
+    output = buildOutput({
+      input: fallbackInput(),
+      policy: PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY,
+      status: "failed",
+      failureGate: "output.shape",
+      candidateRows: 0,
+      attemptedBatches: 0,
+      committedBatches: 0,
+      committedRows: 0,
+      proof: "not_run",
+    });
+  }
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+  if (output.status === "failed") process.exitCode = 1;
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  runCli().catch(() => {
+    const output = buildOutput({
+      input: fallbackInput(),
+      policy: PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY,
+      status: "failed",
+      failureGate: "unexpected",
+      candidateRows: 0,
+      attemptedBatches: 0,
+      committedBatches: 0,
+      committedRows: 0,
+      proof: "not_run",
+    });
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -168,6 +169,16 @@ function testCompletePartitionAndStrictSnapshots(): void {
   );
   assertAllClosuresExact(result);
   assert.deepEqual(result.failureGates, ["launchSnapshots.integrity_conflict"]);
+  assert.equal(
+    createHash("sha256").update(JSON.stringify(result.output)).digest("hex"),
+    "931238caecc364f74931a1aa0e47fe24316fe4c836b7f4346bf271a14f7580a2",
+  );
+  for (const classification of result.classifications) {
+    assert.equal(
+      "snapshot" in classification,
+      classification.disposition === "exactly_recoverable",
+    );
+  }
 
   for (const launchSnapshot of [
     null,
@@ -187,6 +198,129 @@ function testCompletePartitionAndStrictSnapshots(): void {
       assert.equal(invalid.output.dispositions.integrity_conflict.count, 1);
     }
   }
+}
+
+function testExactSnapshotValueConstruction(): void {
+  const cases = [
+    {
+      id: "claude-default",
+      content: agentContent({
+        framework: "claude-code",
+        name: "claude-default",
+      }),
+      run: {},
+      snapshot: {
+        schemaVersion: 1,
+        framework: "claude-code",
+        runnerProfile: "vm0/default",
+      },
+    },
+    {
+      id: "claude-explicit",
+      content: agentContent({
+        framework: "claude-code",
+        name: "claude-explicit",
+        profile: "vm0/claude-private",
+        profilePresent: true,
+      }),
+      run: {},
+      snapshot: {
+        schemaVersion: 1,
+        framework: "claude-code",
+        runnerProfile: "vm0/claude-private",
+      },
+    },
+    {
+      id: "codex-default",
+      content: agentContent({ framework: "codex", name: "codex-default" }),
+      run: { modelProvider: "openai-api-key" },
+      snapshot: {
+        schemaVersion: 1,
+        framework: "codex",
+        runnerProfile: "vm0/default",
+      },
+    },
+    {
+      id: "codex-explicit",
+      content: agentContent({
+        framework: "codex",
+        name: "codex-explicit",
+        profile: "vm0/codex-private",
+        profilePresent: true,
+      }),
+      run: { modelProvider: "openai-api-key" },
+      snapshot: {
+        schemaVersion: 1,
+        framework: "codex",
+        runnerProfile: "vm0/codex-private",
+      },
+    },
+    {
+      id: "pi-default",
+      content: agentContent({ framework: "codex", name: "pi-default" }),
+      run: {
+        chatThreadPresent: true,
+        createdAt: new Date("2026-08-13T00:00:00.000Z"),
+        modelProvider: "openai-api-key",
+        selectedModel: "deepseek-v4-flash",
+        triggerSource: "web",
+      },
+      snapshot: {
+        schemaVersion: 1,
+        framework: "pi",
+        runnerProfile: "vm0/default",
+      },
+    },
+    {
+      id: "pi-explicit",
+      content: agentContent({
+        framework: "codex",
+        name: "pi-explicit",
+        profile: "vm0/pi-private",
+        profilePresent: true,
+      }),
+      run: {
+        chatThreadPresent: true,
+        createdAt: new Date("2026-08-13T00:00:00.000Z"),
+        modelProvider: "openai-api-key",
+        selectedModel: "deepseek-v4-flash",
+        triggerSource: "web",
+      },
+      snapshot: {
+        schemaVersion: 1,
+        framework: "pi",
+        runnerProfile: "vm0/pi-private",
+      },
+    },
+  ] as const;
+  const storedVersions = cases.map((testCase) => {
+    return version(testCase.content);
+  });
+  const result = classify({
+    runs: cases.map((testCase, index) => {
+      return run(testCase.id, storedVersions[index]!.id, testCase.run);
+    }),
+    versions: storedVersions,
+    conversations: cases
+      .filter((testCase) => {
+        return testCase.snapshot.framework === "pi";
+      })
+      .map((testCase) => {
+        return conversation(testCase.id, "pi");
+      }),
+  });
+
+  for (const testCase of cases) {
+    const classification = result.classifications.find((item) => {
+      return item.runId === testCase.id;
+    });
+    assert.ok(classification);
+    assert.equal(classification.disposition, "exactly_recoverable");
+    if (classification.disposition === "exactly_recoverable") {
+      assert.deepEqual(classification.snapshot, testCase.snapshot);
+    }
+  }
+  assertAllClosuresExact(result);
 }
 
 function testVersionAndCheckpointEvidence(): void {
@@ -1303,6 +1437,7 @@ async function testClassifierHasNoCurrentAuthorityLookup(): Promise<void> {
 
 export async function validateLaunchSnapshotRecoverabilityStatic(): Promise<void> {
   testCompletePartitionAndStrictSnapshots();
+  testExactSnapshotValueConstruction();
   testVersionAndCheckpointEvidence();
   testProviderAndProductionRolloutHistory();
   testExactProductionBoundaryEdges();

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -37,6 +37,10 @@ import {
 } from "./agent-compose-consolidation-preflight-refinements";
 import { validateLaunchSnapshotRecoverabilityStatic } from "./test-agent-compose-consolidation-preflight-launch-snapshots";
 import {
+  validateLaunchSnapshotBackfillDatabase,
+  validateLaunchSnapshotBackfillStatic,
+} from "./test-agent-run-launch-snapshot-backfill";
+import {
   PREFLIGHT_OUTPUT_ALLOWLIST,
   SanitizedPreflightError,
   assertPreflightOutputShape,
@@ -2897,6 +2901,7 @@ async function testDatabaseBoundaries(databaseUrl: string): Promise<void> {
 
 export async function validateAgentComposeConsolidationPreflightStatic(): Promise<void> {
   await validateLaunchSnapshotRecoverabilityStatic();
+  await validateLaunchSnapshotBackfillStatic();
   testSchemaV3DomainsRemainByteStable();
   testApplicationOwnedPlanAndCanonicalCompatibility();
   testIdentityAndApprovedArtifacts();
@@ -2919,6 +2924,7 @@ export async function validateAgentComposeConsolidationPreflight(): Promise<void
   const databaseUrl = process.env.DATABASE_URL;
   assert.ok(databaseUrl, "DATABASE_URL is required");
   await testDatabaseBoundaries(databaseUrl);
+  await validateLaunchSnapshotBackfillDatabase(databaseUrl);
   console.log("agent compose consolidation preflight passed");
 }
 

--- a/turbo/packages/db/scripts/test-agent-run-launch-snapshot-backfill.ts
+++ b/turbo/packages/db/scripts/test-agent-run-launch-snapshot-backfill.ts
@@ -1,0 +1,1129 @@
+#!/usr/bin/env tsx
+
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "pg";
+import { computeComposeVersionId } from "../../../apps/api/src/signals/services/agent-compose-content";
+import {
+  classifyLaunchSnapshotRecoverability,
+  type ExactLaunchSnapshotValue,
+} from "./agent-compose-consolidation-preflight-launch-snapshots";
+import {
+  LAUNCH_SNAPSHOT_BACKFILL_APPLY_CONFIRMATION,
+  LAUNCH_SNAPSHOT_BACKFILL_MAX_BATCH_SIZE,
+  LAUNCH_SNAPSHOT_BACKFILL_OUTPUT_ALLOWLIST,
+  PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY,
+  SanitizedLaunchSnapshotBackfillError,
+  analyzeLaunchSnapshotBackfillInventory,
+  applyLaunchSnapshotBackfillBatch,
+  assertLaunchSnapshotBackfillInventorySafe,
+  assertLaunchSnapshotBackfillOutputShape,
+  collectLaunchSnapshotBackfillInventory,
+  executeLaunchSnapshotBackfill,
+  proveLaunchSnapshotBackfill,
+  validateLaunchSnapshotBackfillInput,
+  type LaunchSnapshotBackfillInventory,
+  type LaunchSnapshotBackfillPolicy,
+} from "./agent-run-launch-snapshot-backfill";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(dirname, "../../../..");
+const testSchema = "agent_run_launch_snapshot_backfill_test";
+const applyConfirmation = LAUNCH_SNAPSHOT_BACKFILL_APPLY_CONFIRMATION;
+const defaultSnapshot: ExactLaunchSnapshotValue = {
+  schemaVersion: 1,
+  framework: "claude-code",
+  runnerProfile: "vm0/default",
+};
+
+function uuid(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+}
+
+function agentContent(name: string): Record<string, unknown> {
+  return {
+    version: "1",
+    agents: { [name]: { framework: "claude-code" } },
+  };
+}
+
+function version(name: string): {
+  readonly content: Record<string, unknown>;
+  readonly id: string;
+} {
+  const content = agentContent(name);
+  return { content, id: computeComposeVersionId(content) };
+}
+
+function inMemoryRun(args: {
+  readonly id: string;
+  readonly versionId: string | null;
+  readonly launchSnapshot?: unknown;
+  readonly status?: string;
+}) {
+  return {
+    id: args.id,
+    versionId: args.versionId,
+    createdAt: new Date("2026-08-14T00:00:00.000Z"),
+    launchSnapshot: args.launchSnapshot ?? null,
+    modelProvider: "anthropic-api-key",
+    selectedModel: null,
+    triggerSource: "slack",
+    chatThreadPresent: false,
+    metadataShape: "product" as const,
+    status: args.status ?? "completed",
+  };
+}
+
+function policyForInventory(
+  inventory: LaunchSnapshotBackfillInventory,
+  timeouts: { readonly lock?: number; readonly statement?: number } = {},
+): LaunchSnapshotBackfillPolicy {
+  const classified = classifyLaunchSnapshotRecoverability(inventory);
+  return {
+    frozenHistoricalUnknown: classified.output.dispositions.historical_unknown,
+    frozenIntegrityConflict: classified.output.dispositions.integrity_conflict,
+    lockTimeoutMs:
+      timeouts.lock ?? PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY.lockTimeoutMs,
+    statementTimeoutMs:
+      timeouts.statement ??
+      PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY.statementTimeoutMs,
+  };
+}
+
+function outputPaths(value: unknown, prefix = ""): string[] {
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value)
+      .flatMap(([key, child]) => {
+        return outputPaths(child, prefix ? `${prefix}.${key}` : key);
+      })
+      .sort();
+  }
+  return [prefix];
+}
+
+function assertGate(
+  action: () => unknown,
+  gate: SanitizedLaunchSnapshotBackfillError["gate"],
+): void {
+  assert.throws(action, (error: unknown) => {
+    return (
+      error instanceof SanitizedLaunchSnapshotBackfillError &&
+      error.gate === gate
+    );
+  });
+}
+
+async function assertRejectedGate(
+  action: Promise<unknown>,
+  gate: SanitizedLaunchSnapshotBackfillError["gate"],
+): Promise<void> {
+  await assert.rejects(action, (error: unknown) => {
+    return (
+      error instanceof SanitizedLaunchSnapshotBackfillError &&
+      error.gate === gate
+    );
+  });
+}
+
+function testBoundedInputs(): void {
+  assert.deepEqual(
+    PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY.frozenHistoricalUnknown,
+    {
+      count: 2627,
+      digest:
+        "314360539273450908d01e647338c39ee30c12e131bcddf67c54023c57bad94c",
+    },
+  );
+  assert.deepEqual(
+    PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY.frozenIntegrityConflict,
+    {
+      count: 9,
+      digest:
+        "c74f9a7cbeba3d52589f7b7bfb569ca7ecc25b7fa00e4a88ab728df7d22e2159",
+    },
+  );
+  for (const batchSize of [1, 499, 500]) {
+    validateLaunchSnapshotBackfillInput({
+      mode: "dry-run",
+      batchSize,
+      maxBatches: 1,
+    });
+  }
+  for (const batchSize of [0, 501]) {
+    assertGate(() => {
+      validateLaunchSnapshotBackfillInput({
+        mode: "dry-run",
+        batchSize,
+        maxBatches: 1,
+      });
+    }, "input");
+  }
+  for (const maxBatches of [1, 20, 300]) {
+    validateLaunchSnapshotBackfillInput({
+      mode: "dry-run",
+      batchSize: 500,
+      maxBatches,
+    });
+  }
+  assertGate(() => {
+    validateLaunchSnapshotBackfillInput({
+      mode: "dry-run",
+      batchSize: 500,
+      maxBatches: 2,
+    });
+  }, "input");
+  assertGate(() => {
+    validateLaunchSnapshotBackfillInput({
+      mode: "unexpected" as "dry-run",
+      batchSize: 500,
+      maxBatches: 1,
+    });
+  }, "input");
+  assertGate(() => {
+    validateLaunchSnapshotBackfillInput({
+      mode: "apply",
+      batchSize: 500,
+      maxBatches: 1,
+    });
+  }, "input");
+  validateLaunchSnapshotBackfillInput({
+    mode: "apply",
+    batchSize: 500,
+    maxBatches: 1,
+    applyConfirmation,
+  });
+}
+
+function testInventoryGatesAndConcurrentValidRows(): void {
+  const storedVersion = version("inventory");
+  const candidateId = uuid(1);
+  const beforeInventory: LaunchSnapshotBackfillInventory = {
+    runs: [
+      inMemoryRun({ id: candidateId, versionId: storedVersion.id }),
+      inMemoryRun({
+        id: uuid(2),
+        versionId: storedVersion.id,
+        launchSnapshot: defaultSnapshot,
+      }),
+    ],
+    versions: [storedVersion],
+    checkpoints: [],
+    conversations: [],
+  };
+  const policy = policyForInventory(beforeInventory);
+  const before = analyzeLaunchSnapshotBackfillInventory(
+    beforeInventory,
+    policy,
+  );
+  assertLaunchSnapshotBackfillInventorySafe(before);
+  assert.deepEqual(
+    before.candidates.map((candidate) => {
+      return candidate.runId;
+    }),
+    [candidateId],
+  );
+
+  const afterInventory: LaunchSnapshotBackfillInventory = {
+    ...beforeInventory,
+    runs: [
+      inMemoryRun({
+        id: candidateId,
+        versionId: storedVersion.id,
+        launchSnapshot: defaultSnapshot,
+      }),
+      beforeInventory.runs[1]!,
+      inMemoryRun({
+        id: uuid(3),
+        versionId: storedVersion.id,
+        launchSnapshot: defaultSnapshot,
+      }),
+    ],
+  };
+  const after = analyzeLaunchSnapshotBackfillInventory(afterInventory, policy);
+  proveLaunchSnapshotBackfill({
+    before,
+    after,
+    committed: new Map([[candidateId, defaultSnapshot]]),
+  });
+  assert.equal(after.summary.total, before.summary.total + 1);
+  assert.equal(
+    after.summary.dispositions.already_valid.count,
+    before.summary.dispositions.already_valid.count + 2,
+  );
+
+  const unknownInventory: LaunchSnapshotBackfillInventory = {
+    ...beforeInventory,
+    runs: [
+      ...beforeInventory.runs,
+      inMemoryRun({ id: uuid(4), versionId: null }),
+    ],
+  };
+  assertGate(() => {
+    assertLaunchSnapshotBackfillInventorySafe(
+      analyzeLaunchSnapshotBackfillInventory(unknownInventory, policy),
+    );
+  }, "inventory.frozen_historical_unknown");
+
+  const conflictId = uuid(5);
+  const conflictInventory: LaunchSnapshotBackfillInventory = {
+    ...beforeInventory,
+    runs: [
+      ...beforeInventory.runs,
+      inMemoryRun({ id: conflictId, versionId: storedVersion.id }),
+    ],
+    conversations: [{ runId: conflictId, framework: "codex" }],
+  };
+  assertGate(() => {
+    assertLaunchSnapshotBackfillInventorySafe(
+      analyzeLaunchSnapshotBackfillInventory(conflictInventory, policy),
+    );
+  }, "inventory.frozen_integrity_conflict");
+
+  const activeInventory: LaunchSnapshotBackfillInventory = {
+    ...beforeInventory,
+    runs: [
+      inMemoryRun({
+        id: candidateId,
+        versionId: storedVersion.id,
+        status: "running",
+      }),
+      beforeInventory.runs[1]!,
+    ],
+  };
+  assertGate(() => {
+    assertLaunchSnapshotBackfillInventorySafe(
+      analyzeLaunchSnapshotBackfillInventory(activeInventory, policy),
+    );
+  }, "inventory.active_null");
+
+  const unsupportedStatusInventory: LaunchSnapshotBackfillInventory = {
+    ...beforeInventory,
+    runs: [
+      inMemoryRun({
+        id: candidateId,
+        versionId: storedVersion.id,
+        launchSnapshot: defaultSnapshot,
+        status: "future-status",
+      }),
+      beforeInventory.runs[1]!,
+    ],
+  };
+  assertGate(() => {
+    assertLaunchSnapshotBackfillInventorySafe(
+      analyzeLaunchSnapshotBackfillInventory(
+        unsupportedStatusInventory,
+        policy,
+      ),
+    );
+  }, "inventory.unsupported_status");
+
+  const duplicateInventory: LaunchSnapshotBackfillInventory = {
+    ...beforeInventory,
+    checkpoints: [
+      { runId: candidateId, snapshot: null },
+      { runId: candidateId, snapshot: null },
+    ],
+  };
+  const duplicatePolicy = policyForInventory(duplicateInventory);
+  assertGate(() => {
+    assertLaunchSnapshotBackfillInventorySafe(
+      analyzeLaunchSnapshotBackfillInventory(
+        duplicateInventory,
+        duplicatePolicy,
+      ),
+    );
+  }, "inventory.duplicate_evidence");
+}
+
+async function testStaticSafetyContracts(): Promise<void> {
+  const runner = await fs.readFile(
+    path.join(dirname, "agent-run-launch-snapshot-backfill.ts"),
+    "utf8",
+  );
+  const workflow = await fs.readFile(
+    path.join(
+      repositoryRoot,
+      ".github/workflows/agent-run-launch-snapshot-backfill.yml",
+    ),
+    "utf8",
+  );
+
+  assert.match(
+    runner,
+    /BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY/u,
+  );
+  assert.match(runner, /BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ"/u);
+  assert.match(runner, /FOR UPDATE OF "run" SKIP LOCKED/u);
+  assert.match(
+    runner,
+    /UPDATE "agent_runs" AS "run"[\s\S]*?SET "launch_snapshot" = "payload"\."snapshot"[\s\S]*?AND "run"\."launch_snapshot" IS NULL/u,
+  );
+  assert.equal(runner.match(/UPDATE "agent_runs" AS "run"/gu)?.length, 1);
+  assert.equal(/LOCK TABLE|pg_advisory/u.test(runner), false);
+  assert.equal(
+    /agent_composes|zero_agents|feature_switch/u.test(runner),
+    false,
+  );
+  assert.equal(/console\.(?:log|error)|upload-artifact/u.test(runner), false);
+  assert.match(runner, /const PRODUCTION_LOCK_TIMEOUT_MS = 1000/u);
+  assert.match(runner, /const PRODUCTION_STATEMENT_TIMEOUT_MS = 30_000/u);
+  assert.match(runner, /LAUNCH_SNAPSHOT_BACKFILL_MAX_BATCH_SIZE = 500/u);
+  assert.match(runner, /count: 2627/u);
+  assert.match(
+    runner,
+    /314360539273450908d01e647338c39ee30c12e131bcddf67c54023c57bad94c/u,
+  );
+  assert.match(runner, /count: 9/u);
+  assert.match(
+    runner,
+    /c74f9a7cbeba3d52589f7b7bfb569ca7ecc25b7fa00e4a88ab728df7d22e2159/u,
+  );
+
+  assert.match(workflow, /^on:\n {2}workflow_dispatch:/mu);
+  assert.match(workflow, /default: dry-run/u);
+  assert.match(workflow, /environment: production/u);
+  assert.match(workflow, /ref: main/u);
+  assert.equal(/ref:.*\$\{\{/u.test(workflow), false);
+  assert.match(
+    workflow,
+    /group: production-agent-run-launch-snapshot-backfill/u,
+  );
+  assert.match(workflow, /cancel-in-progress: false/u);
+  assert.match(workflow, /timeout-minutes: 60/u);
+  assert.match(workflow, /inputs\.confirmed_apply != 'yes'/u);
+  assert.match(
+    workflow,
+    /--confirm-apply apply-agent-run-launch-snapshot-backfill/u,
+  );
+  for (const choice of ['- "1"', '- "20"', '- "300"', '- "500"']) {
+    assert.ok(workflow.includes(choice));
+  }
+  assert.match(workflow, /--pooled/u);
+  assert.match(workflow, /--ssl verify-full/u);
+  assert.equal(workflow.includes("upload-artifact"), false);
+  assert.equal(workflow.includes("pull_request"), false);
+}
+
+async function testSanitizedConnectionFailure(): Promise<void> {
+  const secret = "not-a-report-field";
+  const output = await executeLaunchSnapshotBackfill({
+    connectionString: `postgresql://127.0.0.1:1/${secret}`,
+    mode: "dry-run",
+    batchSize: 500,
+    maxBatches: 1,
+  });
+  assert.equal(output.status, "failed");
+  assert.equal(output.failureGate, "database.connection");
+  assertLaunchSnapshotBackfillOutputShape(output);
+  assert.deepEqual(
+    outputPaths(output),
+    LAUNCH_SNAPSHOT_BACKFILL_OUTPUT_ALLOWLIST,
+  );
+  assert.equal(JSON.stringify(output).includes(secret), false);
+}
+
+export async function validateLaunchSnapshotBackfillStatic(): Promise<void> {
+  testBoundedInputs();
+  testInventoryGatesAndConcurrentValidRows();
+  await testStaticSafetyContracts();
+  await testSanitizedConnectionFailure();
+}
+
+interface BaselineFixture {
+  readonly candidateIds: readonly [string, string];
+  readonly conflictId: string;
+  readonly existingId: string;
+  readonly existingSnapshot: ExactLaunchSnapshotValue;
+  readonly unknownId: string;
+}
+
+function databaseUrlForSchema(databaseUrl: string): string {
+  const result = new URL(databaseUrl);
+  result.searchParams.set("options", `-c search_path=${testSchema}`);
+  return result.toString();
+}
+
+async function createTestSchema(admin: Client): Promise<void> {
+  await admin.query(`DROP SCHEMA IF EXISTS "${testSchema}" CASCADE`);
+  await admin.query(`CREATE SCHEMA "${testSchema}"`);
+  await admin.query(`
+    CREATE TABLE "${testSchema}"."agent_runs" (
+      "id" uuid PRIMARY KEY,
+      "agent_compose_version_id" varchar(64),
+      "created_at" timestamp NOT NULL,
+      "launch_snapshot" jsonb,
+      "model_provider" varchar(100),
+      "selected_model" varchar(255),
+      "trigger_source" varchar(20),
+      "chat_thread_id" uuid,
+      "autonomy_budget" integer,
+      "workflow_automation_id" uuid,
+      "goal_id" uuid,
+      "model_provider_id" uuid,
+      "model_provider_credential_scope" varchar(20),
+      "codex_service_tier" varchar(20),
+      "selected_video_model" varchar(255),
+      "selected_image_model" varchar(255),
+      "api_started_at" timestamp,
+      "first_assistant_event_acknowledged_at" timestamp,
+      "summary" text,
+      "trigger_brief" text,
+      "status" varchar(20) NOT NULL
+    );
+    CREATE TABLE "${testSchema}"."agent_compose_versions" (
+      "id" varchar(64) NOT NULL,
+      "content" jsonb
+    );
+    CREATE TABLE "${testSchema}"."checkpoints" (
+      "id" uuid PRIMARY KEY,
+      "run_id" uuid NOT NULL,
+      "agent_compose_snapshot" jsonb
+    );
+    CREATE TABLE "${testSchema}"."conversations" (
+      "run_id" uuid NOT NULL,
+      "cli_agent_type" varchar(50) NOT NULL
+    );
+  `);
+}
+
+async function insertProductRun(
+  client: Client,
+  args: {
+    readonly id: string;
+    readonly versionId: string | null;
+    readonly status?: string;
+    readonly launchSnapshot?: ExactLaunchSnapshotValue | null;
+  },
+): Promise<void> {
+  await client.query(
+    `INSERT INTO "agent_runs" (
+       "id", "agent_compose_version_id", "created_at", "launch_snapshot",
+       "model_provider", "selected_model", "trigger_source",
+       "autonomy_budget", "status"
+     ) VALUES ($1, $2, '2026-08-14T00:00:00.000Z', $3::jsonb,
+       'anthropic-api-key', NULL, 'slack', 5, $4)`,
+    [
+      args.id,
+      args.versionId,
+      args.launchSnapshot === undefined
+        ? null
+        : JSON.stringify(args.launchSnapshot),
+      args.status ?? "completed",
+    ],
+  );
+}
+
+async function resetBaseline(client: Client): Promise<BaselineFixture> {
+  await client.query(
+    `TRUNCATE "conversations", "checkpoints", "agent_runs", "agent_compose_versions"`,
+  );
+  const firstVersion = version("database-first");
+  const secondVersion = version("database-second");
+  const conflictVersion = version("database-conflict");
+  const existingVersion = version("database-existing");
+  for (const storedVersion of [
+    firstVersion,
+    secondVersion,
+    conflictVersion,
+    existingVersion,
+  ]) {
+    await client.query(
+      `INSERT INTO "agent_compose_versions" ("id", "content")
+       VALUES ($1, $2::jsonb)`,
+      [storedVersion.id, JSON.stringify(storedVersion.content)],
+    );
+  }
+
+  const fixture: BaselineFixture = {
+    candidateIds: [uuid(101), uuid(102)],
+    unknownId: uuid(103),
+    conflictId: uuid(104),
+    existingId: uuid(105),
+    existingSnapshot: {
+      schemaVersion: 1,
+      framework: "claude-code",
+      runnerProfile: "vm0/existing",
+    },
+  };
+  await insertProductRun(client, {
+    id: fixture.candidateIds[1],
+    versionId: secondVersion.id,
+  });
+  await insertProductRun(client, {
+    id: fixture.candidateIds[0],
+    versionId: firstVersion.id,
+  });
+  await insertProductRun(client, {
+    id: fixture.unknownId,
+    versionId: null,
+  });
+  await insertProductRun(client, {
+    id: fixture.conflictId,
+    versionId: conflictVersion.id,
+  });
+  await client.query(
+    `INSERT INTO "conversations" ("run_id", "cli_agent_type")
+     VALUES ($1, 'codex')`,
+    [fixture.conflictId],
+  );
+  await insertProductRun(client, {
+    id: fixture.existingId,
+    versionId: existingVersion.id,
+    launchSnapshot: fixture.existingSnapshot,
+  });
+  return fixture;
+}
+
+async function collectAnalysis(
+  client: Client,
+  policy: LaunchSnapshotBackfillPolicy,
+) {
+  const inventory = await collectLaunchSnapshotBackfillInventory({
+    client,
+    policy,
+  });
+  return analyzeLaunchSnapshotBackfillInventory(inventory, policy);
+}
+
+async function policyFromDatabase(
+  client: Client,
+  timeouts: { readonly lock?: number; readonly statement?: number } = {},
+): Promise<LaunchSnapshotBackfillPolicy> {
+  const inventory = await collectLaunchSnapshotBackfillInventory({
+    client,
+    policy: PRODUCTION_LAUNCH_SNAPSHOT_BACKFILL_POLICY,
+  });
+  return policyForInventory(inventory, timeouts);
+}
+
+async function snapshots(
+  client: Client,
+): Promise<ReadonlyMap<string, unknown>> {
+  const result = await client.query<{
+    readonly id: string;
+    readonly launchSnapshot: unknown;
+  }>(`
+    SELECT "id"::text AS "id", "launch_snapshot" AS "launchSnapshot"
+    FROM "agent_runs"
+    ORDER BY "id"
+  `);
+  return new Map(
+    result.rows.map((row) => {
+      return [row.id, row.launchSnapshot] as const;
+    }),
+  );
+}
+
+async function testDryRunPartialRestartAndNoOp(args: {
+  readonly client: Client;
+  readonly connectionString: string;
+}): Promise<void> {
+  const fixture = await resetBaseline(args.client);
+  const policy = await policyFromDatabase(args.client);
+  const dryRun = await executeLaunchSnapshotBackfill(
+    {
+      connectionString: args.connectionString,
+      mode: "dry-run",
+      batchSize: 500,
+      maxBatches: 1,
+    },
+    policy,
+  );
+  assert.equal(dryRun.status, "dry-run");
+  assert.equal(dryRun.progress.candidateRows, 2);
+  assert.equal(dryRun.progress.committedRows, 0);
+  assert.equal(dryRun.before.frozenHistoricalUnknown, "exact");
+  assert.equal(dryRun.before.frozenIntegrityConflict, "exact");
+
+  const partial = await executeLaunchSnapshotBackfill(
+    {
+      connectionString: args.connectionString,
+      mode: "apply",
+      batchSize: 1,
+      maxBatches: 1,
+      applyConfirmation,
+    },
+    policy,
+  );
+  assert.equal(partial.status, "partial");
+  assert.equal(partial.proof, "exact");
+  assert.equal(partial.progress.committedRows, 1);
+  const afterPartial = await snapshots(args.client);
+  assert.deepEqual(afterPartial.get(fixture.candidateIds[0]), defaultSnapshot);
+  assert.equal(afterPartial.get(fixture.candidateIds[1]), null);
+  assert.equal(afterPartial.get(fixture.unknownId), null);
+  assert.equal(afterPartial.get(fixture.conflictId), null);
+  assert.deepEqual(
+    afterPartial.get(fixture.existingId),
+    fixture.existingSnapshot,
+  );
+
+  const restart = await executeLaunchSnapshotBackfill(
+    {
+      connectionString: args.connectionString,
+      mode: "apply",
+      batchSize: 500,
+      maxBatches: 1,
+      applyConfirmation,
+    },
+    policy,
+  );
+  assert.equal(restart.status, "complete");
+  assert.equal(restart.progress.committedRows, 1);
+  assert.equal(restart.proof, "exact");
+
+  const beforeNoOp = await snapshots(args.client);
+  const noOp = await executeLaunchSnapshotBackfill(
+    {
+      connectionString: args.connectionString,
+      mode: "apply",
+      batchSize: 500,
+      maxBatches: 1,
+      applyConfirmation,
+    },
+    policy,
+  );
+  assert.equal(noOp.status, "no-op");
+  assert.equal(noOp.progress.committedRows, 0);
+  assert.equal(noOp.proof, "exact");
+  assert.deepEqual(await snapshots(args.client), beforeNoOp);
+}
+
+async function testDriftAndGuardedUpdate(client: Client): Promise<void> {
+  const fixture = await resetBaseline(client);
+  const policy = await policyFromDatabase(client);
+  const before = await collectAnalysis(client, policy);
+  assertLaunchSnapshotBackfillInventorySafe(before);
+  const driftedCandidate = before.candidates.find((candidate) => {
+    return candidate.runId === fixture.candidateIds[1];
+  });
+  assert.ok(driftedCandidate);
+  const driftedRun = before.runById.get(driftedCandidate.runId);
+  assert.ok(driftedRun?.versionId);
+  await client.query(
+    `UPDATE "agent_compose_versions"
+     SET "content" = '{"version":"1","agents":{"changed":{"framework":"codex"}}}'::jsonb
+     WHERE "id" = $1`,
+    [driftedRun.versionId],
+  );
+  await assertRejectedGate(
+    applyLaunchSnapshotBackfillBatch({
+      client,
+      candidates: before.candidates,
+      policy,
+    }),
+    "batch.drift",
+  );
+  let observed = await snapshots(client);
+  assert.equal(observed.get(fixture.candidateIds[0]), null);
+  assert.equal(observed.get(fixture.candidateIds[1]), null);
+
+  await resetBaseline(client);
+  const guardedPolicy = await policyFromDatabase(client);
+  const guardedBefore = await collectAnalysis(client, guardedPolicy);
+  await client.query(
+    `UPDATE "agent_runs" SET "launch_snapshot" = $2::jsonb WHERE "id" = $1`,
+    [fixture.candidateIds[1], JSON.stringify(defaultSnapshot)],
+  );
+  await assertRejectedGate(
+    applyLaunchSnapshotBackfillBatch({
+      client,
+      candidates: guardedBefore.candidates,
+      policy: guardedPolicy,
+    }),
+    "batch.drift",
+  );
+  observed = await snapshots(client);
+  assert.equal(observed.get(fixture.candidateIds[0]), null);
+  assert.deepEqual(observed.get(fixture.candidateIds[1]), defaultSnapshot);
+  assert.equal(observed.get(fixture.unknownId), null);
+  assert.equal(observed.get(fixture.conflictId), null);
+}
+
+async function testContentionAndLockTimeout(args: {
+  readonly client: Client;
+  readonly connectionString: string;
+}): Promise<void> {
+  const fixture = await resetBaseline(args.client);
+  const policy = await policyFromDatabase(args.client);
+  const before = await collectAnalysis(args.client, policy);
+  const blocker = new Client({ connectionString: args.connectionString });
+  await blocker.connect();
+  try {
+    await blocker.query("BEGIN");
+    await blocker.query(
+      `SELECT "id" FROM "agent_runs" WHERE "id" = $1 FOR UPDATE`,
+      [fixture.candidateIds[0]],
+    );
+    await assertRejectedGate(
+      applyLaunchSnapshotBackfillBatch({
+        client: args.client,
+        candidates: before.candidates,
+        policy,
+      }),
+      "batch.contention",
+    );
+    const observed = await snapshots(args.client);
+    assert.equal(observed.get(fixture.candidateIds[0]), null);
+    assert.equal(observed.get(fixture.candidateIds[1]), null);
+    await blocker.query("ROLLBACK");
+
+    await blocker.query("BEGIN");
+    await blocker.query(`LOCK TABLE "agent_runs" IN ACCESS EXCLUSIVE MODE`);
+    await assertRejectedGate(
+      applyLaunchSnapshotBackfillBatch({
+        client: args.client,
+        candidates: before.candidates.slice(0, 1),
+        policy: { ...policy, lockTimeoutMs: 50 },
+      }),
+      "lock_timeout",
+    );
+    await blocker.query("ROLLBACK");
+  } finally {
+    await blocker.query("ROLLBACK").catch(() => {});
+    await blocker.end();
+  }
+}
+
+async function installUpdateTrigger(
+  client: Client,
+  body: string,
+): Promise<void> {
+  await client.query(`
+    CREATE OR REPLACE FUNCTION "backfill_test_update"()
+    RETURNS trigger LANGUAGE plpgsql AS $body$
+    BEGIN
+      ${body}
+    END
+    $body$;
+    CREATE TRIGGER "backfill_test_update"
+    BEFORE UPDATE OF "launch_snapshot" ON "agent_runs"
+    FOR EACH ROW EXECUTE FUNCTION "backfill_test_update"();
+  `);
+}
+
+async function removeUpdateTrigger(client: Client): Promise<void> {
+  await client.query(
+    `DROP TRIGGER IF EXISTS "backfill_test_update" ON "agent_runs";
+     DROP FUNCTION IF EXISTS "backfill_test_update"()`,
+  );
+}
+
+async function testAffectedRowsAndReadBack(client: Client): Promise<void> {
+  const fixture = await resetBaseline(client);
+  const policy = await policyFromDatabase(client);
+  const before = await collectAnalysis(client, policy);
+  const candidate = before.candidates[0]!;
+
+  await installUpdateTrigger(client, "RETURN NULL;");
+  await assertRejectedGate(
+    applyLaunchSnapshotBackfillBatch({
+      client,
+      candidates: [candidate],
+      policy,
+    }),
+    "batch.affected_rows",
+  );
+  await removeUpdateTrigger(client);
+  assert.equal((await snapshots(client)).get(fixture.candidateIds[0]), null);
+
+  await installUpdateTrigger(
+    client,
+    `NEW."launch_snapshot" :=
+       '{"schemaVersion":1,"framework":"codex","runnerProfile":"vm0/changed"}'::jsonb;
+     RETURN NEW;`,
+  );
+  await assertRejectedGate(
+    applyLaunchSnapshotBackfillBatch({
+      client,
+      candidates: [candidate],
+      policy,
+    }),
+    "batch.read_back",
+  );
+  await removeUpdateTrigger(client);
+  assert.equal((await snapshots(client)).get(fixture.candidateIds[0]), null);
+}
+
+async function testStatementTimeoutPreservesEarlierBatch(args: {
+  readonly client: Client;
+  readonly connectionString: string;
+}): Promise<void> {
+  const fixture = await resetBaseline(args.client);
+  const policy = await policyFromDatabase(args.client, { statement: 50 });
+  await installUpdateTrigger(
+    args.client,
+    `IF NEW."id" = '${fixture.candidateIds[1]}'::uuid THEN
+       PERFORM pg_sleep(0.2);
+     END IF;
+     RETURN NEW;`,
+  );
+  const interrupted = await executeLaunchSnapshotBackfill(
+    {
+      connectionString: args.connectionString,
+      mode: "apply",
+      batchSize: 1,
+      maxBatches: 20,
+      applyConfirmation,
+    },
+    policy,
+  );
+  assert.equal(interrupted.status, "failed");
+  assert.equal(interrupted.failureGate, "statement_timeout");
+  assert.equal(interrupted.progress.committedBatches, 1);
+  assert.equal(interrupted.progress.committedRows, 1);
+  assert.equal(interrupted.proof, "exact");
+  let observed = await snapshots(args.client);
+  assert.deepEqual(observed.get(fixture.candidateIds[0]), defaultSnapshot);
+  assert.equal(observed.get(fixture.candidateIds[1]), null);
+
+  await removeUpdateTrigger(args.client);
+  const restarted = await executeLaunchSnapshotBackfill(
+    {
+      connectionString: args.connectionString,
+      mode: "apply",
+      batchSize: 500,
+      maxBatches: 1,
+      applyConfirmation,
+    },
+    { ...policy, statementTimeoutMs: 30_000 },
+  );
+  assert.equal(restarted.status, "complete");
+  assert.equal(restarted.progress.committedRows, 1);
+  observed = await snapshots(args.client);
+  assert.deepEqual(observed.get(fixture.candidateIds[1]), defaultSnapshot);
+}
+
+async function testCancellationRollsBack(args: {
+  readonly client: Client;
+  readonly connectionString: string;
+}): Promise<void> {
+  const fixture = await resetBaseline(args.client);
+  const policy = await policyFromDatabase(args.client);
+  await installUpdateTrigger(args.client, "PERFORM pg_sleep(10); RETURN NEW;");
+  const controller = new AbortController();
+  const applicationName = "launch_snapshot_backfill_cancel_test";
+  const cancellationUrl = new URL(args.connectionString);
+  cancellationUrl.searchParams.set("application_name", applicationName);
+  const execution = executeLaunchSnapshotBackfill(
+    {
+      connectionString: cancellationUrl.toString(),
+      mode: "apply",
+      batchSize: 2,
+      maxBatches: 1,
+      applyConfirmation,
+      signal: controller.signal,
+    },
+    policy,
+  );
+  try {
+    await waitForActiveBackfillUpdate(args.client, applicationName);
+    controller.abort();
+    const cancelled = await execution;
+    assert.equal(cancelled.status, "failed");
+    assert.equal(cancelled.failureGate, "cancelled");
+    assert.equal(cancelled.progress.committedRows, 0);
+  } finally {
+    controller.abort();
+    await execution.catch(() => {});
+    await removeUpdateTrigger(args.client);
+  }
+  const observed = await snapshots(args.client);
+  assert.equal(observed.get(fixture.candidateIds[0]), null);
+  assert.equal(observed.get(fixture.candidateIds[1]), null);
+}
+
+async function waitForActiveBackfillUpdate(
+  client: Client,
+  applicationName: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 500; attempt++) {
+    const activity = await client.query<{ readonly active: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1
+         FROM "pg_stat_activity"
+         WHERE "application_name" = $1
+           AND "state" = 'active'
+           AND "query" LIKE '%UPDATE "agent_runs" AS "run"%'
+       ) AS "active"`,
+      [applicationName],
+    );
+    if (activity.rows[0]?.active) return;
+  }
+  throw new Error("backfill update did not become active");
+}
+
+async function testConnectionInterruptionRollsBack(args: {
+  readonly client: Client;
+  readonly connectionString: string;
+}): Promise<void> {
+  const fixture = await resetBaseline(args.client);
+  const policy = await policyFromDatabase(args.client);
+  await installUpdateTrigger(
+    args.client,
+    "PERFORM pg_terminate_backend(pg_backend_pid()); RETURN NEW;",
+  );
+  try {
+    const interrupted = await executeLaunchSnapshotBackfill(
+      {
+        connectionString: args.connectionString,
+        mode: "apply",
+        batchSize: 2,
+        maxBatches: 1,
+        applyConfirmation,
+      },
+      policy,
+    );
+    assert.equal(interrupted.status, "failed");
+    assert.equal(interrupted.failureGate, "database.connection");
+    assert.equal(interrupted.progress.committedRows, 0);
+  } finally {
+    await removeUpdateTrigger(args.client);
+  }
+  const observed = await snapshots(args.client);
+  assert.equal(observed.get(fixture.candidateIds[0]), null);
+  assert.equal(observed.get(fixture.candidateIds[1]), null);
+}
+
+async function seedExactCandidates(
+  client: Client,
+  count: number,
+): Promise<readonly string[]> {
+  await client.query(
+    `TRUNCATE "conversations", "checkpoints", "agent_runs", "agent_compose_versions"`,
+  );
+  const storedVersion = version(`batch-bound-${count}`);
+  await client.query(
+    `INSERT INTO "agent_compose_versions" ("id", "content")
+     VALUES ($1, $2::jsonb)`,
+    [storedVersion.id, JSON.stringify(storedVersion.content)],
+  );
+  const runIds = Array.from({ length: count }, (_, index) => {
+    return uuid(2000 + index);
+  });
+  await client.query(
+    `INSERT INTO "agent_runs" (
+       "id", "agent_compose_version_id", "created_at", "launch_snapshot",
+       "model_provider", "selected_model", "trigger_source",
+       "autonomy_budget", "status"
+     )
+     SELECT "id", $2, '2026-08-14T00:00:00.000Z', NULL,
+       'anthropic-api-key', NULL, 'slack', 5, 'completed'
+     FROM unnest($1::uuid[]) AS "candidate"("id")`,
+    [runIds, storedVersion.id],
+  );
+  return runIds;
+}
+
+async function testIndependentBatchBounds(client: Client): Promise<void> {
+  await seedExactCandidates(client, 500);
+  let policy = await policyFromDatabase(client);
+  let before = await collectAnalysis(client, policy);
+  assert.equal(before.candidates.length, 500);
+  assert.equal(
+    await applyLaunchSnapshotBackfillBatch({
+      client,
+      candidates: before.candidates.slice(0, 499),
+      policy,
+    }),
+    499,
+  );
+  assert.equal(
+    [...(await snapshots(client)).values()].filter((snapshot) => {
+      return snapshot !== null;
+    }).length,
+    499,
+  );
+
+  await seedExactCandidates(client, 500);
+  policy = await policyFromDatabase(client);
+  before = await collectAnalysis(client, policy);
+  assert.equal(
+    await applyLaunchSnapshotBackfillBatch({
+      client,
+      candidates: before.candidates,
+      policy,
+    }),
+    500,
+  );
+  assert.equal(
+    [...(await snapshots(client)).values()].filter((snapshot) => {
+      return snapshot !== null;
+    }).length,
+    500,
+  );
+
+  await assertRejectedGate(
+    applyLaunchSnapshotBackfillBatch({
+      client,
+      candidates: [],
+      policy,
+    }),
+    "batch.size",
+  );
+  await assertRejectedGate(
+    applyLaunchSnapshotBackfillBatch({
+      client,
+      candidates: Array.from(
+        { length: LAUNCH_SNAPSHOT_BACKFILL_MAX_BATCH_SIZE + 1 },
+        (_, index) => {
+          return { runId: uuid(1000 + index), snapshot: defaultSnapshot };
+        },
+      ),
+      policy,
+    }),
+    "batch.size",
+  );
+}
+
+export async function validateLaunchSnapshotBackfillDatabase(
+  databaseUrl: string,
+): Promise<void> {
+  const admin = new Client({ connectionString: databaseUrl });
+  await admin.connect();
+  await createTestSchema(admin);
+  const testUrl = databaseUrlForSchema(databaseUrl);
+  const client = new Client({ connectionString: testUrl });
+  await client.connect();
+  try {
+    await testDryRunPartialRestartAndNoOp({
+      client,
+      connectionString: testUrl,
+    });
+    await testDriftAndGuardedUpdate(client);
+    await testContentionAndLockTimeout({ client, connectionString: testUrl });
+    await testAffectedRowsAndReadBack(client);
+    await testStatementTimeoutPreservesEarlierBatch({
+      client,
+      connectionString: testUrl,
+    });
+    await testCancellationRollsBack({ client, connectionString: testUrl });
+    await testConnectionInterruptionRollsBack({
+      client,
+      connectionString: testUrl,
+    });
+    await testIndependentBatchBounds(client);
+  } finally {
+    await client.end();
+    await admin.query(`DROP SCHEMA IF EXISTS "${testSchema}" CASCADE`);
+    await admin.end();
+  }
+}
+
+export async function validateLaunchSnapshotBackfill(): Promise<void> {
+  await validateLaunchSnapshotBackfillStatic();
+  const databaseUrl = process.env.DATABASE_URL;
+  assert.ok(databaseUrl, "DATABASE_URL is required");
+  await validateLaunchSnapshotBackfillDatabase(databaseUrl);
+  console.log("agent run launch snapshot backfill passed");
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) {
+  validateLaunchSnapshotBackfill().catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- expose a discriminated per-Run exact snapshot from the accepted schema-v4 classifier while pinning aggregate output bytes
- add a restartable aggregate-only runner with deterministic batches, transaction-local reclassification, frozen-set gates, and strict post-apply proof
- add a protected `workflow_dispatch` path that checks out `main`, defaults to dry-run, requires explicit apply confirmation, uses pooled Neon with `verify-full`, and uploads no artifact
- add focused static and PostgreSQL coverage for boundaries, contention, drift, rollback, timeouts, cancellation, connection loss, restart, idempotence, and redaction

## Safety contract

The only write statement updates `agent_runs.launch_snapshot` where it is still NULL. Every target is selected from the discovered `exactly_recoverable` set, locked in deterministic order with `FOR UPDATE SKIP LOCKED`, and re-read/reclassified from same-Run version, checkpoint, and conversation evidence inside its at-most-500-row transaction. Any missing, skipped, active, drifted, or unprovable row aborts the entire current batch.

The fixed report contains only `schemaVersion`, `mode`, `status`, `failureGate`, bounded parameters, aggregate progress, before/after summaries, and `proof`. Each summary contains total population, four disposition count/digest pairs, closure/frozen-set classifications, and count/digest pairs for critical reasons, duplicate evidence, active NULL rows, unsupported statuses, and existing snapshots. String values are allowlisted and all digests are 64-character domain-separated SHA-256 values; IDs, content, labels, timestamps, errors, URLs, and samples cannot enter output.

The historical-unknown gate is frozen at 2,627 / `314360539273450908d01e647338c39ee30c12e131bcddf67c54023c57bad94c`; integrity-conflict is frozen at 9 / `c74f9a7cbeba3d52589f7b7bfb569ca7ecc25b7fa00e4a88ab728df7d22e2159`. Existing non-NULL snapshots are proven unchanged. No migration, runtime writer, API, Runner, Session, checkpoint, Storage, Agent, provider, Connector, Workflow, billing, or telemetry behavior changes.

## Validation

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged non-API, app, and API type-checks
- `pnpm --filter @okouai/db exec tsx scripts/test-agent-compose-consolidation-preflight-launch-snapshots.ts`
- `DATABASE_URL=... pnpm --filter @okouai/db exec tsx scripts/test-agent-run-launch-snapshot-backfill.ts`
- `DATABASE_URL=... pnpm --filter @okouai/db test:migration-consistency`
- Neon workflow inventory: 12 reviewed connection-string invocations and 9 reviewed masked outputs; shell syntax passed locally (the container lacks `/dev/fd`, so the exact process-substitution harness remains a CI check)
- no full Vitest suite and no development server

## Controller-owned rollout commands (not run)

After merge and normal release of the exact merged revision:

```bash
gh workflow run agent-run-launch-snapshot-backfill.yml --ref main -f mode=dry-run -f batch_size=500 -f max_batches=1 -f confirmed_apply=no
gh workflow run agent-run-launch-snapshot-backfill.yml --ref main -f mode=apply -f batch_size=500 -f max_batches=1 -f confirmed_apply=yes
gh workflow run agent-run-launch-snapshot-backfill.yml --ref main -f mode=apply -f batch_size=500 -f max_batches=20 -f confirmed_apply=yes
```

Production approval, dry-run acceptance, canary, bounded bulk progression, MaskDB checks, and Axiom acceptance remain with the EPIC controller.

Closes #27820
Parent #26938