### PR TITLE
fix(app): refresh members after paid invitation completion

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -47,6 +47,7 @@ import {
 } from "../bootstrap/paid-funnel-telemetry.ts";
 import { currentLocale, i18n } from "../../i18n/index.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
+import { refreshOrgMembers$ } from "../external/org-members.ts";
 import { sessionStorageSignals } from "../external/session-storage.ts";
 import {
   setUsagePackMigrationRevisionPreview$,
@@ -726,6 +727,7 @@ const reloadBillingStatusFromRemoteChange$ = command(
     set(reloadQueueData$);
     set(reloadUsagePackManagement$);
     set(reloadUsageRecords$);
+    set(refreshOrgMembers$);
     await set(reconcilePendingBillingPayment$, signal);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-members-tab.test.tsx
@@ -65,7 +65,9 @@ function mockMembersStory(): {
   readonly addPendingInvitation: (
     invitation: NonNullable<OrgMembersResponse["pendingInvitations"]>[number],
   ) => void;
+  readonly membersRequestCount: () => number;
 } {
+  let membersRequestCount = 0;
   let response: OrgMembersResponse = {
     name: "Test Org",
     role: "admin",
@@ -135,6 +137,7 @@ function mockMembersStory(): {
     role: "admin",
   });
   context.mocks.api(orgMembersContract.members, ({ respond }) => {
+    membersRequestCount += 1;
     return respond(200, response);
   });
   context.mocks.api(orgInviteContract.invite, ({ body, respond }) => {
@@ -231,6 +234,9 @@ function mockMembersStory(): {
           invitation,
         ],
       };
+    },
+    membersRequestCount() {
+      return membersRequestCount;
     },
   };
 }
@@ -421,13 +427,6 @@ describe("organization members settings", () => {
       orgInviteContract.confirmPurchase,
       ({ params, respond }) => {
         confirmedPurchaseId = params.purchaseId;
-        membersStory.addPendingInvitation({
-          id: "inv-paid",
-          email: "paid.invitee@example.com",
-          role: "member",
-          createdAt: "2026-01-06T00:00:00Z",
-          usagePackUsd: 50,
-        });
         return respond(200, {
           message: "Invitation purchased and sent",
         });
@@ -445,6 +444,11 @@ describe("organization members settings", () => {
       ).toBeInTheDocument();
     });
     await expect(screen.findByText("Usage pack")).resolves.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("billing:changed"),
+      ).toBeTruthy();
+    });
     expect(
       within(rowByEmail("alice@example.com")).getByText("$20/month"),
     ).toBeInTheDocument();
@@ -501,13 +505,37 @@ describe("organization members settings", () => {
       ).toString(),
     });
     expect(window.location.href).toBe(initialHref);
+    const membersRequestsBeforeConfirm = membersStory.membersRequestCount();
     click(buttonByText("Pay and invite", confirmationDialog));
 
     await waitFor(() => {
       expect(confirmedPurchaseId).toBe("c08a5fab-a05d-43f9-a1ee-10feaf27584c");
+      expect(membersStory.membersRequestCount()).toBeGreaterThan(
+        membersRequestsBeforeConfirm,
+      );
       expect(
         screen.queryByRole("dialog", { name: "Review invitation" }),
       ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("paid.invitee@example.com"),
+    ).not.toBeInTheDocument();
+
+    membersStory.addPendingInvitation({
+      id: "inv-paid",
+      email: "paid.invitee@example.com",
+      role: "member",
+      createdAt: "2026-01-06T00:00:00Z",
+      usagePackUsd: 50,
+    });
+    const membersRequestsBeforeBillingChange =
+      membersStory.membersRequestCount();
+    context.mocks.ably.trigger("billing:changed");
+
+    await waitFor(() => {
+      expect(membersStory.membersRequestCount()).toBeGreaterThan(
+        membersRequestsBeforeBillingChange,
+      );
     });
     await screen.findByText("paid.invitee@example.com");
     expect(


### PR DESCRIPTION
## Summary

- refresh organization members from the existing `billing:changed` completion signal
- cover the paid-invitation confirm/webhook ownership race with a deterministic page-level regression
- preserve the paid invitation invariant: the pending member appears with the selected monthly package without leaving Settings

## Root cause

[Turbo run 32149515026](https://github.com/vm0-ai/vm0/actions/runs/32149515026), [job 95755080325](https://github.com/vm0-ai/vm0/actions/runs/32149515026/job/95755080325) failed after the Settings dialog was already open because the target pending invitation row never appeared.

Bounded request and trace correlation showed this interleaving:

1. The confirm request returned `200` after a concurrent Stripe webhook had claimed invitation creation, so confirm did not own or await the Clerk create operation.
2. The client immediately refreshed organization members at `14:49:47.914Z`, while the webhook's successful Clerk invitation create was still in flight (`14:49:47.852Z` to approximately `14:49:48.037Z`). The invitation list read completed with an empty result.
3. The webhook then persisted the allocation and published `billing:changed`, but the App's billing realtime handler did not invalidate organization members. No later members request occurred before the locator timeout.

All relevant Stripe and Clerk operations returned `200`; there was no correlated `429` or `5xx`. The late Clerk Testing `route.fetch` warning occurred more than a minute after the Playwright failure marker and also appears in passing runs. Cleanup began after the failed test step, and `ci-gate-turbo` only aggregated the substantive failure.

The same SHA passed in [merge-group run 32148731153](https://github.com/vm0-ai/vm0/actions/runs/32148731153): in that interleaving, confirm owned invitation creation and the subsequent members read began after Clerk creation and allocation persistence. The adjacent parent-main run also passed. This isolates request ownership timing, rather than a deterministic change from #28042.

## Duplicate guards

- #27897 stabilizes the root-to-Settings route handoff; this failure was already inside Settings and begins after confirm.
- #28051 adds a restored billing sequence and optional package arguments; it does not change this paid-invitation helper or realtime refresh boundary.
- No other open PR, remote repair branch, active repair chat, or goal matched this fingerprint before implementation or PR creation.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- controlled red check: the focused regression fails at the new members-request assertion when the `billing:changed` organization-members refresh is removed
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/org-members-tab.test.tsx` — 5 consecutive passes, 13/13 each
- the same targeted file passed again after rebasing onto latest `origin/main`
- `git diff --check origin/main...HEAD`
- [PR Turbo run 32154730180](https://github.com/vm0-ai/vm0/actions/runs/32154730180) passed, including [cli-e2e-02-playwright](https://github.com/vm0-ai/vm0/actions/runs/32154730180/job/95770181625)

## Preview verification

- App: https://pr-28062-app.omby.ai
- API: https://pr-28062-api.vm6.ai
- Deployment: [App job 95769074823](https://github.com/vm0-ai/vm0/actions/runs/32154730180/job/95769074823) and [API job 95769268124](https://github.com/vm0-ai/vm0/actions/runs/32154730180/job/95769268124), built from head `f6390a436e78759a0008b1ee2f95ce4780563503` via merge commit `19c6b34d307744c8015458ea33c1ac496a1eba20`
- Browser: 1440×1000 Chromium against the deployed App/API preview, with the `usagePackPlans` Lab switch enabled and a new test-mode Pro workspace
- Result: 5 consecutive paid-invitation flows passed with unique synthetic invitees. Each selected the `$50` package, completed payment, stayed in Settings, rendered a `Pending` row with `$50/month` inside the original 30-second budget without reload, then revoked the invitation and verified the row disappeared.
- The first setup account was excluded before the five-run sample because it had been provisioned on the legacy Pro path before enabling `usagePackPlans`; no invariant run used that fixture.
- Evidence: [review invitation](https://cdn.vm0.io/artifacts/1il18uy1z3.png) · [pending `$50/month` row](https://cdn.vm0.io/artifacts/wkqd77utlf.png)

The independent Security workflow's initial `Workflow Lint` job was canceled while `apt-get update` stalled on the Azure Ubuntu mirror; it did not reach repository linting. Turbo and all substantive security scans passed, and the canceled infrastructure-only job is being rerun.
