### PR TITLE
feat: show relative video model pricing

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4240,6 +4240,7 @@
         "loadError": "Modelle können nicht geladen werden.",
         "loading": "Modelle werden geladen...",
         "manageMoreModels": "Weitere Modelle verwalten",
+        "mini": "Mini",
         "models": "Modelle",
         "noConfiguredModels": "Keine konfigurierten Modelle",
         "priceTiers": {
@@ -4255,7 +4256,8 @@
           "deepseek": "Deepseek"
         },
         "standard": "Standard",
-        "videoModels": "Videomodelle"
+        "videoModels": "Videomodelle",
+        "videoModelVariant": "{{model}}-Variante: {{variant}}"
       },
       "policies": {
         "actionsFor": "Aktionen für {{model}}",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4240,6 +4240,7 @@
         "loadError": "Unable to load models.",
         "loading": "Loading models...",
         "manageMoreModels": "Manage more models",
+        "mini": "Mini",
         "models": "Models",
         "noConfiguredModels": "No configured models",
         "priceTiers": {
@@ -4255,7 +4256,8 @@
           "deepseek": "Deepseek"
         },
         "standard": "Standard",
-        "videoModels": "Video models"
+        "videoModels": "Video models",
+        "videoModelVariant": "{{model}} variant: {{variant}}"
       },
       "policies": {
         "actionsFor": "Actions for {{model}}",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -4290,6 +4290,7 @@
         "loadError": "No se pudieron cargar los modelos.",
         "loading": "Cargando modelos...",
         "manageMoreModels": "Gestionar más modelos",
+        "mini": "Mini",
         "models": "Modelos",
         "noConfiguredModels": "Sin modelos configurados",
         "priceTiers": {
@@ -4305,7 +4306,8 @@
           "deepseek": "Deepseek"
         },
         "standard": "Estándar",
-        "videoModels": "Modelos de vídeo"
+        "videoModels": "Modelos de vídeo",
+        "videoModelVariant": "Variante de {{model}}: {{variant}}"
       },
       "policies": {
         "actionsFor": "Acciones para {{model}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -4290,6 +4290,7 @@
         "loadError": "Impossible de charger les modèles.",
         "loading": "Chargement des modèles...",
         "manageMoreModels": "Gérer d'autres modèles",
+        "mini": "Mini",
         "models": "Modèles",
         "noConfiguredModels": "Aucun modèle configuré",
         "priceTiers": {
@@ -4305,7 +4306,8 @@
           "deepseek": "Deepseek"
         },
         "standard": "Standard",
-        "videoModels": "Modèles vidéo"
+        "videoModels": "Modèles vidéo",
+        "videoModelVariant": "Variante de {{model}} : {{variant}}"
       },
       "policies": {
         "actionsFor": "Actions pour {{model}}",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4240,6 +4240,7 @@
         "loadError": "मॉडल लोड करने में असमर्थ.",
         "loading": "मॉडल लोड हो रहे हैं...",
         "manageMoreModels": "और मॉडल प्रबंधित करें",
+        "mini": "Mini",
         "models": "मॉडल",
         "noConfiguredModels": "कोई कॉन्फ़िगर मॉडल नहीं",
         "priceTiers": {
@@ -4255,7 +4256,8 @@
           "deepseek": "गहन खोज"
         },
         "standard": "मानक",
-        "videoModels": "वीडियो मॉडल"
+        "videoModels": "वीडियो मॉडल",
+        "videoModelVariant": "{{model}} वैरिएंट: {{variant}}"
       },
       "policies": {
         "actionsFor": "{{model}} के लिए क्रियाएँ",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4239,6 +4239,7 @@
         "loadError": "Tidak dapat memuat model.",
         "loading": "Memuat model...",
         "manageMoreModels": "Kelola model lainnya",
+        "mini": "Mini",
         "models": "Model",
         "noConfiguredModels": "Tidak ada model yang dikonfigurasi",
         "priceTiers": {
@@ -4254,7 +4255,8 @@
           "deepseek": "Deepseek"
         },
         "standard": "Standar",
-        "videoModels": "Model video"
+        "videoModels": "Model video",
+        "videoModelVariant": "Varian {{model}}: {{variant}}"
       },
       "policies": {
         "actionsFor": "Tindakan untuk {{model}}",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -4290,6 +4290,7 @@
         "loadError": "Impossibile caricare i modelli.",
         "loading": "Caricamento modelli...",
         "manageMoreModels": "Gestisci altri modelli",
+        "mini": "Mini",
         "models": "Modelli",
         "noConfiguredModels": "Nessun modello configurato",
         "priceTiers": {
@@ -4305,7 +4306,8 @@
           "deepseek": "Ricerca profonda"
         },
         "standard": "Norma",
-        "videoModels": "Modelli video"
+        "videoModels": "Modelli video",
+        "videoModelVariant": "Variante di {{model}}: {{variant}}"
       },
       "policies": {
         "actionsFor": "Azioni per {{model}}",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4239,6 +4239,7 @@
         "loadError": "モデルをロードできません。",
         "loading": "モデルをロード中...",
         "manageMoreModels": "他のモデルを管理",
+        "mini": "Mini",
         "models": "モデル",
         "noConfiguredModels": "設定されたモデルはありません",
         "priceTiers": {
@@ -4254,7 +4255,8 @@
           "deepseek": "ディープシーク"
         },
         "standard": "標準",
-        "videoModels": "動画モデル"
+        "videoModels": "動画モデル",
+        "videoModelVariant": "{{model}} のバリエーション: {{variant}}"
       },
       "policies": {
         "actionsFor": "{{model}} のアクション",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4239,6 +4239,7 @@
         "loadError": "모델을 불러올 수 없습니다.",
         "loading": "모델 불러오는 중...",
         "manageMoreModels": "더 많은 모델 관리",
+        "mini": "Mini",
         "models": "모델",
         "noConfiguredModels": "구성된 모델 없음",
         "priceTiers": {
@@ -4254,7 +4255,8 @@
           "deepseek": "Deepseek"
         },
         "standard": "표준",
-        "videoModels": "동영상 모델"
+        "videoModels": "동영상 모델",
+        "videoModelVariant": "{{model}} 변형: {{variant}}"
       },
       "policies": {
         "actionsFor": "{{model}}에 대한 작업",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4290,6 +4290,7 @@
         "loadError": "Não foi possível carregar os modelos.",
         "loading": "Carregando modelos...",
         "manageMoreModels": "Gerenciar mais modelos",
+        "mini": "Mini",
         "models": "Modelos",
         "noConfiguredModels": "Nenhum modelo configurado",
         "priceTiers": {
@@ -4305,7 +4306,8 @@
           "deepseek": "Deepseek"
         },
         "standard": "Padrão",
-        "videoModels": "Modelos de vídeo"
+        "videoModels": "Modelos de vídeo",
+        "videoModelVariant": "Variante do {{model}}: {{variant}}"
       },
       "policies": {
         "actionsFor": "Ações para {{model}}",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3435,7 +3435,10 @@ describe("chat composer video model", () => {
 
   function videoPanelButton(label: string): HTMLElement | undefined {
     return queryAllByRoleFast("button").find((candidate) => {
-      return candidate.textContent?.replace(/\s+/g, " ").trim() === label;
+      return (
+        candidate.getAttribute("aria-label") === label ||
+        candidate.textContent?.replace(/\s+/g, " ").trim() === label
+      );
     });
   }
 
@@ -3446,6 +3449,22 @@ describe("chat composer video model", () => {
         throw new Error(`${label} button not found`);
       }
       return button;
+    });
+  }
+
+  function variantMenuItem(label: string): HTMLElement | undefined {
+    return queryAllByRoleFast("menuitem").find((candidate) => {
+      return candidate.getAttribute("aria-label") === label;
+    });
+  }
+
+  function findVariantMenuItem(label: string): Promise<HTMLElement> {
+    return waitFor(() => {
+      const item = variantMenuItem(label);
+      if (!item) {
+        throw new Error(`${label} menu item not found`);
+      }
+      return item;
     });
   }
 
@@ -3665,17 +3684,23 @@ describe("chat composer video model", () => {
       "false",
     );
 
-    // Every public catalog model is offered, with no plan or provider filter.
-    await expect(
-      findVideoPanelButton("Seedance 2.5"),
-    ).resolves.toBeInTheDocument();
-    expect(videoPanelButton("Veo 3.1 fast")).toBeInTheDocument();
-    expect(videoPanelButton("Kling v3 4K")).toBeInTheDocument();
-    expect(videoPanelButton("MiniMax H3")).toBeInTheDocument();
-    expect(videoPanelButton("Seedance 2.0 fast")).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    // Every public model family is offered, with the three Seedance 2.0
+    // variants sharing one row and relative price tiers visible at a glance.
+    const seedance25 = await findVideoPanelButton("Seedance 2.5");
+    const seedance20 = await findVideoPanelButton("Seedance 2.0");
+    const seedance15 = await findVideoPanelButton("Seedance 1.5 pro");
+    const veo = await findVideoPanelButton("Veo 3.1 fast");
+    const kling = await findVideoPanelButton("Kling v3 4K");
+    const minimax = await findVideoPanelButton("MiniMax H3");
+    expect(seedance25.parentElement).toHaveTextContent("$$$");
+    expect(seedance20.parentElement).toHaveTextContent("Fast$$");
+    expect(seedance15.parentElement).toHaveTextContent("$");
+    expect(veo.parentElement).toHaveTextContent("$$");
+    expect(kling.parentElement).toHaveTextContent("$$$$");
+    expect(minimax.parentElement).toHaveTextContent("$$");
+    expect(videoPanelButton("Seedance 2.0 fast")).toBeUndefined();
+    expect(videoPanelButton("Seedance 2.0 Mini")).toBeUndefined();
+    expect(seedance20).toHaveAttribute("aria-pressed", "true");
 
     await user.click(await findVideoPanelButton("Veo 3.1 fast"));
 
@@ -3696,6 +3721,42 @@ describe("chat composer video model", () => {
     await expect(
       findVideoPanelButton("Manage more models"),
     ).resolves.toBeInTheDocument();
+  });
+
+  it("selects and reprices a grouped Seedance 2.0 variant", async () => {
+    const user = userEvent.setup({ delay: null });
+    context.mocks.browser.matchMedia(true);
+    const { bodies } = mockVideoModelThread(null);
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.VideoModelSelection]: true },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    await user.click(await findDesktopVideoModelButton());
+    const variantTrigger = await findVideoPanelButton(
+      "Seedance 2.0 variant: Fast",
+    );
+    await user.click(variantTrigger);
+
+    const standard = await findVariantMenuItem("Standard $$");
+    const fast = await findVariantMenuItem("Fast $$");
+    const mini = await findVariantMenuItem("Mini $");
+    expect(standard).toBeInTheDocument();
+    expect(fast.querySelector("svg.lucide-check")).not.toBeNull();
+    expect(mini.querySelector("svg.lucide-check")).toBeNull();
+
+    await user.click(mini);
+
+    await waitFor(() => {
+      expect(bodies).toStrictEqual([
+        { model: "dreamina-seedance-2-0-mini-260615" },
+      ]);
+    });
+    await waitFor(() => {
+      expect(variantMenuItem("Mini $")).toBeUndefined();
+    });
   });
 
   it("preserves the shared popup state while switching desktop model modes", async () => {
@@ -3813,7 +3874,7 @@ describe("chat composer video model", () => {
     expect(videoPanelButton("MiniMax H3")).toBeUndefined();
     await user.click(await findVideoPanelButton("Manage more models"));
 
-    await user.click(await findVideoPanelButton("Seedance 2.0 fast"));
+    await user.click(await findVideoPanelButton("Seedance 2.0"));
 
     await waitFor(() => {
       expect(bodies).toStrictEqual([

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1117,7 +1117,7 @@ function ModelFirstModelPickerContentLayout({
     <SelectContent
       anchor={contentAnchor}
       className={cn(
-        "max-h-[320px] min-w-[260px]",
+        "max-h-[380px] min-w-[260px]",
         mediaModelPanelOpen && "min-w-[340px]",
       )}
     >

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -8,6 +8,7 @@ import {
 } from "ccstate-react";
 import {
   Check,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   Cpu,
@@ -15,6 +16,10 @@ import {
   Zap,
 } from "lucide-react";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Select,
   SelectContent,
   SelectGroup,
@@ -78,9 +83,22 @@ export interface ModelProviderSelection {
 export interface MediaModelPanelOption {
   readonly key: string;
   readonly label: string;
+  readonly detail: string;
   readonly icon: ReactNode;
+  readonly priceTier: Vm0ModelPriceTier;
   readonly selected: boolean;
   readonly onSelect: () => void;
+  readonly variantPicker?: {
+    readonly ariaLabel: string;
+    readonly valueLabel: string;
+    readonly options: readonly {
+      readonly key: string;
+      readonly label: string;
+      readonly priceTier: Vm0ModelPriceTier;
+      readonly selected: boolean;
+      readonly onSelect: () => void;
+    }[];
+  };
 }
 
 export interface MediaModelPanelCategory {
@@ -754,7 +772,7 @@ function ModelFirstPolicyItems({
 // Select's value space belongs to the run model, and a SelectItem here would
 // both join it and close the popover on click.
 const MEDIA_MODEL_PANEL_ROW_CLASS =
-  "relative flex w-full cursor-pointer select-none items-center gap-2 rounded-lg py-1.5 pl-2 pr-8 text-left text-sm outline-none transition-colors hover:bg-state-hover hover:text-accent-foreground";
+  "relative flex w-full select-none items-center rounded-lg text-sm outline-none transition-colors hover:bg-state-hover hover:text-accent-foreground";
 
 const BYTEDANCE_ICON_PATH =
   "M19.8772 1.4685 24 2.5326v18.9426l-4.1228 1.0563V1.4685zm-13.3481 9.428 4.115 1.0641v8.9786l-4.115 1.0642v-11.107zM0 2.572l4.115 1.0642v16.7354L0 21.428V2.572zm17.4553 5.6205v11.107l-4.1228-1.0642V9.2568l4.1228-1.0642z";
@@ -910,21 +928,94 @@ export function VideoModelBrandIcon({ model }: { model: VideoModel }) {
   );
 }
 
+function MediaModelPriceTier({ tier }: { tier: Vm0ModelPriceTier }) {
+  return (
+    <span
+      className="min-w-7 shrink-0 text-right text-xs font-medium text-muted-foreground"
+      aria-label={getVm0ModelPriceTierLabel(tier)}
+    >
+      {tier}
+    </span>
+  );
+}
+
+function MediaModelVariantPicker({
+  picker,
+}: {
+  picker: NonNullable<MediaModelPanelOption["variantPicker"]>;
+}) {
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={picker.ariaLabel}
+          className="inline-flex h-7 shrink-0 items-center gap-1 rounded-full border border-border bg-background px-2.5 text-xs font-medium text-foreground shadow-sm outline-none transition-colors hover:bg-state-hover focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {picker.valueLabel}
+          <ChevronDown size={13} className="text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={6} className="w-44 p-1.5">
+        {picker.options.map((variant) => {
+          return (
+            <DropdownMenuItem
+              key={variant.key}
+              aria-label={`${variant.label} ${variant.priceTier}`}
+              className={cn(
+                "grid grid-cols-[1fr_auto_15px] gap-3 px-2.5 py-2",
+                variant.selected && "bg-state-selected",
+              )}
+              onClick={variant.onSelect}
+            >
+              <span>{variant.label}</span>
+              <MediaModelPriceTier tier={variant.priceTier} />
+              {variant.selected ? (
+                <Check size={15} className="text-foreground" />
+              ) : (
+                <span aria-hidden="true" />
+              )}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function MediaModelPanelRow({ option }: { option: MediaModelPanelOption }) {
   return (
-    <button
-      type="button"
-      aria-label={option.label}
-      aria-pressed={option.selected}
-      className={MEDIA_MODEL_PANEL_ROW_CLASS}
-      onClick={option.onSelect}
-    >
-      {option.icon}
-      <span className="min-w-0 flex-1 truncate">{option.label}</span>
-      {option.selected && (
-        <Check size={15} className="absolute right-2 text-foreground" />
+    <div
+      className={cn(
+        MEDIA_MODEL_PANEL_ROW_CLASS,
+        option.selected && "bg-state-selected hover:bg-state-selected-hover",
       )}
-    </button>
+    >
+      <button
+        type="button"
+        aria-label={option.label}
+        aria-pressed={option.selected}
+        className="flex min-w-0 flex-1 items-center gap-2 rounded-lg py-2 pl-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={option.onSelect}
+      >
+        {option.icon}
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate">{option.label}</span>
+          <span className="truncate text-[11px] leading-4 text-muted-foreground">
+            {option.detail}
+          </span>
+        </span>
+      </button>
+      <span className="flex shrink-0 items-center gap-2.5 pr-2">
+        {option.variantPicker && (
+          <MediaModelVariantPicker picker={option.variantPicker} />
+        )}
+        <MediaModelPriceTier tier={option.priceTier} />
+      </span>
+      {option.selected && (
+        <Check size={15} className="mr-2 shrink-0 text-foreground" />
+      )}
+    </div>
   );
 }
 
@@ -1025,7 +1116,10 @@ function ModelFirstModelPickerContentLayout({
   return (
     <SelectContent
       anchor={contentAnchor}
-      className="max-h-[280px] min-w-[260px]"
+      className={cn(
+        "max-h-[320px] min-w-[260px]",
+        mediaModelPanelOpen && "min-w-[340px]",
+      )}
     >
       {/* A media-model panel replaces the model rows, so keep the selected run
           model measurable the same way a hidden select value is. */}

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -930,10 +930,7 @@ export function VideoModelBrandIcon({ model }: { model: VideoModel }) {
 
 function MediaModelPriceTier({ tier }: { tier: Vm0ModelPriceTier }) {
   return (
-    <span
-      className="min-w-7 shrink-0 text-right text-xs font-medium text-muted-foreground"
-      aria-label={getVm0ModelPriceTierLabel(tier)}
-    >
+    <span className="min-w-7 shrink-0 text-right text-xs font-medium text-muted-foreground">
       {tier}
     </span>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -151,6 +151,7 @@ import {
   ModelProviderPicker,
   VideoModelBrandIcon,
   type MediaModelPanelCategory,
+  type MediaModelPanelOption,
   type MediaModelPanelState,
   type ModelProviderSelection,
 } from "./components/model-provider-picker.tsx";
@@ -7614,32 +7615,146 @@ function ComposerVideoModelControl({
   );
 }
 
+const SEEDANCE_2_VARIANT_MODELS = [
+  "dreamina-seedance-2-0-260128",
+  "dreamina-seedance-2-0-fast-260128",
+  "dreamina-seedance-2-0-mini-260615",
+] as const satisfies readonly VideoModel[];
+
+function seedance2Variants() {
+  return [
+    {
+      model: SEEDANCE_2_VARIANT_MODELS[0],
+      label: i18n.t(($) => {
+        return $.settings.models.picker.standard;
+      }),
+    },
+    {
+      model: SEEDANCE_2_VARIANT_MODELS[1],
+      label: i18n.t(($) => {
+        return $.settings.models.picker.fast;
+      }),
+    },
+    {
+      model: SEEDANCE_2_VARIANT_MODELS[2],
+      label: i18n.t(($) => {
+        return $.settings.models.picker.mini;
+      }),
+    },
+  ] as const;
+}
+
+const VIDEO_MODEL_PRICE_TIER = {
+  "dreamina-seedance-2-5-260628": "$$$",
+  "dreamina-seedance-2-0-260128": "$$",
+  "dreamina-seedance-2-0-fast-260128": "$$",
+  "dreamina-seedance-2-0-mini-260615": "$",
+  "seedance-1-5-pro-251215": "$",
+  "fal-ai/veo3.1/fast": "$$",
+  "fal-ai/kling-video/v3/4k/text-to-video": "$$$$",
+  "MiniMax-H3": "$$",
+} as const satisfies Readonly<
+  Record<VideoModel, MediaModelPanelOption["priceTier"]>
+>;
+
+function videoModelDetail(model: VideoModel, audioLabel: string): string {
+  const config = VIDEO_MODEL_CONFIGS[model];
+  const resolution = config.defaultResolution.endsWith("k")
+    ? config.defaultResolution.toUpperCase()
+    : config.defaultResolution;
+  return config.supportsGenerateAudio
+    ? `${resolution} · ${audioLabel}`
+    : resolution;
+}
+
 function composerVideoModelPanelCategory({
   selectedModel,
   onChange,
   label,
   menuLabel,
+  audioLabel,
 }: {
   selectedModel: VideoModel;
   onChange: (next: VideoModel | null) => void;
   label: string;
   menuLabel: string;
+  audioLabel: string;
 }): MediaModelPanelCategory {
+  const variants = seedance2Variants();
+  const selectedVariant =
+    variants.find((variant) => {
+      return variant.model === selectedModel;
+    }) ?? variants[1];
   return {
     id: "video",
     label,
     menuLabel,
-    options: PUBLIC_VIDEO_MODELS.map((candidate) => {
-      return {
-        key: candidate,
-        label: VIDEO_MODEL_CONFIGS[candidate].label,
-        icon: <VideoModelBrandIcon model={candidate} />,
-        selected: selectedModel === candidate,
-        onSelect: () => {
-          onChange(candidate);
-        },
-      };
-    }),
+    options: PUBLIC_VIDEO_MODELS.flatMap(
+      (candidate): MediaModelPanelOption[] => {
+        if (
+          SEEDANCE_2_VARIANT_MODELS.some((model) => {
+            return model === candidate;
+          })
+        ) {
+          if (candidate !== SEEDANCE_2_VARIANT_MODELS[0]) {
+            return [];
+          }
+          const selected = SEEDANCE_2_VARIANT_MODELS.some((model) => {
+            return model === selectedModel;
+          });
+          return [
+            {
+              key: "seedance-2",
+              label: VIDEO_MODEL_CONFIGS[SEEDANCE_2_VARIANT_MODELS[0]].label,
+              detail: videoModelDetail(selectedVariant.model, audioLabel),
+              icon: <VideoModelBrandIcon model={selectedVariant.model} />,
+              priceTier: VIDEO_MODEL_PRICE_TIER[selectedVariant.model],
+              selected,
+              onSelect: () => {
+                onChange(selectedVariant.model);
+              },
+              variantPicker: {
+                ariaLabel: i18n.t(
+                  ($) => {
+                    return $.settings.models.picker.videoModelVariant;
+                  },
+                  {
+                    model:
+                      VIDEO_MODEL_CONFIGS[SEEDANCE_2_VARIANT_MODELS[0]].label,
+                    variant: selectedVariant.label,
+                  },
+                ),
+                valueLabel: selectedVariant.label,
+                options: variants.map((variant) => {
+                  return {
+                    key: variant.model,
+                    label: variant.label,
+                    priceTier: VIDEO_MODEL_PRICE_TIER[variant.model],
+                    selected: variant.model === selectedVariant.model,
+                    onSelect: () => {
+                      onChange(variant.model);
+                    },
+                  };
+                }),
+              },
+            },
+          ];
+        }
+        return [
+          {
+            key: candidate,
+            label: VIDEO_MODEL_CONFIGS[candidate].label,
+            detail: videoModelDetail(candidate, audioLabel),
+            icon: <VideoModelBrandIcon model={candidate} />,
+            priceTier: VIDEO_MODEL_PRICE_TIER[candidate],
+            selected: selectedModel === candidate,
+            onSelect: () => {
+              onChange(candidate);
+            },
+          },
+        ];
+      },
+    ),
   };
 }
 
@@ -7683,6 +7798,9 @@ function ComposerModelPickerControls({
             }),
             menuLabel: t(($) => {
               return $.settings.models.picker.manageMoreModels;
+            }),
+            audioLabel: t(($) => {
+              return $.artifacts.kinds.audio;
             }),
           }),
         ],


### PR DESCRIPTION
## Summary

- show relative price tiers for every public video model
- group Seedance 2.0 Standard, Fast, and Mini behind a compact variant chip
- show each model's default resolution and audio capability, updating the tier with the selected variant

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx --silent=passed-only` (69 tests)
- `pnpm knip --workspace @okouai/app`
- `pnpm exec prettier --check <changed files>`