### PR TITLE
fix(billing): preserve purchased pro through atom grants

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1919,6 +1919,9 @@ jobs:
           ZERO_APP_URL: ${{ needs.deploy-app.outputs.preview-url }}
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          ATOM_GRANT_PRICE: ${{ vars.ATOM_GRANT_PRICE }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Cleanup Playwright E2E accounts

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -18,7 +18,8 @@
     "@clerk/testing": "^2.2.13",
     "@playwright/test": "^1.60.0",
     "@types/node": "^25.9.3",
-    "dotenv": "^17.4.2"
+    "dotenv": "^17.4.2",
+    "stripe": "20.4.1"
   },
   "devDependencies": {
     "tsx": "^4.22.4",

--- a/e2e/playwright/lib/stripe-billing.ts
+++ b/e2e/playwright/lib/stripe-billing.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from "node:crypto";
+
+import Stripe from "stripe";
+
+type LegacyPlanTier = "pro" | "team";
+
+export interface LegacyPlanSubscription {
+  readonly customerId: string;
+  readonly id: string;
+  readonly status: string;
+  readonly tier: LegacyPlanTier;
+}
+
+export interface AtomGrantInvoice {
+  readonly expiresAt: Date;
+  readonly id: string;
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required for billing transition E2E tests`);
+  }
+  return value;
+}
+
+function stripeClient(): Stripe {
+  return new Stripe(requiredEnvironment("STRIPE_SECRET_KEY"));
+}
+
+function subscriptionCustomerId(subscription: Stripe.Subscription): string {
+  return typeof subscription.customer === "string"
+    ? subscription.customer
+    : subscription.customer.id;
+}
+
+function isActiveSubscription(subscription: Stripe.Subscription): boolean {
+  return subscription.status === "active" || subscription.status === "trialing";
+}
+
+export async function findOrgLegacyPlanSubscription(args: {
+  readonly orgId: string;
+  readonly tier: LegacyPlanTier;
+}): Promise<LegacyPlanSubscription> {
+  const subscriptions = await stripeClient().subscriptions.list({
+    limit: 100,
+    status: "all",
+  });
+  const matches = subscriptions.data.filter((subscription) => {
+    return (
+      subscription.metadata.orgId === args.orgId &&
+      subscription.metadata.tier === args.tier &&
+      isActiveSubscription(subscription)
+    );
+  });
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one active ${args.tier} legacy Plan subscription for the E2E organization; found ${matches.length}`,
+    );
+  }
+  const subscription = matches[0];
+  if (!subscription) {
+    throw new Error("Legacy Plan subscription lookup returned no match");
+  }
+  return {
+    customerId: subscriptionCustomerId(subscription),
+    id: subscription.id,
+    status: subscription.status,
+    tier: args.tier,
+  };
+}
+
+export async function readStripeSubscriptionStatus(
+  subscriptionId: string,
+): Promise<string> {
+  return (await stripeClient().subscriptions.retrieve(subscriptionId)).status;
+}
+
+export async function createMarkedAtomTeamGrant(args: {
+  readonly orgId: string;
+  readonly subscription: LegacyPlanSubscription;
+  readonly lifetimeMs?: number;
+}): Promise<AtomGrantInvoice> {
+  const stripe = stripeClient();
+  const atomGrantPrice = requiredEnvironment("ATOM_GRANT_PRICE");
+  const startsAt = Math.floor(Date.now() / 1000);
+  const expiresAt = new Date(Date.now() + (args.lifetimeMs ?? 60_000));
+  const expiresAtUnix = Math.floor(expiresAt.getTime() / 1000);
+  const idempotencyScope = `playwright-atom-${args.orgId}-${randomUUID()}`;
+  const metadata = {
+    type: "atom_grant",
+    purpose: "atom_grant",
+    source: "atom_entitlement",
+    orgId: args.orgId,
+    tier: "team",
+    duration: "e2e",
+    atomGrantExpiresAt: expiresAt.toISOString(),
+    planOverrideMode: "preserve_purchased_pro_v1",
+  };
+
+  const invoice = await stripe.invoices.create(
+    {
+      auto_advance: false,
+      collection_method: "charge_automatically",
+      customer: args.subscription.customerId,
+      metadata,
+    },
+    { idempotencyKey: `${idempotencyScope}-invoice` },
+  );
+  await stripe.invoiceItems.create(
+    {
+      customer: args.subscription.customerId,
+      invoice: invoice.id,
+      metadata,
+      period: { start: startsAt, end: expiresAtUnix },
+      pricing: { price: atomGrantPrice },
+      quantity: 1,
+    },
+    { idempotencyKey: `${idempotencyScope}-line` },
+  );
+  const finalized = await stripe.invoices.finalizeInvoice(
+    invoice.id,
+    {},
+    { idempotencyKey: `${idempotencyScope}-finalize` },
+  );
+  const paid =
+    finalized.status === "paid"
+      ? finalized
+      : await stripe.invoices.pay(
+          invoice.id,
+          {},
+          { idempotencyKey: `${idempotencyScope}-pay` },
+        );
+  if (paid.status !== "paid") {
+    throw new Error("Atom grant invoice did not reach paid status");
+  }
+  return { expiresAt, id: paid.id };
+}
+
+export async function reconcileBillingEntitlements(
+  apiUrl: string,
+): Promise<void> {
+  const response = await fetch(
+    new URL("/api/cron/reconcile-billing-entitlements", apiUrl),
+    {
+      headers: {
+        Authorization: `Bearer ${requiredEnvironment("CRON_SECRET")}`,
+        ...(process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+          ? {
+              "x-vercel-protection-bypass":
+                process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+            }
+          : {}),
+      },
+    },
+  );
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new Error(
+      `Billing entitlement reconciliation failed with HTTP ${response.status}`,
+    );
+  }
+  await response.body?.cancel();
+}

--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -499,7 +499,7 @@ test("Team paid invitation and runner usage consume purchased credits first", as
         "This follow-up run should be cancelled immediately.",
       );
       expect(settlement.threadId).toBe(first.threadId);
-      expect(settlement.status).toBe("pending");
+      expect(["pending", "queued"]).toContain(settlement.status);
       await cancelRun(page, token, settlement.runId);
 
       await expect

--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from "@playwright/test";
+import type { Locator, Page, Request, Response } from "@playwright/test";
 import { expect, test } from "../fixtures";
 import {
   refreshClerkSessionToken,
@@ -15,6 +15,12 @@ import {
   completeExploreOnboarding,
 } from "../lib/onboarding";
 import { fillStripeCheckout } from "../lib/stripe-checkout";
+import {
+  createMarkedAtomTeamGrant,
+  findOrgLegacyPlanSubscription,
+  readStripeSubscriptionStatus,
+  reconcileBillingEntitlements,
+} from "../lib/stripe-billing";
 import { deriveAppUrl } from "../playwright.config";
 
 type PaidTier = "pro" | "team";
@@ -24,6 +30,11 @@ interface BillingOwner {
   readonly organizationId: string;
   readonly session: BillingSession;
   readonly userId: string;
+}
+
+interface BillingOwnerSwitches {
+  readonly realAgentInPreview?: boolean;
+  readonly usagePackPlans: boolean;
 }
 
 interface BillingSession {
@@ -48,8 +59,11 @@ interface BillingSummary {
   readonly concurrencyLimit: number;
   readonly concurrencyPurchaseReviewAvailable: boolean;
   readonly concurrencySubscriptions: readonly ConcurrencySubscriptionSummary[];
+  readonly credits: number;
   readonly hasSubscription: boolean;
+  readonly payAsYouGoCredits: number;
   readonly scheduledChange: ScheduledPlanChangeSummary | null;
+  readonly subscriptionStatus: string | null;
   readonly tier: string;
 }
 
@@ -63,6 +77,24 @@ interface UsagePackSummary {
   readonly pendingChange: UsagePackPendingChangeSummary | null;
   readonly tier: string;
   readonly usagePackUsd: number;
+}
+
+interface PendingInvitationSummary {
+  readonly email: string;
+  readonly role: string;
+  readonly usagePackUsd: number | null;
+}
+
+interface UsagePackCreditSummary {
+  readonly bonusCredits: number;
+  readonly purchasedCredits: number;
+  readonly purchasedGrantRemaining: number;
+}
+
+interface ChatSendSummary {
+  readonly runId: string;
+  readonly status: string | null;
+  readonly threadId: string;
 }
 
 const apiUrl = process.env.VM0_API_BACKEND_URL!;
@@ -322,10 +354,182 @@ test("concurrency transitions handle schedules, cancellation, and restoration", 
   });
 });
 
+test("legacy Plan purchases preserve Pro through a marked Atom override", async ({
+  page,
+}) => {
+  test.setTimeout(360_000);
+
+  await withBillingOwner(
+    page,
+    "E2E Legacy Billing Purchases",
+    async (owner) => {
+      let token = await buyLegacyPlan(page, owner, "pro");
+      await expectPlanIdentity(page, token, {
+        hasSubscription: true,
+        subscriptionStatus: "active",
+        tier: "pro",
+      });
+
+      const preservedPro = await findOrgLegacyPlanSubscription({
+        orgId: owner.organizationId,
+        tier: "pro",
+      });
+      expect(["active", "trialing"]).toContain(preservedPro.status);
+      const atomGrant = await createMarkedAtomTeamGrant({
+        orgId: owner.organizationId,
+        subscription: preservedPro,
+      });
+      expect(atomGrant.expiresAt.getTime()).toBeGreaterThan(Date.now());
+      expect(atomGrant.id).toMatch(/^in_/u);
+
+      await expectPlanIdentity(page, token, {
+        hasSubscription: false,
+        subscriptionStatus: "atom_grant",
+        tier: "team",
+      });
+      await expect
+        .poll(async () => await readStripeSubscriptionStatus(preservedPro.id), {
+          intervals: POLL_INTERVALS_MS,
+          message: "the purchased Pro subscription should remain active",
+          timeout: STATE_TIMEOUT_MS,
+        })
+        .toMatch(/^(?:active|trialing)$/u);
+
+      await expect
+        .poll(
+          async () => {
+            if (Date.now() < atomGrant.expiresAt.getTime()) {
+              return null;
+            }
+            await reconcileBillingEntitlements(apiUrl);
+            token = await currentToken(page, owner);
+            const state = await readBillingSummary(page, token);
+            return {
+              hasSubscription: state.hasSubscription,
+              subscriptionStatus: state.subscriptionStatus,
+              tier: state.tier,
+            };
+          },
+          {
+            intervals: [2_000, 3_000],
+            message: "the expired Atom grant should restore purchased Pro",
+            timeout: 90_000,
+          },
+        )
+        .toEqual({
+          hasSubscription: true,
+          subscriptionStatus: "active",
+          tier: "pro",
+        });
+      expect(await readStripeSubscriptionStatus(preservedPro.id)).toMatch(
+        /^(?:active|trialing)$/u,
+      );
+
+      token = await upgradeLegacyProToTeamWithSavedCard(page, owner);
+      await expectPlanIdentity(page, token, {
+        hasSubscription: true,
+        subscriptionStatus: "active",
+        tier: "team",
+      });
+      const teamSubscription = await findOrgLegacyPlanSubscription({
+        orgId: owner.organizationId,
+        tier: "team",
+      });
+      expect(["active", "trialing"]).toContain(teamSubscription.status);
+
+      token = await buyCreditsWithSavedCardAndReopen(page, owner);
+      await expectPlanIdentity(page, token, {
+        hasSubscription: true,
+        subscriptionStatus: "active",
+        tier: "team",
+      });
+    },
+    { usagePackPlans: false },
+  );
+});
+
+test("Team paid invitation and runner usage consume purchased credits first", async ({
+  page,
+}) => {
+  test.setTimeout(360_000);
+
+  await withBillingOwner(
+    page,
+    "E2E Team Purchase Consumption",
+    async (owner) => {
+      let token = await buyUsagePackPlan(page, owner, "team");
+      await expectPlanState(page, token, {
+        cancelAtPeriodEnd: false,
+        hasSubscription: true,
+        scheduledChange: null,
+        tier: "team",
+      });
+
+      const inviteEmail = generateTestEmail("paid-onboarding");
+      token = await purchasePaidInvitation(page, owner, inviteEmail, 20);
+      await expectPendingInvitation(page, token, {
+        email: inviteEmail,
+        role: "member",
+        usagePackUsd: 20,
+      });
+
+      const before = await waitForUsagePackCredits(page, token);
+      expect(before.purchasedCredits).toBeGreaterThan(0);
+      expect(before.purchasedGrantRemaining).toBeGreaterThan(0);
+      await expectVm0ManagedModelPolicy(page, token, "gpt-5.6-sol");
+
+      await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+      await page.waitForURL(/agents\/.*\/chat/u, { timeout: 30_000 });
+      await selectComposerModel(page, "GPT 5.6 Sol");
+      const marker = `BILLING_USAGE_E2E_${Date.now()}`;
+      const first = await sendComposerMessage(
+        page,
+        `Briefly reply with this exact marker: ${marker}`,
+      );
+      await expectRunStatus(page, token, first.runId, "completed");
+      await expect(
+        page
+          .locator('[data-role="assistant"]')
+          .filter({ hasText: marker })
+          .first(),
+      ).toBeVisible({ timeout: 90_000 });
+
+      const settlement = await sendComposerMessage(
+        page,
+        "This follow-up run should be cancelled immediately.",
+      );
+      expect(settlement.threadId).toBe(first.threadId);
+      expect(settlement.status).toBe("pending");
+      await cancelRun(page, token, settlement.runId);
+
+      await expect
+        .poll(
+          async () => {
+            return (await readUsagePackCreditSummary(page, token))
+              .purchasedCredits;
+          },
+          {
+            intervals: POLL_INTERVALS_MS,
+            message: "runner usage should reduce purchased credits",
+            timeout: STATE_TIMEOUT_MS,
+          },
+        )
+        .toBeLessThan(before.purchasedCredits);
+      const after = await readUsagePackCreditSummary(page, token);
+      expect(after.bonusCredits).toBe(before.bonusCredits);
+      expect(after.purchasedGrantRemaining).toBeLessThan(
+        before.purchasedGrantRemaining,
+      );
+    },
+    { realAgentInPreview: true, usagePackPlans: true },
+  );
+});
+
 async function withBillingOwner(
   page: Page,
   organizationName: string,
   run: (owner: BillingOwner) => Promise<void>,
+  switches: BillingOwnerSwitches = { usagePackPlans: true },
 ): Promise<void> {
   const email = generateTestEmail("paid-onboarding");
   let organizationId: string | undefined;
@@ -341,7 +545,7 @@ async function withBillingOwner(
       activeOrganizationId: organizationId,
     });
     await completeExploreOnboarding(page, { appUrl });
-    await enableUsagePackPlans(page, token);
+    await configureBillingFeatureSwitches(page, token, switches);
     await run({
       organizationId,
       session: { refreshedAt: Date.now(), token },
@@ -356,11 +560,15 @@ async function withBillingOwner(
   }
 }
 
-async function enableUsagePackPlans(page: Page, token: string): Promise<void> {
+async function configureBillingFeatureSwitches(
+  page: Page,
+  token: string,
+  switches: BillingOwnerSwitches,
+): Promise<void> {
   const response = await page.request.post(
     `${apiUrl}/api/okou/feature-switches`,
     {
-      data: { switches: { usagePackPlans: true } },
+      data: { switches },
       headers: authHeadersForToken(token),
     },
   );
@@ -375,9 +583,39 @@ async function enableUsagePackPlans(page: Page, token: string): Promise<void> {
     responseBody.effectiveSwitches,
     "effective feature switches",
   );
-  if (effectiveSwitches.usagePackPlans !== true) {
-    throw new Error("usagePackPlans was not enabled for the billing E2E owner");
+  for (const [key, expected] of Object.entries(switches)) {
+    if (effectiveSwitches[key] !== expected) {
+      throw new Error(
+        `${key} did not become ${String(expected)} for the billing E2E owner`,
+      );
+    }
   }
+}
+
+async function buyLegacyPlan(
+  page: Page,
+  owner: BillingOwner,
+  tier: PaidTier,
+): Promise<string> {
+  const planLabel = tier === "pro" ? "Pro" : "Team";
+  const settings = await openBillingSettings(page);
+  await expect(
+    settings.getByText("No active plan", { exact: true }),
+  ).toBeVisible();
+  await settings.getByRole("button", { name: "Upgrade", exact: true }).click();
+  await expect(
+    settings.getByText("Compare plans", { exact: true }).first(),
+  ).toBeVisible();
+  await settings
+    .getByRole("button", { name: `Start with ${planLabel}`, exact: true })
+    .click();
+
+  await fillStripeCheckout(page);
+  await page.waitForURL((url) => url.origin === appOrigin, {
+    timeout: 120_000,
+    waitUntil: "domcontentloaded",
+  });
+  return await currentToken(page, owner);
 }
 
 async function buyUsagePackPlan(
@@ -417,6 +655,242 @@ async function buyUsagePackPlan(
     waitUntil: "domcontentloaded",
   });
   return await currentToken(page, owner);
+}
+
+async function upgradeLegacyProToTeamWithSavedCard(
+  page: Page,
+  owner: BillingOwner,
+): Promise<string> {
+  const token = await currentToken(page, owner);
+  const usagePackRequests: string[] = [];
+  const recordUsagePackRequest = (request: Request): void => {
+    const path = new URL(request.url()).pathname;
+    if (
+      request.method() === "POST" &&
+      path.startsWith("/api/okou/billing/usage-pack-subscription/")
+    ) {
+      usagePackRequests.push(path);
+    }
+  };
+  page.on("request", recordUsagePackRequest);
+  try {
+    const settings = await openBillingSettings(page);
+    await settings
+      .getByRole("button", { name: "Upgrade", exact: true })
+      .click();
+    await expect(
+      settings.getByText("Compare plans", { exact: true }).first(),
+    ).toBeVisible();
+    const previewResponsePromise = waitForPostResponse(
+      page,
+      "/api/okou/billing/checkout",
+    );
+    await settings
+      .getByRole("button", { name: "Upgrade to Team", exact: true })
+      .click();
+    const preview = await responseRecord(
+      await previewResponsePromise,
+      "saved Plan preview",
+    );
+    expect(preview.status).toBe("preview");
+    expect(preview.purchaseType).toBe("plan");
+    expect(preview.tier).toBe("team");
+    requireString(preview.previewToken, "saved Plan preview token");
+
+    const dialog = page.getByRole("dialog", { name: "Upgrade to Team" });
+    await expect(dialog).toBeVisible();
+    const confirmResponsePromise = waitForPostResponse(
+      page,
+      "/api/okou/billing/checkout",
+    );
+    await dialog
+      .getByRole("button", { name: "Upgrade to Team", exact: true })
+      .click();
+    const confirmation = await responseRecord(
+      await confirmResponsePromise,
+      "saved Plan confirmation",
+    );
+    expect(confirmation.status).toBe("completed");
+    expect(confirmation.hostedInvoiceUrl).toBeNull();
+    await expect(dialog).toBeHidden({ timeout: 30_000 });
+    expect(new URL(page.url()).origin).toBe(appOrigin);
+    expect(usagePackRequests).toStrictEqual([]);
+    return token;
+  } finally {
+    page.off("request", recordUsagePackRequest);
+  }
+}
+
+async function buyCreditsWithSavedCardAndReopen(
+  page: Page,
+  owner: BillingOwner,
+): Promise<string> {
+  const token = await currentToken(page, owner);
+  const before = await readBillingSummary(page, token);
+  const settings = await openBillingSettings(page);
+  const locationOrigin = new URL(page.url()).origin;
+  const previewResponsePromise = waitForPostResponse(
+    page,
+    "/api/okou/billing/credit-checkout",
+  );
+  await settings
+    .getByRole("button", { name: "Quick buy $20.00", exact: true })
+    .click();
+  const preview = await responseRecord(
+    await previewResponsePromise,
+    "saved credit preview",
+  );
+  expect(preview.status).toBe("preview");
+  const previewToken = requireString(
+    preview.previewToken,
+    "saved credit preview token",
+  );
+  const purchasedCredits = requireNumber(
+    preview.credits,
+    "saved credit preview credits",
+  );
+  const dialog = page.getByRole("dialog", {
+    name: "Review credit purchase",
+  });
+  await expect(dialog).toBeVisible();
+  const confirmResponsePromise = waitForPostResponse(
+    page,
+    "/api/okou/billing/credit-checkout/confirm",
+  );
+  await dialog
+    .getByRole("button", { name: "Pay and add credits", exact: true })
+    .click();
+  const confirmation = await responseRecord(
+    await confirmResponsePromise,
+    "saved credit confirmation",
+  );
+  expect(confirmation.status).toBe("completed");
+  expect(confirmation.hostedInvoiceUrl).toBeNull();
+  await expect(dialog).toBeHidden({ timeout: 30_000 });
+  expect(new URL(page.url()).origin).toBe(locationOrigin);
+
+  await expect
+    .poll(
+      async () => {
+        const state = await readBillingSummary(page, token);
+        return {
+          credits: state.credits,
+          payAsYouGoCredits: state.payAsYouGoCredits,
+        };
+      },
+      {
+        intervals: POLL_INTERVALS_MS,
+        message: "saved credit purchase should update public balances",
+        timeout: STATE_TIMEOUT_MS,
+      },
+    )
+    .toEqual({
+      credits: before.credits + purchasedCredits,
+      payAsYouGoCredits: before.payAsYouGoCredits + purchasedCredits,
+    });
+
+  const reopenedSettings = await openBillingSettings(page);
+  const reopenedResponsePromise = waitForPostResponse(
+    page,
+    "/api/okou/billing/credit-checkout",
+  );
+  await reopenedSettings
+    .getByRole("button", { name: "Quick buy $20.00", exact: true })
+    .click();
+  const reopenedPreview = await responseRecord(
+    await reopenedResponsePromise,
+    "reopened saved credit preview",
+  );
+  expect(reopenedPreview.status).toBe("preview");
+  expect(
+    requireString(
+      reopenedPreview.previewToken,
+      "reopened saved credit preview token",
+    ),
+  ).not.toBe(previewToken);
+  const reopenedDialog = page.getByRole("dialog", {
+    name: "Review credit purchase",
+  });
+  await expect(reopenedDialog).toBeVisible();
+  await expect(
+    reopenedDialog.getByText(
+      "Could not complete this credit purchase. Review your billing details and try again.",
+      { exact: true },
+    ),
+  ).toHaveCount(0);
+  await expect(
+    reopenedDialog.getByRole("button", {
+      name: "Pay and add credits",
+      exact: true,
+    }),
+  ).toBeEnabled();
+  await reopenedDialog
+    .getByRole("button", { name: "Cancel", exact: true })
+    .click();
+  await expect(reopenedDialog).toBeHidden();
+  return token;
+}
+
+async function purchasePaidInvitation(
+  page: Page,
+  owner: BillingOwner,
+  email: string,
+  usagePackUsd: UsagePackUsd,
+): Promise<string> {
+  const token = await currentToken(page, owner);
+  await page.goto(new URL("/?settings=people", appUrl).toString(), {
+    waitUntil: "domcontentloaded",
+  });
+  const settings = page.getByRole("dialog", { name: "Settings" });
+  await expect(settings).toBeVisible({ timeout: 30_000 });
+  await expect(settings.getByRole("heading", { name: "People" })).toBeVisible();
+  await settings
+    .getByRole("button", { name: "Add member", exact: true })
+    .click();
+  const invite = page.getByRole("dialog", { name: "Invite member" });
+  await invite.getByPlaceholder("email@example.com").fill(email);
+  const usagePack = invite.getByRole("combobox").nth(1);
+  await usagePack.click();
+  await page
+    .getByRole("option", { name: USAGE_PACK_OPTION_PATTERNS[usagePackUsd] })
+    .click();
+
+  const previewResponsePromise = waitForPostResponse(
+    page,
+    "/api/okou/org/invite/purchase/preview",
+  );
+  await invite.getByRole("button", { name: "Continue", exact: true }).click();
+  const preview = await responseRecord(
+    await previewResponsePromise,
+    "paid invitation preview",
+  );
+  const purchaseId = requireString(
+    preview.purchaseId,
+    "paid invitation purchase ID",
+  );
+  expect(preview.usagePackUsd).toBe(usagePackUsd);
+  const confirmationDialog = page.getByRole("dialog", {
+    name: "Review invitation",
+  });
+  await expect(confirmationDialog).toBeVisible();
+  await expect(
+    confirmationDialog.getByText(email, { exact: true }),
+  ).toBeVisible();
+  const confirmationResponsePromise = waitForPostResponse(
+    page,
+    `/api/okou/org/invite/purchase/${purchaseId}/confirm`,
+  );
+  await confirmationDialog
+    .getByRole("button", { name: "Pay and invite", exact: true })
+    .click();
+  const confirmation = await responseRecord(
+    await confirmationResponsePromise,
+    "paid invitation confirmation",
+  );
+  requireString(confirmation.message, "paid invitation confirmation message");
+  await expect(confirmationDialog).toBeHidden({ timeout: 30_000 });
+  expect(new URL(page.url()).origin).toBe(appOrigin);
+  return token;
 }
 
 async function changeUsagePack(
@@ -751,6 +1225,185 @@ async function currentToken(page: Page, owner: BillingOwner): Promise<string> {
   return token;
 }
 
+async function expectPlanIdentity(
+  page: Page,
+  token: string,
+  expected: {
+    readonly hasSubscription: boolean;
+    readonly subscriptionStatus: string;
+    readonly tier: string;
+  },
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const state = await pollSafely(async () => {
+          return await readBillingSummary(page, token);
+        });
+        if ("pollingError" in state) {
+          return state;
+        }
+        return {
+          hasSubscription: state.hasSubscription,
+          subscriptionStatus: state.subscriptionStatus,
+          tier: state.tier,
+        };
+      },
+      {
+        intervals: POLL_INTERVALS_MS,
+        message: `billing identity should become ${JSON.stringify(expected)}`,
+        timeout: STATE_TIMEOUT_MS,
+      },
+    )
+    .toEqual(expected);
+}
+
+async function expectPendingInvitation(
+  page: Page,
+  token: string,
+  expected: PendingInvitationSummary,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        return await pollSafely(async () => {
+          const invitations = await readPendingInvitations(page, token);
+          return (
+            invitations.find((invitation) => {
+              return invitation.email === expected.email;
+            }) ?? null
+          );
+        });
+      },
+      {
+        intervals: POLL_INTERVALS_MS,
+        message: `pending invitation should become ${JSON.stringify(expected)}`,
+        timeout: STATE_TIMEOUT_MS,
+      },
+    )
+    .toEqual(expected);
+}
+
+async function waitForUsagePackCredits(
+  page: Page,
+  token: string,
+): Promise<UsagePackCreditSummary> {
+  await expect
+    .poll(
+      async () => {
+        return (await readUsagePackCreditSummary(page, token)).purchasedCredits;
+      },
+      {
+        intervals: POLL_INTERVALS_MS,
+        message:
+          "the owner usage-pack allocation should have purchased credits",
+        timeout: STATE_TIMEOUT_MS,
+      },
+    )
+    .toBeGreaterThan(0);
+  return await readUsagePackCreditSummary(page, token);
+}
+
+async function expectVm0ManagedModelPolicy(
+  page: Page,
+  token: string,
+  model: string,
+): Promise<void> {
+  const body = requireRecord(
+    await getApiJson(page, "/api/okou/model-policies", token),
+    "model policies",
+  );
+  const policy = requireArray(body.policies, "model policies")
+    .map((value, index) => {
+      return requireRecord(value, `model policy ${index}`);
+    })
+    .find((value) => value.model === model);
+  if (!policy) {
+    throw new Error(`Model policy ${model} was not found`);
+  }
+  expect(policy.defaultProviderType).toBe("vm0");
+  expect(policy.credentialScope).toBe("org");
+  expect(policy.modelProviderId).toBeNull();
+}
+
+async function selectComposerModel(page: Page, label: string): Promise<void> {
+  const composer = page.locator(".zero-composer");
+  const picker = composer.getByRole("combobox").first();
+  await expect(picker).toBeVisible();
+  await picker.click();
+  await page.getByRole("option", { name: label, exact: true }).click();
+  await expect(
+    composer.getByRole("combobox", { name: label, exact: true }),
+  ).toBeVisible();
+}
+
+async function sendComposerMessage(
+  page: Page,
+  message: string,
+): Promise<ChatSendSummary> {
+  const composer = page.locator(".zero-composer");
+  const editor = composer.getByRole("textbox", { name: "Message" });
+  await expect(editor).toBeVisible();
+  await editor.fill(message);
+  const responsePromise = waitForPostResponse(page, "/api/okou/chat/events");
+  await composer.getByRole("button", { name: "Send", exact: true }).click();
+  const body = await responseRecord(
+    await responsePromise,
+    "chat send response",
+  );
+  return {
+    runId: requireString(body.runId, "chat send run ID"),
+    status:
+      body.status === undefined
+        ? null
+        : requireString(body.status, "chat send status"),
+    threadId: requireString(body.threadId, "chat send thread ID"),
+  };
+}
+
+async function expectRunStatus(
+  page: Page,
+  token: string,
+  runId: string,
+  expectedStatus: string,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const body = requireRecord(
+          await getApiJson(page, `/api/okou/runs/${runId}`, token),
+          "run status",
+        );
+        return requireString(body.status, "run status value");
+      },
+      {
+        intervals: POLL_INTERVALS_MS,
+        message: `run ${runId} should become ${expectedStatus}`,
+        timeout: 180_000,
+      },
+    )
+    .toBe(expectedStatus);
+}
+
+async function cancelRun(
+  page: Page,
+  token: string,
+  runId: string,
+): Promise<void> {
+  const response = await page.request.post(
+    new URL(`/api/okou/runs/${runId}/cancel`, apiUrl).toString(),
+    { headers: authHeadersForToken(token) },
+  );
+  if (response.status() !== 200) {
+    throw new Error(
+      `run cancellation failed with ${response.status()}: ${await response.text()}`,
+    );
+  }
+  const body = requireRecord(await response.json(), "run cancellation");
+  expect(body.id).toBe(runId);
+  expect(body.status).toBe("cancelled");
+}
+
 async function expectPlanState(
   page: Page,
   token: string,
@@ -887,6 +1540,19 @@ async function readBillingSummary(
       ),
     };
   });
+  const payAsYouGoCredits = requireArray(
+    body.creditBreakdown,
+    "billing credit breakdown",
+  )
+    .map((value, index) => {
+      return requireRecord(value, `billing credit breakdown ${index}`);
+    })
+    .filter((segment) => segment.category === "payAsYouGo")
+    .reduce((total, segment) => {
+      return (
+        total + requireNumber(segment.credits, "pay-as-you-go credit breakdown")
+      );
+    }, 0);
 
   return {
     cancelAtPeriodEnd: requireBoolean(
@@ -906,11 +1572,17 @@ async function readBillingSummary(
       "billing concurrencyPurchaseReviewAvailable",
     ),
     concurrencySubscriptions: subscriptions,
+    credits: requireNumber(body.credits, "billing credits"),
     hasSubscription: requireBoolean(
       body.hasSubscription,
       "billing hasSubscription",
     ),
+    payAsYouGoCredits,
     scheduledChange,
+    subscriptionStatus: optionalNullableString(
+      body.subscriptionStatus,
+      "billing subscriptionStatus",
+    ),
     tier: requireString(body.tier, "billing tier"),
   };
 }
@@ -941,6 +1613,91 @@ async function readUsagePackSummary(
       "usage-pack allocation amount",
     ),
   };
+}
+
+async function readPendingInvitations(
+  page: Page,
+  token: string,
+): Promise<readonly PendingInvitationSummary[]> {
+  const body = requireRecord(
+    await getApiJson(page, "/api/okou/org/members", token),
+    "organization members",
+  );
+  if (body.pendingInvitations === undefined) {
+    return [];
+  }
+  return requireArray(
+    body.pendingInvitations,
+    "pending organization invitations",
+  ).map((value, index) => {
+    const invitation = requireRecord(value, `pending invitation ${index}`);
+    return {
+      email: requireString(invitation.email, "pending invitation email"),
+      role: requireString(invitation.role, "pending invitation role"),
+      usagePackUsd: optionalNullableNumber(
+        invitation.usagePackUsd,
+        "pending invitation usage pack",
+      ),
+    };
+  });
+}
+
+async function readUsagePackCreditSummary(
+  page: Page,
+  token: string,
+): Promise<UsagePackCreditSummary> {
+  const body = requireRecord(
+    await getApiJson(page, "/api/okou/billing/usage-pack-credits", token),
+    "usage-pack credits",
+  );
+  const purchasedGrantRemaining = requireArray(
+    body.creditGrants,
+    "usage-pack credit grants",
+  )
+    .map((value, index) => {
+      return requireRecord(value, `usage-pack credit grant ${index}`);
+    })
+    .filter((grant) => grant.grantType === "purchased")
+    .reduce((total, grant) => {
+      return (
+        total +
+        requireNumber(grant.remaining, "purchased credit grant remaining")
+      );
+    }, 0);
+  return {
+    bonusCredits: requireNumber(body.bonusCredits, "usage-pack bonus credits"),
+    purchasedCredits: requireNumber(
+      body.purchasedCredits,
+      "usage-pack purchased credits",
+    ),
+    purchasedGrantRemaining,
+  };
+}
+
+function waitForPostResponse(page: Page, path: string): Promise<Response> {
+  return page.waitForResponse(
+    (response) => {
+      if (response.request().method() !== "POST") {
+        return false;
+      }
+      const responsePath = new URL(response.url()).pathname;
+      return responsePath === path;
+    },
+    { timeout: STATE_TIMEOUT_MS },
+  );
+}
+
+async function responseRecord(
+  response: Response,
+  description: string,
+): Promise<Record<string, unknown>> {
+  if (!response.ok()) {
+    throw new Error(
+      `${description} failed with ${response.status()}: ${await response.text()}`,
+    );
+  }
+  const body: unknown = await response.json();
+  return requireRecord(body, description);
 }
 
 async function getApiJson(

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      stripe:
+        specifier: 20.4.1
+        version: 20.4.1(@types/node@25.9.3)
     devDependencies:
       tsx:
         specifier: ^4.22.4
@@ -278,6 +281,15 @@ packages:
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
+  stripe@20.4.1:
+    resolution: {integrity: sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@types/node': '>=16'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -472,6 +484,10 @@ snapshots:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
+
+  stripe@20.4.1(@types/node@25.9.3):
+    optionalDependencies:
+      '@types/node': 25.9.3
 
   tslib@2.8.1: {}
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -257,17 +257,78 @@ function proSubscription(args: {
   readonly status?: string;
   readonly trialEnd?: number;
   readonly metadata?: Record<string, string>;
+  readonly priceId?: string;
+  readonly periodStart?: number;
+  readonly periodEnd?: number;
+  readonly cancelAt?: number | null;
+  readonly cancelAtPeriodEnd?: boolean;
+  readonly schedule?: string | null;
 }): Record<string, unknown> {
   return {
     id: args.id,
     status: args.status ?? "active",
     customer: args.customerId,
-    cancel_at: null,
-    cancel_at_period_end: false,
-    schedule: null,
+    cancel_at: args.cancelAt ?? null,
+    cancel_at_period_end: args.cancelAtPeriodEnd ?? false,
+    schedule: args.schedule ?? null,
     trial_end: args.trialEnd ?? null,
     metadata: args.metadata ?? {},
-    items: { data: [{ price: { id: "price_bdd_pro" } }] },
+    items: {
+      data: [
+        {
+          price: { id: args.priceId ?? "price_bdd_pro" },
+          ...(args.periodStart === undefined
+            ? {}
+            : { current_period_start: args.periodStart }),
+          ...(args.periodEnd === undefined
+            ? {}
+            : { current_period_end: args.periodEnd }),
+        },
+      ],
+    },
+  };
+}
+
+function atomPlanGrantInvoice(args: {
+  readonly id: string;
+  readonly customerId: string;
+  readonly orgId: string;
+  readonly tier: "team" | "custom";
+  readonly startsAtUnix: number;
+  readonly expiresAtUnix: number;
+  readonly preservePurchasedPro?: boolean;
+}): Record<string, unknown> {
+  return {
+    id: args.id,
+    customer: args.customerId,
+    metadata: {
+      type: "atom_grant",
+      purpose: "atom_grant",
+      source: "atom_entitlement",
+      orgId: args.orgId,
+      tier: args.tier,
+      duration: "7d",
+      atomGrantExpiresAt: isoOf(args.expiresAtUnix),
+      ...(args.preservePurchasedPro
+        ? { planOverrideMode: "preserve_purchased_pro_v1" }
+        : {}),
+    },
+    parent: null,
+    lines: {
+      has_more: false,
+      data: [
+        {
+          id: `il_${args.id}`,
+          quantity: 1,
+          price: { id: "price_bdd_atom_grant" },
+          period: {
+            start: args.startsAtUnix,
+            end: args.expiresAtUnix,
+          },
+          parent: { type: "invoice_item_details" },
+        },
+      ],
+    },
   };
 }
 
@@ -3094,6 +3155,305 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     expect((await billing.readUsageMembers(actor)).body.period).toStrictEqual({
       start: isoOf(grantStartsAtUnix),
       end: isoOf(grantExpiresAtUnix),
+    });
+  });
+
+  it("preserves hidden Pro renewals and restores Pro after a marked Atom override", async () => {
+    const bdd = createBddApi(context);
+    const billing = createBillingMediaApi(context);
+    const runs = createRunsApi(context);
+    const actor = bdd.user();
+    const orgId = orgOf(actor);
+    const suffix = randomUUID().slice(0, 8);
+    const proPeriodStartUnix = epochSeconds(-1);
+    const proPeriodEndUnix = epochSeconds(29);
+    const atomStartsAtUnix = epochSeconds(0);
+    const teamGrantExpiresAtUnix = epochSeconds(7);
+    const customGrantExpiresAtUnix = epochSeconds(14);
+    const teamInvoiceId = `in_bdd_atom_preserve_team_${suffix}`;
+    const hiddenRenewalInvoiceId = `in_bdd_atom_hidden_pro_${suffix}`;
+    const customInvoiceId = `in_bdd_atom_preserve_custom_${suffix}`;
+    const duplicateSubscriptionId = `sub_bdd_atom_duplicate_${suffix}`;
+    const granted = await runs.grantProEntitlement(actor, {
+      periodEndUnix: proPeriodEndUnix,
+      subscriptionMetadata: { orgId },
+    });
+    const preservedSubscription = proSubscription({
+      id: granted.subscriptionId,
+      customerId: granted.customerId,
+      metadata: { orgId },
+      periodStart: proPeriodStartUnix,
+      periodEnd: proPeriodEndUnix,
+    });
+    const duplicateSubscription = proSubscription({
+      id: duplicateSubscriptionId,
+      customerId: granted.customerId,
+      metadata: { orgId },
+      priceId: "price_bdd_team",
+      periodStart: proPeriodStartUnix,
+      periodEnd: proPeriodEndUnix,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      preservedSubscription,
+    );
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [preservedSubscription, duplicateSubscription],
+      has_more: false,
+    });
+    context.mocks.stripe.subscriptions.cancel.mockResolvedValue(
+      duplicateSubscription,
+    );
+
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "invoice.paid",
+        object: atomPlanGrantInvoice({
+          id: teamInvoiceId,
+          customerId: granted.customerId,
+          orgId,
+          tier: "team",
+          startsAtUnix: atomStartsAtUnix,
+          expiresAtUnix: teamGrantExpiresAtUnix,
+          preservePurchasedPro: true,
+        }),
+      }),
+      [200],
+    );
+
+    expect(context.mocks.stripe.subscriptions.cancel).toHaveBeenCalledTimes(1);
+    expect(context.mocks.stripe.subscriptions.cancel).toHaveBeenCalledWith(
+      duplicateSubscriptionId,
+      { invoice_now: false, prorate: false },
+    );
+    expect(context.mocks.stripe.subscriptions.cancel).not.toHaveBeenCalledWith(
+      granted.subscriptionId,
+      expect.anything(),
+    );
+    const overridden = await billing.readBillingStatus(actor);
+    expect(overridden).toMatchObject({
+      tier: "team",
+      credits: 140_000,
+      hasSubscription: false,
+      subscriptionStatus: "atom_grant",
+    });
+    await expect(readOrgPlanEntitlementFixture(orgId)).resolves.toMatchObject({
+      planKey: "team",
+      source: "stripe_atom_grant",
+      stripeSubscriptionId: null,
+      sourceMetadata: {
+        planOverrideMode: "preserve_purchased_pro_v1",
+        preservedPurchasedProSubscriptionId: granted.subscriptionId,
+      },
+    });
+
+    const hiddenRenewalEvent = stripeEvent({
+      type: "invoice.paid",
+      object: {
+        id: hiddenRenewalInvoiceId,
+        customer: granted.customerId,
+        metadata: {},
+        parent: {
+          subscription_details: { subscription: granted.subscriptionId },
+        },
+        lines: subscriptionLines(proPeriodEndUnix),
+      },
+    });
+    await api.postStripeEvent(hiddenRenewalEvent, [200]);
+    await api.postStripeEvent(hiddenRenewalEvent, [200]);
+
+    const renewedUnderOverride = await billing.readBillingStatus(actor);
+    expect(renewedUnderOverride).toMatchObject({
+      tier: "team",
+      credits: 160_000,
+      hasSubscription: false,
+      subscriptionStatus: "atom_grant",
+    });
+    expect(renewedUnderOverride.creditGrants).toHaveLength(3);
+    await expect(readOrgPlanEntitlementFixture(orgId)).resolves.toMatchObject({
+      planKey: "team",
+      source: "stripe_atom_grant",
+      stripeSubscriptionId: null,
+      sourceMetadata: {
+        preservedPurchasedProSubscriptionId: granted.subscriptionId,
+      },
+    });
+
+    context.mocks.stripe.subscriptions.cancel.mockClear();
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [preservedSubscription],
+      has_more: false,
+    });
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "invoice.paid",
+        object: atomPlanGrantInvoice({
+          id: customInvoiceId,
+          customerId: granted.customerId,
+          orgId,
+          tier: "custom",
+          startsAtUnix: teamGrantExpiresAtUnix,
+          expiresAtUnix: customGrantExpiresAtUnix,
+          preservePurchasedPro: true,
+        }),
+      }),
+      [200],
+    );
+    expect(context.mocks.stripe.subscriptions.cancel).not.toHaveBeenCalled();
+    await expect(readOrgPlanEntitlementFixture(orgId)).resolves.toMatchObject({
+      planKey: "custom",
+      sourceMetadata: {
+        preservedPurchasedProSubscriptionId: granted.subscriptionId,
+      },
+    });
+
+    const expiredAt = new Date(now() - 1000);
+    await expireAtomGrantFixture({
+      orgId,
+      expiredAt,
+      creditInvoiceIds: [teamInvoiceId],
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      preservedSubscription,
+    );
+    await runs.reconcileBillingOrganizations([orgId]);
+
+    const restored = await billing.readBillingStatus(actor);
+    expect(restored).toMatchObject({
+      tier: "pro",
+      credits: 40_000,
+      hasSubscription: true,
+      subscriptionStatus: "active",
+      currentPeriodEnd: isoOf(proPeriodEndUnix),
+    });
+    await expect(readOrgPlanEntitlementFixture(orgId)).resolves.toMatchObject({
+      planKey: "pro",
+      source: "stripe_subscription",
+      status: "active",
+      stripeSubscriptionId: granted.subscriptionId,
+      stripePriceId: "price_bdd_pro",
+      currentPeriodStart: isoOf(proPeriodStartUnix),
+      currentPeriodEnd: isoOf(proPeriodEndUnix),
+      sourceMetadata: { orgId },
+    });
+  });
+
+  it("falls back after a marked Atom override when the preserved Pro is missing", async () => {
+    const bdd = createBddApi(context);
+    const billing = createBillingMediaApi(context);
+    const runs = createRunsApi(context);
+    const actor = bdd.user();
+    const orgId = orgOf(actor);
+    const suffix = randomUUID().slice(0, 8);
+    const proPeriodEndUnix = epochSeconds(30);
+    const atomInvoiceId = `in_bdd_atom_missing_pro_${suffix}`;
+    const atomExpiresAtUnix = epochSeconds(7);
+    const granted = await runs.grantProEntitlement(actor, {
+      periodEndUnix: proPeriodEndUnix,
+      subscriptionMetadata: { orgId },
+    });
+    const preservedSubscription = proSubscription({
+      id: granted.subscriptionId,
+      customerId: granted.customerId,
+      metadata: { orgId },
+      periodStart: epochSeconds(0),
+      periodEnd: proPeriodEndUnix,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      preservedSubscription,
+    );
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [preservedSubscription],
+      has_more: false,
+    });
+
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "invoice.paid",
+        object: atomPlanGrantInvoice({
+          id: atomInvoiceId,
+          customerId: granted.customerId,
+          orgId,
+          tier: "team",
+          startsAtUnix: epochSeconds(0),
+          expiresAtUnix: atomExpiresAtUnix,
+          preservePurchasedPro: true,
+        }),
+      }),
+      [200],
+    );
+
+    await expireAtomGrantFixture({
+      orgId,
+      expiredAt: new Date(now() - 1000),
+      creditInvoiceIds: [atomInvoiceId],
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockRejectedValueOnce({
+      code: "resource_missing",
+    });
+    await runs.reconcileBillingOrganizations([orgId]);
+
+    const downgraded = await billing.readBillingStatus(actor);
+    expect(downgraded).toMatchObject({
+      tier: "limited-free-1",
+      credits: 20_000,
+      hasSubscription: false,
+      subscriptionStatus: "expired",
+    });
+    await expect(readOrgPlanEntitlementFixture(orgId)).resolves.toMatchObject({
+      planKey: "limited-free-1",
+      source: "stripe_atom_grant",
+      stripeSubscriptionId: null,
+      stripePriceId: null,
+    });
+  });
+
+  it("rejects a marked Atom override when the purchased Pro cannot be preserved safely", async () => {
+    const bdd = createBddApi(context);
+    const billing = createBillingMediaApi(context);
+    const runs = createRunsApi(context);
+    const actor = bdd.user();
+    const orgId = orgOf(actor);
+    const suffix = randomUUID().slice(0, 8);
+    const granted = await runs.grantProEntitlement(actor, {
+      subscriptionMetadata: { orgId },
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      proSubscription({
+        id: granted.subscriptionId,
+        customerId: granted.customerId,
+        metadata: { orgId },
+        periodStart: epochSeconds(0),
+        periodEnd: epochSeconds(30),
+        schedule: `sched_bdd_atom_${suffix}`,
+      }),
+    );
+
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "invoice.paid",
+        object: atomPlanGrantInvoice({
+          id: `in_bdd_atom_unsafe_pro_${suffix}`,
+          customerId: granted.customerId,
+          orgId,
+          tier: "team",
+          startsAtUnix: epochSeconds(0),
+          expiresAtUnix: epochSeconds(7),
+          preservePurchasedPro: true,
+        }),
+      }),
+      [500],
+    );
+
+    expect(context.mocks.stripe.subscriptions.cancel).not.toHaveBeenCalled();
+    await expect(billing.readBillingStatus(actor)).resolves.toMatchObject({
+      tier: "pro",
+      hasSubscription: true,
+      subscriptionStatus: "active",
+    });
+    await expect(readOrgPlanEntitlementFixture(orgId)).resolves.toMatchObject({
+      planKey: "pro",
+      source: "stripe_subscription",
+      stripeSubscriptionId: granted.subscriptionId,
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3337,6 +3337,88 @@ describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
     });
   });
 
+  it("restores preserved Pro when renewal arrives after Atom expiry but before cron", async () => {
+    const bdd = createBddApi(context);
+    const billing = createBillingMediaApi(context);
+    const runs = createRunsApi(context);
+    const actor = bdd.user();
+    const orgId = orgOf(actor);
+    const suffix = randomUUID().slice(0, 8);
+    const proPeriodStartUnix = epochSeconds(-1);
+    const proPeriodEndUnix = epochSeconds(30);
+    const atomInvoiceId = `in_bdd_atom_expired_before_renewal_${suffix}`;
+    const renewalInvoiceId = `in_bdd_pro_after_atom_expiry_${suffix}`;
+    const granted = await runs.grantProEntitlement(actor, {
+      periodEndUnix: proPeriodEndUnix,
+      subscriptionMetadata: { orgId },
+    });
+    const preservedSubscription = proSubscription({
+      id: granted.subscriptionId,
+      customerId: granted.customerId,
+      metadata: { orgId },
+      periodStart: proPeriodStartUnix,
+      periodEnd: proPeriodEndUnix,
+    });
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      preservedSubscription,
+    );
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({
+      data: [preservedSubscription],
+      has_more: false,
+    });
+
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "invoice.paid",
+        object: atomPlanGrantInvoice({
+          id: atomInvoiceId,
+          customerId: granted.customerId,
+          orgId,
+          tier: "team",
+          startsAtUnix: epochSeconds(0),
+          expiresAtUnix: epochSeconds(7),
+          preservePurchasedPro: true,
+        }),
+      }),
+      [200],
+    );
+
+    await expireAtomGrantFixture({
+      orgId,
+      expiredAt: new Date(now() - 1000),
+      creditInvoiceIds: [atomInvoiceId],
+    });
+    await api.postStripeEvent(
+      stripeEvent({
+        type: "invoice.paid",
+        object: {
+          id: renewalInvoiceId,
+          customer: granted.customerId,
+          metadata: {},
+          parent: {
+            subscription_details: { subscription: granted.subscriptionId },
+          },
+          lines: subscriptionLines(proPeriodEndUnix),
+        },
+      }),
+      [200],
+    );
+
+    await expect(billing.readBillingStatus(actor)).resolves.toMatchObject({
+      tier: "pro",
+      credits: 40_000,
+      hasSubscription: true,
+      subscriptionStatus: "active",
+      currentPeriodEnd: isoOf(proPeriodEndUnix),
+    });
+    await expect(readOrgPlanEntitlementFixture(orgId)).resolves.toMatchObject({
+      planKey: "pro",
+      source: "stripe_subscription",
+      stripeSubscriptionId: granted.subscriptionId,
+      currentPeriodEnd: isoOf(proPeriodEndUnix),
+    });
+  });
+
   it("falls back after a marked Atom override when the preserved Pro is missing", async () => {
     const bdd = createBddApi(context);
     const billing = createBillingMediaApi(context);

--- a/turbo/apps/api/src/signals/services/atom-plan-override.ts
+++ b/turbo/apps/api/src/signals/services/atom-plan-override.ts
@@ -1,0 +1,33 @@
+const ATOM_PLAN_OVERRIDE_MODE_METADATA_KEY = "planOverrideMode";
+const PRESERVE_PURCHASED_PRO_OVERRIDE_MODE = "preserve_purchased_pro_v1";
+const PRESERVED_PURCHASED_PRO_SUBSCRIPTION_ID_METADATA_KEY =
+  "preservedPurchasedProSubscriptionId";
+
+export function requestsPurchasedProPreservation(
+  metadata: Readonly<Record<string, string>> | null | undefined,
+): boolean {
+  return (
+    metadata?.[ATOM_PLAN_OVERRIDE_MODE_METADATA_KEY] ===
+    PRESERVE_PURCHASED_PRO_OVERRIDE_MODE
+  );
+}
+
+export function preservedPurchasedProSubscriptionId(
+  metadata: Readonly<Record<string, string>> | null | undefined,
+): string | null {
+  return (
+    metadata?.[PRESERVED_PURCHASED_PRO_SUBSCRIPTION_ID_METADATA_KEY] ?? null
+  );
+}
+
+export function withPreservedPurchasedProSubscription(
+  metadata: Readonly<Record<string, string>>,
+  subscriptionId: string | null,
+): Record<string, string> {
+  return subscriptionId
+    ? {
+        ...metadata,
+        [PRESERVED_PURCHASED_PRO_SUBSCRIPTION_ID_METADATA_KEY]: subscriptionId,
+      }
+    : { ...metadata };
+}

--- a/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
@@ -2,6 +2,7 @@ import type { OrgTier } from "@okouai/api-contracts/contracts/orgs";
 import { creditExpiresRecord } from "@okouai/db/schema/credit-expires-record";
 import { orgConcurrencySubscriptions } from "@okouai/db/schema/org-concurrency-subscription";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
+import { orgPlanEntitlements } from "@okouai/db/schema/org-plan-entitlement";
 import { orgUsageAllowanceEntitlements } from "@okouai/db/schema/org-usage-allowance";
 import { command } from "ccstate";
 import {
@@ -20,7 +21,12 @@ import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 import { clerk$ } from "../external/clerk";
-import { getStripeClient } from "../external/stripe-client";
+import {
+  getStripeClient,
+  isStripeResourceMissingError,
+} from "../external/stripe-client";
+import { settle } from "../utils";
+import { preservedPurchasedProSubscriptionId } from "./atom-plan-override";
 import type { BillingReconciliationScope } from "./billing-reconciliation-scope";
 import {
   CONCURRENCY_SUBSCRIPTION_PAYMENT_FAILED_STATUSES,
@@ -32,6 +38,7 @@ import {
 } from "./org-plan-entitlements.service";
 import {
   knownPlanPriceItem,
+  tierForKnownPriceId,
   tierFromPriceId,
 } from "./zero-billing-checkout.service";
 import {
@@ -66,10 +73,12 @@ interface SubscriptionInput {
   readonly metadata?: Record<string, string> | null;
   readonly cancel_at?: number | null;
   readonly cancel_at_period_end: boolean;
+  readonly schedule?: string | { readonly id: string } | null;
   readonly items: {
     readonly data: readonly {
       readonly price: { readonly id: string };
       readonly quantity?: number | null;
+      readonly current_period_start?: number | null;
       readonly current_period_end?: number | null;
     }[];
   };
@@ -87,6 +96,7 @@ interface StripeBillingCandidate {
 
 interface AtomGrantCandidate {
   readonly orgId: string;
+  readonly sourceMetadata: Readonly<Record<string, string>> | null;
 }
 
 interface ConcurrencyCandidate {
@@ -169,6 +179,13 @@ function subscriptionPeriodEnd(subscription: SubscriptionInput): Date | null {
   const periodEndUnix = subscription.items.data[0]?.current_period_end;
   return typeof periodEndUnix === "number"
     ? new Date(periodEndUnix * 1000)
+    : null;
+}
+
+function subscriptionPeriodStart(subscription: SubscriptionInput): Date | null {
+  const periodStartUnix = subscription.items.data[0]?.current_period_start;
+  return typeof periodStartUnix === "number"
+    ? new Date(periodStartUnix * 1000)
     : null;
 }
 
@@ -293,6 +310,7 @@ async function upsertStripeSubscriptionPlanSnapshot(
     status: args.status,
     stripeSubscriptionId: args.stripeSubscriptionId,
     stripePriceId: args.stripePriceId ?? null,
+    currentPeriodStart: subscriptionPeriodStart(args.subscription),
     currentPeriodEnd: scheduledEnd,
     cancelAt,
     expiresAt: cancelAt,
@@ -670,16 +688,105 @@ async function expireOrgCredits(
   });
 }
 
-async function reconcileAtomGrantCandidate(
+function subscriptionCanRestorePreservedPro(
+  subscription: SubscriptionInput,
+  orgId: string,
+): boolean {
+  const planItem = knownPlanPriceItem(subscription.items.data);
+  return (
+    subscription.metadata?.orgId === orgId &&
+    subscription.metadata?.purpose !== USAGE_PACK_SUBSCRIPTION_PURPOSE &&
+    (subscription.status === "active" || subscription.status === "trialing") &&
+    !subscriptionWillCancel(subscription) &&
+    (subscription.schedule === null || subscription.schedule === undefined) &&
+    planItem !== undefined &&
+    tierForKnownPriceId(planItem.price.id) === "pro" &&
+    subscriptionPeriodEnd(subscription) !== null
+  );
+}
+
+async function retrievePreservedProSubscription(
+  context: ReconcileBillingContext,
+  subscriptionId: string,
+): Promise<SubscriptionInput | null> {
+  const result = await settle(
+    context.stripe.subscriptions.retrieve(subscriptionId),
+  );
+  if (result.ok) {
+    return result.value;
+  }
+  if (isStripeResourceMissingError(result.error)) {
+    return null;
+  }
+  throw result.error;
+}
+
+async function restorePreservedProSubscription(
   context: ReconcileBillingContext,
   candidate: AtomGrantCandidate,
-  signal: AbortSignal,
-): Promise<DowngradedSubscription[]> {
+  subscriptionId: string,
+  subscription: SubscriptionInput,
+): Promise<boolean> {
   const { db, now } = context;
-  await expireOrgCredits(db, candidate.orgId, now);
-  signal.throwIfAborted();
+  const planItem = knownPlanPriceItem(subscription.items.data);
+  const periodEnd = subscriptionPeriodEnd(subscription);
+  if (!planItem || !periodEnd) {
+    return false;
+  }
 
   const rows = await db.transaction(async (tx) => {
+    return await writeOrgMetadataWithPlanEntitlements(tx, {
+      writeOrgMetadata: async (writeTx) => {
+        return await writeTx
+          .update(orgMetadata)
+          .set({
+            tier: "pro",
+            stripeSubscriptionId: subscriptionId,
+            subscriptionStatus: subscription.status,
+            cancelAtPeriodEnd: false,
+            onboardingPaymentPending: false,
+            currentPeriodEnd: periodEnd,
+            pendingSubscriptionScheduleId: null,
+            pendingSubscriptionTargetTier: null,
+            pendingSubscriptionChangeAt: null,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(orgMetadata.orgId, candidate.orgId),
+              inArray(orgMetadata.tier, PAID_TIERS),
+              isNull(orgMetadata.stripeSubscriptionId),
+              eq(
+                orgMetadata.subscriptionStatus,
+                ATOM_GRANT_SUBSCRIPTION_STATUS,
+              ),
+              isNotNull(orgMetadata.currentPeriodEnd),
+              lte(orgMetadata.currentPeriodEnd, now),
+            ),
+          )
+          .returning({ orgId: orgMetadata.orgId });
+      },
+      writePlanEntitlement: async (writeTx, row) => {
+        await upsertStripeSubscriptionPlanSnapshot(writeTx, {
+          orgId: row.orgId,
+          tier: "pro",
+          subscription,
+          stripeSubscriptionId: subscriptionId,
+          stripePriceId: planItem.price.id,
+          status: subscription.status,
+        });
+      },
+    });
+  });
+  return rows.length > 0;
+}
+
+async function downgradeExpiredAtomGrant(
+  context: ReconcileBillingContext,
+  candidate: AtomGrantCandidate,
+): Promise<DowngradedSubscription[]> {
+  const { db, now } = context;
+  return await db.transaction(async (tx) => {
     return await writeOrgMetadataWithPlanEntitlements(tx, {
       writeOrgMetadata: async (writeTx) => {
         return await writeTx
@@ -722,6 +829,41 @@ async function reconcileAtomGrantCandidate(
       },
     });
   });
+}
+
+async function reconcileAtomGrantCandidate(
+  context: ReconcileBillingContext,
+  candidate: AtomGrantCandidate,
+  signal: AbortSignal,
+): Promise<DowngradedSubscription[]> {
+  await expireOrgCredits(context.db, candidate.orgId, context.now);
+  signal.throwIfAborted();
+
+  const preservedSubscriptionId = preservedPurchasedProSubscriptionId(
+    candidate.sourceMetadata,
+  );
+  if (preservedSubscriptionId) {
+    const subscription = await retrievePreservedProSubscription(
+      context,
+      preservedSubscriptionId,
+    );
+    signal.throwIfAborted();
+    if (
+      subscription &&
+      subscriptionCanRestorePreservedPro(subscription, candidate.orgId) &&
+      (await restorePreservedProSubscription(
+        context,
+        candidate,
+        preservedSubscriptionId,
+        subscription,
+      ))
+    ) {
+      signal.throwIfAborted();
+      return [];
+    }
+  }
+
+  const rows = await downgradeExpiredAtomGrant(context, candidate);
   signal.throwIfAborted();
   return rows;
 }
@@ -964,8 +1106,13 @@ async function loadReconcileCandidateRows(
     db
       .select({
         orgId: orgMetadata.orgId,
+        sourceMetadata: orgPlanEntitlements.sourceMetadata,
       })
       .from(orgMetadata)
+      .leftJoin(
+        orgPlanEntitlements,
+        eq(orgPlanEntitlements.orgId, orgMetadata.orgId),
+      )
       .where(
         and(
           scope ? inArray(orgMetadata.orgId, [...scope.orgIds]) : undefined,

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -66,6 +66,7 @@ import {
   handleUsagePackSubscriptionCreated,
   handleUsagePackSubscriptionDeleted,
   handleUsagePackSubscriptionUpdated,
+  USAGE_PACK_SUBSCRIPTION_PURPOSE,
 } from "./usage-pack-subscription.service";
 import { createUsagePackCreditGrant } from "./usage-pack-credit.service";
 import {
@@ -78,6 +79,11 @@ import {
   handleUsagePackMigrationInvoicePaid,
   handleUsagePackMigrationSubscriptionUpdated,
 } from "./usage-pack-subscription-migration.service";
+import {
+  preservedPurchasedProSubscriptionId,
+  requestsPurchasedProPreservation,
+  withPreservedPurchasedProSubscription,
+} from "./atom-plan-override";
 
 const L = logger("WebhookStripe");
 
@@ -218,8 +224,11 @@ interface InvoicePaidOrg {
 }
 
 interface LockedInvoicePaidOrg extends InvoicePaidOrg {
+  readonly cancelAtPeriodEnd: boolean;
+  readonly pendingSubscriptionScheduleId: string | null;
   readonly planEntitlementSource: string | null;
   readonly planEntitlementPeriodEnd: Date | null;
+  readonly planEntitlementStripeSubscriptionId: string | null;
   readonly planEntitlementSourceMetadata: Readonly<
     Record<string, string>
   > | null;
@@ -258,6 +267,7 @@ interface AtomPlanGrantInvoiceDetails {
   readonly customerId: string | null;
   readonly credits: number;
   readonly memberUsagePack: AtomMemberUsagePackDetails | null;
+  readonly preservePurchasedPro: boolean;
 }
 
 interface AtomCreditGrantInvoiceDetails {
@@ -915,6 +925,9 @@ function atomGrantInvoiceDetails(
     credits:
       metadata.planVersion === "usagePack" ? 0 : monthlyCreditsForTier(tier),
     memberUsagePack: memberUsagePack.value,
+    preservePurchasedPro:
+      (tier === "team" || tier === "custom") &&
+      requestsPurchasedProPreservation(metadata),
   };
 }
 
@@ -1359,8 +1372,12 @@ async function lockInvoicePaidOrg(
       stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
       subscriptionStatus: orgMetadata.subscriptionStatus,
       tier: orgMetadata.tier,
+      cancelAtPeriodEnd: orgMetadata.cancelAtPeriodEnd,
+      pendingSubscriptionScheduleId: orgMetadata.pendingSubscriptionScheduleId,
       planEntitlementSource: orgPlanEntitlements.source,
       planEntitlementPeriodEnd: orgPlanEntitlements.currentPeriodEnd,
+      planEntitlementStripeSubscriptionId:
+        orgPlanEntitlements.stripeSubscriptionId,
       planEntitlementSourceMetadata: orgPlanEntitlements.sourceMetadata,
     })
     .from(orgMetadata)
@@ -1698,6 +1715,143 @@ async function grantAtomRedeemMemberUsagePack(
   });
 }
 
+function locallyEligiblePurchasedProSubscriptionId(
+  lockedOrg: LockedInvoicePaidOrg,
+): string | null {
+  if (
+    lockedOrg.tier !== "pro" ||
+    !lockedOrg.stripeSubscriptionId ||
+    (lockedOrg.subscriptionStatus !== "active" &&
+      lockedOrg.subscriptionStatus !== "trialing") ||
+    lockedOrg.cancelAtPeriodEnd ||
+    lockedOrg.pendingSubscriptionScheduleId !== null ||
+    lockedOrg.planEntitlementSource !== "stripe_subscription" ||
+    lockedOrg.planEntitlementSourceMetadata?.purpose ===
+      USAGE_PACK_SUBSCRIPTION_PURPOSE ||
+    lockedOrg.planEntitlementStripeSubscriptionId !==
+      lockedOrg.stripeSubscriptionId
+  ) {
+    return null;
+  }
+
+  return lockedOrg.stripeSubscriptionId;
+}
+
+function stripeSubscriptionCanBePreservedForAtomGrant(args: {
+  readonly subscription: StripeSubscription;
+  readonly subscriptionId: string;
+  readonly customerId: string;
+  readonly orgId: string;
+}): boolean {
+  return (
+    args.subscription.id === args.subscriptionId &&
+    customerIdFromSubscription(args.subscription) === args.customerId &&
+    args.subscription.metadata?.orgId === args.orgId &&
+    args.subscription.metadata?.purpose !== USAGE_PACK_SUBSCRIPTION_PURPOSE &&
+    (args.subscription.status === "active" ||
+      args.subscription.status === "trialing") &&
+    !subscriptionWillCancel(args.subscription) &&
+    (args.subscription.schedule === null ||
+      args.subscription.schedule === undefined) &&
+    tierFromSubscription(args.subscription) === "pro"
+  );
+}
+
+async function purchasedProSubscriptionIdForAtomGrant(args: {
+  readonly details: AtomPlanGrantInvoiceDetails;
+  readonly lockedOrg: LockedInvoicePaidOrg;
+}): Promise<string | null> {
+  const carriedSubscriptionId = preservedPurchasedProSubscriptionId(
+    args.lockedOrg.planEntitlementSourceMetadata,
+  );
+  if (carriedSubscriptionId) {
+    return carriedSubscriptionId;
+  }
+  if (!args.details.preservePurchasedPro) {
+    return null;
+  }
+
+  const subscriptionId = locallyEligiblePurchasedProSubscriptionId(
+    args.lockedOrg,
+  );
+  if (!subscriptionId || !args.details.customerId) {
+    const hasExpectedPurchasedPlan =
+      args.lockedOrg.tier === "pro" ||
+      args.lockedOrg.stripeSubscriptionId !== null;
+    if (hasExpectedPurchasedPlan) {
+      throw new Error(
+        `Cannot safely preserve the purchased Pro subscription for Atom grant in org ${args.details.orgId}`,
+      );
+    }
+    return null;
+  }
+
+  const subscription =
+    await getStripeClient().subscriptions.retrieve(subscriptionId);
+  if (
+    !stripeSubscriptionCanBePreservedForAtomGrant({
+      subscription,
+      subscriptionId,
+      customerId: args.details.customerId,
+      orgId: args.details.orgId,
+    })
+  ) {
+    throw new Error(
+      `Cannot safely preserve purchased Pro subscription ${subscriptionId} for Atom grant in org ${args.details.orgId}`,
+    );
+  }
+
+  return subscriptionId;
+}
+
+async function processExistingAtomPlanGrantInvoice(args: {
+  readonly tx: WriteTx;
+  readonly invoice: InvoiceInput;
+  readonly details: AtomPlanGrantInvoiceDetails;
+  readonly lockedOrg: LockedInvoicePaidOrg;
+  readonly preservedSubscriptionId: string | null;
+}): Promise<boolean> {
+  if (args.lockedOrg.lastProcessedInvoiceId === args.invoice.id) {
+    if (
+      args.lockedOrg.tier === args.details.tier &&
+      args.lockedOrg.subscriptionStatus === ATOM_GRANT_SUBSCRIPTION_STATUS &&
+      args.lockedOrg.stripeSubscriptionId === null
+    ) {
+      await upsertAtomGrantPlanEntitlement(
+        args.tx,
+        args.invoice,
+        args.details,
+        args.preservedSubscriptionId,
+      );
+    }
+    await grantAtomRedeemMemberUsagePack(args.tx, args.invoice, args.details);
+    await cancelReplacedSubscriptionsAfterAtomGrant({
+      orgId: args.details.orgId,
+      customerId: args.details.customerId,
+      invoiceId: args.invoice.id,
+      knownOldSubscriptionId: args.lockedOrg.stripeSubscriptionId,
+      preservedSubscriptionId: args.preservedSubscriptionId,
+      failOnUnpreservedPro: args.details.preservePurchasedPro,
+    });
+    L.debug("atom grant invoice already processed", {
+      invoiceId: args.invoice.id,
+      orgId: args.details.orgId,
+    });
+    return true;
+  }
+  if (
+    atomUsagePackGrantWouldNotExtendEntitlement({
+      invoice: args.invoice,
+      details: args.details,
+      lockedOrg: args.lockedOrg,
+    })
+  ) {
+    await grantAtomRedeemMemberUsagePack(args.tx, args.invoice, args.details);
+    return true;
+  }
+  return false;
+}
+
 async function processAtomPlanGrantInvoicePaid(
   db: Db,
   invoice: InvoiceInput,
@@ -1716,35 +1870,17 @@ async function processAtomPlanGrantInvoicePaid(
     if (!lockedOrg) {
       return false;
     }
-    if (lockedOrg.lastProcessedInvoiceId === invoice.id) {
-      if (
-        lockedOrg.tier === details.tier &&
-        lockedOrg.subscriptionStatus === ATOM_GRANT_SUBSCRIPTION_STATUS &&
-        lockedOrg.stripeSubscriptionId === null
-      ) {
-        await upsertAtomGrantPlanEntitlement(tx, invoice, details);
-      }
-      await grantAtomRedeemMemberUsagePack(tx, invoice, details);
-      await cancelReplacedSubscriptionsAfterAtomGrant({
-        orgId: details.orgId,
-        customerId: details.customerId,
-        invoiceId: invoice.id,
-        knownOldSubscriptionId: lockedOrg.stripeSubscriptionId,
-      });
-      L.debug("atom grant invoice already processed", {
-        invoiceId: invoice.id,
-        orgId: details.orgId,
-      });
-      return true;
-    }
+    const preservedSubscriptionId =
+      await purchasedProSubscriptionIdForAtomGrant({ details, lockedOrg });
     if (
-      atomUsagePackGrantWouldNotExtendEntitlement({
+      await processExistingAtomPlanGrantInvoice({
+        tx,
         invoice,
         details,
         lockedOrg,
+        preservedSubscriptionId,
       })
     ) {
-      await grantAtomRedeemMemberUsagePack(tx, invoice, details);
       return true;
     }
     if (
@@ -1771,13 +1907,20 @@ async function processAtomPlanGrantInvoicePaid(
           lockedOrg.subscriptionStatus === ATOM_GRANT_SUBSCRIPTION_STATUS &&
           lockedOrg.stripeSubscriptionId === null
         ) {
-          await upsertAtomGrantPlanEntitlement(tx, invoice, details);
+          await upsertAtomGrantPlanEntitlement(
+            tx,
+            invoice,
+            details,
+            preservedSubscriptionId,
+          );
         }
         await cancelReplacedSubscriptionsAfterAtomGrant({
           orgId: details.orgId,
           customerId: details.customerId,
           invoiceId: invoice.id,
           knownOldSubscriptionId: lockedOrg.stripeSubscriptionId,
+          preservedSubscriptionId,
+          failOnUnpreservedPro: details.preservePurchasedPro,
         });
         L.debug("atom grant invoice credits already processed", {
           invoiceId: invoice.id,
@@ -1814,7 +1957,12 @@ async function processAtomPlanGrantInvoicePaid(
           .returning({ orgId: orgMetadata.orgId });
       },
       writePlanEntitlement: async (writeTx) => {
-        await upsertAtomGrantPlanEntitlement(writeTx, invoice, details);
+        await upsertAtomGrantPlanEntitlement(
+          writeTx,
+          invoice,
+          details,
+          preservedSubscriptionId,
+        );
       },
     });
     await grantAtomRedeemMemberUsagePack(tx, invoice, details);
@@ -1823,6 +1971,8 @@ async function processAtomPlanGrantInvoicePaid(
       customerId: details.customerId,
       invoiceId: invoice.id,
       knownOldSubscriptionId: lockedOrg.stripeSubscriptionId,
+      preservedSubscriptionId,
+      failOnUnpreservedPro: details.preservePurchasedPro,
     });
     return true;
   });
@@ -1832,6 +1982,7 @@ async function upsertAtomGrantPlanEntitlement(
   tx: WriteTx,
   invoice: InvoiceInput,
   details: AtomPlanGrantInvoiceDetails,
+  preservedSubscriptionId: string | null,
 ): Promise<void> {
   const grantLine = invoiceAtomGrantLine(invoice);
   const periodStart = grantLine?.period.start;
@@ -1846,10 +1997,13 @@ async function upsertAtomGrantPlanEntitlement(
     stripePriceId: grantLine ? invoiceLinePriceId(grantLine) : null,
     memberInviteUsagePackRequired:
       invoice.metadata?.planVersion === "usagePack",
-    sourceMetadata: {
-      ...invoice.metadata,
-      atomPlanInvoiceId: invoice.id,
-    },
+    sourceMetadata: withPreservedPurchasedProSubscription(
+      {
+        ...invoice.metadata,
+        atomPlanInvoiceId: invoice.id,
+      },
+      preservedSubscriptionId,
+    ),
   });
 }
 
@@ -3131,10 +3285,10 @@ function isReplaceablePaidSubscriptionForAtomGrant(args: {
   );
 }
 
-async function replacedAtomGrantSubscriptionIdsForCustomer(args: {
+async function replacedAtomGrantSubscriptionsForCustomer(args: {
   readonly orgId: string;
   readonly customerId: string;
-}): Promise<readonly string[]> {
+}): Promise<readonly StripeSubscription[]> {
   const stripe = getStripeClient();
   const subscriptions = await stripe.subscriptions.list({
     customer: args.customerId,
@@ -3142,16 +3296,12 @@ async function replacedAtomGrantSubscriptionIdsForCustomer(args: {
     limit: 100,
   });
 
-  return subscriptions.data
-    .filter((subscription) => {
-      return isReplaceablePaidSubscriptionForAtomGrant({
-        orgId: args.orgId,
-        subscription,
-      });
-    })
-    .map((subscription) => {
-      return subscription.id;
+  return subscriptions.data.filter((subscription) => {
+    return isReplaceablePaidSubscriptionForAtomGrant({
+      orgId: args.orgId,
+      subscription,
     });
+  });
 }
 
 async function cancelReplacedSubscriptionsAfterAtomGrant(args: {
@@ -3159,16 +3309,35 @@ async function cancelReplacedSubscriptionsAfterAtomGrant(args: {
   readonly customerId: string | null;
   readonly invoiceId: string;
   readonly knownOldSubscriptionId: string | null;
+  readonly preservedSubscriptionId: string | null;
+  readonly failOnUnpreservedPro: boolean;
 }): Promise<void> {
+  const listedSubscriptions = args.customerId
+    ? await replacedAtomGrantSubscriptionsForCustomer({
+        orgId: args.orgId,
+        customerId: args.customerId,
+      })
+    : [];
+  if (
+    args.failOnUnpreservedPro &&
+    !args.preservedSubscriptionId &&
+    listedSubscriptions.some((subscription) => {
+      return tierFromSubscription(subscription) === "pro";
+    })
+  ) {
+    throw new Error(
+      `Cannot safely preserve a purchased Pro subscription for Atom grant in org ${args.orgId}`,
+    );
+  }
+
   const replacedSubscriptionIds = [
     ...(args.knownOldSubscriptionId ? [args.knownOldSubscriptionId] : []),
-    ...(args.customerId
-      ? await replacedAtomGrantSubscriptionIdsForCustomer({
-          orgId: args.orgId,
-          customerId: args.customerId,
-        })
-      : []),
-  ];
+    ...listedSubscriptions.map((subscription) => {
+      return subscription.id;
+    }),
+  ].filter((subscriptionId) => {
+    return subscriptionId !== args.preservedSubscriptionId;
+  });
   if (replacedSubscriptionIds.length === 0) {
     return;
   }
@@ -3450,6 +3619,124 @@ function subscriptionPlanEntitlementIsCurrent(
   );
 }
 
+function hiddenPurchasedProSubscriptionMatches(args: {
+  readonly lockedOrg: LockedInvoicePaidOrg;
+  readonly subscriptionId: string;
+}): boolean {
+  return (
+    args.lockedOrg.planEntitlementSource === "stripe_atom_grant" &&
+    args.lockedOrg.subscriptionStatus === ATOM_GRANT_SUBSCRIPTION_STATUS &&
+    args.lockedOrg.stripeSubscriptionId === null &&
+    preservedPurchasedProSubscriptionId(
+      args.lockedOrg.planEntitlementSourceMetadata,
+    ) === args.subscriptionId
+  );
+}
+
+async function processHiddenPurchasedProInvoicePaid(
+  tx: WriteTx,
+  args: {
+    readonly invoice: InvoiceInput;
+    readonly customerId: string;
+    readonly subscriptionId: string;
+    readonly orgId: string;
+    readonly details: SubscriptionInvoiceDetails;
+  },
+): Promise<boolean> {
+  if (
+    args.details.tier !== "pro" ||
+    (args.details.subscription.status !== "active" &&
+      args.details.subscription.status !== "trialing") ||
+    customerIdFromSubscription(args.details.subscription) !== args.customerId ||
+    args.details.subscription.metadata?.orgId !== args.orgId
+  ) {
+    throw new Error(
+      `Preserved subscription ${args.subscriptionId} is no longer an active org-owned Pro subscription`,
+    );
+  }
+
+  await expireCredits(tx, args.orgId);
+  const inserted = await createExpiresRecord(tx, args.orgId, {
+    source: "subscription_renewal",
+    stripeInvoiceId: args.invoice.id,
+    amount: args.details.credits,
+    expiresAt: args.details.expiresAt,
+  });
+  if (!inserted) {
+    L.debug("hidden purchased Pro invoice already processed", {
+      invoiceId: args.invoice.id,
+      orgId: args.orgId,
+      subscriptionId: args.subscriptionId,
+    });
+    return true;
+  }
+
+  await grantOrgCredits(tx, args.orgId, args.details.credits);
+  L.debug("hidden purchased Pro renewal credits granted", {
+    invoiceId: args.invoice.id,
+    orgId: args.orgId,
+    subscriptionId: args.subscriptionId,
+  });
+  return true;
+}
+
+async function processHiddenPurchasedProInvoiceIfMatched(
+  tx: WriteTx,
+  args: {
+    readonly invoice: InvoiceInput;
+    readonly customerId: string;
+    readonly subscriptionId: string;
+    readonly orgId: string;
+    readonly details: SubscriptionInvoiceDetails;
+  },
+  lockedOrg: LockedInvoicePaidOrg,
+): Promise<boolean | null> {
+  if (
+    !hiddenPurchasedProSubscriptionMatches({
+      lockedOrg,
+      subscriptionId: args.subscriptionId,
+    })
+  ) {
+    return null;
+  }
+  return await processHiddenPurchasedProInvoicePaid(tx, args);
+}
+
+async function processExistingSubscriptionInvoice(args: {
+  readonly tx: WriteTx;
+  readonly invoice: InvoiceInput;
+  readonly customerId: string;
+  readonly subscriptionId: string;
+  readonly orgId: string;
+  readonly details: SubscriptionInvoiceDetails;
+  readonly lockedOrg: LockedInvoicePaidOrg;
+  readonly replacedSubscriptionId: string | null;
+}): Promise<boolean> {
+  if (args.lockedOrg.lastProcessedInvoiceId !== args.invoice.id) {
+    return false;
+  }
+  if (subscriptionPlanEntitlementIsCurrent(args.lockedOrg, args)) {
+    await upsertSubscriptionPlanEntitlement(args.tx, {
+      orgId: args.orgId,
+      subscriptionId: args.subscriptionId,
+      details: args.details,
+    });
+  }
+  await cancelReplacedProSubscriptionsAfterTeamInvoice({
+    orgId: args.orgId,
+    customerId: args.customerId,
+    invoiceId: args.invoice.id,
+    newSubscriptionId: args.subscriptionId,
+    targetTier: args.details.tier,
+    knownOldSubscriptionId: args.replacedSubscriptionId,
+  });
+  L.debug("invoice.paid already processed by concurrent delivery", {
+    invoiceId: args.invoice.id,
+    orgId: args.orgId,
+  });
+  return true;
+}
+
 async function processSubscriptionInvoicePaid(
   tx: WriteTx,
   args: {
@@ -3464,6 +3751,11 @@ async function processSubscriptionInvoicePaid(
   if (!lockedOrg) {
     return false;
   }
+  const hiddenPurchasedProResult =
+    await processHiddenPurchasedProInvoiceIfMatched(tx, args, lockedOrg);
+  if (hiddenPurchasedProResult !== null) {
+    return hiddenPurchasedProResult;
+  }
   const replacedSubscriptionId = replacedProSubscriptionId({
     currentSubscriptionId: lockedOrg.stripeSubscriptionId,
     currentSubscriptionStatus: lockedOrg.subscriptionStatus,
@@ -3472,26 +3764,14 @@ async function processSubscriptionInvoicePaid(
     targetTier: args.details.tier,
   });
 
-  if (lockedOrg.lastProcessedInvoiceId === args.invoice.id) {
-    if (subscriptionPlanEntitlementIsCurrent(lockedOrg, args)) {
-      await upsertSubscriptionPlanEntitlement(tx, {
-        orgId: args.orgId,
-        subscriptionId: args.subscriptionId,
-        details: args.details,
-      });
-    }
-    await cancelReplacedProSubscriptionsAfterTeamInvoice({
-      orgId: args.orgId,
-      customerId: args.customerId,
-      invoiceId: args.invoice.id,
-      newSubscriptionId: args.subscriptionId,
-      targetTier: args.details.tier,
-      knownOldSubscriptionId: replacedSubscriptionId,
-    });
-    L.debug("invoice.paid already processed by concurrent delivery", {
-      invoiceId: args.invoice.id,
-      orgId: args.orgId,
-    });
+  if (
+    await processExistingSubscriptionInvoice({
+      tx,
+      ...args,
+      lockedOrg,
+      replacedSubscriptionId,
+    })
+  ) {
     return true;
   }
 

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -225,6 +225,7 @@ interface InvoicePaidOrg {
 
 interface LockedInvoicePaidOrg extends InvoicePaidOrg {
   readonly cancelAtPeriodEnd: boolean;
+  readonly currentPeriodEnd: Date | null;
   readonly pendingSubscriptionScheduleId: string | null;
   readonly planEntitlementSource: string | null;
   readonly planEntitlementPeriodEnd: Date | null;
@@ -1373,6 +1374,7 @@ async function lockInvoicePaidOrg(
       subscriptionStatus: orgMetadata.subscriptionStatus,
       tier: orgMetadata.tier,
       cancelAtPeriodEnd: orgMetadata.cancelAtPeriodEnd,
+      currentPeriodEnd: orgMetadata.currentPeriodEnd,
       pendingSubscriptionScheduleId: orgMetadata.pendingSubscriptionScheduleId,
       planEntitlementSource: orgPlanEntitlements.source,
       planEntitlementPeriodEnd: orgPlanEntitlements.currentPeriodEnd,
@@ -3627,6 +3629,8 @@ function hiddenPurchasedProSubscriptionMatches(args: {
     args.lockedOrg.planEntitlementSource === "stripe_atom_grant" &&
     args.lockedOrg.subscriptionStatus === ATOM_GRANT_SUBSCRIPTION_STATUS &&
     args.lockedOrg.stripeSubscriptionId === null &&
+    (args.lockedOrg.currentPeriodEnd === null ||
+      args.lockedOrg.currentPeriodEnd.getTime() > now()) &&
     preservedPurchasedProSubscriptionId(
       args.lockedOrg.planEntitlementSourceMetadata,
     ) === args.subscriptionId

--- a/turbo/apps/api/src/test-fixtures/org-metadata.ts
+++ b/turbo/apps/api/src/test-fixtures/org-metadata.ts
@@ -18,7 +18,7 @@ import { orgTierSchema } from "@okouai/api-contracts/contracts/orgs";
 import { creditExpiresRecord } from "@okouai/db/schema/credit-expires-record";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
 import { createStore } from "ccstate";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { writeDb$ } from "../signals/external/db";
 import { upsertOrgPlanEntitlement } from "../signals/services/org-plan-entitlements.service";
@@ -54,6 +54,7 @@ export async function upsertOrgMetadataFixture(values: {
 export async function expireAtomGrantFixture(values: {
   readonly orgId: string;
   readonly expiredAt: Date;
+  readonly creditInvoiceIds?: readonly string[];
 }): Promise<void> {
   const db = createStore().set(writeDb$);
   await db
@@ -66,7 +67,16 @@ export async function expireAtomGrantFixture(values: {
   await db
     .update(creditExpiresRecord)
     .set({ expiresAt: values.expiredAt })
-    .where(eq(creditExpiresRecord.orgId, values.orgId));
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, values.orgId),
+        values.creditInvoiceIds === undefined
+          ? undefined
+          : inArray(creditExpiresRecord.stripeInvoiceId, [
+              ...values.creditInvoiceIds,
+            ]),
+      ),
+    );
 }
 
 interface OrgAcquisitionAttributionRow {

--- a/turbo/apps/api/src/test-fixtures/org-plan-entitlement.ts
+++ b/turbo/apps/api/src/test-fixtures/org-plan-entitlement.ts
@@ -37,6 +37,7 @@ interface OrgPlanEntitlementFixtureState {
   readonly currentPeriodEnd: string | null;
   readonly cancelAt: string | null;
   readonly expiresAt: string | null;
+  readonly sourceMetadata: Record<string, string> | null;
 }
 
 export async function upsertOrgPlanEntitlementFixture(values: {
@@ -176,6 +177,7 @@ export async function readOrgPlanEntitlementFixture(
       currentPeriodEnd: orgPlanEntitlements.currentPeriodEnd,
       cancelAt: orgPlanEntitlements.cancelAt,
       expiresAt: orgPlanEntitlements.expiresAt,
+      sourceMetadata: orgPlanEntitlements.sourceMetadata,
     })
     .from(orgPlanEntitlements)
     .where(eq(orgPlanEntitlements.orgId, orgId))


### PR DESCRIPTION
## Summary

- preserve one eligible legacy purchased Pro subscription beneath an explicitly marked Atom Team or Custom grant, keep hidden renewal credits idempotent, and atomically restore the live Pro entitlement after expiry
- retain the existing behavior for unmarked Atom invoices and safely fall back when the preserved subscription is missing or no longer eligible
- add deployed Playwright coverage for saved-card Plan upgrades, credit purchase and reopen, paid invitations, Atom restoration, and purchased Usage Pack consumption
- pass Stripe and reconciliation credentials only to the trusted Playwright execution step

## Testing

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --maxWorkers=1 --silent=passed-only` (51 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/global-sweep-contracts.test.ts --maxWorkers=1 --silent=passed-only` (10 passed)
- `pnpm knip`
- `pnpm install --frozen-lockfile`, `pnpm check-types`, and `pnpm test` in `e2e` (35 passed)
- `lefthook run pre-commit`

The deployed billing journeys require the preview app, API, runner, Stripe listener, and trusted credentials; `cli-e2e-02-playwright` is the authoritative browser run.

## Rollout

Deploy this VM0 compatibility slice first and wait for pre-marker API instances and the normal rollback window to drain. Only then should `vm0-atom` emit `planOverrideMode=preserve_purchased_pro_v1` for eligible legacy Team or Custom grants. Roll the producer back first if rollback is needed, and retain this backend behavior until every marked grant has expired.

Refs #27847
