### PR TITLE
docs(rust): correct guest archive toctou claim

### DIFF
--- a/crates/guest-download/src/archive.rs
+++ b/crates/guest-download/src/archive.rs
@@ -16,6 +16,21 @@ use std::path::Path;
 /// are logged and skipped. Consequently, `Ok(())` means that all accepted
 /// entries were processed, not that every archive entry was unpacked.
 ///
+/// # TOCTOU (documented, not mitigated)
+///
+/// The ancestor checks performed before each `unpack_in` do not provide TOCTOU
+/// protection. Sequential entry processing only orders entries within this
+/// process; it does not prevent another process from concurrently mutating the
+/// destination tree (for example, atomically replacing a checked directory with
+/// a symlink) between a check and the extraction below. The `tar` crate's
+/// threat model explicitly excludes concurrent destination mutation, and
+/// preventing such races requires OS primitives (e.g. `openat`/`O_PATH`) that
+/// this crate does not use. Exposure is reduced by lifecycle assumptions owned
+/// by callers: the runner applies storage before spawning the guest agent, and
+/// the guest-download scheduler serializes logically or physically overlapping
+/// targets within this process. Callers that permit concurrent access to an
+/// extraction target must not rely on this function for containment.
+///
 /// # Errors
 ///
 /// An unreadable archive entry or entry path, or a failure to unpack an
@@ -134,9 +149,11 @@ pub(crate) fn extract_tar_gz(source: ArchiveSource, target: &Path) -> Result<(),
             continue;
         }
 
-        // TOCTOU is not a concern here: entries are processed sequentially from a single
-        // archive stream, so no external actor can modify the filesystem between our checks
-        // and the extraction below.
+        // This check-plus-unpack sequence is not TOCTOU-safe: sequential processing of a single
+        // archive stream only orders entries within this process, and another process can still
+        // replace a checked directory or symlink between the ancestor check and the extraction
+        // below. Safety relies on the caller's lifecycle/exclusivity assumptions documented on
+        // `extract_tar_gz`.
         entry.unpack_in(target).map_err(|e| {
             archive_error(
                 &http_body_read_failure,


### PR DESCRIPTION
## Summary

Corrects the TOCTOU claim at `crates/guest-download/src/archive.rs:137-139`. The previous comment
said TOCTOU was not a concern because entries are processed sequentially from a single archive
stream; that is inaccurate. Sequential processing only orders entries within this process and does
not prevent another process from mutating the destination tree between the ancestor check and
`entry.unpack_in`.

The change is documentation-only:

- Replaces the inline comment with wording consistent with the `tar 0.4.46` threat model, which
  explicitly excludes concurrent mutation of the destination tree.
- Adds a `TOCTOU (documented, not mitigated)` section to the `extract_tar_gz` doc comment,
  following the repository's existing pattern in `crates/runner/src/cmd/service/gate.rs`, and
  documents the lifecycle/exclusivity assumptions extraction relies on (runner applies storage
  before spawning the guest agent; the guest-download scheduler serializes overlapping targets
  within the process).

No code, dependency, or behavioral change. Hardening extraction against concurrent mutation (e.g.
`cap-std`/`openat`) is intentionally out of scope for this issue.

## Validation

Run from `crates/` on the submitted head:

- `cargo fmt --check -p guest-download` — passed
- `cargo test -p guest-download` — 71 passed, 0 failed (plus doc-tests)
- `cargo clippy -p guest-download --all-targets` — clean
- `cargo doc -p guest-download --no-deps` — clean

Closes #27890
