### PR TITLE
fix(api): reset autonomy for human-forwarded content

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -9159,12 +9159,16 @@ describe("CHAT-02: shared user message queue", () => {
 
   it("persists user-forwarded run provenance across chat threads", async () => {
     const { actor, agentId } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped chat actor");
+    }
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const source = await sendChatRun(actor, {
       agentId,
       prompt: "source content selected for forwarding",
     });
+    await setRunAutonomyBudgetFixture(context, source.runId, 0);
     const targetThread = await chat.createThread(actor, { agentId });
     const forwardedEventId = randomUUID();
     const forwarded = await chat.requestSendEvent(
@@ -9225,18 +9229,34 @@ describe("CHAT-02: shared user message queue", () => {
     });
 
     const forwardedRun = await api.readRun(actor, forwardedRunId);
+    const forwardedState = await runStateStore.set(
+      readAgentRunState$,
+      {
+        orgId: actor.orgId,
+        userId: actor.userId,
+        runId: forwardedRunId,
+      },
+      context.signal,
+    );
+    expect(forwardedState.zero_run).toMatchObject({ triggerSource: "web" });
     const forwardedSystemPrompt = forwardedRun.appendSystemPrompt ?? "";
     expect(forwardedSystemPrompt).toContain("# This Run's Trigger");
+    expect(forwardedSystemPrompt).toContain(
+      "was sent by a person who forwarded selected content",
+    );
+    expect(forwardedSystemPrompt).not.toContain(
+      "A person did not type it here.",
+    );
     expect(forwardedSystemPrompt).toContain(`SOURCE_RUN_ID: ${source.runId}`);
     expect(forwardedSystemPrompt).toContain(
       `SOURCE_THREAD_ID: ${source.threadId}`,
     );
     await expect(
       readRunAutonomyBudgetFixture(context, source.runId),
-    ).resolves.toBe(10);
+    ).resolves.toBe(0);
     await expect(
       readRunAutonomyBudgetFixture(context, forwardedRunId),
-    ).resolves.toBe(9);
+    ).resolves.toBe(10);
 
     const unknownSource = await chat.requestSendEvent(
       actor,

--- a/turbo/apps/api/src/signals/routes/test-chat-event-retention.ts
+++ b/turbo/apps/api/src/signals/routes/test-chat-event-retention.ts
@@ -63,6 +63,7 @@ const resolveSessionPromptFixturesRoute$ = command(
         generationTemplatePrompt: "",
         videoRunOptions: null,
         computerUseHostDisplayName: null,
+        triggerSource: "web",
         agentRunSource: null,
       },
     });

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2702,6 +2702,7 @@ const loadWebQueuedLaunchMaterial: LaunchLoader = (_db, args) => {
         // replay here.
         videoRunOptions: null,
         computerUseHostDisplayName: null,
+        triggerSource: args.contextType === "agent_run" ? "agent" : "web",
         agentRunSource: args.agentRunSource,
       },
     }),

--- a/turbo/apps/api/src/signals/services/web-chat-session-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/web-chat-session-prompt.service.ts
@@ -67,6 +67,7 @@ export interface WebChatSessionPromptContext {
    */
   readonly videoRunOptions: ChatRunVideoOptionsRequest | null;
   readonly computerUseHostDisplayName: string | null;
+  readonly triggerSource: "web" | "agent";
   readonly agentRunSource: ChatAgentRunSourceAnnotation | null;
 }
 
@@ -96,10 +97,9 @@ function buildCurrentThreadContext(threadId: string): string {
 }
 
 /**
- * Provenance for a run whose prompt arrived from an agent run in another chat
- * thread. The message text is all that crosses the thread boundary, so without
- * this block the run cannot tell that a person did not write it, and has no
- * identifier for the conversation it came from.
+ * Provenance for a run whose prompt references an agent run in another chat
+ * thread. The source coordinates let the run inspect the originating context,
+ * while the trigger source distinguishes a human Forward from agent delegation.
  *
  * These are facts about how the run was created, not instructions about what
  * to do with them. What the run needs from the source thread depends on the
@@ -107,18 +107,27 @@ function buildCurrentThreadContext(threadId: string): string {
  */
 function buildAgentRunSourceContext(
   source: ChatAgentRunSourceAnnotation,
+  triggerSource: "web" | "agent",
 ): string {
+  const triggerDescription =
+    triggerSource === "web"
+      ? "The message this run was created for was sent by a person who forwarded selected content from an agent run in another chat thread."
+      : "The message this run was created for was sent by an agent run in another chat thread. A person did not type it here.";
+  const carriedContextDescription =
+    triggerSource === "web"
+      ? "The message text contains the forwarded selection and any feedback that person chose to add. The source run's own instructions, surrounding conversation, and other findings stayed in the source thread and are not included above."
+      : "The message text is everything that run chose to carry across the thread boundary. Its own instructions, the conversation it came from, and whatever it already found stayed in the source thread and are not included above.";
   return [
     "# This Run's Trigger",
     "",
-    "The message this run was created for was sent by an agent run in another chat thread. A person did not type it here.",
+    triggerDescription,
     "",
     `- SOURCE_RUN_ID: ${source.runId}`,
     `- SOURCE_THREAD_ID: ${source.threadId}`,
     `- SOURCE_AGENT_ID: ${source.agentId}`,
     `- SOURCE_THREAD_TITLE: ${source.titleSnapshot}`,
     "",
-    "The message text is everything that run chose to carry across the thread boundary. Its own instructions, the conversation it came from, and whatever it already found stayed in the source thread and are not included above.",
+    carriedContextDescription,
     "",
     "Reading the source, each through OKOU_TOKEN:",
     `- \`okou chat messages --thread-id ${source.threadId} --output-dir threads\` synchronizes the source thread's raw snapshot and hot events into \`threads/${source.threadId}/\`; use \`rg -n '"seqId":<SEQ_ID>' threads/${source.threadId}/\` to inspect an event (chat-event:read)`,
@@ -148,7 +157,10 @@ export function buildWebChatAppendSystemPrompt(args: {
     buildWebChatPrompt(),
     buildCurrentThreadContext(args.threadId),
     args.context.agentRunSource
-      ? buildAgentRunSourceContext(args.context.agentRunSource)
+      ? buildAgentRunSourceContext(
+          args.context.agentRunSource,
+          args.context.triggerSource,
+        )
       : "",
     args.priorContext,
     args.incompleteContext,

--- a/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-events.command.ts
@@ -1527,7 +1527,7 @@ function appendUnassociatedUserMessage(params: {
             contextId: webChatPublicBrandContextId(params.publicBrand),
           }
         : {}),
-      ...(params.agentRunSource
+      ...(params.triggerSource === "agent" && params.agentRunSource
         ? {
             agentRunContext: {
               sourceRunId: params.agentRunSource.runId,
@@ -2934,6 +2934,7 @@ function buildCreateZeroRunArgs(params: {
     videoRunOptions: prepared.videoRunOptions,
     computerUseHostDisplayName:
       prepared.computerUseHostGrant?.displayName ?? null,
+    triggerSource: prepared.triggerSource,
     agentRunSource: prepared.agentRunSource,
   };
   return {


### PR DESCRIPTION
## Summary

- classify session-authenticated Chat Forward messages as human web triggers while retaining their source-run annotation
- reset the forwarded run's autonomy budget instead of inheriting the source run's remaining budget
- keep agent-originated delegation behavior unchanged and describe human Forward provenance truthfully in the system prompt

## Compatibility

- no database migration or public API contract change
- existing persisted launches keep their recorded context; newly queued human Forward messages use web launch semantics
- mixed-version deployments remain compatible because the stored source annotation format is unchanged

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts apps/api/src/signals/routes/test-chat-event-retention.ts apps/api/src/signals/services/internal-chat-run-callback.service.ts apps/api/src/signals/services/web-chat-session-prompt.service.ts apps/api/src/signals/services/zero-chat-events.command.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "persists user-forwarded run provenance|persists agent-run provenance|blocks cross-thread delegation from a zero-budget run"`
- pre-commit hook: full Turbo type checks passed (14/14 packages)

Closes #27828
