### PR TITLE
docs(python): clarify x tweet body refinement conditions

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -8,8 +8,11 @@ server-side billing processor to look up ``unit_price`` in
 
 Body-dependent refinement is applied on top via
 :func:`refine_bucket_with_body` — currently used to drop
-``content.create_with_url`` to ``content.create`` when the POST /2/tweets
-body contains no URL.
+``content.create_with_url`` to ``content.create`` only when the POST
+/2/tweets body is valid plain text with neither a URL nor a rendered-link
+signal such as a quote reference, media attachment, card, or DM deep link.
+Parse failures and ambiguous bodies stay on the more expensive bucket,
+matching the "never under-charge" rule.
 
 Design:
 


### PR DESCRIPTION
## Summary

Clarify the X tweet body refinement overview in
`crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py`.

The module overview previously stated `refine_bucket_with_body()` drops
`content.create_with_url` to `content.create` when a `POST /2/tweets` body contains no
URL. In reality, the downgrade applies only to a valid plain-text body with neither a URL
nor a rendered-link signal (a quote reference, attached media, a card, or a DM deep link);
parse failures and ambiguous bodies stay on the more expensive bucket.

## Changes

- Rewrite the module overview paragraph to match the implemented contract and the
  function-level docstring.

## Exclusions

- Documentation only; no runtime behavior, tests, or pricing mappings are changed.

## Validation

- `python3 -m py_compile crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py`
- Confirmed no edited line exceeds the ruff 100-character line limit.

Closes #27962
