### PR TITLE
test(ci): allow cross-session systemd reload coalescing

### DIFF
--- a/.github/scripts/runner-behavior-systemd-reload.sh
+++ b/.github/scripts/runner-behavior-systemd-reload.sh
@@ -139,8 +139,8 @@ RELOAD_COUNT=$(sudo journalctl -b _PID=1 --after-cursor="$JOURNAL_CURSOR" \
     'index($0, "Reloading requested") && index($0, scope) { count++ } END { print count + 0 }')
 
 echo "Session ${XDG_SESSION_ID} requested ${RELOAD_COUNT} systemd manager reload(s)"
-[ "$RELOAD_COUNT" -ge 2 ] \
-  || fail "expected at least one install and one uninstall reload, got $RELOAD_COUNT"
+# Another session may absorb either completed lifecycle generation, so only
+# this session's upper bound is attributable.
 [ "$RELOAD_COUNT" -le 4 ] \
   || fail "expected at most one reload per successful lifecycle operation, got $RELOAD_COUNT"
 


### PR DESCRIPTION
## Summary

- allow another SSH session's host-global systemd reload to absorb either
  completed lifecycle generation without failing the metal scenario
- retain all effective install and uninstall state checks and the current
  session's four-reload amplification ceiling
- document why only the session-scoped upper bound is attributable

## Scope

This changes only the real-metal CI assertion. It does not change runner
production behavior, workflow scheduling, retries, timeouts, APIs, schemas,
persisted state, queue payloads, guest contracts, or deployment compatibility.

## Validation

- `bash -n .github/scripts/runner-behavior-systemd-reload.sh`
- `shellcheck .github/scripts/runner-behavior-systemd-reload.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/crates.yml`
- `git diff --check`
- pre-commit file-size check
- commit message lint

The real-metal `runner-behavior-lane-c` job remains the behavioral integration
gate.

Closes #27907
