### PR TITLE
test(feishu): mirror legacy oauth callback state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -1902,7 +1902,7 @@ describe("Feishu integration", () => {
       userId: admin.userId,
       customConnectorId: managedConnector.id,
       storageVersion: managedConnector.storageVersion,
-      redirectUri: `${APP_ORIGIN}/connectors/custom/callback`,
+      redirectUri: `${APP_ORIGIN}/connectors/feishu/callback`,
     });
     const legacyGenericCallbackResponse = await createAppWithRoutes({
       signal: context.signal,


### PR DESCRIPTION
## Summary

- make the legacy Feishu custom OAuth state fixture use the callback URL that historical production states actually stored
- keep the regression test aligned with the rollout behavior introduced in #27898

## Scope

- test-only follow-up to #27898
- no production behavior changes

## Validation

- `cd turbo && pnpm exec prettier --check apps/api/src/signals/routes/__tests__/feishu-integration.test.ts`
- `cd turbo && pnpm turbo run lint --filter=api`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/feishu-integration.test.ts --maxWorkers=1`

Follow-up to #27898
