### PR TITLE
fix(python): bound body capture dependency headers

### DIFF
--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -251,7 +251,7 @@ def _sanitize_header_name_for_capture(name: str) -> str:
 @dataclass(frozen=True)
 class _CaptureHeaderInspection:
     serialized: dict[str, str]
-    truncated: bool
+    serialized_truncated: bool
     body_dependency_headers: http.Headers | None
 
 
@@ -371,7 +371,7 @@ def _inspect_headers_for_capture(headers: http.Headers) -> _CaptureHeaderInspect
 def _sanitize_headers_for_capture(headers: http.Headers) -> tuple[dict[str, str], bool]:
     """Build a bounded header prefix safe for persistent network logs."""
     inspection = _inspect_headers_for_capture(headers)
-    return inspection.serialized, inspection.truncated
+    return inspection.serialized, inspection.serialized_truncated
 
 
 def _set_body_capture_failure(
@@ -434,14 +434,14 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
 
     Response bodies prefer streaming metadata from
     ``response_streaming.configure_response_stream()`` because that path keeps a
-    bounded raw wire-byte buffer and records whether it was truncated. The
-    Bounded ``flow.response.raw_content`` decoding is used only when no stream
+    bounded raw wire-byte buffer and records whether it was truncated. Bounded
+    ``flow.response.raw_content`` decoding is used only when no stream
     buffer metadata exists.
     """
     # Request headers (always available)
     request_inspection = _inspect_headers_for_capture(flow.request.headers)
     log_entry["request_headers"] = request_inspection.serialized
-    if request_inspection.truncated:
+    if request_inspection.serialized_truncated:
         log_entry["request_headers_truncated"] = True
 
     # Request body
@@ -502,7 +502,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     if flow.response:
         response_inspection = _inspect_headers_for_capture(flow.response.headers)
         log_entry["response_headers"] = response_inspection.serialized
-        if response_inspection.truncated:
+        if response_inspection.serialized_truncated:
             log_entry["response_headers_truncated"] = True
         stream_body = response_streaming.captured_response_stream_body(flow)
         stream_truncated = False

--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -352,7 +352,7 @@ def _inspect_headers_for_capture(headers: http.Headers) -> _CaptureHeaderInspect
                 or dependency_bytes > _MAX_CAPTURE_HEADER_BYTES
             ):
                 dependencies_within_budget = False
-            elif dependencies_within_budget:
+            else:
                 dependency_fields.append((raw_name, raw_value))
             dependency_names.add(normalized_raw_name)
 

--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -2,7 +2,7 @@
 
 import base64
 import re
-import zlib
+from dataclasses import dataclass
 from email.utils import parsedate_to_datetime
 from typing import Literal
 
@@ -52,6 +52,16 @@ _MAX_CAPTURE_HEADER_NAME_LENGTH = 256
 _MAX_CAPTURE_HEADER_VALUE_TO_PRESERVE = 256
 _MAX_CAPTURE_HEADER_FIELDS = 512
 _MAX_CAPTURE_HEADER_BYTES = 32 * 1024
+_CAPTURE_HEADER_FOLD_SEPARATOR_BYTES = len(b", ")
+_BODY_CAPTURE_DEPENDENCY_HEADER_NAMES = frozenset(
+    {
+        b"content-encoding",
+        b"content-type",
+    }
+)
+_BODY_CAPTURE_DEPENDENCY_HEADER_NAME_LENGTHS = frozenset(
+    len(name) for name in _BODY_CAPTURE_DEPENDENCY_HEADER_NAMES
+)
 _REDACTED_HEADER_NAME = "[redacted-header-name]"
 _VALUE_PRESERVING_CAPTURE_CONTENT_TYPES = frozenset(
     {
@@ -238,29 +248,143 @@ def _sanitize_header_name_for_capture(name: str) -> str:
     return name
 
 
-def _sanitize_headers_for_capture(headers: http.Headers) -> tuple[dict[str, str], bool]:
-    """Build a bounded header prefix safe for persistent network logs."""
+@dataclass(frozen=True)
+class _CaptureHeaderInspection:
+    serialized: dict[str, str]
+    truncated: bool
+    body_dependency_headers: http.Headers | None
+
+
+def _has_valid_body_capture_content_type(headers: http.Headers) -> bool:
+    values = headers.get_all("content-type")
+    if not values:
+        return True
+    if len(values) != 1:
+        return False
+
+    value = values[0]
+    if _UNSAFE_CAPTURE_HEADER_VALUE_CHARS.search(value) is not None:
+        return False
+    media_type = value.partition(";")[0].strip(_HTTP_OPTIONAL_WHITESPACE)
+    type_name, separator, subtype_name = media_type.partition("/")
+    return (
+        separator == "/"
+        and _MEDIA_TYPE_NAME_PATTERN.fullmatch(type_name) is not None
+        and _MEDIA_TYPE_NAME_PATTERN.fullmatch(subtype_name) is not None
+    )
+
+
+def _has_valid_body_capture_content_encoding(headers: http.Headers) -> bool:
+    values = headers.get_all("content-encoding")
+    if not values:
+        return True
+
+    folded_value = ", ".join(values)
+    if _UNSAFE_CAPTURE_HEADER_VALUE_CHARS.search(folded_value) is not None:
+        return False
+    for raw_coding in folded_value.split(","):
+        coding = raw_coding.strip(_HTTP_OPTIONAL_WHITESPACE)
+        if not coding or _HTTP_FIELD_NAME_PATTERN.fullmatch(coding) is None:
+            return False
+    return True
+
+
+def _has_valid_body_capture_dependencies(headers: http.Headers) -> bool:
+    if not _has_valid_body_capture_content_type(headers):
+        return False
+    return _has_valid_body_capture_content_encoding(headers)
+
+
+def _body_capture_dependency_header_name(raw_name: bytes) -> bytes | None:
+    if len(raw_name) not in _BODY_CAPTURE_DEPENDENCY_HEADER_NAME_LENGTHS:
+        return None
+    normalized_name = raw_name.lower()
+    if normalized_name not in _BODY_CAPTURE_DEPENDENCY_HEADER_NAMES:
+        return None
+    return normalized_name
+
+
+def _inspect_headers_for_capture(headers: http.Headers) -> _CaptureHeaderInspection:
+    """Inspect bounded serialization and body dependencies before string access.
+
+    Serialization stops decoding at its prefix limit. Raw-name inspection keeps
+    looking for the two body dependencies so unrelated overflow does not hide a
+    later matching field or suppress an otherwise bounded body capture.
+    """
     result: dict[str, str] = {}
     seen_names: set[str] = set()
+    dependency_fields: list[tuple[bytes, bytes]] = []
+    dependency_names: set[bytes] = set()
+    dependency_bytes = 0
+    dependency_field_count = 0
+    dependencies_within_budget = True
     captured_bytes = 0
+    serialized_truncated = False
     for index, (raw_name, raw_value) in enumerate(headers.fields):
-        field_bytes = len(raw_name) + len(raw_value)
-        if (
-            index >= _MAX_CAPTURE_HEADER_FIELDS
-            or field_bytes > _MAX_CAPTURE_HEADER_BYTES - captured_bytes
-        ):
-            return result, True
-        captured_bytes += field_bytes
+        if not serialized_truncated:
+            field_bytes = len(raw_name) + len(raw_value)
+            if (
+                index >= _MAX_CAPTURE_HEADER_FIELDS
+                or field_bytes > _MAX_CAPTURE_HEADER_BYTES - captured_bytes
+            ):
+                serialized_truncated = True
+            else:
+                captured_bytes += field_bytes
+                name = raw_name.decode("utf-8", "surrogateescape")
+                value = raw_value.decode("utf-8", "surrogateescape")
+                captured_name = _sanitize_header_name_for_capture(name)
+                case_insensitive_name = captured_name.lower()
+                if case_insensitive_name not in seen_names:
+                    seen_names.add(case_insensitive_name)
+                    result[captured_name] = _sanitize_header_value_for_capture(captured_name, value)
 
-        name = raw_name.decode("utf-8", "surrogateescape")
-        value = raw_value.decode("utf-8", "surrogateescape")
-        captured_name = _sanitize_header_name_for_capture(name)
-        case_insensitive_name = captured_name.lower()
-        if case_insensitive_name in seen_names:
-            continue  # keep first occurrence only (raw fields contain all)
-        seen_names.add(case_insensitive_name)
-        result[captured_name] = _sanitize_header_value_for_capture(captured_name, value)
-    return result, False
+        normalized_raw_name = _body_capture_dependency_header_name(raw_name)
+        if normalized_raw_name is not None and dependencies_within_budget:
+            fold_separator_bytes = (
+                _CAPTURE_HEADER_FOLD_SEPARATOR_BYTES
+                if normalized_raw_name in dependency_names
+                else 0
+            )
+            dependency_bytes += len(raw_value) + fold_separator_bytes
+            dependency_field_count += 1
+            if (
+                dependency_field_count > _MAX_CAPTURE_HEADER_FIELDS
+                or dependency_bytes > _MAX_CAPTURE_HEADER_BYTES
+            ):
+                dependencies_within_budget = False
+            elif dependencies_within_budget:
+                dependency_fields.append((raw_name, raw_value))
+            dependency_names.add(normalized_raw_name)
+
+        if serialized_truncated and not dependencies_within_budget:
+            break
+
+    if not dependencies_within_budget:
+        return _CaptureHeaderInspection(result, serialized_truncated, None)
+
+    dependency_headers = http.Headers(dependency_fields)
+    if not _has_valid_body_capture_dependencies(dependency_headers):
+        dependency_headers = None
+    return _CaptureHeaderInspection(result, serialized_truncated, dependency_headers)
+
+
+def _sanitize_headers_for_capture(headers: http.Headers) -> tuple[dict[str, str], bool]:
+    """Build a bounded header prefix safe for persistent network logs."""
+    inspection = _inspect_headers_for_capture(headers)
+    return inspection.serialized, inspection.truncated
+
+
+def _set_body_capture_failure(
+    log_entry: dict,
+    side: Literal["request", "response"],
+    body: bytes,
+    *,
+    truncated: bool = False,
+) -> None:
+    if truncated:
+        log_entry[f"{side}_body_truncated"] = True
+    if body:
+        log_entry[f"{side}_body_encoding"] = "binary"
 
 
 def _set_body_fields(
@@ -311,13 +435,13 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     Response bodies prefer streaming metadata from
     ``response_streaming.configure_response_stream()`` because that path keeps a
     bounded raw wire-byte buffer and records whether it was truncated. The
-    mitmproxy ``flow.response.content`` fallback is used only when no stream
+    Bounded ``flow.response.raw_content`` decoding is used only when no stream
     buffer metadata exists.
     """
     # Request headers (always available)
-    request_headers, request_headers_truncated = _sanitize_headers_for_capture(flow.request.headers)
-    log_entry["request_headers"] = request_headers
-    if request_headers_truncated:
+    request_inspection = _inspect_headers_for_capture(flow.request.headers)
+    log_entry["request_headers"] = request_inspection.serialized
+    if request_inspection.truncated:
         log_entry["request_headers_truncated"] = True
 
     # Request body
@@ -329,66 +453,98 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             request_stream_incomplete = (
                 flow.metadata.get(metadata_keys.REQUEST_STREAM_COMPLETE) is not True
             )
-            req_ct = flow.request.headers.get("content-type", "")
-            request_body = body_decoding.decode_request_body_for_network_log_capture(
-                bytes(request_stream_body.buffer),
-                flow.request.headers,
-                max_output=BODY_CAPTURE_LIMIT + 1,
-            )
-            if request_body is None:
-                if request_stream_body.truncated or request_stream_incomplete:
-                    log_entry["request_body_truncated"] = True
-                log_entry["request_body_encoding"] = "binary"
-            else:
-                _set_body_fields(
+            raw_request_body = bytes(request_stream_body.buffer)
+            request_dependency_headers = request_inspection.body_dependency_headers
+            if request_dependency_headers is None:
+                _set_body_capture_failure(
                     log_entry,
                     "request",
-                    request_body,
-                    req_ct,
-                    already_truncated=request_stream_incomplete,
-                    truncated_at_limit=request_stream_body.truncated,
+                    raw_request_body,
+                    truncated=request_stream_body.truncated or request_stream_incomplete,
                 )
-        elif flow.request.raw_content:
-            req_ct = flow.request.headers.get("content-type", "")
-            request_body = body_decoding.decode_request_body_for_network_log_capture(
-                flow.request.raw_content,
-                flow.request.headers,
-                max_output=BODY_CAPTURE_LIMIT + 1,
-            )
-            if request_body is None:
-                log_entry["request_body_encoding"] = "binary"
             else:
-                _set_body_fields(log_entry, "request", request_body, req_ct)
+                req_ct = request_dependency_headers.get("content-type", "")
+                request_body = body_decoding.decode_request_body_for_network_log_capture(
+                    raw_request_body,
+                    request_dependency_headers,
+                    max_output=BODY_CAPTURE_LIMIT + 1,
+                )
+                if request_body is None:
+                    if request_stream_body.truncated or request_stream_incomplete:
+                        log_entry["request_body_truncated"] = True
+                    log_entry["request_body_encoding"] = "binary"
+                else:
+                    _set_body_fields(
+                        log_entry,
+                        "request",
+                        request_body,
+                        req_ct,
+                        already_truncated=request_stream_incomplete,
+                        truncated_at_limit=request_stream_body.truncated,
+                    )
+        elif flow.request.raw_content:
+            request_dependency_headers = request_inspection.body_dependency_headers
+            if request_dependency_headers is None:
+                _set_body_capture_failure(log_entry, "request", flow.request.raw_content)
+            else:
+                req_ct = request_dependency_headers.get("content-type", "")
+                request_body = body_decoding.decode_request_body_for_network_log_capture(
+                    flow.request.raw_content,
+                    request_dependency_headers,
+                    max_output=BODY_CAPTURE_LIMIT + 1,
+                )
+                if request_body is None:
+                    log_entry["request_body_encoding"] = "binary"
+                else:
+                    _set_body_fields(log_entry, "request", request_body, req_ct)
 
     # Response headers
     if flow.response:
-        response_headers, response_headers_truncated = _sanitize_headers_for_capture(
-            flow.response.headers
-        )
-        log_entry["response_headers"] = response_headers
-        if response_headers_truncated:
+        response_inspection = _inspect_headers_for_capture(flow.response.headers)
+        log_entry["response_headers"] = response_inspection.serialized
+        if response_inspection.truncated:
             log_entry["response_headers_truncated"] = True
-
-    if flow.response:
         stream_body = response_streaming.captured_response_stream_body(flow)
         stream_truncated = False
         if stream_body is not None:
             stream_truncated = stream_body.truncated
+            raw_response_body = bytes(stream_body.buffer)
+        else:
+            raw_response_body = flow.response.raw_content
+        if raw_response_body is None:
+            return
+
+        response_dependency_headers = response_inspection.body_dependency_headers
+        if response_dependency_headers is None:
+            _set_body_capture_failure(
+                log_entry,
+                "response",
+                raw_response_body,
+                truncated=stream_truncated,
+            )
+            return
+
+        if stream_body is not None:
             body = body_decoding.decompress_body(
-                bytes(stream_body.buffer),
-                flow.response.headers,
+                raw_response_body,
+                response_dependency_headers,
                 max_output=BODY_CAPTURE_LIMIT + 1,
             )
         else:
-            try:
-                body = flow.response.content
-            except (zlib.error, ValueError):
-                # ZlibError (decompression failure) or ValueError from mitmproxy
-                log_entry["response_body_encoding"] = "binary"
-                return
+            body = body_decoding.decode_response_body_for_network_log_capture(
+                raw_response_body,
+                response_dependency_headers,
+                max_output=BODY_CAPTURE_LIMIT + 1,
+            )
         if body is None:
+            _set_body_capture_failure(
+                log_entry,
+                "response",
+                raw_response_body,
+                truncated=stream_truncated,
+            )
             return
-        res_ct = flow.response.headers.get("content-type", "")
+        res_ct = response_dependency_headers.get("content-type", "")
         # Also check decompressed size in case it expanded beyond the limit.
         _set_body_fields(
             log_entry,

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -333,7 +333,10 @@ def decode_response_body_for_network_log_capture(
     *,
     max_output: int = DEFAULT_BODY_DECODE_LIMIT,
 ) -> bytes | None:
-    """Decode a response body while hiding supported-codec failures."""
+    """Decode a buffered response body with mitmproxy-compatible strictness."""
+    encoding = headers.get("content-encoding", "").strip().lower()
+    if encoding and encoding != "identity" and encoding not in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
+        return None
     result = _decode_body_bounded(data, headers, max_output=max_output)
     _log_body_decompression_failure(result, headers)
     if result.failed:

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -327,21 +327,67 @@ def decompress_body(
     return result.body
 
 
+def _decode_single_zlib_stream_for_network_log_capture(
+    data: bytes,
+    *,
+    wbits: int,
+    max_output: int,
+    require_complete: bool,
+) -> bytes | None:
+    if not data or max_output <= 0:
+        return b""
+
+    obj = zlib.decompressobj(wbits)
+    try:
+        body = obj.decompress(data, max_length=max_output)
+    except zlib.error:
+        return None
+    if require_complete and len(body) < max_output and not obj.eof:
+        return None
+    return body
+
+
 def decode_response_body_for_network_log_capture(
     data: bytes,
     headers: http.Headers,
     *,
     max_output: int = DEFAULT_BODY_DECODE_LIMIT,
 ) -> bytes | None:
-    """Decode a buffered response body with mitmproxy-compatible strictness."""
+    """Decode a buffered response body with bounded mitmproxy compatibility."""
     encoding = headers.get("content-encoding", "").strip().lower()
-    if encoding and encoding != "identity" and encoding not in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
+    if not encoding or encoding == "identity":
+        return data
+    if encoding == "gzip":
+        # mitmproxy uses zlib's gzip/zlib auto-detection and accepts partial
+        # output when a gzip stream ends before its trailer.
+        return _decode_single_zlib_stream_for_network_log_capture(
+            data,
+            wbits=32 + zlib.MAX_WBITS,
+            max_output=max_output,
+            require_complete=False,
+        )
+    if encoding == "deflate":
+        body = _decode_single_zlib_stream_for_network_log_capture(
+            data,
+            wbits=zlib.MAX_WBITS,
+            max_output=max_output,
+            require_complete=True,
+        )
+        if body is not None:
+            return body
+        return _decode_single_zlib_stream_for_network_log_capture(
+            data,
+            wbits=-zlib.MAX_WBITS,
+            max_output=max_output,
+            require_complete=True,
+        )
+    if encoding not in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
         return None
-    result = _decode_body_bounded(data, headers, max_output=max_output)
-    _log_body_decompression_failure(result, headers)
-    if result.failed:
+
+    body, error = _decode_supported_body_with_complete_status(data, encoding, max_output)
+    if error is not None and error != DECODED_BODY_LIMIT_EXCEEDED:
         return None
-    return result.body
+    return body
 
 
 def _log_body_decompression_failure(result: _BodyDecodeResult, headers: http.Headers) -> None:

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -393,16 +393,15 @@ def decode_response_body_for_network_log_capture(
             max_output=max_output,
             require_complete=True,
         )
-    if encoding not in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
-        return None
     if encoding == "br":
         body, error = _decode_supported_body_with_complete_status(data, encoding, max_output)
         if error is not None and error != DECODED_BODY_LIMIT_EXCEEDED:
             return None
         return body
-
-    result = _decode_body_bounded(data, headers, max_output=max_output)
-    return None if result.failed else result.body
+    if encoding == "zstd":
+        result = _decode_body_bounded(data, headers, max_output=max_output)
+        return None if result.failed else result.body
+    return None
 
 
 def _log_body_decompression_failure(result: _BodyDecodeResult, headers: http.Headers) -> None:

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -338,13 +338,25 @@ def _decode_single_zlib_stream_for_network_log_capture(
         return b""
 
     obj = zlib.decompressobj(wbits)
-    try:
-        body = obj.decompress(data, max_length=max_output)
-    except zlib.error:
+    input_cursor = ZlibInputCursor(data)
+    out = bytearray()
+    while input_cursor and len(out) < max_output:
+        try:
+            decoded = obj.decompress(
+                input_cursor.take(),
+                max_length=max_output - len(out),
+            )
+        except zlib.error:
+            return None
+        out.extend(decoded)
+        if obj.eof:
+            break
+        if obj.unconsumed_tail:
+            input_cursor.carry(obj.unconsumed_tail)
+
+    if require_complete and len(out) < max_output and not obj.eof:
         return None
-    if require_complete and len(body) < max_output and not obj.eof:
-        return None
-    return body
+    return bytes(out)
 
 
 def decode_response_body_for_network_log_capture(

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -383,11 +383,14 @@ def decode_response_body_for_network_log_capture(
         )
     if encoding not in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
         return None
+    if encoding == "br":
+        body, error = _decode_supported_body_with_complete_status(data, encoding, max_output)
+        if error is not None and error != DECODED_BODY_LIMIT_EXCEEDED:
+            return None
+        return body
 
-    body, error = _decode_supported_body_with_complete_status(data, encoding, max_output)
-    if error is not None and error != DECODED_BODY_LIMIT_EXCEEDED:
-        return None
-    return body
+    result = _decode_body_bounded(data, headers, max_output=max_output)
+    return None if result.failed else result.body
 
 
 def _log_body_decompression_failure(result: _BodyDecodeResult, headers: http.Headers) -> None:

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -4,7 +4,7 @@ Exports:
 
 - Bounded streaming usage decoding for gzip, deflate; one-shot
   decompression for gzip, deflate, br, zstd.
-- Request network-log capture decoding that hides opaque encoded bodies.
+- Request and response network-log capture decoding that hides failed bodies.
 - JSON usage decompression with diagnostic error classification.
 """
 
@@ -323,6 +323,25 @@ def decompress_body(
     on that (see #10287).
     """
     result = _decode_body_bounded(data, headers, max_output=max_output)
+    _log_body_decompression_failure(result, headers)
+    return result.body
+
+
+def decode_response_body_for_network_log_capture(
+    data: bytes,
+    headers: http.Headers,
+    *,
+    max_output: int = DEFAULT_BODY_DECODE_LIMIT,
+) -> bytes | None:
+    """Decode a response body while hiding supported-codec failures."""
+    result = _decode_body_bounded(data, headers, max_output=max_output)
+    _log_body_decompression_failure(result, headers)
+    if result.failed:
+        return None
+    return result.body
+
+
+def _log_body_decompression_failure(result: _BodyDecodeResult, headers: http.Headers) -> None:
     if result.failed and result.error is not None:
         with contextlib.suppress(AttributeError):
             # ctx.log unavailable outside mitmproxy runtime
@@ -330,7 +349,6 @@ def decompress_body(
                 "Decompression failed "
                 f"({headers.get('content-encoding', '').strip().lower()}): {result.error}"
             )
-    return result.body
 
 
 def _decompress_zlib_best_effort_bounded(

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -359,6 +359,20 @@ def _decode_single_zlib_stream_for_network_log_capture(
     return bytes(out)
 
 
+def _decode_zstd_for_network_log_capture(data: bytes, max_output: int) -> bytes | None:
+    if not data or max_output <= 0:
+        return b""
+
+    try:
+        with zstandard.ZstdDecompressor().stream_reader(
+            data,
+            read_across_frames=True,
+        ) as reader:
+            return reader.read(max_output)
+    except zstandard.ZstdError:
+        return None
+
+
 def decode_response_body_for_network_log_capture(
     data: bytes,
     headers: http.Headers,
@@ -399,8 +413,7 @@ def decode_response_body_for_network_log_capture(
             return None
         return body
     if encoding == "zstd":
-        result = _decode_body_bounded(data, headers, max_output=max_output)
-        return None if result.failed else result.body
+        return _decode_zstd_for_network_log_capture(data, max_output)
     return None
 
 

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -6,7 +6,6 @@ import zlib
 
 import brotli
 import pytest
-import zstandard
 
 from body_capture import add_capture_fields
 from body_limits import BODY_CAPTURE_LIMIT
@@ -382,19 +381,14 @@ class TestAddCaptureFields:
         assert entry["response_body"] == body.decode()
         assert entry["response_body_encoding"] == "utf-8"
 
-    @pytest.mark.parametrize("encoding", ["br", "zstd"])
-    def test_response_incomplete_strict_compression_skips_body(self, real_flow, encoding):
+    def test_response_incomplete_brotli_skips_body(self, real_flow):
         body = b"incomplete response body" * 100
-        if encoding == "br":
-            compressed = brotli.compress(body)
-        else:
-            compressed = zstandard.ZstdCompressor().compress(body)
         flow = real_flow(
             method="POST",
             host="api.example.com",
             response_content_type="text/plain",
-            response_body=compressed[:-1],
-            response_encoding=encoding,
+            response_body=brotli.compress(body)[:-1],
+            response_encoding="br",
         )
 
         entry = {}

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -9,6 +9,34 @@ import pytest
 
 from body_capture import add_capture_fields
 from body_limits import BODY_CAPTURE_LIMIT
+from tests.body_decode_helpers import pseudo_random_ascii
+
+
+def _track_zlib_max_input(monkeypatch) -> dict[str, int]:
+    real_factory = zlib.decompressobj
+    stats = {"max_input": 0}
+
+    class TrackingDecompressionObj:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def decompress(self, chunk, *args, **kwargs):
+            stats["max_input"] = max(stats["max_input"], len(chunk))
+            return self._wrapped.decompress(chunk, *args, **kwargs)
+
+        @property
+        def eof(self):
+            return self._wrapped.eof
+
+        @property
+        def unconsumed_tail(self):
+            return self._wrapped.unconsumed_tail
+
+    def factory(*args, **kwargs):
+        return TrackingDecompressionObj(real_factory(*args, **kwargs))
+
+    monkeypatch.setattr("body_decoding.zlib.decompressobj", factory)
+    return stats
 
 
 class TestAddCaptureFields:
@@ -380,6 +408,26 @@ class TestAddCaptureFields:
 
         assert entry["response_body"] == body.decode()
         assert entry["response_body_encoding"] == "utf-8"
+
+    def test_response_large_gzip_bounds_compressed_input_chunks(self, real_flow, monkeypatch):
+        body = pseudo_random_ascii(BODY_CAPTURE_LIMIT * 4)
+        compressed = gzip.compress(body)
+        assert len(compressed) > 1024
+        stats = _track_zlib_max_input(monkeypatch)
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="text/plain",
+            response_body=compressed,
+            response_encoding="gzip",
+        )
+
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert entry["response_body_truncated"] is True
+        assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
+        assert stats["max_input"] <= 1024
 
     def test_response_incomplete_brotli_skips_body(self, real_flow):
         body = b"incomplete response body" * 100

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -40,6 +40,34 @@ def _track_zlib_max_input(monkeypatch) -> dict[str, int]:
     return stats
 
 
+def _track_zstd_max_read(monkeypatch) -> dict[str, int]:
+    real_factory = zstandard.ZstdDecompressor
+    stats = {"max_read": 0, "read_across_frames": 0}
+
+    class TrackingReader:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def __enter__(self):
+            self._wrapped.__enter__()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return self._wrapped.__exit__(exc_type, exc_value, traceback)
+
+        def read(self, size=-1):
+            stats["max_read"] = max(stats["max_read"], size)
+            return self._wrapped.read(size)
+
+    class TrackingDecompressor:
+        def stream_reader(self, *args, **kwargs):
+            stats["read_across_frames"] = int(kwargs.get("read_across_frames") is True)
+            return TrackingReader(real_factory().stream_reader(*args, **kwargs))
+
+    monkeypatch.setattr("body_decoding.zstandard.ZstdDecompressor", TrackingDecompressor)
+    return stats
+
+
 class TestAddCaptureFields:
     def test_captures_request_body(self, real_flow):
         flow = real_flow(
@@ -480,6 +508,27 @@ class TestAddCaptureFields:
 
         assert "response_body" not in entry
         assert entry["response_body_encoding"] == "binary"
+
+    def test_response_zstd_zip_bomb_bounds_decoded_output(self, real_flow, monkeypatch):
+        compressed = zstandard.ZstdCompressor().compress(b"x" * (BODY_CAPTURE_LIMIT * 4))
+        stats = _track_zstd_max_read(monkeypatch)
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="text/plain",
+            response_body=compressed,
+            response_encoding="zstd",
+        )
+
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert entry["response_body_truncated"] is True
+        assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
+        assert stats == {
+            "max_read": BODY_CAPTURE_LIMIT + 1,
+            "read_across_frames": 1,
+        }
 
     def test_request_decompression_error_marks_body_binary(self, real_flow):
         # Request capture decodes the captured stream buffer or raw_content with the

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -325,8 +325,8 @@ class TestAddCaptureFields:
         assert entry["request_body_encoding"] == "binary"
 
     def test_response_decompression_error_skips_body(self, real_flow):
-        # Content-Encoding: gzip + non-gzip bytes makes flow.response.content
-        # raise ValueError, which add_capture_fields is expected to catch.
+        # Content-Encoding: gzip + non-gzip bytes makes the bounded capture
+        # decoder fail, which add_capture_fields is expected to hide.
         flow = real_flow(
             method="POST",
             host="api.example.com",
@@ -347,8 +347,7 @@ class TestAddCaptureFields:
     def test_request_decompression_error_marks_body_binary(self, real_flow):
         # Request capture decodes the captured stream buffer or raw_content with the
         # bounded helper. Malformed gzip returns None, so add_capture_fields marks the
-        # body binary without accessing flow.request.content, unlike the response
-        # fallback above.
+        # body binary without accessing flow.request.content.
         flow = real_flow(
             method="POST",
             host="api.example.com",

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -344,6 +344,19 @@ class TestAddCaptureFields:
         assert "response_body" not in entry  # response body skipped
         assert entry["response_body_encoding"] == "binary"  # marked as binary
 
+    def test_response_unsupported_encoding_skips_body(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="text/plain",
+            response_body=b"opaque response body",
+            response_encoding="x-custom",
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
+
     def test_request_decompression_error_marks_body_binary(self, real_flow):
         # Request capture decodes the captured stream buffer or raw_content with the
         # bounded helper. Malformed gzip returns None, so add_capture_fields marks the

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -2,8 +2,11 @@
 
 import base64
 import gzip
+import zlib
 
+import brotli
 import pytest
+import zstandard
 
 from body_capture import add_capture_fields
 from body_limits import BODY_CAPTURE_LIMIT
@@ -354,6 +357,49 @@ class TestAddCaptureFields:
         )
         entry = {}
         add_capture_fields(flow, entry)
+        assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_response_preserves_mitmproxy_compatible_zlib_variants(self, real_flow, encoding):
+        body = b"compatible response body"
+        if encoding == "gzip":
+            compressed = zlib.compress(body)
+        else:
+            compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+            compressed = compressor.compress(body) + compressor.flush()
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="text/plain",
+            response_body=compressed,
+            response_encoding=encoding,
+        )
+
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert entry["response_body"] == body.decode()
+        assert entry["response_body_encoding"] == "utf-8"
+
+    @pytest.mark.parametrize("encoding", ["br", "zstd"])
+    def test_response_incomplete_strict_compression_skips_body(self, real_flow, encoding):
+        body = b"incomplete response body" * 100
+        if encoding == "br":
+            compressed = brotli.compress(body)
+        else:
+            compressed = zstandard.ZstdCompressor().compress(body)
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="text/plain",
+            response_body=compressed[:-1],
+            response_encoding=encoding,
+        )
+
+        entry = {}
+        add_capture_fields(flow, entry)
+
         assert "response_body" not in entry
         assert entry["response_body_encoding"] == "binary"
 

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -6,6 +6,7 @@ import zlib
 
 import brotli
 import pytest
+import zstandard
 
 from body_capture import add_capture_fields
 from body_limits import BODY_CAPTURE_LIMIT
@@ -437,6 +438,41 @@ class TestAddCaptureFields:
             response_content_type="text/plain",
             response_body=brotli.compress(body)[:-1],
             response_encoding="br",
+        )
+
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
+
+    def test_response_zstd_concatenated_frames_capture_all_frames(self, real_flow):
+        first = b"first response frame"
+        second = b" and second response frame"
+        compressor = zstandard.ZstdCompressor()
+        compressed = compressor.compress(first) + compressor.compress(second)
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="text/plain",
+            response_body=compressed,
+            response_encoding="zstd",
+        )
+
+        entry = {}
+        add_capture_fields(flow, entry)
+
+        assert entry["response_body"] == (first + second).decode()
+        assert entry["response_body_encoding"] == "utf-8"
+
+    def test_response_zstd_trailing_garbage_skips_body(self, real_flow):
+        compressed = zstandard.ZstdCompressor().compress(b"response body")
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="text/plain",
+            response_body=compressed + b"garbage",
+            response_encoding="zstd",
         )
 
         entry = {}

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -1,5 +1,6 @@
 """Response hook integration tests for network and proxy logging."""
 
+import gzip
 import json
 import time
 import tracemalloc
@@ -28,6 +29,7 @@ from tests.request_handler_helpers import (
     _write_registry,
 )
 from tests.requestheaders_helpers import await_requestheaders_result
+from tests.stream_buffer_helpers import set_request_stream_buffer, set_response_stream_buffer
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
@@ -44,6 +46,11 @@ class _BoundedFindUrl(str):
         if end is None:
             raise AssertionError("oversized retained URLs must not use an unbounded delimiter scan")
         return super().find(sub, start, end)
+
+
+class _DecodeGuardHeaderValue(bytes):
+    def decode(self, encoding="utf-8", errors="strict"):
+        raise AssertionError("over-budget dependency header values must not be decoded")
 
 
 def test_calculates_latency_and_logs(registry_file, tmp_path, real_flow, mitm_ctx, headers):
@@ -461,6 +468,149 @@ def test_capture_headers_bound_both_sides_and_final_row(tmp_path, real_flow, mit
     assert entry["response_headers_truncated"] is True
     assert len(entry["request_body"]) == BODY_CAPTURE_LIMIT
     assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
+
+
+def _body_capture_dependency_attack_fields(
+    header_name: bytes, attack: str
+) -> list[tuple[bytes, bytes]]:
+    if attack == "oversized-single":
+        return [(header_name, _DecodeGuardHeaderValue(b"x" * (32 * 1024 + 1)))]
+    if attack == "malformed":
+        value = b"not a media type" if header_name == b"Content-Type" else b"gzip,,br"
+        return [(header_name, value)]
+    if header_name == b"Content-Type":
+        return [(header_name, b"text/plain")] * 512
+    return [(b"Content-Type", b"text/plain"), *[(header_name, b"identity")] * 512]
+
+
+@pytest.mark.parametrize("side", ["request", "response"])
+@pytest.mark.parametrize("streamed", [False, True], ids=["buffered", "streamed"])
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        pytest.param(b"Content-Type", id="content-type"),
+        pytest.param(b"Content-Encoding", id="content-encoding"),
+    ],
+)
+@pytest.mark.parametrize("attack", ["oversized-single", "duplicate-amplification", "malformed"])
+def test_body_capture_bounds_dependency_headers_and_writes_final_row(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    side,
+    streamed,
+    header_name,
+    attack,
+):
+    raw_url = "https://target.example.com/path"
+    attack_headers = http.Headers(_body_capture_dependency_attack_fields(header_name, attack))
+    valid_headers = header_map({"Content-Type": "text/plain"})
+    request_headers = attack_headers if side == "request" else valid_headers
+    response_headers = attack_headers if side == "response" else valid_headers
+    flow = real_flow(
+        host="target.example.com",
+        method="POST",
+        request_headers=request_headers,
+        request_body=b"request body",
+        response_headers=response_headers,
+        response_body=b"response body",
+    )
+    if streamed and side == "request":
+        set_request_stream_buffer(flow, b"request body", truncated=True)
+    if streamed and side == "response":
+        set_response_stream_buffer(flow, b"response body", truncated=True)
+
+    log_path = tmp_path / "network.jsonl"
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(log_path)
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+    flow.metadata[metadata_keys.CAPTURE_BODY] = True
+    http_network_log.set_target(
+        flow,
+        url=raw_url,
+        host="target.example.com",
+        port=443,
+    )
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    serialized = read_jsonl_text_after_flush(log_path)
+    entry = json.loads(serialized)
+    assert len(serialized.encode()) <= 1_000_000
+    assert entry["url"] == raw_url
+    assert f"{side}_body" not in entry
+    assert entry[f"{side}_body_encoding"] == "binary"
+    if streamed:
+        assert entry[f"{side}_body_truncated"] is True
+    other_side = "response" if side == "request" else "request"
+    assert entry[f"{other_side}_body"] == f"{other_side} body"
+    assert entry[f"{other_side}_body_encoding"] == "utf-8"
+
+
+def test_body_capture_preserves_bounded_valid_dependency_headers(tmp_path, real_flow, mitm_ctx):
+    raw_url = "https://target.example.com/path"
+    content_type = f"text/plain; boundary={'x' * 5_000}"
+    flow = real_flow(
+        host="target.example.com",
+        method="POST",
+        request_headers=header_map({"Content-Type": content_type, "Content-Encoding": "identity"}),
+        request_body=b"request body",
+        response_headers=header_map({"Content-Type": content_type, "Content-Encoding": "x-custom"}),
+        response_body=b"response body",
+    )
+    log_path = tmp_path / "network.jsonl"
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(log_path)
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+    flow.metadata[metadata_keys.CAPTURE_BODY] = True
+    http_network_log.set_target(
+        flow,
+        url=raw_url,
+        host="target.example.com",
+        port=443,
+    )
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    [entry] = read_jsonl_entries_after_flush(log_path)
+    assert entry["request_body"] == "request body"
+    assert entry["request_body_encoding"] == "utf-8"
+    assert entry["response_body"] == "response body"
+    assert entry["response_body_encoding"] == "utf-8"
+
+
+def test_body_capture_decompresses_buffered_response_with_bounded_headers(
+    tmp_path, real_flow, mitm_ctx
+):
+    raw_url = "https://target.example.com/path"
+    flow = real_flow(
+        host="target.example.com",
+        response_headers=header_map({"Content-Type": "text/plain", "Content-Encoding": "gzip"}),
+        response_body=gzip.compress(b"response body"),
+    )
+    log_path = tmp_path / "network.jsonl"
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(log_path)
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+    flow.metadata[metadata_keys.CAPTURE_BODY] = True
+    http_network_log.set_target(
+        flow,
+        url=raw_url,
+        host="target.example.com",
+        port=443,
+    )
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    [entry] = read_jsonl_entries_after_flush(log_path)
+    assert entry["response_body"] == "response body"
+    assert entry["response_body_encoding"] == "utf-8"
 
 
 @pytest.mark.parametrize("delimiter", ["?", "#"], ids=["query", "fragment"])

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -480,7 +480,11 @@ def _body_capture_dependency_attack_fields(
         return [(header_name, value)]
     if header_name == b"Content-Type":
         return [(header_name, b"text/plain")] * 512
-    return [(b"Content-Type", b"text/plain"), *[(header_name, b"identity")] * 512]
+    return [
+        (b"X-Padding", b"x" * 32_700),
+        (header_name, _DecodeGuardHeaderValue(b"a" * (16 * 1024))),
+        (header_name, _DecodeGuardHeaderValue(b"b" * (16 * 1024))),
+    ]
 
 
 @pytest.mark.parametrize("side", ["request", "response"])
@@ -557,7 +561,7 @@ def test_body_capture_preserves_bounded_valid_dependency_headers(tmp_path, real_
         method="POST",
         request_headers=header_map({"Content-Type": content_type, "Content-Encoding": "identity"}),
         request_body=b"request body",
-        response_headers=header_map({"Content-Type": content_type, "Content-Encoding": "x-custom"}),
+        response_headers=header_map({"Content-Type": content_type, "Content-Encoding": "identity"}),
         response_body=b"response body",
     )
     log_path = tmp_path / "network.jsonl"


### PR DESCRIPTION
## Summary

- inspect raw `Content-Type` and `Content-Encoding` fields under fixed byte and cardinality budgets before any body-capture getter, decoding, folding, or media parsing
- pass only a bounded dependency header projection into request and response body capture
- decode buffered responses from `raw_content` with bounded output and 1-KiB zlib input chunks instead of mitmproxy's unbounded `response.content` path
- preserve independent serialized-header truncation, bounded valid media parameters, streamed best-effort decoding, and buffered strict decoding
- retain mitmproxy-compatible buffered gzip/zlib, raw-deflate, incomplete-gzip, incomplete-zstd, and concatenated zstd behavior while rejecting codec failures and invalid zstd trailing data

## Tests

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (`6035 passed`)

## Scope

This does not change the network-log schema, general billing/usage decoding, or proxy-level request header limits.

Closes #27843
