### PR TITLE
test(e2e): report runner api curl failure context

### DIFF
--- a/.github/scripts/tests/runner-api-curl-test.sh
+++ b/.github/scripts/tests/runner-api-curl-test.sh
@@ -40,29 +40,47 @@ assert_file_excludes() {
 }
 
 curl() {
-    local fail_enabled=false
+    local request_url="${!#}"
+    local fail_with_body_enabled=false
     local saw_fail_with_body=false
-    local argument
+    local saw_no_fail_with_body=false
+    local saw_vercel_write_out=false
+    local write_out=''
 
-    for argument in "$@"; do
-        case "$argument" in
+    while (($# > 0)); do
+        case "$1" in
             --fail-with-body)
-                fail_enabled=true
+                fail_with_body_enabled=true
                 saw_fail_with_body=true
                 ;;
             --no-fail)
-                fail_enabled=false
+                ;;
+            --no-fail-with-body)
+                fail_with_body_enabled=false
+                saw_no_fail_with_body=true
+                ;;
+            --write-out)
+                shift
+                write_out="$1"
+                if [[ "$write_out" == "$MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT" ]]; then
+                    saw_vercel_write_out=true
+                fi
                 ;;
         esac
+        shift
     done
 
     [[ "$saw_fail_with_body" == true ]] || {
         echo "curl did not receive --fail-with-body" >&2
         return 90
     }
-    [[ "${!#}" == "$MOCK_CURL_EXPECTED_URL" ]] || {
-        echo "curl received an unexpected request URL" >&2
+    [[ "$saw_vercel_write_out" == true ]] || {
+        echo "curl did not receive the Vercel log write-out" >&2
         return 91
+    }
+    [[ "$request_url" == "$MOCK_CURL_EXPECTED_URL" ]] || {
+        echo "curl received an unexpected request URL" >&2
+        return 92
     }
 
     case "$MOCK_CURL_MODE" in
@@ -70,20 +88,33 @@ curl() {
             printf '{"ok":true}\n'
             ;;
         failure)
+            [[ "$fail_with_body_enabled" == true ]] || {
+                echo "curl failure mode did not retain --fail-with-body" >&2
+                return 93
+            }
             printf '{"error":"rate limited"}\n'
             echo "curl: (22) The requested URL returned error: 429" >&2
+            echo "Vercel log query: requestHost:pr-27981-api.vm6.ai requestPath:/api/okou/chat/events status:429" >&2
             return 22
             ;;
-        no-fail)
-            [[ "$fail_enabled" == false ]] || {
-                echo "caller --no-fail did not override --fail-with-body" >&2
-                return 92
+        no-fail-with-body)
+            [[ "$saw_no_fail_with_body" == true ]] || {
+                echo "curl did not receive --no-fail-with-body" >&2
+                return 94
             }
-            printf '{"error":"handled"}\n409'
+            [[ "$fail_with_body_enabled" == false ]] || {
+                echo "caller --no-fail-with-body did not override --fail-with-body" >&2
+                return 95
+            }
+            [[ "$write_out" == $'\n%{http_code}' ]] || {
+                echo "curl did not retain the caller write-out" >&2
+                return 96
+            }
+            printf '{"error":{"message":"Cannot delete agent while its configuration is being migrated","code":"CONFLICT"}}\n409'
             ;;
         *)
             echo "unexpected mock curl mode: $MOCK_CURL_MODE" >&2
-            return 93
+            return 97
             ;;
     esac
 }
@@ -100,6 +131,7 @@ export E2E_API_URL="https://pr-27981-api.vm6.ai/"
 export E2E_API_TOKEN="sensitive-api-token"
 export VERCEL_AUTOMATION_BYPASS_SECRET="sensitive-bypass-secret"
 payload='{"secret":"sensitive-request-payload"}'
+MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel log query: requestHost:pr-27981-api.vm6.ai requestPath:/api/okou/chat/events status:%{http_code}\n'
 
 MOCK_CURL_MODE=success
 MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/okou/chat/events"
@@ -109,24 +141,29 @@ assert_file_equals $'{"ok":true}\n' "$stdout_file"
 assert_file_equals '' "$stderr_file"
 
 MOCK_CURL_MODE=failure
-run_request "/api/okou/chat/events" -X POST -d "$payload"
+MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/okou/chat/events?cursor=sensitive-query-value"
+run_request "/api/okou/chat/events?cursor=sensitive-query-value" -X POST -d "$payload"
 assert_status 22
 assert_file_equals $'{"error":"rate limited"}\n' "$stdout_file"
 assert_file_equals \
-    $'curl: (22) The requested URL returned error: 429\nrunner_api_curl failed: url=https://pr-27981-api.vm6.ai/api/okou/chat/events curl_status=22\n' \
+    $'curl: (22) The requested URL returned error: 429\nVercel log query: requestHost:pr-27981-api.vm6.ai requestPath:/api/okou/chat/events status:429\nrunner_api_curl failed: url=https://pr-27981-api.vm6.ai/api/okou/chat/events curl_status=22\n' \
     "$stderr_file"
 assert_file_excludes "$stderr_file" "$E2E_API_TOKEN"
 assert_file_excludes "$stderr_file" "$VERCEL_AUTOMATION_BYPASS_SECRET"
 assert_file_excludes "$stderr_file" "sensitive-request-payload"
+assert_file_excludes "$stderr_file" "sensitive-query-value"
 
-MOCK_CURL_MODE=no-fail
+MOCK_CURL_MODE=no-fail-with-body
 MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/okou/agents/agent-1"
-run_request \
-    "/api/okou/agents/agent-1" \
-    --no-fail \
-    --write-out $'\n%{http_code}'
+MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel log query: requestHost:pr-27981-api.vm6.ai requestPath:/api/okou/agents/agent-1 status:%{http_code}\n'
+if delete_runner_agent_for_stage0_teardown "agent-1" \
+    >"$stdout_file" 2>"$stderr_file"; then
+    request_status=0
+else
+    request_status=$?
+fi
 assert_status 0
-assert_file_equals $'{"error":"handled"}\n409' "$stdout_file"
+assert_file_equals '' "$stdout_file"
 assert_file_equals '' "$stderr_file"
 
 echo "runner_api_curl tests passed"

--- a/.github/scripts/tests/runner-api-curl-test.sh
+++ b/.github/scripts/tests/runner-api-curl-test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+runner_chat_helper="${repo_root}/e2e/helpers/runner-chat.bash"
+# shellcheck source=e2e/helpers/runner-chat.bash
+source "$runner_chat_helper"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+stdout_file="${tmp_dir}/stdout"
+stderr_file="${tmp_dir}/stderr"
+expected_file="${tmp_dir}/expected"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+assert_status() {
+    local expected_status="$1"
+    if [[ "$request_status" -ne "$expected_status" ]]; then
+        fail "expected status ${expected_status}, got ${request_status}"
+    fi
+}
+
+assert_file_equals() {
+    local expected="$1"
+    local actual_file="$2"
+    printf '%s' "$expected" >"$expected_file"
+    diff -u "$expected_file" "$actual_file" || fail "unexpected output in ${actual_file}"
+}
+
+assert_file_excludes() {
+    local actual_file="$1"
+    local sensitive_value="$2"
+    if grep -Fq "$sensitive_value" "$actual_file"; then
+        fail "sensitive value appeared in ${actual_file}"
+    fi
+}
+
+curl() {
+    local fail_enabled=false
+    local saw_fail_with_body=false
+    local argument
+
+    for argument in "$@"; do
+        case "$argument" in
+            --fail-with-body)
+                fail_enabled=true
+                saw_fail_with_body=true
+                ;;
+            --no-fail)
+                fail_enabled=false
+                ;;
+        esac
+    done
+
+    [[ "$saw_fail_with_body" == true ]] || {
+        echo "curl did not receive --fail-with-body" >&2
+        return 90
+    }
+    [[ "${!#}" == "$MOCK_CURL_EXPECTED_URL" ]] || {
+        echo "curl received an unexpected request URL" >&2
+        return 91
+    }
+
+    case "$MOCK_CURL_MODE" in
+        success)
+            printf '{"ok":true}\n'
+            ;;
+        failure)
+            printf '{"error":"rate limited"}\n'
+            echo "curl: (22) The requested URL returned error: 429" >&2
+            return 22
+            ;;
+        no-fail)
+            [[ "$fail_enabled" == false ]] || {
+                echo "caller --no-fail did not override --fail-with-body" >&2
+                return 92
+            }
+            printf '{"error":"handled"}\n409'
+            ;;
+        *)
+            echo "unexpected mock curl mode: $MOCK_CURL_MODE" >&2
+            return 93
+            ;;
+    esac
+}
+
+run_request() {
+    if runner_api_curl "$@" >"$stdout_file" 2>"$stderr_file"; then
+        request_status=0
+    else
+        request_status=$?
+    fi
+}
+
+export E2E_API_URL="https://pr-27981-api.vm6.ai/"
+export E2E_API_TOKEN="sensitive-api-token"
+export VERCEL_AUTOMATION_BYPASS_SECRET="sensitive-bypass-secret"
+payload='{"secret":"sensitive-request-payload"}'
+
+MOCK_CURL_MODE=success
+MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/okou/chat/events"
+run_request "/api/okou/chat/events" -X POST -d "$payload"
+assert_status 0
+assert_file_equals $'{"ok":true}\n' "$stdout_file"
+assert_file_equals '' "$stderr_file"
+
+MOCK_CURL_MODE=failure
+run_request "/api/okou/chat/events" -X POST -d "$payload"
+assert_status 22
+assert_file_equals $'{"error":"rate limited"}\n' "$stdout_file"
+assert_file_equals \
+    $'curl: (22) The requested URL returned error: 429\nrunner_api_curl failed: url=https://pr-27981-api.vm6.ai/api/okou/chat/events curl_status=22\n' \
+    "$stderr_file"
+assert_file_excludes "$stderr_file" "$E2E_API_TOKEN"
+assert_file_excludes "$stderr_file" "$VERCEL_AUTOMATION_BYPASS_SECRET"
+assert_file_excludes "$stderr_file" "sensitive-request-payload"
+
+MOCK_CURL_MODE=no-fail
+MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/okou/agents/agent-1"
+run_request \
+    "/api/okou/agents/agent-1" \
+    --no-fail \
+    --write-out $'\n%{http_code}'
+assert_status 0
+assert_file_equals $'{"error":"handled"}\n409' "$stdout_file"
+assert_file_equals '' "$stderr_file"
+
+echo "runner_api_curl tests passed"

--- a/.github/scripts/tests/runner-api-curl-test.sh
+++ b/.github/scripts/tests/runner-api-curl-test.sh
@@ -94,7 +94,7 @@ curl() {
             }
             printf '{"error":"rate limited"}\n'
             echo "curl: (22) The requested URL returned error: 429" >&2
-            echo "Vercel log query: requestHost:pr-27981-api.vm6.ai requestPath:/api/okou/chat/events status:429" >&2
+            echo "Vercel logs: $MOCK_CURL_EXPECTED_VERCEL_URL" >&2
             return 22
             ;;
         no-fail-with-body)
@@ -131,7 +131,8 @@ export E2E_API_URL="https://pr-27981-api.vm6.ai/"
 export E2E_API_TOKEN="sensitive-api-token"
 export VERCEL_AUTOMATION_BYPASS_SECRET="sensitive-bypass-secret"
 payload='{"secret":"sensitive-request-payload"}'
-MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel log query: requestHost:pr-27981-api.vm6.ai requestPath:/api/okou/chat/events status:%{http_code}\n'
+MOCK_CURL_EXPECTED_VERCEL_URL='https://vercel.com/vm0/vm0-api/logs?search=requestHost%3Apr-27981-api.vm6.ai+requestPath%3A%2Fapi%2Fokou%2Fchat%2Fevents+status%3A429&timeline=past12Hours'
+MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel logs: https://vercel.com/vm0/vm0-api/logs?search=requestHost%%3Apr-27981-api.vm6.ai+requestPath%%3A%%2Fapi%%2Fokou%%2Fchat%%2Fevents+status%%3A%{http_code}&timeline=past12Hours\n'
 
 MOCK_CURL_MODE=success
 MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/okou/chat/events"
@@ -146,7 +147,7 @@ run_request "/api/okou/chat/events?cursor=sensitive-query-value" -X POST -d "$pa
 assert_status 22
 assert_file_equals $'{"error":"rate limited"}\n' "$stdout_file"
 assert_file_equals \
-    $'curl: (22) The requested URL returned error: 429\nVercel log query: requestHost:pr-27981-api.vm6.ai requestPath:/api/okou/chat/events status:429\nrunner_api_curl failed: url=https://pr-27981-api.vm6.ai/api/okou/chat/events curl_status=22\n' \
+    $'curl: (22) The requested URL returned error: 429\nVercel logs: '"$MOCK_CURL_EXPECTED_VERCEL_URL"$'\nrunner_api_curl failed: url=https://pr-27981-api.vm6.ai/api/okou/chat/events curl_status=22\n' \
     "$stderr_file"
 assert_file_excludes "$stderr_file" "$E2E_API_TOKEN"
 assert_file_excludes "$stderr_file" "$VERCEL_AUTOMATION_BYPASS_SECRET"
@@ -155,7 +156,7 @@ assert_file_excludes "$stderr_file" "sensitive-query-value"
 
 MOCK_CURL_MODE=no-fail-with-body
 MOCK_CURL_EXPECTED_URL="https://pr-27981-api.vm6.ai/api/okou/agents/agent-1"
-MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel log query: requestHost:pr-27981-api.vm6.ai requestPath:/api/okou/agents/agent-1 status:%{http_code}\n'
+MOCK_CURL_EXPECTED_VERCEL_WRITE_OUT='%{onerror}%{stderr}Vercel logs: https://vercel.com/vm0/vm0-api/logs?search=requestHost%%3Apr-27981-api.vm6.ai+requestPath%%3A%%2Fapi%%2Fokou%%2Fagents%%2Fagent-1+status%%3A%{http_code}&timeline=past12Hours\n'
 if delete_runner_agent_for_stage0_teardown "agent-1" \
     >"$stdout_file" 2>"$stderr_file"; then
     request_status=0

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -24,10 +24,18 @@ runner_api_curl() {
     local path="$1"
     shift
 
-    local token base request_url
+    local token base request_url diagnostic_url request_host request_path
+    local request_host_write_out request_path_write_out vercel_log_write_out
     token="$(runner_api_token)" || return 1
     base="$(runner_api_url)" || return 1
     request_url="$base$path"
+    diagnostic_url="${request_url%%\?*}"
+    request_host="${base#*://}"
+    request_host="${request_host%%/*}"
+    request_path="${path%%\?*}"
+    request_host_write_out="${request_host//%/%%}"
+    request_path_write_out="${request_path//%/%%}"
+    vercel_log_write_out="%{onerror}%{stderr}Vercel log query: requestHost:${request_host_write_out} requestPath:${request_path_write_out} status:%{http_code}\n"
 
     local -a headers=(
         -H "Authorization: Bearer $token"
@@ -41,6 +49,7 @@ runner_api_curl() {
 
     local curl_status=0
     curl --fail-with-body --silent --show-error \
+        --write-out "$vercel_log_write_out" \
         --connect-timeout "${E2E_CURL_CONNECT_TIMEOUT_SECONDS:-10}" \
         --max-time "${E2E_CURL_MAX_TIME_SECONDS:-30}" \
         "${headers[@]}" \
@@ -49,7 +58,7 @@ runner_api_curl() {
 
     if ((curl_status != 0)); then
         printf 'runner_api_curl failed: url=%s curl_status=%d\n' \
-            "$request_url" "$curl_status" >&2
+            "$diagnostic_url" "$curl_status" >&2
     fi
     return "$curl_status"
 }
@@ -147,7 +156,7 @@ delete_runner_agent_for_stage0_teardown() {
     response="$(runner_api_curl \
         "/api/okou/agents/$agent_id" \
         -X DELETE \
-        --no-fail \
+        --no-fail-with-body \
         --write-out $'\n%{http_code}')" || return
     http_status="${response##*$'\n'}"
     response_body="${response%$'\n'*}"

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -24,9 +24,10 @@ runner_api_curl() {
     local path="$1"
     shift
 
-    local token base
+    local token base request_url
     token="$(runner_api_token)" || return 1
     base="$(runner_api_url)" || return 1
+    request_url="$base$path"
 
     local -a headers=(
         -H "Authorization: Bearer $token"
@@ -38,12 +39,19 @@ runner_api_curl() {
         )
     fi
 
-    curl -fsS \
+    local curl_status=0
+    curl --fail-with-body --silent --show-error \
         --connect-timeout "${E2E_CURL_CONNECT_TIMEOUT_SECONDS:-10}" \
         --max-time "${E2E_CURL_MAX_TIME_SECONDS:-30}" \
         "${headers[@]}" \
         "$@" \
-        "$base$path"
+        "$request_url" || curl_status=$?
+
+    if ((curl_status != 0)); then
+        printf 'runner_api_curl failed: url=%s curl_status=%d\n' \
+            "$request_url" "$curl_status" >&2
+    fi
+    return "$curl_status"
 }
 
 runner_chat_event_rows() {

--- a/e2e/helpers/runner-chat.bash
+++ b/e2e/helpers/runner-chat.bash
@@ -25,7 +25,8 @@ runner_api_curl() {
     shift
 
     local token base request_url diagnostic_url request_host request_path
-    local request_host_write_out request_path_write_out vercel_log_write_out
+    local request_host_search request_path_search vercel_logs_url_prefix
+    local vercel_logs_url_prefix_write_out vercel_log_write_out
     token="$(runner_api_token)" || return 1
     base="$(runner_api_url)" || return 1
     request_url="$base$path"
@@ -33,9 +34,14 @@ runner_api_curl() {
     request_host="${base#*://}"
     request_host="${request_host%%/*}"
     request_path="${path%%\?*}"
-    request_host_write_out="${request_host//%/%%}"
-    request_path_write_out="${request_path//%/%%}"
-    vercel_log_write_out="%{onerror}%{stderr}Vercel log query: requestHost:${request_host_write_out} requestPath:${request_path_write_out} status:%{http_code}\n"
+    request_host_search="${request_host//%/%25}"
+    request_host_search="${request_host_search//:/%3A}"
+    request_path_search="${request_path//%/%25}"
+    request_path_search="${request_path_search//\//%2F}"
+    request_path_search="${request_path_search//:/%3A}"
+    vercel_logs_url_prefix="https://vercel.com/vm0/vm0-api/logs?search=requestHost%3A${request_host_search}+requestPath%3A${request_path_search}+status%3A"
+    vercel_logs_url_prefix_write_out="${vercel_logs_url_prefix//%/%%}"
+    vercel_log_write_out="%{onerror}%{stderr}Vercel logs: ${vercel_logs_url_prefix_write_out}%{http_code}&timeline=past12Hours\n"
 
     local -a headers=(
         -H "Authorization: Bearer $token"


### PR DESCRIPTION
## Summary

- retain HTTP error response bodies from Runner E2E first-party API requests
- report a sanitized request URL and original curl status without logging headers, payloads, or query values
- emit a clickable Vercel Logs URL filtered by request host, request path, HTTP status, and the past 12 hours
- preserve Stage 0 teardown handling for expected 404/409 responses with `--no-fail-with-body`
- add deterministic shell integration coverage for output compatibility, URL encoding, query redaction, status propagation, and curl option semantics

## Scope

This PR only changes Runner E2E request diagnostics and the existing Stage 0 teardown compatibility call. It does not change Clerk rate-limit handling, PAT authentication, deployed API behavior, or the separate signed upload request path.

## Validation

- `bash .github/scripts/tests/runner-api-curl-test.sh`
- `bash -n e2e/helpers/runner-chat.bash .github/scripts/tests/runner-api-curl-test.sh`
- `shellcheck e2e/helpers/runner-chat.bash .github/scripts/tests/runner-api-curl-test.sh`
- `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `bash -n .github/actions/report-memory-peak/*.sh .github/scripts/*.sh .github/scripts/tests/*.sh`
- `lefthook run pre-commit`
- real curl probes against local HTTP 500 and expected Stage 0 HTTP 409 responses

Closes #27981
