### PR TITLE
perf(guest-download): attribute archive task shape

### DIFF
--- a/crates/guest-download/src/archive.rs
+++ b/crates/guest-download/src/archive.rs
@@ -319,7 +319,7 @@ mod tests {
     fn extract_archive(tar_gz: Vec<u8>, mount: &Path) -> bool {
         std::fs::create_dir_all(mount).unwrap();
         let target = mount.canonicalize().unwrap();
-        extract_tar_gz(ArchiveSource::local(Cursor::new(tar_gz)), &target).is_ok()
+        extract_tar_gz(ArchiveSource::local(Cursor::new(tar_gz), None), &target).is_ok()
     }
 
     #[test]

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -317,17 +317,23 @@ fn run_download_task(task: PreparedDownloadTask) -> bool {
         task.task.mount_path
     );
     let mut remote_metrics = task.task.telemetry.remote_metrics();
+    let mut opened_file_compressed_bytes = None;
 
     match download_with_retry(
         &task.task.url,
         task.effective_mount_path(),
+        &mut opened_file_compressed_bytes,
         remote_metrics.as_mut(),
     ) {
         Ok(()) => {
             let elapsed = start.elapsed();
-            task.task
-                .telemetry
-                .record_result(elapsed, true, None, remote_metrics.as_ref());
+            task.task.telemetry.record_result(
+                elapsed,
+                true,
+                None,
+                opened_file_compressed_bytes,
+                remote_metrics.as_ref(),
+            );
             log_info!(
                 LOG_TAG,
                 "{} downloaded in {}ms",
@@ -342,6 +348,7 @@ fn run_download_task(task: PreparedDownloadTask) -> bool {
                 start.elapsed(),
                 false,
                 Some(&failure_detail),
+                opened_file_compressed_bytes,
                 remote_metrics.as_ref(),
             );
             log_error!(LOG_TAG, "{failure_detail}");
@@ -358,6 +365,7 @@ fn run_download_task(task: PreparedDownloadTask) -> bool {
 fn download_with_retry(
     url: &str,
     target_path: &Path,
+    opened_file_compressed_bytes: &mut Option<u64>,
     mut remote_metrics: Option<&mut RemoteArchiveTaskMetrics>,
 ) -> Result<(), DownloadError> {
     let mut last_error = None;
@@ -367,7 +375,12 @@ fn download_with_retry(
             metrics.begin_attempt();
         }
         let attempt_start = Instant::now();
-        match download_and_extract(url, target_path, remote_metrics.as_deref_mut()) {
+        match download_and_extract(
+            url,
+            target_path,
+            opened_file_compressed_bytes,
+            remote_metrics.as_deref_mut(),
+        ) {
             Ok(()) => return Ok(()),
             Err(e) => {
                 log_warn!(
@@ -393,6 +406,7 @@ fn download_with_retry(
 fn download_and_extract(
     url: &str,
     target_path: &Path,
+    opened_file_compressed_bytes: &mut Option<u64>,
     remote_metrics: Option<&mut RemoteArchiveTaskMetrics>,
 ) -> Result<(), DownloadError> {
     fs::create_dir_all(target_path).map_err(|e| {
@@ -414,6 +428,7 @@ fn download_and_extract(
             return Err(error);
         }
     };
+    *opened_file_compressed_bytes = reader.compressed_bytes();
     let extract_start = Instant::now();
     let result = archive::extract_tar_gz(reader, target_path);
     let extract_wall = extract_start.elapsed();

--- a/crates/guest-download/src/source.rs
+++ b/crates/guest-download/src/source.rs
@@ -38,7 +38,12 @@ pub(crate) fn open_archive(
         log_info!(LOG_TAG, "Reading local archive");
         let file = std::fs::File::open(path)
             .map_err(|e| DownloadError::fatal(format!("Failed to open local archive: {e}")))?;
-        return Ok(ArchiveSource::local(file));
+        let compressed_bytes = file
+            .metadata()
+            .ok()
+            .filter(|metadata| metadata.is_file())
+            .map(|metadata| metadata.len());
+        return Ok(ArchiveSource::local(file, compressed_bytes));
     }
 
     let metrics = metrics.cloned().unwrap_or_default();
@@ -123,13 +128,15 @@ fn timeout_phase(timeout: ureq::Timeout) -> &'static str {
 pub(crate) struct ArchiveSource {
     reader: Box<dyn Read>,
     http_body_read_failure: HttpBodyReadFailure,
+    compressed_bytes: Option<u64>,
 }
 
 impl ArchiveSource {
-    pub(crate) fn local(reader: impl Read + 'static) -> Self {
+    pub(crate) fn local(reader: impl Read + 'static, compressed_bytes: Option<u64>) -> Self {
         Self {
             reader: Box::new(reader),
             http_body_read_failure: HttpBodyReadFailure::disabled(),
+            compressed_bytes,
         }
     }
 
@@ -142,7 +149,12 @@ impl ArchiveSource {
                 metrics,
             }),
             http_body_read_failure,
+            compressed_bytes: None,
         }
+    }
+
+    pub(crate) fn compressed_bytes(&self) -> Option<u64> {
+        self.compressed_bytes
     }
 
     pub(crate) fn into_parts(self) -> (Box<dyn Read>, HttpBodyReadFailure) {

--- a/crates/guest-download/src/telemetry.rs
+++ b/crates/guest-download/src/telemetry.rs
@@ -1,5 +1,7 @@
 use crate::source;
-use guest_common::telemetry::record_sandbox_op;
+use guest_common::telemetry::{
+    SandboxOpDimensions, record_sandbox_op, record_sandbox_op_with_dimensions,
+};
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
@@ -37,9 +39,22 @@ impl DownloadTaskTelemetry {
         duration: Duration,
         success: bool,
         error: Option<&str>,
+        opened_file_compressed_bytes: Option<u64>,
         remote_metrics: Option<&RemoteArchiveTaskMetrics>,
     ) {
-        record_sandbox_op(self.archive_kind.total_action(), duration, success, error);
+        record_sandbox_op_with_dimensions(
+            self.archive_kind.total_action(),
+            duration,
+            success,
+            error,
+            SandboxOpDimensions {
+                outcome: Some(
+                    self.url_kind
+                        .source_size_outcome(opened_file_compressed_bytes, remote_metrics),
+                ),
+                reason: Some(self.task_kind.label()),
+            },
+        );
         if let Some(metrics) = remote_metrics {
             record_remote_archive_attribution(self.archive_kind, metrics, success);
         }
@@ -285,6 +300,16 @@ enum DownloadTaskKind {
     Other,
 }
 
+impl DownloadTaskKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::FrameworkHomeInstructions => "framework_home_instructions",
+            Self::FrameworkSkillChild => "framework_skill_child",
+            Self::Other => "other",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum DownloadUrlKind {
     Remote,
@@ -300,6 +325,24 @@ impl DownloadUrlKind {
             Self::File
         } else {
             Self::Other
+        }
+    }
+
+    fn source_size_outcome(
+        self,
+        opened_file_compressed_bytes: Option<u64>,
+        remote_metrics: Option<&RemoteArchiveTaskMetrics>,
+    ) -> &'static str {
+        match self {
+            Self::File => opened_file_compressed_bytes
+                .map(CompressedBytesBucket::from_bytes)
+                .map(CompressedBytesBucket::file_outcome)
+                .unwrap_or("file_unknown"),
+            Self::Remote => remote_metrics
+                .map(|metrics| CompressedBytesBucket::from_bytes(metrics.compressed_bytes_consumed))
+                .map(CompressedBytesBucket::remote_outcome)
+                .unwrap_or("remote_unknown"),
+            Self::Other => "other_unknown",
         }
     }
 }
@@ -353,6 +396,32 @@ impl CompressedBytesBucket {
             4_194_304..16_777_216 => Self::Mib4To16,
             16_777_216..67_108_864 => Self::Mib16To64,
             _ => Self::Mib64Plus,
+        }
+    }
+
+    fn file_outcome(self) -> &'static str {
+        match self {
+            Self::Zero => "file_zero",
+            Self::Under64Kib => "file_lt_64_kib",
+            Self::Kib64To256 => "file_64_kib_to_256_kib",
+            Self::Kib256To1Mib => "file_256_kib_to_1_mib",
+            Self::Mib1To4 => "file_1_mib_to_4_mib",
+            Self::Mib4To16 => "file_4_mib_to_16_mib",
+            Self::Mib16To64 => "file_16_mib_to_64_mib",
+            Self::Mib64Plus => "file_64_mib_plus",
+        }
+    }
+
+    fn remote_outcome(self) -> &'static str {
+        match self {
+            Self::Zero => "remote_zero",
+            Self::Under64Kib => "remote_lt_64_kib",
+            Self::Kib64To256 => "remote_64_kib_to_256_kib",
+            Self::Kib256To1Mib => "remote_256_kib_to_1_mib",
+            Self::Mib1To4 => "remote_1_mib_to_4_mib",
+            Self::Mib4To16 => "remote_4_mib_to_16_mib",
+            Self::Mib16To64 => "remote_16_mib_to_64_mib",
+            Self::Mib64Plus => "remote_64_mib_plus",
         }
     }
 }
@@ -747,6 +816,15 @@ mod tests {
 
     #[test]
     fn task_kind_classification_identifies_instructions_and_skill_children() {
+        assert_eq!(
+            DownloadTaskKind::FrameworkHomeInstructions.label(),
+            "framework_home_instructions"
+        );
+        assert_eq!(
+            DownloadTaskKind::FrameworkSkillChild.label(),
+            "framework_skill_child"
+        );
+        assert_eq!(DownloadTaskKind::Other.label(), "other");
         assert_eq!(
             DownloadTaskTelemetry::storage(
                 "https://example.com/archive.tar.gz",

--- a/crates/guest-download/tests/integration/binary_logging/attribution.rs
+++ b/crates/guest-download/tests/integration/binary_logging/attribution.rs
@@ -2,7 +2,7 @@ use super::{BinaryLoggingFixture, assert_action_types_present};
 use crate::support::{create_tar_gz, read_http_request_path, write_manifest};
 use httpmock::prelude::*;
 use httpmock::{HttpMockRequest, HttpMockResponse};
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::io::Write as _;
 use std::net::TcpListener;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -14,6 +14,17 @@ const ARTIFACT_REMOTE_PREFIX: &str = "artifact_download_remote_";
 
 fn operation<'a>(ops: &'a [Value], action: &str) -> Option<&'a Value> {
     ops.iter().find(|entry| entry["action_type"] == action)
+}
+
+fn operation_with_dimensions<'a>(
+    ops: &'a [Value],
+    action: &str,
+    outcome: &str,
+    reason: &str,
+) -> Option<&'a Value> {
+    ops.iter().find(|entry| {
+        entry["action_type"] == action && entry["outcome"] == outcome && entry["reason"] == reason
+    })
 }
 
 fn action_precedes(actions: &[String], earlier: &str, later: &str) -> bool {
@@ -131,6 +142,14 @@ fn binary_records_download_scheduler_attribution() {
             "download_total",
         ],
     );
+    let storage_total =
+        operation_with_dimensions(&ops, "storage_download", "remote_lt_64_kib", "other").unwrap();
+    assert_eq!(storage_total["success"], true);
+    assert!(storage_total.get("error").is_none());
+    let artifact_total =
+        operation_with_dimensions(&ops, "artifact_download", "file_lt_64_kib", "other").unwrap();
+    assert_eq!(artifact_total["success"], true);
+    assert!(artifact_total.get("error").is_none());
     for phase in [
         "guest_download_plan_build",
         "guest_download_cleanup",
@@ -327,6 +346,12 @@ fn binary_records_scheduler_attribution_for_failed_download() {
         .unwrap()["duration_ms"],
         0
     );
+    let storage_total =
+        operation_with_dimensions(&ops, "storage_download", "remote_zero", "other").unwrap();
+    assert_eq!(storage_total["success"], false);
+    assert!(storage_total["error"].as_str().is_some_and(|error| {
+        error.contains("HTTP status 404") && error.contains("urlScheme=http")
+    }));
 }
 
 #[test]
@@ -431,6 +456,16 @@ fn binary_records_remote_artifact_attribution_and_compressed_byte_bucket() {
     archive_mock.assert_calls(1);
     assert_eq!(std::fs::read(mount.join("artifact.bin")).unwrap(), content);
 
+    let ops = fixture.ops_entries().unwrap();
+    let artifact_total = operation_with_dimensions(
+        &ops,
+        "artifact_download",
+        "remote_64_kib_to_256_kib",
+        "other",
+    )
+    .unwrap();
+    assert_eq!(artifact_total["success"], true);
+    assert!(artifact_total.get("error").is_none());
     let actions = fixture.action_types().unwrap();
     assert_action_types_present(
         &actions,
@@ -544,4 +579,104 @@ fn binary_separates_response_header_and_body_read_wait() {
         "header wait was {header_wait}ms: {ops:?}"
     );
     assert!(body_wait >= 50, "body wait was {body_wait}ms: {ops:?}");
+}
+
+#[test]
+fn binary_records_opened_file_size_around_bucket_boundary() {
+    let fixture = BinaryLoggingFixture::new("opened-file-size-boundary").unwrap();
+    let below_boundary = fixture.dir.path().join("below-boundary.tar.gz");
+    let at_boundary = fixture.dir.path().join("at-boundary.tar.gz");
+    std::fs::write(&below_boundary, vec![0_u8; 65_535]).unwrap();
+    std::fs::write(&at_boundary, vec![0_u8; 65_536]).unwrap();
+
+    let below_mount = fixture.dir.path().join("below-mount");
+    let at_mount = fixture.dir.path().join("at-mount");
+    let below_url = format!("file://{}", below_boundary.display());
+    let at_url = format!("file://{}", at_boundary.display());
+    let manifest = write_manifest(
+        &fixture.dir,
+        &[
+            (below_mount.to_str().unwrap(), Some(&below_url)),
+            (at_mount.to_str().unwrap(), Some(&at_url)),
+        ],
+        None,
+    )
+    .unwrap();
+
+    let output = fixture.run_manifest_path(&manifest).unwrap();
+
+    assert!(!output.status.success());
+    let ops = fixture.ops_entries().unwrap();
+    for outcome in ["file_lt_64_kib", "file_64_kib_to_256_kib"] {
+        let task = operation_with_dimensions(&ops, "storage_download", outcome, "other").unwrap();
+        assert_eq!(task["success"], false);
+        assert!(
+            task["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("invalid gzip header")),
+            "unexpected task entry: {task:?}"
+        );
+    }
+    assert_eq!(
+        ops.iter()
+            .filter(|entry| entry["action_type"] == "storage_download")
+            .count(),
+        2,
+        "unexpected task totals: {ops:?}"
+    );
+    assert_eq!(
+        operation(&ops, "guest_download_archive_scheduler").unwrap()["success"],
+        false
+    );
+    assert_eq!(operation(&ops, "download_total").unwrap()["success"], false);
+}
+
+#[test]
+fn binary_records_framework_home_instructions_role() {
+    let fixture = BinaryLoggingFixture::new("framework-home-instructions-role").unwrap();
+    let archive = create_tar_gz(&[("AGENTS.md", b"runtime instructions")]).unwrap();
+    assert!(archive.len() < 65_536);
+    let archive_path = fixture.dir.path().join("instructions.tar.gz");
+    std::fs::write(&archive_path, archive).unwrap();
+
+    let framework_home = fixture.dir.path().join(".codex");
+    let extract_path = fixture.dir.path().join("instructions-stage");
+    let manifest_path = fixture.dir.path().join("instructions-manifest.json");
+    let manifest = json!({
+        "storageMounts": [{
+            "mountPath": framework_home,
+            "extractPath": extract_path,
+            "archiveUrl": format!("file://{}", archive_path.display()),
+            "instructionsTargetFilename": "AGENTS.md"
+        }]
+    });
+    std::fs::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+    let output = fixture.run_manifest_path(&manifest_path).unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(framework_home.join("AGENTS.md")).unwrap(),
+        "runtime instructions"
+    );
+    assert!(!extract_path.exists());
+    let ops = fixture.ops_entries().unwrap();
+    let task = operation_with_dimensions(
+        &ops,
+        "storage_download",
+        "file_lt_64_kib",
+        "framework_home_instructions",
+    )
+    .unwrap();
+    assert_eq!(task["success"], true);
+    assert!(task.get("error").is_none());
+    assert_eq!(
+        operation(&ops, "guest_download_instruction_normalize").unwrap()["success"],
+        true
+    );
+    assert_eq!(operation(&ops, "download_total").unwrap()["success"], true);
 }

--- a/crates/guest-download/tests/integration/binary_logging/redaction.rs
+++ b/crates/guest-download/tests/integration/binary_logging/redaction.rs
@@ -580,4 +580,53 @@ fn binary_does_not_log_file_archive_path_on_missing_local_file() {
     assert_does_not_contain_any("stderr", &stderr, &forbidden);
     assert_does_not_contain_any("system log", &system_log_content, &forbidden);
     assert_does_not_contain_any("sandbox ops log", &ops_log_content, &forbidden);
+    let ops = fixture.ops_entries().unwrap();
+    assert!(
+        ops.iter().any(|entry| {
+            entry["action_type"] == "storage_download"
+                && entry["success"] == false
+                && entry["outcome"] == "file_unknown"
+                && entry["reason"] == "other"
+        }),
+        "missing bounded failed local attribution: {ops_log_content}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn binary_classifies_non_file_local_archive_as_unknown_without_logging_path() {
+    let fixture = BinaryLoggingFixture::new("secret-non-file-path").unwrap();
+    let non_file = fixture.dir.path().join("secret-staged-archive-directory");
+    std::fs::create_dir(&non_file).unwrap();
+
+    let mount = fixture.dir.path().join("mount");
+    let url = format!("file://{}", non_file.display());
+    let manifest =
+        write_manifest(&fixture.dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let output = fixture.run_manifest_path(&manifest).unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let system_log_content = fixture.read_system_log().unwrap();
+    let ops_log_content = fixture.read_ops_log().unwrap();
+    let non_file_path = non_file.to_string_lossy();
+    let forbidden = [
+        url.as_str(),
+        non_file_path.as_ref(),
+        "secret-staged-archive",
+    ];
+    assert_does_not_contain_any("stderr", &stderr, &forbidden);
+    assert_does_not_contain_any("system log", &system_log_content, &forbidden);
+    assert_does_not_contain_any("sandbox ops log", &ops_log_content, &forbidden);
+    let ops = fixture.ops_entries().unwrap();
+    assert!(
+        ops.iter().any(|entry| {
+            entry["action_type"] == "storage_download"
+                && entry["success"] == false
+                && entry["outcome"] == "file_unknown"
+                && entry["reason"] == "other"
+        }),
+        "missing bounded failed local attribution: {ops_log_content}"
+    );
 }


### PR DESCRIPTION
## Summary

- add fixed-cardinality source/size and task-role dimensions to existing archive task total rows
- measure local regular-file size from opened file metadata and reuse cumulative remote bytes consumed across retries
- cover remote, local, failure, bucket-boundary, framework-instructions, and redaction behavior with binary integration tests

## Scope

- keeps existing `storage_download` and `artifact_download` actions and row counts
- does not change download scheduling, retry, extraction, manifest, API, or persisted protocols
- preserves existing sanitized task errors; the new dimensions never contain paths, URLs, storage keys, versions, or raw byte counts

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-download --all-targets --all-features -- -D warnings`
- `cd crates && RUSTDOCFLAGS="-D warnings" cargo doc -p guest-download --no-deps --all-features`
- `cd crates && cargo test -p guest-download`

Closes #27833

Parent context: #24203
