### PR TITLE
feat(app): add new-chat image model defaults

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1342,6 +1342,7 @@
       "setAsDefault": "Als Standard festlegen",
       "temporaryFastModeDisabledNotice": "Der Fast-Modus ist für diesen Lauf vorübergehend deaktiviert",
       "temporaryFastModeEnabledNotice": "Der Fast-Modus ist für diesen Lauf vorübergehend aktiviert",
+      "temporaryImageModelNotice": "Für Bilder vorübergehend zu {{model}} gewechselt",
       "temporaryModelNotice": "Vorübergehend zu {{model}} gewechselt",
       "temporaryVideoModelNotice": "Für Videos vorübergehend zu {{model}} gewechselt",
       "threadSuggestions": "Chat-Threads",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1342,6 +1342,7 @@
       "setAsDefault": "Set as default",
       "temporaryFastModeDisabledNotice": "Fast mode is temporarily disabled for this run",
       "temporaryFastModeEnabledNotice": "Fast mode is temporarily enabled for this run",
+      "temporaryImageModelNotice": "Temporarily switched to {{model}} for images",
       "temporaryModelNotice": "Temporarily switched to {{model}}",
       "temporaryVideoModelNotice": "Temporarily switched to {{model}} for video",
       "threadSuggestions": "Chat threads",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1368,6 +1368,7 @@
       "setAsDefault": "Establecer como predeterminado",
       "temporaryFastModeDisabledNotice": "El modo rápido está desactivado temporalmente para esta ejecución",
       "temporaryFastModeEnabledNotice": "El modo rápido está activado temporalmente para esta ejecución",
+      "temporaryImageModelNotice": "Cambio temporal a {{model}} para imágenes",
       "temporaryModelNotice": "Cambio temporal a {{model}}",
       "temporaryVideoModelNotice": "Cambio temporal a {{model}} para vídeo",
       "threadSuggestions": "Conversaciones",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1368,6 +1368,7 @@
       "setAsDefault": "Définir par défaut",
       "temporaryFastModeDisabledNotice": "Le mode rapide est temporairement désactivé pour cette exécution",
       "temporaryFastModeEnabledNotice": "Le mode rapide est temporairement activé pour cette exécution",
+      "temporaryImageModelNotice": "Passage temporaire à {{model}} pour les images",
       "temporaryModelNotice": "Passage temporaire à {{model}}",
       "temporaryVideoModelNotice": "Passage temporaire à {{model}} pour la vidéo",
       "threadSuggestions": "Conversations",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1342,6 +1342,7 @@
       "setAsDefault": "डिफ़ॉल्ट के रूप में सेट करें",
       "temporaryFastModeDisabledNotice": "इस रन के लिए फ़ास्ट मोड अस्थायी रूप से बंद है",
       "temporaryFastModeEnabledNotice": "इस रन के लिए फ़ास्ट मोड अस्थायी रूप से चालू है",
+      "temporaryImageModelNotice": "इमेज के लिए अस्थायी रूप से {{model}} पर स्विच किया गया",
       "temporaryModelNotice": "अस्थायी रूप से {{model}} पर स्विच किया गया",
       "temporaryVideoModelNotice": "वीडियो के लिए अस्थायी रूप से {{model}} पर स्विच किया गया",
       "threadSuggestions": "चैट थ्रेड",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1342,6 +1342,7 @@
       "setAsDefault": "Jadikan default",
       "temporaryFastModeDisabledNotice": "Mode Cepat dinonaktifkan sementara untuk proses ini",
       "temporaryFastModeEnabledNotice": "Mode Cepat diaktifkan sementara untuk proses ini",
+      "temporaryImageModelNotice": "Sementara beralih ke {{model}} untuk gambar",
       "temporaryModelNotice": "Sementara beralih ke {{model}}",
       "temporaryVideoModelNotice": "Sementara beralih ke {{model}} untuk video",
       "threadSuggestions": "Thread chat",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1368,6 +1368,7 @@
       "setAsDefault": "Imposta come predefinito",
       "temporaryFastModeDisabledNotice": "La modalità Fast è temporaneamente disattivata per questa esecuzione",
       "temporaryFastModeEnabledNotice": "La modalità Fast è temporaneamente attivata per questa esecuzione",
+      "temporaryImageModelNotice": "Passaggio temporaneo a {{model}} per le immagini",
       "temporaryModelNotice": "Passaggio temporaneo a {{model}}",
       "temporaryVideoModelNotice": "Passaggio temporaneo a {{model}} per i video",
       "threadSuggestions": "Thread di chat",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1342,6 +1342,7 @@
       "setAsDefault": "デフォルトに設定",
       "temporaryFastModeDisabledNotice": "この実行では一時的に高速モードが無効です",
       "temporaryFastModeEnabledNotice": "この実行では一時的に高速モードが有効です",
+      "temporaryImageModelNotice": "画像モデルを一時的に {{model}} に切り替えました",
       "temporaryModelNotice": "一時的に {{model}} に切り替えました",
       "temporaryVideoModelNotice": "動画モデルを一時的に {{model}} に切り替えました",
       "threadSuggestions": "チャットスレッド",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1342,6 +1342,7 @@
       "setAsDefault": "기본값으로 설정",
       "temporaryFastModeDisabledNotice": "이 실행에서는 빠른 모드가 일시적으로 비활성화되었습니다",
       "temporaryFastModeEnabledNotice": "이 실행에서는 빠른 모드가 일시적으로 활성화되었습니다",
+      "temporaryImageModelNotice": "이미지 모델을 일시적으로 {{model}}(으)로 전환함",
       "temporaryModelNotice": "일시적으로 {{model}}(으)로 전환됨",
       "temporaryVideoModelNotice": "동영상 모델을 일시적으로 {{model}}(으)로 전환함",
       "threadSuggestions": "채팅 스레드",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1368,6 +1368,7 @@
       "setAsDefault": "Definir como padrão",
       "temporaryFastModeDisabledNotice": "O modo rápido está temporariamente desativado para esta execução",
       "temporaryFastModeEnabledNotice": "O modo rápido está temporariamente ativado para esta execução",
+      "temporaryImageModelNotice": "Alternado temporariamente para {{model}} em imagens",
       "temporaryModelNotice": "Alternado temporariamente para {{model}}",
       "temporaryVideoModelNotice": "Alternado temporariamente para {{model}} em vídeo",
       "threadSuggestions": "Conversas",

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -57,11 +57,7 @@ import {
 } from "./model-selection-request.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { registerOptimisticChatThreadEvent$ } from "./chat-thread-event-sourcing.ts";
-import {
-  chatPageImageModelSelection$,
-  chatPageModelSelection$,
-  resetChatPageImageModelSelection$,
-} from "../zero-page/zero-chat-page.ts";
+import { chatPageModelSelection$ } from "../zero-page/zero-chat-page.ts";
 import { selectedModelAvailable$ } from "../zero-page/model-first-personal-oauth.ts";
 import type { OptimisticChatThreadEvent } from "./chat-thread-event-types.ts";
 import { toast } from "@okouai/ui/components/ui/sonner";
@@ -490,9 +486,7 @@ const startNewChatThreadCreate$ = command(
         : undefined;
     const imageModel =
       (featureSwitches[FeatureSwitchKey.ImageModelSelection] ?? false)
-        ? ((await get(chatPageImageModelSelection$)) ??
-          userPreference.selectedImageModel ??
-          DEFAULT_IMAGE_MODEL)
+        ? (userPreference.selectedImageModel ?? DEFAULT_IMAGE_MODEL)
         : undefined;
     signal.throwIfAborted();
     await set(
@@ -553,8 +547,6 @@ export const createNewChatThread$ = command(
       signal,
     );
     await result.createResult;
-    signal.throwIfAborted();
-    set(resetChatPageImageModelSelection$);
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -1,6 +1,10 @@
 import { command, computed } from "ccstate";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
+  DEFAULT_IMAGE_MODEL,
+  type ImageModel,
+} from "@okouai/core/image-model-catalog";
+import {
   DEFAULT_VIDEO_MODEL,
   type VideoModel,
 } from "@okouai/core/video-model-catalog";
@@ -42,6 +46,7 @@ import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
 import {
   featureSwitch$,
+  imageModelSelectionEnabled$,
   imageRecognitionAvailable$,
   videoModelSelectionEnabled$,
 } from "../external/feature-switch.ts";
@@ -52,7 +57,11 @@ import {
 } from "./model-selection-request.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { registerOptimisticChatThreadEvent$ } from "./chat-thread-event-sourcing.ts";
-import { chatPageModelSelection$ } from "../zero-page/zero-chat-page.ts";
+import {
+  chatPageImageModelSelection$,
+  chatPageModelSelection$,
+  resetChatPageImageModelSelection$,
+} from "../zero-page/zero-chat-page.ts";
 import { selectedModelAvailable$ } from "../zero-page/model-first-personal-oauth.ts";
 import type { OptimisticChatThreadEvent } from "./chat-thread-event-types.ts";
 import { toast } from "@okouai/ui/components/ui/sonner";
@@ -83,6 +92,7 @@ interface SendNewThreadMessageRequest {
   editorDocument?: EditorDocumentSnapshot;
   computerUseHostId?: string | null;
   cloudBrowserEnabled?: boolean;
+  imageModel?: ImageModel;
   videoModel?: VideoModel;
   videoRunOptions?: ChatRunVideoOptionsRequest;
   routeSearchParams?: URLSearchParams;
@@ -132,6 +142,27 @@ function userMessageForNewThread(
     throw new Error("Failed to serialize user message");
   }
   return userMessage;
+}
+
+function annotatedMessagesForNewThread(
+  request: SendNewThreadMessageRequest,
+  userMessage: UserMessageInputDocument,
+  modelSelection: ModelProviderSelection,
+): {
+  readonly annotatedUserMessage: UserMessageDocument;
+  readonly optimisticUserMessage: UserMessageDocument;
+} {
+  const annotatedUserMessage = withSelectedModelAnnotation(
+    userMessage,
+    modelSelection.selectedModel,
+    modelSelection.codexServiceTier === "fast" ? "priority" : undefined,
+  );
+  return {
+    annotatedUserMessage,
+    optimisticUserMessage: request.forward
+      ? withOptimisticAgentRunSource(annotatedUserMessage, request.forward)
+      : annotatedUserMessage,
+  };
 }
 
 function createNewThreadOptimisticEventEntry({
@@ -265,6 +296,24 @@ const resolveCurrentNewThreadModelSelection$ = command(
   },
 );
 
+const resolveNewThreadImageModel$ = command(
+  async (
+    { get },
+    requested: ImageModel | undefined,
+    signal: AbortSignal,
+  ): Promise<ImageModel | undefined> => {
+    if (!get(imageModelSelectionEnabled$)) {
+      return undefined;
+    }
+    if (requested) {
+      return requested;
+    }
+    const preference = await get(userModelPreference$);
+    signal.throwIfAborted();
+    return preference.selectedImageModel ?? DEFAULT_IMAGE_MODEL;
+  },
+);
+
 const routeMainChatThread$ = command(
   (
     { get, set },
@@ -331,6 +380,7 @@ const mintOptimisticThreadWithEvent$ = command(
       readonly serviceTier: "priority" | null;
       readonly computerUseHostId: string | null;
       readonly cloudBrowserEnabled: boolean;
+      readonly selectedImageModel: ImageModel | null;
       readonly selectedVideoModel: VideoModel | null;
     },
     signal: AbortSignal,
@@ -352,7 +402,7 @@ const mintOptimisticThreadWithEvent$ = command(
       computerUseHostId: args.computerUseHostId,
       cloudBrowserEnabled: args.cloudBrowserEnabled,
       selectedVideoModel: args.selectedVideoModel,
-      selectedImageModel: null,
+      selectedImageModel: args.selectedImageModel,
       createdAt,
     } satisfies OptimisticChatThreadEvent);
   },
@@ -366,6 +416,7 @@ async function createChatThread(
     readonly clientThreadId: string;
     readonly eventId: string;
     readonly modelSelection: ModelProviderSelection;
+    readonly imageModel?: ImageModel;
     readonly videoModel?: VideoModel;
   },
   signal: AbortSignal,
@@ -380,6 +431,7 @@ async function createChatThread(
         model: args.modelSelection.selectedModel,
         serviceTier:
           args.modelSelection.codexServiceTier === "fast" ? "priority" : null,
+        ...(args.imageModel ? { imageModel: args.imageModel } : {}),
         ...(args.videoModel ? { videoModel: args.videoModel } : {}),
         ...(args.title ? { title: args.title } : {}),
       },
@@ -436,6 +488,13 @@ const startNewChatThreadCreate$ = command(
       (featureSwitches[FeatureSwitchKey.VideoModelSelection] ?? false)
         ? (userPreference.selectedVideoModel ?? DEFAULT_VIDEO_MODEL)
         : undefined;
+    const imageModel =
+      (featureSwitches[FeatureSwitchKey.ImageModelSelection] ?? false)
+        ? ((await get(chatPageImageModelSelection$)) ??
+          userPreference.selectedImageModel ??
+          DEFAULT_IMAGE_MODEL)
+        : undefined;
+    signal.throwIfAborted();
     await set(
       mintOptimisticThreadWithEvent$,
       {
@@ -447,6 +506,7 @@ const startNewChatThreadCreate$ = command(
           modelSelection.codexServiceTier === "fast" ? "priority" : null,
         computerUseHostId: null,
         cloudBrowserEnabled: false,
+        selectedImageModel: imageModel ?? null,
         selectedVideoModel: videoModel ?? null,
       },
       signal,
@@ -463,6 +523,7 @@ const startNewChatThreadCreate$ = command(
           clientThreadId: threadId,
           eventId,
           modelSelection,
+          imageModel,
           videoModel,
         },
         signal,
@@ -492,6 +553,8 @@ export const createNewChatThread$ = command(
       signal,
     );
     await result.createResult;
+    signal.throwIfAborted();
+    set(resetChatPageImageModelSelection$);
   },
 );
 
@@ -542,20 +605,20 @@ const sendNewThreadMessage$ = command(
       return null;
     }
     const features = get(featureSwitch$);
-    const videoModel = get(videoModelSelectionEnabled$)
-      ? request.videoModel
-      : undefined;
-    const userMessage = userMessageForNewThread(request, prepared);
-    const annotatedUserMessage = withSelectedModelAnnotation(
-      userMessage,
-      resolvedModelSelection.selectedModel,
-      resolvedModelSelection.codexServiceTier === "fast"
-        ? "priority"
-        : undefined,
+    const imageModel = await set(
+      resolveNewThreadImageModel$,
+      request.imageModel,
+      signal,
     );
-    const optimisticUserMessage = request.forward
-      ? withOptimisticAgentRunSource(annotatedUserMessage, request.forward)
-      : annotatedUserMessage;
+    signal.throwIfAborted();
+    const videoModelEnabled = get(videoModelSelectionEnabled$);
+    const videoModel = videoModelEnabled ? request.videoModel : undefined;
+    const { annotatedUserMessage, optimisticUserMessage } =
+      annotatedMessagesForNewThread(
+        request,
+        userMessageForNewThread(request, prepared),
+        resolvedModelSelection,
+      );
     const threadId = crypto.randomUUID();
     const clientEventId = crypto.randomUUID();
     const chatThreadEventId = crypto.randomUUID();
@@ -582,6 +645,7 @@ const sendNewThreadMessage$ = command(
             : null,
         computerUseHostId: computerUseHostId ?? null,
         cloudBrowserEnabled: cloudBrowserEnabled ?? false,
+        selectedImageModel: imageModel ?? null,
         selectedVideoModel: videoModel ?? null,
       },
       signal,
@@ -601,6 +665,7 @@ const sendNewThreadMessage$ = command(
         clientThreadId: threadId,
         eventId: chatThreadEventId,
         modelSelection: resolvedModelSelection,
+        imageModel,
         videoModel,
       },
       signal,
@@ -617,7 +682,6 @@ const sendNewThreadMessage$ = command(
       userMessage: annotatedUserMessage,
       computerUseHostId,
       cloudBrowserEnabled,
-      // Gated with the control that produces them, like the pin above.
       videoRunOptions:
         videoModel === undefined ? undefined : request.videoRunOptions,
       sourceRunId: request.forward?.runId,
@@ -625,7 +689,6 @@ const sendNewThreadMessage$ = command(
     const sendResult = (async (): Promise<SendNewThreadMessageResult> => {
       await Promise.all([clearDraftResult, createResult]);
       signal.throwIfAborted();
-
       const result = await sendChatEvent(createClient, sendBody, signal);
       signal.throwIfAborted();
       L.debug("sendNewThreadMessage$ POST chat/events 201", {

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -1,9 +1,6 @@
 import { command, computed } from "ccstate";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import {
-  DEFAULT_IMAGE_MODEL,
-  type ImageModel,
-} from "@okouai/core/image-model-catalog";
+import type { ImageModel } from "@okouai/core/image-model-catalog";
 import type { VideoModel } from "@okouai/core/video-model-catalog";
 import {
   chatThreadModelSelectionContract,
@@ -289,24 +286,6 @@ const resolveCurrentNewThreadModelSelection$ = command(
   },
 );
 
-const resolveNewThreadImageModel$ = command(
-  async (
-    { get },
-    requested: ImageModel | undefined,
-    signal: AbortSignal,
-  ): Promise<ImageModel | undefined> => {
-    if (!get(imageModelSelectionEnabled$)) {
-      return undefined;
-    }
-    if (requested) {
-      return requested;
-    }
-    const preference = await get(userModelPreference$);
-    signal.throwIfAborted();
-    return preference.selectedImageModel ?? DEFAULT_IMAGE_MODEL;
-  },
-);
-
 const routeMainChatThread$ = command(
   (
     { get, set },
@@ -587,12 +566,11 @@ const sendNewThreadMessage$ = command(
       return null;
     }
     const features = get(featureSwitch$);
-    const imageModel = await set(
-      resolveNewThreadImageModel$,
-      request.imageModel,
-      signal,
-    );
-    signal.throwIfAborted();
+    // Pin only an explicit per-thread pick; an unpinned (null) thread follows
+    // the member's live default, so changing the default later updates it.
+    const imageModel = get(imageModelSelectionEnabled$)
+      ? request.imageModel
+      : undefined;
     const videoModelEnabled = get(videoModelSelectionEnabled$);
     const videoModel = videoModelEnabled ? request.videoModel : undefined;
     const { annotatedUserMessage, optimisticUserMessage } =
@@ -664,8 +642,7 @@ const sendNewThreadMessage$ = command(
       userMessage: annotatedUserMessage,
       computerUseHostId,
       cloudBrowserEnabled,
-      videoRunOptions:
-        videoModel === undefined ? undefined : request.videoRunOptions,
+      videoRunOptions: videoModelEnabled ? request.videoRunOptions : undefined,
       sourceRunId: request.forward?.runId,
     });
     const sendResult = (async (): Promise<SendNewThreadMessageResult> => {

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -4,10 +4,7 @@ import {
   DEFAULT_IMAGE_MODEL,
   type ImageModel,
 } from "@okouai/core/image-model-catalog";
-import {
-  DEFAULT_VIDEO_MODEL,
-  type VideoModel,
-} from "@okouai/core/video-model-catalog";
+import type { VideoModel } from "@okouai/core/video-model-catalog";
 import {
   chatThreadModelSelectionContract,
   chatThreadsContract,
@@ -480,14 +477,9 @@ const startNewChatThreadCreate$ = command(
     if (!modelSelection) {
       throw new Error("A model selection is required");
     }
-    const videoModel =
-      (featureSwitches[FeatureSwitchKey.VideoModelSelection] ?? false)
-        ? (userPreference.selectedVideoModel ?? DEFAULT_VIDEO_MODEL)
-        : undefined;
-    const imageModel =
-      (featureSwitches[FeatureSwitchKey.ImageModelSelection] ?? false)
-        ? (userPreference.selectedImageModel ?? DEFAULT_IMAGE_MODEL)
-        : undefined;
+    // A blank thread carries no image or video model pin, so it follows the
+    // member's live default: changing that default later updates every thread
+    // that was never explicitly repinned, matching the run-model behavior.
     signal.throwIfAborted();
     await set(
       mintOptimisticThreadWithEvent$,
@@ -500,8 +492,8 @@ const startNewChatThreadCreate$ = command(
           modelSelection.codexServiceTier === "fast" ? "priority" : null,
         computerUseHostId: null,
         cloudBrowserEnabled: false,
-        selectedImageModel: imageModel ?? null,
-        selectedVideoModel: videoModel ?? null,
+        selectedImageModel: null,
+        selectedVideoModel: null,
       },
       signal,
     );
@@ -517,8 +509,6 @@ const startNewChatThreadCreate$ = command(
           clientThreadId: threadId,
           eventId,
           modelSelection,
-          imageModel,
-          videoModel,
         },
         signal,
       );

--- a/turbo/apps/platform/src/signals/external/user-model-preference.ts
+++ b/turbo/apps/platform/src/signals/external/user-model-preference.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import type { ImageModel } from "@okouai/core/image-model-catalog";
 import type { VideoModel } from "@okouai/core/video-model-catalog";
 import {
   type UserPreferenceChangedPayload,
@@ -80,6 +81,28 @@ export const updateDefaultVideoModel$ = command(
         selectedModel: preference.selectedModel,
         serviceTier: preference.serviceTier,
         selectedVideoModel: videoModel,
+      },
+      signal,
+    );
+  },
+);
+
+/** Makes an image model the member default without disturbing sibling fields. */
+export const updateDefaultImageModel$ = command(
+  async (
+    { get, set },
+    imageModel: ImageModel,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    set(reloadUserModelPreference$);
+    const preference = await get(userModelPreference$);
+    signal.throwIfAborted();
+    await set(
+      updateUserModelPreference$,
+      {
+        selectedModel: preference.selectedModel,
+        serviceTier: preference.serviceTier,
+        selectedImageModel: imageModel,
       },
       signal,
     );

--- a/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
@@ -201,10 +201,11 @@ function createAgentComposerSignalsWithDraft(
       }
       const access = get(newThreadComputerAccess$);
       const imageModelEnabled = get(imageModelSelectionEnabled$);
+      const videoModelEnabled = get(videoModelSelectionEnabled$);
       const [hosts, imageModelPin, videoModelPin] = await Promise.all([
         get(computerUseHosts$),
         imageModelEnabled ? get(chatPageImageModelPin$) : Promise.resolve(null),
-        get(chatPageVideoModelPin$),
+        videoModelEnabled ? get(chatPageVideoModelPin$) : Promise.resolve(null),
       ]);
       signal.throwIfAborted();
       const hostId =

--- a/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
@@ -1,14 +1,8 @@
 import { command, computed, state } from "ccstate";
 import { isSupportedRunModel } from "@okouai/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import {
-  DEFAULT_IMAGE_MODEL,
-  type ImageModel,
-} from "@okouai/core/image-model-catalog";
-import {
-  DEFAULT_VIDEO_MODEL,
-  type VideoModel,
-} from "@okouai/core/video-model-catalog";
+import type { ImageModel } from "@okouai/core/image-model-catalog";
+import type { VideoModel } from "@okouai/core/video-model-catalog";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { currentAgentId$ } from "../agent.ts";
 import {
@@ -41,9 +35,11 @@ import type { ChatEvent } from "../chat-page/chat-event-types.ts";
 import {
   chatPageEffectiveImageModel$,
   chatPageEffectiveVideoModel$,
+  chatPageImageModelPin$,
   chatPageImageModelSelection$,
   chatPageModelSelection$,
   chatPageSelectedModelOauthAvailable$,
+  chatPageVideoModelPin$,
   chatPageVideoModelSelection$,
   configureChatPageSelectedModel$,
   resetChatPageImageModelSelection$,
@@ -205,14 +201,11 @@ function createAgentComposerSignalsWithDraft(
       }
       const access = get(newThreadComputerAccess$);
       const imageModelEnabled = get(imageModelSelectionEnabled$);
-      const [hosts, imageModelSelection, videoModelSelection] =
-        await Promise.all([
-          get(computerUseHosts$),
-          imageModelEnabled
-            ? get(chatPageImageModelSelection$)
-            : Promise.resolve(undefined),
-          get(chatPageVideoModelSelection$),
-        ]);
+      const [hosts, imageModelPin, videoModelPin] = await Promise.all([
+        get(computerUseHosts$),
+        imageModelEnabled ? get(chatPageImageModelPin$) : Promise.resolve(null),
+        get(chatPageVideoModelPin$),
+      ]);
       signal.throwIfAborted();
       const hostId =
         access.kind === "computerUse"
@@ -229,10 +222,11 @@ function createAgentComposerSignalsWithDraft(
           prompt: submission.prompt,
           generationTemplate: submission.generationTemplate,
           editorDocument: submission.editorDocument,
-          ...(imageModelEnabled
-            ? { imageModel: imageModelSelection ?? DEFAULT_IMAGE_MODEL }
-            : {}),
-          videoModel: videoModelSelection ?? DEFAULT_VIDEO_MODEL,
+          // Forward only an explicit per-thread pick; an untouched picker sends
+          // nothing so the new thread stays unpinned and follows the member's
+          // live default.
+          ...(imageModelPin !== null ? { imageModel: imageModelPin } : {}),
+          ...(videoModelPin !== null ? { videoModel: videoModelPin } : {}),
           ...(submission.videoRunOptions === undefined
             ? {}
             : { videoRunOptions: submission.videoRunOptions }),

--- a/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-composer-signals.ts
@@ -2,6 +2,10 @@ import { command, computed, state } from "ccstate";
 import { isSupportedRunModel } from "@okouai/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
+  DEFAULT_IMAGE_MODEL,
+  type ImageModel,
+} from "@okouai/core/image-model-catalog";
+import {
   DEFAULT_VIDEO_MODEL,
   type VideoModel,
 } from "@okouai/core/video-model-catalog";
@@ -14,6 +18,7 @@ import {
 import type { ChatForwardContext } from "../chat-page/chat-forward.ts";
 import {
   featureSwitch$,
+  imageModelSelectionEnabled$,
   videoModelSelectionEnabled$,
 } from "../external/feature-switch.ts";
 import {
@@ -34,13 +39,17 @@ import {
 } from "./composer-signals.ts";
 import type { ChatEvent } from "../chat-page/chat-event-types.ts";
 import {
+  chatPageEffectiveImageModel$,
   chatPageEffectiveVideoModel$,
+  chatPageImageModelSelection$,
   chatPageModelSelection$,
   chatPageSelectedModelOauthAvailable$,
   chatPageVideoModelSelection$,
   configureChatPageSelectedModel$,
+  resetChatPageImageModelSelection$,
   resetChatPageModelSelection$,
   resetChatPageVideoModelSelection$,
+  setChatPageImageModelSelection$,
   setChatPageModelSelection$,
   setChatPageVideoModelSelection$,
 } from "./zero-chat-page.ts";
@@ -113,6 +122,35 @@ const setVideoModel$ = command(
   },
 );
 
+const setImageModel$ = command(
+  async (
+    { get, set },
+    imageModel: ImageModel | null,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    if (!get(imageModelSelectionEnabled$)) {
+      return;
+    }
+    set(setChatPageImageModelSelection$, imageModel);
+    const explicitDefaultActionEnabled =
+      get(featureSwitch$)[FeatureSwitchKey.NewChatDefaultModelAction] ?? false;
+    if (explicitDefaultActionEnabled) {
+      return;
+    }
+    const userPreference = await get(userModelPreference$);
+    signal.throwIfAborted();
+    await set(
+      updateUserModelPreference$,
+      {
+        selectedModel: userPreference.selectedModel,
+        serviceTier: userPreference.serviceTier,
+        selectedImageModel: imageModel,
+      },
+      signal,
+    );
+  },
+);
+
 const computerUseHostId$ = computed((get): string | null => {
   const selection = get(newThreadComputerAccess$);
   return selection.kind === "computerUse" ? selection.hostId : null;
@@ -166,10 +204,15 @@ function createAgentComposerSignalsWithDraft(
         return false;
       }
       const access = get(newThreadComputerAccess$);
-      const [hosts, videoModelSelection] = await Promise.all([
-        get(computerUseHosts$),
-        get(chatPageVideoModelSelection$),
-      ]);
+      const imageModelEnabled = get(imageModelSelectionEnabled$);
+      const [hosts, imageModelSelection, videoModelSelection] =
+        await Promise.all([
+          get(computerUseHosts$),
+          imageModelEnabled
+            ? get(chatPageImageModelSelection$)
+            : Promise.resolve(undefined),
+          get(chatPageVideoModelSelection$),
+        ]);
       signal.throwIfAborted();
       const hostId =
         access.kind === "computerUse"
@@ -186,6 +229,9 @@ function createAgentComposerSignalsWithDraft(
           prompt: submission.prompt,
           generationTemplate: submission.generationTemplate,
           editorDocument: submission.editorDocument,
+          ...(imageModelEnabled
+            ? { imageModel: imageModelSelection ?? DEFAULT_IMAGE_MODEL }
+            : {}),
           videoModel: videoModelSelection ?? DEFAULT_VIDEO_MODEL,
           ...(submission.videoRunOptions === undefined
             ? {}
@@ -205,6 +251,7 @@ function createAgentComposerSignalsWithDraft(
       );
       if (sent) {
         set(resetNewThreadComputerAccess$);
+        set(resetChatPageImageModelSelection$);
         set(resetChatPageModelSelection$);
         set(resetChatPageVideoModelSelection$);
       }
@@ -224,6 +271,11 @@ function createAgentComposerSignalsWithDraft(
     selectedModelOauthAvailable$: chatPageSelectedModelOauthAvailable$,
     setModelSelection$,
     configureSelectedModel$: configureChatPageSelectedModel$,
+    imageModel: {
+      selectedImageModel$: chatPageImageModelSelection$,
+      effectiveImageModel$: chatPageEffectiveImageModel$,
+      setImageModel$,
+    },
     videoModel: {
       selectedVideoModel$: chatPageVideoModelSelection$,
       effectiveVideoModel$: chatPageEffectiveVideoModel$,

--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -188,7 +188,7 @@ export interface ComposerVideoModelSignals {
   >;
 }
 
-/** Image model selected for an existing chat composer. */
+/** Image model selected for a composer that supports image generation. */
 export interface ComposerImageModelSignals {
   readonly selectedImageModel$: Computed<
     ImageModel | null | Promise<ImageModel | null>

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -361,6 +361,7 @@ function createBasicComposerUiSignals() {
   const setMobileMediaModelCategory$ = command(
     ({ set }, category: MediaModelCategory | null) => {
       set(internalMobileMediaModelCategory$, category);
+      set(internalDesktopModelCategory$, category ?? "chat");
     },
   );
   const desktopModelCategory$ = computed((get) => {
@@ -409,6 +410,9 @@ function createBasicComposerUiSignals() {
       });
       const desktopMediaModelCategoriesAvailable =
         mediaModelCategoriesAvailable && get(desktopModelPickerLayout$);
+      if (!get(desktopModelPickerLayout$) && open) {
+        set(internalDesktopModelCategory$, "chat");
+      }
       if (
         desktopMediaModelCategoriesAvailable &&
         !open &&

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -194,6 +194,22 @@ export const chatPageEffectiveImageModel$ = computed(
   },
 );
 
+/**
+ * The explicit landing-composer pin: the model the user actively chose for the
+ * next new chat, or null when they never touched the picker. Unlike
+ * chatPage*ModelSelection$, this does NOT fall back to the member default, so an
+ * untouched new thread is created unpinned and follows the live default.
+ */
+export const chatPageVideoModelPin$ = computed((get): VideoModel | null => {
+  const user = get(internalChatPageVideoModelOverride$);
+  return user.kind === "set" ? user.value : null;
+});
+
+export const chatPageImageModelPin$ = computed((get): ImageModel | null => {
+  const user = get(internalChatPageImageModelOverride$);
+  return user.kind === "set" ? user.value : null;
+});
+
 export const setChatPageVideoModelSelection$ = command(
   ({ set }, value: VideoModel | null) => {
     set(internalChatPageVideoModelOverride$, { kind: "set", value });

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -1,5 +1,9 @@
 import { command, computed, state } from "ccstate";
 import {
+  DEFAULT_IMAGE_MODEL,
+  type ImageModel,
+} from "@okouai/core/image-model-catalog";
+import {
   DEFAULT_VIDEO_MODEL,
   type VideoModel,
 } from "@okouai/core/video-model-catalog";
@@ -65,6 +69,10 @@ const internalChatPageUserOverride$ = state<
 
 const internalChatPageVideoModelOverride$ = state<
   { kind: "unset" } | { kind: "set"; value: VideoModel | null }
+>({ kind: "unset" });
+
+const internalChatPageImageModelOverride$ = state<
+  { kind: "unset" } | { kind: "set"; value: ImageModel | null }
 >({ kind: "unset" });
 
 export const chatPageModelSelection$ = computed(
@@ -148,6 +156,17 @@ export const chatPageVideoModelSelection$ = computed(
   },
 );
 
+export const chatPageImageModelSelection$ = computed(
+  async (get): Promise<ImageModel | null> => {
+    const user = get(internalChatPageImageModelOverride$);
+    if (user.kind === "set") {
+      return user.value;
+    }
+    const userPreference = await get(userModelPreference$);
+    return userPreference.selectedImageModel ?? DEFAULT_IMAGE_MODEL;
+  },
+);
+
 /**
  * What a video run started from the new-thread composer would use. The
  * selection above is null when the user cleared it back to "follow my
@@ -164,9 +183,26 @@ export const chatPageEffectiveVideoModel$ = computed(
   },
 );
 
+/** The image model a run started from the new-thread composer would use. */
+export const chatPageEffectiveImageModel$ = computed(
+  async (get): Promise<ImageModel> => {
+    return (
+      (await get(chatPageImageModelSelection$)) ??
+      (await get(userModelPreference$)).selectedImageModel ??
+      DEFAULT_IMAGE_MODEL
+    );
+  },
+);
+
 export const setChatPageVideoModelSelection$ = command(
   ({ set }, value: VideoModel | null) => {
     set(internalChatPageVideoModelOverride$, { kind: "set", value });
+  },
+);
+
+export const setChatPageImageModelSelection$ = command(
+  ({ set }, value: ImageModel | null) => {
+    set(internalChatPageImageModelOverride$, { kind: "set", value });
   },
 );
 
@@ -179,5 +215,11 @@ export const resetChatPageModelSelection$ = command(({ get, set }) => {
 export const resetChatPageVideoModelSelection$ = command(({ get, set }) => {
   if (get(internalChatPageVideoModelOverride$).kind === "set") {
     set(internalChatPageVideoModelOverride$, { kind: "unset" });
+  }
+});
+
+export const resetChatPageImageModelSelection$ = command(({ get, set }) => {
+  if (get(internalChatPageImageModelOverride$).kind === "set") {
+    set(internalChatPageImageModelOverride$, { kind: "unset" });
   }
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -50,6 +50,7 @@ import {
   setChatPageModelSelection$,
 } from "../../../signals/zero-page/zero-chat-page.ts";
 import { loadLeftThread$ } from "../../../signals/chat-page/chat-thread-panes.ts";
+import { eventDrivenChatThread } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
 import {
   click,
   detachedSetupPage,
@@ -3497,6 +3498,450 @@ describe("chat composer image model", () => {
     }
     return icon;
   }
+
+  function desktopVideoModelButton(): HTMLElement | undefined {
+    return queryAllByRoleFast("button").find((candidate) => {
+      return (
+        candidate.getAttribute("aria-label") === "Video models" &&
+        candidate.hasAttribute("aria-pressed")
+      );
+    });
+  }
+
+  it("uses the live member image default for an untouched new chat", async () => {
+    const user = userEvent.setup({ delay: null });
+    context.mocks.browser.matchMedia(true);
+    const initialPreference: UserModelPreferenceResponse = {
+      selectedModel: null,
+      serviceTier: null,
+      selectedImageModel: "fal-ai/qwen-image",
+      updatedAt: "2026-08-18T00:00:00Z",
+    };
+    let createdImageModel: string | undefined;
+
+    mockOrgModelRoutes("claude-fable-5");
+    context.mocks.data.userModelPreference(initialPreference);
+    mockAgent();
+    mockChatLifecycle(context, {
+      onThreadCreate: (body) => {
+        createdImageModel = body.imageModel;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.ImageModelSelection]: true },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    const imageModelButton = await findDesktopImageModelButton();
+    await waitFor(() => {
+      expect(imageModelButton).toHaveTextContent("Qwen Image");
+    });
+
+    context.mocks.data.userModelPreference({
+      ...initialPreference,
+      selectedImageModel: "gpt-image-2",
+      updatedAt: "2026-08-18T00:01:00Z",
+    });
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("userPreferenceChanged"),
+      ).toBeTruthy();
+    });
+    act(() => {
+      triggerAblyEvent("userPreferenceChanged", {
+        kinds: ["defaultImageModel"],
+      });
+    });
+    await waitFor(() => {
+      expect(imageModelButton).toHaveTextContent("GPT Image 2");
+    });
+
+    await sendMessageInUI(
+      user,
+      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      "Use my current image default",
+    );
+
+    await waitFor(() => {
+      expect(createdImageModel).toBe("gpt-image-2");
+    });
+  });
+
+  it("keeps a mobile image pick temporary, pins it, and resets after send", async () => {
+    const user = userEvent.setup({ delay: null });
+    context.mocks.browser.matchMedia(false);
+    const updates: UpdateUserModelPreferenceRequest[] = [];
+    let createdThreadId: string | undefined;
+    let createdImageModel: string | undefined;
+
+    mockOrgModelRoutes("claude-fable-5");
+    context.mocks.data.userModelPreference({
+      selectedModel: null,
+      serviceTier: null,
+      selectedImageModel: "fal-ai/qwen-image",
+      selectedVideoModel: "MiniMax-H3",
+      updatedAt: "2026-08-18T00:00:00Z",
+    });
+    context.mocks.api(
+      userModelPreferenceContract.update,
+      ({ body, respond }) => {
+        updates.push(body);
+        return respond(200, {
+          ...body,
+          updatedAt: "2026-08-18T00:01:00Z",
+        });
+      },
+    );
+    mockAgent();
+    mockChatLifecycle(context, {
+      onThreadCreate: (body) => {
+        createdThreadId = body.clientThreadId;
+        createdImageModel = body.imageModel;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.ImageModelSelection]: true,
+        [FeatureSwitchKey.VideoModelSelection]: true,
+        [FeatureSwitchKey.NewChatDefaultModelAction]: true,
+      },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await user.click(await findComposerModel("Claude Fable 5"));
+    await user.click(await findMediaPanelButton("Image models"));
+    expect(
+      screen.queryByText("Temporarily switched to Qwen Image for images"),
+    ).not.toBeInTheDocument();
+    await user.click(await findMediaPanelButton("GPT Image 2"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Temporarily switched to GPT Image 2 for images"),
+      ).toBeInTheDocument();
+    });
+    expect(updates).toStrictEqual([]);
+
+    await sendMessageInUI(
+      user,
+      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      "Use my temporary image choice",
+    );
+
+    await waitFor(() => {
+      expect(createdThreadId).toBeDefined();
+      expect(createdImageModel).toBe("gpt-image-2");
+    });
+    if (!createdThreadId) {
+      throw new Error("Created thread id not captured");
+    }
+    const optimisticThreadId = createdThreadId;
+    await waitFor(() => {
+      expect(
+        context.store.get(eventDrivenChatThread(optimisticThreadId)),
+      ).toMatchObject({ selectedImageModel: "gpt-image-2" });
+    });
+
+    act(() => {
+      context.store.set(detachedNavigateTo$, ROUTES.agentChat, {
+        pathParams: { agentId: AGENT_ID },
+      });
+    });
+    await user.click(await findComposerModel("Claude Fable 5"));
+    await user.click(await findMediaPanelButton("Image models"));
+    await expect(findMediaPanelButton("Qwen Image")).resolves.toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(updates).toStrictEqual([]);
+  });
+
+  it("writes an image pick immediately when the default action is off", async () => {
+    const user = userEvent.setup({ delay: null });
+    context.mocks.browser.matchMedia(true);
+    const updates: UpdateUserModelPreferenceRequest[] = [];
+    let createdImageModel: string | undefined;
+
+    mockOrgModelRoutes("claude-fable-5");
+    context.mocks.data.userModelPreference({
+      selectedModel: null,
+      serviceTier: null,
+      selectedImageModel: "fal-ai/qwen-image",
+      selectedVideoModel: "MiniMax-H3",
+      updatedAt: "2026-08-18T00:00:00Z",
+    });
+    context.mocks.api(
+      userModelPreferenceContract.update,
+      ({ body, respond }) => {
+        updates.push(body);
+        return respond(200, {
+          ...body,
+          updatedAt: "2026-08-18T00:01:00Z",
+        });
+      },
+    );
+    mockAgent();
+    mockChatLifecycle(context, {
+      onThreadCreate: (body) => {
+        createdImageModel = body.imageModel;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.ImageModelSelection]: true },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await user.click(await findDesktopImageModelButton());
+    await user.click(await findMediaPanelButton("Seedream 4"));
+    await waitFor(() => {
+      expect(updates).toStrictEqual([
+        {
+          selectedModel: null,
+          serviceTier: null,
+          selectedImageModel: "fal-ai/bytedance/seedream/v4/text-to-image",
+        },
+      ]);
+    });
+
+    await sendMessageInUI(
+      user,
+      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      "Persist and pin my image choice",
+    );
+    await waitFor(() => {
+      expect(createdImageModel).toBe(
+        "fal-ai/bytedance/seedream/v4/text-to-image",
+      );
+    });
+  });
+
+  it("sets only the image default from a fresh member preference", async () => {
+    const user = userEvent.setup({ delay: null });
+    const updateGate = context.mocks.deferred<void>();
+    const updates: UpdateUserModelPreferenceRequest[] = [];
+    context.mocks.browser.matchMedia(true);
+    let stored: UserModelPreferenceResponse = {
+      selectedModel: "claude-fable-5",
+      serviceTier: null,
+      selectedImageModel: "fal-ai/qwen-image",
+      selectedVideoModel: "MiniMax-H3",
+      updatedAt: "2026-08-18T00:00:00Z",
+    };
+
+    mockOrgModelRoutes("claude-fable-5");
+    context.mocks.api(userModelPreferenceContract.get, ({ respond }) => {
+      return respond(200, stored);
+    });
+    context.mocks.api(
+      userModelPreferenceContract.update,
+      async ({ body, respond, withSignal }) => {
+        updates.push(body);
+        await withSignal(updateGate.promise);
+        stored = {
+          ...stored,
+          ...body,
+          updatedAt: "2026-08-18T00:02:00Z",
+        };
+        return respond(200, stored);
+      },
+    );
+    mockAgent();
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.ImageModelSelection]: true,
+        [FeatureSwitchKey.NewChatDefaultModelAction]: true,
+      },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await user.click(await findDesktopImageModelButton());
+    await user.click(await findMediaPanelButton("GPT Image 2"));
+    expect(updates).toStrictEqual([]);
+    await screen.findByText("Temporarily switched to GPT Image 2 for images");
+
+    stored = {
+      ...stored,
+      selectedModel: "gpt-5.6-sol",
+      serviceTier: "priority",
+      selectedVideoModel: "fal-ai/veo3.1/fast",
+      updatedAt: "2026-08-18T00:01:00Z",
+    };
+    const setAsDefault = buttonContainingText("Set as default", document.body);
+    await user.click(setAsDefault);
+
+    await waitFor(() => {
+      expect(updates).toStrictEqual([
+        {
+          selectedModel: "gpt-5.6-sol",
+          serviceTier: "priority",
+          selectedImageModel: "gpt-image-2",
+        },
+      ]);
+      expect(setAsDefault).toBeDisabled();
+      expect(setAsDefault).toHaveAttribute("aria-busy", "true");
+    });
+    fireEvent.click(setAsDefault);
+    expect(updates).toHaveLength(1);
+    updateGate.resolve();
+
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("userPreferenceChanged"),
+      ).toBeTruthy();
+    });
+    act(() => {
+      triggerAblyEvent("userPreferenceChanged", {
+        kinds: ["defaultImageModel"],
+      });
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Temporarily switched to GPT Image 2 for images"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows only the active Chat, Image, or Video notice", async () => {
+    const user = userEvent.setup({ delay: null });
+    const updates: UpdateUserModelPreferenceRequest[] = [];
+    context.mocks.browser.matchMedia(true);
+    mockOrgModelRoutes("claude-fable-5");
+    context.mocks.data.userModelPreference({
+      selectedModel: "claude-fable-5",
+      serviceTier: null,
+      selectedImageModel: "fal-ai/qwen-image",
+      selectedVideoModel: "MiniMax-H3",
+      updatedAt: "2026-08-18T00:00:00Z",
+    });
+    context.mocks.api(
+      userModelPreferenceContract.update,
+      ({ body, respond }) => {
+        updates.push(body);
+        return respond(200, {
+          ...body,
+          updatedAt: "2026-08-18T00:01:00Z",
+        });
+      },
+    );
+    mockAgent();
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.ImageModelSelection]: true,
+        [FeatureSwitchKey.VideoModelSelection]: true,
+        [FeatureSwitchKey.NewChatDefaultModelAction]: true,
+      },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    const chatNotice = "Temporarily switched to Claude Sonnet 4.6";
+    const imageNotice = "Temporarily switched to GPT Image 2 for images";
+    const videoNotice = "Temporarily switched to Veo 3.1 Fast for video";
+
+    await user.click(await findComposerModel("Claude Fable 5"));
+    await user.click(
+      await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    );
+    await screen.findByText(chatNotice);
+
+    const imageModelButton = await findDesktopImageModelButton();
+    await user.click(imageModelButton);
+    await user.click(await findMediaPanelButton("GPT Image 2"));
+    await screen.findByText(imageNotice);
+    expect(screen.queryByText(chatNotice)).not.toBeInTheDocument();
+
+    const videoModelButton = desktopVideoModelButton();
+    if (!videoModelButton) {
+      throw new Error("Desktop video model button not found");
+    }
+    await user.click(videoModelButton);
+    await waitFor(() => {
+      expect(screen.queryByText(imageNotice)).not.toBeInTheDocument();
+    });
+    await user.click(videoModelButton);
+    await user.click(await findMediaPanelButton("Veo 3.1 fast"));
+    await screen.findByText(videoNotice);
+    expect(screen.queryByText(imageNotice)).not.toBeInTheDocument();
+
+    await user.click(imageModelButton);
+    await screen.findByText(imageNotice);
+    expect(screen.queryByText(videoNotice)).not.toBeInTheDocument();
+
+    await user.click(videoModelButton);
+    await screen.findByText(videoNotice);
+    expect(screen.queryByText(imageNotice)).not.toBeInTheDocument();
+
+    const chatModelButton = await findComposerModel("Claude Sonnet 4.6");
+    chatModelButton.focus();
+    await user.keyboard("{Enter}");
+    await screen.findByText(chatNotice);
+    expect(screen.queryByText(imageNotice)).not.toBeInTheDocument();
+    expect(screen.queryByText(videoNotice)).not.toBeInTheDocument();
+    expect(updates).toStrictEqual([]);
+  });
+
+  it("omits image UI, preference writes, and thread pins when disabled", async () => {
+    const user = userEvent.setup({ delay: null });
+    let preferenceUpdateCount = 0;
+    let createdThreadId: string | undefined;
+    let createdImageModel: string | undefined;
+    context.mocks.browser.matchMedia(true);
+
+    mockOrgModelRoutes("claude-fable-5");
+    context.mocks.data.userModelPreference({
+      selectedModel: null,
+      serviceTier: null,
+      selectedImageModel: "fal-ai/qwen-image",
+      updatedAt: "2026-08-18T00:00:00Z",
+    });
+    context.mocks.api(
+      userModelPreferenceContract.update,
+      ({ body, respond }) => {
+        preferenceUpdateCount += 1;
+        return respond(200, {
+          ...body,
+          updatedAt: "2026-08-18T00:01:00Z",
+        });
+      },
+    );
+    mockAgent();
+    mockChatLifecycle(context, {
+      onThreadCreate: (body) => {
+        createdThreadId = body.clientThreadId;
+        createdImageModel = body.imageModel;
+      },
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await findComposerModel("Claude Fable 5");
+    expect(desktopImageModelButton()).toBeUndefined();
+    await sendMessageInUI(
+      user,
+      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      "Keep image selection disabled",
+    );
+    await waitFor(() => {
+      expect(createdThreadId).toBeDefined();
+    });
+    expect(createdImageModel).toBeUndefined();
+    expect(preferenceUpdateCount).toBe(0);
+    if (!createdThreadId) {
+      throw new Error("Created thread id not captured");
+    }
+    expect(
+      context.store.get(eventDrivenChatThread(createdThreadId)),
+    ).toMatchObject({ selectedImageModel: null });
+  });
 
   it("shows the effective member default and pins an image model optimistically", async () => {
     const user = userEvent.setup({ delay: null });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -3564,8 +3564,10 @@ describe("chat composer image model", () => {
       "Use my current image default",
     );
 
+    // Untouched: the thread is created unpinned so it follows the live member
+    // default (already reflected in the button above) instead of freezing it.
     await waitFor(() => {
-      expect(createdImageModel).toBe("gpt-image-2");
+      expect(createdImageModel).toBeUndefined();
     });
   });
 
@@ -4374,8 +4376,10 @@ describe("chat composer video model", () => {
       "Use my current video default",
     );
 
+    // Untouched: the thread is created unpinned so it follows the live member
+    // default (already reflected in the panel above) instead of freezing it.
     await waitFor(() => {
-      expect(createdVideoModel).toBe("fal-ai/veo3.1/fast");
+      expect(createdVideoModel).toBeUndefined();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -375,6 +375,7 @@ export function mockChatLifecycle(
       model?: string;
       modelSelection: ModelSelectionRequest;
       serviceTier?: ChatThreadServiceTier | null;
+      imageModel?: string;
       videoModel?: string;
     }) => void;
     onModelSelectionUpdate?: (body: {
@@ -775,6 +776,7 @@ export function mockChatLifecycle(
       model: body.model,
       modelSelection,
       serviceTier: body.serviceTier,
+      imageModel: body.imageModel,
       videoModel: body.videoModel,
     });
     return respond(201, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -40,6 +40,7 @@ import {
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
 import { eventDrivenChatThread } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
+import { setChatPageImageModelSelection$ } from "../../../signals/zero-page/zero-chat-page.ts";
 import {
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
   getChatThreadVirtualListScrollMargin,
@@ -2955,6 +2956,64 @@ describe("zero sidebar", () => {
       expect(pathname()).toBe(`/chats/${createdThreadId}`);
       expect(within(list).getByText("New chat")).toBeInTheDocument();
     });
+    if (!createdThreadId) {
+      throw new Error("Created thread id not captured");
+    }
+    expect(
+      context.store.get(eventDrivenChatThread(createdThreadId)),
+    ).toMatchObject({ selectedImageModel: "fal-ai/qwen-image" });
+  });
+
+  it("ignores a temporary landing image pick when creating a blank thread", async () => {
+    prepareDefaultAgent();
+    context.mocks.data.userModelPreference({
+      selectedModel: null,
+      serviceTier: null,
+      selectedImageModel: "fal-ai/qwen-image",
+      updatedAt: "2026-08-18T00:00:00Z",
+    });
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Existing conversation"),
+    ]);
+    let createdThreadId: string | undefined;
+    let createdImageModel: string | undefined;
+    context.mocks.api(chatThreadsContract.create, ({ body, respond }) => {
+      createdThreadId = body.clientThreadId ?? "created-thread-id";
+      createdImageModel = body.imageModel;
+      return respond(201, {
+        id: createdThreadId,
+        title: null,
+        createdAt: "2026-03-10T00:00:00Z",
+        selectedModel: body.model ?? "claude-sonnet-4-6",
+        serviceTier: body.serviceTier ?? null,
+      });
+    });
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+        [FeatureSwitchKey.ImageModelSelection]: true,
+      },
+    });
+
+    // The user temporarily switched the landing composer image model without
+    // pressing "Set as default". A blank thread must still be created with the
+    // member default, mirroring how the video model is resolved here.
+    context.store.set(setChatPageImageModelSelection$, "fal-ai/flux-pro/v1.1");
+
+    const list = await screen.findByTestId("chat-list-column");
+    const newChatButton = within(list).getByLabelText("New chat");
+    await waitFor(() => {
+      expect(newChatButton).toBeEnabled();
+    });
+    click(newChatButton);
+
+    await waitFor(() => {
+      expect(createdThreadId).toBeDefined();
+    });
+    expect(createdImageModel).toBe("fal-ai/qwen-image");
     if (!createdThreadId) {
       throw new Error("Created thread id not captured");
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2951,7 +2951,9 @@ describe("zero sidebar", () => {
     expect(pathname()).not.toBe("/");
     await waitFor(() => {
       expect(createdAgentId).toBe(AGENT_ID);
-      expect(createdImageModel).toBe("fal-ai/qwen-image");
+      // A blank thread pins no image model, so it follows the live member
+      // default instead of freezing it at creation time.
+      expect(createdImageModel).toBeUndefined();
       expect(createdThreadId).toBeDefined();
       expect(pathname()).toBe(`/chats/${createdThreadId}`);
       expect(within(list).getByText("New chat")).toBeInTheDocument();
@@ -2961,7 +2963,7 @@ describe("zero sidebar", () => {
     }
     expect(
       context.store.get(eventDrivenChatThread(createdThreadId)),
-    ).toMatchObject({ selectedImageModel: "fal-ai/qwen-image" });
+    ).toMatchObject({ selectedImageModel: null });
   });
 
   it("ignores a temporary landing image pick when creating a blank thread", async () => {
@@ -2999,8 +3001,8 @@ describe("zero sidebar", () => {
     });
 
     // The user temporarily switched the landing composer image model without
-    // pressing "Set as default". A blank thread must still be created with the
-    // member default, mirroring how the video model is resolved here.
+    // pressing "Set as default". A blank thread must not pin that pick; it
+    // stays unpinned (null) so it follows the live member default.
     context.store.set(setChatPageImageModelSelection$, "fal-ai/flux-pro/v1.1");
 
     const list = await screen.findByTestId("chat-list-column");
@@ -3013,13 +3015,13 @@ describe("zero sidebar", () => {
     await waitFor(() => {
       expect(createdThreadId).toBeDefined();
     });
-    expect(createdImageModel).toBe("fal-ai/qwen-image");
+    expect(createdImageModel).toBeUndefined();
     if (!createdThreadId) {
       throw new Error("Created thread id not captured");
     }
     expect(
       context.store.get(eventDrivenChatThread(createdThreadId)),
-    ).toMatchObject({ selectedImageModel: "fal-ai/qwen-image" });
+    ).toMatchObject({ selectedImageModel: null });
   });
 
   it("preserves pinned agent rows across a loading refresh", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -39,6 +39,7 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
+import { eventDrivenChatThread } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
 import {
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
   getChatThreadVirtualListScrollMargin,
@@ -2905,14 +2906,22 @@ describe("zero sidebar", () => {
 
   it("creates a new chat thread from the three-column header", async () => {
     prepareDefaultAgent();
+    context.mocks.data.userModelPreference({
+      selectedModel: null,
+      serviceTier: null,
+      selectedImageModel: "fal-ai/qwen-image",
+      updatedAt: "2026-08-18T00:00:00Z",
+    });
     mockSidebarThreadStory([
       createThread(EXISTING_THREAD_ID, "Existing conversation"),
     ]);
     let createdThreadId: string | undefined;
     let createdAgentId: string | undefined;
+    let createdImageModel: string | undefined;
     context.mocks.api(chatThreadsContract.create, ({ body, respond }) => {
       createdThreadId = body.clientThreadId ?? "created-thread-id";
       createdAgentId = body.agentId;
+      createdImageModel = body.imageModel;
       return respond(201, {
         id: createdThreadId,
         title: null,
@@ -2927,6 +2936,7 @@ describe("zero sidebar", () => {
       path: `/chats/${EXISTING_THREAD_ID}`,
       featureSwitches: {
         [FeatureSwitchKey.ThreeColumnNav]: true,
+        [FeatureSwitchKey.ImageModelSelection]: true,
       },
     });
 
@@ -2940,10 +2950,17 @@ describe("zero sidebar", () => {
     expect(pathname()).not.toBe("/");
     await waitFor(() => {
       expect(createdAgentId).toBe(AGENT_ID);
+      expect(createdImageModel).toBe("fal-ai/qwen-image");
       expect(createdThreadId).toBeDefined();
       expect(pathname()).toBe(`/chats/${createdThreadId}`);
       expect(within(list).getByText("New chat")).toBeInTheDocument();
     });
+    if (!createdThreadId) {
+      throw new Error("Created thread id not captured");
+    }
+    expect(
+      context.store.get(eventDrivenChatThread(createdThreadId)),
+    ).toMatchObject({ selectedImageModel: "fal-ai/qwen-image" });
   });
 
   it("preserves pinned agent rows across a loading refresh", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -185,6 +185,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { orgModelPolicies$ } from "../../signals/external/org-model-policies.ts";
 import {
+  updateDefaultImageModel$,
   updateDefaultVideoModel$,
   updateUserModelPreference$,
   userModelPreference$,
@@ -8322,29 +8323,86 @@ function ComposerTemporaryVideoModelNotice({
   );
 }
 
+function ComposerTemporaryImageModelNotice({
+  imageModelSignals,
+}: {
+  imageModelSignals: ComposerImageModelSignals;
+}) {
+  const { t } = useTranslation();
+  const selection = useLastResolved(imageModelSignals.effectiveImageModel$);
+  const userPreference = useLastResolved(userModelPreference$);
+  const [updateLoadable, updateDefaultImageModel] = useLoadableSet(
+    updateDefaultImageModel$,
+  );
+  const pageSignal = useGet(pageSignal$);
+  if (!userPreference) {
+    return null;
+  }
+  const defaultImageModel =
+    userPreference.selectedImageModel ?? DEFAULT_IMAGE_MODEL;
+  if (!selection || selection === defaultImageModel) {
+    return null;
+  }
+  const updating = updateLoadable.state === "loading";
+  const setAsDefault = () => {
+    if (updating) {
+      return;
+    }
+    detach(updateDefaultImageModel(selection, pageSignal), Reason.DomCallback);
+  };
+  return (
+    <ComposerTemporaryModelNoticeRow
+      notice={t(
+        ($) => {
+          return $.chat.composer.temporaryImageModelNotice;
+        },
+        { model: IMAGE_MODEL_CONFIGS[selection].label },
+      )}
+      updating={updating}
+      onSetAsDefault={setAsDefault}
+    />
+  );
+}
+
 function ComposerTemporaryModelNoticeSlot({
   signals,
 }: {
   signals: ComposerSignals;
 }) {
   const enabled = useGet(signals.model.temporaryModelNoticeEnabled$);
+  const imageModelEnabled = useGet(imageModelSelectionEnabled$);
   const videoModelEnabled = useGet(videoModelSelectionEnabled$);
-  const desktopLayout = useGet(signals.model.desktopModelPickerLayout$);
   const desktopModelCategory = useGet(signals.model.desktopModelCategory$);
+  const imageModelSignals = signals.imageModel;
   const videoModelSignals = signals.videoModel;
   if (!enabled) {
     return null;
   }
   // One notice at a time: it belongs to whichever model the composer is
   // currently pointed at, matching the pressed state of the two mode chips.
-  return videoModelEnabled &&
+  if (
+    imageModelEnabled &&
+    imageModelSignals &&
+    desktopModelCategory === "image"
+  ) {
+    return (
+      <ComposerTemporaryImageModelNotice
+        imageModelSignals={imageModelSignals}
+      />
+    );
+  }
+  if (
+    videoModelEnabled &&
     videoModelSignals &&
-    desktopLayout &&
-    desktopModelCategory === "video" ? (
-    <ComposerTemporaryVideoModelNotice videoModelSignals={videoModelSignals} />
-  ) : (
-    <ComposerTemporaryModelNotice signals={signals} />
-  );
+    desktopModelCategory === "video"
+  ) {
+    return (
+      <ComposerTemporaryVideoModelNotice
+        videoModelSignals={videoModelSignals}
+      />
+    );
+  }
+  return <ComposerTemporaryModelNotice signals={signals} />;
 }
 
 // ---------------------------------------------------------------------------

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -107,7 +107,7 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ImageModelSelection]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ImageModelSelection]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       true,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -299,6 +299,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Let the chat composer model picker choose the default built-in image model for a chat thread.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

- Add the existing shared Image category and nine-model picker to the new-thread composer on desktop and mobile when `ImageModelSelection` is enabled.
- Mirror the video new-chat flow for live member defaults, temporary image overrides, active-category notices, explicit default writes, realtime invalidation, and post-send reset.
- Pass the canonical `imageModel` through blank-thread and first-message creation, including the optimistic `selectedImageModel` metadata; preserve the field-omission/null behavior while the feature is off.
- Enable `ImageModelSelection` for staff orgs only after the PR7 production CLI/API compatibility window drained. The global switch remains disabled.

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx -t 'chat composer image model|keeps a new-chat video pick temporary|shows only the notice for the model mode|keeps a just-written run model'` — 13 passed, 65 skipped by filter.
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t 'creates a new chat thread from the three-column header'` — 1 passed, 58 skipped by filter.
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` — 24 passed.
- `pnpm -F @okouai/app check-types` — passed production and test TypeScript projects.
- `pnpm -F @okouai/core check-types` — passed.
- `pnpm -F @okouai/app lint` — passed; existing unrelated warnings remain.
- `pnpm -F @okouai/core lint` — passed.
- `pnpm knip --workspace @okouai/app --workspace @okouai/core` — passed.
- `git -C .. diff --name-only -z origin/main...HEAD -- 'turbo/**' | sed -z 's#^turbo/##' | xargs -0 pnpm exec prettier --check` — all 22 changed files matched the pinned Prettier version.
- Local dev-server/browser validation was not run, per the task constraint; preview validation is left to the PR pipeline.

## Rollout evidence

- PR7 merge `026c19c9cc8694fb0afb7aee36428f5338e9ca89` is an ancestor of release target `7342a54c471ae1f6d89822314194b0395a5b1a20`.
- [Release workflow run 32100814299](https://github.com/vm0-ai/vm0/actions/runs/32100814299) completed successfully. Its production API job verified and injected `https://static.vm0.io/okou-cli/7342a54c471ae1f6d89822314194b0395a5b1a20/package.tgz`; API v1.458.1 promotion completed at `2026-08-18T05:05:46Z`.
- The repository bounds old contexts by 15 minutes of queue TTL, 7,200 seconds of execution, 90 seconds of finalization, and 10 seconds of terminal grace: 8,200 seconds total. The conservative drain completed at `2026-08-18T07:22:26Z`; the rollout decision was rechecked after that point.
- PR7 intentionally emitted no endpoint-resolution or snapshot telemetry. An Axiom schema-only inspection found no dedicated selected/requested/effective/source image-model telemetry, and no prompt fields or prompt text were queried.
- The gate therefore adds only `enabledOrgIdHashes: STAFF_ORG_ID_HASHES`; `enabled` remains `false`, and general-user rollout is outside this PR.

## Fallback plan

- Remove the staff-org allowlist line to return the switch to fully off without changing API or database contracts.
- Revert this PR if the new-thread UI or create-path pinning regresses; feature-off clients retain the prior request and optimistic metadata behavior.

Follow-up to #27688
