### PR TITLE
fix(ci): serialize shared preview ownership

### DIFF
--- a/.github/scripts/cancel-superseded-merge-group-runs.sh
+++ b/.github/scripts/cancel-superseded-merge-group-runs.sh
@@ -89,16 +89,29 @@ fi
 
 discover_selected_runs() {
   local active_statuses=(queued in_progress pending waiting requested)
+  local recent_workflow_files=(turbo.yml crates.yml runner-image.yml)
   local status
+  local workflow_file
 
-  for status in "${active_statuses[@]}"; do
-    gh api --method GET \
-      "repos/${GITHUB_REPOSITORY}/actions/runs" \
-      -f "status=${status}" \
-      -f per_page=100 \
-      --paginate \
-      --slurp
-  done |
+  {
+    # GitHub's status-filtered workflow-run index can omit a concurrently
+    # active sibling workflow. Keep the exhaustive active-status scan, then
+    # union it with each shared-resource workflow's most recent unfiltered
+    # page so a newly overlapping owner cannot disappear at this boundary.
+    for status in "${active_statuses[@]}"; do
+      gh api --method GET \
+        "repos/${GITHUB_REPOSITORY}/actions/runs" \
+        -f "status=${status}" \
+        -f per_page=100 \
+        --paginate \
+        --slurp
+    done
+    for workflow_file in "${recent_workflow_files[@]}"; do
+      gh api --method GET \
+        "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_file}/runs" \
+        -f per_page=100
+    done
+  } |
     jq -r \
       --argjson current_run_id "$GITHUB_RUN_ID" \
       --arg current_head_sha "${GITHUB_SHA:-}" \
@@ -106,7 +119,15 @@ discover_selected_runs() {
       --argjson pr_number "$pr_number" \
       --arg pr_head_ref "$pr_head_ref" \
       --arg pr_head_repository "$pr_head_repository" '
-        .[] | .workflow_runs[]?
+        (if type == "array" then .[] else . end)
+        | .workflow_runs[]?
+        | select(
+            .status == "queued" or
+            .status == "in_progress" or
+            .status == "pending" or
+            .status == "waiting" or
+            .status == "requested"
+          )
         | select(
             if $owner_scope == "closed-pr-cleanup" then
               .id != $current_run_id
@@ -144,8 +165,8 @@ discover_selected_runs() {
 previous_run_ids=""
 have_previous_run_ids=false
 discovery_started_at=$SECONDS
-# Each status filter is a separate API snapshot. Require the selected run IDs
-# to stabilize so a run changing statuses cannot fall between those snapshots.
+# Each API query is a separate snapshot. Require the selected run IDs to
+# stabilize so a run changing statuses cannot fall between those snapshots.
 while true; do
   discovered_runs=$(discover_selected_runs)
   discovered_run_ids=$(printf '%s\n' "$discovered_runs" | cut -f1)

--- a/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
+++ b/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
@@ -64,7 +64,13 @@ JSON
       printf '[{"workflow_runs":[]}]\n'
       exit 0
     fi
-    cat <<'JSON'
+    cat <<'JSON' | jq -c --argjson omit_turbo "${MOCK_FILTERED_TURBO_OMITTED:-0}" '
+      if $omit_turbo == 1 then
+        .[0].workflow_runs |= map(select(.id != 100))
+      else
+        .
+      end
+    '
 [{"workflow_runs":[
   {"id":100,"name":"Turbo","status":"in_progress","event":"merge_group","head_sha":"old-a","head_branch":"gh-readonly-queue/main/pr-42-old-a","path":".github/workflows/turbo.yml","pull_requests":[],"html_url":"https://example.test/100"},
   {"id":110,"name":"Crates","status":"in_progress","event":"pull_request","head_sha":"old-b","head_branch":"feature/safe-shared-runner","head_repository":{"full_name":"vm0-ai/vm0"},"path":".github/workflows/crates.yml","pull_requests":[],"html_url":"https://example.test/110"},
@@ -76,6 +82,20 @@ JSON
   {"id":300,"name":"Turbo","status":"in_progress","event":"merge_group","head_sha":"newer-sha","head_branch":"gh-readonly-queue/main/pr-42-newer","path":".github/workflows/turbo.yml","pull_requests":[],"html_url":"https://example.test/300"}
 ]}]
 JSON
+    ;;
+  repos/vm0-ai/vm0/actions/workflows/turbo.yml/runs)
+    if [ "${MOCK_FILTERED_TURBO_OMITTED:-0}" = "1" ]; then
+      cat <<'JSON'
+{"workflow_runs":[
+  {"id":100,"name":"Turbo","status":"in_progress","event":"merge_group","head_sha":"old-a","head_branch":"gh-readonly-queue/main/pr-42-old-a","path":".github/workflows/turbo.yml","pull_requests":[],"html_url":"https://example.test/100"}
+]}
+JSON
+    else
+      printf '{"workflow_runs":[]}\n'
+    fi
+    ;;
+  repos/vm0-ai/vm0/actions/workflows/*/runs)
+    printf '{"workflow_runs":[]}\n'
     ;;
   repos/vm0-ai/vm0/actions/runs/*/force-cancel)
     [ "$method" = "POST" ] || exit 1
@@ -180,6 +200,16 @@ cancelled_runs=$(cat "${tmp_dir}/cancel.log")
   fail "expected only older same-PR consumer runs to be cancelled, got: ${cancelled_runs}"
 [ ! -s "${tmp_dir}/sleep.log" ] ||
   fail "already-completed superseded runs must not poll"
+
+: >"${tmp_dir}/gh.log"
+: >"${tmp_dir}/cancel.log"
+: >"${tmp_dir}/sleep.log"
+output=$(run_cancel MOCK_FILTERED_TURBO_OMITTED=1)
+cancelled_runs=$(cat "${tmp_dir}/cancel.log")
+[ "$cancelled_runs" = $'100\n110\n120' ] ||
+  fail "recent workflow fallback must recover a Turbo owner omitted by status filters, got: ${cancelled_runs}"
+grep -q "actions/workflows/turbo.yml/runs" "${tmp_dir}/gh.log" ||
+  fail "expected recent Turbo workflow discovery"
 
 : >"${tmp_dir}/gh.log"
 : >"${tmp_dir}/cancel.log"

--- a/.github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh
+++ b/.github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh
@@ -123,8 +123,48 @@ unless locked_probe_index && barrier_index && delete_index &&
 end
 
 turbo = YAML.load_file(ARGV.fetch(2)).fetch("jobs")
+turbo_cancel = turbo.fetch("cancel-superseded")
+unless turbo_cancel.fetch("name") == "Cancel superseded merge-group CI" &&
+    turbo_cancel.fetch("if") == "github.event_name == 'merge_group'" &&
+    turbo_cancel.fetch("permissions") == {
+      "actions" => "write",
+      "contents" => "read",
+      "pull-requests" => "read",
+    }
+  raise "Turbo must establish merge-group ownership before shared preview reuse"
+end
+turbo_handoff = named_step(
+  turbo_cancel,
+  "Cancel and await older runs for the queued PR",
+)
+raise "missing Turbo merge-group ownership handoff" unless turbo_handoff
+unless turbo_handoff.dig("env", "GH_TOKEN") == "${{ github.token }}" &&
+    turbo_handoff.dig("env", "GITHUB_REPOSITORY") == "${{ github.repository }}" &&
+    turbo_handoff.dig("env", "GITHUB_RUN_ID") == "${{ github.run_id }}" &&
+    turbo_handoff.dig("env", "GITHUB_SHA") == "${{ github.sha }}" &&
+    turbo_handoff.dig("env", "MERGE_GROUP_HEAD_REF") ==
+      "${{ github.event.merge_group.head_ref }}" &&
+    turbo_handoff.fetch("run") ==
+      ".github/scripts/cancel-superseded-merge-group-runs.sh" &&
+    !turbo_handoff.key?("continue-on-error")
+  raise "Turbo merge-group ownership handoff must fail closed"
+end
+
+detect_release = turbo.fetch("detect-release")
+detect_release_if = detect_release.fetch("if")
+unless detect_release.fetch("needs") == ["cancel-superseded"] &&
+    detect_release_if.include?("!cancelled()") &&
+    detect_release_if.include?("needs.cancel-superseded.result == 'success'")
+  raise "Turbo work must wait for the merge-group ownership handoff"
+end
+
 prepare = turbo.fetch("deploy-runner-prepare")
 start = turbo.fetch("deploy-runner-start")
+deploy_api = turbo.fetch("deploy-api")
+unless turbo.fetch("prepare").fetch("needs") == ["detect-release"] &&
+    deploy_api.fetch("needs") == ["prepare"]
+  raise "shared preview deployment must remain downstream of the ownership handoff"
+end
 unless prepare.dig("outputs", "runner-sha-map") ==
     "${{ steps.manifest.outputs.runner-sha-map }}"
   raise "runner prepare must expose producer SHA ownership by target"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -12,10 +12,43 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Turbo reuses one preview database, API alias, and runner namespace per PR.
+  # A replacement merge-group run must finish the older owner before any of
+  # those shared resources can be reset or replaced.
+  cancel-superseded:
+    name: Cancel superseded merge-group CI
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Cancel and await older runs for the queued PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SHA: ${{ github.sha }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: .github/scripts/cancel-superseded-merge-group-runs.sh
+
   # Detect release-please context across all event types (PR, push, merge queue).
   # github.head_ref is empty in merge_group events, so we extract the PR number
   # from the merge queue head_ref and check via GitHub API.
   detect-release:
+    needs: [cancel-superseded]
+    if: >-
+      ${{
+        !cancelled() &&
+        (
+          github.event_name != 'merge_group' ||
+          needs.cancel-superseded.result == 'success'
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
## Summary

- gate Turbo merge-group work on a fail-closed handoff that force-cancels and awaits older CI owners for the same PR
- harden owner discovery by unioning the active-status index with recent unfiltered Turbo, Crates, and Runner Image workflow pages
- preserve the existing shared `pr-N` preview database, API alias, runner namespace, failed-run retention, and PR cleanup model

## Root cause

Trigger: [Turbo run 32097392483](https://github.com/vm0-ai/vm0/actions/runs/32097392483), attempt 1, merge-group SHA `7c6cafc3a072b40cf129973a43726f8040ec6123` for PR #27845.

This was a cross-run shared-state ownership race, not a test-specific assertion failure:

1. Both merge-group refs encoded PR #27845, so Turbo resolved both to `job-ref=pr-27845` and the shared Neon branch `preview/pr-27845`.
2. The first run deployed the API by 04:01:06Z, generated four runner CLI credentials from 04:01:46Z through 04:03:04Z, uploaded the token artifact, and completed runner bootstrap at 04:03:22Z.
3. CLI issuance inserts each token ID into the preview database's `cli_tokens` table. Bearer authentication verifies the JWT and then requires that persisted row to exist, so resetting the database invalidates otherwise well-formed tokens.
4. A replacement [Turbo run 32097631659](https://github.com/vm0-ai/vm0/actions/runs/32097631659) started at 04:02:07Z. Its `Create Neon Branch` step reset `preview/pr-27845` at 04:03:32Z and reseeded it through 04:03:47Z.
5. All 12 old runner shards made authenticated API calls during that reset and failed first with `curl: (22) ... 401` between 04:03:37Z and 04:03:45Z. A representative `setup_file` failure is [job 95592172142](https://github.com/vm0-ai/vm0/actions/runs/32097392483/job/95592172142) at 04:03:38Z. The aggregate `ci-gate-turbo` failure and successful cleanup were downstream outcomes, not causes.
6. The replacement run generated fresh credentials after the reset and all equivalent shards passed by 04:07:55Z.

The existing Runner Image ownership handoff did not close the database boundary. In [Runner Image run 32097631625](https://github.com/vm0-ai/vm0/actions/runs/32097631625), its cancellation step selected old Crates run 32097392443 but omitted the still-live old Turbo run 32097392483. Turbo could also begin `deploy-api` independently of that other workflow's handoff.

PR #27845 changed only Python documentation strings. Its merge-group recurrence changed the queue base, which created the overlap; it did not change token or runtime behavior.

## Fix

Turbo now owns the handoff before `detect-release`, making `prepare`, `deploy-api`, the Neon reset, API alias replacement, runner deployment, and runner E2E transitively wait for the older owner to reach terminal state.

The shared coordinator keeps its exhaustive status-filtered scan and also reads the latest unfiltered page for each resource-owning workflow. The union is filtered locally to active runs, deduplicated, and stabilized before cancellation. This directly covers the observed condition where one same-PR workflow was visible while the old Turbo sibling was absent from the status-filtered result.

Same-SHA siblings, newer runs, unrelated PRs, unrelated repositories, and unrelated workflows remain excluded. Pull-request and push behavior is unchanged, resource names remain `pr-N`, and the existing cleanup paths continue to use the same coordinator.

No retries, test sleeps, timeout increases, skipped tests, weakened assertions, swallowed 401s, or detached cleanup were added.

## Validation

All checks were rerun after rebasing onto current `origin/main` (`6d1b23334818f9bf6efb1b7a3983256964af7005`):

- `cancel-superseded-merge-group-runs-test.sh`: 5/5 consecutive passes, including the status-filter omission regression
- `runner-lifecycle-ownership-workflow-test.sh`: pass
- `bash -n` on the changed scripts and tests: pass
- ShellCheck on the changed scripts and tests: pass
- Prettier 3.8.1 check for `.github/workflows/turbo.yml`: pass
- actionlint 1.7.12 for `.github/workflows/turbo.yml`: pass
- `git diff --check`: pass

The deployed `03-runner` suite is CI-only and requires temporary Clerk accounts, API tokens, preview deployments, and the preview runner fleet, so it was not run locally. PR CI is the service-backed validation boundary.

Browser/staging validation is not applicable: this changes only GitHub Actions ownership orchestration and shell/workflow contract tests, with no app, API, or browser-facing behavior to exercise on a preview.
