### PR TITLE
refactor(contracts): neutralize media generation contract naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -24,14 +24,14 @@ import {
 } from "@okouai/api-contracts/contracts/zero-billing";
 import { builtInGenerationContract } from "@okouai/api-contracts/contracts/built-in-generation";
 import { zeroFeatureSwitchesContract } from "@okouai/api-contracts/contracts/zero-feature-switches";
-import { zeroImageIoGenerateContract } from "@okouai/api-contracts/contracts/zero-image-io-generate";
+import { imageIoGenerateContract } from "@okouai/api-contracts/contracts/image-io-generate";
 import { mapsContract } from "@okouai/api-contracts/contracts/maps";
 import { zeroUsageMembersContract } from "@okouai/api-contracts/contracts/zero-usage";
 import {
   usageRecordContract,
   type UsageRecordRange,
 } from "@okouai/api-contracts/contracts/usage-record";
-import { zeroVideoIoGenerateContract } from "@okouai/api-contracts/contracts/zero-video-io-generate";
+import { videoIoGenerateContract } from "@okouai/api-contracts/contracts/video-io-generate";
 import { voiceIoQuotaContract } from "@okouai/api-contracts/contracts/voice-io-quota";
 import { voiceIoSpeechContract } from "@okouai/api-contracts/contracts/voice-io-speech";
 import { voiceIoSttContract } from "@okouai/api-contracts/contracts/voice-io-stt";
@@ -663,7 +663,7 @@ export function createBillingMediaApi(context: TestContext) {
       statuses: readonly ImageIoStatus[],
     ) {
       const client = setupApp({ context, routes: imageIoGenerateRoutes })(
-        zeroImageIoGenerateContract,
+        imageIoGenerateContract,
       );
       return await accept(
         client.post({ headers: authenticate(actor), body }),
@@ -693,7 +693,7 @@ export function createBillingMediaApi(context: TestContext) {
       statuses: readonly VideoIoStatus[],
     ) {
       const client = setupApp({ context, routes: videoIoGenerateRoutes })(
-        zeroVideoIoGenerateContract,
+        videoIoGenerateContract,
       );
       return await accept(
         client.post({ headers: authenticate(actor), body }),

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
-import { zeroImageIoGenerateContract } from "@okouai/api-contracts/contracts/zero-image-io-generate";
+import { imageIoGenerateContract } from "@okouai/api-contracts/contracts/image-io-generate";
 import type { BuiltInGenerationRealtimeSubscription } from "@okouai/api-contracts/contracts/built-in-generation";
 import { isImageModelId } from "@okouai/api-contracts/contracts/image-models";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
@@ -49,7 +49,7 @@ import {
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 
 const L = logger("ImageGeneration");
-const imageBody$ = bodyResultOf(zeroImageIoGenerateContract.post);
+const imageBody$ = bodyResultOf(imageIoGenerateContract.post);
 
 interface GenerationError {
   readonly message: string;
@@ -343,7 +343,7 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 export const imageIoGenerateRoutes: readonly RouteEntry[] = [
   {
-    route: zeroImageIoGenerateContract.post,
+    route: imageIoGenerateContract.post,
     handler: authRoute(
       {
         requireOrganization: true,

--- a/turbo/apps/api/src/signals/routes/video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/video-io-generate.ts
@@ -2,9 +2,9 @@ import { randomUUID } from "node:crypto";
 
 import { command } from "ccstate";
 import {
-  zeroVideoIoGenerateContract,
-  type ZeroVideoIoGenerateRequest,
-} from "@okouai/api-contracts/contracts/zero-video-io-generate";
+  videoIoGenerateContract,
+  type VideoIoGenerateRequest,
+} from "@okouai/api-contracts/contracts/video-io-generate";
 import type { BuiltInGenerationRealtimeSubscription } from "@okouai/api-contracts/contracts/built-in-generation";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { VIDEO_MODEL_CONFIGS } from "@okouai/core/video-model-catalog";
@@ -57,7 +57,7 @@ import {
 } from "../services/run-built-in-admission.service";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 
-const videoBody$ = bodyResultOf(zeroVideoIoGenerateContract.post);
+const videoBody$ = bodyResultOf(videoIoGenerateContract.post);
 
 async function loadRunVideoModel(
   db: ReadonlyDb,
@@ -125,9 +125,9 @@ async function loadEnforcedRunVideoModel(
  * was actually used.
  */
 function withEnforcedRunVideoModel(
-  body: ZeroVideoIoGenerateRequest,
+  body: VideoIoGenerateRequest,
   runVideoModel: VideoModelId,
-): ZeroVideoIoGenerateRequest {
+): VideoIoGenerateRequest {
   const config = VIDEO_MODEL_CONFIGS[runVideoModel];
   const honours = <T>(
     supported: readonly T[],
@@ -527,7 +527,7 @@ const postVideoInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 export const videoIoGenerateRoutes: readonly RouteEntry[] = [
   {
-    route: zeroVideoIoGenerateContract.post,
+    route: videoIoGenerateContract.post,
     handler: authRoute(
       {
         requireOrganization: true,

--- a/turbo/packages/api-contracts/src/contracts/image-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/image-io-generate.ts
@@ -11,7 +11,7 @@ const stringOrStringArraySchema = z.union([
 ]);
 const numberOrStringSchema = z.union([z.number(), z.string()]);
 
-export const zeroImageIoGenerateRequestSchema = z
+export const imageIoGenerateRequestSchema = z
   .object({
     prompt: z.string().optional(),
     model: z.string().optional(),
@@ -37,7 +37,7 @@ export const zeroImageIoGenerateRequestSchema = z
   })
   .passthrough();
 
-export const zeroImageIoGenerateResponseSchema = z.object({
+export const imageIoGenerateResponseSchema = z.object({
   id: z.string(),
   filename: z.string(),
   contentType: z.string(),
@@ -67,21 +67,21 @@ export const zeroImageIoGenerateResponseSchema = z.object({
   imagePromptStrength: z.number().optional(),
 });
 
-export type ZeroImageIoGenerateRequest = z.infer<
-  typeof zeroImageIoGenerateRequestSchema
+export type ImageIoGenerateRequest = z.infer<
+  typeof imageIoGenerateRequestSchema
 >;
-export type ZeroImageIoGenerateResponse = z.infer<
-  typeof zeroImageIoGenerateResponseSchema
+export type ImageIoGenerateResponse = z.infer<
+  typeof imageIoGenerateResponseSchema
 >;
 
-export const zeroImageIoGenerateContract = c.router({
+export const imageIoGenerateContract = c.router({
   post: {
     method: "POST",
     path: "/api/okou/image-io/generate",
     headers: authHeadersSchema,
-    body: zeroImageIoGenerateRequestSchema,
+    body: imageIoGenerateRequestSchema,
     responses: {
-      200: zeroImageIoGenerateResponseSchema,
+      200: imageIoGenerateResponseSchema,
       202: builtInGenerationAcceptedResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
@@ -95,4 +95,4 @@ export const zeroImageIoGenerateContract = c.router({
   },
 });
 
-export type ZeroImageIoGenerateContract = typeof zeroImageIoGenerateContract;
+export type ImageIoGenerateContract = typeof imageIoGenerateContract;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1588,13 +1588,13 @@ export {
   type ZeroAvatarVideoVoicesQuery,
 } from "./zero-avatar-video";
 export {
-  zeroImageIoGenerateContract,
-  zeroImageIoGenerateRequestSchema,
-  zeroImageIoGenerateResponseSchema,
-  type ZeroImageIoGenerateContract,
-  type ZeroImageIoGenerateRequest,
-  type ZeroImageIoGenerateResponse,
-} from "./zero-image-io-generate";
+  imageIoGenerateContract,
+  imageIoGenerateRequestSchema,
+  imageIoGenerateResponseSchema,
+  type ImageIoGenerateContract,
+  type ImageIoGenerateRequest,
+  type ImageIoGenerateResponse,
+} from "./image-io-generate";
 export {
   imageShareXContract,
   imageShareXRequestSchema,
@@ -1676,13 +1676,13 @@ export {
   type AirQualityCurrentRequest,
 } from "./weather";
 export {
-  zeroVideoIoGenerateContract,
-  zeroVideoIoGenerateRequestSchema,
-  zeroVideoIoGenerateResponseSchema,
-  type ZeroVideoIoGenerateContract,
-  type ZeroVideoIoGenerateRequest,
-  type ZeroVideoIoGenerateResponse,
-} from "./zero-video-io-generate";
+  videoIoGenerateContract,
+  videoIoGenerateRequestSchema,
+  videoIoGenerateResponseSchema,
+  type VideoIoGenerateContract,
+  type VideoIoGenerateRequest,
+  type VideoIoGenerateResponse,
+} from "./video-io-generate";
 export {
   builtInGenerationContract,
   builtInGenerationTypeSchema,

--- a/turbo/packages/api-contracts/src/contracts/video-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/video-io-generate.ts
@@ -10,7 +10,7 @@ const stringOrStringArraySchema = z.union([
   z.array(z.string()).readonly(),
 ]);
 
-export const zeroVideoIoGenerateRequestSchema = z
+export const videoIoGenerateRequestSchema = z
   .object({
     prompt: z.string().optional(),
     model: z.string().optional(),
@@ -33,7 +33,7 @@ export const zeroVideoIoGenerateRequestSchema = z
   })
   .passthrough();
 
-export const zeroVideoIoGenerateResponseSchema = z.object({
+export const videoIoGenerateResponseSchema = z.object({
   id: z.string(),
   filename: z.string(),
   contentType: z.string(),
@@ -50,21 +50,21 @@ export const zeroVideoIoGenerateResponseSchema = z.object({
   requestId: z.string().optional(),
 });
 
-export type ZeroVideoIoGenerateRequest = z.infer<
-  typeof zeroVideoIoGenerateRequestSchema
+export type VideoIoGenerateRequest = z.infer<
+  typeof videoIoGenerateRequestSchema
 >;
-export type ZeroVideoIoGenerateResponse = z.infer<
-  typeof zeroVideoIoGenerateResponseSchema
+export type VideoIoGenerateResponse = z.infer<
+  typeof videoIoGenerateResponseSchema
 >;
 
-export const zeroVideoIoGenerateContract = c.router({
+export const videoIoGenerateContract = c.router({
   post: {
     method: "POST",
     path: "/api/okou/video-io/generate",
     headers: authHeadersSchema,
-    body: zeroVideoIoGenerateRequestSchema,
+    body: videoIoGenerateRequestSchema,
     responses: {
-      200: zeroVideoIoGenerateResponseSchema,
+      200: videoIoGenerateResponseSchema,
       202: builtInGenerationAcceptedResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
@@ -79,4 +79,4 @@ export const zeroVideoIoGenerateContract = c.router({
   },
 });
 
-export type ZeroVideoIoGenerateContract = typeof zeroVideoIoGenerateContract;
+export type VideoIoGenerateContract = typeof videoIoGenerateContract;


### PR DESCRIPTION
## Summary

Phase 2 contract naming cleanup for the two built-in media generation contract modules. Pure rename plus import updates — no compatibility alias, no old-path re-export.

The HTTP `path:` literals in both modules are already canonical `/api/okou/**`, so this change is internal only and has no wire impact.

## Old → new mapping

| Old | New |
|---|---|
| `contracts/zero-video-io-generate.ts` | `contracts/video-io-generate.ts` |
| `zeroVideoIoGenerateRequestSchema` | `videoIoGenerateRequestSchema` |
| `zeroVideoIoGenerateResponseSchema` | `videoIoGenerateResponseSchema` |
| `zeroVideoIoGenerateContract` | `videoIoGenerateContract` |
| `ZeroVideoIoGenerateRequest` | `VideoIoGenerateRequest` |
| `ZeroVideoIoGenerateResponse` | `VideoIoGenerateResponse` |
| `ZeroVideoIoGenerateContract` | `VideoIoGenerateContract` |
| `contracts/zero-image-io-generate.ts` | `contracts/image-io-generate.ts` |
| `zeroImageIoGenerateRequestSchema` | `imageIoGenerateRequestSchema` |
| `zeroImageIoGenerateResponseSchema` | `imageIoGenerateResponseSchema` |
| `zeroImageIoGenerateContract` | `imageIoGenerateContract` |
| `ZeroImageIoGenerateRequest` | `ImageIoGenerateRequest` |
| `ZeroImageIoGenerateResponse` | `ImageIoGenerateResponse` |
| `ZeroImageIoGenerateContract` | `ImageIoGenerateContract` |

## Call sites updated

- `packages/api-contracts/src/contracts/index.ts` — both barrel re-export blocks, updated in place (no reordering).
- `apps/api/src/signals/routes/image-io-generate.ts`
- `apps/api/src/signals/routes/video-io-generate.ts`
- `apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts`

The `./contracts/*` wildcard subpath export makes the filenames a compile-time public API, so both subpath specifiers were migrated together with the barrel.

## Not changed

- No `path:` string, method, header schema, request/response schema, provider enum value, or status code.
- No provider or model identifier string inside the request schemas — those are external identities.
- No other old-branded contract module.
- No API route, service, platform, or database logic; those files only had their import lines updated.

`docs/typecheck-memory-experiments.md` still mentions `zero-image-io-generate.test.ts` and `zero-video-io-generate.test.ts`. That is a historical experiment log listing test filenames as they existed at the time — those test files no longer exist under any name, and per the naming model in #26873 historical records are preserved. Left untouched.

## Verification

- Repo-wide grep: no `zeroVideoIoGenerate`, `ZeroVideoIoGenerate`, `zeroImageIoGenerate`, `ZeroImageIoGenerate` identifier and no `zero-video-io-generate` / `zero-image-io-generate` specifier remains outside the historical doc above. No dynamic imports reference either module.
- `pnpm -F @okouai/api-contracts check-types` — pass
- `pnpm -F api check-types` — pass
- `pnpm -F @okouai/api-contracts lint` / `pnpm -F api lint` — pass (only pre-existing warnings elsewhere)
- `pnpm knip` — exit 0, no findings for the renamed modules
- `prettier --check` on all six touched files — already formatted, no reflow
- Per repo convention the full vitest suite was not run locally; relying on the PR pipeline.

Base verified against `main`. The issue recorded `332e8aef`; `main` has since advanced to `026c19c9`, and all facts in the issue (2 callers each, both barrel re-exports, no colliding target names, no open PR touching these files) still hold at that newer commit.

Closes #27857

Parent: #27432
