### PR TITLE
fix(platform): keep sidebar search icon tone consistent

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2821,7 +2821,16 @@ describe("zero sidebar", () => {
     // The middle list column owns the chat header and pinned agents.
     const list = screen.getByTestId("chat-list-column");
     expect(within(list).getByText("Chat")).toBeInTheDocument();
-    expect(within(list).getByLabelText("New chat")).toBeInTheDocument();
+    const searchButton = within(list).getByLabelText("Search conversations");
+    const newChatButton = within(list).getByLabelText("New chat");
+    expect(searchButton.querySelector("svg")).toHaveClass(
+      "text-muted-foreground",
+      "opacity-70",
+    );
+    expect(newChatButton.querySelector("svg")).toHaveClass(
+      "text-muted-foreground",
+      "opacity-70",
+    );
     expect(
       within(list).getByTestId("pinned-agents-horizontal"),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -5,6 +5,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -2800,6 +2801,21 @@ describe("zero sidebar", () => {
   });
 
   it("renders the three-column navigation when the flag is on", async () => {
+    const user = userEvent.setup();
+    const mutedIconColor = "rgb(89, 89, 89)";
+    document.documentElement.style.setProperty(
+      "--color-muted-foreground",
+      mutedIconColor,
+    );
+    context.signal.addEventListener(
+      "abort",
+      () => {
+        document.documentElement.style.removeProperty(
+          "--color-muted-foreground",
+        );
+      },
+      { once: true },
+    );
     prepareDefaultAgent();
 
     setupSidebarPage({
@@ -2823,14 +2839,29 @@ describe("zero sidebar", () => {
     expect(within(list).getByText("Chat")).toBeInTheDocument();
     const searchButton = within(list).getByLabelText("Search conversations");
     const newChatButton = within(list).getByLabelText("New chat");
-    expect(searchButton.querySelector("svg")).toHaveClass(
-      "text-muted-foreground",
-      "opacity-70",
-    );
-    expect(newChatButton.querySelector("svg")).toHaveClass(
-      "text-muted-foreground",
-      "opacity-70",
-    );
+    const searchIcon = searchButton.querySelector("svg");
+    const newChatIcon = newChatButton.querySelector("svg");
+    if (!(searchIcon instanceof SVGElement)) {
+      throw new Error("Search icon is not rendered");
+    }
+    if (!(newChatIcon instanceof SVGElement)) {
+      throw new Error("New chat icon is not rendered");
+    }
+    const searchColor = getComputedStyle(searchIcon).color;
+    const newChatColor = getComputedStyle(newChatIcon).color;
+    expect(searchColor).toBe(mutedIconColor);
+    expect(newChatColor).toBe(mutedIconColor);
+    expect(getComputedStyle(searchIcon).opacity).toBe("0.7");
+    expect(getComputedStyle(newChatIcon).opacity).toBe("0.7");
+
+    await user.hover(searchButton);
+    expect(getComputedStyle(searchIcon).color).toBe(searchColor);
+    expect(getComputedStyle(searchIcon).opacity).toBe("0.7");
+
+    await user.unhover(searchButton);
+    await user.hover(newChatButton);
+    expect(getComputedStyle(newChatIcon).color).toBe(newChatColor);
+    expect(getComputedStyle(newChatIcon).opacity).toBe("0.7");
     expect(
       within(list).getByTestId("pinned-agents-horizontal"),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -62,6 +62,10 @@ import {
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 
 const slackIcon = settingsIconAssetUrl("slack");
+const chatHeaderIconStyle = {
+  color: "var(--color-muted-foreground)",
+  opacity: 0.7,
+} as const;
 
 type ManageNavId = "agents" | "artifacts" | "connectors" | "workflows";
 
@@ -781,10 +785,7 @@ function ChatListColumn() {
                 variant="quiet"
                 size="icon-sm"
               >
-                <Search
-                  className="text-muted-foreground opacity-70"
-                  size={17}
-                />
+                <Search style={chatHeaderIconStyle} size={17} />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -801,7 +802,7 @@ function ChatListColumn() {
                 variant="quiet"
                 size="icon-sm"
               >
-                <Edit className="text-muted-foreground opacity-70" size={17} />
+                <Edit style={chatHeaderIconStyle} size={17} />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -781,7 +781,10 @@ function ChatListColumn() {
                 variant="quiet"
                 size="icon-sm"
               >
-                <Search className="opacity-50" size={17} />
+                <Search
+                  className="text-muted-foreground opacity-50"
+                  size={17}
+                />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -782,7 +782,7 @@ function ChatListColumn() {
                 size="icon-sm"
               >
                 <Search
-                  className="text-muted-foreground opacity-50"
+                  className="text-muted-foreground opacity-70"
                   size={17}
                 />
               </Button>
@@ -801,7 +801,7 @@ function ChatListColumn() {
                 variant="quiet"
                 size="icon-sm"
               >
-                <Edit className="opacity-50" size={17} />
+                <Edit className="text-muted-foreground opacity-70" size={17} />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">


### PR DESCRIPTION
## Summary

- keep the three-column sidebar search and new-chat icons on the muted color while their quiet buttons are hovered
- raise both chat-header icons from 50% to 70% opacity for a darker, more legible tone
- preserve the shared Lucide stroke-width token so the icons remain consistent without local stroke overrides

## Verification

- npx --yes prettier@3.8.1 --check turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
- cd turbo/apps/platform && npx --yes oxlint@1.75.0 --deny-warnings src/views/zero-page/zero-sidebar.tsx

Full Vitest and local dev-server verification were not run per repository guidance; PR CI covers the broader checks.