### PR TITLE
refactor(rust): neutralize session-history identity type names

### DIFF
--- a/crates/guest-agent/src/checkpoint/mod.rs
+++ b/crates/guest-agent/src/checkpoint/mod.rs
@@ -486,7 +486,7 @@ mod tests {
         let session_metadata = CapturedSessionMetadata::for_test(
             thread_id,
             Some(
-                guest_contracts::session_history_identity::FinalSessionHistorySourceRef::Codex {
+                guest_contracts::session_history_identity::SessionHistorySourceRef::Codex {
                     sessions_dir: std::path::Path::new(&home_dir)
                         .join(".codex/sessions")
                         .to_string_lossy()

--- a/crates/guest-agent/src/checkpoint/session_history.rs
+++ b/crates/guest-agent/src/checkpoint/session_history.rs
@@ -7,7 +7,7 @@ use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::session_history as history;
 use crate::session_history_identity::{
-    FinalSessionHistoryIdentityBuildError, build_final_session_history_identity,
+    SessionHistoryIdentityBuildError, build_final_session_history_identity,
 };
 use api_contracts::generated::constants::runners::{
     RESUME_SESSION_HISTORY_MAX_BYTES, SESSION_HISTORY_ENCODING_GZIP,
@@ -19,7 +19,7 @@ use guest_common::telemetry::{
     SandboxOpDimensions, record_sandbox_op, record_sandbox_op_with_dimensions,
 };
 use guest_common::{log_info, log_warn};
-use guest_contracts::session_history_identity::FinalSessionHistorySourceRef;
+use guest_contracts::session_history_identity::SessionHistorySourceRef;
 use guest_session_prune::{
     ClaudeHistoryIneligibleReason, ClaudeHistorySelection, CodexHistoryIneligibleReason,
     CodexHistorySelection, select_claude_compact_generation_from_file,
@@ -316,7 +316,7 @@ pub(super) struct CheckpointSessionHistoryInputs {
     framework: env::Framework,
     limits: CheckpointSessionHistoryLimits,
     cli_agent_session_id: String,
-    history_source: Option<FinalSessionHistorySourceRef>,
+    history_source: Option<SessionHistorySourceRef>,
 }
 
 impl CheckpointSessionHistoryInputs {
@@ -333,7 +333,7 @@ impl CheckpointSessionHistoryInputs {
 
 pub(super) struct UploadedCheckpointSessionHistory {
     pub(super) cli_agent_session_id: String,
-    pub(super) history_source: FinalSessionHistorySourceRef,
+    pub(super) history_source: SessionHistorySourceRef,
     pub(super) history_hash: String,
     pub(super) history_size: u64,
     pub(super) live_history: PreparedLiveHistory,
@@ -517,7 +517,7 @@ fn prepare_session_history(
     framework: env::Framework,
     limits: CheckpointSessionHistoryLimits,
     cli_agent_session_id: &str,
-    history_source: &FinalSessionHistorySourceRef,
+    history_source: &SessionHistorySourceRef,
     history_read_start: std::time::Instant,
 ) -> Result<PreparedSessionHistoryOutcome, AgentError> {
     let mut resolved =
@@ -1044,7 +1044,7 @@ pub(super) fn write_final_session_history_identity(
     cli_agent_session_id: &str,
     history_hash: &str,
     history_size: u64,
-    history_source: &FinalSessionHistorySourceRef,
+    history_source: &SessionHistorySourceRef,
     framework: env::Framework,
     final_session_history_identity_file: &str,
 ) {
@@ -1061,13 +1061,13 @@ pub(super) fn write_final_session_history_identity(
         Ok(identity) => identity,
         Err(error) => {
             match error {
-                FinalSessionHistoryIdentityBuildError::InvalidSessionId => record_sandbox_op(
+                SessionHistoryIdentityBuildError::InvalidSessionId => record_sandbox_op(
                     "session_history_identity_write_skipped_invalid_session_id",
                     Duration::ZERO,
                     true,
                     None,
                 ),
-                FinalSessionHistoryIdentityBuildError::InvalidMetadata(_) => record_sandbox_op(
+                SessionHistoryIdentityBuildError::InvalidMetadata(_) => record_sandbox_op(
                     "session_history_identity_write_skipped_invalid_metadata",
                     Duration::ZERO,
                     true,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -26,9 +26,9 @@ use guest_contracts::diagnostics::{
     FailureDiagnostic, FailureReason, WorkloadResourceLimitDiagnostic,
 };
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryIdentityExpectation, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS, SessionHistoryIdentityExpectation,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -168,7 +168,7 @@ fn helper_exit_code_from_args() -> Option<i32> {
 }
 
 fn session_history_identity_helper_exit_code(
-    error: &session_history_identity::FinalSessionHistoryIdentityVerifyError,
+    error: &session_history_identity::SessionHistoryIdentityVerifyError,
 ) -> i32 {
     let exit_code = error.helper_exit_code();
     if exit_code == SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS {
@@ -179,7 +179,7 @@ fn session_history_identity_helper_exit_code(
 }
 
 fn session_history_sidecar_export_helper_exit_code(
-    error: &session_history_identity::FinalSessionHistorySidecarExportError,
+    error: &session_history_identity::SessionHistorySidecarExportError,
 ) -> i32 {
     let exit_code = error.helper_exit_code();
     let Some(failure) = error.output_failure() else {
@@ -205,7 +205,7 @@ fn final_session_history_identity_path_from_process_env() -> std::ffi::OsString 
 
 fn parse_session_history_identity_expectation(
     args: &[std::ffi::OsString],
-) -> Result<Option<FinalSessionHistoryIdentityExpectation>, ()> {
+) -> Result<Option<SessionHistoryIdentityExpectation>, ()> {
     let [
         framework,
         session_id_hash,
@@ -234,7 +234,7 @@ fn parse_session_history_identity_expectation(
     let history_ref_kind = history_ref_kind.to_str().ok_or(())?;
     let history_hash = history_hash.to_str().ok_or(())?;
     let history_size_bytes = history_size_bytes.to_str().ok_or(())?;
-    FinalSessionHistoryIdentityExpectation::from_cli_args([
+    SessionHistoryIdentityExpectation::from_cli_args([
         framework,
         session_id_hash,
         history_ref_kind,
@@ -1836,7 +1836,7 @@ mod tests {
         let session_metadata = session_metadata::CapturedSessionMetadata::for_test(
             session_id,
             Some(
-                guest_contracts::session_history_identity::FinalSessionHistorySourceRef::ClaudeCode {
+                guest_contracts::session_history_identity::SessionHistorySourceRef::ClaudeCode {
                     config_dir: config_dir.to_string_lossy().into_owned(),
                     working_dir: paths::CANONICAL_WORKING_DIR.to_string(),
                     session_id: session_id.to_string(),

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -16,7 +16,7 @@ use crate::error::AgentError;
 use crate::nofollow_fs::Dir;
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
 use guest_contracts::codex_thread_id::codex_thread_id_filename_key;
-use guest_contracts::session_history_identity::FinalSessionHistorySourceRef;
+use guest_contracts::session_history_identity::SessionHistorySourceRef;
 use sha2::{Digest, Sha256};
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
@@ -182,10 +182,10 @@ impl PreparedSessionHistorySidecar {
 
 /// Resolve one canonical framework source and return its already-open regular file.
 pub(crate) fn resolve_session_history_from_source(
-    source: &FinalSessionHistorySourceRef,
+    source: &SessionHistorySourceRef,
 ) -> Result<ResolvedSessionHistory, AgentError> {
     match source {
-        FinalSessionHistorySourceRef::ClaudeCode {
+        SessionHistorySourceRef::ClaudeCode {
             config_dir,
             working_dir,
             session_id,
@@ -210,7 +210,7 @@ pub(crate) fn resolve_session_history_from_source(
             let leaf = format!("{session_id}.jsonl");
             open_exact_session_history(&config_dir, &["projects", &project_dir], OsStr::new(&leaf))
         }
-        FinalSessionHistorySourceRef::Codex {
+        SessionHistorySourceRef::Codex {
             sessions_dir,
             thread_id,
         } => {
@@ -230,7 +230,7 @@ pub(crate) fn resolve_session_history_from_source(
                 ))
             }
         }
-        FinalSessionHistorySourceRef::Pi {
+        SessionHistorySourceRef::Pi {
             session_path,
             session_id,
         } => {
@@ -252,7 +252,7 @@ pub(crate) fn resolve_session_history_from_source(
 }
 
 pub(crate) fn digest_session_history_from_source_bounded(
-    source: &FinalSessionHistorySourceRef,
+    source: &SessionHistorySourceRef,
     max_bytes: u64,
 ) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
     resolve_session_history_from_source(source)?
@@ -261,7 +261,7 @@ pub(crate) fn digest_session_history_from_source_bounded(
 }
 
 pub(crate) fn prepare_session_history_sidecar_from_source_bounded(
-    source: &FinalSessionHistorySourceRef,
+    source: &SessionHistorySourceRef,
     max_decoded_bytes: u64,
     max_encoded_bytes: u64,
 ) -> Result<PreparedSessionHistorySidecar, SessionHistoryDigestError> {
@@ -987,8 +987,8 @@ mod tests {
 
     const TEST_CLAUDE_SESSION_ID: &str = "session-history-source-test";
 
-    fn claude_source(config_dir: &Path) -> FinalSessionHistorySourceRef {
-        FinalSessionHistorySourceRef::ClaudeCode {
+    fn claude_source(config_dir: &Path) -> SessionHistorySourceRef {
+        SessionHistorySourceRef::ClaudeCode {
             config_dir: config_dir.to_string_lossy().into_owned(),
             working_dir: crate::paths::CANONICAL_WORKING_DIR.to_string(),
             session_id: TEST_CLAUDE_SESSION_ID.to_string(),
@@ -1001,8 +1001,8 @@ mod tests {
             .join(format!("{TEST_CLAUDE_SESSION_ID}.jsonl"))
     }
 
-    fn codex_source(sessions_dir: &Path, thread_id: &str) -> FinalSessionHistorySourceRef {
-        FinalSessionHistorySourceRef::Codex {
+    fn codex_source(sessions_dir: &Path, thread_id: &str) -> SessionHistorySourceRef {
+        SessionHistorySourceRef::Codex {
             sessions_dir: sessions_dir.to_string_lossy().into_owned(),
             thread_id: thread_id.to_string(),
         }
@@ -1056,7 +1056,7 @@ mod tests {
     }
 
     fn read_session_history_from_source_for_test_bounded(
-        source: &FinalSessionHistorySourceRef,
+        source: &SessionHistorySourceRef,
         max_bytes: u64,
     ) -> Result<Vec<u8>, AgentError> {
         match resolve_session_history_from_source(source)?
@@ -1203,7 +1203,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn rejects_proc_magic_link_source() {
-        let source = FinalSessionHistorySourceRef::ClaudeCode {
+        let source = SessionHistorySourceRef::ClaudeCode {
             config_dir: "/proc/self".to_string(),
             working_dir: crate::paths::CANONICAL_WORKING_DIR.to_string(),
             session_id: TEST_CLAUDE_SESSION_ID.to_string(),

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -6,9 +6,8 @@ use crate::session_history;
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
 use guest_contracts::session_history_identity::{
-    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
-    FinalSessionHistoryIdentity, FinalSessionHistoryIdentityError,
-    FinalSessionHistoryIdentityExpectation, FinalSessionHistoryRefKind,
+    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryIdentity,
+    FinalSessionHistoryIdentityError, FinalSessionHistoryIdentityExpectation,
     FinalSessionHistorySourceRef, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
@@ -16,9 +15,9 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
-    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistorySidecarExportFailure,
-    SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
-    SessionHistorySidecarRepresentation,
+    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistoryFramework,
+    SessionHistoryRefKind, SessionHistorySidecarExportFailure, SessionHistorySidecarExportMetadata,
+    SessionHistorySidecarIoErrorClass, SessionHistorySidecarRepresentation,
 };
 use sha2::{Digest, Sha256};
 use std::fmt;
@@ -39,7 +38,7 @@ pub(crate) fn build_final_session_history_identity(
     FinalSessionHistoryIdentity::new(
         framework,
         session_id_hash,
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         history_hash,
         history_size_bytes,
         history_source.clone(),
@@ -56,11 +55,11 @@ fn session_id_hash(framework: env::Framework, session_id: &str) -> Option<String
     Some(hex::encode(Sha256::digest(normalized.as_bytes())))
 }
 
-fn final_framework(framework: env::Framework) -> FinalSessionHistoryFramework {
+fn final_framework(framework: env::Framework) -> SessionHistoryFramework {
     match framework {
-        env::Framework::ClaudeCode => FinalSessionHistoryFramework::ClaudeCode,
-        env::Framework::Codex => FinalSessionHistoryFramework::Codex,
-        env::Framework::Pi => FinalSessionHistoryFramework::Pi,
+        env::Framework::ClaudeCode => SessionHistoryFramework::ClaudeCode,
+        env::Framework::Codex => SessionHistoryFramework::Codex,
+        env::Framework::Pi => SessionHistoryFramework::Pi,
     }
 }
 
@@ -205,22 +204,21 @@ fn validated_history_source(
 ) -> Result<&FinalSessionHistorySourceRef, FinalSessionHistoryIdentityVerifyError> {
     let source_session_id = match (&identity.framework, &identity.history_source) {
         (
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             FinalSessionHistorySourceRef::ClaudeCode { session_id, .. },
         ) => session_id.as_str(),
-        (
-            FinalSessionHistoryFramework::Codex,
-            FinalSessionHistorySourceRef::Codex { thread_id, .. },
-        ) => thread_id.as_str(),
-        (FinalSessionHistoryFramework::Pi, FinalSessionHistorySourceRef::Pi { session_id, .. }) => {
+        (SessionHistoryFramework::Codex, FinalSessionHistorySourceRef::Codex { thread_id, .. }) => {
+            thread_id.as_str()
+        }
+        (SessionHistoryFramework::Pi, FinalSessionHistorySourceRef::Pi { session_id, .. }) => {
             session_id.as_str()
         }
         _ => return Err(FinalSessionHistoryIdentityVerifyError::FrameworkMismatch),
     };
     let framework = match identity.framework {
-        FinalSessionHistoryFramework::ClaudeCode => env::Framework::ClaudeCode,
-        FinalSessionHistoryFramework::Codex => env::Framework::Codex,
-        FinalSessionHistoryFramework::Pi => env::Framework::Pi,
+        SessionHistoryFramework::ClaudeCode => env::Framework::ClaudeCode,
+        SessionHistoryFramework::Codex => env::Framework::Codex,
+        SessionHistoryFramework::Pi => env::Framework::Pi,
     };
     if session_id_hash(framework, source_session_id).as_deref() != Some(&identity.session_id_hash) {
         return Err(FinalSessionHistoryIdentityVerifyError::FrameworkMismatch);
@@ -448,9 +446,9 @@ mod tests {
         history_size: u64,
     ) -> FinalSessionHistoryIdentity {
         FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             session_hash(CLAUDE_SESSION_ID),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             history_hash,
             history_size,
             source,
@@ -511,7 +509,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(identity.framework, FinalSessionHistoryFramework::Pi);
+        assert_eq!(identity.framework, SessionHistoryFramework::Pi);
         assert_eq!(identity.history_source, history_source);
         assert_eq!(
             identity.session_id_hash,
@@ -537,9 +535,9 @@ mod tests {
             thread_id: thread_id.to_string(),
         };
         let identity = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::Codex,
+            SessionHistoryFramework::Codex,
             session_hash(thread_id),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             hex::encode(Sha256::digest(history)),
             history.len() as u64,
             source,
@@ -570,9 +568,9 @@ mod tests {
             thread_id: thread_id.to_string(),
         };
         let identity = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::Codex,
+            SessionHistoryFramework::Codex,
             session_hash(thread_id),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             hex::encode(Sha256::digest(history)),
             history.len() as u64,
             source,
@@ -717,9 +715,9 @@ mod tests {
             history.len() as u64,
         );
         let expected = FinalSessionHistoryIdentityExpectation::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             session_hash(CLAUDE_SESSION_ID),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             "b".repeat(64),
             history.len() as u64,
         )

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -6,9 +6,8 @@ use crate::session_history;
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
 use guest_contracts::session_history_identity::{
-    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryIdentity,
-    FinalSessionHistoryIdentityError, FinalSessionHistoryIdentityExpectation,
-    FinalSessionHistorySourceRef, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
+    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
@@ -16,8 +15,10 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
     SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistoryFramework,
+    SessionHistoryIdentity, SessionHistoryIdentityError, SessionHistoryIdentityExpectation,
     SessionHistoryRefKind, SessionHistorySidecarExportFailure, SessionHistorySidecarExportMetadata,
     SessionHistorySidecarIoErrorClass, SessionHistorySidecarRepresentation,
+    SessionHistorySourceRef,
 };
 use sha2::{Digest, Sha256};
 use std::fmt;
@@ -30,12 +31,12 @@ pub(crate) fn build_final_session_history_identity(
     cli_agent_session_id: &str,
     history_hash: &str,
     history_size_bytes: u64,
-    history_source: &FinalSessionHistorySourceRef,
-) -> Result<FinalSessionHistoryIdentity, FinalSessionHistoryIdentityBuildError> {
+    history_source: &SessionHistorySourceRef,
+) -> Result<SessionHistoryIdentity, SessionHistoryIdentityBuildError> {
     let session_id_hash = session_id_hash(framework, cli_agent_session_id)
-        .ok_or(FinalSessionHistoryIdentityBuildError::InvalidSessionId)?;
+        .ok_or(SessionHistoryIdentityBuildError::InvalidSessionId)?;
     let framework = final_framework(framework);
-    FinalSessionHistoryIdentity::new(
+    SessionHistoryIdentity::new(
         framework,
         session_id_hash,
         SessionHistoryRefKind::Blob,
@@ -43,7 +44,7 @@ pub(crate) fn build_final_session_history_identity(
         history_size_bytes,
         history_source.clone(),
     )
-    .map_err(FinalSessionHistoryIdentityBuildError::InvalidMetadata)
+    .map_err(SessionHistoryIdentityBuildError::InvalidMetadata)
 }
 
 fn session_id_hash(framework: env::Framework, session_id: &str) -> Option<String> {
@@ -66,13 +67,13 @@ fn final_framework(framework: env::Framework) -> SessionHistoryFramework {
 /// Verify the current guest session history matches final identity metadata.
 pub fn verify_final_session_history_identity_file(
     metadata_path: impl AsRef<Path>,
-    expected: Option<&FinalSessionHistoryIdentityExpectation>,
-) -> Result<(), FinalSessionHistoryIdentityVerifyError> {
+    expected: Option<&SessionHistoryIdentityExpectation>,
+) -> Result<(), SessionHistoryIdentityVerifyError> {
     let identity = read_final_session_history_identity(metadata_path)?;
     if let Some(expected) = expected
         && !expected.matches_identity(&identity)
     {
-        return Err(FinalSessionHistoryIdentityVerifyError::ExpectedIdentityMismatch);
+        return Err(SessionHistoryIdentityVerifyError::ExpectedIdentityMismatch);
     }
     verify_final_session_history_identity(&identity)
 }
@@ -112,14 +113,14 @@ pub fn verify_final_session_history_identity_file(
 ///
 /// # Errors
 ///
-/// Returns [`FinalSessionHistorySidecarExportError::Verification`] when identity
+/// Returns [`SessionHistorySidecarExportError::Verification`] when identity
 /// metadata or source history cannot be verified. Returns
-/// [`FinalSessionHistorySidecarExportError::OutputWrite`] when the verified
+/// [`SessionHistorySidecarExportError::OutputWrite`] when the verified
 /// sidecar bytes cannot be created or written at `export_path`.
 pub fn export_final_session_history_sidecar_file(
     metadata_path: impl AsRef<Path>,
     export_path: impl AsRef<Path>,
-) -> Result<SessionHistorySidecarExportMetadata, FinalSessionHistorySidecarExportError> {
+) -> Result<SessionHistorySidecarExportMetadata, SessionHistorySidecarExportError> {
     let identity = read_final_session_history_identity(metadata_path)?;
     let history_source = validated_history_source(&identity)?;
     verify_final_session_history_identity_constraints(&identity)?;
@@ -140,7 +141,7 @@ pub fn export_final_session_history_sidecar_file(
         }
     };
     crate::paths::write_private(export_path.as_ref(), &bytes)
-        .map_err(FinalSessionHistorySidecarExportError::OutputWrite)?;
+        .map_err(SessionHistorySidecarExportError::OutputWrite)?;
     Ok(SessionHistorySidecarExportMetadata {
         representation,
         encoded_size: bytes.len() as u64,
@@ -149,37 +150,37 @@ pub fn export_final_session_history_sidecar_file(
 
 fn read_final_session_history_identity(
     metadata_path: impl AsRef<Path>,
-) -> Result<FinalSessionHistoryIdentity, FinalSessionHistoryIdentityVerifyError> {
+) -> Result<SessionHistoryIdentity, SessionHistoryIdentityVerifyError> {
     let metadata_path = metadata_path.as_ref();
     let read_limit =
         usize::try_from(FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES + 1).map_err(|_| {
-            FinalSessionHistoryIdentityVerifyError::InvalidMetadata(
-                FinalSessionHistoryIdentityError::MetadataTooLarge,
+            SessionHistoryIdentityVerifyError::InvalidMetadata(
+                SessionHistoryIdentityError::MetadataTooLarge,
             )
         })?;
     let bytes =
         match guest_contracts::runtime_paths::read_private_bounded(metadata_path, read_limit) {
             Ok(Some(bytes)) => bytes,
-            Ok(None) => return Err(FinalSessionHistoryIdentityVerifyError::MetadataRead),
+            Ok(None) => return Err(SessionHistoryIdentityVerifyError::MetadataRead),
             Err(error) if error.kind() == io::ErrorKind::InvalidData => {
-                return Err(FinalSessionHistoryIdentityVerifyError::InvalidMetadata(
-                    FinalSessionHistoryIdentityError::MetadataTooLarge,
+                return Err(SessionHistoryIdentityVerifyError::InvalidMetadata(
+                    SessionHistoryIdentityError::MetadataTooLarge,
                 ));
             }
-            Err(_) => return Err(FinalSessionHistoryIdentityVerifyError::MetadataRead),
+            Err(_) => return Err(SessionHistoryIdentityVerifyError::MetadataRead),
         };
     if bytes.len() as u64 > FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES {
-        return Err(FinalSessionHistoryIdentityVerifyError::InvalidMetadata(
-            FinalSessionHistoryIdentityError::MetadataTooLarge,
+        return Err(SessionHistoryIdentityVerifyError::InvalidMetadata(
+            SessionHistoryIdentityError::MetadataTooLarge,
         ));
     }
-    FinalSessionHistoryIdentity::from_json_slice(&bytes)
-        .map_err(FinalSessionHistoryIdentityVerifyError::InvalidMetadata)
+    SessionHistoryIdentity::from_json_slice(&bytes)
+        .map_err(SessionHistoryIdentityVerifyError::InvalidMetadata)
 }
 
 fn verify_final_session_history_identity(
-    identity: &FinalSessionHistoryIdentity,
-) -> Result<(), FinalSessionHistoryIdentityVerifyError> {
+    identity: &SessionHistoryIdentity,
+) -> Result<(), SessionHistoryIdentityVerifyError> {
     let history_source = validated_history_source(identity)?;
     verify_final_session_history_identity_constraints(identity)?;
     let digest = session_history::digest_session_history_from_source_bounded(
@@ -191,29 +192,29 @@ fn verify_final_session_history_identity(
 }
 
 fn verify_final_session_history_identity_constraints(
-    identity: &FinalSessionHistoryIdentity,
-) -> Result<(), FinalSessionHistoryIdentityVerifyError> {
+    identity: &SessionHistoryIdentity,
+) -> Result<(), SessionHistoryIdentityVerifyError> {
     if identity.history_size_bytes > RESUME_SESSION_HISTORY_MAX_BYTES {
-        return Err(FinalSessionHistoryIdentityVerifyError::HistoryTooLarge);
+        return Err(SessionHistoryIdentityVerifyError::HistoryTooLarge);
     }
     Ok(())
 }
 
 fn validated_history_source(
-    identity: &FinalSessionHistoryIdentity,
-) -> Result<&FinalSessionHistorySourceRef, FinalSessionHistoryIdentityVerifyError> {
+    identity: &SessionHistoryIdentity,
+) -> Result<&SessionHistorySourceRef, SessionHistoryIdentityVerifyError> {
     let source_session_id = match (&identity.framework, &identity.history_source) {
         (
             SessionHistoryFramework::ClaudeCode,
-            FinalSessionHistorySourceRef::ClaudeCode { session_id, .. },
+            SessionHistorySourceRef::ClaudeCode { session_id, .. },
         ) => session_id.as_str(),
-        (SessionHistoryFramework::Codex, FinalSessionHistorySourceRef::Codex { thread_id, .. }) => {
+        (SessionHistoryFramework::Codex, SessionHistorySourceRef::Codex { thread_id, .. }) => {
             thread_id.as_str()
         }
-        (SessionHistoryFramework::Pi, FinalSessionHistorySourceRef::Pi { session_id, .. }) => {
+        (SessionHistoryFramework::Pi, SessionHistorySourceRef::Pi { session_id, .. }) => {
             session_id.as_str()
         }
-        _ => return Err(FinalSessionHistoryIdentityVerifyError::FrameworkMismatch),
+        _ => return Err(SessionHistoryIdentityVerifyError::FrameworkMismatch),
     };
     let framework = match identity.framework {
         SessionHistoryFramework::ClaudeCode => env::Framework::ClaudeCode,
@@ -221,47 +222,47 @@ fn validated_history_source(
         SessionHistoryFramework::Pi => env::Framework::Pi,
     };
     if session_id_hash(framework, source_session_id).as_deref() != Some(&identity.session_id_hash) {
-        return Err(FinalSessionHistoryIdentityVerifyError::FrameworkMismatch);
+        return Err(SessionHistoryIdentityVerifyError::FrameworkMismatch);
     }
     Ok(&identity.history_source)
 }
 
 fn verify_final_session_history_digest(
-    identity: &FinalSessionHistoryIdentity,
+    identity: &SessionHistoryIdentity,
     digest: &session_history::SessionHistoryDigest,
-) -> Result<(), FinalSessionHistoryIdentityVerifyError> {
+) -> Result<(), SessionHistoryIdentityVerifyError> {
     if digest.size_bytes != identity.history_size_bytes {
-        return Err(FinalSessionHistoryIdentityVerifyError::HistoryMismatch);
+        return Err(SessionHistoryIdentityVerifyError::HistoryMismatch);
     }
     if digest.sha256_hex != identity.history_hash {
-        return Err(FinalSessionHistoryIdentityVerifyError::HistoryMismatch);
+        return Err(SessionHistoryIdentityVerifyError::HistoryMismatch);
     }
     Ok(())
 }
 
 fn map_session_history_digest_error(
     error: session_history::SessionHistoryDigestError,
-) -> FinalSessionHistoryIdentityVerifyError {
+) -> SessionHistoryIdentityVerifyError {
     match error {
         session_history::SessionHistoryDigestError::Read(error) => {
-            FinalSessionHistoryIdentityVerifyError::HistoryRead(error)
+            SessionHistoryIdentityVerifyError::HistoryRead(error)
         }
         session_history::SessionHistoryDigestError::ExceedsMaxBytes => {
-            FinalSessionHistoryIdentityVerifyError::HistoryMismatch
+            SessionHistoryIdentityVerifyError::HistoryMismatch
         }
     }
 }
 
 /// Error returned while building final identity metadata.
 #[derive(Debug)]
-pub(crate) enum FinalSessionHistoryIdentityBuildError {
+pub(crate) enum SessionHistoryIdentityBuildError {
     /// Session id cannot be normalized for the current framework.
     InvalidSessionId,
     /// Metadata violates the shared final identity contract.
-    InvalidMetadata(FinalSessionHistoryIdentityError),
+    InvalidMetadata(SessionHistoryIdentityError),
 }
 
-impl fmt::Display for FinalSessionHistoryIdentityBuildError {
+impl fmt::Display for SessionHistoryIdentityBuildError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidSessionId => {
@@ -272,18 +273,18 @@ impl fmt::Display for FinalSessionHistoryIdentityBuildError {
     }
 }
 
-impl std::error::Error for FinalSessionHistoryIdentityBuildError {}
+impl std::error::Error for SessionHistoryIdentityBuildError {}
 
 /// Error returned while exporting a verified final session-history sidecar.
 #[derive(Debug)]
-pub enum FinalSessionHistorySidecarExportError {
+pub enum SessionHistorySidecarExportError {
     /// Identity metadata or source history verification failed.
-    Verification(FinalSessionHistoryIdentityVerifyError),
+    Verification(SessionHistoryIdentityVerifyError),
     /// The verified sidecar output could not be created or written.
     OutputWrite(io::Error),
 }
 
-impl FinalSessionHistorySidecarExportError {
+impl SessionHistorySidecarExportError {
     /// Return the stable helper exit code for this export failure.
     pub fn helper_exit_code(&self) -> i32 {
         match self {
@@ -303,13 +304,13 @@ impl FinalSessionHistorySidecarExportError {
     }
 }
 
-impl From<FinalSessionHistoryIdentityVerifyError> for FinalSessionHistorySidecarExportError {
-    fn from(error: FinalSessionHistoryIdentityVerifyError) -> Self {
+impl From<SessionHistoryIdentityVerifyError> for SessionHistorySidecarExportError {
+    fn from(error: SessionHistoryIdentityVerifyError) -> Self {
         Self::Verification(error)
     }
 }
 
-impl fmt::Display for FinalSessionHistorySidecarExportError {
+impl fmt::Display for SessionHistorySidecarExportError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Verification(error) => write!(f, "{error}"),
@@ -318,7 +319,7 @@ impl fmt::Display for FinalSessionHistorySidecarExportError {
     }
 }
 
-impl std::error::Error for FinalSessionHistorySidecarExportError {}
+impl std::error::Error for SessionHistorySidecarExportError {}
 
 fn sidecar_io_error_class(error: &io::Error) -> SessionHistorySidecarIoErrorClass {
     match error.kind() {
@@ -332,11 +333,11 @@ fn sidecar_io_error_class(error: &io::Error) -> SessionHistorySidecarIoErrorClas
 
 /// Error returned while verifying final identity metadata.
 #[derive(Debug)]
-pub enum FinalSessionHistoryIdentityVerifyError {
+pub enum SessionHistoryIdentityVerifyError {
     /// Metadata file could not be read.
     MetadataRead,
     /// Metadata failed shared contract validation.
-    InvalidMetadata(FinalSessionHistoryIdentityError),
+    InvalidMetadata(SessionHistoryIdentityError),
     /// Metadata framework does not match its history source.
     FrameworkMismatch,
     /// Metadata does not match the identity runner expected to verify.
@@ -349,7 +350,7 @@ pub enum FinalSessionHistoryIdentityVerifyError {
     HistoryTooLarge,
 }
 
-impl FinalSessionHistoryIdentityVerifyError {
+impl SessionHistoryIdentityVerifyError {
     /// Return the stable helper exit code for this verification failure.
     pub fn helper_exit_code(&self) -> i32 {
         match self {
@@ -366,7 +367,7 @@ impl FinalSessionHistoryIdentityVerifyError {
     }
 }
 
-impl fmt::Display for FinalSessionHistoryIdentityVerifyError {
+impl fmt::Display for SessionHistoryIdentityVerifyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MetadataRead => f.write_str("final session history identity could not be read"),
@@ -386,7 +387,7 @@ impl fmt::Display for FinalSessionHistoryIdentityVerifyError {
     }
 }
 
-impl std::error::Error for FinalSessionHistoryIdentityVerifyError {}
+impl std::error::Error for SessionHistoryIdentityVerifyError {}
 
 #[cfg(test)]
 mod tests {
@@ -398,7 +399,7 @@ mod tests {
 
     fn write_metadata(
         dir: &tempfile::TempDir,
-        identity: &FinalSessionHistoryIdentity,
+        identity: &SessionHistoryIdentity,
     ) -> std::path::PathBuf {
         let path = dir.path().join("identity.json");
         crate::paths::write_private(&path, identity.to_json_vec().unwrap()).unwrap();
@@ -423,7 +424,7 @@ mod tests {
 
     fn claude_history_source(
         dir: &tempfile::TempDir,
-    ) -> (std::path::PathBuf, FinalSessionHistorySourceRef) {
+    ) -> (std::path::PathBuf, SessionHistorySourceRef) {
         let config_dir = dir.path().join("claude-config");
         let history_path = config_dir
             .join("projects")
@@ -432,7 +433,7 @@ mod tests {
         std::fs::create_dir_all(history_path.parent().unwrap()).unwrap();
         (
             history_path,
-            FinalSessionHistorySourceRef::ClaudeCode {
+            SessionHistorySourceRef::ClaudeCode {
                 config_dir: config_dir.to_string_lossy().into_owned(),
                 working_dir: crate::paths::CANONICAL_WORKING_DIR.to_string(),
                 session_id: CLAUDE_SESSION_ID.to_string(),
@@ -441,11 +442,11 @@ mod tests {
     }
 
     fn claude_identity(
-        source: FinalSessionHistorySourceRef,
+        source: SessionHistorySourceRef,
         history_hash: impl Into<String>,
         history_size: u64,
-    ) -> FinalSessionHistoryIdentity {
-        FinalSessionHistoryIdentity::new(
+    ) -> SessionHistoryIdentity {
+        SessionHistoryIdentity::new(
             SessionHistoryFramework::ClaudeCode,
             session_hash(CLAUDE_SESSION_ID),
             SessionHistoryRefKind::Blob,
@@ -496,7 +497,7 @@ mod tests {
             "{}/restored-{session_id}.jsonl",
             api_contracts::generated::constants::runners::paths::CANONICAL_PI_SESSION_DIR,
         );
-        let history_source = FinalSessionHistorySourceRef::Pi {
+        let history_source = SessionHistorySourceRef::Pi {
             session_path: history_path,
             session_id: session_id.to_string(),
         };
@@ -530,11 +531,11 @@ mod tests {
             history,
         )
         .unwrap();
-        let source = FinalSessionHistorySourceRef::Codex {
+        let source = SessionHistorySourceRef::Codex {
             sessions_dir: sessions_dir.to_string_lossy().into_owned(),
             thread_id: thread_id.to_string(),
         };
-        let identity = FinalSessionHistoryIdentity::new(
+        let identity = SessionHistoryIdentity::new(
             SessionHistoryFramework::Codex,
             session_hash(thread_id),
             SessionHistoryRefKind::Blob,
@@ -563,11 +564,11 @@ mod tests {
             compressed,
         )
         .unwrap();
-        let source = FinalSessionHistorySourceRef::Codex {
+        let source = SessionHistorySourceRef::Codex {
             sessions_dir: sessions_dir.to_string_lossy().into_owned(),
             thread_id: thread_id.to_string(),
         };
-        let identity = FinalSessionHistoryIdentity::new(
+        let identity = SessionHistoryIdentity::new(
             SessionHistoryFramework::Codex,
             session_hash(thread_id),
             SessionHistoryRefKind::Blob,
@@ -592,7 +593,7 @@ mod tests {
         let err = verify_final_session_history_identity_file(metadata_path, None).unwrap_err();
         assert!(matches!(
             err,
-            FinalSessionHistoryIdentityVerifyError::HistoryMismatch
+            SessionHistoryIdentityVerifyError::HistoryMismatch
         ));
     }
 
@@ -609,8 +610,8 @@ mod tests {
         let err = verify_final_session_history_identity_file(metadata_path, None).unwrap_err();
         assert!(matches!(
             err,
-            FinalSessionHistoryIdentityVerifyError::InvalidMetadata(
-                FinalSessionHistoryIdentityError::MetadataTooLarge
+            SessionHistoryIdentityVerifyError::InvalidMetadata(
+                SessionHistoryIdentityError::MetadataTooLarge
             )
         ));
     }
@@ -618,7 +619,7 @@ mod tests {
     #[test]
     fn build_allows_large_history_metadata() {
         let identity = claude_identity(
-            FinalSessionHistorySourceRef::ClaudeCode {
+            SessionHistorySourceRef::ClaudeCode {
                 config_dir: "/claude-config".to_string(),
                 working_dir: crate::paths::CANONICAL_WORKING_DIR.to_string(),
                 session_id: CLAUDE_SESSION_ID.to_string(),
@@ -683,7 +684,7 @@ mod tests {
         let err = verify_final_session_history_identity_file(metadata_path, None).unwrap_err();
         assert!(matches!(
             err,
-            FinalSessionHistoryIdentityVerifyError::HistoryMismatch
+            SessionHistoryIdentityVerifyError::HistoryMismatch
         ));
     }
 
@@ -699,7 +700,7 @@ mod tests {
         let err = verify_final_session_history_identity_file(metadata_path, None).unwrap_err();
         assert!(matches!(
             err,
-            FinalSessionHistoryIdentityVerifyError::HistoryTooLarge
+            SessionHistoryIdentityVerifyError::HistoryTooLarge
         ));
     }
 
@@ -714,7 +715,7 @@ mod tests {
             hex::encode(Sha256::digest(history)),
             history.len() as u64,
         );
-        let expected = FinalSessionHistoryIdentityExpectation::new(
+        let expected = SessionHistoryIdentityExpectation::new(
             SessionHistoryFramework::ClaudeCode,
             session_hash(CLAUDE_SESSION_ID),
             SessionHistoryRefKind::Blob,
@@ -728,7 +729,7 @@ mod tests {
             verify_final_session_history_identity_file(metadata_path, Some(&expected)).unwrap_err();
         assert!(matches!(
             err,
-            FinalSessionHistoryIdentityVerifyError::ExpectedIdentityMismatch
+            SessionHistoryIdentityVerifyError::ExpectedIdentityMismatch
         ));
     }
 }

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -5,7 +5,7 @@ use crate::paths;
 use guest_common::{log_info, log_warn};
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
-use guest_contracts::session_history_identity::FinalSessionHistorySourceRef;
+use guest_contracts::session_history_identity::SessionHistorySourceRef;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
@@ -83,13 +83,14 @@ impl SessionHistoryLaunchSource {
                 if !is_valid_cli_agent_session_id(raw_session_id) {
                     return None;
                 }
-                let source = config_dir.as_ref().map(|config_dir| {
-                    FinalSessionHistorySourceRef::ClaudeCode {
-                        config_dir: config_dir.clone(),
-                        working_dir: working_dir.clone(),
-                        session_id: raw_session_id.to_string(),
-                    }
-                });
+                let source =
+                    config_dir
+                        .as_ref()
+                        .map(|config_dir| SessionHistorySourceRef::ClaudeCode {
+                            config_dir: config_dir.clone(),
+                            working_dir: working_dir.clone(),
+                            session_id: raw_session_id.to_string(),
+                        });
                 (raw_session_id.to_string(), source)
             }
             Self::Codex { sessions_dir } => {
@@ -97,7 +98,7 @@ impl SessionHistoryLaunchSource {
                 let source =
                     sessions_dir
                         .as_ref()
-                        .map(|sessions_dir| FinalSessionHistorySourceRef::Codex {
+                        .map(|sessions_dir| SessionHistorySourceRef::Codex {
                             sessions_dir: sessions_dir.clone(),
                             thread_id: thread_id.clone(),
                         });
@@ -146,11 +147,11 @@ pub(crate) fn is_pi_session_history_path(session_path: &str, session_id: &str) -
 fn pi_session_history_source(
     session_path: &str,
     session_id: &str,
-) -> Option<FinalSessionHistorySourceRef> {
+) -> Option<SessionHistorySourceRef> {
     if !is_pi_session_history_path(session_path, session_id) {
         return None;
     }
-    Some(FinalSessionHistorySourceRef::Pi {
+    Some(SessionHistorySourceRef::Pi {
         session_path: session_path.to_string(),
         session_id: session_id.to_string(),
     })
@@ -160,7 +161,7 @@ fn pi_session_history_source(
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CapturedSessionMetadata {
     cli_agent_session_id: String,
-    history_source: Option<FinalSessionHistorySourceRef>,
+    history_source: Option<SessionHistorySourceRef>,
 }
 
 impl CapturedSessionMetadata {
@@ -170,7 +171,7 @@ impl CapturedSessionMetadata {
     }
 
     /// Return the canonical history source when launch and event validation succeeded.
-    pub fn history_source(&self) -> Option<&FinalSessionHistorySourceRef> {
+    pub fn history_source(&self) -> Option<&SessionHistorySourceRef> {
         self.history_source.as_ref()
     }
 
@@ -178,7 +179,7 @@ impl CapturedSessionMetadata {
     #[doc(hidden)]
     pub fn for_test(
         cli_agent_session_id: impl Into<String>,
-        history_source: Option<FinalSessionHistorySourceRef>,
+        history_source: Option<SessionHistorySourceRef>,
     ) -> Self {
         Self {
             cli_agent_session_id: cli_agent_session_id.into(),
@@ -325,7 +326,7 @@ mod tests {
             store.captured(),
             Some(&CapturedSessionMetadata {
                 cli_agent_session_id: "session-first".to_string(),
-                history_source: Some(FinalSessionHistorySourceRef::ClaudeCode {
+                history_source: Some(SessionHistorySourceRef::ClaudeCode {
                     config_dir: "/home/user/custom-claude".to_string(),
                     working_dir: paths::CANONICAL_WORKING_DIR.to_string(),
                     session_id: "session-first".to_string(),
@@ -364,7 +365,7 @@ mod tests {
             store
                 .captured()
                 .and_then(CapturedSessionMetadata::history_source),
-            Some(&FinalSessionHistorySourceRef::Codex {
+            Some(&SessionHistorySourceRef::Codex {
                 sessions_dir: "/home/custom/.codex/sessions".to_string(),
                 thread_id: "0193abcd-ef01-7234-89ab-cdef01234567".to_string(),
             })
@@ -392,7 +393,7 @@ mod tests {
             store
                 .captured()
                 .and_then(CapturedSessionMetadata::history_source),
-            Some(&FinalSessionHistorySourceRef::Pi {
+            Some(&SessionHistorySourceRef::Pi {
                 session_path,
                 session_id: session_id.to_string(),
             })

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -140,7 +140,7 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
     let session_metadata = guest_agent::session_metadata::CapturedSessionMetadata::for_test(
         session_id,
         Some(
-            guest_contracts::session_history_identity::FinalSessionHistorySourceRef::ClaudeCode {
+            guest_contracts::session_history_identity::SessionHistorySourceRef::ClaudeCode {
                 config_dir: config_dir.to_string_lossy().into_owned(),
                 working_dir: guest_agent::paths::CANONICAL_WORKING_DIR.to_string(),
                 session_id: session_id.to_string(),

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -235,7 +235,7 @@ fn recovery_checkpoint_resolves_history_from_codex_sessions_root() -> TestResult
     let session_metadata = guest_agent::session_metadata::CapturedSessionMetadata::for_test(
         thread_id,
         Some(
-            guest_contracts::session_history_identity::FinalSessionHistorySourceRef::Codex {
+            guest_contracts::session_history_identity::SessionHistorySourceRef::Codex {
                 sessions_dir: Path::new(&guest_runtime.config.home_dir)
                     .join(".codex/sessions")
                     .to_string_lossy()

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -1,7 +1,7 @@
 use super::support::*;
 use crate::support::*;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryIdentity, SessionHistoryFramework, SessionHistoryRefKind,
+    SessionHistoryFramework, SessionHistoryIdentity, SessionHistoryRefKind,
 };
 use httpmock::prelude::*;
 use serde_json::{Value, json};
@@ -433,7 +433,7 @@ async fn success_checkpoint_reconciles_claude_compact_generation_after_commit() 
 
     let identity_bytes =
         std::fs::read(runtime.paths.final_session_history_identity_file()).unwrap();
-    let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
+    let identity = SessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
     assert_eq!(identity.framework, SessionHistoryFramework::ClaudeCode);
     assert_eq!(identity.history_size_bytes, history_size as u64);
     assert_eq!(identity.history_hash, history_hash);
@@ -525,13 +525,13 @@ async fn success_checkpoint_reconciles_codex_compact_generation_after_commit() {
 
     let identity_bytes =
         std::fs::read(runtime.paths.final_session_history_identity_file()).unwrap();
-    let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
+    let identity = SessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
     assert_eq!(identity.framework, SessionHistoryFramework::Codex);
     assert_eq!(identity.history_size_bytes, history_size as u64);
     assert_eq!(identity.history_hash, history_hash);
     assert!(matches!(
         identity.history_source,
-        guest_contracts::session_history_identity::FinalSessionHistorySourceRef::Codex {
+        guest_contracts::session_history_identity::SessionHistorySourceRef::Codex {
             ref thread_id,
             ..
         } if thread_id == session_id
@@ -705,7 +705,7 @@ async fn success_checkpoint_writes_large_final_identity_metadata()
 
     let identity_bytes =
         std::fs::read(runtime.paths.final_session_history_identity_file()).unwrap();
-    let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
+    let identity = SessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
     assert_eq!(identity.framework, SessionHistoryFramework::ClaudeCode);
     assert_eq!(identity.history_ref_kind, SessionHistoryRefKind::Blob);
     assert_eq!(

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -1,7 +1,7 @@
 use super::support::*;
 use crate::support::*;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+    FinalSessionHistoryIdentity, SessionHistoryFramework, SessionHistoryRefKind,
 };
 use httpmock::prelude::*;
 use serde_json::{Value, json};
@@ -434,7 +434,7 @@ async fn success_checkpoint_reconciles_claude_compact_generation_after_commit() 
     let identity_bytes =
         std::fs::read(runtime.paths.final_session_history_identity_file()).unwrap();
     let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
-    assert_eq!(identity.framework, FinalSessionHistoryFramework::ClaudeCode);
+    assert_eq!(identity.framework, SessionHistoryFramework::ClaudeCode);
     assert_eq!(identity.history_size_bytes, history_size as u64);
     assert_eq!(identity.history_hash, history_hash);
     assert_eq!(
@@ -526,7 +526,7 @@ async fn success_checkpoint_reconciles_codex_compact_generation_after_commit() {
     let identity_bytes =
         std::fs::read(runtime.paths.final_session_history_identity_file()).unwrap();
     let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
-    assert_eq!(identity.framework, FinalSessionHistoryFramework::Codex);
+    assert_eq!(identity.framework, SessionHistoryFramework::Codex);
     assert_eq!(identity.history_size_bytes, history_size as u64);
     assert_eq!(identity.history_hash, history_hash);
     assert!(matches!(
@@ -706,8 +706,8 @@ async fn success_checkpoint_writes_large_final_identity_metadata()
     let identity_bytes =
         std::fs::read(runtime.paths.final_session_history_identity_file()).unwrap();
     let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
-    assert_eq!(identity.framework, FinalSessionHistoryFramework::ClaudeCode);
-    assert_eq!(identity.history_ref_kind, FinalSessionHistoryRefKind::Blob);
+    assert_eq!(identity.framework, SessionHistoryFramework::ClaudeCode);
+    assert_eq!(identity.history_ref_kind, SessionHistoryRefKind::Blob);
     assert_eq!(
         identity.session_id_hash,
         hex::encode(Sha256::digest(b"success-large-session"))

--- a/crates/guest-agent/tests/integration/checkpoint/support.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/support.rs
@@ -50,7 +50,7 @@ pub(super) fn checkpoint_session_metadata(
         .to_string();
     let source = match runtime.config.framework {
         guest_agent::env::Framework::ClaudeCode => Some(
-            guest_contracts::session_history_identity::FinalSessionHistorySourceRef::ClaudeCode {
+            guest_contracts::session_history_identity::SessionHistorySourceRef::ClaudeCode {
                 config_dir: runtime
                     .config
                     .user_env
@@ -68,7 +68,7 @@ pub(super) fn checkpoint_session_metadata(
             },
         ),
         guest_agent::env::Framework::Codex => Some(
-            guest_contracts::session_history_identity::FinalSessionHistorySourceRef::Codex {
+            guest_contracts::session_history_identity::SessionHistorySourceRef::Codex {
                 sessions_dir: std::path::Path::new(&runtime.config.home_dir)
                     .join(".codex/sessions")
                     .to_string_lossy()
@@ -77,7 +77,7 @@ pub(super) fn checkpoint_session_metadata(
             },
         ),
         guest_agent::env::Framework::Pi => Some(
-            guest_contracts::session_history_identity::FinalSessionHistorySourceRef::Pi {
+            guest_contracts::session_history_identity::SessionHistorySourceRef::Pi {
                 session_path: format!(
                     "{}/restored-{session_id}.jsonl",
                     api_contracts::generated::constants::runners::paths::CANONICAL_PI_SESSION_DIR,

--- a/crates/guest-agent/tests/session_history_identity_helper.rs
+++ b/crates/guest-agent/tests/session_history_identity_helper.rs
@@ -2,8 +2,8 @@ mod common;
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    FinalSessionHistorySourceRef, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
+    FinalSessionHistoryIdentity, FinalSessionHistorySourceRef,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
@@ -12,9 +12,9 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
-    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistorySidecarExportFailure,
-    SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
-    SessionHistorySidecarRepresentation,
+    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistoryFramework,
+    SessionHistoryRefKind, SessionHistorySidecarExportFailure, SessionHistorySidecarExportMetadata,
+    SessionHistorySidecarIoErrorClass, SessionHistorySidecarRepresentation,
 };
 #[cfg(target_os = "linux")]
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
@@ -131,9 +131,9 @@ async fn verify_session_history_identity_returns_stable_exit_codes() -> TestResu
     std::fs::write(&matching_history_path, matching_history)?;
     let matching_history_hash = sha256_hex(matching_history);
     let matching_identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(matching_session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         matching_history_hash.clone(),
         matching_history.len() as u64,
         matching_source.clone(),
@@ -145,9 +145,9 @@ async fn verify_session_history_identity_returns_stable_exit_codes() -> TestResu
     guest_contracts::runtime_paths::write_private(&invalid_metadata_path, b"not-json")?;
 
     let framework_mismatch_identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash("different-session"),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         matching_history_hash,
         matching_history.len() as u64,
         matching_source.clone(),
@@ -162,9 +162,9 @@ async fn verify_session_history_identity_returns_stable_exit_codes() -> TestResu
     let (_missing_history_path, missing_source) =
         claude_history_fixture(dir.path(), missing_session_id)?;
     let history_read_identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(missing_session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         "b".repeat(64),
         1,
         missing_source,
@@ -180,9 +180,9 @@ async fn verify_session_history_identity_returns_stable_exit_codes() -> TestResu
         claude_history_fixture(dir.path(), mismatch_session_id)?;
     std::fs::write(&mismatched_history_path, b"actual!")?;
     let history_mismatch_identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(mismatch_session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         sha256_hex(b"expect!"),
         7,
         mismatch_source,
@@ -194,9 +194,9 @@ async fn verify_session_history_identity_returns_stable_exit_codes() -> TestResu
     )?;
 
     let history_too_large_identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(matching_session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         "b".repeat(64),
         RESUME_SESSION_HISTORY_MAX_BYTES + 1,
         matching_source,
@@ -287,9 +287,9 @@ async fn export_session_history_sidecar_reads_raw_source_once() -> TestResult {
     let (history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     std::fs::write(&history_path, history)?;
     let identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         sha256_hex(history),
         history.len() as u64,
         history_source,
@@ -325,9 +325,9 @@ async fn export_session_history_sidecar_rejects_proc_magic_link_source_without_o
     let sentinel = b"parent-only-secret-sentinel";
     let session_id = "proc-magic-link-source";
     let identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         sha256_hex(sentinel),
         sentinel.len() as u64,
         FinalSessionHistorySourceRef::ClaudeCode {
@@ -374,9 +374,9 @@ async fn export_session_history_sidecar_rejects_final_symlink_without_output() -
     std::fs::write(&outside_path, sentinel)?;
     symlink(&outside_path, &history_path)?;
     let identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         sha256_hex(sentinel),
         sentinel.len() as u64,
         history_source,
@@ -422,9 +422,9 @@ async fn export_session_history_sidecar_reads_native_codex_zstd_once() -> TestRe
         thread_id: thread_id.to_string(),
     };
     let identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::Codex,
+        SessionHistoryFramework::Codex,
         session_id_hash(thread_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         sha256_hex(history),
         history.len() as u64,
         history_source,
@@ -460,9 +460,9 @@ async fn export_session_history_sidecar_rejects_metadata_above_resume_limit_befo
     let session_id = "missing-oversized-history";
     let (_history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     let identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         "b".repeat(64),
         RESUME_SESSION_HISTORY_MAX_BYTES + 1,
         history_source,
@@ -490,9 +490,9 @@ async fn export_session_history_sidecar_keeps_source_read_failures() -> TestResu
     let session_id = "missing-source-history";
     let (_history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     let identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         "b".repeat(64),
         1,
         history_source,
@@ -524,9 +524,9 @@ async fn export_session_history_sidecar_reports_safe_output_write_failure() -> T
     let (history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     std::fs::write(&history_path, history)?;
     let identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         sha256_hex(history),
         history.len() as u64,
         history_source,
@@ -567,9 +567,9 @@ async fn export_session_history_sidecar_rejects_history_mismatch() -> TestResult
     let (history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     std::fs::write(&history_path, history)?;
     let identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         sha256_hex(b"expect"),
         history.len() as u64,
         history_source,
@@ -602,9 +602,9 @@ async fn export_session_history_sidecar_rejects_symlinked_metadata_without_openi
     let (history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     std::fs::write(&history_path, history)?;
     let identity = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         sha256_hex(history),
         history.len() as u64,
         history_source,

--- a/crates/guest-agent/tests/session_history_identity_helper.rs
+++ b/crates/guest-agent/tests/session_history_identity_helper.rs
@@ -2,7 +2,6 @@ mod common;
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryIdentity, FinalSessionHistorySourceRef,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
@@ -13,8 +12,9 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
     SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistoryFramework,
-    SessionHistoryRefKind, SessionHistorySidecarExportFailure, SessionHistorySidecarExportMetadata,
-    SessionHistorySidecarIoErrorClass, SessionHistorySidecarRepresentation,
+    SessionHistoryIdentity, SessionHistoryRefKind, SessionHistorySidecarExportFailure,
+    SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
+    SessionHistorySidecarRepresentation, SessionHistorySourceRef,
 };
 #[cfg(target_os = "linux")]
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
@@ -32,7 +32,7 @@ const SESSION_HISTORY_HELPER_TIMEOUT: Duration = Duration::from_secs(10);
 fn claude_history_fixture(
     root: &Path,
     session_id: &str,
-) -> TestResult<(PathBuf, FinalSessionHistorySourceRef)> {
+) -> TestResult<(PathBuf, SessionHistorySourceRef)> {
     let config_dir = root.join(format!("{session_id}-config"));
     let history_path = config_dir
         .join("projects/-home-user-workspace")
@@ -43,7 +43,7 @@ fn claude_history_fixture(
     std::fs::create_dir_all(history_parent)?;
     Ok((
         history_path,
-        FinalSessionHistorySourceRef::ClaudeCode {
+        SessionHistorySourceRef::ClaudeCode {
             config_dir: config_dir.to_string_lossy().into_owned(),
             working_dir: guest_agent::paths::CANONICAL_WORKING_DIR.to_string(),
             session_id: session_id.to_string(),
@@ -130,7 +130,7 @@ async fn verify_session_history_identity_returns_stable_exit_codes() -> TestResu
         claude_history_fixture(dir.path(), matching_session_id)?;
     std::fs::write(&matching_history_path, matching_history)?;
     let matching_history_hash = sha256_hex(matching_history);
-    let matching_identity = FinalSessionHistoryIdentity::new(
+    let matching_identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(matching_session_id),
         SessionHistoryRefKind::Blob,
@@ -144,7 +144,7 @@ async fn verify_session_history_identity_returns_stable_exit_codes() -> TestResu
     let invalid_metadata_path = dir.path().join("invalid-identity.json");
     guest_contracts::runtime_paths::write_private(&invalid_metadata_path, b"not-json")?;
 
-    let framework_mismatch_identity = FinalSessionHistoryIdentity::new(
+    let framework_mismatch_identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash("different-session"),
         SessionHistoryRefKind::Blob,
@@ -161,7 +161,7 @@ async fn verify_session_history_identity_returns_stable_exit_codes() -> TestResu
     let missing_session_id = "missing-history";
     let (_missing_history_path, missing_source) =
         claude_history_fixture(dir.path(), missing_session_id)?;
-    let history_read_identity = FinalSessionHistoryIdentity::new(
+    let history_read_identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(missing_session_id),
         SessionHistoryRefKind::Blob,
@@ -179,7 +179,7 @@ async fn verify_session_history_identity_returns_stable_exit_codes() -> TestResu
     let (mismatched_history_path, mismatch_source) =
         claude_history_fixture(dir.path(), mismatch_session_id)?;
     std::fs::write(&mismatched_history_path, b"actual!")?;
-    let history_mismatch_identity = FinalSessionHistoryIdentity::new(
+    let history_mismatch_identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(mismatch_session_id),
         SessionHistoryRefKind::Blob,
@@ -193,7 +193,7 @@ async fn verify_session_history_identity_returns_stable_exit_codes() -> TestResu
         &history_mismatch_identity,
     )?;
 
-    let history_too_large_identity = FinalSessionHistoryIdentity::new(
+    let history_too_large_identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(matching_session_id),
         SessionHistoryRefKind::Blob,
@@ -286,7 +286,7 @@ async fn export_session_history_sidecar_reads_raw_source_once() -> TestResult {
     let session_id = "raw-sidecar-history";
     let (history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     std::fs::write(&history_path, history)?;
-    let identity = FinalSessionHistoryIdentity::new(
+    let identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
         SessionHistoryRefKind::Blob,
@@ -324,13 +324,13 @@ async fn export_session_history_sidecar_rejects_proc_magic_link_source_without_o
     let dir = tempfile::tempdir()?;
     let sentinel = b"parent-only-secret-sentinel";
     let session_id = "proc-magic-link-source";
-    let identity = FinalSessionHistoryIdentity::new(
+    let identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
         SessionHistoryRefKind::Blob,
         sha256_hex(sentinel),
         sentinel.len() as u64,
-        FinalSessionHistorySourceRef::ClaudeCode {
+        SessionHistorySourceRef::ClaudeCode {
             config_dir: "/proc/self".to_string(),
             working_dir: guest_agent::paths::CANONICAL_WORKING_DIR.to_string(),
             session_id: session_id.to_string(),
@@ -373,7 +373,7 @@ async fn export_session_history_sidecar_rejects_final_symlink_without_output() -
     let outside_path = dir.path().join("outside-history.jsonl");
     std::fs::write(&outside_path, sentinel)?;
     symlink(&outside_path, &history_path)?;
-    let identity = FinalSessionHistoryIdentity::new(
+    let identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
         SessionHistoryRefKind::Blob,
@@ -417,11 +417,11 @@ async fn export_session_history_sidecar_reads_native_codex_zstd_once() -> TestRe
     let encoded = zstd::encode_all(history.as_slice(), 0)?;
     let history_path = day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl.zst");
     std::fs::write(&history_path, &encoded)?;
-    let history_source = FinalSessionHistorySourceRef::Codex {
+    let history_source = SessionHistorySourceRef::Codex {
         sessions_dir: sessions_dir.to_string_lossy().into_owned(),
         thread_id: thread_id.to_string(),
     };
-    let identity = FinalSessionHistoryIdentity::new(
+    let identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::Codex,
         session_id_hash(thread_id),
         SessionHistoryRefKind::Blob,
@@ -459,7 +459,7 @@ async fn export_session_history_sidecar_rejects_metadata_above_resume_limit_befo
     let dir = tempfile::tempdir()?;
     let session_id = "missing-oversized-history";
     let (_history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
-    let identity = FinalSessionHistoryIdentity::new(
+    let identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
         SessionHistoryRefKind::Blob,
@@ -489,7 +489,7 @@ async fn export_session_history_sidecar_keeps_source_read_failures() -> TestResu
     let dir = tempfile::tempdir()?;
     let session_id = "missing-source-history";
     let (_history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
-    let identity = FinalSessionHistoryIdentity::new(
+    let identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
         SessionHistoryRefKind::Blob,
@@ -523,7 +523,7 @@ async fn export_session_history_sidecar_reports_safe_output_write_failure() -> T
     let session_id = "output-failure-history";
     let (history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     std::fs::write(&history_path, history)?;
-    let identity = FinalSessionHistoryIdentity::new(
+    let identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
         SessionHistoryRefKind::Blob,
@@ -566,7 +566,7 @@ async fn export_session_history_sidecar_rejects_history_mismatch() -> TestResult
     let session_id = "sidecar-mismatched-history";
     let (history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     std::fs::write(&history_path, history)?;
-    let identity = FinalSessionHistoryIdentity::new(
+    let identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
         SessionHistoryRefKind::Blob,
@@ -601,7 +601,7 @@ async fn export_session_history_sidecar_rejects_symlinked_metadata_without_openi
     let session_id = "symlinked-metadata";
     let (history_path, history_source) = claude_history_fixture(dir.path(), session_id)?;
     std::fs::write(&history_path, history)?;
-    let identity = FinalSessionHistoryIdentity::new(
+    let identity = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         session_id_hash(session_id),
         SessionHistoryRefKind::Blob,
@@ -632,17 +632,14 @@ async fn export_session_history_sidecar_rejects_symlinked_metadata_without_openi
 fn write_metadata(
     dir: &Path,
     name: &str,
-    identity: &FinalSessionHistoryIdentity,
+    identity: &SessionHistoryIdentity,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let path = dir.join(name);
     guest_contracts::runtime_paths::write_private(&path, identity.to_json_vec()?)?;
     Ok(path)
 }
 
-fn expectation_args(
-    identity: &FinalSessionHistoryIdentity,
-    session_id_hash: String,
-) -> Vec<OsString> {
+fn expectation_args(identity: &SessionHistoryIdentity, session_id_hash: String) -> Vec<OsString> {
     vec![
         OsString::from(identity.framework.as_str()),
         OsString::from(session_id_hash),

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -529,6 +529,8 @@ mod tests {
             FinalSessionHistoryIdentity::from_json_slice(&bytes).unwrap(),
             identity
         );
+        assert_eq!(value["framework"], "claude-code");
+        assert_eq!(value["historyRefKind"], "blob");
         assert!(value.get("version").is_none());
         assert!(value.get("historySource").is_some());
         assert!(value.get("historyMarkerPayload").is_none());
@@ -640,6 +642,8 @@ mod tests {
     #[test]
     fn final_identity_expectation_parses_cli_args_and_matches_identity() {
         let identity = valid_identity();
+        assert_eq!(identity.framework.as_str(), "claude-code");
+        assert_eq!(identity.history_ref_kind.as_str(), "blob");
         let expectation = FinalSessionHistoryIdentityExpectation::from_cli_args([
             identity.framework.as_str(),
             &identity.session_id_hash,

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -35,10 +35,10 @@ pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE: i32 = 9;
 /// Exit code 10 previously represented sidecar export unavailability and
 /// remains reserved for that historical meaning.
 pub const SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE: i32 = 11;
-/// Framework that owns a final session-history file.
+/// Framework that owns session-history bytes.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum FinalSessionHistoryFramework {
+pub enum SessionHistoryFramework {
     /// Claude Code session history.
     ClaudeCode,
     /// Codex session history.
@@ -47,10 +47,10 @@ pub enum FinalSessionHistoryFramework {
     Pi,
 }
 
-/// Storage ref kind for final session-history bytes.
+/// Storage ref kind for session-history bytes.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum FinalSessionHistoryRefKind {
+pub enum SessionHistoryRefKind {
     /// Hash-backed blob storage.
     Blob,
 }
@@ -178,11 +178,11 @@ pub struct SessionHistorySidecarExportFailure {
 #[serde(rename_all = "camelCase")]
 pub struct FinalSessionHistoryIdentity {
     /// CLI framework.
-    pub framework: FinalSessionHistoryFramework,
+    pub framework: SessionHistoryFramework,
     /// SHA-256 hash of the framework-normalized CLI session id.
     pub session_id_hash: String,
     /// Server resume history ref kind.
-    pub history_ref_kind: FinalSessionHistoryRefKind,
+    pub history_ref_kind: SessionHistoryRefKind,
     /// SHA-256 hash of final session-history bytes.
     pub history_hash: String,
     /// Exact final session-history byte length.
@@ -194,9 +194,9 @@ pub struct FinalSessionHistoryIdentity {
 impl FinalSessionHistoryIdentity {
     /// Build validated final identity metadata.
     pub fn new(
-        framework: FinalSessionHistoryFramework,
+        framework: SessionHistoryFramework,
         session_id_hash: impl Into<String>,
-        history_ref_kind: FinalSessionHistoryRefKind,
+        history_ref_kind: SessionHistoryRefKind,
         history_hash: impl Into<String>,
         history_size_bytes: u64,
         history_source: FinalSessionHistorySourceRef,
@@ -250,13 +250,13 @@ impl FinalSessionHistoryIdentity {
         if !matches!(
             (self.framework, &self.history_source),
             (
-                FinalSessionHistoryFramework::ClaudeCode,
+                SessionHistoryFramework::ClaudeCode,
                 FinalSessionHistorySourceRef::ClaudeCode { .. }
             ) | (
-                FinalSessionHistoryFramework::Codex,
+                SessionHistoryFramework::Codex,
                 FinalSessionHistorySourceRef::Codex { .. }
             ) | (
-                FinalSessionHistoryFramework::Pi,
+                SessionHistoryFramework::Pi,
                 FinalSessionHistorySourceRef::Pi { .. }
             )
         ) {
@@ -266,7 +266,7 @@ impl FinalSessionHistoryIdentity {
     }
 }
 
-impl FinalSessionHistoryFramework {
+impl SessionHistoryFramework {
     /// Return the stable CLI argument spelling used by runner and guest-agent.
     pub fn as_str(self) -> &'static str {
         match self {
@@ -287,7 +287,7 @@ impl FinalSessionHistoryFramework {
     }
 }
 
-impl FinalSessionHistoryRefKind {
+impl SessionHistoryRefKind {
     /// Return the stable CLI argument spelling used by runner and guest-agent.
     pub fn as_str(self) -> &'static str {
         match self {
@@ -309,11 +309,11 @@ impl FinalSessionHistoryRefKind {
 #[derive(Clone, Eq, PartialEq)]
 pub struct FinalSessionHistoryIdentityExpectation {
     /// CLI framework expected by runner.
-    pub framework: FinalSessionHistoryFramework,
+    pub framework: SessionHistoryFramework,
     /// SHA-256 hash of the framework-normalized CLI session id expected by runner.
     pub session_id_hash: String,
     /// Server resume history ref kind expected by runner.
-    pub history_ref_kind: FinalSessionHistoryRefKind,
+    pub history_ref_kind: SessionHistoryRefKind,
     /// SHA-256 hash of final session-history bytes expected by runner.
     pub history_hash: String,
     /// Exact final session-history byte length expected by runner.
@@ -335,9 +335,9 @@ impl fmt::Debug for FinalSessionHistoryIdentityExpectation {
 impl FinalSessionHistoryIdentityExpectation {
     /// Build validated expected final identity fields.
     pub fn new(
-        framework: FinalSessionHistoryFramework,
+        framework: SessionHistoryFramework,
         session_id_hash: impl Into<String>,
-        history_ref_kind: FinalSessionHistoryRefKind,
+        history_ref_kind: SessionHistoryRefKind,
         history_hash: impl Into<String>,
         history_size_bytes: u64,
     ) -> Result<Self, FinalSessionHistoryIdentityError> {
@@ -358,9 +358,9 @@ impl FinalSessionHistoryIdentityExpectation {
             .parse::<u64>()
             .map_err(|_| FinalSessionHistoryIdentityError::InvalidHistorySize)?;
         Self::new(
-            FinalSessionHistoryFramework::parse_cli_arg(args[0])?,
+            SessionHistoryFramework::parse_cli_arg(args[0])?,
             args[1],
-            FinalSessionHistoryRefKind::parse_cli_arg(args[2])?,
+            SessionHistoryRefKind::parse_cli_arg(args[2])?,
             args[3],
             history_size_bytes,
         )
@@ -509,9 +509,9 @@ mod tests {
 
     fn valid_identity() -> FinalSessionHistoryIdentity {
         FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             "b".repeat(64),
             12,
             valid_source(),
@@ -537,9 +537,9 @@ mod tests {
     #[test]
     fn final_identity_rejects_invalid_hashes() {
         let err = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             "not-a-hash",
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             "b".repeat(64),
             12,
             valid_source(),
@@ -548,9 +548,9 @@ mod tests {
         assert_eq!(err, FinalSessionHistoryIdentityError::InvalidSessionIdHash);
 
         let err = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             "not-a-hash",
             12,
             valid_source(),
@@ -562,9 +562,9 @@ mod tests {
     #[test]
     fn final_identity_rejects_zero_history() {
         let err = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             "b".repeat(64),
             0,
             valid_source(),
@@ -576,9 +576,9 @@ mod tests {
     #[test]
     fn final_identity_accepts_large_history_size() {
         let identity = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             "b".repeat(64),
             u64::MAX,
             valid_source(),
@@ -595,9 +595,9 @@ mod tests {
     #[test]
     fn final_identity_rejects_invalid_history_source() {
         let err = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             "b".repeat(64),
             12,
             FinalSessionHistorySourceRef::ClaudeCode {
@@ -613,9 +613,9 @@ mod tests {
     #[test]
     fn final_identity_rejects_history_source_from_another_framework() {
         let err = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::Codex,
+            SessionHistoryFramework::Codex,
             "a".repeat(64),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             "b".repeat(64),
             12,
             valid_source(),
@@ -655,9 +655,9 @@ mod tests {
     #[test]
     fn final_identity_expectation_accepts_large_history_size() {
         let expectation = FinalSessionHistoryIdentityExpectation::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             "b".repeat(64),
             u64::MAX,
         )

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -58,7 +58,7 @@ pub enum SessionHistoryRefKind {
 /// Canonical framework-owned source for final session-history bytes.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
-pub enum FinalSessionHistorySourceRef {
+pub enum SessionHistorySourceRef {
     /// Claude Code history derived from its effective config directory and cwd.
     ClaudeCode {
         /// Effective Claude config directory from the finalized child environment.
@@ -91,8 +91,8 @@ pub enum FinalSessionHistorySourceRef {
     },
 }
 
-impl FinalSessionHistorySourceRef {
-    fn validate(&self) -> Result<(), FinalSessionHistoryIdentityError> {
+impl SessionHistorySourceRef {
+    fn validate(&self) -> Result<(), SessionHistoryIdentityError> {
         let valid = match self {
             Self::ClaudeCode {
                 config_dir,
@@ -111,7 +111,7 @@ impl FinalSessionHistorySourceRef {
         if valid {
             Ok(())
         } else {
-            Err(FinalSessionHistoryIdentityError::InvalidHistorySource)
+            Err(SessionHistoryIdentityError::InvalidHistorySource)
         }
     }
 }
@@ -176,7 +176,7 @@ pub struct SessionHistorySidecarExportFailure {
 /// Run-private final session-history identity metadata.
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct FinalSessionHistoryIdentity {
+pub struct SessionHistoryIdentity {
     /// CLI framework.
     pub framework: SessionHistoryFramework,
     /// SHA-256 hash of the framework-normalized CLI session id.
@@ -188,10 +188,10 @@ pub struct FinalSessionHistoryIdentity {
     /// Exact final session-history byte length.
     pub history_size_bytes: u64,
     /// Canonical structured source used to read final framework history.
-    pub history_source: FinalSessionHistorySourceRef,
+    pub history_source: SessionHistorySourceRef,
 }
 
-impl FinalSessionHistoryIdentity {
+impl SessionHistoryIdentity {
     /// Build validated final identity metadata.
     pub fn new(
         framework: SessionHistoryFramework,
@@ -199,8 +199,8 @@ impl FinalSessionHistoryIdentity {
         history_ref_kind: SessionHistoryRefKind,
         history_hash: impl Into<String>,
         history_size_bytes: u64,
-        history_source: FinalSessionHistorySourceRef,
-    ) -> Result<Self, FinalSessionHistoryIdentityError> {
+        history_source: SessionHistorySourceRef,
+    ) -> Result<Self, SessionHistoryIdentityError> {
         let identity = Self {
             framework,
             session_id_hash: session_id_hash.into(),
@@ -214,53 +214,53 @@ impl FinalSessionHistoryIdentity {
     }
 
     /// Parse and validate final identity metadata from JSON bytes.
-    pub fn from_json_slice(bytes: &[u8]) -> Result<Self, FinalSessionHistoryIdentityError> {
+    pub fn from_json_slice(bytes: &[u8]) -> Result<Self, SessionHistoryIdentityError> {
         if bytes.len() as u64 > FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES {
-            return Err(FinalSessionHistoryIdentityError::MetadataTooLarge);
+            return Err(SessionHistoryIdentityError::MetadataTooLarge);
         }
-        let identity: Self = serde_json::from_slice(bytes)
-            .map_err(|_| FinalSessionHistoryIdentityError::InvalidJson)?;
+        let identity: Self =
+            serde_json::from_slice(bytes).map_err(|_| SessionHistoryIdentityError::InvalidJson)?;
         identity.validate()?;
         Ok(identity)
     }
 
     /// Serialize validated final identity metadata to JSON bytes.
-    pub fn to_json_vec(&self) -> Result<Vec<u8>, FinalSessionHistoryIdentityError> {
+    pub fn to_json_vec(&self) -> Result<Vec<u8>, SessionHistoryIdentityError> {
         self.validate()?;
         let bytes =
-            serde_json::to_vec(self).map_err(|_| FinalSessionHistoryIdentityError::InvalidJson)?;
+            serde_json::to_vec(self).map_err(|_| SessionHistoryIdentityError::InvalidJson)?;
         if bytes.len() as u64 > FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES {
-            return Err(FinalSessionHistoryIdentityError::MetadataTooLarge);
+            return Err(SessionHistoryIdentityError::MetadataTooLarge);
         }
         Ok(bytes)
     }
 
     /// Validate final identity metadata invariants.
-    pub fn validate(&self) -> Result<(), FinalSessionHistoryIdentityError> {
+    pub fn validate(&self) -> Result<(), SessionHistoryIdentityError> {
         if !is_sha256_hex(&self.session_id_hash) {
-            return Err(FinalSessionHistoryIdentityError::InvalidSessionIdHash);
+            return Err(SessionHistoryIdentityError::InvalidSessionIdHash);
         }
         if !is_sha256_hex(&self.history_hash) {
-            return Err(FinalSessionHistoryIdentityError::InvalidHistoryHash);
+            return Err(SessionHistoryIdentityError::InvalidHistoryHash);
         }
         if self.history_size_bytes == 0 {
-            return Err(FinalSessionHistoryIdentityError::InvalidHistorySize);
+            return Err(SessionHistoryIdentityError::InvalidHistorySize);
         }
         self.history_source.validate()?;
         if !matches!(
             (self.framework, &self.history_source),
             (
                 SessionHistoryFramework::ClaudeCode,
-                FinalSessionHistorySourceRef::ClaudeCode { .. }
+                SessionHistorySourceRef::ClaudeCode { .. }
             ) | (
                 SessionHistoryFramework::Codex,
-                FinalSessionHistorySourceRef::Codex { .. }
+                SessionHistorySourceRef::Codex { .. }
             ) | (
                 SessionHistoryFramework::Pi,
-                FinalSessionHistorySourceRef::Pi { .. }
+                SessionHistorySourceRef::Pi { .. }
             )
         ) {
-            return Err(FinalSessionHistoryIdentityError::InvalidHistorySource);
+            return Err(SessionHistoryIdentityError::InvalidHistorySource);
         }
         Ok(())
     }
@@ -277,12 +277,12 @@ impl SessionHistoryFramework {
     }
 
     /// Parse the stable CLI argument spelling used by runner and guest-agent.
-    pub fn parse_cli_arg(value: &str) -> Result<Self, FinalSessionHistoryIdentityError> {
+    pub fn parse_cli_arg(value: &str) -> Result<Self, SessionHistoryIdentityError> {
         match value {
             "claude-code" => Ok(Self::ClaudeCode),
             "codex" => Ok(Self::Codex),
             "pi" => Ok(Self::Pi),
-            _ => Err(FinalSessionHistoryIdentityError::InvalidFramework),
+            _ => Err(SessionHistoryIdentityError::InvalidFramework),
         }
     }
 }
@@ -296,10 +296,10 @@ impl SessionHistoryRefKind {
     }
 
     /// Parse the stable CLI argument spelling used by runner and guest-agent.
-    pub fn parse_cli_arg(value: &str) -> Result<Self, FinalSessionHistoryIdentityError> {
+    pub fn parse_cli_arg(value: &str) -> Result<Self, SessionHistoryIdentityError> {
         match value {
             "blob" => Ok(Self::Blob),
-            _ => Err(FinalSessionHistoryIdentityError::InvalidHistoryRefKind),
+            _ => Err(SessionHistoryIdentityError::InvalidHistoryRefKind),
         }
     }
 }
@@ -307,7 +307,7 @@ impl SessionHistoryRefKind {
 /// Expected final identity fields supplied by runner when verifying a parked
 /// sandbox's checkpointed metadata.
 #[derive(Clone, Eq, PartialEq)]
-pub struct FinalSessionHistoryIdentityExpectation {
+pub struct SessionHistoryIdentityExpectation {
     /// CLI framework expected by runner.
     pub framework: SessionHistoryFramework,
     /// SHA-256 hash of the framework-normalized CLI session id expected by runner.
@@ -320,9 +320,9 @@ pub struct FinalSessionHistoryIdentityExpectation {
     pub history_size_bytes: u64,
 }
 
-impl fmt::Debug for FinalSessionHistoryIdentityExpectation {
+impl fmt::Debug for SessionHistoryIdentityExpectation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("FinalSessionHistoryIdentityExpectation")
+        f.debug_struct("SessionHistoryIdentityExpectation")
             .field("framework", &self.framework)
             .field("session_id_hash", &"[redacted]")
             .field("history_ref_kind", &self.history_ref_kind)
@@ -332,7 +332,7 @@ impl fmt::Debug for FinalSessionHistoryIdentityExpectation {
     }
 }
 
-impl FinalSessionHistoryIdentityExpectation {
+impl SessionHistoryIdentityExpectation {
     /// Build validated expected final identity fields.
     pub fn new(
         framework: SessionHistoryFramework,
@@ -340,7 +340,7 @@ impl FinalSessionHistoryIdentityExpectation {
         history_ref_kind: SessionHistoryRefKind,
         history_hash: impl Into<String>,
         history_size_bytes: u64,
-    ) -> Result<Self, FinalSessionHistoryIdentityError> {
+    ) -> Result<Self, SessionHistoryIdentityError> {
         let expectation = Self {
             framework,
             session_id_hash: session_id_hash.into(),
@@ -353,10 +353,10 @@ impl FinalSessionHistoryIdentityExpectation {
     }
 
     /// Parse expected final identity fields from helper CLI arguments.
-    pub fn from_cli_args(args: [&str; 5]) -> Result<Self, FinalSessionHistoryIdentityError> {
+    pub fn from_cli_args(args: [&str; 5]) -> Result<Self, SessionHistoryIdentityError> {
         let history_size_bytes = args[4]
             .parse::<u64>()
-            .map_err(|_| FinalSessionHistoryIdentityError::InvalidHistorySize)?;
+            .map_err(|_| SessionHistoryIdentityError::InvalidHistorySize)?;
         Self::new(
             SessionHistoryFramework::parse_cli_arg(args[0])?,
             args[1],
@@ -367,21 +367,21 @@ impl FinalSessionHistoryIdentityExpectation {
     }
 
     /// Validate expected final identity invariants.
-    pub fn validate(&self) -> Result<(), FinalSessionHistoryIdentityError> {
+    pub fn validate(&self) -> Result<(), SessionHistoryIdentityError> {
         if !is_sha256_hex(&self.session_id_hash) {
-            return Err(FinalSessionHistoryIdentityError::InvalidSessionIdHash);
+            return Err(SessionHistoryIdentityError::InvalidSessionIdHash);
         }
         if !is_sha256_hex(&self.history_hash) {
-            return Err(FinalSessionHistoryIdentityError::InvalidHistoryHash);
+            return Err(SessionHistoryIdentityError::InvalidHistoryHash);
         }
         if self.history_size_bytes == 0 {
-            return Err(FinalSessionHistoryIdentityError::InvalidHistorySize);
+            return Err(SessionHistoryIdentityError::InvalidHistorySize);
         }
         Ok(())
     }
 
     /// Return whether metadata read from the guest still matches runner's expected identity.
-    pub fn matches_identity(&self, identity: &FinalSessionHistoryIdentity) -> bool {
+    pub fn matches_identity(&self, identity: &SessionHistoryIdentity) -> bool {
         self.framework == identity.framework
             && self.session_id_hash == identity.session_id_hash
             && self.history_ref_kind == identity.history_ref_kind
@@ -390,9 +390,9 @@ impl FinalSessionHistoryIdentityExpectation {
     }
 }
 
-impl fmt::Debug for FinalSessionHistoryIdentity {
+impl fmt::Debug for SessionHistoryIdentity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("FinalSessionHistoryIdentity")
+        f.debug_struct("SessionHistoryIdentity")
             .field("framework", &self.framework)
             .field("session_id_hash", &"[redacted]")
             .field("history_ref_kind", &self.history_ref_kind)
@@ -405,7 +405,7 @@ impl fmt::Debug for FinalSessionHistoryIdentity {
 
 /// Final identity metadata validation error.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum FinalSessionHistoryIdentityError {
+pub enum SessionHistoryIdentityError {
     /// Metadata file exceeds the metadata read cap.
     MetadataTooLarge,
     /// Metadata is not valid JSON.
@@ -424,7 +424,7 @@ pub enum FinalSessionHistoryIdentityError {
     InvalidHistorySource,
 }
 
-impl fmt::Display for FinalSessionHistoryIdentityError {
+impl fmt::Display for SessionHistoryIdentityError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MetadataTooLarge => f.write_str("final session history identity is too large"),
@@ -451,7 +451,7 @@ impl fmt::Display for FinalSessionHistoryIdentityError {
     }
 }
 
-impl std::error::Error for FinalSessionHistoryIdentityError {}
+impl std::error::Error for SessionHistoryIdentityError {}
 
 fn is_sha256_hex(value: &str) -> bool {
     value.len() == 64
@@ -464,8 +464,8 @@ fn is_sha256_hex(value: &str) -> bool {
 mod tests {
     use super::*;
 
-    fn valid_source() -> FinalSessionHistorySourceRef {
-        FinalSessionHistorySourceRef::ClaudeCode {
+    fn valid_source() -> SessionHistorySourceRef {
+        SessionHistorySourceRef::ClaudeCode {
             config_dir: "/home/user/.claude".to_string(),
             working_dir: "/home/user/workspace".to_string(),
             session_id: "session".to_string(),
@@ -507,8 +507,8 @@ mod tests {
         assert_eq!(failure.io_error_class.as_str(), "storage-full");
     }
 
-    fn valid_identity() -> FinalSessionHistoryIdentity {
-        FinalSessionHistoryIdentity::new(
+    fn valid_identity() -> SessionHistoryIdentity {
+        SessionHistoryIdentity::new(
             SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
             SessionHistoryRefKind::Blob,
@@ -526,7 +526,7 @@ mod tests {
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
 
         assert_eq!(
-            FinalSessionHistoryIdentity::from_json_slice(&bytes).unwrap(),
+            SessionHistoryIdentity::from_json_slice(&bytes).unwrap(),
             identity
         );
         assert_eq!(value["framework"], "claude-code");
@@ -538,7 +538,7 @@ mod tests {
 
     #[test]
     fn final_identity_rejects_invalid_hashes() {
-        let err = FinalSessionHistoryIdentity::new(
+        let err = SessionHistoryIdentity::new(
             SessionHistoryFramework::ClaudeCode,
             "not-a-hash",
             SessionHistoryRefKind::Blob,
@@ -547,9 +547,9 @@ mod tests {
             valid_source(),
         )
         .unwrap_err();
-        assert_eq!(err, FinalSessionHistoryIdentityError::InvalidSessionIdHash);
+        assert_eq!(err, SessionHistoryIdentityError::InvalidSessionIdHash);
 
-        let err = FinalSessionHistoryIdentity::new(
+        let err = SessionHistoryIdentity::new(
             SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
             SessionHistoryRefKind::Blob,
@@ -558,12 +558,12 @@ mod tests {
             valid_source(),
         )
         .unwrap_err();
-        assert_eq!(err, FinalSessionHistoryIdentityError::InvalidHistoryHash);
+        assert_eq!(err, SessionHistoryIdentityError::InvalidHistoryHash);
     }
 
     #[test]
     fn final_identity_rejects_zero_history() {
-        let err = FinalSessionHistoryIdentity::new(
+        let err = SessionHistoryIdentity::new(
             SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
             SessionHistoryRefKind::Blob,
@@ -572,12 +572,12 @@ mod tests {
             valid_source(),
         )
         .unwrap_err();
-        assert_eq!(err, FinalSessionHistoryIdentityError::InvalidHistorySize);
+        assert_eq!(err, SessionHistoryIdentityError::InvalidHistorySize);
     }
 
     #[test]
     fn final_identity_accepts_large_history_size() {
-        let identity = FinalSessionHistoryIdentity::new(
+        let identity = SessionHistoryIdentity::new(
             SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
             SessionHistoryRefKind::Blob,
@@ -589,32 +589,32 @@ mod tests {
 
         assert_eq!(identity.history_size_bytes, u64::MAX);
         assert_eq!(
-            FinalSessionHistoryIdentity::from_json_slice(&identity.to_json_vec().unwrap()).unwrap(),
+            SessionHistoryIdentity::from_json_slice(&identity.to_json_vec().unwrap()).unwrap(),
             identity
         );
     }
 
     #[test]
     fn final_identity_rejects_invalid_history_source() {
-        let err = FinalSessionHistoryIdentity::new(
+        let err = SessionHistoryIdentity::new(
             SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
             SessionHistoryRefKind::Blob,
             "b".repeat(64),
             12,
-            FinalSessionHistorySourceRef::ClaudeCode {
+            SessionHistorySourceRef::ClaudeCode {
                 config_dir: String::new(),
                 working_dir: "/home/user/workspace".to_string(),
                 session_id: "session".to_string(),
             },
         )
         .unwrap_err();
-        assert_eq!(err, FinalSessionHistoryIdentityError::InvalidHistorySource);
+        assert_eq!(err, SessionHistoryIdentityError::InvalidHistorySource);
     }
 
     #[test]
     fn final_identity_rejects_history_source_from_another_framework() {
-        let err = FinalSessionHistoryIdentity::new(
+        let err = SessionHistoryIdentity::new(
             SessionHistoryFramework::Codex,
             "a".repeat(64),
             SessionHistoryRefKind::Blob,
@@ -624,7 +624,7 @@ mod tests {
         )
         .unwrap_err();
 
-        assert_eq!(err, FinalSessionHistoryIdentityError::InvalidHistorySource);
+        assert_eq!(err, SessionHistoryIdentityError::InvalidHistorySource);
     }
 
     #[test]
@@ -644,7 +644,7 @@ mod tests {
         let identity = valid_identity();
         assert_eq!(identity.framework.as_str(), "claude-code");
         assert_eq!(identity.history_ref_kind.as_str(), "blob");
-        let expectation = FinalSessionHistoryIdentityExpectation::from_cli_args([
+        let expectation = SessionHistoryIdentityExpectation::from_cli_args([
             identity.framework.as_str(),
             &identity.session_id_hash,
             identity.history_ref_kind.as_str(),
@@ -658,7 +658,7 @@ mod tests {
 
     #[test]
     fn final_identity_expectation_accepts_large_history_size() {
-        let expectation = FinalSessionHistoryIdentityExpectation::new(
+        let expectation = SessionHistoryIdentityExpectation::new(
             SessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
             SessionHistoryRefKind::Blob,
@@ -673,7 +673,7 @@ mod tests {
     #[test]
     fn final_identity_expectation_detects_mismatch() {
         let identity = valid_identity();
-        let expectation = FinalSessionHistoryIdentityExpectation::new(
+        let expectation = SessionHistoryIdentityExpectation::new(
             identity.framework,
             identity.session_id_hash.clone(),
             identity.history_ref_kind,
@@ -688,7 +688,7 @@ mod tests {
     #[test]
     fn final_identity_expectation_debug_redacts_sensitive_fields() {
         let identity = valid_identity();
-        let expectation = FinalSessionHistoryIdentityExpectation::new(
+        let expectation = SessionHistoryIdentityExpectation::new(
             identity.framework,
             identity.session_id_hash.clone(),
             identity.history_ref_kind,

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1008,8 +1008,8 @@ mod tests {
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
     use guest_contracts::reuse_preparation::{ReusePreparationReport, RootFilesystemCapacity};
     use guest_contracts::session_history_identity::{
-        FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-        FinalSessionHistorySourceRef, SessionHistorySidecarExportMetadata,
+        FinalSessionHistoryIdentity, FinalSessionHistorySourceRef, SessionHistoryFramework,
+        SessionHistoryRefKind, SessionHistorySidecarExportMetadata,
     };
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
     use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory, MockSandboxOverrides};
@@ -1262,35 +1262,35 @@ mod tests {
     }
 
     fn test_restored_session_identity(
-        framework: FinalSessionHistoryFramework,
+        framework: SessionHistoryFramework,
         session_id: &str,
         history: &[u8],
     ) -> RestoredSessionIdentity {
         RestoredSessionIdentity::new(
             framework,
             session_id,
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             hex::encode(Sha256::digest(history)),
             Some(history.len() as u64),
         )
     }
 
     fn test_verified_restored_session_identity(
-        framework: FinalSessionHistoryFramework,
+        framework: SessionHistoryFramework,
         session_id: &str,
         history: &[u8],
     ) -> RestoredSessionIdentity {
         let history_source = match framework {
-            FinalSessionHistoryFramework::ClaudeCode => FinalSessionHistorySourceRef::ClaudeCode {
+            SessionHistoryFramework::ClaudeCode => FinalSessionHistorySourceRef::ClaudeCode {
                 config_dir: "/home/user/.claude".to_string(),
                 working_dir: CANONICAL_WORKING_DIR.to_string(),
                 session_id: session_id.to_string(),
             },
-            FinalSessionHistoryFramework::Codex => FinalSessionHistorySourceRef::Codex {
+            SessionHistoryFramework::Codex => FinalSessionHistorySourceRef::Codex {
                 sessions_dir: "/home/user/.codex/sessions".to_string(),
                 thread_id: session_id.to_string(),
             },
-            FinalSessionHistoryFramework::Pi => FinalSessionHistorySourceRef::Pi {
+            SessionHistoryFramework::Pi => FinalSessionHistorySourceRef::Pi {
                 session_path: format!(
                     "{}/restored-{session_id}.jsonl",
                     api_contracts::generated::constants::runners::paths::CANONICAL_PI_SESSION_DIR,
@@ -1301,7 +1301,7 @@ mod tests {
         let metadata = FinalSessionHistoryIdentity::new(
             framework,
             hex::encode(Sha256::digest(session_id.as_bytes())),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             hex::encode(Sha256::digest(history)),
             history.len() as u64,
             history_source,
@@ -1325,7 +1325,7 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let restored_session_identity = test_restored_session_identity(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             session_id,
             history,
         );
@@ -2170,7 +2170,7 @@ mod tests {
         let previous_sidecar_body = tokio::fs::read(&sidecar_body_path).await.unwrap();
         let previous_sidecar_metadata = tokio::fs::read(&sidecar_metadata_path).await.unwrap();
         let codex_identity = test_restored_session_identity(
-            FinalSessionHistoryFramework::Codex,
+            SessionHistoryFramework::Codex,
             "codex-session-b",
             previous_history,
         );
@@ -2336,7 +2336,7 @@ mod tests {
         let next_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
         let next_history = br#"{"type":"message","content":"codex-b"}"#;
         let next_identity = test_verified_restored_session_identity(
-            FinalSessionHistoryFramework::Codex,
+            SessionHistoryFramework::Codex,
             next_session_id,
             next_history,
         );

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1008,8 +1008,8 @@ mod tests {
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
     use guest_contracts::reuse_preparation::{ReusePreparationReport, RootFilesystemCapacity};
     use guest_contracts::session_history_identity::{
-        FinalSessionHistoryIdentity, FinalSessionHistorySourceRef, SessionHistoryFramework,
-        SessionHistoryRefKind, SessionHistorySidecarExportMetadata,
+        SessionHistoryFramework, SessionHistoryIdentity, SessionHistoryRefKind,
+        SessionHistorySidecarExportMetadata, SessionHistorySourceRef,
     };
     use sandbox::{ExecResult, SandboxFactory, SandboxId};
     use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxFactory, MockSandboxOverrides};
@@ -1281,16 +1281,16 @@ mod tests {
         history: &[u8],
     ) -> RestoredSessionIdentity {
         let history_source = match framework {
-            SessionHistoryFramework::ClaudeCode => FinalSessionHistorySourceRef::ClaudeCode {
+            SessionHistoryFramework::ClaudeCode => SessionHistorySourceRef::ClaudeCode {
                 config_dir: "/home/user/.claude".to_string(),
                 working_dir: CANONICAL_WORKING_DIR.to_string(),
                 session_id: session_id.to_string(),
             },
-            SessionHistoryFramework::Codex => FinalSessionHistorySourceRef::Codex {
+            SessionHistoryFramework::Codex => SessionHistorySourceRef::Codex {
                 sessions_dir: "/home/user/.codex/sessions".to_string(),
                 thread_id: session_id.to_string(),
             },
-            SessionHistoryFramework::Pi => FinalSessionHistorySourceRef::Pi {
+            SessionHistoryFramework::Pi => SessionHistorySourceRef::Pi {
                 session_path: format!(
                     "{}/restored-{session_id}.jsonl",
                     api_contracts::generated::constants::runners::paths::CANONICAL_PI_SESSION_DIR,
@@ -1298,7 +1298,7 @@ mod tests {
                 session_id: session_id.to_string(),
             },
         };
-        let metadata = FinalSessionHistoryIdentity::new(
+        let metadata = SessionHistoryIdentity::new(
             framework,
             hex::encode(Sha256::digest(session_id.as_bytes())),
             SessionHistoryRefKind::Blob,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -4,7 +4,6 @@ use std::time::{Duration, Instant};
 
 use guest_contracts::diagnostics::{CliTerminationReason, FailureDiagnostic};
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryIdentity, FinalSessionHistoryIdentityError,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
@@ -12,7 +11,8 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ, SessionHistoryIdentity,
+    SessionHistoryIdentityError,
 };
 use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, GuestProcessCancelHandle,
@@ -167,20 +167,16 @@ impl SessionHistoryIdentityReason {
         }
     }
 
-    const fn from_final_metadata_error(error: FinalSessionHistoryIdentityError) -> Self {
+    const fn from_final_metadata_error(error: SessionHistoryIdentityError) -> Self {
         match error {
-            FinalSessionHistoryIdentityError::MetadataTooLarge => {
-                Self::FinalizeUnverifiableMetadata
-            }
-            FinalSessionHistoryIdentityError::InvalidJson
-            | FinalSessionHistoryIdentityError::InvalidFramework
-            | FinalSessionHistoryIdentityError::InvalidHistoryRefKind
-            | FinalSessionHistoryIdentityError::InvalidSessionIdHash
-            | FinalSessionHistoryIdentityError::InvalidHistoryHash
-            | FinalSessionHistoryIdentityError::InvalidHistorySize
-            | FinalSessionHistoryIdentityError::InvalidHistorySource => {
-                Self::FinalizeInvalidMetadata
-            }
+            SessionHistoryIdentityError::MetadataTooLarge => Self::FinalizeUnverifiableMetadata,
+            SessionHistoryIdentityError::InvalidJson
+            | SessionHistoryIdentityError::InvalidFramework
+            | SessionHistoryIdentityError::InvalidHistoryRefKind
+            | SessionHistoryIdentityError::InvalidSessionIdHash
+            | SessionHistoryIdentityError::InvalidHistoryHash
+            | SessionHistoryIdentityError::InvalidHistorySize
+            | SessionHistoryIdentityError::InvalidHistorySource => Self::FinalizeInvalidMetadata,
         }
     }
 }
@@ -616,7 +612,7 @@ async fn read_final_session_history_identity(
         Ok(None) => return Err(SessionHistoryIdentityReason::FinalizeMissingMetadata),
         Err(_) => return Err(SessionHistoryIdentityReason::FinalizeMetadataReadFailed),
     };
-    let metadata = match FinalSessionHistoryIdentity::from_json_slice(&bytes) {
+    let metadata = match SessionHistoryIdentity::from_json_slice(&bytes) {
         Ok(metadata) => metadata,
         Err(error) => {
             return Err(SessionHistoryIdentityReason::from_final_metadata_error(

--- a/crates/runner/src/executor/session_history_restore_plan.rs
+++ b/crates/runner/src/executor/session_history_restore_plan.rs
@@ -284,8 +284,8 @@ mod tests {
     use guest_contracts::{
         codex_thread_id::canonical_codex_thread_id,
         session_history_identity::{
-            FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-            FinalSessionHistorySourceRef,
+            FinalSessionHistoryIdentity, FinalSessionHistorySourceRef, SessionHistoryFramework,
+            SessionHistoryRefKind,
         },
     };
     use sha2::{Digest, Sha256};
@@ -333,9 +333,9 @@ mod tests {
 
     fn final_metadata_identity(history_hash: String, size: u64) -> RestoredSessionIdentity {
         let metadata = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             hex::encode(Sha256::digest(b"sess-restore-plan")),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             history_hash,
             size,
             FinalSessionHistorySourceRef::ClaudeCode {
@@ -439,9 +439,9 @@ mod tests {
             "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json";
         let runtime_dir = "/home/user/.vm0/guest-agent/runs/previous";
         let metadata = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::Codex,
+            SessionHistoryFramework::Codex,
             hex::encode(Sha256::digest(canonical_thread_id.as_bytes())),
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             history_hash,
             12,
             FinalSessionHistorySourceRef::Codex {
@@ -629,9 +629,9 @@ mod tests {
         let history_hash = "a".repeat(64);
         let context = context_with_history_ref(&history_hash);
         let restored_identity = RestoredSessionIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             "sess-other",
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             history_hash,
             Some(12),
         );
@@ -660,9 +660,9 @@ mod tests {
         let history_hash = "a".repeat(64);
         let context = context_with_history_ref(&history_hash);
         let restored_identity = RestoredSessionIdentity::new(
-            FinalSessionHistoryFramework::Codex,
+            SessionHistoryFramework::Codex,
             "sess-restore-plan",
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             history_hash,
             Some(12),
         );

--- a/crates/runner/src/executor/session_history_restore_plan.rs
+++ b/crates/runner/src/executor/session_history_restore_plan.rs
@@ -284,8 +284,8 @@ mod tests {
     use guest_contracts::{
         codex_thread_id::canonical_codex_thread_id,
         session_history_identity::{
-            FinalSessionHistoryIdentity, FinalSessionHistorySourceRef, SessionHistoryFramework,
-            SessionHistoryRefKind,
+            SessionHistoryFramework, SessionHistoryIdentity, SessionHistoryRefKind,
+            SessionHistorySourceRef,
         },
     };
     use sha2::{Digest, Sha256};
@@ -332,13 +332,13 @@ mod tests {
     }
 
     fn final_metadata_identity(history_hash: String, size: u64) -> RestoredSessionIdentity {
-        let metadata = FinalSessionHistoryIdentity::new(
+        let metadata = SessionHistoryIdentity::new(
             SessionHistoryFramework::ClaudeCode,
             hex::encode(Sha256::digest(b"sess-restore-plan")),
             SessionHistoryRefKind::Blob,
             history_hash,
             size,
-            FinalSessionHistorySourceRef::ClaudeCode {
+            SessionHistorySourceRef::ClaudeCode {
                 config_dir: "/home/user/.claude".to_string(),
                 working_dir: "/home/user/workspace".to_string(),
                 session_id: "sess-restore-plan".to_string(),
@@ -438,13 +438,13 @@ mod tests {
         let metadata_path =
             "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json";
         let runtime_dir = "/home/user/.vm0/guest-agent/runs/previous";
-        let metadata = FinalSessionHistoryIdentity::new(
+        let metadata = SessionHistoryIdentity::new(
             SessionHistoryFramework::Codex,
             hex::encode(Sha256::digest(canonical_thread_id.as_bytes())),
             SessionHistoryRefKind::Blob,
             history_hash,
             12,
-            FinalSessionHistorySourceRef::Codex {
+            SessionHistorySourceRef::Codex {
                 sessions_dir: "/home/user/.codex/sessions".to_string(),
                 thread_id: canonical_thread_id,
             },

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -7,9 +7,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
-use guest_contracts::session_history_identity::{
-    FinalSessionHistoryFramework, FinalSessionHistoryRefKind,
-};
+use guest_contracts::session_history_identity::{SessionHistoryFramework, SessionHistoryRefKind};
 use sandbox::Sandbox;
 use tracing::{info, warn};
 
@@ -27,12 +25,12 @@ impl RestoredSessionIdentity {
         let history_ref = resume_session.history_ref()?;
         let effective_framework = effective_cli_framework(&context.cli_agent_type);
         let framework = match effective_framework {
-            EffectiveCliFramework::ClaudeCode => FinalSessionHistoryFramework::ClaudeCode,
-            EffectiveCliFramework::Codex => FinalSessionHistoryFramework::Codex,
-            EffectiveCliFramework::Pi => FinalSessionHistoryFramework::Pi,
+            EffectiveCliFramework::ClaudeCode => SessionHistoryFramework::ClaudeCode,
+            EffectiveCliFramework::Codex => SessionHistoryFramework::Codex,
+            EffectiveCliFramework::Pi => SessionHistoryFramework::Pi,
         };
         let history_ref_kind = match history_ref.kind {
-            ResumeSessionHistoryRefKind::Blob => FinalSessionHistoryRefKind::Blob,
+            ResumeSessionHistoryRefKind::Blob => SessionHistoryRefKind::Blob,
         };
         let session_id = restored_session_identity_session_id(
             effective_framework,

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use guest_contracts::session_history_identity::{
-    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryIdentity,
+    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
@@ -11,7 +11,7 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ, SessionHistoryFramework,
-    SessionHistoryRefKind,
+    SessionHistoryIdentity, SessionHistoryRefKind,
 };
 use httpmock::prelude::*;
 use sandbox::{ExecResult, ExecTermination, ProcessExit};
@@ -63,7 +63,7 @@ fn context_with_checkpointed_session_identity(
     });
     let runtime_dir = format!("/home/user/.vm0/guest-agent/runs/{session_id}-previous");
     let metadata_path = format!("{runtime_dir}/final-session-history-identity.json");
-    let metadata = FinalSessionHistoryIdentity::new(
+    let metadata = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
         SessionHistoryRefKind::Blob,
@@ -109,7 +109,7 @@ async fn assert_checkpointed_final_identity_helper_failure_falls_back(
         },
     });
     let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
-    let metadata = FinalSessionHistoryIdentity::new(
+    let metadata = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
         SessionHistoryRefKind::Blob,
@@ -189,7 +189,7 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
     let previous_metadata_path =
         "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json";
     let previous_runtime_dir = "/home/user/.vm0/guest-agent/runs/previous";
-    let metadata = FinalSessionHistoryIdentity::new(
+    let metadata = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
         SessionHistoryRefKind::Blob,
@@ -482,7 +482,7 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_reports
         },
     });
     let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
-    let metadata = FinalSessionHistoryIdentity::new(
+    let metadata = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
         SessionHistoryRefKind::Blob,
@@ -577,7 +577,7 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_exec_er
         },
     });
     let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
-    let metadata = FinalSessionHistoryIdentity::new(
+    let metadata = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
         SessionHistoryRefKind::Blob,

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use guest_contracts::session_history_identity::{
-    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
-    FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryIdentity,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
@@ -11,7 +10,8 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ, SessionHistoryFramework,
+    SessionHistoryRefKind,
 };
 use httpmock::prelude::*;
 use sandbox::{ExecResult, ExecTermination, ProcessExit};
@@ -64,9 +64,9 @@ fn context_with_checkpointed_session_identity(
     let runtime_dir = format!("/home/user/.vm0/guest-agent/runs/{session_id}-previous");
     let metadata_path = format!("{runtime_dir}/final-session-history-identity.json");
     let metadata = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(history)),
         history.len() as u64,
         claude_history_source(session_id),
@@ -110,9 +110,9 @@ async fn assert_checkpointed_final_identity_helper_failure_falls_back(
     });
     let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
     let metadata = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(history)),
         history.len() as u64,
         claude_history_source(session_id),
@@ -190,9 +190,9 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
         "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json";
     let previous_runtime_dir = "/home/user/.vm0/guest-agent/runs/previous";
     let metadata = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(&history)),
         history.len() as u64,
         claude_history_source(session_id),
@@ -483,9 +483,9 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_reports
     });
     let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
     let metadata = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(history)),
         history.len() as u64,
         claude_history_source(session_id),
@@ -578,9 +578,9 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_exec_er
     });
     let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
     let metadata = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(history)),
         history.len() as u64,
         claude_history_source(session_id),

--- a/crates/runner/src/executor/tests/agent_run_tests/support.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/support.rs
@@ -1,7 +1,7 @@
 use api_contracts::generated::constants::runners::paths::CANONICAL_GUEST_HOME_DIR;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    FinalSessionHistorySourceRef,
+    FinalSessionHistoryIdentity, FinalSessionHistorySourceRef, SessionHistoryFramework,
+    SessionHistoryRefKind,
 };
 use sha2::{Digest, Sha256};
 use tokio_util::sync::CancellationToken;
@@ -60,9 +60,9 @@ pub(super) fn final_identity_runtime_paths(
 
 pub(super) fn final_identity_metadata_bytes(session_id: &str, history: &[u8]) -> Vec<u8> {
     FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(history)),
         history.len() as u64,
         claude_history_source(session_id),

--- a/crates/runner/src/executor/tests/agent_run_tests/support.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/support.rs
@@ -1,7 +1,6 @@
 use api_contracts::generated::constants::runners::paths::CANONICAL_GUEST_HOME_DIR;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryIdentity, FinalSessionHistorySourceRef, SessionHistoryFramework,
-    SessionHistoryRefKind,
+    SessionHistoryFramework, SessionHistoryIdentity, SessionHistoryRefKind, SessionHistorySourceRef,
 };
 use sha2::{Digest, Sha256};
 use tokio_util::sync::CancellationToken;
@@ -35,8 +34,8 @@ pub(super) fn claude_history_path(session_id: &str) -> String {
     format!("/home/user/.claude/projects/-home-user-workspace/{session_id}.jsonl")
 }
 
-pub(super) fn claude_history_source(session_id: &str) -> FinalSessionHistorySourceRef {
-    FinalSessionHistorySourceRef::ClaudeCode {
+pub(super) fn claude_history_source(session_id: &str) -> SessionHistorySourceRef {
+    SessionHistorySourceRef::ClaudeCode {
         config_dir: "/home/user/.claude".to_string(),
         working_dir: "/home/user/workspace".to_string(),
         session_id: session_id.to_string(),
@@ -59,7 +58,7 @@ pub(super) fn final_identity_runtime_paths(
 }
 
 pub(super) fn final_identity_metadata_bytes(session_id: &str, history: &[u8]) -> Vec<u8> {
-    FinalSessionHistoryIdentity::new(
+    SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
         SessionHistoryRefKind::Blob,

--- a/crates/runner/src/executor/tests/session_restore_tests/identity.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/identity.rs
@@ -1,8 +1,6 @@
 use super::*;
 use crate::restored_session_identity::RestoredSessionIdentity;
-use guest_contracts::session_history_identity::{
-    FinalSessionHistoryFramework, FinalSessionHistoryRefKind,
-};
+use guest_contracts::session_history_identity::{SessionHistoryFramework, SessionHistoryRefKind};
 
 #[test]
 fn restored_session_identity_requires_valid_hash_ref() {
@@ -27,17 +25,17 @@ fn restored_session_identity_maps_request_boundary_types() {
         (
             claude_context(),
             "sess-identity-claude",
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
         ),
         (
             codex_context(),
             CODEX_SESSION_ID,
-            FinalSessionHistoryFramework::Codex,
+            SessionHistoryFramework::Codex,
         ),
         (
             pi_context(),
             "sess-identity-pi",
-            FinalSessionHistoryFramework::Pi,
+            SessionHistoryFramework::Pi,
         ),
     ];
 
@@ -48,7 +46,7 @@ fn restored_session_identity_maps_request_boundary_types() {
         let expected = RestoredSessionIdentity::new(
             framework,
             session_id,
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             "hash-a",
             Some(12),
         );

--- a/crates/runner/src/idle_pool/park_transition_tests.rs
+++ b/crates/runner/src/idle_pool/park_transition_tests.rs
@@ -4,8 +4,8 @@ use std::time::{Duration, Instant};
 
 use guest_contracts::reuse_preparation::ReusePreparationRequest;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    FinalSessionHistorySourceRef,
+    FinalSessionHistoryIdentity, FinalSessionHistorySourceRef, SessionHistoryFramework,
+    SessionHistoryRefKind,
 };
 use sandbox::{ResourceLimits, SandboxConfig, SandboxFactory, SandboxId};
 use sandbox_mock::{MockSandboxFactory, MockSandboxOverrides};
@@ -139,9 +139,9 @@ async fn idle_park_request_protects_retained_identity_runtime_directory() {
     let run_id = request.parts.run_id;
     let retained_runtime_dir = "/home/user/.vm0/guest-agent/runs/previous-run";
     let metadata = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(b"history")),
         b"history".len() as u64,
         FinalSessionHistorySourceRef::ClaudeCode {

--- a/crates/runner/src/idle_pool/park_transition_tests.rs
+++ b/crates/runner/src/idle_pool/park_transition_tests.rs
@@ -4,8 +4,7 @@ use std::time::{Duration, Instant};
 
 use guest_contracts::reuse_preparation::ReusePreparationRequest;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryIdentity, FinalSessionHistorySourceRef, SessionHistoryFramework,
-    SessionHistoryRefKind,
+    SessionHistoryFramework, SessionHistoryIdentity, SessionHistoryRefKind, SessionHistorySourceRef,
 };
 use sandbox::{ResourceLimits, SandboxConfig, SandboxFactory, SandboxId};
 use sandbox_mock::{MockSandboxFactory, MockSandboxOverrides};
@@ -138,13 +137,13 @@ async fn idle_park_request_protects_retained_identity_runtime_directory() {
     .await;
     let run_id = request.parts.run_id;
     let retained_runtime_dir = "/home/user/.vm0/guest-agent/runs/previous-run";
-    let metadata = FinalSessionHistoryIdentity::new(
+    let metadata = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
         SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(b"history")),
         b"history".len() as u64,
-        FinalSessionHistorySourceRef::ClaudeCode {
+        SessionHistorySourceRef::ClaudeCode {
             config_dir: "/home/user/.claude".to_string(),
             working_dir: "/home/user/workspace".to_string(),
             session_id: session_id.to_string(),

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -20,8 +20,8 @@ use std::fmt;
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::session_history_identity::{
-    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
-    FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryIdentity, SessionHistoryFramework,
+    SessionHistoryRefKind,
 };
 use sha2::{Digest, Sha256};
 
@@ -104,9 +104,9 @@ impl RestoredSessionHistoryHashSizeRelationship {
 /// that requires retained verification provenance.
 #[derive(Clone, Eq)]
 pub(crate) struct RestoredSessionIdentity {
-    framework: FinalSessionHistoryFramework,
+    framework: SessionHistoryFramework,
     session_id_hash: String,
-    history_ref_kind: FinalSessionHistoryRefKind,
+    history_ref_kind: SessionHistoryRefKind,
     history_hash: String,
     history_size_bytes: Option<u64>,
     verifier: Option<RestoredSessionIdentityVerifier>,
@@ -128,9 +128,9 @@ enum RestoredSessionIdentityVerifier {
 pub(crate) struct RestoredSessionFinalMetadataVerification<'a> {
     pub(crate) metadata_path: &'a str,
     pub(crate) runtime_dir: &'a str,
-    pub(crate) framework: FinalSessionHistoryFramework,
+    pub(crate) framework: SessionHistoryFramework,
     pub(crate) session_id_hash: &'a str,
-    pub(crate) history_ref_kind: FinalSessionHistoryRefKind,
+    pub(crate) history_ref_kind: SessionHistoryRefKind,
     pub(crate) history_hash: &'a str,
     pub(crate) history_size_bytes: u64,
 }
@@ -140,9 +140,9 @@ pub(crate) struct RestoredSessionFinalMetadataVerification<'a> {
 /// This projection requires a stored history size but does not require
 /// final-metadata verifier provenance.
 pub(crate) struct RestoredSessionIdentityFields<'a> {
-    pub(crate) framework: FinalSessionHistoryFramework,
+    pub(crate) framework: SessionHistoryFramework,
     pub(crate) session_id_hash: &'a str,
-    pub(crate) history_ref_kind: FinalSessionHistoryRefKind,
+    pub(crate) history_ref_kind: SessionHistoryRefKind,
     pub(crate) history_hash: &'a str,
     pub(crate) history_size_bytes: u64,
 }
@@ -164,9 +164,9 @@ impl RestoredSessionIdentity {
     /// supply the canonical thread id. The id is stored only as a SHA-256 hash.
     /// This constructor never attaches final-metadata verifier provenance.
     pub(crate) fn new(
-        framework: FinalSessionHistoryFramework,
+        framework: SessionHistoryFramework,
         identity_session_id: &str,
-        history_ref_kind: FinalSessionHistoryRefKind,
+        history_ref_kind: SessionHistoryRefKind,
         history_hash: impl Into<String>,
         history_size_bytes: Option<u64>,
     ) -> Self {
@@ -210,9 +210,9 @@ impl RestoredSessionIdentity {
     #[cfg(test)]
     pub(crate) fn claude_code_for_test(history_hash: impl Into<String>) -> Self {
         Self::new(
-            FinalSessionHistoryFramework::ClaudeCode,
+            SessionHistoryFramework::ClaudeCode,
             "sess-restore-plan",
-            FinalSessionHistoryRefKind::Blob,
+            SessionHistoryRefKind::Blob,
             history_hash,
             None,
         )

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -20,7 +20,7 @@ use std::fmt;
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::session_history_identity::{
-    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryIdentity, SessionHistoryFramework,
+    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, SessionHistoryFramework, SessionHistoryIdentity,
     SessionHistoryRefKind,
 };
 use sha2::{Digest, Sha256};
@@ -186,7 +186,7 @@ impl RestoredSessionIdentity {
     /// path and runtime directory cannot form a usable verification
     /// projection.
     pub(crate) fn from_final_metadata(
-        metadata: FinalSessionHistoryIdentity,
+        metadata: SessionHistoryIdentity,
         metadata_path: impl Into<String>,
         runtime_dir: impl Into<String>,
     ) -> Option<Self> {

--- a/crates/runner/src/workspace_image_cache/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/sidecar.rs
@@ -45,9 +45,7 @@
 use std::path::Path;
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
-use guest_contracts::session_history_identity::{
-    FinalSessionHistoryFramework, FinalSessionHistoryRefKind,
-};
+use guest_contracts::session_history_identity::{SessionHistoryFramework, SessionHistoryRefKind};
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
@@ -103,9 +101,9 @@ fn session_history_sidecar_body_paths(paths: &CacheEntryPaths) -> [std::path::Pa
 #[serde(rename_all = "camelCase")]
 struct WorkspaceSessionHistorySidecarMetadata {
     version: u8,
-    framework: FinalSessionHistoryFramework,
+    framework: SessionHistoryFramework,
     session_id_hash: String,
-    history_ref_kind: FinalSessionHistoryRefKind,
+    history_ref_kind: SessionHistoryRefKind,
     history_hash: String,
     history_size_bytes: u64,
     representation: WorkspaceSessionHistorySidecarRepresentation,
@@ -173,7 +171,7 @@ impl WorkspaceSessionHistorySidecarMetadata {
                 Ok(())
             }
             (
-                FinalSessionHistoryFramework::Codex,
+                SessionHistoryFramework::Codex,
                 WorkspaceSessionHistorySidecarRepresentation::CodexZstd,
             ) => Ok(()),
             _ => Err(WorkspaceSessionHistorySidecarMiss::UnsupportedFormat),

--- a/crates/runner/src/workspace_image_cache/tests/sidecar.rs
+++ b/crates/runner/src/workspace_image_cache/tests/sidecar.rs
@@ -4,9 +4,7 @@ use std::path::Path;
 use api_contracts::generated::constants::runners::{
     RESUME_SESSION_HISTORY_MAX_BYTES, paths::CANONICAL_WORKING_DIR,
 };
-use guest_contracts::session_history_identity::{
-    FinalSessionHistoryFramework, FinalSessionHistoryRefKind,
-};
+use guest_contracts::session_history_identity::{SessionHistoryFramework, SessionHistoryRefKind};
 use sha2::{Digest, Sha256};
 use tokio::fs;
 
@@ -30,9 +28,9 @@ fn mode(path: &Path) -> u32 {
 
 fn test_restored_session_identity(session_id: &str, history: &[u8]) -> RestoredSessionIdentity {
     RestoredSessionIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         session_id,
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(history)),
         Some(history.len() as u64),
     )

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -11,11 +11,11 @@ use api_contracts::generated::constants::runners::{
 };
 use async_trait::async_trait;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryIdentity, FinalSessionHistorySourceRef,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
     SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistoryFramework,
-    SessionHistoryRefKind, SessionHistorySidecarExportFailure, SessionHistorySidecarExportMetadata,
-    SessionHistorySidecarIoErrorClass, SessionHistorySidecarRepresentation,
+    SessionHistoryIdentity, SessionHistoryRefKind, SessionHistorySidecarExportFailure,
+    SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
+    SessionHistorySidecarRepresentation, SessionHistorySourceRef,
 };
 use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
@@ -56,13 +56,13 @@ async fn mock_sandbox_with_overrides(
 }
 
 fn test_restored_session_identity(session_id: &str, history: &[u8]) -> RestoredSessionIdentity {
-    let metadata = FinalSessionHistoryIdentity::new(
+    let metadata = SessionHistoryIdentity::new(
         SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
         SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(history)),
         history.len() as u64,
-        FinalSessionHistorySourceRef::ClaudeCode {
+        SessionHistorySourceRef::ClaudeCode {
             config_dir: "/home/user/.claude".to_string(),
             working_dir: CANONICAL_WORKING_DIR.to_string(),
             session_id: session_id.to_string(),

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -11,11 +11,11 @@ use api_contracts::generated::constants::runners::{
 };
 use async_trait::async_trait;
 use guest_contracts::session_history_identity::{
-    FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    FinalSessionHistorySourceRef, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
-    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistorySidecarExportFailure,
-    SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
-    SessionHistorySidecarRepresentation,
+    FinalSessionHistoryIdentity, FinalSessionHistorySourceRef,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistoryFramework,
+    SessionHistoryRefKind, SessionHistorySidecarExportFailure, SessionHistorySidecarExportMetadata,
+    SessionHistorySidecarIoErrorClass, SessionHistorySidecarRepresentation,
 };
 use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
@@ -57,9 +57,9 @@ async fn mock_sandbox_with_overrides(
 
 fn test_restored_session_identity(session_id: &str, history: &[u8]) -> RestoredSessionIdentity {
     let metadata = FinalSessionHistoryIdentity::new(
-        FinalSessionHistoryFramework::ClaudeCode,
+        SessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
-        FinalSessionHistoryRefKind::Blob,
+        SessionHistoryRefKind::Blob,
         hex::encode(Sha256::digest(history)),
         history.len() as u64,
         FinalSessionHistorySourceRef::ClaudeCode {


### PR DESCRIPTION
## Summary

- rename the canonical shared identity types to `SessionHistoryFramework`, `SessionHistoryRefKind`, `SessionHistorySourceRef`, `SessionHistoryIdentity`, and `SessionHistoryIdentityExpectation`
- rename the corresponding contract and guest-helper error types to lifecycle-neutral names
- update all `guest-contracts`, `guest-agent`, and runner consumers and existing tests atomically
- keep final-checkpoint artifact names where `final` still describes the actual file lifecycle

## Compatibility

- enum variants and serde attributes are unchanged
- serialized JSON values, persisted session-history identity bytes, guest-helper CLI commands and spellings, exit codes, and final metadata file paths are unchanged
- no compatibility aliases, duplicate types, conversions, database migrations, or rollout gates are introduced

This is a Rust source-level public symbol rename. All known consumers are updated in this workspace; any undocumented external Rust source consumer must update its imports.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --no-deps`
- exhaustive repository search for stale `FinalSession*` Rust identifiers
- `git diff --check`
- `lefthook run pre-commit`

Closes #27894
