### PR TITLE
test(runner): synchronize workspace cache lock retry

### DIFF
--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -2,9 +2,6 @@ use super::*;
 use async_trait::async_trait;
 use httpmock::prelude::*;
 use sha2::{Digest, Sha256};
-use std::os::unix::fs::PermissionsExt;
-use std::sync::mpsc;
-use std::time::Instant;
 
 use crate::executor::session_history_cpu::{SessionHistoryCpuPool, SessionHistoryCpuTestGate};
 use crate::executor::tests::support::RUN_IN_SANDBOX_TEST_TIMEOUT;
@@ -14,7 +11,9 @@ use crate::types::{
     ResumeSessionHistory, ResumeSessionHistoryEncoding, ResumeSessionHistoryRef,
     ResumeSessionHistoryRefKind, WorkspaceReuseResult,
 };
-use crate::workspace_image_cache::WorkspaceSessionHistorySidecarRepresentation;
+use crate::workspace_image_cache::{
+    WorkspaceImagePrepareLockTestGate, WorkspaceSessionHistorySidecarRepresentation,
+};
 
 fn enable_api_start_telemetry(context: &mut crate::types::ExecutionContext) {
     context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
@@ -806,13 +805,18 @@ async fn execute_inner_cache_hit_retry_requires_completed_cleanup() {
 
 #[tokio::test]
 async fn execute_inner_waits_for_transient_workspace_cache_lock() {
-    const LOCK_ATTEMPT_WATCHDOG: Duration = Duration::from_secs(1);
+    const LOCK_CONTENTION_WATCHDOG: Duration = Duration::from_secs(1);
 
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));
     let cache = WorkspaceImageCache::new(runner_paths.clone());
+    let prepare_lock_gate = WorkspaceImagePrepareLockTestGate::default();
     let mut config = test_executor_config(dir.path()).await;
-    config.workspace_cache = Some(cache.clone());
+    config.workspace_cache = Some(
+        cache
+            .clone()
+            .with_prepare_lock_test_gate(prepare_lock_gate.clone()),
+    );
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
@@ -830,57 +834,42 @@ async fn execute_inner_waits_for_transient_workspace_cache_lock() {
         CANONICAL_WORKING_DIR,
         u64::from(params.workspace_disk_mb) * 1024 * 1024,
     );
-    let lock_path = crate::paths::workspace_image_cache_lock_path(
+    let held_lock = crate::lock::acquire(crate::paths::workspace_image_cache_lock_path(
         &runner_paths.base_dir().join("locks"),
         &cache_key,
-    );
-    let held_lock = crate::lock::acquire(lock_path.clone()).await.unwrap();
-    // Each acquisition attempt tightens this safe mode to 0600 before flock.
-    // Two tightenings while the guard is held prove the first attempt observed contention.
-    std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o644)).unwrap();
-    let (controller_ready_tx, controller_ready_rx) = mpsc::sync_channel(0);
-    let release = std::thread::spawn(move || {
-        let wait_for_attempt = |attempt| {
-            let deadline = Instant::now() + LOCK_ATTEMPT_WATCHDOG;
-            while std::fs::metadata(&lock_path).unwrap().permissions().mode() & 0o777 != 0o600 {
-                assert!(
-                    Instant::now() < deadline,
-                    "workspace cache lock attempt {attempt} did not tighten the lock file"
-                );
-                std::thread::yield_now();
-            }
-        };
-
-        controller_ready_tx.send(()).unwrap();
-        wait_for_attempt(1);
-        std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o644)).unwrap();
-        wait_for_attempt(2);
-        drop(held_lock);
-    });
-    controller_ready_rx
-        .recv_timeout(LOCK_ATTEMPT_WATCHDOG)
-        .expect("workspace cache lock controller should become ready");
+    ))
+    .await
+    .unwrap();
     let mut telemetry = test_telemetry(&config, &ctx);
 
-    let outcome = tokio::time::timeout(
-        RUN_IN_SANDBOX_TEST_TIMEOUT,
-        execute_new_sandbox(
-            &factory,
-            &ctx,
-            NewSandboxDispatch {
-                id: SandboxId::new_v4(),
-                reuse_result: SandboxReuseResult::PoolMiss,
-            },
-            &config,
-            &params,
-            &mut telemetry,
-            tokio_util::sync::CancellationToken::new(),
-        ),
-    )
-    .await
-    .expect("transient workspace lock wait should remain bounded")
-    .unwrap();
-    release.join().unwrap();
+    let outcome = {
+        let outcome = tokio::time::timeout(
+            RUN_IN_SANDBOX_TEST_TIMEOUT,
+            execute_new_sandbox(
+                &factory,
+                &ctx,
+                NewSandboxDispatch {
+                    id: SandboxId::new_v4(),
+                    reuse_result: SandboxReuseResult::PoolMiss,
+                },
+                &config,
+                &params,
+                &mut telemetry,
+                tokio_util::sync::CancellationToken::new(),
+            ),
+        );
+        tokio::pin!(outcome);
+        tokio::select! {
+            () = prepare_lock_gate.wait_entered(LOCK_CONTENTION_WATCHDOG) => {}
+            _ = &mut outcome => panic!("sandbox execution ended before workspace cache lock contention"),
+        }
+        drop(held_lock);
+        prepare_lock_gate.release();
+        outcome
+            .await
+            .expect("transient workspace lock wait should remain bounded")
+            .unwrap()
+    };
 
     assert_eq!(outcome.exit_code(), 0);
     assert!(outcome.workspace_image.is_some());

--- a/crates/runner/src/lock.rs
+++ b/crates/runner/src/lock.rs
@@ -273,9 +273,19 @@ pub async fn acquire_with_contention_timeout(
     path: PathBuf,
     contention_timeout: Duration,
 ) -> RunnerResult<TryLock> {
+    acquire_with_contention_timeout_after_busy(path, contention_timeout, std::future::ready(()))
+        .await
+}
+
+async fn acquire_with_contention_timeout_after_busy(
+    path: PathBuf,
+    contention_timeout: Duration,
+    after_busy: impl std::future::Future<Output = ()>,
+) -> RunnerResult<TryLock> {
     match acquire_result_once(&path, LockMode::Exclusive).await? {
         LockAcquire::Acquired(lock) => Ok(TryLock::Acquired(lock)),
         LockAcquire::Busy => {
+            after_busy.await;
             match tokio::time::timeout(
                 contention_timeout,
                 acquire_after_busy(&path, LockMode::Exclusive),
@@ -287,6 +297,15 @@ pub async fn acquire_with_contention_timeout(
             }
         }
     }
+}
+
+#[cfg(test)]
+pub(crate) async fn acquire_with_contention_timeout_after_busy_for_test(
+    path: PathBuf,
+    contention_timeout: Duration,
+    after_busy: impl std::future::Future<Output = ()>,
+) -> RunnerResult<TryLock> {
+    acquire_with_contention_timeout_after_busy(path, contention_timeout, after_busy).await
 }
 
 pub async fn try_acquire_or_busy(path: PathBuf) -> RunnerResult<TryLock> {

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -212,6 +212,24 @@ impl WorkspaceImageLease {
 }
 
 impl WorkspaceImageCache {
+    async fn acquire_prepare_lock(&self, lock_path: PathBuf) -> RunnerResult<crate::lock::TryLock> {
+        #[cfg(test)]
+        if let Some(gate) = &self.prepare_lock_test_gate {
+            return crate::lock::acquire_with_contention_timeout_after_busy_for_test(
+                lock_path,
+                WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT,
+                gate.enter_and_wait(),
+            )
+            .await;
+        }
+
+        crate::lock::acquire_with_contention_timeout(
+            lock_path,
+            WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT,
+        )
+        .await
+    }
+
     pub(crate) fn expected_promotion_identity(
         &self,
         request: WorkspaceImagePromotionIdentityRequest<'_>,
@@ -395,12 +413,7 @@ impl WorkspaceImageCache {
 
         let cache_key = common.cache_key(self, reuse_key, working_dir);
         let lock_path = self.entry_lock_path(&cache_key);
-        let lock = match crate::lock::acquire_with_contention_timeout(
-            lock_path,
-            WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT,
-        )
-        .await
-        {
+        let lock = match self.acquire_prepare_lock(lock_path).await {
             Ok(crate::lock::TryLock::Acquired(lock)) => lock,
             Ok(crate::lock::TryLock::Busy) => {
                 info!(

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -87,6 +87,33 @@ const TEST_FS_AVAILABLE_BYTES: u64 = 1_000 * GIB;
 #[derive(Clone)]
 pub(crate) struct WorkspaceImageCache {
     inner: Arc<WorkspaceImageCacheInner>,
+    #[cfg(test)]
+    prepare_lock_test_gate: Option<WorkspaceImagePrepareLockTestGate>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub(crate) struct WorkspaceImagePrepareLockTestGate {
+    entered: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+#[cfg(test)]
+impl WorkspaceImagePrepareLockTestGate {
+    pub(crate) async fn enter_and_wait(&self) {
+        self.entered.notify_one();
+        self.release.notified().await;
+    }
+
+    pub(crate) async fn wait_entered(&self, timeout: std::time::Duration) {
+        tokio::time::timeout(timeout, self.entered.notified())
+            .await
+            .expect("workspace image prepare should observe lock contention");
+    }
+
+    pub(crate) fn release(&self) {
+        self.release.notify_one();
+    }
 }
 
 struct WorkspaceImageCacheInner {
@@ -183,10 +210,20 @@ impl WorkspaceImageCache {
                 gc_root_scan_count: AtomicUsize::new(0),
                 fail_next_session_history_sidecar_metadata_commit: AtomicBool::new(false),
             }),
+            prepare_lock_test_gate: None,
         }
     }
 
     pub(crate) fn paths(&self) -> &RunnerPaths {
         &self.inner.paths
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_prepare_lock_test_gate(
+        mut self,
+        gate: WorkspaceImagePrepareLockTestGate,
+    ) -> Self {
+        self.prepare_lock_test_gate = Some(gate);
+        self
     }
 }


### PR DESCRIPTION
## Summary

- replace the workspace-cache executor test's permission polling and controller thread with an instance-scoped one-shot test gate
- signal the gate only after the first real lock acquisition returns busy, then release the held lock before the existing contention timeout starts
- keep production lock/cache behavior, the 50 ms timeout, retry cadence, workspace configuration, and telemetry unchanged

## Scope

The gate, cache injection field, builder, and gated entry are compiled only for runner tests. Production and test wrappers share the same timeout acquisition implementation. This PR does not change APIs, protocols, persisted state, migrations, deployment behavior, or runtime timeout values.

Closes #27765

Parent context: #27738

## Validation

- `cargo fmt --all -- --check`
- target test repeated 20 times:
  `cargo test -q -p runner executor::tests::sandbox_run_tests::workspace_cache::execute_inner_waits_for_transient_workspace_cache_lock -- --exact`
- `cargo test -p runner lock::tests`
- `cargo test -p runner workspace_image_cache::tests::lifecycle`
- `cargo test -p runner executor::tests::sandbox_run_tests::workspace_cache`
- `cargo test -q -p runner` (3 complete runs; each 3,160 passed, 20 ignored; guest inventory passed)
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
