### PR TITLE
perf(runner): attribute workspace mount guest duration

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -444,7 +444,7 @@ async fn run_in_sandbox(
     let mount_result = ensure_workspace_drive_mounted(sandbox, sandbox.id()).await;
     timing.workspace_mount_ms = Some(t_mount.elapsed().as_millis());
     if let Err(e) = mount_result {
-        return (Err(e), timing);
+        return (Err(e.error), timing);
     }
 
     let t_guest_restore = Instant::now();
@@ -628,6 +628,7 @@ mod tests {
     ) -> ExecResult {
         ExecResult {
             termination,
+            guest_duration_ms: None,
             stdout: stdout.to_vec(),
             stderr: stderr.to_vec(),
             diagnostic: diagnostic.to_string(),

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -56,6 +56,10 @@ use crate::workspace_mount::ensure_workspace_drive_mounted;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
 const SLOW_PROXY_REGISTER_THRESHOLD: Duration = Duration::from_secs(3);
+const WORKSPACE_DRIVE_MOUNT: &str = "workspace_drive_mount";
+const WORKSPACE_DRIVE_MOUNT_GUEST_EXEC: &str = "workspace_drive_mount_guest_exec";
+const WORKSPACE_DRIVE_MOUNT_GUEST_EXEC_UNAVAILABLE: &str =
+    "workspace_drive_mount_guest_exec_unavailable";
 const RUNNER_FRESH_WORKSPACE_IMAGE_PREPARE: &str = "runner_fresh_workspace_image_prepare";
 const RUNNER_FRESH_SANDBOX_FACTORY_CREATE: &str = "runner_fresh_sandbox_factory_create";
 const RUNNER_FRESH_SANDBOX_FACTORY_COW_POOL_ACQUIRE: &str =
@@ -1197,42 +1201,49 @@ async fn create_started_sandbox(
         .await;
 
     let mount_started = Instant::now();
-    if let Err(e) = ensure_workspace_drive_mounted(sandbox.as_ref(), context.run_id).await {
-        telemetry.record(
-            "workspace_drive_mount",
-            mount_started.elapsed(),
-            false,
-            Some(&e.to_string()),
-        );
-        if let Some(prepared_guest_runtime) = prepared_guest_runtime.take() {
-            prepared_guest_runtime
-                .finish(sandbox.as_ref(), telemetry)
+    let mount_result = ensure_workspace_drive_mounted(sandbox.as_ref(), context.run_id).await;
+    let mount_duration = mount_started.elapsed();
+    let guest_duration = match mount_result {
+        Ok(guest_duration) => guest_duration,
+        Err(e) => {
+            telemetry.record(
+                WORKSPACE_DRIVE_MOUNT,
+                mount_duration,
+                false,
+                Some(&e.error.to_string()),
+            );
+            record_workspace_drive_mount_guest_exec(telemetry, e.guest_duration, false);
+            if let Some(prepared_guest_runtime) = prepared_guest_runtime.take() {
+                prepared_guest_runtime
+                    .finish(sandbox.as_ref(), telemetry)
+                    .await;
+            }
+            let unregister_completed =
+                match unregister_proxy_registry(config, &source_ip, context.run_id).await {
+                    Ok(()) => true,
+                    Err(unregister_error) => {
+                        warn!(
+                            run_id = %context.run_id,
+                            error = %unregister_error,
+                            "failed to unregister VM from proxy after workspace mount failure"
+                        );
+                        false
+                    }
+                };
+            network_log_session
+                .close_for_upload(context.run_id, &config.network_log_drain)
                 .await;
+            let destroy_completed = destroy_sandbox_panic_safe(factory, sandbox)
+                .await
+                .is_completed();
+            return Err(SandboxPrepareError::retry_without_workspace_image(
+                e.error,
+                unregister_completed && destroy_completed,
+            ));
         }
-        let unregister_completed =
-            match unregister_proxy_registry(config, &source_ip, context.run_id).await {
-                Ok(()) => true,
-                Err(unregister_error) => {
-                    warn!(
-                        run_id = %context.run_id,
-                        error = %unregister_error,
-                        "failed to unregister VM from proxy after workspace mount failure"
-                    );
-                    false
-                }
-            };
-        network_log_session
-            .close_for_upload(context.run_id, &config.network_log_drain)
-            .await;
-        let destroy_completed = destroy_sandbox_panic_safe(factory, sandbox)
-            .await
-            .is_completed();
-        return Err(SandboxPrepareError::retry_without_workspace_image(
-            e,
-            unregister_completed && destroy_completed,
-        ));
-    }
-    telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
+    };
+    telemetry.record(WORKSPACE_DRIVE_MOUNT, mount_duration, true, None);
+    record_workspace_drive_mount_guest_exec(telemetry, guest_duration, true);
     if let Some(notifier) = sandbox_prepared {
         notifier.notify(context.run_id, sandbox_id).await;
     }
@@ -1243,6 +1254,24 @@ async fn create_started_sandbox(
         network_log_session,
         prepared_guest_runtime,
     })
+}
+
+fn record_workspace_drive_mount_guest_exec(
+    telemetry: &mut JobTelemetry,
+    guest_duration: Option<Duration>,
+    success: bool,
+) {
+    match guest_duration {
+        Some(duration) => {
+            telemetry.record(WORKSPACE_DRIVE_MOUNT_GUEST_EXEC, duration, success, None)
+        }
+        None => telemetry.record_bounded_outcome(
+            WORKSPACE_DRIVE_MOUNT_GUEST_EXEC_UNAVAILABLE,
+            success,
+            "unavailable",
+            None,
+        ),
+    }
 }
 
 pub(super) async fn invalidate_workspace_cache_hit(

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -354,6 +354,7 @@ mod tests {
     fn exec_result(stdout: Vec<u8>, stdout_truncated: bool) -> ExecResult {
         ExecResult {
             termination: ExecTermination::Exited { exit_code: 0 },
+            guest_duration_ms: None,
             stdout,
             stderr: Vec::new(),
             diagnostic: String::new(),

--- a/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/session_history/reuse_identity.rs
@@ -631,6 +631,7 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_times_o
         "sess-final-helper-timeout-123",
         ExecResult {
             termination: ExecTermination::TimedOut,
+            guest_duration_ms: None,
             stdout: Vec::new(),
             stderr: Vec::new(),
             diagnostic: "session history identity helper timed out".to_string(),

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -234,6 +234,7 @@ async fn restore_guest_state_fails_on_non_exited_result() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_exec_result(Ok(ExecResult {
         termination: ExecTermination::WaitFailed,
+        guest_duration_ms: None,
         stdout: b"restore stdout".to_vec(),
         stderr: b"wait failed".to_vec(),
         diagnostic: String::new(),
@@ -454,6 +455,7 @@ async fn sync_guest_timezone_logs_non_exited_result() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_exec_result(Ok(ExecResult {
         termination: ExecTermination::StartFailed,
+        guest_duration_ms: None,
         stdout: b"timezone stdout".to_vec(),
         stderr: b"start failed".to_vec(),
         diagnostic: String::new(),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -301,6 +301,7 @@ async fn execute_inner_ignores_non_exited_dmesg_oom_output() {
         "dmesg",
         ExecResult {
             termination: ExecTermination::TimedOut,
+            guest_duration_ms: None,
             stdout: b"Out of memory: Killed process 1234".to_vec(),
             stderr: b"Timeout".to_vec(),
             diagnostic: String::new(),
@@ -1053,6 +1054,7 @@ async fn execute_inner_keeps_partial_resource_output_when_diagnostic_helper_fail
         "guest-agent-binary",
         ExecResult {
             termination: ExecTermination::WaitFailed,
+            guest_duration_ms: None,
             stdout: b"/dev/root       7.8G  7.4G   20K 100% /\n/dev/vdb         16G   24K   15G   1% /home/user/workspace\nMem:            3934        3310         255           0         552         624\n".to_vec(),
             stderr: b"wait failed".to_vec(),
             diagnostic: String::new(),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -844,7 +844,7 @@ async fn execute_job_workspace_mount_failure_drains_early_prefetch_before_destro
     );
     wait_gate.release_one();
 
-    let (outcome, _telemetry) = tokio::time::timeout(Duration::from_secs(5), task)
+    let (outcome, telemetry) = tokio::time::timeout(Duration::from_secs(5), task)
         .await
         .expect("mount-failure cleanup should finish after the prefetch wait is released")
         .expect("mount-failure task should not panic");
@@ -856,6 +856,18 @@ async fn execute_job_workspace_mount_failure_drains_early_prefetch_before_destro
         "got: {error}"
     );
     assert!(error.contains("mount denied"), "got: {error}");
+    let operations = telemetry.pending_ops_with_outcome_snapshot();
+    let unavailable = operations
+        .iter()
+        .find(|operation| operation.0 == "workspace_drive_mount_guest_exec_unavailable")
+        .unwrap_or_else(|| panic!("missing unavailable mount guest duration: {operations:?}"));
+    assert!(!unavailable.1);
+    assert_eq!(unavailable.2.as_deref(), Some("unavailable"));
+    assert!(
+        operations
+            .iter()
+            .all(|operation| operation.0 != "workspace_drive_mount_guest_exec")
+    );
     assert!(
         outcome.sandbox.is_none(),
         "fresh mount failure should be destroyed inline"

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -748,12 +748,9 @@ async fn execute_new_sandbox_does_not_notify_after_post_start_prepare_failure() 
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
-        pattern: "mount -t ext4".to_string(),
-        exit_code: 64,
-        stdout: Vec::new(),
-        stderr: b"mount denied".to_vec(),
-    });
+    let mut mount_result = ExecResult::new(64, Vec::new(), b"mount denied".to_vec());
+    mount_result.guest_duration_ms = Some(31);
+    overrides.add_exec_result_matcher("mount -t ext4", mount_result);
     let factory = MockSandboxFactory::with_overrides(overrides);
     let ctx = minimal_context();
     let notifications = Arc::new(AtomicUsize::new(0));
@@ -787,6 +784,13 @@ async fn execute_new_sandbox_does_not_notify_after_post_start_prepare_failure() 
 
     assert!(result.is_err());
     assert_eq!(notifications.load(Ordering::SeqCst), 0);
+    let operations = telemetry.pending_ops_with_duration_snapshot();
+    let guest_exec = operations
+        .iter()
+        .find(|operation| operation.0 == "workspace_drive_mount_guest_exec")
+        .unwrap_or_else(|| panic!("missing mount guest duration: {operations:?}"));
+    assert_eq!(guest_exec.1, 31);
+    assert!(!guest_exec.2);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/session_restore_tests/codex.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/codex.rs
@@ -342,6 +342,7 @@ async fn restore_session_rejects_truncated_codex_cleanup_success_output() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_exec_result(Ok(ExecResult {
         termination: ExecTermination::Exited { exit_code: 0 },
+        guest_duration_ms: None,
         stdout: format!("{CODEX_EXISTING_ROLLOUT_PATH}\n").into_bytes(),
         stderr: Vec::new(),
         diagnostic: String::new(),
@@ -400,6 +401,7 @@ async fn restore_session_preserves_non_exited_codex_cleanup_failure_output() {
     );
     sandbox.push_exec_result(Ok(ExecResult {
         termination: ExecTermination::WaitFailed,
+        guest_duration_ms: None,
         stdout: format!("stdout includes {CODEX_SESSION_ID_NO_DASHES}").into_bytes(),
         stderr: format!("find: {CODEX_CANONICAL_ROLLOUT_PATH}: Permission denied").into_bytes(),
         diagnostic: String::new(),

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -244,6 +244,7 @@ async fn non_exited_helper_result_is_failure() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_exec_result(Ok(ExecResult {
         termination: ExecTermination::TimedOut,
+        guest_duration_ms: None,
         stdout: b"partial stdout".to_vec(),
         stderr: b"Timeout".to_vec(),
         diagnostic: String::new(),

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -231,7 +231,14 @@ impl Sandbox for ObservedStartSandbox {
         request: &ExecRequest<'_>,
         label: &'static str,
     ) -> sandbox::Result<ExecResult> {
-        self.inner.exec_with_diagnostic_label(request, label).await
+        let mut result = self
+            .inner
+            .exec_with_diagnostic_label(request, label)
+            .await?;
+        if label == "workspace-mount" {
+            result.guest_duration_ms = Some(23);
+        }
+        Ok(result)
     }
 
     async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
@@ -610,6 +617,12 @@ async fn execute_job_records_sandbox_reuse_miss_in_telemetry() {
     assert_lacks_action(&telemetry, "runner_claim_resume_session_validation");
     assert_lacks_action(&telemetry, "runner_claim_task_schedule_wait");
     assert_action_success(&telemetry, "runner_fresh_sandbox_start", true);
+    assert_action_success(
+        &telemetry,
+        "workspace_drive_mount_guest_exec_unavailable",
+        true,
+    );
+    assert_lacks_action(&telemetry, "workspace_drive_mount_guest_exec");
     for action in FRESH_SANDBOX_START_STAGE_ACTIONS {
         assert_lacks_action(&telemetry, action);
     }
@@ -699,11 +712,14 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         "sandbox_reuse_miss",
         "vm_create",
         "workspace_drive_mount",
+        "workspace_drive_mount_guest_exec",
         "agent_execute",
     ] {
         assert_has_action(&telemetry, action);
     }
     assert_action_duration(&telemetry, "runner_claim_http_request", 42);
+    assert_action_duration(&telemetry, "workspace_drive_mount_guest_exec", 23);
+    assert_lacks_action(&telemetry, "workspace_drive_mount_guest_exec_unavailable");
     for action in FRESH_SANDBOX_FACTORY_STAGE_ACTIONS {
         assert_action_success(&telemetry, action, true);
     }
@@ -1054,6 +1070,8 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_start");
     assert_lacks_action(&telemetry, "runner_guest_timezone_sync");
     assert_lacks_action(&telemetry, "workspace_drive_mount");
+    assert_lacks_action(&telemetry, "workspace_drive_mount_guest_exec");
+    assert_lacks_action(&telemetry, "workspace_drive_mount_guest_exec_unavailable");
 }
 
 #[tokio::test]

--- a/crates/runner/src/helper_exec.rs
+++ b/crates/runner/src/helper_exec.rs
@@ -153,6 +153,7 @@ mod tests {
     fn exec_result(termination: ExecTermination) -> ExecResult {
         ExecResult {
             termination,
+            guest_duration_ms: None,
             stdout: Vec::new(),
             stderr: Vec::new(),
             diagnostic: String::new(),

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -25,10 +25,16 @@ const WORKSPACE_DEVICE: &str = "/dev/vdb";
 const WORKSPACE_MOUNT_SCRIPT: &str = include_str!("../scripts/mount-workspace-drive.sh");
 const WORKSPACE_FREEZE_SCRIPT: &str = include_str!("../scripts/freeze-workspace-drive.sh");
 
+#[derive(Debug)]
+pub(crate) struct WorkspaceDriveMountError {
+    pub(crate) error: RunnerError,
+    pub(crate) guest_duration: Option<Duration>,
+}
+
 pub(crate) async fn ensure_workspace_drive_mounted(
     sandbox: &dyn Sandbox,
     diagnostic_id: impl std::fmt::Display,
-) -> RunnerResult<()> {
+) -> Result<Option<Duration>, WorkspaceDriveMountError> {
     run_workspace_drive_command(
         sandbox,
         diagnostic_id,
@@ -53,6 +59,8 @@ pub(crate) async fn freeze_workspace_drive(
         WORKSPACE_FREEZE_TIMEOUT,
     )
     .await
+    .map(|_| ())
+    .map_err(|error| error.error)
 }
 
 async fn run_workspace_drive_command(
@@ -62,7 +70,7 @@ async fn run_workspace_drive_command(
     operation: &'static str,
     label: &'static str,
     timeout: Duration,
-) -> RunnerResult<()> {
+) -> Result<Option<Duration>, WorkspaceDriveMountError> {
     let result = sandbox
         .exec_with_diagnostic_label(
             &ExecRequest {
@@ -77,14 +85,23 @@ async fn run_workspace_drive_command(
             label,
         )
         .await
-        .map_err(RunnerError::from)?;
+        .map_err(|error| WorkspaceDriveMountError {
+            error: RunnerError::from(error),
+            guest_duration: None,
+        })?;
+    let guest_duration = result
+        .guest_duration_ms
+        .map(|duration_ms| Duration::from_millis(u64::from(duration_ms)));
     if helper_exec_succeeded(&result) {
-        return Ok(());
+        return Ok(guest_duration);
     }
 
     let mut message = format_helper_exec_failure(operation, &result);
     message.push_str(&format!("; diagnostic id: {diagnostic_id}"));
-    Err(RunnerError::Internal(message))
+    Err(WorkspaceDriveMountError {
+        error: RunnerError::Internal(message),
+        guest_duration,
+    })
 }
 
 pub(crate) fn workspace_mount_command() -> String {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1778,6 +1778,7 @@ fn exec_result_from_operation_result(
 
     Ok(ExecResult {
         termination: exec_termination_from_vsock_termination(result.termination),
+        guest_duration_ms: Some(result.duration_ms),
         stdout,
         stderr,
         diagnostic: result.diagnostic,

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -2336,6 +2336,7 @@ fn exec_result_from_operation_result_preserves_terminal_metadata() {
     .expect("bounded exec result should convert");
 
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 7 });
+    assert_eq!(result.guest_duration_ms, Some(10));
     assert_eq!(result.stdout, b"out");
     assert_eq!(result.stderr, b"err");
     assert_eq!(result.diagnostic, "ignored on ordinary exit");
@@ -2388,6 +2389,7 @@ fn exec_result_from_operation_result_maps_terminal_edge_states() {
         .expect("bounded exec result should convert");
 
         assert_eq!(result.termination, expected_termination);
+        assert_eq!(result.guest_duration_ms, Some(10));
         assert_eq!(result.stderr, input_stderr);
         assert_eq!(result.diagnostic, diagnostic);
     }

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -1012,6 +1012,7 @@ impl Sandbox for MockSandbox {
 fn clone_exec_result(result: &ExecResult) -> ExecResult {
     ExecResult {
         termination: result.termination,
+        guest_duration_ms: result.guest_duration_ms,
         stdout: result.stdout.clone(),
         stderr: result.stderr.clone(),
         diagnostic: result.diagnostic.clone(),

--- a/crates/sandbox-mock/src/tests/exec.rs
+++ b/crates/sandbox-mock/src/tests/exec.rs
@@ -83,6 +83,7 @@ async fn sandbox_queued_exec_results() {
     let sandbox = MockSandbox::new("test-1");
     sandbox.push_exec_result(Ok(ExecResult {
         termination: ExecTermination::Exited { exit_code: 42 },
+        guest_duration_ms: Some(17),
         stdout: b"out".to_vec(),
         stderr: b"err".to_vec(),
         diagnostic: String::new(),
@@ -91,6 +92,7 @@ async fn sandbox_queued_exec_results() {
     }));
     sandbox.push_exec_result(Ok(ExecResult {
         termination: ExecTermination::WaitFailed,
+        guest_duration_ms: None,
         stdout: Vec::new(),
         stderr: b"wait failed".to_vec(),
         diagnostic: "wait failed".to_string(),
@@ -116,6 +118,7 @@ async fn sandbox_queued_exec_results() {
     // First call returns queued result.
     let r1 = sandbox.exec(&req).await.unwrap();
     assert_eq!(r1.termination, ExecTermination::Exited { exit_code: 42 });
+    assert_eq!(r1.guest_duration_ms, Some(17));
     assert_eq!(r1.stdout, b"out");
 
     // Second call preserves a queued non-exited terminal state.

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -277,6 +277,9 @@ where
 pub struct ExecResult {
     /// Structured terminal state reported by the provider.
     pub termination: ExecTermination,
+    /// Guest-reported wall-clock duration in milliseconds, when the provider has
+    /// terminal duration metadata.
+    pub guest_duration_ms: Option<u32>,
     /// Captured stdout bytes, capped by the requested output limit.
     pub stdout: Vec<u8>,
     /// Captured stderr bytes, capped by the requested output limit.
@@ -291,9 +294,13 @@ pub struct ExecResult {
 
 impl ExecResult {
     /// Construct an ordinary exited-process result.
+    ///
+    /// The returned value has no guest duration, diagnostic, or truncation
+    /// metadata.
     pub fn new(exit_code: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> Self {
         Self {
             termination: ExecTermination::Exited { exit_code },
+            guest_duration_ms: None,
             stdout,
             stderr,
             diagnostic: String::new(),
@@ -1239,6 +1246,7 @@ mod tests {
         let result = ExecResult::new(7, b"out".to_vec(), b"err".to_vec());
 
         assert_eq!(result.termination, ExecTermination::Exited { exit_code: 7 });
+        assert_eq!(result.guest_duration_ms, None);
         assert_eq!(result.stdout, b"out");
         assert_eq!(result.stderr, b"err");
         assert!(result.diagnostic.is_empty());


### PR DESCRIPTION
## Summary

- preserve guest-reported one-shot exec duration in sandbox results
- attribute fresh workspace mount guest execution separately from the existing end-to-end mount event
- emit a bounded unavailable marker when a provider cannot supply terminal duration metadata

## Scope

- fresh workspace mount telemetry only
- no mount, cache, image, retry, queue, database, API, or runner protocol behavior changes
- exact-reuse runs continue to emit no workspace mount events

## Validation

- `cargo test -p sandbox -p sandbox-mock -p sandbox-fc -p runner --quiet`
- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p sandbox -p sandbox-mock -p sandbox-fc -p runner --all-features --no-deps`
- repository pre-commit hooks (Rust fmt, workspace Clippy, workspace rustdoc, file-size check)

Closes #28049

Parent context: #24203
