### PR TITLE
refactor(cli): neutralize the agent api domain module

### DIFF
--- a/turbo/apps/cli/src/commands/agent/create.ts
+++ b/turbo/apps/cli/src/commands/agent/create.ts
@@ -3,9 +3,9 @@ import { Command, Option } from "commander";
 import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import {
-  createZeroAgent,
-  updateZeroAgentInstructions,
-} from "../../lib/api/domains/zero-agents";
+  createAgent,
+  updateAgentInstructions,
+} from "../../lib/api/domains/agents";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { resolveAvatarUrl } from "./avatar";
 import { parseAgentVisibility } from "./visibility";
@@ -93,7 +93,7 @@ Examples:
       }) => {
         const avatarUrl = resolveAvatarUrl(options);
 
-        const agent = await createZeroAgent({
+        const agent = await createAgent({
           displayName: options.displayName,
           description: options.description,
           sound: options.sound,
@@ -103,7 +103,7 @@ Examples:
 
         if (options.instructionsFile) {
           const content = readFileSync(options.instructionsFile, "utf-8");
-          await updateZeroAgentInstructions(agent.agentId, content);
+          await updateAgentInstructions(agent.agentId, content);
         }
 
         console.log(chalk.green(`✓ Agent "${agent.agentId}" created`));

--- a/turbo/apps/cli/src/commands/agent/delete.ts
+++ b/turbo/apps/cli/src/commands/agent/delete.ts
@@ -1,9 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import {
-  getZeroAgent,
-  deleteZeroAgent,
-} from "../../lib/api/domains/zero-agents";
+import { getAgent, deleteAgent } from "../../lib/api/domains/agents";
 import { isInteractive, promptConfirm } from "../../lib/utils/prompt-utils";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 
@@ -25,7 +22,7 @@ Notes:
   )
   .action(
     withErrorHandler(async (agentId: string, options: { yes?: boolean }) => {
-      await getZeroAgent(agentId);
+      await getAgent(agentId);
 
       if (!options.yes) {
         if (!isInteractive()) {
@@ -41,7 +38,7 @@ Notes:
         }
       }
 
-      await deleteZeroAgent(agentId);
+      await deleteAgent(agentId);
       console.log(chalk.green(`✓ Agent "${agentId}" deleted`));
     }),
   );

--- a/turbo/apps/cli/src/commands/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/agent/edit.ts
@@ -3,10 +3,10 @@ import { Command, Option } from "commander";
 import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import {
-  getZeroAgent,
-  updateZeroAgent,
-  updateZeroAgentInstructions,
-} from "../../lib/api/domains/zero-agents";
+  getAgent,
+  updateAgent,
+  updateAgentInstructions,
+} from "../../lib/api/domains/agents";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { type AvatarOptions, resolveAvatarUrl } from "./avatar";
 import { parseAgentVisibility } from "./visibility";
@@ -48,13 +48,13 @@ async function applyAgentUpdate(
   const hasAvatar = hasAvatarUpdate(options);
   const resolvedAvatarUrl = hasAvatar ? resolveAvatarUrl(options) : undefined;
 
-  const current = await getZeroAgent(agentId);
+  const current = await getAgent(agentId);
 
   const avatarUrl = hasAvatar
     ? resolvedAvatarUrl
     : (current.avatarUrl ?? undefined);
 
-  await updateZeroAgent(agentId, {
+  await updateAgent(agentId, {
     displayName:
       options.displayName !== undefined
         ? options.displayName
@@ -159,7 +159,7 @@ Notes:
 
       if (options.instructionsFile) {
         const content = readFileSync(options.instructionsFile, "utf-8");
-        await updateZeroAgentInstructions(agentId, content);
+        await updateAgentInstructions(agentId, content);
       }
 
       console.log(chalk.green(`✓ Agent "${agentId}" updated`));

--- a/turbo/apps/cli/src/commands/agent/list.ts
+++ b/turbo/apps/cli/src/commands/agent/list.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { listZeroAgents } from "../../lib/api/domains/zero-agents";
+import { listAgents } from "../../lib/api/domains/agents";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 
 export const listCommand = new Command()
@@ -18,7 +18,7 @@ Notes:
   )
   .action(
     withErrorHandler(async () => {
-      const agents = await listZeroAgents();
+      const agents = await listAgents();
 
       if (agents.length === 0) {
         console.log(chalk.dim("No agents found"));

--- a/turbo/apps/cli/src/commands/agent/view.ts
+++ b/turbo/apps/cli/src/commands/agent/view.ts
@@ -1,11 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import {
-  getZeroAgent,
-  getZeroAgentInstructions,
-  getZeroAgentUserConnectors,
-  listZeroUserPermissionGrants,
-} from "../../lib/api/domains/zero-agents";
+  getAgent,
+  getAgentInstructions,
+  getAgentUserConnectors,
+  listUserPermissionGrants,
+} from "../../lib/api/domains/agents";
 import { listConnectors } from "../../lib/api/domains/connectors";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import type { Connector } from "../../lib/api/domains/connectors";
@@ -102,8 +102,8 @@ Examples:
         options: { instructions?: boolean; permissions?: boolean },
       ) => {
         const [agent, connectorSlugs, connectorIdentities] = await Promise.all([
-          getZeroAgent(agentId),
-          getZeroAgentUserConnectors(agentId),
+          getAgent(agentId),
+          getAgentUserConnectors(agentId),
           listConnectors().catch(() => {
             return { connectors: [] as Connector[] };
           }),
@@ -123,7 +123,7 @@ Examples:
 
         const storedPolicies = options.permissions
           ? connectorPermissionGrantsToFirewallPolicies(
-              await listZeroUserPermissionGrants(agent.agentId),
+              await listUserPermissionGrants(agent.agentId),
             )
           : null;
         const connectorInfos = await loadConnectorPermissionInfos({
@@ -164,7 +164,7 @@ Examples:
 
         if (options.instructions) {
           console.log();
-          const result = await getZeroAgentInstructions(agentId);
+          const result = await getAgentInstructions(agentId);
           if (result.content) {
             console.log(chalk.dim("── Instructions ──"));
             console.log(result.content);

--- a/turbo/apps/cli/src/commands/connector/agent-context.ts
+++ b/turbo/apps/cli/src/commands/connector/agent-context.ts
@@ -1,8 +1,8 @@
 import {
-  getZeroAgent,
-  getZeroAgentCustomConnectorGrants,
-  getZeroAgentUserConnectors,
-} from "../../lib/api/domains/zero-agents";
+  getAgent,
+  getAgentCustomConnectorGrants,
+  getAgentUserConnectors,
+} from "../../lib/api/domains/agents";
 import { getOkouAgentId } from "../../lib/okou-env";
 
 interface AgentContext {
@@ -22,8 +22,8 @@ export async function resolveAgentContext(
   if (!agentId) return null;
 
   const [agent, enabledConnectorSlugs] = await Promise.all([
-    getZeroAgent(agentId),
-    getZeroAgentUserConnectors(agentId),
+    getAgent(agentId),
+    getAgentUserConnectors(agentId),
   ]);
 
   return {
@@ -41,9 +41,9 @@ export async function resolveConnectorDiscoveryAgentContext(
 
   const [agent, enabledConnectorSlugs, customConnectorGrants] =
     await Promise.all([
-      getZeroAgent(agentId),
-      getZeroAgentUserConnectors(agentId),
-      getZeroAgentCustomConnectorGrants(agentId),
+      getAgent(agentId),
+      getAgentUserConnectors(agentId),
+      getAgentCustomConnectorGrants(agentId),
     ]);
 
   return {

--- a/turbo/apps/cli/src/commands/connector/check.ts
+++ b/turbo/apps/cli/src/commands/connector/check.ts
@@ -11,7 +11,7 @@ import {
   diagnoseConnectorCheck,
   getConnector,
 } from "../../lib/api/domains/connectors";
-import { getZeroAgentUserConnectors } from "../../lib/api/domains/zero-agents";
+import { getAgentUserConnectors } from "../../lib/api/domains/agents";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { getOkouAgentId } from "../../lib/okou-env";
 import { toPlatformUrl } from "../doctor/platform-url";
@@ -558,9 +558,7 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
 
   const [connector, enabledConnectorSlugs] = await Promise.all([
     getConnector(ctx.connectorSlug),
-    ctx.agentId
-      ? getZeroAgentUserConnectors(ctx.agentId)
-      : Promise.resolve(null),
+    ctx.agentId ? getAgentUserConnectors(ctx.agentId) : Promise.resolve(null),
   ]);
 
   const isConnected = connector !== null;

--- a/turbo/apps/cli/src/commands/connector/custom/index.ts
+++ b/turbo/apps/cli/src/commands/connector/custom/index.ts
@@ -1,9 +1,9 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import {
-  getZeroAgent,
-  getZeroAgentCustomConnectorGrants,
-} from "../../../lib/api/domains/zero-agents";
+  getAgent,
+  getAgentCustomConnectorGrants,
+} from "../../../lib/api/domains/agents";
 import {
   getCustomConnector,
   listCustomConnectors,
@@ -38,8 +38,8 @@ async function resolveCustomAgentContext(agentId: string | undefined): Promise<{
     return null;
   }
   const [agent, grants] = await Promise.all([
-    getZeroAgent(resolvedAgentId),
-    getZeroAgentCustomConnectorGrants(resolvedAgentId),
+    getAgent(resolvedAgentId),
+    getAgentCustomConnectorGrants(resolvedAgentId),
   ]);
   return {
     agentId: agent.agentId,

--- a/turbo/apps/cli/src/commands/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/generate/lib/lister.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import type { ConnectorCatalogStatus } from "../../../lib/api/domains/connectors";
 import { getBillingStatus } from "../../../lib/api/domains/billing";
-import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
+import { getAgentUserConnectors } from "../../../lib/api/domains/agents";
 import { listConnectorCatalogStatus } from "../../../lib/api/domains/connectors";
 import { getPlatformOrigin } from "../../doctor/platform-url";
 import {
@@ -645,7 +645,7 @@ export async function runLister(
   const [catalog, enabledConnectorSlugs, platformOrigin, billing] =
     await Promise.all([
       listConnectorCatalogStatus(),
-      agentId ? getZeroAgentUserConnectors(agentId) : Promise.resolve(null),
+      agentId ? getAgentUserConnectors(agentId) : Promise.resolve(null),
       getPlatformOrigin(),
       (generationType === "video" || generationType === "avatar-video") &&
       currentTokenCanReadBilling()

--- a/turbo/apps/cli/src/commands/shared/firewall-permissions.ts
+++ b/turbo/apps/cli/src/commands/shared/firewall-permissions.ts
@@ -10,7 +10,7 @@ import {
   getConnectorCatalogPermissions,
   type ConnectorCatalogPermissionDetail,
 } from "../../lib/api/domains/connectors";
-import type { ZeroUserPermissionGrant } from "../../lib/api/domains/zero-agents";
+import type { UserPermissionGrant } from "../../lib/api/domains/agents";
 
 export interface ConnectorPermissionInfo {
   readonly connectorSlug: string;
@@ -115,7 +115,7 @@ export async function loadConnectorPermissionInfos(args: {
 }
 
 export function connectorPermissionGrantsToFirewallPolicies(
-  grants: readonly ZeroUserPermissionGrant[],
+  grants: readonly UserPermissionGrant[],
 ): FirewallPolicies | null {
   return permissionGrantsToFirewallPolicies(grants);
 }

--- a/turbo/apps/cli/src/commands/whoami.ts
+++ b/turbo/apps/cli/src/commands/whoami.ts
@@ -8,9 +8,9 @@ import {
 } from "../lib/api/config";
 import { listConnectors } from "../lib/api/domains/connectors";
 import {
-  getZeroAgentUserConnectors,
-  listZeroUserPermissionGrants,
-} from "../lib/api/domains/zero-agents";
+  getAgentUserConnectors,
+  listUserPermissionGrants,
+} from "../lib/api/domains/agents";
 import { getOrg } from "../lib/api/domains/orgs";
 import { withErrorHandler } from "../lib/command/with-error-handler";
 import { getOkouAgentId } from "../lib/okou-env";
@@ -125,8 +125,8 @@ async function showSandboxInfo(showPermissions: boolean): Promise<void> {
       const [connectorsResult, grantsResult, enabledResult] =
         await Promise.allSettled([
           listConnectors(),
-          listZeroUserPermissionGrants(agentId!),
-          getZeroAgentUserConnectors(agentId!),
+          listUserPermissionGrants(agentId!),
+          getAgentUserConnectors(agentId!),
         ]);
 
       if (connectorsResult.status === "rejected") return;

--- a/turbo/apps/cli/src/lib/api/domains/agents.ts
+++ b/turbo/apps/cli/src/lib/api/domains/agents.ts
@@ -19,9 +19,9 @@ import {
 } from "@okouai/api-contracts/contracts/zero-agent-custom-connectors";
 import { getClientConfig, handleError } from "../core/client-factory";
 
-export type ZeroUserPermissionGrant = UserPermissionGrantResponse;
+export type UserPermissionGrant = UserPermissionGrantResponse;
 
-export async function createZeroAgent(
+export async function createAgent(
   body: ZeroAgentRequest,
 ): Promise<ZeroAgentResponse> {
   const config = await getClientConfig();
@@ -31,7 +31,7 @@ export async function createZeroAgent(
   handleError(result, "Failed to create agent");
 }
 
-export async function listZeroAgents(): Promise<ZeroAgentResponse[]> {
+export async function listAgents(): Promise<ZeroAgentResponse[]> {
   const config = await getClientConfig();
   const client = initClient(zeroAgentsMainContract, config);
   const result = await client.list({ headers: {} });
@@ -39,7 +39,7 @@ export async function listZeroAgents(): Promise<ZeroAgentResponse[]> {
   handleError(result, "Failed to list agents");
 }
 
-export async function getZeroAgent(id: string): Promise<ZeroAgentResponse> {
+export async function getAgent(id: string): Promise<ZeroAgentResponse> {
   const config = await getClientConfig();
   const client = initClient(zeroAgentsByIdContract, config);
   const result = await client.get({ params: { id } });
@@ -47,7 +47,7 @@ export async function getZeroAgent(id: string): Promise<ZeroAgentResponse> {
   handleError(result, `Agent "${id}" not found`);
 }
 
-export async function updateZeroAgent(
+export async function updateAgent(
   id: string,
   body: ZeroAgentRequest,
 ): Promise<ZeroAgentResponse> {
@@ -58,7 +58,7 @@ export async function updateZeroAgent(
   handleError(result, `Failed to update agent "${id}"`);
 }
 
-export async function deleteZeroAgent(id: string): Promise<void> {
+export async function deleteAgent(id: string): Promise<void> {
   const config = await getClientConfig();
   const client = initClient(zeroAgentsByIdContract, config);
   const result = await client.delete({ params: { id } });
@@ -66,7 +66,7 @@ export async function deleteZeroAgent(id: string): Promise<void> {
   handleError(result, `Agent "${id}" not found`);
 }
 
-export async function getZeroAgentInstructions(
+export async function getAgentInstructions(
   id: string,
 ): Promise<ZeroAgentInstructionsResponse> {
   const config = await getClientConfig();
@@ -76,7 +76,7 @@ export async function getZeroAgentInstructions(
   handleError(result, `Failed to get instructions for agent "${id}"`);
 }
 
-export async function getZeroAgentUserConnectors(
+export async function getAgentUserConnectors(
   id: string,
 ): Promise<ConnectorSlug[]> {
   const config = await getClientConfig();
@@ -88,7 +88,7 @@ export async function getZeroAgentUserConnectors(
   handleError(result, `Failed to get connector permissions for agent "${id}"`);
 }
 
-export async function getZeroAgentCustomConnectorGrants(
+export async function getAgentCustomConnectorGrants(
   id: string,
 ): Promise<AgentCustomConnectorGrant[]> {
   const config = await getClientConfig();
@@ -101,9 +101,9 @@ export async function getZeroAgentCustomConnectorGrants(
   );
 }
 
-export async function listZeroUserPermissionGrants(
+export async function listUserPermissionGrants(
   agentId: string,
-): Promise<ZeroUserPermissionGrant[]> {
+): Promise<UserPermissionGrant[]> {
   const config = await getClientConfig();
   const client = initClient(zeroUserPermissionGrantsContract, config);
   const result = await client.list({ query: { agentId } });
@@ -113,7 +113,7 @@ export async function listZeroUserPermissionGrants(
   handleError(result, `Failed to get permission grants for agent "${agentId}"`);
 }
 
-export async function updateZeroAgentInstructions(
+export async function updateAgentInstructions(
   id: string,
   content: string,
 ): Promise<void> {


### PR DESCRIPTION
## Summary

Renames the last old-branded source path in `turbo/apps/cli`. With this slice merged, **`apps/cli` has zero old-brand residue** — the acceptance scan `find turbo/apps/cli -type f | grep -iE '(zero|vm0)'` returns nothing.

Phase 2 naming cleanup (#27432; naming model: #26873). Follows the same pure-rename shape as the already-merged #27866 / #27870 / #27868 — no compatibility aliases, no old-path re-exports.

## Mapping

| Old | New |
|---|---|
| `lib/api/domains/zero-agents.ts` | `lib/api/domains/agents.ts` |
| `createZeroAgent` | `createAgent` |
| `listZeroAgents` | `listAgents` |
| `getZeroAgent` | `getAgent` |
| `updateZeroAgent` | `updateAgent` |
| `deleteZeroAgent` | `deleteAgent` |
| `getZeroAgentInstructions` | `getAgentInstructions` |
| `updateZeroAgentInstructions` | `updateAgentInstructions` |
| `getZeroAgentUserConnectors` | `getAgentUserConnectors` |
| `getZeroAgentCustomConnectorGrants` | `getAgentCustomConnectorGrants` |
| `listZeroUserPermissionGrants` | `listUserPermissionGrants` |
| `ZeroUserPermissionGrant` | `UserPermissionGrant` |

All 11 caller files were migrated: `commands/agent/{list,view,create,edit,delete}.ts`, `commands/connector/{check,agent-context}.ts`, `commands/connector/custom/index.ts`, `commands/whoami.ts`, `commands/generate/lib/lister.ts`, `commands/shared/firewall-permissions.ts`.

## Out of scope — deliberately untouched

- **`packages/api-contracts`: zero changes.** The module imports `zeroAgentsMainContract`, `zeroAgentsByIdContract`, `zeroAgentInstructionsContract`, `ZeroAgentResponse`, `ZeroAgentRequest`, `ZeroAgentInstructionsResponse`, `zeroUserPermissionGrantsContract` and `zeroAgentCustomConnectorsContract` from the contracts package. Every one of them is preserved verbatim — they belong to contract slices that have not been dispatched yet.
  - Note: the ninth import, `zeroUserConnectorsContract`, is now `userConnectorsContract` on this branch. That rename came from **#28001** (already merged to `main`) and was inherited through the rebase — it is not part of this diff.
- The `@okouai/api-contracts/contracts/zero-agents` specifier used by `commands/agent/{visibility,create,edit}.ts` for `ZeroAgentVisibility` is a contracts-package path, not this module, and is unchanged.
- **Public CLI surface is byte-identical**: `okou agent list|view|create|edit|delete`, `okou whoami`, `okou connector check` and all other commands keep their spelling, flags, output shape and exit codes. No error string (`"Failed to create agent"` etc.), HTTP call, endpoint, header or request/response handling was modified.
- No other module under `lib/api/domains/`.

## Verification

- `find turbo/apps/cli -type f | grep -iE '(zero|vm0)'` → empty ✅
- Repo-wide grep for every renamed identifier and for the `domains/zero-agents` specifier → no hits ✅
- `git diff --stat` → 12 files, all under `turbo/apps/cli`; nothing under `turbo/packages/api-contracts` ✅
- `pnpm -F @okouai/cli check-types` → pass
- `pnpm -F @okouai/cli lint` → pass
- `pnpm knip --workspace apps/cli` → clean
- `prettier --check` on the touched files → clean (some import blocks and a ternary collapse to one line now that the names are shorter — formatting reflow only)
- Targeted vitest for the affected commands (`agent/*`, `whoami`, `connector check`, `connector custom`, `generate lister`) → 9 files / 168 tests pass. No test file needed changing: these are Commander + MSW integration tests with no `vi.mock` of internal modules, so the rename is transparent to them.

Full suite left to the PR pipeline.

## Rebase note

Rebased onto `main` after #28064 (`feat: add byteplus seedream 5 image models`) touched `commands/generate/lib/lister.ts`. That was a pure text conflict — #28064 added no reference to any renamed symbol. Both sides are preserved: its seedream model entries are intact and only the two `getAgentUserConnectors` lines differ from `main`.

Closes #27948
