### PR TITLE
docs(python): clarify anthropic json metadata-only results

### DIFF
--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -231,10 +231,12 @@ class AnthropicMessagesJsonUsageExtractor:
     """Incrementally extract usage from non-SSE Anthropic Messages JSON chunks.
 
     Callers feed decoded response chunks with ``feed()`` and call ``finish()``
-    once. ``finish()`` returns ``(usage, None)`` when selected usage quantities
-    or model metadata were parsed, ``(None, error)`` when parsing fails or an
-    extractor bound is exceeded, and ``(None, None)`` when the complete JSON
-    contains no reportable usage or model metadata.
+    once. ``finish()`` returns ``(usage, None)`` when the complete JSON contains
+    at least one valid usage quantity (including zero) or a non-empty ``model``.
+    A non-empty ``message_id`` is included only with an otherwise reportable
+    result; an ID alone is not reportable. It returns ``(None, error)`` when
+    parsing fails or an extractor bound is exceeded, and ``(None, None)`` when
+    the complete JSON contains no reportable usage or model metadata.
     """
 
     def __init__(self) -> None:
@@ -290,8 +292,10 @@ def extract_anthropic_messages_usage_with_error_from_json(
     """Extract usage from a non-streaming Anthropic API JSON response.
 
     This is the diagnostic API: it returns ``(None, error)`` when decoding or
-    parsing fails, and ``(None, None)`` when the decoded body is empty or no
-    selected usage or metadata fields are found.
+    parsing fails, and ``(None, None)`` when the decoded body is empty or the
+    complete JSON contains no valid usage quantity or non-empty ``model``.
+    A non-empty response ``id`` is returned as ``message_id`` only with an
+    otherwise reportable result; an ID alone is not reportable.
     """
     if headers:
         body, decompress_error = body_decoding.decompress_json_usage_body(


### PR DESCRIPTION
## Summary

- Clarify when the Anthropic Messages JSON extractor returns a reportable usage result.
- Document that `message_id` is supplemental and an ID-only response is not reportable.

## Scope

This is a documentation-only change in `crates/runner/mitm-addon/src/usage/anthropic_messages.py`. It keeps the parser implementation, shared dispatch, response streaming, usage reporting, and existing behavioral tests unchanged.

Closes #28006

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check src/usage/anthropic_messages.py`
- `uv run --no-sync ruff check src/usage/anthropic_messages.py`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_anthropic_messages.py` — 57 passed
- `uv run --no-sync python -m pytest tests/` — 6332 passed, 59 existing deprecation warnings
