### PR TITLE
fix(platform): suppress request failed toast on stale permission-status cancellation

### DIFF
--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -149,6 +149,7 @@ export function userPermissionGrantsByAgent(
           fetchOptions: { signal },
         }),
         [200],
+        signal,
       );
     }, get(rootSignal$));
     return result.body;
@@ -168,6 +169,7 @@ export function userPermissionGrantsByAgentIfExists(
           fetchOptions: { signal },
         }),
         [200, 404],
+        signal,
       );
     }, get(rootSignal$));
     return result.status === 404 ? null : result.body;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -33,6 +33,7 @@ import {
 } from "@okouai/api-contracts/contracts/zero-user-permission-grants";
 import { UNKNOWN_PERMISSION_GRANT } from "@okouai/connectors/firewall-types";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { toast } from "@okouai/ui/components/ui/sonner";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse } from "msw";
@@ -3898,6 +3899,7 @@ describe("chat event action cards", () => {
 
   it("keeps permission success and composer connectors visible while grants reload", async () => {
     mockNow(context.signal);
+    const toastError = vi.spyOn(toast, "error");
     const user = userEvent.setup({ delay: null });
     const threadId = "b0000000-0000-4000-a000-000000000991";
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?connectorSlug=gmail&permission=messages.write&action=allow&expiresIn=1h`;
@@ -4046,6 +4048,7 @@ describe("chat event action cards", () => {
         within(permissionCard).getByText("Permissions updated"),
       ).toBeInTheDocument();
     });
+    expect(toastError).not.toHaveBeenCalled();
   });
 
   it("lets users change permission duration before confirming", async () => {


### PR DESCRIPTION
## Summary

Fixes #25632.

When confirming a connector permission from a Permission card in Chat Thread, the post-save reload increments \internalUserPermissionGrantsReload$\, invalidating \userPermissionGrantsByAgent\ and cancelling previous in-flight permission-status fetches.

Passing \signal\ to \ccept()\ in \userPermissionGrantsByAgent\ and \userPermissionGrantsByAgentIfExists\ ensures that aborted requests propagate through \signal.throwIfAborted()\ as normal lifecycle cancellation (\AbortError\), preventing \equestErrorMessage()\ from emitting a false \Request failed\ error toast.

## Changes

- Pass \signal\ into \ccept(client.list(...), [200], signal)\ and \ccept(client.list(...), [200, 404], signal)\ in \permission-allow-signals.ts\.
- Add regression assertion to the permission save reload test in \chat-event-action-cards.test.tsx\ ensuring \	oast.error\ is not called during stale request cancellation.