### PR TITLE
refactor(db): rename vm0 api key schema module to built-in model key

### DIFF
--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -13,7 +13,7 @@ import {
 } from "@okouai/core/storage-names";
 import { GOAL_SKILL_NAME, SEED_SKILLS } from "@okouai/core/seed-skills";
 import { usagePricing } from "@okouai/db/schema/usage-pricing";
-import { vm0ApiKeys } from "@okouai/db/schema/vm0-api-key";
+import { builtInModelKeys } from "@okouai/db/schema/built-in-model-key";
 import { skills } from "@okouai/db/schema/skill";
 import { storages } from "@okouai/db/schema/storage";
 import { createStore } from "ccstate";
@@ -674,14 +674,14 @@ type LineWriter = (message: string) => void;
 export function buildVm0ApiKeys(
   readEnv: OptionalEnvReader = optionalEnv,
   logLine: LineWriter = writeLine,
-): (typeof vm0ApiKeys.$inferInsert)[] {
+): (typeof builtInModelKeys.$inferInsert)[] {
   const vendors = new Set(
     Object.values(VM0_MODEL_TO_PROVIDER).map(({ vendor }) => {
       return vendor;
     }),
   );
 
-  const keys: (typeof vm0ApiKeys.$inferInsert)[] = [];
+  const keys: (typeof builtInModelKeys.$inferInsert)[] = [];
   for (const vendor of vendors) {
     const envVars = getVendorApiKeyEnvVars(vendor);
     const apiKey = envVars
@@ -726,9 +726,9 @@ async function devSeed() {
   writeLine("Seeding vm0_api_keys");
   const apiKeys = buildVm0ApiKeys();
   await database.transaction(async (tx) => {
-    await tx.delete(vm0ApiKeys);
+    await tx.delete(builtInModelKeys);
     if (apiKeys.length > 0) {
-      await tx.insert(vm0ApiKeys).values(apiKeys);
+      await tx.insert(builtInModelKeys).values(apiKeys);
     }
   });
   for (const k of apiKeys) {

--- a/turbo/apps/api/src/signals/routes/test-teams-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-state.ts
@@ -20,7 +20,7 @@ import { teamsChatThreadRoutes } from "@okouai/db/schema/teams-chat-thread-route
 import { teamsOrgConnections } from "@okouai/db/schema/teams-org-connection";
 import { teamsOrgInstallations } from "@okouai/db/schema/teams-org-installation";
 import { teamsUserAgentPreferences } from "@okouai/db/schema/teams-user-agent-preference";
-import { vm0ApiKeys } from "@okouai/db/schema/vm0-api-key";
+import { builtInModelKeys } from "@okouai/db/schema/built-in-model-key";
 import { zeroAgents } from "@okouai/db/schema/zero-agent";
 import {
   and,
@@ -270,11 +270,13 @@ async function seedDefaultAgent(
 }
 
 async function seedVm0ManagedKeys(db: Db, composeId: string): Promise<void> {
-  await db.delete(vm0ApiKeys).where(eq(vm0ApiKeys.label, composeId));
   await db
-    .insert(vm0ApiKeys)
+    .delete(builtInModelKeys)
+    .where(eq(builtInModelKeys.label, composeId));
+  await db
+    .insert(builtInModelKeys)
     .values(vm0ManagedKeyRows(composeId))
-    .onConflictDoNothing({ target: vm0ApiKeys.vendor });
+    .onConflictDoNothing({ target: builtInModelKeys.vendor });
 }
 
 function vm0ManagedKeyRows(composeId: string) {
@@ -319,11 +321,11 @@ async function deleteVm0ManagedKeysForSeededDefaultAgent(
     return row.apiKey;
   });
   await db
-    .delete(vm0ApiKeys)
+    .delete(builtInModelKeys)
     .where(
       and(
-        eq(vm0ApiKeys.label, compose.id),
-        inArray(vm0ApiKeys.apiKey, apiKeys),
+        eq(builtInModelKeys.label, compose.id),
+        inArray(builtInModelKeys.apiKey, apiKeys),
       ),
     );
 }

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -38,7 +38,7 @@ import { telegramMessages } from "@okouai/db/schema/telegram-message";
 import { telegramOfficialUserLinks } from "@okouai/db/schema/telegram-official-user-link";
 import { telegramUserAgentPreferences } from "@okouai/db/schema/telegram-user-agent-preference";
 import { telegramUserLinks } from "@okouai/db/schema/telegram-user-link";
-import { vm0ApiKeys } from "@okouai/db/schema/vm0-api-key";
+import { builtInModelKeys } from "@okouai/db/schema/built-in-model-key";
 import { zeroAgents } from "@okouai/db/schema/zero-agent";
 import { pgTextDecoder } from "../../lib/db-structured-result";
 import { request$ } from "../context/hono";
@@ -877,7 +877,7 @@ async function seedTelegramPostModelKeys(
   signal: AbortSignal,
 ): Promise<void> {
   await db
-    .insert(vm0ApiKeys)
+    .insert(builtInModelKeys)
     .values([
       {
         vendor: getVm0Vendor(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL),
@@ -895,7 +895,7 @@ async function seedTelegramPostModelKeys(
         label: seed.composeId,
       },
     ])
-    .onConflictDoNothing({ target: vm0ApiKeys.vendor });
+    .onConflictDoNothing({ target: builtInModelKeys.vendor });
   signal.throwIfAborted();
 }
 
@@ -1062,7 +1062,9 @@ async function deleteTelegramPostFixtureForAction(
       ),
     );
   signal.throwIfAborted();
-  await db.delete(vm0ApiKeys).where(eq(vm0ApiKeys.label, composeId));
+  await db
+    .delete(builtInModelKeys)
+    .where(eq(builtInModelKeys.label, composeId));
   signal.throwIfAborted();
   await db
     .delete(telegramMessages)
@@ -1444,13 +1446,13 @@ async function seedModelPoliciesForAction(
   ]);
   signal.throwIfAborted();
   await db
-    .insert(vm0ApiKeys)
+    .insert(builtInModelKeys)
     .values({
       vendor: "anthropic",
       apiKey: "vm0-key-anthropic",
       label: required.compose_id!,
     })
-    .onConflictDoNothing({ target: vm0ApiKeys.vendor });
+    .onConflictDoNothing({ target: builtInModelKeys.vendor });
   signal.throwIfAborted();
   await db
     .insert(orgMembersMetadata)

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -131,7 +131,7 @@ import { orgMembersMetadata } from "@okouai/db/schema/org-members-metadata";
 import { runnerJobQueue } from "@okouai/db/schema/runner-job-queue";
 import { secrets as secretsTable } from "@okouai/db/schema/secret";
 import { userCache } from "@okouai/db/schema/user-cache";
-import { vm0ApiKeys } from "@okouai/db/schema/vm0-api-key";
+import { builtInModelKeys } from "@okouai/db/schema/built-in-model-key";
 import { variables } from "@okouai/db/schema/variable";
 import type { PersistedStorageMount } from "@okouai/db/types";
 import {
@@ -2292,9 +2292,9 @@ async function vm0ModelProviderEnvironment(
   const vendor = getVm0Vendor(selectedModel);
   const apiModel = getProviderRuntimeModel("vm0", selectedModel);
   const rows = await db
-    .select({ apiKey: vm0ApiKeys.apiKey })
-    .from(vm0ApiKeys)
-    .where(eq(vm0ApiKeys.vendor, vendor))
+    .select({ apiKey: builtInModelKeys.apiKey })
+    .from(builtInModelKeys)
+    .where(eq(builtInModelKeys.vendor, vendor))
     .limit(1);
   const apiKey = rows[0]?.apiKey;
   const secretName = getSecretNameForType(concreteType);

--- a/turbo/apps/api/src/signals/services/managed-model-key-fixture.ts
+++ b/turbo/apps/api/src/signals/services/managed-model-key-fixture.ts
@@ -1,4 +1,4 @@
-import { vm0ApiKeys } from "@okouai/db/schema/vm0-api-key";
+import { builtInModelKeys } from "@okouai/db/schema/built-in-model-key";
 import { eq, like } from "drizzle-orm";
 import { z } from "zod";
 
@@ -55,22 +55,22 @@ export async function acquireManagedModelKeyFixture(
   for (const value of rows) {
     const apiKey = await db.transaction(async (tx) => {
       const [row] = await tx
-        .insert(vm0ApiKeys)
+        .insert(builtInModelKeys)
         .values({
           ...value,
           label: vm0ManagedModelKeyFixtureLabel([fixtureId]),
         })
         .onConflictDoUpdate({
-          target: vm0ApiKeys.vendor,
+          target: builtInModelKeys.vendor,
           // Keep the existing key while atomically locking and returning its
           // vendor row. DO NOTHING followed by SELECT FOR UPDATE leaves a
           // window where the previous fixture owner can delete the row.
           set: { vendor: value.vendor },
         })
         .returning({
-          id: vm0ApiKeys.id,
-          apiKey: vm0ApiKeys.apiKey,
-          label: vm0ApiKeys.label,
+          id: builtInModelKeys.id,
+          apiKey: builtInModelKeys.apiKey,
+          label: builtInModelKeys.label,
         });
       if (!row) {
         throw new Error(`Expected VM0 managed key for vendor: ${value.vendor}`);
@@ -89,12 +89,12 @@ export async function acquireManagedModelKeyFixture(
           ? undefined
           : row.label;
       await tx
-        .update(vm0ApiKeys)
+        .update(builtInModelKeys)
         .set({
           label: vm0ManagedModelKeyFixtureLabel(fixtureIds, preservedLabel),
           updatedAt: nowDate(),
         })
-        .where(eq(vm0ApiKeys.id, row.id));
+        .where(eq(builtInModelKeys.id, row.id));
       return row.apiKey;
     });
     acquiredRows.push({ vendor: value.vendor, apiKey });
@@ -109,10 +109,10 @@ export async function releaseManagedModelKeyFixture(
 ): Promise<void> {
   await db.transaction(async (tx) => {
     const rows = await tx
-      .select({ id: vm0ApiKeys.id, label: vm0ApiKeys.label })
-      .from(vm0ApiKeys)
-      .where(like(vm0ApiKeys.label, `%${fixtureId}%`))
-      .orderBy(vm0ApiKeys.vendor)
+      .select({ id: builtInModelKeys.id, label: builtInModelKeys.label })
+      .from(builtInModelKeys)
+      .where(like(builtInModelKeys.label, `%${fixtureId}%`))
+      .orderBy(builtInModelKeys.vendor)
       .for("update");
 
     for (const row of rows) {
@@ -125,7 +125,7 @@ export async function releaseManagedModelKeyFixture(
       });
       if (remainingFixtureIds.length > 0) {
         await tx
-          .update(vm0ApiKeys)
+          .update(builtInModelKeys)
           .set({
             label: vm0ManagedModelKeyFixtureLabel(
               remainingFixtureIds,
@@ -133,20 +133,20 @@ export async function releaseManagedModelKeyFixture(
             ),
             updatedAt: nowDate(),
           })
-          .where(eq(vm0ApiKeys.id, row.id));
+          .where(eq(builtInModelKeys.id, row.id));
         continue;
       }
       if (fixtureLabel.preservedLabel !== undefined) {
         await tx
-          .update(vm0ApiKeys)
+          .update(builtInModelKeys)
           .set({
             label: fixtureLabel.preservedLabel,
             updatedAt: nowDate(),
           })
-          .where(eq(vm0ApiKeys.id, row.id));
+          .where(eq(builtInModelKeys.id, row.id));
         continue;
       }
-      await tx.delete(vm0ApiKeys).where(eq(vm0ApiKeys.id, row.id));
+      await tx.delete(builtInModelKeys).where(eq(builtInModelKeys.id, row.id));
     }
   });
 }

--- a/turbo/packages/db/src/index.ts
+++ b/turbo/packages/db/src/index.ts
@@ -92,7 +92,7 @@ import * as userPermissionGrantSchema from "./schema/user-permission-grant";
 import * as threadGoalSchema from "./schema/thread-goal";
 import * as storageVersionLineageSchema from "./schema/storage-version-lineage";
 import * as runUploadedFileSchema from "./schema/run-uploaded-file";
-import * as vm0ApiKeySchema from "./schema/vm0-api-key";
+import * as builtInModelKeySchema from "./schema/built-in-model-key";
 import * as workflowSchema from "./schema/workflow";
 import * as morningBriefSchema from "./schema/morning-brief";
 import * as computerUseHostSchema from "./schema/computer-use-host";
@@ -221,7 +221,7 @@ export const schema = {
   ...threadGoalSchema,
   ...storageVersionLineageSchema,
   ...runUploadedFileSchema,
-  ...vm0ApiKeySchema,
+  ...builtInModelKeySchema,
   ...workflowSchema,
   ...morningBriefSchema,
   ...computerUseHostSchema,

--- a/turbo/packages/db/src/schema/built-in-model-key.ts
+++ b/turbo/packages/db/src/schema/built-in-model-key.ts
@@ -8,11 +8,11 @@ import {
 } from "drizzle-orm/pg-core";
 
 /**
- * VM0 API Keys table
- * Platform-managed key pool for the VM0 managed model provider.
- * Each vendor has one platform-managed key.
+ * Built-in model keys table
+ * Platform-held key pool for the built-in model provider.
+ * Each vendor has one platform-held key.
  */
-export const vm0ApiKeys = pgTable(
+export const builtInModelKeys = pgTable(
   "vm0_api_keys",
   {
     id: uuid("id").defaultRandom().primaryKey(),


### PR DESCRIPTION
## Summary

Phase 2 naming cleanup (#27432; naming model #26873). Renames the last database TypeScript module owned by this tracker.

This table is not a pool of API keys for vm0 — it is the platform-held credential pool for the **built-in model provider**, one key per vendor, read only by `vm0ModelProviderEnvironment()` in `agent-run-create.service.ts`. `built-in` is already the product vocabulary (model picker i18n `settings.models.picker.builtInModel`, the org model-policy route literal `"built-in"`, the CLI classification, and `contracts/built-in-generation.ts`).

## Mapping

| Old | New |
|---|---|
| `packages/db/src/schema/vm0-api-key.ts` | `packages/db/src/schema/built-in-model-key.ts` |
| `vm0ApiKeys` | `builtInModelKeys` |
| `vm0ApiKeySchema` (namespace import in `packages/db/src/index.ts`) | `builtInModelKeySchema` |
| `pgTable("vm0_api_keys")` | **unchanged** |
| columns `id`, `vendor`, `api_key`, `label`, `created_at`, `updated_at` | **unchanged** |
| `uniqueIndex("idx_vm0_api_keys_vendor")` | **unchanged** |

## Physical identity is frozen

`git diff` on the schema module shows only the doc comment and the exported binding changing. The `pgTable` first argument, all six column name strings and the unique index name are byte-identical, so no migration is needed and none was touched — `git diff --stat` reports zero changes under `packages/db/src/migrations/`.

## Scope

Updated the six referencing files (import specifier and usages only): `services/agent-run-create.service.ts`, `services/managed-model-key-fixture.ts`, `routes/test-telegram-state.ts`, `routes/test-teams-state.ts`, `scripts/dev-seed.ts`, `packages/db/src/index.ts`. `packages/db/package.json` needs no change — it exports `./schema/*` by wildcard.

Deliberately untouched, per the issue's non-goals:

- `contracts/model-providers.ts` (including `VM0_MODEL_TO_PROVIDER` / `VM0_MODEL_ALIAS_TO_MODEL`) — read-only fan-in boundary from #27940.
- The `"vm0"` provider-type identifier, `vm0ModelProviderEnvironment`, `getVm0Vendor`, `getVm0ConcreteProviderType`.
- `label: "VM0 Managed"` in `MODEL_PROVIDER_TYPES.vm0` — user-visible brand copy owned by #27750.
- The `services/managed-model-key-fixture.ts` filename.
- Local helper names that are not the renamed symbol (`buildVm0ApiKeys` in `dev-seed.ts`, `seedVm0ManagedKeys` / `vm0ManagedKeyRows` in `test-teams-state.ts`) and the `"Seeding vm0_api_keys"` log line, which names the unchanged physical table.

No compatibility alias and no old-path re-export. No behavior change to run resolution, key selection, seeding or fixtures.

The two-file reformatting in `test-teams-state.ts` and `test-telegram-state.ts` is pure Prettier reflow caused by the longer identifier.

## Verification

- `pnpm -F @okouai/db check-types` — pass
- `pnpm -F api check-types` — pass (all six tsconfig projects)
- `pnpm knip --workspace packages/db` — clean
- `pnpm knip --workspace apps/api` — two unused exports reported, both pre-existing on `main` in files this PR does not touch (`agent-compose-provenance-lifecycle.service.ts`, `agent-execution-authority.ts`)
- `prettier --check` on all changed files — pass
- Repository-wide: no `vm0ApiKeys` identifier and no `schema/vm0-api-key` specifier remains; remaining `vm0_api_keys` occurrences are the physical table name in migrations, snapshots, the schema module, the dev-seed log line, `apps/api/README.md` and `test-fixtures/chat-events.ts`

The #26938 preflight consumer registry (`packages/db/scripts/agent-compose-consolidation-preflight-consumers.ts`) is not modified: this PR does not rename `agent-run-create.service.ts`, and the registered edges (content-type, raw content source, storage forwarding, launch plurality) do not cover the model-provider key lookup. That workflow is `workflow_dispatch`-only and does not gate PRs.

Closes #28021
