### PR TITLE
refactor(contracts): neutralize email banking and agentphone contract naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/banking.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/banking.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type { ZeroCapability } from "@okouai/api-contracts/contracts/capabilities";
 import type { TriggerSource } from "@okouai/api-contracts/contracts/logs";
-import { zeroBankingContract } from "@okouai/api-contracts/contracts/zero-banking";
+import { bankingContract } from "@okouai/api-contracts/contracts/banking";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { beforeEach } from "vitest";
@@ -209,7 +209,7 @@ describe("POST /api/zero/banking/*", () => {
     );
 
     const client = setupApp({ context, routes: bankingRoutes })(
-      zeroBankingContract,
+      bankingContract,
     );
     const response = await accept(
       client.accounts({
@@ -262,7 +262,7 @@ describe("POST /api/zero/banking/*", () => {
     );
 
     const client = setupApp({ context, routes: bankingRoutes })(
-      zeroBankingContract,
+      bankingContract,
     );
     const response = await accept(
       client.accounts({
@@ -318,7 +318,7 @@ describe("POST /api/zero/banking/*", () => {
     );
 
     const client = setupApp({ context, routes: bankingRoutes })(
-      zeroBankingContract,
+      bankingContract,
     );
     const response = await accept(
       client.balances({
@@ -366,7 +366,7 @@ describe("POST /api/zero/banking/*", () => {
     );
 
     const client = setupApp({ context, routes: bankingRoutes })(
-      zeroBankingContract,
+      bankingContract,
     );
     const response = await accept(
       client.balances({
@@ -410,7 +410,7 @@ describe("POST /api/zero/banking/*", () => {
     );
 
     const client = setupApp({ context, routes: bankingRoutes })(
-      zeroBankingContract,
+      bankingContract,
     );
     const response = await accept(
       client.accounts({
@@ -444,7 +444,7 @@ describe("POST /api/zero/banking/*", () => {
       );
 
       const client = setupApp({ context, routes: bankingRoutes })(
-        zeroBankingContract,
+        bankingContract,
       );
       const response = await accept(
         client.accounts({
@@ -486,7 +486,7 @@ describe("POST /api/zero/banking/*", () => {
       );
 
       const client = setupApp({ context, routes: bankingRoutes })(
-        zeroBankingContract,
+        bankingContract,
       );
       const response = await accept(
         client.accounts({
@@ -522,7 +522,7 @@ describe("POST /api/zero/banking/*", () => {
     );
 
     const client = setupApp({ context, routes: bankingRoutes })(
-      zeroBankingContract,
+      bankingContract,
     );
     const response = await accept(
       client.accounts({
@@ -575,7 +575,7 @@ describe("POST /api/zero/banking/*", () => {
     );
 
     const client = setupApp({ context, routes: bankingRoutes })(
-      zeroBankingContract,
+      bankingContract,
     );
     const response = await accept(
       client.transactions({

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import type StripeSDK from "stripe";
 import { testUsageSettlementContract } from "@okouai/api-contracts/contracts/test-usage-settlement";
 import { acquisitionAttributionContract } from "@okouai/api-contracts/contracts/acquisition-attribution";
-import { zeroBankingContract } from "@okouai/api-contracts/contracts/zero-banking";
+import { bankingContract } from "@okouai/api-contracts/contracts/banking";
 import {
   zeroBillingAutoRechargeContract,
   zeroBillingCheckoutContract,
@@ -822,7 +822,7 @@ export function createBillingMediaApi(context: TestContext) {
       statuses: readonly (200 | 400 | 401 | 403 | 502 | 503)[],
     ) {
       const client = setupApp({ context, routes: bankingRoutes })(
-        zeroBankingContract,
+        bankingContract,
       );
       return await accept(
         client.accounts({ headers: authenticate(actor), body: {} }),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -37,7 +37,7 @@ import {
 import type { SupportedRunModel } from "@okouai/api-contracts/contracts/model-providers";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { testSlackStateContract } from "@okouai/api-contracts/contracts/test-slack-state";
-import { zeroIntegrationsAgentPhoneContract } from "@okouai/api-contracts/contracts/zero-integrations-agentphone";
+import { integrationsAgentPhoneContract } from "@okouai/api-contracts/contracts/integrations-agentphone";
 import { zeroIntegrationsSlackContract } from "@okouai/api-contracts/contracts/zero-integrations-slack";
 import { zeroIntegrationsTelegramContract } from "@okouai/api-contracts/contracts/zero-integrations-telegram";
 import { zeroFeatureSwitchesContract } from "@okouai/api-contracts/contracts/zero-feature-switches";
@@ -1671,7 +1671,7 @@ export function createBddIntegrationApi(context: TestContext) {
       const client = setupApp({
         context,
         routes: integrationsAgentPhoneRoutes,
-      })(zeroIntegrationsAgentPhoneContract);
+      })(integrationsAgentPhoneContract);
       const response = await accept(
         client.getLinkStatus({
           headers: authenticate(context, routeMocks, actor),
@@ -1689,7 +1689,7 @@ export function createBddIntegrationApi(context: TestContext) {
       const client = setupApp({
         context,
         routes: integrationsAgentPhoneRoutes,
-      })(zeroIntegrationsAgentPhoneContract);
+      })(integrationsAgentPhoneContract);
       return await accept(
         client.startLink({
           headers: authenticate(context, routeMocks, actor),
@@ -1706,7 +1706,7 @@ export function createBddIntegrationApi(context: TestContext) {
       const client = setupApp({
         context,
         routes: integrationsAgentPhoneRoutes,
-      })(zeroIntegrationsAgentPhoneContract);
+      })(integrationsAgentPhoneContract);
       return await accept(
         client.unlink({
           headers: authenticate(context, routeMocks, actor),
@@ -1730,7 +1730,7 @@ export function createBddIntegrationApi(context: TestContext) {
       const client = setupApp({
         context,
         routes: integrationsAgentPhoneRoutes,
-      })(zeroIntegrationsAgentPhoneContract);
+      })(integrationsAgentPhoneContract);
       return await accept(
         client.connectAgentPhone({
           headers: authenticate(context, routeMocks, actor),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -1,6 +1,6 @@
 import { createHmac, randomUUID } from "node:crypto";
 
-import { zeroEmailInboundContract } from "@okouai/api-contracts/contracts/zero-email";
+import { emailInboundContract } from "@okouai/api-contracts/contracts/email";
 import {
   webhookBuiltInGenerationBytePlusContract,
   webhookBuiltInGenerationFalContract,
@@ -405,7 +405,7 @@ export function createWebhookCallbackApi(context: TestContext) {
     ) {
       return await accept(
         setupApp({ context, routes: emailInboundRoutes })(
-          zeroEmailInboundContract,
+          emailInboundContract,
         ).post({
           headers,
           body,

--- a/turbo/apps/api/src/signals/routes/banking.ts
+++ b/turbo/apps/api/src/signals/routes/banking.ts
@@ -1,4 +1,4 @@
-import { zeroBankingContract } from "@okouai/api-contracts/contracts/zero-banking";
+import { bankingContract } from "@okouai/api-contracts/contracts/banking";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { command } from "ccstate";
@@ -26,7 +26,7 @@ function zeroTokenRequired() {
   };
 }
 
-const zeroBankingDisabled = Object.freeze({
+const bankingDisabled = Object.freeze({
   status: 403 as const,
   body: Object.freeze({
     error: Object.freeze({
@@ -36,7 +36,7 @@ const zeroBankingDisabled = Object.freeze({
   }),
 });
 
-const zeroBankingEnabled$ = command(async ({ get }) => {
+const bankingEnabled$ = command(async ({ get }) => {
   const auth = get(organizationAuthContext$);
   const overrides = await get(
     userFeatureSwitchOverrides(auth.orgId, auth.userId),
@@ -48,17 +48,17 @@ const zeroBankingEnabled$ = command(async ({ get }) => {
   });
 });
 
-const accountsBody$ = bodyResultOf(zeroBankingContract.accounts);
-const balancesBody$ = bodyResultOf(zeroBankingContract.balances);
-const transactionsBody$ = bodyResultOf(zeroBankingContract.transactions);
+const accountsBody$ = bodyResultOf(bankingContract.accounts);
+const balancesBody$ = bodyResultOf(bankingContract.balances);
+const transactionsBody$ = bodyResultOf(bankingContract.transactions);
 
 const accountsInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   if (auth.tokenType !== "zero") {
     return zeroTokenRequired();
   }
-  if (!(await set(zeroBankingEnabled$))) {
-    return zeroBankingDisabled;
+  if (!(await set(bankingEnabled$))) {
+    return bankingDisabled;
   }
   signal.throwIfAborted();
 
@@ -76,8 +76,8 @@ const balancesInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (auth.tokenType !== "zero") {
     return zeroTokenRequired();
   }
-  if (!(await set(zeroBankingEnabled$))) {
-    return zeroBankingDisabled;
+  if (!(await set(bankingEnabled$))) {
+    return bankingDisabled;
   }
   signal.throwIfAborted();
 
@@ -96,8 +96,8 @@ const transactionsInner$ = command(
     if (auth.tokenType !== "zero") {
       return zeroTokenRequired();
     }
-    if (!(await set(zeroBankingEnabled$))) {
-      return zeroBankingDisabled;
+    if (!(await set(bankingEnabled$))) {
+      return bankingDisabled;
     }
     signal.throwIfAborted();
 
@@ -124,15 +124,15 @@ const bankingAuth = {
 
 export const bankingRoutes: readonly RouteEntry[] = [
   {
-    route: zeroBankingContract.accounts,
+    route: bankingContract.accounts,
     handler: authRoute(bankingAuth, accountsInner$),
   },
   {
-    route: zeroBankingContract.balances,
+    route: bankingContract.balances,
     handler: authRoute(bankingAuth, balancesInner$),
   },
   {
-    route: zeroBankingContract.transactions,
+    route: bankingContract.transactions,
     handler: authRoute(bankingAuth, transactionsInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/routes/email-inbound.ts
+++ b/turbo/apps/api/src/signals/routes/email-inbound.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { zeroEmailInboundContract } from "@okouai/api-contracts/contracts/zero-email";
+import { emailInboundContract } from "@okouai/api-contracts/contracts/email";
 import { emailSuppressions } from "@okouai/db/schema/email-suppression";
 
 import { request$ } from "../context/hono";
@@ -126,7 +126,7 @@ const handleInboundRoute$ = command(
 
 export const emailInboundRoutes: readonly RouteEntry[] = [
   {
-    route: zeroEmailInboundContract.post,
+    route: emailInboundContract.post,
     handler: handleInboundRoute$,
   },
 ];

--- a/turbo/apps/api/src/signals/routes/integrations-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-agentphone.ts
@@ -1,4 +1,4 @@
-import { zeroIntegrationsAgentPhoneContract } from "@okouai/api-contracts/contracts/zero-integrations-agentphone";
+import { integrationsAgentPhoneContract } from "@okouai/api-contracts/contracts/integrations-agentphone";
 import { agentphoneVerificationSendCooldowns } from "@okouai/db/schema/agentphone-verification-send-cooldown";
 import { agentphoneUserLinks } from "@okouai/db/schema/agentphone-user-link";
 import { publicBrandPresentation } from "@okouai/core/public-brand";
@@ -59,11 +59,9 @@ const agentPhoneAuthOptions = {
 const VERIFICATION_SEND_COOLDOWN_MS = 60_000;
 const log = logger("api:agentphone:link");
 
-const startLinkBody$ = bodyResultOf(
-  zeroIntegrationsAgentPhoneContract.startLink,
-);
+const startLinkBody$ = bodyResultOf(integrationsAgentPhoneContract.startLink);
 const connectBody$ = bodyResultOf(
-  zeroIntegrationsAgentPhoneContract.connectAgentPhone,
+  integrationsAgentPhoneContract.connectAgentPhone,
 );
 
 const webhookBodySchema = z.record(z.string(), z.unknown());
@@ -976,23 +974,23 @@ const webhook$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 export const integrationsAgentPhoneRoutes: readonly RouteEntry[] = [
   {
-    route: zeroIntegrationsAgentPhoneContract.connectAgentPhone,
+    route: integrationsAgentPhoneContract.connectAgentPhone,
     handler: authRoute(agentPhoneAuthOptions, connectAgentPhone$),
   },
   {
-    route: zeroIntegrationsAgentPhoneContract.webhook,
+    route: integrationsAgentPhoneContract.webhook,
     handler: webhook$,
   },
   {
-    route: zeroIntegrationsAgentPhoneContract.getLinkStatus,
+    route: integrationsAgentPhoneContract.getLinkStatus,
     handler: authRoute(agentPhoneAuthOptions, getLinkStatus$),
   },
   {
-    route: zeroIntegrationsAgentPhoneContract.startLink,
+    route: integrationsAgentPhoneContract.startLink,
     handler: authRoute(agentPhoneAuthOptions, startLink$),
   },
   {
-    route: zeroIntegrationsAgentPhoneContract.unlink,
+    route: integrationsAgentPhoneContract.unlink,
     handler: authRoute(agentPhoneAuthOptions, unlink$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/banking.service.ts
+++ b/turbo/apps/api/src/signals/services/banking.service.ts
@@ -1,13 +1,13 @@
 import type {
-  ZeroBankingAccount,
-  ZeroBankingAccountsResponse,
-  ZeroBankingBalance,
-  ZeroBankingBalancesRequest,
-  ZeroBankingBalancesResponse,
-  ZeroBankingTransaction,
-  ZeroBankingTransactionsRequest,
-  ZeroBankingTransactionsResponse,
-} from "@okouai/api-contracts/contracts/zero-banking";
+  BankingAccount,
+  BankingAccountsResponse,
+  BankingBalance,
+  BankingBalancesRequest,
+  BankingBalancesResponse,
+  BankingTransaction,
+  BankingTransactionsRequest,
+  BankingTransactionsResponse,
+} from "@okouai/api-contracts/contracts/banking";
 import {
   bankingAccessAuditEvents,
   bankingAccounts,
@@ -295,7 +295,7 @@ function providerTransactionId(
 function toBankingAccount(
   row: BankingAccountRow,
   providerAccount: Record<string, unknown> | undefined,
-): ZeroBankingAccount {
+): BankingAccount {
   return {
     id: row.providerAccountId,
     name: stringValue(providerAccount?.name) ?? row.displayName,
@@ -312,7 +312,7 @@ function toBankingAccount(
 function toBankingBalance(
   row: BankingAccountRow,
   providerAccount: Record<string, unknown>,
-): ZeroBankingBalance {
+): BankingBalance {
   return {
     accountId: row.providerAccountId,
     name: stringValue(providerAccount.name) ?? row.displayName,
@@ -327,7 +327,7 @@ function toBankingBalance(
 function toBankingTransaction(
   accountId: string,
   transaction: Record<string, unknown>,
-): ZeroBankingTransaction | null {
+): BankingTransaction | null {
   const id = providerTransactionId(transaction);
   if (!id) {
     return null;
@@ -623,7 +623,7 @@ export const bankingAccounts$ = command(
       return auth.response;
     }
     if (auth.access.accounts.length === 0) {
-      const body: ZeroBankingAccountsResponse = {
+      const body: BankingAccountsResponse = {
         operation: "accounts",
         provider: PROVIDER,
         accounts: [],
@@ -664,7 +664,7 @@ export const bankingAccounts$ = command(
         return id !== null && allowedAccountIds.has(id);
       },
     );
-    const body: ZeroBankingAccountsResponse = {
+    const body: BankingAccountsResponse = {
       operation: "accounts",
       provider: PROVIDER,
       accounts: auth.access.accounts.map((row) => {
@@ -692,7 +692,7 @@ export const bankingAccounts$ = command(
 export const bankingBalances$ = command(
   async (
     { set },
-    args: BankingGatewayArgs<ZeroBankingBalancesRequest>,
+    args: BankingGatewayArgs<BankingBalancesRequest>,
     signal: AbortSignal,
   ) => {
     const db = set(writeDb$);
@@ -729,7 +729,7 @@ export const bankingBalances$ = command(
       return badGateway("Finicity account was not found", "FINICITY_NOT_FOUND");
     }
 
-    const body: ZeroBankingBalancesResponse = {
+    const body: BankingBalancesResponse = {
       operation: "balances",
       provider: PROVIDER,
       balance: toBankingBalance(auth.access.account, providerAccount),
@@ -753,7 +753,7 @@ export const bankingBalances$ = command(
 export const bankingTransactions$ = command(
   async (
     { set },
-    args: BankingGatewayArgs<ZeroBankingTransactionsRequest>,
+    args: BankingGatewayArgs<BankingTransactionsRequest>,
     signal: AbortSignal,
   ) => {
     const db = set(writeDb$);
@@ -796,7 +796,7 @@ export const bankingTransactions$ = command(
       return providerResult;
     }
 
-    const body: ZeroBankingTransactionsResponse = {
+    const body: BankingTransactionsResponse = {
       operation: "transactions",
       provider: PROVIDER,
       accountId: args.body.accountId,

--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-agentphone.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-agentphone.ts
@@ -1,7 +1,7 @@
 import {
-  zeroIntegrationsAgentPhoneContract,
+  integrationsAgentPhoneContract,
   type AgentPhoneLinkStatusResponse,
-} from "@okouai/api-contracts/contracts/zero-integrations-agentphone";
+} from "@okouai/api-contracts/contracts/integrations-agentphone";
 import { mockApi } from "../msw-contract.ts";
 
 let mockAgentPhoneStatus: AgentPhoneLinkStatusResponse = {
@@ -33,11 +33,11 @@ function isValidAgentPhoneHandle(value: string): boolean {
 }
 
 export const apiIntegrationsAgentPhoneHandlers = [
-  mockApi(zeroIntegrationsAgentPhoneContract.getLinkStatus, ({ respond }) => {
+  mockApi(integrationsAgentPhoneContract.getLinkStatus, ({ respond }) => {
     return respond(200, mockAgentPhoneStatus);
   }),
 
-  mockApi(zeroIntegrationsAgentPhoneContract.startLink, ({ body, respond }) => {
+  mockApi(integrationsAgentPhoneContract.startLink, ({ body, respond }) => {
     const phoneHandle = normalizeAgentPhoneHandle(body.phoneHandle);
     if (!isValidAgentPhoneHandle(phoneHandle)) {
       return respond(400, {
@@ -53,7 +53,7 @@ export const apiIntegrationsAgentPhoneHandlers = [
     });
   }),
 
-  mockApi(zeroIntegrationsAgentPhoneContract.unlink, ({ respond }) => {
+  mockApi(integrationsAgentPhoneContract.unlink, ({ respond }) => {
     mockAgentPhoneStatus = {
       linked: false,
       agentPhoneNumber: mockAgentPhoneStatus.agentPhoneNumber,

--- a/turbo/apps/platform/src/signals/zero-page/agentphone-connect-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agentphone-connect-signals.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { zeroIntegrationsAgentPhoneContract } from "@okouai/api-contracts/contracts/zero-integrations-agentphone";
+import { integrationsAgentPhoneContract } from "@okouai/api-contracts/contracts/integrations-agentphone";
 import { accept } from "../../lib/accept.ts";
 import { capturePlausibleEvent } from "../../lib/plausible.ts";
 import { zeroClient$ } from "../api-client.ts";
@@ -13,7 +13,7 @@ export const connectAgentPhoneAccount$ = command(
       return null;
     }
 
-    const client = get(zeroClient$)(zeroIntegrationsAgentPhoneContract);
+    const client = get(zeroClient$)(integrationsAgentPhoneContract);
     const result = await accept(
       client.connectAgentPhone({
         headers: {},

--- a/turbo/apps/platform/src/signals/zero-page/zero-agentphone.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-agentphone.ts
@@ -1,10 +1,10 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import {
-  zeroIntegrationsAgentPhoneContract,
+  integrationsAgentPhoneContract,
   type AgentPhoneLinkStatusResponse,
   type AgentPhoneStartLinkResponse,
-} from "@okouai/api-contracts/contracts/zero-integrations-agentphone";
+} from "@okouai/api-contracts/contracts/integrations-agentphone";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import { setAblyLoop$ } from "../realtime.ts";
@@ -110,7 +110,7 @@ export const setAgentPhoneShowPhoneError$ = command(
 export const agentPhoneLinkStatus$ = computed(
   async (get): Promise<AgentPhoneLinkStatusResponse> => {
     get(internalReload$);
-    const client = get(zeroClient$)(zeroIntegrationsAgentPhoneContract, {
+    const client = get(zeroClient$)(integrationsAgentPhoneContract, {
       apiBase: "api",
     });
     const result = await accept(client.getLinkStatus({ headers: {} }), [200]);
@@ -206,7 +206,7 @@ export const startAgentPhoneLink$ = command(
       );
     }
 
-    const client = get(zeroClient$)(zeroIntegrationsAgentPhoneContract, {
+    const client = get(zeroClient$)(integrationsAgentPhoneContract, {
       apiBase: "api",
     });
     await accept(
@@ -230,7 +230,7 @@ export const startAgentPhoneLink$ = command(
 
 export const disconnectAgentPhone$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    const client = get(zeroClient$)(zeroIntegrationsAgentPhoneContract, {
+    const client = get(zeroClient$)(integrationsAgentPhoneContract, {
       apiBase: "api",
     });
     await accept(

--- a/turbo/packages/api-contracts/src/contracts/banking.ts
+++ b/turbo/packages/api-contracts/src/contracts/banking.ts
@@ -9,9 +9,9 @@ const dateOnlySchema = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be formatted as YYYY-MM-DD");
 
-export const zeroBankingProviderSchema = z.literal("finicity");
+export const bankingProviderSchema = z.literal("finicity");
 
-export const zeroBankingAccountSchema = z.object({
+export const bankingAccountSchema = z.object({
   id: z.string(),
   name: z.string().nullable(),
   institutionName: z.string().nullable(),
@@ -21,7 +21,7 @@ export const zeroBankingAccountSchema = z.object({
   currency: z.string().nullable(),
 });
 
-export const zeroBankingBalanceSchema = z.object({
+export const bankingBalanceSchema = z.object({
   accountId: z.string(),
   name: z.string().nullable(),
   type: z.string().nullable(),
@@ -31,7 +31,7 @@ export const zeroBankingBalanceSchema = z.object({
   balanceDate: z.number().nullable(),
 });
 
-export const zeroBankingTransactionSchema = z.object({
+export const bankingTransactionSchema = z.object({
   id: z.string(),
   accountId: z.string(),
   amount: z.number().nullable(),
@@ -44,38 +44,38 @@ export const zeroBankingTransactionSchema = z.object({
   merchant: z.string().nullable(),
 });
 
-export const zeroBankingAccountsResponseSchema = z.object({
+export const bankingAccountsResponseSchema = z.object({
   operation: z.literal("accounts"),
-  provider: zeroBankingProviderSchema,
-  accounts: z.array(zeroBankingAccountSchema),
+  provider: bankingProviderSchema,
+  accounts: z.array(bankingAccountSchema),
 });
 
-export const zeroBankingBalancesRequestSchema = z.object({
+export const bankingBalancesRequestSchema = z.object({
   accountId: z.string().trim().min(1),
 });
 
-export const zeroBankingBalancesResponseSchema = z.object({
+export const bankingBalancesResponseSchema = z.object({
   operation: z.literal("balances"),
-  provider: zeroBankingProviderSchema,
-  balance: zeroBankingBalanceSchema,
+  provider: bankingProviderSchema,
+  balance: bankingBalanceSchema,
 });
 
-export const zeroBankingTransactionsRequestSchema = z.object({
+export const bankingTransactionsRequestSchema = z.object({
   accountId: z.string().trim().min(1),
   from: dateOnlySchema,
   to: dateOnlySchema,
   limit: z.number().int().min(1).max(1000).default(100),
 });
 
-export const zeroBankingTransactionsResponseSchema = z.object({
+export const bankingTransactionsResponseSchema = z.object({
   operation: z.literal("transactions"),
-  provider: zeroBankingProviderSchema,
+  provider: bankingProviderSchema,
   accountId: z.string(),
-  transactions: z.array(zeroBankingTransactionSchema),
+  transactions: z.array(bankingTransactionSchema),
 });
 
-const zeroBankingAccountsResponses = {
-  200: zeroBankingAccountsResponseSchema,
+const bankingAccountsResponses = {
+  200: bankingAccountsResponseSchema,
   400: apiErrorSchema,
   401: apiErrorSchema,
   403: apiErrorSchema,
@@ -83,8 +83,8 @@ const zeroBankingAccountsResponses = {
   503: apiErrorSchema,
 } as const;
 
-const zeroBankingBalancesResponses = {
-  200: zeroBankingBalancesResponseSchema,
+const bankingBalancesResponses = {
+  200: bankingBalancesResponseSchema,
   400: apiErrorSchema,
   401: apiErrorSchema,
   403: apiErrorSchema,
@@ -92,8 +92,8 @@ const zeroBankingBalancesResponses = {
   503: apiErrorSchema,
 } as const;
 
-const zeroBankingTransactionsResponses = {
-  200: zeroBankingTransactionsResponseSchema,
+const bankingTransactionsResponses = {
+  200: bankingTransactionsResponseSchema,
   400: apiErrorSchema,
   401: apiErrorSchema,
   403: apiErrorSchema,
@@ -101,52 +101,50 @@ const zeroBankingTransactionsResponses = {
   503: apiErrorSchema,
 } as const;
 
-export const zeroBankingContract = c.router({
+export const bankingContract = c.router({
   accounts: {
     method: "POST",
     path: "/api/okou/banking/accounts",
     headers: authHeadersSchema,
     body: z.object({}),
-    responses: zeroBankingAccountsResponses,
+    responses: bankingAccountsResponses,
     summary: "List accounts through the managed Zero Banking gateway",
   },
   balances: {
     method: "POST",
     path: "/api/okou/banking/balances",
     headers: authHeadersSchema,
-    body: zeroBankingBalancesRequestSchema,
-    responses: zeroBankingBalancesResponses,
+    body: bankingBalancesRequestSchema,
+    responses: bankingBalancesResponses,
     summary: "Read an account balance through the managed Zero Banking gateway",
   },
   transactions: {
     method: "POST",
     path: "/api/okou/banking/transactions",
     headers: authHeadersSchema,
-    body: zeroBankingTransactionsRequestSchema,
-    responses: zeroBankingTransactionsResponses,
+    body: bankingTransactionsRequestSchema,
+    responses: bankingTransactionsResponses,
     summary:
       "Read account transactions through the managed Zero Banking gateway",
   },
 });
 
-export type ZeroBankingContract = typeof zeroBankingContract;
-export type ZeroBankingAccount = z.infer<typeof zeroBankingAccountSchema>;
-export type ZeroBankingBalance = z.infer<typeof zeroBankingBalanceSchema>;
-export type ZeroBankingTransaction = z.infer<
-  typeof zeroBankingTransactionSchema
+export type BankingContract = typeof bankingContract;
+export type BankingAccount = z.infer<typeof bankingAccountSchema>;
+export type BankingBalance = z.infer<typeof bankingBalanceSchema>;
+export type BankingTransaction = z.infer<typeof bankingTransactionSchema>;
+export type BankingAccountsResponse = z.infer<
+  typeof bankingAccountsResponseSchema
 >;
-export type ZeroBankingAccountsResponse = z.infer<
-  typeof zeroBankingAccountsResponseSchema
+export type BankingBalancesRequest = z.infer<
+  typeof bankingBalancesRequestSchema
 >;
-export type ZeroBankingBalancesRequest = z.infer<
-  typeof zeroBankingBalancesRequestSchema
+export type BankingBalancesResponse = z.infer<
+  typeof bankingBalancesResponseSchema
 >;
-export type ZeroBankingBalancesResponse = z.infer<
-  typeof zeroBankingBalancesResponseSchema
+export type BankingTransactionsRequest = z.infer<
+  typeof bankingTransactionsRequestSchema
 >;
-export type ZeroBankingTransactionsRequest = z.infer<
-  typeof zeroBankingTransactionsRequestSchema
->;
-export type ZeroBankingTransactionsResponse = z.infer<
-  typeof zeroBankingTransactionsResponseSchema
+export type BankingTransactionsResponse = z.infer<
+  typeof bankingTransactionsResponseSchema
 >;

--- a/turbo/packages/api-contracts/src/contracts/email.ts
+++ b/turbo/packages/api-contracts/src/contracts/email.ts
@@ -4,7 +4,7 @@ import { initContract } from "./base";
 
 const c = initContract();
 
-export const zeroEmailInboundContract = c.router({
+export const emailInboundContract = c.router({
   post: {
     method: "POST",
     path: "/api/okou/email/inbound",

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -218,7 +218,7 @@ export {
   type TestTeamsDispatchProbeContract,
   type TestTeamsDispatchProbeResponse,
 } from "./test-teams-dispatch-probe";
-export { zeroEmailInboundContract } from "./zero-email";
+export { emailInboundContract } from "./email";
 export {
   sandboxReuseResultSchema,
   workspaceReuseResultSchema,
@@ -1614,26 +1614,26 @@ export {
   type ZeroMailProvider,
 } from "./zero-mail";
 export {
-  zeroBankingContract,
-  zeroBankingProviderSchema,
-  zeroBankingAccountSchema,
-  zeroBankingBalanceSchema,
-  zeroBankingTransactionSchema,
-  zeroBankingAccountsResponseSchema,
-  zeroBankingBalancesRequestSchema,
-  zeroBankingBalancesResponseSchema,
-  zeroBankingTransactionsRequestSchema,
-  zeroBankingTransactionsResponseSchema,
-  type ZeroBankingContract,
-  type ZeroBankingAccount,
-  type ZeroBankingBalance,
-  type ZeroBankingTransaction,
-  type ZeroBankingAccountsResponse,
-  type ZeroBankingBalancesRequest,
-  type ZeroBankingBalancesResponse,
-  type ZeroBankingTransactionsRequest,
-  type ZeroBankingTransactionsResponse,
-} from "./zero-banking";
+  bankingContract,
+  bankingProviderSchema,
+  bankingAccountSchema,
+  bankingBalanceSchema,
+  bankingTransactionSchema,
+  bankingAccountsResponseSchema,
+  bankingBalancesRequestSchema,
+  bankingBalancesResponseSchema,
+  bankingTransactionsRequestSchema,
+  bankingTransactionsResponseSchema,
+  type BankingContract,
+  type BankingAccount,
+  type BankingBalance,
+  type BankingTransaction,
+  type BankingAccountsResponse,
+  type BankingBalancesRequest,
+  type BankingBalancesResponse,
+  type BankingTransactionsRequest,
+  type BankingTransactionsResponse,
+} from "./banking";
 export {
   mapsContract,
   mapsOperationSchema,
@@ -1759,12 +1759,12 @@ export {
   type TelegramSetupStatus,
 } from "./zero-integrations-telegram";
 export {
-  zeroIntegrationsAgentPhoneContract,
-  type ZeroIntegrationsAgentPhoneContract,
+  integrationsAgentPhoneContract,
+  type IntegrationsAgentPhoneContract,
   type AgentPhoneConnectResponse,
   type AgentPhoneLinkStatusResponse,
   type AgentPhoneStartLinkResponse,
-} from "./zero-integrations-agentphone";
+} from "./integrations-agentphone";
 export {
   sharedMessageSchema,
   sharedThreadsContract,

--- a/turbo/packages/api-contracts/src/contracts/integrations-agentphone.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations-agentphone.ts
@@ -46,7 +46,7 @@ const agentPhoneStartLinkResponseSchema = z.object({
   verificationSent: z.literal(true),
 });
 
-export const zeroIntegrationsAgentPhoneContract = c.router({
+export const integrationsAgentPhoneContract = c.router({
   connectAgentPhone: {
     method: "POST",
     path: "/api/agentphone/connect",
@@ -112,8 +112,8 @@ export const zeroIntegrationsAgentPhoneContract = c.router({
   },
 });
 
-export type ZeroIntegrationsAgentPhoneContract =
-  typeof zeroIntegrationsAgentPhoneContract;
+export type IntegrationsAgentPhoneContract =
+  typeof integrationsAgentPhoneContract;
 export type AgentPhoneConnectResponse = z.infer<
   typeof agentPhoneConnectResponseSchema
 >;


### PR DESCRIPTION
## Summary

Neutralizes the inbound-email, banking and AgentPhone API contract modules, per the Phase 2 naming model in #27432 (#26873). Pure rename: module paths, exported identifiers and their importers. No behavior change.

## Old → new

### Modules

| Old | New |
|---|---|
| `contracts/zero-email.ts` | `contracts/email.ts` |
| `contracts/zero-banking.ts` | `contracts/banking.ts` |
| `contracts/zero-integrations-agentphone.ts` | `contracts/integrations-agentphone.ts` |

### Declarations

| Old | New |
|---|---|
| `zeroEmailInboundContract` | `emailInboundContract` |
| `zeroBankingProviderSchema` | `bankingProviderSchema` |
| `zeroBankingAccountSchema` | `bankingAccountSchema` |
| `zeroBankingBalanceSchema` | `bankingBalanceSchema` |
| `zeroBankingTransactionSchema` | `bankingTransactionSchema` |
| `zeroBankingAccountsResponseSchema` | `bankingAccountsResponseSchema` |
| `zeroBankingBalancesRequestSchema` | `bankingBalancesRequestSchema` |
| `zeroBankingBalancesResponseSchema` | `bankingBalancesResponseSchema` |
| `zeroBankingTransactionsRequestSchema` | `bankingTransactionsRequestSchema` |
| `zeroBankingTransactionsResponseSchema` | `bankingTransactionsResponseSchema` |
| `zeroBankingContract` | `bankingContract` |
| `ZeroBankingContract` | `BankingContract` |
| `ZeroBankingAccount` | `BankingAccount` |
| `ZeroBankingBalance` | `BankingBalance` |
| `ZeroBankingTransaction` | `BankingTransaction` |
| `ZeroBankingAccountsResponse` | `BankingAccountsResponse` |
| `ZeroBankingBalancesRequest` | `BankingBalancesRequest` |
| `ZeroBankingBalancesResponse` | `BankingBalancesResponse` |
| `ZeroBankingTransactionsRequest` | `BankingTransactionsRequest` |
| `ZeroBankingTransactionsResponse` | `BankingTransactionsResponse` |
| `zeroIntegrationsAgentPhoneContract` | `integrationsAgentPhoneContract` |
| `ZeroIntegrationsAgentPhoneContract` | `IntegrationsAgentPhoneContract` |

Three module-private response maps in `contracts/banking.ts` (`zeroBankingAccountsResponses`, `zeroBankingBalancesResponses`, `zeroBankingTransactionsResponses`) follow the same rule.

## Scope note

`apps/api/src/signals/routes/banking.ts` holds two file-local constants, `zeroBankingDisabled` and `zeroBankingEnabled$`, that are not in the issue's mapping table. They are renamed to `bankingDisabled` and `bankingEnabled$` because acceptance criterion 2 requires that no `zeroBanking` identifier remain anywhere in the repository. Both are private to that file and only its import line would otherwise have changed. Nothing else in the route, service or platform layers is touched beyond import and type-reference updates.

## Preserved exactly

- Every `path:` literal, method, header schema, request/response schema and status code.
- The `"finicity"` provider literal in `contracts/banking.ts`.
- The already-neutral `AgentPhoneConnectResponse`, `AgentPhoneLinkStatusResponse` and `AgentPhoneStartLinkResponse` types.
- Contract `summary` strings, including the ones reading "managed Zero Banking gateway", which are copy rather than identifiers.
- The adjacent `services/zero-email-common.service` module, which is a different unit of work.

No compatibility alias and no old-path re-export were added.

## Verification

- The 11 external importers (2 email, 4 banking, 5 AgentPhone) and all three `contracts/index.ts` re-export blocks are migrated. Counts match the issue.
- Repository-wide grep for `zeroEmailInboundContract`, `zeroBanking`, `ZeroBanking`, `zeroIntegrationsAgentPhone`, `ZeroIntegrationsAgentPhone`: no matches.
- Repository-wide grep for the three old subpath specifiers: no matches.
- No dynamic imports reference these modules.
- `check-types` passes for `@okouai/api-contracts`, `api` and `@okouai/app`.
- `lint` passes for the same three workspaces; no changed file is flagged.
- `pnpm knip` exits 0 and reports nothing about these modules.
- Two files were reformatted by Prettier purely because the shorter names now fit on one line.

Per repository guidance, the full local Vitest suite was not run; repository-wide validation is left to the PR pipeline.

Closes #27858
