### PR TITLE
test(rebranding): close dual-brand routing matrix

### DIFF
--- a/turbo/apps/api/src/__tests__/test-app.ts
+++ b/turbo/apps/api/src/__tests__/test-app.ts
@@ -12,10 +12,14 @@ import type { UsagePricingResolution } from "../signals/context/usage-pricing-re
 import type { RouteEntry } from "../signals/route-entry";
 import type { TestContext } from "./test-context";
 
-interface SetupAppWithRoutesOptions {
+interface TestAppWithRoutesOptions {
   readonly context: TestContext;
   readonly routes: readonly RouteEntry[];
   readonly signal?: AbortSignal;
+}
+
+interface SetupAppWithRoutesOptions extends TestAppWithRoutesOptions {
+  readonly baseUrl?: string;
   readonly usagePricingResolution?: UsagePricingResolution;
 }
 
@@ -80,7 +84,7 @@ export function setupRawAppRequestWithRoutes({
   context,
   routes,
   signal,
-}: SetupAppWithRoutesOptions) {
+}: TestAppWithRoutesOptions) {
   const app = createAppWithRoutes({
     signal: signal ?? context.signal,
     routes,
@@ -96,6 +100,7 @@ export function setupRawAppRequestWithRoutes({
 }
 
 export function setupAppWithRoutes({
+  baseUrl = "http://api.test",
   context,
   routes,
   signal,
@@ -107,7 +112,7 @@ export function setupAppWithRoutes({
     contract: TContract,
   ): InitClientReturn<TContract, InitClientArgs> => {
     return initClient(contract, {
-      baseUrl: "http://api.test",
+      baseUrl,
       jsonQuery: false,
       throwOnUnknownStatus: true,
       validateResponse: true,

--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -3,20 +3,26 @@ import type { RouteEntry } from "../signals/route-entry";
 import { setupAppWithRoutes, setupRawAppRequestWithRoutes } from "./test-app";
 import type { TestContext } from "./test-context";
 
-interface SetupAppOptions {
+interface SetupRawAppOptions {
   readonly context: TestContext;
   readonly routes: readonly RouteEntry[];
   readonly signal?: AbortSignal;
+}
+
+interface SetupAppOptions extends SetupRawAppOptions {
+  readonly baseUrl?: string;
   readonly usagePricingResolution?: UsagePricingResolution;
 }
 
 export function setupApp({
+  baseUrl = "http://api.test",
   context,
   routes,
   signal,
   usagePricingResolution,
 }: SetupAppOptions) {
   return setupAppWithRoutes({
+    baseUrl,
     context,
     routes,
     signal,
@@ -32,6 +38,6 @@ export function setupRawAppRequest({
   context,
   routes,
   signal,
-}: SetupAppOptions) {
+}: SetupRawAppOptions) {
   return setupRawAppRequestWithRoutes({ context, routes, signal });
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-downgrade.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-downgrade.test.ts
@@ -483,13 +483,14 @@ describe("POST /api/zero/billing/downgrade", () => {
     });
   });
 
-  it("returns setup checkout URL when team to pro needs a payment method", async () => {
+  it("returns branded setup checkout URLs when team to pro needs a payment method", async () => {
     const subId = `sub-team-pro-no-card-${randomUUID().slice(0, 8)}`;
     const customerId = `cus-team-pro-${randomUUID().slice(0, 8)}`;
     const periodStart = 1_782_809_751;
     const periodEnd = 1_785_401_751;
     const checkoutUrl = "https://checkout.stripe.com/setup/downgrade";
-    const fallbackReturnUrl = "https://app.okou.ai";
+    const okouFallbackReturnUrl = "https://app.okou.ai";
+    const vm0FallbackReturnUrl = "https://app.vm0.ai";
     const explicitReturnUrl = "https://app.vm0.ai/settings?settings=billing";
     const fixture = await track(
       store.set(
@@ -557,8 +558,8 @@ describe("POST /api/zero/billing/downgrade", () => {
       mode: "setup",
       customer: customerId,
       currency: "usd",
-      success_url: fallbackReturnUrl,
-      cancel_url: fallbackReturnUrl,
+      success_url: okouFallbackReturnUrl,
+      cancel_url: okouFallbackReturnUrl,
       metadata: {
         purpose: "billing_downgrade",
         orgId: fixture.orgId,
@@ -574,6 +575,22 @@ describe("POST /api/zero/billing/downgrade", () => {
         },
       },
     });
+    context.mocks.stripe.checkout.sessions.create.mockClear();
+    const vm0Response = await accept(
+      client.create({
+        body: { targetTier: "pro" },
+        headers: { authorization: "Bearer clerk-session" },
+        extraHeaders: { origin: "https://app.vm0.ai" },
+      }),
+      [200],
+    );
+    expect(vm0Response.body).toStrictEqual(response.body);
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url: vm0FallbackReturnUrl,
+        cancel_url: vm0FallbackReturnUrl,
+      }),
+    );
     context.mocks.stripe.checkout.sessions.create.mockClear();
     const explicitResponse = await accept(
       client.create({

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-restore.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-restore.test.ts
@@ -273,7 +273,8 @@ describe("POST /api/zero/billing/restore", () => {
   it("uses the request brand fallback and preserves an explicit return URL when restore requires a payment method", async () => {
     const subId = `sub-restore-card-${randomUUID().slice(0, 8)}`;
     const customerId = `cus-restore-card-${randomUUID().slice(0, 8)}`;
-    const fallbackReturnUrl = "https://app.okou.ai";
+    const okouFallbackReturnUrl = "https://app.okou.ai";
+    const vm0FallbackReturnUrl = "https://app.vm0.ai";
     const explicitReturnUrl = "https://app.vm0.ai/settings/billing";
     const checkoutUrl = "https://checkout.stripe.com/setup/restore";
     const fixture = await track(
@@ -327,8 +328,8 @@ describe("POST /api/zero/billing/restore", () => {
       mode: "setup",
       customer: customerId,
       currency: "usd",
-      success_url: fallbackReturnUrl,
-      cancel_url: fallbackReturnUrl,
+      success_url: okouFallbackReturnUrl,
+      cancel_url: okouFallbackReturnUrl,
       metadata: {
         purpose: "billing_restore",
         orgId: fixture.orgId,
@@ -342,6 +343,22 @@ describe("POST /api/zero/billing/restore", () => {
         },
       },
     });
+    context.mocks.stripe.checkout.sessions.create.mockClear();
+    const vm0Response = await accept(
+      client.create({
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+        extraHeaders: { origin: "https://app.vm0.ai" },
+      }),
+      [200],
+    );
+    expect(vm0Response.body).toStrictEqual(response.body);
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url: vm0FallbackReturnUrl,
+        cancel_url: vm0FallbackReturnUrl,
+      }),
+    );
     context.mocks.stripe.checkout.sessions.create.mockClear();
     const explicitResponse = await accept(
       client.create({

--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -87,10 +87,12 @@ function client() {
   return setupApp({ context, routes: browserRoutes })(zeroBrowserContract);
 }
 
-function authorizationClient() {
-  return setupApp({ context, routes: browserAuthorizationRoutes })(
-    zeroBrowserAuthorizationRequestsContract,
-  );
+function authorizationClient(baseUrl = "http://api.test") {
+  return setupApp({
+    baseUrl,
+    context,
+    routes: browserAuthorizationRoutes,
+  })(zeroBrowserAuthorizationRequestsContract);
 }
 
 function chatThreadsClient() {
@@ -409,7 +411,7 @@ describe("okou browser route", () => {
     });
   });
 
-  it("lets an agent request cloud browser access for its chat thread", async () => {
+  it("uses the run token brand for browser access requested through the Okou API", async () => {
     const { routeMocks, runs, chat, actor, agent } =
       await setupBrowserScenario();
     const sent = await chat.requestSendEvent(
@@ -434,24 +436,42 @@ describe("okou browser route", () => {
     expect(new URL(legacyCreated.body.authorizationUrl).origin).toBe(
       "https://app.vm0.ai",
     );
-    const runToken = runs.zeroTokenForRunWithCapabilities(
+    const vm0RunToken = runs.zeroTokenForRunWithCapabilities(
+      actor,
+      sent.body.runId,
+      [],
+      "vm0",
+    );
+    const vm0CreatedOnOkouApi = await accept(
+      authorizationClient("https://api.okou.ai").create({
+        headers: { authorization: `Bearer ${vm0RunToken}` },
+        body: {},
+      }),
+      [200],
+    );
+    expect(new URL(vm0CreatedOnOkouApi.body.authorizationUrl).origin).toBe(
+      "https://app.vm0.ai",
+    );
+    const okouRunToken = runs.zeroTokenForRunWithCapabilities(
       actor,
       sent.body.runId,
       [],
       "okou",
     );
-    const created = await accept(
-      authorizationClient().create({
-        headers: { authorization: `Bearer ${runToken}` },
+    const createdOnOkouApi = await accept(
+      authorizationClient("https://api.okou.ai").create({
+        headers: { authorization: `Bearer ${okouRunToken}` },
         body: {},
       }),
       [200],
     );
-    expect(new URL(created.body.authorizationUrl).origin).toBe(
+    expect(new URL(createdOnOkouApi.body.authorizationUrl).origin).toBe(
       "https://app.okou.ai",
     );
     const requestToken = decodeURIComponent(
-      new URL(created.body.authorizationUrl).pathname.split("/").at(-1) ?? "",
+      new URL(createdOnOkouApi.body.authorizationUrl).pathname
+        .split("/")
+        .at(-1) ?? "",
     );
     expect(requestToken).toMatch(/^vm0_browser_authorization_request_/u);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -3916,165 +3916,184 @@ describe("CHAT-02: chat output extraction and progress callbacks", () => {
 });
 
 describe("CHAT-02: drain-time admission failure", () => {
-  it("terminalizes a queued Web message when credits are lost before drain", async () => {
-    mockEnv("APP_URL", "https://app.vm0.ai");
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped Web chat actor");
-    }
-    const startedAt = now();
-    mockNow(startedAt);
-    onTestFinished(() => {
-      clearMockNow();
-    });
-    chatCallbacks.failIfChatCallbackRouteIsFetched();
+  it.each([
+    {
+      publicBrand: "okou",
+      anchorBrand: "vm0",
+      expectedUrl: "https://app.okou.ai/?settings=billing&billingView=credits",
+      otherOrigin: "https://app.vm0.ai",
+    },
+    {
+      publicBrand: "vm0",
+      anchorBrand: "okou",
+      expectedUrl: "https://app.vm0.ai/?settings=billing&billingView=credits",
+      otherOrigin: "https://app.okou.ai",
+    },
+  ] as const)(
+    "terminalizes a queued $publicBrand Web message when credits are lost before drain",
+    async ({ publicBrand, anchorBrand, expectedUrl, otherOrigin }) => {
+      mockEnv("APP_URL", "https://app.vm0.ai");
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      if (!actor.orgId) {
+        throw new Error("Expected an org-scoped Web chat actor");
+      }
+      const startedAt = now();
+      mockNow(startedAt);
+      onTestFinished(() => {
+        clearMockNow();
+      });
+      chatCallbacks.failIfChatCallbackRouteIsFetched();
 
-    const anchor = await startChatRun(
-      actor,
-      {
-        agentId,
-        prompt: "finish after queued Web credit loss",
-      },
-      { publicBrand: "okou" },
-    );
-    const anchorHeaders = await claimChatRun(runnerGroup, anchor.runId);
-    const queuedEventId = randomUUID();
-    const queuedPrompt = "reject this queued Web message after credit loss";
-    const queued = await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: anchor.threadId,
-        prompt: queuedPrompt,
-        clientEventId: queuedEventId,
-      },
-      [201],
-      undefined,
-      "vm0",
-    );
-    if ("error" in queued.body) {
-      throw new Error(queued.body.error.message);
-    }
-    expect(queued.body.runId).toBeNull();
-
-    await seedOrgMetadata({
-      orgId: actor.orgId,
-      tier: "pro-suspend",
-      credits: 0,
-    });
-    await upsertOrgPlanEntitlementFixture({
-      orgId: actor.orgId,
-      status: "suspended",
-      canBuyCredits: true,
-    });
-    context.mocks.ably.publish.mockClear();
-    context.mocks.ably.publish.mockRejectedValue(
-      new Error("Injected queued Web admission realtime failure"),
-    );
-
-    await completeChatRunOk(anchor.runId, anchorHeaders);
-    await flushWaitUntilForTest();
-    context.mocks.ably.publish.mockResolvedValue(undefined);
-    const terminal = await waitForThreadMessages(
-      actor,
-      anchor.threadId,
-      (events) => {
-        return (
-          userMessages(events).some((event) => {
-            return (
-              event.eventType === "input.rejected" &&
-              event.revokesEventId === queuedEventId &&
-              event.error === "insufficient_credits"
-            );
-          }) &&
-          assistantMessages(events).some((event) => {
-            return (
-              event.eventType === "output.error" &&
-              event.error === "insufficient_credits"
-            );
-          })
-        );
-      },
-    );
-    const original = userMessages(terminal.events).find((event) => {
-      return event.id === queuedEventId;
-    });
-    expect(original).toMatchObject({
-      eventType: "input.prompt",
-    });
-    expect(original ? chatEventDisplayText(original) : null).toBe(queuedPrompt);
-    const replacements = userMessages(terminal.events).filter((event) => {
-      return event.revokesEventId === queuedEventId;
-    });
-    expect(replacements).toStrictEqual([
-      expect.objectContaining({
-        eventType: "input.rejected",
-        error: "insufficient_credits",
-      }),
-    ]);
-    const errors = assistantMessages(terminal.events).filter((event) => {
-      return (
-        event.eventType === "output.error" &&
-        event.error === "insufficient_credits"
+      const anchor = await startChatRun(
+        actor,
+        {
+          agentId,
+          prompt: "finish after queued Web credit loss",
+        },
+        { publicBrand: anchorBrand },
       );
-    });
-    expect(errors).toHaveLength(1);
-    expect(errors[0]?.content).toContain("Add credits");
-    expect(errors[0]?.content).toContain(
-      "https://app.vm0.ai/?settings=billing&billingView=credits",
-    );
-    expect(errors[0]?.content).not.toContain("https://app.okou.ai");
-    expect(
-      (await api.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
-        return run.prompt === queuedPrompt;
-      }),
-    ).toHaveLength(0);
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      `chatThreadMessageCreated:${anchor.threadId}`,
-      null,
-    );
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      "threadListChanged",
-      null,
-    );
-    mockNow(startedAt + CANCELLATION_RECOVERY_STALE_AFTER_MS + 1);
-    await reconcileCancellationRecoveryFixtures(anchor.threadId);
-    const retried = await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: anchor.threadId,
-        prompt: queuedPrompt,
-        clientEventId: queuedEventId,
-      },
-      [201],
-    );
-    if ("error" in retried.body) {
-      throw new Error(retried.body.error.message);
-    }
-    expect(retried.body.runId).toBeNull();
-    await flushWaitUntilForTest();
+      const anchorHeaders = await claimChatRun(runnerGroup, anchor.runId);
+      const queuedEventId = randomUUID();
+      const queuedPrompt = "reject this queued Web message after credit loss";
+      const queued = await chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          threadId: anchor.threadId,
+          prompt: queuedPrompt,
+          clientEventId: queuedEventId,
+        },
+        [201],
+        undefined,
+        publicBrand,
+      );
+      if ("error" in queued.body) {
+        throw new Error(queued.body.error.message);
+      }
+      expect(queued.body.runId).toBeNull();
 
-    const afterRecovery = await chat.listThreadEvents(actor, anchor.threadId);
-    expect(
-      userMessages(afterRecovery.events).filter((event) => {
+      await seedOrgMetadata({
+        orgId: actor.orgId,
+        tier: "pro-suspend",
+        credits: 0,
+      });
+      await upsertOrgPlanEntitlementFixture({
+        orgId: actor.orgId,
+        status: "suspended",
+        canBuyCredits: true,
+      });
+      context.mocks.ably.publish.mockClear();
+      context.mocks.ably.publish.mockRejectedValue(
+        new Error("Injected queued Web admission realtime failure"),
+      );
+
+      await completeChatRunOk(anchor.runId, anchorHeaders);
+      await flushWaitUntilForTest();
+      context.mocks.ably.publish.mockResolvedValue(undefined);
+      const terminal = await waitForThreadMessages(
+        actor,
+        anchor.threadId,
+        (events) => {
+          return (
+            userMessages(events).some((event) => {
+              return (
+                event.eventType === "input.rejected" &&
+                event.revokesEventId === queuedEventId &&
+                event.error === "insufficient_credits"
+              );
+            }) &&
+            assistantMessages(events).some((event) => {
+              return (
+                event.eventType === "output.error" &&
+                event.error === "insufficient_credits"
+              );
+            })
+          );
+        },
+      );
+      const original = userMessages(terminal.events).find((event) => {
+        return event.id === queuedEventId;
+      });
+      expect(original).toMatchObject({
+        eventType: "input.prompt",
+      });
+      expect(original ? chatEventDisplayText(original) : null).toBe(
+        queuedPrompt,
+      );
+      const replacements = userMessages(terminal.events).filter((event) => {
         return event.revokesEventId === queuedEventId;
-      }),
-    ).toHaveLength(1);
-    expect(
-      assistantMessages(afterRecovery.events).filter((event) => {
+      });
+      expect(replacements).toStrictEqual([
+        expect.objectContaining({
+          eventType: "input.rejected",
+          error: "insufficient_credits",
+        }),
+      ]);
+      const errors = assistantMessages(terminal.events).filter((event) => {
         return (
           event.eventType === "output.error" &&
           event.error === "insufficient_credits"
         );
-      }),
-    ).toHaveLength(1);
-    expect(
-      (await api.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
-        return run.prompt === queuedPrompt;
-      }),
-    ).toHaveLength(0);
-  }, 90_000);
+      });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.content).toContain("Add credits");
+      expect(errors[0]?.content).toContain(expectedUrl);
+      expect(errors[0]?.content).not.toContain(otherOrigin);
+      expect(
+        (await api.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
+          return run.prompt === queuedPrompt;
+        }),
+      ).toHaveLength(0);
+      expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+        `chatThreadMessageCreated:${anchor.threadId}`,
+        null,
+      );
+      expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+        "threadListChanged",
+        null,
+      );
+      mockNow(startedAt + CANCELLATION_RECOVERY_STALE_AFTER_MS + 1);
+      await reconcileCancellationRecoveryFixtures(anchor.threadId);
+      const retried = await chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          threadId: anchor.threadId,
+          prompt: queuedPrompt,
+          clientEventId: queuedEventId,
+        },
+        [201],
+        undefined,
+        publicBrand,
+      );
+      if ("error" in retried.body) {
+        throw new Error(retried.body.error.message);
+      }
+      expect(retried.body.runId).toBeNull();
+      await flushWaitUntilForTest();
+
+      const afterRecovery = await chat.listThreadEvents(actor, anchor.threadId);
+      expect(
+        userMessages(afterRecovery.events).filter((event) => {
+          return event.revokesEventId === queuedEventId;
+        }),
+      ).toHaveLength(1);
+      expect(
+        assistantMessages(afterRecovery.events).filter((event) => {
+          return (
+            event.eventType === "output.error" &&
+            event.error === "insufficient_credits"
+          );
+        }),
+      ).toHaveLength(1);
+      expect(
+        (await api.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
+          return run.prompt === queuedPrompt;
+        }),
+      ).toHaveLength(0);
+    },
+    90_000,
+  );
 });
 
 describe("CHAT-02: failed chat callbacks", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -3950,7 +3950,7 @@ describe("CHAT-02: drain-time admission failure", () => {
       },
       [201],
       undefined,
-      "okou",
+      "vm0",
     );
     if ("error" in queued.body) {
       throw new Error(queued.body.error.message);
@@ -4021,9 +4021,9 @@ describe("CHAT-02: drain-time admission failure", () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]?.content).toContain("Add credits");
     expect(errors[0]?.content).toContain(
-      "https://app.okou.ai/?settings=billing&billingView=credits",
+      "https://app.vm0.ai/?settings=billing&billingView=credits",
     );
-    expect(errors[0]?.content).not.toContain("https://app.vm0.ai");
+    expect(errors[0]?.content).not.toContain("https://app.okou.ai");
     expect(
       (await api.listAgentRuns(actor, { limit: 20 })).runs.filter((run) => {
         return run.prompt === queuedPrompt;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -8523,108 +8523,140 @@ describe("CHAT-02: public-brand default assistant identity", () => {
       throw new Error("Expected the system default agent to exist");
     }
 
-    const okouAnchor = await sendChatRun(
-      actor,
-      { agentId: defaultAgentId, prompt: "start an Okou-branded run" },
-      "okou",
-    );
-    const okouAnchorRun = await api.readRun(actor, okouAnchor.runId);
-    expect(okouAnchorRun.appendSystemPrompt).toContain("Your name is Okou.");
-    expect(okouAnchorRun.appendSystemPrompt).not.toContain(
-      "Your name is Zero.",
-    );
-
-    const anchorClaim = await claimChatRun(runnerGroup, okouAnchor.runId);
-    await expectRunPublicBrandTransport({
-      actor,
-      runId: okouAnchor.runId,
-      claim: anchorClaim.claim,
-      publicBrand: "okou",
-      appUrl: "https://app.okou.ai",
-    });
-    const queuedEventId = randomUUID();
-    const queued = await chat.requestSendEvent(
-      actor,
+    const brandPresentation = {
+      vm0: {
+        assistantName: "Zero",
+        otherAssistantName: "Okou",
+        appUrl: "https://app.vm0.ai",
+        contextId: "e1884e98-ab77-4eca-a420-90e591078804",
+      },
+      okou: {
+        assistantName: "Okou",
+        otherAssistantName: "Zero",
+        appUrl: "https://app.okou.ai",
+        contextId: "0bdfae9e-63be-43dd-8193-a96e07787c20",
+      },
+    } satisfies Record<
+      PublicBrand,
       {
-        agentId: defaultAgentId,
-        threadId: okouAnchor.threadId,
-        prompt: "continue from the VM0 domain",
-        clientEventId: queuedEventId,
-      },
-      [201],
-      undefined,
-      "vm0",
-    );
-    if (queued.status !== 201) {
-      throw new Error("Expected the VM0 follow-up to enter the chat queue");
-    }
-    expect(queued.body.runId).toBeNull();
+        readonly assistantName: string;
+        readonly otherAssistantName: string;
+        readonly appUrl: string;
+        readonly contextId: string;
+      }
+    >;
 
-    const rawQueuedEvent = (
-      await chat.listThreadEventRows(actor, okouAnchor.threadId)
-    ).find((event) => {
-      return event.id === queuedEventId;
-    });
-    if (!rawQueuedEvent) {
-      throw new Error("Expected the queued VM0 event in Raw Events");
-    }
-    expect(rawQueuedEvent).toMatchObject({
-      contextType: "web",
-      contextId: "e1884e98-ab77-4eca-a420-90e591078804",
-    });
-    // The previous strict raw-row reader accepts this event because the new
-    // context uses existing outer fields and does not widen payload JSONB.
-    expect(rawQueuedEvent.payload).not.toHaveProperty("publicBrand");
+    const expectCrossBrandQueuedRun = async (
+      anchorBrand: PublicBrand,
+      queuedBrand: PublicBrand,
+    ): Promise<void> => {
+      const anchorPresentation = brandPresentation[anchorBrand];
+      const queuedPresentation = brandPresentation[queuedBrand];
+      const anchor = await sendChatRun(
+        actor,
+        {
+          agentId: defaultAgentId,
+          prompt: `start a ${anchorBrand}-branded run`,
+        },
+        anchorBrand,
+      );
+      const anchorRun = await api.readRun(actor, anchor.runId);
+      expect(anchorRun.appendSystemPrompt).toContain(
+        `Your name is ${anchorPresentation.assistantName}.`,
+      );
+      expect(anchorRun.appendSystemPrompt).not.toContain(
+        `Your name is ${anchorPresentation.otherAssistantName}.`,
+      );
 
-    chatCallbacks.mockChatOutputEvents([]);
-    await completeChatRunOk(okouAnchor.runId, anchorClaim.sandboxHeaders);
-    await flushWaitUntilForTest();
-    const promotedMessages = await waitForThreadMessages(
-      actor,
-      okouAnchor.threadId,
-      (items) => {
-        return userMessages(items).some((message) => {
-          return (
-            message.revokesEventId === queuedEventId &&
-            message.runId !== undefined
-          );
-        });
-      },
-    );
-    const promoted = userMessages(promotedMessages.events).find((message) => {
-      return message.revokesEventId === queuedEventId;
-    });
-    if (!promoted?.runId) {
-      throw new Error("Expected the queued VM0 message to auto-send");
-    }
-    const promotedRun = await api.readRun(actor, promoted.runId);
-    expect(promotedRun.appendSystemPrompt).toContain("Your name is Zero.");
-    expect(promotedRun.appendSystemPrompt).not.toContain("Your name is Okou.");
-    const promotedClaim = await claimChatRun(runnerGroup, promoted.runId);
-    await expectRunPublicBrandTransport({
-      actor,
-      runId: promoted.runId,
-      claim: promotedClaim.claim,
-      publicBrand: "vm0",
-      appUrl: "https://app.vm0.ai",
-    });
-    await cancelChatRun(actor, promoted.runId);
+      const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
+      await expectRunPublicBrandTransport({
+        actor,
+        runId: anchor.runId,
+        claim: anchorClaim.claim,
+        publicBrand: anchorBrand,
+        appUrl: anchorPresentation.appUrl,
+      });
+      const queuedEventId = randomUUID();
+      const queued = await chat.requestSendEvent(
+        actor,
+        {
+          agentId: defaultAgentId,
+          threadId: anchor.threadId,
+          prompt: `continue from the ${queuedBrand} domain`,
+          clientEventId: queuedEventId,
+        },
+        [201],
+        undefined,
+        queuedBrand,
+      );
+      if (queued.status !== 201) {
+        throw new Error(
+          `Expected the ${queuedBrand} follow-up to enter the chat queue`,
+        );
+      }
+      expect(queued.body.runId).toBeNull();
 
-    const vm0Run = await sendChatRun(actor, {
-      agentId: defaultAgentId,
-      prompt: "start a VM0-branded run",
-    });
-    expect(
-      (await api.readRun(actor, vm0Run.runId)).appendSystemPrompt,
-    ).toContain("Your name is Zero.");
-    const vm0Claim = await claimChatRun(runnerGroup, vm0Run.runId);
-    await expectRunPublicBrandTransport({
-      actor,
-      runId: vm0Run.runId,
-      claim: vm0Claim.claim,
-      publicBrand: "vm0",
-      appUrl: "https://app.vm0.ai",
-    });
+      const rawQueuedEvent = (
+        await chat.listThreadEventRows(actor, anchor.threadId)
+      ).find((event) => {
+        return event.id === queuedEventId;
+      });
+      if (!rawQueuedEvent) {
+        throw new Error(
+          `Expected the queued ${queuedBrand} event in Raw Events`,
+        );
+      }
+      expect(rawQueuedEvent).toMatchObject({
+        contextType: "web",
+        contextId: queuedPresentation.contextId,
+      });
+      // The previous strict raw-row reader accepts this event because the new
+      // context uses existing outer fields and does not widen payload JSONB.
+      expect(rawQueuedEvent.payload).not.toHaveProperty("publicBrand");
+
+      chatCallbacks.mockChatOutputEvents([]);
+      await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+      await flushWaitUntilForTest();
+      const promotedMessages = await waitForThreadMessages(
+        actor,
+        anchor.threadId,
+        (items) => {
+          return userMessages(items).some((message) => {
+            return (
+              message.revokesEventId === queuedEventId &&
+              message.runId !== undefined
+            );
+          });
+        },
+      );
+      const promoted = userMessages(promotedMessages.events).find((message) => {
+        return message.revokesEventId === queuedEventId;
+      });
+      if (!promoted?.runId) {
+        throw new Error(
+          `Expected the queued ${queuedBrand} message to auto-send`,
+        );
+      }
+      const promotedRun = await api.readRun(actor, promoted.runId);
+      expect(promotedRun.appendSystemPrompt).toContain(
+        `Your name is ${queuedPresentation.assistantName}.`,
+      );
+      expect(promotedRun.appendSystemPrompt).not.toContain(
+        `Your name is ${queuedPresentation.otherAssistantName}.`,
+      );
+      const promotedClaim = await claimChatRun(runnerGroup, promoted.runId);
+      await expectRunPublicBrandTransport({
+        actor,
+        runId: promoted.runId,
+        claim: promotedClaim.claim,
+        publicBrand: queuedBrand,
+        appUrl: queuedPresentation.appUrl,
+      });
+      await cancelChatRun(actor, promoted.runId);
+    };
+
+    await expectCrossBrandQueuedRun("okou", "vm0");
+    await expectCrossBrandQueuedRun("vm0", "okou");
 
     mockEnv("APP_URL", "https://preview.example.test");
     const customZero = await bdd.createAgent(actor, {
@@ -8649,7 +8681,6 @@ describe("CHAT-02: public-brand default assistant identity", () => {
       appUrl: "https://preview.example.test",
     });
 
-    await cancelChatRun(actor, vm0Run.runId);
     await cancelChatRun(actor, customRun.runId);
   }, 90_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -3314,7 +3314,7 @@ describe("CHAT-02: dispatch failure", () => {
 });
 
 describe("CHAT-02: admission without spendable credits", () => {
-  it("blocks admission for model-first sends through visible chat messages", async () => {
+  it("blocks admission with request-branded guidance through visible chat messages", async () => {
     mockEnv("APP_URL", "https://app.vm0.ai");
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
@@ -3438,6 +3438,34 @@ describe("CHAT-02: admission without spendable credits", () => {
     expect(retry.body).toStrictEqual(sent.body);
     const afterRetry = await chat.listThreadEvents(actor, sent.body.threadId);
     expect(afterRetry.events).toHaveLength(3);
+
+    const vm0Sent = await chat.requestSendEvent(
+      actor,
+      {
+        ...sendBody,
+        prompt: "blocked from the VM0 domain",
+        clientEventId: randomUUID(),
+      },
+      [201],
+    );
+    if (vm0Sent.status !== 201) {
+      throw new Error("Expected the VM0 blocked send to return 201");
+    }
+    expect(vm0Sent.body.runId).toBeNull();
+    const vm0Messages = await chat.listThreadEvents(
+      actor,
+      vm0Sent.body.threadId,
+    );
+    const vm0Guidance = assistantMessages(vm0Messages.events).find(
+      (message) => {
+        return message.eventType === "output.error";
+      },
+    );
+    if (!vm0Guidance) {
+      throw new Error("Expected VM0 insufficient-credits guidance");
+    }
+    expect(vm0Guidance.content).toContain("https://app.vm0.ai/?settings=usage");
+    expect(vm0Guidance.content).not.toContain("https://app.okou.ai");
   }, 60_000);
 });
 
@@ -8485,7 +8513,7 @@ describe("CHAT-02: queued attachments on auto-send", () => {
 });
 
 describe("CHAT-02: public-brand default assistant identity", () => {
-  it("uses the request brand for immediate and auto-sent runs without renaming custom agents", async () => {
+  it("uses each request brand for immediate and auto-sent runs without renaming custom agents", async () => {
     mockEnv("APP_URL", "https://app.vm0.ai");
     const { actor, runnerGroup } = await entitledChatActor();
     bdd.acceptAgentStorageWrites();
@@ -8520,15 +8548,15 @@ describe("CHAT-02: public-brand default assistant identity", () => {
       {
         agentId: defaultAgentId,
         threadId: okouAnchor.threadId,
-        prompt: "continue from the Okou domain",
+        prompt: "continue from the VM0 domain",
         clientEventId: queuedEventId,
       },
       [201],
       undefined,
-      "okou",
+      "vm0",
     );
     if (queued.status !== 201) {
-      throw new Error("Expected the Okou follow-up to enter the chat queue");
+      throw new Error("Expected the VM0 follow-up to enter the chat queue");
     }
     expect(queued.body.runId).toBeNull();
 
@@ -8538,11 +8566,11 @@ describe("CHAT-02: public-brand default assistant identity", () => {
       return event.id === queuedEventId;
     });
     if (!rawQueuedEvent) {
-      throw new Error("Expected the queued Okou event in Raw Events");
+      throw new Error("Expected the queued VM0 event in Raw Events");
     }
     expect(rawQueuedEvent).toMatchObject({
       contextType: "web",
-      contextId: "0bdfae9e-63be-43dd-8193-a96e07787c20",
+      contextId: "e1884e98-ab77-4eca-a420-90e591078804",
     });
     // The previous strict raw-row reader accepts this event because the new
     // context uses existing outer fields and does not widen payload JSONB.
@@ -8567,18 +8595,18 @@ describe("CHAT-02: public-brand default assistant identity", () => {
       return message.revokesEventId === queuedEventId;
     });
     if (!promoted?.runId) {
-      throw new Error("Expected the queued Okou message to auto-send");
+      throw new Error("Expected the queued VM0 message to auto-send");
     }
     const promotedRun = await api.readRun(actor, promoted.runId);
-    expect(promotedRun.appendSystemPrompt).toContain("Your name is Okou.");
-    expect(promotedRun.appendSystemPrompt).not.toContain("Your name is Zero.");
+    expect(promotedRun.appendSystemPrompt).toContain("Your name is Zero.");
+    expect(promotedRun.appendSystemPrompt).not.toContain("Your name is Okou.");
     const promotedClaim = await claimChatRun(runnerGroup, promoted.runId);
     await expectRunPublicBrandTransport({
       actor,
       runId: promoted.runId,
       claim: promotedClaim.claim,
-      publicBrand: "okou",
-      appUrl: "https://app.okou.ai",
+      publicBrand: "vm0",
+      appUrl: "https://app.vm0.ai",
     });
     await cancelChatRun(actor, promoted.runId);
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -3313,12 +3313,14 @@ describe("chat event action cards", () => {
     expect(screen.queryByTestId("connector-action-card")).toBeNull();
   });
 
-  it("renders delegated computer use authorization links as action cards", async () => {
+  it("keeps a persisted Okou computer use authorization local on VM0", async () => {
+    const threadId = "e4000000-0000-4000-a000-000000000020";
+    context.mocks.browser.url(`https://app.vm0.ai/chats/${threadId}`);
     const authorizationUrl =
-      "https://app.vm0.ai/computer-use/authorize/vm0_computer_use_authorization_request_test";
+      "https://app.okou.ai/computer-use/authorize/vm0_computer_use_authorization_request_test";
 
     mockChatLifecycle(context, {
-      threadId: "e4000000-0000-4000-a000-000000000020",
+      threadId,
       threadTitle: "Computer Use authorization card",
       chatEvents: [
         {
@@ -3340,7 +3342,7 @@ describe("chat event action cards", () => {
 
     detachedSetupPage({
       context,
-      path: "/chats/e4000000-0000-4000-a000-000000000020",
+      path: `/chats/${threadId}`,
     });
 
     const card = await screen.findByTestId("computer-use-authorization-card");
@@ -4306,9 +4308,10 @@ describe("chat event action cards", () => {
     });
   });
 
-  it("renders current-thread browser links as cards and keeps other browser links", async () => {
+  it("renders persisted VM0 browser links as cards on Okou and keeps other browser links", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "c0000000-0000-4000-a000-000000000080";
+    context.mocks.browser.url(`https://app.okou.ai/chats/${threadId}`);
     const otherThreadId = "c0000000-0000-4000-a000-000000000079";
     const liveUrl =
       "https://live.browser-use.com/?wss=test-browser-session-token";


### PR DESCRIPTION
## Summary

- verify that run-scoped browser authorization URLs follow the signed token brand even when both requests use `api.okou.ai`
- cover VM0 and Okou brand provenance for immediate credit guidance, queued runs, callback failures, and billing fallback URLs
- extend page-level historical link coverage across computer use and browser actions on the opposite app domain

This is a test-only change. It does not change production routing or user-visible behavior.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- targeted API browser authorization, credit guidance, and billing tests
- targeted Platform cross-brand action-card matrix
