### PR TITLE
fix: allow quote-only feedback messages

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,14 +27,6 @@ rules as a newer message.
 The best-effort recent chat context supplied automatically when a new session
 starts. It is distinct from explicit retrieval of a thread's complete history.
 
-## Referenced passage
-
-A passage of assistant-produced content that the user selects and submits as
-part of a message. It may carry an optional user comment; the absence of a
-comment does not make the message empty.
-
-_Avoid_: Annotation, feedback-only quote
-
 ## Restricted explicit content
 
 Content intended for sexual arousal, sexual depictions involving minors,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,6 +27,14 @@ rules as a newer message.
 The best-effort recent chat context supplied automatically when a new session
 starts. It is distinct from explicit retrieval of a thread's complete history.
 
+## Referenced passage
+
+A passage of assistant-produced content that the user selects and submits as
+part of a message. It may carry an optional user comment; the absence of a
+comment does not make the message empty.
+
+_Avoid_: Annotation, feedback-only quote
+
 ## Restricted explicit content
 
 Content intended for sexual arousal, sexual depictions involving minors,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7471,6 +7471,60 @@ describe("CHAT-02: generation templates and attachments", () => {
     await cancelChatRun(actor, sent.runId);
   }, 90_000);
 
+  it("projects referenced passages without requiring every feedback note", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const userMessage: UserMessageInputDocument = {
+      version: 1,
+      parts: [
+        {
+          type: "feedback",
+          quote: "First quote",
+          note: [{ type: "text", text: "Clarify the owner" }],
+        },
+        {
+          type: "feedback",
+          quote: "Second quote",
+          note: [],
+        },
+      ],
+    };
+    const prompt =
+      "The user referenced 2 parts of your reply:\n\n" +
+      "> First quote\n\nUser comment:\nClarify the owner\n\n---\n\n" +
+      "> Second quote";
+
+    const sent = await sendChatRun(actor, {
+      agentId,
+      prompt: "legacy fallback",
+      userMessage,
+    });
+
+    const run = await api.readRun(actor, sent.runId);
+    expect(run.prompt).toBe(prompt);
+
+    const messages = await waitForThreadMessages(
+      actor,
+      sent.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return message.runId === sent.runId;
+        });
+      },
+    );
+    const message = userMessages(messages.events).find(
+      (item): item is PromptMessage => {
+        return item.eventType === "input.prompt" && item.runId === sent.runId;
+      },
+    );
+    expect(message?.userMessage?.parts.slice(0, 2)).toStrictEqual(
+      userMessage.parts,
+    );
+
+    await cancelChatRun(actor, sent.runId);
+  }, 90_000);
+
   it("projects multiple inline templates into one ordered prompt and one shared context", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7492,7 +7492,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     };
     const prompt =
       "The user referenced 2 parts of your reply:\n\n" +
-      "> First quote\n\nUser comment:\nClarify the owner\n\n---\n\n" +
+      "> First quote\n\nClarify the owner\n\n---\n\n" +
       "> Second quote";
 
     const sent = await sendChatRun(actor, {

--- a/turbo/apps/api/src/signals/services/chat-user-message.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-user-message.service.ts
@@ -259,42 +259,6 @@ function inlineGenerationTemplatePrompt(
   return `[Template #${referenceNumber}: ${part.titleSnapshot} (${generationTemplateTypeLabel(part.template)})]`;
 }
 
-function feedbackPromptIntro(args: {
-  readonly count: number;
-  readonly commonMailSourceLabel: string | null;
-  readonly hasSourceContext: boolean;
-  readonly hasQuoteOnlyPart: boolean;
-}): string {
-  const { count, commonMailSourceLabel, hasSourceContext, hasQuoteOnlyPart } =
-    args;
-  if (hasQuoteOnlyPart) {
-    if (commonMailSourceLabel !== null) {
-      return count === 1
-        ? `The user referenced this part of ${commonMailSourceLabel}:`
-        : `The user referenced ${count} parts of ${commonMailSourceLabel}:`;
-    }
-    if (hasSourceContext) {
-      return count === 1
-        ? "The user referenced this selected passage:"
-        : `The user referenced ${count} selected passages:`;
-    }
-    return count === 1
-      ? "The user referenced this part of your reply:"
-      : `The user referenced ${count} parts of your reply:`;
-  }
-  if (commonMailSourceLabel !== null) {
-    return count === 1
-      ? `Feedback on this part of ${commonMailSourceLabel}:`
-      : `Feedback on ${count} parts of ${commonMailSourceLabel}:`;
-  }
-  if (hasSourceContext) {
-    return `Feedback on ${count} selected ${count === 1 ? "passage" : "passages"}:`;
-  }
-  return count === 1
-    ? "Feedback on this part of your reply:"
-    : `Feedback on ${count} parts of your reply:`;
-}
-
 function formatFeedbackParts(
   parts: readonly Extract<UserMessagePart, { type: "feedback" }>[],
   serializeTemplate: (
@@ -354,13 +318,17 @@ function formatFeedbackParts(
           : `\n\n${note}`;
     return `${source}${quoted}${comment}`;
   });
-  const intro = feedbackPromptIntro({
-    count: parts.length,
-    commonMailSourceLabel:
-      commonMailSource === null ? null : mailSourceLabel(commonMailSource),
-    hasSourceContext,
-    hasQuoteOnlyPart,
-  });
+  const intro = hasQuoteOnlyPart
+    ? `The user referenced ${parts.length} parts of your reply:`
+    : commonMailSource
+      ? parts.length === 1
+        ? `Feedback on this part of ${mailSourceLabel(commonMailSource)}:`
+        : `Feedback on ${parts.length} parts of ${mailSourceLabel(commonMailSource)}:`
+      : hasSourceContext
+        ? `Feedback on ${parts.length} selected ${parts.length === 1 ? "passage" : "passages"}:`
+        : parts.length === 1
+          ? "Feedback on this part of your reply:"
+          : `Feedback on ${parts.length} parts of your reply:`;
   return `${intro}\n\n${blocks.join("\n\n---\n\n")}`;
 }
 

--- a/turbo/apps/api/src/signals/services/chat-user-message.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-user-message.service.ts
@@ -310,13 +310,9 @@ function formatFeedbackParts(
       commonMailSource === null && part.source?.type === "mail"
         ? `Source: ${mailSourceLabel(part.source)}\n\n`
         : "";
-    const comment =
-      note.length === 0
-        ? ""
-        : hasQuoteOnlyPart
-          ? `\n\nUser comment:\n${note}`
-          : `\n\n${note}`;
-    return `${source}${quoted}${comment}`;
+    return note.length === 0
+      ? `${source}${quoted}`
+      : `${source}${quoted}\n\n${note}`;
   });
   const intro = hasQuoteOnlyPart
     ? `The user referenced ${parts.length} parts of your reply:`

--- a/turbo/apps/api/src/signals/services/chat-user-message.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-user-message.service.ts
@@ -259,6 +259,42 @@ function inlineGenerationTemplatePrompt(
   return `[Template #${referenceNumber}: ${part.titleSnapshot} (${generationTemplateTypeLabel(part.template)})]`;
 }
 
+function feedbackPromptIntro(args: {
+  readonly count: number;
+  readonly commonMailSourceLabel: string | null;
+  readonly hasSourceContext: boolean;
+  readonly hasQuoteOnlyPart: boolean;
+}): string {
+  const { count, commonMailSourceLabel, hasSourceContext, hasQuoteOnlyPart } =
+    args;
+  if (hasQuoteOnlyPart) {
+    if (commonMailSourceLabel !== null) {
+      return count === 1
+        ? `The user referenced this part of ${commonMailSourceLabel}:`
+        : `The user referenced ${count} parts of ${commonMailSourceLabel}:`;
+    }
+    if (hasSourceContext) {
+      return count === 1
+        ? "The user referenced this selected passage:"
+        : `The user referenced ${count} selected passages:`;
+    }
+    return count === 1
+      ? "The user referenced this part of your reply:"
+      : `The user referenced ${count} parts of your reply:`;
+  }
+  if (commonMailSourceLabel !== null) {
+    return count === 1
+      ? `Feedback on this part of ${commonMailSourceLabel}:`
+      : `Feedback on ${count} parts of ${commonMailSourceLabel}:`;
+  }
+  if (hasSourceContext) {
+    return `Feedback on ${count} selected ${count === 1 ? "passage" : "passages"}:`;
+  }
+  return count === 1
+    ? "Feedback on this part of your reply:"
+    : `Feedback on ${count} parts of your reply:`;
+}
+
 function formatFeedbackParts(
   parts: readonly Extract<UserMessagePart, { type: "feedback" }>[],
   serializeTemplate: (
@@ -281,6 +317,15 @@ function formatFeedbackParts(
   const hasSourceContext = parts.some((part) => {
     return part.source !== undefined;
   });
+  const entries = parts.map((part) => {
+    return {
+      part,
+      note: serializeFeedbackNote(part.note, serializeTemplate).trim(),
+    };
+  });
+  const hasQuoteOnlyPart = entries.some((entry) => {
+    return entry.note.length === 0;
+  });
   const mailSourceLabel = (
     source: NonNullable<
       Extract<UserMessagePart, { type: "feedback" }>["source"]
@@ -290,7 +335,7 @@ function formatFeedbackParts(
       ? `an email draft (mail draft ID: ${source.id})`
       : `a sent email (mail ID: ${source.id}${source.sentId ? `, sent ID: ${source.sentId}` : ""})`;
   };
-  const blocks = parts.map((part) => {
+  const blocks = entries.map(({ part, note }) => {
     const quoted = part.quote
       .split("\n")
       .map((line) => {
@@ -301,20 +346,21 @@ function formatFeedbackParts(
       commonMailSource === null && part.source?.type === "mail"
         ? `Source: ${mailSourceLabel(part.source)}\n\n`
         : "";
-    return `${source}${quoted}\n\n${serializeFeedbackNote(
-      part.note,
-      serializeTemplate,
-    ).trim()}`;
+    const comment =
+      note.length === 0
+        ? ""
+        : hasQuoteOnlyPart
+          ? `\n\nUser comment:\n${note}`
+          : `\n\n${note}`;
+    return `${source}${quoted}${comment}`;
   });
-  const intro = commonMailSource
-    ? parts.length === 1
-      ? `Feedback on this part of ${mailSourceLabel(commonMailSource)}:`
-      : `Feedback on ${parts.length} parts of ${mailSourceLabel(commonMailSource)}:`
-    : hasSourceContext
-      ? `Feedback on ${parts.length} selected ${parts.length === 1 ? "passage" : "passages"}:`
-      : parts.length === 1
-        ? "Feedback on this part of your reply:"
-        : `Feedback on ${parts.length} parts of your reply:`;
+  const intro = feedbackPromptIntro({
+    count: parts.length,
+    commonMailSourceLabel:
+      commonMailSource === null ? null : mailSourceLabel(commonMailSource),
+    hasSourceContext,
+    hasQuoteOnlyPart,
+  });
   return `${intro}\n\n${blocks.join("\n\n---\n\n")}`;
 }
 

--- a/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
@@ -672,6 +672,90 @@ describe("user message document codec", () => {
     ).toStrictEqual(structured);
   });
 
+  it("serializes referenced passages without requiring every feedback note", () => {
+    const editorDocument = workflowComposerDocument({
+      type: "doc",
+      content: [
+        {
+          type: "feedbackItem",
+          attrs: {
+            feedbackId: 1,
+            quote: "First quote",
+            showDivider: false,
+            fill: false,
+          },
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "First note" }],
+            },
+          ],
+        },
+        {
+          type: "feedbackItem",
+          attrs: {
+            feedbackId: 2,
+            quote: "Second quote",
+            showDivider: true,
+            fill: true,
+            eventId: FEEDBACK_EVENT_ID,
+            rangeStart: 18,
+            rangeEnd: 30,
+          },
+          content: [{ type: "paragraph" }],
+        },
+      ],
+    });
+
+    expect(editorDocToMessageDocument(editorDocument)).toStrictEqual({
+      version: 1,
+      parts: [
+        {
+          type: "feedback",
+          quote: "First quote",
+          note: [{ type: "text", text: "First note" }],
+        },
+      ],
+    });
+
+    const structured = editorDocToMessageDocument(editorDocument, {
+      includeQuoteOnlyFeedback: true,
+    });
+    expect(structured).toStrictEqual({
+      version: 1,
+      parts: [
+        {
+          type: "feedback",
+          quote: "First quote",
+          note: [{ type: "text", text: "First note" }],
+        },
+        {
+          type: "feedback",
+          quote: "Second quote",
+          eventId: FEEDBACK_EVENT_ID,
+          range: { start: 18, end: 30 },
+          note: [],
+        },
+      ],
+    });
+    const expectedPrompt =
+      "The user referenced 2 parts of your reply:\n\n" +
+      "> First quote\n\nUser comment:\nFirst note\n\n---\n\n" +
+      "> Second quote";
+    expect(messageDocumentToPrompt(structured)).toBe(expectedPrompt);
+    expect(messageDocumentToDisplayText(structured)).toBe(expectedPrompt);
+
+    const restored = messageDocumentToEditorDoc(structured);
+    if (!restored) {
+      throw new Error("Expected quote-only feedback document to restore");
+    }
+    expect(
+      editorDocToMessageDocument(workflowComposerDocument(restored), {
+        includeQuoteOnlyFeedback: true,
+      }),
+    ).toStrictEqual(structured);
+  });
+
   it("preserves mail source metadata for structured feedback", () => {
     const structured: UserMessageDocument = {
       version: 1,

--- a/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/user-message-document-codec.test.ts
@@ -740,7 +740,7 @@ describe("user message document codec", () => {
     });
     const expectedPrompt =
       "The user referenced 2 parts of your reply:\n\n" +
-      "> First quote\n\nUser comment:\nFirst note\n\n---\n\n" +
+      "> First quote\n\nFirst note\n\n---\n\n" +
       "> Second quote";
     expect(messageDocumentToPrompt(structured)).toBe(expectedPrompt);
     expect(messageDocumentToDisplayText(structured)).toBe(expectedPrompt);

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -118,42 +118,6 @@ export function createComposerFeedbackModel(): ComposerFeedbackModel {
   };
 }
 
-function feedbackPromptIntro(args: {
-  readonly count: number;
-  readonly commonMailSourceLabel: string | null;
-  readonly hasSourceContext: boolean;
-  readonly hasQuoteOnlyItem: boolean;
-}): string {
-  const { count, commonMailSourceLabel, hasSourceContext, hasQuoteOnlyItem } =
-    args;
-  if (hasQuoteOnlyItem) {
-    if (commonMailSourceLabel !== null) {
-      return count === 1
-        ? `The user referenced this part of ${commonMailSourceLabel}:`
-        : `The user referenced ${count} parts of ${commonMailSourceLabel}:`;
-    }
-    if (hasSourceContext) {
-      return count === 1
-        ? "The user referenced this selected passage:"
-        : `The user referenced ${count} selected passages:`;
-    }
-    return count === 1
-      ? "The user referenced this part of your reply:"
-      : `The user referenced ${count} parts of your reply:`;
-  }
-  if (commonMailSourceLabel !== null) {
-    return count === 1
-      ? `Feedback on this part of ${commonMailSourceLabel}:`
-      : `Feedback on ${count} parts of ${commonMailSourceLabel}:`;
-  }
-  if (hasSourceContext) {
-    return `Feedback on ${count} selected ${count === 1 ? "passage" : "passages"}:`;
-  }
-  return count === 1
-    ? "Feedback on this part of your reply:"
-    : `Feedback on ${count} parts of your reply:`;
-}
-
 // Compose every selected fragment into a single follow-up turn. A passage can
 // carry a comment, but the reference itself remains meaningful without one.
 export function formatFeedbackPrompt(
@@ -203,12 +167,16 @@ export function formatFeedbackPrompt(
           : `\n\n${note}`;
     return `${source}${quoted}${comment}`;
   });
-  const intro = feedbackPromptIntro({
-    count: items.length,
-    commonMailSourceLabel:
-      commonMailSource === null ? null : mailSourceLabel(commonMailSource),
-    hasSourceContext,
-    hasQuoteOnlyItem,
-  });
+  const intro = hasQuoteOnlyItem
+    ? `The user referenced ${items.length} parts of your reply:`
+    : commonMailSource
+      ? items.length === 1
+        ? `Feedback on this part of ${mailSourceLabel(commonMailSource)}:`
+        : `Feedback on ${items.length} parts of ${mailSourceLabel(commonMailSource)}:`
+      : hasSourceContext
+        ? `Feedback on ${items.length} selected ${items.length === 1 ? "passage" : "passages"}:`
+        : items.length === 1
+          ? "Feedback on this part of your reply:"
+          : `Feedback on ${items.length} parts of your reply:`;
   return `${intro}\n\n${blocks.join("\n\n---\n\n")}`;
 }

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -159,13 +159,9 @@ export function formatFeedbackPrompt(
         ? `Source: ${mailSourceLabel(item.source)}\n\n`
         : "";
     const note = item.note.trim();
-    const comment =
-      note.length === 0
-        ? ""
-        : hasQuoteOnlyItem
-          ? `\n\nUser comment:\n${note}`
-          : `\n\n${note}`;
-    return `${source}${quoted}${comment}`;
+    return note.length === 0
+      ? `${source}${quoted}`
+      : `${source}${quoted}\n\n${note}`;
   });
   const intro = hasQuoteOnlyItem
     ? `The user referenced ${items.length} parts of your reply:`

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -118,8 +118,44 @@ export function createComposerFeedbackModel(): ComposerFeedbackModel {
   };
 }
 
-// Compose every noted fragment into a single follow-up turn, each passage
-// quoted above the note that belongs to it.
+function feedbackPromptIntro(args: {
+  readonly count: number;
+  readonly commonMailSourceLabel: string | null;
+  readonly hasSourceContext: boolean;
+  readonly hasQuoteOnlyItem: boolean;
+}): string {
+  const { count, commonMailSourceLabel, hasSourceContext, hasQuoteOnlyItem } =
+    args;
+  if (hasQuoteOnlyItem) {
+    if (commonMailSourceLabel !== null) {
+      return count === 1
+        ? `The user referenced this part of ${commonMailSourceLabel}:`
+        : `The user referenced ${count} parts of ${commonMailSourceLabel}:`;
+    }
+    if (hasSourceContext) {
+      return count === 1
+        ? "The user referenced this selected passage:"
+        : `The user referenced ${count} selected passages:`;
+    }
+    return count === 1
+      ? "The user referenced this part of your reply:"
+      : `The user referenced ${count} parts of your reply:`;
+  }
+  if (commonMailSourceLabel !== null) {
+    return count === 1
+      ? `Feedback on this part of ${commonMailSourceLabel}:`
+      : `Feedback on ${count} parts of ${commonMailSourceLabel}:`;
+  }
+  if (hasSourceContext) {
+    return `Feedback on ${count} selected ${count === 1 ? "passage" : "passages"}:`;
+  }
+  return count === 1
+    ? "Feedback on this part of your reply:"
+    : `Feedback on ${count} parts of your reply:`;
+}
+
+// Compose every selected fragment into a single follow-up turn. A passage can
+// carry a comment, but the reference itself remains meaningful without one.
 export function formatFeedbackPrompt(
   items: readonly Pick<FeedbackItem, "quote" | "note" | "source">[],
 ): string {
@@ -139,6 +175,9 @@ export function formatFeedbackPrompt(
   const hasSourceContext = items.some((item) => {
     return item.source !== undefined;
   });
+  const hasQuoteOnlyItem = items.some((item) => {
+    return item.note.trim().length === 0;
+  });
   const mailSourceLabel = (source: FeedbackSource) => {
     return source.status === "draft"
       ? `an email draft (mail draft ID: ${source.id})`
@@ -155,16 +194,21 @@ export function formatFeedbackPrompt(
       commonMailSource === null && item.source?.type === "mail"
         ? `Source: ${mailSourceLabel(item.source)}\n\n`
         : "";
-    return `${source}${quoted}\n\n${item.note.trim()}`;
+    const note = item.note.trim();
+    const comment =
+      note.length === 0
+        ? ""
+        : hasQuoteOnlyItem
+          ? `\n\nUser comment:\n${note}`
+          : `\n\n${note}`;
+    return `${source}${quoted}${comment}`;
   });
-  const intro = commonMailSource
-    ? items.length === 1
-      ? `Feedback on this part of ${mailSourceLabel(commonMailSource)}:`
-      : `Feedback on ${items.length} parts of ${mailSourceLabel(commonMailSource)}:`
-    : hasSourceContext
-      ? `Feedback on ${items.length} selected ${items.length === 1 ? "passage" : "passages"}:`
-      : items.length === 1
-        ? "Feedback on this part of your reply:"
-        : `Feedback on ${items.length} parts of your reply:`;
+  const intro = feedbackPromptIntro({
+    count: items.length,
+    commonMailSourceLabel:
+      commonMailSource === null ? null : mailSourceLabel(commonMailSource),
+    hasSourceContext,
+    hasQuoteOnlyItem,
+  });
   return `${intro}\n\n${blocks.join("\n\n---\n\n")}`;
 }

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -477,6 +477,9 @@ export function createComposerSignals(
     return options.agentId;
   });
   const feedback = createComposerFeedbackModel();
+  const quoteOnlyFeedbackEnabled$ = computed((get): boolean => {
+    return get(featureSwitch$)[FeatureSwitchKey.ChatQuoteOnlyFeedback] ?? false;
+  });
   const temporaryModelNoticeEnabled$ = computed((get): boolean => {
     return (
       options.threadId === undefined &&
@@ -491,6 +494,7 @@ export function createComposerSignals(
       singleLineOnMobile: options.singleLineOnMobile,
     },
     feedback,
+    quoteOnlyFeedbackEnabled$,
   );
   const ui = createComposerUiSignals();
   const submission = createComposerSubmissionSignals(

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -97,6 +97,9 @@ interface MountedWorkflowNamesSync {
 const mountedWorkflowNamesSyncs$ = state<ReadonlySet<MountedWorkflowNamesSync>>(
   new Set(),
 );
+const quoteOnlyFeedbackDisabled$ = computed(() => {
+  return false;
+});
 
 const registerMountedWorkflowNamesSync$ = command(
   ({ get, set }, mountedWorkflowNamesSync: MountedWorkflowNamesSync): void => {
@@ -263,12 +266,17 @@ function connectComposerFeedback(
 function createReadInputForSubmissionCommand(
   editor: Editor,
   compositionGate: CompositionGate,
+  quoteOnlyFeedbackEnabled$: Computed<boolean>,
 ) {
-  return command((_context, signal: AbortSignal) => {
+  return command(({ get }, signal: AbortSignal) => {
+    const includeQuoteOnlyFeedback = get(quoteOnlyFeedbackEnabled$);
     return compositionGate.runWhenSettled(() => {
       return {
-        prompt: workflowComposerDocToString(editor),
-        editorDocument: createEditorDocumentSnapshot(editor.state.doc),
+        prompt: workflowComposerDocToString(editor, includeQuoteOnlyFeedback),
+        editorDocument: createEditorDocumentSnapshot(
+          editor.state.doc,
+          includeQuoteOnlyFeedback,
+        ),
       };
     }, signal);
   });
@@ -1340,7 +1348,10 @@ function nodeText(
   });
 }
 
-function workflowComposerDocToString(editor: Editor): string {
+function workflowComposerDocToString(
+  editor: Editor,
+  includeQuoteOnlyFeedback = false,
+): string {
   const sections: string[] = [];
   let textBlocks: string[] = [];
   let feedbackItems: FeedbackItem[] = [];
@@ -1352,11 +1363,13 @@ function workflowComposerDocToString(editor: Editor): string {
     textBlocks = [];
   };
   const flushFeedbackItems = () => {
-    const notedItems = feedbackItems.filter((item) => {
-      return item.note.trim().length > 0;
-    });
-    if (notedItems.length > 0) {
-      sections.push(formatFeedbackPrompt(notedItems));
+    const includedItems = includeQuoteOnlyFeedback
+      ? feedbackItems
+      : feedbackItems.filter((item) => {
+          return item.note.trim().length > 0;
+        });
+    if (includedItems.length > 0) {
+      sections.push(formatFeedbackPrompt(includedItems));
     }
     feedbackItems = [];
   };
@@ -1940,6 +1953,7 @@ interface MountEditorOptions {
   compositionGate: CompositionGate;
   syncWorkflowNames$: WorkflowNamesSyncCommand;
   syncAgentMentionAvatars$: AgentMentionAvatarsSyncCommand;
+  quoteOnlyFeedbackEnabled$: Computed<boolean>;
   autoFocus: boolean;
   singleLineOnMobile: boolean;
 }
@@ -1957,6 +1971,54 @@ function focusMountedEditorAtEnd(editor: Editor): void {
   editor.commands.scrollIntoView();
 }
 
+interface MountedDraftInputSyncTargetOptions {
+  editor: Editor;
+  runtime: WorkflowComposerRuntime;
+  includeQuoteOnlyFeedback: boolean;
+  setEditorDocument(snapshot: EditorDocumentSnapshot): void;
+}
+
+function createMountedDraftInputSyncTarget({
+  editor,
+  runtime,
+  includeQuoteOnlyFeedback,
+  setEditorDocument,
+}: MountedDraftInputSyncTargetOptions): DraftInputSyncTarget {
+  const syncEditorDocument = () => {
+    setEditorDocument(
+      createEditorDocumentSnapshot(editor.state.doc, includeQuoteOnlyFeedback),
+    );
+  };
+  return {
+    syncInput(value) {
+      if (
+        workflowComposerDocToString(editor, includeQuoteOnlyFeedback) === value
+      ) {
+        return;
+      }
+      const changed = setWorkflowComposerDocument(
+        editor,
+        workflowComposerDocumentForValue(editor, value),
+      );
+      if (changed) {
+        runtime.replaceFeedbackItems(feedbackItemsFromWorkflowComposer(editor));
+        syncEditorDocument();
+      }
+    },
+    syncUserMessage(value) {
+      const document = workflowComposerDocumentForUserMessage(editor, value);
+      if (!document) {
+        return;
+      }
+      const changed = setWorkflowComposerDocument(editor, document);
+      if (changed) {
+        runtime.replaceFeedbackItems(feedbackItemsFromWorkflowComposer(editor));
+      }
+      syncEditorDocument();
+    },
+  };
+}
+
 function createMountEditorCommand({
   editor,
   draft,
@@ -1968,19 +2030,27 @@ function createMountEditorCommand({
   compositionGate,
   syncWorkflowNames$,
   syncAgentMentionAvatars$,
+  quoteOnlyFeedbackEnabled$,
   autoFocus,
   singleLineOnMobile,
 }: MountEditorOptions) {
   return onRef(
     command(async ({ get, set }, element: HTMLElement, signal: AbortSignal) => {
+      const includeQuoteOnlyFeedback = get(quoteOnlyFeedbackEnabled$);
       runtime.update = (updatedEditor) => {
         runtime.replaceFeedbackItems(
           feedbackItemsFromWorkflowComposer(updatedEditor),
         );
-        set(draft.setInput$, workflowComposerDocToString(updatedEditor));
+        set(
+          draft.setInput$,
+          workflowComposerDocToString(updatedEditor, includeQuoteOnlyFeedback),
+        );
         set(
           draft.setEditorDocument$,
-          createEditorDocumentSnapshot(updatedEditor.state.doc),
+          createEditorDocumentSnapshot(
+            updatedEditor.state.doc,
+            includeQuoteOnlyFeedback,
+          ),
         );
         set(selectedSuggestionIndexState$, 0);
         set(caretIndex$, updatedEditor.state.selection.head);
@@ -2015,50 +2085,25 @@ function createMountEditorCommand({
       );
       set(
         draft.setEditorDocument$,
-        createEditorDocumentSnapshot(editor.state.doc),
+        createEditorDocumentSnapshot(
+          editor.state.doc,
+          includeQuoteOnlyFeedback,
+        ),
       );
       editor.mount(element);
       mountLocalizationListener(editor, runtime, signal);
       mountCompositionListeners(editor, compositionGate, signal);
-      set(draft.setInputSyncTarget$, {
-        syncInput(value: string) {
-          if (workflowComposerDocToString(editor) === value) {
-            return;
-          }
-          const changed = setWorkflowComposerDocument(
-            editor,
-            workflowComposerDocumentForValue(editor, value),
-          );
-          if (changed) {
-            runtime.replaceFeedbackItems(
-              feedbackItemsFromWorkflowComposer(editor),
-            );
-            set(
-              draft.setEditorDocument$,
-              createEditorDocumentSnapshot(editor.state.doc),
-            );
-          }
-        },
-        syncUserMessage(value) {
-          const document = workflowComposerDocumentForUserMessage(
-            editor,
-            value,
-          );
-          if (!document) {
-            return;
-          }
-          const changed = setWorkflowComposerDocument(editor, document);
-          if (changed) {
-            runtime.replaceFeedbackItems(
-              feedbackItemsFromWorkflowComposer(editor),
-            );
-          }
-          set(
-            draft.setEditorDocument$,
-            createEditorDocumentSnapshot(editor.state.doc),
-          );
-        },
-      });
+      set(
+        draft.setInputSyncTarget$,
+        createMountedDraftInputSyncTarget({
+          editor,
+          runtime,
+          includeQuoteOnlyFeedback,
+          setEditorDocument(snapshot) {
+            set(draft.setEditorDocument$, snapshot);
+          },
+        }),
+      );
       // Keep workflow decoration sync scoped to real editor mounts.
       const mountedWorkflowNamesSync = {
         command$: syncWorkflowNames$,
@@ -2496,6 +2541,7 @@ export function createWorkflowComposerSignals<
   agentIdSource$: Computed<T> = currentChatAgentRecordId$ as Computed<T>,
   mountOptions: WorkflowComposerMountOptions = {},
   feedback: ComposerFeedbackModel = createComposerFeedbackModel(),
+  quoteOnlyFeedbackEnabled$: Computed<boolean> = quoteOnlyFeedbackDisabled$,
 ): WorkflowComposerSignals {
   const caretIndex$ = state(-1);
   const editorFocusedState$ = state(false);
@@ -2567,6 +2613,7 @@ export function createWorkflowComposerSignals<
     compositionGate,
     syncWorkflowNames$,
     syncAgentMentionAvatars$,
+    quoteOnlyFeedbackEnabled$,
     autoFocus: mountOptions.autoFocus ?? false,
     singleLineOnMobile: mountOptions.singleLineOnMobile ?? false,
   });
@@ -2581,6 +2628,7 @@ export function createWorkflowComposerSignals<
   const readInputForSubmission$ = createReadInputForSubmissionCommand(
     editor,
     compositionGate,
+    quoteOnlyFeedbackEnabled$,
   );
   const hasInput$ = computed((get) => {
     return get(draft.hasInput$) || get(feedback.active$);

--- a/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
+++ b/turbo/apps/platform/src/signals/zero-page/user-message-document-codec.ts
@@ -30,6 +30,7 @@ const FEEDBACK_ITEM_NODE_NAME = "feedbackItem";
 export interface EditorDocumentContext {
   readonly selectedTemplate?: GenerationTemplateRequest;
   readonly attachments?: readonly PersistedAttachment[];
+  readonly includeQuoteOnlyFeedback?: boolean;
 }
 
 export interface EditorDocumentSnapshot {
@@ -315,6 +316,7 @@ function appendFeedbackGroup(
   document: ProseMirrorNode,
   startIndex: number,
   parts: UserMessagePart[],
+  includeQuoteOnlyFeedback: boolean,
 ): { readonly nextIndex: number; readonly emitted: boolean } | null {
   const feedbackParts: UserMessagePart[] = [];
   let index = startIndex;
@@ -327,7 +329,10 @@ function appendFeedbackGroup(
     if (!part || part.type !== "feedback") {
       return null;
     }
-    if (feedbackNoteToPrompt(part.note).trim().length > 0) {
+    if (
+      includeQuoteOnlyFeedback ||
+      feedbackNoteToPrompt(part.note).trim().length > 0
+    ) {
       feedbackParts.push(part);
     }
     index += 1;
@@ -373,7 +378,12 @@ export function editorDocToMessageDocument(
       filesAppended = true;
     }
     if (node.type.name === FEEDBACK_ITEM_NODE_NAME) {
-      const feedbackGroup = appendFeedbackGroup(document, index, parts);
+      const feedbackGroup = appendFeedbackGroup(
+        document,
+        index,
+        parts,
+        context.includeQuoteOnlyFeedback ?? false,
+      );
       if (feedbackGroup === null) {
         return null;
       }
@@ -412,13 +422,17 @@ export function editorDocToMessageDocument(
  */
 export function createEditorDocumentSnapshot(
   document: ProseMirrorNode,
+  includeQuoteOnlyFeedback = false,
 ): EditorDocumentSnapshot {
   return Object.freeze({
     toEditorDocument() {
       return document.toJSON();
     },
     toMessageDocument(context: EditorDocumentContext = {}) {
-      return editorDocToMessageDocument(document, context);
+      return editorDocToMessageDocument(document, {
+        ...context,
+        includeQuoteOnlyFeedback,
+      });
     },
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -2076,6 +2076,109 @@ describe("chat inline feedback", () => {
     expect(sentPrompts[0]).toContain("Add dates.");
   });
 
+  it("sends multiple referenced passages without comments", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The launch summary needs clearer risk ownership.";
+    const firstQuote = "launch summary";
+    const secondQuote = "risk ownership";
+    const firstRange = {
+      start: assistantReply.indexOf(firstQuote),
+      end: assistantReply.indexOf(firstQuote) + firstQuote.length,
+    };
+    const secondRange = {
+      start: assistantReply.indexOf(secondQuote),
+      end: assistantReply.indexOf(secondQuote) + secondQuote.length,
+    };
+    const sentMessages: RunCreateCapture[] = [];
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatEvents: [
+        {
+          id: "msg-quote-only-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-quote-only",
+          createdAt: "2026-08-18T10:00:00Z",
+        },
+        {
+          id: "msg-quote-only-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-quote-only",
+          createdAt: "2026-08-18T10:01:00Z",
+        },
+      ],
+      onRunCreate: (body) => {
+        sentMessages.push(body);
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatQuoteOnlyFeedback]: true,
+      },
+    });
+
+    const assistantReplyElement = await screen.findByText(assistantReply);
+    selectTextForInlineFeedback(assistantReplyElement, firstRange);
+    await user.click(await screen.findByText("Quote"));
+    await findFeedbackNote();
+
+    selectTextForInlineFeedback(assistantReplyElement, secondRange);
+    await user.click(await screen.findByText("Quote"));
+    await findFeedbackNotes(2);
+    await user.click(screen.getByLabelText("Send"));
+
+    await waitFor(() => {
+      expect(sentMessages).toHaveLength(1);
+    });
+    expect(sentMessages[0]).toMatchObject({
+      prompt:
+        "The user referenced 2 parts of your reply:\n\n" +
+        `> ${firstQuote}\n\n---\n\n` +
+        `> ${secondQuote}`,
+      hasTextContent: true,
+      userMessage: {
+        version: 1,
+        parts: [
+          {
+            type: "feedback",
+            quote: firstQuote,
+            eventId: "msg-quote-only-assistant",
+            range: firstRange,
+            note: [],
+          },
+          {
+            type: "feedback",
+            quote: secondQuote,
+            eventId: "msg-quote-only-assistant",
+            range: secondRange,
+            note: [],
+          },
+        ],
+      },
+    });
+    const sentFeedbackGroup = await waitFor(() => {
+      const group = document.querySelector("[data-structured-feedback-group]");
+      expect(group).toBeInstanceOf(HTMLElement);
+      return group as HTMLElement;
+    });
+    expect(
+      Array.from(
+        sentFeedbackGroup.querySelectorAll("[data-structured-feedback-quote]"),
+      ).map((quote) => {
+        return quote.textContent;
+      }),
+    ).toStrictEqual([firstQuote, secondQuote]);
+    await waitFor(() => {
+      expect(feedbackNotes()).toHaveLength(0);
+    });
+  });
+
   it("keeps the divider spacing off the first inline feedback item", async () => {
     const user = userEvent.setup({ delay: null });
     const assistantReply = "The launch summary needs clearer risk ownership.";

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -414,6 +414,26 @@ describe("chat thread generation template contract", () => {
     expect(parsed.success).toBe(true);
   });
 
+  it("accepts referenced feedback passages without a user comment", () => {
+    const userMessage = {
+      version: 1,
+      parts: [
+        {
+          type: "feedback",
+          quote: "Original reply",
+          note: [],
+        },
+      ],
+    };
+
+    expect(userMessageDocumentSchema.safeParse(userMessage)).toMatchObject({
+      success: true,
+    });
+    expect(userMessageInputDocumentSchema.safeParse(userMessage)).toMatchObject(
+      { success: true },
+    );
+  });
+
   it("accepts feedback event ranges without requiring them on legacy data", () => {
     const legacyFeedback = {
       version: 1,

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -437,7 +437,7 @@ const userMessageInputPartSchema = z.discriminatedUnion("type", [
     .object({
       type: z.literal("feedback"),
       quote: z.string().min(1),
-      note: z.array(feedbackNotePartSchema).min(1),
+      note: z.array(feedbackNotePartSchema),
       eventId: z.string().min(1).optional(),
       range: feedbackRangeSchema.optional(),
       source: z

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -97,6 +97,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatForward]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ChatQuoteOnlyFeedback]).toBe(true);
     expect(
       staffOrgStates[FeatureSwitchKey.ChatRunContinuationPresentation],
     ).toBe(true);
@@ -132,6 +133,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatForward]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ChatQuoteOnlyFeedback]).toBe(false);
     expect(
       otherOrgStates[FeatureSwitchKey.ChatRunContinuationPresentation],
     ).toBe(false);

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -57,6 +57,7 @@ export enum FeatureSwitchKey {
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   ChatErrorRecovery = "chatErrorRecovery",
   ChatForward = "chatForward",
+  ChatQuoteOnlyFeedback = "chatQuoteOnlyFeedback",
   ChatRunContinuationPresentation = "chatRunContinuationPresentation",
   ChatSmoothAutoScroll = "chatSmoothAutoScroll",
   ResponsiveFollowupCards = "responsiveFollowupCards",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -379,6 +379,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ChatQuoteOnlyFeedback]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Allow quoted assistant passages to be sent without an added user comment.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatRunContinuationPresentation]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- gate quote-only feedback authoring behind `chatQuoteOnlyFeedback` (off by default, enabled for the staff org)
- accept and persist feedback parts with `note: []`, so a selected passage remains a valid structured message without an added comment
- preserve multiple quoted passages in order and project each non-empty note directly under its quote
- keep the existing feedback prompt byte-compatible when every quote has a comment, and clear quote-only drafts after a successful send

## Compatibility

- readers and API contracts always accept empty feedback notes so persisted messages remain readable
- only authoring quote-only messages is feature-gated

## Testing

- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/chat-threads.test.ts`
- `pnpm -F @okouai/app exec vitest run src/signals/__tests__/user-message-document-codec.test.ts`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "projects referenced passages without requiring every feedback note"`
- `pnpm exec prettier --check <13 changed files>`
