### PR TITLE
refactor(feishu): remove runtime ownership fallback

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -56,6 +56,7 @@ import {
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { readProjectedChatEvents } from "./helpers/chat-event-test-reader";
 import {
+  clearFeishuConnectorOwnership,
   readCustomConnectorCredentialStorageParent,
   seedLegacyCustomFeishuOAuthState,
 } from "./helpers/connector-credential-storage-state";
@@ -1546,6 +1547,82 @@ describe("Feishu integration", () => {
       }),
       [200],
     );
+  });
+
+  it("preserves an unlinked connector when removing its installation", async () => {
+    const actor = authOrgApi.user({
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      orgRole: "org:admin",
+    });
+    authOrgApi.acceptAgentStorageWrites();
+    await enableFeishuIntegration(actor);
+    const agent = await authOrgApi.createAgent(actor, {
+      displayName: "Feishu unlinked removal agent",
+      visibility: "public",
+    });
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const client = setupApp({ context, routes: feishuConnectRoutes })(
+      feishuConnectContract,
+    );
+    const configured = await accept(
+      client.setup({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          appId: `cli_${randomUUID()}`,
+          appSecret: APP_SECRET,
+          verificationToken: VERIFICATION_TOKEN,
+          defaultAgentId: agent.agentId,
+          createNew: true,
+        },
+      }),
+      [200],
+    );
+    const installationId = requireValue(
+      configured.body.installationId,
+      "Expected Feishu setup to return an installation id",
+    );
+    const customConnectorClient = setupApp({
+      context,
+      routes: customConnectorsRoutes,
+    })(zeroCustomConnectorsContract);
+    const connectorBeforeRemoval = requireValue(
+      (
+        await accept(
+          customConnectorClient.list({
+            headers: { authorization: "Bearer clerk-session" },
+          }),
+          [200],
+        )
+      ).body.connectors[0],
+      "Expected Feishu setup to create a managed connector",
+    );
+
+    // Production APIs cannot clear this relationship. This scoped test-only
+    // transition models historical ownership loss before exercising removal
+    // and verification through production routes.
+    await clearFeishuConnectorOwnership(context, {
+      orgId: requireValue(actor.orgId, "Expected an organization"),
+      installationId,
+    });
+
+    await accept(
+      client.removeInstallation({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { installationId },
+      }),
+      [200],
+    );
+
+    const connectorsAfterRemoval = await accept(
+      customConnectorClient.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(connectorsAfterRemoval.body.connectors).toMatchObject([
+      { id: connectorBeforeRemoval.id },
+    ]);
   });
 
   it("keeps the managed connector and skill HEAD active when repair publication fails", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -101,6 +101,20 @@ export async function deleteCustomConnectorCredentialValues(
   });
 }
 
+export async function clearFeishuConnectorOwnership(
+  context: TestContext,
+  args: {
+    readonly orgId: string;
+    readonly installationId: string;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "clear-feishu-connector-ownership",
+    org_id: args.orgId,
+    installation_id: args.installationId,
+  });
+}
+
 export async function seedLegacyCustomFeishuOAuthState(
   context: TestContext,
   args: {

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -5,6 +5,7 @@ import {
 } from "@okouai/api-contracts/contracts/test-connector-credential-storage-state";
 import { connectors } from "@okouai/db/schema/connector";
 import { connectorOauthStates } from "@okouai/db/schema/connector-oauth-state";
+import { feishuOrgInstallations } from "@okouai/db/schema/feishu-org-installation";
 import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
 import { secrets } from "@okouai/db/schema/secret";
 import { userCustomConnectors } from "@okouai/db/schema/user-custom-connector";
@@ -277,6 +278,30 @@ async function deleteCustomCredentialValues(
   });
   signal.throwIfAborted();
   return actionOk();
+}
+
+async function clearFeishuConnectorOwnership(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"clear-feishu-connector-ownership">,
+  signal: AbortSignal,
+) {
+  const [updated] = await db
+    .update(feishuOrgInstallations)
+    .set({ customConnectorId: null })
+    .where(
+      and(
+        eq(feishuOrgInstallations.orgId, body.org_id),
+        eq(feishuOrgInstallations.id, body.installation_id),
+      ),
+    )
+    .returning({ id: feishuOrgInstallations.id });
+  signal.throwIfAborted();
+  return updated
+    ? actionOk()
+    : {
+        status: 400 as const,
+        body: { error: "Feishu installation test fixture was not found" },
+      };
 }
 
 async function seedLegacyCustomFeishuOAuthState(
@@ -571,6 +596,9 @@ const mutateConnectorCredentialStorageState$ = command(
       }
       case "delete-custom-credential-values": {
         return await deleteCustomCredentialValues(db, body, signal);
+      }
+      case "clear-feishu-connector-ownership": {
+        return await clearFeishuConnectorOwnership(db, body, signal);
       }
       case "seed-legacy-custom-feishu-oauth-state": {
         return await seedLegacyCustomFeishuOAuthState(db, body, signal);

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -345,9 +345,7 @@ async function preflightFeishuCustomConnectorId(
 ): Promise<string | null> {
   const [target] = await db
     .select({
-      installationId: feishuOrgInstallations.id,
       customConnectorId: feishuOrgInstallations.customConnectorId,
-      appId: feishuOrgInstallations.appId,
     })
     .from(feishuOrgInstallations)
     .where(
@@ -361,33 +359,7 @@ async function preflightFeishuCustomConnectorId(
   if (!target) {
     return null;
   }
-  if (target.customConnectorId) {
-    return target.customConnectorId;
-  }
-  const [legacyConnector] = await db
-    .select({ id: orgCustomConnectors.id })
-    .from(orgCustomConnectors)
-    .innerJoin(
-      orgCustomConnectorOauthConfigs,
-      and(
-        eq(orgCustomConnectorOauthConfigs.connectorId, orgCustomConnectors.id),
-        eq(orgCustomConnectorOauthConfigs.orgId, orgCustomConnectors.orgId),
-      ),
-    )
-    .where(
-      and(
-        eq(orgCustomConnectors.orgId, args.orgId),
-        eq(
-          orgCustomConnectors.slug,
-          getFeishuCustomConnectorSlug(args.installationId),
-        ),
-        eq(orgCustomConnectorOauthConfigs.providerAdapter, "feishu"),
-        eq(orgCustomConnectorOauthConfigs.clientId, target.appId),
-      ),
-    )
-    .limit(1);
-  signal.throwIfAborted();
-  return legacyConnector?.id ?? randomUUID();
+  return target.customConnectorId ?? randomUUID();
 }
 
 async function reconcileFeishuCustomConnector(
@@ -423,34 +395,32 @@ async function reconcileFeishuCustomConnector(
     return { kind: "installation-missing" };
   }
 
-  const slug = getFeishuCustomConnectorSlug(args.installationId);
-  const [existing] = await tx
-    .select({
-      connector: customConnectorDefinitionSelection(),
-      oauthConfig: orgCustomConnectorOauthConfigs,
-    })
-    .from(orgCustomConnectors)
-    .leftJoin(
-      orgCustomConnectorOauthConfigs,
-      and(
-        eq(orgCustomConnectorOauthConfigs.connectorId, orgCustomConnectors.id),
-        eq(orgCustomConnectorOauthConfigs.orgId, orgCustomConnectors.orgId),
-      ),
-    )
-    .where(
-      and(
-        eq(orgCustomConnectors.orgId, args.orgId),
-        installation.customConnectorId
-          ? eq(orgCustomConnectors.id, installation.customConnectorId)
-          : and(
-              eq(orgCustomConnectors.slug, slug),
-              eq(orgCustomConnectorOauthConfigs.providerAdapter, "feishu"),
-              eq(orgCustomConnectorOauthConfigs.clientId, installation.appId),
+  const [existing] = installation.customConnectorId
+    ? await tx
+        .select({
+          connector: customConnectorDefinitionSelection(),
+          oauthConfig: orgCustomConnectorOauthConfigs,
+        })
+        .from(orgCustomConnectors)
+        .leftJoin(
+          orgCustomConnectorOauthConfigs,
+          and(
+            eq(
+              orgCustomConnectorOauthConfigs.connectorId,
+              orgCustomConnectors.id,
             ),
-      ),
-    )
-    .for("update", { of: orgCustomConnectors })
-    .limit(1);
+            eq(orgCustomConnectorOauthConfigs.orgId, orgCustomConnectors.orgId),
+          ),
+        )
+        .where(
+          and(
+            eq(orgCustomConnectors.orgId, args.orgId),
+            eq(orgCustomConnectors.id, installation.customConnectorId),
+          ),
+        )
+        .for("update", { of: orgCustomConnectors })
+        .limit(1)
+    : [];
   signal.throwIfAborted();
   if (existing && existing.connector.id !== prepared.connectorId) {
     return {
@@ -607,7 +577,6 @@ export const deleteFeishuInstallationAndCustomConnector$ = command(
       const [installation] = await tx
         .select({
           id: feishuOrgInstallations.id,
-          appId: feishuOrgInstallations.appId,
           customConnectorId: feishuOrgInstallations.customConnectorId,
         })
         .from(feishuOrgInstallations)
@@ -624,38 +593,7 @@ export const deleteFeishuInstallationAndCustomConnector$ = command(
         return { installationDeleted: false, connectorId: null };
       }
 
-      let connectorId = installation.customConnectorId;
-      if (!connectorId) {
-        const [legacyConnector] = await tx
-          .select({ id: orgCustomConnectors.id })
-          .from(orgCustomConnectors)
-          .innerJoin(
-            orgCustomConnectorOauthConfigs,
-            and(
-              eq(
-                orgCustomConnectorOauthConfigs.connectorId,
-                orgCustomConnectors.id,
-              ),
-              eq(
-                orgCustomConnectorOauthConfigs.orgId,
-                orgCustomConnectors.orgId,
-              ),
-            ),
-          )
-          .where(
-            and(
-              eq(orgCustomConnectors.orgId, args.orgId),
-              eq(
-                orgCustomConnectors.slug,
-                getFeishuCustomConnectorSlug(args.installationId),
-              ),
-              eq(orgCustomConnectorOauthConfigs.providerAdapter, "feishu"),
-              eq(orgCustomConnectorOauthConfigs.clientId, installation.appId),
-            ),
-          )
-          .limit(1);
-        connectorId = legacyConnector?.id ?? null;
-      }
+      const connectorId = installation.customConnectorId;
 
       await tx
         .delete(feishuOrgInstallations)

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -54,6 +54,11 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       custom_connector_id: z.uuid(),
     }),
     z.object({
+      action: z.literal("clear-feishu-connector-ownership"),
+      org_id: z.string(),
+      installation_id: z.uuid(),
+    }),
+    z.object({
       action: z.literal("seed-legacy-custom-feishu-oauth-state"),
       state: z.string().min(1),
       org_id: z.string(),


### PR DESCRIPTION
## Summary

- remove Feishu runtime ownership inference by slug, OAuth provider, and app ID
- make reconcile and deletion trust only `feishu_org_installations.custom_connector_id`
- add a narrowly scoped test-only state action and verify that removal preserves an unlinked connector

## Why

Migration 0940 backfilled authoritative Feishu connector ownership and removed historical unlinked managed connectors. The [production migration job](https://github.com/vm0-ai/vm0/actions/runs/32131618561/job/95697178438) completed successfully in API release `api-v1.459.1` at 2026-08-18 11:40:58 UTC, and API production deployment completed at 11:41:40 UTC. The repository's observed maximum DB/API exposure window is 102 minutes; that window ended at 13:22:58 UTC before this implementation began.

## Compatibility

- No production schema or API behavior is added.
- Existing linked installations continue to reconcile and delete their exact managed connector.
- A null ownership link no longer causes a heuristic connector match; reconcile creates a new authoritative connector and deletion leaves unrelated connectors untouched.
- Rollback to the previous post-0940 API remains safe because it accepts both persisted exact IDs and the reachable initially-null setup state.

## Exclusions

- no changes to Feishu Integration UI or custom connector visibility
- no new migration or historical cleanup logic
- no fallback for unmigrated databases

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/feishu-integration.test.ts` (33 passed)
- `pnpm -F @okouai/db test:migration-consistency`
- `pnpm turbo run lint --filter=api --filter=@okouai/api-contracts`
- `pnpm check-types`
- `pnpm knip`
- targeted Prettier check and `git diff --check`
- pre-commit hooks (Prettier, Knip, type checks, file size, commitlint)

Closes #27960

Parent: #27891

Related rollout migration: #27933
