### PR TITLE
refactor(contracts): neutralize the teams connect contract naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-teams.test.ts
@@ -5,7 +5,7 @@ import {
   integrationsTeamsMessageContract,
   integrationsTeamsUploadCompleteContract,
 } from "@okouai/api-contracts/contracts/integrations";
-import { zeroTeamsConnectContract } from "@okouai/api-contracts/contracts/zero-teams-connect";
+import { teamsConnectContract } from "@okouai/api-contracts/contracts/teams-connect";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -141,7 +141,7 @@ async function seedConnectedTeams(fixture: TeamsConnectFixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
   const client = setupApp({ context, routes: teamsConnectRoutes })(
-    zeroTeamsConnectContract,
+    teamsConnectContract,
   );
   await accept(
     client.connect({

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -2,7 +2,7 @@ import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 
 import { chatThreadsContract } from "@okouai/api-contracts/contracts/chat-threads";
-import { zeroTeamsConnectContract } from "@okouai/api-contracts/contracts/zero-teams-connect";
+import { teamsConnectContract } from "@okouai/api-contracts/contracts/teams-connect";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -342,7 +342,7 @@ async function connectTeamsFixture(
   const client = setupApp({
     context,
     routes: teamsConnectRoutes,
-  })(zeroTeamsConnectContract);
+  })(teamsConnectContract);
   await accept(
     client.connect({
       headers: {

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -7,7 +7,7 @@ import {
 } from "node:crypto";
 
 import { chatThreadsContract } from "@okouai/api-contracts/contracts/chat-threads";
-import { zeroTeamsConnectContract } from "@okouai/api-contracts/contracts/zero-teams-connect";
+import { teamsConnectContract } from "@okouai/api-contracts/contracts/teams-connect";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
@@ -801,7 +801,7 @@ async function connectTeamsFixture(
 ): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
   const client = setupApp({ context, routes: teamsConnectRoutes })(
-    zeroTeamsConnectContract,
+    teamsConnectContract,
   );
   await accept(
     client.connect({
@@ -1103,7 +1103,7 @@ describe("POST /api/zero/teams/bot", () => {
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     await accept(
       client.connect({
@@ -3294,7 +3294,7 @@ describe("POST /api/zero/teams/bot", () => {
     await flushWaitUntilForTest();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     await accept(
       client.connect({

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-browser-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-browser-connect.test.ts
@@ -1,4 +1,4 @@
-import { zeroTeamsConnectContract } from "@okouai/api-contracts/contracts/zero-teams-connect";
+import { teamsConnectContract } from "@okouai/api-contracts/contracts/teams-connect";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
@@ -130,7 +130,7 @@ async function bindTeamsInstallation(
 ): Promise<void> {
   mocks.clerk.session(userId, fixture.orgId, "org:admin");
   const client = setupApp({ context, routes: teamsConnectRoutes })(
-    zeroTeamsConnectContract,
+    teamsConnectContract,
   );
   await accept(
     client.connect({
@@ -153,7 +153,7 @@ async function expectTeamsConnected(
   } = {},
 ): Promise<void> {
   const client = setupApp({ context, routes: teamsConnectRoutes })(
-    zeroTeamsConnectContract,
+    teamsConnectContract,
   );
   const status = await accept(
     client.getStatus({

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-connect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { zeroTeamsConnectContract } from "@okouai/api-contracts/contracts/zero-teams-connect";
+import { teamsConnectContract } from "@okouai/api-contracts/contracts/teams-connect";
 import { HttpResponse, http } from "msw";
 
 import { mockEnv } from "../../../lib/env";
@@ -160,7 +160,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
 
   it("returns 401 when the request is unauthenticated", async () => {
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
 
     const response = await accept(client.getStatus({ headers: {} }), [401]);
@@ -178,7 +178,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
 
     const response = await accept(
@@ -206,7 +206,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
 
     const response = await accept(
@@ -236,7 +236,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     await accept(
       client.connect({
@@ -279,7 +279,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
     const fixture = await seedTeamsInstallation(track);
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     await accept(
       client.connect({
@@ -325,7 +325,7 @@ describe("GET /api/zero/integrations/teams/connect", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     await accept(
@@ -379,7 +379,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     const response = await accept(
       client.connect({
@@ -423,7 +423,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     const response = await accept(
       client.connect({
@@ -448,7 +448,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     );
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
     await accept(
@@ -481,7 +481,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
   it("rejects users from the wrong org with a clear error", async () => {
     const fixture = await seedTeamsInstallation(track);
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
@@ -510,7 +510,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     const first = await accept(
       client.connect({
@@ -545,7 +545,7 @@ describe("POST /api/zero/integrations/teams/connect", () => {
     const welcomeRequests = teamsWelcomeHandlers(fixture);
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     const body = {
       ...connectBody(fixture),
@@ -620,7 +620,7 @@ describe("DELETE /api/zero/integrations/teams/connect", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     await accept(
       client.connect({
@@ -656,7 +656,7 @@ describe("DELETE /api/zero/integrations/teams/connect", () => {
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     await accept(
       client.connect({

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -1,5 +1,5 @@
 import { createStore } from "ccstate";
-import { zeroTeamsConnectContract } from "@okouai/api-contracts/contracts/zero-teams-connect";
+import { teamsConnectContract } from "@okouai/api-contracts/contracts/teams-connect";
 import { HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -294,7 +294,7 @@ describe("Teams OAuth API routes", () => {
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     const pendingStatus = await accept(
       client.getStatus({
@@ -360,7 +360,7 @@ describe("Teams OAuth API routes", () => {
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     const status = await accept(
       client.getStatus({
@@ -381,7 +381,7 @@ describe("Teams OAuth API routes", () => {
     await seedMembership(fixture.orgId, fixture.userId, "admin");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
     const client = setupApp({ context, routes: teamsConnectRoutes })(
-      zeroTeamsConnectContract,
+      teamsConnectContract,
     );
     await accept(
       client.connect({

--- a/turbo/apps/api/src/signals/routes/teams-connect.ts
+++ b/turbo/apps/api/src/signals/routes/teams-connect.ts
@@ -1,5 +1,5 @@
 import { command, computed } from "ccstate";
-import { zeroTeamsConnectContract } from "@okouai/api-contracts/contracts/zero-teams-connect";
+import { teamsConnectContract } from "@okouai/api-contracts/contracts/teams-connect";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -46,7 +46,7 @@ const connectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const publicBrand = get(publicBrand$);
   signal.throwIfAborted();
 
-  const bodyResult = await get(bodyResultOf(zeroTeamsConnectContract.connect));
+  const bodyResult = await get(bodyResultOf(teamsConnectContract.connect));
   signal.throwIfAborted();
   if (!bodyResult.ok) {
     return bodyResult.response;
@@ -106,7 +106,7 @@ const connectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
 const disconnectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
-  const query = get(queryOf(zeroTeamsConnectContract.disconnect));
+  const query = get(queryOf(teamsConnectContract.disconnect));
 
   if (query.action === "uninstall") {
     if (!("orgRole" in auth) || auth.orgRole !== "admin") {
@@ -171,15 +171,15 @@ const teamsConnectAuth = {
 
 export const teamsConnectRoutes: readonly RouteEntry[] = [
   {
-    route: zeroTeamsConnectContract.getStatus,
+    route: teamsConnectContract.getStatus,
     handler: authRoute(teamsConnectAuth, getTeamsConnectStatusInner$),
   },
   {
-    route: zeroTeamsConnectContract.connect,
+    route: teamsConnectContract.connect,
     handler: authRoute(teamsConnectAuth, connectInner$),
   },
   {
-    route: zeroTeamsConnectContract.disconnect,
+    route: teamsConnectContract.disconnect,
     handler: authRoute(teamsConnectAuth, disconnectInner$),
   },
 ];

--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-teams.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-teams.ts
@@ -1,7 +1,7 @@
 import {
   type TeamsConnectStatus,
-  zeroTeamsConnectContract,
-} from "@okouai/api-contracts/contracts/zero-teams-connect";
+  teamsConnectContract,
+} from "@okouai/api-contracts/contracts/teams-connect";
 import { mockApi } from "../msw-contract.ts";
 
 let mockTeamsData: TeamsConnectStatus = {
@@ -25,11 +25,11 @@ export function resetMockTeamsIntegration(): void {
 }
 
 export const apiIntegrationsTeamsHandlers = [
-  mockApi(zeroTeamsConnectContract.getStatus, ({ respond }) => {
+  mockApi(teamsConnectContract.getStatus, ({ respond }) => {
     return respond(200, mockTeamsData);
   }),
 
-  mockApi(zeroTeamsConnectContract.connect, ({ body, respond }) => {
+  mockApi(teamsConnectContract.connect, ({ body, respond }) => {
     mockTeamsData = {
       ...mockTeamsData,
       isInstalled: true,
@@ -47,7 +47,7 @@ export const apiIntegrationsTeamsHandlers = [
     });
   }),
 
-  mockApi(zeroTeamsConnectContract.disconnect, ({ query, respond }) => {
+  mockApi(teamsConnectContract.disconnect, ({ query, respond }) => {
     if (query.action === "uninstall") {
       mockTeamsData = {
         ...mockTeamsData,

--- a/turbo/apps/platform/src/signals/zero-page/teams-connect-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/teams-connect-signals.ts
@@ -1,5 +1,5 @@
 import { command, computed } from "ccstate";
-import { zeroTeamsConnectContract } from "@okouai/api-contracts/contracts/zero-teams-connect";
+import { teamsConnectContract } from "@okouai/api-contracts/contracts/teams-connect";
 import { replaceSearchParams$, searchParams$ } from "../route.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
@@ -26,7 +26,7 @@ export const teamsConnectStatus$ = computed(
       return "idle";
     }
 
-    const client = get(zeroClient$)(zeroTeamsConnectContract);
+    const client = get(zeroClient$)(teamsConnectContract);
     const [result] = await Promise.allSettled([
       accept(client.getStatus(), [200]),
     ]);
@@ -72,7 +72,7 @@ export const connectTeamsAccount$ = command(
       return;
     }
 
-    const client = get(zeroClient$)(zeroTeamsConnectContract);
+    const client = get(zeroClient$)(teamsConnectContract);
     const displayName = teamsParam(
       params,
       "teamsUserDisplayName",

--- a/turbo/apps/platform/src/signals/zero-page/zero-teams.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-teams.ts
@@ -1,9 +1,9 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import {
-  zeroTeamsConnectContract,
+  teamsConnectContract,
   type TeamsConnectStatus,
-} from "@okouai/api-contracts/contracts/zero-teams-connect";
+} from "@okouai/api-contracts/contracts/teams-connect";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 import { setAblyLoop$ } from "../realtime.ts";
@@ -14,7 +14,7 @@ const internalTeamsStatus$ = state<TeamsConnectStatus | null>(null);
 
 export const teamsOrgData$ = computed(async (get) => {
   get(internalReload$);
-  const client = get(zeroClient$)(zeroTeamsConnectContract);
+  const client = get(zeroClient$)(teamsConnectContract);
   const result = await accept(client.getStatus(), [200]);
   return result.body;
 });
@@ -93,7 +93,7 @@ export const setShowTeamsUninstallDialog$ = command(
 
 export const disconnectTeamsOrg$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroTeamsConnectContract);
+    const client = get(zeroClient$)(teamsConnectContract);
     await accept(client.disconnect(), [200]);
     signal.throwIfAborted();
     set(reloadTeamsOrg$);
@@ -102,7 +102,7 @@ export const disconnectTeamsOrg$ = command(
 
 export const uninstallTeamsOrg$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const client = get(zeroClient$)(zeroTeamsConnectContract);
+    const client = get(zeroClient$)(teamsConnectContract);
     await accept(client.disconnect({ query: { action: "uninstall" } }), [200]);
     signal.throwIfAborted();
     set(reloadTeamsOrg$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-teams-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-teams-connect-page.test.tsx
@@ -1,4 +1,4 @@
-import { zeroTeamsConnectContract } from "@okouai/api-contracts/contracts/zero-teams-connect";
+import { teamsConnectContract } from "@okouai/api-contracts/contracts/teams-connect";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -52,7 +52,7 @@ describe("zero Teams connect page", () => {
   });
 
   it("connects from a Teams link with tenant and user parameters", async () => {
-    context.mocks.api(zeroTeamsConnectContract.getStatus, ({ respond }) => {
+    context.mocks.api(teamsConnectContract.getStatus, ({ respond }) => {
       return respond(200, {
         isConnected: false,
         isInstalled: true,
@@ -64,7 +64,7 @@ describe("zero Teams connect page", () => {
         defaultAgentName: null,
       });
     });
-    context.mocks.api(zeroTeamsConnectContract.connect, ({ body, respond }) => {
+    context.mocks.api(teamsConnectContract.connect, ({ body, respond }) => {
       expect(body).toMatchObject({
         tenantId: "tenant-123",
         tenantName: "Acme Tenant",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -3,9 +3,9 @@ import {
   type SlackOrgStatus,
 } from "@okouai/api-contracts/contracts/zero-integrations-slack";
 import {
-  zeroTeamsConnectContract,
+  teamsConnectContract,
   type TeamsConnectStatus,
-} from "@okouai/api-contracts/contracts/zero-teams-connect";
+} from "@okouai/api-contracts/contracts/teams-connect";
 import {
   FEISHU_OAUTH_SCOPES,
   zeroFeishuConnectContract,
@@ -87,7 +87,7 @@ function mockTeamsAPI(overrides: Partial<TeamsConnectStatus> = {}): void {
       "https://teams.microsoft.com/l/app/00000000-0000-0000-0000-000000000001",
     connectUrl: "/api/okou/teams/oauth/connect?orgId=org_1&userId=user_1",
   };
-  context.mocks.api(zeroTeamsConnectContract.getStatus, ({ respond }) => {
+  context.mocks.api(teamsConnectContract.getStatus, ({ respond }) => {
     return respond(200, { ...defaults, ...overrides });
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -1,6 +1,6 @@
 import { useGet, useSet, useLastLoadable, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import type { TeamsConnectStatus } from "@okouai/api-contracts/contracts/zero-teams-connect";
+import type { TeamsConnectStatus } from "@okouai/api-contracts/contracts/teams-connect";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   AlertTriangle,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1449,13 +1449,13 @@ export {
   type TeamsBotContract,
 } from "./teams-bot";
 export {
-  zeroTeamsConnectContract,
+  teamsConnectContract,
   type TeamsConnectBody,
   type TeamsConnectResponse,
   type TeamsConnectStatus,
   type TeamsDisconnectResponse,
-  type ZeroTeamsConnectContract,
-} from "./zero-teams-connect";
+  type TeamsConnectContract,
+} from "./teams-connect";
 export {
   teamsBrowserConnectContract,
   teamsBrowserConnectQuerySchema,

--- a/turbo/packages/api-contracts/src/contracts/teams-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/teams-connect.ts
@@ -67,7 +67,7 @@ const teamsDisconnectResponseSchema = z.object({
   success: z.literal(true),
 });
 
-export const zeroTeamsConnectContract = c.router({
+export const teamsConnectContract = c.router({
   getStatus: {
     method: "GET",
     path: "/api/okou/integrations/teams/connect",
@@ -115,4 +115,4 @@ export type TeamsConnectResponse = z.infer<typeof teamsConnectResponseSchema>;
 export type TeamsDisconnectResponse = z.infer<
   typeof teamsDisconnectResponseSchema
 >;
-export type ZeroTeamsConnectContract = typeof zeroTeamsConnectContract;
+export type TeamsConnectContract = typeof teamsConnectContract;


### PR DESCRIPTION
## What

Phase 2 contract naming cleanup for the Microsoft Teams connect contract module (parent #27432, naming model #26873). Pure rename plus import updates — no compatibility alias, no re-export shim.

## Mapping

| Old | New |
|---|---|
| `contracts/zero-teams-connect.ts` | `contracts/teams-connect.ts` |
| `zeroTeamsConnectContract` | `teamsConnectContract` |
| `ZeroTeamsConnectContract` | `TeamsConnectContract` |

The module file plus the barrel and all 13 callers were updated in the same commit (15 files, 61 insertions / 61 deletions — fully symmetric).

## Non-goals honored

- No `path:` literal, method, header schema, request/response schema, or status code changed. All four `path:` values remain the canonical `/api/okou/integrations/teams/connect`.
- The four already-neutral types (`TeamsConnectStatus`, `TeamsConnectBody`, `TeamsConnectResponse`, `TeamsDisconnectResponse`) are unchanged.
- No Microsoft Teams tenant/app identifier, activity type name, or Bot Framework wire key touched.
- `apps/api/src/signals/services/zero-teams-connect.service.ts` is untouched — it is owned by a separate parallel API-side issue, imports the contracts barrel rather than this subpath, and does not reference the renamed identifiers.
- `contracts/teams-bot.ts`, `contracts/teams-oauth.ts`, `contracts/teams-browser-connect.ts` (already migrated by #27855) are untouched.
- No `@deprecated` alias and no old-path re-export left behind.

## Verification

- Repository-wide grep across all file types: no `zeroTeamsConnectContract`, `ZeroTeamsConnectContract`, or `@okouai/api-contracts/contracts/zero-teams-connect` specifier remains.
- `pnpm -F @okouai/api-contracts check-types`, `pnpm -F api check-types`, `pnpm -F @okouai/app check-types` — all pass.
- `pnpm knip` — exit 0.
- `pnpm lint` in `packages/api-contracts`, `apps/api`, and `apps/platform` — all exit 0, with no finding in any touched file.
- `prettier --check` on every changed file — clean.

Per repository convention the full local vitest suite was not run; the PR pipeline owns whole-repo verification.

Closes #27914
