### PR TITLE
perf(guest): isolate receipt journal fsyncs from tokio workers

### DIFF
--- a/crates/guest-agent/src/active_input/tests.rs
+++ b/crates/guest-agent/src/active_input/tests.rs
@@ -194,7 +194,7 @@ fn active_input_capacity_counts_pending_inputs() {
     ));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn active_input_can_release_capacity_for_sink_without_replay() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();

--- a/crates/guest-agent/src/active_input/tests.rs
+++ b/crates/guest-agent/src/active_input/tests.rs
@@ -194,7 +194,7 @@ fn active_input_capacity_counts_pending_inputs() {
     ));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn active_input_can_release_capacity_for_sink_without_replay() {
     let runtime = enabled_runtime();
     let controller = runtime.controller();

--- a/crates/guest-agent/src/active_input_receipts.rs
+++ b/crates/guest-agent/src/active_input_receipts.rs
@@ -316,7 +316,7 @@ mod tests {
 
     const RUN_ID: &str = "receipt-journal-scheduler-test";
     const DELIVERY_ID: &str = "60fca608-d174-4c1a-a1b2-57607b3adf46";
-    const WAIT_TIMEOUT: Duration = Duration::from_secs(2);
+    const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
     #[test]
     fn blocked_journal_persistence_does_not_stall_unrelated_async_work() {

--- a/crates/guest-agent/src/active_input_receipts.rs
+++ b/crates/guest-agent/src/active_input_receipts.rs
@@ -16,6 +16,23 @@ use crate::http::HttpClient;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
+fn run_journal_io<T>(operation: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle)
+            if matches!(
+                handle.runtime_flavor(),
+                tokio::runtime::RuntimeFlavor::MultiThread
+            ) =>
+        {
+            tokio::task::block_in_place(operation)
+        }
+        Ok(_) => Err(io::Error::other(
+            "active-input receipt persistence requires a multi-thread Tokio runtime",
+        )),
+        Err(_) => operation(),
+    }
+}
+
 #[derive(Debug)]
 struct ReceiptJournalState {
     outstanding: Vec<String>,
@@ -30,10 +47,9 @@ struct ReceiptJournal {
 
 impl ReceiptJournal {
     fn load(run_id: &str, path: PathBuf) -> io::Result<Self> {
-        let outstanding =
-            guest_contracts::active_input_receipts::read_active_input_receipt_journal(
-                &path, run_id,
-            )?;
+        let outstanding = run_journal_io(|| {
+            guest_contracts::active_input_receipts::read_active_input_receipt_journal(&path, run_id)
+        })?;
         Ok(Self {
             run_id: run_id.to_owned(),
             path,
@@ -50,39 +66,43 @@ impl ReceiptJournal {
     }
 
     fn persist_acceptance(&self, delivery_id: &str) -> io::Result<()> {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        if state.outstanding.iter().any(|id| id == delivery_id) {
-            return Ok(());
-        }
-        let mut next = state.outstanding.clone();
-        next.push(delivery_id.to_owned());
-        guest_contracts::active_input_receipts::write_active_input_receipt_journal(
-            &self.path,
-            &self.run_id,
-            &next,
-        )?;
-        state.outstanding = next;
-        Ok(())
+        run_journal_io(|| {
+            let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+            if state.outstanding.iter().any(|id| id == delivery_id) {
+                return Ok(());
+            }
+            let mut next = state.outstanding.clone();
+            next.push(delivery_id.to_owned());
+            guest_contracts::active_input_receipts::write_active_input_receipt_journal(
+                &self.path,
+                &self.run_id,
+                &next,
+            )?;
+            state.outstanding = next;
+            Ok(())
+        })
     }
 
     fn acknowledge(&self, delivery_id: &str) -> io::Result<()> {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        if !state.outstanding.iter().any(|id| id == delivery_id) {
-            return Ok(());
-        }
-        let next = state
-            .outstanding
-            .iter()
-            .filter(|id| id.as_str() != delivery_id)
-            .cloned()
-            .collect::<Vec<_>>();
-        guest_contracts::active_input_receipts::write_active_input_receipt_journal(
-            &self.path,
-            &self.run_id,
-            &next,
-        )?;
-        state.outstanding = next;
-        Ok(())
+        run_journal_io(|| {
+            let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+            if !state.outstanding.iter().any(|id| id == delivery_id) {
+                return Ok(());
+            }
+            let next = state
+                .outstanding
+                .iter()
+                .filter(|id| id.as_str() != delivery_id)
+                .cloned()
+                .collect::<Vec<_>>();
+            guest_contracts::active_input_receipts::write_active_input_receipt_journal(
+                &self.path,
+                &self.run_id,
+                &next,
+            )?;
+            state.outstanding = next;
+            Ok(())
+        })
     }
 }
 
@@ -286,4 +306,71 @@ async fn receipt_worker(
         }
     }
     finalize_outstanding(&run_id, &http, &journal, &mut rejected).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+
+    use super::*;
+
+    const RUN_ID: &str = "receipt-journal-scheduler-test";
+    const DELIVERY_ID: &str = "60fca608-d174-4c1a-a1b2-57607b3adf46";
+    const WAIT_TIMEOUT: Duration = Duration::from_secs(2);
+
+    #[test]
+    fn blocked_journal_persistence_does_not_stall_unrelated_async_work() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("active-input-receipts.json");
+        let journal = Arc::new(ReceiptJournal::load(RUN_ID, path.clone()).unwrap());
+
+        let held_journal = journal.clone();
+        let (lock_held_tx, lock_held_rx) = mpsc::channel();
+        let (release_lock_tx, release_lock_rx) = mpsc::channel();
+        let lock_holder = std::thread::spawn(move || {
+            let _guard = held_journal
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            lock_held_tx.send(()).unwrap();
+            release_lock_rx.recv().unwrap();
+        });
+        lock_held_rx.recv_timeout(WAIT_TIMEOUT).unwrap();
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        let operation_journal = journal.clone();
+        let (operation_started_tx, operation_started_rx) = mpsc::channel();
+        let operation = runtime.spawn(async move {
+            operation_started_tx.send(()).unwrap();
+            operation_journal.persist_acceptance(DELIVERY_ID)
+        });
+        operation_started_rx.recv_timeout(WAIT_TIMEOUT).unwrap();
+
+        let (probe_tx, probe_rx) = mpsc::channel();
+        let probe = runtime.spawn(async move {
+            probe_tx.send(()).unwrap();
+        });
+        let probe_progressed = probe_rx.recv_timeout(WAIT_TIMEOUT).is_ok();
+
+        release_lock_tx.send(()).unwrap();
+        runtime.block_on(async {
+            operation.await.unwrap().unwrap();
+            probe.await.unwrap();
+        });
+        lock_holder.join().unwrap();
+
+        assert!(
+            probe_progressed,
+            "unrelated async work should progress while journal persistence is blocked"
+        );
+        assert_eq!(
+            guest_contracts::active_input_receipts::read_active_input_receipt_journal(path, RUN_ID)
+                .unwrap(),
+            vec![DELIVERY_ID.to_owned()]
+        );
+    }
 }

--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -663,7 +663,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn writer_uses_official_steer_ack_for_active_input_receipts() {
         let mut child = tokio::process::Command::new("cat")
             .stdin(Stdio::piped())

--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -663,7 +663,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn writer_uses_official_steer_ack_for_active_input_receipts() {
         let mut child = tokio::process::Command::new("cat")
             .stdin(Stdio::piped())

--- a/crates/guest-agent/tests/active_input_receipts.rs
+++ b/crates/guest-agent/tests/active_input_receipts.rs
@@ -19,7 +19,7 @@ fn payload(text: &str) -> Result<Vec<u8>, serde_json::Error> {
     guest_contracts::active_input::encode_active_input(DELIVERY_ID, text)
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn explicit_null_delivery_id_is_rejected() -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
     let tmp = tempfile::tempdir()?;
@@ -45,7 +45,7 @@ async fn explicit_null_delivery_id_is_rejected() -> Result<(), Box<dyn std::erro
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn accepted_input_is_deduplicated_reported_and_compacted()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
@@ -131,7 +131,7 @@ async fn accepted_input_is_deduplicated_reported_and_compacted()
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn failed_input_creates_no_receipt_or_completion_evidence()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
@@ -185,7 +185,7 @@ async fn failed_input_creates_no_receipt_or_completion_evidence()
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn rejected_receipt_is_retained_without_a_finalization_retry()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
@@ -239,7 +239,7 @@ async fn rejected_receipt_is_retained_without_a_finalization_retry()
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn transport_failure_gets_only_one_finalization_retry()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
@@ -296,7 +296,7 @@ async fn transport_failure_gets_only_one_finalization_retry()
 }
 
 #[cfg(unix)]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn journal_publication_failure_is_terminal_after_backend_acceptance()
 -> Result<(), Box<dyn std::error::Error>> {
     use std::os::unix::fs::symlink;
@@ -346,7 +346,7 @@ async fn journal_publication_failure_is_terminal_after_backend_acceptance()
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn unacknowledged_journal_recovers_without_requeueing_the_backend()
 -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;

--- a/crates/guest-agent/tests/active_input_receipts.rs
+++ b/crates/guest-agent/tests/active_input_receipts.rs
@@ -19,7 +19,7 @@ fn payload(text: &str) -> Result<Vec<u8>, serde_json::Error> {
     guest_contracts::active_input::encode_active_input(DELIVERY_ID, text)
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn explicit_null_delivery_id_is_rejected() -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
     let tmp = tempfile::tempdir()?;
@@ -45,7 +45,7 @@ async fn explicit_null_delivery_id_is_rejected() -> Result<(), Box<dyn std::erro
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn accepted_input_is_deduplicated_reported_and_compacted()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
@@ -131,7 +131,7 @@ async fn accepted_input_is_deduplicated_reported_and_compacted()
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn failed_input_creates_no_receipt_or_completion_evidence()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
@@ -185,7 +185,7 @@ async fn failed_input_creates_no_receipt_or_completion_evidence()
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn rejected_receipt_is_retained_without_a_finalization_retry()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
@@ -239,7 +239,7 @@ async fn rejected_receipt_is_retained_without_a_finalization_retry()
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn transport_failure_gets_only_one_finalization_retry()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
@@ -296,7 +296,7 @@ async fn transport_failure_gets_only_one_finalization_retry()
 }
 
 #[cfg(unix)]
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn journal_publication_failure_is_terminal_after_backend_acceptance()
 -> Result<(), Box<dyn std::error::Error>> {
     use std::os::unix::fs::symlink;
@@ -346,7 +346,7 @@ async fn journal_publication_failure_is_terminal_after_backend_acceptance()
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn unacknowledged_journal_recovers_without_requeueing_the_backend()
 -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir()?;

--- a/crates/guest-agent/tests/active_input_receipts.rs
+++ b/crates/guest-agent/tests/active_input_receipts.rs
@@ -19,6 +19,29 @@ fn payload(text: &str) -> Result<Vec<u8>, serde_json::Error> {
     guest_contracts::active_input::encode_active_input(DELIVERY_ID, text)
 }
 
+#[tokio::test]
+async fn receipt_runtime_rejects_current_thread_runtime() -> Result<(), Box<dyn std::error::Error>>
+{
+    let tmp = tempfile::tempdir()?;
+    let result = ActiveInputRuntime::new_with_receipts(
+        RUN_ID,
+        "initial",
+        tmp.path().join("active-input-receipts.json"),
+        HttpClient::new()?,
+    );
+    let error = match result {
+        Ok(_) => return Err("receipt runtime should require a multi-thread Tokio runtime".into()),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.kind(), std::io::ErrorKind::Other);
+    assert_eq!(
+        error.to_string(),
+        "active-input receipt persistence requires a multi-thread Tokio runtime"
+    );
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn explicit_null_delivery_id_is_rejected() -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();

--- a/crates/guest-agent/tests/claude_active_input_receipt.rs
+++ b/crates/guest-agent/tests/claude_active_input_receipt.rs
@@ -15,7 +15,7 @@ use serde_json::{Value, json};
 
 const DELIVERY_ID: &str = "09065b04-cb85-4dd3-8cde-965e61ab8bfa";
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn claude_receipts_delivery_only_after_follow_up_reaches_stdin()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;

--- a/crates/guest-agent/tests/claude_active_input_receipt.rs
+++ b/crates/guest-agent/tests/claude_active_input_receipt.rs
@@ -15,7 +15,7 @@ use serde_json::{Value, json};
 
 const DELIVERY_ID: &str = "09065b04-cb85-4dd3-8cde-965e61ab8bfa";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn claude_receipts_delivery_only_after_follow_up_reaches_stdin()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 const RUN_ID: &str = "codex-app-server-backend-active-input-test";
 const DELIVERY_ID: &str = "6bd71939-58df-48f2-81d4-468da3c788a5";
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn codex_app_server_backend_steers_active_input_into_active_turn()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 const RUN_ID: &str = "codex-app-server-backend-active-input-test";
 const DELIVERY_ID: &str = "6bd71939-58df-48f2-81d4-468da3c788a5";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn codex_app_server_backend_steers_active_input_into_active_turn()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
@@ -9,7 +9,7 @@ use guest_agent::active_input::ActiveInputControlOutcome;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn codex_app_server_backend_rejects_active_input_after_turn_completion()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
@@ -9,7 +9,7 @@ use guest_agent::active_input::ActiveInputControlOutcome;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn codex_app_server_backend_rejects_active_input_after_turn_completion()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use std::time::Duration;
 use uuid::Uuid;
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn codex_app_server_backend_steers_accepted_input_before_buffered_completion()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use std::time::Duration;
 use uuid::Uuid;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn codex_app_server_backend_steers_accepted_input_before_buffered_completion()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_cancellation.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_cancellation.rs
@@ -21,7 +21,7 @@ const RUN_ID: &str = "codex-app-server-backend-active-input-cancellation-test";
 const DELIVERY_ID: &str = "2532261d-b0e1-471e-b93d-1acae383d001";
 const LATE_DELIVERY_ID: &str = "2532261d-b0e1-471e-b93d-1acae383d002";
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn cancellation_preserves_a_steer_response_already_in_flight()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_cancellation.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_cancellation.rs
@@ -21,7 +21,7 @@ const RUN_ID: &str = "codex-app-server-backend-active-input-cancellation-test";
 const DELIVERY_ID: &str = "2532261d-b0e1-471e-b93d-1acae383d001";
 const LATE_DELIVERY_ID: &str = "2532261d-b0e1-471e-b93d-1acae383d002";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn cancellation_preserves_a_steer_response_already_in_flight()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
@@ -9,7 +9,7 @@ use guest_agent::active_input::ActiveInputControlOutcome;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn codex_app_server_backend_fails_visible_when_child_exits_during_steer()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
@@ -9,7 +9,7 @@ use guest_agent::active_input::ActiveInputControlOutcome;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn codex_app_server_backend_fails_visible_when_child_exits_during_steer()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_execution_timeout.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_execution_timeout.rs
@@ -19,8 +19,8 @@ use tokio_util::sync::CancellationToken;
 const RUN_ID: &str = "codex-app-server-backend-active-input-execution-timeout-test";
 const DELIVERY_ID: &str = "2532261d-b0e1-471e-b93d-1acae383d003";
 
-#[tokio::test]
-async fn execution_timeout_terminates_a_stuck_active_input_steer()
+#[test]
+fn execution_timeout_terminates_a_stuck_active_input_steer()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
@@ -55,12 +55,42 @@ async fn execution_timeout_terminates_a_stuck_active_input_steer()
     let journal_path = guest_contracts::runtime_paths::active_input_receipt_journal_file(
         runtime.paths.runtime_dir(),
     );
-    let active_input = ActiveInputRuntime::new_with_receipts(
-        RUN_ID,
-        &runtime.config.prompt,
-        &journal_path,
-        HttpClient::with_api_config(server.base_url(), "test-token", "", RUN_ID, Duration::ZERO)?,
-    )?;
+    let receipt_runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()?;
+    let receipt_http =
+        HttpClient::with_api_config(server.base_url(), "test-token", "", RUN_ID, Duration::ZERO)?;
+    let active_input = receipt_runtime.block_on(async {
+        ActiveInputRuntime::new_with_receipts(
+            RUN_ID,
+            &runtime.config.prompt,
+            &journal_path,
+            receipt_http,
+        )
+    })?;
+    let test_runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    test_runtime.block_on(assert_execution_timeout(&tmp, &runtime, active_input))?;
+
+    receipt.assert_calls(0);
+    assert!(
+        guest_contracts::active_input_receipts::read_active_input_receipt_journal(
+            &journal_path,
+            RUN_ID,
+        )?
+        .is_empty()
+    );
+
+    Ok(())
+}
+
+async fn assert_execution_timeout(
+    tmp: &tempfile::TempDir,
+    runtime: &guest_agent::run_context::GuestRuntime,
+    active_input: ActiveInputRuntime,
+) -> Result<(), Box<dyn std::error::Error>> {
     let active_input_controller = active_input.controller();
     assert_eq!(
         active_input_controller.handle_control_payload(
@@ -89,7 +119,7 @@ async fn execution_timeout_terminates_a_stuck_active_input_steer()
     let execution_timeout = runtime
         .config
         .agent_execution_timeout
-        .expect("test config should set an execution timeout");
+        .ok_or_else(|| std::io::Error::other("test config should set an execution timeout"))?;
     let checkpoints = [
         common::VirtualTimeCheckpoint::new(
             ready_file,
@@ -111,35 +141,25 @@ async fn execution_timeout_terminates_a_stuck_active_input_steer()
         common::execute_with_virtual_time_checkpoints(execution, &checkpoints),
     )
     .await
-    .expect("execution deadline should terminate the stuck steer")??;
+    .map_err(|_| {
+        std::io::Error::other("execution deadline should terminate the stuck steer")
+    })???;
 
     assert_eq!(result.exit_code, AGENT_EXECUTION_TIMEOUT_EXIT_CODE);
-    let error = result
-        .control_error
-        .as_ref()
-        .expect("execution timeout should preserve a controlled error");
+    let error = result.control_error.as_ref().ok_or_else(|| {
+        std::io::Error::other("execution timeout should preserve a controlled error")
+    })?;
     assert!(
         error
             .to_string()
             .contains("Agent execution timed out after 1 seconds"),
         "unexpected timeout error: {error}"
     );
-    assert_eq!(
-        result
-            .cli_termination
-            .expect("execution timeout should attach termination diagnostics")
-            .reason,
-        CliTerminationReason::ExecutionTimeout
-    );
+    let termination = result.cli_termination.ok_or_else(|| {
+        std::io::Error::other("execution timeout should attach termination diagnostics")
+    })?;
+    assert_eq!(termination.reason, CliTerminationReason::ExecutionTimeout);
     assert!(result.active_input_delivery_ids.is_empty());
-    receipt.assert_calls(0);
-    assert!(
-        guest_contracts::active_input_receipts::read_active_input_receipt_journal(
-            &journal_path,
-            RUN_ID,
-        )?
-        .is_empty()
-    );
 
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 const RUN_ID: &str = "codex-app-server-backend-active-input-no-turn-test";
 const DELIVERY_ID: &str = "34919e72-7fb3-4b8f-b2ad-9a5e2e1ba0a6";
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn codex_app_server_backend_fails_visible_when_no_active_turn()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 const RUN_ID: &str = "codex-app-server-backend-active-input-no-turn-test";
 const DELIVERY_ID: &str = "34919e72-7fb3-4b8f-b2ad-9a5e2e1ba0a6";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn codex_app_server_backend_fails_visible_when_no_active_turn()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use std::time::Duration;
 use uuid::Uuid;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn codex_app_server_backend_closes_input_before_ingesting_queued_terminal()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use std::time::Duration;
 use uuid::Uuid;
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn codex_app_server_backend_closes_input_before_ingesting_queued_terminal()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
@@ -10,7 +10,7 @@ use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn codex_app_server_backend_fails_visible_on_stale_active_turn()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
@@ -10,7 +10,7 @@ use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn codex_app_server_backend_fails_visible_on_stale_active_turn()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
@@ -14,7 +14,7 @@ const SECONDARY_THREAD_ID: &str = "00000000-0000-4000-8000-000000000def";
 const SECONDARY_NOTIFICATION_LOG: &str =
     "Ignoring codex app-server notification for secondary thread";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn codex_app_server_backend_ignores_secondary_thread_notifications()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_secondary_thread.rs
@@ -14,7 +14,7 @@ const SECONDARY_THREAD_ID: &str = "00000000-0000-4000-8000-000000000def";
 const SECONDARY_NOTIFICATION_LOG: &str =
     "Ignoring codex app-server notification for secondary thread";
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn codex_app_server_backend_ignores_secondary_thread_notifications()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -53,7 +53,7 @@ unsafe fn setup_api_env(
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock_cli = common::build_and_locate_mock()?;

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -53,7 +53,7 @@ unsafe fn setup_api_env(
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock_cli = common::build_and_locate_mock()?;

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn no_api_mode_drains_background_webhook_users_without_network_client()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn no_api_mode_drains_background_webhook_users_without_network_client()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;


### PR DESCRIPTION
## Summary

- run active-input receipt journal loads and complete snapshot mutations inside Tokio blocking regions
- preserve the existing synchronous acceptance transaction, journal mutex ordering, and durable file format
- exercise receipt-enabled async tests on the production multi-thread runtime and add a deterministic scheduler-progress regression

## Scope

- no journal format, guest/runner protocol, API, migration, or rollout changes
- current-thread runtimes now receive a contextual I/O error instead of a `block_in_place` panic

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features`
- `cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent --all-features`
- repository pre-commit Rust formatting, Clippy, and documentation hooks

Closes #27963
