### PR TITLE
ci(e2e): avoid apt in playwright browser setup

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -80,6 +80,20 @@ unless browser_install_index && fixture_test_index &&
   raise "Playwright browsers must be installed before browser fixture tests"
 end
 
+expected_browser_install =
+  "cd e2e && pnpm exec playwright install --only-shell chromium"
+{
+  "Playwright E2E" => playwright,
+  "runner E2E preparation" => account_prepare,
+}.each do |job_name, job|
+  install_step = job.fetch("steps").find do |step|
+    step["name"] == "Install Playwright browsers"
+  end
+  unless install_step&.fetch("run", nil) == expected_browser_install
+    raise "#{job_name} must install only the Chromium headless shell"
+  end
+end
+
 unless prepare.dig("outputs", "turbo-runner-consumer-needed") ==
     "${{ steps.runner-e2e.outputs.turbo-runner-consumer-needed }}"
   raise "Turbo must expose the historical runner E2E consumer decision"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1862,7 +1862,7 @@ jobs:
       - name: Check Playwright E2E types
         run: cd e2e && pnpm check-types
       - name: Install Playwright browsers
-        run: cd e2e && pnpm exec playwright install --with-deps chromium
+        run: cd e2e && pnpm exec playwright install --only-shell chromium
       - name: Run Playwright fixture integration tests
         run: cd e2e && pnpm test
       - name: Start Stripe webhook forwarding
@@ -2430,7 +2430,7 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
       - name: Install Playwright browsers
-        run: cd e2e && pnpm exec playwright install --with-deps chromium
+        run: cd e2e && pnpm exec playwright install --only-shell chromium
       - name: Generate runner E2E API tokens
         run: cd e2e && pnpm exec tsx playwright/runner-token.ts /tmp
         env:


### PR DESCRIPTION
## Summary

- install only Playwright's Chromium headless shell in both Playwright E2E setup jobs
- remove the runtime Ubuntu package-manager dependency that intermittently exhausts job timeouts
- enforce the same apt-free install command for both jobs in the existing workflow contract test

## Why

`playwright install --with-deps chromium` invokes `apt` on every hosted runner. Recent runs stalled
on `azure.archive.ubuntu.com` before any browser download or E2E test began, cancelling the
Playwright job at 8 minutes and runner preparation at 12 minutes. All current consumers launch
Chromium headlessly, and the hosted runner already contains the required native browser libraries.

## Scope

- keep the existing 8-minute and 12-minute job limits unchanged
- preserve the browser version pinned by `@playwright/test`
- do not change application code, APIs, runner protocols, deployment behavior, or E2E scenarios

## Validation

- `bash -n .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `actionlint`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm exec playwright install --only-shell chromium`
- `cd e2e && pnpm exec playwright install --dry-run --only-shell chromium`
- `cd e2e && pnpm test` (35 passed)

Closes #27876
