### PR TITLE
test(python): exhaustively cover shared http header syntax

### DIFF
--- a/crates/runner/mitm-addon/tests/test_http_header_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_http_header_syntax.py
@@ -1,0 +1,91 @@
+"""Shared HTTP header syntax contract tests.
+
+Exhaustively classify every ASCII code point against the RFC tchar set and
+the header-value control-character rule using an independent reference, so a
+regression in the shared predicates fails the suite.
+"""
+
+import pytest
+
+import http_header_syntax
+
+# RFC 9110 tchar: "!#$%&'*+-.^_`|~" plus ASCII digits and letters. Deliberately
+# independent of http_header_syntax._HTTP_TOKEN_CHARS so mutations are caught.
+_TCHAR = frozenset("!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+_ASCII_CODE_POINTS = range(128)
+
+
+def _is_forbidden_value_control(char: str) -> bool:
+    code_point = ord(char)
+    return (code_point <= 0x1F and char != "\t") or code_point == 0x7F
+
+
+@pytest.mark.parametrize("char", [chr(code_point) for code_point in _ASCII_CODE_POINTS])
+def test_is_http_header_name_classifies_every_ascii_code_point(char: str) -> None:
+    assert http_header_syntax.is_http_header_name(char) == (char in _TCHAR)
+
+
+@pytest.mark.parametrize("char", [chr(code_point) for code_point in _ASCII_CODE_POINTS])
+def test_has_forbidden_header_value_control_classifies_every_ascii_code_point(
+    char: str,
+) -> None:
+    assert http_header_syntax.has_forbidden_header_value_control(
+        char
+    ) == _is_forbidden_value_control(char)
+
+
+def test_is_http_header_name_rejects_empty_name() -> None:
+    assert http_header_syntax.is_http_header_name("") is False
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("X|Trace", id="uncommon-tchar-pipe"),
+        pytest.param("x-amz-date", id="common-token-name"),
+    ],
+)
+def test_is_http_header_name_accepts_multi_char_tchar_names(name: str) -> None:
+    assert http_header_syntax.is_http_header_name(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("x y", id="embedded-space"),
+        pytest.param("x:y", id="colon"),
+        pytest.param("x\ny", id="newline"),
+        pytest.param("x\x00y", id="nul"),
+        pytest.param("\u00e9", id="non-ascii"),
+    ],
+)
+def test_is_http_header_name_rejects_multi_char_invalid_names(name: str) -> None:
+    assert http_header_syntax.is_http_header_name(name) is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("a\t b", id="tab-and-space-allowed"),
+        pytest.param("plain value", id="printable"),
+    ],
+)
+def test_has_forbidden_header_value_control_accepts_legal_values(value: str) -> None:
+    assert http_header_syntax.has_forbidden_header_value_control(value) is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("a\n b", id="newline"),
+        pytest.param("a\r b", id="carriage-return"),
+        pytest.param("a\x00b", id="nul"),
+        pytest.param("a\x7fb", id="delete"),
+    ],
+)
+def test_has_forbidden_header_value_control_rejects_control_values(value: str) -> None:
+    assert http_header_syntax.has_forbidden_header_value_control(value) is True
+
+
+def test_has_forbidden_header_value_control_accepts_non_ascii_value() -> None:
+    assert http_header_syntax.has_forbidden_header_value_control("\u00e9") is False


### PR DESCRIPTION
## Summary

Adds direct, exhaustive tests for the shared HTTP header syntax predicates in
`crates/runner/mitm-addon/src/http_header_syntax.py`:

- `is_http_header_name` — every ASCII code point is classified against the RFC `tchar` set, and
  the empty name is rejected.
- `has_forbidden_header_value_control` — every ASCII code point is classified against the
  C0/HTAB/printable/DEL rule.
- Multi-character boundary cases pin uncommon valid punctuation (`X|Trace`) and representative
  forbidden values.

The reference sets are written independently in the test and deliberately do not import the
implementation constants, so regressions such as removing `|` from the token set or admitting a C0
control other than HTAB now fail the suite. Existing caller-level AWS SigV4 and resolved-auth
coverage is unchanged.

Closes #27903

## Validation

Run from `crates/runner/mitm-addon`:

- `uv lock --check`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 6306 passed
- Mutation check: removing `|` from `_HTTP_TOKEN_CHARS` and exempting `\x01` from the value-control
  rule each fail the new tests (3 failed, 268 passed under mutation).
