### PR TITLE
fix(platform): use chat icon for mark unread

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -16,7 +16,7 @@ import {
   Trash,
   Pencil,
   Ellipsis,
-  Mail,
+  MessageSquareDot,
   Pin,
   PinOff,
 } from "lucide-react";
@@ -195,7 +195,7 @@ function ChatThreadMarkUnreadMenuItem({
         detach(markUnread(pageSignal), Reason.DomCallback);
       }}
     >
-      <Mail size={16} className="mr-2" />
+      <MessageSquareDot size={16} className="mr-2" />
       {t(($) => {
         return $.chat.sidebar.markUnread;
       })}


### PR DESCRIPTION
## Summary

- replace the email-shaped Mail icon in the Mark unread thread action
- use MessageSquareDot to match the chat context and existing unread-dot language

## Testing

- npx --yes prettier@3.8.1 --check turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
- git diff --check

No tests were added because this is an icon-only visual change with no behavior or copy changes.