### PR TITLE
fix(e2e): reuse authenticated onboarding page

### DIFF
--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -45,6 +45,7 @@ interface LoadedClerkContext {
 
 export interface ClerkTestingSignInOptions {
   readonly activeOrganizationId?: string;
+  readonly preserveAppPage?: boolean;
 }
 
 export interface LoadedClerkTestingPageOptions {
@@ -160,7 +161,9 @@ export async function signInWithLoadedClerkTestingHelper(
     ...clerkState,
   });
 
-  await gotoAboutBlankAfterClerkNavigation(page);
+  if (!options.preserveAppPage) {
+    await gotoAboutBlankAfterClerkNavigation(page);
+  }
   return token;
 }
 

--- a/e2e/playwright/lib/onboarding.test.ts
+++ b/e2e/playwright/lib/onboarding.test.ts
@@ -2,7 +2,49 @@ import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import { test } from "node:test";
 
-import { ensureRunnerOrganizationReady } from "./onboarding";
+import { chromium } from "@playwright/test";
+
+import {
+  completeExploreOnboarding,
+  ensureRunnerOrganizationReady,
+} from "./onboarding";
+
+test("continues onboarding on the authenticated app document", async () => {
+  let documentRequests = 0;
+  const server = createServer((request, response) => {
+    const pathname = new URL(request.url ?? "/", "http://app.fixture").pathname;
+    if (pathname === "/bootstrap") {
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+
+    documentRequests += 1;
+    response.writeHead(200, { "Content-Type": "text/html" });
+    response.end(onboardingFixtureDocument());
+  });
+
+  await listen(server);
+  try {
+    const browser = await chromium.launch();
+    try {
+      const address = server.address();
+      assert(address && typeof address === "object");
+      const appUrl = `http://127.0.0.1:${address.port}`;
+      const page = await browser.newPage();
+
+      await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+      await completeExploreOnboarding(page, { appUrl });
+
+      assert.equal(new URL(page.url()).pathname, "/agents/agent_default/chat");
+      assert.equal(documentRequests, 1);
+    } finally {
+      await browser.close();
+    }
+  } finally {
+    await close(server);
+  }
+});
 
 test("synchronizes runner organization onboarding through the public status route", async () => {
   const requests: Array<{
@@ -118,4 +160,28 @@ function headerValue(
     return value;
   }
   return value?.[0] ?? null;
+}
+
+function onboardingFixtureDocument(): string {
+  return `<!doctype html>
+<main role="status">Loading your workspace...</main>
+<script>
+  fetch("/bootstrap").then(() => {
+    history.replaceState({}, "", "/onboarding");
+    document.body.innerHTML = \`
+      <h1>What do you want to make first</h1>
+      <div role="radio" aria-label="I will explore on my own" aria-checked="false">
+        I will explore on my own
+      </div>
+      <button>Continue</button>
+    \`;
+    const option = document.querySelector('[role="radio"]');
+    option.addEventListener("click", () => {
+      option.setAttribute("aria-checked", "true");
+    });
+    document.querySelector("button").addEventListener("click", () => {
+      history.pushState({}, "", "/agents/agent_default/chat");
+    });
+  });
+</script>`;
 }

--- a/e2e/playwright/lib/onboarding.ts
+++ b/e2e/playwright/lib/onboarding.ts
@@ -142,9 +142,17 @@ async function openOnboarding(
   page: Page,
   options: OnboardingFlowOptions,
 ): Promise<void> {
-  await page.goto(new URL("/onboarding", options.appUrl).toString(), {
-    waitUntil: "domcontentloaded",
-  });
+  const onboardingUrl = new URL("/onboarding", options.appUrl);
+  const currentUrl = new URL(page.url());
+  const canReuseAppPage =
+    currentUrl.origin === onboardingUrl.origin &&
+    (currentUrl.pathname === "/" || currentUrl.pathname === "/onboarding");
+
+  if (!canReuseAppPage) {
+    await page.goto(onboardingUrl.toString(), {
+      waitUntil: "domcontentloaded",
+    });
+  }
   await expect(
     page.getByRole("heading", { name: "What do you want to make first" }),
   ).toBeVisible({ timeout: 60_000 });

--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -339,6 +339,7 @@ async function withBillingOwner(
     );
     const token = await signInWithClerkTestingHelper(page, email, appUrl, {
       activeOrganizationId: organizationId,
+      preserveAppPage: true,
     });
     await completeExploreOnboarding(page, { appUrl });
     await enableUsagePackPlans(page, token);

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -33,6 +33,7 @@ test("paid onboarding completes through the video workflow", async ({
 
     await signInWithClerkTestingHelper(page, email, appUrl, {
       activeOrganizationId: organizationId,
+      preserveAppPage: true,
     });
 
     await startVideoOnboardingCheckout(page, { appUrl });

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -14,6 +14,7 @@ test("complete app onboarding to chat page", async ({ browser, page }) => {
 
   await signInWithClerkTestingHelper(page, email, appUrl, {
     activeOrganizationId: orgId,
+    preserveAppPage: true,
   });
 
   await completeExploreOnboarding(page, {


### PR DESCRIPTION
## Summary

- keep the authenticated app document created by Clerk organization activation for onboarding flows
- synchronize on the product's automatic root-to-onboarding transition instead of forcing a second cold app load
- cover the handoff with a browser integration fixture that proves the onboarding path uses one app document

## Diagnosis

Trigger: [Turbo run 32125353691](https://github.com/vm0-ai/vm0/actions/runs/32125353691), [cli-e2e-02-playwright job 95675329665](https://github.com/vm0-ai/vm0/actions/runs/32125353691/job/95675329665)

The failed smoke setup established a Clerk session and active organization, and the activation navigation had already moved the page from the Clerk helper route to the app root. The sign-in helper then unconditionally parked the page on about:blank. completeExploreOnboarding immediately performed a new navigation to /onboarding, creating a second Clerk and app bootstrap for the same invariant.

That second, redundant bootstrap is the first causal nondeterminism. Its retained error context shows only the real "Loading your workspace" bootstrap skeleton for the full 60-second heading wait. During the failure window, the preview onboarding status and completion endpoints returned HTTP 200, so the evidence does not indicate an onboarding API failure. The queued product PR changed only the sidebar mark-unread icon, while its source-head Playwright job and a simultaneous preview shard both passed 25/25.

The fix makes retaining the post-sign-in app page explicit and opt-in for the three flows that immediately perform onboarding. Other sign-in callers retain the existing about:blank handoff. openOnboarding reuses only the configured app origin at / or /onboarding; all other starting pages retain the direct navigation fallback.

## Validation

- pnpm check-types (e2e): passed
- targeted authenticated-document onboarding integration: 5/5 consecutive passes
- auth fixture regressions: 5/5 passed
- onboarding fixture regressions: 3/3 passed
- complete E2E fixture integration suite: 36/36 passed
- git diff --check: passed
- deployed preview validation: 5/5 fresh browser sessions reached a visible first-step heading at /onboarding on https://pr-28039-app.omby.ai with https://pr-28039-api.vm6.ai
