### PR TITLE
refactor(api): neutralize run detail route and model key fixture naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -119,7 +119,7 @@ import { queuePositionRoutes } from "./routes/queue-position";
 import { realtimeTokenRoutes } from "./routes/realtime-token";
 import { imageRecognitionRoutes } from "./routes/image-recognition";
 import { translationRoutes } from "./routes/translation";
-import { zeroRunDetailRoutes } from "./routes/zero-run-detail";
+import { runDetailRoutes } from "./routes/run-detail";
 import { zeroRunsRoutes } from "./routes/zero-runs";
 import { zeroRunsCancelRoutes } from "./routes/zero-runs-cancel";
 import { meModelProvidersDeleteRoutes } from "./routes/me-model-providers-delete";
@@ -318,7 +318,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...realtimeTokenRoutes,
   ...imageRecognitionRoutes,
   ...translationRoutes,
-  ...zeroRunDetailRoutes,
+  ...runDetailRoutes,
   ...zeroRunsRoutes,
   ...zeroRunsCancelRoutes,
   ...onboardingCompleteRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-reads.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-run-reads.ts
@@ -21,12 +21,12 @@ import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 import { logsRoutes } from "../../logs";
 import { queuePositionRoutes } from "../../queue-position";
-import { zeroRunDetailRoutes } from "../../zero-run-detail";
+import { runDetailRoutes } from "../../run-detail";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...logsRoutes,
   ...queuePositionRoutes,
-  ...zeroRunDetailRoutes,
+  ...runDetailRoutes,
 ]);
 
 type AuthHeaders = {
@@ -161,7 +161,7 @@ export function createRunReadsApi(context: TestContext) {
       statuses: readonly TStatus[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroRunDetailRoutes })(
+        setupApp({ context, routes: runDetailRoutes })(
           zeroRunAgentEventsContract,
         ).getAgentEvents({
           headers: authenticate(context, actor),
@@ -181,7 +181,7 @@ export function createRunReadsApi(context: TestContext) {
       statuses: readonly TStatus[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroRunDetailRoutes })(
+        setupApp({ context, routes: runDetailRoutes })(
           zeroRunNetworkLogsContract,
         ).getNetworkLogs({
           headers: authenticate(context, actor),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -71,7 +71,7 @@ import { agentsRoutes } from "../../agents";
 import { billingStatusRoutes } from "../../billing-status";
 import { modelPoliciesRoutes } from "../../model-policies";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
-import { zeroRunDetailRoutes } from "../../zero-run-detail";
+import { runDetailRoutes } from "../../run-detail";
 import { zeroRunsCancelRoutes } from "../../zero-runs-cancel";
 import { zeroRunsRoutes } from "../../zero-runs";
 import {
@@ -157,7 +157,7 @@ const runRoutes = [
   ...billingStatusRoutes,
   ...modelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
-  ...zeroRunDetailRoutes,
+  ...runDetailRoutes,
   ...zeroRunFixtureRoutes,
   ...zeroRunsRoutes,
   ...zeroRunsCancelRoutes,

--- a/turbo/apps/api/src/signals/routes/run-detail.ts
+++ b/turbo/apps/api/src/signals/routes/run-detail.ts
@@ -81,7 +81,7 @@ const getAgentEventsInner$ = computed(async (get) => {
   return { status: 200 as const, body: result };
 });
 
-export const zeroRunDetailRoutes: readonly RouteEntry[] = [
+export const runDetailRoutes: readonly RouteEntry[] = [
   {
     route: zeroRunContextContract.getContext,
     handler: authRoute(runReadAuth, getContextInner$),

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -39,9 +39,9 @@ import {
   settleIncludingAbort,
 } from "../utils";
 import {
-  acquireVm0ManagedModelKeyFixture,
-  releaseVm0ManagedModelKeyFixture,
-} from "../services/test-vm0-managed-model-key-fixture.service";
+  acquireManagedModelKeyFixture,
+  releaseManagedModelKeyFixture,
+} from "../services/managed-model-key-fixture";
 import { browserScreenshotSchemaAvailable } from "../services/browser-screenshot-schema.service";
 import { usagePackInvitationPurchaseSchemaAvailable } from "../services/usage-pack-invitation-purchase.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
@@ -222,7 +222,7 @@ async function seedVm0ManagedModelKey(
   signal: AbortSignal,
 ): Promise<string> {
   const vendor = getVm0Vendor(selectedModel);
-  await acquireVm0ManagedModelKeyFixture(db, fixtureId, [
+  await acquireManagedModelKeyFixture(db, fixtureId, [
     {
       vendor,
       apiKey: `${VM0_MANAGED_MODEL_KEY_FIXTURE_PREFIX}${fixtureId}`,
@@ -237,7 +237,7 @@ async function deleteVm0ManagedModelKey(
   fixtureId: string,
   signal: AbortSignal,
 ): Promise<void> {
-  await releaseVm0ManagedModelKeyFixture(db, fixtureId);
+  await releaseManagedModelKeyFixture(db, fixtureId);
   signal.throwIfAborted();
 }
 

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -36,9 +36,9 @@ import type { RouteEntry } from "../route-entry";
 import { resolveTestOrgId$, testUserId$ } from "../services/cli-auth.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
 import {
-  acquireVm0ManagedModelKeyFixture,
-  releaseVm0ManagedModelKeyFixture,
-} from "../services/test-vm0-managed-model-key-fixture.service";
+  acquireManagedModelKeyFixture,
+  releaseManagedModelKeyFixture,
+} from "../services/managed-model-key-fixture";
 import { chatEventTypeIn } from "../services/chat-event-type.service";
 import {
   isTestEndpointAllowed,
@@ -231,7 +231,7 @@ async function seedDefaultAgent(
 }
 
 async function seedVm0ManagedKeys(db: Db, composeId: string): Promise<void> {
-  await acquireVm0ManagedModelKeyFixture(
+  await acquireManagedModelKeyFixture(
     db,
     composeId,
     vm0ManagedKeyRows(composeId),
@@ -277,7 +277,7 @@ async function deleteVm0ManagedKeysForSeededDefaultAgent(
     return;
   }
 
-  await releaseVm0ManagedModelKeyFixture(db, compose.id);
+  await releaseManagedModelKeyFixture(db, compose.id);
 }
 
 async function getOrInsertCompose(

--- a/turbo/apps/api/src/signals/services/managed-model-key-fixture.ts
+++ b/turbo/apps/api/src/signals/services/managed-model-key-fixture.ts
@@ -46,7 +46,7 @@ function parseVm0ManagedModelKeyFixtureLabel(label: string | null) {
  * different integrations share each vendor row, so every owner must be
  * recorded under the same row lock before any fixture can release it.
  */
-export async function acquireVm0ManagedModelKeyFixture(
+export async function acquireManagedModelKeyFixture(
   db: Db,
   fixtureId: string,
   rows: readonly Vm0ManagedModelKeyRow[],
@@ -103,7 +103,7 @@ export async function acquireVm0ManagedModelKeyFixture(
 }
 
 /** Releases only one fixture's ownership, deleting the row at the last owner. */
-export async function releaseVm0ManagedModelKeyFixture(
+export async function releaseManagedModelKeyFixture(
   db: Db,
   fixtureId: string,
 ): Promise<void> {

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -52,9 +52,9 @@ import {
   runOwnedChatEventForRunCondition,
 } from "../signals/services/chat-event-type.service";
 import {
-  acquireVm0ManagedModelKeyFixture,
-  releaseVm0ManagedModelKeyFixture,
-} from "../signals/services/test-vm0-managed-model-key-fixture.service";
+  acquireManagedModelKeyFixture,
+  releaseManagedModelKeyFixture,
+} from "../signals/services/managed-model-key-fixture";
 import { visibleChatEventCondition } from "../signals/services/chat-event-shared.service";
 import { createChatEventSourcePart } from "../signals/services/chat-event-annotation.service";
 import { buildFeishuChatOpenUrl } from "../signals/services/feishu-config";
@@ -1572,16 +1572,12 @@ export async function acquireBddVm0ApiKey(args: {
       `acquireBddVm0ApiKey: api key must start with one of ${VM0_BDD_API_KEY_PREFIXES.join(", ")}`,
     );
   }
-  const [acquired] = await acquireVm0ManagedModelKeyFixture(
-    db(),
-    args.fixtureId,
-    [
-      {
-        vendor: args.vendor,
-        apiKey: args.apiKey,
-      },
-    ],
-  );
+  const [acquired] = await acquireManagedModelKeyFixture(db(), args.fixtureId, [
+    {
+      vendor: args.vendor,
+      apiKey: args.apiKey,
+    },
+  ]);
   if (!acquired) {
     throw new Error(`Expected VM0 managed key for vendor: ${args.vendor}`);
   }
@@ -1592,7 +1588,7 @@ export async function acquireBddVm0ApiKey(args: {
 export async function releaseBddVm0ApiKey(args: {
   readonly fixtureId: string;
 }): Promise<void> {
-  await releaseVm0ManagedModelKeyFixture(db(), args.fixtureId);
+  await releaseManagedModelKeyFixture(db(), args.fixtureId);
 }
 
 /**


### PR DESCRIPTION
## Summary

- rename `routes/zero-run-detail.ts` to `routes/run-detail.ts` and its exported `zeroRunDetailRoutes` registry to `runDetailRoutes`
- rename `services/test-vm0-managed-model-key-fixture.service.ts` to `services/managed-model-key-fixture.ts` and its two exported functions to neutral names
- update every importer atomically in the same commit

This is an internal naming change only. The route module carries no HTTP `path:` literal — the paths live in `contracts/zero-runs.ts` and are already canonical `/api/okou/**` — so nothing wire-visible changes.

## Mapping

| Old | New |
|---|---|
| `routes/zero-run-detail.ts` | `routes/run-detail.ts` |
| `zeroRunDetailRoutes` | `runDetailRoutes` |
| `services/test-vm0-managed-model-key-fixture.service.ts` | `services/managed-model-key-fixture.ts` |
| `acquireVm0ManagedModelKeyFixture` | `acquireManagedModelKeyFixture` |
| `releaseVm0ManagedModelKeyFixture` | `releaseManagedModelKeyFixture` |

Updated importers: `signals/route.ts`, `routes/__tests__/helpers/api-bdd-run-reads.ts`, `routes/__tests__/helpers/api-bdd-runs.ts`, `routes/test-runtime-state.ts`, `routes/test-slack-state.ts`, `test-fixtures/chat-events.ts`.

No compatibility alias and no old-path re-export is left behind.

## Out of scope, deliberately left alone

- `contracts/zero-runs.ts` and the `zeroRunAgentEventsContract`, `zeroRunContextContract`, `zeroRunNetworkLogsContract` identifiers it exports — a different slice; `routes/run-detail.ts` keeps importing them from `@okouai/api-contracts/contracts/zero-runs` unchanged.
- `services/run-detail.service.ts` — a pre-existing, different module that this route imports. Not merged, not renamed.
- `routes/zero-runs.ts`, `routes/zero-runs-cancel.ts`, `routes/zero-model-providers.ts` — separate slices.
- The fixture module's internal `VM0_MANAGED_MODEL_KEY_FIXTURE_LABEL_KIND` label kind and the `vm0ApiKeys`-scoped internal helpers — the label kind is a persisted value and the helpers name the platform-managed VM0 key table.
- The registered route order in `signals/route.ts`, and every request/response shape, capability string and path literal.

## Validation

- `pnpm exec prettier --check` on the touched files — one reflow in `test-fixtures/chat-events.ts`, where the shorter call now fits the argument hug
- `pnpm -F api run check-types` — clean; the `check-types:boundaries` gate reports `missing=0; extra=0; overlaps=0`, confirming both files stay in the same tsconfig projects after the rename
- `pnpm turbo run lint --filter=api` — 0 errors
- `pnpm knip` — exit 0, only the pre-existing configuration hints
- Repository-wide grep confirms no `zeroRunDetailRoutes`, `acquireVm0ManagedModelKeyFixture` or `releaseVm0ManagedModelKeyFixture` identifier and no `zero-run-detail` or `test-vm0-managed-model-key-fixture` specifier remains

Full-repository test coverage is left to the PR pipeline.

Closes #27918