### PR TITLE
style(platform): narrow labeled navigation rail

### DIFF
--- a/turbo/apps/platform/src/views/components/avatar.tsx
+++ b/turbo/apps/platform/src/views/components/avatar.tsx
@@ -38,7 +38,10 @@ type ThumbnailSize = keyof typeof THUMBNAIL_SIZE;
 const THUMBNAIL_BASE = "shrink-0 zero-thumb-border";
 
 /**
- * A person: always a circle, so it never reads as a workspace or an app icon.
+ * A person: a circle by default, so it never reads as a workspace or an app
+ * icon. The labeled navigation rail asks for `square` instead: there the
+ * account mark sits directly under the workspace logo in a column of rounded
+ * squares, and matching that shape is what keeps the column reading as a grid.
  * Falls back to the name's initial when the account has no picture.
  */
 export function UserAvatar({
@@ -46,13 +49,19 @@ export function UserAvatar({
   name,
   initial,
   size = "md",
+  shape = "circle",
 }: {
   imageUrl: string | null | undefined;
   name: string;
   initial: string;
   size?: ThumbnailSize;
+  shape?: "circle" | "square";
 }) {
-  const base = cn(THUMBNAIL_BASE, THUMBNAIL_SIZE[size], "rounded-full");
+  const base = cn(
+    THUMBNAIL_BASE,
+    THUMBNAIL_SIZE[size],
+    shape === "square" ? THUMBNAIL_RADIUS[size] : "rounded-full",
+  );
 
   if (imageUrl) {
     return (

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -219,6 +219,7 @@ function renderAccountTrigger(
   display: AccountDisplay,
   collapsed: boolean,
   realtimeIndicator: ZeroDebugRealtimeIndicator,
+  avatarShape: "circle" | "square",
 ) {
   if (collapsed) {
     return (
@@ -233,6 +234,7 @@ function renderAccountTrigger(
           name={display.name}
           initial={display.initial}
           size="sm"
+          shape={avatarShape}
         />
       </Button>
     );
@@ -249,6 +251,7 @@ function renderAccountTrigger(
         name={display.name}
         initial={display.initial}
         size="sm"
+        shape={avatarShape}
       />
       <span className="min-w-0 flex-1 text-left text-sm font-medium leading-tight truncate">
         {display.name}
@@ -860,6 +863,12 @@ export function AccountDropdown({
     features?.[FeatureSwitchKey.SidebarSubscriptionUsage] ?? false;
   const usagePackPlansEnabled =
     features?.[FeatureSwitchKey.UsagePackPlans] ?? false;
+  // The three-column nav stacks the account mark under the workspace logo, so
+  // it takes the same rounded square there and stays a circle everywhere else.
+  const avatarShape =
+    (features?.[FeatureSwitchKey.ThreeColumnNav] ?? false)
+      ? "square"
+      : "circle";
   const realtimeIndicator = useGet(zeroDebugRealtimeIndicator$);
   const openSettings = useSet(openSettingsDialogAt$);
   const setPendingSettingsSection = useSet(
@@ -1005,7 +1014,12 @@ export function AccountDropdown({
     <>
       <DropdownMenu onOpenChange={handleMenuOpenChange}>
         <DropdownMenuTrigger asChild>
-          {renderAccountTrigger(accountDisplay, collapsed, realtimeIndicator)}
+          {renderAccountTrigger(
+            accountDisplay,
+            collapsed,
+            realtimeIndicator,
+            avatarShape,
+          )}
         </DropdownMenuTrigger>
 
         <DropdownMenuContent

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -634,7 +634,7 @@ function LabeledRailLink({
       className="group flex w-full flex-col items-center gap-1 no-underline"
     >
       <span
-        className={`relative inline-flex h-9 w-10 items-center justify-center rounded-xl transition-colors duration-200 ${
+        className={`relative inline-flex h-8 w-9 items-center justify-center rounded-md transition-colors duration-200 ${
           isActive
             ? "bg-state-selected text-sidebar-foreground"
             : "text-sidebar-foreground group-hover:bg-state-hover"
@@ -658,10 +658,8 @@ function LabeledRailLink({
         )}
       </span>
       <span
-        className={`text-[10px] leading-none ${
-          isActive
-            ? "font-semibold text-sidebar-foreground"
-            : "text-sidebar-foreground/60"
+        className={`max-w-full truncate px-0.5 text-[9px] font-medium leading-none ${
+          isActive ? "text-sidebar-foreground" : "text-sidebar-foreground/60"
         }`}
       >
         {caption}
@@ -699,7 +697,7 @@ function LabeledNavRail() {
   return (
     <aside
       data-testid="labeled-nav-rail"
-      className="zero-nav hidden md:flex h-full w-16 shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar px-1.5 pb-2 pt-3"
+      className="zero-nav hidden md:flex h-full w-[68px] shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar px-1.5 pb-2 pt-3"
     >
       <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
       <div className="mb-3 shrink-0">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -634,7 +634,7 @@ function LabeledRailLink({
       className="group flex w-full flex-col items-center gap-1 no-underline"
     >
       <span
-        className={`relative inline-flex h-8 w-9 items-center justify-center rounded-md transition-colors duration-200 ${
+        className={`relative inline-flex h-8 w-9 items-center justify-center rounded-lg transition-colors duration-200 ${
           isActive
             ? "bg-state-selected text-sidebar-foreground"
             : "text-sidebar-foreground hover:bg-state-hover group-hover:bg-state-hover"

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -637,7 +637,7 @@ function LabeledRailLink({
         className={`relative inline-flex h-8 w-9 items-center justify-center rounded-md transition-colors duration-200 ${
           isActive
             ? "bg-state-selected text-sidebar-foreground"
-            : "text-sidebar-foreground group-hover:bg-state-hover"
+            : "text-sidebar-foreground hover:bg-state-hover group-hover:bg-state-hover"
         }`}
       >
         {iconImg ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -699,7 +699,7 @@ function LabeledNavRail() {
   return (
     <aside
       data-testid="labeled-nav-rail"
-      className="zero-nav hidden md:flex h-full w-[76px] shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar px-1.5 pb-2 pt-3"
+      className="zero-nav hidden md:flex h-full w-16 shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar px-1.5 pb-2 pt-3"
     >
       <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
       <div className="mb-3 shrink-0">


### PR DESCRIPTION
## Summary

- narrow the three-column labeled navigation rail from 76px to 68px
- resize the nav item block to 36x32 with an 8px corner radius, and set the caption to 9px medium
- restore the hover state layer on non-selected rail items
- render the account mark in the rail as a rounded square so it matches the workspace logo above it; `UserAvatar` gains a `shape` prop and stays circular for every other caller

## Verification

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar` (87 tests passed)
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-account-menu` (26 tests passed)
- Visual walkthrough on the PR preview (`pr-27909-app.omby.ai`) against a main-baseline preview: rail 68px, selected block 36x32 at 8px radius, caption 9px/500, hover state layer paints at the same radius, and both identity marks measure 24x24 at 6px radius

Local dev server was not started per repo guidance.
