### PR TITLE
test(python): exhaustively cover shared http header syntax

### DIFF
--- a/crates/runner/mitm-addon/tests/test_http_header_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_http_header_syntax.py
@@ -1,0 +1,57 @@
+"""Protocol contract for shared HTTP header syntax predicates."""
+
+import string
+
+import pytest
+
+import http_header_syntax
+
+_HTTP_TCHARS = frozenset(string.ascii_letters + string.digits + "!#$%&'*+-.^_`|~")
+
+
+@pytest.mark.parametrize("code_point", range(0x80))
+def test_http_header_name_classifies_ascii(code_point: int) -> None:
+    char = chr(code_point)
+
+    assert http_header_syntax.is_http_header_name(char) is (char in _HTTP_TCHARS)
+
+
+def test_http_header_name_rejects_empty_name() -> None:
+    assert http_header_syntax.is_http_header_name("") is False
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("X|Trace", True, id="uncommon-valid-punctuation"),
+        pytest.param("x other", False, id="embedded-space"),
+        pytest.param("x:other", False, id="embedded-colon"),
+        pytest.param("x\nother", False, id="embedded-control"),
+        pytest.param("é", False, id="non-ascii"),
+    ],
+)
+def test_http_header_name_classifies_strings(value: str, expected: bool) -> None:
+    assert http_header_syntax.is_http_header_name(value) is expected
+
+
+@pytest.mark.parametrize("code_point", range(0x80))
+def test_header_value_control_classifies_ascii(code_point: int) -> None:
+    char = chr(code_point)
+    expected = (code_point <= 0x1F and char != "\t") or code_point == 0x7F
+
+    assert http_header_syntax.has_forbidden_header_value_control(char) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("a\t b", False, id="horizontal-tab"),
+        pytest.param("a\n b", True, id="line-feed"),
+        pytest.param("a\r b", True, id="carriage-return"),
+        pytest.param("a\x00b", True, id="null"),
+        pytest.param("a\x7fb", True, id="delete"),
+        pytest.param("café", False, id="non-ascii"),
+    ],
+)
+def test_header_value_control_classifies_strings(value: str, expected: bool) -> None:
+    assert http_header_syntax.has_forbidden_header_value_control(value) is expected

--- a/crates/runner/mitm-addon/tests/test_http_header_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_http_header_syntax.py
@@ -7,6 +7,9 @@ import pytest
 import http_header_syntax
 
 _HTTP_TCHARS = frozenset(string.ascii_letters + string.digits + "!#$%&'*+-.^_`|~")
+_ALLOWED_ASCII_HEADER_VALUE_CHARS = frozenset(
+    chr(code_point) for code_point in range(0x20, 0x7F)
+) | {"\t"}
 
 
 @pytest.mark.parametrize("code_point", range(0x80))
@@ -37,9 +40,10 @@ def test_http_header_name_classifies_strings(value: str, expected: bool) -> None
 @pytest.mark.parametrize("code_point", range(0x80))
 def test_header_value_control_classifies_ascii(code_point: int) -> None:
     char = chr(code_point)
-    expected = (code_point <= 0x1F and char != "\t") or code_point == 0x7F
 
-    assert http_header_syntax.has_forbidden_header_value_control(char) is expected
+    assert http_header_syntax.has_forbidden_header_value_control(char) is (
+        char not in _ALLOWED_ASCII_HEADER_VALUE_CHARS
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- classify every ASCII code point against a test-owned HTTP `tchar` reference
- pin C0, HTAB, printable ASCII, and DEL handling for header values
- cover empty and multi-character header-name/value composition cases

## Exclusions

- no production-code or runtime behavior changes
- no changes to existing AWS SigV4 or resolved-auth caller coverage

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_http_header_syntax.py` (268 passed)
- `uv run --no-sync python -m pytest tests/` (6269 passed)

Closes #27903
