### PR TITLE
fix(billing): sync subscription metadata after upgrades

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -6241,7 +6241,13 @@ describe("usage pack allocation management", () => {
     const userId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([{ userId, usagePackUsd: 20 }]);
     const quantities = new Map([[TEST_PRICE_USAGE_PACK_20, 1]]);
-    const proSubscription = managedUsagePackSubscription(fixture, quantities);
+    const proSubscription = {
+      ...managedUsagePackSubscription(fixture, quantities),
+      metadata: {
+        ...managedUsagePackMetadata(fixture),
+        utm_source: "google",
+      },
+    };
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
       proSubscription,
     );
@@ -6334,6 +6340,19 @@ describe("usage pack allocation management", () => {
       context.mocks.stripe.checkout.sessions.create,
     ).not.toHaveBeenCalled();
     await postManagedUsagePackEvent("invoice.paid", invoice);
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenLastCalledWith(
+      fixture.subscriptionId,
+      {
+        metadata: {
+          ...proSubscription.metadata,
+          tier: "team",
+          priceId: TEST_PRICE_USAGE_PACK_PLAN_TEAM,
+        },
+      },
+      {
+        idempotencyKey: `usage-pack-subscription-metadata:${invoice.id}`,
+      },
+    );
     const state = await readUsagePackState(
       fixture.orgId,
       fixture.usagePackSubscriptionId,
@@ -7646,10 +7665,13 @@ describe("usage pack allocation management", () => {
         .allocations[0]?.userId ?? "";
     const oldQuantities = new Map([[TEST_PRICE_USAGE_PACK_20, 1]]);
     const newQuantities = new Map([[TEST_PRICE_USAGE_PACK_50, 1]]);
-    const oldSubscription = managedUsagePackSubscription(
-      fixture,
-      oldQuantities,
-    );
+    const oldSubscription = {
+      ...managedUsagePackSubscription(fixture, oldQuantities),
+      metadata: {
+        ...managedUsagePackMetadata(fixture),
+        utm_source: "google",
+      },
+    };
     context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
       oldSubscription,
     );
@@ -7736,11 +7758,19 @@ describe("usage pack allocation management", () => {
       targetPriceId: TEST_PRICE_USAGE_PACK_50,
       prorationTimestamp,
     });
-    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
-      managedUsagePackSubscription(fixture, newQuantities),
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      ...managedUsagePackSubscription(fixture, newQuantities),
+      metadata: oldSubscription.metadata,
+    });
+    await postManagedUsagePackEvent("invoice.paid", paidInvoice);
+    await postManagedUsagePackEvent("invoice.paid", paidInvoice);
+    expect(context.mocks.stripe.subscriptions.update).toHaveBeenLastCalledWith(
+      fixture.subscriptionId,
+      { metadata: oldSubscription.metadata },
+      {
+        idempotencyKey: `usage-pack-subscription-metadata:${paidInvoice.id}`,
+      },
     );
-    await postManagedUsagePackEvent("invoice.paid", paidInvoice);
-    await postManagedUsagePackEvent("invoice.paid", paidInvoice);
 
     const upgraded = await readUsagePackState(
       fixture.orgId,

--- a/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
@@ -34,10 +34,8 @@ import {
   knownPlanPriceItem,
   tierFromPriceId,
 } from "./zero-billing-checkout.service";
-import {
-  reconcileUsagePackSubscriptions,
-  USAGE_PACK_SUBSCRIPTION_PURPOSE,
-} from "./usage-pack-subscription.service";
+import { reconcileUsagePackSubscriptions } from "./usage-pack-subscription.service";
+import { USAGE_PACK_SUBSCRIPTION_PURPOSE } from "./usage-pack-subscription-metadata.service";
 import { reconcileUsagePackCreditRefunds } from "./usage-pack-credit-refund.service";
 import { reconcileUsagePackInvitationPurchases } from "./usage-pack-invitation-purchase.service";
 import { reconcileUsagePackSubscriptionMigrations } from "./usage-pack-subscription-migration.service";

--- a/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
@@ -58,6 +58,7 @@ import {
   isUsagePackPlanPriceId,
   usagePackUsdForKnownPriceId,
 } from "./zero-billing-checkout.service";
+import { updateUsagePackSubscriptionMetadata } from "./usage-pack-subscription-metadata.service";
 
 const PREVIEW_TTL_MS = 15 * 60 * 1000;
 const CHANGE_RECONCILIATION_DELAY_MS = 5 * 60 * 1000;
@@ -3086,6 +3087,23 @@ export async function fulfillUsagePackSubscriptionChangeInvoice(
   });
 }
 
+async function updateAllocationSubscriptionMetadata(
+  context: UsagePackChangeContext,
+  subscriptionId: string,
+  invoiceId: string,
+): Promise<StripeSubscription> {
+  const stripe = getStripeClient();
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  return await updateUsagePackSubscriptionMetadata(stripe, {
+    subscription,
+    orgId: context.subscription.orgId,
+    tier: context.subscription.tier,
+    planPriceId: context.subscription.stripePlanPriceId,
+    usagePackSubscriptionId: context.subscription.id,
+    idempotencyKey: `usage-pack-subscription-metadata:${invoiceId}`,
+  });
+}
+
 export async function handleUsagePackAllocationChangeInvoicePaid(
   db: Db,
   invoice: UsagePackChangeInvoiceInput,
@@ -3142,9 +3160,15 @@ export async function handleUsagePackAllocationChangeInvoicePaid(
       `Usage pack change invoice ${invoice.id} has the wrong customer`,
     );
   }
-  const stripeSubscription =
-    await getStripeClient().subscriptions.retrieve(subscriptionId);
-  await reconcileUsagePackAllocationChangeSubscription(db, stripeSubscription);
+  const subscriptionWithMetadata = await updateAllocationSubscriptionMetadata(
+    context,
+    subscriptionId,
+    invoice.id,
+  );
+  await reconcileUsagePackAllocationChangeSubscription(
+    db,
+    subscriptionWithMetadata,
+  );
   if (
     change.kind !== "upgrade" ||
     !change.sourceAllocationId ||

--- a/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-plan-change.service.ts
@@ -54,6 +54,7 @@ import {
   type BillingPurchasePaymentMethod,
 } from "./billing-payment-method.service";
 import { subscriptionScheduleHasNoFutureChanges } from "./stripe-subscription-schedules.service";
+import { updateUsagePackSubscriptionMetadata } from "./usage-pack-subscription-metadata.service";
 import {
   activeUsagePackPlanPriceId,
   activeUsagePackPriceId,
@@ -2704,10 +2705,10 @@ export async function handleUsagePackSubscriptionChangeInvoicePaid(
       `Subscription change invoice ${invoice.id} has the wrong customer`,
     );
   }
-  const subscription = await getStripeClient().subscriptions.retrieve(
-    subscriptionId,
-    { expand: ["latest_invoice"] },
-  );
+  const stripe = getStripeClient();
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId, {
+    expand: ["latest_invoice"],
+  });
   const expectedImmediateTier = planIsUpgrade(root.sourceTier, root.targetTier)
     ? root.targetTier
     : root.sourceTier;
@@ -2716,8 +2717,22 @@ export async function handleUsagePackSubscriptionChangeInvoicePaid(
       `Subscription change invoice ${invoice.id} was paid before the plan change was applied`,
     );
   }
-  const period = usagePackPeriod(subscription);
-  await reconcileUsagePackAllocationChangeSubscription(db, subscription);
+  const subscriptionWithMetadata = await updateUsagePackSubscriptionMetadata(
+    stripe,
+    {
+      subscription,
+      orgId: root.orgId,
+      tier: expectedImmediateTier,
+      planPriceId: subscriptionPlanItem(subscription).price.id,
+      usagePackSubscriptionId: stored.subscription.id,
+      idempotencyKey: `usage-pack-subscription-metadata:${invoice.id}`,
+    },
+  );
+  const period = usagePackPeriod(subscriptionWithMetadata);
+  await reconcileUsagePackAllocationChangeSubscription(
+    db,
+    subscriptionWithMetadata,
+  );
   await fulfillUsagePackSubscriptionChangeInvoice(db, {
     subscriptionChangeId: root.id,
     prorationTimestamp: root.prorationTimestamp,
@@ -2738,7 +2753,7 @@ export async function handleUsagePackSubscriptionChangeInvoicePaid(
     await scheduleDeferredSubscriptionChange(
       db,
       refreshed,
-      subscription,
+      subscriptionWithMetadata,
       undefined,
     );
   } else {
@@ -2748,7 +2763,11 @@ export async function handleUsagePackSubscriptionChangeInvoicePaid(
       .set({ status: "completed", completedAt, updatedAt: completedAt })
       .where(eq(usagePackSubscriptionChanges.id, root.id));
   }
-  return { handled: true, orgId: root.orgId, subscription };
+  return {
+    handled: true,
+    orgId: root.orgId,
+    subscription: subscriptionWithMetadata,
+  };
 }
 
 async function failExpiredPendingSubscriptionChange(

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription-metadata.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription-metadata.service.ts
@@ -1,0 +1,50 @@
+import type {
+  StripeClient,
+  StripeSubscription,
+} from "../external/stripe-client";
+import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
+
+export const USAGE_PACK_SUBSCRIPTION_PURPOSE = "usage_pack_subscription";
+export const USAGE_PACK_SUBSCRIPTION_ID_METADATA_KEY =
+  "usagePackSubscriptionId";
+
+type UsagePackTier = "pro" | "team";
+
+interface UsagePackSubscriptionMetadataArgs {
+  readonly orgId: string;
+  readonly tier: UsagePackTier;
+  readonly planPriceId: string;
+  readonly usagePackSubscriptionId: string;
+}
+
+export function usagePackSubscriptionMetadata(
+  args: UsagePackSubscriptionMetadataArgs,
+): Record<string, string> {
+  return {
+    orgId: args.orgId,
+    tier: args.tier,
+    priceId: args.planPriceId,
+    purpose: USAGE_PACK_SUBSCRIPTION_PURPOSE,
+    [USAGE_PACK_SUBSCRIPTION_ID_METADATA_KEY]: args.usagePackSubscriptionId,
+    ...stripePreviewMetadata(),
+  };
+}
+
+export async function updateUsagePackSubscriptionMetadata(
+  stripe: StripeClient,
+  args: UsagePackSubscriptionMetadataArgs & {
+    readonly subscription: StripeSubscription;
+    readonly idempotencyKey: string;
+  },
+): Promise<StripeSubscription> {
+  const metadata = {
+    ...args.subscription.metadata,
+    ...usagePackSubscriptionMetadata(args),
+  };
+  await stripe.subscriptions.update(
+    args.subscription.id,
+    { metadata },
+    { idempotencyKey: args.idempotencyKey },
+  );
+  return { ...args.subscription, metadata };
+}

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription-migration.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription-migration.service.ts
@@ -44,10 +44,10 @@ import {
   handleUsagePackSubscriptionUpdated,
   loadUsagePackCatalog,
   usagePackSubscriptionIdFromMetadata,
-  usagePackSubscriptionMetadata,
   type UsagePackInvoiceInput,
   type UsagePackSubscriptionInput,
 } from "./usage-pack-subscription.service";
+import { usagePackSubscriptionMetadata } from "./usage-pack-subscription-metadata.service";
 import { safeJsonParse, settle } from "../utils";
 import {
   activeUsagePackPlanPriceId,

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -42,7 +42,6 @@ import {
 import { getOrCreateStripeCustomer$ } from "./billing-customer.service";
 import { persistOrgAcquisitionAttribution$ } from "./acquisition-attribution.service";
 import { upsertOrgPlanEntitlement } from "./org-plan-entitlements.service";
-import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 import {
   handleUsagePackAllocationChangeInvoicePaid,
   reconcileUsagePackAllocationChanges,
@@ -74,9 +73,11 @@ import {
   resolveBillingPurchaseRoute,
   stripeBillingPurchasePaymentParams,
 } from "./billing-payment-method.service";
-
-export const USAGE_PACK_SUBSCRIPTION_PURPOSE = "usage_pack_subscription";
-const USAGE_PACK_SUBSCRIPTION_ID_METADATA_KEY = "usagePackSubscriptionId";
+import {
+  USAGE_PACK_SUBSCRIPTION_ID_METADATA_KEY,
+  USAGE_PACK_SUBSCRIPTION_PURPOSE,
+  usagePackSubscriptionMetadata,
+} from "./usage-pack-subscription-metadata.service";
 
 const CREDITS_PER_DOLLAR = 1000;
 const PAYABLE_USAGE_PACK_ALLOCATION_STATUSES = [
@@ -483,22 +484,6 @@ export async function activeUsagePackBillingContext(
         stripeSubscriptionId: subscription.stripeSubscriptionId,
       }
     : null;
-}
-
-export function usagePackSubscriptionMetadata(args: {
-  readonly orgId: string;
-  readonly tier: SubscriptionCheckoutTier;
-  readonly planPriceId: string;
-  readonly usagePackSubscriptionId: string;
-}): StripeMetadataParam {
-  return {
-    orgId: args.orgId,
-    tier: args.tier,
-    priceId: args.planPriceId,
-    purpose: USAGE_PACK_SUBSCRIPTION_PURPOSE,
-    [USAGE_PACK_SUBSCRIPTION_ID_METADATA_KEY]: args.usagePackSubscriptionId,
-    ...stripePreviewMetadata(),
-  };
 }
 
 function usagePackCheckoutMetadata(args: {


### PR DESCRIPTION
## Summary

- centralize canonical usage-pack subscription metadata
- sync the main Stripe subscription metadata after paid plan and usage-pack upgrades
- preserve existing attribution metadata and make the sync idempotent per invoice

## Why

Stripe pending subscription updates do not support metadata. Updating metadata when the change starts would also expose the target plan before payment succeeds. The paid-invoice reconciliation now refreshes metadata only after confirming that Stripe applied the requested subscription items.

Stripe reference: https://docs.stripe.com/billing/subscriptions/pending-updates

## Testing

- `pnpm exec prettier --check` on all changed files
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/billing-checkout.test.ts src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts --maxWorkers=1 --silent=passed-only` (163 passed)
- pre-commit hooks, including repository-wide TypeScript checks (14/14 passed)