### PR TITLE
refactor(run): use application authority for parity agents

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -823,6 +823,16 @@ function environmentShadowFieldsForRun(runId: string): Record<string, unknown> {
   );
 }
 
+function agentExecutionAuthorityFieldsForRun(
+  runId: string,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(runContextSnapshotForRun(runId)).filter(([key]) => {
+      return key.startsWith("agentExecutionAuthority");
+    }),
+  );
+}
+
 function sandboxOperationEventsForRun(
   runId: string,
 ): readonly Record<string, unknown>[] {
@@ -3264,6 +3274,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect.objectContaining({
         runId: created.runId,
         prompt,
+        agentExecutionAuthority: "application",
+        agentExecutionAuthorityClassification: "completeSemanticParity",
       }),
     ]);
 
@@ -3869,6 +3881,22 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       prompt: "start a session",
       modelProvider: "anthropic-api-key",
     });
+    const currentHead = await readHistoricalAgentComposeHeadFixture(agentId);
+    const continuationOnlyMarker = `continuation-persisted-\${{ secrets.CONTINUATION_CONTENT_SECRET }}`;
+    const replacementHead = await api.createHistoricalCompose(actor, {
+      version: "1",
+      agents: {
+        [currentHead.name]: {
+          framework: "claude-code",
+          instructions: "CLAUDE.md",
+          description: continuationOnlyMarker,
+          environment: {
+            OKOU_AGENT_ID: `\${{ vars.OKOU_AGENT_ID }}`,
+            OKOU_TOKEN: `\${{ secrets.OKOU_TOKEN }}`,
+          },
+        },
+      },
+    });
 
     const resumed = await api.createRun(actor, {
       agentId,
@@ -3879,6 +3907,15 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(resumed.sessionId).toBe(first.sessionId);
     const resumedClaim = await api.claimRunnerJob(resumed.runId);
     expect(resumedClaim.resumeSession).toBeNull();
+    expect(resumedClaim.agentComposeVersionId).toBe(replacementHead.versionId);
+    expect(JSON.stringify(resumedClaim)).not.toContain(continuationOnlyMarker);
+    expect(JSON.stringify(resumedClaim)).not.toContain(
+      "CONTINUATION_CONTENT_SECRET",
+    );
+    expect(agentExecutionAuthorityFieldsForRun(resumed.runId)).toStrictEqual({
+      agentExecutionAuthority: "application",
+      agentExecutionAuthorityClassification: "completeSemanticParity",
+    });
     await expect(
       readRunLaunchSnapshotFixture(context, resumed.runId),
     ).resolves.toStrictEqual({
@@ -12433,6 +12470,23 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
         "The environment shadow fixture requires an organization",
       );
     }
+    const canonicalCompose =
+      await readHistoricalAgentComposeHeadFixture(agentId);
+    const persistedOnlyMarker = `persisted-only-\${{ secrets.PERSISTED_VERSION_CONTENT_SECRET }}`;
+    const parityHead = await api.createHistoricalCompose(actor, {
+      version: "1",
+      agents: {
+        [canonicalCompose.name]: {
+          framework: "claude-code",
+          instructions: "CLAUDE.md",
+          description: persistedOnlyMarker,
+          environment: {
+            OKOU_AGENT_ID: `\${{ vars.OKOU_AGENT_ID }}`,
+            OKOU_TOKEN: `\${{ secrets.OKOU_TOKEN }}`,
+          },
+        },
+      },
+    });
 
     const run = await api.createRun(actor, {
       agentId,
@@ -12441,6 +12495,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     });
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
+    expect(claim.agentComposeVersionId).toBe(parityHead.versionId);
 
     expectCanonicalOkouRunEnvironment({
       environment: claim.environment,
@@ -12475,9 +12530,33 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       environmentShadowCandidateOnlyCountBucket: "0",
       environmentShadowSharedValueDifferenceCountBucket: "0",
     });
+    expect(agentExecutionAuthorityFieldsForRun(run.runId)).toStrictEqual({
+      agentExecutionAuthority: "application",
+      agentExecutionAuthorityClassification: "completeSemanticParity",
+    });
     expect(JSON.stringify(claim)).not.toContain("environmentShadow");
+    expect(JSON.stringify(claim)).not.toContain("agentExecutionAuthority");
+    expect(JSON.stringify(claim)).not.toContain(persistedOnlyMarker);
+    expect(JSON.stringify(claim)).not.toContain(
+      "PERSISTED_VERSION_CONTENT_SECRET",
+    );
+    await expect(
+      readRunLaunchSnapshotFixture(context, run.runId),
+    ).resolves.toStrictEqual({
+      exists: true,
+      launch_snapshot: {
+        schemaVersion: 1,
+        framework: claim.cliAgentType,
+        runnerProfile: DEFAULT_PROFILE,
+      },
+    });
 
     await api.requestCancelRun(actor, run.runId, [200]);
+    const unchangedHead = await readHistoricalAgentComposeHeadFixture(agentId);
+    expect(unchangedHead.headVersionId).toBe(parityHead.versionId);
+    expect(
+      Object.values(unchangedHead.content?.agents ?? {})[0]?.description,
+    ).toBe(persistedOnlyMarker);
   });
 
   it("classifies active legacy environment value shapes without exposing them", async () => {
@@ -12543,6 +12622,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
         agents: {
           [canonicalCompose.name]: {
             framework: "claude-code",
+            instructions: "CLAUDE.md",
             environment: {
               OKOU_AGENT_ID: `\${{ vars.OKOU_AGENT_ID }}`,
               OKOU_TOKEN: `\${{ secrets.OKOU_TOKEN }}`,
@@ -12578,6 +12658,22 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
         expect(serializedShadowFields).not.toContain(forbidden);
       }
       expect(JSON.stringify(claim)).not.toContain("environmentShadow");
+      const authorityFields = agentExecutionAuthorityFieldsForRun(run.runId);
+      expect(authorityFields).toStrictEqual({
+        agentExecutionAuthority: "version_content",
+        agentExecutionAuthorityClassification: "systemEnvironmentDifferences",
+      });
+      const serializedAuthorityFields = JSON.stringify(authorityFields);
+      for (const forbidden of [
+        legacyKey,
+        legacyCase.value,
+        legacyCase.expectedValue,
+        agentId,
+        run.runId,
+      ]) {
+        expect(serializedAuthorityFields).not.toContain(forbidden);
+      }
+      expect(JSON.stringify(claim)).not.toContain("agentExecutionAuthority");
       await api.requestCancelRun(actor, run.runId, [200]);
     }
   });
@@ -12683,6 +12779,9 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       scope: "zero",
     });
     expect(historicalClaim.secretValues).toContain(historicalZeroToken);
+    expect(agentExecutionAuthorityFieldsForRun(historical.runId)).toStrictEqual(
+      {},
+    );
     await api.requestCancelRun(actor, historical.runId, [200]);
 
     const current = await api.createRun(actor, {
@@ -12693,6 +12792,11 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     await api.heartbeatRunner(runnerGroup);
     const currentClaim = await api.claimRunnerJob(current.runId);
     expect(currentClaim.agentComposeVersionId).toBe(legacyCompose.versionId);
+    expect(agentExecutionAuthorityFieldsForRun(current.runId)).toStrictEqual({
+      agentExecutionAuthority: "version_content",
+      agentExecutionAuthorityClassification:
+        "agentInstructionsMarkerOrMountDifferences",
+    });
     expectCanonicalOkouRunEnvironment({
       environment: currentClaim.environment,
       secretValues: currentClaim.secretValues,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -2700,6 +2700,9 @@ describe("RUN-04: agent run telemetry families", () => {
             environmentShadowLegacyOnlyCountBucket: "2_4",
             environmentShadowCandidateOnlyCountBucket: "1",
             environmentShadowSharedValueDifferenceCountBucket: "5_8",
+            agentExecutionAuthority: "version_content",
+            agentExecutionAuthorityClassification:
+              "systemEnvironmentDifferences",
             environment: { LEGACY_IGNORED: "legacy-map" },
             environmentEntries: [
               { name: "NODE_ENV", value: "production" },
@@ -2859,6 +2862,10 @@ describe("RUN-04: agent run telemetry families", () => {
     });
     expect(contextRead.body).not.toHaveProperty(
       "environmentShadowClassification",
+    );
+    expect(contextRead.body).not.toHaveProperty("agentExecutionAuthority");
+    expect(contextRead.body).not.toHaveProperty(
+      "agentExecutionAuthorityClassification",
     );
     expect(Object.keys(contextRead.body.networkPolicies ?? {})).toStrictEqual([
       "github",

--- a/turbo/apps/api/src/signals/services/agent-execution-authority.ts
+++ b/turbo/apps/api/src/signals/services/agent-execution-authority.ts
@@ -1,0 +1,246 @@
+import { isDeepStrictEqual } from "node:util";
+import { agentComposeApiContentSchema } from "@okouai/api-contracts/contracts/composes";
+
+import { computeComposeVersionId } from "./agent-compose-content";
+import { APPLICATION_OWNED_AGENT_EXECUTION_PLAN } from "./agent-execution-plan";
+
+export const AGENT_EXECUTION_PLAN_DIMENSIONS = [
+  "danglingOrMissingHeadVersion",
+  "unsupportedOrInvalidContent",
+  "frameworkOrFallbackDifferences",
+  "systemEnvironmentDifferences",
+  "runnerGroupPolicyDifferences",
+  "runnerProfilePolicyDifferences",
+  "agentInstructionsMarkerOrMountDifferences",
+  "composeArtifactOrVolumeDifferences",
+  "otherLaunchAffectingLegacyFields",
+  "unclassifiedContent",
+] as const;
+
+export type AgentExecutionPlanDimension =
+  (typeof AGENT_EXECUTION_PLAN_DIMENSIONS)[number];
+
+export type AgentExecutionAuthority = "application" | "version_content";
+
+export type AgentExecutionAuthorityClassification =
+  | "completeSemanticParity"
+  | AgentExecutionPlanDimension
+  | "multipleDimensions";
+
+interface AgentExecutionAuthorityInput {
+  readonly agentName: string;
+  readonly headVersionId: string | null;
+  readonly versionId: string | null;
+  readonly content: unknown;
+}
+
+export interface AgentExecutionAuthorityDecision {
+  readonly authority: AgentExecutionAuthority;
+  readonly classification: AgentExecutionAuthorityClassification;
+  readonly dimensions: readonly AgentExecutionPlanDimension[];
+}
+
+type ParsedAgentComposeContent = ReturnType<
+  typeof agentComposeApiContentSchema.parse
+>;
+type ParsedAgentDefinition = ParsedAgentComposeContent["agents"][string];
+
+type ValidatedAgentExecutionPlan =
+  | {
+      readonly classification: "exception";
+      readonly dimension: AgentExecutionPlanDimension;
+    }
+  | {
+      readonly classification: "supported";
+      readonly content: ParsedAgentComposeContent;
+      readonly activeAgentName: string;
+      readonly activeAgent: ParsedAgentDefinition;
+    };
+
+function hasInvalidActiveVolumeReference(args: {
+  readonly declarations: readonly string[] | undefined;
+  readonly volumeNames: ReadonlySet<string>;
+}): boolean {
+  return (args.declarations ?? []).some((declaration) => {
+    const [name, mountPath, extra] = declaration.split(":");
+    return (
+      extra !== undefined ||
+      !name?.trim() ||
+      !mountPath?.trim() ||
+      !args.volumeNames.has(name.trim())
+    );
+  });
+}
+
+function hasLegacyEnvironmentInfluence(
+  environment: Readonly<Record<string, string>> | undefined,
+): boolean {
+  if (!environment) {
+    return false;
+  }
+  const plan = APPLICATION_OWNED_AGENT_EXECUTION_PLAN.environment;
+  const runtimeOverrideKeys = new Set<string>(plan.runtimeOverrideKeys);
+  return Object.keys(environment).some((key) => {
+    return (
+      !runtimeOverrideKeys.has(key) &&
+      !plan.legacyRemovedPrefixes.some((prefix) => {
+        return key.startsWith(prefix);
+      })
+    );
+  });
+}
+
+function isMissingCurrentPlanHead(row: AgentExecutionAuthorityInput): boolean {
+  return (
+    row.headVersionId === null || row.versionId === null || row.content === null
+  );
+}
+
+function hasValidCurrentPlanHash(
+  row: AgentExecutionAuthorityInput,
+): row is AgentExecutionAuthorityInput & {
+  readonly headVersionId: string;
+  readonly versionId: string;
+  readonly content: Record<string, unknown>;
+} {
+  return (
+    row.versionId !== null &&
+    row.versionId === row.headVersionId &&
+    typeof row.content === "object" &&
+    row.content !== null &&
+    !Array.isArray(row.content) &&
+    computeComposeVersionId(row.content as Record<string, unknown>) ===
+      row.versionId
+  );
+}
+
+function validateAgentExecutionPlanRow(
+  row: AgentExecutionAuthorityInput,
+): ValidatedAgentExecutionPlan {
+  if (isMissingCurrentPlanHead(row)) {
+    return {
+      classification: "exception",
+      dimension: "danglingOrMissingHeadVersion",
+    };
+  }
+  if (!hasValidCurrentPlanHash(row)) {
+    return {
+      classification: "exception",
+      dimension: "unsupportedOrInvalidContent",
+    };
+  }
+  const parsed = agentComposeApiContentSchema.safeParse(row.content);
+  if (!parsed.success) {
+    return {
+      classification: "exception",
+      dimension: "unsupportedOrInvalidContent",
+    };
+  }
+  if (!isDeepStrictEqual(row.content, parsed.data)) {
+    // Zod strips unknown object keys. Any such key could acquire runtime
+    // meaning later, so application authority must fail closed.
+    return { classification: "exception", dimension: "unclassifiedContent" };
+  }
+  const firstEntry = Object.entries(parsed.data.agents)[0];
+  const activeAgentName = firstEntry?.[0];
+  const activeAgent = firstEntry?.[1];
+  if (!activeAgentName || !activeAgent) {
+    return {
+      classification: "exception",
+      dimension: "unsupportedOrInvalidContent",
+    };
+  }
+  if (
+    hasInvalidActiveVolumeReference({
+      declarations: activeAgent.volumes,
+      volumeNames: new Set(Object.keys(parsed.data.volumes ?? {})),
+    })
+  ) {
+    return {
+      classification: "exception",
+      dimension: "unsupportedOrInvalidContent",
+    };
+  }
+  return {
+    classification: "supported",
+    content: parsed.data,
+    activeAgentName,
+    activeAgent,
+  };
+}
+
+function semanticAgentExecutionPlanDimensions(
+  row: AgentExecutionAuthorityInput,
+  validated: Extract<
+    ValidatedAgentExecutionPlan,
+    { readonly classification: "supported" }
+  >,
+): Set<AgentExecutionPlanDimension> {
+  const dimensions = new Set<AgentExecutionPlanDimension>();
+  const plan = APPLICATION_OWNED_AGENT_EXECUTION_PLAN;
+  const { activeAgent, activeAgentName, content } = validated;
+  // Selected providers supply the same effective framework to both plans.
+  // Compare only the version value that remains capable of acting as fallback.
+  if (activeAgent.framework !== plan.framework.fallback) {
+    dimensions.add("frameworkOrFallbackDifferences");
+  }
+  if (hasLegacyEnvironmentInfluence(activeAgent.environment)) {
+    dimensions.add("systemEnvironmentDifferences");
+  }
+  if (activeAgent.experimental_runner !== undefined) {
+    dimensions.add("runnerGroupPolicyDifferences");
+  }
+  if (
+    activeAgent.experimental_profile !== undefined &&
+    activeAgent.experimental_profile !== plan.runner.profile.fallback
+  ) {
+    dimensions.add("runnerProfilePolicyDifferences");
+  }
+  if (
+    plan.instructions.enabled &&
+    (activeAgent.instructions === undefined ||
+      activeAgentName !== row.agentName)
+  ) {
+    dimensions.add("agentInstructionsMarkerOrMountDifferences");
+  }
+  if (
+    (content.artifacts?.length ?? 0) > 0 ||
+    (activeAgent.volumes?.length ?? 0) > 0
+  ) {
+    dimensions.add("composeArtifactOrVolumeDifferences");
+  }
+  if (activeAgentName !== row.agentName) {
+    dimensions.add("otherLaunchAffectingLegacyFields");
+  }
+  return dimensions;
+}
+
+export function classifyAgentExecutionAuthority(
+  row: AgentExecutionAuthorityInput,
+): AgentExecutionAuthorityDecision {
+  const validated = validateAgentExecutionPlanRow(row);
+  const dimensions =
+    validated.classification === "exception"
+      ? new Set<AgentExecutionPlanDimension>([validated.dimension])
+      : semanticAgentExecutionPlanDimensions(row, validated);
+  const orderedDimensions = AGENT_EXECUTION_PLAN_DIMENSIONS.filter(
+    (dimension) => {
+      return dimensions.has(dimension);
+    },
+  );
+  if (orderedDimensions.length === 0) {
+    return {
+      authority: "application",
+      classification: "completeSemanticParity",
+      dimensions: orderedDimensions,
+    };
+  }
+  return {
+    authority: "version_content",
+    classification:
+      orderedDimensions.length === 1
+        ? orderedDimensions[0]!
+        : "multipleDimensions",
+    dimensions: orderedDimensions,
+  };
+}

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -181,6 +181,11 @@ import {
   compareApplicationOwnedEnvironment,
   type EnvironmentShadowObservation,
 } from "./agent-environment-shadow";
+import { buildZeroAgentComposeContent } from "./agent-compose-content";
+import {
+  classifyAgentExecutionAuthority,
+  type AgentExecutionAuthorityDecision,
+} from "./agent-execution-authority";
 import {
   decryptStoredSecretValue,
   encryptPersistentSecretValue,
@@ -552,6 +557,7 @@ interface AgentComposeContent {
 }
 
 interface ResolvedCompose {
+  readonly headVersionId: string;
   readonly agentComposeVersionId: string;
   readonly composeId: string;
   readonly composeUserId: string;
@@ -566,7 +572,18 @@ interface ResolvedCompose {
   readonly agentSessionId?: string;
   readonly continuedFromAgentSessionId?: string;
   readonly resumeSession?: StoredExecutionContext["resumeSession"];
+  readonly agentExecutionAuthorityObservation?: Pick<
+    AgentExecutionAuthorityDecision,
+    "authority" | "classification"
+  >;
 }
+
+type PersistedPlan = Omit<
+  ResolvedCompose,
+  "content" | "agentExecutionAuthorityObservation"
+> & {
+  readonly content: unknown;
+};
 
 type ConnectorScopeSource = "explicit" | "zero_agent" | "empty";
 
@@ -864,6 +881,10 @@ interface BuiltStoredExecutionContext {
   // Plain secret values used for run-context redaction; values, not names.
   readonly secretValues: readonly string[];
   readonly environmentShadowObservation?: EnvironmentShadowObservation;
+  readonly agentExecutionAuthorityObservation?: Pick<
+    AgentExecutionAuthorityDecision,
+    "authority" | "classification"
+  >;
 }
 
 type BuiltStoredExecutionContextDraft = Omit<
@@ -917,6 +938,7 @@ export interface CreateAgentRunArgs {
   readonly chatThreadId?: string;
   readonly threadSessionResolution?: ChatThreadSessionResolution;
   readonly includeZeroTokenSecret?: boolean;
+  readonly productAgentName?: string;
   readonly zeroTokenPublicBrand?: PublicBrand;
   readonly zeroTokenComputerUseHostId?: string;
   readonly zeroTokenCloudBrowserEnabled?: boolean;
@@ -1306,12 +1328,42 @@ function canonicalOkouComposeContent(
 // Content-addressed compose versions remain persisted unchanged. New branded
 // contexts interpret legacy versions through this runtime-only projection.
 function runtimeResolvedCompose(
-  resolved: ResolvedCompose,
-  canonicalOkouRuntime: boolean,
+  resolved: PersistedPlan,
+  productAgentName: string | undefined,
 ): ResolvedCompose {
-  return canonicalOkouRuntime
-    ? { ...resolved, content: canonicalOkouComposeContent(resolved.content) }
-    : resolved;
+  if (productAgentName === undefined) {
+    return { ...resolved, content: resolved.content as AgentComposeContent };
+  }
+  const decision = classifyAgentExecutionAuthority({
+    agentName: productAgentName,
+    headVersionId: resolved.headVersionId,
+    versionId: resolved.agentComposeVersionId,
+    content: resolved.content,
+  });
+  const observation = {
+    authority: decision.authority,
+    classification: decision.classification,
+  };
+  if (decision.authority === "application") {
+    // Persisted JSON stops at the classifier. Every downstream launch
+    // consumer receives a fresh projection of the application-owned plan.
+    return {
+      ...resolved,
+      content: buildZeroAgentComposeContent(
+        productAgentName,
+      ) as AgentComposeContent,
+      agentExecutionAuthorityObservation: observation,
+    };
+  }
+  // Stage 4B transition: fail-closed exception domains retain the exact
+  // pre-Stage-4B runtime projection until #26938 Stage 8 removes this path.
+  return {
+    ...resolved,
+    content: canonicalOkouComposeContent(
+      resolved.content as AgentComposeContent,
+    ),
+    agentExecutionAuthorityObservation: observation,
+  };
 }
 
 function resolveFramework(
@@ -5321,7 +5373,7 @@ async function resolveByAgentId(
   db: Db,
   agentId: string,
   timing?: ApiDispatchTimingCollector,
-): Promise<ResolvedCompose | CreateRunErrorResult> {
+): Promise<PersistedPlan | CreateRunErrorResult> {
   const [row] = await measureApiDispatchTiming(
     timing,
     "api_dispatch_resolve_compose_lookup_agent",
@@ -5357,6 +5409,7 @@ async function resolveByAgentId(
   }
 
   return {
+    headVersionId: row.headVersionId,
     agentComposeVersionId: row.versionId,
     composeId: row.composeId,
     composeUserId: row.composeUserId,
@@ -5461,8 +5514,8 @@ function resolveBySessionId(
   userId: string,
   orgId: string,
   timing?: ApiDispatchTimingCollector,
-): Computed<Promise<ResolvedCompose | CreateRunErrorResult>> {
-  return computed(async (): Promise<ResolvedCompose | CreateRunErrorResult> => {
+): Computed<Promise<PersistedPlan | CreateRunErrorResult>> {
+  return computed(async (): Promise<PersistedPlan | CreateRunErrorResult> => {
     const [snapshot] = await measureApiDispatchTiming(
       timing,
       "api_dispatch_resolve_compose_lookup_session_snapshot",
@@ -5560,6 +5613,7 @@ function resolveBySessionId(
       : undefined;
 
     return {
+      headVersionId: snapshot.compose.headVersionId,
       agentComposeVersionId: snapshot.version.id,
       composeId: snapshot.compose.id,
       composeUserId: snapshot.compose.userId,
@@ -5583,9 +5637,9 @@ function resolveCompose(
   userId: string,
   orgId: string,
   timing?: ApiDispatchTimingCollector,
-): Computed<Promise<ResolvedCompose | CreateRunErrorResult>> {
+): Computed<Promise<PersistedPlan | CreateRunErrorResult>> {
   return computed(
-    async (get): Promise<ResolvedCompose | CreateRunErrorResult> => {
+    async (get): Promise<PersistedPlan | CreateRunErrorResult> => {
       if (body.sessionId) {
         const sessionId = body.sessionId;
         const resolved = await measureApiDispatchTiming(
@@ -6076,6 +6130,8 @@ async function buildStoredExecutionContextDraft(args: {
     secretNames,
     secretValues,
     environmentShadowObservation,
+    agentExecutionAuthorityObservation:
+      args.resolved.agentExecutionAuthorityObservation,
   };
 }
 
@@ -6133,6 +6189,8 @@ function buildRunContextSnapshot(args: {
   const cliAgentSessionId =
     storedContext.piSessionId ?? storedContext.resumeSession?.sessionId ?? null;
   const environmentShadow = args.builtContext.environmentShadowObservation;
+  const agentExecutionAuthority =
+    args.builtContext.agentExecutionAuthorityObservation;
   let environmentShadowFields: Partial<
     Pick<
       RunContextAxiomSnapshot,
@@ -6175,6 +6233,13 @@ function buildRunContextSnapshot(args: {
     artifact: args.builtContext.runContextStorage.artifact,
     featureFlagEntries: featureFlagsRecordToEntries(storedContext.featureFlags),
     ...environmentShadowFields,
+    ...(agentExecutionAuthority
+      ? {
+          agentExecutionAuthority: agentExecutionAuthority.authority,
+          agentExecutionAuthorityClassification:
+            agentExecutionAuthority.classification,
+        }
+      : {}),
   };
   return snapshot;
 }
@@ -8221,9 +8286,12 @@ async function prepareRunBodyContext(
     return persistedResolved;
   }
   const canonicalOkouRuntime = args.createArgs.includeZeroTokenSecret === true;
+  if (canonicalOkouRuntime && args.createArgs.productAgentName === undefined) {
+    throw new Error("Product Agent name is required for canonical runtime");
+  }
   const resolved = runtimeResolvedCompose(
     persistedResolved,
-    canonicalOkouRuntime,
+    canonicalOkouRuntime ? args.createArgs.productAgentName : undefined,
   );
   if (resolved.orgId !== args.createArgs.orgId) {
     return notFound("Resource not found");

--- a/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
+++ b/turbo/apps/api/src/signals/services/run-context-snapshot.service.ts
@@ -15,6 +15,10 @@ import type {
   EnvironmentShadowClassification,
   EnvironmentShadowCountBucket,
 } from "./agent-environment-shadow";
+import type {
+  AgentExecutionAuthority,
+  AgentExecutionAuthorityClassification,
+} from "./agent-execution-authority";
 
 type UnknownRecord = Record<string, unknown>;
 type NetworkPolicy = NetworkPolicies[string];
@@ -103,6 +107,8 @@ export type RunContextAxiomSnapshot = Omit<
   readonly environmentShadowLegacyOnlyCountBucket?: EnvironmentShadowCountBucket;
   readonly environmentShadowCandidateOnlyCountBucket?: EnvironmentShadowCountBucket;
   readonly environmentShadowSharedValueDifferenceCountBucket?: EnvironmentShadowCountBucket;
+  readonly agentExecutionAuthority?: AgentExecutionAuthority;
+  readonly agentExecutionAuthorityClassification?: AgentExecutionAuthorityClassification;
 };
 
 interface NormalizedRunContextSnapshot {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -102,6 +102,7 @@ const TONE_INSTRUCTIONS: Readonly<Record<string, string>> = {
 
 interface ZeroAgentRunRecord {
   readonly id: string;
+  readonly name: string;
   readonly orgId: string;
   readonly defaultAgentId: string | null;
   readonly owner: string;
@@ -503,6 +504,7 @@ async function loadZeroAgent(
   const [agent] = await db
     .select({
       id: zeroAgents.id,
+      name: zeroAgents.name,
       orgId: zeroAgents.orgId,
       defaultAgentId: orgMetadata.defaultAgentId,
       owner: zeroAgents.owner,
@@ -868,6 +870,7 @@ function buildZeroCreateAgentRunArgs(args: {
     }),
     callbacks: command.callbacks,
     includeZeroTokenSecret: true,
+    productAgentName: args.agent.name,
     zeroTokenPublicBrand: command.publicBrand,
     zeroTokenComputerUseHostId: command.computerUseHostId,
     zeroTokenCloudBrowserEnabled: args.cloudBrowserEnabled,

--- a/turbo/packages/db/MIGRATIONS.md
+++ b/turbo/packages/db/MIGRATIONS.md
@@ -39,9 +39,17 @@ delete the workflow, probe, focused validator, and this entry together.
 | --------------------------------- | ------------------------------------------------- | -------------- |
 | #27613 / #27656 / #27671 / #27792 | Agent/Compose consolidation production preflight  | #26938 Stage 8 |
 | #27665                            | Integration identity Contract readiness preflight | #27602         |
+| #27896                            | Agent execution authority classifier and helpers  | #26938 Stage 8 |
+| #27896                            | Application Compose projection adapter            | #26938 Stage 8 |
+| #27896                            | Legacy exception runtime path                     | #26938 Stage 8 |
+| #27896                            | Run-context authority telemetry                   | #26938 Stage 8 |
 
 <!-- vm0-transition-validator:#27613+#27656+#27671+#27792|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8 -->
 <!-- vm0-transition-validator:#27665|integration-identity-contract-readiness-preflight|removal-owner:#27602 -->
+<!-- vm0-transition-validator:#27896|agent-execution-authority-classifier-and-helpers|removal-owner:#26938-stage-8 -->
+<!-- vm0-transition-validator:#27896|application-compose-projection-adapter|removal-owner:#26938-stage-8 -->
+<!-- vm0-transition-validator:#27896|legacy-exception-runtime-path|removal-owner:#26938-stage-8 -->
+<!-- vm0-transition-validator:#27896|run-context-authority-telemetry|removal-owner:#26938-stage-8 -->
 
 ## Migration patterns
 

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-consumers.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-consumers.ts
@@ -10,6 +10,7 @@ export interface RuntimeContentConsumerManifest {
 }
 
 type RuntimeContentConsumerMode =
+  | "application-authority-classifier"
   | "compose-independent-environment-shadow"
   | "first-plural-schema-parse"
   | "first-plural-framework-display"
@@ -45,6 +46,25 @@ const REVIEWED_CONSUMERS: readonly ReviewedConsumer[] = [
   {
     relativePath: "turbo/apps/api/src/signals/routes/integrations-slack.ts",
     mode: "raw-recursive-variable-secret-scan",
+  },
+  {
+    relativePath:
+      "turbo/apps/api/src/signals/services/agent-execution-authority.ts",
+    mode: "application-authority-classifier",
+    interfaces: [
+      "AgentExecutionAuthorityDecision",
+      "AgentExecutionAuthorityInput",
+    ],
+    functions: [
+      "classifyAgentExecutionAuthority",
+      "hasInvalidActiveVolumeReference",
+      "hasLegacyEnvironmentInfluence",
+      "hasValidCurrentPlanHash",
+      "isMissingCurrentPlanHead",
+      "semanticAgentExecutionPlanDimensions",
+      "validateAgentExecutionPlanRow",
+    ],
+    variables: ["AGENT_EXECUTION_PLAN_DIMENSIONS"],
   },
   {
     relativePath:
@@ -183,6 +203,7 @@ export const EXPECTED_RUNTIME_CONTENT_CONSUMER_MANIFEST: RuntimeContentConsumerM
       "rawRecursiveScan|turbo/apps/api/src/signals/routes/integrations-slack.ts|1|0357a0f694d2882516d811fff5f28d57abb01a6df4f2bdcb1f8435d0827ea17f",
       "rawRecursiveScan|turbo/apps/api/src/signals/services/teams-connect.service.ts|1|0357a0f694d2882516d811fff5f28d57abb01a6df4f2bdcb1f8435d0827ea17f",
       "rawRecursiveScan|turbo/apps/api/src/signals/services/telegram-data.service.ts|1|0357a0f694d2882516d811fff5f28d57abb01a6df4f2bdcb1f8435d0827ea17f",
+      "schemaParse|turbo/apps/api/src/signals/services/agent-execution-authority.ts|1|bc9d01f8197c2f9bc1e86be04a1f255c158608fe252eb6afcdc56c4f0d7bef35",
       "schemaParse|turbo/apps/api/src/signals/services/agent-instructions.service.ts|1|712fe12ea1d29b388940ea5921cabf4e2dd2dbc2229162e5210dba575ac256f9",
       "storageForwarding|turbo/apps/api/src/signals/services/agent-run-create.service.ts|1|14ef880a94a1bae38cf026d24cd1a98096a30e4a16df5a32a746f93fee32c04d",
       "zeroRunRawContentUse|turbo/apps/api/src/signals/services/zero-runs-create.service.ts|1|b59eb415f1b94645a15ac9a30463465caac4a5420b05052a4120ba65c9481e9b",
@@ -190,8 +211,9 @@ export const EXPECTED_RUNTIME_CONTENT_CONSUMER_MANIFEST: RuntimeContentConsumerM
     reviewedConsumers: [
       "turbo/apps/api/src/signals/routes/integrations-slack.ts|raw-recursive-variable-secret-scan|1|0357a0f694d2882516d811fff5f28d57abb01a6df4f2bdcb1f8435d0827ea17f",
       "turbo/apps/api/src/signals/services/agent-environment-shadow.ts|compose-independent-environment-shadow|4|bb1c66722499e90deb9a6471567a6d374aefe0f68b878249d0fc4822ddaf3f13",
+      "turbo/apps/api/src/signals/services/agent-execution-authority.ts|application-authority-classifier|11|6f84ff19ccb4f3fdc398973ddc67d010b73264c187004d0a2b6bfbdc706427f9",
       "turbo/apps/api/src/signals/services/agent-instructions.service.ts|first-plural-schema-parse|2|5e0e03733f7327b9e719691adccd8ef9e643f7945e7a2011884b50c17cd0d5ca",
-      "turbo/apps/api/src/signals/services/agent-run-create.service.ts|singular-or-first-plural-launch|17|2bd6e27e3eb4d51e1263c040e2f39b599322e2574e9b30f2826f73061e9301d9",
+      "turbo/apps/api/src/signals/services/agent-run-create.service.ts|singular-or-first-plural-launch|17|3ba4be01b537988945707f15b9e9e8c60f67bcb8f212be00749e4343c7f2a336",
       "turbo/apps/api/src/signals/services/agent-run-storage.service.ts|singular-or-first-plural-storage-and-volumes|8|f892995687452b9c164950e90aab24e9da198326187dea19b646864d71d35cf9",
       "turbo/apps/api/src/signals/services/logs.service.ts|first-plural-framework-display|1|ea68586f0591ce59e883d688f75c0a37ac6022e9eb4e5a2fb2cda1be037123ce",
       "turbo/apps/api/src/signals/services/teams-connect.service.ts|raw-recursive-variable-secret-scan|1|0357a0f694d2882516d811fff5f28d57abb01a6df4f2bdcb1f8435d0827ea17f",

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
@@ -275,6 +275,7 @@ export const EXPECTED_REPOSITORY_DEPENDENCIES = {
     "turbo/apps/api/src/signals/services/agent-compose-provenance-lifecycle.service.ts|agentComposes",
     "turbo/apps/api/src/signals/services/agent-compose.service.ts|agentComposeId,agentComposeVersions,agentComposes,headVersionId",
     "turbo/apps/api/src/signals/services/agent-data.service.ts|agentComposes,headVersionId,zeroAgents",
+    "turbo/apps/api/src/signals/services/agent-execution-authority.ts|headVersionId",
     "turbo/apps/api/src/signals/services/agent-instructions.service.ts|agentComposeVersions,agentComposes,headVersionId,zeroAgents",
     "turbo/apps/api/src/signals/services/agent-run-create.service.ts|agentComposeId,agentComposeVersionId,agentComposeVersions,agentComposes,headVersionId",
     "turbo/apps/api/src/signals/services/agent-run-storage.service.ts|headVersionId",
@@ -398,6 +399,10 @@ export const EXPECTED_REPOSITORY_DEPENDENCIES = {
   transitionValidators: [
     "#27613+#27656+#27671+#27792|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8",
     "#27665|integration-identity-contract-readiness-preflight|removal-owner:#27602",
+    "#27896|agent-execution-authority-classifier-and-helpers|removal-owner:#26938-stage-8",
+    "#27896|application-compose-projection-adapter|removal-owner:#26938-stage-8",
+    "#27896|legacy-exception-runtime-path|removal-owner:#26938-stage-8",
+    "#27896|run-context-authority-telemetry|removal-owner:#26938-stage-8",
   ],
 } as const satisfies RepositoryDependencyManifest;
 

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
@@ -9,7 +9,11 @@ import {
   buildZeroAgentComposeContent,
   computeComposeVersionId,
 } from "../../../apps/api/src/signals/services/agent-compose-content";
-import { APPLICATION_OWNED_AGENT_EXECUTION_PLAN } from "../../../apps/api/src/signals/services/agent-execution-plan";
+import {
+  AGENT_EXECUTION_PLAN_DIMENSIONS,
+  classifyAgentExecutionAuthority,
+  type AgentExecutionPlanDimension,
+} from "../../../apps/api/src/signals/services/agent-execution-authority";
 import {
   CATALOG_DEPENDENCY_KINDS,
   CATALOG_DEPENDENCY_QUERY,
@@ -953,22 +957,6 @@ function classifyIdentity(
   };
 }
 
-const AGENT_EXECUTION_PLAN_DIMENSIONS = [
-  "danglingOrMissingHeadVersion",
-  "unsupportedOrInvalidContent",
-  "frameworkOrFallbackDifferences",
-  "systemEnvironmentDifferences",
-  "runnerGroupPolicyDifferences",
-  "runnerProfilePolicyDifferences",
-  "agentInstructionsMarkerOrMountDifferences",
-  "composeArtifactOrVolumeDifferences",
-  "otherLaunchAffectingLegacyFields",
-  "unclassifiedContent",
-] as const;
-
-type AgentExecutionPlanDimension =
-  (typeof AGENT_EXECUTION_PLAN_DIMENSIONS)[number];
-
 function cardinalityAwareComparison(
   domain: string,
   expected: readonly string[],
@@ -987,181 +975,6 @@ function cardinalityAwareComparison(
   };
 }
 
-function hasInvalidActiveVolumeReference(args: {
-  readonly declarations: readonly string[] | undefined;
-  readonly volumeNames: ReadonlySet<string>;
-}): boolean {
-  return (args.declarations ?? []).some((declaration) => {
-    const [name, mountPath, extra] = declaration.split(":");
-    return (
-      extra !== undefined ||
-      !name?.trim() ||
-      !mountPath?.trim() ||
-      !args.volumeNames.has(name.trim())
-    );
-  });
-}
-
-function hasLegacyEnvironmentInfluence(
-  environment: Readonly<Record<string, string>> | undefined,
-): boolean {
-  if (!environment) return false;
-  const plan = APPLICATION_OWNED_AGENT_EXECUTION_PLAN.environment;
-  const runtimeOverrideKeys = new Set<string>(plan.runtimeOverrideKeys);
-  return Object.keys(environment).some((key) => {
-    return (
-      !runtimeOverrideKeys.has(key) &&
-      !plan.legacyRemovedPrefixes.some((prefix) => {
-        return key.startsWith(prefix);
-      })
-    );
-  });
-}
-
-type ParsedAgentComposeContent = ReturnType<
-  typeof agentComposeApiContentSchema.parse
->;
-type ParsedAgentDefinition = ParsedAgentComposeContent["agents"][string];
-
-type ValidatedAgentExecutionPlan =
-  | {
-      readonly classification: "exception";
-      readonly dimension: AgentExecutionPlanDimension;
-    }
-  | {
-      readonly classification: "supported";
-      readonly content: ParsedAgentComposeContent;
-      readonly activeAgentName: string;
-      readonly activeAgent: ParsedAgentDefinition;
-    };
-
-function isMissingCurrentPlanHead(
-  row: AgentExecutionPlanInventoryRow,
-): boolean {
-  return (
-    row.headVersionId === null || row.versionId === null || row.content === null
-  );
-}
-
-function hasValidCurrentPlanHash(
-  row: AgentExecutionPlanInventoryRow,
-): row is AgentExecutionPlanInventoryRow & {
-  readonly headVersionId: string;
-  readonly versionId: string;
-  readonly content: Record<string, unknown>;
-} {
-  return (
-    row.versionId !== null &&
-    row.versionId === row.headVersionId &&
-    typeof row.content === "object" &&
-    row.content !== null &&
-    !Array.isArray(row.content) &&
-    computeComposeVersionId(row.content as Record<string, unknown>) ===
-      row.versionId
-  );
-}
-
-function validateAgentExecutionPlanRow(
-  row: AgentExecutionPlanInventoryRow,
-): ValidatedAgentExecutionPlan {
-  if (isMissingCurrentPlanHead(row)) {
-    return {
-      classification: "exception",
-      dimension: "danglingOrMissingHeadVersion",
-    };
-  }
-  if (!hasValidCurrentPlanHash(row)) {
-    return {
-      classification: "exception",
-      dimension: "unsupportedOrInvalidContent",
-    };
-  }
-  const parsed = agentComposeApiContentSchema.safeParse(row.content);
-  if (!parsed.success) {
-    return {
-      classification: "exception",
-      dimension: "unsupportedOrInvalidContent",
-    };
-  }
-  if (!isDeepStrictEqual(row.content, parsed.data)) {
-    // Zod strips unknown object keys. Any such key could acquire runtime
-    // meaning later, so the shadow must not silently call it parity.
-    return { classification: "exception", dimension: "unclassifiedContent" };
-  }
-  const firstEntry = Object.entries(parsed.data.agents)[0];
-  const activeAgentName = firstEntry?.[0];
-  const activeAgent = firstEntry?.[1];
-  if (!activeAgentName || !activeAgent) {
-    return {
-      classification: "exception",
-      dimension: "unsupportedOrInvalidContent",
-    };
-  }
-  if (
-    hasInvalidActiveVolumeReference({
-      declarations: activeAgent.volumes,
-      volumeNames: new Set(Object.keys(parsed.data.volumes ?? {})),
-    })
-  ) {
-    return {
-      classification: "exception",
-      dimension: "unsupportedOrInvalidContent",
-    };
-  }
-  return {
-    classification: "supported",
-    content: parsed.data,
-    activeAgentName,
-    activeAgent,
-  };
-}
-
-function semanticAgentExecutionPlanDimensions(
-  row: AgentExecutionPlanInventoryRow,
-  validated: Extract<
-    ValidatedAgentExecutionPlan,
-    { readonly classification: "supported" }
-  >,
-): Set<AgentExecutionPlanDimension> {
-  const dimensions = new Set<AgentExecutionPlanDimension>();
-  const plan = APPLICATION_OWNED_AGENT_EXECUTION_PLAN;
-  const { activeAgent, activeAgentName, content } = validated;
-  // Selected providers supply the same effective framework to both plans.
-  // Compare only the legacy value that remains capable of acting as fallback.
-  if (activeAgent.framework !== plan.framework.fallback) {
-    dimensions.add("frameworkOrFallbackDifferences");
-  }
-  if (hasLegacyEnvironmentInfluence(activeAgent.environment)) {
-    dimensions.add("systemEnvironmentDifferences");
-  }
-  if (activeAgent.experimental_runner !== undefined) {
-    dimensions.add("runnerGroupPolicyDifferences");
-  }
-  if (
-    activeAgent.experimental_profile !== undefined &&
-    activeAgent.experimental_profile !== plan.runner.profile.fallback
-  ) {
-    dimensions.add("runnerProfilePolicyDifferences");
-  }
-  if (
-    plan.instructions.enabled &&
-    (activeAgent.instructions === undefined ||
-      activeAgentName !== row.agentName)
-  ) {
-    dimensions.add("agentInstructionsMarkerOrMountDifferences");
-  }
-  if (
-    (content.artifacts?.length ?? 0) > 0 ||
-    (activeAgent.volumes?.length ?? 0) > 0
-  ) {
-    dimensions.add("composeArtifactOrVolumeDifferences");
-  }
-  if (activeAgentName !== row.agentName) {
-    dimensions.add("otherLaunchAffectingLegacyFields");
-  }
-  return dimensions;
-}
-
 function dimensionsForAgentExecutionPlanRows(
   rows: readonly AgentExecutionPlanInventoryRow[],
 ): Set<AgentExecutionPlanDimension> {
@@ -1172,11 +985,7 @@ function dimensionsForAgentExecutionPlanRows(
   if (rows.length !== 1 || !row) {
     return new Set(["unclassifiedContent"]);
   }
-  const validated = validateAgentExecutionPlanRow(row);
-  if (validated.classification === "exception") {
-    return new Set([validated.dimension]);
-  }
-  return semanticAgentExecutionPlanDimensions(row, validated);
+  return new Set(classifyAgentExecutionAuthority(row).dimensions);
 }
 
 function classifyAgentExecutionPlans(

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -10,6 +10,7 @@ import {
   buildZeroAgentComposeContent,
   computeComposeVersionId,
 } from "../../../apps/api/src/signals/services/agent-compose-content";
+import { classifyAgentExecutionAuthority } from "../../../apps/api/src/signals/services/agent-execution-authority";
 import { APPLICATION_OWNED_AGENT_EXECUTION_PLAN } from "../../../apps/api/src/signals/services/agent-execution-plan";
 import {
   CATALOG_DEPENDENCY_KINDS,
@@ -798,6 +799,14 @@ function testAgentExecutionPlanClassifications(): void {
     canonical.agentExecutionPlans.dimensionUnionClosure.classification,
     "exact",
   );
+  const canonicalAuthority = classifyAgentExecutionAuthority(
+    executionPlanRow({ id: id(601), agentName: "canonical-agent" }),
+  );
+  assert.deepEqual(canonicalAuthority, {
+    authority: "application",
+    classification: "completeSemanticParity",
+    dimensions: [],
+  });
 
   const injected = mutableAgentContent("injected-agent");
   injected.agents["injected-agent"]!.environment = {
@@ -820,6 +829,16 @@ function testAgentExecutionPlanClassifications(): void {
   assert.equal(
     injectedResult.agentExecutionPlans.completeSemanticParity.count,
     1,
+  );
+  assert.equal(
+    classifyAgentExecutionAuthority(
+      executionPlanRow({
+        id: id(602),
+        agentName: "injected-agent",
+        content: injected,
+      }),
+    ).authority,
+    "application",
   );
 
   const ignoredLegacyFields = mutableAgentContent("ignored-fields-agent");
@@ -854,6 +873,20 @@ function testAgentExecutionPlanClassifications(): void {
   assert.equal(
     environmentResult.agentExecutionPlans.systemEnvironmentDifferences.count,
     1,
+  );
+  assert.deepEqual(
+    classifyAgentExecutionAuthority(
+      executionPlanRow({
+        id: id(604),
+        agentName: "environment-agent",
+        content: environment,
+      }),
+    ),
+    {
+      authority: "version_content",
+      classification: "systemEnvironmentDifferences",
+      dimensions: ["systemEnvironmentDifferences"],
+    },
   );
 
   const framework = mutableAgentContent("framework-agent");
@@ -1015,6 +1048,16 @@ function testAgentExecutionPlanClassifications(): void {
     }),
   ]);
   assert.equal(unknownResult.agentExecutionPlans.unclassifiedContent.count, 1);
+  assert.equal(
+    classifyAgentExecutionAuthority(
+      executionPlanRow({
+        id: id(615),
+        agentName: "unknown-agent",
+        content: unknown,
+      }),
+    ).classification,
+    "unclassifiedContent",
+  );
 
   const dangling = classifyPlanRows([
     executionPlanRow({
@@ -1028,6 +1071,18 @@ function testAgentExecutionPlanClassifications(): void {
   assert.equal(
     dangling.agentExecutionPlans.danglingOrMissingHeadVersion.count,
     1,
+  );
+  assert.equal(
+    classifyAgentExecutionAuthority(
+      executionPlanRow({
+        id: id(616),
+        agentName: "dangling-plan-agent",
+        content: null,
+        headVersionId: "a".repeat(64),
+        versionId: null,
+      }),
+    ).classification,
+    "danglingOrMissingHeadVersion",
   );
   const absent = classifyPlanRows([], [id(617)]);
   assert.equal(
@@ -1106,6 +1161,16 @@ function testAgentExecutionPlanClassifications(): void {
   assert.equal(
     combinedResult.agentExecutionPlans.multiDimensionExceptions.count,
     1,
+  );
+  assert.equal(
+    classifyAgentExecutionAuthority(
+      executionPlanRow({
+        id: id(623),
+        agentName: "combined-agent",
+        content: combined,
+      }),
+    ).classification,
+    "multipleDimensions",
   );
   assert.equal(
     combinedResult.agentExecutionPlans.dimensionUnionClosure.classification,


### PR DESCRIPTION
## Summary

- share the protected fail-closed execution-authority classifier between the consolidation preflight and product-Agent run creation
- regenerate a fresh application-owned Compose projection for complete-parity current heads before any runtime consumer, while retaining the existing read-only legacy projection for every exception
- record bounded authority telemetry on the existing run-context observation without changing public or Runner payloads
- retain exact latest-head `agent_runs.agent_compose_version_id` provenance and the existing immutable launch snapshot

## Authority classifier

The pure classifier receives only the product Agent name plus the exact `headVersionId`, joined version ID, and version content already loaded by Agent resolution. It performs no query and never uses `agent_compose_versions.compose_id` as ownership.

Application authority requires all of the existing protected preflight facts:

- present current head, matching joined version, and a content hash equal to that version ID
- successful exact schema parse with deep equality to the raw JSON, so stripped or unknown material fails closed
- an unambiguous selected Agent whose name equals the product Agent name
- application framework fallback, no surviving legacy environment influence, no runner-group override, and absent/default runner profile
- the application-owned instructions marker/mount invariant
- no active invalid volume reference, Compose artifact/active volume, or other launch-affecting legacy field

The ordered fail-closed dimensions remain exactly:

`danglingOrMissingHeadVersion`, `unsupportedOrInvalidContent`, `frameworkOrFallbackDifferences`, `systemEnvironmentDifferences`, `runnerGroupPolicyDifferences`, `runnerProfilePolicyDifferences`, `agentInstructionsMarkerOrMountDifferences`, `composeArtifactOrVolumeDifferences`, `otherLaunchAffectingLegacyFields`, and `unclassifiedContent`.

Zero dimensions returns `application / completeSemanticParity`; one dimension returns `version_content / <dimension>`; multiple dimensions return `version_content / multipleDimensions`. The protected preflight calls this same function and retains its cardinality, partition, digest, and refinement gates.

For application authority, persisted JSON stops at this classifier and downstream validation, environment, framework, routing/profile, instructions, Storage, stored-context, and Runner-payload consumers receive a freshly generated `buildZeroAgentComposeContent(productAgentName)` projection. Exception authority keeps the exact prior `canonicalOkouComposeContent` path.

## Fallbacks

- `agent-run-create.service.ts:runtimeResolvedCompose` — when a current product-Agent head fails the protected complete-parity classifier, retain the pre-Stage-4B version-content projection or existing deterministic resolution/validation error instead of applying application authority. Surface/window: persisted Agent transition population, not deploy-version skew; bounded to the accepted 913 current exception rows and any protected-gate failure. Removal condition: #26938 Stage 8, only after the protected preflight proves the exception population is retired; tracked by `#27896|legacy-exception-runtime-path|removal-owner:#26938-stage-8`.

## Accepted transition domains

The implementation does not mutate, repair, synthesize, delete, or broaden the accepted 913 exceptions:

- 659 system-environment heads: `version_content / systemEnvironmentDifferences`
- 167 reachable schema-stripped contents: `version_content / unclassifiedContent`
- 70 unsupported or missing-framework contents: `version_content / unsupportedOrInvalidContent` or the existing deterministic launch error
- 17 dangling or missing heads: the existing deterministic resolution error

All other reviewed production dimensions remain zero and continue to fail the protected gate if they grow.

## Safe telemetry schema

Exactly one existing run-context observation for each successful product-Agent launch may add only:

- `agentExecutionAuthority`: `application | version_content`
- `agentExecutionAuthorityClassification`: `completeSemanticParity | <ordered code-defined dimension> | multipleDimensions`

No Agent/run/version ID, name, content, hash, environment key/value, secret, URL, prompt, or error material is added. The existing safe ingestion wrapper keeps telemetry failure observation-only. The public run-context normalizer and Runner payload omit both fields.

## Final caller and overlap inventory

Final base: `d46487f9911378c1ea7dff89c4bc08b3d04f30ee`; final head: `888a07b36e51fa6a7588333629f542a959f5c158`.

The complete paginated inventory immediately before push contained 38 open PRs and 504 `(PR, head, file)` entries; canonical sorted SHA-256: `3c922c5c2c49a70e741ff2ea9311ebae6c00148ab3d07b7d8786e1f9621abe96`.

Current external exact-path overlaps are unmerged:

- #27955 at `4cc6d6adb7e67a4fe424b36a38476d10a5669382`: `run-lifecycle.bdd.test.ts`, `agent-run-create.service.ts`, and `zero-runs-create.service.ts` (bounded catalog-miss removable-work telemetry)
- #27949 at `5d034c72302d3bc34c917a27c3f640f281e35481`: `run-context-snapshot.service.ts` and `zero-runs-create.service.ts` (run-route contract-module rename)
- #27926 at `5e66197a5e52e426b491c9fb819fb3dbb6890280`: consolidation preflight manifest (Slack connect/data filename neutralization)
- #26947 at `aeed157a62dffab0f9275b9afed09bfadae921bd`: `agent-run-create.service.ts` (bounded internal run/callback work)
- #25722 at `2aed1f0de2a54db881ca266151c1362ea6c9dd62`: `agent-run-create.service.ts` (unrelated broad Cloudflare cutover)

#27886 is landed in the final base and its additive `chat-threads-mark-unread.ts` preflight-manifest entry is preserved. #27931 is also landed; the consumer registry preserves its filename-neutralized `teams-connect.service.ts` entries alongside every Stage 4B semantic consumer.

#27870 is already present in the base. The implementation uses `agent-runs.service.ts`, `run-bootstrap-context.service.ts`, and `compose-data.service.ts`; exhaustive regression search found no former service path or compatibility alias.

The production invocation inventory has one product authority caller: `zero-runs-create.service.ts` is the only production site setting `includeZeroTokenSecret: true`, and it supplies the Agent name from its existing query. New and continuation launches both pass through the same latest-head resolver and authority boundary. Direct lower-level/non-product execution leaves `productAgentName` absent and retains prior behavior.

The machine-collected runtime-content inventory is exact: 24 discovery edges and these 14 reviewed production consumers/modes:

- `integrations-slack.ts`: raw recursive variable/secret scan
- `agent-environment-shadow.ts`: Compose-independent environment shadow
- `agent-execution-authority.ts`: application authority classifier
- `agent-instructions.service.ts`: first-plural schema parse
- `agent-run-create.service.ts`: singular-or-first-plural launch
- `agent-run-storage.service.ts`: singular-or-first-plural Storage/volumes
- `logs.service.ts`: first-plural framework display
- `teams-connect.service.ts`: raw recursive variable/secret scan
- `telegram-data.service.ts`: raw recursive variable/secret scan
- `zero-runs-create.service.ts`: head-content selection/type projection
- `contracts/composes.ts`: schema authority
- `contracts/model-providers.ts`: model-provider binding authority
- `contracts/runs.ts`: run-status authority
- `variable-expander.ts`: recursive reference authority

## Transition-removal manifest

- `#27896|agent-execution-authority-classifier-and-helpers|removal-owner:#26938-stage-8`
- `#27896|application-compose-projection-adapter|removal-owner:#26938-stage-8`
- `#27896|legacy-exception-runtime-path|removal-owner:#26938-stage-8`
- `#27896|run-context-authority-telemetry|removal-owner:#26938-stage-8`

## Validation

- `pnpm format` — passed with no changes
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` — passed (13/13)
- `pnpm knip` — passed (configuration hints only)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` — passed (12/12)
- `pnpm --filter @okouai/app run check-types` — passed
- `pnpm --filter api run check-types` — passed, including exact boundaries and test/bootstrap wiring
- protected semantic consumer gate — passed after the final rebase: 24 discovery edges, 14 reviewed consumers, exact manifest equality
- protected static consolidation-preflight validator — passed after the final rebase onto `d46487f9911378c1ea7dff89c4bc08b3d04f30ee`
- focused database-backed lifecycle/read cases were isolated by exact file/name against a locally initialized PostgreSQL 18 cluster, but the runner queue returned a broad baseline `Job not found in queue` 404 before the Stage 4B assertions (125 unrelated lifecycle cases shared the same failure); the PR pipeline remains the supported-environment authority. A package-script forwarding attempt briefly expanded beyond the named file and was stopped immediately when the first unrelated file appeared; no full local suite completed and no development server was started.

## Acceptance self-review

- [x] Complete-parity product Agents receive only a freshly generated application-owned runtime projection after the shared classifier.
- [x] New and continuation paths classify the latest head, persist that exact version ID as temporary provenance, and do not reuse prior Run/checkpoint configuration.
- [x] The 659/167/70/17 exception domains remain behind the explicit prior behavior/error path with bounded telemetry and no mutation.
- [x] Runtime and preflight use one fail-closed classifier; exact partition/digest and semantic-consumer gates remain protected.
- [x] Framework/profile values continue to define the immutable v1 launch snapshot actually sent to the Runner in either mode.
- [x] No checkpoint, public/Runner contract, database/schema/data, canonical Agents table, or non-product execution-service behavior changes.
- [x] Focused coverage exercises canonical and normalized parity, persisted-content replacement, continuation/latest provenance, safe telemetry and redaction, reader/Runner omission, legacy environment behavior, unknown/hash/unsupported/dangling/multi-dimension drift, and protected classifier/preflight equality.
- [x] This is one focused PR with an entirely lowercase conventional title; `/pr-auto` will be invoked in this implementation thread after creation.

Closes #27896

Parent #26938
