### PR TITLE
test(api): synchronize queued workflow successor state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -371,7 +371,10 @@ async function startOrgConcurrencyBlocker(scenario: Scenario): Promise<string> {
   return response.body.runId;
 }
 
-async function completeRunThroughSandbox(scenario: Scenario, runId: string) {
+async function requestRunCompletionThroughSandbox(
+  scenario: Scenario,
+  runId: string,
+) {
   await runsApi.heartbeatRunner(scenario.runnerGroup);
   const claim = await runsApi.claimRunnerJob(runId);
   const sandboxHeaders = { authorization: `Bearer ${claim.sandboxToken}` };
@@ -412,6 +415,11 @@ async function completeRunThroughSandbox(scenario: Scenario, runId: string) {
     sandboxHeaders,
     [200],
   );
+  return claim;
+}
+
+async function completeRunThroughSandbox(scenario: Scenario, runId: string) {
+  const claim = await requestRunCompletionThroughSandbox(scenario, runId);
   await flushWaitUntilForTest();
   return claim;
 }
@@ -968,10 +976,28 @@ describe("workflow queue", () => {
     );
 
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
-    await completeRunThroughSandbox(scenario, firstRunId);
+    await requestRunCompletionThroughSandbox(scenario, firstRunId);
 
+    // The completion response precedes its waitUntil callback. Observe the
+    // successor through the product APIs instead of waiting for unrelated
+    // summary, notification, org-queue, and usage side effects to finish.
+    await expect
+      .poll(() => {
+        return workflowRunIds(automation.threadId);
+      })
+      .toHaveLength(2);
     const runIds = await workflowRunIds(automation.threadId);
-    expect(runIds).toHaveLength(2);
+    const queue = await runsApi.readRunQueue(scenario.actor);
+    expect(queue.body.concurrency).toMatchObject({
+      limit: 1,
+      active: 1,
+      available: 0,
+    });
+    expect(queue.body.queue).toHaveLength(1);
+    expect(queue.body.queue[0]).toMatchObject({
+      runId: runIds[1],
+      triggerSource: "automation-event",
+    });
     await runsApi.requestCancelRun(scenario.actor, runIds[1]!, [200]);
     await runsApi.requestCancelRun(scenario.actor, blockerRunId, [200]);
   });


### PR DESCRIPTION
## Summary

- synchronize the org-concurrency workflow queue test on the observable queued-successor milestone
- preserve the full `waitUntil` flush for tests that need all completion side effects
- assert the successor's public queue state, concurrency saturation, and automation trigger source

## Root cause

The completion endpoint returns before its terminal callback runs through `waitUntil`. The failing test used a shared helper that then awaited the global `waitUntil` tracker, coupling the queued-successor assertion to unrelated terminal work such as summaries, notifications, org-queue draining, and usage processing.

In the failing [Turbo run 32127940952](https://github.com/vm0-ai/vm0/actions/runs/32127940952), the run-summary warnings appear only after the callback has already drained the workflow thread queue and persisted the successor. That proves the product milestone completed before the timeout; the first causal nondeterminism was the test waiting for the broader background-work set under shard contention. The 5-second timeout itself was not changed.

Failing job: [test-api (1), job 95682631822](https://github.com/vm0-ai/vm0/actions/runs/32127940952/job/95682631822)

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `git diff --check`
- targeted `test-api (1)` 5x on [Turbo run 32130589218](https://github.com/vm0-ai/vm0/actions/runs/32130589218), attempts 1-5:
  - target test: 833ms, 853ms, 1018ms, 1779ms, 684ms
  - full `workflow-queue.test.ts`: 19.865s, 17.573s, 16.523s, 48.064s, 16.357s
  - jobs: [95690697481](https://github.com/vm0-ai/vm0/actions/runs/32130589218/job/95690697481), [95691711175](https://github.com/vm0-ai/vm0/actions/runs/32130589218/job/95691711175), [95692383902](https://github.com/vm0-ai/vm0/actions/runs/32130589218/job/95692383902), [95693078551](https://github.com/vm0-ai/vm0/actions/runs/32130589218/job/95693078551), [95694108268](https://github.com/vm0-ai/vm0/actions/runs/32130589218/job/95694108268)

The targeted test was not run locally because it requires PostgreSQL; no local service was started under the repair contract.
