### PR TITLE
perf(runner): measure claim http duration

### DIFF
--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -104,7 +104,8 @@ async fn run_finalizing_claim(
         factory,
     } = request;
     let run_id = claimed.context().run_id;
-    let mut pre_spawn_timing = RunnerPreSpawnTiming::start_at(claim_returned_at);
+    let mut pre_spawn_timing =
+        RunnerPreSpawnTiming::start_at(claim_returned_at, claimed.api_claim_request_elapsed());
     pre_spawn_timing.mark_task_enqueued();
     let started_at = Instant::now();
     let mut reserved_exact = None;

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -317,7 +317,8 @@ pub(super) async fn handle_discovered_job(
         .await;
         return DiscoveredJobResult::completed(true);
     }
-    let mut pre_spawn_timing = RunnerPreSpawnTiming::start_at(claim_returned_at);
+    let mut pre_spawn_timing =
+        RunnerPreSpawnTiming::start_at(claim_returned_at, claimed.api_claim_request_elapsed());
     let started_at = Instant::now();
     let resume_session_error = validate_resume_session_id(claimed.context()).err();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::ResumeSessionValidation, started_at);

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -119,6 +119,7 @@ impl RunnerPreSpawnPhaseDurations {
 
 pub(crate) struct RunnerPreSpawnTiming {
     claim_returned_at: Instant,
+    api_claim_request_elapsed: Option<Duration>,
     phase_durations: RunnerPreSpawnPhaseDurations,
     task_enqueued_at: Option<Instant>,
     exact_reuse_speculation: Option<ExactReuseSpeculationTiming>,
@@ -148,12 +149,16 @@ pub(super) struct RunnerSpawnTiming {
 impl RunnerPreSpawnTiming {
     #[cfg(test)]
     pub(crate) fn start_after_claim() -> Self {
-        Self::start_at(Instant::now())
+        Self::start_at(Instant::now(), None)
     }
 
-    pub(crate) fn start_at(claim_returned_at: Instant) -> Self {
+    pub(crate) fn start_at(
+        claim_returned_at: Instant,
+        api_claim_request_elapsed: Option<Duration>,
+    ) -> Self {
         Self {
             claim_returned_at,
+            api_claim_request_elapsed,
             phase_durations: RunnerPreSpawnPhaseDurations::default(),
             task_enqueued_at: None,
             exact_reuse_speculation: None,
@@ -181,6 +186,9 @@ impl RunnerPreSpawnTiming {
     }
 
     fn record_collected_phases(&self, telemetry: &mut JobTelemetry, executor_started_at: Instant) {
+        if let Some(duration) = self.api_claim_request_elapsed {
+            telemetry.record("runner_claim_http_request", duration, true, None);
+        }
         for phase in RunnerPreSpawnPhase::ALL {
             if let Some(duration) = self.phase_durations.get(phase) {
                 telemetry.record(phase.action_type(), duration, true, None);

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use sandbox::{
@@ -510,7 +510,8 @@ fn assert_pre_spawn_phase_actions_succeeded(telemetry: &JobTelemetry) {
 }
 
 fn pre_spawn_timing_with_phases() -> RunnerPreSpawnTiming {
-    let mut timing = RunnerPreSpawnTiming::start_after_claim();
+    let mut timing =
+        RunnerPreSpawnTiming::start_at(Instant::now(), Some(Duration::from_millis(42)));
     for (phase, duration_ms) in [
         (RunnerPreSpawnPhase::ResumeSessionValidation, 1),
         (RunnerPreSpawnPhase::SessionHistoryMaterializerStart, 2),
@@ -605,6 +606,7 @@ async fn execute_job_records_sandbox_reuse_miss_in_telemetry() {
     assert_eq!(reuse_events.len(), 1);
     assert_eq!(reuse_events[0].0, "sandbox_reuse_miss");
     assert_lacks_action(&telemetry, "runner_claim_to_executor_start");
+    assert_lacks_action(&telemetry, "runner_claim_http_request");
     assert_lacks_action(&telemetry, "runner_claim_resume_session_validation");
     assert_lacks_action(&telemetry, "runner_claim_task_schedule_wait");
     assert_action_success(&telemetry, "runner_fresh_sandbox_start", true);
@@ -682,6 +684,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     .await;
 
     for action in [
+        "runner_claim_http_request",
         "runner_claim_to_executor_start",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
@@ -700,6 +703,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     ] {
         assert_has_action(&telemetry, action);
     }
+    assert_action_duration(&telemetry, "runner_claim_http_request", 42);
     for action in FRESH_SANDBOX_FACTORY_STAGE_ACTIONS {
         assert_action_success(&telemetry, action, true);
     }
@@ -1025,6 +1029,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     .await;
 
     for action in [
+        "runner_claim_http_request",
         "runner_claim_to_executor_start",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
@@ -1038,6 +1043,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     ] {
         assert_has_action(&telemetry, action);
     }
+    assert_action_duration(&telemetry, "runner_claim_http_request", 42);
     assert_pre_spawn_phase_actions_succeeded(&telemetry);
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_prepare");
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_factory_create");
@@ -1086,6 +1092,7 @@ async fn start_process_failure_records_phase_failure_without_spawn_completion() 
 
     assert_action_success(&telemetry, "runner_agent_start_process", false);
     assert_action_success(&telemetry, "agent_execute", false);
+    assert_lacks_action(&telemetry, "runner_claim_http_request");
     assert_lacks_action(&telemetry, "runner_executor_start_to_spawn");
     assert_lacks_action(&telemetry, "runner_claim_to_spawn");
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -631,7 +631,10 @@ impl JobProvider for ApiProvider {
 
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
         let run_id = candidate.run_id();
-        match self.api.claim(&candidate, &self.runner_identity).await {
+        let claim_request_started_at = Instant::now();
+        let claim_result = self.api.claim(&candidate, &self.runner_identity).await;
+        let claim_request_elapsed = claim_request_started_at.elapsed();
+        match claim_result {
             Ok(Some(ctx)) => {
                 let active_input_source = (ctx.cli_agent_type != "pi"
                     && supports_thread_active_input(ctx.reuse_key.as_deref()))
@@ -644,9 +647,14 @@ impl JobProvider for ApiProvider {
                     )
                 });
                 let claimed = match if let Some(active_input_source) = active_input_source {
-                    ClaimedJob::api_with_active_input_source(run_id, ctx, active_input_source)
+                    ClaimedJob::api_with_active_input_source(
+                        run_id,
+                        ctx,
+                        active_input_source,
+                        claim_request_elapsed,
+                    )
                 } else {
-                    ClaimedJob::api(run_id, ctx)
+                    ClaimedJob::api(run_id, ctx, claim_request_elapsed)
                 } {
                     Ok(claimed) => claimed,
                     Err(error) => {
@@ -3901,6 +3909,7 @@ mod tests {
             ))
             .await
             .expect("shared current claim response should decode");
+        assert!(claimed.api_claim_request_elapsed().is_some());
         let context = claimed.context();
 
         assert_eq!(context.run_id, run_id);

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -516,6 +516,7 @@ pub struct ClaimedJob {
     context: ExecutionContext,
     completion_auth: CompletionAuth,
     active_input_source: Option<ActiveInputSource>,
+    api_claim_request_elapsed: Option<Duration>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -542,22 +543,30 @@ impl ClaimedJob {
     pub(crate) fn api(
         expected_run_id: RunId,
         context: ExecutionContext,
+        api_claim_request_elapsed: Duration,
     ) -> Result<Self, ClaimedJobRunIdMismatch> {
-        Self::api_with_optional_source(expected_run_id, context, None)
+        Self::api_with_optional_source(expected_run_id, context, None, api_claim_request_elapsed)
     }
 
     pub(crate) fn api_with_active_input_source(
         expected_run_id: RunId,
         context: ExecutionContext,
         active_input_source: ActiveInputSource,
+        api_claim_request_elapsed: Duration,
     ) -> Result<Self, ClaimedJobRunIdMismatch> {
-        Self::api_with_optional_source(expected_run_id, context, Some(active_input_source))
+        Self::api_with_optional_source(
+            expected_run_id,
+            context,
+            Some(active_input_source),
+            api_claim_request_elapsed,
+        )
     }
 
     fn api_with_optional_source(
         expected_run_id: RunId,
         context: ExecutionContext,
         active_input_source: Option<ActiveInputSource>,
+        api_claim_request_elapsed: Duration,
     ) -> Result<Self, ClaimedJobRunIdMismatch> {
         Self::validate_run_id(expected_run_id, &context)?;
         let completion_auth =
@@ -566,6 +575,7 @@ impl ClaimedJob {
             context,
             completion_auth,
             active_input_source,
+            api_claim_request_elapsed: Some(api_claim_request_elapsed),
         })
     }
 
@@ -587,6 +597,7 @@ impl ClaimedJob {
             context,
             completion_auth: CompletionAuth::local(),
             active_input_source,
+            api_claim_request_elapsed: None,
         })
     }
 
@@ -598,6 +609,10 @@ impl ClaimedJob {
 
     pub(crate) fn context(&self) -> &ExecutionContext {
         &self.context
+    }
+
+    pub(crate) fn api_claim_request_elapsed(&self) -> Option<Duration> {
+        self.api_claim_request_elapsed
     }
 
     #[cfg(test)]
@@ -775,7 +790,11 @@ mod tests {
         let expected_run_id = RunId::nil();
         let context_run_id = RunId::new_v4();
 
-        let Err(err) = ClaimedJob::api(expected_run_id, minimal_context(context_run_id)) else {
+        let Err(err) = ClaimedJob::api(
+            expected_run_id,
+            minimal_context(context_run_id),
+            Duration::from_millis(1),
+        ) else {
             panic!("mismatched context must be rejected");
         };
 
@@ -792,8 +811,8 @@ mod tests {
     fn claimed_job_accepts_matching_api_context() {
         let run_id = RunId::nil();
 
-        let claimed =
-            ClaimedJob::api(run_id, minimal_context(run_id)).expect("matching context is valid");
+        let claimed = ClaimedJob::api(run_id, minimal_context(run_id), Duration::from_millis(1))
+            .expect("matching context is valid");
         let (context, completion_auth, active_input_source) = claimed.into_parts();
 
         assert_eq!(context.run_id, run_id);


### PR DESCRIPTION
## Summary

- measure the complete successful Runner-to-API claim request, including response body decoding
- carry the duration through API-backed claimed jobs into the existing startup telemetry batch
- emit `runner_claim_http_request` for both fresh and reusable sandbox execution paths

## Scope

- unsuccessful claims keep their existing bounded failure logs and do not emit a successful operation
- local providers do not emit the API-only operation
- this PR adds observability only; it does not change claim behavior, scheduling, reuse, or API contracts

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner` (3172 passed, 0 failed, 20 ignored)
- pre-commit hooks: workspace Rust format, Clippy, documentation, and file-size checks

Closes #28014
Parent: #27735
