### PR TITLE
fix: show selection toolbar for whole assistant paragraphs

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -101,6 +101,20 @@ function resolveSelectionSource(range: Range): Element | null {
   // common ancestor even when both endpoints are inside assistant bubbles.
   const startSource = closestFeedbackSource(range.startContainer);
   const endSource = closestFeedbackSource(range.endContainer);
+  if (startSource && !endSource && range.endOffset === 0) {
+    // Chromium can end a whole-paragraph selection at offset 0 in the
+    // following action-area sibling. Accept only that trailing boundary in
+    // the same assistant group as the selected content.
+    const endElement =
+      range.endContainer instanceof Element
+        ? range.endContainer
+        : range.endContainer.parentElement;
+    const startGroup = startSource.closest(ASSISTANT_GROUP_SELECTOR);
+    const endGroup = endElement?.closest(ASSISTANT_GROUP_SELECTOR);
+    if (startGroup !== null && startGroup === endGroup) {
+      return startSource;
+    }
+  }
   if (!startSource || !endSource) {
     return null;
   }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -147,6 +147,55 @@ function selectTextAcrossElementsForInlineFeedback(
   endElement.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 }
 
+function assistantActionArea(element: HTMLElement): HTMLElement {
+  const assistantGroup = element.closest('[data-role="assistant"]');
+  if (!(assistantGroup instanceof HTMLElement)) {
+    throw new Error("Assistant group not found");
+  }
+  const primaryActions = assistantGroup.querySelector(
+    '[data-testid="chat-event-actions"]',
+  );
+  const actionArea = primaryActions?.parentElement?.parentElement;
+  if (
+    !(actionArea instanceof HTMLElement) ||
+    actionArea.parentElement !== assistantGroup
+  ) {
+    throw new Error("Assistant action area not found");
+  }
+  return actionArea;
+}
+
+function selectTextToAssistantActionBoundaryForInlineFeedback(
+  startElement: HTMLElement,
+  endAssistantElement = startElement,
+): Range {
+  const startNode = startElement.firstChild;
+  if (!(startNode instanceof Text)) {
+    throw new Error("Selection source must start with a text node");
+  }
+  const actionArea = assistantActionArea(endAssistantElement);
+  startElement.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  const range = document.createRange();
+  range.setStart(startNode, 0);
+  range.setEnd(actionArea, 0);
+  Object.defineProperty(range, "getBoundingClientRect", {
+    configurable: true,
+    value: () => {
+      return new DOMRect(24, 32, 180, 20);
+    },
+  });
+
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error("Selection API is not available");
+  }
+  selection.removeAllRanges();
+  selection.addRange(range);
+  document.dispatchEvent(new Event("selectionchange"));
+  actionArea.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  return range;
+}
+
 function buttonByText(text: string): HTMLElement {
   const button = queryAllByRoleFast("button").find((candidate) => {
     const label = candidate.textContent?.replace(/\s+/g, " ").trim();
@@ -1742,6 +1791,117 @@ describe("chat inline feedback", () => {
     await waitFor(() => {
       expect(screen.getByText("Quote")).toBeInTheDocument();
     });
+  });
+
+  it("shows the inline feedback toolbar when a whole paragraph selection ends at the action area", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The rollout dates are unclear in this summary.";
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatEvents: [
+        {
+          id: "msg-feedback-paragraph-boundary-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-paragraph-boundary",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-paragraph-boundary-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-paragraph-boundary",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ChatForward]: true },
+    });
+
+    const assistantReplyElement = await screen.findByText(assistantReply);
+    assistantReplyElement.append(document.createTextNode("\n  "));
+    const assistantGroup = assistantReplyElement.closest(
+      '[data-role="assistant"]',
+    );
+    const actionArea = assistantActionArea(assistantReplyElement);
+    const range = selectTextToAssistantActionBoundaryForInlineFeedback(
+      assistantReplyElement,
+    );
+
+    expect(range.commonAncestorContainer).toBe(assistantGroup);
+    expect(range.endContainer).toBe(actionArea);
+    expect(range.endOffset).toBe(0);
+    await waitFor(() => {
+      expect(buttonByText("Copy")).toBeInTheDocument();
+      expect(buttonByText("Quote")).toBeInTheDocument();
+      expect(buttonByText("Forward")).toBeInTheDocument();
+    });
+
+    await user.click(buttonByText("Quote"));
+    const [feedbackItem] = await findFeedbackItems(1);
+    expect(feedbackItem?.firstElementChild?.textContent).toBe(assistantReply);
+  });
+
+  it("rejects an action-boundary selection that crosses unrelated messages", async () => {
+    const firstReply = "The rollout dates are unclear in this summary.";
+    const secondReply = "The risk owners are missing from the plan.";
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatEvents: [
+        {
+          id: "msg-feedback-cross-boundary-user-one",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-cross-boundary-one",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-cross-boundary-assistant-one",
+          role: "assistant",
+          content: firstReply,
+          runId: "run-feedback-cross-boundary-one",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+        {
+          id: "msg-feedback-cross-boundary-user-two",
+          role: "user",
+          content: "Review the risk plan too",
+          runId: "run-feedback-cross-boundary-two",
+          createdAt: "2026-06-09T10:02:00Z",
+        },
+        {
+          id: "msg-feedback-cross-boundary-assistant-two",
+          role: "assistant",
+          content: secondReply,
+          runId: "run-feedback-cross-boundary-two",
+          createdAt: "2026-06-09T10:03:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+    });
+
+    const firstReplyElement = await screen.findByText(firstReply);
+    const secondReplyElement = await screen.findByText(secondReply);
+    selectTextToAssistantActionBoundaryForInlineFeedback(
+      firstReplyElement,
+      secondReplyElement,
+    );
+    await waitForDeferredSelectionCapture();
+
+    expect(window.getSelection()?.isCollapsed).toBeFalsy();
+    expect(screen.queryByText("Quote")).not.toBeInTheDocument();
   });
 
   it("dismisses the inline feedback toolbar when a click clears the selection", async () => {


### PR DESCRIPTION
## Summary

- accept Chromium's zero-offset action-area boundary for whole-paragraph selections only when it remains in the same assistant group
- preserve rejection of selections that cross unrelated user and assistant messages
- add page-level regression coverage for the real text-node-to-action-area Range and trailing whitespace trimming

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx` (29 passed)
- `pnpm -F @okouai/app check-types`
- `pnpm exec prettier --check apps/platform/src/signals/chat-page/chat-thread-feedback.ts apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`
- `pnpm exec oxlint src/signals/chat-page/chat-thread-feedback.ts src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`
- `pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/signals/chat-page/chat-thread-feedback.ts src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`
- `pnpm exec eslint src/signals/chat-page/chat-thread-feedback.ts src/views/zero-page/__tests__/chat-inline-feedback.test.tsx --max-warnings 0`
