### PR TITLE
test(python): cover static base path segment boundaries

### DIFF
--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_base_path_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_base_path_matching.py
@@ -374,6 +374,41 @@ def test_compiled_matches_static_base_boundary_and_query():
     assert compiled is None
 
 
+def test_compiled_static_base_rejects_sibling_path_segment():
+    fws = wrap_firewalls(
+        [
+            {
+                "base": "https://api.example.com/v1",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [
+                    {"name": "read", "rules": ["ANY /{path*}"]},
+                ],
+            }
+        ],
+        name="example",
+    )
+    policies = {"example": {"allow": ["read"], "deny": [], "unknownPolicy": "deny"}}
+    compiled_firewalls = compile_firewalls_or_fail(fws)
+
+    result = matching.match_compiled_firewall_request(
+        "https://api.example.com/v10/items",
+        "GET",
+        compiled_firewalls,
+        policies,
+    )
+
+    assert result is None
+
+    linear_result = matching._match_compiled_firewall_request_linear(
+        "https://api.example.com/v10/items",
+        "GET",
+        compiled_firewalls,
+        policies,
+    )
+
+    assert linear_result is None
+
+
 def test_compiled_static_base_preserves_repeated_terminal_empty_segments():
     fws = wrap_firewalls(
         [

--- a/crates/runner/mitm-addon/tests/test_matching_base_url_static.py
+++ b/crates/runner/mitm-addon/tests/test_matching_base_url_static.py
@@ -28,6 +28,29 @@ class TestMatchBaseUrl:
         )
         assert result is None
 
+    def test_static_base_exact_path_returns_root(self):
+        result = matching.match_base_url("https://api.example.com/v1", "https://api.example.com/v1")
+        assert result == ("/", {})
+
+    def test_static_base_descendant_path(self):
+        result = matching.match_base_url(
+            "https://api.example.com/v1/items", "https://api.example.com/v1"
+        )
+        assert result == ("/items", {})
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://api.example.com/v10",
+            "https://api.example.com/v10/items",
+            "https://api.example.com/v1foo",
+            "https://api.example.com/v1.0",
+        ],
+    )
+    def test_static_base_rejects_sibling_path_segment(self, url):
+        result = matching.match_base_url(url, "https://api.example.com/v1")
+        assert result is None
+
     def test_static_base_exact(self):
         result = matching.match_base_url("https://api.github.com", "https://api.github.com")
         assert result == ("/", {})


### PR DESCRIPTION
## Summary

Add regression tests that pin the static base-path segment boundary so a sibling path such as `/v10` cannot be classified under the `/v1` API base.

- Low-level `match_base_url` cases reject `/v10`, `/v10/items`, `/v1foo`, and `/v1.0` against base `/v1`, while preserving positive coverage for the exact `/v1` path and descendant `/v1/items`.
- A compiled firewall request regression asserts a sibling-prefix URL is not evaluated under the `/v1` base in both the indexed and linear matchers.

## Validation

Run from `crates/runner/mitm-addon`:

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6008 passed)

## Notes

- Test-only change; no production source is modified.
- The new cases fail when the `rest[0] != "/"` guard in `src/firewall_matching/base_url.py` is removed.

Closes #27838
