### PR TITLE
feat: render thinking blocks inline in chat

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1377,13 +1377,7 @@ function lastRunThinkingEvent(
   if (!lastEvent || !isThinkingMarkerSemanticEvent(lastEvent)) {
     return undefined;
   }
-  const runId = lastEvent.event.runId;
-  const runHasAssistantText = events.some((entry) => {
-    return (
-      entry.event.runId === runId && isRenderableAssistantSemanticEvent(entry)
-    );
-  });
-  return runHasAssistantText ? undefined : lastEvent;
+  return lastEvent;
 }
 
 interface ThinkingIndicatorProjection {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1369,6 +1369,7 @@ function isThinkingMarkerSemanticEvent(entry: SemanticChatEvent): boolean {
 
 function lastRunThinkingEvent(
   groups: readonly SemanticChatEventGroup[],
+  inlineThinkingBlocksEnabled: boolean,
 ): SemanticChatEvent | undefined {
   const events = groups.flatMap((group) => {
     return group.events;
@@ -1376,6 +1377,17 @@ function lastRunThinkingEvent(
   const lastEvent = events.at(-1);
   if (!lastEvent || !isThinkingMarkerSemanticEvent(lastEvent)) {
     return undefined;
+  }
+  if (!inlineThinkingBlocksEnabled) {
+    const runId = lastEvent.event.runId;
+    const runHasAssistantText = events.some((entry) => {
+      return (
+        entry.event.runId === runId && isRenderableAssistantSemanticEvent(entry)
+      );
+    });
+    if (runHasAssistantText) {
+      return undefined;
+    }
   }
   return lastEvent;
 }
@@ -1440,6 +1452,7 @@ function resolveThinkingIndicatorMode({
 function thinkingIndicatorProjectionFromGroups(
   groups: SemanticChatGroups,
   runState: RunIndicatorState,
+  inlineThinkingBlocksEnabled: boolean,
 ): ThinkingIndicatorProjection {
   const { activeGroups } = groups;
   const lastGroup = activeGroups.at(-1);
@@ -1450,7 +1463,10 @@ function thinkingIndicatorProjectionFromGroups(
   const lastAssistantEvent = lastIsAssistant
     ? lastGroup.events.at(-1)?.event
     : undefined;
-  const rawThinkingEvent = lastRunThinkingEvent(activeGroups);
+  const rawThinkingEvent = lastRunThinkingEvent(
+    activeGroups,
+    inlineThinkingBlocksEnabled,
+  );
   const lastAssistantOnlyThinking = assistantGroupOnlyHasThinking(
     lastGroup,
     rawThinkingEvent,
@@ -1550,6 +1566,7 @@ function createEventSemanticSignals(
       return thinkingIndicatorProjectionFromGroups(
         get(semanticGroups$),
         runState,
+        get(featureSwitch$)[FeatureSwitchKey.ChatInlineThinkingBlocks] ?? false,
       );
     },
   );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
@@ -1020,13 +1020,24 @@ describe("initial thinking indicator", () => {
     });
 
     await screen.findByText("Here is the checklist.");
+    const thinkingLabel = screen.getByText("Thinking");
     const thinkingContent = screen.getAllByText("Reviewing your request");
     expect(thinkingContent).toHaveLength(2);
-    const thinkingBlock = thinkingContent[0]?.closest("details");
-    expect(thinkingBlock).toHaveAttribute("data-thinking-block");
-    expect(thinkingBlock).not.toHaveAttribute("open");
-    expect(
-      document.querySelector("[data-thinking-indicator]"),
-    ).toBeInTheDocument();
+    const [thinkingPreview, thinkingBody] = thinkingContent;
+    if (!thinkingPreview || !thinkingBody) {
+      throw new Error("Inline thinking copy was not rendered");
+    }
+    expect(thinkingPreview).toBeVisible();
+    expect(thinkingBody).not.toBeVisible();
+    const runningLabel = screen.getAllByText(
+      /^(Assembling|Brewing|Mapping|On it|Piecing|Shaping|Sketching|Spinning|Tuning|Wiring)/,
+    )[0];
+    if (!runningLabel) {
+      throw new Error("Running thinking label was not rendered");
+    }
+    expect(runningLabel).toBeVisible();
+
+    click(thinkingLabel);
+    expect(thinkingBody).toBeVisible();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
@@ -1014,6 +1014,9 @@ describe("initial thinking indicator", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatInlineThinkingBlocks]: true,
+      },
     });
 
     await screen.findByText("Here is the checklist.");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx
@@ -980,7 +980,7 @@ describe("initial thinking indicator", () => {
     });
   });
 
-  it("hides the thinking marker when the same run has assistant text", async () => {
+  it("keeps the thinking block inline when the same run has assistant text", async () => {
     const threadId = "e1000000-0000-4000-a000-000000000018";
     mockChatLifecycle(context, {
       threadId,
@@ -1017,8 +1017,13 @@ describe("initial thinking indicator", () => {
     });
 
     await screen.findByText("Here is the checklist.");
+    const thinkingContent = screen.getAllByText("Reviewing your request");
+    expect(thinkingContent).toHaveLength(2);
+    const thinkingBlock = thinkingContent[0]?.closest("details");
+    expect(thinkingBlock).toHaveAttribute("data-thinking-block");
+    expect(thinkingBlock).not.toHaveAttribute("open");
     expect(
-      screen.queryByText("Reviewing your request"),
-    ).not.toBeInTheDocument();
+      document.querySelector("[data-thinking-indicator]"),
+    ).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -1635,6 +1635,9 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/e7000000-0000-4000-a000-000000000018",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatInlineThinkingBlocks]: true,
+      },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -1605,7 +1605,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("does not fold a completed run when the only prior assistant message is thinking", async () => {
+  it("folds a completed run when the only prior assistant message is thinking", async () => {
     mockChatLifecycle(context, {
       threadId: "e7000000-0000-4000-a000-000000000018",
       chatEvents: [
@@ -1641,12 +1641,19 @@ describe("chat lifecycle", () => {
       expect(
         screen.getByText("Summarize the launch status"),
       ).toBeInTheDocument();
+      expect(screen.getByText("Launch status is ready.")).toBeInTheDocument();
+      expect(document.querySelector("[data-thinking-block]")).toBeNull();
+      expect(screen.getByLabelText("Expand work history")).toHaveTextContent(
+        "Worked for 5s",
+      );
+    });
+
+    click(screen.getByLabelText("Expand work history"));
+
+    await waitFor(() => {
       expect(document.querySelector("[data-thinking-block]")).toHaveTextContent(
         "Reviewing launch context",
       );
-      expect(screen.getByText("Launch status is ready.")).toBeInTheDocument();
-      expect(screen.queryByText("Worked for 5s")).not.toBeInTheDocument();
-      expect(screen.queryByLabelText("Expand work history")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -1645,7 +1645,7 @@ describe("chat lifecycle", () => {
         screen.getByText("Summarize the launch status"),
       ).toBeInTheDocument();
       expect(screen.getByText("Launch status is ready.")).toBeInTheDocument();
-      expect(document.querySelector("[data-thinking-block]")).toBeNull();
+      expect(screen.queryByText("Reviewing launch context")).toBeNull();
       expect(screen.getByLabelText("Expand work history")).toHaveTextContent(
         "Worked for 5s",
       );
@@ -1654,9 +1654,15 @@ describe("chat lifecycle", () => {
     click(screen.getByLabelText("Expand work history"));
 
     await waitFor(() => {
-      expect(document.querySelector("[data-thinking-block]")).toHaveTextContent(
-        "Reviewing launch context",
-      );
+      const thinkingSummary = screen
+        .getAllByText("Reviewing launch context")
+        .map((candidate) => {
+          return candidate.closest("summary");
+        })
+        .find((summary): summary is HTMLElement => {
+          return summary instanceof HTMLElement;
+        });
+      expect(thinkingSummary).toBeVisible();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-results.test.tsx
@@ -1641,6 +1641,9 @@ describe("chat lifecycle", () => {
       expect(
         screen.getByText("Summarize the launch status"),
       ).toBeInTheDocument();
+      expect(document.querySelector("[data-thinking-block]")).toHaveTextContent(
+        "Reviewing launch context",
+      );
       expect(screen.getByText("Launch status is ready.")).toBeInTheDocument();
       expect(screen.queryByText("Worked for 5s")).not.toBeInTheDocument();
       expect(screen.queryByLabelText("Expand work history")).toBeNull();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
@@ -9,6 +9,35 @@ const THREAD_ID = "b0000000-0000-4000-a000-000000000211";
 const RUN_ID = "run-inline-thinking-blocks";
 const COMPLETED_THREAD_ID = "b0000000-0000-4000-a000-000000000212";
 const COMPLETED_RUN_ID = "run-completed-inline-thinking-blocks";
+
+function thinkingSummaries(): HTMLElement[] {
+  const summaries = screen
+    .getAllByText("Thinking")
+    .map((label) => {
+      return label.closest("summary");
+    })
+    .filter((summary): summary is HTMLElement => {
+      return summary instanceof HTMLElement;
+    });
+
+  return [...new Set(summaries)];
+}
+
+function thinkingContent(text: string): HTMLElement {
+  const content = screen.getAllByText(text).find((candidate) => {
+    return candidate.closest("summary") === null;
+  });
+  if (!content) {
+    throw new Error(`Expanded thinking copy was not rendered: ${text}`);
+  }
+  return content;
+}
+
+function expectBefore(before: HTMLElement, after: HTMLElement): void {
+  expect(
+    before.compareDocumentPosition(after) & Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+}
 
 describe("chat thinking blocks", () => {
   it("keeps thinking events in transcript order with independent open states", async () => {
@@ -70,79 +99,33 @@ describe("chat thinking blocks", () => {
     const messageTwo = screen.getByText(
       "The strongest split is second-workflow activation.",
     );
-    const thinkingBlocks = await waitFor(() => {
-      const blocks = document.querySelectorAll<HTMLDetailsElement>(
-        "[data-thinking-block]",
-      );
-      expect(blocks).toHaveLength(2);
-      return blocks;
-    });
-
-    const firstThinking = thinkingBlocks[0];
-    const secondThinking = thinkingBlocks[1];
-    if (!firstThinking || !secondThinking) {
-      throw new Error("Thinking blocks were not rendered");
-    }
-    expect(
-      firstThinking.compareDocumentPosition(messageOne) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      messageOne.compareDocumentPosition(messageTwo) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      messageTwo.compareDocumentPosition(secondThinking) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-
-    expect(firstThinking.open).toBeFalsy();
-    expect(secondThinking.open).toBeTruthy();
-    const firstSummary = firstThinking.querySelector("summary");
-    const secondSummary = secondThinking.querySelector("summary");
+    const summaries = thinkingSummaries();
+    expect(summaries).toHaveLength(2);
+    const firstSummary = summaries[0];
+    const secondSummary = summaries[1];
     if (!firstSummary || !secondSummary) {
       throw new Error("Thinking block summaries were not rendered");
     }
-    const firstContent = firstThinking.querySelector(
-      "[data-thinking-block-content]",
+    const firstContent = thinkingContent(
+      "Comparing retained and churned trial cohorts.",
     );
-    expect(firstThinking.parentElement).toHaveClass("-mx-2");
-    expect(firstSummary).toHaveClass(
-      "inline-flex",
-      "px-2",
-      "hover:bg-state-hover",
+    const secondContent = thinkingContent(
+      "Checking whether collaboration changes the result.",
     );
-    expect(firstSummary).not.toHaveClass("w-full", "group-open:bg-muted/50");
-    const firstIcon = firstSummary.querySelector("[data-thinking-block-icon]");
-    const secondIcon = secondSummary.querySelector(
-      "[data-thinking-block-icon]",
-    );
-    expect(firstIcon).toHaveClass(
-      "inline-flex",
-      "size-3.5",
-      "items-center",
-      "justify-center",
-    );
-    expect(firstIcon?.querySelector("svg")).toHaveClass("-translate-y-px");
-    expect(secondIcon).toHaveClass(
-      "inline-flex",
-      "size-3.5",
-      "items-center",
-      "justify-center",
-    );
-    expect(firstContent).toHaveClass(
-      "text-muted-foreground/80",
-      "[&_.wmde-markdown]:!text-muted-foreground/80",
-    );
-    expect(firstContent).not.toHaveClass("bg-muted/50");
+
+    expectBefore(firstSummary, messageOne);
+    expectBefore(messageOne, messageTwo);
+    expectBefore(messageTwo, secondSummary);
+    expect(firstContent).not.toBeVisible();
+    expect(secondContent).toBeVisible();
 
     await user.click(firstSummary);
-    expect(firstThinking.open).toBeTruthy();
-    expect(secondThinking.open).toBeTruthy();
+    expect(firstContent).toBeVisible();
+    expect(secondContent).toBeVisible();
 
     await user.click(secondSummary);
-    expect(firstThinking.open).toBeTruthy();
-    expect(secondThinking.open).toBeFalsy();
+    expect(firstContent).toBeVisible();
+    expect(secondContent).not.toBeVisible();
   });
 
   it("folds completed thinking and intermediate messages behind the final result", async () => {
@@ -218,19 +201,20 @@ describe("chat thinking blocks", () => {
     expect(
       screen.queryByText("The enterprise cohort leads the increase."),
     ).toBeNull();
-    expect(document.querySelectorAll("[data-thinking-block]")).toHaveLength(0);
+    expect(
+      screen.queryByText("Comparing expansion by customer cohort."),
+    ).toBeNull();
+    expect(
+      screen.queryByText("Checking whether seat growth explains the result."),
+    ).toBeNull();
 
     await user.click(expandButton);
+    await screen.findAllByText("Comparing expansion by customer cohort.");
 
-    const thinkingBlocks = await waitFor(() => {
-      const blocks = document.querySelectorAll<HTMLDetailsElement>(
-        "[data-thinking-block]",
-      );
-      expect(blocks).toHaveLength(2);
-      return blocks;
-    });
-    const firstThinking = thinkingBlocks[0];
-    const secondThinking = thinkingBlocks[1];
+    const summaries = thinkingSummaries();
+    expect(summaries).toHaveLength(2);
+    const firstSummary = summaries[0];
+    const secondSummary = summaries[1];
     const messageOne = screen.getByText("I loaded the expansion records.");
     const messageTwo = screen.getByText(
       "The enterprise cohort leads the increase.",
@@ -238,40 +222,30 @@ describe("chat thinking blocks", () => {
     const result = screen.getByText(
       "Expansion revenue grew 18%, led by enterprise accounts.",
     );
-    if (!firstThinking || !secondThinking) {
-      throw new Error("Completed thinking blocks were not rendered");
-    }
-    expect(
-      firstThinking.compareDocumentPosition(messageOne) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      messageOne.compareDocumentPosition(messageTwo) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      messageTwo.compareDocumentPosition(secondThinking) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      secondThinking.compareDocumentPosition(result) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(firstThinking.open).toBeFalsy();
-    expect(secondThinking.open).toBeFalsy();
-
-    const firstSummary = firstThinking.querySelector("summary");
-    const secondSummary = secondThinking.querySelector("summary");
     if (!firstSummary || !secondSummary) {
       throw new Error("Completed thinking summaries were not rendered");
     }
+    const firstContent = thinkingContent(
+      "Comparing expansion by customer cohort.",
+    );
+    const secondContent = thinkingContent(
+      "Checking whether seat growth explains the result.",
+    );
+
+    expectBefore(firstSummary, messageOne);
+    expectBefore(messageOne, messageTwo);
+    expectBefore(messageTwo, secondSummary);
+    expectBefore(secondSummary, result);
+    expect(firstContent).not.toBeVisible();
+    expect(secondContent).not.toBeVisible();
+
     await user.click(firstSummary);
-    expect(firstThinking.open).toBeTruthy();
-    expect(secondThinking.open).toBeFalsy();
+    expect(firstContent).toBeVisible();
+    expect(secondContent).not.toBeVisible();
 
     await user.click(secondSummary);
-    expect(firstThinking.open).toBeTruthy();
-    expect(secondThinking.open).toBeTruthy();
+    expect(firstContent).toBeVisible();
+    expect(secondContent).toBeVisible();
   });
 
   it("keeps thinking events on the legacy presentation while the switch is off", async () => {
@@ -315,9 +289,57 @@ describe("chat thinking blocks", () => {
     });
 
     await screen.findByText("Here is the account summary.");
-    expect(document.querySelector("[data-thinking-block]")).toBeNull();
     expect(
       screen.queryByText("This thought stays out of the transcript."),
     ).toBeNull();
+  });
+
+  it("keeps completed thinking history on the legacy presentation while the switch is off", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000214";
+    const runId = "run-completed-legacy-thinking-presentation";
+    mockChatLifecycle(context, {
+      threadId,
+      chatEvents: [
+        {
+          id: "msg-completed-legacy-thinking-user",
+          role: "user",
+          content: "Summarize the legacy account",
+          runId,
+          createdAt: "2026-08-18T10:00:00Z",
+        },
+        {
+          id: "msg-completed-legacy-thinking-marker",
+          role: "assistant",
+          content: null,
+          thinking: "This completed thought stays out of the transcript.",
+          runId,
+          createdAt: "2026-08-18T10:00:01Z",
+        },
+        {
+          id: "msg-completed-legacy-thinking-result",
+          role: "assistant",
+          content: "Here is the completed legacy account summary.",
+          runId,
+          runLifecycleEvent: "completed",
+          createdAt: "2026-08-18T10:00:05Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatInlineThinkingBlocks]: false,
+      },
+    });
+
+    await screen.findByText("Here is the completed legacy account summary.");
+    expect(screen.getByText("Summarize the legacy account")).toBeVisible();
+    expect(
+      screen.queryByText("This completed thought stays out of the transcript."),
+    ).toBeNull();
+    expect(screen.queryByLabelText("Expand work history")).toBeNull();
+    expect(screen.queryByText("Worked for 5s")).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
@@ -1,0 +1,109 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { context, detachedSetupPage } from "./chat-lifecycle-test-helpers.ts";
+import { mockChatLifecycle } from "./chat-test-helpers.ts";
+
+const THREAD_ID = "b0000000-0000-4000-a000-000000000211";
+const RUN_ID = "run-inline-thinking-blocks";
+
+describe("chat thinking blocks", () => {
+  it("keeps thinking events in transcript order with independent open states", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      activeRunIds: [RUN_ID],
+      chatEvents: [
+        {
+          id: "msg-inline-thinking-user",
+          role: "user",
+          content: "Analyze trial retention",
+          runId: RUN_ID,
+          createdAt: "2026-08-18T10:00:00Z",
+        },
+        {
+          id: "msg-inline-thinking-first",
+          role: "assistant",
+          content: null,
+          thinking: "Comparing retained and churned trial cohorts.",
+          runId: RUN_ID,
+          createdAt: "2026-08-18T10:00:01Z",
+        },
+        {
+          id: "msg-inline-thinking-message-one",
+          role: "assistant",
+          content: "I loaded the trial accounts.",
+          runId: RUN_ID,
+          createdAt: "2026-08-18T10:00:02Z",
+        },
+        {
+          id: "msg-inline-thinking-message-two",
+          role: "assistant",
+          content: "The strongest split is second-workflow activation.",
+          runId: RUN_ID,
+          createdAt: "2026-08-18T10:00:03Z",
+        },
+        {
+          id: "msg-inline-thinking-second",
+          role: "assistant",
+          content: null,
+          thinking: "Checking whether collaboration changes the result.",
+          runId: RUN_ID,
+          createdAt: "2026-08-18T10:00:04Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    await screen.findByText("I loaded the trial accounts.");
+    const messageOne = screen.getByText("I loaded the trial accounts.");
+    const messageTwo = screen.getByText(
+      "The strongest split is second-workflow activation.",
+    );
+    const thinkingBlocks = await waitFor(() => {
+      const blocks = document.querySelectorAll<HTMLDetailsElement>(
+        "[data-thinking-block]",
+      );
+      expect(blocks).toHaveLength(2);
+      return blocks;
+    });
+
+    const firstThinking = thinkingBlocks[0];
+    const secondThinking = thinkingBlocks[1];
+    if (!firstThinking || !secondThinking) {
+      throw new Error("Thinking blocks were not rendered");
+    }
+    expect(
+      firstThinking.compareDocumentPosition(messageOne) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      messageOne.compareDocumentPosition(messageTwo) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      messageTwo.compareDocumentPosition(secondThinking) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    expect(firstThinking.open).toBeFalsy();
+    expect(secondThinking.open).toBeTruthy();
+    const firstSummary = firstThinking.querySelector("summary");
+    const secondSummary = secondThinking.querySelector("summary");
+    if (!firstSummary || !secondSummary) {
+      throw new Error("Thinking block summaries were not rendered");
+    }
+
+    await user.click(firstSummary);
+    expect(firstThinking.open).toBeTruthy();
+    expect(secondThinking.open).toBeTruthy();
+
+    await user.click(secondSummary);
+    expect(firstThinking.open).toBeTruthy();
+    expect(secondThinking.open).toBeFalsy();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
@@ -6,6 +6,8 @@ import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
 const THREAD_ID = "b0000000-0000-4000-a000-000000000211";
 const RUN_ID = "run-inline-thinking-blocks";
+const COMPLETED_THREAD_ID = "b0000000-0000-4000-a000-000000000212";
+const COMPLETED_RUN_ID = "run-completed-inline-thinking-blocks";
 
 describe("chat thinking blocks", () => {
   it("keeps thinking events in transcript order with independent open states", async () => {
@@ -97,6 +99,18 @@ describe("chat thinking blocks", () => {
     if (!firstSummary || !secondSummary) {
       throw new Error("Thinking block summaries were not rendered");
     }
+    const firstContent = firstThinking.querySelector(
+      "[data-thinking-block-content]",
+    );
+    expect(firstThinking.parentElement).toHaveClass("-mx-2");
+    expect(firstSummary).toHaveClass(
+      "inline-flex",
+      "px-2",
+      "hover:bg-state-hover",
+    );
+    expect(firstSummary).not.toHaveClass("w-full", "group-open:bg-muted/50");
+    expect(firstContent).toHaveClass("text-muted-foreground/80");
+    expect(firstContent).not.toHaveClass("bg-muted/50");
 
     await user.click(firstSummary);
     expect(firstThinking.open).toBeTruthy();
@@ -105,5 +119,131 @@ describe("chat thinking blocks", () => {
     await user.click(secondSummary);
     expect(firstThinking.open).toBeTruthy();
     expect(secondThinking.open).toBeFalsy();
+  });
+
+  it("folds completed thinking and intermediate messages behind the final result", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle(context, {
+      threadId: COMPLETED_THREAD_ID,
+      chatEvents: [
+        {
+          id: "msg-completed-thinking-user",
+          role: "user",
+          content: "Analyze expansion revenue",
+          runId: COMPLETED_RUN_ID,
+          createdAt: "2026-08-18T10:00:00Z",
+        },
+        {
+          id: "msg-completed-thinking-first",
+          role: "assistant",
+          content: null,
+          thinking: "Comparing expansion by customer cohort.",
+          runId: COMPLETED_RUN_ID,
+          createdAt: "2026-08-18T10:00:05Z",
+        },
+        {
+          id: "msg-completed-thinking-message-one",
+          role: "assistant",
+          content: "I loaded the expansion records.",
+          runId: COMPLETED_RUN_ID,
+          createdAt: "2026-08-18T10:00:15Z",
+        },
+        {
+          id: "msg-completed-thinking-message-two",
+          role: "assistant",
+          content: "The enterprise cohort leads the increase.",
+          runId: COMPLETED_RUN_ID,
+          createdAt: "2026-08-18T10:00:25Z",
+        },
+        {
+          id: "msg-completed-thinking-second",
+          role: "assistant",
+          content: null,
+          thinking: "Checking whether seat growth explains the result.",
+          runId: COMPLETED_RUN_ID,
+          createdAt: "2026-08-18T10:00:35Z",
+        },
+        {
+          id: "msg-completed-thinking-result",
+          role: "assistant",
+          content: "Expansion revenue grew 18%, led by enterprise accounts.",
+          runId: COMPLETED_RUN_ID,
+          runLifecycleEvent: "completed",
+          createdAt: "2026-08-18T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${COMPLETED_THREAD_ID}`,
+    });
+
+    const expandButton = await screen.findByLabelText("Expand work history");
+    expect(expandButton).toHaveTextContent("Worked for 1m");
+    expect(screen.getByText("Analyze expansion revenue")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Expansion revenue grew 18%, led by enterprise accounts.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("I loaded the expansion records.")).toBeNull();
+    expect(
+      screen.queryByText("The enterprise cohort leads the increase."),
+    ).toBeNull();
+    expect(document.querySelectorAll("[data-thinking-block]")).toHaveLength(0);
+
+    await user.click(expandButton);
+
+    const thinkingBlocks = await waitFor(() => {
+      const blocks = document.querySelectorAll<HTMLDetailsElement>(
+        "[data-thinking-block]",
+      );
+      expect(blocks).toHaveLength(2);
+      return blocks;
+    });
+    const firstThinking = thinkingBlocks[0];
+    const secondThinking = thinkingBlocks[1];
+    const messageOne = screen.getByText("I loaded the expansion records.");
+    const messageTwo = screen.getByText(
+      "The enterprise cohort leads the increase.",
+    );
+    const result = screen.getByText(
+      "Expansion revenue grew 18%, led by enterprise accounts.",
+    );
+    if (!firstThinking || !secondThinking) {
+      throw new Error("Completed thinking blocks were not rendered");
+    }
+    expect(
+      firstThinking.compareDocumentPosition(messageOne) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      messageOne.compareDocumentPosition(messageTwo) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      messageTwo.compareDocumentPosition(secondThinking) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      secondThinking.compareDocumentPosition(result) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(firstThinking.open).toBeFalsy();
+    expect(secondThinking.open).toBeFalsy();
+
+    const firstSummary = firstThinking.querySelector("summary");
+    const secondSummary = secondThinking.querySelector("summary");
+    if (!firstSummary || !secondSummary) {
+      throw new Error("Completed thinking summaries were not rendered");
+    }
+    await user.click(firstSummary);
+    expect(firstThinking.open).toBeTruthy();
+    expect(secondThinking.open).toBeFalsy();
+
+    await user.click(secondSummary);
+    expect(firstThinking.open).toBeTruthy();
+    expect(secondThinking.open).toBeTruthy();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
@@ -109,7 +109,10 @@ describe("chat thinking blocks", () => {
       "hover:bg-state-hover",
     );
     expect(firstSummary).not.toHaveClass("w-full", "group-open:bg-muted/50");
-    expect(firstContent).toHaveClass("text-muted-foreground/80");
+    expect(firstContent).toHaveClass(
+      "text-muted-foreground/80",
+      "[&_.wmde-markdown]:!text-muted-foreground/80",
+    );
     expect(firstContent).not.toHaveClass("bg-muted/50");
 
     await user.click(firstSummary);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { context, detachedSetupPage } from "./chat-lifecycle-test-helpers.ts";
@@ -59,6 +60,9 @@ describe("chat thinking blocks", () => {
     detachedSetupPage({
       context,
       path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatInlineThinkingBlocks]: true,
+      },
     });
 
     await screen.findByText("I loaded the trial accounts.");
@@ -109,6 +113,23 @@ describe("chat thinking blocks", () => {
       "hover:bg-state-hover",
     );
     expect(firstSummary).not.toHaveClass("w-full", "group-open:bg-muted/50");
+    const firstIcon = firstSummary.querySelector("[data-thinking-block-icon]");
+    const secondIcon = secondSummary.querySelector(
+      "[data-thinking-block-icon]",
+    );
+    expect(firstIcon).toHaveClass(
+      "inline-flex",
+      "size-3.5",
+      "items-center",
+      "justify-center",
+    );
+    expect(firstIcon?.querySelector("svg")).toHaveClass("-translate-y-px");
+    expect(secondIcon).toHaveClass(
+      "inline-flex",
+      "size-3.5",
+      "items-center",
+      "justify-center",
+    );
     expect(firstContent).toHaveClass(
       "text-muted-foreground/80",
       "[&_.wmde-markdown]:!text-muted-foreground/80",
@@ -180,6 +201,9 @@ describe("chat thinking blocks", () => {
     detachedSetupPage({
       context,
       path: `/chats/${COMPLETED_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatInlineThinkingBlocks]: true,
+      },
     });
 
     const expandButton = await screen.findByLabelText("Expand work history");
@@ -248,5 +272,52 @@ describe("chat thinking blocks", () => {
     await user.click(secondSummary);
     expect(firstThinking.open).toBeTruthy();
     expect(secondThinking.open).toBeTruthy();
+  });
+
+  it("keeps thinking events on the legacy presentation while the switch is off", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000213";
+    const runId = "run-legacy-thinking-presentation";
+    mockChatLifecycle(context, {
+      threadId,
+      activeRunIds: [runId],
+      chatEvents: [
+        {
+          id: "msg-legacy-thinking-user",
+          role: "user",
+          content: "Summarize the account",
+          runId,
+          createdAt: "2026-08-18T10:00:00Z",
+        },
+        {
+          id: "msg-legacy-thinking-marker",
+          role: "assistant",
+          content: null,
+          thinking: "This thought stays out of the transcript.",
+          runId,
+          createdAt: "2026-08-18T10:00:01Z",
+        },
+        {
+          id: "msg-legacy-thinking-result",
+          role: "assistant",
+          content: "Here is the account summary.",
+          runId,
+          createdAt: "2026-08-18T10:00:02Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatInlineThinkingBlocks]: false,
+      },
+    });
+
+    await screen.findByText("Here is the account summary.");
+    expect(document.querySelector("[data-thinking-block]")).toBeNull();
+    expect(
+      screen.queryByText("This thought stays out of the transcript."),
+    ).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3844,7 +3844,7 @@ function canFoldCompletedWorkTrailingEvent(event: EnrichedChatEvent): boolean {
   const role = chatEventCompatibilityRole(event.eventType);
   return (
     role === "user" ||
-    (role === "assistant" && !isRenderableAssistantResultEvent(event))
+    (role === "assistant" && !isRenderableAssistantEvent(event))
   );
 }
 
@@ -3863,16 +3863,10 @@ function foldCompletedWorkPhase(
   const precedingEvents =
     finalEventIndex > 0 ? events.slice(0, finalEventIndex) : [];
   const hiddenEvents = precedingEvents.filter((event) => {
-    return (
-      chatEventCompatibilityRole(event.eventType) !== "user" &&
-      !isThinkingOnlyAssistantEvent(event)
-    );
+    return chatEventCompatibilityRole(event.eventType) !== "user";
   });
   const visiblePrecedingEvents = precedingEvents.filter((event) => {
-    return (
-      chatEventCompatibilityRole(event.eventType) === "user" ||
-      isThinkingOnlyAssistantEvent(event)
-    );
+    return chatEventCompatibilityRole(event.eventType) === "user";
   });
   const trailingEvents =
     finalEventIndex >= 0 ? events.slice(finalEventIndex + 1) : [];
@@ -7816,7 +7810,7 @@ function PagedAssistantThinkingBlock({
       data-chat-scroll-anchor-event-id={event.id}
       data-chat-run-id={event.runId}
       className={cn(
-        "min-w-0",
+        "-mx-2 min-w-0",
         compactTop ? "@[900px]:pt-0" : "@[900px]:pt-2.5",
       )}
     >
@@ -7826,7 +7820,7 @@ function PagedAssistantThinkingBlock({
         open={current}
         className="group max-w-[710px]"
       >
-        <summary className="flex min-h-9 w-full cursor-pointer list-none items-center gap-2 rounded-[10px] px-2.5 py-1.5 text-left text-muted-foreground transition-colors hover:bg-muted/50 group-open:bg-muted/50 group-open:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+        <summary className="inline-flex min-h-9 max-w-full cursor-pointer list-none items-center gap-2 rounded-lg px-2 py-1.5 text-left text-muted-foreground transition-colors hover:bg-state-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
           {current ? (
             <PagedAssistantCurrentThinkingSummary
               event={event}
@@ -7837,7 +7831,7 @@ function PagedAssistantThinkingBlock({
           ) : (
             <>
               <Brain aria-hidden size={14} className="shrink-0" />
-              <span className="shrink-0 text-xs font-semibold">{label}</span>
+              <span className="shrink-0 text-[13px]">{label}</span>
               <span className="min-w-0 flex-1 truncate font-serif text-[0.8125rem] font-normal group-open:hidden">
                 {preview}
               </span>
@@ -7846,12 +7840,12 @@ function PagedAssistantThinkingBlock({
           <ChevronRight
             aria-hidden
             size={14}
-            className="ml-auto shrink-0 text-muted-foreground/70 transition-transform group-open:rotate-90"
+            className="shrink-0 text-muted-foreground/70 transition-transform group-open:rotate-90"
           />
         </summary>
         <div
           data-thinking-block-content
-          className="mt-1 rounded-xl bg-muted/50 px-3 py-2.5 font-serif text-[0.875rem] leading-[1.55] text-foreground/80 [overflow-wrap:anywhere]"
+          className="px-2 pb-2 pt-1 font-serif text-[0.875rem] leading-[1.55] text-muted-foreground/80 [overflow-wrap:anywhere]"
         >
           <Markdown
             source={event.thinking}
@@ -7907,7 +7901,7 @@ function PagedAssistantCurrentThinkingSummary({
         <span />
         <span />
       </span>
-      <span className="shrink-0 text-xs font-semibold">{label}</span>
+      <span className="shrink-0 text-[13px]">{label}</span>
       {serverThinkingLabel ? (
         <ShimmerText
           key={serverThinkingLabel.id}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -7845,7 +7845,7 @@ function PagedAssistantThinkingBlock({
         </summary>
         <div
           data-thinking-block-content
-          className="px-2 pb-2 pt-1 font-serif text-[0.875rem] leading-[1.55] text-muted-foreground/80 [overflow-wrap:anywhere]"
+          className="px-2 pb-2 pt-1 font-serif text-[0.875rem] leading-[1.55] text-muted-foreground/80 [overflow-wrap:anywhere] [&_.wmde-markdown]:!text-muted-foreground/80"
         >
           <Markdown
             source={event.thinking}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../signals/chat-page/run-usage-popover.ts";
 import {
   AlertCircle,
+  Brain,
   Coffee,
   Flag,
   Hand,
@@ -3330,7 +3331,7 @@ function chatRunPresentationForGroups(
       if (runId !== undefined) {
         lastAssociatedRunId = runId;
       }
-      if (!isRenderableAssistantEvent(event)) {
+      if (!isRenderableAssistantResultEvent(event)) {
         continue;
       }
       if (runId === undefined) {
@@ -3739,7 +3740,7 @@ function attachUsageToCompletedWorkGroups(
   for (const [index, group] of groups.entries()) {
     if (
       group.role !== "assistant" ||
-      !group.events.some(isRenderableAssistantEvent)
+      !group.events.some(isRenderableAssistantResultEvent)
     ) {
       continue;
     }
@@ -3764,7 +3765,20 @@ function attachUsageToCompletedWorkGroups(
   });
 }
 
-function isRenderableAssistantEvent(event: EnrichedChatEvent): boolean {
+type EnrichedThinkingChatEvent = Extract<
+  EnrichedChatEvent,
+  { eventType: "output.thinking" }
+>;
+
+function isThinkingOnlyAssistantEvent(
+  event: EnrichedChatEvent,
+): event is EnrichedThinkingChatEvent {
+  return (
+    event.eventType === "output.thinking" && event.thinking.trim().length > 0
+  );
+}
+
+function isRenderableAssistantResultEvent(event: EnrichedChatEvent): boolean {
   return (
     chatEventCompatibilityRole(event.eventType) === "assistant" &&
     ((isChatEventContentTextType(event.eventType) && Boolean(event.content)) ||
@@ -3774,9 +3788,10 @@ function isRenderableAssistantEvent(event: EnrichedChatEvent): boolean {
   );
 }
 
-function isThinkingOnlyAssistantEvent(event: EnrichedChatEvent): boolean {
+function isRenderableAssistantEvent(event: EnrichedChatEvent): boolean {
   return (
-    event.eventType === "output.thinking" && event.thinking.trim().length > 0
+    isThinkingOnlyAssistantEvent(event) ||
+    isRenderableAssistantResultEvent(event)
   );
 }
 
@@ -3822,14 +3837,14 @@ function lastCompletedWorkEventIndex(
 function completedWorkFinalEventIndex(
   events: readonly EnrichedChatEvent[],
 ): number {
-  return lastCompletedWorkEventIndex(events, isRenderableAssistantEvent);
+  return lastCompletedWorkEventIndex(events, isRenderableAssistantResultEvent);
 }
 
 function canFoldCompletedWorkTrailingEvent(event: EnrichedChatEvent): boolean {
   const role = chatEventCompatibilityRole(event.eventType);
   return (
     role === "user" ||
-    (role === "assistant" && !isRenderableAssistantEvent(event))
+    (role === "assistant" && !isRenderableAssistantResultEvent(event))
   );
 }
 
@@ -3853,8 +3868,11 @@ function foldCompletedWorkPhase(
       !isThinkingOnlyAssistantEvent(event)
     );
   });
-  const userEvents = events.filter((event) => {
-    return chatEventCompatibilityRole(event.eventType) === "user";
+  const visiblePrecedingEvents = precedingEvents.filter((event) => {
+    return (
+      chatEventCompatibilityRole(event.eventType) === "user" ||
+      isThinkingOnlyAssistantEvent(event)
+    );
   });
   const trailingEvents =
     finalEventIndex >= 0 ? events.slice(finalEventIndex + 1) : [];
@@ -3870,7 +3888,7 @@ function foldCompletedWorkPhase(
   }
   return {
     visibleEvents: [
-      ...userEvents,
+      ...visiblePrecedingEvents,
       finalEvent,
       ...trailingEvents.filter(isRenderableAssistantEvent),
     ],
@@ -5363,6 +5381,11 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
       : undefined;
 
   if (mode === null) {
+    return null;
+  }
+
+  // The active thinking event is already rendered inline in transcript order.
+  if (serverThinkingLabel) {
     return null;
   }
 
@@ -7620,6 +7643,7 @@ function PagedAssistantGroup({
     onToggle: () => void;
   };
 }) {
+  const currentThinkingEventId = useLastResolved(thread.thinkingEventId$);
   const hasRenderableEvent = group.events.some((event) => {
     return isRenderableAssistantEvent(event);
   });
@@ -7649,6 +7673,7 @@ function PagedAssistantGroup({
         key={event.id}
         event={event}
         compactTop={compactTop}
+        currentThinking={event.id === currentThinkingEventId}
         thread={thread}
       />
     );
@@ -7707,12 +7732,25 @@ function PagedAssistantGroup({
 function PagedAssistantEventItem({
   event,
   compactTop = false,
+  currentThinking,
   thread,
 }: {
   event: EnrichedChatEvent;
   compactTop?: boolean;
+  currentThinking: boolean;
   thread: ChatPanelSignals;
 }) {
+  if (isThinkingOnlyAssistantEvent(event)) {
+    return (
+      <PagedAssistantThinkingBlock
+        event={event}
+        compactTop={compactTop}
+        current={currentThinking}
+        thread={thread}
+      />
+    );
+  }
+
   const error = chatEventError(event);
   if (error) {
     return (
@@ -7754,6 +7792,141 @@ function PagedAssistantEventItem({
   }
 
   return null;
+}
+
+function PagedAssistantThinkingBlock({
+  event,
+  compactTop,
+  current,
+  thread,
+}: {
+  event: EnrichedThinkingChatEvent;
+  compactTop: boolean;
+  current: boolean;
+  thread: ChatPanelSignals;
+}) {
+  const { t } = useTranslation();
+  const label = t(($) => {
+    return $.activity.events.thinking;
+  });
+  const preview = event.thinking.trim().replace(/\s+/g, " ");
+
+  return (
+    <div
+      data-chat-scroll-anchor-event-id={event.id}
+      data-chat-run-id={event.runId}
+      className={cn(
+        "min-w-0",
+        compactTop ? "@[900px]:pt-0" : "@[900px]:pt-2.5",
+      )}
+    >
+      <details
+        data-thinking-block
+        data-thinking-indicator={current ? "" : undefined}
+        open={current}
+        className="group max-w-[710px]"
+      >
+        <summary className="flex min-h-9 w-full cursor-pointer list-none items-center gap-2 rounded-[10px] px-2.5 py-1.5 text-left text-muted-foreground transition-colors hover:bg-muted/50 group-open:bg-muted/50 group-open:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+          {current ? (
+            <PagedAssistantCurrentThinkingSummary
+              event={event}
+              label={label}
+              preview={preview}
+              thread={thread}
+            />
+          ) : (
+            <>
+              <Brain aria-hidden size={14} className="shrink-0" />
+              <span className="shrink-0 text-xs font-semibold">{label}</span>
+              <span className="min-w-0 flex-1 truncate font-serif text-[0.8125rem] font-normal group-open:hidden">
+                {preview}
+              </span>
+            </>
+          )}
+          <ChevronRight
+            aria-hidden
+            size={14}
+            className="ml-auto shrink-0 text-muted-foreground/70 transition-transform group-open:rotate-90"
+          />
+        </summary>
+        <div
+          data-thinking-block-content
+          className="mt-1 rounded-xl bg-muted/50 px-3 py-2.5 font-serif text-[0.875rem] leading-[1.55] text-foreground/80 [overflow-wrap:anywhere]"
+        >
+          <Markdown
+            source={event.thinking}
+            escapeHtml
+            mathEnabled
+            style={{ fontSize: "inherit", lineHeight: "inherit" }}
+          />
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function PagedAssistantCurrentThinkingSummary({
+  event,
+  label,
+  preview,
+  thread,
+}: {
+  event: EnrichedThinkingChatEvent;
+  label: string;
+  preview: string;
+  thread: ChatPanelSignals;
+}) {
+  const thinkingText = useLastResolved(thread.thinkingText$);
+  const displayedThinkingText =
+    useLastResolved(thread.displayedThinkingText$) ?? "";
+  const thinkingTextFadingOut =
+    useLastResolved(thread.thinkingTextFadingOut$) ?? false;
+  const setThinkingIndicatorTextRef = useSet(
+    thread.setThinkingIndicatorTextRef$,
+  );
+  const [c1, c2, c3] = useGet(thread.blockColors$);
+  const blockStyle = {
+    "--zb-c1": c1,
+    "--zb-c2": c2,
+    "--zb-c3": c3,
+  } as CSSProperties;
+  const serverThinkingLabel = thinkingText
+    ? {
+        displayedText: displayedThinkingText,
+        fadingOut: thinkingTextFadingOut,
+        fullText: thinkingText,
+        id: event.id,
+        setRef: setThinkingIndicatorTextRef,
+      }
+    : undefined;
+
+  return (
+    <>
+      <span className="zero-blocks shrink-0" style={blockStyle}>
+        <span />
+        <span />
+        <span />
+      </span>
+      <span className="shrink-0 text-xs font-semibold">{label}</span>
+      {serverThinkingLabel ? (
+        <ShimmerText
+          key={serverThinkingLabel.id}
+          setRef={serverThinkingLabel.setRef}
+          className={cn(
+            "min-w-0 group-open:hidden transition-opacity duration-200",
+            serverThinkingLabel.fadingOut ? "opacity-0" : "opacity-100",
+          )}
+          ariaLabel={serverThinkingLabel.fullText}
+        >
+          {serverThinkingLabel.displayedText || "\u00a0"}
+        </ShimmerText>
+      ) : (
+        <span className="min-w-0 flex-1 truncate font-serif text-[0.8125rem] font-normal group-open:hidden">
+          {preview}
+        </span>
+      )}
+    </>
+  );
 }
 
 function formatCredits(value: number): string {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3082,7 +3082,12 @@ function ChatThreadRenderedEventGroups({
   );
   const runGroupVisibleGroups =
     runGroupFolding?.visibleGroups ?? renderedActiveGroups;
-  const completedWorkFolding = buildCompletedWorkFolding(runGroupVisibleGroups);
+  const inlineThinkingBlocksEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ChatInlineThinkingBlocks] ?? false;
+  const completedWorkFolding = buildCompletedWorkFolding(
+    runGroupVisibleGroups,
+    inlineThinkingBlocksEnabled,
+  );
   const completedWorkExpandedKeys = useGet(completedWorkExpandedKeys$);
   const effectiveCompletedWorkExpandedKeys =
     completedWorkExpandedKeysForScrollTarget(
@@ -3368,6 +3373,7 @@ function groupRendersContent(
   group: ChatEventGroup,
   embeddedFolds: readonly RunGroupFoldControl[],
   completedWorkFold: CompletedWorkFold | null,
+  inlineThinkingBlocksEnabled: boolean,
 ): boolean {
   if (embeddedFolds.length > 0 || completedWorkFold !== null) {
     return true;
@@ -3375,7 +3381,9 @@ function groupRendersContent(
   if (group.role === "user") {
     return group.events.some(rendersUserBubble);
   }
-  return group.events.some(isRenderableAssistantEvent);
+  return group.events.some((event) => {
+    return isRenderableAssistantEvent(event, inlineThinkingBlocksEnabled);
+  });
 }
 
 // A user group can be on screen for its fold alone, with every message in it
@@ -3409,8 +3417,11 @@ function ChatThreadEventGroups({
       runGroupFolding,
       onToggleRunGroup,
     });
+  const features = useGet(featureSwitch$);
   const continuationPresentationEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ChatRunContinuationPresentation];
+    features[FeatureSwitchKey.ChatRunContinuationPresentation];
+  const inlineThinkingBlocksEnabled =
+    features[FeatureSwitchKey.ChatInlineThinkingBlocks] ?? false;
   const runPresentation = continuationPresentationEnabled
     ? chatRunPresentationForGroups(groups)
     : null;
@@ -3437,7 +3448,14 @@ function ChatThreadEventGroups({
           previousVisibleGroup !== undefined &&
           previousVisibleGroup.role === "user" &&
           groupHasUserBubble(previousVisibleGroup);
-        if (groupRendersContent(group, embeddedFolds, completedWorkFold)) {
+        if (
+          groupRendersContent(
+            group,
+            embeddedFolds,
+            completedWorkFold,
+            inlineThinkingBlocksEnabled,
+          )
+        ) {
           previousVisibleGroup = group;
         }
         const completedWorkExpanded =
@@ -3788,9 +3806,12 @@ function isRenderableAssistantResultEvent(event: EnrichedChatEvent): boolean {
   );
 }
 
-function isRenderableAssistantEvent(event: EnrichedChatEvent): boolean {
+function isRenderableAssistantEvent(
+  event: EnrichedChatEvent,
+  inlineThinkingBlocksEnabled: boolean,
+): boolean {
   return (
-    isThinkingOnlyAssistantEvent(event) ||
+    (inlineThinkingBlocksEnabled && isThinkingOnlyAssistantEvent(event)) ||
     isRenderableAssistantResultEvent(event)
   );
 }
@@ -3840,11 +3861,15 @@ function completedWorkFinalEventIndex(
   return lastCompletedWorkEventIndex(events, isRenderableAssistantResultEvent);
 }
 
-function canFoldCompletedWorkTrailingEvent(event: EnrichedChatEvent): boolean {
+function canFoldCompletedWorkTrailingEvent(
+  event: EnrichedChatEvent,
+  inlineThinkingBlocksEnabled: boolean,
+): boolean {
   const role = chatEventCompatibilityRole(event.eventType);
   return (
     role === "user" ||
-    (role === "assistant" && !isRenderableAssistantEvent(event))
+    (role === "assistant" &&
+      !isRenderableAssistantEvent(event, inlineThinkingBlocksEnabled))
   );
 }
 
@@ -3856,6 +3881,7 @@ interface CompletedWorkPhaseFolding {
 function foldCompletedWorkPhase(
   runId: string,
   events: readonly EnrichedChatEvent[],
+  inlineThinkingBlocksEnabled: boolean,
 ): CompletedWorkPhaseFolding {
   const finalEventIndex = completedWorkFinalEventIndex(events);
   const finalEvent =
@@ -3863,7 +3889,10 @@ function foldCompletedWorkPhase(
   const precedingEvents =
     finalEventIndex > 0 ? events.slice(0, finalEventIndex) : [];
   const hiddenEvents = precedingEvents.filter((event) => {
-    return chatEventCompatibilityRole(event.eventType) !== "user";
+    return (
+      chatEventCompatibilityRole(event.eventType) !== "user" &&
+      (inlineThinkingBlocksEnabled || !isThinkingOnlyAssistantEvent(event))
+    );
   });
   const visiblePrecedingEvents = precedingEvents.filter((event) => {
     return chatEventCompatibilityRole(event.eventType) === "user";
@@ -3871,7 +3900,10 @@ function foldCompletedWorkPhase(
   const trailingEvents =
     finalEventIndex >= 0 ? events.slice(finalEventIndex + 1) : [];
   const trailingEventsCanFold = trailingEvents.every((event) => {
-    return canFoldCompletedWorkTrailingEvent(event);
+    return canFoldCompletedWorkTrailingEvent(
+      event,
+      inlineThinkingBlocksEnabled,
+    );
   });
   if (
     finalEvent === undefined ||
@@ -3884,7 +3916,9 @@ function foldCompletedWorkPhase(
     visibleEvents: [
       ...visiblePrecedingEvents,
       finalEvent,
-      ...trailingEvents.filter(isRenderableAssistantEvent),
+      ...trailingEvents.filter((event) => {
+        return isRenderableAssistantEvent(event, inlineThinkingBlocksEnabled);
+      }),
     ],
     fold: {
       key: `${runId}:${finalEvent.id}`,
@@ -3897,6 +3931,7 @@ function foldCompletedWorkPhase(
 
 function buildCompletedWorkFolding(
   groups: readonly ChatEventGroup[],
+  inlineThinkingBlocksEnabled: boolean,
 ): CompletedWorkFolding | null {
   const usageByRunId = usageByRunIdFromGroups(groups);
   const events = groups.flatMap((group) => {
@@ -3932,7 +3967,11 @@ function buildCompletedWorkFolding(
       hasCompletedWorkPhaseBoundary = true;
     }
     for (const completedWorkEvents of completedWorkEventGroups) {
-      const phaseFolding = foldCompletedWorkPhase(runId, completedWorkEvents);
+      const phaseFolding = foldCompletedWorkPhase(
+        runId,
+        completedWorkEvents,
+        inlineThinkingBlocksEnabled,
+      );
       visibleEvents.push(...phaseFolding.visibleEvents);
       if (phaseFolding.fold !== null) {
         folds.push(phaseFolding.fold);
@@ -5340,6 +5379,8 @@ function equalRecommendedFollowupSources(
 }
 
 function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
+  const inlineThinkingBlocksEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ChatInlineThinkingBlocks] ?? false;
   const [c1, c2, c3] = useGet(thread.blockColors$);
   const blockStyle = {
     "--zb-c1": c1,
@@ -5379,7 +5420,7 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
   }
 
   // The active thinking event is already rendered inline in transcript order.
-  if (serverThinkingLabel) {
+  if (inlineThinkingBlocksEnabled && serverThinkingLabel) {
     return null;
   }
 
@@ -7637,9 +7678,11 @@ function PagedAssistantGroup({
     onToggle: () => void;
   };
 }) {
+  const inlineThinkingBlocksEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ChatInlineThinkingBlocks] ?? false;
   const currentThinkingEventId = useLastResolved(thread.thinkingEventId$);
   const hasRenderableEvent = group.events.some((event) => {
-    return isRenderableAssistantEvent(event);
+    return isRenderableAssistantEvent(event, inlineThinkingBlocksEnabled);
   });
   const hasRunGroupFolds = (runGroupFolds?.length ?? 0) > 0;
   const showCompletedWorkFold = completedWorkFold && !hasRunGroupFolds;
@@ -7657,7 +7700,10 @@ function PagedAssistantGroup({
     .join("\n\n");
   let renderedAssistantEventCount = 0;
   const renderAssistantEventItem = (event: EnrichedChatEvent) => {
-    const isRenderable = isRenderableAssistantEvent(event);
+    const isRenderable = isRenderableAssistantEvent(
+      event,
+      inlineThinkingBlocksEnabled,
+    );
     const compactTop = isRenderable && renderedAssistantEventCount > 0;
     if (isRenderable) {
       renderedAssistantEventCount += 1;
@@ -7668,6 +7714,7 @@ function PagedAssistantGroup({
         event={event}
         compactTop={compactTop}
         currentThinking={event.id === currentThinkingEventId}
+        inlineThinkingBlocksEnabled={inlineThinkingBlocksEnabled}
         thread={thread}
       />
     );
@@ -7727,14 +7774,16 @@ function PagedAssistantEventItem({
   event,
   compactTop = false,
   currentThinking,
+  inlineThinkingBlocksEnabled,
   thread,
 }: {
   event: EnrichedChatEvent;
   compactTop?: boolean;
   currentThinking: boolean;
+  inlineThinkingBlocksEnabled: boolean;
   thread: ChatPanelSignals;
 }) {
-  if (isThinkingOnlyAssistantEvent(event)) {
+  if (inlineThinkingBlocksEnabled && isThinkingOnlyAssistantEvent(event)) {
     return (
       <PagedAssistantThinkingBlock
         event={event}
@@ -7830,7 +7879,13 @@ function PagedAssistantThinkingBlock({
             />
           ) : (
             <>
-              <Brain aria-hidden size={14} className="shrink-0" />
+              <span
+                data-thinking-block-icon
+                aria-hidden
+                className="inline-flex size-3.5 shrink-0 items-center justify-center"
+              >
+                <Brain size={14} className="-translate-y-px" />
+              </span>
               <span className="shrink-0 text-[13px]">{label}</span>
               <span className="min-w-0 flex-1 truncate font-serif text-[0.8125rem] font-normal group-open:hidden">
                 {preview}
@@ -7896,10 +7951,16 @@ function PagedAssistantCurrentThinkingSummary({
 
   return (
     <>
-      <span className="zero-blocks shrink-0" style={blockStyle}>
-        <span />
-        <span />
-        <span />
+      <span
+        data-thinking-block-icon
+        aria-hidden
+        className="inline-flex size-3.5 shrink-0 items-center justify-center"
+      >
+        <span className="zero-blocks" style={blockStyle}>
+          <span />
+          <span />
+          <span />
+        </span>
       </span>
       <span className="shrink-0 text-[13px]">{label}</span>
       {serverThinkingLabel ? (

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -102,6 +102,9 @@ describe("getAllFeatureStates", () => {
       staffOrgStates[FeatureSwitchKey.ChatRunContinuationPresentation],
     ).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatSmoothAutoScroll]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ChatInlineThinkingBlocks]).toBe(
+      true,
+    );
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
@@ -138,6 +141,9 @@ describe("getAllFeatureStates", () => {
       otherOrgStates[FeatureSwitchKey.ChatRunContinuationPresentation],
     ).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatSmoothAutoScroll]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ChatInlineThinkingBlocks]).toBe(
+      false,
+    );
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -60,6 +60,7 @@ export enum FeatureSwitchKey {
   ChatQuoteOnlyFeedback = "chatQuoteOnlyFeedback",
   ChatRunContinuationPresentation = "chatRunContinuationPresentation",
   ChatSmoothAutoScroll = "chatSmoothAutoScroll",
+  ChatInlineThinkingBlocks = "chatInlineThinkingBlocks",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   ConnectorDiscovery = "connectorDiscovery",
   ConnectorCatalogCount = "connectorCatalogCount",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -400,6 +400,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ChatInlineThinkingBlocks]: {
+    maintainer: "yuma@vm0.ai",
+    description:
+      "Render model thinking as independently collapsible blocks in transcript order.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.EmojiPickerCategoryRail]: {
     maintainer: "tongx@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- render every `output.thinking` event at its exact position among assistant messages
- give each thinking block an independent native disclosure state, with the active tail block open by default
- fold completed thinking and intermediate assistant messages behind `Worked for …`, leaving only the final result visible
- keep the disclosure background transparent outside hover, mute expanded thinking copy, and optically align a fixed icon slot with the completed-work row
- gate the presentation behind `chatInlineThinkingBlocks`, enabled by default for staff orgs only

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, platform, and API type checks from `commit-check`
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --reporter=dot --no-color`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx --reporter=dot --no-color`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-billing-and-errors.test.tsx --reporter=dot --no-color`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-run-results.test.tsx --reporter=dot --no-color`
