### PR TITLE
docs(python): clarify unconnected destination match semantics

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -444,6 +444,16 @@ def has_bound_destination(
     *,
     allowed_kinds: frozenset[upstream_destination_binding.BindingKind],
 ) -> bool:
+    """Return whether the flow authority matches binding evidence for a kind.
+
+    This delegates to
+    ``upstream_destination_binding.flow_matches_bound_destination``. A ``True``
+    result does not prove a durable direct binding exists: it may be an
+    unconnected, retargetable normalized-address match or a prior-client match.
+    Callers that need durable direct admission must still require
+    ``upstream_destination_binding.has_server_binding`` or use
+    ``ensure_bound_destination``.
+    """
     return upstream_destination_binding.flow_matches_bound_destination(
         flow,
         allowed_kinds=allowed_kinds,

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -480,11 +480,21 @@ def flow_matches_bound_destination(
     *,
     allowed_kinds: frozenset[BindingKind],
 ) -> bool:
-    """Return whether a flow is bound to its authority for an allowed kind.
+    """Return whether the flow authority matches binding evidence for a kind.
 
-    A direct server binding is checked first. Without one, a prior binding from
-    the same client may be used as fallback, but connected flows still require
-    authoritative endpoint evidence matching the bound concrete endpoint.
+    This convenience wrapper normalizes the current trusted authority and
+    delegates to ``flow_matches_normalized_destination``. A ``True`` result does
+    not by itself prove that a durable direct binding exists. It can come from:
+
+    - a matching direct server binding,
+    - a connected prior same-client binding with authoritative endpoint
+      evidence, or
+    - an unconnected server whose normalized address matches the destination,
+      even when no direct or client-associated binding is stored. This last
+      case is retargetable, not durable authorization.
+
+    Callers that need durable admission must additionally require
+    ``has_server_binding`` or go through the privileged binding path.
     """
     trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
     if not trusted_host:
@@ -510,11 +520,22 @@ def flow_matches_normalized_destination(
     destination: NormalizedUpstreamDestination,
     allowed_kinds: frozenset[BindingKind],
 ) -> bool:
-    """Match current binding evidence against an already-normalized authority.
+    """Return whether the flow matches the normalized destination for a kind.
 
-    The caller must derive ``destination`` from the current flow authority.
-    This function revalidates mutable endpoint evidence but does not authorize
-    an unrelated destination.
+    The caller must derive ``destination`` from the current flow authority. A
+    ``True`` result can come from one of three modes:
+
+    1. The current server has a direct binding whose host, port, and kind match
+       and whose current destination still matches the binding.
+    2. The server is connected and a prior same-client binding matches with
+       authoritative connected-endpoint evidence.
+    3. The server is unconnected and its normalized address equals
+       ``destination``. This mode returns ``True`` even when no direct or
+       client-associated binding is stored, so it is retargetable evidence, not
+       durable direct-binding authorization.
+
+    Callers that need durable admission must additionally require
+    ``has_server_binding`` or go through the privileged binding path.
     """
     server = flow.server_conn
     server_id = _connection_id(server)


### PR DESCRIPTION
## Summary

Clarify the exported destination-matching docstrings so callers do not mistake a retargetable unconnected address match for durable direct-binding authorization.

- `flow_matches_bound_destination` and `flow_matches_normalized_destination` now enumerate all successful `True` modes, including the unconnected normalized-address match that returns `True` without a stored binding.
- `upstream_admission.has_bound_destination` now documents that it delegates to `flow_matches_bound_destination` and that durable admission still requires `has_server_binding` or `ensure_bound_destination`.

No runtime behavior, signature, or return-type changes.

## Validation

- `python3 -m py_compile crates/runner/mitm-addon/src/upstream_destination_binding.py crates/runner/mitm-addon/src/upstream_admission.py`
- `ruff format --check .` from `crates/runner/mitm-addon` (ruff 0.16.0, matching `uv.lock`)
- `ruff check .` from `crates/runner/mitm-addon` (ruff 0.16.0, matching `uv.lock`)

`basedpyright` and `pytest` are unaffected by docstring-only changes and are covered by CI.

Closes #27835
