### PR TITLE
fix(guest-agent): report telemetry position persistence status

### DIFF
--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -77,8 +77,23 @@ pub enum UploadMode {
 }
 
 /// Persist the current read position for a file.
-fn save_position(pos_path: impl AsRef<Path>, pos: u64) {
-    let _ = paths::write_private(pos_path, pos.to_string());
+fn save_position(pos_path: impl AsRef<Path>, pos: u64) -> std::io::Result<()> {
+    paths::write_private(pos_path, pos.to_string())
+}
+
+/// Persist all read positions and return the first error after attempting each write.
+fn save_positions(positions: [(&str, u64); 3]) -> std::io::Result<()> {
+    let mut first_error = None;
+    for (path, pos) in positions {
+        if let Err(error) = save_position(path, pos) {
+            first_error = first_error.or(Some(error));
+        }
+    }
+
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
 }
 
 /// Perform one telemetry upload cycle.
@@ -122,9 +137,14 @@ async fn upload_telemetry(
     if system_log.content.is_empty() && metrics.entries.is_empty() && sandbox_ops.entries.is_empty()
     {
         if made_progress {
-            save_position(&telemetry_paths.system_log_pos_file, log_pos);
-            save_position(&telemetry_paths.metrics_pos_file, metrics_pos);
-            save_position(&telemetry_paths.sandbox_ops_pos_file, sandbox_ops_pos);
+            save_positions([
+                (telemetry_paths.system_log_pos_file.as_str(), log_pos),
+                (telemetry_paths.metrics_pos_file.as_str(), metrics_pos),
+                (
+                    telemetry_paths.sandbox_ops_pos_file.as_str(),
+                    sandbox_ops_pos,
+                ),
+            ])?;
         }
         return Ok(());
     }
@@ -149,9 +169,14 @@ async fn upload_telemetry(
     let url = http.telemetry_url()?;
     match http.post_json(url, &payload, 1).await {
         Ok(_) => {
-            save_position(&telemetry_paths.system_log_pos_file, log_pos);
-            save_position(&telemetry_paths.metrics_pos_file, metrics_pos);
-            save_position(&telemetry_paths.sandbox_ops_pos_file, sandbox_ops_pos);
+            save_positions([
+                (telemetry_paths.system_log_pos_file.as_str(), log_pos),
+                (telemetry_paths.metrics_pos_file.as_str(), metrics_pos),
+                (
+                    telemetry_paths.sandbox_ops_pos_file.as_str(),
+                    sandbox_ops_pos,
+                ),
+            ])?;
             Ok(())
         }
         Err(e) => {
@@ -344,7 +369,7 @@ mod tests {
     fn save_position_and_read_back() {
         let dir = tempfile::tempdir().unwrap();
         let pos = dir.path().join("test.pos");
-        save_position(&pos, 42);
+        save_position(&pos, 42).unwrap();
         let val: u64 = fs::read_to_string(&pos).unwrap().trim().parse().unwrap();
         assert_eq!(val, 42);
     }
@@ -353,8 +378,8 @@ mod tests {
     fn save_position_overwrites_existing() {
         let dir = tempfile::tempdir().unwrap();
         let pos = dir.path().join("overwrite.pos");
-        save_position(&pos, 10);
-        save_position(&pos, 20);
+        save_position(&pos, 10).unwrap();
+        save_position(&pos, 20).unwrap();
         let val: u64 = fs::read_to_string(&pos).unwrap().trim().parse().unwrap();
         assert_eq!(val, 20);
     }

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -76,6 +76,15 @@ pub enum UploadMode {
     Final,
 }
 
+/// Result of a completed telemetry flush.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FlushReport {
+    /// Whether the flush sent a non-empty payload to the telemetry endpoint.
+    pub uploaded: bool,
+    /// Whether all positions changed by the flush were persisted successfully.
+    pub position_persisted: bool,
+}
+
 /// Persist the current read position for a file.
 fn save_position(pos_path: impl AsRef<Path>, pos: u64) -> std::io::Result<()> {
     paths::write_private(pos_path, pos.to_string())
@@ -96,6 +105,21 @@ fn save_positions(positions: [(&str, u64); 3]) -> std::io::Result<()> {
     }
 }
 
+/// Persist positions while keeping the upload result successful if the local
+/// replay cursor cannot be recorded.
+fn save_positions_with_warning(positions: [(&str, u64); 3], warning: &str) -> bool {
+    match save_positions(positions) {
+        Ok(()) => true,
+        Err(error) => {
+            log_warn!(
+                LOG_TAG,
+                "{warning}; processed data may be replayed: {error}"
+            );
+            false
+        }
+    }
+}
+
 /// Perform one telemetry upload cycle.
 ///
 /// `UploadMode::Final` should be used only for the very last upload before
@@ -110,7 +134,7 @@ async fn upload_telemetry(
     run_id: &str,
     telemetry_paths: &TelemetryPaths,
     mode: UploadMode,
-) -> Result<(), AgentError> {
+) -> Result<FlushReport, AgentError> {
     // Read deltas
     let system_log = read_file_delta(
         &telemetry_paths.system_log_file,
@@ -136,17 +160,25 @@ async fn upload_telemetry(
     // Nothing new
     if system_log.content.is_empty() && metrics.entries.is_empty() && sandbox_ops.entries.is_empty()
     {
-        if made_progress {
-            save_positions([
-                (telemetry_paths.system_log_pos_file.as_str(), log_pos),
-                (telemetry_paths.metrics_pos_file.as_str(), metrics_pos),
-                (
-                    telemetry_paths.sandbox_ops_pos_file.as_str(),
-                    sandbox_ops_pos,
-                ),
-            ])?;
-        }
-        return Ok(());
+        let position_persisted = if made_progress {
+            save_positions_with_warning(
+                [
+                    (telemetry_paths.system_log_pos_file.as_str(), log_pos),
+                    (telemetry_paths.metrics_pos_file.as_str(), metrics_pos),
+                    (
+                        telemetry_paths.sandbox_ops_pos_file.as_str(),
+                        sandbox_ops_pos,
+                    ),
+                ],
+                "Telemetry skip-only progress was processed but position persistence failed",
+            )
+        } else {
+            true
+        };
+        return Ok(FlushReport {
+            uploaded: false,
+            position_persisted,
+        });
     }
 
     // Mask secrets in text content
@@ -169,15 +201,21 @@ async fn upload_telemetry(
     let url = http.telemetry_url()?;
     match http.post_json(url, &payload, 1).await {
         Ok(_) => {
-            save_positions([
-                (telemetry_paths.system_log_pos_file.as_str(), log_pos),
-                (telemetry_paths.metrics_pos_file.as_str(), metrics_pos),
-                (
-                    telemetry_paths.sandbox_ops_pos_file.as_str(),
-                    sandbox_ops_pos,
-                ),
-            ])?;
-            Ok(())
+            let position_persisted = save_positions_with_warning(
+                [
+                    (telemetry_paths.system_log_pos_file.as_str(), log_pos),
+                    (telemetry_paths.metrics_pos_file.as_str(), metrics_pos),
+                    (
+                        telemetry_paths.sandbox_ops_pos_file.as_str(),
+                        sandbox_ops_pos,
+                    ),
+                ],
+                "Telemetry upload succeeded but position persistence failed",
+            );
+            Ok(FlushReport {
+                uploaded: true,
+                position_persisted,
+            })
         }
         Err(e) => {
             log_warn!(LOG_TAG, "Telemetry upload failed (will retry): {e}");
@@ -192,11 +230,11 @@ enum Cmd {
     /// `mode` is propagated to [`upload_telemetry`]; see [`UploadMode`].
     Flush {
         mode: UploadMode,
-        reply: oneshot::Sender<Result<(), AgentError>>,
+        reply: oneshot::Sender<Result<FlushReport, AgentError>>,
     },
     /// Perform the EOF-consuming final flush, then stop the loop.
     FinalFlushAndShutdown {
-        reply: oneshot::Sender<Result<(), AgentError>>,
+        reply: oneshot::Sender<Result<FlushReport, AgentError>>,
     },
     /// Stop the loop. Any in-flight upload completes first.
     Shutdown,
@@ -245,8 +283,10 @@ impl Telemetry {
     /// Use [`UploadMode::Live`] for any flush while the agent is still
     /// running (the producer continues writing). Use [`UploadMode::Final`]
     /// for the very last flush before exit, which consumes the EOF tail when
-    /// it fits in one bounded read.
-    pub async fn flush(&self, mode: UploadMode) -> Result<(), AgentError> {
+    /// it fits in one bounded read. A completed upload with a position
+    /// persistence failure is reported in [`FlushReport`] rather than as an
+    /// upload error.
+    pub async fn flush(&self, mode: UploadMode) -> Result<FlushReport, AgentError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.tx
             .send(Cmd::Flush {
@@ -274,8 +314,9 @@ impl Telemetry {
     /// Perform the final telemetry upload and stop the uploader task.
     ///
     /// Consumes `self`, so no later periodic `Live` tick or caller-driven
-    /// flush can run after the EOF-consuming final pass.
-    pub async fn final_flush_and_shutdown(self) -> Result<(), AgentError> {
+    /// flush can run after the EOF-consuming final pass. A completed upload
+    /// with a position persistence failure is reported in [`FlushReport`].
+    pub async fn final_flush_and_shutdown(self) -> Result<FlushReport, AgentError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         if self
             .tx
@@ -311,10 +352,16 @@ async fn run(
         while let Some(cmd) = rx.recv().await {
             match cmd {
                 Cmd::Flush { reply, .. } => {
-                    let _ = reply.send(Ok(()));
+                    let _ = reply.send(Ok(FlushReport {
+                        uploaded: false,
+                        position_persisted: true,
+                    }));
                 }
                 Cmd::FinalFlushAndShutdown { reply } => {
-                    let _ = reply.send(Ok(()));
+                    let _ = reply.send(Ok(FlushReport {
+                        uploaded: false,
+                        position_persisted: true,
+                    }));
                     break;
                 }
                 Cmd::Shutdown => break,

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -87,13 +87,20 @@ pub struct FlushReport {
 
 /// Persist the current read position for a file.
 fn save_position(pos_path: impl AsRef<Path>, pos: u64) -> std::io::Result<()> {
-    paths::write_private(pos_path, pos.to_string())
+    let pos_path = pos_path.as_ref();
+    paths::write_private(pos_path, pos.to_string()).map_err(|error| {
+        std::io::Error::new(
+            error.kind(),
+            format!("persist telemetry position {}: {error}", pos_path.display()),
+        )
+    })
 }
 
-/// Persist all read positions and return the first error after attempting each write.
-fn save_positions(positions: [(&str, u64); 3]) -> std::io::Result<()> {
+/// Persist each advanced read position and return the first error after
+/// attempting every required write.
+fn save_positions(positions: [Option<(&str, u64)>; 3]) -> std::io::Result<()> {
     let mut first_error = None;
-    for (path, pos) in positions {
+    for (path, pos) in positions.into_iter().flatten() {
         if let Err(error) = save_position(path, pos) {
             first_error = first_error.or(Some(error));
         }
@@ -107,7 +114,7 @@ fn save_positions(positions: [(&str, u64); 3]) -> std::io::Result<()> {
 
 /// Persist positions while keeping the upload result successful if the local
 /// replay cursor cannot be recorded.
-fn save_positions_with_warning(positions: [(&str, u64); 3], warning: &str) -> bool {
+fn save_positions_with_warning(positions: [Option<(&str, u64)>; 3], warning: &str) -> bool {
     match save_positions(positions) {
         Ok(()) => true,
         Err(error) => {
@@ -154,22 +161,26 @@ async fn upload_telemetry(
     let log_pos = system_log.new_pos;
     let metrics_pos = metrics.new_pos;
     let sandbox_ops_pos = sandbox_ops.new_pos;
-    let made_progress =
-        system_log.made_progress || metrics.made_progress || sandbox_ops.made_progress;
+    let position_updates = [
+        system_log
+            .made_progress
+            .then_some((telemetry_paths.system_log_pos_file.as_str(), log_pos)),
+        metrics
+            .made_progress
+            .then_some((telemetry_paths.metrics_pos_file.as_str(), metrics_pos)),
+        sandbox_ops.made_progress.then_some((
+            telemetry_paths.sandbox_ops_pos_file.as_str(),
+            sandbox_ops_pos,
+        )),
+    ];
+    let made_progress = position_updates.iter().any(Option::is_some);
 
     // Nothing new
     if system_log.content.is_empty() && metrics.entries.is_empty() && sandbox_ops.entries.is_empty()
     {
         let position_persisted = if made_progress {
             save_positions_with_warning(
-                [
-                    (telemetry_paths.system_log_pos_file.as_str(), log_pos),
-                    (telemetry_paths.metrics_pos_file.as_str(), metrics_pos),
-                    (
-                        telemetry_paths.sandbox_ops_pos_file.as_str(),
-                        sandbox_ops_pos,
-                    ),
-                ],
+                position_updates,
                 "Telemetry skip-only progress was processed but position persistence failed",
             )
         } else {
@@ -202,14 +213,7 @@ async fn upload_telemetry(
     match http.post_json(url, &payload, 1).await {
         Ok(_) => {
             let position_persisted = save_positions_with_warning(
-                [
-                    (telemetry_paths.system_log_pos_file.as_str(), log_pos),
-                    (telemetry_paths.metrics_pos_file.as_str(), metrics_pos),
-                    (
-                        telemetry_paths.sandbox_ops_pos_file.as_str(),
-                        sandbox_ops_pos,
-                    ),
-                ],
+                position_updates,
                 "Telemetry upload succeeded but position persistence failed",
             );
             Ok(FlushReport {

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -544,6 +544,66 @@ async fn flush_reports_position_persistence_status_after_upload_then_recovers() 
 }
 
 #[tokio::test]
+async fn flush_ignores_unadvanced_position_write_failures() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+    let files = ExplicitTelemetryFiles::new("unadvanced-position-write-failure").unwrap();
+    let paths = &files.paths;
+    let system_log = paths.system_log_file();
+    let metrics_pos = paths.telemetry_metrics_pos_file();
+    let marker = "unadvanced-position-write-failure";
+    ensure_parent_dir(system_log);
+    ensure_parent_dir(metrics_pos);
+    std::fs::write(system_log, format!("{marker}\n")).expect("system log should be written");
+    std::fs::create_dir(metrics_pos).expect("unadvanced position directory should be created");
+    let system_log_guard = SystemLogOverrideGuard::set(system_log);
+
+    let upload_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.status(200);
+    });
+
+    let masker = Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        masker,
+        http_client!(),
+    );
+
+    let first_report = telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await
+        .expect("system log upload should ignore an unadvanced metrics position");
+    assert_eq!(
+        first_report,
+        guest_agent::telemetry::FlushReport {
+            uploaded: true,
+            position_persisted: true,
+        },
+    );
+
+    let second_report = telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await
+        .expect("empty follow-up flush should remain successful");
+    assert_eq!(
+        second_report,
+        guest_agent::telemetry::FlushReport {
+            uploaded: false,
+            position_persisted: true,
+        },
+    );
+    upload_mock.assert_calls_async(1).await;
+
+    telemetry.shutdown().await;
+    drop(system_log_guard);
+    std::fs::remove_dir(metrics_pos).expect("unadvanced position directory should be removed");
+    upload_mock.delete_async().await;
+    remove_telemetry_files(paths);
+}
+
+#[tokio::test]
 async fn skip_only_metrics_progress_saves_position_without_posting_empty_payload() {
     let api = SharedApiMock::new().await;
     let server = api.server();

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -441,6 +441,103 @@ async fn flush_propagates_error_then_loop_recovers() {
 }
 
 #[tokio::test]
+async fn flush_reports_position_persistence_error_after_upload_then_recovers() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+    let files = ExplicitTelemetryFiles::new("position-write-failure-upload").unwrap();
+    let paths = &files.paths;
+    let system_log = paths.system_log_file();
+    let system_log_pos = paths.telemetry_system_log_pos_file();
+    let marker = "position-persistence-upload";
+    ensure_parent_dir(system_log);
+    ensure_parent_dir(system_log_pos);
+    std::fs::write(system_log, format!("{marker}\n")).expect("system log should be written");
+    std::fs::create_dir(system_log_pos).expect("position failure directory should be created");
+
+    let request_bodies = Arc::new(Mutex::new(Vec::new()));
+    let request_bodies_for_mock = Arc::clone(&request_bodies);
+    let upload_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.respond_with(move |request| {
+            request_bodies_for_mock
+                .lock()
+                .unwrap()
+                .push(request.body_vec());
+            http_status(200)
+        });
+    });
+
+    let masker = Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        masker,
+        http_client!(),
+    );
+
+    let first_result = telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await;
+    assert!(
+        first_result.is_err(),
+        "flush must report a position persistence failure after upload"
+    );
+    upload_mock.assert_calls_async(1).await;
+    {
+        let request_bodies = request_bodies.lock().unwrap();
+        assert_eq!(
+            request_bodies.len(),
+            1,
+            "first flush should make one upload"
+        );
+        let payload: serde_json::Value = serde_json::from_slice(&request_bodies[0])
+            .expect("first telemetry request should contain valid JSON");
+        let expected_log = format!("{marker}\n");
+        assert_eq!(payload["systemLog"].as_str(), Some(expected_log.as_str()));
+    }
+
+    std::fs::remove_dir(system_log_pos).expect("position failure directory should be removed");
+    let second_result = telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await;
+    assert!(
+        second_result.is_ok(),
+        "flush should recover after the position path is restored: {second_result:?}"
+    );
+    upload_mock.assert_calls_async(2).await;
+    {
+        let request_bodies = request_bodies.lock().unwrap();
+        assert_eq!(
+            request_bodies.len(),
+            2,
+            "recovery should make a second upload"
+        );
+        let payload: serde_json::Value = serde_json::from_slice(&request_bodies[1])
+            .expect("recovery telemetry request should contain valid JSON");
+        let expected_log = format!("{marker}\n");
+        assert_eq!(payload["systemLog"].as_str(), Some(expected_log.as_str()));
+    }
+
+    telemetry.shutdown().await;
+
+    let pos: u64 = std::fs::read_to_string(system_log_pos)
+        .expect("system log telemetry position should be written after recovery")
+        .trim()
+        .parse()
+        .expect("system log telemetry position should be numeric");
+    assert_eq!(
+        pos,
+        std::fs::metadata(system_log)
+            .expect("system log metadata should be available")
+            .len(),
+        "recovered position must match the source file length"
+    );
+
+    upload_mock.delete_async().await;
+    remove_telemetry_files(paths);
+}
+
+#[tokio::test]
 async fn skip_only_metrics_progress_saves_position_without_posting_empty_payload() {
     let api = SharedApiMock::new().await;
     let server = api.server();
@@ -482,6 +579,84 @@ async fn skip_only_metrics_progress_saves_position_without_posting_empty_payload
         .parse()
         .expect("metrics telemetry position should be numeric");
     assert_eq!(pos, TELEMETRY_DELTA_READ_LIMIT as u64);
+
+    upload_mock.delete_async().await;
+    remove_telemetry_files(paths);
+}
+
+#[tokio::test]
+async fn skip_only_flush_reports_position_persistence_error_then_recovers() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+    let files = ExplicitTelemetryFiles::new("position-write-failure-skip-only").unwrap();
+    let paths = &files.paths;
+    let metrics_file = paths.metrics_log_file();
+    let metrics_pos_file = paths.telemetry_metrics_pos_file();
+    ensure_parent_dir(metrics_file);
+    ensure_parent_dir(metrics_pos_file);
+    assert!(
+        std::fs::write(metrics_file, "x".repeat(TELEMETRY_DELTA_READ_LIMIT + 1)).is_ok(),
+        "oversized metrics log should be written",
+    );
+    std::fs::create_dir(metrics_pos_file).expect("position failure directory should be created");
+
+    let upload_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.status(200);
+    });
+
+    let masker = Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        masker,
+        http_client!(),
+    );
+
+    let first_result = telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await;
+    assert!(
+        first_result.is_err(),
+        "skip-only flush must report a position persistence failure"
+    );
+    upload_mock.assert_calls_async(0).await;
+
+    std::fs::remove_dir(metrics_pos_file).expect("position failure directory should be removed");
+    let second_result = telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await;
+    assert!(
+        second_result.is_ok(),
+        "skip-only flush should recover after the position path is restored: {second_result:?}"
+    );
+    upload_mock.assert_calls_async(0).await;
+
+    // The bounded live read consumes the oversized entry in two chunks after
+    // the failed position write falls back to offset zero.
+    let third_result = telemetry
+        .flush(guest_agent::telemetry::UploadMode::Live)
+        .await;
+    assert!(
+        third_result.is_ok(),
+        "skip-only tail flush should complete recovery: {third_result:?}"
+    );
+    upload_mock.assert_calls_async(0).await;
+
+    telemetry.shutdown().await;
+
+    let pos: u64 = std::fs::read_to_string(metrics_pos_file)
+        .expect("metrics telemetry position should be written after recovery")
+        .trim()
+        .parse()
+        .expect("metrics telemetry position should be numeric");
+    assert_eq!(
+        pos,
+        std::fs::metadata(metrics_file)
+            .expect("metrics metadata should be available")
+            .len(),
+        "recovered position must match the source file length"
+    );
 
     upload_mock.delete_async().await;
     remove_telemetry_files(paths);

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -448,10 +448,14 @@ async fn flush_reports_position_persistence_status_after_upload_then_recovers() 
     let paths = &files.paths;
     let system_log = paths.system_log_file();
     let system_log_pos = paths.telemetry_system_log_pos_file();
+    let metrics_log = paths.metrics_log_file();
+    let metrics_pos = paths.telemetry_metrics_pos_file();
     let marker = "position-persistence-upload";
+    let metric = serde_json::json!({"name": "position-persistence-metric"});
     ensure_parent_dir(system_log);
     ensure_parent_dir(system_log_pos);
     std::fs::write(system_log, format!("{marker}\n")).expect("system log should be written");
+    std::fs::write(metrics_log, format!("{metric}\n")).expect("metrics log should be written");
     std::fs::create_dir(system_log_pos).expect("position failure directory should be created");
 
     let request_bodies = Arc::new(Mutex::new(Vec::new()));
@@ -497,7 +501,20 @@ async fn flush_reports_position_persistence_status_after_upload_then_recovers() 
             .expect("first telemetry request should contain valid JSON");
         let expected_log = format!("{marker}\n");
         assert_eq!(payload["systemLog"].as_str(), Some(expected_log.as_str()));
+        assert_eq!(payload["metrics"], serde_json::json!([metric]));
     }
+    let persisted_metrics_pos: u64 = std::fs::read_to_string(metrics_pos)
+        .expect("metrics position should persist after the earlier system position fails")
+        .trim()
+        .parse()
+        .expect("metrics position should be numeric");
+    assert_eq!(
+        persisted_metrics_pos,
+        std::fs::metadata(metrics_log)
+            .expect("metrics metadata should be available")
+            .len(),
+        "a later advanced position must persist after an earlier position write fails"
+    );
 
     std::fs::remove_dir(system_log_pos).expect("position failure directory should be removed");
     let second_report = telemetry
@@ -522,6 +539,7 @@ async fn flush_reports_position_persistence_status_after_upload_then_recovers() 
             .expect("recovery telemetry request should contain valid JSON");
         let expected_log = format!("{marker}\n");
         assert_eq!(payload["systemLog"].as_str(), Some(expected_log.as_str()));
+        assert_eq!(payload["metrics"], serde_json::json!([]));
     }
 
     telemetry.shutdown().await;

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -441,7 +441,7 @@ async fn flush_propagates_error_then_loop_recovers() {
 }
 
 #[tokio::test]
-async fn flush_reports_position_persistence_error_after_upload_then_recovers() {
+async fn flush_reports_position_persistence_status_after_upload_then_recovers() {
     let api = SharedApiMock::new().await;
     let server = api.server();
     let files = ExplicitTelemetryFiles::new("position-write-failure-upload").unwrap();
@@ -475,12 +475,15 @@ async fn flush_reports_position_persistence_error_after_upload_then_recovers() {
         http_client!(),
     );
 
-    let first_result = telemetry
+    let first_report = telemetry
         .flush(guest_agent::telemetry::UploadMode::Live)
         .await;
-    assert!(
-        first_result.is_err(),
-        "flush must report a position persistence failure after upload"
+    assert_eq!(
+        first_report.expect("upload should succeed despite position persistence failure"),
+        guest_agent::telemetry::FlushReport {
+            uploaded: true,
+            position_persisted: false,
+        },
     );
     upload_mock.assert_calls_async(1).await;
     {
@@ -497,12 +500,15 @@ async fn flush_reports_position_persistence_error_after_upload_then_recovers() {
     }
 
     std::fs::remove_dir(system_log_pos).expect("position failure directory should be removed");
-    let second_result = telemetry
+    let second_report = telemetry
         .flush(guest_agent::telemetry::UploadMode::Live)
         .await;
-    assert!(
-        second_result.is_ok(),
-        "flush should recover after the position path is restored: {second_result:?}"
+    assert_eq!(
+        second_report.expect("flush should recover after the position path is restored"),
+        guest_agent::telemetry::FlushReport {
+            uploaded: true,
+            position_persisted: true,
+        },
     );
     upload_mock.assert_calls_async(2).await;
     {
@@ -585,7 +591,7 @@ async fn skip_only_metrics_progress_saves_position_without_posting_empty_payload
 }
 
 #[tokio::test]
-async fn skip_only_flush_reports_position_persistence_error_then_recovers() {
+async fn skip_only_flush_reports_position_persistence_status_then_recovers() {
     let api = SharedApiMock::new().await;
     let server = api.server();
     let files = ExplicitTelemetryFiles::new("position-write-failure-skip-only").unwrap();
@@ -613,33 +619,42 @@ async fn skip_only_flush_reports_position_persistence_error_then_recovers() {
         http_client!(),
     );
 
-    let first_result = telemetry
+    let first_report = telemetry
         .flush(guest_agent::telemetry::UploadMode::Live)
         .await;
-    assert!(
-        first_result.is_err(),
-        "skip-only flush must report a position persistence failure"
+    assert_eq!(
+        first_report.expect("skip-only progress should remain a successful flush"),
+        guest_agent::telemetry::FlushReport {
+            uploaded: false,
+            position_persisted: false,
+        },
     );
     upload_mock.assert_calls_async(0).await;
 
     std::fs::remove_dir(metrics_pos_file).expect("position failure directory should be removed");
-    let second_result = telemetry
+    let second_report = telemetry
         .flush(guest_agent::telemetry::UploadMode::Live)
         .await;
-    assert!(
-        second_result.is_ok(),
-        "skip-only flush should recover after the position path is restored: {second_result:?}"
+    assert_eq!(
+        second_report.expect("skip-only flush should recover after the position path is restored"),
+        guest_agent::telemetry::FlushReport {
+            uploaded: false,
+            position_persisted: true,
+        },
     );
     upload_mock.assert_calls_async(0).await;
 
     // The bounded live read consumes the oversized entry in two chunks after
     // the failed position write falls back to offset zero.
-    let third_result = telemetry
+    let third_report = telemetry
         .flush(guest_agent::telemetry::UploadMode::Live)
         .await;
-    assert!(
-        third_result.is_ok(),
-        "skip-only tail flush should complete recovery: {third_result:?}"
+    assert_eq!(
+        third_report.expect("skip-only tail flush should complete recovery"),
+        guest_agent::telemetry::FlushReport {
+            uploaded: false,
+            position_persisted: true,
+        },
     );
     upload_mock.assert_calls_async(0).await;
 


### PR DESCRIPTION
## Summary

- Return a `FlushReport` that separates telemetry upload success from position persistence status.
- Keep HTTP, configuration, and actor failures as errors; treat a successful upload with a failed required position write as a non-fatal, explicitly logged degraded result.
- Persist only positions that advanced during the current pass, attempt every required write, and include the failing path in diagnostics.
- Prevent an unrelated unavailable position path from falsely degrading a flush or causing warning-only follow-up uploads.
- Cover upload and skip-only recovery plus the unadvanced-position case with report fields, request counts/bodies, zero-HTTP behavior, and durable source-file-length positions.

## Scope

- Closes #28023
- Excludes a transaction manifest, journal, retry policy, exactly-once delivery, telemetry protocol changes, and task/checkpoint failure on local position persistence warnings.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration telemetry::` (11 passed)
- `CARGO_INCREMENTAL=0 cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib telemetry::` (27 passed)
- `CARGO_INCREMENTAL=0 cargo check --manifest-path crates/Cargo.toml -p guest-agent --all-targets`
- `CARGO_INCREMENTAL=0 cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --lib -- -D warnings`
- `CARGO_INCREMENTAL=0 cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --test integration -- -D warnings`

The broader `cargo test --manifest-path crates/Cargo.toml -p guest-agent` run was attempted with one build job but stopped while it was still compiling independent test targets because build artifacts were again consuming most of the 16 GB workspace. All-target compilation and the focused unit/integration suites pass.
