### PR TITLE
fix(platform): update connector catalog count to 1000+

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -658,7 +658,7 @@ describe("connectors page", () => {
       screen.findByTestId("connector-card-label"),
     ).resolves.toHaveTextContent("GitHub");
     await expect(
-      screen.findByText("Connect 700+ services for your agents to use."),
+      screen.findByText("Connect 1000+ services for your agents to use."),
     ).resolves.toBeInTheDocument();
 
     await fill(await screen.findByPlaceholderText("Find connectors"), "Slack");
@@ -692,7 +692,7 @@ describe("connectors page", () => {
     });
 
     await expect(
-      screen.findByText("Connect 700+ services for your agents to use."),
+      screen.findByText("Connect 1000+ services for your agents to use."),
     ).resolves.toBeInTheDocument();
   });
 
@@ -721,7 +721,7 @@ describe("connectors page", () => {
       screen.findByText("Connect third-party services for your agents to use."),
     ).resolves.toBeInTheDocument();
     expect(
-      screen.queryByText("Connect 700+ services for your agents to use."),
+      screen.queryByText("Connect 1000+ services for your agents to use."),
     ).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -1039,7 +1039,7 @@ export function ZeroConnectorsPage() {
                   ($) => {
                     return $.connectors.catalog.descriptionWithCount;
                   },
-                  { value: "700+" },
+                  { value: "1000+" },
                 )}
               </p>
             ) : (


### PR DESCRIPTION
## Summary

- update the feature-gated connector catalog description from `700+` to `1000+`
- update the existing page-level coverage for the enabled and disabled count states

## Exclusions

- does not restore the dynamic exact connector count
- does not change connector catalog APIs or discovery behavior

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx -t 'uses bounded discovery|shows the static connector catalog size|keeps the existing catalog description' --maxWorkers=4 --silent=passed-only`
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-connectors-page.tsx apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit hooks: full Knip, full TypeScript checks, file-size check, and commitlint
