### PR TITLE
fix(platform): defer settings until home route stabilizes

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -380,7 +380,9 @@ const ROUTE_CONFIG = [
   },
   {
     path: ROUTES.home,
-    setup: setupAuthPageWrapper(setupHomePage$),
+    setup: setupAuthPageWrapper(
+      setupSettingsParamAfterStableRoute(setupHomePage$),
+    ),
   },
 
   // --- Redirect routes (backward compatibility) ---

--- a/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { homeAgentId$ } from "../agent.ts";
+import { setupAgentsPage$ } from "../agents-page/agents-page-setup.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 
 export const setupHomePage$ = command(
@@ -15,6 +16,7 @@ export const setupHomePage$ = command(
     const homeAgentId = await get(homeAgentId$);
     signal.throwIfAborted();
     if (!homeAgentId) {
+      await set(setupAgentsPage$, signal);
       return;
     }
     const params = get(searchParams$);

--- a/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/home-page-setup.ts
@@ -1,9 +1,5 @@
 import { command } from "ccstate";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
-import {
-  checkUnifiedSettingsParam$,
-  handoffSettingsDialogSession$,
-} from "./settings/settings-dialog.ts";
 import { homeAgentId$ } from "../agent.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 
@@ -12,8 +8,6 @@ export const setupHomePage$ = command(
     if (await set(onboardGuard$, signal)) {
       return;
     }
-
-    await set(checkUnifiedSettingsParam$, signal);
 
     // Redirect bare / to /agents/:id/chat. Keep prompt deep links intact so
     // paid-onboarding handoffs can prefill the chat composer on arrival.
@@ -40,9 +34,6 @@ export const setupHomePage$ = command(
     }
     if (billingView) {
       forwardParams.set("billingView", billingView);
-    }
-    if (settings) {
-      set(handoffSettingsDialogSession$);
     }
     set(detachedNavigateTo$, "/agents/:agentId/chat", {
       pathParams: { agentId: homeAgentId },

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -56,7 +56,6 @@ const internalSettingsDialogSignal$ = state<AbortSignal | null>(null);
 const resetSettingsDialogSignal$ = resetSignal();
 const internalSettingsDialogSessionActive$ = state(false);
 const internalSettingsDialogInitialized$ = state(false);
-const internalSettingsDialogHandoffPending$ = state(false);
 const pendingAccountMenuSettingsSection$ = state<{
   readonly ownerId: string;
   readonly section: SettingsSection;
@@ -167,34 +166,18 @@ export const openSettingsUsagePackUpgrade$ = command(
   },
 );
 
-const releaseSettingsDialogSession$ = command(({ get, set }) => {
+const releaseSettingsDialogSession$ = command(({ set }) => {
   set(internalSettingsDialogSignal$, null);
   set(internalSettingsDialogSessionActive$, false);
   set(clearPendingLogo$);
   set(resetUsagePackPricing$);
-
-  const handoffPending = get(internalSettingsDialogHandoffPending$);
-  set(internalSettingsDialogHandoffPending$, false);
-  if (!handoffPending) {
-    set(internalSettingsDialogOpen$, false);
-    set(internalSettingsDialogInitialized$, false);
-  }
-});
-
-const clearSettingsDialogSession$ = command(({ set }) => {
-  set(releaseSettingsDialogSession$);
   set(internalSettingsDialogOpen$, false);
   set(internalSettingsDialogInitialized$, false);
-  set(internalSettingsDialogHandoffPending$, false);
-});
-
-export const handoffSettingsDialogSession$ = command(({ set }) => {
-  set(internalSettingsDialogHandoffPending$, true);
 });
 
 export const closeSettingsModal$ = command(({ get, set }) => {
   set(resetSettingsDialogSignal$);
-  set(clearSettingsDialogSession$);
+  set(releaseSettingsDialogSession$);
   set(clearBillingScrollTarget$);
 
   const params = new URLSearchParams(get(searchParams$));
@@ -228,12 +211,14 @@ export const setSettingsDialogOpen$ = command(
     );
     set(internalSettingsDialogSignal$, modalSignal);
     set(internalSettingsDialogSessionActive$, true);
+    if (!dialogInitialized) {
+      set(reloadBillingStatus$);
+    }
     set(internalSettingsDialogOpen$, true);
     if (!dialogInitialized) {
       await set(initProfileName$, modalSignal);
       pageSignal.throwIfAborted();
       modalSignal.throwIfAborted();
-      set(reloadBillingStatus$);
       set(internalSettingsDialogInitialized$, true);
     }
     const params = new URLSearchParams(get(searchParams$));

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -55,7 +55,6 @@ const internalSettingsDialogOpen$ = state(false);
 const internalSettingsDialogSignal$ = state<AbortSignal | null>(null);
 const resetSettingsDialogSignal$ = resetSignal();
 const internalSettingsDialogSessionActive$ = state(false);
-const internalSettingsDialogInitialized$ = state(false);
 const pendingAccountMenuSettingsSection$ = state<{
   readonly ownerId: string;
   readonly section: SettingsSection;
@@ -172,7 +171,6 @@ const releaseSettingsDialogSession$ = command(({ set }) => {
   set(clearPendingLogo$);
   set(resetUsagePackPricing$);
   set(internalSettingsDialogOpen$, false);
-  set(internalSettingsDialogInitialized$, false);
 });
 
 export const closeSettingsModal$ = command(({ get, set }) => {
@@ -200,7 +198,6 @@ export const setSettingsDialogOpen$ = command(
       return;
     }
 
-    const dialogInitialized = get(internalSettingsDialogInitialized$);
     const modalSignal = set(resetSettingsDialogSignal$, pageSignal);
     modalSignal.addEventListener(
       "abort",
@@ -211,16 +208,11 @@ export const setSettingsDialogOpen$ = command(
     );
     set(internalSettingsDialogSignal$, modalSignal);
     set(internalSettingsDialogSessionActive$, true);
-    if (!dialogInitialized) {
-      set(reloadBillingStatus$);
-    }
+    set(reloadBillingStatus$);
     set(internalSettingsDialogOpen$, true);
-    if (!dialogInitialized) {
-      await set(initProfileName$, modalSignal);
-      pageSignal.throwIfAborted();
-      modalSignal.throwIfAborted();
-      set(internalSettingsDialogInitialized$, true);
-    }
+    await set(initProfileName$, modalSignal);
+    pageSignal.throwIfAborted();
+    modalSignal.throwIfAborted();
     const params = new URLSearchParams(get(searchParams$));
     const section = get(internalActiveSection$);
     if (section === "model") {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-deep-link-handoff.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-deep-link-handoff.test.tsx
@@ -9,10 +9,6 @@ import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { localStorageSignals } from "../../../signals/external/local-storage.ts";
 import { pathname } from "../../../signals/location.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import {
-  settingsActiveSection$,
-  settingsDialogOpen$,
-} from "../../../signals/zero-page/settings/settings-dialog.ts";
 
 const context = testContext();
 const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
@@ -46,7 +42,6 @@ describe("settings deep-link handoff", () => {
     });
 
     await teamRequestStarted.promise;
-    expect(context.store.get(settingsDialogOpen$)).toBeFalsy();
     expect(
       screen.queryByRole("dialog", { name: "Settings" }),
     ).not.toBeInTheDocument();
@@ -79,10 +74,12 @@ describe("settings deep-link handoff", () => {
       path: "/?settings=billing",
     });
 
-    await waitFor(() => {
-      expect(context.store.get(settingsDialogOpen$)).toBeTruthy();
-      expect(context.store.get(settingsActiveSection$)).toBe("billing");
-    });
+    await expect(
+      screen.findByRole("dialog", { name: "Settings" }),
+    ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByRole("heading", { name: "Billing" }),
+    ).resolves.toBeInTheDocument();
     expect(pathname()).toBe("/");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-deep-link-handoff.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-deep-link-handoff.test.tsx
@@ -1,0 +1,88 @@
+import {
+  zeroTeamContract,
+  type TeamComposeItem,
+} from "@okouai/api-contracts/contracts/zero-team";
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { localStorageSignals } from "../../../signals/external/local-storage.ts";
+import { pathname } from "../../../signals/location.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  settingsActiveSection$,
+  settingsDialogOpen$,
+} from "../../../signals/zero-page/settings/settings-dialog.ts";
+
+const context = testContext();
+const LAST_USED_AGENT_STORAGE_KEY = "zero.lastUsedAgentId";
+const { set$: setLastUsedAgentId$, clear$: clearLastUsedAgentId$ } =
+  localStorageSignals(LAST_USED_AGENT_STORAGE_KEY);
+
+const DEFAULT_AGENT = {
+  id: "c0000000-0000-4000-a000-000000000001",
+  displayName: "Zero",
+  description: null,
+  sound: null,
+  avatarUrl: null,
+  headVersionId: "version_1",
+  updatedAt: "2026-08-18T00:00:00Z",
+} satisfies TeamComposeItem;
+
+describe("settings deep-link handoff", () => {
+  it("waits for the stable agent route before opening settings", async () => {
+    context.store.set(setLastUsedAgentId$, DEFAULT_AGENT.id);
+    const teamRequestStarted = context.mocks.deferred<void>();
+    const releaseTeamRequest = context.mocks.deferred<void>();
+    context.mocks.api(zeroTeamContract.list, async ({ respond }) => {
+      teamRequestStarted.resolve(undefined);
+      await releaseTeamRequest.promise;
+      return respond(200, [DEFAULT_AGENT]);
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/?settings=billing&billingView=plans",
+    });
+
+    await teamRequestStarted.promise;
+    expect(context.store.get(settingsDialogOpen$)).toBeFalsy();
+    expect(
+      screen.queryByRole("dialog", { name: "Settings" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Compare plans" }),
+    ).not.toBeInTheDocument();
+
+    releaseTeamRequest.resolve(undefined);
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${DEFAULT_AGENT.id}/chat`);
+    });
+    await expect(
+      screen.findByRole("dialog", { name: "Settings" }),
+    ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByRole("heading", { name: "Compare plans" }),
+    ).resolves.toBeInTheDocument();
+  });
+
+  it("processes settings on the root route when no home agent exists", async () => {
+    context.store.set(clearLastUsedAgentId$);
+    context.mocks.data.onboardingStatus({
+      hasDefaultAgent: false,
+      defaultAgentId: null,
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/?settings=billing",
+    });
+
+    await waitFor(() => {
+      expect(context.store.get(settingsDialogOpen$)).toBeTruthy();
+      expect(context.store.get(settingsActiveSection$)).toBe("billing");
+    });
+    expect(pathname()).toBe("/");
+  });
+});


### PR DESCRIPTION
## Summary

- defer root settings deep-link processing until home route setup confirms that the pathname is stable
- let the agent destination own forwarded `settings` and `billingView` state instead of opening and handing off a transient root session
- mount the existing Agents page shell when no home agent exists so root Settings deep links remain visible and usable
- remove the now-unused settings handoff state and reload billing resources before exposing a newly initialized dialog, avoiding an immediate duplicate credits request
- add production-bootstrap integration coverage for delayed home-agent resolution, forwarded plan deep links, and the no-home-agent branch

## Problem

The root route opened Settings before asynchronously resolving and redirecting to the user's home agent. The destination then parsed the same query again. A user or Playwright could click `Upgrade` in the transient dialog, only for destination setup to reset the billing subpage and remove `Choose a plan`.

The non-redirecting no-home-agent branch also left the app skeleton mounted, so setting the internal dialog state there did not produce a visible Settings surface.

## Solution

The home route now uses the existing `setupSettingsParamAfterStableRoute` wrapper. Redirecting roots only forward the query; the stable agent route opens Settings once. Non-redirecting roots mount the existing Agents page shell and then parse the query locally. Because there is no longer a root-owned Settings session to preserve, the one-shot handoff state is removed.

## Validation

- `TZ=UTC pnpm -F @okouai/app test -- --silent=passed-only` (146 files, 1780 tests)
- `TZ=UTC pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/settings-deep-link-handoff.test.tsx --silent=passed-only` (2 tests)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- repository pre-commit checks, including full Knip and Turbo type checking
- verified the redirect regression test fails with the previous ordering and passes with this change
- verified the no-home-agent test fails when only internal dialog state is updated and passes when a visible Settings host is mounted

## Excluded

- no Clerk, Stripe, billing API, timeout, retry, or Playwright synchronization changes
- no API, schema, migration, runner protocol, or deployment-contract changes

Closes #28036
