### PR TITLE
perf(runner): defer workspace cache gc to routine maintenance

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -29,6 +29,8 @@
 //!   main reactor or overlap a newer snapshot;
 //! - workspace-cache watcher work is pinned across reactor turns so async
 //!   metadata classification cannot lose already-drained kernel events;
+//! - routine workspace-cache GC is pinned and single-flight so its I/O does
+//!   not stall the main reactor or queue behind another capacity-lock owner;
 //! - the first routine heartbeat tick is deferred;
 //! - teardown drains heartbeat work and drops discovery before provider
 //!   shutdown.
@@ -118,6 +120,8 @@ use signals::{
 };
 
 const READY_DIRECT_CANDIDATE_DRAIN_LIMIT: usize = 8;
+/// Bounds routine cache-budget and stale-state cleanup without returning full scans to promotions.
+const WORKSPACE_CACHE_GC_PERIOD: Duration = Duration::from_secs(60);
 
 fn candidate_for_admission(
     candidate: JobCandidate,
@@ -178,6 +182,21 @@ async fn next_workspace_cache_change(
     WorkspaceCacheWatcher,
     RunnerResult<crate::workspace_image_cache::WorkspaceCacheChange>,
 ) {
+    match future {
+        Some(future) => future.await,
+        None => std::future::pending().await,
+    }
+}
+
+type WorkspaceCacheGcFuture = BoxFuture<'static, RunnerResult<Option<u64>>>;
+
+fn workspace_cache_gc_future(cache: WorkspaceImageCache) -> WorkspaceCacheGcFuture {
+    Box::pin(async move { cache.try_gc().await })
+}
+
+async fn next_workspace_cache_gc(
+    future: &mut Option<WorkspaceCacheGcFuture>,
+) -> RunnerResult<Option<u64>> {
     match future {
         Some(future) => future.await,
         None => std::future::pending().await,
@@ -1696,6 +1715,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         #[cfg(test)]
         test_observer: test_hooks.test_observer.clone(),
     };
+    let mut workspace_cache_gc_tick = tokio::time::interval_at(
+        tokio::time::Instant::now() + WORKSPACE_CACHE_GC_PERIOD,
+        WORKSPACE_CACHE_GC_PERIOD,
+    );
+    workspace_cache_gc_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut workspace_cache_gc_fut = None;
     let mut draining_idle_pool_drained = false;
     let mut pending_finalizing_candidate = None;
     let mut terminal_error = None;
@@ -1885,6 +1910,28 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     }
                 }
             }
+            result = next_workspace_cache_gc(&mut workspace_cache_gc_fut) => {
+                workspace_cache_gc_fut = None;
+                workspace_cache_gc_tick.reset();
+                match result {
+                    Ok(Some(freed_bytes)) if freed_bytes > 0 => info!(
+                        freed_bytes,
+                        "periodic workspace image cache GC completed"
+                    ),
+                    Ok(Some(_) | None) => {}
+                    Err(error) => warn!(
+                        error = %error,
+                        "periodic workspace image cache GC failed"
+                    ),
+                }
+            }
+            _ = workspace_cache_gc_tick.tick() => {
+                if workspace_cache_gc_fut.is_none()
+                    && let Some(cache) = exec_config.workspace_cache.clone()
+                {
+                    workspace_cache_gc_fut = Some(workspace_cache_gc_future(cache));
+                }
+            }
             // Mode changes (signals)
             _ = mode_rx.changed() => {}
             // Signal handler task should run until teardown aborts it. If it
@@ -2060,6 +2107,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // -----------------------------------------------------------------------
     // Shutdown — drain idle pool, release discovery resources, then drain running jobs
     // -----------------------------------------------------------------------
+    drop(workspace_cache_gc_fut);
     let teardown = TeardownTimer::start();
     memory_prefetch.cancel();
     teardown.event("memory_prefetch_cancelled");

--- a/crates/runner/src/workspace_image_cache/gc.rs
+++ b/crates/runner/src/workspace_image_cache/gc.rs
@@ -85,6 +85,15 @@ impl WorkspaceImageCache {
         self.gc_locked(dry_run).await
     }
 
+    pub(crate) async fn try_gc(&self) -> RunnerResult<Option<u64>> {
+        let _capacity_lock =
+            match crate::lock::try_acquire_or_busy(self.capacity_lock_path()).await? {
+                crate::lock::TryLock::Acquired(lock) => lock,
+                crate::lock::TryLock::Busy => return Ok(None),
+            };
+        self.gc_locked(false).await.map(Some)
+    }
+
     pub(super) async fn gc_locked(&self, dry_run: bool) -> RunnerResult<u64> {
         let inventory = self.gc_inventory(dry_run).await?;
         let stats = self.fs_stats().await?;

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1153,14 +1153,6 @@ impl WorkspaceImageCache {
             allocated_bytes = allocated,
             "workspace image cache promoted"
         );
-        if let Err(e) = self.gc_locked(false).await {
-            warn!(
-                run_id = %input.run_id,
-                cache_key = input.cache_key,
-                error = %e,
-                "workspace image cache GC failed after promotion"
-            );
-        }
         Ok(WorkspaceImagePromotionOutcome::Promoted)
     }
 }

--- a/crates/runner/src/workspace_image_cache/tests/gc.rs
+++ b/crates/runner/src/workspace_image_cache/tests/gc.rs
@@ -107,6 +107,42 @@ async fn maintenance_gc_preserves_valid_group_scoped_entry() {
 }
 
 #[tokio::test]
+async fn routine_gc_cleans_stale_entries_when_capacity_lock_is_available() {
+    let (_dir, _paths, cache) = local_cache().await;
+    let cache_key = workspace_image_cache_key("sess-stale", "/workspace");
+    tokio::fs::create_dir_all(cache.entry_paths(&cache_key).entry_dir().to_path_buf())
+        .await
+        .unwrap();
+    cache.reset_gc_root_scan_count();
+
+    let freed = cache.try_gc().await.unwrap();
+
+    assert!(freed.is_some());
+    assert_eq!(cache.gc_root_scan_count(), 1);
+    assert!(
+        !cache
+            .entry_paths(&cache_key)
+            .entry_dir()
+            .to_path_buf()
+            .exists()
+    );
+}
+
+#[tokio::test]
+async fn routine_gc_skips_without_scanning_when_capacity_lock_is_busy() {
+    let (_dir, _paths, cache) = local_cache().await;
+    let _capacity_lock = crate::lock::acquire(cache.capacity_lock_path())
+        .await
+        .unwrap();
+    cache.reset_gc_root_scan_count();
+
+    let freed = cache.try_gc().await.unwrap();
+
+    assert_eq!(freed, None);
+    assert_eq!(cache.gc_root_scan_count(), 0);
+}
+
+#[tokio::test]
 async fn unknown_metadata_format_is_not_reused_or_advertised_and_is_reclaimed() {
     let (_dir, _paths, cache) = local_cache().await;
     let checkout_reuse_key = "thread:unknown-format-checkout";
@@ -298,7 +334,11 @@ async fn global_gc_evicts_old_entry_from_other_group_under_free_space_pressure()
     )
     .await;
 
-    let freed = cache_b.gc(false).await.unwrap();
+    let freed = cache_b
+        .try_gc()
+        .await
+        .unwrap()
+        .expect("routine GC should acquire the idle capacity lock");
 
     assert!(freed > 0);
     assert!(

--- a/crates/runner/src/workspace_image_cache/tests/promotion.rs
+++ b/crates/runner/src/workspace_image_cache/tests/promotion.rs
@@ -263,7 +263,7 @@ async fn promotion_overwrites_older_cache_entry() {
 }
 
 #[tokio::test]
-async fn successful_multi_entry_promotion_scans_cache_root_once() {
+async fn successful_multi_entry_promotions_do_not_scan_cache_root() {
     let (_dir, paths, cache) = local_cache().await;
     let run_id = RunId::new_v4();
     let first_key = write_current_cache_entry(
@@ -286,28 +286,41 @@ async fn successful_multi_entry_promotion_scans_cache_root_once() {
     .await;
     cache.reset_gc_root_scan_count();
 
-    let promoted_key = promote_current_cache_entry(
+    let first_promoted_key = promote_current_cache_entry(
         &cache,
         &paths,
-        "sess-promoted",
-        b"promoted image",
+        "sess-promoted-1",
+        b"promoted image 1",
         "2026-05-01T00:02:00.000Z",
+    )
+    .await;
+    let second_promoted_key = promote_current_cache_entry(
+        &cache,
+        &paths,
+        "sess-promoted-2",
+        b"promoted image 2",
+        "2026-05-01T00:03:00.000Z",
     )
     .await;
 
     assert_eq!(
         cache.gc_root_scan_count(),
-        1,
-        "successful promotion should inventory the cache root once during mandatory post-promotion GC"
+        0,
+        "healthy under-budget promotions should not inventory the cache root"
     );
-    for cache_key in [first_key, second_key, promoted_key] {
+    for cache_key in [
+        first_key,
+        second_key,
+        first_promoted_key,
+        second_promoted_key,
+    ] {
         assert!(
             cache
                 .entry_paths(&cache_key)
                 .current_image()
                 .to_path_buf()
                 .exists(),
-            "healthy under-budget entries should remain after post-promotion GC"
+            "healthy under-budget entries should remain available for routine GC"
         );
     }
 }


### PR DESCRIPTION
## Summary

- remove full workspace-cache inventory from every successful promotion
- run authoritative cache GC on a delayed 60-second single-flight runner cadence
- skip routine GC without scanning when another promotion or GC owns the global capacity lock
- preserve immediate free-space GC, manual waiting GC, cross-group eviction, byte budgets, and the 1,024-entry cap

## Compatibility

- no workspace-cache metadata, sidecar, file-layout, API, or runner/guest protocol changes
- old runners can continue post-promotion GC during rollout; the existing global capacity lock remains the cross-process serialization boundary

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache::tests`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- Rust pre-commit hooks: cargo fmt, rustdoc, Clippy, file-size check

Closes #28009
