### PR TITLE
feat: mark all chats read in three-column navigation

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2827,6 +2827,82 @@ describe("zero sidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("marks all chats read from the three-column chat list menu", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Existing conversation"),
+      createThread(INCIDENT_THREAD_ID, "Unread conversation"),
+    ]);
+
+    let hasUnread = true;
+    const markedAgentIds: string[] = [];
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, {
+        agents: hasUnread ? { [AGENT_ID]: "unread" } : {},
+        threads: hasUnread ? { [INCIDENT_THREAD_ID]: "unread" } : {},
+      });
+    });
+    context.mocks.api(chatThreadsContract.unreads, ({ respond }) => {
+      return respond(200, {
+        unreads: hasUnread
+          ? [
+              {
+                threadId: INCIDENT_THREAD_ID,
+                unreadAt: "2026-03-10T00:05:00Z",
+              },
+            ]
+          : [],
+      });
+    });
+    context.mocks.api(
+      chatThreadMarkAgentReadContract.markAgentRead,
+      ({ body, respond }) => {
+        markedAgentIds.push(body.agentId);
+        hasUnread = false;
+        return respond(204);
+      },
+    );
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+      },
+    });
+
+    const list = await screen.findByTestId("chat-list-column");
+    await waitFor(() => {
+      expect(within(list).getByText("Unread conversation")).toBeInTheDocument();
+      expect(within(list).getAllByLabelText("Unread").length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    click(within(list).getByLabelText("Open chat list menu"));
+    await waitFor(() => {
+      expect(
+        queryAllByRoleFast("menuitem").map((item) => {
+          return item.textContent?.replace(/\s+/g, " ").trim();
+        }),
+      ).toStrictEqual([
+        "New chat",
+        "Mark all read",
+        "All chats",
+        "Unread only",
+      ]);
+    });
+    click(menuItemByText("Mark all read"));
+
+    await waitFor(() => {
+      expect(markedAgentIds).toStrictEqual([AGENT_ID]);
+      expect(within(list).queryByLabelText("Unread")).not.toBeInTheDocument();
+    });
+
+    click(within(list).getByLabelText("Open chat list menu"));
+    expect(queryMenuItemByText("Mark all read")).not.toBeInTheDocument();
+  });
+
   it("creates a new chat thread from the three-column header", async () => {
     prepareDefaultAgent();
     mockSidebarThreadStory([

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -6,10 +6,12 @@ import {
   useLastResolved,
   useLastLoadable,
 } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import {
   Plus,
   Check,
+  CheckCheck,
   ChevronRight,
   Trash,
   Pencil,
@@ -74,6 +76,8 @@ import {
   chatThreadOnlyUnread$,
   setChatThreadOnlyUnread$,
 } from "../../signals/chat-page/chat-thread-only-unread.ts";
+import { unreadAgentIds$ } from "../../signals/chat-page/chat-thread-indicators.ts";
+import { markAgentThreadsRead$ } from "../../signals/chat-page/sidebar-unread-threads.ts";
 import {
   closeRenameChatThreadDialog$,
   pendingDeleteThreadId$,
@@ -669,15 +673,14 @@ function ChatThreadsListMenuTooltip() {
   );
 }
 
-function ChatThreadsTitle() {
-  const { t } = useTranslation();
+function useNewChatMenuAction() {
   const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;
   const createNewChat = useSet(createNewChatThread$);
   const setExpanded = useSet(setSidebarExpanded$);
   const rootSignal = useGet(rootSignal$);
-  const { titleLabel } = useChatThreadsTitleLabels();
   const newChatDisabled = useGet(newChatThreadDisabled$);
-  const onNewChat = (pane: NewChatThreadPane) => {
+
+  function onSelect(pane: NewChatThreadPane) {
     if (!currentChatAgentId) {
       return;
     }
@@ -686,9 +689,87 @@ function ChatThreadsTitle() {
       Reason.DomCallback,
     );
     setExpanded(false);
+  }
+
+  return {
+    disabled: !currentChatAgentId || newChatDisabled,
+    onSelect,
   };
+}
+
+function NewChatMenuItem({
+  disabled,
+  onSelect,
+}: {
+  disabled: boolean;
+  onSelect: (pane: NewChatThreadPane) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenuItem
+      onSelect={() => {
+        onSelect("main");
+      }}
+      disabled={disabled}
+    >
+      <Plus size={16} className="mr-2" />
+      {t(($) => {
+        return $.chat.newChat;
+      })}
+    </DropdownMenuItem>
+  );
+}
+
+function useMarkAllReadMenuAction(showMarkAllRead: boolean) {
+  const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;
+  const unreadAgentIds = useLastResolved(unreadAgentIds$);
+  const [markReadLoadable, markAgentThreadsRead] = useLoadableSet(
+    markAgentThreadsRead$,
+  );
+  const pageSignal = useGet(pageSignal$);
+  const markingRead = markReadLoadable.state === "loading";
+  const visible =
+    showMarkAllRead &&
+    currentChatAgentId !== null &&
+    (unreadAgentIds?.has(currentChatAgentId) ?? false);
+
+  function onSelect() {
+    if (!currentChatAgentId) {
+      return;
+    }
+    detach(
+      markAgentThreadsRead(currentChatAgentId, pageSignal),
+      Reason.DomCallback,
+      "markAgentThreadsRead",
+    );
+  }
+
+  return { disabled: markingRead, onSelect, visible };
+}
+
+function MarkAllReadMenuItem({
+  disabled,
+  onSelect,
+}: {
+  disabled: boolean;
+  onSelect: () => void;
+}) {
+  const { t } = useTranslation("agents");
+
+  return (
+    <DropdownMenuItem onSelect={onSelect} disabled={disabled}>
+      <CheckCheck size={16} className="mr-2" />
+      {t(($) => {
+        return $.sidebar.markAllRead;
+      })}
+    </DropdownMenuItem>
+  );
+}
+
+function ChatThreadFilterMenuItems() {
+  const { t } = useTranslation();
   const setCollapsed = useSet(setSessionListCollapsed$);
-  const collapsed = useGet(sessionListCollapsed$);
   const unreadOnly = useGet(chatThreadOnlyUnread$);
   const setUnreadOnly = useSet(setChatThreadOnlyUnread$);
 
@@ -698,6 +779,82 @@ function ChatThreadsTitle() {
       setCollapsed(false);
     }
   }
+
+  return (
+    <>
+      <DropdownMenuItem
+        onSelect={() => {
+          toggleUnreadOnly(false);
+        }}
+      >
+        <Check size={16} className={`mr-2 ${unreadOnly ? "invisible" : ""}`} />
+        {t(($) => {
+          return $.chat.sidebar.allChats;
+        })}
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        onSelect={() => {
+          toggleUnreadOnly(true);
+        }}
+      >
+        <Check size={16} className={`mr-2 ${unreadOnly ? "" : "invisible"}`} />
+        {t(($) => {
+          return $.chat.sidebar.unreadOnly;
+        })}
+      </DropdownMenuItem>
+    </>
+  );
+}
+
+function ChatThreadsListMenu({
+  showMarkAllRead,
+}: {
+  showMarkAllRead: boolean;
+}) {
+  const { t } = useTranslation();
+  const newChatAction = useNewChatMenuAction();
+  const markAllReadAction = useMarkAllReadMenuAction(showMarkAllRead);
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+            className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-state-selected-hover transition-colors"
+            aria-label={t(($) => {
+              return $.chat.sidebar.openListMenu;
+            })}
+          >
+            <ChatThreadsListMenuTooltip />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className="w-44"
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          <NewChatMenuItem {...newChatAction} />
+          {markAllReadAction.visible ? (
+            <MarkAllReadMenuItem {...markAllReadAction} />
+          ) : null}
+          <DropdownMenuSeparator />
+          <ChatThreadFilterMenuItems />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </TooltipProvider>
+  );
+}
+
+function ChatThreadsTitle({ showMarkAllRead }: { showMarkAllRead: boolean }) {
+  const { titleLabel } = useChatThreadsTitleLabels();
+  const setCollapsed = useSet(setSessionListCollapsed$);
+  const collapsed = useGet(sessionListCollapsed$);
 
   return (
     <div
@@ -716,70 +873,7 @@ function ChatThreadsTitle() {
         </span>
       </span>
       <div className="flex items-center gap-0.5">
-        <TooltipProvider delayDuration={200}>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                }}
-                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-state-selected-hover transition-colors"
-                aria-label={t(($) => {
-                  return $.chat.sidebar.openListMenu;
-                })}
-              >
-                <ChatThreadsListMenuTooltip />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="w-44"
-              onClick={(e) => {
-                e.stopPropagation();
-              }}
-            >
-              <DropdownMenuItem
-                onSelect={() => {
-                  onNewChat("main");
-                }}
-                disabled={!currentChatAgentId || newChatDisabled}
-              >
-                <Plus size={16} className="mr-2" />
-                {t(($) => {
-                  return $.chat.newChat;
-                })}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onSelect={() => {
-                  toggleUnreadOnly(false);
-                }}
-              >
-                <Check
-                  size={16}
-                  className={`mr-2 ${unreadOnly ? "invisible" : ""}`}
-                />
-                {t(($) => {
-                  return $.chat.sidebar.allChats;
-                })}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => {
-                  toggleUnreadOnly(true);
-                }}
-              >
-                <Check
-                  size={16}
-                  className={`mr-2 ${unreadOnly ? "" : "invisible"}`}
-                />
-                {t(($) => {
-                  return $.chat.sidebar.unreadOnly;
-                })}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </TooltipProvider>
+        <ChatThreadsListMenu showMarkAllRead={showMarkAllRead} />
       </div>
     </div>
   );
@@ -974,12 +1068,19 @@ function ExpandedChatThreadsContent() {
     </OverlayScrollArea>
   );
 }
-export function ChatThreadsSection() {
+export function ChatThreadsSection({
+  showMarkAllRead = false,
+}: {
+  showMarkAllRead?: boolean;
+} = {}) {
   const agentScope = useGet(currentChatAgentScope$);
 
   return (
     <div className="mt-4 flex flex-col min-h-0 flex-1">
-      <ChatThreadsTitle key={agentScope ?? "no-agent"} />
+      <ChatThreadsTitle
+        key={agentScope ?? "no-agent"}
+        showMarkAllRead={showMarkAllRead}
+      />
       <ChatThreadsContent />
       <ChatThreadRenameDialog />
       <DeleteChatThreadDialog />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -809,7 +809,7 @@ function ChatListColumn() {
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-2 pt-1">
         <PinnedAgentListSection layout="horizontal" />
-        <ChatThreadsSection />
+        <ChatThreadsSection showMarkAllRead />
       </div>
       <div className="px-2 pb-2">
         <SidebarUpgradeCard />


### PR DESCRIPTION
## Summary

- add a **Mark all read** action to the three-column chat-list menu when the current agent has unread chats
- reuse the existing agent-level mark-read command, unread state, icon, and translations
- add regression coverage for menu placement, API scope, unread indicator refresh, and conditional visibility

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter @okouai/app run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx` (59 tests)
