### PR TITLE
refactor(contracts): neutralize the feishu connect contract naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -19,7 +19,7 @@ import {
   zeroCustomConnectorsContract,
 } from "@okouai/api-contracts/contracts/zero-custom-connectors";
 import { zeroAgentCustomConnectorsContract } from "@okouai/api-contracts/contracts/zero-agent-custom-connectors";
-import { zeroFeishuConnectContract } from "@okouai/api-contracts/contracts/zero-feishu-connect";
+import { feishuConnectContract } from "@okouai/api-contracts/contracts/feishu-connect";
 import { feishuOauthContract } from "@okouai/api-contracts/contracts/feishu-oauth";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -763,7 +763,7 @@ describe("Feishu integration", () => {
     await runsApi.ensureOrgModelProvider(actor);
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     const configured = await accept(
       client.setup({
@@ -1027,7 +1027,7 @@ describe("Feishu integration", () => {
       fixture.actor.orgRole,
     );
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     await accept(
       client.removeInstallation({
@@ -1082,7 +1082,7 @@ describe("Feishu integration", () => {
     await connectFixtureUser(fixture, doomed, "ou_feishu_doomed");
 
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     mocks.clerk.session(doomed.userId, doomed.orgId, "org:member");
     const connectedBeforeDeletion = await accept(
@@ -1141,7 +1141,7 @@ describe("Feishu integration", () => {
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
 
     const response = await accept(
@@ -1174,7 +1174,7 @@ describe("Feishu integration", () => {
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     const configured = await accept(
       client.setup({
@@ -1238,7 +1238,7 @@ describe("Feishu integration", () => {
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
 
     await accept(
@@ -1336,7 +1336,7 @@ describe("Feishu integration", () => {
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     const bothTokenRequestsStarted = createDeferredPromise<void>(
       context.signal,
@@ -1424,7 +1424,7 @@ describe("Feishu integration", () => {
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     context.mocks.s3.send.mockRejectedValue(
       new Error("Managed connector skill upload failed"),
@@ -1432,7 +1432,7 @@ describe("Feishu integration", () => {
 
     const failedSetup = await requestFeishuConfigurationFailure({
       method: "POST",
-      path: zeroFeishuConnectContract.setup.path,
+      path: feishuConnectContract.setup.path,
       body: {
         appId: `cli_${randomUUID()}`,
         appSecret: APP_SECRET,
@@ -1548,7 +1548,7 @@ describe("Feishu integration", () => {
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     const configured = await accept(
       client.setup({
@@ -1592,7 +1592,7 @@ describe("Feishu integration", () => {
 
     const failedRepair = await requestFeishuConfigurationFailure({
       method: "PATCH",
-      path: zeroFeishuConnectContract.updateInstallation.path.replace(
+      path: feishuConnectContract.updateInstallation.path.replace(
         ":installationId",
         installationId,
       ),
@@ -1644,7 +1644,7 @@ describe("Feishu integration", () => {
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
 
     const configured = await accept(
@@ -1757,7 +1757,7 @@ describe("Feishu integration", () => {
     mockAuthoritativeOrganizationMembers([admin, member]);
     mocks.clerk.session(admin.userId, admin.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     clearConnectorInvalidationMocks();
     const configured = await accept(
@@ -2261,7 +2261,7 @@ describe("Feishu integration", () => {
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     const configured = await accept(
       client.setup({
@@ -2346,7 +2346,7 @@ describe("Feishu integration", () => {
     });
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     const configured = await accept(
       client.setup({
@@ -2469,7 +2469,7 @@ describe("Feishu integration", () => {
     );
     await accept(
       setupApp({ context, routes: feishuConnectRoutes })(
-        zeroFeishuConnectContract,
+        feishuConnectContract,
       ).removeInstallation({
         headers: { authorization: "Bearer clerk-session" },
         params: { installationId: fixture.installationId },
@@ -2504,7 +2504,7 @@ describe("Feishu integration", () => {
     const fixture = await setupFeishuRunFixture();
     const { actor, appId, callbackUrl, defaultAgentId } = fixture;
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
 
     const firstEvent = directMessage(appId, "hello");
@@ -2784,7 +2784,7 @@ describe("Feishu integration", () => {
     const { appId, callbackUrl } = fixture;
     await connectFixtureUser(fixture);
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     for (const command of [
       "/help",
@@ -3446,7 +3446,7 @@ describe("Feishu integration", () => {
     expect(removedReactions).toHaveLength(1);
 
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     await accept(
       client.removeInstallation({
@@ -3481,7 +3481,7 @@ describe("Feishu integration", () => {
     });
 
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     await accept(
       client.removeInstallation({
@@ -3538,7 +3538,7 @@ describe("Feishu integration", () => {
     expect(completedQuotedReply?.replyInThread).toBeFalsy();
 
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     await accept(
       client.removeInstallation({
@@ -3586,7 +3586,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
 
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     await accept(
       client.removeInstallation({
@@ -3660,7 +3660,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
 
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     await accept(
       client.removeInstallation({
@@ -3759,7 +3759,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
 
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     await accept(
       client.removeInstallation({
@@ -3827,7 +3827,7 @@ describe("Feishu integration", () => {
     }
     await flushWaitUntilForTest();
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     await accept(
       client.removeInstallation({
@@ -4256,7 +4256,7 @@ describe("Feishu integration", () => {
 
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const client = setupApp({ context, routes: feishuConnectRoutes })(
-      zeroFeishuConnectContract,
+      feishuConnectContract,
     );
     await accept(
       client.removeInstallation({

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-feishu-message.test.ts
@@ -8,7 +8,7 @@ import {
   integrationsFeishuUploadCompleteContract,
   integrationsFeishuUploadInitContract,
 } from "@okouai/api-contracts/contracts/integrations";
-import { zeroFeishuConnectContract } from "@okouai/api-contracts/contracts/zero-feishu-connect";
+import { feishuConnectContract } from "@okouai/api-contracts/contracts/feishu-connect";
 import { feishuOauthContract } from "@okouai/api-contracts/contracts/feishu-oauth";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
@@ -122,7 +122,7 @@ async function setupFeishuInstallation(
   });
   mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
   const client = setupApp({ context, routes: feishuConnectRoutes })(
-    zeroFeishuConnectContract,
+    feishuConnectContract,
   );
   const setup = await accept(
     client.setup({
@@ -165,7 +165,7 @@ function requireTestValue<T>(value: T | null | undefined, message: string): T {
 
 async function connectCurrentFeishuUser(actor: FeishuTestActor): Promise<void> {
   const statusClient = setupApp({ context, routes: feishuConnectRoutes })(
-    zeroFeishuConnectContract,
+    feishuConnectContract,
   );
   const status = await accept(
     statusClient.getStatus({

--- a/turbo/apps/api/src/signals/routes/feishu-connect.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-connect.ts
@@ -1,6 +1,6 @@
 import { command, computed } from "ccstate";
 import { eq } from "drizzle-orm";
-import { zeroFeishuConnectContract } from "@okouai/api-contracts/contracts/zero-feishu-connect";
+import { feishuConnectContract } from "@okouai/api-contracts/contracts/feishu-connect";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { feishuOrgInstallations } from "@okouai/db/schema/feishu-org-installation";
@@ -79,7 +79,7 @@ const checkAppId$ = computed(async (get) => {
   if (auth.orgRole !== "admin") {
     return adminRequired();
   }
-  const query = get(queryOf(zeroFeishuConnectContract.checkAppId));
+  const query = get(queryOf(feishuConnectContract.checkAppId));
   const [installation] = await get(db$)
     .select({ id: feishuOrgInstallations.id })
     .from(feishuOrgInstallations)
@@ -99,7 +99,7 @@ const setup$ = command(async ({ get, set }, signal: AbortSignal) => {
   if (auth.orgRole !== "admin") {
     return adminRequired();
   }
-  const bodyResult = await get(bodyResultOf(zeroFeishuConnectContract.setup));
+  const bodyResult = await get(bodyResultOf(feishuConnectContract.setup));
   signal.throwIfAborted();
   if (!bodyResult.ok) {
     return bodyResult.response;
@@ -191,10 +191,10 @@ const updateInstallation$ = command(
       return adminRequired();
     }
     const params = get(
-      pathParamsOf(zeroFeishuConnectContract.updateInstallation),
+      pathParamsOf(feishuConnectContract.updateInstallation),
     );
     const bodyResult = await get(
-      bodyResultOf(zeroFeishuConnectContract.updateInstallation),
+      bodyResultOf(feishuConnectContract.updateInstallation),
     );
     signal.throwIfAborted();
     if (!bodyResult.ok) {
@@ -245,7 +245,7 @@ const removeInstallation$ = command(
       return adminRequired();
     }
     const params = get(
-      pathParamsOf(zeroFeishuConnectContract.removeInstallation),
+      pathParamsOf(feishuConnectContract.removeInstallation),
     );
     const removed = await set(
       removeFeishuInstallation$,
@@ -297,7 +297,7 @@ const disconnectInstallation$ = command(
     }
     const auth = get(organizationAuthContext$);
     const params = get(
-      pathParamsOf(zeroFeishuConnectContract.disconnectInstallation),
+      pathParamsOf(feishuConnectContract.disconnectInstallation),
     );
     const disconnected = await set(
       disconnectFeishuConnection$,
@@ -322,35 +322,35 @@ const auth = {
 
 export const feishuConnectRoutes: readonly RouteEntry[] = [
   {
-    route: zeroFeishuConnectContract.getStatus,
+    route: feishuConnectContract.getStatus,
     handler: authRoute(auth, getStatus$),
   },
   {
-    route: zeroFeishuConnectContract.checkAppId,
+    route: feishuConnectContract.checkAppId,
     handler: authRoute(auth, checkAppId$),
   },
   {
-    route: zeroFeishuConnectContract.setup,
+    route: feishuConnectContract.setup,
     handler: authRoute(auth, setup$),
   },
   {
-    route: zeroFeishuConnectContract.updateInstallation,
+    route: feishuConnectContract.updateInstallation,
     handler: authRoute(auth, updateInstallation$),
   },
   {
-    route: zeroFeishuConnectContract.removeInstallation,
+    route: feishuConnectContract.removeInstallation,
     handler: authRoute(auth, removeInstallation$),
   },
   {
-    route: zeroFeishuConnectContract.disconnectInstallation,
+    route: feishuConnectContract.disconnectInstallation,
     handler: authRoute(auth, disconnectInstallation$),
   },
   {
-    route: zeroFeishuConnectContract.remove,
+    route: feishuConnectContract.remove,
     handler: authRoute(auth, remove$),
   },
   {
-    route: zeroFeishuConnectContract.disconnect,
+    route: feishuConnectContract.disconnect,
     handler: authRoute(auth, disconnect$),
   },
 ];

--- a/turbo/apps/api/src/signals/routes/feishu-connect.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-connect.ts
@@ -190,9 +190,7 @@ const updateInstallation$ = command(
     if (auth.orgRole !== "admin") {
       return adminRequired();
     }
-    const params = get(
-      pathParamsOf(feishuConnectContract.updateInstallation),
-    );
+    const params = get(pathParamsOf(feishuConnectContract.updateInstallation));
     const bodyResult = await get(
       bodyResultOf(feishuConnectContract.updateInstallation),
     );
@@ -244,9 +242,7 @@ const removeInstallation$ = command(
     if (auth.orgRole !== "admin") {
       return adminRequired();
     }
-    const params = get(
-      pathParamsOf(feishuConnectContract.removeInstallation),
-    );
+    const params = get(pathParamsOf(feishuConnectContract.removeInstallation));
     const removed = await set(
       removeFeishuInstallation$,
       { orgId: auth.orgId, installationId: params.installationId },

--- a/turbo/apps/api/src/signals/services/feishu-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-connect.service.ts
@@ -5,7 +5,7 @@ import {
   FEISHU_OAUTH_SCOPES,
   type FeishuConnectStatus,
   type FeishuInstallationStatus,
-} from "@okouai/api-contracts/contracts/zero-feishu-connect";
+} from "@okouai/api-contracts/contracts/feishu-connect";
 import { feishuOrgConnections } from "@okouai/db/schema/feishu-org-connection";
 import { feishuOrgInstallations } from "@okouai/db/schema/feishu-org-installation";
 import { zeroAgents } from "@okouai/db/schema/zero-agent";

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { command } from "ccstate";
 import { and, eq, sql } from "drizzle-orm";
-import { FEISHU_OAUTH_SCOPES } from "@okouai/api-contracts/contracts/zero-feishu-connect";
+import { FEISHU_OAUTH_SCOPES } from "@okouai/api-contracts/contracts/feishu-connect";
 import { connectors } from "@okouai/db/schema/connector";
 import { feishuOrgInstallations } from "@okouai/db/schema/feishu-org-installation";
 import { orgCustomConnectorOauthConfigs } from "@okouai/db/schema/org-custom-connector-oauth-config";

--- a/turbo/apps/platform/src/signals/zero-page/zero-feishu.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-feishu.ts
@@ -1,9 +1,9 @@
 import { command, computed, state } from "ccstate";
 import {
-  zeroFeishuConnectContract,
+  feishuConnectContract,
   type FeishuConnectStatus,
   type FeishuInstallationStatus,
-} from "@okouai/api-contracts/contracts/zero-feishu-connect";
+} from "@okouai/api-contracts/contracts/feishu-connect";
 import { toast } from "@okouai/ui/components/ui/sonner";
 
 import { accept } from "../../lib/accept.ts";
@@ -37,7 +37,7 @@ const FEISHU_SETUP_STEP_ORDER = [
 export const feishuOrgData$ = computed(
   async (get): Promise<FeishuConnectStatus> => {
     get(reload$);
-    const client = get(zeroClient$)(zeroFeishuConnectContract);
+    const client = get(zeroClient$)(feishuConnectContract);
     const result = await accept(client.getStatus(), [200]);
     return result.body;
   },
@@ -100,7 +100,7 @@ export const feishuInstallations$ = computed(
 
 export const disconnectFeishuOrg$ = command(
   async ({ get, set }, installationId: string | null, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroFeishuConnectContract);
+    const client = get(zeroClient$)(feishuConnectContract);
     if (installationId) {
       await accept(
         client.disconnectInstallation({
@@ -236,7 +236,7 @@ export const setupFeishuOrg$ = command(
     },
     signal: AbortSignal,
   ): Promise<FeishuConnectStatus> => {
-    const client = get(zeroClient$)(zeroFeishuConnectContract);
+    const client = get(zeroClient$)(feishuConnectContract);
     const result = await accept(
       client.setup({ body: input, fetchOptions: { signal } }),
       [200],
@@ -256,7 +256,7 @@ export const setupFeishuOrg$ = command(
 
 export const checkFeishuAppIdAvailable$ = command(
   async ({ get }, appId: string, signal: AbortSignal): Promise<void> => {
-    const client = get(zeroClient$)(zeroFeishuConnectContract);
+    const client = get(zeroClient$)(feishuConnectContract);
     await accept(
       client.checkAppId({
         query: { appId },
@@ -275,7 +275,7 @@ export const updateFeishuInstallationAgent$ = command(
     defaultAgentId: string,
     signal: AbortSignal,
   ) => {
-    const client = get(zeroClient$)(zeroFeishuConnectContract);
+    const client = get(zeroClient$)(feishuConnectContract);
     await accept(
       client.updateInstallation({
         params: { installationId },
@@ -298,7 +298,7 @@ export const completeFeishuInstallationSetup$ = command(
     defaultAgentId: string,
     signal: AbortSignal,
   ) => {
-    const client = get(zeroClient$)(zeroFeishuConnectContract);
+    const client = get(zeroClient$)(feishuConnectContract);
     await accept(
       client.updateInstallation({
         params: { installationId },
@@ -321,7 +321,7 @@ export const completeFeishuInstallationSetup$ = command(
 
 export const uninstallFeishuInstallation$ = command(
   async ({ get, set }, installationId: string, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroFeishuConnectContract);
+    const client = get(zeroClient$)(feishuConnectContract);
     await accept(
       client.removeInstallation({
         params: { installationId },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -183,25 +183,22 @@ async function disconnectAndReopenAgentPhone(): Promise<HTMLElement> {
 describe("works page", () => {
   it("shows skeleton rows while Feishu settings load", async () => {
     const responseReady = context.mocks.deferred<void>();
-    context.mocks.api(
-      feishuConnectContract.getStatus,
-      async ({ respond }) => {
-        await responseReady.promise;
-        return respond(200, {
-          isConnected: false,
-          isInstalled: false,
-          isAdmin: true,
-          appId: null,
-          callbackUrl: null,
-          callbackVerified: false,
-          messageReceived: false,
-          tenantKey: null,
-          tenantName: null,
-          defaultAgentId: null,
-          defaultAgentName: "Okou",
-        });
-      },
-    );
+    context.mocks.api(feishuConnectContract.getStatus, async ({ respond }) => {
+      await responseReady.promise;
+      return respond(200, {
+        isConnected: false,
+        isInstalled: false,
+        isAdmin: true,
+        appId: null,
+        callbackUrl: null,
+        callbackVerified: false,
+        messageReceived: false,
+        tenantKey: null,
+        tenantName: null,
+        defaultAgentId: null,
+        defaultAgentName: "Okou",
+      });
+    });
 
     detachedSetupPage({
       context,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -8,9 +8,9 @@ import {
 } from "@okouai/api-contracts/contracts/zero-teams-connect";
 import {
   FEISHU_OAUTH_SCOPES,
-  zeroFeishuConnectContract,
+  feishuConnectContract,
   type FeishuConnectStatus,
-} from "@okouai/api-contracts/contracts/zero-feishu-connect";
+} from "@okouai/api-contracts/contracts/feishu-connect";
 import { strapiIntegrationsContract } from "@okouai/api-contracts/contracts/strapi-integrations";
 import { integrationsGithubContract } from "@okouai/api-contracts/contracts/integrations-github";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -106,10 +106,10 @@ function mockFeishuAPI(overrides: Partial<FeishuConnectStatus> = {}): void {
     defaultAgentId: null,
     defaultAgentName: "Okou",
   };
-  context.mocks.api(zeroFeishuConnectContract.getStatus, ({ respond }) => {
+  context.mocks.api(feishuConnectContract.getStatus, ({ respond }) => {
     return respond(200, { ...defaults, ...overrides });
   });
-  context.mocks.api(zeroFeishuConnectContract.checkAppId, ({ respond }) => {
+  context.mocks.api(feishuConnectContract.checkAppId, ({ respond }) => {
     return respond(200, { available: true });
   });
 }
@@ -184,7 +184,7 @@ describe("works page", () => {
   it("shows skeleton rows while Feishu settings load", async () => {
     const responseReady = context.mocks.deferred<void>();
     context.mocks.api(
-      zeroFeishuConnectContract.getStatus,
+      feishuConnectContract.getStatus,
       async ({ respond }) => {
         await responseReady.promise;
         return respond(200, {
@@ -943,7 +943,7 @@ describe("works page", () => {
     let callbackVerified = false;
     let isConnected = false;
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
-    context.mocks.api(zeroFeishuConnectContract.getStatus, ({ respond }) => {
+    context.mocks.api(feishuConnectContract.getStatus, ({ respond }) => {
       const installation = {
         id: installationId,
         isConnected,
@@ -1070,7 +1070,7 @@ describe("works page", () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     mockFeishuAPI({ isAdmin: true });
     context.mocks.api(
-      zeroFeishuConnectContract.checkAppId,
+      feishuConnectContract.checkAppId,
       ({ query, respond }) => {
         expect(query.appId).toBe("cli_registered");
         return respond(409, {

--- a/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/feishu-card.tsx
@@ -12,7 +12,7 @@ import {
   Plus,
   Settings,
 } from "lucide-react";
-import { FEISHU_OAUTH_SCOPES } from "@okouai/api-contracts/contracts/zero-feishu-connect";
+import { FEISHU_OAUTH_SCOPES } from "@okouai/api-contracts/contracts/feishu-connect";
 import type { TeamComposeItem } from "@okouai/api-contracts/contracts/zero-team";
 import { Button } from "@okouai/ui";
 import {

--- a/turbo/packages/api-contracts/src/contracts/feishu-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/feishu-connect.ts
@@ -88,7 +88,7 @@ const feishuConnectStatusSchema = z.object({
   installations: z.array(feishuInstallationStatusSchema).optional(),
 });
 
-export const zeroFeishuConnectContract = c.router({
+export const feishuConnectContract = c.router({
   getStatus: {
     method: "GET",
     path: "/api/okou/integrations/feishu",
@@ -215,4 +215,4 @@ export type FeishuConnectStatus = z.infer<typeof feishuConnectStatusSchema>;
 export type FeishuInstallationStatus = z.infer<
   typeof feishuInstallationStatusSchema
 >;
-export type ZeroFeishuConnectContract = typeof zeroFeishuConnectContract;
+export type FeishuConnectContract = typeof feishuConnectContract;


### PR DESCRIPTION
## Summary

Phase 2 contract naming cleanup (#27432, naming model #26873). This slice neutralizes the Feishu connect contract module: the `zero` brand prefix is redundant on a Feishu-domain contract.

Pure rename plus import updates. No compatibility alias, no old-path re-export, no `@deprecated` shim.

## Mapping

| Old | New |
|---|---|
| `contracts/zero-feishu-connect.ts` | `contracts/feishu-connect.ts` |
| `zeroFeishuConnectContract` | `feishuConnectContract` |
| `ZeroFeishuConnectContract` | `FeishuConnectContract` |

`FEISHU_OAUTH_SCOPES`, `FeishuConnectStatus` and `FeishuInstallationStatus` were already neutral and are unchanged.

## Out of scope, explicitly unchanged

- No `path:` literal, method, header schema, request/response schema or status code was touched.
- `FEISHU_OAUTH_SCOPES` contents are byte-identical — they are external Feishu OAuth scope identities.
- The module is still **not** exported from `contracts/index.ts`; its absence from the barrel is intentional and adding it would widen the package's public export surface.
- `contracts/feishu-oauth.ts` and `contracts/feishu-browser-connect.ts` (migrated by #27856) are untouched.
- `apps/api/src/signals/services/feishu-connect.service.ts` (renamed by #27860) is a different package and does not collide with the new contract path.

## Verification

- Repository-wide grep confirms no `zero-feishu-connect` specifier and no `zeroFeishuConnectContract` / `ZeroFeishuConnectContract` identifier remains, including dynamic imports.
- `check-types` passes for `@okouai/api-contracts`, `api` and `@okouai/app`.
- `pnpm knip` exits clean.
- Per repository convention the full local vitest suite was not run; the PR pipeline owns full-repo verification.

Closes #27913
