### PR TITLE
fix(composer): flush pending ime dom changes before submit

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -63,6 +63,10 @@ export const imageModelSelectionEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ImageModelSelection] ?? false;
 });
 
+export const composerImeSubmitFlushEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.ComposerImeSubmitFlush] ?? false;
+});
+
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -16,7 +16,12 @@ import {
   type EditorState,
   type Transaction,
 } from "@tiptap/pm/state";
-import { Decoration, DecorationSet, type NodeView } from "@tiptap/pm/view";
+import {
+  Decoration,
+  DecorationSet,
+  type EditorView,
+  type NodeView,
+} from "@tiptap/pm/view";
 import { StarterKit } from "@tiptap/starter-kit";
 import { createCompositionGate, type CompositionGate } from "@okouai/ui";
 import {
@@ -27,6 +32,7 @@ import {
 import type { ZeroWorkflowSummary } from "@okouai/api-contracts/contracts/zero-workflows";
 import { agents$ } from "../agent.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
+import { composerImeSubmitFlushEnabled$ } from "../external/feature-switch.ts";
 import { onRef, resetSignal } from "../utils.ts";
 import type { DraftInputSyncTarget, DraftSignals } from "./chat-draft.ts";
 import {
@@ -263,6 +269,33 @@ function connectComposerFeedback(
   });
 }
 
+interface PendingDomChangeObserver {
+  readonly flush: () => void;
+}
+
+function hasPendingDomChangeObserver(
+  view: EditorView,
+): view is EditorView & { readonly domObserver: PendingDomChangeObserver } {
+  return "domObserver" in view;
+}
+
+/**
+ * ProseMirror defers reading the contenteditable while an IME composition is in
+ * flight. On a busy page the composed tail can still be missing from
+ * `editor.state.doc` after the composition gate settles, which submits only the
+ * already committed prefix. Flushing the observer applies those pending DOM
+ * changes before the document is serialized.
+ *
+ * `domObserver` is internal to prosemirror-view, so it is narrowed structurally
+ * rather than imported.
+ */
+function flushPendingDomChanges(editor: Editor): void {
+  if (!hasPendingDomChangeObserver(editor.view)) {
+    return;
+  }
+  editor.view.domObserver.flush();
+}
+
 function createReadInputForSubmissionCommand(
   editor: Editor,
   compositionGate: CompositionGate,
@@ -270,7 +303,11 @@ function createReadInputForSubmissionCommand(
 ) {
   return command(({ get }, signal: AbortSignal) => {
     const includeQuoteOnlyFeedback = get(quoteOnlyFeedbackEnabled$);
+    const flushBeforeRead = get(composerImeSubmitFlushEnabled$);
     return compositionGate.runWhenSettled(() => {
+      if (flushBeforeRead) {
+        flushPendingDomChanges(editor);
+      }
       return {
         prompt: workflowComposerDocToString(editor, includeQuoteOnlyFeedback),
         editorDocument: createEditorDocumentSnapshot(

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -269,14 +269,8 @@ function connectComposerFeedback(
   });
 }
 
-interface PendingDomChangeObserver {
-  readonly flush: () => void;
-}
-
-function hasPendingDomChangeObserver(
-  view: EditorView,
-): view is EditorView & { readonly domObserver: PendingDomChangeObserver } {
-  return "domObserver" in view;
+interface EditorViewWithDomObserver extends EditorView {
+  readonly domObserver: { readonly flush: () => void };
 }
 
 /**
@@ -286,14 +280,13 @@ function hasPendingDomChangeObserver(
  * already committed prefix. Flushing the observer applies those pending DOM
  * changes before the document is serialized.
  *
- * `domObserver` is internal to prosemirror-view, so it is narrowed structurally
- * rather than imported.
+ * Every `EditorView` constructs `domObserver`, but prosemirror-view marks it
+ * internal and omits it from the published types, so it is reached through a
+ * cast. A future rename must fail loudly here rather than silently restore the
+ * truncated submission.
  */
 function flushPendingDomChanges(editor: Editor): void {
-  if (!hasPendingDomChangeObserver(editor.view)) {
-    return;
-  }
-  editor.view.domObserver.flush();
+  (editor.view as EditorViewWithDomObserver).domObserver.flush();
 }
 
 function createReadInputForSubmissionCommand(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -1460,26 +1460,26 @@ describe("chat run queue", () => {
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
     });
     const composer = await activeRunComposer();
-    await fill(composer, "排");
+    await fill(composer, "que");
 
-    fireEvent.compositionStart(composer, { data: "排" });
+    fireEvent.compositionStart(composer, { data: "que" });
     const paragraph = composer.querySelector("p");
     if (!paragraph) {
       throw new Error("Composer paragraph not found");
     }
-    paragraph.textContent = "排队完整内容";
+    paragraph.textContent = "queued full composed text";
 
     fireEvent.click(screen.getByLabelText("Send"));
     expect(queuedBodies).toHaveLength(0);
 
     // iOS Safari can leave the composed tail in the DOM without delivering the
     // input event that would normally flush it into the document.
-    fireEvent.compositionEnd(composer, { data: "排队完整内容" });
+    fireEvent.compositionEnd(composer, { data: "queued full composed text" });
 
     await waitFor(() => {
       expect(queuedBodies).toHaveLength(1);
     });
-    expect(queuedBodies[0]?.content).toBe("排队完整内容");
+    expect(queuedBodies[0]?.content).toBe("queued full composed text");
   });
 
   it("renders a server-reconciled follow-up inline", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -1442,6 +1442,46 @@ describe("chat run queue", () => {
     expect(queuedBodies[0]?.content).toBe("排队完整内容");
   });
 
+  it("queues the full composed text when no input event follows composition end", async () => {
+    const queuedBodies: QueuedMessageCapture[] = [];
+    mockActiveRunThread(THREAD_ID, {
+      onQueuedEventAppend: (body) => {
+        queuedBodies.push(body);
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: CHAT_PATH,
+      featureSwitches: { [FeatureSwitchKey.ComposerImeSubmitFlush]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+    const composer = await activeRunComposer();
+    await fill(composer, "排");
+
+    fireEvent.compositionStart(composer, { data: "排" });
+    const paragraph = composer.querySelector("p");
+    if (!paragraph) {
+      throw new Error("Composer paragraph not found");
+    }
+    paragraph.textContent = "排队完整内容";
+
+    fireEvent.click(screen.getByLabelText("Send"));
+    expect(queuedBodies).toHaveLength(0);
+
+    // iOS Safari can leave the composed tail in the DOM without delivering the
+    // input event that would normally flush it into the document.
+    fireEvent.compositionEnd(composer, { data: "排队完整内容" });
+
+    await waitFor(() => {
+      expect(queuedBodies).toHaveLength(1);
+    });
+    expect(queuedBodies[0]?.content).toBe("排队完整内容");
+  });
+
   it("renders a server-reconciled follow-up inline", async () => {
     const user = userEvent.setup({ delay: null });
     const queuedBodies: QueuedMessageCapture[] = [];

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-run-queue.test.tsx
@@ -1442,7 +1442,7 @@ describe("chat run queue", () => {
     expect(queuedBodies[0]?.content).toBe("排队完整内容");
   });
 
-  it("queues the full composed text when no input event follows composition end", async () => {
+  it("queues the full composed text with the ime submit flush enabled", async () => {
     const queuedBodies: QueuedMessageCapture[] = [];
     mockActiveRunThread(THREAD_ID, {
       onQueuedEventAppend: (body) => {
@@ -1472,8 +1472,10 @@ describe("chat run queue", () => {
     fireEvent.click(screen.getByLabelText("Send"));
     expect(queuedBodies).toHaveLength(0);
 
-    // iOS Safari can leave the composed tail in the DOM without delivering the
-    // input event that would normally flush it into the document.
+    // No input event follows, so the submission depends on the flush rather
+    // than on prosemirror-view's input handler. This does not reproduce the
+    // iOS stall itself: happy-dom delivers the pending mutation as a microtask
+    // before the gate settles, so the document is already current here.
     fireEvent.compositionEnd(composer, { data: "queued full composed text" });
 
     await waitFor(() => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -83,4 +83,5 @@ export enum FeatureSwitchKey {
   LatestWebsiteTemplates = "latestWebsiteTemplates",
   ChatConversationLocator = "chatConversationLocator",
   SharedChatDatabase = "sharedChatDatabase",
+  ComposerImeSubmitFlush = "composerImeSubmitFlush",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -366,6 +366,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ComposerImeSubmitFlush]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Flush pending IME DOM changes into the composer document before reading a submission.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatForward]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

On iOS Safari (both the browser and the installed PWA), sending a message composed with a Chinese IME can submit only the first character or two even though the input box visibly shows the full text.

- Flush the ProseMirror DOM observer before serializing a submission, so composition text still pending in the contenteditable is applied to `editor.state.doc` first.
- Gate the behavior behind a new `composerImeSubmitFlush` feature switch (off by default, staff orgs only).

## Why

Submission reads the document, not the DOM: `readInputForSubmission$` serializes `editor.state.doc` via `workflowComposerDocToString`. ProseMirror intentionally defers reading the contenteditable while a composition is in flight, and normally catches up when the browser delivers an `input` event — prosemirror-view's `input` handler is what flushes the observer.

When the page is busy, that catch-up can lag by seconds. The composition gate added in #22024 releases a pending submit one `requestAnimationFrame` after `compositionend` regardless of whether the document caught up, so the read can still see only the committed prefix. Reported behavior matches this: the text is visible in the box, waiting ~8s makes the send correct, and waiting 2-3s does not.

Flushing at submit time removes the dependency on when that `input` event arrives.

## Notes

`domObserver` is internal to prosemirror-view, so it is reached through a documented cast instead of being imported. It is not guarded: every `EditorView` constructs it, and a future rename must fail loudly rather than silently restore the truncated submission.

This does not change the composition gate itself; the `requestAnimationFrame` fallback still exists and is unaffected when the switch is off.

## Test plan

- Added `queues the full composed text with the ime submit flush enabled` in `chat-run-queue.test.tsx`: composition ends with the composed tail in the DOM and no following `input` event, so the submission goes through the flush path rather than prosemirror-view's `input` handler.
- **This is not a regression guard, and the PR does not have one.** Verified by direct experiment: with the flush removed the test still passes, because happy-dom delivers the pending mutation as a microtask before the composition gate settles, so the document is already current at read time. The iOS deferral this PR fixes is not reproducible under happy-dom.
- Existing IME regressions in `chat-inline-feedback.test.tsx` and `chat-run-queue.test.tsx` continue to cover the ordered path.
- Local checks run and green: `pnpm format`, `pnpm turbo run lint` (13 tasks, 0 errors), `@okouai/core` and `@okouai/app` `check-types`, and `chat-run-queue.test.tsx` (33 passed).
- **Device verification is the real gate**: enable `composerImeSubmitFlush` in Lab, then reproduce the truncation on iOS Safari and the installed PWA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
