### PR TITLE
test(e2e): isolate serpapi auth probe from ipv6 dns

### DIFF
--- a/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
+++ b/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
@@ -27,8 +27,13 @@ teardown() {
 
     local prompt
     prompt=$(cat <<'EOF'
+set -euo pipefail
 printf 'SERPAPI_TOKEN=%s\n' "$SERPAPI_TOKEN"
-curl --silent --show-error --max-time 5 --output /dev/null 'https://serpapi.com/search?q=vm0-e2e&engine=google' || true
+# Raw DNS has dedicated runner coverage. Keep this firewall-auth probe on IPv4
+# so an unavailable AAAA response cannot block an otherwise valid request.
+curl --ipv4 --silent --show-error --max-time 5 \
+    --output /dev/null \
+    'https://serpapi.com/search?q=vm0-e2e&engine=google'
 printf 'SERPAPI_REQUEST_SENT\n'
 EOF
 )

--- a/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
+++ b/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
@@ -31,10 +31,15 @@ set -euo pipefail
 printf 'SERPAPI_TOKEN=%s\n' "$SERPAPI_TOKEN"
 # Raw DNS has dedicated runner coverage. Keep this firewall-auth probe on IPv4
 # so an unavailable AAAA response cannot block an otherwise valid request.
-curl --ipv4 --silent --show-error --max-time 5 \
+if curl --ipv4 --silent --show-error --max-time 5 \
     --output /dev/null \
-    'https://serpapi.com/search?q=vm0-e2e&engine=google'
-printf 'SERPAPI_REQUEST_SENT\n'
+    'https://serpapi.com/search?q=vm0-e2e&engine=google'; then
+    printf 'SERPAPI_REQUEST_SENT\n'
+else
+    curl_status=$?
+    printf 'SERPAPI_REQUEST_FAILED=%s\n' "$curl_status"
+    exit "$curl_status"
+fi
 EOF
 )
     run runner_e2e_start_chat_run "$AGENT_ID" "$prompt"
@@ -47,9 +52,12 @@ EOF
     echo "$output"
     assert_success
 
-    run runner_e2e_wait_for_chat_text "$THREAD_ID" "$RUN_ID" SERPAPI_REQUEST_SENT
+    # Both outcomes use this prefix so a transport failure surfaces without
+    # waiting for a success marker that can no longer be emitted.
+    run runner_e2e_wait_for_chat_text "$THREAD_ID" "$RUN_ID" SERPAPI_REQUEST_
     echo "$output"
     assert_success
+    assert_output --partial "SERPAPI_REQUEST_SENT"
     assert_output --partial "SERPAPI_TOKEN=CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocalCof"
 
     run runner_e2e_wait_for_firewall_log \


### PR DESCRIPTION
## Summary

- constrain the SerpAPI firewall-auth probe to IPv4 while preserving the real provider hostname and proxy path
- stop suppressing DNS and transport failures so the success marker proves transport completion
- emit a common success/failure prefix before exit, then require the success outcome so request errors surface without a second 90-second wait
- keep the existing safe-secret output and firewall telemetry assertions unchanged

## Scope

- changes only the SerpAPI runner Bats E2E
- does not change production DNS behavior, runner protocols, APIs, migrations, or other provider probes

## Validation

- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/run-t04-firewall-serpapi.bats` (`1` test discovered)
- focused shell failure-path simulation verified exit status `6`, `SERPAPI_REQUEST_FAILED=6`, and no success marker
- `git diff --check`
- repository pre-commit hook for the staged Bats file (`check-file-size`)
- commitlint

The deployed `cli-e2e-03-runner` shard remains the acceptance-level integration gate because runner Bats tests are CI-only.

Closes #27785
