### PR TITLE
fix(api): reconcile every paid plan tier

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-billing-entitlements.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-billing-entitlements.test.ts
@@ -20,7 +20,9 @@ const INITIAL_STATUSES: readonly (readonly [
   BillingReconciliationFixtureKind,
   string,
 ])[] = [
-  ["plan-subscription", "past_due"],
+  ["plan-subscription-pro", "past_due"],
+  ["plan-subscription-team", "past_due"],
+  ["plan-subscription-custom", "past_due"],
   ["atom-grant", "atom_grant"],
   ["concurrency", "past_due"],
   ["usage-allowance", "past_due"],
@@ -36,7 +38,9 @@ const RECONCILED_STATUSES: readonly (readonly [
   BillingReconciliationFixtureKind,
   string,
 ])[] = [
-  ["plan-subscription", "canceled"],
+  ["plan-subscription-pro", "canceled"],
+  ["plan-subscription-team", "canceled"],
+  ["plan-subscription-custom", "canceled"],
   ["atom-grant", "expired"],
   ["concurrency", "canceled"],
   ["usage-allowance", "canceled"],
@@ -153,19 +157,27 @@ describe("billing entitlement reconciliation", () => {
       }),
       [200],
     );
-    expect(response.body).toStrictEqual({ success: true, downgraded: 2 });
+    expect(response.body).toStrictEqual({ success: true, downgraded: 4 });
 
     const selected = await readState(selectedMarker);
     expect(statuses(selected)).toStrictEqual(RECONCILED_STATUSES);
-    expect(selected[0]).toStrictEqual({
-      kind: "plan-subscription",
-      orgId: seededFixture(selectedFixtures, "plan-subscription").orgId,
-      status: "canceled",
-      tier: "limited-free-1",
-      credits: 0,
-      stripeSubscriptionId: null,
-    });
-    expect(selected[1]).toStrictEqual({
+    for (const [index, kind] of (
+      [
+        "plan-subscription-pro",
+        "plan-subscription-team",
+        "plan-subscription-custom",
+      ] as const
+    ).entries()) {
+      expect(selected[index]).toStrictEqual({
+        kind,
+        orgId: seededFixture(selectedFixtures, kind).orgId,
+        status: "canceled",
+        tier: "limited-free-1",
+        credits: 0,
+        stripeSubscriptionId: null,
+      });
+    }
+    expect(selected[3]).toStrictEqual({
       kind: "atom-grant",
       orgId: seededFixture(selectedFixtures, "atom-grant").orgId,
       status: "expired",

--- a/turbo/apps/api/src/signals/routes/test-billing-reconciliation-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-billing-reconciliation-state.ts
@@ -35,6 +35,19 @@ import {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+type PlanSubscriptionFixtureKind = Extract<
+  BillingReconciliationFixtureKind,
+  `plan-subscription-${string}`
+>;
+
+const PLAN_SUBSCRIPTION_FIXTURE_TIERS: Readonly<
+  Record<PlanSubscriptionFixtureKind, "pro" | "team" | "custom">
+> = {
+  "plan-subscription-pro": "pro",
+  "plan-subscription-team": "team",
+  "plan-subscription-custom": "custom",
+};
+
 const actionBody$ = bodyResultOf(testBillingReconciliationStateContract.action);
 const reconcileBody$ = bodyResultOf(
   testBillingReconciliationStateContract.reconcile,
@@ -54,7 +67,9 @@ function fixtureReference(
 ): FixtureReference {
   const orgId = `org_billing_reconciliation_${kind}_${marker}`;
   switch (kind) {
-    case "plan-subscription":
+    case "plan-subscription-pro":
+    case "plan-subscription-team":
+    case "plan-subscription-custom":
     case "concurrency":
     case "usage-allowance": {
       return {
@@ -159,10 +174,12 @@ async function insertOrganizationFixtures(
   await tx.insert(orgMetadata).values(
     fixtures.map((fixture) => {
       switch (fixture.kind) {
-        case "plan-subscription": {
+        case "plan-subscription-pro":
+        case "plan-subscription-team":
+        case "plan-subscription-custom": {
           return {
             orgId: fixture.orgId,
-            tier: "pro",
+            tier: PLAN_SUBSCRIPTION_FIXTURE_TIERS[fixture.kind],
             stripeSubscriptionId: fixture.stripeSubscriptionId,
             subscriptionStatus: "past_due",
             currentPeriodEnd: old,
@@ -610,7 +627,9 @@ function candidateStateForFixture(
   rows: BillingReconciliationStateRows,
 ): CandidateState {
   switch (fixture.kind) {
-    case "plan-subscription":
+    case "plan-subscription-pro":
+    case "plan-subscription-team":
+    case "plan-subscription-custom":
     case "atom-grant": {
       const row = stateRowForOrg(rows.orgRows, fixture);
       if (!row.subscriptionStatus) {

--- a/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-billing-entitlements.service.ts
@@ -359,7 +359,7 @@ function currentBillingCandidateWhere(candidate: StripeBillingCandidate) {
   return and(
     eq(orgMetadata.orgId, candidate.orgId),
     eq(orgMetadata.stripeSubscriptionId, candidate.stripeSubscriptionId),
-    inArray(orgMetadata.tier, ["pro", "team"]),
+    inArray(orgMetadata.tier, PAID_TIERS),
     inArray(orgMetadata.subscriptionStatus, [
       ...PAYMENT_FAILED_SUBSCRIPTION_STATUSES,
     ]),

--- a/turbo/packages/api-contracts/src/contracts/test-billing-reconciliation-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-billing-reconciliation-state.ts
@@ -6,7 +6,9 @@ import { initContract } from "./base";
 const c = initContract();
 
 export const BILLING_RECONCILIATION_FIXTURE_KINDS = [
-  "plan-subscription",
+  "plan-subscription-pro",
+  "plan-subscription-team",
+  "plan-subscription-custom",
   "atom-grant",
   "concurrency",
   "usage-allowance",


### PR DESCRIPTION
## Summary

- reuse the canonical `PAID_TIERS` set in the Stripe plan-subscription reconciliation write guard, so every candidate selected by the cron can be updated
- expand the billing reconciliation fixtures to cover Pro, Team, and Custom plan subscriptions explicitly
- verify that canceled Stripe subscriptions downgrade every paid plan tier to Limited Free while preserving the existing sentinel isolation and all other billing candidate coverage

## Root cause

`loadReconcileCandidateRows` selected `pro`, `team`, and `custom` organizations, but `currentBillingCandidateWhere` only allowed writes for `pro` and `team`. The cron therefore fetched Custom subscriptions from Stripe while every reconciliation update for those rows became a no-op.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-billing-entitlements.test.ts` — 1 test passed
