### PR TITLE
refactor(python): share builtin base url template layout

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_base_url.py
+++ b/crates/runner/mitm-addon/src/builtin_base_url.py
@@ -11,7 +11,7 @@ transport and built-in host-policy validation are a subsequent registry step.
 import re
 import urllib.parse
 
-import connector_template_syntax
+import builtin_base_url_template
 import matching
 from authority_utils import percent_decode_host
 from path_security import has_unsafe_path, has_unsafe_url_path
@@ -284,30 +284,13 @@ def _validate_base_url_path_variable(
         )
 
 
-def _prefix_is_inside_authority(prefix: str) -> bool:
-    scheme_end = prefix.find("://")
-    if scheme_end == -1:
-        return False
-    after_scheme = prefix[scheme_end + 3 :]
-    return _URL_COMPONENT_DELIMITER_PATTERN.search(after_scheme) is None
-
-
-def _prefix_is_inside_path(prefix: str) -> bool:
-    scheme_end = prefix.find("://")
-    if scheme_end == -1:
-        return False
-    after_scheme = prefix[scheme_end + 3 :]
-    if "?" in after_scheme or "#" in after_scheme:
-        return False
-    return "/" in after_scheme
-
-
 def _validate_base_url_template_variable(
     *,
     firewall_name: str,
     base: str,
     name: str,
     value: str,
+    kind: builtin_base_url_template.BaseUrlTemplateComponentKind,
     prefix: str,
     suffix: str,
 ) -> None:
@@ -317,9 +300,9 @@ def _validate_base_url_template_variable(
         name=name,
         value=value,
     )
-    if prefix == "" and suffix == "":
-        return
-    if prefix == "" and suffix.startswith("/"):
+    if kind == "whole-base":
+        if suffix == "":
+            return
         _validate_base_url_prefix_variable(
             firewall_name=firewall_name,
             base=base,
@@ -327,7 +310,7 @@ def _validate_base_url_template_variable(
             value=value,
         )
         return
-    if prefix.endswith("://") and (suffix == "" or suffix.startswith("/")):
+    if kind == "whole-authority":
         _validate_base_url_authority_variable(
             firewall_name=firewall_name,
             base=base,
@@ -335,11 +318,7 @@ def _validate_base_url_template_variable(
             value=value,
         )
         return
-    if (
-        _prefix_is_inside_authority(prefix)
-        and prefix.endswith(":")
-        and (suffix == "" or suffix.startswith("/"))
-    ):
+    if kind == "port":
         _validate_base_url_port_variable(
             firewall_name=firewall_name,
             base=base,
@@ -347,7 +326,7 @@ def _validate_base_url_template_variable(
             value=value,
         )
         return
-    if _prefix_is_inside_authority(prefix):
+    if kind == "authority-fragment":
         _validate_base_url_authority_fragment_variable(
             firewall_name=firewall_name,
             base=base,
@@ -355,21 +334,13 @@ def _validate_base_url_template_variable(
             value=value,
         )
         return
-    if _prefix_is_inside_path(prefix):
-        _validate_base_url_path_variable(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            value=value,
-            prefix=prefix,
-            suffix=suffix,
-        )
-        return
-    raise _base_url_variable_error(
+    _validate_base_url_path_variable(
         firewall_name=firewall_name,
         base=base,
         name=name,
-        detail="is used in an unsupported base URL template position",
+        value=value,
+        prefix=prefix,
+        suffix=suffix,
     )
 
 
@@ -398,11 +369,17 @@ def resolve_base_url_template(
             a value or position violates the safety contract, or the resolved base
             is invalid.
     """
+    try:
+        variables = builtin_base_url_template.analyze_base_url_template(base)
+    except builtin_base_url_template.BaseUrlTemplateLayoutError as e:
+        raise BuiltinBaseUrlResolutionError(
+            f'builtin firewall "{firewall_name}" {e}: {base}'
+        ) from e
+
     resolved_parts: list[str] = []
     last_index = 0
-    for reference in connector_template_syntax.iter_simple_references(base):
-        if reference.namespace != "vars":
-            continue
+    for variable in variables:
+        reference = variable.reference
         name = reference.name
         value = vars_map.get(name)
         if not value:
@@ -414,6 +391,7 @@ def resolve_base_url_template(
             base=base,
             name=name,
             value=value,
+            kind=variable.kind,
             prefix=base[: reference.start],
             suffix=base[reference.end :],
         )

--- a/crates/runner/mitm-addon/src/builtin_base_url_template.py
+++ b/crates/runner/mitm-addon/src/builtin_base_url_template.py
@@ -12,6 +12,7 @@ BaseUrlTemplateComponentKind = Literal[
     "port",
     "path",
 ]
+AuthorityFragmentShape = Literal["hostname", "ip-literal"]
 
 
 class BaseUrlTemplateLayoutError(ValueError):
@@ -22,6 +23,7 @@ class BaseUrlTemplateLayoutError(ValueError):
 class BaseUrlTemplateVariable:
     reference: connector_template_syntax.SimpleTemplateReference
     kind: BaseUrlTemplateComponentKind
+    authority_fragment_shape: AuthorityFragmentShape | None
 
 
 class _BaseUrlComponentBoundaries(NamedTuple):
@@ -55,10 +57,19 @@ def analyze_base_url_template(base: str) -> tuple[BaseUrlTemplateVariable, ...]:
         if reference.namespace != "vars":
             raise BaseUrlTemplateLayoutError("base template must use vars")
 
+        kind = _component_kind(base, reference, boundaries)
+        authority_fragment_shape: AuthorityFragmentShape | None = None
+        if kind == "authority-fragment":
+            authority_fragment_shape = (
+                "ip-literal"
+                if _reference_is_inside_ip_literal(base, reference, boundaries)
+                else "hostname"
+            )
         variables.append(
             BaseUrlTemplateVariable(
                 reference=reference,
-                kind=_component_kind(base, reference, boundaries),
+                kind=kind,
+                authority_fragment_shape=authority_fragment_shape,
             )
         )
         search_start = template_end
@@ -100,7 +111,7 @@ def _component_kind(
             raise BaseUrlTemplateLayoutError(
                 "base template variable is used in an unsupported position"
             )
-        if base.endswith(":", 0, reference.start) and ends_base_or_starts_path:
+        if _reference_is_inside_port(base, reference, boundaries):
             return "port"
         return "authority-fragment"
     if _reference_is_inside_path(reference, boundaries):
@@ -134,6 +145,31 @@ def _reference_is_inside_userinfo(
         default=len(base),
     )
     return base.find("@", reference.end, authority_end) != -1
+
+
+def _reference_is_inside_port(
+    base: str,
+    reference: connector_template_syntax.SimpleTemplateReference,
+    boundaries: _BaseUrlComponentBoundaries,
+) -> bool:
+    if boundaries.authority_start is None:
+        return False
+    prefix = base[boundaries.authority_start : reference.start]
+    if _reference_is_inside_ip_literal(base, reference, boundaries):
+        return False
+    port_delimiter = prefix.rfind(":")
+    return port_delimiter > max(prefix.rfind("@"), prefix.rfind("]"))
+
+
+def _reference_is_inside_ip_literal(
+    base: str,
+    reference: connector_template_syntax.SimpleTemplateReference,
+    boundaries: _BaseUrlComponentBoundaries,
+) -> bool:
+    if boundaries.authority_start is None:
+        return False
+    prefix = base[boundaries.authority_start : reference.start]
+    return prefix.rfind("[") > prefix.rfind("]")
 
 
 def _reference_is_inside_path(

--- a/crates/runner/mitm-addon/src/builtin_base_url_template.py
+++ b/crates/runner/mitm-addon/src/builtin_base_url_template.py
@@ -1,0 +1,150 @@
+"""Analyze value-independent layout for built-in firewall base URL templates."""
+
+from dataclasses import dataclass
+from typing import Literal, NamedTuple
+
+import connector_template_syntax
+
+BaseUrlTemplateComponentKind = Literal[
+    "whole-base",
+    "whole-authority",
+    "authority-fragment",
+    "port",
+    "path",
+]
+
+
+class BaseUrlTemplateLayoutError(ValueError):
+    """A base URL template reference has invalid syntax or placement."""
+
+
+@dataclass(frozen=True, slots=True)
+class BaseUrlTemplateVariable:
+    reference: connector_template_syntax.SimpleTemplateReference
+    kind: BaseUrlTemplateComponentKind
+
+
+class _BaseUrlComponentBoundaries(NamedTuple):
+    authority_start: int | None
+    path_start: int | None
+    query_or_fragment_start: int | None
+
+
+def analyze_base_url_template(base: str) -> tuple[BaseUrlTemplateVariable, ...]:
+    """Return simple ``vars`` references with their canonical URL component kinds."""
+    references_by_start = {
+        reference.start: reference
+        for reference in connector_template_syntax.iter_simple_references(base)
+    }
+    boundaries = _component_boundaries(base)
+    variables: list[BaseUrlTemplateVariable] = []
+    search_start = 0
+    while True:
+        start = base.find("${{", search_start)
+        if start == -1:
+            return tuple(variables)
+
+        content_start = start + len("${{")
+        end = base.find("}}", content_start)
+        if end == -1:
+            raise BaseUrlTemplateLayoutError("base template is unterminated")
+        template_end = end + len("}}")
+        reference = references_by_start.get(start)
+        if reference is None or reference.end != template_end:
+            raise BaseUrlTemplateLayoutError("base template variable is invalid")
+        if reference.namespace != "vars":
+            raise BaseUrlTemplateLayoutError("base template must use vars")
+
+        variables.append(
+            BaseUrlTemplateVariable(
+                reference=reference,
+                kind=_component_kind(base, reference, boundaries),
+            )
+        )
+        search_start = template_end
+
+
+def _component_boundaries(base: str) -> _BaseUrlComponentBoundaries:
+    scheme_delimiter = base.find("://")
+    if scheme_delimiter == -1:
+        return _BaseUrlComponentBoundaries(None, None, None)
+
+    authority_start = scheme_delimiter + len("://")
+    path_start = base.find("/", authority_start)
+    query_start = base.find("?", authority_start)
+    fragment_start = base.find("#", authority_start)
+    query_or_fragment_start = min(
+        (index for index in (query_start, fragment_start) if index != -1),
+        default=None,
+    )
+    return _BaseUrlComponentBoundaries(
+        authority_start=authority_start,
+        path_start=None if path_start == -1 else path_start,
+        query_or_fragment_start=query_or_fragment_start,
+    )
+
+
+def _component_kind(
+    base: str,
+    reference: connector_template_syntax.SimpleTemplateReference,
+    boundaries: _BaseUrlComponentBoundaries,
+) -> BaseUrlTemplateComponentKind:
+    ends_base_or_starts_path = reference.end == len(base) or base.startswith("/", reference.end)
+
+    if reference.start == 0 and ends_base_or_starts_path:
+        return "whole-base"
+    if base.endswith("://", 0, reference.start) and ends_base_or_starts_path:
+        return "whole-authority"
+    if _reference_is_inside_authority(reference, boundaries):
+        if _reference_is_inside_userinfo(base, reference, boundaries):
+            raise BaseUrlTemplateLayoutError(
+                "base template variable is used in an unsupported position"
+            )
+        if base.endswith(":", 0, reference.start) and ends_base_or_starts_path:
+            return "port"
+        return "authority-fragment"
+    if _reference_is_inside_path(reference, boundaries):
+        return "path"
+    raise BaseUrlTemplateLayoutError("base template variable is used in an unsupported position")
+
+
+def _reference_is_inside_authority(
+    reference: connector_template_syntax.SimpleTemplateReference,
+    boundaries: _BaseUrlComponentBoundaries,
+) -> bool:
+    if boundaries.authority_start is None or boundaries.authority_start > reference.start:
+        return False
+    return all(
+        boundary is None or reference.start <= boundary
+        for boundary in (boundaries.path_start, boundaries.query_or_fragment_start)
+    )
+
+
+def _reference_is_inside_userinfo(
+    base: str,
+    reference: connector_template_syntax.SimpleTemplateReference,
+    boundaries: _BaseUrlComponentBoundaries,
+) -> bool:
+    authority_end = min(
+        (
+            boundary
+            for boundary in (boundaries.path_start, boundaries.query_or_fragment_start)
+            if boundary is not None
+        ),
+        default=len(base),
+    )
+    return base.find("@", reference.end, authority_end) != -1
+
+
+def _reference_is_inside_path(
+    reference: connector_template_syntax.SimpleTemplateReference,
+    boundaries: _BaseUrlComponentBoundaries,
+) -> bool:
+    return (
+        boundaries.path_start is not None
+        and boundaries.path_start < reference.start
+        and (
+            boundaries.query_or_fragment_start is None
+            or reference.start <= boundaries.query_or_fragment_start
+        )
+    )

--- a/crates/runner/mitm-addon/src/builtin_base_url_template.py
+++ b/crates/runner/mitm-addon/src/builtin_base_url_template.py
@@ -28,8 +28,13 @@ class BaseUrlTemplateVariable:
 
 class _BaseUrlComponentBoundaries(NamedTuple):
     authority_start: int | None
+    authority_end: int | None
     path_start: int | None
     query_or_fragment_start: int | None
+    userinfo_end: int | None
+    ip_literal_start: int | None
+    ip_literal_end: int | None
+    port_delimiter: int | None
 
 
 def analyze_base_url_template(base: str) -> tuple[BaseUrlTemplateVariable, ...]:
@@ -62,7 +67,7 @@ def analyze_base_url_template(base: str) -> tuple[BaseUrlTemplateVariable, ...]:
         if kind == "authority-fragment":
             authority_fragment_shape = (
                 "ip-literal"
-                if _reference_is_inside_ip_literal(base, reference, boundaries)
+                if _reference_is_inside_ip_literal(reference, boundaries)
                 else "hostname"
             )
         variables.append(
@@ -78,7 +83,7 @@ def analyze_base_url_template(base: str) -> tuple[BaseUrlTemplateVariable, ...]:
 def _component_boundaries(base: str) -> _BaseUrlComponentBoundaries:
     scheme_delimiter = base.find("://")
     if scheme_delimiter == -1:
-        return _BaseUrlComponentBoundaries(None, None, None)
+        return _BaseUrlComponentBoundaries(None, None, None, None, None, None, None, None)
 
     authority_start = scheme_delimiter + len("://")
     path_start = base.find("/", authority_start)
@@ -88,10 +93,41 @@ def _component_boundaries(base: str) -> _BaseUrlComponentBoundaries:
         (index for index in (query_start, fragment_start) if index != -1),
         default=None,
     )
+    normalized_path_start = None if path_start == -1 else path_start
+    authority_end = min(
+        (
+            boundary
+            for boundary in (normalized_path_start, query_or_fragment_start)
+            if boundary is not None
+        ),
+        default=len(base),
+    )
+    raw_userinfo_end = base.rfind("@", authority_start, authority_end)
+    userinfo_end = None if raw_userinfo_end == -1 else raw_userinfo_end
+    host_start = authority_start if userinfo_end is None else userinfo_end + 1
+    raw_ip_literal_start = base.find("[", host_start, authority_end)
+    ip_literal_start = None if raw_ip_literal_start == -1 else raw_ip_literal_start
+    raw_ip_literal_end = (
+        -1 if ip_literal_start is None else base.find("]", ip_literal_start + 1, authority_end)
+    )
+    ip_literal_end = None if raw_ip_literal_end == -1 else raw_ip_literal_end
+    if ip_literal_start is None:
+        port_search_start = host_start
+    elif ip_literal_end is None:
+        port_search_start = authority_end
+    else:
+        port_search_start = ip_literal_end + 1
+    raw_port_delimiter = base.find(":", port_search_start, authority_end)
+    port_delimiter = None if raw_port_delimiter == -1 else raw_port_delimiter
     return _BaseUrlComponentBoundaries(
         authority_start=authority_start,
-        path_start=None if path_start == -1 else path_start,
+        authority_end=authority_end,
+        path_start=normalized_path_start,
         query_or_fragment_start=query_or_fragment_start,
+        userinfo_end=userinfo_end,
+        ip_literal_start=ip_literal_start,
+        ip_literal_end=ip_literal_end,
+        port_delimiter=port_delimiter,
     )
 
 
@@ -107,11 +143,11 @@ def _component_kind(
     if base.endswith("://", 0, reference.start) and ends_base_or_starts_path:
         return "whole-authority"
     if _reference_is_inside_authority(reference, boundaries):
-        if _reference_is_inside_userinfo(base, reference, boundaries):
+        if _reference_is_inside_userinfo(reference, boundaries):
             raise BaseUrlTemplateLayoutError(
                 "base template variable is used in an unsupported position"
             )
-        if _reference_is_inside_port(base, reference, boundaries):
+        if _reference_is_inside_port(reference, boundaries):
             return "port"
         return "authority-fragment"
     if _reference_is_inside_path(reference, boundaries):
@@ -123,53 +159,36 @@ def _reference_is_inside_authority(
     reference: connector_template_syntax.SimpleTemplateReference,
     boundaries: _BaseUrlComponentBoundaries,
 ) -> bool:
-    if boundaries.authority_start is None or boundaries.authority_start > reference.start:
-        return False
-    return all(
-        boundary is None or reference.start <= boundary
-        for boundary in (boundaries.path_start, boundaries.query_or_fragment_start)
+    return (
+        boundaries.authority_start is not None
+        and boundaries.authority_end is not None
+        and boundaries.authority_start <= reference.start < boundaries.authority_end
     )
 
 
 def _reference_is_inside_userinfo(
-    base: str,
     reference: connector_template_syntax.SimpleTemplateReference,
     boundaries: _BaseUrlComponentBoundaries,
 ) -> bool:
-    authority_end = min(
-        (
-            boundary
-            for boundary in (boundaries.path_start, boundaries.query_or_fragment_start)
-            if boundary is not None
-        ),
-        default=len(base),
-    )
-    return base.find("@", reference.end, authority_end) != -1
+    return boundaries.userinfo_end is not None and reference.start < boundaries.userinfo_end
 
 
 def _reference_is_inside_port(
-    base: str,
     reference: connector_template_syntax.SimpleTemplateReference,
     boundaries: _BaseUrlComponentBoundaries,
 ) -> bool:
-    if boundaries.authority_start is None:
-        return False
-    prefix = base[boundaries.authority_start : reference.start]
-    if _reference_is_inside_ip_literal(base, reference, boundaries):
-        return False
-    port_delimiter = prefix.rfind(":")
-    return port_delimiter > max(prefix.rfind("@"), prefix.rfind("]"))
+    return boundaries.port_delimiter is not None and boundaries.port_delimiter < reference.start
 
 
 def _reference_is_inside_ip_literal(
-    base: str,
     reference: connector_template_syntax.SimpleTemplateReference,
     boundaries: _BaseUrlComponentBoundaries,
 ) -> bool:
-    if boundaries.authority_start is None:
-        return False
-    prefix = base[boundaries.authority_start : reference.start]
-    return prefix.rfind("[") > prefix.rfind("]")
+    return (
+        boundaries.ip_literal_start is not None
+        and boundaries.ip_literal_end is not None
+        and boundaries.ip_literal_start < reference.start < boundaries.ip_literal_end
+    )
 
 
 def _reference_is_inside_path(

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -463,7 +463,10 @@ def _base_url_template_syntax_target(firewall_name: str, raw_base: str) -> str |
     for variable in variables:
         reference = variable.reference
         result.append(raw_base[last_index : reference.start])
-        result.append(_BASE_URL_TEMPLATE_PLACEHOLDERS[variable.kind])
+        placeholder = _BASE_URL_TEMPLATE_PLACEHOLDERS[variable.kind]
+        if variable.authority_fragment_shape == "ip-literal":
+            placeholder = _BASE_URL_TEMPLATE_PORT_PLACEHOLDER
+        result.append(placeholder)
         last_index = reference.end
     result.append(raw_base[last_index:])
     return "".join(result)

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -10,8 +10,8 @@ from typing import Literal, NamedTuple
 
 from mitmproxy import ctx
 
+import builtin_base_url_template
 import builtin_host_policy
-import connector_template_syntax
 import matching
 import state_file
 from path_security import has_unsafe_url_path
@@ -27,6 +27,15 @@ _BASE_URL_TEMPLATE_WHOLE_BASE_PLACEHOLDER = "https://x.y"
 _BASE_URL_TEMPLATE_HOST_PLACEHOLDER = "x.y"
 _BASE_URL_TEMPLATE_PORT_PLACEHOLDER = "1"
 _BASE_URL_TEMPLATE_PATH_PLACEHOLDER = "x"
+_BASE_URL_TEMPLATE_PLACEHOLDERS: dict[
+    builtin_base_url_template.BaseUrlTemplateComponentKind, str
+] = {
+    "whole-base": _BASE_URL_TEMPLATE_WHOLE_BASE_PLACEHOLDER,
+    "whole-authority": _BASE_URL_TEMPLATE_HOST_PLACEHOLDER,
+    "authority-fragment": _BASE_URL_TEMPLATE_HOST_PLACEHOLDER,
+    "port": _BASE_URL_TEMPLATE_PORT_PLACEHOLDER,
+    "path": _BASE_URL_TEMPLATE_PATH_PLACEHOLDER,
+}
 
 
 CatalogFileKey = state_file.StateFileIdentity
@@ -44,13 +53,6 @@ class CatalogIdentity(NamedTuple):
     catalog_digest: str
     catalog_version: str
     file_key: CatalogFileKey
-
-
-# Precompute fixed URL delimiters once; a catalog base can contain many templates.
-class _BaseUrlTemplateComponentBoundaries(NamedTuple):
-    authority_start: int | None
-    path_start: int | None
-    query_or_fragment_start: int | None
 
 
 CatalogUnavailableReason = Literal[
@@ -447,121 +449,24 @@ def _validate_api_entry(firewall_name: str, api: dict) -> None:
 
 
 def _base_url_template_syntax_target(firewall_name: str, raw_base: str) -> str | None:
-    search_start = 0
+    try:
+        variables = builtin_base_url_template.analyze_base_url_template(raw_base)
+    except builtin_base_url_template.BaseUrlTemplateLayoutError as e:
+        raise BuiltinFirewallCatalogCacheError(
+            f'catalog cache firewall "{firewall_name}" api {e}'
+        ) from e
+    if not variables:
+        return None
+
     result: list[str] = []
-    found = False
-    boundaries = _base_url_template_component_boundaries(raw_base)
-    while True:
-        start = raw_base.find("${{", search_start)
-        if start == -1:
-            if not found:
-                return None
-            result.append(raw_base[search_start:])
-            return "".join(result)
-        found = True
-        content_start = start + len("${{")
-        end = raw_base.find("}}", content_start)
-        if end == -1:
-            raise BuiltinFirewallCatalogCacheError(
-                f'catalog cache firewall "{firewall_name}" api base template is unterminated'
-            )
-        template_end = end + len("}}")
-        template = raw_base[start:template_end]
-        reference = next(connector_template_syntax.iter_simple_references(template), None)
-        if reference is None or reference.start != 0 or reference.end != len(template):
-            raise BuiltinFirewallCatalogCacheError(
-                f'catalog cache firewall "{firewall_name}" api base template variable is invalid'
-            )
-        if reference.namespace != "vars":
-            raise BuiltinFirewallCatalogCacheError(
-                f'catalog cache firewall "{firewall_name}" api base template must use vars'
-            )
-        result.append(raw_base[search_start:start])
-        result.append(
-            _base_url_template_syntax_placeholder(
-                firewall_name,
-                raw_base,
-                start,
-                template_end,
-                boundaries,
-            )
-        )
-        search_start = template_end
-
-
-def _base_url_template_component_boundaries(
-    raw_base: str,
-) -> _BaseUrlTemplateComponentBoundaries:
-    scheme_delimiter = raw_base.find("://")
-    if scheme_delimiter == -1:
-        return _BaseUrlTemplateComponentBoundaries(None, None, None)
-
-    authority_start = scheme_delimiter + len("://")
-    path_start = raw_base.find("/", authority_start)
-    query_start = raw_base.find("?", authority_start)
-    fragment_start = raw_base.find("#", authority_start)
-    query_or_fragment_start = min(
-        (index for index in (query_start, fragment_start) if index != -1),
-        default=None,
-    )
-    return _BaseUrlTemplateComponentBoundaries(
-        authority_start=authority_start,
-        path_start=None if path_start == -1 else path_start,
-        query_or_fragment_start=query_or_fragment_start,
-    )
-
-
-def _base_url_template_syntax_placeholder(
-    firewall_name: str,
-    raw_base: str,
-    start: int,
-    template_end: int,
-    boundaries: _BaseUrlTemplateComponentBoundaries,
-) -> str:
-    ends_base_or_starts_path = template_end == len(raw_base) or raw_base.startswith(
-        "/", template_end
-    )
-
-    if start == 0 and ends_base_or_starts_path:
-        return _BASE_URL_TEMPLATE_WHOLE_BASE_PLACEHOLDER
-    if raw_base.endswith("://", 0, start) and ends_base_or_starts_path:
-        return _BASE_URL_TEMPLATE_HOST_PLACEHOLDER
-    if _base_url_prefix_is_inside_authority(start, boundaries):
-        if raw_base.endswith(":", 0, start) and ends_base_or_starts_path:
-            return _BASE_URL_TEMPLATE_PORT_PLACEHOLDER
-        return _BASE_URL_TEMPLATE_HOST_PLACEHOLDER
-    if _base_url_prefix_is_inside_path(start, boundaries):
-        return _BASE_URL_TEMPLATE_PATH_PLACEHOLDER
-    raise BuiltinFirewallCatalogCacheError(
-        f'catalog cache firewall "{firewall_name}" api base template variable '
-        "is used in an unsupported position"
-    )
-
-
-def _base_url_prefix_is_inside_authority(
-    template_start: int,
-    boundaries: _BaseUrlTemplateComponentBoundaries,
-) -> bool:
-    if boundaries.authority_start is None or boundaries.authority_start > template_start:
-        return False
-    return all(
-        boundary is None or template_start <= boundary
-        for boundary in (boundaries.path_start, boundaries.query_or_fragment_start)
-    )
-
-
-def _base_url_prefix_is_inside_path(
-    template_start: int,
-    boundaries: _BaseUrlTemplateComponentBoundaries,
-) -> bool:
-    return (
-        boundaries.path_start is not None
-        and boundaries.path_start < template_start
-        and (
-            boundaries.query_or_fragment_start is None
-            or template_start <= boundaries.query_or_fragment_start
-        )
-    )
+    last_index = 0
+    for variable in variables:
+        reference = variable.reference
+        result.append(raw_base[last_index : reference.start])
+        result.append(_BASE_URL_TEMPLATE_PLACEHOLDERS[variable.kind])
+        last_index = reference.end
+    result.append(raw_base[last_index:])
+    return "".join(result)
 
 
 def _warn(message: str) -> None:

--- a/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
@@ -89,6 +89,8 @@ def test_firewall_catalog_base_url_validity_matches_shared_contract(
 @pytest.mark.parametrize("case", _BASE_URL_TEMPLATE_RESOLUTION_CASES, ids=_case_name)
 def test_firewall_base_url_template_resolution_matches_shared_contract(
     case: dict[str, object],
+    tmp_path: Path,
+    mitm_ctx,
 ) -> None:
     base = case["base"]
     assert isinstance(base, str)
@@ -119,3 +121,21 @@ def test_firewall_base_url_template_resolution_matches_shared_contract(
         )
         == expected_resolved_base
     )
+
+    cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+    write_catalog_cache(
+        cache_path,
+        digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        version="catalog-contract",
+        firewalls={
+            "contract": {
+                "name": "contract",
+                "apis": [{"base": base, "auth": {}}],
+            }
+        },
+    )
+    with mitm_ctx():
+        snapshot = builtin_firewall_cache.load_catalog_snapshot(str(cache_path))
+
+    assert snapshot.catalog is not None
+    assert snapshot.unavailable_reason is None

--- a/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
@@ -66,6 +66,15 @@ def test_firewall_catalog_base_url_validity_matches_shared_contract(
     assert isinstance(base, str)
     expected_valid = case["expectedValid"]
     assert isinstance(expected_valid, bool)
+    raw_vars = case["vars"]
+    assert isinstance(raw_vars, dict)
+    vars_map: dict[str, str] = {}
+    for name, value in raw_vars.items():
+        assert isinstance(name, str)
+        assert isinstance(value, str)
+        vars_map[name] = value
+    expected_resolved_base = case["expectedResolvedBase"]
+    assert expected_resolved_base is None or isinstance(expected_resolved_base, str)
 
     cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
     write_catalog_cache(
@@ -84,6 +93,24 @@ def test_firewall_catalog_base_url_validity_matches_shared_contract(
 
     assert (snapshot.catalog is not None) is expected_valid
     assert snapshot.unavailable_reason == (None if expected_valid else "cache_invalid")
+
+    if expected_resolved_base is None:
+        with pytest.raises(builtin_base_url.BuiltinBaseUrlResolutionError):
+            builtin_base_url.resolve_base_url_template(
+                firewall_name="contract",
+                base=base,
+                vars_map=vars_map,
+            )
+        return
+
+    assert (
+        builtin_base_url.resolve_base_url_template(
+            firewall_name="contract",
+            base=base,
+            vars_map=vars_map,
+        )
+        == expected_resolved_base
+    )
 
 
 @pytest.mark.parametrize("case", _BASE_URL_TEMPLATE_RESOLUTION_CASES, ids=_case_name)

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -69,6 +69,20 @@
       "expectedResolvedBase": "https://api.example.com:8443/acme/v1"
     },
     {
+      "category": "port",
+      "name": "port fragments across references resolve",
+      "base": "https://api.example.com:${{ vars.PORT_MAJOR }}${{ vars.PORT_MINOR }}/v1",
+      "vars": { "PORT_MAJOR": "84", "PORT_MINOR": "43" },
+      "expectedResolvedBase": "https://api.example.com:8443/v1"
+    },
+    {
+      "category": "authority-fragment",
+      "name": "ipv6 authority fragment resolves",
+      "base": "https://[2001:db8::${{ vars.SUFFIX }}]/v1",
+      "vars": { "SUFFIX": "1" },
+      "expectedResolvedBase": "https://[2001:db8::1]/v1"
+    },
+    {
       "category": "query-fragment",
       "name": "trailing authority fragment before query is invalid",
       "base": "https://api-${{ vars.HOST }}?page=1",

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -23,6 +23,52 @@
       "expectedResolvedBase": "https://tenant.example.com/v1/{resource}"
     },
     {
+      "category": "whole-base",
+      "name": "whole base at end resolves",
+      "base": "${{ vars.API_BASE_URL }}",
+      "vars": { "API_BASE_URL": "https://api.example.com/v2" },
+      "expectedResolvedBase": "https://api.example.com/v2"
+    },
+    {
+      "category": "whole-base",
+      "name": "whole base before fixed path resolves",
+      "base": "${{ vars.API_BASE_URL }}/v1/{resource}",
+      "vars": { "API_BASE_URL": "https://api.example.com" },
+      "expectedResolvedBase": "https://api.example.com/v1/{resource}"
+    },
+    {
+      "category": "whole-authority",
+      "name": "whole authority at end resolves",
+      "base": "https://${{ vars.HOST }}",
+      "vars": { "HOST": "api.example.com" },
+      "expectedResolvedBase": "https://api.example.com"
+    },
+    {
+      "category": "port",
+      "name": "port before fixed path resolves",
+      "base": "https://api.example.com:${{ vars.PORT }}/v1",
+      "vars": { "PORT": "8443" },
+      "expectedResolvedBase": "https://api.example.com:8443/v1"
+    },
+    {
+      "category": "path",
+      "name": "path segment before fixed suffix resolves",
+      "base": "https://api.example.com/accounts/${{ vars.TENANT }}/v1",
+      "vars": { "TENANT": "acme" },
+      "expectedResolvedBase": "https://api.example.com/accounts/acme/v1"
+    },
+    {
+      "category": "multiple",
+      "name": "authority port and path references resolve in source order",
+      "base": "https://${{ vars.HOST }}:${{ vars.PORT }}/${{ vars.TENANT }}/v1",
+      "vars": {
+        "HOST": "api.example.com",
+        "PORT": "8443",
+        "TENANT": "acme"
+      },
+      "expectedResolvedBase": "https://api.example.com:8443/acme/v1"
+    },
+    {
       "category": "query-fragment",
       "name": "trailing authority fragment before query is invalid",
       "base": "https://api-${{ vars.HOST }}?page=1",


### PR DESCRIPTION
## Summary

- add one value-independent analyzer for built-in base URL template reference spans, component kinds, and authority-fragment structure
- use the shared layout for catalog witness materialization and runtime value validation/substitution while preserving phase-specific safety policy
- extend the shared TypeScript/Python contract so every successful runtime layout, including fragmented ports and IPv6 host fragments, is also admitted by the catalog cache

## Compatibility

- no API, catalog schema, cache schema, VM payload, persisted-state, database, or migration changes
- preserves fail-closed malformed and unsupported template handling
- preserves runtime value, complete URL, credentialed HTTPS, and host-policy enforcement
- all changes ship within one runner artifact; no cross-version protocol is introduced

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_firewall_base_url_validation_contract.py tests/test_registry_builtin_base_url_vars.py tests/test_registry_builtin_catalog_validation.py` (224 passed)
- `uv run --no-sync python -m pytest tests/` (6,009 passed)
- `pnpm exec prettier --check packages/connectors/src/__tests__/firewall-base-url-validation-contract.json`
- `pnpm -F @okouai/connectors lint`
- `pnpm -F @okouai/connectors check-types`
- `pnpm -F @okouai/connectors test` (1,037 passed)
- `pnpm knip --workspace @okouai/connectors`
- staged-path pre-commit checks: Prettier, full Turbo Knip, Ruff, file-size check, and commitlint

Closes #27834
