### PR TITLE
fix(platform): separate progress from thinking blocks

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -83,6 +83,7 @@ export interface MessageListSignals {
   readonly hasEvents$: Computed<Promise<boolean>>;
   readonly thinkingIndicatorMode$: Computed<Promise<ThinkingIndicatorMode>>;
   readonly thinkingEventId$: Computed<Promise<string | null>>;
+  readonly thinkingEventInline$: Computed<Promise<boolean>>;
   readonly thinkingText$: Computed<Promise<string | null>>;
   readonly recommendedFollowupSource$: Computed<
     Promise<RecommendedFollowupSource | null>
@@ -200,6 +201,7 @@ export interface ChatPanelSignals {
   readonly hasEvents$: Computed<Promise<boolean>>;
   readonly thinkingIndicatorMode$: Computed<Promise<ThinkingIndicatorMode>>;
   readonly thinkingEventId$: Computed<Promise<string | null>>;
+  readonly thinkingEventInline$: Computed<Promise<boolean>>;
   readonly thinkingText$: Computed<Promise<string | null>>;
   readonly recommendedFollowupSource$: Computed<
     Promise<RecommendedFollowupSource | null>

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1444,7 +1444,20 @@ function lastRunThinkingEvent(
 interface ThinkingIndicatorProjection {
   readonly mode: ThinkingIndicatorMode;
   readonly thinkingEventId: string | null;
+  readonly thinkingEventInline: boolean;
   readonly thinkingText: string | null;
+}
+
+const INITIAL_THINKING_RUN_EVENT_ID = "thinking:initial";
+
+function thinkingEventRendersInline(
+  entry: SemanticChatEvent | undefined,
+): boolean {
+  return (
+    entry !== undefined &&
+    isThinkingMarkerSemanticEvent(entry) &&
+    entry.event.runEventId !== INITIAL_THINKING_RUN_EVENT_ID
+  );
 }
 
 function assistantGroupOnlyHasThinking(
@@ -1506,7 +1519,12 @@ function thinkingIndicatorProjectionFromGroups(
   const { activeGroups } = groups;
   const lastGroup = activeGroups.at(-1);
   if (!lastGroup) {
-    return { mode: null, thinkingEventId: null, thinkingText: null };
+    return {
+      mode: null,
+      thinkingEventId: null,
+      thinkingEventInline: false,
+      thinkingText: null,
+    };
   }
   const lastIsAssistant = lastGroup.role === "assistant";
   const lastAssistantEvent = lastIsAssistant
@@ -1534,7 +1552,12 @@ function thinkingIndicatorProjectionFromGroups(
       running,
     })
   ) {
-    return { mode: null, thinkingEventId: null, thinkingText: null };
+    return {
+      mode: null,
+      thinkingEventId: null,
+      thinkingEventInline: false,
+      thinkingText: null,
+    };
   }
 
   const mode = resolveThinkingIndicatorMode({
@@ -1552,6 +1575,7 @@ function thinkingIndicatorProjectionFromGroups(
   return {
     mode,
     thinkingEventId: thinkingText ? (rawThinkingEvent?.event.id ?? null) : null,
+    thinkingEventInline: thinkingEventRendersInline(rawThinkingEvent),
     thinkingText,
   };
 }
@@ -1637,6 +1661,9 @@ function createEventSemanticSignals(
   const thinkingEventId$ = computed(async (get): Promise<string | null> => {
     return (await get(thinkingIndicatorProjection$)).thinkingEventId;
   });
+  const thinkingEventInline$ = computed(async (get): Promise<boolean> => {
+    return (await get(thinkingIndicatorProjection$)).thinkingEventInline;
+  });
   const recommendedFollowupSource$ = computed(
     (get): Promise<RecommendedFollowupSource | null> => {
       return Promise.resolve(
@@ -1656,6 +1683,7 @@ function createEventSemanticSignals(
     hasEvents$,
     thinkingIndicatorMode$,
     thinkingEventId$,
+    thinkingEventInline$,
     thinkingText$,
     recommendedFollowupSource$,
     donePhrase$,
@@ -3729,6 +3757,7 @@ function publicChatThreadEventSignals(events: MessageListSignals) {
     hasEvents$: events.hasEvents$,
     thinkingIndicatorMode$: events.thinkingIndicatorMode$,
     thinkingEventId$: events.thinkingEventId$,
+    thinkingEventInline$: events.thinkingEventInline$,
     thinkingText$: events.thinkingText$,
     recommendedFollowupSource$: events.recommendedFollowupSource$,
     donePhrase$: events.donePhrase$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx
@@ -40,6 +40,94 @@ function expectBefore(before: HTMLElement, after: HTMLElement): void {
 }
 
 describe("chat thinking blocks", () => {
+  it("keeps generated initial progress in the status row instead of an inline block", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000215";
+    const runId = "run-generated-initial-thinking";
+    const thinking = "Reviewing the request before the agent responds.";
+    mockChatLifecycle(context, {
+      threadId,
+      activeRunIds: [runId],
+      chatEvents: [
+        {
+          id: "msg-generated-initial-thinking-user",
+          role: "user",
+          content: "Review this account",
+          runId,
+          createdAt: "2026-08-18T10:00:00Z",
+        },
+        {
+          id: "msg-generated-initial-thinking-marker",
+          role: "assistant",
+          content: null,
+          thinking,
+          runId,
+          runEventId: "thinking:initial",
+          createdAt: "2026-08-18T10:00:01Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatInlineThinkingBlocks]: true,
+      },
+    });
+
+    const progress = await screen.findByLabelText(thinking);
+    expect(progress.closest("[data-thinking-indicator]")).not.toBeNull();
+    expect(document.querySelector("[data-thinking-block]")).toBeNull();
+  });
+
+  it("does not retain generated initial progress in completed work history", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000216";
+    const runId = "run-completed-generated-initial-thinking";
+    const thinking = "Preparing a concise account summary.";
+    mockChatLifecycle(context, {
+      threadId,
+      chatEvents: [
+        {
+          id: "msg-completed-generated-thinking-user",
+          role: "user",
+          content: "Summarize this account",
+          runId,
+          createdAt: "2026-08-18T10:00:00Z",
+        },
+        {
+          id: "msg-completed-generated-thinking-marker",
+          role: "assistant",
+          content: null,
+          thinking,
+          runId,
+          runEventId: "thinking:initial",
+          createdAt: "2026-08-18T10:00:01Z",
+        },
+        {
+          id: "msg-completed-generated-thinking-result",
+          role: "assistant",
+          content: "The account is healthy and expanding.",
+          runId,
+          runLifecycleEvent: "completed",
+          createdAt: "2026-08-18T10:00:05Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatInlineThinkingBlocks]: true,
+      },
+    });
+
+    await screen.findByText("The account is healthy and expanding.");
+    expect(screen.queryByText(thinking)).toBeNull();
+    expect(screen.queryByLabelText("Expand work history")).toBeNull();
+    expect(document.querySelector("[data-thinking-block]")).toBeNull();
+  });
+
   it("keeps thinking events in transcript order with independent open states", async () => {
     const user = userEvent.setup();
     mockChatLifecycle(context, {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3788,11 +3788,29 @@ type EnrichedThinkingChatEvent = Extract<
   { eventType: "output.thinking" }
 >;
 
+const INITIAL_THINKING_RUN_EVENT_ID = "thinking:initial";
+
 function isThinkingOnlyAssistantEvent(
   event: EnrichedChatEvent,
 ): event is EnrichedThinkingChatEvent {
   return (
     event.eventType === "output.thinking" && event.thinking.trim().length > 0
+  );
+}
+
+function isInlineThinkingAssistantEvent(
+  event: EnrichedChatEvent,
+): event is EnrichedThinkingChatEvent {
+  return (
+    isThinkingOnlyAssistantEvent(event) &&
+    event.runEventId !== INITIAL_THINKING_RUN_EVENT_ID
+  );
+}
+
+function isInitialThinkingPlaceholderEvent(event: EnrichedChatEvent): boolean {
+  return (
+    isThinkingOnlyAssistantEvent(event) &&
+    event.runEventId === INITIAL_THINKING_RUN_EVENT_ID
   );
 }
 
@@ -3811,7 +3829,7 @@ function isRenderableAssistantEvent(
   inlineThinkingBlocksEnabled: boolean,
 ): boolean {
   return (
-    (inlineThinkingBlocksEnabled && isThinkingOnlyAssistantEvent(event)) ||
+    (inlineThinkingBlocksEnabled && isInlineThinkingAssistantEvent(event)) ||
     isRenderableAssistantResultEvent(event)
   );
 }
@@ -3890,6 +3908,7 @@ function foldCompletedWorkPhase(
     finalEventIndex > 0 ? events.slice(0, finalEventIndex) : [];
   const hiddenEvents = precedingEvents.filter((event) => {
     return (
+      !isInitialThinkingPlaceholderEvent(event) &&
       chatEventCompatibilityRole(event.eventType) !== "user" &&
       (inlineThinkingBlocksEnabled || !isThinkingOnlyAssistantEvent(event))
     );
@@ -5397,6 +5416,8 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
   const running = thinkingIndicatorRunning(mode);
   const isQueued = thinkingIndicatorQueued(mode);
   const thinkingEventId = useLastResolved(thread.thinkingEventId$);
+  const thinkingEventInline =
+    useLastResolved(thread.thinkingEventInline$) ?? false;
   const displayedThinkingText =
     useLastResolved(thread.displayedThinkingText$) ?? "";
   const thinkingTextFadingOut =
@@ -5420,7 +5441,11 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
   }
 
   // The active thinking event is already rendered inline in transcript order.
-  if (inlineThinkingBlocksEnabled && serverThinkingLabel) {
+  if (
+    inlineThinkingBlocksEnabled &&
+    thinkingEventInline &&
+    serverThinkingLabel
+  ) {
     return null;
   }
 
@@ -7783,7 +7808,7 @@ function PagedAssistantEventItem({
   inlineThinkingBlocksEnabled: boolean;
   thread: ChatPanelSignals;
 }) {
-  if (inlineThinkingBlocksEnabled && isThinkingOnlyAssistantEvent(event)) {
+  if (inlineThinkingBlocksEnabled && isInlineThinkingAssistantEvent(event)) {
     return (
       <PagedAssistantThinkingBlock
         event={event}
@@ -7869,34 +7894,37 @@ function PagedAssistantThinkingBlock({
         open={current}
         className="group max-w-[710px]"
       >
-        <summary className="inline-flex min-h-9 max-w-full cursor-pointer list-none items-center gap-2 rounded-lg px-2 py-1.5 text-left text-muted-foreground transition-colors hover:bg-state-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-          {current ? (
-            <PagedAssistantCurrentThinkingSummary
-              event={event}
-              label={label}
-              preview={preview}
-              thread={thread}
+        <summary className="inline-block max-w-full cursor-pointer list-none rounded-lg text-left text-muted-foreground transition-colors hover:bg-state-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+          {/* Keep flex off summary: iOS WebKit misplaces its first flex child. */}
+          <span className="inline-flex min-h-9 max-w-full items-center gap-2 px-2 py-1.5">
+            {current ? (
+              <PagedAssistantCurrentThinkingSummary
+                event={event}
+                label={label}
+                preview={preview}
+                thread={thread}
+              />
+            ) : (
+              <>
+                <span
+                  data-thinking-block-icon
+                  aria-hidden
+                  className="inline-flex size-3.5 shrink-0 items-center justify-center"
+                >
+                  <Brain size={14} className="-translate-y-px" />
+                </span>
+                <span className="shrink-0 text-[13px]">{label}</span>
+                <span className="min-w-0 flex-1 truncate font-serif text-[0.8125rem] font-normal group-open:hidden">
+                  {preview}
+                </span>
+              </>
+            )}
+            <ChevronRight
+              aria-hidden
+              size={14}
+              className="shrink-0 text-muted-foreground/70 transition-transform group-open:rotate-90"
             />
-          ) : (
-            <>
-              <span
-                data-thinking-block-icon
-                aria-hidden
-                className="inline-flex size-3.5 shrink-0 items-center justify-center"
-              >
-                <Brain size={14} className="-translate-y-px" />
-              </span>
-              <span className="shrink-0 text-[13px]">{label}</span>
-              <span className="min-w-0 flex-1 truncate font-serif text-[0.8125rem] font-normal group-open:hidden">
-                {preview}
-              </span>
-            </>
-          )}
-          <ChevronRight
-            aria-hidden
-            size={14}
-            className="shrink-0 text-muted-foreground/70 transition-transform group-open:rotate-90"
-          />
+          </span>
         </summary>
         <div
           data-thinking-block-content


### PR DESCRIPTION
## Summary

- keep server-generated `thinking:initial` progress in the transient status indicator instead of the transcript or completed-work folds
- render only agent/model-originated thinking as inline expandable blocks
- keep native `summary` out of flex layout so the real thinking indicator stays aligned in iOS WebKit

## Verification

- `pnpm format`
- `pnpm --filter @okouai/app run check-types`
- `pnpm turbo run lint --filter=@okouai/app --concurrency=1 --log-order=grouped`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-thinking-blocks.test.tsx --reporter=dot --no-color` (6 tests passed)