### PR TITLE
fix(feishu): harden oauth callbacks and connector reconciliation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -55,7 +55,10 @@ import {
 } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { readProjectedChatEvents } from "./helpers/chat-event-test-reader";
-import { readCustomConnectorCredentialStorageParent } from "./helpers/connector-credential-storage-state";
+import {
+  readCustomConnectorCredentialStorageParent,
+  seedLegacyCustomFeishuOAuthState,
+} from "./helpers/connector-credential-storage-state";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { agentsRoutes } from "../agents";
@@ -1891,6 +1894,31 @@ describe("Feishu integration", () => {
     expect(managedOAuthStart.body.error.message).toBe(
       "This connector is managed by its integration",
     );
+
+    const legacyGenericState = `legacy-generic-feishu-${randomUUID()}`;
+    await seedLegacyCustomFeishuOAuthState(context, {
+      state: legacyGenericState,
+      orgId: requireValue(admin.orgId, "Expected an organization"),
+      userId: admin.userId,
+      customConnectorId: managedConnector.id,
+      storageVersion: managedConnector.storageVersion,
+      redirectUri: `${APP_ORIGIN}/connectors/custom/callback`,
+    });
+    const legacyGenericCallbackResponse = await createAppWithRoutes({
+      signal: context.signal,
+      routes: feishuOauthRoutes,
+    }).request(
+      `${feishuOauthContract.callback.path}?${new URLSearchParams({
+        code: "legacy-generic-feishu-code",
+        responseMode: "json",
+        state: legacyGenericState,
+      })}`,
+    );
+    expect(legacyGenericCallbackResponse.status).toBe(400);
+    await expect(legacyGenericCallbackResponse.json()).resolves.toStrictEqual({
+      error: "Invalid or expired connect state",
+    });
+    expect(oauthTokenRedirectUris).toStrictEqual([]);
 
     const customConnectorByIdClient = setupApp({
       context,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -101,6 +101,28 @@ export async function deleteCustomConnectorCredentialValues(
   });
 }
 
+export async function seedLegacyCustomFeishuOAuthState(
+  context: TestContext,
+  args: {
+    readonly state: string;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly customConnectorId: string;
+    readonly storageVersion: number;
+    readonly redirectUri: string;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "seed-legacy-custom-feishu-oauth-state",
+    state: args.state,
+    org_id: args.orgId,
+    user_id: args.userId,
+    custom_connector_id: args.customConnectorId,
+    storage_version: args.storageVersion,
+    redirect_uri: args.redirectUri,
+  });
+}
+
 export async function seedOwnedConnectorSecret(
   context: TestContext,
   args: {

--- a/turbo/apps/api/src/signals/routes/feishu-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-browser-connect.ts
@@ -120,7 +120,6 @@ const startFeishuAccountOAuth$ = command(
         connectorId,
         redirectUri: feishuOAuthAppCallbackUrl(),
         feishuContext: {
-          completionTarget: "feishu",
           installationId: args.installationId,
           expectedOpenId: args.openId,
         },

--- a/turbo/apps/api/src/signals/routes/feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-oauth.ts
@@ -83,14 +83,16 @@ interface FeishuInstallationOAuthRow {
   readonly defaultAgentId: string;
 }
 
-type FeishuOAuthCompletionTarget = "custom" | "feishu";
 type FeishuCustomConnectorOAuthContext = Omit<
   CustomConnectorOAuthStateContext,
   "providerContext"
 > & {
-  readonly providerContext: NonNullable<
-    CustomConnectorOAuthStateContext["providerContext"]
-  >;
+  readonly providerContext: Omit<
+    NonNullable<CustomConnectorOAuthStateContext["providerContext"]>,
+    "completionTarget"
+  > & {
+    readonly completionTarget: "feishu";
+  };
 };
 
 function redirectResponse(url: string): Response {
@@ -119,24 +121,8 @@ function settingsRedirect(params: Readonly<Record<string, string>>): Response {
   return redirectResponse(settingsUrl(params));
 }
 
-function customConnectorCallbackUrl(
-  status: "error" | "success",
-  message?: string,
-): string {
-  const url = new URL(`/connectors/custom/callback/${status}`, env("APP_URL"));
-  if (message) {
-    url.searchParams.set("message", message);
-  }
-  return url.toString();
-}
-
-function completionErrorUrl(
-  target: FeishuOAuthCompletionTarget,
-  message: string,
-): string {
-  return target === "custom"
-    ? customConnectorCallbackUrl("error", message)
-    : settingsUrl({ error: message });
+function completionErrorUrl(message: string): string {
+  return settingsUrl({ error: message });
 }
 
 function appCallbackUrl(query: FeishuOAuthCallbackQuery): string {
@@ -179,11 +165,18 @@ function validCustomFeishuState(
   const context = parseValidCustomConnectorOAuthState(storedState);
   if (
     !context?.providerContext ||
-    context.providerContext.provider !== "feishu"
+    context.providerContext.provider !== "feishu" ||
+    context.providerContext.completionTarget !== "feishu"
   ) {
     return null;
   }
-  return { ...context, providerContext: context.providerContext };
+  return {
+    ...context,
+    providerContext: {
+      ...context.providerContext,
+      completionTarget: "feishu",
+    },
+  };
 }
 
 async function exchangeOAuthTokenAndUserInfo(
@@ -591,7 +584,6 @@ const connect$ = command(async ({ get, set }, signal: AbortSignal) => {
       connectorId,
       redirectUri: oauthRedirectUri(query.callbackTarget),
       feishuContext: {
-        completionTarget: "feishu",
         installationId: state.installationId,
       },
     },
@@ -615,10 +607,9 @@ const completeLegacyFeishuOAuth$ = command(
     signal: AbortSignal,
   ) => {
     const { db, query, state } = args;
-    const target: FeishuOAuthCompletionTarget = "feishu";
     if (query.error) {
       return callbackRedirectResponse(
-        completionErrorUrl(target, query.error_description ?? query.error),
+        completionErrorUrl(query.error_description ?? query.error),
         query.responseMode,
       );
     }
@@ -629,7 +620,7 @@ const completeLegacyFeishuOAuth$ = command(
     signal.throwIfAborted();
     if (!config || config.orgId !== state.orgId) {
       return callbackRedirectResponse(
-        completionErrorUrl(target, "Feishu bot not found."),
+        completionErrorUrl("Feishu bot not found."),
         query.responseMode,
       );
     }
@@ -643,7 +634,6 @@ const completeLegacyFeishuOAuth$ = command(
     if (!installation?.setupCompletedAt) {
       return callbackRedirectResponse(
         completionErrorUrl(
-          target,
           "Finish setting up this Feishu bot before connecting.",
         ),
         query.responseMode,
@@ -660,7 +650,7 @@ const completeLegacyFeishuOAuth$ = command(
     );
     if (!connectorId) {
       return callbackRedirectResponse(
-        completionErrorUrl(target, "Feishu connector not found."),
+        completionErrorUrl("Feishu connector not found."),
         query.responseMode,
       );
     }
@@ -677,7 +667,7 @@ const completeLegacyFeishuOAuth$ = command(
       connector.oauthConfig.providerAdapter !== "feishu"
     ) {
       return callbackRedirectResponse(
-        completionErrorUrl(target, "Feishu connector is unavailable."),
+        completionErrorUrl("Feishu connector is unavailable."),
         query.responseMode,
       );
     }
@@ -696,7 +686,6 @@ const completeLegacyFeishuOAuth$ = command(
     if (!exchanged) {
       return callbackRedirectResponse(
         completionErrorUrl(
-          target,
           "Failed to connect Feishu account. Please try again.",
         ),
         query.responseMode,
@@ -719,7 +708,7 @@ const completeLegacyFeishuOAuth$ = command(
     );
     if (completed !== "connected") {
       return callbackRedirectResponse(
-        completionErrorUrl(target, connectionErrorMessage(completed)),
+        completionErrorUrl(connectionErrorMessage(completed)),
         query.responseMode,
       );
     }
@@ -742,10 +731,9 @@ const completeClaimedCustomFeishuOAuth$ = command(
     signal: AbortSignal,
   ) => {
     const { context, db, query, state } = args;
-    const target = context.providerContext.completionTarget;
     if (query.error) {
       return callbackRedirectResponse(
-        completionErrorUrl(target, query.error_description ?? query.error),
+        completionErrorUrl(query.error_description ?? query.error),
         query.responseMode,
       );
     }
@@ -768,7 +756,6 @@ const completeClaimedCustomFeishuOAuth$ = command(
     ) {
       return callbackRedirectResponse(
         completionErrorUrl(
-          target,
           "Feishu connector configuration changed. Please try again.",
         ),
         query.responseMode,
@@ -784,7 +771,6 @@ const completeClaimedCustomFeishuOAuth$ = command(
     if (!installation?.setupCompletedAt) {
       return callbackRedirectResponse(
         completionErrorUrl(
-          target,
           "Finish setting up this Feishu bot before connecting.",
         ),
         query.responseMode,
@@ -800,10 +786,7 @@ const completeClaimedCustomFeishuOAuth$ = command(
     signal.throwIfAborted();
     if (!credentials) {
       return callbackRedirectResponse(
-        completionErrorUrl(
-          target,
-          "Could not read Feishu OAuth client credentials.",
-        ),
+        completionErrorUrl("Could not read Feishu OAuth client credentials."),
         query.responseMode,
       );
     }
@@ -822,7 +805,6 @@ const completeClaimedCustomFeishuOAuth$ = command(
     if (!exchanged) {
       return callbackRedirectResponse(
         completionErrorUrl(
-          target,
           "Failed to connect Feishu account. Please try again.",
         ),
         query.responseMode,
@@ -847,14 +829,12 @@ const completeClaimedCustomFeishuOAuth$ = command(
     );
     if (completed !== "connected") {
       return callbackRedirectResponse(
-        completionErrorUrl(target, connectionErrorMessage(completed)),
+        completionErrorUrl(connectionErrorMessage(completed)),
         query.responseMode,
       );
     }
     return callbackRedirectResponse(
-      target === "custom"
-        ? customConnectorCallbackUrl("success")
-        : feishuBotOpenUrl(installation.appId),
+      feishuBotOpenUrl(installation.appId),
       query.responseMode,
     );
   },

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -14,6 +14,7 @@ import { and, asc, eq, inArray } from "drizzle-orm";
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
+import { connectorOAuthStateExpiresAt } from "../../lib/connector-oauth-state";
 import type { RouteEntry } from "../route-entry";
 import { parseCustomConnectorOAuthStateContext } from "../services/custom-connector-oauth2.service";
 import {
@@ -273,6 +274,33 @@ async function deleteCustomCredentialValues(
           eq(variables.type, "connector"),
         ),
       );
+  });
+  signal.throwIfAborted();
+  return actionOk();
+}
+
+async function seedLegacyCustomFeishuOAuthState(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"seed-legacy-custom-feishu-oauth-state">,
+  signal: AbortSignal,
+) {
+  await db.insert(connectorOauthStates).values({
+    state: body.state,
+    customConnectorId: body.custom_connector_id,
+    storageVersion: body.storage_version,
+    authMethod: "oauth",
+    userId: body.user_id,
+    orgId: body.org_id,
+    redirectUri: body.redirect_uri,
+    oauthContext: JSON.stringify({
+      connectorId: body.custom_connector_id,
+      storageVersion: body.storage_version,
+      providerContext: {
+        provider: "feishu",
+        completionTarget: "custom",
+      },
+    }),
+    expiresAt: connectorOAuthStateExpiresAt(),
   });
   signal.throwIfAborted();
   return actionOk();
@@ -543,6 +571,9 @@ const mutateConnectorCredentialStorageState$ = command(
       }
       case "delete-custom-credential-values": {
         return await deleteCustomCredentialValues(db, body, signal);
+      }
+      case "seed-legacy-custom-feishu-oauth-state": {
+        return await seedLegacyCustomFeishuOAuthState(db, body, signal);
       }
       case "seed-owned-secret": {
         return await seedOwnedSecret(db, body, signal);

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -480,7 +480,6 @@ export const startCustomConnectorOAuth2$ = command(
       readonly redirectUri: string;
       readonly agentId?: string;
       readonly feishuContext?: {
-        readonly completionTarget: "custom" | "feishu";
         readonly installationId?: string;
         readonly expectedOpenId?: string;
       };
@@ -532,8 +531,9 @@ export const startCustomConnectorOAuth2$ = command(
         ? {
             providerContext: {
               provider: "feishu" as const,
-              completionTarget:
-                args.feishuContext?.completionTarget ?? ("custom" as const),
+              completionTarget: args.feishuContext
+                ? ("feishu" as const)
+                : ("custom" as const),
               ...(args.feishuContext?.installationId
                 ? { installationId: args.feishuContext.installationId }
                 : {}),

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -527,17 +527,15 @@ export const startCustomConnectorOAuth2$ = command(
     const context: CustomConnectorOAuthStateContext = {
       connectorId: connector.id,
       storageVersion: connector.storageVersion,
-      ...(providerAdapter === "feishu"
+      ...(providerAdapter === "feishu" && args.feishuContext
         ? {
             providerContext: {
               provider: "feishu" as const,
-              completionTarget: args.feishuContext
-                ? ("feishu" as const)
-                : ("custom" as const),
-              ...(args.feishuContext?.installationId
+              completionTarget: "feishu" as const,
+              ...(args.feishuContext.installationId
                 ? { installationId: args.feishuContext.installationId }
                 : {}),
-              ...(args.feishuContext?.expectedOpenId
+              ...(args.feishuContext.expectedOpenId
                 ? { expectedOpenId: args.feishuContext.expectedOpenId }
                 : {}),
             },

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -416,6 +416,7 @@ async function reconcileFeishuCustomConnector(
         eq(feishuOrgInstallations.orgId, args.orgId),
       ),
     )
+    .for("update", { of: feishuOrgInstallations })
     .limit(1);
   signal.throwIfAborted();
   if (!installation) {

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -54,6 +54,15 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       custom_connector_id: z.uuid(),
     }),
     z.object({
+      action: z.literal("seed-legacy-custom-feishu-oauth-state"),
+      state: z.string().min(1),
+      org_id: z.string(),
+      user_id: z.string(),
+      custom_connector_id: z.uuid(),
+      storage_version: z.number().int().positive(),
+      redirect_uri: z.url(),
+    }),
+    z.object({
       action: z.literal("seed-owned-secret"),
       org_id: z.string(),
       user_id: z.string(),


### PR DESCRIPTION
## Summary

- reject pre-deployment generic Feishu custom connector OAuth states instead of allowing them to complete through the Integration callback
- make Integration-issued Feishu OAuth completion targets server-selected and remove the now-unreachable generic callback branch
- lock the Feishu installation row during connector reconciliation so concurrent Integration deletion cannot leave an orphan connector

## Scope

- this is a focused follow-up to #27884
- this PR does not add fallback lookup behavior for installations whose `customConnectorId` is null
- this PR does not change Feishu credentials, permissions, or runtime connector behavior

## Validation

- `cd turbo && pnpm exec prettier --check <changed TypeScript files>`
- `cd turbo && pnpm turbo run lint --filter=api --filter=@okouai/api-contracts`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/feishu-integration.test.ts --maxWorkers=1`
- `cd turbo && pnpm knip`

Follow-up to #27884

Relates to #27837

Parent context: #22832
