### PR TITLE
test(api): own runtime sync boundary cleanup

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9431,7 +9431,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
   it("hands off more than one runtime-sync batch without truncation", async () => {
     const api = createRunsApi(context);
-    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const { actor, agentId } = await entitledRunActor();
     if (!actor.orgId) {
       throw new Error("Expected a custom connector actor with an organization");
     }
@@ -9463,7 +9463,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       prompt: "use more than one connector runtime sync batch",
       modelProvider: "anthropic-api-key",
     });
-    await api.heartbeatRunner(runnerGroup);
+    onTestFinished(async () => {
+      await api.requestCancelRun(actor, run.runId, [200]);
+    });
     const claim = await api.claimRunnerJob(run.runId);
     const expectedIds = [...createdIds].sort();
     expect(
@@ -9473,8 +9475,6 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         })
         .sort(),
     ).toStrictEqual(expectedIds);
-
-    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("keeps a granted custom skill independent from runtime admission", async () => {


### PR DESCRIPTION
## Summary

- keep the full 257-authorized-custom-connector setup, real run creation, persisted claim handoff, and strict ID equality assertion
- remove the unrelated runner heartbeat from the timed assertion path because a run-specific authenticated claim does not depend on runner advertisement
- register run cancellation with Vitest's awaited `onTestFinished` lifecycle so cleanup remains owned and failure-visible without consuming the 5-second business assertion budget

## Diagnosis

The first causal nondeterminism is wall-clock scheduling and shared shard load against Vitest's fixed 5-second test boundary, not a product assertion failure or an async ownership race.

- Triggering push run: https://github.com/vm0-ai/vm0/actions/runs/32093441910
- Causal job: https://github.com/vm0-ai/vm0/actions/runs/32093441910/job/95580979072
- Failure: the exact test reached the 5-second boundary at 5010ms; the other 420 tests passed
- Same code passed at 3155ms in merge-group run 32092951176, 3693ms immediately after #27806, 3986ms in adjacent main run 32093299031, and 4457ms in the latest unchanged main run 32095246463
- The triggering #27825 changed only `.github/scripts/tests/cloudflare-ssh-command-test.sh`; current `origin/main` has no changes to this API test or runtime-sync path
- `ci-gate-turbo` is aggregate-only. Expected negative-fixture errors, teardown PostgreSQL messages, and cancellation/abort noise were not causal failures.

This is a post-#27806 regression. The successful 4457ms main result still leaves only 543ms of margin, so the unchanged path remains timing-sensitive.

The patch does not add retries, sleeps, timeout changes, skipped coverage, detached cleanup, swallowed rejections, or weaker assertions.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts` x5: 76/76 passed each run
- `git diff --check`

The focused BDD requires PostgreSQL. It was not run locally because this repair explicitly forbids starting a local database, app, API, runner, or other service; the PR's `test-api (7)` job supplies the supported PostgreSQL environment.

## Preview validation

Not applicable. This is a test-only lifecycle change with no deployable App or API behavior, so there is no preview URL or browser invariant to validate. The original invariant is the unchanged strict assertion that every one of the 257 authorized connector target IDs is returned by the real claim path without truncation.

