### PR TITLE
test(e2e): stabilize billing settings route handoff

### DIFF
--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -731,12 +731,28 @@ async function restoreConcurrency(
 }
 
 async function openBillingSettings(page: Page): Promise<Locator> {
-  await page.goto(new URL("/?settings=billing", appUrl).toString(), {
+  // The root route hands off to the canonical chat route. Starting the billing
+  // flow during that handoff lets the destination route reset its sub-page.
+  await page.waitForURL(isCanonicalChatUrl, {
+    waitUntil: "domcontentloaded",
+  });
+  const settingsUrl = new URL(page.url());
+  settingsUrl.hash = "";
+  settingsUrl.search = "";
+  settingsUrl.searchParams.set("settings", "billing");
+  await page.goto(settingsUrl.toString(), {
     waitUntil: "domcontentloaded",
   });
   const settings = page.getByRole("dialog", { name: "Settings" });
   await expect(settings).toBeVisible({ timeout: 30_000 });
   return settings;
+}
+
+function isCanonicalChatUrl(url: URL): boolean {
+  return (
+    url.origin === appOrigin &&
+    /^\/(?:agents\/[^/]+\/chat|chats\/[^/]+)$/u.test(url.pathname)
+  );
 }
 
 async function currentToken(page: Page, owner: BillingOwner): Promise<string> {


### PR DESCRIPTION
## Summary

- wait for the canonical chat route before opening Billing settings in the deployed transition tests
- add the Billing deep-link to that stable route instead of navigating back through the root-to-chat handoff
- preserve every usage-pack, Plan, cancellation, restoration, downgrade, and scheduled-intent assertion

## Failure evidence

Trigger: [Turbo run 32102263738](https://github.com/vm0-ai/vm0/actions/runs/32102263738), [`cli-e2e-02-playwright`](https://github.com/vm0-ai/vm0/actions/runs/32102263738/job/95605460900), test `usage-pack and Plan transitions preserve scheduled intent` at main SHA `bf523a51e475adb81fab2d295cd9b65effa66994`.

The Playwright error context captured the signed-in Settings > Billing page before the first purchase: **No active plan**, an active **Upgrade** button, and no **Choose a plan** dialog. Request telemetry narrows the stalled operation further:

- the failing page opened the pricing flow and completed `GET /api/okou/billing/usage-pack-catalog` plus the expected pre-subscription `404` from `GET /api/okou/billing/usage-pack-subscription`
- it never loaded organization members for the package step and never issued a billing checkout or transition mutation
- the page had just moved from `/` to the canonical `/agents/:id/chat` route; the destination route reran the settings deep-link initializer, whose code resets `billingSubPage$` before reopening the handed-off Settings session
- that reset unmounted the briefly opened **Choose a plan** flow before the plan action completed, leaving the unbounded Playwright locator action waiting until the test's 360-second top-level budget expired

The identical SHA passed in [merge-group run 32101816880](https://github.com/vm0-ai/vm0/actions/runs/32101816880), including [the same Playwright shard](https://github.com/vm0-ai/vm0/actions/runs/32101816880/job/95604197053). In that run both billing owners reached `POST /api/okou/billing/usage-pack-checkout`; the pass/fail outcome therefore depended on whether the root-route handoff reset the pricing sub-page before the plan click committed.

This is distinct from Draft PR [#27672](https://github.com/vm0-ai/vm0/pull/27672). That PR changes the API cancellation-to-downgrade scheduling order after a proved stale webhook overwrite and later billing-status 401. This run never reached a billing mutation and did not record a 401, so widening #27672 would combine unrelated causes and boundaries.

The `route.fetch: Test ended` Clerk warning occurred after the timeout marker and also appeared in the successful exact-SHA comparison. `ci-gate-turbo` is only the aggregate result.

## Subsequent merge-group triage

Three later merge-group runs failed in the same two test names, but artifact-to-request correlation proves that their first causal events were a separate shared Clerk Backend API rate-limit incident, not the route handoff repaired here:

| Run | Test boundary | First causal request evidence |
| --- | --- | --- |
| [32109231601](https://github.com/vm0-ai/vm0/actions/runs/32109231601) | scheduled-intent: member-package combobox absent | `GET /api/okou/org/members` returned `500` at `07:02:21.229Z`; the paired server error is `OrganizationAPI.request: Too Many Requests` |
| [32109231601](https://github.com/vm0-ai/vm0/actions/runs/32109231601) | concurrency: Settings absent while **Loading your workspace** | `GET /api/okou/org` returned `500` at `07:02:26.839Z`; the paired server error is `OrganizationAPI.request: Too Many Requests` |
| [32109724060](https://github.com/vm0-ai/vm0/actions/runs/32109724060) | scheduled-intent: Settings absent while **Loading your workspace** | `GET /api/okou/org` returned `500` at `07:08:15.996Z` and repeated; each paired server error is `OrganizationAPI.request: Too Many Requests` |
| [32109724060](https://github.com/vm0-ai/vm0/actions/runs/32109724060) | concurrency: member-package combobox absent | catalog returned `200` and the expected pre-subscription request returned `404`, then `GET /api/okou/org/members` returned `500` at `07:08:30.685Z`; the paired server error is `OrganizationAPI.request: Too Many Requests` |
| [32109721844](https://github.com/vm0-ai/vm0/actions/runs/32109721844) | scheduled-intent: Stripe navigation absent | `POST /api/okou/billing/usage-pack-checkout` was issued and returned `500` at `07:08:30.334Z`; the dialog rendered `ApiError: HTTP 500`, and the paired server stack is `OrganizationAPI.request: Too Many Requests` from `listAllPendingOrganizationInvitations` through `loadUsagePackCheckoutAllocations` |
| [32109721844](https://github.com/vm0-ai/vm0/actions/runs/32109721844) | concurrency: Settings absent while **Loading your workspace** | `GET /api/okou/org` returned `500` at `07:08:34.589Z` and again at `07:08:36.917Z`; both paired server errors are `OrganizationAPI.request: Too Many Requests` |

The reversed locator assignment between the first two runs reflects which parallel test encountered the rate limit at `/org` versus `/org/members`; it does not establish one shared UI race. The two `07:08` merge groups hit Clerk-backed endpoints on different preview hosts within the same second. Their representative PR-head Playwright shards passed independently: [#27926](https://github.com/vm0-ai/vm0/actions/runs/32108736425/job/95624020369), [#27928](https://github.com/vm0-ai/vm0/actions/runs/32108755611/job/95624107049), and [#27172](https://github.com/vm0-ai/vm0/actions/runs/32106814375/job/95618420853). The adjacent main shard also [passed](https://github.com/vm0-ai/vm0/actions/runs/32109077592/job/95625011922).

Later browser-side `route.fetch: Test ended` warnings remain end-of-test noise. They are distinct from the earlier server-side Clerk `Too Many Requests` errors above. This PR intentionally does not add retries, timeout changes, or unrelated rate-limit handling for that external fingerprint.

## Fix

`openBillingSettings()` now waits at the existing canonical chat-route domain boundary, clears transient query/hash state, and navigates to that same route with `settings=billing`. The test no longer creates a second root-to-chat handoff while interacting with the billing modal. No retry, sleep, timeout increase, skipped assertion, or product-state mutation was added.

## Verification

- `npx --yes prettier@3.6.2 --check e2e/playwright/tests/billing-transitions.spec.ts`
- `cd e2e && npx --yes pnpm@10.33.4 check-types`
- Playwright test discovery lists both tests in `billing-transitions.spec.ts`
- `cd e2e && npx --yes pnpm@10.33.4 test` — 5/5 consecutive runs, 35/35 tests per run
- `git diff --check origin/main...HEAD`
- PR-head [`cli-e2e-02-playwright`](https://github.com/vm0-ai/vm0/actions/runs/32104473778/job/95611627007) — passed, 25/25

The deployed billing transition test requires real Clerk, Stripe, App, and API environments and was not run against local services.

## Preview validation

- App deployment: `https://pr-27897-app.omby.ai` (`deploy-app` succeeded)
- API deployment: `https://pr-27897-api.vm6.ai` (`deploy-api` succeeded)
- Original scheduled-intent browser validation: pending cloud-browser authorization

The PR remains Draft until the deployed-preview invariant is validated.



## Recurrence evidence: run 32115322830

[Turbo run 32115322830](https://github.com/vm0-ai/vm0/actions/runs/32115322830) reproduced the same unstable root-to-canonical-chat handoff during the later restorePlan step on merge SHA 57fbeaa2284d8546e09a041485e63b50d6f3c2e6. The Playwright artifact stopped at Loading your workspace rather than rendering the Settings dialog.

Bounded request correlation on pr-27933-api.vm6.ai proves the owning business operation completed before the handoff stalled: POST /api/okou/billing/usage-pack-subscription/subscription-change/confirm returned 200 at 08:19:03.726Z, followed by successful usage-pack and billing-status reads through 08:19:06.669Z. restorePlan then entered openBillingSettings, which navigates back to /?settings=billing, but no subsequent App API request, including /org, /org/members, billing status, subscription, or catalog, arrived before Playwright marked the test failed at 08:19:37.860Z. There was no 401, 429, or 5xx in that owning window; the first preview-host 5xx occurred later at 08:19:48.577Z, after the failure marker. The later Clerk route.fetch: Test ended warning is therefore post-failure noise.

The passing PR-head comparison [run 32112872498](https://github.com/vm0-ai/vm0/actions/runs/32112872498) completed the equivalent boundary: after the scheduled-downgrade confirm returned 200 at 07:50:26.384Z and status converged, the next root handoff reached GET /api/okou/org with 200 at 07:50:32.360Z and POST /api/okou/billing/restore with 200 at 07:50:34.583Z. The pass or fail outcome therefore depends on whether the extra root handoff reaches the canonical chat route.

This recurrence is not the excluded Clerk OrganizationAPI 429 fingerprint from runs 32109231601, 32109724060, and 32109721844. It is covered by the existing change in this PR to reopen Billing on the already-canonical chat URL. No code or scope change was needed for this recurrence.


## Recurrence evidence: run 32121908904

[Turbo run 32121908904](https://github.com/vm0-ai/vm0/actions/runs/32121908904) reproduced the same unstable root-to-canonical-chat handoff at the first buyUsagePackPlan call in the concurrency transition scenario on merge SHA a1c160f7da019a29bf9a8fa4ae8591bc60d3ae4a. The Playwright artifact stopped at Loading your workspace / Connecting the dots while openBillingSettings waited for the Settings dialog.

The authenticated owner completed Clerk sign-in at 09:33:41.341Z with hasSession=true and hasUser=true. Its onboarding page then completed GET /api/okou/org with 200 at 09:33:43.479Z, POST /api/okou/onboarding/complete with 200 at 09:33:43.907Z, and the final onboarding-status read with 200 at 09:33:44.051Z. The test-only public feature-switch update returned 200 at 09:33:44.213Z. The current helper next navigated back through /?settings=billing, but the failed owner never produced the next page-load or initial-purchase sequence before the Playwright failure marker at 09:35:11.291Z: there was no second pre-subscription 404 and no POST /api/okou/billing/usage-pack-checkout. The preview host recorded no 429 or 5xx request in that bounded window. The other billing test continued successful, already-subscribed transition requests and does not supply the missing initial-purchase sequence.

The exact PR-head comparison [run 32119515548](https://github.com/vm0-ai/vm0/actions/runs/32119515548) completed the equivalent boundary twice and passed 25/25. For the later billing owner, POST /api/okou/feature-switches returned 200 at 09:06:48.624Z; the next root handoff reached GET /api/okou/org with 200 at 09:06:50.754Z, the expected pre-subscription GET returned 404 at 09:06:51.950Z, and POST /api/okou/billing/usage-pack-checkout returned 200 at 09:06:53.110Z. The adjacent base merge-group [run 32121566229](https://github.com/vm0-ai/vm0/actions/runs/32121566229) also passed this Playwright shard.

The merge commit only contains the unrelated GitHub webhook review change from #27984, and the failing billing-transitions source is byte-identical to the parent and current main versions. This recurrence is covered by the existing change in this PR: reopen Billing on the already-canonical chat URL instead of creating another root handoff. No code or scope change was needed.

## Excluded recurrence: run 32125934610

[Turbo run 32125934610](https://github.com/vm0-ai/vm0/actions/runs/32125934610) reached the same concurrency `openBillingSettings` locator boundary, but artifact-to-request correlation proves that it is not another root-handoff race owned by this PR. The authenticated owner completed sign-in with `hasSession=true` and `hasUser=true`; its artifact later showed **Loading your workspace / Almost there...** while Settings was absent.

The owner had already received a `500` from `GET /api/okou/org` at `10:22:53.951Z`; the paired server event at `10:22:53.998Z` records `errorStatus=429`, `clerkError=true`, Clerk trace `a2d033336a5c1561-PDX`, and `retryAfter=7`. After `POST /api/okou/onboarding/complete` returned `200` at `10:22:55.865Z` and the test-only feature-switch update returned `200` at `10:22:56.179Z`, `openBillingSettings` navigated through the root handoff. Unlike the route-handoff recurrence in run 32121908904, this handoff did emit the next App boot requests: `GET /api/okou/org` returned `500` at `10:22:57.453Z`. Its paired server event at `10:22:57.476Z` is another Clerk `429` with `clerkError=true`, trace `a2d033492c69962a-PDX`, and `retryAfter=3`. No organization-members or initial-purchase request followed before the Settings timeout.

The other failed billing test in the same run shared this external rate-budget incident rather than a UI boundary. `POST /api/okou/billing/usage-pack-checkout` returned `500` at `10:22:49.923Z`; the paired server event at `10:22:50.124Z` records Clerk `429`, `clerkError=true`, trace `a2d0331b1f171561-PDX`, and `retryAfter=10`. Its artifact rendered `ApiError: HTTP 500` inside the package dialog. The later Clerk Testing `route.fetch: Test ended` warning at `10:23:51.804Z` occurred after both Playwright failure markers at `10:23:27.608Z` and remains teardown/background noise.

The represented #27949 change is unrelated, and the failing test source is byte-identical to its parent and current main. The PR-head shard [passed 25/25](https://github.com/vm0-ai/vm0/actions/runs/32124602874/job/95672973446), as did an [adjacent merge-group shard](https://github.com/vm0-ai/vm0/actions/runs/32125931494/job/95677102504); neither is a rerun of merge SHA `4c4104c23c77dbd6fd20e132affff11819778fe8`. This run is excluded from the route-handoff fix and requires no code or scope change here.

## Excluded recurrence: run 32229824496

[Turbo run 32229824496](https://github.com/vm0-ai/vm0/actions/runs/32229824496) failed the scheduled-intent test on main SHA `2c9ac1e3541ffbb14f732fcf98a62a117681ad04`, but artifact-to-request correlation proves that this instance is not another root-to-canonical-chat handoff owned by this PR.

The artifact captured an already active **Pro plan** with Settings > Billing open and **Configure member packages / Step 2 of 3** active, but the dialog contained only an empty **Order summary** and no `Usage for ...` combobox. The owner had completed its initial purchase: `POST /api/okou/billing/usage-pack-checkout` returned `200` at `07:56:11.747Z`, then the direct post-checkout `GET /api/okou/billing/status` and `GET /api/okou/billing/usage-pack-subscription` reads returned `200` at `07:56:15.707Z` and `07:56:15.949Z`.

The next package-management page session successfully loaded the organization, billing status, active usage-pack subscription, and catalog. Its first failing request was `GET /api/okou/org/members`, which returned `500` at `07:56:18.735Z`. The paired server event at `07:56:18.769Z` records `OrganizationAPI.request: Too Many Requests`, `status=429`, `clerkError=true`, Clerk trace `a2d799d93e22ff07-PDX`, and `retryAfter=7`. That was the session final request; no package preview/confirm, checkout, or later billing mutation followed. The test was therefore left in the empty member-package dialog while the unbounded locator action waited for the missing combobox until the 360-second top-level budget ended.

Playwright printed the timeout marker at `08:01:51.536Z`. The Clerk Testing `route.fetch: Test ended` warning arrived later at `08:02:12.121Z`, so it remains end-of-test/background noise rather than the first cause. The aggregate gate is also downstream only.

The merged #28131 change touches only connector credential-source services/tests, and its [PR-head shard passed](https://github.com/vm0-ai/vm0/actions/runs/32227058394/job/95989425680). A near-parallel [merge-group shard also passed](https://github.com/vm0-ai/vm0/actions/runs/32229828834/job/95998271923). The failing billing test file is byte-identical between the trigger SHA and current main. Open PR #28136 owns the separate initial-allocation activation observer fingerprint; it does not cover this Clerk-backed member-list `500`.

This recurrence is excluded from the route-handoff fix and requires no code or scope change in this PR. No retry, timeout increase, or assertion change was added.

## Excluded recurrence: run 32231200486

[Turbo run 32231200486](https://github.com/vm0-ai/vm0/actions/runs/32231200486), job [96001892642](https://github.com/vm0-ai/vm0/actions/runs/32231200486/job/96001892642), failed the scheduled-intent test on main SHA `664e5e14477556d2c910bcd73304e527fdc1a89f`. The artifact narrowed the previous empty-dialog symptom to `submitUsagePackConfiguration -> downgradeTeamToPro`: **Configure member packages / Step 2 of 3** rendered the calculated **Downgrade** schedule text, but the **Order summary** contained no member-package rows and no enabled `Confirm` button.

The final page session successfully loaded `GET /api/okou/org` with `200` at `08:13:47.247Z`, `GET /api/okou/billing/usage-pack-catalog` with `200` at `08:13:48.388Z`, and `GET /api/okou/billing/usage-pack-subscription` with `200` at `08:13:48.400Z`; billing-status reads also succeeded. Its first failing request was `GET /api/okou/org/members`, which returned `500` at `08:13:48.620Z`. The paired server event at `08:13:48.678Z` records `OrganizationAPI.request: Too Many Requests`, `status=429`, `clerkError=true`, Clerk trace `a2d7b37b0a5eda91-PDX`, and `retryAfter=9` (request `c2f1b45a-f21d-4b70-9a28-36eb3436c3ba`). That was the session final request; no package preview, confirm, or later billing mutation followed. The missing member response therefore explains both the absent controls and the `Confirm` assertion failure at `08:13:54.898Z`.

The Clerk Testing `route.fetch: Test ended` warnings began at `08:15:05.902Z`, more than one minute after this failure marker, so they remain teardown/background noise. The other failed paid-invitation test in this run is separately routed and is not used as evidence for this fingerprint.

The merged #28114 change only touches composer model controls, provider/video UI, i18n, and their tests. Both the [#28114 PR-head shard](https://github.com/vm0-ai/vm0/actions/runs/32229198693/job/95996350195) and the [exact-SHA merge-group shard](https://github.com/vm0-ai/vm0/actions/runs/32230317848/job/95999823146) passed. The billing-transitions test blob is identical between the trigger SHA and current main.

This is the same external Clerk-backed `/org/members` rate-limit fingerprint as excluded run 32229824496, now exposed by the bounded `Confirm` assertion at a later downgrade step. It is not the root-to-canonical-chat route handoff fixed by this PR, so no code or scope change was made. No retry, sleep, timeout increase, skip, or assertion weakening was added.

## Excluded recurrence: run 32231695589

[Turbo run 32231695589](https://github.com/vm0-ai/vm0/actions/runs/32231695589), job [96003647258](https://github.com/vm0-ai/vm0/actions/runs/32231695589/job/96003647258), failed the scheduled-intent test on main SHA `b01ceb574842aaeb171ec4f0cbe57e8492a0b9c9`. Its artifact again captured Settings > Billing open on an active **Pro plan**, with **Configure member packages / Step 2 of 3** active but an empty **Order summary** and no member-package combobox.

The owner completed the initial purchase normally. In page session `67411635-ec99-4d41-bfec-04ca51f1fd93`, the expected pre-subscription read returned `404`, `GET /api/okou/org/members` returned `200` at `08:19:51.971Z`, and `POST /api/okou/billing/usage-pack-checkout` returned `200` at `08:19:52.831Z`. After Stripe returned to the app, the direct billing-status and usage-pack-subscription checks returned `200` at `08:20:07.047Z` and `08:20:07.260Z`.

The next package-management page session, `1585558d-d7d5-4fbd-b2f6-06fc783ee2fe`, loaded billing status and the organization with `200`, then loaded the active usage-pack subscription and catalog with `200` at `08:20:09.460Z` and `08:20:09.468Z`. Its first failing request was `GET /api/okou/org/members`, which returned `500` at `08:20:09.874Z` (request `95d38376-ae8d-4877-a920-3c52929fa692`). The paired server event at `08:20:09.936Z` records `OrganizationAPI.request: Too Many Requests`, `status=429`, `clerkError=true`, Clerk trace `a2d7bcc9eef09935-PDX`, and `retryAfter=2`, through `listAllOrganizationMemberships`. This was the session final request; no package preview, confirm, checkout, or later billing mutation followed. It was also the only `5xx` from this CI runner during the bounded target window.

At this exact source, the first post-purchase package change calls [`selectUsagePack`](https://github.com/vm0-ai/vm0/blob/b01ceb574842aaeb171ec4f0cbe57e8492a0b9c9/e2e/playwright/tests/billing-transitions.spec.ts#L735-L745), whose bare locator `click()` waits for the missing member combobox under the test budget because the Playwright config has no separate action timeout. The empty member response therefore explains why this instance stayed silent until the top-level marker at `08:25:41.958Z`, 5 minutes 32 seconds after the failed request. The Clerk Testing `route.fetch: Test ended` warning arrived later at `08:26:02.571Z`, and `ci-gate-turbo` was downstream only.

The merged #28130 change touches only connector-catalog diagnostics Settings signals and its page test. Its [PR-head Playwright shard passed 27/27](https://github.com/vm0-ai/vm0/actions/runs/32216429403/job/95959188255). The [same merge SHA had already shown the same top-level timeout in merge-group job 96000576366](https://github.com/vm0-ai/vm0/actions/runs/32230766639/job/96000576366), but this current-owner request correlation proves the external boundary without inferring from the other test in that cancelled shard. The billing-transitions test blob is identical between the trigger SHA and current main.

This is another external Clerk-backed `/org/members` rate-limit recurrence, equivalent to the excluded request boundary in runs 32229824496 and 32231200486, not the root-to-canonical-chat handoff fixed by this PR. No code or scope change was made, and no retry, sleep, timeout increase, skip, or assertion weakening was added.

## Excluded recurrence: run 32236985536

[Turbo run 32236985536](https://github.com/vm0-ai/vm0/actions/runs/32236985536), job [96019848840](https://github.com/vm0-ai/vm0/actions/runs/32236985536/job/96019848840), reached the concurrency `openBillingSettings` locator boundary on merge SHA `ea929ecbf06c26b7e9d061d81e6659d848e55c1b`, but artifact-to-request correlation proves this occurrence is a shared Clerk Backend API rate-budget incident rather than the no-request route handoff fixed by this PR.

The authenticated owner completed sign-in at `09:24:59.342Z` with `hasSession=true` and `hasUser=true`. Its artifact captured a fully rendered canonical chat page for **E2E Concurrency Transitions**, including the sidebar and **What's on your mind?** composer, with Settings absent; it did not stop on **Loading your workspace**. In App client session `71436b97-bc31-4fee-9a63-45747f5656d6`, the first causal failure after auth was `GET /api/okou/org`, which returned application `500` at `09:24:59.426Z` (`x_client_request_id=c414fe44-5a00-4e28-b10d-2a23c8652fc4`). The paired service event at `09:24:59.510Z` records `OrganizationAPI.request: Too Many Requests`, `errorStatus=429`, `clerkError=true`, Clerk trace `a2d81bbfb8d4ef83-PDX`, and `retryAfter=7`; Clerk's response body has `code=too_many_requests` and message `Too many requests. Please try again in a bit.`

After onboarding completion and the test feature-switch update both returned `200`, `openBillingSettings` did emit the next page-boot request sequence. In App client session `55091c1f-4271-4ff5-beb9-56158ded8865`, feature switches returned `200` at `09:25:01.531Z`, onboarding status returned `200` at `09:25:01.579Z`, and billing status returned `200` at `09:25:01.820Z`; the subsequent `GET /api/okou/org` returned application `500` at `09:25:01.841Z` (`x_client_request_id=bae0b969-d30c-4511-845e-645e839a16e9`). Its paired service event at `09:25:01.863Z` is another Clerk `429`, with `clerkError=true`, trace `a2d81bce9db9ef83-PDX`, `retryAfter=5`, and the same `too_many_requests` response body. No organization-members, catalog, subscription, or checkout request followed for this owner before the Playwright failure marker at `09:25:32.123Z`.

The separate restored-Team checkout fingerprint in the same run shared the external incident but retains its own owner. `POST /api/okou/billing/usage-pack-checkout` returned application `500` at `09:23:37.989Z` (`x_client_request_id=988e43ae-ddfc-422a-be48-e4118621fb34`); its paired service event at `09:23:38.128Z` records Clerk `429`, trace `a2d819c33feb0dcf-PDX`, and `retryAfter=9`. A later `GET /api/okou/org/members` also returned `500` at `09:23:44.080Z`, paired with Clerk `429` at `09:23:44.138Z` (trace `a2d819e8a9771d57-PDX`, `retryAfter=3`). This shared incident does not merge the two exact fingerprints or their owners.

The represented #28155 change modifies only three Google Drive artifact-folder API files, and the billing transition test blob is identical at the merge SHA, its parent, the #28155 head, and current main. The [#28155 PR-head shard](https://github.com/vm0-ai/vm0/actions/runs/32232171090/job/96004911327) and the [exact-parent merge-group shard](https://github.com/vm0-ai/vm0/actions/runs/32236120384/job/96018100151) passed, although neither is a rerun of this merge SHA. The Clerk Testing `route.fetch: Test ended` warnings at `09:25:39.829Z` and `09:25:53.072Z` occurred after the failure marker, and `ci-gate-turbo` was downstream only.

This occurrence is classified as external infrastructure and excluded from the route-handoff recurrence set. It requires no code, test, timeout, retry, or scope change in this PR.

## Excluded recurrence: run 32237660723

[Turbo run 32237660723](https://github.com/vm0-ai/vm0/actions/runs/32237660723), job [96022033866](https://github.com/vm0-ai/vm0/actions/runs/32237660723/job/96022033866), failed the scheduled-intent test on merge-group SHA `bc899c82e3b36a82f8752ac89e0fc7ee1480c194`. Its artifact captured Settings > Billing open on an active **Pro plan**, with **Configure member packages / Step 2 of 3** active but an empty **Order summary** and no `Usage for ...` combobox.

The owner completed the initial purchase normally. Page session `68961b96-ef35-46f5-a291-4fd9f68e2a7a` loaded the organization, billing status, usage-pack catalog, and organization members successfully; the expected pre-purchase usage-pack subscription read returned `404`, then `POST /api/okou/billing/usage-pack-checkout` returned `200` at `09:31:35.721Z`. After Stripe returned to the app, direct billing-status and active usage-pack-subscription reads returned `200` at `09:31:48.424Z` and `09:31:48.539Z`.

The next package-management page session, `b022ef40-8682-4e46-a678-d0f57039eb5f`, loaded `GET /api/okou/org` with `200` at `09:31:50.586Z`, then loaded billing status, the catalog, and the active subscription successfully. Its first failing request was `GET /api/okou/org/members`, which returned application `500` at `09:31:51.663Z` (request `701edaf7-d5d5-41e5-9284-2aa57ad79441`). The paired server event at `09:31:51.731Z` records `Unhandled request error: Too Many Requests`, `status=429`, `clerkError=true`, Clerk trace `a2d825d009d7f7ed-PDX`, and `retryAfter=4` from the Clerk Organization API. This was the page session final request; no package preview, confirm, checkout, or later billing mutation followed.

At this source, the first post-purchase package change enters `selectUsagePack`, whose bare combobox `click()` has no separate action timeout. The missing member response therefore explains both the empty package UI and why the locator waited under the 360-second test budget until the timeout marker at `09:37:25.768Z`, 5 minutes 34 seconds after the failed request. The Clerk Testing `route.fetch: Test ended` warning arrived later at `09:37:46.736Z`, and `ci-gate-turbo` was downstream only.

The represented [#28178](https://github.com/vm0-ai/vm0/pull/28178) changes only `.github/actions/web-api-env/action.yml` and its shell contract test. Its [PR-head Playwright shard passed](https://github.com/vm0-ai/vm0/actions/runs/32235157589/job/96014116803), and the billing-transitions test blob is identical between the failing merge-group SHA and current main. The separate restored-Team checkout-navigation failure in the same shard retains its independent exact-key owner and is not used to classify this occurrence.

This is another external Clerk-backed `/org/members` rate-limit recurrence, equivalent to excluded runs 32229824496, 32231200486, and 32231695589. It is not the root-to-canonical-chat route handoff fixed by this PR, so no code or scope change was made. No retry, sleep, timeout increase, skip, or assertion weakening was added.

## Excluded recurrence: run 32239098022

[Turbo run 32239098022](https://github.com/vm0-ai/vm0/actions/runs/32239098022), job [96026452016](https://github.com/vm0-ai/vm0/actions/runs/32239098022/job/96026452016), failed the scheduled-intent test on merge-group SHA `ce44eb446437a17c684d6e160b3615ef1f73246c`. The artifact reached the final `downgradeTeamToPro` flow: **Configure member packages / Step 2 of 3** rendered the **Downgrade** schedule, but **Order summary** had no member-package rows or `Confirm` button. This proves that the Settings route handoff and package-dialog navigation completed.

The last completed business operation was the preceding Team restoration. `POST /api/okou/billing/restore` returned `200` at `09:49:40.731Z`, and the direct billing-status verification returned `200` at `09:49:41.545Z`. The next Team-to-Pro page session, `56ab61ee-8dc7-4717-91c3-edcb61f52581`, loaded `GET /api/okou/org` with `200` at `09:49:42.979Z`, loaded billing status successfully, received the expected `404` from usage-pack migration, and loaded the usage-pack catalog and active subscription with `200` at `09:49:43.516Z` and `09:49:43.523Z`.

Its first failing request was `GET /api/okou/org/members`, which returned application `500` at `09:49:43.911Z` (request `9600a91b-4f12-45e9-a0c3-97d2f3f1b231`). The paired server event at `09:49:43.984Z` records `Unhandled request error: Too Many Requests`, `status=429`, `clerkError=true`, Clerk trace `a2d83ffd98eadabf-PDX`, and `retryAfter=1` from the Clerk Organization API. This was the page session final request; no package-change preview, confirm, checkout, or later billing mutation followed. The absent member response directly explains the empty Order summary and the bounded `Confirm` assertion failure at the Playwright marker `09:49:50.022Z`.

The Clerk Testing `route.fetch: Test ended` warning arrived later at `09:51:28.720Z`, after both test failure markers, and `ci-gate-turbo` was downstream only. The separately owned paid-invitation Settings failure is not used to classify this occurrence. Current-run evidence proves a Clerk rate limit, but it does not identify which concurrent activity consumed the provider budget; the earlier merge-group global-setup `403` is also not copied onto this successful-setup run.

The represented [#28167](https://github.com/vm0-ai/vm0/pull/28167) changes only the release-please component validation shell script and its shell test. Its [PR-head Playwright shard passed 27/27](https://github.com/vm0-ai/vm0/actions/runs/32236018655/job/96016894205), and the billing-transitions test blob is identical between this merge-group SHA and current main. Open PR [#28136](https://github.com/vm0-ai/vm0/pull/28136) owns the distinct post-checkout allocation-activation observer; it does not cover this failed Clerk-backed member read.

This is the same external Clerk-backed `/org/members` rate-limit fingerprint as excluded run 32231200486 at the same `downgradeTeamToPro -> submitUsagePackConfiguration` UI boundary. It is not the root-to-canonical-chat route handoff fixed by this PR, so no code or scope change was made. No retry, sleep, timeout increase, skip, or assertion weakening was added.

## Excluded recurrence: run 32240497626

[Turbo run 32240497626](https://github.com/vm0-ai/vm0/actions/runs/32240497626), job [96030501000](https://github.com/vm0-ai/vm0/actions/runs/32240497626/job/96030501000), failed the scheduled-intent test on merge-group SHA `567c613f7ad1ecb85fbc122678f7fa093aa162f7`. Its artifact captured Settings > Billing open on an active **Pro plan**, with **Configure member packages / Step 2 of 3** active but an empty **Order summary** and no `Usage for ...` combobox. The Settings route handoff and package-dialog navigation therefore completed before the stall.

The owner completed its initial purchase normally. In page session `16217352-5bd7-4042-8567-98893678be85`, `GET /api/okou/org`, billing status, the usage-pack catalog, and `GET /api/okou/org/members` returned `200`; the expected pre-purchase usage-pack-subscription read returned `404`, then `POST /api/okou/billing/usage-pack-checkout` returned `200` at `10:04:07.270Z`. After Stripe returned to the app, direct billing-status and active usage-pack-subscription reads returned `200` at `10:04:18.982Z` and `10:04:19.146Z`.

The next package-management page session, `5277c844-41c3-400c-8e8c-244aeef2d78f`, loaded `GET /api/okou/org` with `200` at `10:04:21.089Z`, loaded billing status successfully, received the expected `404` from usage-pack migration, and loaded the active usage-pack subscription plus catalog with `200` at `10:04:21.812Z` and `10:04:21.886Z`. Its first failing request was `GET /api/okou/org/members`, which returned application `500` at `10:04:22.677Z` (request `ec4378e7-e7b9-415e-a038-d6e0b6f740be`). The paired server event at `10:04:22.705Z` records `Unhandled request error: Too Many Requests`, `status=429`, `clerkError=true`, Clerk trace `a2d85571db725913-PDX`, and `retryAfter=10`, with the stack passing through `listAllOrganizationMemberships`. This was the page session final request; no package preview, confirm, checkout, or later billing mutation followed.

At this source, the first post-purchase package change enters `selectUsagePack`, whose bare member-combobox `click()` has no separate action timeout. The failed member read therefore explains both the empty package UI and why the locator remained silent under the 360-second test budget until the timeout marker at `10:09:56.670Z`, 5 minutes 34 seconds after the failed request. The Clerk Testing `route.fetch: Test ended` warning arrived later at `10:10:16.397Z`, and `ci-gate-turbo` was downstream only. The separate runner-bootstrap `PUT /api/okou/model-policies` `500` came from a curl client at a different remote address and retains its independent owner.

The represented [#28031](https://github.com/vm0-ai/vm0/pull/28031) changes only presentation-template import routes, services, contracts, schema, and migration files. The billing-transitions test blob is identical between this merge-group SHA and current `origin/main`. An overlapping [adjacent merge-group shard passed 27/27](https://github.com/vm0-ai/vm0/actions/runs/32240428352/job/96030699676); the #28031 PR-head Playwright job [was cancelled](https://github.com/vm0-ai/vm0/actions/runs/32231461703/job/96007790402) and is not treated as a passing comparison.

Open PR [#28229](https://github.com/vm0-ai/vm0/pull/28229) is the separate duplicate guard for general Clerk organization-member read recovery. Open PR [#28136](https://github.com/vm0-ai/vm0/pull/28136) remains limited to the distinct post-checkout allocation-activation observer. Neither changes the classification of this historical occurrence, and this PR does not duplicate or evaluate their solutions. Current-run evidence proves the provider rate-limit boundary but does not identify which concurrent activity consumed the shared Clerk budget.

This is another excluded external Clerk-backed `/org/members` rate-limit recurrence, equivalent to runs 32229824496, 32231695589, and 32237660723. It is not the root-to-canonical-chat route handoff fixed by this PR, so no code or scope change was made. No retry, sleep, timeout increase, skip, or assertion weakening was added.

## Excluded recurrence: run 32240989727

[Turbo run 32240989727](https://github.com/vm0-ai/vm0/actions/runs/32240989727), job [96032028621](https://github.com/vm0-ai/vm0/actions/runs/32240989727/job/96032028621), reached the restored-Team `openBillingSettings` locator boundary on merge-group SHA `365c69a08fa2698ac4c5bee04568e87830c3e5ba`. Its artifact captured a fully rendered canonical chat page for **E2E Combined Billing Transitions**, including the workspace sidebar, Okou agent link, composer, and suggestions, with Settings absent. It did not stop on a loading or onboarding surface.

Artifact agent `1b33bd72-d91c-46eb-81b0-c89fd571641e` correlates the owner to the API trace and App sessions. Clerk testing authentication completed at `10:10:04.092Z` with `hasSession=true` and `hasUser=true`. The initial App session, `ff78bc18-a3b5-4758-8061-0fc22a9c1f02`, then received application `500` from `POST /api/okou/attribution/signup` at `10:10:04.868Z` and `GET /api/okou/org` at `10:10:04.909Z`. Their paired server events at `10:10:04.932Z` and `10:10:05.001Z` are Clerk `429` responses with `clerkError=true`, traces `a2d85dcc9f24962a-PDX` and `a2d85dcd0b0387ab-PDX`, and `retryAfter=6`. Onboarding completion and the subsequent canonical-chat bootstrap continued with successful requests.

`openBillingSettings` then created App session `fb263d33-643d-4a2c-baf9-319b88660e43`. Feature switches, indicators, realtime token, onboarding status, user preferences, team, and the canonical chat-thread read all returned `200`. The first causal failure in this handoff was `GET /api/okou/org`, which returned application `500` at `10:10:07.263Z` (`x_client_request_id=8d9c26ab-4121-4ded-a86d-73100cc87c33`, OTel trace `28e61bca014e678894218b7b0efd3937`). The paired service event at `10:10:07.328Z` records `OrganizationAPI.request: Too Many Requests`, `status=429`, `clerkError=true`, Clerk trace `a2d85ddbbd296289-PDX`, and `retryAfter=3`; the provider body has `code=too_many_requests` and `message=Too many requests. Please try again in a bit.` Billing status and the remaining canonical-chat bootstrap requests returned `200`, but this owner emitted no organization-members, usage-pack catalog, usage-pack subscription, or checkout request before the Settings locator failed at `10:10:37.035Z`.

This differs from the all-`200` root-to-canonical-chat lifecycle race owned by this PR: the Settings handoff here emitted the next page boot and encountered a proved Clerk-backed organization read failure before Settings could open. The Clerk Testing `route.fetch: Test ended` warnings began at `10:12:00.149Z`, after all three job failure markers, and `ci-gate-turbo` was downstream only. The same-run scheduled-intent Stripe-navigation and paid-invitation failures retain their separate fingerprints and are not used to classify this occurrence.

The represented [#28183](https://github.com/vm0-ai/vm0/pull/28183) changes only the staff-organization shared-chat-database feature switch and its unit test. The billing-transitions test blob is identical at the merge SHA, its parent, the #28183 head, and current `origin/main`. The [#28183 PR-head shard passed](https://github.com/vm0-ai/vm0/actions/runs/32236975862/job/96020884049), as did an [overlapping adjacent merge-group shard](https://github.com/vm0-ai/vm0/actions/runs/32240428352/job/96030699676). Open PR [#28229](https://github.com/vm0-ai/vm0/pull/28229) is limited to idempotent organization-member reads and does not cover this root `/api/okou/org` failure.

This occurrence is classified as external Clerk rate limiting and excluded from the route-handoff recurrence set. It requires no code, test, timeout, retry, or scope change in this PR.

## Excluded recurrence: run 32244247909

[Turbo run 32244247909](https://github.com/vm0-ai/vm0/actions/runs/32244247909), job [96042190535](https://github.com/vm0-ai/vm0/actions/runs/32244247909/job/96042190535), failed the scheduled-intent test on main SHA `af55210c0311daf5c2b38ff048157238e748376a`. The Playwright artifact captured the canonical chat route with **Settings > Billing** open on an active **Pro plan**. **Configure member packages / Step 2 of 3** was open and **Order summary** showed the existing **Downgrade scheduled** intent, but no `Usage for ...` member combobox or action button rendered. This proves the route/settings handoff and package-dialog navigation completed.

On the actual staging API host, the target browser page session `59de0c6d-4a72-4c90-a4fa-2f96b20f1dbd` loaded `GET /api/okou/org` with `200` at `10:51:19.230Z`, billing status with `200`, the active usage-pack subscription with `200` at `10:51:19.942Z`, and the catalog with `200` at `10:51:19.985Z`. Its first failed request was `GET /api/okou/org/members`, which returned application `500` at `10:51:20.418Z` (request `523170e6-b894-4f08-884a-7b4149468bc8`). The paired server event at `10:51:20.470Z` records `OrganizationAPI.request: Too Many Requests`, provider `status=429`, `clerkError=true`, Clerk trace `a2d89a3cbbe0ac0d-PDX`, and `retryAfter=9` through the organization-members read. This was the target session's final request; no package preview, confirm, checkout, or later billing mutation followed.

The last proved business state was therefore the active Pro subscription with its scheduled downgrade intact, followed by a failed member-directory dependency needed to render the package controls. At this source, `selectUsagePack` performs a bare combobox `click()`, while the Playwright config has no separate action timeout. The missing combobox consequently waited under the remaining test budget until the top-level marker at `10:56:26.211Z`, 5 minutes 5.793 seconds after the failed member request. The Clerk Testing `route.fetch: Test ended` warning arrived later at `10:56:47.738Z`, and `ci-gate-turbo` was downstream only.

The merged [#28181](https://github.com/vm0-ai/vm0/pull/28181) change touches only `.github/scripts/runner-behavior-exec.sh`. The billing-transitions test blob is identical between the trigger SHA, its parent, and current `origin/main`. The identical SHA's [merge-group Playwright shard passed 27/27](https://github.com/vm0-ai/vm0/actions/runs/32243595495/job/96039911265), and its preview host had no `5xx` during that target test window. Nearly simultaneous `/org/members` failures on other preview hosts support shared provider pressure only after the current owner's own request proves the boundary; they are not used as a substitute for that proof.

Open PR [#28229](https://github.com/vm0-ai/vm0/pull/28229) is the separate active owner and duplicate guard for bounded Clerk-backed organization-member read recovery, including the exact `listAllOrganizationMemberships` path reached here. This occurrence is therefore classified as an excluded external Clerk rate-limit recurrence already owned outside this PR, not the root-to-canonical-chat route handoff fixed by #27897. No code, scope, retry, sleep, timeout, skip, or assertion change was made.

## Excluded recurrence: run 32245558099

[Turbo run 32245558099](https://github.com/vm0-ai/vm0/actions/runs/32245558099), job [96045863749](https://github.com/vm0-ai/vm0/actions/runs/32245558099/job/96045863749), failed the same scheduled-intent test on merge-group SHA `5dc1b9ab6ca1029aaa4b670bd2a63658599f7c14`. Its independent artifact reached the same later UI state on the #28183 preview: canonical chat, **Settings > Billing**, active **Pro plan**, and **Configure member packages / Step 2 of 3** with **Downgrade scheduled**, but without the member combobox or action button. The original route/settings handoff again completed.

On that preview's API host, target page session `b2a53434-b6ba-419a-acaa-67e78c105e77` loaded billing status with `200` at `11:05:56.176Z`, `GET /api/okou/org` with `200` at `11:05:56.231Z`, the catalog with `200` at `11:05:56.702Z`, and the active subscription with `200` at `11:05:56.711Z`. Its first failed request on the package-control dependency was `GET /api/okou/org/members`, which returned application `500` at `11:05:57.056Z` (request `b86a096c-bb98-4d48-8b59-225356e368b4`). The paired server event at `11:05:57.070Z` records a Clerk Organization API `429 Too Many Requests`, `clerkError=true`, trace `a2d8afa3ab501a0b-PDX`, and `retryAfter=7` through the organization-members read. It was the target session's final request; no package preview, confirm, checkout, or later billing mutation followed.

A background `POST /api/okou/attribution/signup` in the same page session also returned application `500` at `11:05:56.523Z`, paired with a Clerk User API `429`. That is additional same-window provider-pressure evidence, but it is not substituted for the later, direct organization-members dependency that explains the missing package controls. The member failure preceded the top-level timeout marker at `11:11:09.921Z` by 5 minutes 12.865 seconds. Clerk Testing `route.fetch: Test ended` warnings arrived later at `11:11:23.563Z` and `11:11:28.083Z`; the runner-bootstrap job passed and `ci-gate-turbo` was downstream only.

The represented [#28183](https://github.com/vm0-ai/vm0/pull/28183) change edits only `turbo/packages/core/src/feature-switch.ts` and its unit test. The billing-transitions test blob is identical between this merge SHA, its parent, and current `origin/main`, while the [#28183 PR-head Playwright shard passed 27/27](https://github.com/vm0-ai/vm0/actions/runs/32236975862/job/96020884049). Passing comparison supports nondeterminism but is not used to name the cause; the current occurrence's own browser/server pair proves it.

As with run 32244247909, open PR [#28229](https://github.com/vm0-ai/vm0/pull/28229) separately owns the exact Clerk-backed organization-member read boundary. This recurrence is excluded from #27897's route-handoff set and requires no code or scope expansion here. All scheduled-intent assertions remain unchanged; no retry, sleep, timeout increase, skip, detached cleanup, swallowed rejection, or weakened assertion was added.
## Excluded recurrence: run 32246453445

[Turbo run 32246453445](https://github.com/vm0-ai/vm0/actions/runs/32246453445), job [96048630794](https://github.com/vm0-ai/vm0/actions/runs/32246453445/job/96048630794), failed the scheduled-intent test on merge-group SHA `d32b654b26f93c927f790c03f6556138fa29f493`. The deployed origins reported by this run were `https://pr-28212-app.omby.ai` and `https://pr-28212-api.vm6.ai`.

The uploaded Playwright artifact contains the two `error-context.md` files only; it contains no trace archive or screenshot file. The scheduled-intent DOM context nevertheless shows a fully rendered canonical workspace/chat page for **E2E Usage Pack Transitions**, including the workspace sidebar, agent link, composer, and model control, while the Settings dialog is absent. Authentication had completed with `hasSession=true` and `hasUser=true`.

The compact job log has two unlabeled failure markers. Correlating their operation timeouts with the two artifacts corrects the intake timestamp: the scheduled-intent Settings wait is the first marker at `11:16:56.006Z`; the marker at `11:17:14.533Z` belongs to the separately owned paid-invitation failure. The later Clerk Testing `route.fetch: Test ended` warnings at `11:18:37.731Z` and `11:18:52.403Z` therefore remain teardown/background noise.

The scheduled-intent owner first received application `500` from `GET /api/okou/org` at `11:16:23.380Z` during its initial App session (request `08af5cd1-8d03-411c-903c-3a2335e2bf15`). The paired server event at `11:16:23.400Z` records Clerk `429 Too Many Requests`, `clerkError=true`, trace `a2d8beee3f8eff0e-PDX`, and `retryAfter=6`. Onboarding completion and the test feature-switch update subsequently returned `200`.

The direct `openBillingSettings` page session, `6d85ee16-89c9-4cec-9d33-ba2b105617b2`, began at `11:16:25.900Z`. Feature switches, indicators, realtime, onboarding, team, billing status, and the canonical chat bootstrap returned `200`. Its `GET /api/okou/org` returned application `500` at `11:16:26.305Z` (request `ad4ce7f7-269e-4514-94aa-07929df8ae14`); the paired service event at `11:16:26.366Z` is a Clerk Organization API `429`, with `clerkError=true`, trace `a2d8bf00b801ef18-PDX`, and `retryAfter=3`. The page emitted no organization-members, usage-pack catalog/subscription, package preview/confirm, checkout, or billing mutation request before the Settings assertion failed 29.700 seconds later.

The exact trigger-SHA code path makes this request causal rather than merely adjacent. `checkUnifiedSettingsParam$` awaits `isOrgAdmin$` before selecting the requested Settings section and before calling `setSettingsDialogOpen$`; `isOrgAdmin$ -> orgRole$ -> org$` performs the organization read, and `org$` accepts only `200` or `404`. The application `500` therefore rejects deep-link initialization before the dialog-open state is set. This differs from the all-`200` root-to-canonical-chat lifecycle race fixed by this PR.

The represented [#28212](https://github.com/vm0-ai/vm0/pull/28212) changes only a neutral API test-helper name and its test imports. The billing-transitions test blob is identical at the failing merge SHA, its parent, the #28212 head, and current `origin/main`. The [#28212 PR-head shard passed 27/27](https://github.com/vm0-ai/vm0/actions/runs/32241291531/job/96032953629), as did the [immediately preceding main shard](https://github.com/vm0-ai/vm0/actions/runs/32245603917/job/96046901863). Passing comparisons support nondeterminism but are not used to name the cause; this occurrence's own request/server pair does.

Open PR [#28229](https://github.com/vm0-ai/vm0/pull/28229) separately owns bounded recovery for Clerk-backed organization-member reads. Its current scope does not cover this root `/api/okou/org` failure, and the same-run paid-invitation failure remains with that separate owner.

This occurrence is classified as an excluded external Clerk rate-limit recurrence, not evidence that #27897's route-handoff repair applies. No code, scope, retry, sleep, timeout, skip, cleanup, or assertion change was made. Preview validation is inapplicable to this historical external occurrence; #27897 remains Draft pending validation of its original focused route-handoff repair.
## Excluded recurrence: run 32247841761

[Turbo run 32247841761](https://github.com/vm0-ai/vm0/actions/runs/32247841761), job [96052821187](https://github.com/vm0-ai/vm0/actions/runs/32247841761/job/96052821187), failed the scheduled-intent test on merge-group SHA `bbe66f0c319b85a6839d66dd5a15114effd4fd78`. The run reported `https://pr-28220-app.omby.ai` and `https://pr-28220-api.vm6.ai` as its deployed origins.

The uploaded Playwright artifact contains one `error-context.md` file and no trace archive or screenshot file. Its DOM snapshot reached canonical chat with **Settings > Billing** open on an active **Pro plan**. **Configure member packages / Step 2 of 3** was active and **Order summary** retained **Downgrade scheduled**, but the member-package combobox and action controls were absent. The Settings route handoff and package-dialog navigation therefore completed before the stall.

The last completed package mutation occurred in owner page session `c4b94024-d128-4ab1-96d5-2d819ef61469`. Organization, billing status, usage-pack catalog, active subscription, and organization members all returned `200`; package-change preview returned `200` at `11:33:57.804Z`, confirm returned `200` at `11:33:59.129Z`, and the direct subscription and billing-state reads returned `200` at `11:34:00.416Z` and `11:34:00.422Z`.

The next active package-management page session, `8e23ffab-86d8-424b-9e7f-6b84514e55d5`, began at `11:34:01.260Z`. It loaded billing status and `GET /api/okou/org` with `200`, received the expected `404` from usage-pack migration, and loaded the usage-pack catalog plus active subscription with `200` at `11:34:02.432Z` and `11:34:02.441Z`. Its first and final failed request was `GET /api/okou/org/members`, which returned application `500` at `11:34:02.781Z` (request `aa4251d4-8732-41a4-8751-e8be2301b8da`). The paired server event at `11:34:02.796Z` records `Unhandled request error: Too Many Requests`, provider status `429`, `clerkError=true`, Clerk trace `a2d8d8cb6837121f-PDX`, and `retryAfter=5` from the Clerk Organization API. The session had 31 requests and emitted nothing after this failure; no later package preview, confirm, checkout, or billing mutation followed.

At this source, the flow had already returned from `openUsagePackManagement` and entered `selectUsagePack`, whose combobox `click()` has no separate action timeout. The Playwright configuration also defines no `actionTimeout`. The missing member directory therefore explains the empty controls and why this operation silently consumed the remaining test budget until the top-level marker at `11:39:11.239Z`, 5 minutes 8.458 seconds after the failed member request. The Clerk Testing `route.fetch: Test ended` warning arrived later at `11:39:30.270Z`, and `ci-gate-turbo` was downstream only.

The represented [#28220](https://github.com/vm0-ai/vm0/pull/28220) changes five API runtime-state and agent-run compose-remediation files only. The billing-transitions test blob is identical at the failing SHA, its parent, the #28220 head, and current `origin/main`. The exact #28220 head `81924b44bdecba9aa52716ab0390e223d46dae1d` [passed the same shard 27/27](https://github.com/vm0-ai/vm0/actions/runs/32243205558/job/96038791399). Passing comparison supports nondeterminism but is not used to name the cause; this occurrence's own request/server pair proves it.

Open PR [#28229](https://github.com/vm0-ai/vm0/pull/28229) is the existing separate owner for this exact Clerk-backed organization-member read boundary, including bounded `Retry-After` recovery for `listAllOrganizationMemberships` and in-place Billing recovery. This recurrence is therefore classified as an excluded external Clerk `/org/members` rate-limit occurrence already owned by #28229, not the all-`200` route-handoff race fixed by #27897.

No code, scope, retry, sleep, timeout, skip, cleanup, or assertion change was made in this PR. Preview validation is inapplicable to this historical external occurrence; #27897 remains Draft pending validation of its original focused route-handoff repair.
