### PR TITLE
docs(rust): document firecracker api client construction semantics

### DIFF
--- a/crates/sandbox-fc/src/api/client.rs
+++ b/crates/sandbox-fc/src/api/client.rs
@@ -94,6 +94,16 @@ pub struct ApiClient {
 }
 
 impl ApiClient {
+    /// Construct a client configured for the Firecracker API Unix socket.
+    ///
+    /// This configures the HTTP transport for `socket_path` without checking
+    /// whether the socket exists or connecting to Firecracker. The constructor
+    /// can therefore succeed before the socket is created or the API is ready.
+    /// Missing, unavailable, or not-yet-ready sockets are reported when
+    /// [`Self::wait_for_ready`] or another request method is awaited.
+    ///
+    /// Call [`Self::wait_for_ready`] before issuing Firecracker API operations
+    /// when a readiness guarantee is required.
     pub fn new(socket_path: &Path) -> Result<Self, ApiError> {
         Ok(Self {
             socket_path: socket_path.to_owned(),


### PR DESCRIPTION
## Summary

- Document the lifecycle contract of the public `sandbox-fc::ApiClient::new` constructor.
- Clarify that construction configures Unix-socket transport but does not check socket existence or Firecracker readiness.
- Direct callers to `wait_for_ready` when readiness is required before API operations.

## Behavior Changed

None. This PR adds rustdoc only and preserves deferred socket connection and readiness behavior.

## Explicit Exclusions

- No constructor validation or runtime behavior changes.
- No test, API signature, protocol, migration, or rollout changes.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p sandbox-fc --all-targets --all-features`
- `cd crates && cargo test -p sandbox-fc api::tests` (48 passed)
- `cd crates && cargo doc -p sandbox-fc --all-features --no-deps`

Closes #28020
