### PR TITLE
feat(core): enable image model selection for the staff org

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -108,7 +108,7 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.VideoModelSelection]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ImageModelSelection]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ImageModelSelection]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       true,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -299,6 +299,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Let the chat composer model picker choose the default built-in image model for a chat thread.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PiLoop]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

Rolls out the `imageModelSelection` feature switch to the internal staff org (the team) by adding `enabledOrgIdHashes: STAFF_ORG_ID_HASHES`, matching the existing `videoModelSelection` rollout.

## Changes

- `turbo/packages/core/src/feature-switch.ts`: gate `ImageModelSelection` to the staff org.
- `turbo/packages/core/src/__tests__/feature-switch.test.ts`: update the staff-org rollout matrix assertion from `false` to `true`.

## Verification

- Ran `prettier --check` on both changed files: passing.
- Left the non-staff-org assertion unchanged, so other organizations remain excluded.