### PR TITLE
feat(platform): report confirmed onboarding role

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap/paid-funnel-telemetry.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/paid-funnel-telemetry.ts
@@ -100,6 +100,15 @@ export const capturePaidOnboardingCheckoutCreated$ = command(
   },
 );
 
+export const capturePaidOnboardingRoleConfirmed$ = command(
+  ({ set }, role: string): void => {
+    capturePaidOnboardingEvent("RoleConfirmed", {
+      ...attributionProperties(set(readStoredAdAttributionMetadata$)),
+      role,
+    });
+  },
+);
+
 export const capturePaidOnboardingRedirectToStripe$ = command(
   ({ get, set }, checkoutSource: string): void => {
     capturePaidOnboardingEvent("RedirectToStripe", {

--- a/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/onboarding/onboarding-actions.ts
@@ -18,12 +18,14 @@ import { featureSwitch$ } from "../external/feature-switch.ts";
 import { reloadOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 import {
   ONBOARDING_CHECKOUT_STATE_PARAM,
+  onboardingDraft$,
   resetOnboardingDraft$,
   storeOnboardingCheckoutDraft$,
 } from "./onboarding-state.ts";
 import {
   capturePaidOnboardingCheckoutCreated$,
   capturePaidOnboardingRedirectToStripe$,
+  capturePaidOnboardingRoleConfirmed$,
 } from "../bootstrap/paid-funnel-telemetry.ts";
 
 export const completeOnboarding$ = command(
@@ -33,6 +35,8 @@ export const completeOnboarding$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const createClient = get(zeroClient$);
+    const draft = get(onboardingDraft$);
+    const role = draft.choice === "workflow" ? draft.categoryId : null;
     if (redeemCode) {
       const redeemClient = createClient(zeroBillingRedeemCodeContract);
       await accept(
@@ -54,6 +58,9 @@ export const completeOnboarding$ = command(
       [200],
     );
     signal.throwIfAborted();
+    if (role) {
+      set(capturePaidOnboardingRoleConfirmed$, role);
+    }
     set(reloadOnboardingStatus$);
     set(resetOnboardingDraft$);
   },

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-role-telemetry.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-role-telemetry.test.tsx
@@ -1,0 +1,120 @@
+import { screen, waitFor } from "@testing-library/react";
+import { onboardingCompleteContract } from "@okouai/api-contracts/contracts/onboarding";
+import { expect, test, vi } from "vitest";
+
+import {
+  click,
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
+
+type Capture = (
+  eventName: string,
+  properties?: Record<string, unknown>,
+) => void;
+type Identify = (
+  distinctId: string,
+  properties?: Record<string, unknown>,
+) => void;
+type Init = (key: string, config?: unknown) => void;
+type Register = (properties: Record<string, unknown>) => void;
+type Reset = () => void;
+type Unregister = (property: string) => void;
+
+const posthog = vi.hoisted(() => {
+  vi.stubEnv("VITE_POSTHOG_KEY", "phc_test_key");
+  window.location.href = "https://app.vm0.ai/";
+  return {
+    capture: vi.fn<Capture>(),
+    identify: vi.fn<Identify>(),
+    init: vi.fn<Init>(),
+    register: vi.fn<Register>(),
+    reset: vi.fn<Reset>(),
+    unregister: vi.fn<Unregister>(),
+  };
+});
+
+vi.mock("posthog-js", () => {
+  return { posthog };
+});
+
+const context = testContext();
+
+function buttonByText(text: string): HTMLElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.textContent?.includes(text) ?? false;
+  });
+  if (!button) {
+    throw new Error(`Button not found for ${text}`);
+  }
+  return button;
+}
+
+function roleConfirmedCalls(): unknown[][] {
+  return posthog.capture.mock.calls.filter(([eventName]) => {
+    return eventName === "PaidOnboarding: RoleConfirmed";
+  });
+}
+
+test("reports the final role for the identified user after onboarding completes", async () => {
+  const completion = createDeferredPromise<void>(context.signal);
+  const completionStarted = vi.fn<() => void>();
+  context.mocks.api(
+    onboardingCompleteContract.complete,
+    async ({ respond }) => {
+      completionStarted();
+      await completion.promise;
+      return respond(200, {
+        onboardingComplete: true,
+        needsOnboarding: false,
+      });
+    },
+  );
+  context.mocks.data.onboardingStatus({
+    needsOnboarding: true,
+    onboardingComplete: false,
+  });
+
+  detachedSetupPage({ context, path: "/onboarding" });
+  await expect(
+    screen.findByRole("heading", { name: "What do you want to make first" }),
+  ).resolves.toBeInTheDocument();
+  click(screen.getByRole("radio", { name: /Workflow automation/u }));
+  click(buttonByText("Continue"));
+
+  await expect(
+    screen.findByRole("heading", { name: "What do you work on?" }),
+  ).resolves.toBeInTheDocument();
+  click(buttonByText("Engineer"));
+  await expect(
+    screen.findByRole("heading", { name: "Engineer workflows" }),
+  ).resolves.toBeInTheDocument();
+  click(buttonByText("Talk to Zero and make my own"));
+  click(buttonByText("Continue"));
+
+  await waitFor(() => {
+    expect(completionStarted).toHaveBeenCalledOnce();
+  });
+  expect(roleConfirmedCalls()).toStrictEqual([]);
+
+  completion.resolve();
+  await waitFor(() => {
+    expect(roleConfirmedCalls()).toStrictEqual([
+      [
+        "PaidOnboarding: RoleConfirmed",
+        expect.objectContaining({
+          flow: "paid_onboarding",
+          role: "engineering",
+        }),
+      ],
+    ]);
+    expect(pathname()).not.toMatch(/^\/onboarding/u);
+  });
+  expect(posthog.identify).toHaveBeenCalledWith("test-user-123", {
+    email: undefined,
+    name: "Test User",
+  });
+});


### PR DESCRIPTION
## Summary

- emit `PaidOnboarding: RoleConfirmed` only after onboarding completion succeeds
- report the final workflow category as `role`, while preserving the existing paid-onboarding attribution properties
- rely on the existing PostHog user identification and organization registration so the event stays associated with the user and workspace

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged Turbo, platform, and API type checks
- `pnpm --filter @okouai/app exec vitest run src/views/onboarding/__tests__/onboarding-role-telemetry.test.tsx`
