### PR TITLE
fix(app): hide chat model brand icon in media picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -280,8 +280,13 @@ describe("chat composer models", () => {
     });
     const modelPicker = await findComposerModel("Claude Fable 5");
     expect(
-      modelPicker.querySelector(".hidden.min-w-0 > img"),
-    ).toBeInTheDocument();
+      Array.from(
+        modelPicker.querySelectorAll<HTMLImageElement>("img"),
+        (icon) => {
+          return icon.width;
+        },
+      ),
+    ).toStrictEqual([18, 16]);
   });
 
   it.each([
@@ -296,7 +301,7 @@ describe("chat composer models", () => {
       categoryLabel: "Video models",
     },
   ])(
-    "hides the desktop model brand icon when $kind model selection is enabled",
+    "keeps the mobile model brand icon and hides the desktop icon when $kind model selection is enabled",
     async ({ featureSwitch, categoryLabel }) => {
       context.mocks.browser.matchMedia(true);
       mockOrgModelRoutes("claude-fable-5");
@@ -318,9 +323,13 @@ describe("chat composer models", () => {
         ).toBeInTheDocument();
       });
       expect(
-        modelPicker.querySelector(".lucide-message-circle"),
-      ).toBeInTheDocument();
-      expect(modelPicker.querySelector(".hidden.min-w-0 > img")).toBeNull();
+        Array.from(
+          modelPicker.querySelectorAll<HTMLImageElement>("img"),
+          (icon) => {
+            return icon.width;
+          },
+        ),
+      ).toStrictEqual([18]);
     },
   );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -278,8 +278,51 @@ describe("chat composer models", () => {
     await waitFor(() => {
       expect(document.title).toContain("Scout");
     });
-    await expectComposerModel("Claude Fable 5");
+    const modelPicker = await findComposerModel("Claude Fable 5");
+    expect(
+      modelPicker.querySelector(".hidden.min-w-0 > img"),
+    ).toBeInTheDocument();
   });
+
+  it.each([
+    {
+      kind: "image",
+      featureSwitch: FeatureSwitchKey.ImageModelSelection,
+      categoryLabel: "Image models",
+    },
+    {
+      kind: "video",
+      featureSwitch: FeatureSwitchKey.VideoModelSelection,
+      categoryLabel: "Video models",
+    },
+  ])(
+    "hides the desktop model brand icon when $kind model selection is enabled",
+    async ({ featureSwitch, categoryLabel }) => {
+      context.mocks.browser.matchMedia(true);
+      mockOrgModelRoutes("claude-fable-5");
+      mockAgent();
+      mockThread({ selectedModel: "claude-fable-5" });
+
+      detachedSetupPage({
+        context,
+        featureSwitches: { [featureSwitch]: true },
+        path: `/chats/${THREAD_ID}`,
+      });
+
+      const modelPicker = await findComposerModel("Claude Fable 5");
+      await waitFor(() => {
+        expect(
+          queryAllByRoleFast("button").find((button) => {
+            return button.getAttribute("aria-label") === categoryLabel;
+          }),
+        ).toBeInTheDocument();
+      });
+      expect(
+        modelPicker.querySelector(".lucide-message-circle"),
+      ).toBeInTheDocument();
+      expect(modelPicker.querySelector(".hidden.min-w-0 > img")).toBeNull();
+    },
+  );
 
   it("shows user preference over workspace default", async () => {
     mockOrgModelRoutes("claude-fable-5");

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -236,10 +236,12 @@ function ProBadge() {
 
 function ResponsiveTriggerContent({
   mobileIcon,
+  showDesktopIcon,
   iconType,
   label,
 }: {
   mobileIcon: boolean;
+  showDesktopIcon: boolean;
   iconType: ModelProviderType | undefined;
   label: ReactNode;
 }) {
@@ -256,7 +258,9 @@ function ResponsiveTriggerContent({
         )}
       </span>
       <span className="hidden min-w-0 sm:inline-flex sm:items-center sm:gap-1.5">
-        {iconType && <ProviderIcon type={iconType} size={16} />}
+        {showDesktopIcon && iconType && (
+          <ProviderIcon type={iconType} size={16} />
+        )}
         {label}
       </span>
     </span>
@@ -386,12 +390,14 @@ function ModelFirstTriggerLabel({
   selection,
   placeholder,
   mobileIcon,
+  showDesktopIcon,
   codexFastModeEnabled,
   fastLabel,
 }: {
   selection: ModelProviderSelection | null;
   placeholder: string;
   mobileIcon: boolean;
+  showDesktopIcon: boolean;
   codexFastModeEnabled: boolean;
   fastLabel: string;
 }) {
@@ -399,6 +405,7 @@ function ModelFirstTriggerLabel({
     return (
       <ResponsiveTriggerContent
         mobileIcon={mobileIcon}
+        showDesktopIcon={showDesktopIcon}
         iconType={undefined}
         label={<span>{placeholder}</span>}
       />
@@ -408,6 +415,7 @@ function ModelFirstTriggerLabel({
   return (
     <ResponsiveTriggerContent
       mobileIcon={mobileIcon}
+      showDesktopIcon={showDesktopIcon}
       iconType={iconType}
       label={
         <span className="min-w-0 truncate">
@@ -450,6 +458,7 @@ function ModelFirstTriggerContent({
         selection={selection}
         placeholder={placeholder}
         mobileIcon={mobileIcon}
+        showDesktopIcon={desktopModeLabel === undefined}
         codexFastModeEnabled={codexFastModeEnabled}
         fastLabel={fastLabel}
       />


### PR DESCRIPTION
## Summary

- hide the desktop run-model brand icon when image or video model selection is enabled
- keep the mobile trigger and media-model row brand icons unchanged
- preserve the standard chat model trigger icon when media-model selection is disabled

## Testing

- `pnpm exec prettier --check apps/platform/src/views/zero-page/components/model-provider-picker.tsx apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx --maxWorkers=1` (80 passed)
- `pnpm knip --workspace @okouai/app`