### PR TITLE
test(ci): eliminate cancelled ssh descendant race

### DIFF
--- a/.github/scripts/tests/cloudflare-ssh-command-test.sh
+++ b/.github/scripts/tests/cloudflare-ssh-command-test.sh
@@ -392,11 +392,16 @@ FAKE_TIMEOUT_MODE=real \
     > "$actual_cancel/stdout" 2> "$actual_cancel/stderr" &
 actual_cancel_invocation_pid=$!
 for _ in {1..50}; do
-  [ -s "$actual_cancel/actual-ssh.pid" ] && break
+  if [ -s "$actual_cancel/actual-ssh.pid" ] \
+    && [ -s "$actual_cancel/actual-ssh-child.pid" ]; then
+    break
+  fi
   sleep 0.1
 done
 [ -s "$actual_cancel/actual-ssh.pid" ] \
   || fail "cancelled SSH caller did not start"
+[ -s "$actual_cancel/actual-ssh-child.pid" ] \
+  || fail "cancelled SSH descendant did not start"
 actual_cancel_pid=$(< "$actual_cancel/actual-ssh.pid")
 actual_cancel_timeout_pid=$(ps -o ppid= -p "$actual_cancel_pid" \
   | tr -d '[:space:]')


### PR DESCRIPTION
## Summary

- wait for both cancelled SSH caller and descendant PID files before signalling the wrapper
- report descendant startup failure before process-parent discovery and cancellation
- preserve production cancellation behavior, status 143, and both process-reclamation assertions

## Scope

- test-only change in the Cloudflare SSH command integration fixture
- no production wrapper, workflow, API, data, or deployment changes

## Validation

- `bash -n .github/scripts/tests/cloudflare-ssh-command-test.sh`
- `shellcheck .github/scripts/tests/cloudflare-ssh-command-test.sh`
- `bash .github/scripts/tests/cloudflare-ssh-command-test.sh`
- focused script repeated 10 times
- `lefthook run pre-commit`

Closes #27782
