### PR TITLE
fix(python): fail closed on unsafe platform api paths

### DIFF
--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -21,6 +21,7 @@ _BUILTIN_HOST_POLICY_DENIED_ERROR: Final = "builtin_host_policy_denied"
 _AMBIGUOUS_CONNECTOR_ROUTE_ERROR: Final = "ambiguous_connector_route"
 _FIREWALL_AUTHORIZATION_CHANGED_ERROR: Final = "firewall_authorization_changed"
 _STALE_TLS_ADMISSION_ERROR: Final = "stale_tls_admission"
+_UNSAFE_PLATFORM_PATH_ERROR: Final = "unsafe_platform_path"
 _UPSTREAM_DESTINATION_UNBOUND_ERROR: Final = "upstream_destination_unbound"
 _HTTP_STATUS_CONFLICT = 409
 
@@ -150,6 +151,31 @@ def block_stale_tls_admission(flow: http.HTTPFlow, *, reason: str) -> None:
                 "Request blocked: TLS admission is no longer backed by a valid proxy registry VM"
             ),
             "reason": reason,
+        },
+    )
+
+
+def block_platform_path_denied(flow: http.HTTPFlow) -> None:
+    message = "Request blocked: unsafe platform API path"
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        message,
+        type="platform_path_admission",
+        reason=_UNSAFE_PLATFORM_PATH_ERROR,
+    )
+    flow_metadata.set_firewall_decision(
+        flow.metadata,
+        "BLOCK",
+        error=_UNSAFE_PLATFORM_PATH_ERROR,
+    )
+    flow.response = make_local_json_response(
+        flow,
+        403,
+        {
+            "error": _UNSAFE_PLATFORM_PATH_ERROR,
+            "message": message,
         },
     )
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -355,24 +355,20 @@ def _prebind_bounded_requestheaders_upstream_destination(
         except AuthorityValidationError:
             return None
         flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
-        if upstream_admission.api_destination_matches(
+        is_api_destination = upstream_admission.api_destination_matches(
             api_url,
             scheme=flow.request.scheme,
             hostname=trusted_authority.host,
             port=trusted_authority.port,
-        ) and not upstream_admission.request_path_uses_platform_firewall(flow.request.path):
-            classification = _classify_request_for_flow_with_trusted_authority(
+        )
+        if (
+            not is_api_destination
+            and upstream_admission.has_bound_destination(
                 flow,
-                trusted_authority=trusted_authority,
-                defer_unresolved_public_destination=True,
+                allowed_kinds=frozenset(("connector_auth",)),
             )
-            if classification.kind == "api_allow":
-                _admit_platform_api_request(flow)
-            return classification
-        if upstream_admission.has_bound_destination(
-            flow,
-            allowed_kinds=frozenset(("connector_auth",)),
-        ) and not _request_may_use_aws_sigv4(flow):
+            and not _request_may_use_aws_sigv4(flow)
+        ):
             return None
         classification = _classify_request_for_flow_with_trusted_authority(
             flow,
@@ -649,6 +645,10 @@ def _block_invalid_registry_vm(
 
 def _block_stale_tls_admission(flow: http.HTTPFlow, *, reason: str) -> None:
     http_local_responses.block_stale_tls_admission(flow, reason=reason)
+
+
+def _block_platform_path_denied(flow: http.HTTPFlow) -> None:
+    http_local_responses.block_platform_path_denied(flow)
 
 
 def _block_firewall_authorization_changed(
@@ -1222,6 +1222,9 @@ def _block_current_firewall_authorization(
     if classification.kind == "authority_denied":
         _block_authority_validation_error(flow, classification.authority_error)
         return
+    if classification.kind == "platform_path_denied":
+        _block_platform_path_denied(flow)
+        return
     if classification.kind == "firewall_ambiguous":
         _set_firewall_ambiguous_response(flow, classification.firewall_ambiguous)
         return
@@ -1343,6 +1346,9 @@ async def request(flow: http.HTTPFlow) -> None:
                 _block_upstream_destination_unbound(flow, reason="api_allow")
                 return
             flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
+            return
+        if classification.kind == "platform_path_denied":
+            _block_platform_path_denied(flow)
             return
         if classification.kind == "browser_allow":
             # Browser-originated traffic intentionally bypasses connector

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -144,6 +144,15 @@ class ApiAllow:
 
 
 @dataclass(frozen=True)
+class PlatformPathDenied:
+    vm_info: dict
+    kind: Literal["platform_path_denied"] = field(
+        init=False,
+        default="platform_path_denied",
+    )
+
+
+@dataclass(frozen=True)
 class BrowserAllow:
     vm_info: dict
     kind: Literal["browser_allow"] = field(init=False, default="browser_allow")
@@ -209,6 +218,7 @@ RequestClassification = (
     | InvalidRegistryVm
     | AuthorityDenied
     | ApiAllow
+    | PlatformPathDenied
     | BrowserAllow
     | FirewallAmbiguous
     | FirewallBlock
@@ -292,8 +302,9 @@ def classify_request(
     """Classify a flow and write metadata needed by downstream hook handling.
 
     The decision order is registry/TLS admission, registered VM resolution,
-    trusted authority validation, platform API allow, browser passthrough,
-    firewall match, publicDestination runtime validation, and default allow.
+    trusted authority validation, platform path admission, platform API allow,
+    browser passthrough, firewall match, publicDestination runtime validation,
+    and default allow.
 
     After registry and TLS admission checks accept a registered VM,
     classification stores VM/run metadata on the flow. Once trusted authority
@@ -422,8 +433,14 @@ def _classify_request(
         scheme=flow.request.scheme,
         hostname=trusted_authority.host,
         port=trusted_authority.port,
-    ) and not upstream_admission.request_path_uses_platform_firewall(flow.request.path):
-        return ApiAllow(vm_info=vm_info)
+    ):
+        platform_path_decision = upstream_admission.platform_request_path_decision(
+            flow.request.path
+        )
+        if platform_path_decision == "deny":
+            return PlatformPathDenied(vm_info=vm_info)
+        if platform_path_decision == "api_allow":
+            return ApiAllow(vm_info=vm_info)
 
     if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
         return BrowserAllow(vm_info=vm_info)
@@ -509,6 +526,7 @@ def classification_needs_request_timing(classification: RequestClassification) -
     return classification.kind in (
         "authority_denied",
         "api_allow",
+        "platform_path_denied",
         "browser_allow",
         "firewall_ambiguous",
         "firewall_block",

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -10,9 +10,11 @@ from mitmproxy import connection, ctx, http, tls
 import connection_endpoints
 import flow_metadata
 import matching
+import path_security
 import registry
 import upstream_destination_binding
 from host_normalization import normalize_hostname
+from runtime_url_parsing import strip_url_query_and_fragment
 
 TLS_ADMISSION_VALID_REGISTRY_VM: Final = "valid_registry_vm"
 TLS_ADMISSION_INVALID_REGISTRY_VM: Final = "invalid_registry_vm"
@@ -27,6 +29,7 @@ TlsAdmissionKind = Literal[
     "invalid_registry_vm",
     "registry_unavailable",
 ]
+PlatformRequestPathDecision = Literal["api_allow", "firewall", "deny"]
 _tls_admissions: dict[str, "TlsAdmission"] = {}
 
 
@@ -123,7 +126,7 @@ def _connected_verified_tls_destination_endpoint(
 
 
 def _request_has_platform_test_endpoint_bypass(flow: http.HTTPFlow) -> bool:
-    if not flow.request.path.startswith(_TEST_ENDPOINT_PATH_PREFIX):
+    if platform_request_path_decision(flow.request.path) != "firewall":
         return False
     expected_bypass = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
     if not expected_bypass:
@@ -131,8 +134,13 @@ def _request_has_platform_test_endpoint_bypass(flow: http.HTTPFlow) -> bool:
     return flow.request.headers.get(_TEST_ENDPOINT_BYPASS_HEADER) == expected_bypass
 
 
-def request_path_uses_platform_firewall(path: str) -> bool:
-    return path.startswith(_TEST_ENDPOINT_PATH_PREFIX)
+def platform_request_path_decision(path: str) -> PlatformRequestPathDecision:
+    pathname = strip_url_query_and_fragment(path)
+    if path_security.has_unsafe_path(pathname):
+        return "deny"
+    if pathname.startswith(_TEST_ENDPOINT_PATH_PREFIX):
+        return "firewall"
+    return "api_allow"
 
 
 def api_destination_matches(

--- a/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
@@ -116,6 +116,97 @@ async def test_vm0_api_auto_allow_injects_runner_preview_bypass(
     assert flow.request.headers["x-vercel-protection-bypass"] == "preview-secret"
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/api/ordinary/../test/example", id="literal-dot-segment"),
+        pytest.param(
+            "/api/ordinary/%2e%2e/test/example",
+            id="encoded-dot-segment",
+        ),
+        pytest.param("/api\\test\\example", id="backslash"),
+        pytest.param("/api/ordinary/%zz/test/example", id="malformed-escape"),
+    ],
+)
+async def test_vm0_api_unsafe_paths_fail_closed_before_binding_or_bypass(
+    registry_file, real_flow, mitm_ctx, monkeypatch, path
+):
+    flow = real_flow(
+        with_response=False,
+        host="preview-api.vm6.ai",
+        path=path,
+    )
+    monkeypatch.setattr(platform_api, "VERCEL_BYPASS", "preview-secret")
+
+    with mitm_ctx(
+        registry_path=str(registry_file),
+        api_url="https://preview-api.vm6.ai",
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert json.loads(flow.response.content) == {
+        "error": "unsafe_platform_path",
+        "message": "Request blocked: unsafe platform API path",
+    }
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_platform_path"
+    assert "x-vercel-protection-bypass" not in flow.request.headers
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_vm0_api_unsafe_browser_path_does_not_fall_through_to_browser_allow(
+    registry_file, real_flow, mitm_ctx, headers, monkeypatch
+):
+    flow = real_flow(
+        with_response=False,
+        host="preview-api.vm6.ai",
+        path="/api/ordinary/../test/example",
+        request_headers=headers(
+            ("Host", "preview-api.vm6.ai"),
+            ("User-Agent", "Mozilla/5.0 Chrome/151.0.0.0 Safari/537.36"),
+        ),
+    )
+    monkeypatch.setattr(platform_api, "VERCEL_BYPASS", "preview-secret")
+
+    with mitm_ctx(
+        registry_path=str(registry_file),
+        api_url="https://preview-api.vm6.ai",
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_platform_path"
+    assert flow.metadata[metadata_keys.BROWSER_USER_AGENT] is True
+    assert "x-vercel-protection-bypass" not in flow.request.headers
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_vm0_api_safe_repeated_separator_path_remains_auto_allowed(
+    registry_file, real_flow, mitm_ctx, monkeypatch
+):
+    flow = real_flow(
+        with_response=False,
+        host="preview-api.vm6.ai",
+        path="/api//test/example",
+    )
+    monkeypatch.setattr(platform_api, "VERCEL_BYPASS", "preview-secret")
+
+    with mitm_ctx(
+        registry_path=str(registry_file),
+        api_url="https://preview-api.vm6.ai",
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.request.headers["x-vercel-protection-bypass"] == "preview-secret"
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[flow.server_conn.id]
+    assert binding.kinds == frozenset(("api_allow",))
+
+
 async def test_non_api_request_does_not_receive_runner_preview_bypass(
     registry_file, real_flow, mitm_ctx, monkeypatch
 ):
@@ -459,8 +550,24 @@ async def test_unknown_cached_classification_does_not_bypass_registry_gate(
     assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/api/test/oauth-provider/echo", id="pathname"),
+        pytest.param(
+            "/api/test/oauth-provider/echo?visible=1#fragment",
+            id="query-and-fragment",
+        ),
+    ],
+)
 async def test_vm0_api_test_paths_skip_auto_allow(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    monkeypatch,
+    path,
 ):
     """`/api/test/*` routes exist to exercise the firewall pipeline itself.
 
@@ -493,7 +600,7 @@ async def test_vm0_api_test_paths_skip_auto_allow(
     flow = real_flow(
         with_response=False,
         host="api.vm0.ai",
-        path="/api/test/oauth-provider/echo",
+        path=path,
         request_headers=headers(
             ("Host", "api.vm0.ai"),
             ("x-vm0-test-endpoint-bypass", "preview-secret"),

--- a/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
@@ -93,6 +93,78 @@ async def test_streamed_api_allow_injects_runner_preview_bypass_before_body(
     assert flow.request.headers["x-vercel-protection-bypass"] == "preview-secret"
 
 
+async def test_bounded_unsafe_platform_path_does_not_prebind_before_request_denial(
+    tmp_path, real_flow, mitm_ctx, headers, monkeypatch
+):
+    reg_path = _write_api_registry(tmp_path, capture_network_bodies=False)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="preview-api.vm6.ai",
+        method="POST",
+        path="/api/ordinary/../test/example",
+        request_headers=headers(
+            ("Host", "preview-api.vm6.ai"),
+            ("Content-Length", "4"),
+        ),
+    )
+    monkeypatch.setattr(platform_api, "VERCEL_BYPASS", "preview-secret")
+
+    with mitm_ctx(
+        registry_path=str(reg_path),
+        api_url="https://preview-api.vm6.ai",
+    ):
+        mitm_addon.requestheaders(flow)
+
+        _assert_no_request_stream(flow)
+        assert flow.response is None
+        assert "x-vercel-protection-bypass" not in flow.request.headers
+        assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_platform_path"
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_streamed_unsafe_platform_path_does_not_start_stream_before_request_denial(
+    tmp_path, real_flow, mitm_ctx, headers, monkeypatch
+):
+    reg_path = _write_api_registry(tmp_path, capture_network_bodies=True)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="preview-api.vm6.ai",
+        method="POST",
+        path="/api/ordinary/%2e%2e/test/example",
+        request_headers=headers(
+            ("Host", "preview-api.vm6.ai"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    monkeypatch.setattr(platform_api, "VERCEL_BYPASS", "preview-secret")
+
+    with mitm_ctx(
+        registry_path=str(reg_path),
+        api_url="https://preview-api.vm6.ai",
+    ):
+        mitm_addon.requestheaders(flow)
+
+        _assert_no_request_stream(flow)
+        assert flow.response is None
+        assert "x-vercel-protection-bypass" not in flow.request.headers
+        assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_platform_path"
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
 async def test_streamed_wrong_scheme_does_not_receive_runner_preview_bypass(
     tmp_path, real_flow, mitm_ctx, headers, monkeypatch
 ):

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -109,6 +109,13 @@ const errorTestContract = c.router({
       500: z.object({ error: z.string() }),
     },
   },
+  pathIdentity: {
+    method: "GET",
+    path: "/api/test/path-identity",
+    responses: {
+      200: z.object({ matched: z.literal(true) }),
+    },
+  },
 });
 
 describe("createApp", () => {
@@ -131,6 +138,57 @@ describe("createApp", () => {
     await expect(response.json()).resolves.toStrictEqual({
       error: "Service unavailable",
     });
+  });
+
+  it.each([
+    [
+      "literal dot segment",
+      "http://api.test/api/ordinary/../test/path-identity",
+    ],
+    [
+      "encoded dot segment",
+      "http://api.test/api/ordinary/%2e%2e/test/path-identity",
+    ],
+    ["backslash", String.raw`http://api.test/api\test\path-identity`],
+    [
+      "query and fragment",
+      "http://api.test/api/test/path-identity?visible=1#fragment",
+    ],
+  ])("normalizes a %s to the registered pathname", async (_case, url) => {
+    const handler$ = computed(() => {
+      return { status: 200 as const, body: { matched: true as const } };
+    });
+    const app = createAppWithRoutes({
+      routes: [{ route: errorTestContract.pathIdentity, handler: handler$ }],
+      schemaReadiness: () => {
+        return Promise.resolve(true);
+      },
+      signal: context.signal,
+    });
+
+    const response = await app.request(url);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ matched: true });
+  });
+
+  it("retains a repeated pathname separator", async () => {
+    const handler$ = computed(() => {
+      return { status: 200 as const, body: { matched: true as const } };
+    });
+    const app = createAppWithRoutes({
+      routes: [{ route: errorTestContract.pathIdentity, handler: handler$ }],
+      schemaReadiness: () => {
+        return Promise.resolve(true);
+      },
+      signal: context.signal,
+    });
+
+    const response = await app.request(
+      "http://api.test/api//test/path-identity",
+    );
+
+    expect(response.status).toBe(404);
   });
 
   it("captures unhandled errors and returns a sanitized response", async () => {


### PR DESCRIPTION
## Summary

- classify configured platform-origin paths through one bounded three-way decision before API allow, firewall routing, browser fallback, or upstream binding
- reject unsafe and ambiguous paths with a stable `unsafe_platform_path` response before preview bypass or connector credentials can be injected
- preserve canonical `/api/test/*`, ordinary platform API, repeated-separator, query, and fragment behavior and pin the Fetch/Hono pathname contract in an API entry-point test

## Scope and compatibility

- no production API routes or middleware are changed; the API change is test-only
- no API contract, runner protocol, queue payload, schema, migration, or persisted-state change is required
- new runners enforce the rejection independently while old runners can drain normally, so no coordinated deployment is required

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6044 passed)
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/__tests__/app-factory.test.ts --silent=passed-only` (54 passed)
- `pnpm knip`

Closes #27900
