### PR TITLE
perf(api): measure catalog miss removable work

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -366,6 +366,19 @@ const CONNECTOR_CATALOG_RAW_SIZE_BUCKETS = [
   "2_4_mib",
   "4_8_mib",
 ] as const;
+const CONNECTOR_CATALOG_COMPRESSED_SIZE_BUCKETS = [
+  ...CONNECTOR_CATALOG_RAW_SIZE_BUCKETS,
+  "8_16_mib",
+] as const;
+const CONNECTOR_CATALOG_RESOLVED_CONNECTOR_FRACTION_BUCKETS = [
+  "not_applicable",
+  "none",
+  "up_to_25_percent",
+  "26_50_percent",
+  "51_75_percent",
+  "76_99_percent",
+  "all",
+] as const;
 const API_DISPATCH_STORAGE_MANIFEST_ACTION_TYPES = [
   "api_dispatch_prepare_storage_manifest_resolve_inputs",
   "api_dispatch_prepare_storage_manifest_ensure_artifacts",
@@ -1053,6 +1066,8 @@ function expectConnectorCatalogLoadTiming(args: {
   readonly acceptedCacheOutcome: "hit" | "miss" | "in_flight";
   readonly runtimeCacheOutcome: "hit" | "miss";
   readonly requestedConnectorCount: "known" | "not_applicable";
+  readonly requestedConnectorCountBucket?: (typeof CONNECTOR_CATALOG_COUNT_BUCKETS)[number];
+  readonly resolvedConnectorFraction: (typeof CONNECTOR_CATALOG_RESOLVED_CONNECTOR_FRACTION_BUCKETS)[number];
   readonly validation:
     | { readonly outcome: "attested" | "not_run" }
     | {
@@ -1086,15 +1101,23 @@ function expectConnectorCatalogLoadTiming(args: {
   expect(CONNECTOR_CATALOG_RAW_SIZE_BUCKETS).toContain(
     event.connector_catalog_raw_size_bucket,
   );
+  expect(CONNECTOR_CATALOG_COMPRESSED_SIZE_BUCKETS).toContain(
+    event.connector_catalog_compressed_size_bucket,
+  );
   expect(CONNECTOR_CATALOG_COUNT_BUCKETS).toContain(
     event.connector_catalog_connector_count_bucket,
   );
   const requestedCountBuckets =
-    args.requestedConnectorCount === "known"
-      ? CONNECTOR_CATALOG_COUNT_BUCKETS
-      : ["not_applicable"];
+    args.requestedConnectorCountBucket === undefined
+      ? args.requestedConnectorCount === "known"
+        ? CONNECTOR_CATALOG_COUNT_BUCKETS
+        : ["not_applicable"]
+      : [args.requestedConnectorCountBucket];
   expect(requestedCountBuckets).toContain(
     event.connector_catalog_requested_connector_count_bucket,
+  );
+  expect(event.connector_catalog_resolved_connector_fraction_bucket).toBe(
+    args.resolvedConnectorFraction,
   );
 }
 
@@ -1704,6 +1727,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const missingAuthorityActor = await entitledRunActor();
     const missingAuthorityPrompt =
       "legacy connector catalog validation authority";
+    const unknownConnectorSlug = "catalog-timing-unknown";
     const missingAuthorityRun = await api.createDirectRun(
       missingAuthorityActor.actor,
       {
@@ -1712,7 +1736,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           prompt: missingAuthorityPrompt,
         }),
         connectorScope: {
-          allowedConnectorSlugs: ["x"],
+          allowedConnectorSlugs: [unknownConnectorSlug, unknownConnectorSlug],
           allowedCustomConnectorIds: [],
         },
       },
@@ -1729,6 +1753,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       acceptedCacheOutcome: "miss",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
+      requestedConnectorCountBucket: "2_4",
+      resolvedConnectorFraction: "none",
       validation: {
         outcome: "full_fallback",
         fallbackReason: "missing_authority",
@@ -1741,6 +1767,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       missingCatalogVersion,
       missingAuthorityPrompt,
       missingAuthorityActor.agentId,
+      unknownConnectorSlug,
       "test-oauth-secret",
       "fixture-confidential-secret",
     ]);
@@ -1789,6 +1816,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       acceptedCacheOutcome: "miss",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
+      resolvedConnectorFraction: "up_to_25_percent",
       validation: {
         outcome: "full_fallback",
         fallbackReason: "missing_compatibility",
@@ -1852,6 +1880,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       acceptedCacheOutcome: "miss",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
+      resolvedConnectorFraction: "up_to_25_percent",
       validation: {
         outcome: "full_fallback",
         fallbackReason: "different_authority",
@@ -1899,6 +1928,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       acceptedCacheOutcome: "hit",
       runtimeCacheOutcome: "hit",
       requestedConnectorCount: "known",
+      resolvedConnectorFraction: "up_to_25_percent",
       validation: { outcome: "not_run" },
     });
     expectApiDispatchTimingEventsNotToLeak(cachedEvents, [

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2012,6 +2012,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         }),
       ),
     ).toStrictEqual(new Set(["attested", "not_run"]));
+    for (const event of concurrentLoadEvents) {
+      expect(CONNECTOR_CATALOG_COMPRESSED_SIZE_BUCKETS).toContain(
+        event.connector_catalog_compressed_size_bucket,
+      );
+      expect(event.connector_catalog_resolved_connector_fraction_bucket).toBe(
+        "up_to_25_percent",
+      );
+    }
     for (const events of concurrentEvents) {
       expectNoApiDispatchActions(
         events,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -8524,7 +8524,7 @@ async function connectorCatalogSelectionForRun(args: {
     args.preloadedConnectorCatalogSnapshot ??
     (await loadConnectorRuntimeSnapshot(args.db, {
       timing: args.timing,
-      requestedConnectorCount: args.connectorScope.allowedConnectorSlugs.length,
+      requestedConnectorSlugs: args.connectorScope.allowedConnectorSlugs,
     }));
   return { kind: "complete", snapshot };
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -77,6 +77,7 @@ interface PrivateAuthMethodFacts {
 export interface AcceptedConnectorCatalogSnapshot {
   readonly identity: ExternalCatalogIdentity;
   readonly catalogRawSize: number;
+  readonly catalogCompressedSize: number;
   readonly artifact: ConnectorCatalogArtifact;
   readonly connectorBySlug: ReadonlyMap<
     string,
@@ -433,6 +434,7 @@ async function readCurrentCatalog(args: {
       return {
         identity: args.identity,
         catalogRawSize: row.catalogRawSize,
+        catalogCompressedSize: row.catalogGzip.byteLength,
         artifact,
         connectorBySlug: new Map(
           artifact.connectors.map((connector) => {

--- a/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
@@ -31,6 +31,17 @@ type ConnectorCatalogRawSizeBucket =
   | "1_2_mib"
   | "2_4_mib"
   | "4_8_mib";
+type ConnectorCatalogCompressedSizeBucket =
+  | ConnectorCatalogRawSizeBucket
+  | "8_16_mib";
+type ConnectorCatalogResolvedConnectorFractionBucket =
+  | "not_applicable"
+  | "none"
+  | "up_to_25_percent"
+  | "26_50_percent"
+  | "51_75_percent"
+  | "76_99_percent"
+  | "all";
 
 function countBucket(count: number): ConnectorCatalogCountBucket {
   if (count === 0) {
@@ -51,23 +62,54 @@ function countBucket(count: number): ConnectorCatalogCountBucket {
   return "17_plus";
 }
 
-function rawSizeBucket(rawSize: number): ConnectorCatalogRawSizeBucket {
-  if (rawSize < 256 * 1024) {
+function rawSizeBucket(size: number): ConnectorCatalogRawSizeBucket {
+  if (size < 256 * 1024) {
     return "0_255_kib";
   }
-  if (rawSize < 512 * 1024) {
+  if (size < 512 * 1024) {
     return "256_511_kib";
   }
-  if (rawSize < 1024 * 1024) {
+  if (size < 1024 * 1024) {
     return "512_1023_kib";
   }
-  if (rawSize < 2 * 1024 * 1024) {
+  if (size < 2 * 1024 * 1024) {
     return "1_2_mib";
   }
-  if (rawSize < 4 * 1024 * 1024) {
+  if (size < 4 * 1024 * 1024) {
     return "2_4_mib";
   }
   return "4_8_mib";
+}
+
+function compressedSizeBucket(
+  size: number,
+): ConnectorCatalogCompressedSizeBucket {
+  return size < 8 * 1024 * 1024 ? rawSizeBucket(size) : "8_16_mib";
+}
+
+function resolvedConnectorFractionBucket(
+  resolvedConnectorCount: number | undefined,
+  connectorCount: number,
+): ConnectorCatalogResolvedConnectorFractionBucket {
+  if (resolvedConnectorCount === undefined) {
+    return "not_applicable";
+  }
+  if (resolvedConnectorCount === 0) {
+    return "none";
+  }
+  if (resolvedConnectorCount === connectorCount) {
+    return "all";
+  }
+  if (resolvedConnectorCount * 4 <= connectorCount) {
+    return "up_to_25_percent";
+  }
+  if (resolvedConnectorCount * 2 <= connectorCount) {
+    return "26_50_percent";
+  }
+  if (resolvedConnectorCount * 4 <= connectorCount * 3) {
+    return "51_75_percent";
+  }
+  return "76_99_percent";
 }
 
 function acceptedCacheOutcomeRank(
@@ -93,7 +135,9 @@ export class ConnectorCatalogLoadTiming {
   private runtimeCacheOutcome: ConnectorRuntimeSnapshotCacheOutcome | undefined;
   private validationResult: ConnectorCatalogValidationResult | undefined;
   private catalogRawSize: number | undefined;
+  private catalogCompressedSize: number | undefined;
   private connectorCount: number | undefined;
+  private resolvedConnectorCount: number | undefined;
 
   constructor(
     private readonly collector: ApiDispatchTimingCollector,
@@ -124,10 +168,14 @@ export class ConnectorCatalogLoadTiming {
 
   recordCatalogFacts(args: {
     readonly rawSize: number;
+    readonly compressedSize: number;
     readonly connectorCount: number;
+    readonly resolvedConnectorCount: number | undefined;
   }): void {
     this.catalogRawSize = args.rawSize;
+    this.catalogCompressedSize = args.compressedSize;
     this.connectorCount = args.connectorCount;
+    this.resolvedConnectorCount = args.resolvedConnectorCount;
   }
 
   async measure<T>(
@@ -185,12 +233,24 @@ export class ConnectorCatalogLoadTiming {
               this.catalogRawSize,
             ),
           }),
+      ...(this.catalogCompressedSize === undefined
+        ? {}
+        : {
+            connector_catalog_compressed_size_bucket: compressedSizeBucket(
+              this.catalogCompressedSize,
+            ),
+          }),
       ...(this.connectorCount === undefined
         ? {}
         : {
             connector_catalog_connector_count_bucket: countBucket(
               this.connectorCount,
             ),
+            connector_catalog_resolved_connector_fraction_bucket:
+              resolvedConnectorFractionBucket(
+                this.resolvedConnectorCount,
+                this.connectorCount,
+              ),
           }),
       connector_catalog_requested_connector_count_bucket:
         this.requestedConnectorCount === undefined

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -570,14 +570,25 @@ const runtimeSnapshotCache = singleton((): RuntimeSnapshotCache => {
 async function loadConnectorRuntimeSnapshotWithTiming(
   db: ReadonlyDb,
   timing: ConnectorCatalogLoadTiming | undefined,
+  requestedConnectorSlugs: readonly ConnectorSlug[] | undefined,
 ): Promise<ConnectorRuntimeSnapshot> {
   const acceptedSnapshot = await loadAcceptedConnectorCatalogSnapshot(
     db,
     timing,
   );
+  const resolvedConnectorCount =
+    requestedConnectorSlugs === undefined
+      ? undefined
+      : new Set(
+          requestedConnectorSlugs.filter((connectorSlug) => {
+            return acceptedSnapshot.connectorBySlug.has(connectorSlug);
+          }),
+        ).size;
   timing?.recordCatalogFacts({
     rawSize: acceptedSnapshot.catalogRawSize,
+    compressedSize: acceptedSnapshot.catalogCompressedSize,
     connectorCount: acceptedSnapshot.artifact.connectors.length,
+    resolvedConnectorCount,
   });
   const key = runtimeSnapshotKey(acceptedSnapshot.identity);
   const cache = runtimeSnapshotCache();
@@ -596,18 +607,26 @@ export async function loadConnectorRuntimeSnapshot(
   db: ReadonlyDb,
   options?: {
     readonly timing: ApiDispatchTimingCollector;
-    readonly requestedConnectorCount: number | undefined;
+    readonly requestedConnectorSlugs: readonly ConnectorSlug[] | undefined;
   },
 ): Promise<ConnectorRuntimeSnapshot> {
   if (options === undefined) {
-    return await loadConnectorRuntimeSnapshotWithTiming(db, undefined);
+    return await loadConnectorRuntimeSnapshotWithTiming(
+      db,
+      undefined,
+      undefined,
+    );
   }
   const timing = new ConnectorCatalogLoadTiming(
     options.timing,
-    options.requestedConnectorCount,
+    options.requestedConnectorSlugs?.length,
   );
   return await timing.measureComplete(async () => {
-    return await loadConnectorRuntimeSnapshotWithTiming(db, timing);
+    return await loadConnectorRuntimeSnapshotWithTiming(
+      db,
+      timing,
+      options.requestedConnectorSlugs,
+    );
   });
 }
 

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -788,8 +788,7 @@ async function loadZeroRunPostAuthorizationContext(
           kind: "complete",
           snapshot: await loadConnectorRuntimeSnapshot(db, {
             timing: args.timing,
-            requestedConnectorCount:
-              bootstrapContext.allowedConnectorSlugs.length,
+            requestedConnectorSlugs: bootstrapContext.allowedConnectorSlugs,
           }),
         };
   signal.throwIfAborted();


### PR DESCRIPTION
## Summary

- record the accepted connector catalog's compressed payload size on the existing complete load timing event
- record the unique accepted subset of requested built-in connectors as a fixed requested/total fraction bucket
- keep raw requested-count telemetry for continuity while excluding duplicate and unknown slugs from the new fraction
- cover attested/fallback/cache paths, exact-empty bypass, bounded values, and identifier non-leakage through the real run route

## Behavior

Timed non-empty catalog loads now add:

- `connector_catalog_compressed_size_bucket`
- `connector_catalog_resolved_connector_fraction_bucket`

Requested connector slugs remain process-local. The runtime loader deduplicates them, intersects them with the accepted catalog, and passes only a number to telemetry. The gzip byte length is captured from the exact payload already loaded from PostgreSQL and remains on the exact identity-local accepted snapshot, so cold and warm rows report the same immutable fact.

The new values are fixed low-cardinality buckets. No exact connector count, connector slug, catalog identity, digest, user, tenant, prompt, credential, secret, or arbitrary error is emitted.

## Explicit exclusions

- no catalog decoder, validation authority, capability filtering, cache, runtime connector, or firewall behavior change
- no runtime-loop split or per-connector timing event
- no database schema, migration, HTTP contract, queue payload, Runner protocol, credential, or stored run/session change
- no lazy runtime, durable projection, codec, or revision-attestation implementation

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` — 160 passed
- `pnpm exec prettier --check <six changed API files>`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- pre-commit hook: staged Prettier, full Knip, full Turbo type checks, and file-size check
- `git diff --check`

## Production gate

After deployment, update #27777 from one fixed API revision with per-run joined compressed size, resolved fraction, cache/validation path, existing catalog phases, pre-create, queue, and `api_to_spawn` data. The parent will select a behavior child only if its realistic per-run counterfactual is material.

Closes #27946

Parent context: #27777
