### PR TITLE
fix(api): refresh api release marker comment

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed for #27796 on 2026-08-17)
+// (no-op API release marker refreshed for #27599 rollback rotation on 2026-08-18)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary\n\n- refresh the comment-only API release marker\n- trigger a new API release entry so #27599 can naturally rotate legacy physical-schema rollback targets\n\n## Safety\n\nThis changes one TypeScript comment only and does not alter runtime behavior.\n\n## Validation\n\n- git diff --check\n- no local Vitest or dev server, per the manual API release-trigger workflow\n- PR pipeline owns repository checks\n\nRelates to #27599