### PR TITLE
test(runner): avoid cancelling watcher mid-transition

### DIFF
--- a/crates/runner/src/workspace_image_cache/watcher.rs
+++ b/crates/runner/src/workspace_image_cache/watcher.rs
@@ -762,15 +762,26 @@ mod tests {
             .unwrap();
         let observer = WorkspaceImageCache::shared(observer_paths, &home, "group-a");
         let publisher = WorkspaceImageCache::shared(publisher_paths, &home, "group-b");
-        let mut watcher = WorkspaceCacheWatcher::new(observer).await.unwrap();
+        let mut watcher = WorkspaceCacheWatcher::new(observer.clone()).await.unwrap();
 
         let foreign_cache_key = commit_entry(&publisher, "foreign-only-entry").await;
 
+        let mut next_change = Box::pin(watcher.next_change());
         assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(100), watcher.next_change())
+            tokio::time::timeout(std::time::Duration::from_millis(100), &mut next_change)
                 .await
                 .is_err()
         );
+        let relevant_cache_key = commit_entry(&observer, "relevant-entry").await;
+        let change = tokio::time::timeout(std::time::Duration::from_secs(2), &mut next_change)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            change.committed_cache_keys,
+            BTreeSet::from([relevant_cache_key])
+        );
+        drop(next_change);
         assert!(!watcher.watch_by_cache_key.contains_key(&foreign_cache_key));
     }
 


### PR DESCRIPTION
## Summary

- preserve the in-flight workspace cache watcher future across the foreign-only timeout
- publish a relevant cache entry afterward as the deterministic processing barrier
- verify the completed change reports only the relevant key before inspecting foreign watch cleanup

## Scope

This is a test-only synchronization change. It does not change production watcher filtering, ownership, timeouts, or runtime behavior.

Closes #27762

Parent context: #27738

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- focused watcher test: 20 consecutive passes
- `cargo test -p runner -- --test-threads=4 --quiet`: two consecutive passes, each with 3,160 passed and 20 ignored runner tests plus the passing guest inventory test
- pre-commit Rust formatting, workspace rustdoc, workspace Clippy, file-size, and commit-message hooks

An earlier full-suite attempt exposed an unrelated existing race in `proxy::process::tests::graceful_stop_kills_descendant_after_parent_exits_cleanly`, where path existence can precede PID-file contents. The watcher test passed in that run, and the two subsequent complete runs passed. The separate flake is tracked in #27830.
