### PR TITLE
perf(runner): hand off finalizing sandboxes before idle compaction

### DIFF
--- a/crates/runner/src/cmd/start/active_runs.rs
+++ b/crates/runner/src/cmd/start/active_runs.rs
@@ -1,8 +1,12 @@
 use std::collections::{HashMap, HashSet, hash_map};
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use tokio::sync::{Notify, watch};
+use sandbox::SandboxFinalExecParkHandoff;
+use tokio::sync::{Notify, oneshot, watch};
 
+use crate::idle_pool::{
+    FinalizingHandoffCandidate, ImmediateHandoffCandidate, ParkedIdleCandidate,
+};
 use crate::ids::RunId;
 
 #[derive(Clone)]
@@ -15,18 +19,31 @@ struct ActiveRunEntry {
     reuse_key: Option<String>,
     profile_name: String,
     reuse_state: watch::Sender<ActiveRunReuseState>,
+    handoff: Arc<Mutex<ActiveRunHandoffBroker>>,
+}
+
+struct ActiveRunHandoffBroker {
+    signal: SandboxFinalExecParkHandoff,
+    delivery: Option<ActiveRunHandoffDelivery>,
+}
+
+struct ActiveRunHandoffDelivery {
+    successor_run_id: RunId,
+    sender: oneshot::Sender<Box<FinalizingHandoffCandidate>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ActiveRunReuseState {
     Pending,
     ExactSandboxPublished,
+    ExactSandboxHandedOff,
     NoExactSandbox,
     Released,
 }
 
 pub(super) struct ActiveRunReuseProof {
     reuse_state: watch::Receiver<ActiveRunReuseState>,
+    handoff: Arc<Mutex<ActiveRunHandoffBroker>>,
 }
 
 impl ActiveRunReuseProof {
@@ -40,20 +57,153 @@ impl ActiveRunReuseProof {
         }
         self.state()
     }
+
+    pub(super) fn request_handoff(
+        &self,
+        successor_run_id: RunId,
+    ) -> Option<ActiveRunHandoffRequest> {
+        let mut broker = lock_handoff(&self.handoff);
+        if self.state() != ActiveRunReuseState::Pending || broker.delivery.is_some() {
+            return None;
+        }
+        let (sender, receiver) = oneshot::channel();
+        broker.delivery = Some(ActiveRunHandoffDelivery {
+            successor_run_id,
+            sender,
+        });
+        if !broker.signal.request() {
+            broker.delivery = None;
+            return None;
+        }
+        Some(ActiveRunHandoffRequest {
+            successor_run_id,
+            signal: broker.signal.clone(),
+            receiver,
+            broker: Arc::clone(&self.handoff),
+        })
+    }
+}
+
+pub(super) struct ActiveRunHandoffRequest {
+    successor_run_id: RunId,
+    signal: SandboxFinalExecParkHandoff,
+    receiver: oneshot::Receiver<Box<FinalizingHandoffCandidate>>,
+    broker: Arc<Mutex<ActiveRunHandoffBroker>>,
+}
+
+impl ActiveRunHandoffRequest {
+    pub(super) async fn accepted(&self) -> bool {
+        self.signal.wait_for_acceptance().await
+    }
+
+    pub(super) async fn receive(
+        &mut self,
+    ) -> Result<Box<FinalizingHandoffCandidate>, oneshot::error::RecvError> {
+        (&mut self.receiver).await
+    }
+}
+
+impl Drop for ActiveRunHandoffRequest {
+    fn drop(&mut self) {
+        self.receiver.close();
+        self.signal.cancel();
+        let mut broker = lock_handoff(&self.broker);
+        if broker
+            .delivery
+            .as_ref()
+            .is_some_and(|delivery| delivery.successor_run_id == self.successor_run_id)
+        {
+            broker.delivery = None;
+        }
+    }
 }
 
 #[derive(Clone)]
 pub(super) struct ActiveRunReusePublisher {
     reuse_state: watch::Sender<ActiveRunReuseState>,
+    handoff: Arc<Mutex<ActiveRunHandoffBroker>>,
+}
+
+pub(super) enum ActiveRunHandoffDeliveryResult<C> {
+    Delivered,
+    NotRequested(C),
+    Failed(C),
 }
 
 impl ActiveRunReusePublisher {
     pub(super) fn publish_exact_sandbox(&self) -> bool {
-        self.resolve_pending(ActiveRunReuseState::ExactSandboxPublished)
+        self.publish_without_handoff(ActiveRunReuseState::ExactSandboxPublished)
     }
 
     pub(super) fn publish_no_exact_sandbox(&self) -> bool {
-        self.resolve_pending(ActiveRunReuseState::NoExactSandbox)
+        self.publish_without_handoff(ActiveRunReuseState::NoExactSandbox)
+    }
+
+    pub(super) fn handoff_signal(&self) -> SandboxFinalExecParkHandoff {
+        lock_handoff(&self.handoff).signal.clone()
+    }
+
+    pub(super) fn deliver_exact_handoff(
+        &self,
+        candidate: ParkedIdleCandidate,
+        predecessor_run_id: RunId,
+    ) -> ActiveRunHandoffDeliveryResult<ParkedIdleCandidate> {
+        self.deliver_handoff(
+            candidate,
+            predecessor_run_id,
+            |candidate, successor_run_id, predecessor_run_id| {
+                candidate.into_finalizing_handoff(successor_run_id, predecessor_run_id)
+            },
+            FinalizingHandoffCandidate::into_parked_candidate,
+        )
+    }
+
+    pub(super) fn deliver_exact_immediate_handoff(
+        &self,
+        candidate: ImmediateHandoffCandidate,
+        predecessor_run_id: RunId,
+    ) -> ActiveRunHandoffDeliveryResult<ImmediateHandoffCandidate> {
+        let handoff_point = candidate.handoff_point();
+        self.deliver_handoff(
+            candidate,
+            predecessor_run_id,
+            |candidate, successor_run_id, predecessor_run_id| {
+                candidate.into_finalizing_handoff(successor_run_id, predecessor_run_id)
+            },
+            |candidate| {
+                candidate
+                    .into_parked_candidate()
+                    .into_immediate_handoff(handoff_point)
+            },
+        )
+    }
+
+    fn deliver_handoff<C>(
+        &self,
+        candidate: C,
+        predecessor_run_id: RunId,
+        bind: impl FnOnce(C, RunId, RunId) -> FinalizingHandoffCandidate,
+        recover: impl FnOnce(Box<FinalizingHandoffCandidate>) -> C,
+    ) -> ActiveRunHandoffDeliveryResult<C> {
+        let mut broker = lock_handoff(&self.handoff);
+        if !broker.signal.accept_if_requested() {
+            return ActiveRunHandoffDeliveryResult::NotRequested(candidate);
+        }
+        let Some(delivery) = broker.delivery.take() else {
+            return ActiveRunHandoffDeliveryResult::Failed(candidate);
+        };
+        let candidate = Box::new(bind(
+            candidate,
+            delivery.successor_run_id,
+            predecessor_run_id,
+        ));
+        match delivery.sender.send(candidate) {
+            Ok(()) => {
+                self.resolve_pending(ActiveRunReuseState::ExactSandboxHandedOff);
+                ActiveRunHandoffDeliveryResult::Delivered
+            }
+            Err(candidate) => ActiveRunHandoffDeliveryResult::Failed(recover(candidate)),
+        }
     }
 
     fn resolve_pending(&self, next: ActiveRunReuseState) -> bool {
@@ -66,10 +216,26 @@ impl ActiveRunReusePublisher {
         })
     }
 
+    fn publish_without_handoff(&self, next: ActiveRunReuseState) -> bool {
+        let mut broker = lock_handoff(&self.handoff);
+        let resolved = self.resolve_pending(next);
+        if resolved {
+            broker.signal.cancel();
+            broker.delivery = None;
+        }
+        resolved
+    }
+
     #[cfg(test)]
     pub(super) fn detached() -> Self {
         let (reuse_state, _reuse_state_rx) = watch::channel(ActiveRunReuseState::Pending);
-        Self { reuse_state }
+        Self {
+            reuse_state,
+            handoff: Arc::new(Mutex::new(ActiveRunHandoffBroker {
+                signal: SandboxFinalExecParkHandoff::new(),
+                delivery: None,
+            })),
+        }
     }
 }
 
@@ -78,6 +244,7 @@ pub(super) struct ActiveRunGuard {
     run_id: Option<RunId>,
     has_reuse_key: bool,
     reuse_state: watch::Sender<ActiveRunReuseState>,
+    handoff: Arc<Mutex<ActiveRunHandoffBroker>>,
 }
 
 impl ActiveRuns {
@@ -95,6 +262,10 @@ impl ActiveRuns {
         profile_name: String,
     ) -> ActiveRunGuard {
         let (reuse_state, _reuse_state_rx) = watch::channel(ActiveRunReuseState::Pending);
+        let handoff = Arc::new(Mutex::new(ActiveRunHandoffBroker {
+            signal: SandboxFinalExecParkHandoff::new(),
+            delivery: None,
+        }));
         let has_reuse_key = reuse_key.is_some();
         let mut entries = lock_entries(&self.entries);
         let entry = entries.entry(run_id);
@@ -107,6 +278,7 @@ impl ActiveRuns {
                 reuse_key,
                 profile_name,
                 reuse_state: reuse_state.clone(),
+                handoff: Arc::clone(&handoff),
             });
         }
         drop(entries);
@@ -115,6 +287,7 @@ impl ActiveRuns {
             run_id: Some(run_id),
             has_reuse_key,
             reuse_state,
+            handoff,
         }
     }
 
@@ -131,6 +304,7 @@ impl ActiveRuns {
         }
         let proof = ActiveRunReuseProof {
             reuse_state: entry.reuse_state.subscribe(),
+            handoff: Arc::clone(&entry.handoff),
         };
         (proof.state() == ActiveRunReuseState::Pending).then_some(proof)
     }
@@ -159,6 +333,7 @@ impl ActiveRunGuard {
     pub(super) fn reuse_publisher(&self) -> ActiveRunReusePublisher {
         ActiveRunReusePublisher {
             reuse_state: self.reuse_state.clone(),
+            handoff: Arc::clone(&self.handoff),
         }
     }
 
@@ -171,8 +346,13 @@ impl ActiveRunGuard {
             return false;
         };
         lock_entries(&self.active_runs.entries).remove(&run_id);
-        let was_pending = self.reuse_state.send_replace(ActiveRunReuseState::Released)
-            == ActiveRunReuseState::Pending;
+        let was_pending = {
+            let mut handoff = lock_handoff(&self.handoff);
+            handoff.signal.cancel();
+            handoff.delivery = None;
+            self.reuse_state.send_replace(ActiveRunReuseState::Released)
+                == ActiveRunReuseState::Pending
+        };
         if self.has_reuse_key && was_pending {
             self.active_runs.reuse_state_notify.notify_one();
         }
@@ -190,6 +370,12 @@ fn lock_entries(
     entries: &Mutex<HashMap<RunId, ActiveRunEntry>>,
 ) -> MutexGuard<'_, HashMap<RunId, ActiveRunEntry>> {
     entries
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn lock_handoff(handoff: &Mutex<ActiveRunHandoffBroker>) -> MutexGuard<'_, ActiveRunHandoffBroker> {
+    handoff
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
@@ -315,6 +501,60 @@ mod tests {
         assert_eq!(
             released_proof.changed().await,
             ActiveRunReuseState::Released
+        );
+    }
+
+    #[test]
+    fn resolved_predecessor_rejects_late_handoff_requests() {
+        let active_runs = ActiveRuns::new(Arc::new(Notify::new()));
+        let published_run_id = RunId::new_v4();
+        let published_guard = active_runs.register(
+            published_run_id,
+            Some("thread:published".into()),
+            "vm0/default".into(),
+        );
+        let published_proof = active_runs
+            .finalizing_predecessor(published_run_id, "thread:published", "vm0/default")
+            .unwrap();
+
+        assert!(published_guard.reuse_publisher().publish_exact_sandbox());
+        assert!(published_proof.request_handoff(RunId::new_v4()).is_none());
+
+        let released_run_id = RunId::new_v4();
+        let released_guard = active_runs.register(
+            released_run_id,
+            Some("thread:released-late".into()),
+            "vm0/default".into(),
+        );
+        let released_proof = active_runs
+            .finalizing_predecessor(released_run_id, "thread:released-late", "vm0/default")
+            .unwrap();
+        drop(released_guard);
+
+        assert!(released_proof.request_handoff(RunId::new_v4()).is_none());
+    }
+
+    #[test]
+    fn predecessor_accepts_only_one_live_handoff_request() {
+        let active_runs = ActiveRuns::new(Arc::new(Notify::new()));
+        let run_id = RunId::new_v4();
+        let _guard = active_runs.register(
+            run_id,
+            Some("thread:single-handoff".into()),
+            "vm0/default".into(),
+        );
+        let proof = active_runs
+            .finalizing_predecessor(run_id, "thread:single-handoff", "vm0/default")
+            .unwrap();
+        let request = proof
+            .request_handoff(RunId::new_v4())
+            .expect("first exact successor should register");
+
+        assert!(proof.request_handoff(RunId::new_v4()).is_none());
+        drop(request);
+        assert!(
+            proof.request_handoff(RunId::new_v4()).is_none(),
+            "a cancelled one-shot request must not transfer to another successor"
         );
     }
 }

--- a/crates/runner/src/cmd/start/active_runs.rs
+++ b/crates/runner/src/cmd/start/active_runs.rs
@@ -109,6 +109,22 @@ impl ActiveRunHandoffRequest {
         self.receiver.try_recv().ok()
     }
 
+    pub(super) fn expire_if_unaccepted(&mut self) -> bool {
+        let mut broker = lock_handoff(&self.broker);
+        if !self.signal.cancel() && self.signal.is_accepted() {
+            return false;
+        }
+        self.receiver.close();
+        if broker
+            .delivery
+            .as_ref()
+            .is_some_and(|delivery| delivery.successor_run_id == self.successor_run_id)
+        {
+            broker.delivery = None;
+        }
+        true
+    }
+
     fn close_delivery(&mut self) {
         let mut broker = lock_handoff(&self.broker);
         self.receiver.close();
@@ -651,6 +667,48 @@ mod tests {
             .cancel_and_recover_delivery()
             .expect("cancellation must recover a candidate sent before receiver closure");
         let (payload, lease) = recovered
+            .into_parked_candidate()
+            .into_active_destroy_parts();
+        drop(payload);
+        drop(lease);
+        assert_eq!(budget.allocated(), (0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn deadline_preserves_accepted_handoff_before_delivery() {
+        let active_runs = ActiveRuns::new(Arc::new(Notify::new()));
+        let predecessor_run_id = RunId::new_v4();
+        let successor_run_id = RunId::new_v4();
+        let guard = active_runs.register(
+            predecessor_run_id,
+            Some("thread:deadline-handoff".into()),
+            "vm0/default".into(),
+        );
+        let publisher = guard.reuse_publisher();
+        let proof = active_runs
+            .finalizing_predecessor(predecessor_run_id, "thread:deadline-handoff", "vm0/default")
+            .unwrap();
+        let mut request = proof
+            .request_handoff(successor_run_id)
+            .expect("exact successor should register a handoff");
+        assert!(publisher.handoff_signal().accept_if_requested());
+
+        assert!(!request.expire_if_unaccepted());
+
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let candidate = ParkedIdleCandidateBuilder::new("thread:deadline-handoff", lease)
+            .with_history_generation_run_id(predecessor_run_id)
+            .build();
+        assert!(matches!(
+            publisher.deliver_exact_handoff(candidate, predecessor_run_id),
+            ActiveRunHandoffDeliveryResult::Delivered
+        ));
+        let candidate = request
+            .receive()
+            .await
+            .expect("accepted handoff should remain deliverable after its deadline");
+        let (payload, lease) = candidate
             .into_parked_candidate()
             .into_active_destroy_parts();
         drop(payload);

--- a/crates/runner/src/cmd/start/active_runs.rs
+++ b/crates/runner/src/cmd/start/active_runs.rs
@@ -101,13 +101,18 @@ impl ActiveRunHandoffRequest {
     ) -> Result<Box<FinalizingHandoffCandidate>, oneshot::error::RecvError> {
         (&mut self.receiver).await
     }
-}
 
-impl Drop for ActiveRunHandoffRequest {
-    fn drop(&mut self) {
+    pub(super) fn cancel_and_recover_delivery(
+        &mut self,
+    ) -> Option<Box<FinalizingHandoffCandidate>> {
+        self.close_delivery();
+        self.receiver.try_recv().ok()
+    }
+
+    fn close_delivery(&mut self) {
+        let mut broker = lock_handoff(&self.broker);
         self.receiver.close();
         self.signal.cancel();
-        let mut broker = lock_handoff(&self.broker);
         if broker
             .delivery
             .as_ref()
@@ -115,6 +120,12 @@ impl Drop for ActiveRunHandoffRequest {
         {
             broker.delivery = None;
         }
+    }
+}
+
+impl Drop for ActiveRunHandoffRequest {
+    fn drop(&mut self) {
+        self.close_delivery();
     }
 }
 
@@ -598,6 +609,50 @@ mod tests {
 
         assert_eq!(proof.state(), ActiveRunReuseState::Pending);
         let (payload, lease) = recovered.into_active_destroy_parts();
+        drop(payload);
+        drop(lease);
+        assert_eq!(budget.allocated(), (0, 0, 0));
+    }
+
+    #[test]
+    fn cancelled_accepted_handoff_recovers_already_sent_candidate() {
+        let active_runs = ActiveRuns::new(Arc::new(Notify::new()));
+        let predecessor_run_id = RunId::new_v4();
+        let successor_run_id = RunId::new_v4();
+        let guard = active_runs.register(
+            predecessor_run_id,
+            Some("thread:cancelled-handoff".into()),
+            "vm0/default".into(),
+        );
+        let publisher = guard.reuse_publisher();
+        let proof = active_runs
+            .finalizing_predecessor(
+                predecessor_run_id,
+                "thread:cancelled-handoff",
+                "vm0/default",
+            )
+            .unwrap();
+        let mut request = proof
+            .request_handoff(successor_run_id)
+            .expect("exact successor should register a handoff");
+        assert!(publisher.handoff_signal().accept_if_requested());
+
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let candidate = ParkedIdleCandidateBuilder::new("thread:cancelled-handoff", lease)
+            .with_history_generation_run_id(predecessor_run_id)
+            .build();
+        assert!(matches!(
+            publisher.deliver_exact_handoff(candidate, predecessor_run_id),
+            ActiveRunHandoffDeliveryResult::Delivered
+        ));
+
+        let recovered = request
+            .cancel_and_recover_delivery()
+            .expect("cancellation must recover a candidate sent before receiver closure");
+        let (payload, lease) = recovered
+            .into_parked_candidate()
+            .into_active_destroy_parts();
         drop(payload);
         drop(lease);
         assert_eq!(budget.allocated(), (0, 0, 0));

--- a/crates/runner/src/cmd/start/active_runs.rs
+++ b/crates/runner/src/cmd/start/active_runs.rs
@@ -384,6 +384,9 @@ fn lock_handoff(handoff: &Mutex<ActiveRunHandoffBroker>) -> MutexGuard<'_, Activ
 mod tests {
     use super::*;
 
+    use crate::idle_pool::test_support::ParkedIdleCandidateBuilder;
+    use crate::resource_budget::ResourceBudget;
+
     #[tokio::test]
     async fn active_runs_prove_exact_predecessor_and_preserve_shared_reuse_key() {
         let active_runs = ActiveRuns::new(Arc::new(Notify::new()));
@@ -556,5 +559,47 @@ mod tests {
             proof.request_handoff(RunId::new_v4()).is_none(),
             "a cancelled one-shot request must not transfer to another successor"
         );
+    }
+
+    #[test]
+    fn closed_accepted_handoff_receiver_returns_candidate_to_publisher() {
+        let active_runs = ActiveRuns::new(Arc::new(Notify::new()));
+        let predecessor_run_id = RunId::new_v4();
+        let successor_run_id = RunId::new_v4();
+        let guard = active_runs.register(
+            predecessor_run_id,
+            Some("thread:closed-handoff".into()),
+            "vm0/default".into(),
+        );
+        let publisher = guard.reuse_publisher();
+        let proof = active_runs
+            .finalizing_predecessor(predecessor_run_id, "thread:closed-handoff", "vm0/default")
+            .unwrap();
+        let mut request = proof
+            .request_handoff(successor_run_id)
+            .expect("exact successor should register a handoff");
+        assert!(publisher.handoff_signal().accept_if_requested());
+        request.receiver.close();
+
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let candidate = ParkedIdleCandidateBuilder::new("thread:closed-handoff", lease)
+            .with_history_generation_run_id(predecessor_run_id)
+            .build();
+        let recovered = match publisher.deliver_exact_handoff(candidate, predecessor_run_id) {
+            ActiveRunHandoffDeliveryResult::Failed(candidate) => candidate,
+            ActiveRunHandoffDeliveryResult::Delivered => {
+                panic!("closed receiver must not take sandbox ownership")
+            }
+            ActiveRunHandoffDeliveryResult::NotRequested(_) => {
+                panic!("provider already accepted the handoff request")
+            }
+        };
+
+        assert_eq!(proof.state(), ActiveRunReuseState::Pending);
+        let (payload, lease) = recovered.into_active_destroy_parts();
+        drop(payload);
+        drop(lease);
+        assert_eq!(budget.allocated(), (0, 0, 0));
     }
 }

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -54,7 +54,7 @@ enum FinalizingWaitOutcome {
         reason: &'static str,
         handoff_outcome: FinalizingHandoffOutcome,
     },
-    Cancelled,
+    Cancelled(Option<Box<FinalizingHandoffCandidate>>),
 }
 
 impl FinalizingWaitOutcome {
@@ -65,11 +65,18 @@ impl FinalizingWaitOutcome {
         }
     }
 
-    fn deadline(reason: &'static str) -> Self {
-        Self::Fallback {
-            reason,
-            handoff_outcome: FinalizingHandoffOutcome::NotAcceptedBeforeDeadline,
+    fn deadline(reason: &'static str, request: &mut ActiveRunHandoffRequest) -> Self {
+        match request.cancel_and_recover_delivery() {
+            Some(candidate) => Self::Handoff(candidate),
+            None => Self::Fallback {
+                reason,
+                handoff_outcome: FinalizingHandoffOutcome::NotAcceptedBeforeDeadline,
+            },
         }
+    }
+
+    fn cancelled(request: Option<&mut ActiveRunHandoffRequest>) -> Self {
+        Self::Cancelled(request.and_then(ActiveRunHandoffRequest::cancel_and_recover_delivery))
     }
 }
 
@@ -416,7 +423,14 @@ async fn prepare_finalizing_resource(
             })
             .await
         }
-        FinalizingWaitOutcome::Cancelled => {
+        FinalizingWaitOutcome::Cancelled(candidate) => {
+            if let Some(candidate) = candidate {
+                candidate
+                    .into_destroy_job()
+                    .run_with_context("cancelled_finalizing_handoff")
+                    .await;
+                ctx.reuse_state_notify.notify_one();
+            }
             pre_spawn_timing.record_finalizing_handoff_outcome(FinalizingHandoffOutcome::Cancelled);
             Err(ExecutionFailure::cancelled())
         }
@@ -447,7 +461,7 @@ async fn wait_for_finalizing_resource(
     };
     loop {
         if cancel.is_cancelled() {
-            return FinalizingWaitOutcome::Cancelled;
+            return FinalizingWaitOutcome::cancelled(handoff.as_mut());
         }
         let state = admission.predecessor.state();
         if state != ActiveRunReuseState::Pending
@@ -459,7 +473,6 @@ async fn wait_for_finalizing_resource(
                     run_id,
                     admission.history_generation_run_id,
                     cancellation,
-                    ctx,
                 )
                 .await;
             }
@@ -491,7 +504,7 @@ async fn wait_for_finalizing_resource(
                     rollback_reserved_idle_for_spawn(*reservation, ctx).await;
                     ctx.reuse_state_notify.notify_one();
                 }
-                return FinalizingWaitOutcome::Cancelled;
+                return FinalizingWaitOutcome::cancelled(None);
             }
             if let Some(reservation) = reserved_exact.take() {
                 info!(
@@ -509,7 +522,7 @@ async fn wait_for_finalizing_resource(
             tokio::select! {
                 biased;
                 () = cancel.cancelled() => {
-                    return FinalizingWaitOutcome::Cancelled;
+                    return FinalizingWaitOutcome::cancelled(Some(request));
                 }
                 accepted = request.accepted() => {
                     if accepted {
@@ -518,7 +531,6 @@ async fn wait_for_finalizing_resource(
                             run_id,
                             admission.history_generation_run_id,
                             cancellation,
-                            ctx,
                         )
                         .await;
                     }
@@ -527,7 +539,13 @@ async fn wait_for_finalizing_resource(
                 _ = admission.predecessor.changed() => {}
                 _ = tokio::time::sleep_until(deadline) => {
                     if admission.predecessor.state() == ActiveRunReuseState::Pending {
-                        return FinalizingWaitOutcome::deadline("handoff_acceptance_deadline");
+                        if cancel.is_cancelled() {
+                            return FinalizingWaitOutcome::cancelled(Some(request));
+                        }
+                        return FinalizingWaitOutcome::deadline(
+                            "handoff_acceptance_deadline",
+                            request,
+                        );
                     }
                 }
             }
@@ -535,7 +553,7 @@ async fn wait_for_finalizing_resource(
             tokio::select! {
                 biased;
                 () = cancel.cancelled() => {
-                    return FinalizingWaitOutcome::Cancelled;
+                    return FinalizingWaitOutcome::cancelled(None);
                 }
                 _ = admission.predecessor.changed() => {}
                 _ = tokio::time::sleep_until(deadline) => {
@@ -553,33 +571,20 @@ async fn receive_finalizing_handoff(
     run_id: RunId,
     predecessor_run_id: RunId,
     cancellation: &RunCancellationRegistration,
-    ctx: &SpawnContext,
 ) -> FinalizingWaitOutcome {
     let cancel = cancellation.token();
     let candidate = tokio::select! {
         biased;
         candidate = request.receive() => candidate,
         () = cancel.cancelled() => {
-            if let Some(candidate) = request.cancel_and_recover_delivery() {
-                candidate
-                    .into_destroy_job()
-                    .run_with_context("cancelled_finalizing_handoff")
-                    .await;
-                ctx.reuse_state_notify.notify_one();
-            }
-            return FinalizingWaitOutcome::Cancelled;
+            return FinalizingWaitOutcome::cancelled(Some(request));
         }
     };
     let Ok(candidate) = candidate else {
         return FinalizingWaitOutcome::no_exact("exact_handoff_closed");
     };
     if cancel.is_cancelled() {
-        candidate
-            .into_destroy_job()
-            .run_with_context("cancelled_finalizing_handoff")
-            .await;
-        ctx.reuse_state_notify.notify_one();
-        return FinalizingWaitOutcome::Cancelled;
+        return FinalizingWaitOutcome::Cancelled(Some(candidate));
     }
     info!(
         run_id = %run_id,
@@ -768,4 +773,96 @@ async fn complete_claimed_without_sandbox(
         )
         .await;
     cancellation
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::Notify;
+
+    use super::super::active_runs::{ActiveRunHandoffDeliveryResult, ActiveRuns};
+    use super::*;
+    use crate::idle_pool::test_support::ParkedIdleCandidateBuilder;
+    use crate::resource_budget::ResourceBudget;
+    use sandbox_mock::{MockSandbox, MockSandboxFactory, MockSandboxOverrides};
+
+    fn delivered_handoff_request() -> (
+        ActiveRunHandoffRequest,
+        Arc<ResourceBudget>,
+        Arc<MockSandboxOverrides>,
+    ) {
+        let active_runs = ActiveRuns::new(Arc::new(Notify::new()));
+        let predecessor_run_id = RunId::new_v4();
+        let successor_run_id = RunId::new_v4();
+        let guard = active_runs.register(
+            predecessor_run_id,
+            Some("thread:finalizing-wait-race".into()),
+            "vm0/default".into(),
+        );
+        let publisher = guard.reuse_publisher();
+        let proof = active_runs
+            .finalizing_predecessor(
+                predecessor_run_id,
+                "thread:finalizing-wait-race",
+                "vm0/default",
+            )
+            .expect("registered predecessor should remain finalizing");
+        let request = proof
+            .request_handoff(successor_run_id)
+            .expect("exact successor should register a handoff");
+        assert!(publisher.handoff_signal().accept_if_requested());
+
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096)
+            .expect("handoff candidate should reserve the test budget");
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let sandbox = Box::new(MockSandbox::with_overrides(
+            "finalizing-wait-race",
+            Arc::clone(&overrides),
+        ));
+        let factory = Arc::new(
+            Box::new(MockSandboxFactory::with_overrides(Arc::clone(&overrides)))
+                as Box<dyn sandbox::SandboxFactory>,
+        );
+        let candidate = ParkedIdleCandidateBuilder::new("thread:finalizing-wait-race", lease)
+            .with_sandbox(sandbox)
+            .with_factory(factory)
+            .with_history_generation_run_id(predecessor_run_id)
+            .build();
+        assert!(matches!(
+            publisher.deliver_exact_handoff(candidate, predecessor_run_id),
+            ActiveRunHandoffDeliveryResult::Delivered
+        ));
+
+        (request, budget, overrides)
+    }
+
+    #[tokio::test]
+    async fn cancellation_before_acceptance_branch_recovers_delivered_handoff() {
+        let (mut request, budget, overrides) = delivered_handoff_request();
+
+        let candidate = match FinalizingWaitOutcome::cancelled(Some(&mut request)) {
+            FinalizingWaitOutcome::Cancelled(Some(candidate)) => candidate,
+            _ => panic!("cancellation should retain an already delivered handoff candidate"),
+        };
+        candidate.into_destroy_job().run().await;
+
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(budget.allocated(), (0, 0, 0));
+    }
+
+    #[tokio::test]
+    async fn deadline_race_prefers_an_already_delivered_handoff() {
+        let (mut request, budget, overrides) = delivered_handoff_request();
+
+        let candidate = match FinalizingWaitOutcome::deadline("test_deadline", &mut request) {
+            FinalizingWaitOutcome::Handoff(candidate) => candidate,
+            _ => panic!("deadline should not discard a handoff that already won delivery"),
+        };
+        candidate.into_destroy_job().run().await;
+
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(budget.allocated(), (0, 0, 0));
+    }
 }

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -29,6 +29,7 @@ use crate::ids::RunId;
 use crate::provider::ClaimedJob;
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::RunCancellationRegistration;
+use crate::telemetry::JobTelemetry;
 use crate::types::{CompleteRequest, SandboxReuseResult};
 
 pub(super) const FINALIZING_HANDOFF_ACCEPTANCE_GRACE: Duration = Duration::from_millis(1500);
@@ -177,8 +178,15 @@ async fn run_finalizing_claim(
             if let Some(reservation) = reserved_exact.take() {
                 rollback_reserved_idle_for_spawn(*reservation, &ctx).await;
             }
-            return complete_claimed_without_sandbox(claimed, cancellation, failure, None, &ctx)
-                .await;
+            return complete_claimed_without_sandbox(
+                claimed,
+                cancellation,
+                failure,
+                None,
+                pre_spawn_timing.finalizing_handoff_outcome(),
+                &ctx,
+            )
+            .await;
         }
         Err(payload) => {
             if let Some(reservation) = reserved_exact.take() {
@@ -191,6 +199,7 @@ async fn run_finalizing_claim(
                     "runner panicked while preparing a claimed finalizing successor",
                 ),
                 None,
+                pre_spawn_timing.finalizing_handoff_outcome(),
                 &ctx,
             )
             .await;
@@ -248,6 +257,7 @@ async fn run_finalizing_claim(
                         cancellation,
                         ExecutionFailure::from_error(error),
                         Some(reuse_result),
+                        pre_spawn_timing.finalizing_handoff_outcome(),
                         &ctx,
                     )
                     .await;
@@ -274,6 +284,7 @@ async fn run_finalizing_claim(
                                 "finalizing handoff identity did not match claimed successor",
                             ),
                             None,
+                            pre_spawn_timing.finalizing_handoff_outcome(),
                             &ctx,
                         )
                         .await;
@@ -315,6 +326,7 @@ async fn run_finalizing_claim(
                         cancellation,
                         ExecutionFailure::from_error(error),
                         Some(reuse_result),
+                        pre_spawn_timing.finalizing_handoff_outcome(),
                         &ctx,
                     )
                     .await;
@@ -754,10 +766,21 @@ async fn complete_claimed_without_sandbox(
     cancellation: RunCancellationRegistration,
     failure: ExecutionFailure,
     reuse_result: Option<SandboxReuseResult>,
+    handoff_outcome: Option<FinalizingHandoffOutcome>,
     ctx: &SpawnContext,
 ) -> RunCancellationRegistration {
     let (context, completion_auth, active_input_source) = claimed.into_parts();
     drop(active_input_source);
+    let telemetry = handoff_outcome.map(|outcome| {
+        let mut telemetry = JobTelemetry::new(
+            ctx.exec_config.http.clone(),
+            context.run_id,
+            context.sandbox_token.clone(),
+            ctx.exec_config.runner_name.clone(),
+        );
+        outcome.record(&mut telemetry);
+        telemetry
+    });
     ctx.provider
         .complete(
             CompleteRequest {
@@ -772,6 +795,9 @@ async fn complete_claimed_without_sandbox(
             completion_auth,
         )
         .await;
+    if let Some(telemetry) = telemetry {
+        telemetry.flush().await;
+    }
     cancellation
 }
 

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -277,6 +277,9 @@ async fn run_finalizing_claim(
                             .run_with_context("finalizing_handoff_identity_mismatch")
                             .await;
                         ctx.reuse_state_notify.notify_one();
+                        pre_spawn_timing.record_finalizing_handoff_outcome(
+                            FinalizingHandoffOutcome::ActivationFailed,
+                        );
                         return complete_claimed_without_sandbox(
                             claimed,
                             cancellation,
@@ -309,18 +312,28 @@ async fn run_finalizing_claim(
                     active_lease,
                     reuse_result,
                     idle_snapshot,
-                } => ReadyClaimedResource {
-                    reuse_entry: reuse_entry.map(|entry| *entry),
-                    active_lease,
-                    reuse_result,
-                    idle_snapshot: Some(idle_snapshot),
-                },
+                } => {
+                    pre_spawn_timing.record_finalizing_handoff_outcome(if reuse_entry.is_some() {
+                        FinalizingHandoffOutcome::Accepted
+                    } else {
+                        FinalizingHandoffOutcome::ActivationFailed
+                    });
+                    ReadyClaimedResource {
+                        reuse_entry: reuse_entry.map(|entry| *entry),
+                        active_lease,
+                        reuse_result,
+                        idle_snapshot: Some(idle_snapshot),
+                    }
+                }
                 ReservedActivation::CannotStart {
                     budget_lease,
                     reuse_result,
                     error,
                 } => {
                     drop(active_run_guard);
+                    pre_spawn_timing.record_finalizing_handoff_outcome(
+                        FinalizingHandoffOutcome::ActivationFailed,
+                    );
                     let cancellation = complete_claimed_without_sandbox(
                         claimed,
                         cancellation,
@@ -403,10 +416,7 @@ async fn prepare_finalizing_resource(
     )
     .await
     {
-        FinalizingWaitOutcome::Handoff(candidate) => {
-            pre_spawn_timing.record_finalizing_handoff_outcome(FinalizingHandoffOutcome::Accepted);
-            Ok(FinalizingResource::Handoff(candidate))
-        }
+        FinalizingWaitOutcome::Handoff(candidate) => Ok(FinalizingResource::Handoff(candidate)),
         FinalizingWaitOutcome::Exact(reservation) => {
             pre_spawn_timing
                 .record_finalizing_handoff_outcome(FinalizingHandoffOutcome::PublishedExact);

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -66,16 +66,6 @@ impl FinalizingWaitOutcome {
         }
     }
 
-    fn deadline(reason: &'static str, request: &mut ActiveRunHandoffRequest) -> Self {
-        match request.cancel_and_recover_delivery() {
-            Some(candidate) => Self::Handoff(candidate),
-            None => Self::Fallback {
-                reason,
-                handoff_outcome: FinalizingHandoffOutcome::NotAcceptedBeforeDeadline,
-            },
-        }
-    }
-
     fn cancelled(request: Option<&mut ActiveRunHandoffRequest>) -> Self {
         Self::Cancelled(request.and_then(ActiveRunHandoffRequest::cancel_and_recover_delivery))
     }
@@ -564,10 +554,20 @@ async fn wait_for_finalizing_resource(
                         if cancel.is_cancelled() {
                             return FinalizingWaitOutcome::cancelled(Some(request));
                         }
-                        return FinalizingWaitOutcome::deadline(
-                            "handoff_acceptance_deadline",
+                        if request.expire_if_unaccepted() {
+                            return FinalizingWaitOutcome::Fallback {
+                                reason: "handoff_acceptance_deadline",
+                                handoff_outcome:
+                                    FinalizingHandoffOutcome::NotAcceptedBeforeDeadline,
+                            };
+                        }
+                        return receive_finalizing_handoff(
                             request,
-                        );
+                            run_id,
+                            admission.history_generation_run_id,
+                            cancellation,
+                        )
+                        .await;
                     }
                 }
             }
@@ -892,10 +892,11 @@ mod tests {
     async fn deadline_race_prefers_an_already_delivered_handoff() {
         let (mut request, budget, overrides) = delivered_handoff_request();
 
-        let candidate = match FinalizingWaitOutcome::deadline("test_deadline", &mut request) {
-            FinalizingWaitOutcome::Handoff(candidate) => candidate,
-            _ => panic!("deadline should not discard a handoff that already won delivery"),
-        };
+        assert!(!request.expire_if_unaccepted());
+        let candidate = request
+            .receive()
+            .await
+            .expect("deadline should not discard a handoff that already won delivery");
         candidate.into_destroy_job().run().await;
 
         assert_eq!(overrides.destroy_call_count(), 1);

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -559,7 +559,16 @@ async fn receive_finalizing_handoff(
     let candidate = tokio::select! {
         biased;
         candidate = request.receive() => candidate,
-        () = cancel.cancelled() => return FinalizingWaitOutcome::Cancelled,
+        () = cancel.cancelled() => {
+            if let Some(candidate) = request.cancel_and_recover_delivery() {
+                candidate
+                    .into_destroy_job()
+                    .run_with_context("cancelled_finalizing_handoff")
+                    .await;
+                ctx.reuse_state_notify.notify_one();
+            }
+            return FinalizingWaitOutcome::Cancelled;
+        }
     };
     let Ok(candidate) = candidate else {
         return FinalizingWaitOutcome::no_exact("exact_handoff_closed");

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -230,18 +230,28 @@ async fn run_finalizing_claim(
                     active_lease,
                     reuse_result,
                     idle_snapshot,
-                } => ReadyClaimedResource {
-                    reuse_entry: reuse_entry.map(|entry| *entry),
-                    active_lease,
-                    reuse_result,
-                    idle_snapshot: Some(idle_snapshot),
-                },
+                } => {
+                    if reuse_entry.is_none() {
+                        pre_spawn_timing.record_finalizing_handoff_outcome(
+                            FinalizingHandoffOutcome::ActivationFailed,
+                        );
+                    }
+                    ReadyClaimedResource {
+                        reuse_entry: reuse_entry.map(|entry| *entry),
+                        active_lease,
+                        reuse_result,
+                        idle_snapshot: Some(idle_snapshot),
+                    }
+                }
                 ReservedActivation::CannotStart {
                     budget_lease,
                     reuse_result,
                     error,
                 } => {
                     drop(active_run_guard);
+                    pre_spawn_timing.record_finalizing_handoff_outcome(
+                        FinalizingHandoffOutcome::ActivationFailed,
+                    );
                     let cancellation = complete_claimed_without_sandbox(
                         claimed,
                         cancellation,

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -1,13 +1,13 @@
 //! Owned claimed-job waiting before a finalizing predecessor publishes reuse.
 
 use std::panic::AssertUnwindSafe;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
 use tokio::task::JoinSet;
 use tracing::info;
 
-use super::active_runs::ActiveRunReuseState;
+use super::active_runs::{ActiveRunHandoffRequest, ActiveRunReuseState};
 use super::factory_lifecycle::SharedFactory;
 use super::idle_lifecycle::{
     IdlePressureRequest, IdlePressureSelection, select_idle_entry_for_pressure,
@@ -21,14 +21,17 @@ use super::job_spawn::{SpawnContext, run_job};
 #[cfg(test)]
 use super::{OuterJobPanicPoint, maybe_panic_outer_job};
 use crate::executor::{
-    ExecutionFailure, RunnerPreSpawnPhase, RunnerPreSpawnTiming, validate_resume_session_id,
+    ExecutionFailure, FinalizingHandoffOutcome, RunnerPreSpawnPhase, RunnerPreSpawnTiming,
+    validate_resume_session_id,
 };
-use crate::idle_pool::ReservedIdleSandbox;
+use crate::idle_pool::{FinalizingHandoffCandidate, ReservedIdleSandbox};
 use crate::ids::RunId;
 use crate::provider::ClaimedJob;
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::RunCancellationRegistration;
 use crate::types::{CompleteRequest, SandboxReuseResult};
+
+pub(super) const FINALIZING_HANDOFF_ACCEPTANCE_GRACE: Duration = Duration::from_millis(1500);
 
 pub(super) struct FinalizingClaimRequest {
     pub(super) claimed: ClaimedJob,
@@ -45,12 +48,33 @@ pub(super) struct FinalizingClaimRequest {
 }
 
 enum FinalizingWaitOutcome {
+    Handoff(Box<FinalizingHandoffCandidate>),
     Exact(Box<ReservedIdleSandbox>),
-    Fallback(&'static str),
+    Fallback {
+        reason: &'static str,
+        handoff_outcome: FinalizingHandoffOutcome,
+    },
     Cancelled,
 }
 
+impl FinalizingWaitOutcome {
+    fn no_exact(reason: &'static str) -> Self {
+        Self::Fallback {
+            reason,
+            handoff_outcome: FinalizingHandoffOutcome::NoExact,
+        }
+    }
+
+    fn deadline(reason: &'static str) -> Self {
+        Self::Fallback {
+            reason,
+            handoff_outcome: FinalizingHandoffOutcome::NotAcceptedBeforeDeadline,
+        }
+    }
+}
+
 enum FinalizingResource {
+    Handoff(Box<FinalizingHandoffCandidate>),
     Exact(Box<ReservedIdleSandbox>),
     Fresh(BudgetLease),
 }
@@ -59,9 +83,21 @@ struct FinalizingPreparation<'a> {
     claimed: &'a ClaimedJob,
     cancellation: &'a RunCancellationRegistration,
     admission: &'a mut FinalizingAdmission,
+    claim_returned_at: Instant,
     profile_name: &'a str,
     vcpu: u32,
     memory_mb: u32,
+    device_rate_limits: &'a Option<sandbox::DeviceRateLimits>,
+    pre_spawn_timing: &'a mut RunnerPreSpawnTiming,
+    ctx: &'a SpawnContext,
+}
+
+struct FinalizingWait<'a> {
+    run_id: RunId,
+    cancellation: &'a RunCancellationRegistration,
+    admission: &'a mut FinalizingAdmission,
+    claim_returned_at: Instant,
+    profile_name: &'a str,
     device_rate_limits: &'a Option<sandbox::DeviceRateLimits>,
     ctx: &'a SpawnContext,
 }
@@ -114,10 +150,12 @@ async fn run_finalizing_claim(
             claimed: &claimed,
             cancellation: &cancellation,
             admission: &mut admission,
+            claim_returned_at,
             profile_name: &profile_name,
             vcpu,
             memory_mb,
             device_rate_limits: &device_rate_limits,
+            pre_spawn_timing: &mut pre_spawn_timing,
             ctx: &ctx,
         },
         &mut reserved_exact,
@@ -172,6 +210,74 @@ async fn run_finalizing_claim(
                 ReservedActivationRequest {
                     run_id,
                     profile_name: &profile_name,
+                    device_rate_limits: &device_rate_limits,
+                    workspace_disk_mb,
+                    context: claimed.context(),
+                },
+                &ctx,
+                &mut pre_spawn_timing,
+            )
+            .await
+            {
+                ReservedActivation::Ready {
+                    reuse_entry,
+                    active_lease,
+                    reuse_result,
+                    idle_snapshot,
+                } => ReadyClaimedResource {
+                    reuse_entry: reuse_entry.map(|entry| *entry),
+                    active_lease,
+                    reuse_result,
+                    idle_snapshot: Some(idle_snapshot),
+                },
+                ReservedActivation::CannotStart {
+                    budget_lease,
+                    reuse_result,
+                    error,
+                } => {
+                    drop(active_run_guard);
+                    let cancellation = complete_claimed_without_sandbox(
+                        claimed,
+                        cancellation,
+                        ExecutionFailure::from_error(error),
+                        Some(reuse_result),
+                        &ctx,
+                    )
+                    .await;
+                    drop(budget_lease);
+                    return cancellation;
+                }
+            }
+        }
+        FinalizingResource::Handoff(candidate) => {
+            let reservation =
+                match candidate.into_reservation(run_id, admission.history_generation_run_id) {
+                    Ok(reservation) => reservation,
+                    Err(candidate) => {
+                        drop(active_run_guard);
+                        candidate
+                            .into_destroy_job()
+                            .run_with_context("finalizing_handoff_identity_mismatch")
+                            .await;
+                        ctx.reuse_state_notify.notify_one();
+                        return complete_claimed_without_sandbox(
+                            claimed,
+                            cancellation,
+                            ExecutionFailure::from_error(
+                                "finalizing handoff identity did not match claimed successor",
+                            ),
+                            None,
+                            &ctx,
+                        )
+                        .await;
+                    }
+                };
+            match activate_reserved_idle(
+                reservation,
+                ReservedActivationRequest {
+                    run_id,
+                    profile_name: &profile_name,
+                    device_rate_limits: &device_rate_limits,
                     workspace_disk_mb,
                     context: claimed.context(),
                 },
@@ -240,10 +346,12 @@ async fn prepare_finalizing_resource(
         claimed,
         cancellation,
         admission,
+        claim_returned_at,
         profile_name,
         vcpu,
         memory_mb,
         device_rate_limits,
+        pre_spawn_timing,
         ctx,
     } = request;
     let run_id = claimed.context().run_id;
@@ -263,18 +371,33 @@ async fn prepare_finalizing_resource(
         "finalizing successor claimed before sandbox publication"
     );
     match wait_for_finalizing_resource(
-        run_id,
-        cancellation,
-        admission,
-        profile_name,
-        device_rate_limits,
-        ctx,
+        FinalizingWait {
+            run_id,
+            cancellation,
+            admission,
+            claim_returned_at,
+            profile_name,
+            device_rate_limits,
+            ctx,
+        },
         reserved_exact,
     )
     .await
     {
-        FinalizingWaitOutcome::Exact(reservation) => Ok(FinalizingResource::Exact(reservation)),
-        FinalizingWaitOutcome::Fallback(reason) => {
+        FinalizingWaitOutcome::Handoff(candidate) => {
+            pre_spawn_timing.record_finalizing_handoff_outcome(FinalizingHandoffOutcome::Accepted);
+            Ok(FinalizingResource::Handoff(candidate))
+        }
+        FinalizingWaitOutcome::Exact(reservation) => {
+            pre_spawn_timing
+                .record_finalizing_handoff_outcome(FinalizingHandoffOutcome::PublishedExact);
+            Ok(FinalizingResource::Exact(reservation))
+        }
+        FinalizingWaitOutcome::Fallback {
+            reason,
+            handoff_outcome,
+        } => {
+            pre_spawn_timing.record_finalizing_handoff_outcome(handoff_outcome);
             info!(
                 run_id = %run_id,
                 finalizing_fallback_reason = reason,
@@ -293,30 +416,63 @@ async fn prepare_finalizing_resource(
             })
             .await
         }
-        FinalizingWaitOutcome::Cancelled => Err(ExecutionFailure::cancelled()),
+        FinalizingWaitOutcome::Cancelled => {
+            pre_spawn_timing.record_finalizing_handoff_outcome(FinalizingHandoffOutcome::Cancelled);
+            Err(ExecutionFailure::cancelled())
+        }
     }
 }
 
 async fn wait_for_finalizing_resource(
-    run_id: RunId,
-    cancellation: &RunCancellationRegistration,
-    admission: &mut FinalizingAdmission,
-    profile_name: &str,
-    device_rate_limits: &Option<sandbox::DeviceRateLimits>,
-    ctx: &SpawnContext,
+    request: FinalizingWait<'_>,
     reserved_exact: &mut Option<Box<ReservedIdleSandbox>>,
 ) -> FinalizingWaitOutcome {
+    let FinalizingWait {
+        run_id,
+        cancellation,
+        admission,
+        claim_returned_at,
+        profile_name,
+        device_rate_limits,
+        ctx,
+    } = request;
     let cancel = cancellation.token();
+    let mut handoff = admission.predecessor.request_handoff(run_id);
+    let pre_acceptance_deadline = if handoff.is_some() {
+        admission
+            .deadline
+            .max(claim_returned_at + FINALIZING_HANDOFF_ACCEPTANCE_GRACE)
+    } else {
+        admission.deadline
+    };
     loop {
         if cancel.is_cancelled() {
             return FinalizingWaitOutcome::Cancelled;
         }
         let state = admission.predecessor.state();
+        if state != ActiveRunReuseState::Pending
+            && let Some(request) = handoff.as_mut()
+        {
+            if request.accepted().await {
+                return receive_finalizing_handoff(
+                    request,
+                    run_id,
+                    admission.history_generation_run_id,
+                    cancellation,
+                    ctx,
+                )
+                .await;
+            }
+            handoff = None;
+        }
         let missing_exact_reason = match state {
             ActiveRunReuseState::ExactSandboxPublished => Some("published_exact_unavailable"),
+            ActiveRunReuseState::ExactSandboxHandedOff => {
+                return FinalizingWaitOutcome::no_exact("exact_handoff_unavailable");
+            }
             ActiveRunReuseState::Released => Some("predecessor_released_without_exact"),
             ActiveRunReuseState::NoExactSandbox => {
-                return FinalizingWaitOutcome::Fallback("predecessor_no_exact");
+                return FinalizingWaitOutcome::no_exact("predecessor_no_exact");
             }
             ActiveRunReuseState::Pending => None,
         };
@@ -345,23 +501,83 @@ async fn wait_for_finalizing_resource(
                 );
                 return FinalizingWaitOutcome::Exact(reservation);
             }
-            return FinalizingWaitOutcome::Fallback(missing_exact_reason);
+            return FinalizingWaitOutcome::no_exact(missing_exact_reason);
         }
 
-        let deadline = tokio::time::Instant::from_std(admission.deadline);
-        tokio::select! {
-            biased;
-            () = cancel.cancelled() => {
-                return FinalizingWaitOutcome::Cancelled;
+        let deadline = tokio::time::Instant::from_std(pre_acceptance_deadline);
+        if let Some(request) = handoff.as_mut() {
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    return FinalizingWaitOutcome::Cancelled;
+                }
+                accepted = request.accepted() => {
+                    if accepted {
+                        return receive_finalizing_handoff(
+                            request,
+                            run_id,
+                            admission.history_generation_run_id,
+                            cancellation,
+                            ctx,
+                        )
+                        .await;
+                    }
+                    handoff = None;
+                }
+                _ = admission.predecessor.changed() => {}
+                _ = tokio::time::sleep_until(deadline) => {
+                    if admission.predecessor.state() == ActiveRunReuseState::Pending {
+                        return FinalizingWaitOutcome::deadline("handoff_acceptance_deadline");
+                    }
+                }
             }
-            _ = admission.predecessor.changed() => {}
-            _ = tokio::time::sleep_until(deadline) => {
-                if admission.predecessor.state() == ActiveRunReuseState::Pending {
-                    return FinalizingWaitOutcome::Fallback("preference_deadline");
+        } else {
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    return FinalizingWaitOutcome::Cancelled;
+                }
+                _ = admission.predecessor.changed() => {}
+                _ = tokio::time::sleep_until(deadline) => {
+                    if admission.predecessor.state() == ActiveRunReuseState::Pending {
+                        return FinalizingWaitOutcome::no_exact("handoff_request_unavailable");
+                    }
                 }
             }
         }
     }
+}
+
+async fn receive_finalizing_handoff(
+    request: &mut ActiveRunHandoffRequest,
+    run_id: RunId,
+    predecessor_run_id: RunId,
+    cancellation: &RunCancellationRegistration,
+    ctx: &SpawnContext,
+) -> FinalizingWaitOutcome {
+    let cancel = cancellation.token();
+    let candidate = tokio::select! {
+        biased;
+        candidate = request.receive() => candidate,
+        () = cancel.cancelled() => return FinalizingWaitOutcome::Cancelled,
+    };
+    let Ok(candidate) = candidate else {
+        return FinalizingWaitOutcome::no_exact("exact_handoff_closed");
+    };
+    if cancel.is_cancelled() {
+        candidate
+            .into_destroy_job()
+            .run_with_context("cancelled_finalizing_handoff")
+            .await;
+        ctx.reuse_state_notify.notify_one();
+        return FinalizingWaitOutcome::Cancelled;
+    }
+    info!(
+        run_id = %run_id,
+        predecessor_run_id = %predecessor_run_id,
+        "finalizing successor received direct parked sandbox handoff"
+    );
+    FinalizingWaitOutcome::Handoff(candidate)
 }
 
 async fn acquire_fallback_resource(

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -341,6 +341,7 @@ mod tests {
             guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
             workspace_image_size_bytes: b"workspace image".len() as u64,
             workspace_promotion: Some(fixture.promotion),
+            handoff: None,
         });
         let candidate = match request.park_for_idle().await {
             Ok(outcome) => outcome

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -200,6 +200,7 @@ struct PreferenceCandidateRequest<'a> {
 pub(super) struct ReservedActivationRequest<'a> {
     pub(super) run_id: RunId,
     pub(super) profile_name: &'a str,
+    pub(super) device_rate_limits: &'a Option<sandbox::DeviceRateLimits>,
     pub(super) workspace_disk_mb: u32,
     pub(super) context: &'a ExecutionContext,
 }
@@ -390,6 +391,7 @@ pub(super) async fn handle_discovered_job(
                 ReservedActivationRequest {
                     run_id,
                     profile_name: &profile_name,
+                    device_rate_limits: &device_rate_limits,
                     workspace_disk_mb: job_workspace_disk_mb,
                     context: claimed.context(),
                 },
@@ -436,6 +438,7 @@ pub(super) async fn handle_discovered_job(
                 ReservedActivationRequest {
                     run_id,
                     profile_name: &profile_name,
+                    device_rate_limits: &device_rate_limits,
                     workspace_disk_mb: job_workspace_disk_mb,
                     context: claimed.context(),
                 },
@@ -1472,6 +1475,7 @@ async fn activate_speculated_exact(
     let ReservedActivationRequest {
         run_id,
         profile_name,
+        device_rate_limits: _,
         workspace_disk_mb,
         context,
     } = request;
@@ -1739,6 +1743,7 @@ pub(super) async fn activate_reserved_idle(
     let ReservedActivationRequest {
         run_id,
         profile_name,
+        device_rate_limits,
         workspace_disk_mb,
         context,
     } = request;
@@ -1746,6 +1751,27 @@ pub(super) async fn activate_reserved_idle(
     let requested_reuse_key = context.reuse_key();
     let reserved_reuse_key = reservation.reuse_key().to_owned();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
+
+    if reservation.profile_name() != profile_name
+        || reservation.device_rate_limits() != device_rate_limits
+    {
+        let reuse_key_fingerprint = diagnostic_reuse_key_fingerprint(&reserved_reuse_key);
+        warn!(
+            run_id = %run_id,
+            reuse_key_fingerprint = %reuse_key_fingerprint,
+            reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+            profile = %profile_name,
+            "reserved idle VM configuration does not match claimed job, destroying before fresh fallback"
+        );
+        return cleanup_reserved_for_fresh_fallback(
+            reservation.into_destroy_job(),
+            SandboxReuseResult::PoolMiss,
+            "reserved_reuse_configuration_mismatch",
+            ctx,
+        )
+        .await
+        .into();
+    }
 
     if requested_reuse_key != Some(reserved_reuse_key.as_str()) {
         let reuse_result = if requested_reuse_key.is_none() {

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -19,6 +19,8 @@ pub(super) enum RunCleanupDisposition {
     ActiveOrUnknown,
     /// The sandbox has been accepted by the idle pool.
     IdlePoolOwned,
+    /// The sandbox and budget were delivered to a claimed exact successor.
+    HandoffOwned,
     /// The active sandbox was explicitly destroyed and destroy returned normally.
     DestroyCompleted,
     /// Normal completion already cleared, or no longer owns, active status.
@@ -35,7 +37,8 @@ impl RunCleanupState {
     const ACTIVE_OR_UNKNOWN: u8 = 0;
     const DESTROY_COMPLETED: u8 = 1;
     const IDLE_POOL_OWNED: u8 = 2;
-    const STATUS_REMOVED: u8 = 3;
+    const HANDOFF_OWNED: u8 = 3;
+    const STATUS_REMOVED: u8 = 4;
 
     pub(super) fn new() -> Self {
         Self {
@@ -47,6 +50,7 @@ impl RunCleanupState {
         match self.state.load(Ordering::Acquire) {
             Self::STATUS_REMOVED => RunCleanupDisposition::StatusRemoved,
             Self::IDLE_POOL_OWNED => RunCleanupDisposition::IdlePoolOwned,
+            Self::HANDOFF_OWNED => RunCleanupDisposition::HandoffOwned,
             Self::DESTROY_COMPLETED => RunCleanupDisposition::DestroyCompleted,
             _ => RunCleanupDisposition::ActiveOrUnknown,
         }
@@ -58,6 +62,10 @@ impl RunCleanupState {
 
     pub(super) fn mark_destroy_completed(&self) {
         self.mark_at_least(Self::DESTROY_COMPLETED);
+    }
+
+    pub(super) fn mark_handoff_owned(&self) {
+        self.mark_at_least(Self::HANDOFF_OWNED);
     }
 
     pub(super) fn mark_status_removed(&self) {
@@ -102,6 +110,8 @@ pub(super) enum BudgetOwnership {
     /// The idle pool accepted the sandbox and its lease, so settlement performs no
     /// release. Reuse transfers the lease; idle destruction drops it.
     IdleOwned,
+    /// A claimed exact successor owns the sandbox and lease directly.
+    HandoffOwned,
 }
 
 impl BudgetOwnership {
@@ -113,10 +123,14 @@ impl BudgetOwnership {
         Self::IdleOwned
     }
 
+    pub(super) fn handoff_owned() -> Self {
+        Self::HandoffOwned
+    }
+
     fn release(self) {
         match self {
             Self::Active(lease) => drop(lease),
-            Self::IdleOwned => {}
+            Self::IdleOwned | Self::HandoffOwned => {}
         }
     }
 }
@@ -504,5 +518,16 @@ mod tests {
         state.mark_status_removed();
         state.mark_idle_pool_owned();
         assert_eq!(state.disposition(), RunCleanupDisposition::StatusRemoved);
+    }
+
+    #[test]
+    fn run_cleanup_state_tracks_direct_handoff_ownership() {
+        let state = RunCleanupState::new();
+
+        state.mark_handoff_owned();
+        assert_eq!(state.disposition(), RunCleanupDisposition::HandoffOwned);
+
+        state.mark_destroy_completed();
+        assert_eq!(state.disposition(), RunCleanupDisposition::HandoffOwned);
     }
 }

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -393,7 +393,7 @@ impl FinalizationPhase {
             );
         }
         let (finalization_action, finalization_success, finalization_error) = match disposition {
-            RunCleanupDisposition::IdlePoolOwned => {
+            RunCleanupDisposition::IdlePoolOwned | RunCleanupDisposition::HandoffOwned => {
                 ("runner_host_finalization_reusable_sandbox", true, None)
             }
             _ if reuse_state_changed => ("runner_host_finalization_workspace_cache", true, None),
@@ -821,6 +821,9 @@ pub(super) async fn cleanup_panicked_job(
         RunCleanupDisposition::IdlePoolOwned => {
             let snapshot = idle_pool.lock().await.status_snapshot();
             ownership.active_idle_pool_owned(run, snapshot).await;
+        }
+        RunCleanupDisposition::HandoffOwned => {
+            ownership.active_completed(run).await;
         }
         RunCleanupDisposition::ActiveOrUnknown => {
             warn!(
@@ -1318,6 +1321,52 @@ mod tests {
             panic!("parked sandbox should unpark");
         };
         assert!(sandbox.restored_session_identity().is_none());
+    }
+
+    #[tokio::test]
+    async fn finalization_delivers_requested_exact_handoff_without_idle_publication() {
+        let fixture = FinalizationTelemetryFixture::new().await;
+        let (_budget, lease) = test_budget_lease();
+        let run_id = RunId::new_v4();
+        let successor_run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let reuse_key = "thread:direct-finalization-handoff";
+        let cleanup_state = RunCleanupState::new();
+        let finalization =
+            fixture.finalization_phase(run_id, sandbox_id, reuse_key, lease, cleanup_state.clone());
+        let proof = fixture
+            .active_runs
+            .finalizing_predecessor(run_id, reuse_key, "vm0/default")
+            .expect("registered predecessor should be available");
+        let mut handoff = proof
+            .request_handoff(successor_run_id)
+            .expect("exact successor should register one handoff");
+
+        let finalized = finalization
+            .finalize(executor_phase_outcome(run_id, "direct-handoff", None))
+            .await;
+
+        assert_telemetry_action(&finalized.telemetry, "runner_host_exact_sandbox_handoff");
+        assert_telemetry_outcome(
+            &finalized.telemetry,
+            "runner_host_exact_sandbox_handoff",
+            Some("after_full_park"),
+        );
+        assert_no_telemetry_action(&finalized.telemetry, "runner_host_idle_publication");
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::HandoffOwned
+        );
+        assert_eq!(fixture.idle_pool.lock().await.len(), 0);
+        assert!(handoff.accepted().await);
+        let candidate = handoff
+            .receive()
+            .await
+            .expect("accepted exact handoff should deliver its sandbox");
+        candidate
+            .into_destroy_job()
+            .run_with_context("test_direct_handoff_cleanup")
+            .await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1342,6 +1342,7 @@ enum OuterJobPanicPoint {
     ClaimedWithoutSandbox,
     ActiveOrUnknown,
     IdlePoolOwned,
+    HandoffOwned,
     DestroyCompleted,
 }
 

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -11,12 +11,13 @@ use std::time::{Duration, Instant};
 use chrono::SecondsFormat;
 use futures_util::FutureExt;
 use sandbox::{
-    Sandbox, SandboxFactory, SandboxFinalExecParkObserver, SandboxFinalExecParkStage,
-    SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome, SandboxId,
+    Sandbox, SandboxFactory, SandboxFinalExecParkHandoffPoint, SandboxFinalExecParkObserver,
+    SandboxFinalExecParkStage, SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome,
+    SandboxId,
 };
 use tracing::{info, warn};
 
-use super::active_runs::ActiveRunReusePublisher;
+use super::active_runs::{ActiveRunHandoffDeliveryResult, ActiveRunReusePublisher};
 use super::heartbeat::WorkspaceCacheStateSnapshot;
 use super::idle_lifecycle::{
     SharedIdlePool, destroy_idle_jobs_and_wait, destroy_idle_payload_and_wait,
@@ -30,8 +31,9 @@ use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::executor::{SandboxReuseDisposition, SandboxReuseTerminal};
 use crate::guest_timezone::GuestTimezoneIntent;
 use crate::idle_pool::{
-    DestroyOutcome, IdleDestroyPayload, IdleParkActiveParts, IdleParkFailureParts, IdleParkRequest,
-    IdleParkRequestParts, ParkResult, ParkingGate,
+    DestroyOutcome, IdleDestroyPayload, IdleParkActiveParts, IdleParkCandidate,
+    IdleParkFailureParts, IdleParkRequest, IdleParkRequestParts, ParkResult, ParkedIdleCandidate,
+    ParkingGate,
 };
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -92,6 +94,23 @@ impl<'a> FinalizationTelemetry<'a> {
             telemetry.record(action_type, Duration::ZERO, false, Some(error));
         }
     }
+
+    fn record_handoff(
+        &mut self,
+        success: bool,
+        error: Option<&'static str>,
+        outcome: &'static str,
+    ) {
+        if let Some(telemetry) = self.telemetry.as_deref_mut() {
+            telemetry.record_with_outcome(
+                "runner_host_exact_sandbox_handoff",
+                Duration::ZERO,
+                success,
+                error,
+                Some(outcome),
+            );
+        }
+    }
 }
 
 impl SandboxFinalExecParkObserver for FinalizationTelemetry<'_> {
@@ -149,6 +168,66 @@ impl SandboxFinalExecParkObserver for FinalizationTelemetry<'_> {
                 error,
                 outcome.map(SandboxFinalExecParkSubstageOutcome::as_str),
             );
+        }
+    }
+}
+
+enum ExactHandoffAttempt {
+    Delivered {
+        handoff_point: Option<SandboxFinalExecParkHandoffPoint>,
+    },
+    ContinueIdle(ParkedIdleCandidate),
+    Destroy {
+        candidate: IdleParkCandidate,
+        error: &'static str,
+    },
+}
+
+enum UndeliveredExactHandoff {
+    ContinueIdle(ParkedIdleCandidate),
+    Destroy {
+        candidate: IdleParkCandidate,
+        error: &'static str,
+    },
+}
+
+fn deliver_exact_handoff(
+    publisher: &ActiveRunReusePublisher,
+    candidate: IdleParkCandidate,
+    predecessor_run_id: RunId,
+) -> ExactHandoffAttempt {
+    match candidate {
+        IdleParkCandidate::Ordinary(candidate) => {
+            match publisher.deliver_exact_handoff(candidate, predecessor_run_id) {
+                ActiveRunHandoffDeliveryResult::Delivered => ExactHandoffAttempt::Delivered {
+                    handoff_point: None,
+                },
+                ActiveRunHandoffDeliveryResult::NotRequested(candidate) => {
+                    ExactHandoffAttempt::ContinueIdle(candidate)
+                }
+                ActiveRunHandoffDeliveryResult::Failed(candidate) => ExactHandoffAttempt::Destroy {
+                    candidate: IdleParkCandidate::Ordinary(candidate),
+                    error: "receiver_unavailable",
+                },
+            }
+        }
+        IdleParkCandidate::Immediate(candidate) => {
+            let handoff_point = candidate.handoff_point();
+            match publisher.deliver_exact_immediate_handoff(candidate, predecessor_run_id) {
+                ActiveRunHandoffDeliveryResult::Delivered => ExactHandoffAttempt::Delivered {
+                    handoff_point: Some(handoff_point),
+                },
+                ActiveRunHandoffDeliveryResult::NotRequested(candidate) => {
+                    ExactHandoffAttempt::Destroy {
+                        candidate: IdleParkCandidate::Immediate(candidate),
+                        error: "request_unavailable",
+                    }
+                }
+                ActiveRunHandoffDeliveryResult::Failed(candidate) => ExactHandoffAttempt::Destroy {
+                    candidate: IdleParkCandidate::Immediate(candidate),
+                    error: "receiver_unavailable",
+                },
+            }
         }
     }
 }
@@ -380,6 +459,7 @@ async fn finalize_sandbox_for_completion_inner(
             guest_timezone_intent,
             workspace_image_size_bytes,
             workspace_promotion,
+            handoff: publishes_exact_sandbox.then(|| active_run_reuse.handoff_signal()),
         });
         let park_outcome = match park_request
             .park_for_idle_with_observer(&mut telemetry)
@@ -601,6 +681,119 @@ async fn finalize_sandbox_for_completion_inner(
             destroy_result.budget
         } else {
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
+            let candidate = candidate.with_last_completed_at(completed_at.clone());
+            let handoff_attempt = if publishes_exact_sandbox {
+                let transfer_guard = cancel.transfer_guard().await;
+                if cancel.is_hard_cancelled() {
+                    drop(transfer_guard);
+                    telemetry.record_outcome("runner_host_finalization_cancelled", "cancelled");
+                    telemetry.record_handoff(false, Some("cancelled"), "cancelled");
+                    let (payload, budget_lease) = candidate.into_active_destroy_parts();
+                    let destroy_result = destroy_active_owned_idle_payload(
+                        payload,
+                        budget_lease,
+                        "hard_cancellation",
+                        destroy_bookkeeping,
+                    )
+                    .await;
+                    let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
+                        &workspace_cache_snapshot,
+                        Some(&reuse_key),
+                        &profile_name,
+                        &completed_at,
+                        destroy_result.workspace_cache_promoted,
+                    );
+                    return mark_reuse_state_refresh(
+                        FinalizationReady::new(destroy_result.budget),
+                        workspace_cache_promoted,
+                    );
+                }
+                match deliver_exact_handoff(&active_run_reuse, candidate, run_id) {
+                    ExactHandoffAttempt::Delivered { handoff_point } => {
+                        cleanup_state.mark_handoff_owned();
+                        #[cfg(test)]
+                        maybe_panic_outer_job(
+                            outer_job_panic,
+                            OuterJobPanicPoint::HandoffOwned,
+                            run_id,
+                        );
+                        drop(transfer_guard);
+                        let handoff_path = match handoff_point {
+                            Some(SandboxFinalExecParkHandoffPoint::BeforeBalloon) => {
+                                "before_balloon"
+                            }
+                            Some(SandboxFinalExecParkHandoffPoint::DuringBalloonSettle) => {
+                                "during_balloon"
+                            }
+                            None => "after_full_park",
+                        };
+                        telemetry.record_handoff(true, None, handoff_path);
+                        info!(
+                            run_id = %run_id,
+                            reuse_key_fingerprint = %reuse_key_fingerprint,
+                            reuse_key_kind = reuse_kind,
+                            handoff_path,
+                            "parked sandbox delivered directly to claimed exact successor"
+                        );
+                        return FinalizationReady::new(BudgetOwnership::handoff_owned());
+                    }
+                    ExactHandoffAttempt::ContinueIdle(candidate) => {
+                        drop(transfer_guard);
+                        UndeliveredExactHandoff::ContinueIdle(candidate)
+                    }
+                    ExactHandoffAttempt::Destroy { candidate, error } => {
+                        drop(transfer_guard);
+                        UndeliveredExactHandoff::Destroy { candidate, error }
+                    }
+                }
+            } else {
+                match candidate {
+                    IdleParkCandidate::Ordinary(candidate) => {
+                        UndeliveredExactHandoff::ContinueIdle(candidate)
+                    }
+                    IdleParkCandidate::Immediate(candidate) => UndeliveredExactHandoff::Destroy {
+                        candidate: IdleParkCandidate::Immediate(candidate),
+                        error: "request_unavailable",
+                    },
+                }
+            };
+            let candidate = match handoff_attempt {
+                UndeliveredExactHandoff::ContinueIdle(candidate) => candidate,
+                UndeliveredExactHandoff::Destroy { candidate, error } => {
+                    let handoff_outcome = if error == "receiver_unavailable" {
+                        "receiver_closed_destroyed"
+                    } else {
+                        "request_unavailable_destroyed"
+                    };
+                    telemetry.record_handoff(false, Some(error), handoff_outcome);
+                    warn!(
+                        run_id = %run_id,
+                        reuse_key_fingerprint = %reuse_key_fingerprint,
+                        reuse_key_kind = reuse_kind,
+                        handoff_error = error,
+                        "exact handoff unavailable, destroying parked sandbox"
+                    );
+                    let (payload, budget_lease) = candidate.into_active_destroy_parts();
+                    let destroy_result = destroy_active_owned_idle_payload(
+                        payload,
+                        budget_lease,
+                        "exact_handoff_unavailable",
+                        destroy_bookkeeping,
+                    )
+                    .await;
+                    let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
+                        &workspace_cache_snapshot,
+                        Some(&reuse_key),
+                        &profile_name,
+                        &completed_at,
+                        destroy_result.workspace_cache_promoted,
+                    );
+                    return mark_reuse_state_refresh(
+                        FinalizationReady::new(destroy_result.budget),
+                        workspace_cache_promoted,
+                    );
+                }
+            };
             #[cfg(test)]
             test_observer.notify_before_idle_pool_ownership_transfer(run_id);
             loop {
@@ -676,7 +869,6 @@ async fn finalize_sandbox_for_completion_inner(
                         workspace_cache_promoted,
                     );
                 }
-                let candidate = candidate.with_last_completed_at(completed_at.clone());
                 break match pool.park(candidate) {
                     ParkResult::Parked => {
                         info!(
@@ -2753,6 +2945,7 @@ mod tests {
             guest_timezone_intent: GuestTimezoneIntent::Unknown,
             workspace_image_size_bytes: b"image".len() as u64,
             workspace_promotion: Some(old_promotion),
+            handoff: None,
         })
         .park_for_idle()
         .await

--- a/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/outer_panic.rs
@@ -1,8 +1,9 @@
 use super::super::super::*;
 use super::super::support::{
-    context_with_session, minimal_context, mock_run_config_with_overrides, push_job, shutdown,
-    test_profiles, wait_budget_count, wait_cancel_token, wait_cancel_token_removed,
-    wait_idle_pool_len, wait_status_idle_reuse_keys_and_active_runs,
+    TEST_HEARTBEAT_GENERATION, TEST_RUNNER_ID, context_with_session, minimal_context,
+    mock_run_config_with_overrides, push_job, shutdown, test_profiles, wait_budget_count,
+    wait_cancel_token, wait_cancel_token_removed, wait_discover_entered, wait_idle_pool_len,
+    wait_status_idle_reuse_keys_and_active_runs,
 };
 use super::support::{assert_no_completion_for_run, assert_successful_completion_for_run};
 
@@ -46,6 +47,97 @@ async fn outer_job_panic_after_idle_pool_owned_cleans_token_and_active_status() 
         "host completion should report before idle-pool finalization panics",
     )
     .await;
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn outer_job_panic_after_handoff_keeps_successor_owned_sandbox() {
+    let wait_gate = MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
+    config.test_hooks.outer_job_panic = Some(OuterJobPanicPoint::HandoffOwned);
+    let cancel_tokens = config.provider.cancel_tokens.clone();
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let reuse_key = "thread:outer-panic-handoff";
+    let predecessor_run_id = RunId::new_v4();
+    let mut predecessor_context = minimal_context(predecessor_run_id);
+    predecessor_context.reuse_key = Some(reuse_key.to_owned());
+    push_job(
+        &env,
+        predecessor_run_id,
+        "vm0/default",
+        Some(predecessor_context),
+    );
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("predecessor should be running before its successor is discovered");
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    let successor_run_id = RunId::new_v4();
+    let mut successor_context = minimal_context(successor_run_id);
+    successor_context.reuse_key = Some(reuse_key.to_owned());
+    env.provider
+        .set_claim_result(successor_run_id, Some(successor_context));
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(successor_run_id, "vm0/default".into())
+                .with_reuse_key(Some(reuse_key.to_owned()))
+                .with_history_generation_run_id(Some(predecessor_run_id))
+                .with_runner_preference_for_test(
+                    crate::provider::ActiveRunnerPreference::ranked_for_test(
+                        crate::runner_process_identity::RunnerProcessIdentity::new(
+                            TEST_RUNNER_ID.parse().unwrap(),
+                            TEST_HEARTBEAT_GENERATION,
+                        )
+                        .unwrap(),
+                        crate::provider::RunnerPreferenceTier::FinalizingPredecessor,
+                        std::time::Instant::now() + Duration::from_secs(30),
+                    ),
+                ),
+        )
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    wait_gate.release_one();
+    wait_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("successor should activate the handed-off sandbox before panic cleanup");
+    wait_cancel_token_removed(&cancel_tokens, predecessor_run_id, Duration::from_secs(5)).await;
+    wait_status_idle_reuse_keys_and_active_runs(
+        &status_path,
+        &[],
+        &[successor_run_id.to_string()],
+        Duration::from_secs(5),
+    )
+    .await;
+
+    wait_gate.release_one();
+    let predecessor_completion = env
+        .handle
+        .wait_completion(predecessor_run_id, Duration::from_secs(5))
+        .await
+        .expect("predecessor completion should survive post-handoff panic");
+    let successor_completion = env
+        .handle
+        .wait_completion(successor_run_id, Duration::from_secs(5))
+        .await
+        .expect("successor should complete with the handed-off sandbox");
+    assert_eq!(
+        successor_completion.reuse_result,
+        Some(crate::types::SandboxReuseResult::Reused)
+    );
+    assert_eq!(
+        successor_completion.sandbox_id, predecessor_completion.sandbox_id,
+        "panic cleanup must not destroy the successor-owned sandbox"
+    );
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -948,13 +948,14 @@ async fn finalizing_capacity_wait_rechecks_when_an_active_vm_parks_idle() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn finalizing_capacity_wait_reuses_matching_vm_parked_after_deadline() {
+async fn finalizing_handoff_reuses_matching_vm_past_preference_deadline() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let wait_gate = sandbox_mock::MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
     overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
-    let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, Arc::clone(&overrides));
     let budget = Arc::clone(&config.capacity.budget);
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(2)).await;
@@ -999,22 +1000,15 @@ async fn finalizing_capacity_wait_reuses_matching_vm_parked_after_deadline() {
     );
 
     tokio::time::advance(Duration::from_millis(101)).await;
-    env.start_observer
-        .wait_finalizing_capacity_wait_entered(successor_run_id, Duration::from_secs(5))
-        .await;
-
     wait_gate.release_one();
-    let parked_reuse_key = env
-        .start_observer
-        .wait_vm_parked_for_reuse(predecessor_run_id, Duration::from_secs(5))
-        .await;
-    assert_eq!(parked_reuse_key, reuse_key);
     wait_gate
         .wait_entered(2, Duration::from_secs(5))
         .await
-        .expect("matching idle publication should activate the successor");
+        .expect("direct handoff should activate the successor");
     assert_eq!(destroy_gate.entered_count(), 0);
     assert_eq!(budget.allocated(), (2, 4096, 1));
+    assert_eq!(env.idle_pool.lock().await.len(), 0);
+    assert_eq!(overrides.unpark_call_count(), 1);
 
     wait_gate.release_one();
     let predecessor_completion = env
@@ -1033,10 +1027,77 @@ async fn finalizing_capacity_wait_reuses_matching_vm_parked_after_deadline() {
     );
     assert_eq!(
         successor_completion.sandbox_id, predecessor_completion.sandbox_id,
-        "successor should reuse the predecessor sandbox after the deadline"
+        "successor should reuse the predecessor sandbox without idle publication"
     );
 
     destroy_gate.release_one();
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn finalizing_handoff_grace_starts_when_claim_returns() {
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 4, 8192, 2, overrides);
+    let reuse_key = "thread:claim-relative-handoff-grace";
+    let predecessor_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        predecessor_run_id,
+        Some(reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate_until(
+            run_id,
+            reuse_key,
+            predecessor_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+            std::time::Instant::now() + Duration::from_millis(100),
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle
+            .claim_candidates()
+            .iter()
+            .any(|candidate| candidate.run_id() == run_id)
+    );
+
+    tokio::time::advance(
+        super::super::super::finalizing_claim::FINALIZING_HANDOFF_ACCEPTANCE_GRACE
+            - Duration::from_millis(1),
+    )
+    .await;
+    tokio::task::yield_now().await;
+    assert_eq!(
+        wait_gate.entered_count(),
+        0,
+        "fresh fallback must not start inside the claim-relative handoff grace"
+    );
+
+    tokio::time::advance(Duration::from_millis(2)).await;
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("fresh fallback should start after the handoff grace expires");
+    wait_gate.release_one();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("fallback run should complete after the claim-relative grace");
+    assert_ne!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+
+    drop(predecessor_guard);
     shutdown(&env, run_handle).await;
 }
 
@@ -1272,7 +1333,7 @@ async fn selected_ranked_finalizing_candidate_falls_back_at_deadline() {
 }
 
 #[tokio::test]
-async fn finalizing_successor_starts_before_replaced_sandbox_cleanup_finishes() {
+async fn finalizing_handoff_starts_before_existing_idle_cleanup() {
     let predecessor_gate = sandbox_mock::MockLifecycleGate::new();
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -1340,22 +1401,22 @@ async fn finalizing_successor_starts_before_replaced_sandbox_cleanup_finishes() 
     .await;
 
     predecessor_gate.release_one();
-    destroy_gate
-        .wait_entered(1, Duration::from_secs(5))
-        .await
-        .expect("replaced sandbox cleanup should remain in predecessor finalization");
     predecessor_gate
         .wait_entered(2, Duration::from_secs(5))
         .await
-        .expect("successor should activate the published sandbox before cleanup finishes");
+        .expect("direct handoff should activate the successor without idle cleanup");
+    assert_eq!(
+        destroy_gate.entered_count(),
+        0,
+        "predecessor handoff should not replace the existing idle sandbox"
+    );
     env.handle
         .wait_completion(history_generation_run_id, Duration::from_secs(5))
         .await
-        .expect("predecessor should report completion while replaced sandbox cleanup is blocked");
-    destroy_gate.release_one();
+        .expect("predecessor should report completion after direct handoff");
     wait_status_idle_reuse_keys_and_active_runs(
         &status_path,
-        &[],
+        &[reuse_key],
         &[run_id.to_string()],
         Duration::from_secs(5),
     )
@@ -1375,6 +1436,11 @@ async fn finalizing_successor_starts_before_replaced_sandbox_cleanup_finishes() 
         .await
         .expect("sandbox publication should wake the claimed successor");
     assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("successor parking should replace the older idle sandbox");
+    destroy_gate.release_one();
     destroy_gate.release_one();
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -948,12 +948,15 @@ async fn finalizing_capacity_wait_rechecks_when_an_active_vm_parks_idle() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn finalizing_handoff_reuses_matching_vm_past_preference_deadline() {
+async fn finalizing_immediate_handoff_reuses_matching_vm_past_preference_deadline() {
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     let wait_gate = sandbox_mock::MockLifecycleGate::new();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
     overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    overrides.push_final_exec_park_handoff_point(
+        sandbox::SandboxFinalExecParkHandoffPoint::BeforeBalloon,
+    );
     let (config, env) =
         mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, Arc::clone(&overrides));
     let budget = Arc::clone(&config.capacity.budget);
@@ -1009,6 +1012,11 @@ async fn finalizing_handoff_reuses_matching_vm_past_preference_deadline() {
     assert_eq!(budget.allocated(), (2, 4096, 1));
     assert_eq!(env.idle_pool.lock().await.len(), 0);
     assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(
+        overrides.completed_final_exec_park_handoff_points(),
+        vec![sandbox::SandboxFinalExecParkHandoffPoint::BeforeBalloon],
+        "runner integration must exercise the typed immediate-handoff path"
+    );
 
     wait_gate.release_one();
     let predecessor_completion = env

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -1,8 +1,9 @@
 use super::super::super::*;
 use super::super::support::{
-    context_with_session, minimal_context, mock_run_config_with_api_url,
-    mock_run_config_with_overrides_and_api_url, push_job, seed_idle_pool, shutdown, test_profiles,
-    test_runner_identity, wait_cancel_handle, wait_discover_entered,
+    SpeculativeIdleSeedSpec, context_with_session, minimal_context, mock_run_config_with_api_url,
+    mock_run_config_with_overrides_and_api_url, push_job, seed_idle_pool,
+    seed_idle_pool_with_speculative_timezone, shutdown, test_profiles, test_runner_identity,
+    wait_cancel_handle, wait_discover_entered,
 };
 use crate::paths::RunnerPaths;
 use crate::workspace_image_cache::WorkspaceImageCache;
@@ -480,6 +481,101 @@ async fn finalizing_handoff_activation_failure_is_not_reported_as_accepted() {
         Some(crate::types::SandboxReuseResult::UnparkFailed)
     );
 
+    shutdown(&env, run_handle).await;
+    telemetry_mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn published_exact_activation_failure_is_reported_as_activation_failed() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_includes("runner_claim_finalizing_handoff")
+                .body_includes(r#""outcome":"activation_failed""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Unpark,
+        message: "simulated published exact activation failure".into(),
+    }));
+    let (config, env) = mock_run_config_with_overrides_and_api_url(
+        test_profiles(),
+        2,
+        4096,
+        1,
+        Arc::clone(&overrides),
+        &server.base_url(),
+    );
+    let budget = Arc::clone(&config.capacity.budget);
+    let reuse_key = "thread:failed-published-exact-activation";
+    let predecessor_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        predecessor_run_id,
+        Some(reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    let predecessor_reuse = predecessor_guard.reuse_publisher();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    let mut context = minimal_context(run_id);
+    context.reuse_key = Some(reuse_key.to_owned());
+    env.provider.set_claim_result(run_id, Some(context));
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+                .with_reuse_key(Some(reuse_key.to_owned()))
+                .with_history_generation_run_id(Some(predecessor_run_id))
+                .with_runner_preference_for_test(
+                    crate::provider::ActiveRunnerPreference::ranked_for_test(
+                        test_runner_identity(),
+                        crate::provider::RunnerPreferenceTier::FinalizingPredecessor,
+                        std::time::Instant::now() + Duration::from_secs(30),
+                    ),
+                ),
+        )
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    seed_idle_pool_with_speculative_timezone(
+        &env.idle_pool,
+        &budget,
+        &overrides,
+        SpeculativeIdleSeedSpec {
+            reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: predecessor_run_id,
+            guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
+            timing: None,
+        },
+    )
+    .await;
+    assert!(predecessor_reuse.publish_exact_sandbox());
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("fresh fallback should complete after exact activation fails");
+    assert_eq!(
+        completion.reuse_result,
+        Some(crate::types::SandboxReuseResult::UnparkFailed)
+    );
+
+    drop(predecessor_guard);
     shutdown(&env, run_handle).await;
     telemetry_mock.assert_calls_async(1).await;
 }

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -2,7 +2,7 @@ use super::super::super::*;
 use super::super::support::{
     context_with_session, minimal_context, mock_run_config_with_api_url,
     mock_run_config_with_overrides_and_api_url, push_job, seed_idle_pool, shutdown, test_profiles,
-    wait_discover_entered,
+    test_runner_identity, wait_cancel_handle, wait_discover_entered,
 };
 use crate::paths::RunnerPaths;
 use crate::workspace_image_cache::WorkspaceImageCache;
@@ -325,4 +325,68 @@ async fn invalid_resume_session_emits_no_reuse_telemetry() {
     shutdown(&env, run_handle).await;
 
     reuse_telemetry_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn cancelled_finalizing_handoff_flushes_outcome_without_executor() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_includes("runner_claim_finalizing_handoff")
+                .body_includes(r#""outcome":"cancelled""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+
+    let (config, env) =
+        mock_run_config_with_api_url(test_profiles(), 2, 4096, 1, &server.base_url());
+    let reuse_key = "thread:cancelled-finalizing-handoff-telemetry";
+    let predecessor_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        predecessor_run_id,
+        Some(reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    let mut context = minimal_context(run_id);
+    context.reuse_key = Some(reuse_key.to_owned());
+    env.provider.set_claim_result(run_id, Some(context));
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+                .with_reuse_key(Some(reuse_key.to_owned()))
+                .with_history_generation_run_id(Some(predecessor_run_id))
+                .with_runner_preference_for_test(
+                    crate::provider::ActiveRunnerPreference::ranked_for_test(
+                        test_runner_identity(),
+                        crate::provider::RunnerPreferenceTier::FinalizingPredecessor,
+                        std::time::Instant::now() + Duration::from_secs(30),
+                    ),
+                ),
+        )
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+
+    cancellation.request_hard_cancellation().await;
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("cancelled finalizing handoff should report completion");
+    assert_eq!(completion.exit_code, 137);
+
+    drop(predecessor_guard);
+    shutdown(&env, run_handle).await;
+    telemetry_mock.assert_calls_async(1).await;
 }

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -390,3 +390,96 @@ async fn cancelled_finalizing_handoff_flushes_outcome_without_executor() {
     shutdown(&env, run_handle).await;
     telemetry_mock.assert_calls_async(1).await;
 }
+
+#[tokio::test]
+async fn finalizing_handoff_activation_failure_is_not_reported_as_accepted() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_includes("runner_claim_finalizing_handoff")
+                .body_includes(r#""outcome":"activation_failed""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Unpark,
+        message: "simulated handoff activation failure".into(),
+    }));
+    let (config, env) = mock_run_config_with_overrides_and_api_url(
+        test_profiles(),
+        2,
+        4096,
+        1,
+        overrides,
+        &server.base_url(),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let reuse_key = "thread:failed-finalizing-handoff-activation";
+    let predecessor_run_id = RunId::new_v4();
+    let mut predecessor_context = minimal_context(predecessor_run_id);
+    predecessor_context.reuse_key = Some(reuse_key.to_owned());
+    push_job(
+        &env,
+        predecessor_run_id,
+        "vm0/default",
+        Some(predecessor_context),
+    );
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("predecessor should still be running when the successor is claimed");
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    let run_id = RunId::new_v4();
+    let mut context = minimal_context(run_id);
+    context.reuse_key = Some(reuse_key.to_owned());
+    env.provider.set_claim_result(run_id, Some(context));
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+                .with_reuse_key(Some(reuse_key.to_owned()))
+                .with_history_generation_run_id(Some(predecessor_run_id))
+                .with_runner_preference_for_test(
+                    crate::provider::ActiveRunnerPreference::ranked_for_test(
+                        test_runner_identity(),
+                        crate::provider::RunnerPreferenceTier::FinalizingPredecessor,
+                        std::time::Instant::now() + Duration::from_secs(30),
+                    ),
+                ),
+        )
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    wait_gate.release_one();
+    wait_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("fresh fallback should start after handoff activation fails");
+    wait_gate.release_one();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("fresh fallback should complete");
+    assert_eq!(
+        completion.reuse_result,
+        Some(crate::types::SandboxReuseResult::UnparkFailed)
+    );
+
+    shutdown(&env, run_handle).await;
+    telemetry_mock.assert_calls_async(1).await;
+}

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -64,8 +64,8 @@ use sandbox_run::{
     NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
 };
 pub(crate) use telemetry::{
-    ExactReuseSpeculationTiming, RunnerPreSpawnOperationTiming, RunnerPreSpawnPhase,
-    RunnerPreSpawnTiming,
+    ExactReuseSpeculationTiming, FinalizingHandoffOutcome, RunnerPreSpawnOperationTiming,
+    RunnerPreSpawnPhase, RunnerPreSpawnTiming,
 };
 use telemetry::{RunnerSpawnTiming, record_api_latency, record_reuse_result};
 

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -29,6 +29,31 @@ pub(crate) enum RunnerPreSpawnPhase {
     SpawnJobSetup,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum FinalizingHandoffOutcome {
+    Accepted,
+    PublishedExact,
+    NotAcceptedBeforeDeadline,
+    NoExact,
+    Cancelled,
+}
+
+impl FinalizingHandoffOutcome {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Accepted => "accepted",
+            Self::PublishedExact => "published_exact",
+            Self::NotAcceptedBeforeDeadline => "not_accepted_before_deadline",
+            Self::NoExact => "no_exact",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    const fn succeeded(self) -> bool {
+        matches!(self, Self::Accepted | Self::PublishedExact)
+    }
+}
+
 impl RunnerPreSpawnPhase {
     const ALL: [Self; 10] = [
         Self::ResumeSessionValidation,
@@ -123,6 +148,7 @@ pub(crate) struct RunnerPreSpawnTiming {
     phase_durations: RunnerPreSpawnPhaseDurations,
     task_enqueued_at: Option<Instant>,
     exact_reuse_speculation: Option<ExactReuseSpeculationTiming>,
+    finalizing_handoff_outcome: Option<FinalizingHandoffOutcome>,
 }
 
 #[derive(Clone, Copy)]
@@ -162,11 +188,16 @@ impl RunnerPreSpawnTiming {
             phase_durations: RunnerPreSpawnPhaseDurations::default(),
             task_enqueued_at: None,
             exact_reuse_speculation: None,
+            finalizing_handoff_outcome: None,
         }
     }
 
     pub(crate) fn record_exact_reuse_speculation(&mut self, timing: ExactReuseSpeculationTiming) {
         self.exact_reuse_speculation = Some(timing);
+    }
+
+    pub(crate) fn record_finalizing_handoff_outcome(&mut self, outcome: FinalizingHandoffOutcome) {
+        self.finalizing_handoff_outcome = Some(outcome);
     }
 
     pub(crate) fn record_phase(&mut self, phase: RunnerPreSpawnPhase, duration: Duration) {
@@ -200,6 +231,15 @@ impl RunnerPreSpawnTiming {
                 executor_started_at.saturating_duration_since(task_enqueued_at),
                 true,
                 None,
+            );
+        }
+        if let Some(outcome) = self.finalizing_handoff_outcome {
+            telemetry.record_with_outcome(
+                "runner_claim_finalizing_handoff",
+                Duration::ZERO,
+                outcome.succeeded(),
+                (!outcome.succeeded()).then_some(outcome.as_str()),
+                Some(outcome.as_str()),
             );
         }
         if let Some(timing) = self.exact_reuse_speculation.as_ref() {

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -32,6 +32,7 @@ pub(crate) enum RunnerPreSpawnPhase {
 #[derive(Clone, Copy)]
 pub(crate) enum FinalizingHandoffOutcome {
     Accepted,
+    ActivationFailed,
     PublishedExact,
     NotAcceptedBeforeDeadline,
     NoExact,
@@ -42,6 +43,7 @@ impl FinalizingHandoffOutcome {
     const fn as_str(self) -> &'static str {
         match self {
             Self::Accepted => "accepted",
+            Self::ActivationFailed => "activation_failed",
             Self::PublishedExact => "published_exact",
             Self::NotAcceptedBeforeDeadline => "not_accepted_before_deadline",
             Self::NoExact => "no_exact",

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -52,6 +52,16 @@ impl FinalizingHandoffOutcome {
     const fn succeeded(self) -> bool {
         matches!(self, Self::Accepted | Self::PublishedExact)
     }
+
+    pub(crate) fn record(self, telemetry: &mut JobTelemetry) {
+        telemetry.record_with_outcome(
+            "runner_claim_finalizing_handoff",
+            Duration::ZERO,
+            self.succeeded(),
+            (!self.succeeded()).then_some(self.as_str()),
+            Some(self.as_str()),
+        );
+    }
 }
 
 impl RunnerPreSpawnPhase {
@@ -200,6 +210,10 @@ impl RunnerPreSpawnTiming {
         self.finalizing_handoff_outcome = Some(outcome);
     }
 
+    pub(crate) fn finalizing_handoff_outcome(&self) -> Option<FinalizingHandoffOutcome> {
+        self.finalizing_handoff_outcome
+    }
+
     pub(crate) fn record_phase(&mut self, phase: RunnerPreSpawnPhase, duration: Duration) {
         *self.phase_durations.get_mut(phase) = Some(duration);
     }
@@ -234,13 +248,7 @@ impl RunnerPreSpawnTiming {
             );
         }
         if let Some(outcome) = self.finalizing_handoff_outcome {
-            telemetry.record_with_outcome(
-                "runner_claim_finalizing_handoff",
-                Duration::ZERO,
-                outcome.succeeded(),
-                (!outcome.succeeded()).then_some(outcome.as_str()),
-                Some(outcome.as_str()),
-            );
+            outcome.record(telemetry);
         }
         if let Some(timing) = self.exact_reuse_speculation.as_ref() {
             telemetry.record(

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -1651,6 +1651,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
         guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
         workspace_image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         workspace_promotion: Some(promotion),
+        handoff: None,
     })
     .park_for_idle()
     .await
@@ -1760,6 +1761,7 @@ async fn reusable_idle_sandbox_with_fresh_workspace_promotion(
         guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
         workspace_image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         workspace_promotion: Some(promotion),
+        handoff: None,
     })
     .park_for_idle()
     .await

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -15,9 +15,9 @@ use super::super::telemetry::{
     RunnerPreSpawnPhase, elapsed_since_api_start_ms, record_api_to_spawn, record_reuse_result,
 };
 use super::super::{
-    ExactReuseSpeculationTiming, ExecutionHooks, NewSandboxDispatch, RunnerPreSpawnOperationTiming,
-    RunnerPreSpawnTiming, SessionHistoryRestorePlan, execute_job, execute_job_reuse,
-    execute_job_reuse_with_hooks, execute_job_with_prepared_notifier,
+    ExactReuseSpeculationTiming, ExecutionHooks, FinalizingHandoffOutcome, NewSandboxDispatch,
+    RunnerPreSpawnOperationTiming, RunnerPreSpawnTiming, SessionHistoryRestorePlan, execute_job,
+    execute_job_reuse, execute_job_reuse_with_hooks, execute_job_with_prepared_notifier,
 };
 use super::support::{
     default_params, make_reusable_idle_sandbox, minimal_context, test_executor_config,
@@ -532,6 +532,7 @@ fn pre_spawn_timing_with_phases() -> RunnerPreSpawnTiming {
     ] {
         timing.record_phase(phase, Duration::from_millis(duration_ms));
     }
+    timing.record_finalizing_handoff_outcome(FinalizingHandoffOutcome::Accepted);
     timing.mark_task_enqueued();
     timing
 }
@@ -701,6 +702,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         "runner_claim_to_executor_start",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
+        "runner_claim_finalizing_handoff",
         "runner_fresh_sandbox_prepare",
         "runner_fresh_sandbox_factory_create",
         "runner_fresh_sandbox_proxy_register",
@@ -720,6 +722,15 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     assert_action_duration(&telemetry, "runner_claim_http_request", 42);
     assert_action_duration(&telemetry, "workspace_drive_mount_guest_exec", 23);
     assert_lacks_action(&telemetry, "workspace_drive_mount_guest_exec_unavailable");
+    assert!(
+        telemetry
+            .pending_ops_with_outcome_snapshot()
+            .iter()
+            .any(|operation| {
+                operation.0 == "runner_claim_finalizing_handoff"
+                    && operation.2.as_deref() == Some("accepted")
+            })
+    );
     for action in FRESH_SANDBOX_FACTORY_STAGE_ACTIONS {
         assert_action_success(&telemetry, action, true);
     }

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -12,15 +12,18 @@ mod entry;
 mod park_transition;
 mod parking_gate;
 
-pub(crate) use entry::{DestroyOutcome, IdleDestroyPayload, IdleDestroyResult};
+pub(crate) use entry::{
+    DestroyOutcome, FinalizingHandoffCandidate, IdleDestroyPayload, IdleDestroyResult,
+    ImmediateHandoffCandidate,
+};
 pub use entry::{
     IdleDestroyJob, IdleEntry, IdleUnparkResult, ParkedIdleCandidate, RejectedParkedIdleCandidate,
     ReservedIdleSandbox, RestoreReservedIdleResult, ReusableIdleSandbox, ReusableIdleSandboxParts,
 };
 pub(crate) use entry::{SpeculativeIdleSandbox, SpeculativeIdleUnparkResult};
 pub(crate) use park_transition::{
-    IdleParkActiveParts, IdleParkFailureParts, IdleParkRequest, IdleParkRequestParts,
-    SpeculativeReparkResult,
+    IdleParkActiveParts, IdleParkCandidate, IdleParkFailureParts, IdleParkRequest,
+    IdleParkRequestParts, SpeculativeReparkResult,
 };
 pub(crate) use parking_gate::ParkingGate;
 #[cfg(test)]

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use futures_util::FutureExt;
-use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
+use sandbox::{
+    DeviceRateLimits, Sandbox, SandboxFactory, SandboxFinalExecParkHandoffPoint, SandboxId,
+};
 
 use crate::guest_timezone::GuestTimezoneIntent;
 use crate::ids::RunId;
@@ -99,6 +101,23 @@ pub struct ParkedIdleCandidate {
     pub(super) budget_lease: BudgetLease,
 }
 
+/// Under-compacted parked sandbox that may only be handed to its waiting exact
+/// successor or destroyed.
+#[must_use = "immediate handoff candidates must be bound to a claimant or explicitly destroyed"]
+pub(crate) struct ImmediateHandoffCandidate {
+    candidate: ParkedIdleCandidate,
+    handoff_point: SandboxFinalExecParkHandoffPoint,
+}
+
+/// Parked sandbox bound to one claimed exact successor without entering the
+/// generic idle pool.
+#[must_use = "finalizing handoff candidates must be activated or explicitly destroyed"]
+pub(crate) struct FinalizingHandoffCandidate {
+    reservation: ReservedIdleSandbox,
+    successor_run_id: RunId,
+    predecessor_run_id: RunId,
+}
+
 impl ParkedIdleCandidate {
     pub(crate) fn reuse_key(&self) -> &str {
         self.metadata.reuse_key()
@@ -129,6 +148,34 @@ impl ParkedIdleCandidate {
         }
     }
 
+    pub(crate) fn into_finalizing_handoff(
+        self,
+        successor_run_id: RunId,
+        predecessor_run_id: RunId,
+    ) -> FinalizingHandoffCandidate {
+        debug_assert_eq!(
+            self.metadata.history_generation_run_id,
+            Some(predecessor_run_id)
+        );
+        FinalizingHandoffCandidate {
+            reservation: ReservedIdleSandbox {
+                entry: self.into_idle_entry(Instant::now()),
+            },
+            successor_run_id,
+            predecessor_run_id,
+        }
+    }
+
+    pub(crate) fn into_immediate_handoff(
+        self,
+        handoff_point: SandboxFinalExecParkHandoffPoint,
+    ) -> ImmediateHandoffCandidate {
+        ImmediateHandoffCandidate {
+            candidate: self,
+            handoff_point,
+        }
+    }
+
     pub(crate) fn into_active_destroy_parts(self) -> (IdleDestroyPayload, BudgetLease) {
         let Self {
             resources,
@@ -150,6 +197,70 @@ impl ParkedIdleCandidate {
 
         RejectedParkedIdleCandidate {
             payload: resources.into_destroy_payload(WorkspacePromotionPolicy::Promote),
+            budget_lease,
+        }
+    }
+}
+
+impl ImmediateHandoffCandidate {
+    pub(crate) fn handoff_point(&self) -> SandboxFinalExecParkHandoffPoint {
+        self.handoff_point
+    }
+
+    pub(crate) fn with_last_completed_at(self, last_completed_at: String) -> Self {
+        let Self {
+            candidate,
+            handoff_point,
+        } = self;
+        Self {
+            candidate: candidate.with_last_completed_at(last_completed_at),
+            handoff_point,
+        }
+    }
+
+    pub(crate) fn into_finalizing_handoff(
+        self,
+        successor_run_id: RunId,
+        predecessor_run_id: RunId,
+    ) -> FinalizingHandoffCandidate {
+        self.candidate
+            .into_finalizing_handoff(successor_run_id, predecessor_run_id)
+    }
+
+    pub(crate) fn into_active_destroy_parts(self) -> (IdleDestroyPayload, BudgetLease) {
+        self.candidate.into_active_destroy_parts()
+    }
+}
+
+impl FinalizingHandoffCandidate {
+    pub(crate) fn into_reservation(
+        self: Box<Self>,
+        successor_run_id: RunId,
+        predecessor_run_id: RunId,
+    ) -> Result<ReservedIdleSandbox, Box<Self>> {
+        if self.successor_run_id == successor_run_id
+            && self.predecessor_run_id == predecessor_run_id
+        {
+            Ok(self.reservation)
+        } else {
+            Err(self)
+        }
+    }
+
+    pub(crate) fn into_destroy_job(self: Box<Self>) -> IdleDestroyJob {
+        self.reservation.into_destroy_job()
+    }
+
+    pub(crate) fn into_parked_candidate(self: Box<Self>) -> ParkedIdleCandidate {
+        let IdleEntry {
+            resources,
+            metadata,
+            budget_lease,
+            parked_at: _,
+        } = self.reservation.entry;
+        ParkedIdleCandidate {
+            resources,
+            metadata,
             budget_lease,
         }
     }
@@ -598,6 +709,14 @@ impl IdleEntry {
 impl ReservedIdleSandbox {
     pub fn reuse_key(&self) -> &str {
         self.entry.reuse_key()
+    }
+
+    pub(crate) fn profile_name(&self) -> &str {
+        self.entry.profile_name()
+    }
+
+    pub(crate) fn device_rate_limits(&self) -> &Option<DeviceRateLimits> {
+        self.entry.device_rate_limits()
     }
 
     pub(crate) fn guest_timezone_intent(&self) -> &GuestTimezoneIntent {

--- a/crates/runner/src/idle_pool/park_transition.rs
+++ b/crates/runner/src/idle_pool/park_transition.rs
@@ -5,7 +5,8 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use futures_util::FutureExt;
 use guest_contracts::reuse_preparation::ReusePreparationReport;
 use sandbox::{
-    DeviceRateLimits, Sandbox, SandboxFactory, SandboxFinalExecParkObserver, SandboxId,
+    DeviceRateLimits, Sandbox, SandboxFactory, SandboxFinalExecParkHandoff,
+    SandboxFinalExecParkHandoffOutcome, SandboxFinalExecParkObserver, SandboxId,
     SandboxParkNonReusableReason, SandboxParkOutcome,
 };
 
@@ -21,9 +22,9 @@ use crate::workspace_image_cache::{
 use crate::workspace_promotion::abandon_unpublished_workspace_promotion;
 
 use super::entry::{
-    IdleDestroyJob, IdleEntry, IdleSandboxMetadata, IdleSandboxResources, ParkedIdleCandidate,
-    RejectedParkedIdleCandidate, ReservedIdleSandbox, SpeculativeIdleSandbox,
-    WorkspacePromotionPolicy,
+    IdleDestroyJob, IdleDestroyPayload, IdleEntry, IdleSandboxMetadata, IdleSandboxResources,
+    ImmediateHandoffCandidate, ParkedIdleCandidate, RejectedParkedIdleCandidate,
+    ReservedIdleSandbox, SpeculativeIdleSandbox, WorkspacePromotionPolicy,
 };
 
 /// One-shot request to transition an active sandbox into same-reuse-key idle
@@ -50,17 +51,44 @@ pub(crate) struct IdleParkRequestParts {
     pub(crate) guest_timezone_intent: GuestTimezoneIntent,
     pub(crate) workspace_image_size_bytes: u64,
     pub(crate) workspace_promotion: Option<WorkspaceImagePromotionContext>,
+    pub(crate) handoff: Option<SandboxFinalExecParkHandoff>,
 }
 
 /// Result after the sandbox successfully reaches the parked state.
 #[must_use = "parked outcomes must be admitted for reuse or explicitly destroyed"]
 pub(crate) enum IdleParkOutcome {
     Reusable(ParkedIdleCandidate),
+    Handoff(ImmediateHandoffCandidate),
     NonReusable {
         candidate: ParkedIdleCandidate,
         reason: SandboxParkNonReusableReason,
         preparation_report: ReusePreparationReport,
     },
+}
+
+pub(crate) enum IdleParkCandidate {
+    Ordinary(ParkedIdleCandidate),
+    Immediate(ImmediateHandoffCandidate),
+}
+
+impl IdleParkCandidate {
+    pub(crate) fn with_last_completed_at(self, last_completed_at: String) -> Self {
+        match self {
+            Self::Ordinary(candidate) => {
+                Self::Ordinary(candidate.with_last_completed_at(last_completed_at))
+            }
+            Self::Immediate(candidate) => {
+                Self::Immediate(candidate.with_last_completed_at(last_completed_at))
+            }
+        }
+    }
+
+    pub(crate) fn into_active_destroy_parts(self) -> (IdleDestroyPayload, BudgetLease) {
+        match self {
+            Self::Ordinary(candidate) => candidate.into_active_destroy_parts(),
+            Self::Immediate(candidate) => candidate.into_active_destroy_parts(),
+        }
+    }
 }
 
 pub(crate) struct IdleParkNonReusable {
@@ -165,6 +193,7 @@ impl IdleParkRequest {
             guest_timezone_intent,
             workspace_image_size_bytes,
             workspace_promotion,
+            handoff,
         } = self.parts;
 
         let metadata = IdleSandboxMetadata {
@@ -194,6 +223,7 @@ impl IdleParkRequest {
                 workspace_image_size_bytes,
             },
             observer,
+            handoff,
         )
         .await
     }
@@ -202,6 +232,7 @@ impl IdleParkRequest {
 async fn park_idle_transition(
     input: IdleParkTransitionInput,
     observer: Option<&mut dyn SandboxFinalExecParkObserver>,
+    handoff: Option<SandboxFinalExecParkHandoff>,
 ) -> Result<IdleParkOutcome, IdleParkFailure> {
     let IdleParkTransitionInput {
         operation_run_id,
@@ -279,13 +310,31 @@ async fn park_idle_transition(
 
     let final_exec_and_park = {
         let request = preparation.exec_request();
-        let transition = match observer {
-            Some(observer) => sandbox.final_exec_and_park_with_observer(
-                &request,
-                "idle-reuse-preparation-and-park",
-                observer,
-            ),
-            None => sandbox.final_exec_and_park(&request, "idle-reuse-preparation-and-park"),
+        let transition = async {
+            match (observer, handoff.as_ref()) {
+                (Some(observer), Some(handoff)) => {
+                    sandbox
+                        .final_exec_and_park_for_handoff(
+                            &request,
+                            "idle-reuse-preparation-and-park",
+                            handoff,
+                            observer,
+                        )
+                        .await
+                }
+                (Some(observer), None) => sandbox
+                    .final_exec_and_park_with_observer(
+                        &request,
+                        "idle-reuse-preparation-and-park",
+                        observer,
+                    )
+                    .await
+                    .map(SandboxFinalExecParkHandoffOutcome::Parked),
+                (None, _) => sandbox
+                    .final_exec_and_park(&request, "idle-reuse-preparation-and-park")
+                    .await
+                    .map(SandboxFinalExecParkHandoffOutcome::Parked),
+            }
         };
         AssertUnwindSafe(transition).catch_unwind().await
     };
@@ -300,7 +349,11 @@ async fn park_idle_transition(
                 metadata,
                 budget_lease,
             };
-            let preparation_report = match preparation.validate_result(&outcome.exec_result) {
+            let exec_result = match &outcome {
+                SandboxFinalExecParkHandoffOutcome::Parked(outcome) => &outcome.exec_result,
+                SandboxFinalExecParkHandoffOutcome::Handoff { exec_result, .. } => exec_result,
+            };
+            let preparation_report = match preparation.validate_result(exec_result) {
                 Ok(report) => report,
                 Err(error) => {
                     return Err(IdleParkFailure {
@@ -312,12 +365,17 @@ async fn park_idle_transition(
                     });
                 }
             };
-            Ok(match outcome.park_outcome {
-                SandboxParkOutcome::Reusable => IdleParkOutcome::Reusable(candidate),
-                SandboxParkOutcome::NonReusable(reason) => IdleParkOutcome::NonReusable {
-                    candidate,
-                    reason,
-                    preparation_report,
+            Ok(match outcome {
+                SandboxFinalExecParkHandoffOutcome::Handoff { point, .. } => {
+                    IdleParkOutcome::Handoff(candidate.into_immediate_handoff(point))
+                }
+                SandboxFinalExecParkHandoffOutcome::Parked(outcome) => match outcome.park_outcome {
+                    SandboxParkOutcome::Reusable => IdleParkOutcome::Reusable(candidate),
+                    SandboxParkOutcome::NonReusable(reason) => IdleParkOutcome::NonReusable {
+                        candidate,
+                        reason,
+                        preparation_report,
+                    },
                 },
             })
         }
@@ -386,6 +444,7 @@ impl SpeculativeIdleSandbox {
                 workspace_image_size_bytes,
             },
             None,
+            None,
         )
         .await
         {
@@ -393,6 +452,19 @@ impl SpeculativeIdleSandbox {
                 SpeculativeReparkResult::Reparked(Box::new(ReservedIdleSandbox {
                     entry: candidate.into_idle_entry(parked_at),
                 }))
+            }
+            Ok(IdleParkOutcome::Handoff(candidate)) => {
+                let (payload, budget_lease) = candidate.into_active_destroy_parts();
+                SpeculativeReparkResult::Destroy {
+                    destroy_job: Box::new(IdleDestroyJob {
+                        payload,
+                        budget_lease,
+                        reuse_key,
+                        profile_name,
+                    }),
+                    reason: "speculative_repark_unexpected_handoff",
+                    error: "speculative re-park unexpectedly produced an immediate handoff".into(),
+                }
             }
             Ok(IdleParkOutcome::NonReusable {
                 candidate, reason, ..
@@ -423,15 +495,16 @@ impl SpeculativeIdleSandbox {
 }
 
 impl IdleParkOutcome {
-    pub(crate) fn into_parts(self) -> (ParkedIdleCandidate, Option<IdleParkNonReusable>) {
+    pub(crate) fn into_parts(self) -> (IdleParkCandidate, Option<IdleParkNonReusable>) {
         match self {
-            Self::Reusable(candidate) => (candidate, None),
+            Self::Reusable(candidate) => (IdleParkCandidate::Ordinary(candidate), None),
+            Self::Handoff(candidate) => (IdleParkCandidate::Immediate(candidate), None),
             Self::NonReusable {
                 candidate,
                 reason,
                 preparation_report,
             } => (
-                candidate,
+                IdleParkCandidate::Ordinary(candidate),
                 Some(IdleParkNonReusable {
                     reason,
                     preparation_report,
@@ -444,6 +517,7 @@ impl IdleParkOutcome {
     pub(crate) fn expect_reusable(self) -> ParkedIdleCandidate {
         match self {
             Self::Reusable(candidate) => candidate,
+            Self::Handoff(_) => panic!("expected ordinary reusable parked candidate, got handoff"),
             Self::NonReusable { reason, .. } => {
                 panic!(
                     "expected reusable parked candidate, got {}",

--- a/crates/runner/src/idle_pool/park_transition_tests.rs
+++ b/crates/runner/src/idle_pool/park_transition_tests.rs
@@ -64,6 +64,7 @@ async fn make_idle_park_request(
         guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
         workspace_image_size_bytes: 0,
         workspace_promotion: None,
+        handoff: None,
     })
 }
 
@@ -238,6 +239,7 @@ async fn idle_park_request_success_preserves_reuse_metadata() {
         guest_timezone_intent: crate::guest_timezone::GuestTimezoneIntent::Unknown,
         workspace_image_size_bytes: 0,
         workspace_promotion: None,
+        handoff: None,
     });
 
     let candidate = match request.park_for_idle().await {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -11,12 +11,13 @@ use sandbox::{
     GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter,
     ProcessControlAck, ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlMode,
     ProcessControlOutcome, ProcessControlWriteState, ProcessExit, ProcessOutputChunk,
-    ProcessOutputMode, Sandbox, SandboxConfig, SandboxError, SandboxFinalExecParkObserver,
-    SandboxFinalExecParkOutcome, SandboxFinalExecParkStage, SandboxFinalExecParkSubstage,
-    SandboxFinalExecParkSubstageOutcome, SandboxIdleTransition, SandboxInvalidStateContext,
-    SandboxOperation, SandboxOperationReason, SandboxParkNonReusableReason, SandboxParkOutcome,
-    SandboxStartObserver, SandboxStartStage, SevereMemoryRetentionDiagnostics, StartProcessRequest,
-    WriteFileEntry,
+    ProcessOutputMode, Sandbox, SandboxConfig, SandboxError, SandboxFinalExecParkHandoff,
+    SandboxFinalExecParkHandoffOutcome, SandboxFinalExecParkHandoffPoint,
+    SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome, SandboxFinalExecParkStage,
+    SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome, SandboxIdleTransition,
+    SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
+    SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver, SandboxStartStage,
+    SevereMemoryRetentionDiagnostics, StartProcessRequest, WriteFileEntry,
 };
 use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, watch};
@@ -1896,8 +1897,9 @@ impl FirecrackerSandbox {
         &mut self,
         request: &ExecRequest<'_>,
         diagnostic_label: &'static str,
+        handoff: Option<&SandboxFinalExecParkHandoff>,
         observer: Option<&mut dyn SandboxFinalExecParkObserver>,
-    ) -> sandbox::Result<SandboxFinalExecParkOutcome> {
+    ) -> sandbox::Result<SandboxFinalExecParkHandoffOutcome> {
         if self.is_parked {
             return Err(idle_transition_error(
                 SandboxIdleTransition::Park,
@@ -1922,7 +1924,7 @@ impl FirecrackerSandbox {
         let balloon_controller = self.runtime.balloon_mut();
         let api_sock = self.sock_paths.api_sock();
         let final_exec_request = exec_capture_request(request, timeout_ms, diagnostic_label);
-        let (normal_operations_fence, park_outcome, exec_result) =
+        let (normal_operations_fence, physical_outcome, exec_result) =
             park_with_ready_for_park_and_preparation_with_observer(
                 &id,
                 &coordinator,
@@ -1965,13 +1967,16 @@ impl FirecrackerSandbox {
                     guest.quiesce_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
                 },
                 |timing, events| async move {
-                    let (events, result) = park_inner_with_guest(
+                    let (events, result) = park_inner_with_guest_and_handoff(
                         is_parked,
                         memory_mb,
                         balloon_controller,
                         &api_sock,
                         &park_id,
-                        physical_park_guest,
+                        PhysicalParkRequest {
+                            guest: physical_park_guest,
+                            handoff,
+                        },
                         events,
                     )
                     .await;
@@ -1980,11 +1985,21 @@ impl FirecrackerSandbox {
             )
             .await?;
         self.park_fence = Some(normal_operations_fence);
-        self.park_outcome = Some(park_outcome.clone());
-        Ok(SandboxFinalExecParkOutcome {
-            exec_result,
-            park_outcome,
-        })
+        match physical_outcome {
+            PhysicalParkOutcome::Idle(park_outcome) => {
+                self.park_outcome = Some(park_outcome.clone());
+                Ok(SandboxFinalExecParkHandoffOutcome::Parked(
+                    SandboxFinalExecParkOutcome {
+                        exec_result,
+                        park_outcome,
+                    },
+                ))
+            }
+            PhysicalParkOutcome::Handoff(point) => {
+                self.park_outcome = None;
+                Ok(SandboxFinalExecParkHandoffOutcome::Handoff { exec_result, point })
+            }
+        }
     }
 }
 
@@ -2243,8 +2258,16 @@ impl Sandbox for FirecrackerSandbox {
         request: &ExecRequest<'_>,
         diagnostic_label: &'static str,
     ) -> sandbox::Result<SandboxFinalExecParkOutcome> {
-        self.final_exec_and_park_with_optional_observer(request, diagnostic_label, None)
-            .await
+        match self
+            .final_exec_and_park_with_optional_observer(request, diagnostic_label, None, None)
+            .await?
+        {
+            SandboxFinalExecParkHandoffOutcome::Parked(outcome) => Ok(outcome),
+            SandboxFinalExecParkHandoffOutcome::Handoff { .. } => Err(idle_transition_error(
+                SandboxIdleTransition::Park,
+                "provider accepted a handoff without a handoff signal",
+            )),
+        }
     }
 
     async fn final_exec_and_park_with_observer(
@@ -2253,8 +2276,37 @@ impl Sandbox for FirecrackerSandbox {
         diagnostic_label: &'static str,
         observer: &mut dyn SandboxFinalExecParkObserver,
     ) -> sandbox::Result<SandboxFinalExecParkOutcome> {
-        self.final_exec_and_park_with_optional_observer(request, diagnostic_label, Some(observer))
-            .await
+        match self
+            .final_exec_and_park_with_optional_observer(
+                request,
+                diagnostic_label,
+                None,
+                Some(observer),
+            )
+            .await?
+        {
+            SandboxFinalExecParkHandoffOutcome::Parked(outcome) => Ok(outcome),
+            SandboxFinalExecParkHandoffOutcome::Handoff { .. } => Err(idle_transition_error(
+                SandboxIdleTransition::Park,
+                "provider accepted a handoff without a handoff signal",
+            )),
+        }
+    }
+
+    async fn final_exec_and_park_for_handoff(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+        handoff: &SandboxFinalExecParkHandoff,
+        observer: &mut dyn SandboxFinalExecParkObserver,
+    ) -> sandbox::Result<SandboxFinalExecParkHandoffOutcome> {
+        self.final_exec_and_park_with_optional_observer(
+            request,
+            diagnostic_label,
+            Some(handoff),
+            Some(observer),
+        )
+        .await
     }
 
     async fn unpark(&mut self) -> sandbox::Result<()> {
@@ -3609,6 +3661,16 @@ struct BalloonSettleResult {
     telemetry_outcome: SandboxFinalExecParkSubstageOutcome,
 }
 
+enum BalloonSettleWaitResult {
+    Settled(BalloonSettleResult),
+    Handoff,
+}
+
+enum PhysicalParkOutcome {
+    Idle(SandboxParkOutcome),
+    Handoff(SandboxFinalExecParkHandoffPoint),
+}
+
 /// Wait until the guest balloon driver inflates close enough to `target_mib`.
 ///
 /// The guest needs running vCPUs to inflate, so this must be called
@@ -3620,11 +3682,24 @@ struct BalloonSettleResult {
 /// [`BALLOON_SETTLE_PROGRESS_GRACE`]. The returned outcome rejects only the
 /// existing severe-deficit classification. Errors from stats fetching are
 /// non-fatal — we log and proceed to pause.
+#[cfg(test)]
 async fn wait_for_balloon_with_outcome(
     client: &ApiClient,
     target_mib: u32,
     log_id: &str,
 ) -> BalloonSettleResult {
+    match wait_for_balloon_with_optional_handoff(client, target_mib, log_id, None).await {
+        BalloonSettleWaitResult::Settled(result) => result,
+        BalloonSettleWaitResult::Handoff => panic!("handoff signal was not provided"),
+    }
+}
+
+async fn wait_for_balloon_with_optional_handoff(
+    client: &ApiClient,
+    target_mib: u32,
+    log_id: &str,
+    handoff: Option<&SandboxFinalExecParkHandoff>,
+) -> BalloonSettleWaitResult {
     let tolerance_mib = balloon_settle_tolerance_mib(target_mib);
     let mut summary = BalloonSettleSummary::new(target_mib);
     let mut settle_timeout = BALLOON_SETTLE_TIMEOUT;
@@ -3648,14 +3723,29 @@ async fn wait_for_balloon_with_outcome(
                     &summary,
                     &outcome,
                 );
-                return BalloonSettleResult {
+                return BalloonSettleWaitResult::Settled(BalloonSettleResult {
                     park_outcome: outcome,
                     telemetry_outcome: SandboxFinalExecParkSubstageOutcome::Deadline,
-                };
+                });
             }
         }
 
-        match tokio::time::timeout_at(deadline, client.get_balloon_statistics()).await {
+        let statistics = match handoff {
+            Some(handoff) => {
+                tokio::select! {
+                    biased;
+                    accepted = handoff.wait_and_accept() => {
+                        if accepted {
+                            return BalloonSettleWaitResult::Handoff;
+                        }
+                        tokio::time::timeout_at(deadline, client.get_balloon_statistics()).await
+                    }
+                    statistics = tokio::time::timeout_at(deadline, client.get_balloon_statistics()) => statistics,
+                }
+            }
+            None => tokio::time::timeout_at(deadline, client.get_balloon_statistics()).await,
+        };
+        match statistics {
             Ok(Ok(stats)) => {
                 let deficit_mib = summary.observe(&stats);
                 if deficit_mib == 0 {
@@ -3679,10 +3769,10 @@ async fn wait_for_balloon_with_outcome(
                         reported_total_mib = ?summary.reported_total_mib(),
                         "balloon fully inflated, proceeding to pause"
                     );
-                    return BalloonSettleResult {
+                    return BalloonSettleWaitResult::Settled(BalloonSettleResult {
                         park_outcome: SandboxParkOutcome::Reusable,
                         telemetry_outcome: SandboxFinalExecParkSubstageOutcome::TargetReached,
-                    };
+                    });
                 }
 
                 if deficit_mib <= tolerance_mib {
@@ -3706,10 +3796,10 @@ async fn wait_for_balloon_with_outcome(
                         reported_total_mib = ?summary.reported_total_mib(),
                         "balloon inflated within tolerance, proceeding to pause"
                     );
-                    return BalloonSettleResult {
+                    return BalloonSettleWaitResult::Settled(BalloonSettleResult {
                         park_outcome: SandboxParkOutcome::Reusable,
                         telemetry_outcome: SandboxFinalExecParkSubstageOutcome::WithinTolerance,
-                    };
+                    });
                 }
 
                 if summary.is_pressure_limited_partial_reclaim(deficit_mib, tolerance_mib) {
@@ -3734,10 +3824,10 @@ async fn wait_for_balloon_with_outcome(
                         reason = BALLOON_PRESSURE_LIMITED_REASON,
                         "balloon pressure-limited partial reclaim, proceeding to pause"
                     );
-                    return BalloonSettleResult {
+                    return BalloonSettleWaitResult::Settled(BalloonSettleResult {
                         park_outcome: SandboxParkOutcome::Reusable,
                         telemetry_outcome: SandboxFinalExecParkSubstageOutcome::PressureLimited,
-                    };
+                    });
                 }
 
                 // Balloon timing tests advance paused time only after a completed stats sample.
@@ -3769,10 +3859,10 @@ async fn wait_for_balloon_with_outcome(
                     %e,
                     "balloon stats unavailable, proceeding to pause"
                 );
-                return BalloonSettleResult {
+                return BalloonSettleWaitResult::Settled(BalloonSettleResult {
                     park_outcome: outcome,
                     telemetry_outcome: SandboxFinalExecParkSubstageOutcome::StatsUnavailable,
-                };
+                });
             }
             Err(_) => {
                 let outcome = summary.park_outcome();
@@ -3784,10 +3874,10 @@ async fn wait_for_balloon_with_outcome(
                     &summary,
                     &outcome,
                 );
-                return BalloonSettleResult {
+                return BalloonSettleWaitResult::Settled(BalloonSettleResult {
                     park_outcome: outcome,
                     telemetry_outcome: SandboxFinalExecParkSubstageOutcome::Deadline,
-                };
+                });
             }
         }
 
@@ -3795,12 +3885,27 @@ async fn wait_for_balloon_with_outcome(
             .next()
             .unwrap_or(BALLOON_SETTLE_MAX_POLL);
         let next_poll = tokio::time::Instant::now() + poll_interval;
-        tokio::time::sleep_until(if next_poll < deadline {
+        let sleep = tokio::time::sleep_until(if next_poll < deadline {
             next_poll
         } else {
             deadline
-        })
-        .await;
+        });
+        tokio::pin!(sleep);
+        match handoff {
+            Some(handoff) => {
+                tokio::select! {
+                    biased;
+                    accepted = handoff.wait_and_accept() => {
+                        if accepted {
+                            return BalloonSettleWaitResult::Handoff;
+                        }
+                        sleep.as_mut().await;
+                    }
+                    () = sleep.as_mut() => {}
+                }
+            }
+            None => sleep.as_mut().await,
+        }
     }
 }
 
@@ -3853,20 +3958,29 @@ async fn terminal_guest_memory_snapshot(
     }
 }
 
-async fn park_inner_with_guest<'observer>(
+struct PhysicalParkRequest<'handoff> {
+    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    handoff: Option<&'handoff SandboxFinalExecParkHandoff>,
+}
+
+async fn park_inner_with_guest_and_handoff<'observer>(
     is_parked: &mut bool,
     memory_mb: u32,
     balloon_controller: &mut Option<balloon::ControllerHandle>,
     api_sock: &std::path::Path,
     log_id: &str,
-    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    request: PhysicalParkRequest<'_>,
     mut events: SandboxFinalExecParkSubstageEvents<'observer>,
 ) -> (
     SandboxFinalExecParkSubstageEvents<'observer>,
-    sandbox::Result<SandboxParkOutcome>,
+    sandbox::Result<PhysicalParkOutcome>,
 ) {
+    let PhysicalParkRequest { guest, handoff } = request;
     if *is_parked {
-        return (events, Ok(SandboxParkOutcome::Reusable));
+        return (
+            events,
+            Ok(PhysicalParkOutcome::Idle(SandboxParkOutcome::Reusable)),
+        );
     }
 
     let target = memory_mb.saturating_sub(balloon::MIN_GUEST_MIB);
@@ -3910,60 +4024,97 @@ async fn park_inner_with_guest<'observer>(
             controller.abort_and_join().await;
         }
 
-        if let Err(e) = client.patch_balloon(target).await {
+        if handoff.is_some_and(SandboxFinalExecParkHandoff::accept_if_requested) {
             events.record(
                 SandboxFinalExecParkSubstage::BalloonSetup,
                 balloon_setup_started.elapsed(),
-                false,
-                Some(SandboxFinalExecParkSubstageOutcome::Failed),
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::HandoffRequested),
             );
-            return (
-                events,
-                Err(SandboxError::IdleTransition {
-                    transition: SandboxIdleTransition::Park,
-                    message: format!("balloon inflate: {e}"),
-                }),
+            events.record(
+                SandboxFinalExecParkSubstage::BalloonSettle,
+                Duration::ZERO,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::Skipped),
             );
-        }
-        events.record(
-            SandboxFinalExecParkSubstage::BalloonSetup,
-            balloon_setup_started.elapsed(),
-            true,
-            None,
-        );
-
-        // Wait for the guest to inflate the balloon close enough before
-        // pausing vCPUs. The guest balloon driver needs running vCPUs to
-        // process the inflate — pausing immediately would negate the memory
-        // savings.
-        let balloon_settle_started = Instant::now();
-        let settle_result = wait_for_balloon_with_outcome(&client, target, log_id).await;
-        let BalloonSettleResult {
-            mut park_outcome,
-            telemetry_outcome,
-        } = settle_result;
-        match &mut park_outcome {
-            SandboxParkOutcome::NonReusable(
-                SandboxParkNonReusableReason::SevereMemoryRetention(diagnostics),
-            ) => {
-                diagnostics.guest_memory_snapshot =
-                    terminal_guest_memory_snapshot(&guest, log_id).await;
+            PhysicalParkOutcome::Handoff(SandboxFinalExecParkHandoffPoint::BeforeBalloon)
+        } else {
+            if let Err(e) = client.patch_balloon(target).await {
+                events.record(
+                    SandboxFinalExecParkSubstage::BalloonSetup,
+                    balloon_setup_started.elapsed(),
+                    false,
+                    Some(SandboxFinalExecParkSubstageOutcome::Failed),
+                );
+                return (
+                    events,
+                    Err(SandboxError::IdleTransition {
+                        transition: SandboxIdleTransition::Park,
+                        message: format!("balloon inflate: {e}"),
+                    }),
+                );
             }
-            SandboxParkOutcome::Reusable => {}
+            events.record(
+                SandboxFinalExecParkSubstage::BalloonSetup,
+                balloon_setup_started.elapsed(),
+                true,
+                None,
+            );
+
+            // Wait for the guest to inflate the balloon close enough before
+            // pausing vCPUs. The guest balloon driver needs running vCPUs to
+            // process the inflate — pausing immediately would negate the memory
+            // savings.
+            let balloon_settle_started = Instant::now();
+            let settle_result =
+                wait_for_balloon_with_optional_handoff(&client, target, log_id, handoff).await;
+            match settle_result {
+                BalloonSettleWaitResult::Handoff => {
+                    events.record(
+                        SandboxFinalExecParkSubstage::BalloonSettle,
+                        balloon_settle_started.elapsed(),
+                        true,
+                        Some(SandboxFinalExecParkSubstageOutcome::HandoffRequested),
+                    );
+                    PhysicalParkOutcome::Handoff(
+                        SandboxFinalExecParkHandoffPoint::DuringBalloonSettle,
+                    )
+                }
+                BalloonSettleWaitResult::Settled(BalloonSettleResult {
+                    mut park_outcome,
+                    telemetry_outcome,
+                }) => {
+                    match &mut park_outcome {
+                        SandboxParkOutcome::NonReusable(
+                            SandboxParkNonReusableReason::SevereMemoryRetention(diagnostics),
+                        ) => {
+                            diagnostics.guest_memory_snapshot =
+                                terminal_guest_memory_snapshot(&guest, log_id).await;
+                        }
+                        SandboxParkOutcome::Reusable => {}
+                    }
+                    events.record(
+                        SandboxFinalExecParkSubstage::BalloonSettle,
+                        balloon_settle_started.elapsed(),
+                        true,
+                        Some(telemetry_outcome),
+                    );
+                    PhysicalParkOutcome::Idle(park_outcome)
+                }
+            }
         }
-        events.record(
-            SandboxFinalExecParkSubstage::BalloonSettle,
-            balloon_settle_started.elapsed(),
-            true,
-            Some(telemetry_outcome),
-        );
-        park_outcome
     } else {
+        let handoff_requested =
+            handoff.is_some_and(SandboxFinalExecParkHandoff::accept_if_requested);
         events.record(
             SandboxFinalExecParkSubstage::BalloonSetup,
             Duration::ZERO,
             true,
-            Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+            Some(if handoff_requested {
+                SandboxFinalExecParkSubstageOutcome::HandoffRequested
+            } else {
+                SandboxFinalExecParkSubstageOutcome::Skipped
+            }),
         );
         events.record(
             SandboxFinalExecParkSubstage::BalloonSettle,
@@ -3971,7 +4122,11 @@ async fn park_inner_with_guest<'observer>(
             true,
             Some(SandboxFinalExecParkSubstageOutcome::Skipped),
         );
-        SandboxParkOutcome::Reusable
+        if handoff_requested {
+            PhysicalParkOutcome::Handoff(SandboxFinalExecParkHandoffPoint::BeforeBalloon)
+        } else {
+            PhysicalParkOutcome::Idle(SandboxParkOutcome::Reusable)
+        }
     };
 
     // Pause vCPUs to eliminate idle CPU overhead (timer ticks, kernel
@@ -4001,21 +4156,69 @@ async fn park_inner_with_guest<'observer>(
     );
 
     *is_parked = true;
-    if target > 0 {
-        info!(
-            id = %log_id,
-            target_mib = target,
-            admission_action = park_admission_action(&outcome),
-            "sandbox parked (balloon settled, vCPUs paused)"
-        );
-    } else {
-        info!(
-            id = %log_id,
-            admission_action = park_admission_action(&outcome),
-            "sandbox parked (vCPUs paused, balloon skipped)"
-        );
+    match &outcome {
+        PhysicalParkOutcome::Handoff(_) => {
+            info!(id = %log_id, "sandbox parked for exact-successor handoff");
+        }
+        PhysicalParkOutcome::Idle(_) if target > 0 => {
+            info!(
+                id = %log_id,
+                target_mib = target,
+                admission_action = physical_park_admission_action(&outcome),
+                "sandbox parked (balloon settled, vCPUs paused)"
+            );
+        }
+        PhysicalParkOutcome::Idle(_) => {
+            info!(
+                id = %log_id,
+                admission_action = physical_park_admission_action(&outcome),
+                "sandbox parked (vCPUs paused, balloon skipped)"
+            );
+        }
     }
     (events, Ok(outcome))
+}
+
+fn physical_park_admission_action(outcome: &PhysicalParkOutcome) -> &'static str {
+    match outcome {
+        PhysicalParkOutcome::Idle(outcome) => park_admission_action(outcome),
+        PhysicalParkOutcome::Handoff(_) => "exact_handoff",
+    }
+}
+
+async fn park_inner_with_guest<'observer>(
+    is_parked: &mut bool,
+    memory_mb: u32,
+    balloon_controller: &mut Option<balloon::ControllerHandle>,
+    api_sock: &std::path::Path,
+    log_id: &str,
+    guest: Arc<tokio::sync::Mutex<Option<Arc<VsockHost>>>>,
+    events: SandboxFinalExecParkSubstageEvents<'observer>,
+) -> (
+    SandboxFinalExecParkSubstageEvents<'observer>,
+    sandbox::Result<SandboxParkOutcome>,
+) {
+    let (events, result) = park_inner_with_guest_and_handoff(
+        is_parked,
+        memory_mb,
+        balloon_controller,
+        api_sock,
+        log_id,
+        PhysicalParkRequest {
+            guest,
+            handoff: None,
+        },
+        events,
+    )
+    .await;
+    let result = result.and_then(|outcome| match outcome {
+        PhysicalParkOutcome::Idle(outcome) => Ok(outcome),
+        PhysicalParkOutcome::Handoff(_) => Err(idle_transition_error(
+            SandboxIdleTransition::Park,
+            "provider accepted a handoff without a handoff signal",
+        )),
+    });
+    (events, result)
 }
 
 #[cfg(test)]

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -5133,6 +5133,132 @@ async fn park_pauses_when_balloon_stats_are_unavailable() {
 }
 
 #[tokio::test]
+async fn exact_handoff_skips_balloon_target_but_still_pauses() {
+    let mut api = MockLifecycleApi::new(std::collections::VecDeque::new(), None);
+    let mut controller = Some(test_balloon_controller());
+    let mut is_parked = false;
+    let mut observer = RecordingFinalExecParkObserver::default();
+    let handoff = SandboxFinalExecParkHandoff::new();
+    assert!(handoff.request());
+
+    let result = {
+        let (_events, result) = park_inner_with_guest_and_handoff(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            api.socket_path(),
+            "handoff-before-balloon",
+            PhysicalParkRequest {
+                guest: Arc::new(tokio::sync::Mutex::new(None)),
+                handoff: Some(&handoff),
+            },
+            SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
+        )
+        .await;
+        result
+    };
+
+    assert!(matches!(
+        result.unwrap(),
+        PhysicalParkOutcome::Handoff(SandboxFinalExecParkHandoffPoint::BeforeBalloon)
+    ));
+    assert!(is_parked);
+    assert!(controller.is_none());
+    assert_eq!(
+        observer.substage_records,
+        vec![
+            (
+                SandboxFinalExecParkSubstage::BalloonSetup,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::HandoffRequested),
+            ),
+            (
+                SandboxFinalExecParkSubstage::BalloonSettle,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+            ),
+            (SandboxFinalExecParkSubstage::VcpuPause, true, None),
+        ]
+    );
+    let requests = api.drain_requests();
+    let patches = patches(&requests);
+    assert_eq!(patches.len(), 1, "handoff should only pause the VM");
+    assert_eq!(patches[0].path, "/vm");
+}
+
+#[tokio::test]
+async fn exact_handoff_interrupts_in_flight_balloon_settle() {
+    let stats_entered = Arc::new(Notify::new());
+    let stats_release = Arc::new(Notify::new());
+    let mut api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([MockBalloonStatsReply::GatedOk {
+            entered: Arc::clone(&stats_entered),
+            release: Arc::clone(&stats_release),
+            stats: MockBalloonStats::new(1536, 0),
+        }]),
+    );
+    let mut controller = Some(test_balloon_controller());
+    let mut is_parked = false;
+    let mut observer = RecordingFinalExecParkObserver::default();
+    let handoff = SandboxFinalExecParkHandoff::new();
+    let result = {
+        let park = park_inner_with_guest_and_handoff(
+            &mut is_parked,
+            2048,
+            &mut controller,
+            api.socket_path(),
+            "handoff-during-balloon",
+            PhysicalParkRequest {
+                guest: Arc::new(tokio::sync::Mutex::new(None)),
+                handoff: Some(&handoff),
+            },
+            SandboxFinalExecParkSubstageEvents::new(Some(&mut observer)),
+        );
+        tokio::pin!(park);
+
+        tokio::select! {
+            () = stats_entered.notified() => {}
+            _ = park.as_mut() => panic!("park completed before balloon settle was interrupted"),
+        }
+        assert!(handoff.request());
+        let (_events, result) = tokio::time::timeout(Duration::from_secs(1), park.as_mut())
+            .await
+            .expect("handoff should wake the in-flight balloon request");
+        result
+    };
+    stats_release.notify_waiters();
+
+    assert!(matches!(
+        result.unwrap(),
+        PhysicalParkOutcome::Handoff(SandboxFinalExecParkHandoffPoint::DuringBalloonSettle)
+    ));
+    assert!(is_parked);
+    assert!(controller.is_none());
+    assert_eq!(
+        observer.substage_records,
+        vec![
+            (SandboxFinalExecParkSubstage::BalloonSetup, true, None),
+            (
+                SandboxFinalExecParkSubstage::BalloonSettle,
+                true,
+                Some(SandboxFinalExecParkSubstageOutcome::HandoffRequested),
+            ),
+            (SandboxFinalExecParkSubstage::VcpuPause, true, None),
+        ]
+    );
+    let requests = api.drain_requests();
+    let patches = patches(&requests);
+    assert_eq!(
+        patches.len(),
+        2,
+        "handoff should inflate once and then pause"
+    );
+    assert_eq!(patches[0].path, "/balloon");
+    assert_eq!(patches[1].path, "/vm");
+}
+
+#[tokio::test]
 async fn snapshot_restore_with_limiters_loads_paused_patches_then_resumes() {
     let mut api =
         MockLifecycleApi::new(std::collections::VecDeque::from(vec![204, 204, 204]), None);

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -86,6 +86,13 @@ pub(crate) struct LifecycleOverrideState {
     /// FIFO queue of park results consumed by every sandbox built with
     /// these overrides. Empty queue → default reusable outcome.
     pub(crate) park_behaviors: LifecycleBehaviors<SandboxParkOutcome>,
+    /// FIFO handoff points returned by `final_exec_and_park_for_handoff` when
+    /// an exact-successor request is pending. Empty queue preserves full park.
+    pub(crate) final_exec_park_handoff_points: Mutex<VecDeque<SandboxFinalExecParkHandoffPoint>>,
+    /// Completed handoff points returned across all sandboxes built with these
+    /// overrides.
+    pub(crate) completed_final_exec_park_handoff_points:
+        Mutex<Vec<SandboxFinalExecParkHandoffPoint>>,
     /// Optional gate that records and blocks every `park()` entry until released.
     pub(crate) park_gate: Mutex<Option<MockLifecycleGate>>,
     /// FIFO queue of unpark results consumed by every sandbox built with
@@ -626,6 +633,28 @@ impl MockSandboxOverrides {
     /// Used by runner tests to exercise panic-safe cleanup boundaries.
     pub fn push_park_panic(&self, message: impl Into<String>) {
         self.lifecycle.park_behaviors.push_panic(message);
+    }
+
+    /// Queue an interrupt point for the next handoff-aware final park.
+    ///
+    /// The point is returned only when a live exact-successor request can be
+    /// accepted after the final guest operation. Otherwise the mock completes
+    /// the ordinary park path.
+    pub fn push_final_exec_park_handoff_point(&self, point: SandboxFinalExecParkHandoffPoint) {
+        self.lifecycle
+            .final_exec_park_handoff_points
+            .lock_ignoring_poison()
+            .push_back(point);
+    }
+
+    /// Return handoff points successfully returned by handoff-aware final park.
+    pub fn completed_final_exec_park_handoff_points(
+        &self,
+    ) -> Vec<SandboxFinalExecParkHandoffPoint> {
+        self.lifecycle
+            .completed_final_exec_park_handoff_points
+            .lock_ignoring_poison()
+            .clone()
     }
 
     /// Block every `park()` call with a durable lifecycle gate.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -101,6 +101,115 @@ impl MockSandbox {
         self
     }
 
+    async fn final_exec_and_park_with_observer_and_handoff(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+        handoff: Option<(
+            &SandboxFinalExecParkHandoff,
+            SandboxFinalExecParkHandoffPoint,
+        )>,
+        observer: &mut dyn SandboxFinalExecParkObserver,
+    ) -> Result<SandboxFinalExecParkHandoffOutcome> {
+        let preparation_started = Instant::now();
+        let exec_result = match self
+            .exec_with_diagnostic_label(request, diagnostic_label)
+            .await
+        {
+            Ok(exec_result) => {
+                observer.record_stage(
+                    SandboxFinalExecParkStage::ReusePreparation,
+                    preparation_started.elapsed(),
+                    true,
+                );
+                exec_result
+            }
+            Err(error) => {
+                observer.record_stage(
+                    SandboxFinalExecParkStage::ReusePreparation,
+                    preparation_started.elapsed(),
+                    false,
+                );
+                return Err(error);
+            }
+        };
+        let handoff_point =
+            handoff.and_then(|(signal, point)| signal.accept_if_requested().then_some(point));
+        let physical_park_started = Instant::now();
+        observer.record_substage(
+            SandboxFinalExecParkSubstage::BalloonSetup,
+            Duration::ZERO,
+            true,
+            match handoff_point {
+                Some(SandboxFinalExecParkHandoffPoint::BeforeBalloon) => {
+                    Some(SandboxFinalExecParkSubstageOutcome::HandoffRequested)
+                }
+                Some(SandboxFinalExecParkHandoffPoint::DuringBalloonSettle) => None,
+                None => Some(SandboxFinalExecParkSubstageOutcome::Skipped),
+            },
+        );
+        observer.record_substage(
+            SandboxFinalExecParkSubstage::BalloonSettle,
+            Duration::ZERO,
+            true,
+            Some(match handoff_point {
+                Some(SandboxFinalExecParkHandoffPoint::DuringBalloonSettle) => {
+                    SandboxFinalExecParkSubstageOutcome::HandoffRequested
+                }
+                Some(SandboxFinalExecParkHandoffPoint::BeforeBalloon) | None => {
+                    SandboxFinalExecParkSubstageOutcome::Skipped
+                }
+            }),
+        );
+        let park_outcome = match self.park().await {
+            Ok(park_outcome) => {
+                observer.record_substage(
+                    SandboxFinalExecParkSubstage::VcpuPause,
+                    Duration::ZERO,
+                    true,
+                    None,
+                );
+                observer.record_stage(
+                    SandboxFinalExecParkStage::PhysicalPark,
+                    physical_park_started.elapsed(),
+                    true,
+                );
+                park_outcome
+            }
+            Err(error) => {
+                observer.record_substage(
+                    SandboxFinalExecParkSubstage::VcpuPause,
+                    Duration::ZERO,
+                    false,
+                    Some(SandboxFinalExecParkSubstageOutcome::Failed),
+                );
+                observer.record_stage(
+                    SandboxFinalExecParkStage::PhysicalPark,
+                    physical_park_started.elapsed(),
+                    false,
+                );
+                return Err(error);
+            }
+        };
+        if let Some(point) = handoff_point {
+            if let Some(overrides) = &self.overrides {
+                overrides
+                    .lifecycle
+                    .completed_final_exec_park_handoff_points
+                    .lock_ignoring_poison()
+                    .push(point);
+            }
+            Ok(SandboxFinalExecParkHandoffOutcome::Handoff { exec_result, point })
+        } else {
+            Ok(SandboxFinalExecParkHandoffOutcome::Parked(
+                SandboxFinalExecParkOutcome {
+                    exec_result,
+                    park_outcome,
+                },
+            ))
+        }
+    }
+
     /// Queue an exec result. Results are consumed in FIFO order.
     pub fn push_exec_result(&self, result: Result<ExecResult>) {
         self.exec_results.lock_ignoring_poison().push_back(result);
@@ -369,75 +478,46 @@ impl Sandbox for MockSandbox {
         diagnostic_label: &'static str,
         observer: &mut dyn SandboxFinalExecParkObserver,
     ) -> Result<SandboxFinalExecParkOutcome> {
-        let preparation_started = Instant::now();
-        let exec_result = match self
-            .exec_with_diagnostic_label(request, diagnostic_label)
-            .await
+        match self
+            .final_exec_and_park_with_observer_and_handoff(
+                request,
+                diagnostic_label,
+                None,
+                observer,
+            )
+            .await?
         {
-            Ok(exec_result) => {
-                observer.record_stage(
-                    SandboxFinalExecParkStage::ReusePreparation,
-                    preparation_started.elapsed(),
-                    true,
-                );
-                exec_result
+            SandboxFinalExecParkHandoffOutcome::Parked(outcome) => Ok(outcome),
+            SandboxFinalExecParkHandoffOutcome::Handoff { .. } => {
+                Err(SandboxError::IdleTransition {
+                    transition: SandboxIdleTransition::Park,
+                    message: "mock accepted a handoff without a handoff signal".into(),
+                })
             }
-            Err(error) => {
-                observer.record_stage(
-                    SandboxFinalExecParkStage::ReusePreparation,
-                    preparation_started.elapsed(),
-                    false,
-                );
-                return Err(error);
-            }
-        };
-        let physical_park_started = Instant::now();
-        observer.record_substage(
-            SandboxFinalExecParkSubstage::BalloonSetup,
-            Duration::ZERO,
-            true,
-            Some(SandboxFinalExecParkSubstageOutcome::Skipped),
-        );
-        observer.record_substage(
-            SandboxFinalExecParkSubstage::BalloonSettle,
-            Duration::ZERO,
-            true,
-            Some(SandboxFinalExecParkSubstageOutcome::Skipped),
-        );
-        let park_outcome = match self.park().await {
-            Ok(park_outcome) => {
-                observer.record_substage(
-                    SandboxFinalExecParkSubstage::VcpuPause,
-                    Duration::ZERO,
-                    true,
-                    None,
-                );
-                observer.record_stage(
-                    SandboxFinalExecParkStage::PhysicalPark,
-                    physical_park_started.elapsed(),
-                    true,
-                );
-                park_outcome
-            }
-            Err(error) => {
-                observer.record_substage(
-                    SandboxFinalExecParkSubstage::VcpuPause,
-                    Duration::ZERO,
-                    false,
-                    Some(SandboxFinalExecParkSubstageOutcome::Failed),
-                );
-                observer.record_stage(
-                    SandboxFinalExecParkStage::PhysicalPark,
-                    physical_park_started.elapsed(),
-                    false,
-                );
-                return Err(error);
-            }
-        };
-        Ok(SandboxFinalExecParkOutcome {
-            exec_result,
-            park_outcome,
-        })
+        }
+    }
+
+    async fn final_exec_and_park_for_handoff(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+        handoff: &SandboxFinalExecParkHandoff,
+        observer: &mut dyn SandboxFinalExecParkObserver,
+    ) -> Result<SandboxFinalExecParkHandoffOutcome> {
+        let point = self.overrides.as_ref().and_then(|overrides| {
+            overrides
+                .lifecycle
+                .final_exec_park_handoff_points
+                .lock_ignoring_poison()
+                .pop_front()
+        });
+        self.final_exec_and_park_with_observer_and_handoff(
+            request,
+            diagnostic_label,
+            point.map(|point| (handoff, point)),
+            observer,
+        )
+        .await
     }
 
     /// Mock unpark: counter + queued-result semantics mirror [`park`]

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -45,7 +45,8 @@ pub use factory::{
 };
 pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::{
-    GuestMemorySnapshot, Sandbox, SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome,
+    GuestMemorySnapshot, Sandbox, SandboxFinalExecParkHandoff, SandboxFinalExecParkHandoffOutcome,
+    SandboxFinalExecParkHandoffPoint, SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome,
     SandboxFinalExecParkStage, SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome,
     SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver, SandboxStartStage,
     SevereMemoryRetentionDiagnostics,

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -165,11 +165,13 @@ impl SandboxFinalExecParkHandoff {
     pub async fn wait_and_accept(&self) -> bool {
         loop {
             let changed = self.inner.changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
             match self.inner.state.load(Ordering::Acquire) {
                 HANDOFF_ACCEPTED => return true,
                 HANDOFF_REQUESTED => return self.accept_if_requested(),
                 HANDOFF_CANCELLED..=u8::MAX => return false,
-                HANDOFF_OPEN => changed.await,
+                HANDOFF_OPEN => changed.as_mut().await,
             }
         }
     }
@@ -178,10 +180,12 @@ impl SandboxFinalExecParkHandoff {
     pub async fn wait_for_acceptance(&self) -> bool {
         loop {
             let changed = self.inner.changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
             match self.inner.state.load(Ordering::Acquire) {
                 HANDOFF_ACCEPTED => return true,
                 HANDOFF_CANCELLED..=u8::MAX => return false,
-                HANDOFF_OPEN | HANDOFF_REQUESTED => changed.await,
+                HANDOFF_OPEN | HANDOFF_REQUESTED => changed.as_mut().await,
             }
         }
     }

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -135,6 +135,11 @@ impl SandboxFinalExecParkHandoff {
         }
     }
 
+    /// Return whether the provider has already accepted the one-shot request.
+    pub fn is_accepted(&self) -> bool {
+        self.inner.state.load(Ordering::Acquire) == HANDOFF_ACCEPTED
+    }
+
     /// Accept a pending request, or confirm that it was already accepted.
     pub fn accept_if_requested(&self) -> bool {
         loop {

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -1,8 +1,11 @@
 use std::any::Any;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use tokio::sync::Notify;
 
 use crate::error::{Result, SandboxError, SandboxIdleTransition};
 use crate::types::{
@@ -29,6 +32,165 @@ pub struct SandboxFinalExecParkOutcome {
     pub exec_result: ExecResult,
     /// Eligibility reported after the sandbox reached the parked state.
     pub park_outcome: SandboxParkOutcome,
+}
+
+/// Point where an exact successor shortened physical park preparation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxFinalExecParkHandoffPoint {
+    /// The request was accepted before submitting the park-time balloon target.
+    BeforeBalloon,
+    /// The request interrupted the bounded balloon-settle wait.
+    DuringBalloonSettle,
+}
+
+/// Completed final guest exec and physical park, optionally shortened for an
+/// already-claimed exact successor.
+pub enum SandboxFinalExecParkHandoffOutcome {
+    /// No handoff request interrupted provider compaction.
+    Parked(SandboxFinalExecParkOutcome),
+    /// The sandbox reached the paused boundary without completing idle memory
+    /// compaction and must be delivered only to the accepted exact successor.
+    Handoff {
+        /// Terminal result of the lifecycle-owned final guest exec.
+        exec_result: ExecResult,
+        /// Provider boundary where the request shortened physical park.
+        point: SandboxFinalExecParkHandoffPoint,
+    },
+}
+
+const HANDOFF_OPEN: u8 = 0;
+const HANDOFF_REQUESTED: u8 = 1;
+const HANDOFF_ACCEPTED: u8 = 2;
+const HANDOFF_CANCELLED: u8 = 3;
+
+struct SandboxFinalExecParkHandoffState {
+    state: AtomicU8,
+    changed: Notify,
+}
+
+/// Monotonic one-shot coordination between an exact successor and physical
+/// sandbox parking.
+///
+/// A lifecycle owner creates one signal for an active run. At most one exact
+/// successor may request it. The provider may accept that request before or
+/// during idle compaction; cancellation before acceptance permanently closes
+/// the signal so another successor cannot inherit the request.
+#[derive(Clone)]
+pub struct SandboxFinalExecParkHandoff {
+    inner: Arc<SandboxFinalExecParkHandoffState>,
+}
+
+impl SandboxFinalExecParkHandoff {
+    /// Create an unrequested one-shot handoff signal.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(SandboxFinalExecParkHandoffState {
+                state: AtomicU8::new(HANDOFF_OPEN),
+                changed: Notify::new(),
+            }),
+        }
+    }
+
+    /// Register the only exact-successor request.
+    pub fn request(&self) -> bool {
+        let requested = self
+            .inner
+            .state
+            .compare_exchange(
+                HANDOFF_OPEN,
+                HANDOFF_REQUESTED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok();
+        if requested {
+            self.inner.changed.notify_waiters();
+        }
+        requested
+    }
+
+    /// Permanently close the signal before the provider accepts a request.
+    pub fn cancel(&self) -> bool {
+        loop {
+            let state = self.inner.state.load(Ordering::Acquire);
+            match state {
+                HANDOFF_OPEN | HANDOFF_REQUESTED => {
+                    if self
+                        .inner
+                        .state
+                        .compare_exchange_weak(
+                            state,
+                            HANDOFF_CANCELLED,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        self.inner.changed.notify_waiters();
+                        return true;
+                    }
+                }
+                HANDOFF_ACCEPTED | HANDOFF_CANCELLED..=u8::MAX => return false,
+            }
+        }
+    }
+
+    /// Accept a pending request, or confirm that it was already accepted.
+    pub fn accept_if_requested(&self) -> bool {
+        loop {
+            match self.inner.state.load(Ordering::Acquire) {
+                HANDOFF_ACCEPTED => return true,
+                HANDOFF_REQUESTED => {
+                    if self
+                        .inner
+                        .state
+                        .compare_exchange_weak(
+                            HANDOFF_REQUESTED,
+                            HANDOFF_ACCEPTED,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        self.inner.changed.notify_waiters();
+                        return true;
+                    }
+                }
+                _ => return false,
+            }
+        }
+    }
+
+    /// Wait for a request and accept it, returning false if it was cancelled.
+    pub async fn wait_and_accept(&self) -> bool {
+        loop {
+            let changed = self.inner.changed.notified();
+            match self.inner.state.load(Ordering::Acquire) {
+                HANDOFF_ACCEPTED => return true,
+                HANDOFF_REQUESTED => return self.accept_if_requested(),
+                HANDOFF_CANCELLED..=u8::MAX => return false,
+                HANDOFF_OPEN => changed.await,
+            }
+        }
+    }
+
+    /// Wait until the provider accepts the request or the request is cancelled.
+    pub async fn wait_for_acceptance(&self) -> bool {
+        loop {
+            let changed = self.inner.changed.notified();
+            match self.inner.state.load(Ordering::Acquire) {
+                HANDOFF_ACCEPTED => return true,
+                HANDOFF_CANCELLED..=u8::MAX => return false,
+                HANDOFF_OPEN | HANDOFF_REQUESTED => changed.await,
+            }
+        }
+    }
+}
+
+impl Default for SandboxFinalExecParkHandoff {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Stable reason why a validly parked sandbox cannot be reused.
@@ -232,6 +394,8 @@ pub enum SandboxFinalExecParkSubstageOutcome {
     Deadline,
     /// Balloon statistics were unavailable and the existing policy proceeded.
     StatsUnavailable,
+    /// Exact-successor demand shortened idle-only memory compaction.
+    HandoffRequested,
     /// The provider operation failed.
     Failed,
 }
@@ -246,6 +410,7 @@ impl SandboxFinalExecParkSubstageOutcome {
             Self::PressureLimited => "pressure_limited",
             Self::Deadline => "deadline",
             Self::StatsUnavailable => "stats_unavailable",
+            Self::HandoffRequested => "handoff_requested",
             Self::Failed => "failed",
         }
     }
@@ -475,6 +640,24 @@ pub trait Sandbox: Send + Sync + Any {
         self.final_exec_and_park(request, diagnostic_label).await
     }
 
+    /// Run the final guest preparation and reach the paused park boundary while
+    /// allowing one already-claimed exact successor to shorten idle-only
+    /// provider compaction.
+    ///
+    /// The default implementation preserves provider compatibility by fully
+    /// parking and never accepting the handoff signal.
+    async fn final_exec_and_park_for_handoff(
+        &mut self,
+        request: &ExecRequest<'_>,
+        diagnostic_label: &'static str,
+        _handoff: &SandboxFinalExecParkHandoff,
+        observer: &mut dyn SandboxFinalExecParkObserver,
+    ) -> Result<SandboxFinalExecParkHandoffOutcome> {
+        self.final_exec_and_park_with_observer(request, diagnostic_label, observer)
+            .await
+            .map(SandboxFinalExecParkHandoffOutcome::Parked)
+    }
+
     /// Transition the sandbox back to the active state.
     ///
     /// Must be called before any further work is dispatched via `exec` /
@@ -630,4 +813,38 @@ pub trait Sandbox: Send + Sync + Any {
         handle: GuestProcessHandle,
         timeout: Duration,
     ) -> Result<ProcessExit>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SandboxFinalExecParkHandoff;
+
+    #[test]
+    fn final_exec_park_handoff_accepts_only_one_request() {
+        let handoff = SandboxFinalExecParkHandoff::new();
+
+        assert!(handoff.request());
+        assert!(!handoff.request());
+        assert!(handoff.accept_if_requested());
+        assert!(!handoff.cancel());
+    }
+
+    #[test]
+    fn final_exec_park_handoff_cancellation_closes_unaccepted_request() {
+        let handoff = SandboxFinalExecParkHandoff::new();
+
+        assert!(handoff.request());
+        assert!(handoff.cancel());
+        assert!(!handoff.accept_if_requested());
+        assert!(!handoff.request());
+    }
+
+    #[test]
+    fn final_exec_park_handoff_cancellation_closes_before_request() {
+        let handoff = SandboxFinalExecParkHandoff::new();
+
+        assert!(handoff.cancel());
+        assert!(!handoff.request());
+        assert!(!handoff.accept_if_requested());
+    }
 }


### PR DESCRIPTION
## Summary

- let a claimed exact successor request the sandbox that its predecessor is still finalizing
- interrupt Firecracker idle balloon compaction at safe boundaries, pause the VM, and transfer a typed candidate directly without publishing it to the generic idle pool
- preserve cancellation, panic cleanup, budget ownership, activation compatibility, fresh fallback, and bounded handoff telemetry
- give only the registered claimant a 1.5 second claim-relative acceptance grace, excluding queue and claim HTTP time

## Behavior

When an exact predecessor is still finalizing, the claimed successor now installs a one-shot handoff request. Firecracker may stop before ballooning or during balloon settling, but always reaches the paused boundary before ownership moves. Once accepted, the handoff is no longer constrained by the pre-accept deadline. Failed delivery or incompatible activation destroys the candidate and continues through the existing fresh-sandbox fallback. Cancellation destroys the candidate and completes the claimed run without spawning.

## Exclusions

- does not race an exact-reuse wait against fresh VM creation
- does not change generic idle-pool admission or eviction policy
- does not let under-compacted candidates enter the generic idle pool
- does not require non-Firecracker providers to implement interruptible parking; the additive default keeps their existing full-park behavior

## Validation

- `cargo test -p sandbox --all-features`
- `cargo test -p sandbox-fc --all-features`
- `cargo test -p runner --all-features`
- `cargo clippy -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p sandbox -p sandbox-fc -p runner --all-features --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #28038