### PR TITLE
refactor(rust): generate codex runtime config from api contracts

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -10,6 +10,33 @@
 pub mod runners {
     /// Run-scoped DTOs exchanged between runners, guests, and the API.
     pub mod runs {
+        /// API-owned provider configuration forwarded to Codex in the sandbox.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct CodexRuntimeConfig {
+            /// Codex provider key used in generated startup settings.
+            pub provider_id: String,
+            /// Display name recorded for the Codex provider.
+            pub name: String,
+            /// Base URL for the provider's Responses API.
+            pub base_url: String,
+            /// Environment variable containing the provider credential.
+            pub env_key: String,
+            /// Optional static HTTP headers for provider requests.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub http_headers: Option<std::collections::BTreeMap<String, String>>,
+            /// Optional override for Codex's built-in OpenAI authentication requirement.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub requires_openai_auth: Option<bool>,
+            /// Codex wire protocol selected for the provider.
+            pub wire_api: String,
+            /// Whether the provider supports the Codex websocket transport.
+            pub supports_websockets: bool,
+            /// Optional opaque Codex model catalog supplied by the API.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub model_catalog: Option<serde_json::Value>,
+        }
+
         /// DTOs for durable active-input delivery.
         pub mod active_inputs {
             /// DTOs for recording active-input acceptance receipts.

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -1,11 +1,100 @@
+use std::collections::BTreeMap;
+
 use api_contracts::generated::types::{
-    runners::storage as runner_storage,
+    runners::{runs::CodexRuntimeConfig, storage as runner_storage},
     webhooks::agent::{
         checkpoints,
         storages::{FileEntryWithHash, commit, prepare},
     },
 };
 use serde_json::json;
+
+#[test]
+fn generated_codex_runtime_config_round_trips_full_wire_shape() {
+    let config = CodexRuntimeConfig {
+        provider_id: "gateway".to_string(),
+        name: "Gateway".to_string(),
+        base_url: "https://gateway.example.test/v1".to_string(),
+        env_key: "OPENAI_API_KEY".to_string(),
+        http_headers: Some(BTreeMap::from([(
+            "x-api-key".to_string(),
+            "__VM0_OPENAI_API_KEY_PLACEHOLDER__".to_string(),
+        )])),
+        requires_openai_auth: Some(false),
+        wire_api: "responses".to_string(),
+        supports_websockets: false,
+        model_catalog: Some(json!({
+            "models": [{
+                "slug": "upstream-model",
+                "input_modalities": ["text"],
+            }],
+        })),
+    };
+
+    let value = serde_json::to_value(&config).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "providerId": "gateway",
+            "name": "Gateway",
+            "baseUrl": "https://gateway.example.test/v1",
+            "envKey": "OPENAI_API_KEY",
+            "httpHeaders": {
+                "x-api-key": "__VM0_OPENAI_API_KEY_PLACEHOLDER__",
+            },
+            "requiresOpenaiAuth": false,
+            "wireApi": "responses",
+            "supportsWebsockets": false,
+            "modelCatalog": {
+                "models": [{
+                    "slug": "upstream-model",
+                    "input_modalities": ["text"],
+                }],
+            },
+        })
+    );
+
+    let round_trip: CodexRuntimeConfig = serde_json::from_value(value).unwrap();
+    assert_eq!(round_trip, config);
+}
+
+#[test]
+fn generated_codex_runtime_config_omits_absent_options_and_accepts_legacy_null() {
+    let canonical = json!({
+        "providerId": "deepseek",
+        "name": "DeepSeek",
+        "baseUrl": "https://api.deepseek.com/",
+        "envKey": "OPENAI_API_KEY",
+        "wireApi": "responses",
+        "supportsWebsockets": false,
+    });
+    let config = CodexRuntimeConfig {
+        provider_id: "deepseek".to_string(),
+        name: "DeepSeek".to_string(),
+        base_url: "https://api.deepseek.com/".to_string(),
+        env_key: "OPENAI_API_KEY".to_string(),
+        http_headers: None,
+        requires_openai_auth: None,
+        wire_api: "responses".to_string(),
+        supports_websockets: false,
+        model_catalog: None,
+    };
+
+    assert_eq!(serde_json::to_value(&config).unwrap(), canonical);
+
+    let legacy: CodexRuntimeConfig = serde_json::from_value(json!({
+        "providerId": "deepseek",
+        "name": "DeepSeek",
+        "baseUrl": "https://api.deepseek.com/",
+        "envKey": "OPENAI_API_KEY",
+        "wireApi": "responses",
+        "supportsWebsockets": false,
+        "modelCatalog": null,
+    }))
+    .unwrap();
+    assert_eq!(legacy.model_catalog, None);
+    assert_eq!(serde_json::to_value(legacy).unwrap(), canonical);
+}
 
 #[test]
 fn generated_checkpoint_request_omits_absent_snapshots() {

--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -3,10 +3,10 @@
 //! The API resolves provider capability metadata before dispatch. The guest
 //! only translates that structured payload into Codex startup configuration.
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
+use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
 use guest_common::telemetry::record_sandbox_op;
 use guest_contracts::runtime_paths::{self, PrivateFileReplacementTarget};
 
@@ -25,23 +25,6 @@ pub(super) fn default_reasoning_effort_for_model(model: &str) -> Option<&'static
         "gpt-5.5" => Some("xhigh"),
         _ => None,
     }
-}
-
-#[derive(Clone, Debug, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) struct CodexRuntimeConfig {
-    pub provider_id: String,
-    pub name: String,
-    pub base_url: String,
-    pub env_key: String,
-    #[serde(default)]
-    pub http_headers: Option<BTreeMap<String, String>>,
-    #[serde(default)]
-    pub requires_openai_auth: Option<bool>,
-    pub wire_api: String,
-    pub supports_websockets: bool,
-    #[serde(default)]
-    pub model_catalog: Option<serde_json::Value>,
 }
 
 pub(super) fn parse_raw(raw: &str) -> Result<Option<CodexRuntimeConfig>, AgentError> {
@@ -210,6 +193,8 @@ pub(super) fn quote_toml_basic_string(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use serde_json::json;
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -52,6 +52,7 @@ use crate::masker::SecretMasker;
 use crate::paths;
 use crate::session_metadata::{SessionHistoryLaunchSource, SessionMetadataStore};
 use crate::timing;
+use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
 use event_delivery::{EventDeliveryRuntime, EventDeliverySender};
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
@@ -330,7 +331,7 @@ pub(super) struct CliRuntimeConfig<'a> {
     anthropic_model: Cow<'a, str>,
     openai_model: Cow<'a, str>,
     openai_base_url: Cow<'a, str>,
-    codex_runtime_config: Option<codex_runtime_config::CodexRuntimeConfig>,
+    codex_runtime_config: Option<CodexRuntimeConfig>,
     codex_oauth_mode: bool,
     codex_fast_mode: bool,
     disable_builtin_web_search: bool,
@@ -1947,14 +1948,14 @@ mod tests {
     use super::{
         CliExitObservation, CliFailureDiagnostic, CliRuntimeConfig, child_env,
         claude_initial_prompt_frame, cli_exit_summary_from_status, codex_home_for_home_dir,
-        codex_runtime_config, command, exec_boundary, pi_child_env_values, record_cli_exit,
-        select_failure_diagnostic, set_cli_current_dir, with_carried_failure_reason,
-        write_pi_launch_payload_file,
+        command, exec_boundary, pi_child_env_values, record_cli_exit, select_failure_diagnostic,
+        set_cli_current_dir, with_carried_failure_reason, write_pi_launch_payload_file,
     };
     use crate::active_input::ActiveInputRuntime;
     use crate::paths;
     use crate::session_metadata::SessionHistoryLaunchSource;
     use crate::{constants, env};
+    use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
     use guest_contracts::diagnostics::{FailureDetailSource, FailureReason};
     use std::borrow::Cow;
     use std::collections::HashMap;
@@ -2214,7 +2215,7 @@ mod tests {
         let user_env = HashMap::new();
         let mut runtime = runtime_for_command_test(env::Framework::Codex, "prompt", "", &user_env);
         runtime.disable_builtin_web_search = true;
-        runtime.codex_runtime_config = Some(codex_runtime_config::CodexRuntimeConfig {
+        runtime.codex_runtime_config = Some(CodexRuntimeConfig {
             provider_id: "deepseek".to_string(),
             name: "DeepSeek".to_string(),
             base_url: "https://api.deepseek.com/".to_string(),
@@ -2298,7 +2299,7 @@ mod tests {
             ),
         ]);
         let mut runtime = runtime_for_command_test(env::Framework::Codex, "prompt", "", &user_env);
-        runtime.codex_runtime_config = Some(codex_runtime_config::CodexRuntimeConfig {
+        runtime.codex_runtime_config = Some(CodexRuntimeConfig {
             provider_id: "deepseek".to_string(),
             name: "DeepSeek".to_string(),
             base_url: "https://api.deepseek.com/".to_string(),

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
+use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
 use sandbox::Sandbox;
@@ -10,9 +11,7 @@ use super::cli_framework::{
 };
 use super::{JOB_TIMEOUT, RunnerError, RunnerResult, guest_runtime_dir, guest_runtime_path};
 use crate::ids::RunId;
-use crate::types::{
-    CodexRuntimeConfig, ExecutionContext, SandboxReuseResult, WorkspaceReuseResult,
-};
+use crate::types::{ExecutionContext, SandboxReuseResult, WorkspaceReuseResult};
 
 pub(super) struct ProtectedModelProviderEnvKey {
     name: &'static str,

--- a/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
 use sandbox::ProcessOutputMode;
 use sandbox_mock::MockLifecycleGate;
 use tokio::sync::Notify;
@@ -11,7 +12,7 @@ use crate::executor::tests::support::{
     RUN_IN_SANDBOX_TEST_TIMEOUT, create_overridden_sandbox, minimal_context, sandbox_exec_error,
     spawn_run_in_sandbox_test, test_executor_config, test_telemetry,
 };
-use crate::types::{CodexRuntimeConfig, ExecutionContext, FirewallEntry, SandboxReuseResult};
+use crate::types::{ExecutionContext, FirewallEntry, SandboxReuseResult};
 
 fn codex_oauth_context() -> ExecutionContext {
     let mut context = minimal_context();

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
-use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
+use api_contracts::generated::types::runners::{
+    runs::CodexRuntimeConfig, storage::ArtifactEntryMissingRootPolicy,
+};
 use sandbox::SandboxId;
 use sandbox_mock::MockSandbox;
 use serde_json::json;
@@ -27,9 +29,7 @@ use crate::host_env::{
 };
 use crate::ids::RunId;
 use crate::storage_manifest::StorageManifest;
-use crate::types::{
-    CodexRuntimeConfig, ExecutionContext, PiModelConfig, ResumeSession, SandboxReuseResult,
-};
+use crate::types::{ExecutionContext, PiModelConfig, ResumeSession, SandboxReuseResult};
 
 fn validate_context_for_test(ctx: &ExecutionContext) -> Result<(), String> {
     let sandbox_id = SandboxId::new_v4().to_string();

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1,7 +1,8 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
 
+use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
 use sandbox::SandboxId;
 use serde::{Deserialize, Serialize};
 use unicode_normalization::UnicodeNormalization;
@@ -157,23 +158,6 @@ pub struct PiModelConfig {
     pub base_url: String,
     pub model: String,
     pub api_key_env: String,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CodexRuntimeConfig {
-    pub provider_id: String,
-    pub name: String,
-    pub base_url: String,
-    pub env_key: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub http_headers: Option<BTreeMap<String, String>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub requires_openai_auth: Option<bool>,
-    pub wire_api: String,
-    pub supports_websockets: bool,
-    #[serde(default)]
-    pub model_catalog: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -10,6 +10,7 @@ import {
   type RustTypeBinding,
   rustTypeBindings,
 } from "../types";
+import { modelProviderCodexRuntimeConfigSchema } from "../../contracts/model-providers";
 import { storageMountEntrySchema } from "../../contracts/runners";
 import { fileEntryWithHashSchema } from "../../contracts/storages";
 import {
@@ -19,6 +20,11 @@ import {
 } from "../../contracts/webhooks";
 
 const expectedBindings = [
+  {
+    rustModulePath: ["runners", "runs"],
+    rustTypeName: "CodexRuntimeConfig",
+    direction: "response",
+  },
   {
     rustModulePath: ["runners", "runs", "active_inputs", "reserve"],
     rustTypeName: "Response",
@@ -202,6 +208,14 @@ describe("Rust type bindings", () => {
     expect(firstRender).not.toContain("pub struct RequestFile {");
     expect(firstRender).toContain("pub uploads: Option<ResponseUploads>,");
     expect(firstRender).toContain("pub struct StorageMountEntry {");
+    expect(firstRender).toContain("pub struct CodexRuntimeConfig {");
+    expect(firstRender).toContain(
+      "pub http_headers: Option<std::collections::BTreeMap<String, String>>",
+    );
+    expect(firstRender).toContain("pub requires_openai_auth: Option<bool>,");
+    expect(firstRender).toContain(
+      "pub model_catalog: Option<serde_json::Value>,",
+    );
     expect(firstRender).toContain("pub storage_id: String,");
     expect(firstRender).toContain("pub version_id: String,");
     expect(firstRender).toContain("pub writeback: Option<bool>,");
@@ -241,6 +255,43 @@ describe("Rust type bindings", () => {
     );
     expect(firstRender.match(/pub archive_size: Option<u64>,/g)).toHaveLength(
       1,
+    );
+  });
+
+  it("keeps the Codex runtime override aligned with its canonical schema", () => {
+    const binding: RustTypeBinding | undefined = rustTypeBindings.find(
+      ({ rustModulePath, rustTypeName }) => {
+        return (
+          rustTypeName === "CodexRuntimeConfig" &&
+          rustModulePath.join("/") === "runners/runs"
+        );
+      },
+    );
+
+    expect(binding?.schema).toBe(modelProviderCodexRuntimeConfigSchema);
+    expect(binding?.fieldTypeOverrides).toEqual({
+      modelCatalog: "serde_json::Value",
+    });
+    expect(z.toJSONSchema(modelProviderCodexRuntimeConfigSchema)).toMatchObject(
+      {
+        required: [
+          "providerId",
+          "name",
+          "baseUrl",
+          "envKey",
+          "wireApi",
+          "supportsWebsockets",
+        ],
+        properties: {
+          httpHeaders: {
+            additionalProperties: { type: "string" },
+          },
+          requiresOpenaiAuth: { type: "boolean" },
+          modelCatalog: {
+            additionalProperties: {},
+          },
+        },
+      },
     );
   });
 

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod";
+import { modelProviderCodexRuntimeConfigSchema } from "../contracts/model-providers";
 import {
   activeInputDeliveryReserveResponseSchema,
   activeInputDeliveryReceiptResponseSchema,
@@ -97,6 +98,42 @@ export const rustTypeModuleDocs = [
 ] satisfies readonly RustTypeModuleDoc[];
 
 export const rustTypeBindings = [
+  {
+    schema: modelProviderCodexRuntimeConfigSchema,
+    rustModulePath: ["runners", "runs"],
+    rustTypeName: "CodexRuntimeConfig",
+    direction: "response",
+    fieldTypeOverrides: {
+      modelCatalog: "serde_json::Value",
+    },
+    declarations: [
+      {
+        rustTypeName: "CodexRuntimeConfig",
+        rustDoc: [
+          "API-owned provider configuration forwarded to Codex in the sandbox.",
+        ],
+        fields: {
+          providerId: [
+            "Codex provider key used in generated startup settings.",
+          ],
+          name: ["Display name recorded for the Codex provider."],
+          baseUrl: ["Base URL for the provider's Responses API."],
+          envKey: ["Environment variable containing the provider credential."],
+          httpHeaders: ["Optional static HTTP headers for provider requests."],
+          requiresOpenaiAuth: [
+            "Optional override for Codex's built-in OpenAI authentication requirement.",
+          ],
+          wireApi: ["Codex wire protocol selected for the provider."],
+          supportsWebsockets: [
+            "Whether the provider supports the Codex websocket transport.",
+          ],
+          modelCatalog: [
+            "Optional opaque Codex model catalog supplied by the API.",
+          ],
+        },
+      },
+    ],
+  },
   {
     schema: activeInputDeliveryReserveResponseSchema,
     rustModulePath: ["runners", "runs", "active_inputs", "reserve"],


### PR DESCRIPTION
## Summary

- register the canonical TypeScript Codex runtime config schema in the Rust binding generator
- replace the runner and guest-agent handwritten DTOs with the generated shared type
- cover generator alignment, full wire round trips, optional-field serialization, and legacy `modelCatalog: null` input

## Compatibility

- preserve the existing camelCase fields, opaque model catalog, runner validation, guest validation, and string-valued runner-to-guest payload
- canonicalize an absent `modelCatalog` as an omitted field instead of `null`; both old and new consumers accept either representation

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test`
- `pnpm knip --workspace @okouai/api-contracts`
- repeated Rust generation with a stable output hash
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p api-contracts -p runner -p guest-agent`

Closes #28024
