### PR TITLE
refactor(api): neutralize run fixture and cancel route naming

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -363,7 +363,7 @@ export default [
       "src/**/__tests__/**/*.ts",
       "src/**/*.test.ts",
       "src/test-fixtures/thread-bound-run-admission.ts",
-      "src/signals/routes/test-zero-run-fixture.ts",
+      "src/signals/routes/test-run-fixture.ts",
     ],
     rules: {
       "no-restricted-imports": [

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -121,7 +121,7 @@ import { imageRecognitionRoutes } from "./routes/image-recognition";
 import { translationRoutes } from "./routes/translation";
 import { runDetailRoutes } from "./routes/run-detail";
 import { zeroRunsRoutes } from "./routes/zero-runs";
-import { zeroRunsCancelRoutes } from "./routes/zero-runs-cancel";
+import { runsCancelRoutes } from "./routes/runs-cancel";
 import { meModelProvidersDeleteRoutes } from "./routes/me-model-providers-delete";
 import { meModelProviderAccountRoutes } from "./routes/me-model-provider-accounts";
 import { meModelProvidersListRoutes } from "./routes/me-model-providers-list";
@@ -321,7 +321,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...translationRoutes,
   ...runDetailRoutes,
   ...zeroRunsRoutes,
-  ...zeroRunsCancelRoutes,
+  ...runsCancelRoutes,
   ...onboardingCompleteRoutes,
   ...onboardingStatusRoutes,
   ...orgInviteRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -72,12 +72,9 @@ import { billingStatusRoutes } from "../../billing-status";
 import { modelPoliciesRoutes } from "../../model-policies";
 import { zeroModelProvidersRoutes } from "../../zero-model-providers";
 import { runDetailRoutes } from "../../run-detail";
-import { zeroRunsCancelRoutes } from "../../zero-runs-cancel";
+import { runsCancelRoutes } from "../../runs-cancel";
 import { zeroRunsRoutes } from "../../zero-runs";
-import {
-  zeroRunFixtureContract,
-  zeroRunFixtureRoutes,
-} from "../../test-zero-run-fixture";
+import { runFixtureContract, runFixtureRoutes } from "../../test-run-fixture";
 import { testBillingReconciliationStateRoutes } from "../../test-billing-reconciliation-state";
 import { userPermissionGrantsRoutes } from "../../user-permission-grants";
 import { createBddApi, type ApiTestUser } from "./api-bdd";
@@ -158,9 +155,9 @@ const runRoutes = [
   ...modelPoliciesRoutes,
   ...zeroModelProvidersRoutes,
   ...runDetailRoutes,
-  ...zeroRunFixtureRoutes,
+  ...runFixtureRoutes,
   ...zeroRunsRoutes,
-  ...zeroRunsCancelRoutes,
+  ...runsCancelRoutes,
   ...agentsRoutes,
   ...userPermissionGrantsRoutes,
 ] as const;
@@ -471,7 +468,7 @@ export function createRunsApi(context: TestContext) {
 
     async createRun(actor: ApiTestUser, body: ZeroRunRequest) {
       const response = await accept(
-        runApp(context)(zeroRunFixtureContract).create({
+        runApp(context)(runFixtureContract).create({
           headers: authenticate(context, actor),
           body,
         }),
@@ -958,7 +955,7 @@ export function createRunsApi(context: TestContext) {
       extraHeaders?: Readonly<Record<string, string>>,
     ) {
       return await accept(
-        runApp(context)(zeroRunFixtureContract).create({
+        runApp(context)(runFixtureContract).create({
           headers: {
             ...authenticate(context, actor),
             ...extraHeaders,
@@ -975,7 +972,7 @@ export function createRunsApi(context: TestContext) {
       statuses: readonly (201 | 400 | 401 | 402 | 403 | 404 | 429 | 503)[],
     ) {
       return await accept(
-        runApp(context)(zeroRunFixtureContract).create({
+        runApp(context)(runFixtureContract).create({
           headers: authenticate(context, actor),
           body: body as ZeroRunRequest,
         }),

--- a/turbo/apps/api/src/signals/routes/runs-cancel.ts
+++ b/turbo/apps/api/src/signals/routes/runs-cancel.ts
@@ -73,7 +73,7 @@ const cancelInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-export const zeroRunsCancelRoutes: readonly RouteEntry[] = [
+export const runsCancelRoutes: readonly RouteEntry[] = [
   {
     route: zeroRunsCancelContract.cancel,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/test-run-fixture.ts
+++ b/turbo/apps/api/src/signals/routes/test-run-fixture.ts
@@ -17,7 +17,7 @@ import { createTestFixtureZeroRun$ } from "../services/zero-runs-create.service"
 
 const c = initContract();
 
-export const zeroRunFixtureContract = c.router({
+export const runFixtureContract = c.router({
   create: {
     method: "POST",
     path: "/api/test/zero-run-fixture",
@@ -36,7 +36,7 @@ export const zeroRunFixtureContract = c.router({
   },
 });
 
-const zeroRunFixtureBody$ = bodyResultOf(zeroRunFixtureContract.create);
+const zeroRunFixtureBody$ = bodyResultOf(runFixtureContract.create);
 
 const createZeroRunFixture$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -77,9 +77,9 @@ const createZeroRunFixture$ = command(
  * Test-only Zero run creation adapter. This route is intentionally omitted
  * from every production and E2E route registry.
  */
-export const zeroRunFixtureRoutes: readonly RouteEntry[] = [
+export const runFixtureRoutes: readonly RouteEntry[] = [
   {
-    route: zeroRunFixtureContract.create,
+    route: runFixtureContract.create,
     handler: authRoute(
       {
         accept: ["session", "pat"],


### PR DESCRIPTION
## Summary

Phase 2 naming cleanup (#27432; naming model #26873). Migrates the two small run-related route modules in `apps/api/src/signals/routes/` to neutral names. Pure rename + import updates — no behavior change.

## Mapping

| Old | New |
|---|---|
| `routes/test-zero-run-fixture.ts` | `routes/test-run-fixture.ts` |
| `zeroRunFixtureContract` | `runFixtureContract` |
| `zeroRunFixtureRoutes` | `runFixtureRoutes` |
| `routes/zero-runs-cancel.ts` | `routes/runs-cancel.ts` |
| `zeroRunsCancelRoutes` | `runsCancelRoutes` |

## Callers updated

- `signals/route.ts` — import + `ROUTES` entry for `runsCancelRoutes`; registered route order unchanged.
- `signals/routes/__tests__/helpers/api-bdd-runs.ts` — imports plus `runRoutes` entries and the three `runApp(context)(runFixtureContract)` call sites.
- `apps/api/eslint.config.mjs` — the `no-restricted-imports` `ignores` entry referenced the old filename; updated to the new path so the existing exemption keeps applying. Only the path string changed; the rule and its `zero-runs-create.service` target are untouched.

## Notes

- The cancel route's contract import stays `zeroRunsCancelContract` from `@okouai/api-contracts/contracts/zero-runs`. `main` is at `8af4053`, so #27943/#27949 have not landed and that module has not been renamed yet — nothing inside `packages/api-contracts` is touched here.
- Module-local identifiers (`zeroRunFixtureBody$`, `createZeroRunFixture$`) are left as-is; they are not in the issue's mapping table, and the service export they wrap (`createTestFixtureZeroRun$`) is an explicit non-goal.
- No `path:` literal, method, request/response shape, capability string, cancellation semantics, or fixture behavior changed. The route path `/api/test/zero-run-fixture` is unchanged.
- No compatibility alias or old-path re-export was left behind.

## Verification

- `grep` repository-wide: no `zeroRunFixtureContract`, `zeroRunFixtureRoutes`, `zeroRunsCancelRoutes`, `test-zero-run-fixture` or `zero-runs-cancel` reference remains.
- `pnpm -F api check-types` — clean.
- `pnpm -F api lint` — exit 0, no errors (only pre-existing test warnings).
- `pnpm knip --workspace apps/api` — the 2 reported unused exports are identical on `main` and unrelated to this change.
- `git diff --stat` shows no change under `packages/api-contracts`.

Closes #27991