### PR TITLE
refactor(runner): canonicalize restored session identity enums

### DIFF
--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1034,12 +1034,12 @@ mod tests {
     use crate::network_log_manager::NetworkLogManager;
     use crate::paths::RunnerPaths;
     use crate::resource_budget::{BudgetLease, ResourceBudget};
-    use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
+    use crate::restored_session_identity::RestoredSessionIdentity;
     use crate::status::StatusTracker;
     use crate::storage_fingerprints::StorageFingerprint;
     use crate::storage_manifest::{ArtifactEntry, StorageEntry, StorageManifest};
     use crate::storage_plan::build_storage_plan;
-    use crate::types::{ResumeSessionHistoryRefKind, SandboxReuseResult};
+    use crate::types::SandboxReuseResult;
     use crate::workspace_image_cache::{
         WorkspaceImageCache, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
         WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityRequest,
@@ -1268,53 +1268,44 @@ mod tests {
     }
 
     fn test_restored_session_identity(
-        framework: RestoredSessionFramework,
+        framework: FinalSessionHistoryFramework,
         session_id: &str,
         history: &[u8],
     ) -> RestoredSessionIdentity {
         RestoredSessionIdentity::new(
             framework,
             session_id,
-            ResumeSessionHistoryRefKind::Blob,
+            FinalSessionHistoryRefKind::Blob,
             hex::encode(Sha256::digest(history)),
             Some(history.len() as u64),
         )
     }
 
     fn test_verified_restored_session_identity(
-        framework: RestoredSessionFramework,
+        framework: FinalSessionHistoryFramework,
         session_id: &str,
         history: &[u8],
     ) -> RestoredSessionIdentity {
-        let (final_framework, history_source) = match framework {
-            RestoredSessionFramework::ClaudeCode => (
-                FinalSessionHistoryFramework::ClaudeCode,
-                FinalSessionHistorySourceRef::ClaudeCode {
-                    config_dir: "/home/user/.claude".to_string(),
-                    working_dir: CANONICAL_WORKING_DIR.to_string(),
-                    session_id: session_id.to_string(),
-                },
-            ),
-            RestoredSessionFramework::Codex => (
-                FinalSessionHistoryFramework::Codex,
-                FinalSessionHistorySourceRef::Codex {
-                    sessions_dir: "/home/user/.codex/sessions".to_string(),
-                    thread_id: session_id.to_string(),
-                },
-            ),
-            RestoredSessionFramework::Pi => (
-                FinalSessionHistoryFramework::Pi,
-                FinalSessionHistorySourceRef::Pi {
-                    session_path: format!(
-                        "{}/restored-{session_id}.jsonl",
-                        api_contracts::generated::constants::runners::paths::CANONICAL_PI_SESSION_DIR,
-                    ),
-                    session_id: session_id.to_string(),
-                },
-            ),
+        let history_source = match framework {
+            FinalSessionHistoryFramework::ClaudeCode => FinalSessionHistorySourceRef::ClaudeCode {
+                config_dir: "/home/user/.claude".to_string(),
+                working_dir: CANONICAL_WORKING_DIR.to_string(),
+                session_id: session_id.to_string(),
+            },
+            FinalSessionHistoryFramework::Codex => FinalSessionHistorySourceRef::Codex {
+                sessions_dir: "/home/user/.codex/sessions".to_string(),
+                thread_id: session_id.to_string(),
+            },
+            FinalSessionHistoryFramework::Pi => FinalSessionHistorySourceRef::Pi {
+                session_path: format!(
+                    "{}/restored-{session_id}.jsonl",
+                    api_contracts::generated::constants::runners::paths::CANONICAL_PI_SESSION_DIR,
+                ),
+                session_id: session_id.to_string(),
+            },
         };
         let metadata = FinalSessionHistoryIdentity::new(
-            final_framework,
+            framework,
             hex::encode(Sha256::digest(session_id.as_bytes())),
             FinalSessionHistoryRefKind::Blob,
             hex::encode(Sha256::digest(history)),
@@ -1340,7 +1331,7 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let restored_session_identity = test_restored_session_identity(
-            RestoredSessionFramework::ClaudeCode,
+            FinalSessionHistoryFramework::ClaudeCode,
             session_id,
             history,
         );
@@ -2185,7 +2176,7 @@ mod tests {
         let previous_sidecar_body = tokio::fs::read(&sidecar_body_path).await.unwrap();
         let previous_sidecar_metadata = tokio::fs::read(&sidecar_metadata_path).await.unwrap();
         let codex_identity = test_restored_session_identity(
-            RestoredSessionFramework::Codex,
+            FinalSessionHistoryFramework::Codex,
             "codex-session-b",
             previous_history,
         );
@@ -2351,7 +2342,7 @@ mod tests {
         let next_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
         let next_history = br#"{"type":"message","content":"codex-b"}"#;
         let next_identity = test_verified_restored_session_identity(
-            RestoredSessionFramework::Codex,
+            FinalSessionHistoryFramework::Codex,
             next_session_id,
             next_history,
         );

--- a/crates/runner/src/executor/session_history_restore_plan.rs
+++ b/crates/runner/src/executor/session_history_restore_plan.rs
@@ -292,9 +292,7 @@ mod tests {
 
     use crate::http::HttpClientConfig;
     use crate::ids::RunId;
-    use crate::restored_session_identity::{
-        RestoredSessionFramework, RestoredSessionHistoryHashSizeRelationship,
-    };
+    use crate::restored_session_identity::RestoredSessionHistoryHashSizeRelationship;
     use crate::test_fixtures::execution_context::execution_context_for_test;
     use crate::types::{
         ResumeSession, ResumeSessionHistory, ResumeSessionHistoryEncoding, ResumeSessionHistoryRef,
@@ -631,9 +629,9 @@ mod tests {
         let history_hash = "a".repeat(64);
         let context = context_with_history_ref(&history_hash);
         let restored_identity = RestoredSessionIdentity::new(
-            RestoredSessionFramework::ClaudeCode,
+            FinalSessionHistoryFramework::ClaudeCode,
             "sess-other",
-            ResumeSessionHistoryRefKind::Blob,
+            FinalSessionHistoryRefKind::Blob,
             history_hash,
             Some(12),
         );
@@ -662,9 +660,9 @@ mod tests {
         let history_hash = "a".repeat(64);
         let context = context_with_history_ref(&history_hash);
         let restored_identity = RestoredSessionIdentity::new(
-            RestoredSessionFramework::Codex,
+            FinalSessionHistoryFramework::Codex,
             "sess-restore-plan",
-            ResumeSessionHistoryRefKind::Blob,
+            FinalSessionHistoryRefKind::Blob,
             history_hash,
             Some(12),
         );

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -7,14 +7,17 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
+use guest_contracts::session_history_identity::{
+    FinalSessionHistoryFramework, FinalSessionHistoryRefKind,
+};
 use sandbox::Sandbox;
 use tracing::{info, warn};
 
 use super::cli_framework::{EffectiveCliFramework, effective_cli_framework};
 use super::env::validate_resume_session_id;
 use super::{RunnerError, RunnerResult};
-use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
-use crate::types::ExecutionContext;
+use crate::restored_session_identity::RestoredSessionIdentity;
+use crate::types::{ExecutionContext, ResumeSessionHistoryRefKind};
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
 impl RestoredSessionIdentity {
@@ -23,7 +26,14 @@ impl RestoredSessionIdentity {
         let resume_session = context.resume_session.as_ref()?;
         let history_ref = resume_session.history_ref()?;
         let effective_framework = effective_cli_framework(&context.cli_agent_type);
-        let framework = restored_session_framework(effective_framework);
+        let framework = match effective_framework {
+            EffectiveCliFramework::ClaudeCode => FinalSessionHistoryFramework::ClaudeCode,
+            EffectiveCliFramework::Codex => FinalSessionHistoryFramework::Codex,
+            EffectiveCliFramework::Pi => FinalSessionHistoryFramework::Pi,
+        };
+        let history_ref_kind = match history_ref.kind {
+            ResumeSessionHistoryRefKind::Blob => FinalSessionHistoryRefKind::Blob,
+        };
         let session_id = restored_session_identity_session_id(
             effective_framework,
             &resume_session.cli_agent_session_id,
@@ -31,7 +41,7 @@ impl RestoredSessionIdentity {
         Some(Self::new(
             framework,
             &session_id,
-            history_ref.kind,
+            history_ref_kind,
             history_ref.hash.clone(),
             Some(history_ref.raw_size),
         ))
@@ -46,14 +56,6 @@ fn restored_session_identity_session_id(
         EffectiveCliFramework::ClaudeCode => Some(session_id.to_owned()),
         EffectiveCliFramework::Codex => canonical_codex_thread_id(session_id),
         EffectiveCliFramework::Pi => Some(session_id.to_owned()),
-    }
-}
-
-fn restored_session_framework(framework: EffectiveCliFramework) -> RestoredSessionFramework {
-    match framework {
-        EffectiveCliFramework::ClaudeCode => RestoredSessionFramework::ClaudeCode,
-        EffectiveCliFramework::Codex => RestoredSessionFramework::Codex,
-        EffectiveCliFramework::Pi => RestoredSessionFramework::Pi,
     }
 }
 

--- a/crates/runner/src/executor/tests/session_restore_tests/identity.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/identity.rs
@@ -1,5 +1,8 @@
 use super::*;
 use crate::restored_session_identity::RestoredSessionIdentity;
+use guest_contracts::session_history_identity::{
+    FinalSessionHistoryFramework, FinalSessionHistoryRefKind,
+};
 
 #[test]
 fn restored_session_identity_requires_valid_hash_ref() {
@@ -16,6 +19,42 @@ fn restored_session_identity_requires_valid_hash_ref() {
 
     ctx.resume_session = Some(resume_ref("../../etc/passwd", history_ref("hash-a", 12)));
     assert!(RestoredSessionIdentity::from_context(&ctx).is_none());
+}
+
+#[test]
+fn restored_session_identity_maps_request_boundary_types() {
+    let cases = [
+        (
+            claude_context(),
+            "sess-identity-claude",
+            FinalSessionHistoryFramework::ClaudeCode,
+        ),
+        (
+            codex_context(),
+            CODEX_SESSION_ID,
+            FinalSessionHistoryFramework::Codex,
+        ),
+        (
+            pi_context(),
+            "sess-identity-pi",
+            FinalSessionHistoryFramework::Pi,
+        ),
+    ];
+
+    for (mut ctx, session_id, framework) in cases {
+        ctx.resume_session = Some(resume_ref(session_id, history_ref("hash-a", 12)));
+
+        let actual = RestoredSessionIdentity::from_context(&ctx).expect("request identity");
+        let expected = RestoredSessionIdentity::new(
+            framework,
+            session_id,
+            FinalSessionHistoryRefKind::Blob,
+            "hash-a",
+            Some(12),
+        );
+
+        assert_eq!(actual, expected);
+    }
 }
 
 #[test]

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -25,16 +25,6 @@ use guest_contracts::session_history_identity::{
 };
 use sha2::{Digest, Sha256};
 
-use crate::types::ResumeSessionHistoryRefKind;
-
-/// CLI framework namespace used by a restored-session identity.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum RestoredSessionFramework {
-    ClaudeCode,
-    Codex,
-    Pi,
-}
-
 /// Reason a resume request cannot use a retained identity.
 ///
 /// [`RestoredSessionIdentity::mismatch_reason_for_request`] defines the stable
@@ -114,9 +104,9 @@ impl RestoredSessionHistoryHashSizeRelationship {
 /// that requires retained verification provenance.
 #[derive(Clone, Eq)]
 pub(crate) struct RestoredSessionIdentity {
-    framework: RestoredSessionFramework,
+    framework: FinalSessionHistoryFramework,
     session_id_hash: String,
-    history_ref_kind: ResumeSessionHistoryRefKind,
+    history_ref_kind: FinalSessionHistoryRefKind,
     history_hash: String,
     history_size_bytes: Option<u64>,
     verifier: Option<RestoredSessionIdentityVerifier>,
@@ -174,9 +164,9 @@ impl RestoredSessionIdentity {
     /// supply the canonical thread id. The id is stored only as a SHA-256 hash.
     /// This constructor never attaches final-metadata verifier provenance.
     pub(crate) fn new(
-        framework: RestoredSessionFramework,
+        framework: FinalSessionHistoryFramework,
         identity_session_id: &str,
-        history_ref_kind: ResumeSessionHistoryRefKind,
+        history_ref_kind: FinalSessionHistoryRefKind,
         history_hash: impl Into<String>,
         history_size_bytes: Option<u64>,
     ) -> Self {
@@ -201,12 +191,10 @@ impl RestoredSessionIdentity {
         runtime_dir: impl Into<String>,
     ) -> Option<Self> {
         metadata.validate().ok()?;
-        let framework = restored_session_framework_from_final(metadata.framework);
-        let history_ref_kind = resume_history_ref_kind_from_final(metadata.history_ref_kind);
         let identity = Self {
-            framework,
+            framework: metadata.framework,
             session_id_hash: metadata.session_id_hash,
-            history_ref_kind,
+            history_ref_kind: metadata.history_ref_kind,
             history_hash: metadata.history_hash,
             history_size_bytes: Some(metadata.history_size_bytes),
             verifier: Some(RestoredSessionIdentityVerifier::FinalIdentityMetadata {
@@ -222,9 +210,9 @@ impl RestoredSessionIdentity {
     #[cfg(test)]
     pub(crate) fn claude_code_for_test(history_hash: impl Into<String>) -> Self {
         Self::new(
-            RestoredSessionFramework::ClaudeCode,
+            FinalSessionHistoryFramework::ClaudeCode,
             "sess-restore-plan",
-            ResumeSessionHistoryRefKind::Blob,
+            FinalSessionHistoryRefKind::Blob,
             history_hash,
             None,
         )
@@ -271,9 +259,9 @@ impl RestoredSessionIdentity {
                 Some(RestoredSessionFinalMetadataVerification {
                     metadata_path,
                     runtime_dir,
-                    framework: final_session_history_framework(self.framework),
+                    framework: self.framework,
                     session_id_hash: &self.session_id_hash,
-                    history_ref_kind: final_session_history_ref_kind(self.history_ref_kind),
+                    history_ref_kind: self.history_ref_kind,
                     history_hash: &self.history_hash,
                     history_size_bytes: expected_size,
                 })
@@ -287,9 +275,9 @@ impl RestoredSessionIdentity {
     /// verifier provenance or retained guest paths.
     pub(crate) fn cache_fields(&self) -> Option<RestoredSessionIdentityFields<'_>> {
         Some(RestoredSessionIdentityFields {
-            framework: final_session_history_framework(self.framework),
+            framework: self.framework,
             session_id_hash: &self.session_id_hash,
-            history_ref_kind: final_session_history_ref_kind(self.history_ref_kind),
+            history_ref_kind: self.history_ref_kind,
             history_hash: &self.history_hash,
             history_size_bytes: self.history_size_bytes?,
         })
@@ -455,37 +443,3 @@ impl fmt::Debug for RestoredSessionIdentity {
 /// Read cap used to reject oversized final-identity metadata.
 pub(crate) const FINAL_SESSION_HISTORY_IDENTITY_READ_LIMIT: u64 =
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES + 1;
-
-fn restored_session_framework_from_final(
-    framework: FinalSessionHistoryFramework,
-) -> RestoredSessionFramework {
-    match framework {
-        FinalSessionHistoryFramework::ClaudeCode => RestoredSessionFramework::ClaudeCode,
-        FinalSessionHistoryFramework::Codex => RestoredSessionFramework::Codex,
-        FinalSessionHistoryFramework::Pi => RestoredSessionFramework::Pi,
-    }
-}
-
-fn final_session_history_framework(
-    framework: RestoredSessionFramework,
-) -> FinalSessionHistoryFramework {
-    match framework {
-        RestoredSessionFramework::ClaudeCode => FinalSessionHistoryFramework::ClaudeCode,
-        RestoredSessionFramework::Codex => FinalSessionHistoryFramework::Codex,
-        RestoredSessionFramework::Pi => FinalSessionHistoryFramework::Pi,
-    }
-}
-
-fn resume_history_ref_kind_from_final(
-    kind: FinalSessionHistoryRefKind,
-) -> ResumeSessionHistoryRefKind {
-    match kind {
-        FinalSessionHistoryRefKind::Blob => ResumeSessionHistoryRefKind::Blob,
-    }
-}
-
-fn final_session_history_ref_kind(kind: ResumeSessionHistoryRefKind) -> FinalSessionHistoryRefKind {
-    match kind {
-        ResumeSessionHistoryRefKind::Blob => FinalSessionHistoryRefKind::Blob,
-    }
-}

--- a/crates/runner/src/workspace_image_cache/tests/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/tests/sidecar.rs
@@ -4,6 +4,9 @@ use std::path::Path;
 use api_contracts::generated::constants::runners::{
     RESUME_SESSION_HISTORY_MAX_BYTES, paths::CANONICAL_WORKING_DIR,
 };
+use guest_contracts::session_history_identity::{
+    FinalSessionHistoryFramework, FinalSessionHistoryRefKind,
+};
 use sha2::{Digest, Sha256};
 use tokio::fs;
 
@@ -19,8 +22,7 @@ use super::super::{
 use super::support::{TEST_PROFILE_NAME, local_cache, write_current_cache_entry};
 use crate::ids::RunId;
 use crate::paths::RunnerPaths;
-use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
-use crate::types::ResumeSessionHistoryRefKind;
+use crate::restored_session_identity::RestoredSessionIdentity;
 
 fn mode(path: &Path) -> u32 {
     std::fs::metadata(path).unwrap().permissions().mode() & 0o777
@@ -28,9 +30,9 @@ fn mode(path: &Path) -> u32 {
 
 fn test_restored_session_identity(session_id: &str, history: &[u8]) -> RestoredSessionIdentity {
     RestoredSessionIdentity::new(
-        RestoredSessionFramework::ClaudeCode,
+        FinalSessionHistoryFramework::ClaudeCode,
         session_id,
-        ResumeSessionHistoryRefKind::Blob,
+        FinalSessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(history)),
         Some(history.len() as u64),
     )


### PR DESCRIPTION
## Summary

- store shared final session-history framework and ref-kind enums directly in the runner's restored identity
- convert effective CLI framework and request ref kind once at the request construction boundary
- remove the runner-only framework enum and four redundant bidirectional conversion helpers
- cover Claude Code, Codex, Pi, and blob boundary mappings through real execution contexts

## Compatibility

- request JSON, final identity metadata, helper CLI spellings, and workspace-cache sidecar formats are unchanged
- mismatch precedence, redacted debug output, verifier eligibility, and sidecar matching behavior are unchanged
- no API, database, queue, dependency, migration, feature-flag, or rollout change

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::session_restore_tests::identity`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `git diff --check`
- `lefthook run pre-commit`

Closes #27841
