### PR TITLE
test(rust): cover codex catalog prefetch telemetry

### DIFF
--- a/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
@@ -1,18 +1,26 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
-use sandbox::ProcessOutputMode;
+use sandbox::{
+    ExecTermination, ProcessExit, ProcessOutputMode, SandboxError, SandboxOperation,
+    SandboxOperationReason,
+};
 use sandbox_mock::MockLifecycleGate;
 use tokio::sync::Notify;
 
 use crate::executor::EXIT_SIGKILL;
 use crate::executor::agent_run::{RunControls, RunStart, run_in_sandbox};
-use crate::executor::codex_model_catalog_prefetch::PREFETCH_HOST_START_TIMEOUT;
+use crate::executor::codex_model_catalog_prefetch::{
+    PREFETCH_HOST_START_TIMEOUT, StartedCodexModelCatalogPrefetch,
+};
 use crate::executor::tests::support::{
     RUN_IN_SANDBOX_TEST_TIMEOUT, create_overridden_sandbox, minimal_context, sandbox_exec_error,
     spawn_run_in_sandbox_test, test_executor_config, test_telemetry,
 };
 use crate::types::{ExecutionContext, FirewallEntry, SandboxReuseResult};
+
+const PREFETCH_ACTION: &str = "runner_codex_model_catalog_prefetch";
 
 fn codex_oauth_context() -> ExecutionContext {
     let mut context = minimal_context();
@@ -24,6 +32,97 @@ fn codex_oauth_context() -> ExecutionContext {
         source_id: None,
     }]);
     context
+}
+
+fn sandbox_start_error(message: impl Into<String>) -> SandboxError {
+    SandboxError::Operation {
+        operation: SandboxOperation::StartProcess,
+        reason: SandboxOperationReason::Guest,
+        message: message.into(),
+    }
+}
+
+fn process_exit(termination: ExecTermination, guest_duration_ms: Option<u32>) -> ProcessExit {
+    let mut exit = ProcessExit::new(1, 0, Vec::new(), Vec::new());
+    exit.termination = termination;
+    exit.guest_duration_ms = guest_duration_ms;
+    exit
+}
+
+fn prefetch_ops(telemetry: &crate::telemetry::JobTelemetry) -> Vec<(String, bool, Option<String>)> {
+    telemetry
+        .pending_ops_snapshot()
+        .into_iter()
+        .filter(|(action, _, _)| action == PREFETCH_ACTION)
+        .collect()
+}
+
+fn assert_prefetch_outcome(
+    telemetry: &crate::telemetry::JobTelemetry,
+    expected_success: bool,
+    expected_error: Option<&str>,
+    scenario: &str,
+) {
+    let ops = prefetch_ops(telemetry);
+    assert_eq!(
+        ops.len(),
+        1,
+        "{scenario}: expected exactly one prefetch event, got {ops:?}"
+    );
+    assert_eq!(ops[0].1, expected_success, "{scenario}: success");
+    assert_eq!(ops[0].2.as_deref(), expected_error, "{scenario}: error");
+}
+
+async fn run_prefetch_state_machine(
+    overrides: Arc<sandbox_mock::MockSandboxOverrides>,
+    cancellation: tokio_util::sync::CancellationToken,
+    scenario: &str,
+    expected_success: bool,
+    expected_error: Option<&str>,
+) -> crate::telemetry::JobTelemetry {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let context = codex_oauth_context();
+    let sandbox = Arc::new(sandbox_mock::MockSandbox::with_overrides(
+        "test",
+        Arc::clone(&overrides),
+    ));
+    let mut telemetry = test_telemetry(&config, &context);
+
+    let started = StartedCodexModelCatalogPrefetch::start(
+        &*sandbox,
+        &context,
+        SandboxReuseResult::PoolMiss,
+        &cancellation,
+    )
+    .await;
+    let mut prefetch = started.supervise(&*sandbox);
+    prefetch.race(async {}).await;
+    prefetch.record_outcome(&mut telemetry);
+    prefetch.record_outcome(&mut telemetry);
+    prefetch.finish(&mut telemetry).await;
+
+    assert_prefetch_outcome(&telemetry, expected_success, expected_error, scenario);
+    telemetry
+}
+
+async fn finish_started_prefetch(
+    started: StartedCodexModelCatalogPrefetch,
+    sandbox: Arc<sandbox_mock::MockSandbox>,
+    scenario: &str,
+    expected_success: bool,
+    expected_error: Option<&str>,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let context = codex_oauth_context();
+    let mut telemetry = test_telemetry(&config, &context);
+    let mut prefetch = started.supervise(&*sandbox);
+    prefetch.record_outcome(&mut telemetry);
+    prefetch.record_outcome(&mut telemetry);
+    prefetch.finish(&mut telemetry).await;
+
+    assert_prefetch_outcome(&telemetry, expected_success, expected_error, scenario);
 }
 #[tokio::test]
 async fn codex_catalog_prefetch_waits_for_guest_state_restore() {
@@ -127,6 +226,245 @@ async fn codex_catalog_prefetch_start_timeout_does_not_delay_agent() {
     assert!(!start_calls[0].cmd.contains("codex --version"));
 }
 
+#[tokio::test]
+async fn codex_catalog_prefetch_records_start_cancellation() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let start_gate = MockLifecycleGate::new();
+    overrides.set_start_process_lifecycle_gate(start_gate.clone());
+    let sandbox = Arc::new(sandbox_mock::MockSandbox::with_overrides(
+        "test",
+        Arc::clone(&overrides),
+    ));
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let start_cancel = cancel.clone();
+    let start_sandbox = Arc::clone(&sandbox);
+    let start_task = tokio::spawn(async move {
+        StartedCodexModelCatalogPrefetch::start(
+            &*start_sandbox,
+            &codex_oauth_context(),
+            SandboxReuseResult::PoolMiss,
+            &start_cancel,
+        )
+        .await
+    });
+
+    start_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("prefetch should enter process start");
+    cancel.cancel();
+
+    let started = start_task.await.unwrap();
+    finish_started_prefetch(
+        started,
+        sandbox,
+        "start_cancelled",
+        false,
+        Some("start_cancelled"),
+    )
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn codex_catalog_prefetch_records_start_timeout() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let start_gate = MockLifecycleGate::new();
+    overrides.set_start_process_lifecycle_gate(start_gate.clone());
+    let sandbox = Arc::new(sandbox_mock::MockSandbox::with_overrides(
+        "test",
+        Arc::clone(&overrides),
+    ));
+    let start_sandbox = Arc::clone(&sandbox);
+    let start_task = tokio::spawn(async move {
+        StartedCodexModelCatalogPrefetch::start(
+            &*start_sandbox,
+            &codex_oauth_context(),
+            SandboxReuseResult::PoolMiss,
+            &tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+    });
+
+    start_gate
+        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+        .await
+        .expect("prefetch should enter process start");
+    tokio::time::advance(PREFETCH_HOST_START_TIMEOUT).await;
+    tokio::task::yield_now().await;
+
+    let started = start_task.await.unwrap();
+    finish_started_prefetch(
+        started,
+        sandbox,
+        "start_timed_out",
+        false,
+        Some("start_timed_out"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn codex_catalog_prefetch_records_start_failure() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_process_error(sandbox_start_error("start failed"));
+    let sandbox = Arc::new(sandbox_mock::MockSandbox::with_overrides(
+        "test",
+        Arc::clone(&overrides),
+    ));
+
+    let started = StartedCodexModelCatalogPrefetch::start(
+        &*sandbox,
+        &codex_oauth_context(),
+        SandboxReuseResult::PoolMiss,
+        &tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+    finish_started_prefetch(
+        started,
+        sandbox,
+        "start_failed",
+        false,
+        Some("start_failed"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn codex_catalog_prefetch_records_process_outcomes() {
+    let cases = [
+        (
+            "success",
+            ExecTermination::Exited { exit_code: 0 },
+            true,
+            None,
+        ),
+        (
+            "process_exit",
+            ExecTermination::Exited { exit_code: 7 },
+            false,
+            Some("process_exit"),
+        ),
+        (
+            "process_timed_out",
+            ExecTermination::TimedOut,
+            false,
+            Some("process_timed_out"),
+        ),
+        (
+            "process_cancelled",
+            ExecTermination::Cancelled,
+            false,
+            Some("process_cancelled"),
+        ),
+        (
+            "process_start_failed",
+            ExecTermination::StartFailed,
+            false,
+            Some("process_start_failed"),
+        ),
+        (
+            "process_wait_failed",
+            ExecTermination::WaitFailed,
+            false,
+            Some("process_wait_failed"),
+        ),
+    ];
+
+    for (scenario, termination, expected_success, expected_error) in cases {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_wait_process_exit(process_exit(termination, Some(1_234)));
+        let telemetry = run_prefetch_state_machine(
+            overrides,
+            tokio_util::sync::CancellationToken::new(),
+            scenario,
+            expected_success,
+            expected_error,
+        )
+        .await;
+        let ops: Vec<_> = telemetry
+            .pending_ops_with_duration_snapshot()
+            .into_iter()
+            .filter(|(action, _, _, _)| action == PREFETCH_ACTION)
+            .collect();
+        assert_eq!(
+            ops,
+            vec![(
+                PREFETCH_ACTION.to_string(),
+                1_234,
+                expected_success,
+                expected_error.map(str::to_string),
+            )],
+            "{scenario}: telemetry details",
+        );
+    }
+
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_error(
+        "wait failed",
+    ));
+    let _telemetry = run_prefetch_state_machine(
+        overrides,
+        tokio_util::sync::CancellationToken::new(),
+        "wait_failed",
+        false,
+        Some("wait_failed"),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn codex_catalog_prefetch_prefers_guest_duration_and_falls_back_to_host_elapsed() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(process_exit(
+        ExecTermination::Exited { exit_code: 0 },
+        Some(7_200_084),
+    ));
+    let telemetry = run_prefetch_state_machine(
+        overrides,
+        tokio_util::sync::CancellationToken::new(),
+        "guest_duration",
+        true,
+        None,
+    )
+    .await;
+    let guest_duration_ops: Vec<_> = telemetry
+        .pending_ops_with_duration_snapshot()
+        .into_iter()
+        .filter(|(action, _, _, _)| action == PREFETCH_ACTION)
+        .collect();
+    assert_eq!(guest_duration_ops[0].1, 7_200_084);
+
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(process_exit(ExecTermination::Exited { exit_code: 0 }, None));
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let context = codex_oauth_context();
+    let sandbox = Arc::new(sandbox_mock::MockSandbox::with_overrides(
+        "test",
+        Arc::clone(&overrides),
+    ));
+    let mut telemetry = test_telemetry(&config, &context);
+    let started = StartedCodexModelCatalogPrefetch::start(
+        &*sandbox,
+        &context,
+        SandboxReuseResult::PoolMiss,
+        &tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    let prefetch = started.supervise(&*sandbox);
+    prefetch.finish(&mut telemetry).await;
+    assert_prefetch_outcome(&telemetry, true, None, "host_duration");
+    let host_duration_ops: Vec<_> = telemetry
+        .pending_ops_with_duration_snapshot()
+        .into_iter()
+        .filter(|(action, _, _, _)| action == PREFETCH_ACTION)
+        .collect();
+    assert!(
+        host_duration_ops[0].1 > 0,
+        "host elapsed duration should be recorded"
+    );
+}
+
 async fn assert_codex_catalog_prefetch_skipped(
     context: ExecutionContext,
     reuse_result: SandboxReuseResult,
@@ -168,6 +506,10 @@ async fn assert_codex_catalog_prefetch_skipped(
     assert!(
         !start_calls[0].cmd.contains("codex --version"),
         "{scenario}"
+    );
+    assert!(
+        prefetch_ops(&telemetry).is_empty(),
+        "{scenario}: ineligible runs must not record prefetch telemetry"
     );
 }
 
@@ -226,6 +568,44 @@ async fn codex_catalog_prefetch_skips_ineligible_runs() {
     for (context, reuse_result, scenario) in scenarios {
         assert_codex_catalog_prefetch_skipped(context, reuse_result, scenario).await;
     }
+}
+
+#[tokio::test]
+async fn codex_catalog_prefetch_records_one_event_through_executor_wiring() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let context = codex_oauth_context();
+    let mut telemetry = test_telemetry(&config, &context);
+
+    let result = tokio::time::timeout(
+        RUN_IN_SANDBOX_TEST_TIMEOUT,
+        run_in_sandbox(
+            &*sandbox,
+            &context,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+        ),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    assert_prefetch_outcome(
+        &telemetry,
+        true,
+        None,
+        "executor wiring should record one prefetch event",
+    );
 }
 
 #[tokio::test]

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -117,6 +117,9 @@ pub(crate) struct ProcessOverrideState {
     /// Optional durable gate that records and blocks every `wait_process`
     /// entry until released.
     pub(crate) wait_process_lifecycle_gate: Mutex<Option<MockLifecycleGate>>,
+    /// FIFO queue of start-process errors consumed by factory-created
+    /// sandboxes. Empty queue follows the default successful start behavior.
+    pub(crate) start_process_errors: Mutex<VecDeque<SandboxError>>,
     /// When `Some`, `wait_process` returns a wait-process operation error to
     /// simulate timeout or crash.
     pub(crate) wait_process_error: Option<String>,
@@ -174,6 +177,7 @@ impl Default for ProcessOverrideState {
             wait_process_code: None,
             wait_process_gate: None,
             wait_process_lifecycle_gate: Mutex::new(None),
+            start_process_errors: Mutex::new(VecDeque::new()),
             wait_process_error: None,
             wait_process_error_reason: SandboxOperationReason::Timeout,
             wait_process_exits: Mutex::new(VecDeque::new()),
@@ -294,6 +298,16 @@ impl MockSandboxOverrides {
             .process
             .wait_process_lifecycle_gate
             .lock_ignoring_poison() = None;
+    }
+
+    /// Queue a start-process error applied to the next matching start call.
+    /// Consumed FIFO across all sandboxes; empty queue follows the default
+    /// successful start behavior.
+    pub fn push_start_process_error(&self, error: SandboxError) {
+        self.process
+            .start_process_errors
+            .lock_ignoring_poison()
+            .push_back(error);
     }
 
     /// Create overrides that make `wait_process` return an error (simulating

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -810,6 +810,15 @@ impl Sandbox for MockSandbox {
                     control: request.control,
                 });
         }
+        if let Some(overrides) = &self.overrides
+            && let Some(error) = overrides
+                .process
+                .start_process_errors
+                .lock_ignoring_poison()
+                .pop_front()
+        {
+            return Err(error);
+        }
         let (mut tx, rx) = match request.output {
             ProcessOutputMode::Stream { queue_capacity, .. } => {
                 let (tx, rx) = tokio::sync::mpsc::channel(queue_capacity.max(1));

--- a/crates/sandbox-mock/src/tests/process.rs
+++ b/crates/sandbox-mock/src/tests/process.rs
@@ -361,6 +361,54 @@ async fn start_process_rejects_invalid_env_key() {
 }
 
 #[tokio::test]
+async fn queued_start_process_errors_are_consumed_fifo() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_start_process_error(SandboxError::Operation {
+        operation: SandboxOperation::StartProcess,
+        reason: SandboxOperationReason::Guest,
+        message: "first start failed".into(),
+    });
+    overrides.push_start_process_error(SandboxError::Operation {
+        operation: SandboxOperation::StartProcess,
+        reason: SandboxOperationReason::Timeout,
+        message: "second start failed".into(),
+    });
+    let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
+    let request = StartProcessRequest {
+        cmd: "agent",
+        timeout: Duration::from_secs(5),
+        env: &[],
+        sudo: false,
+        output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
+        control: ProcessControlMode::None,
+    };
+
+    let first_error = match sandbox.start_process(&request).await {
+        Ok(_) => panic!("expected first start to fail"),
+        Err(error) => error,
+    };
+    assert_operation_error(
+        first_error,
+        SandboxOperation::StartProcess,
+        SandboxOperationReason::Guest,
+        "first start failed",
+    );
+    let second_error = match sandbox.start_process(&request).await {
+        Ok(_) => panic!("expected second start to fail"),
+        Err(error) => error,
+    };
+    assert_operation_error(
+        second_error,
+        SandboxOperation::StartProcess,
+        SandboxOperationReason::Timeout,
+        "second start failed",
+    );
+    sandbox.start_process(&request).await.unwrap();
+
+    assert_eq!(overrides.start_process_calls().len(), 3);
+}
+
+#[tokio::test]
 async fn start_process_lifecycle_gate_blocks_before_recording_or_cancellation() {
     let gate = MockLifecycleGate::new();
     let overrides = Arc::new(MockSandboxOverrides::new());


### PR DESCRIPTION
## Summary

- Add deterministic runner tests for every Codex model catalog prefetch start and process terminal outcome.
- Assert one structured telemetry event, exact success/error mapping, guest-duration precedence, and host-duration fallback.
- Extend `sandbox-mock` with FIFO start-process error injection and cover ineligible-run silence through executor wiring.

## Scope

No production runner behavior changes are included. Existing cancellation and bounded cleanup behavior remains covered by the surrounding prefetch tests.

Closes #28008

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=... cargo check --manifest-path crates/Cargo.toml -p runner --tests` (passed)
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock queued_start_process_errors` (passed)

The filtered runner test binary could not be linked in this 3.8 GiB environment; rustc was SIGKILLed at the final link step under both standard and dynamic-link configurations.
