### PR TITLE
test(api): synchronize slack dm session routing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2502,6 +2502,9 @@ describe("INT-01: Slack app deep webhook flows", () => {
       sandboxToken: mainClaim.sandboxToken,
       cliAgentType: mainClaim.cliAgentType,
     });
+    // The completion response precedes its waitUntil callback and queue drain.
+    // Own that work before the next ingress can enter the same scheduler.
+    await flushWaitUntilForTest();
 
     await integrations.postSlackEvent(teamId, {
       type: "message",
@@ -2520,6 +2523,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       sandboxToken: threadClaim.sandboxToken,
       cliAgentType: threadClaim.cliAgentType,
     });
+    await flushWaitUntilForTest();
 
     await integrations.postSlackEvent(teamId, {
       type: "message",
@@ -2540,6 +2544,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       sandboxToken: threadFollowUpClaim.sandboxToken,
       cliAgentType: threadFollowUpClaim.cliAgentType,
     });
+    await flushWaitUntilForTest();
 
     await integrations.postSlackEvent(teamId, {
       type: "message",


### PR DESCRIPTION
## Summary

- explicitly drain each completed Slack run's `waitUntil` callback and thread-queue work before posting the next Slack ingress
- keep the original product contract and assertions unchanged: a Slack DM can fork to a thread without replacing the canonical main session
- avoid retries, sleeps, timeout increases, skips, or production behavior changes

## Root cause evidence

Trigger: [Turbo run 32104232774](https://github.com/vm0-ai/vm0/actions/runs/32104232774), [`test-api (3)` job 95610489966](https://github.com/vm0-ai/vm0/actions/runs/32104232774/job/95610489966).

The failed test's visible Slack run summaries completed at `05:49:02.382`, `05:49:02.895`, and `05:49:05.919`. The third summary was the last completed domain operation before the 5-second test timeout. The next return-to-main claim never completed inside the test budget.

The first unresolved ownership boundary is earlier than the timeout:

1. `/complete` returns after scheduling `dispatchCompleteSideEffects$` through `waitUntil`.
2. This scenario's `completeSlackTriggeredRun` calls did not flush that work.
3. The following Slack webhook returned after scheduling its own `processCanonicalSlackIngress$` through `waitUntil`.
4. Both paths drain the same thread queue and can contend for the same queued-message launch claim before the later polling helper finally joins deferred work.

This competing-owner interleaving is visible even in successful comparisons: [the same PR-head passing job](https://github.com/vm0-ai/vm0/actions/runs/32102411128/job/95605414659) logged `Auto-send lost the queued-message launch claim` inside this test. A [same-base passing merge-group job](https://github.com/vm0-ai/vm0/actions/runs/32104197333/job/95610388778) took a different successful interleaving, and an [exact-base main job](https://github.com/vm0-ai/vm0/actions/runs/32104633102/job/95611586145) also passed. PR #24397 previously removed these explicit flush boundaries when it split this scenario, which matches the current missing test ownership boundary.

The represented queued PR #27864 changed only Python runner firewall/base-URL layout and contracts. Its diff does not touch this test or adjacent Slack/session implementation.

The expected `OPENROUTER_API_KEY` warnings complete immediately and do not make an external call. The later Notion assertion output occurred after Vitest had already marked this Slack test failed; teardown database errors, Codecov output, and `ci-gate-turbo` are downstream or aggregate noise rather than the first cause.

## Duplicate guards

- no equivalent open PR matched the exact test name or Slack DM session-flake searches
- chat search matched only the current repair thread and stable flaky key
- the final main merge-queue scan contained only unrelated PR #27869

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`

The target database integration test was not run locally five times: PostgreSQL at `localhost:5432` was unavailable, and this repair contract prohibits starting any local service. The PR Turbo shard will perform the database-backed dynamic validation.

## Preview validation

Not applicable. This PR changes only in-process test synchronization and does not alter an app/API deployment, browser surface, or production runtime behavior.
