### PR TITLE
refactor(contracts): neutralize teams oauth and bot contract naming

### DIFF
--- a/turbo/apps/api/src/lib/teams-bot-activity.ts
+++ b/turbo/apps/api/src/lib/teams-bot-activity.ts
@@ -2,7 +2,7 @@ import type {
   TeamsActor,
   TeamsInboundAttachment,
   TeamsInboundActivity,
-} from "@okouai/api-contracts/contracts/zero-teams-bot";
+} from "@okouai/api-contracts/contracts/teams-bot";
 
 interface NormalizedTeamsActivityResult {
   readonly ok: true;

--- a/turbo/apps/api/src/signals/routes/teams-bot.ts
+++ b/turbo/apps/api/src/signals/routes/teams-bot.ts
@@ -1,8 +1,8 @@
 import { command } from "ccstate";
 import {
-  zeroTeamsBotContract,
+  teamsBotContract,
   type TeamsInboundActivity,
-} from "@okouai/api-contracts/contracts/zero-teams-bot";
+} from "@okouai/api-contracts/contracts/teams-bot";
 import { teamsOrgInstallations } from "@okouai/db/schema/teams-org-installation";
 import {
   appUrlForPublicBrand,
@@ -468,7 +468,7 @@ const handleZeroTeamsBot$ = command(
 
 export const teamsBotRoutes: readonly RouteEntry[] = [
   {
-    route: zeroTeamsBotContract.post,
+    route: teamsBotContract.post,
     handler: handleZeroTeamsBot$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/teams-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/teams-browser-connect.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
-import { zeroTeamsBrowserConnectContract } from "@okouai/api-contracts/contracts/zero-teams-browser-connect";
+import { teamsBrowserConnectContract } from "@okouai/api-contracts/contracts/teams-browser-connect";
 import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { teamsOrgInstallations } from "@okouai/db/schema/teams-org-installation";
 import { eq } from "drizzle-orm";
@@ -205,7 +205,7 @@ const browserConnect$ = command(async ({ get, set }, signal: AbortSignal) => {
     return signInRedirect(request.url, publicBrand);
   }
 
-  const query = get(queryOf(zeroTeamsBrowserConnectContract.connect));
+  const query = get(queryOf(teamsBrowserConnectContract.connect));
   const tenantId = query.tenantId;
   const teamsUserId = query.teamsUserId;
   const teamsAadObjectId = query.teamsAadObjectId;
@@ -280,7 +280,7 @@ const browserConnect$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 export const teamsBrowserConnectRoutes: readonly RouteEntry[] = [
   {
-    route: zeroTeamsBrowserConnectContract.connect,
+    route: teamsBrowserConnectContract.connect,
     handler: browserConnect$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/teams-oauth.ts
@@ -1,6 +1,6 @@
 import { command } from "ccstate";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
-import { zeroTeamsOauthContract } from "@okouai/api-contracts/contracts/zero-teams-oauth";
+import { teamsOauthContract } from "@okouai/api-contracts/contracts/teams-oauth";
 import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { z } from "zod";
 
@@ -338,7 +338,7 @@ const connectOauth$ = command(({ get }) => {
     );
   }
 
-  const query = get(queryOf(zeroTeamsOauthContract.connect));
+  const query = get(queryOf(teamsOauthContract.connect));
   const userId = resolveIntegrationUserId(query.userId, query.vm0UserId);
   logIntegrationIdentityCompatibility({
     provider: "teams",
@@ -388,7 +388,7 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
     );
   }
 
-  const query = get(queryOf(zeroTeamsOauthContract.callback));
+  const query = get(queryOf(teamsOauthContract.callback));
   const state = parseOAuthState(query.state);
   const redirectBrand = state?.publicBrand ?? get(publicBrand$);
   if (query.error) {
@@ -493,11 +493,11 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 export const teamsOauthRoutes: readonly RouteEntry[] = [
   {
-    route: zeroTeamsOauthContract.connect,
+    route: teamsOauthContract.connect,
     handler: connectOauth$,
   },
   {
-    route: zeroTeamsOauthContract.callback,
+    route: teamsOauthContract.callback,
     handler: callbackOauth$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/test-teams-dispatch-probe.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-dispatch-probe.ts
@@ -3,7 +3,7 @@ import {
   testTeamsDispatchProbeContract,
   type TestTeamsDispatchProbeBody,
 } from "@okouai/api-contracts/contracts/test-teams-dispatch-probe";
-import type { TeamsInboundActivity } from "@okouai/api-contracts/contracts/zero-teams-bot";
+import type { TeamsInboundActivity } from "@okouai/api-contracts/contracts/teams-bot";
 
 import { now } from "../../lib/time";
 import { request$ } from "../context/hono";

--- a/turbo/apps/api/src/signals/services/zero-teams-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-connect.service.ts
@@ -17,7 +17,7 @@ import { teamsOrgConnections } from "@okouai/db/schema/teams-org-connection";
 import { teamsOrgInstallations } from "@okouai/db/schema/teams-org-installation";
 import { teamsUserAgentPreferences } from "@okouai/db/schema/teams-user-agent-preference";
 import { zeroAgents } from "@okouai/db/schema/zero-agent";
-import type { TeamsInboundActivity } from "@okouai/api-contracts/contracts/zero-teams-bot";
+import type { TeamsInboundActivity } from "@okouai/api-contracts/contracts/teams-bot";
 import { and, eq, isNull, sql } from "drizzle-orm";
 
 import { env } from "../../lib/env";

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -22,7 +22,7 @@ import { zeroAgents } from "@okouai/db/schema/zero-agent";
 import type {
   TeamsInboundActivity,
   TeamsInboundAttachment,
-} from "@okouai/api-contracts/contracts/zero-teams-bot";
+} from "@okouai/api-contracts/contracts/teams-bot";
 import { and, desc, eq, isNull, notExists, or } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { convert } from "html-to-text";

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1437,13 +1437,13 @@ export {
 } from "./slack-commands";
 export { slackEventsContract, type SlackEventsContract } from "./slack-events";
 export {
-  zeroTeamsBotContract,
+  teamsBotContract,
   teamsInboundActivitySchema,
   teamsBotIngressResponseSchema,
   type TeamsInboundActivity,
   type TeamsBotIngressResponse,
-  type ZeroTeamsBotContract,
-} from "./zero-teams-bot";
+  type TeamsBotContract,
+} from "./teams-bot";
 export {
   zeroTeamsConnectContract,
   type TeamsConnectBody,
@@ -1453,19 +1453,19 @@ export {
   type ZeroTeamsConnectContract,
 } from "./zero-teams-connect";
 export {
-  zeroTeamsBrowserConnectContract,
-  zeroTeamsBrowserConnectQuerySchema,
-  type ZeroTeamsBrowserConnectContract,
-  type ZeroTeamsBrowserConnectQuery,
-} from "./zero-teams-browser-connect";
+  teamsBrowserConnectContract,
+  teamsBrowserConnectQuerySchema,
+  type TeamsBrowserConnectContract,
+  type TeamsBrowserConnectQuery,
+} from "./teams-browser-connect";
 export {
-  zeroTeamsOauthContract,
-  zeroTeamsOauthCallbackQuerySchema,
-  zeroTeamsOauthConnectQuerySchema,
-  type ZeroTeamsOauthCallbackQuery,
-  type ZeroTeamsOauthConnectQuery,
-  type ZeroTeamsOauthContract,
-} from "./zero-teams-oauth";
+  teamsOauthContract,
+  teamsOauthCallbackQuerySchema,
+  teamsOauthConnectQuerySchema,
+  type TeamsOauthCallbackQuery,
+  type TeamsOauthConnectQuery,
+  type TeamsOauthContract,
+} from "./teams-oauth";
 export {
   slackInteractiveContract,
   type SlackInteractiveContract,

--- a/turbo/packages/api-contracts/src/contracts/teams-bot.ts
+++ b/turbo/packages/api-contracts/src/contracts/teams-bot.ts
@@ -119,7 +119,7 @@ export const teamsBotIngressResponseSchema = z.object({
   dispatch: teamsBotDispatchResponseSchema.optional(),
 });
 
-export const zeroTeamsBotContract = c.router({
+export const teamsBotContract = c.router({
   post: {
     method: "POST",
     path: "/api/okou/teams/bot",
@@ -146,4 +146,4 @@ export type TeamsBotIngressResponse = z.infer<
 export type TeamsBotDispatchResponse = z.infer<
   typeof teamsBotDispatchResponseSchema
 >;
-export type ZeroTeamsBotContract = typeof zeroTeamsBotContract;
+export type TeamsBotContract = typeof teamsBotContract;

--- a/turbo/packages/api-contracts/src/contracts/teams-browser-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/teams-browser-connect.ts
@@ -4,7 +4,7 @@ import { initContract } from "./base";
 
 const c = initContract();
 
-export const zeroTeamsBrowserConnectQuerySchema = z.object({
+export const teamsBrowserConnectQuerySchema = z.object({
   tenantId: z.string().optional(),
   tenantName: z.string().optional(),
   teamsUserId: z.string().optional(),
@@ -24,11 +24,11 @@ export const zeroTeamsBrowserConnectQuerySchema = z.object({
   orgId: z.string().optional(),
 });
 
-export const zeroTeamsBrowserConnectContract = c.router({
+export const teamsBrowserConnectContract = c.router({
   connect: {
     method: "GET",
     path: "/api/okou/teams/connect",
-    query: zeroTeamsBrowserConnectQuerySchema,
+    query: teamsBrowserConnectQuerySchema,
     responses: {
       307: c.noBody(),
       500: z.object({ error: z.string() }),
@@ -37,8 +37,7 @@ export const zeroTeamsBrowserConnectContract = c.router({
   },
 });
 
-export type ZeroTeamsBrowserConnectContract =
-  typeof zeroTeamsBrowserConnectContract;
-export type ZeroTeamsBrowserConnectQuery = z.infer<
-  typeof zeroTeamsBrowserConnectQuerySchema
+export type TeamsBrowserConnectContract = typeof teamsBrowserConnectContract;
+export type TeamsBrowserConnectQuery = z.infer<
+  typeof teamsBrowserConnectQuerySchema
 >;

--- a/turbo/packages/api-contracts/src/contracts/teams-oauth.ts
+++ b/turbo/packages/api-contracts/src/contracts/teams-oauth.ts
@@ -6,7 +6,7 @@ const c = initContract();
 
 const jsonErrorSchema = z.object({ error: z.string() });
 
-export const zeroTeamsOauthConnectQuerySchema = z.object({
+export const teamsOauthConnectQuerySchema = z.object({
   orgId: z.string().optional(),
   userId: z.string().optional(),
   // Old web/app OAuth fallback (observed maximum: ~2 days).
@@ -15,18 +15,18 @@ export const zeroTeamsOauthConnectQuerySchema = z.object({
   prompt: z.string().optional(),
 });
 
-export const zeroTeamsOauthCallbackQuerySchema = z.object({
+export const teamsOauthCallbackQuerySchema = z.object({
   code: z.string().optional(),
   error: z.string().optional(),
   error_description: z.string().optional(),
   state: z.string().optional(),
 });
 
-export const zeroTeamsOauthContract = c.router({
+export const teamsOauthContract = c.router({
   connect: {
     method: "GET",
     path: "/api/okou/teams/oauth/connect",
-    query: zeroTeamsOauthConnectQuerySchema,
+    query: teamsOauthConnectQuerySchema,
     responses: {
       307: c.noBody(),
       400: jsonErrorSchema,
@@ -37,7 +37,7 @@ export const zeroTeamsOauthContract = c.router({
   callback: {
     method: "GET",
     path: "/api/okou/teams/oauth/callback",
-    query: zeroTeamsOauthCallbackQuerySchema,
+    query: teamsOauthCallbackQuerySchema,
     responses: {
       307: c.noBody(),
       400: jsonErrorSchema,
@@ -47,10 +47,10 @@ export const zeroTeamsOauthContract = c.router({
   },
 });
 
-export type ZeroTeamsOauthContract = typeof zeroTeamsOauthContract;
-export type ZeroTeamsOauthConnectQuery = z.infer<
-  typeof zeroTeamsOauthConnectQuerySchema
+export type TeamsOauthContract = typeof teamsOauthContract;
+export type TeamsOauthConnectQuery = z.infer<
+  typeof teamsOauthConnectQuerySchema
 >;
-export type ZeroTeamsOauthCallbackQuery = z.infer<
-  typeof zeroTeamsOauthCallbackQuerySchema
+export type TeamsOauthCallbackQuery = z.infer<
+  typeof teamsOauthCallbackQuerySchema
 >;


### PR DESCRIPTION
## Summary

- rename the three Microsoft Teams API contract modules from old-branded to neutral domain names
- rename the branded declarations inside them and update every importer atomically
- update the three `contracts/index.ts` re-export blocks to the new paths and identifiers

This is an internal naming change only. The HTTP `path:` literals in all three modules were already canonical `/api/okou/**`, so no wire-visible behavior changes.

## Mapping

| Old | New |
|---|---|
| `contracts/zero-teams-oauth.ts` | `contracts/teams-oauth.ts` |
| `zeroTeamsOauthConnectQuerySchema` | `teamsOauthConnectQuerySchema` |
| `zeroTeamsOauthCallbackQuerySchema` | `teamsOauthCallbackQuerySchema` |
| `zeroTeamsOauthContract` | `teamsOauthContract` |
| `ZeroTeamsOauthContract` | `TeamsOauthContract` |
| `ZeroTeamsOauthConnectQuery` | `TeamsOauthConnectQuery` |
| `ZeroTeamsOauthCallbackQuery` | `TeamsOauthCallbackQuery` |
| `contracts/zero-teams-browser-connect.ts` | `contracts/teams-browser-connect.ts` |
| `zeroTeamsBrowserConnectQuerySchema` | `teamsBrowserConnectQuerySchema` |
| `zeroTeamsBrowserConnectContract` | `teamsBrowserConnectContract` |
| `ZeroTeamsBrowserConnectContract` | `TeamsBrowserConnectContract` |
| `ZeroTeamsBrowserConnectQuery` | `TeamsBrowserConnectQuery` |
| `contracts/zero-teams-bot.ts` | `contracts/teams-bot.ts` |
| `zeroTeamsBotContract` | `teamsBotContract` |
| `ZeroTeamsBotContract` | `TeamsBotContract` |

Because `@okouai/api-contracts` exports the wildcard subpath `./contracts/*`, the module filenames are compile-time public API, so the seven `@okouai/api-contracts/contracts/zero-teams-*` specifiers were updated in the same commit. No compatibility alias or old-path re-export is left behind.

## Out of scope, deliberately left alone

- Every already-neutral export in the bot module (`teamsInboundActivitySchema`, `teamsBotIngressResponseSchema`, `TeamsActor`, …).
- `contracts/zero-teams-connect.ts` and `contracts/zero-team.ts` — different slices.
- The route-internal `handleZeroTeamsBot$` handler name and the `zeroTeamsAction` Adaptive Card payload key, which is a wire value.
- Any `path:` string, method, header schema, request/response schema, or status code.

## Validation

- `pnpm exec prettier --write` on the eleven touched files — only one reflow, in `teams-browser-connect.ts`, where the shorter type name now fits on a single line
- `pnpm turbo run lint --filter=@okouai/api-contracts --filter=api` — 0 errors
- `pnpm -F @okouai/api-contracts run check-types`
- `pnpm -F api run check-types`
- `pnpm knip` — exit 0, only the pre-existing configuration hints
- Repository-wide grep confirms no `zeroTeamsOauth`, `ZeroTeamsOauth`, `zeroTeamsBrowserConnect`, `ZeroTeamsBrowserConnect`, `zeroTeamsBotContract`, `ZeroTeamsBotContract` identifier and no `contracts/zero-teams-oauth`, `contracts/zero-teams-browser-connect` or `contracts/zero-teams-bot` specifier remains

Full-repository test coverage is left to the PR pipeline.

Closes #27855
