### PR TITLE
test(api): measure pi preparation in preview

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -192,6 +192,7 @@ import { voiceIoSttRoutes } from "./routes/voice-io-stt";
 import { videoIoGenerateRoutes } from "./routes/video-io-generate";
 import { webDownloadRoutes } from "./routes/web-download";
 import { webFileUrlRoutes } from "./routes/web-file-url";
+// eslint-disable-next-line no-restricted-imports -- preview-only measurement PR; this route must not be merged
 import { testPiPreparationProbeRoutes } from "./routes/test-pi-preparation-probe";
 
 export const ROUTES: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -192,6 +192,7 @@ import { voiceIoSttRoutes } from "./routes/voice-io-stt";
 import { videoIoGenerateRoutes } from "./routes/video-io-generate";
 import { webDownloadRoutes } from "./routes/web-download";
 import { webFileUrlRoutes } from "./routes/web-file-url";
+import { testPiPreparationProbeRoutes } from "./routes/test-pi-preparation-probe";
 
 export const ROUTES: readonly RouteEntry[] = [
   ...healthRoutes,
@@ -386,5 +387,6 @@ export const ROUTES: readonly RouteEntry[] = [
   ...usageRecordRoutes,
   ...modelStatsRoutes,
   ...presentationImagesRoutes,
+  ...testPiPreparationProbeRoutes,
   ...runnersRoutes,
 ];

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-preparation-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-preparation-probe.test.ts
@@ -1,0 +1,41 @@
+import { testPiPreparationProbeContract } from "@okouai/api-contracts/contracts/test-pi-preparation-probe";
+import { describe, expect, it } from "vitest";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { testPiPreparationProbeRoutes } from "../test-pi-preparation-probe";
+
+const context = testContext();
+
+function client() {
+  return setupApp({ context, routes: testPiPreparationProbeRoutes })(
+    testPiPreparationProbeContract,
+  );
+}
+
+describe("Pi preparation probe", () => {
+  it("hydrates native resources and opens the official JSONL session", async () => {
+    mockEnv("ENV", "development");
+    const response = await accept(
+      client().run({
+        body: {
+          iterations: 1,
+          profile: "minimal",
+          rebuild_fixture: true,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.network_download_measured).toBeFalsy();
+    expect(response.body.samples).toHaveLength(1);
+    expect(response.body.samples[0]?.official).toMatchObject({
+      agents_file_count: 2,
+      diagnostic_count: 0,
+      discovered_skill_count: 4,
+      session_header_cwd: "/home/user/workspace",
+      session_persisted: true,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-preparation-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-preparation-probe.test.ts
@@ -21,6 +21,7 @@ describe("Pi preparation probe", () => {
       client().run({
         body: {
           iterations: 1,
+          mode: "filesystem",
           profile: "minimal",
           rebuild_fixture: true,
         },
@@ -29,6 +30,7 @@ describe("Pi preparation probe", () => {
     );
 
     expect(response.body.network_download_measured).toBeFalsy();
+    expect(response.body.mode).toBe("filesystem");
     expect(response.body.samples).toHaveLength(1);
     expect(response.body.samples[0]?.official).toMatchObject({
       agents_file_count: 2,
@@ -36,6 +38,38 @@ describe("Pi preparation probe", () => {
       discovered_skill_count: 4,
       session_header_cwd: "/home/user/workspace",
       session_persisted: true,
+    });
+  });
+
+  it("loads prewarmed Pi resources and native JSONL from memory", async () => {
+    mockEnv("ENV", "development");
+    const response = await accept(
+      client().run({
+        body: {
+          iterations: 1,
+          mode: "memory",
+          profile: "minimal",
+          rebuild_fixture: true,
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.mode).toBe("memory");
+    expect(response.body.samples).toHaveLength(1);
+    expect(response.body.samples[0]).toMatchObject({
+      archive_extract_ms: 0,
+      cleanup_ms: 0,
+      lease_create_ms: 0,
+      session_write_ms: 0,
+      official: {
+        agents_file_count: 2,
+        diagnostic_count: 0,
+        discovered_skill_count: 4,
+        session_header_cwd: "/home/user/workspace",
+        session_list_ms: 0,
+        session_persisted: false,
+      },
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/test-pi-preparation-probe.ts
+++ b/turbo/apps/api/src/signals/routes/test-pi-preparation-probe.ts
@@ -26,6 +26,7 @@ const runPiPreparationProbeRoute$ = command(
     const result = await runPiPreparationProbe(
       {
         iterations: bodyResult.data.iterations,
+        mode: bodyResult.data.mode,
         profile: bodyResult.data.profile,
         rebuildFixture: bodyResult.data.rebuild_fixture,
         region: optionalEnv("VERCEL_REGION") ?? null,

--- a/turbo/apps/api/src/signals/routes/test-pi-preparation-probe.ts
+++ b/turbo/apps/api/src/signals/routes/test-pi-preparation-probe.ts
@@ -1,0 +1,45 @@
+import { testPiPreparationProbeContract } from "@okouai/api-contracts/contracts/test-pi-preparation-probe";
+import { command } from "ccstate";
+
+import { optionalEnv } from "../../lib/env";
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { runPiPreparationProbe } from "../services/pi-preparation-probe.service";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-endpoint-helpers";
+
+const probeBody$ = bodyResultOf(testPiPreparationProbeContract.run);
+
+const runPiPreparationProbeRoute$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(probeBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    const result = await runPiPreparationProbe(
+      {
+        iterations: bodyResult.data.iterations,
+        profile: bodyResult.data.profile,
+        rebuildFixture: bodyResult.data.rebuild_fixture,
+        region: optionalEnv("VERCEL_REGION") ?? null,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    return { status: 200 as const, body: result };
+  },
+);
+
+export const testPiPreparationProbeRoutes: readonly RouteEntry[] = [
+  {
+    route: testPiPreparationProbeContract.run,
+    handler: runPiPreparationProbeRoute$,
+  },
+];

--- a/turbo/apps/api/src/signals/services/pi-preparation-probe.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-preparation-probe.service.ts
@@ -452,6 +452,7 @@ export async function runPiPreparationProbe(
       "Storage and R2 network download is excluded from timed preparation.",
       "The representative file counts and byte totals match the current installed skill tree, but file contents are synthetic.",
       "No model request, executable extension, or agent tool is invoked.",
+      "The probe initializes Pi's session resource registry through its core entrypoint before disposing a no-model AgentSession.",
     ],
     network_download_measured: false,
     profile: args.profile,

--- a/turbo/apps/api/src/signals/services/pi-preparation-probe.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-preparation-probe.service.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import type {
+  PiPreparationProbeMode,
   PiPreparationProbeProfile,
   PiPreparationProbeResponse,
 } from "@okouai/api-contracts/contracts/test-pi-preparation-probe";
@@ -22,7 +23,11 @@ import {
 } from "@okouai/api-contracts/contracts/runners";
 import {
   createPiNativeSessionFixture,
+  measurePiMemoryPreparation,
   measurePiOfficialPreparation,
+  type PiMemoryFileInput,
+  type PiMemoryResourceSnapshot,
+  type PiMemorySkillInput,
   type PiOfficialPreparationProbeResult,
 } from "@okouai/pi-agent-runtime/node";
 import { create as createTar, extract as extractTar } from "tar";
@@ -50,9 +55,22 @@ interface PreparedFixture {
   readonly archivePath: string;
   readonly buildMs: number;
   readonly config: ProbeProfileConfig;
+  readonly memoryFiles: readonly PiMemoryFileInput[];
+  readonly memoryResources: PiMemoryResourceSnapshot;
   readonly root: string;
   readonly sessionBytes: number;
+  readonly sessionContent: Buffer;
   readonly sessionPath: string;
+}
+
+interface PreparedMemorySkillTree {
+  readonly files: readonly PiMemoryFileInput[];
+  readonly skills: readonly PiMemorySkillInput[];
+}
+
+interface PreparedMemoryContext {
+  readonly agentsFiles: PiMemoryResourceSnapshot["agentsFiles"];
+  readonly files: readonly PiMemoryFileInput[];
 }
 
 interface FixtureResolution {
@@ -150,7 +168,7 @@ function relativePhysicalPath(canonicalPath: string): string {
 async function writeSkillTree(
   sourceRoot: string,
   config: ProbeProfileConfig,
-): Promise<void> {
+): Promise<PreparedMemorySkillTree> {
   const skillsRoot = join(
     sourceRoot,
     relativePhysicalPath(PI_AGENT_DIR),
@@ -158,54 +176,75 @@ async function writeSkillTree(
   );
   const assetFileCount = config.skillFileCount - config.skillCount;
   const assetBytes = config.skillTreeBytes - config.skillMdBytes;
+  const files: PiMemoryFileInput[] = [];
+  const skills: PiMemorySkillInput[] = [];
   const writes: Promise<void>[] = [];
   for (let index = 0; index < config.skillCount; index += 1) {
     const name = `probe-skill-${index.toString().padStart(3, "0")}`;
     const base = `---\nname: ${name}\ndescription: Synthetic preparation probe skill ${index}.\n---\n\n# ${name}\n\n`;
-    writes.push(
-      writeFixtureFile(
-        join(skillsRoot, name, "SKILL.md"),
-        paddedText(
-          base,
-          splitBytes(config.skillMdBytes, config.skillCount, index),
-        ),
-      ),
+    const content = paddedText(
+      base,
+      splitBytes(config.skillMdBytes, config.skillCount, index),
     );
+    const baseDir = join(PI_AGENT_DIR, "skills", name);
+    const filePath = join(baseDir, "SKILL.md");
+    files.push({ content, path: filePath });
+    skills.push({
+      baseDir,
+      description: `Synthetic preparation probe skill ${index}.`,
+      filePath,
+      name,
+      source: "prewarmed-probe",
+    });
+    writes.push(writeFixtureFile(join(skillsRoot, name, "SKILL.md"), content));
   }
   for (let index = 0; index < assetFileCount; index += 1) {
     const skillIndex = index % config.skillCount;
     const skillName = `probe-skill-${skillIndex.toString().padStart(3, "0")}`;
-    writes.push(
-      writeFixtureFile(
-        join(
-          skillsRoot,
-          skillName,
-          "references",
-          `asset-${index.toString().padStart(3, "0")}.bin`,
-        ),
-        deterministicBytes(
-          splitBytes(assetBytes, assetFileCount, index),
-          index,
-        ),
-      ),
+    const content = deterministicBytes(
+      splitBytes(assetBytes, assetFileCount, index),
+      index,
     );
+    const relativePath = join(
+      skillName,
+      "references",
+      `asset-${index.toString().padStart(3, "0")}.bin`,
+    );
+    files.push({
+      content,
+      path: join(PI_AGENT_DIR, "skills", relativePath),
+    });
+    writes.push(writeFixtureFile(join(skillsRoot, relativePath), content));
   }
   await Promise.all(writes);
+  return { files, skills };
 }
 
 async function writeContextAndMemory(
   sourceRoot: string,
   config: ProbeProfileConfig,
-): Promise<void> {
+): Promise<PreparedMemoryContext> {
   const globalAgentsBytes = Math.floor(config.agentsBytes / 2);
   const projectAgentsBytes = config.agentsBytes - globalAgentsBytes;
+  const globalAgents = paddedText(
+    "# Global preparation probe instructions\n\n",
+    globalAgentsBytes,
+  );
+  const projectAgents = paddedText(
+    "# Project preparation probe instructions\n\n",
+    projectAgentsBytes,
+  );
+  const memory = paddedText(
+    "# Preparation probe memory\n\n",
+    config.memoryBytes,
+  );
+  const globalAgentsPath = join(PI_AGENT_DIR, "AGENTS.md");
+  const projectAgentsPath = join(CANONICAL_WORKING_DIR, "AGENTS.md");
+  const memoryPath = join(PI_AGENT_DIR, "memory", "MEMORY.md");
   await Promise.all([
     writeFixtureFile(
       join(sourceRoot, relativePhysicalPath(PI_AGENT_DIR), "AGENTS.md"),
-      paddedText(
-        "# Global preparation probe instructions\n\n",
-        globalAgentsBytes,
-      ),
+      globalAgents,
     ),
     writeFixtureFile(
       join(
@@ -213,10 +252,7 @@ async function writeContextAndMemory(
         relativePhysicalPath(CANONICAL_WORKING_DIR),
         "AGENTS.md",
       ),
-      paddedText(
-        "# Project preparation probe instructions\n\n",
-        projectAgentsBytes,
-      ),
+      projectAgents,
     ),
     writeFixtureFile(
       join(
@@ -225,9 +261,20 @@ async function writeContextAndMemory(
         "memory",
         "MEMORY.md",
       ),
-      paddedText("# Preparation probe memory\n\n", config.memoryBytes),
+      memory,
     ),
   ]);
+  return {
+    agentsFiles: [
+      { content: globalAgents.toString("utf8"), path: globalAgentsPath },
+      { content: projectAgents.toString("utf8"), path: projectAgentsPath },
+    ],
+    files: [
+      { content: globalAgents, path: globalAgentsPath },
+      { content: projectAgents, path: projectAgentsPath },
+      { content: memory, path: memoryPath },
+    ],
+  };
 }
 
 async function buildFixture(
@@ -237,7 +284,7 @@ async function buildFixture(
   const config = profileConfig(profile);
   const root = await mkdtemp(join(tmpdir(), `pi-prep-fixture-${profile}-`));
   const sourceRoot = join(root, "source");
-  await Promise.all([
+  const [memorySkillTree, memoryContext] = await Promise.all([
     writeSkillTree(sourceRoot, config),
     writeContextAndMemory(sourceRoot, config),
   ]);
@@ -271,8 +318,14 @@ async function buildFixture(
     archivePath,
     buildMs: performance.now() - startedAt,
     config,
+    memoryFiles: [...memorySkillTree.files, ...memoryContext.files],
+    memoryResources: {
+      agentsFiles: memoryContext.agentsFiles,
+      skills: memorySkillTree.skills,
+    },
     root,
     sessionBytes: sessionStats.size,
+    sessionContent: sessionFixture,
     sessionPath,
   };
 }
@@ -325,7 +378,7 @@ function currentRss(): number {
   return process.memoryUsage().rss;
 }
 
-async function runPreparationSample(
+async function runFilesystemPreparationSample(
   fixture: PreparedFixture,
   signal: AbortSignal,
 ): Promise<PiPreparationProbeResponse["samples"][number]> {
@@ -404,9 +457,57 @@ async function runPreparationSample(
   });
 }
 
+async function runMemoryPreparationSample(
+  fixture: PreparedFixture,
+  signal: AbortSignal,
+): Promise<PiPreparationProbeResponse["samples"][number]> {
+  const totalStartedAt = performance.now();
+  let peakRss = currentRss();
+  const updatePeakRss = () => {
+    peakRss = Math.max(peakRss, currentRss());
+  };
+
+  signal.throwIfAborted();
+  const measured = await measurePiMemoryPreparation({
+    agentDir: PI_AGENT_DIR,
+    cwd: CANONICAL_WORKING_DIR,
+    files: fixture.memoryFiles,
+    logicalCwd: CANONICAL_WORKING_DIR,
+    resources: fixture.memoryResources,
+    sessionId: PROBE_SESSION_ID,
+    sessionJsonl: fixture.sessionContent,
+  });
+  updatePeakRss();
+  signal.throwIfAborted();
+
+  return {
+    archive_extract_ms: 0,
+    checkpoint_bytes: measured.checkpoint.length,
+    checkpoint_read_ms: measured.checkpointMaterializeMs,
+    cleanup_ms: 0,
+    lease_create_ms: 0,
+    official: officialResponse(measured.official),
+    peak_rss_bytes: peakRss,
+    preparation_ms: measured.preparationMs,
+    session_write_ms: 0,
+    total_ms: performance.now() - totalStartedAt,
+  };
+}
+
+async function runPreparationSample(
+  fixture: PreparedFixture,
+  mode: PiPreparationProbeMode,
+  signal: AbortSignal,
+): Promise<PiPreparationProbeResponse["samples"][number]> {
+  return mode === "memory"
+    ? await runMemoryPreparationSample(fixture, signal)
+    : await runFilesystemPreparationSample(fixture, signal);
+}
+
 export async function runPiPreparationProbe(
   args: {
     readonly iterations: number;
+    readonly mode: PiPreparationProbeMode;
     readonly profile: PiPreparationProbeProfile;
     readonly rebuildFixture: boolean;
     readonly region: string | null;
@@ -421,7 +522,9 @@ export async function runPiPreparationProbe(
     const samples: PiPreparationProbeResponse["samples"] = [];
     for (let index = 0; index < args.iterations; index += 1) {
       signal.throwIfAborted();
-      samples.push(await runPreparationSample(resolution.fixture, signal));
+      samples.push(
+        await runPreparationSample(resolution.fixture, args.mode, signal),
+      );
     }
     return samples;
   })();
@@ -448,12 +551,21 @@ export async function runPiPreparationProbe(
       skill_md_bytes: config.skillMdBytes,
       skill_tree_bytes: config.skillTreeBytes,
     },
-    measurement_limits: [
-      "Storage and R2 network download is excluded from timed preparation.",
-      "The representative file counts and byte totals match the current installed skill tree, but file contents are synthetic.",
-      "No model request, executable extension, or agent tool is invoked.",
-      "The probe initializes Pi's session resource registry through its core entrypoint before disposing a no-model AgentSession.",
-    ],
+    measurement_limits:
+      args.mode === "memory"
+        ? [
+            "Storage, database, and R2 network reads are excluded; the timed path starts with a prewarmed resource snapshot and native JSONL bytes already in process memory.",
+            "The representative file counts and byte totals match the current installed skill tree, but file contents are synthetic.",
+            "Pi 0.84.1 has no public fromJSONL/fromEntries in-memory SessionManager factory, so this preview-only probe hydrates the same internal preloaded entry state used by SessionManager.open.",
+            "No model request, executable extension, or agent tool is invoked; the memory read tool is registered and Pi projects its logical skill paths into the native system prompt.",
+          ]
+        : [
+            "Storage and R2 network download is excluded from timed preparation.",
+            "The representative file counts and byte totals match the current installed skill tree, but file contents are synthetic.",
+            "No model request, executable extension, or agent tool is invoked.",
+            "The probe initializes Pi's session resource registry through its core entrypoint before disposing a no-model AgentSession.",
+          ],
+    mode: args.mode,
     network_download_measured: false,
     profile: args.profile,
     runtime: {

--- a/turbo/apps/api/src/signals/services/pi-preparation-probe.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-preparation-probe.service.ts
@@ -1,0 +1,471 @@
+import { randomUUID } from "node:crypto";
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import type {
+  PiPreparationProbeProfile,
+  PiPreparationProbeResponse,
+} from "@okouai/api-contracts/contracts/test-pi-preparation-probe";
+import {
+  CANONICAL_PI_SESSION_DIR,
+  CANONICAL_WORKING_DIR,
+  PI_AGENT_DIR,
+} from "@okouai/api-contracts/contracts/runners";
+import {
+  createPiNativeSessionFixture,
+  measurePiOfficialPreparation,
+  type PiOfficialPreparationProbeResult,
+} from "@okouai/pi-agent-runtime/node";
+import { create as createTar, extract as extractTar } from "tar";
+
+import { singleton } from "../../lib/singleton";
+import { onRejection } from "../utils";
+
+const REPRESENTATIVE_SKILL_COUNT = 125;
+const REPRESENTATIVE_SKILL_FILE_COUNT = 206;
+const REPRESENTATIVE_SKILL_MD_BYTES = 1_160_041;
+const REPRESENTATIVE_SKILL_TREE_BYTES = 2_497_082;
+const PROBE_SESSION_ID = "9e7abfc3-e40e-4ae5-87ce-16b45c9f7860";
+interface ProbeProfileConfig {
+  readonly agentsBytes: number;
+  readonly memoryBytes: number;
+  readonly sessionTargetBytes: number;
+  readonly skillCount: number;
+  readonly skillFileCount: number;
+  readonly skillMdBytes: number;
+  readonly skillTreeBytes: number;
+}
+
+interface PreparedFixture {
+  readonly archiveBytes: number;
+  readonly archivePath: string;
+  readonly buildMs: number;
+  readonly config: ProbeProfileConfig;
+  readonly root: string;
+  readonly sessionBytes: number;
+  readonly sessionPath: string;
+}
+
+interface FixtureResolution {
+  readonly cacheHit: boolean;
+  readonly disposable: boolean;
+  readonly fixture: PreparedFixture;
+}
+
+interface ProbeInstanceState {
+  readonly fixtureCache: Map<
+    PiPreparationProbeProfile,
+    Promise<PreparedFixture>
+  >;
+  readonly instanceId: string;
+}
+
+const probeInstanceState = singleton((): ProbeInstanceState => {
+  return {
+    fixtureCache: new Map(),
+    instanceId: randomUUID(),
+  };
+});
+
+function profileConfig(profile: PiPreparationProbeProfile): ProbeProfileConfig {
+  const representative = {
+    agentsBytes: 64 * 1024,
+    memoryBytes: 256 * 1024,
+    sessionTargetBytes: 4 * 1024 * 1024,
+    skillCount: REPRESENTATIVE_SKILL_COUNT,
+    skillFileCount: REPRESENTATIVE_SKILL_FILE_COUNT,
+    skillMdBytes: REPRESENTATIVE_SKILL_MD_BYTES,
+    skillTreeBytes: REPRESENTATIVE_SKILL_TREE_BYTES,
+  } satisfies ProbeProfileConfig;
+  switch (profile) {
+    case "minimal": {
+      return {
+        agentsBytes: 16 * 1024,
+        memoryBytes: 32 * 1024,
+        sessionTargetBytes: 64 * 1024,
+        skillCount: 4,
+        skillFileCount: 8,
+        skillMdBytes: 32 * 1024,
+        skillTreeBytes: 128 * 1024,
+      };
+    }
+    case "representative": {
+      return representative;
+    }
+    case "session-16-mib": {
+      return { ...representative, sessionTargetBytes: 16 * 1024 * 1024 };
+    }
+    case "session-64-mib": {
+      return { ...representative, sessionTargetBytes: 64 * 1024 * 1024 };
+    }
+    case "assets-32-mib": {
+      return { ...representative, skillTreeBytes: 32 * 1024 * 1024 };
+    }
+  }
+}
+
+function splitBytes(total: number, count: number, index: number): number {
+  const base = Math.floor(total / count);
+  return base + (index < total % count ? 1 : 0);
+}
+
+function paddedText(base: string, targetBytes: number): Buffer {
+  const baseBytes = Buffer.byteLength(base);
+  if (baseBytes > targetBytes) {
+    throw new Error("Pi preparation probe text target is too small");
+  }
+  return Buffer.from(`${base}${"p".repeat(targetBytes - baseBytes)}`);
+}
+
+function deterministicBytes(length: number, seed: number): Buffer {
+  const buffer = Buffer.allocUnsafe(length);
+  let state = (seed + 1) * 2_654_435_761;
+  for (let index = 0; index < length; index += 1) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    buffer[index] = state & 0xff;
+  }
+  return buffer;
+}
+
+async function writeFixtureFile(path: string, content: Buffer): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content);
+}
+
+function relativePhysicalPath(canonicalPath: string): string {
+  return canonicalPath.replace(/^\//u, "");
+}
+
+async function writeSkillTree(
+  sourceRoot: string,
+  config: ProbeProfileConfig,
+): Promise<void> {
+  const skillsRoot = join(
+    sourceRoot,
+    relativePhysicalPath(PI_AGENT_DIR),
+    "skills",
+  );
+  const assetFileCount = config.skillFileCount - config.skillCount;
+  const assetBytes = config.skillTreeBytes - config.skillMdBytes;
+  const writes: Promise<void>[] = [];
+  for (let index = 0; index < config.skillCount; index += 1) {
+    const name = `probe-skill-${index.toString().padStart(3, "0")}`;
+    const base = `---\nname: ${name}\ndescription: Synthetic preparation probe skill ${index}.\n---\n\n# ${name}\n\n`;
+    writes.push(
+      writeFixtureFile(
+        join(skillsRoot, name, "SKILL.md"),
+        paddedText(
+          base,
+          splitBytes(config.skillMdBytes, config.skillCount, index),
+        ),
+      ),
+    );
+  }
+  for (let index = 0; index < assetFileCount; index += 1) {
+    const skillIndex = index % config.skillCount;
+    const skillName = `probe-skill-${skillIndex.toString().padStart(3, "0")}`;
+    writes.push(
+      writeFixtureFile(
+        join(
+          skillsRoot,
+          skillName,
+          "references",
+          `asset-${index.toString().padStart(3, "0")}.bin`,
+        ),
+        deterministicBytes(
+          splitBytes(assetBytes, assetFileCount, index),
+          index,
+        ),
+      ),
+    );
+  }
+  await Promise.all(writes);
+}
+
+async function writeContextAndMemory(
+  sourceRoot: string,
+  config: ProbeProfileConfig,
+): Promise<void> {
+  const globalAgentsBytes = Math.floor(config.agentsBytes / 2);
+  const projectAgentsBytes = config.agentsBytes - globalAgentsBytes;
+  await Promise.all([
+    writeFixtureFile(
+      join(sourceRoot, relativePhysicalPath(PI_AGENT_DIR), "AGENTS.md"),
+      paddedText(
+        "# Global preparation probe instructions\n\n",
+        globalAgentsBytes,
+      ),
+    ),
+    writeFixtureFile(
+      join(
+        sourceRoot,
+        relativePhysicalPath(CANONICAL_WORKING_DIR),
+        "AGENTS.md",
+      ),
+      paddedText(
+        "# Project preparation probe instructions\n\n",
+        projectAgentsBytes,
+      ),
+    ),
+    writeFixtureFile(
+      join(
+        sourceRoot,
+        relativePhysicalPath(PI_AGENT_DIR),
+        "memory",
+        "MEMORY.md",
+      ),
+      paddedText("# Preparation probe memory\n\n", config.memoryBytes),
+    ),
+  ]);
+}
+
+async function buildFixture(
+  profile: PiPreparationProbeProfile,
+): Promise<PreparedFixture> {
+  const startedAt = performance.now();
+  const config = profileConfig(profile);
+  const root = await mkdtemp(join(tmpdir(), `pi-prep-fixture-${profile}-`));
+  const sourceRoot = join(root, "source");
+  await Promise.all([
+    writeSkillTree(sourceRoot, config),
+    writeContextAndMemory(sourceRoot, config),
+  ]);
+
+  const archivePath = join(root, "resources.tar.gz");
+  await createTar(
+    {
+      cwd: sourceRoot,
+      file: archivePath,
+      gzip: true,
+      mtime: new Date(0),
+      portable: true,
+    },
+    ["home"],
+  );
+  await rm(sourceRoot, { force: true, recursive: true });
+
+  const sessionPath = join(root, "session.jsonl");
+  const sessionFixture = createPiNativeSessionFixture({
+    logicalCwd: CANONICAL_WORKING_DIR,
+    sessionId: PROBE_SESSION_ID,
+    targetBytes: config.sessionTargetBytes,
+  });
+  await writeFile(sessionPath, sessionFixture);
+  const [archiveStats, sessionStats] = await Promise.all([
+    stat(archivePath),
+    stat(sessionPath),
+  ]);
+  return {
+    archiveBytes: archiveStats.size,
+    archivePath,
+    buildMs: performance.now() - startedAt,
+    config,
+    root,
+    sessionBytes: sessionStats.size,
+    sessionPath,
+  };
+}
+
+async function resolveFixture(
+  profile: PiPreparationProbeProfile,
+  rebuild: boolean,
+): Promise<FixtureResolution> {
+  if (rebuild) {
+    return {
+      cacheHit: false,
+      disposable: true,
+      fixture: await buildFixture(profile),
+    };
+  }
+  const cache = probeInstanceState().fixtureCache;
+  const cached = cache.get(profile);
+  if (cached) {
+    return { cacheHit: true, disposable: false, fixture: await cached };
+  }
+  const pending = buildFixture(profile);
+  cache.set(profile, pending);
+  const fixture = await onRejection(pending, () => {
+    cache.delete(profile);
+  });
+  return { cacheHit: false, disposable: false, fixture };
+}
+
+function officialResponse(
+  result: PiOfficialPreparationProbeResult,
+): PiPreparationProbeResponse["samples"][number]["official"] {
+  return {
+    agent_session_create_ms: result.agentSessionCreateMs,
+    agents_file_count: result.agentsFileCount,
+    diagnostic_count: result.diagnosticCount,
+    discovered_skill_count: result.discoveredSkillCount,
+    model_runtime_create_ms: result.modelRuntimeCreateMs,
+    session_entry_count: result.sessionEntryCount,
+    session_header_cwd: result.sessionHeaderCwd,
+    session_list_ms: result.sessionListMs,
+    session_open_ms: result.sessionOpenMs,
+    session_persisted: result.sessionPersisted,
+    session_services_create_ms: result.sessionServicesCreateMs,
+    settings_manager_create_ms: result.settingsManagerCreateMs,
+    total_ms: result.totalMs,
+  };
+}
+
+function currentRss(): number {
+  return process.memoryUsage().rss;
+}
+
+async function runPreparationSample(
+  fixture: PreparedFixture,
+  signal: AbortSignal,
+): Promise<PiPreparationProbeResponse["samples"][number]> {
+  const totalStartedAt = performance.now();
+  let peakRss = currentRss();
+  const updatePeakRss = () => {
+    peakRss = Math.max(peakRss, currentRss());
+  };
+
+  const leaseStartedAt = performance.now();
+  const leaseRoot = await mkdtemp(join(tmpdir(), "pi-prep-run-"));
+  const leaseCreateMs = performance.now() - leaseStartedAt;
+
+  const sample = (async () => {
+    const archiveExtractStartedAt = performance.now();
+    await extractTar({
+      cwd: leaseRoot,
+      file: fixture.archivePath,
+      strict: true,
+    });
+    const archiveExtractMs = performance.now() - archiveExtractStartedAt;
+    updatePeakRss();
+    signal.throwIfAborted();
+
+    const agentDir = join(leaseRoot, relativePhysicalPath(PI_AGENT_DIR));
+    const cwd = join(leaseRoot, relativePhysicalPath(CANONICAL_WORKING_DIR));
+    const sessionDir = join(
+      leaseRoot,
+      relativePhysicalPath(CANONICAL_PI_SESSION_DIR),
+    );
+    await mkdir(sessionDir, { recursive: true });
+    const restoredSessionPath = join(
+      sessionDir,
+      `2026-08-19T00-00-00-000Z_${PROBE_SESSION_ID}.jsonl`,
+    );
+    const sessionWriteStartedAt = performance.now();
+    await copyFile(fixture.sessionPath, restoredSessionPath);
+    const sessionWriteMs = performance.now() - sessionWriteStartedAt;
+    updatePeakRss();
+    signal.throwIfAborted();
+
+    const official = await measurePiOfficialPreparation({
+      agentDir,
+      cwd,
+      logicalCwd: CANONICAL_WORKING_DIR,
+      sessionDir,
+      sessionId: PROBE_SESSION_ID,
+    });
+    updatePeakRss();
+    signal.throwIfAborted();
+    const preparationMs = performance.now() - totalStartedAt;
+
+    const checkpointReadStartedAt = performance.now();
+    const checkpoint = await readFile(restoredSessionPath);
+    const checkpointReadMs = performance.now() - checkpointReadStartedAt;
+    updatePeakRss();
+
+    const cleanupStartedAt = performance.now();
+    await rm(leaseRoot, { force: true, recursive: true });
+    const cleanupMs = performance.now() - cleanupStartedAt;
+    return {
+      archive_extract_ms: archiveExtractMs,
+      checkpoint_bytes: checkpoint.length,
+      checkpoint_read_ms: checkpointReadMs,
+      cleanup_ms: cleanupMs,
+      lease_create_ms: leaseCreateMs,
+      official: officialResponse(official),
+      peak_rss_bytes: peakRss,
+      preparation_ms: preparationMs,
+      session_write_ms: sessionWriteMs,
+      total_ms: performance.now() - totalStartedAt,
+    };
+  })();
+  return await onRejection(sample, async () => {
+    await rm(leaseRoot, { force: true, recursive: true });
+  });
+}
+
+export async function runPiPreparationProbe(
+  args: {
+    readonly iterations: number;
+    readonly profile: PiPreparationProbeProfile;
+    readonly rebuildFixture: boolean;
+    readonly region: string | null;
+  },
+  signal: AbortSignal,
+): Promise<PiPreparationProbeResponse> {
+  const rssBytesBefore = currentRss();
+  const resolution = await resolveFixture(args.profile, args.rebuildFixture);
+  const execution = (async (): Promise<
+    PiPreparationProbeResponse["samples"]
+  > => {
+    const samples: PiPreparationProbeResponse["samples"] = [];
+    for (let index = 0; index < args.iterations; index += 1) {
+      signal.throwIfAborted();
+      samples.push(await runPreparationSample(resolution.fixture, signal));
+    }
+    return samples;
+  })();
+  const samples = await onRejection(execution, async () => {
+    if (resolution.disposable) {
+      await rm(resolution.fixture.root, { force: true, recursive: true });
+    }
+  });
+  if (resolution.disposable) {
+    await rm(resolution.fixture.root, { force: true, recursive: true });
+  }
+  const config = resolution.fixture.config;
+  return {
+    ok: true,
+    fixture: {
+      agents_bytes: config.agentsBytes,
+      archive_bytes: resolution.fixture.archiveBytes,
+      build_ms: resolution.fixture.buildMs,
+      cache_hit: resolution.cacheHit,
+      expected_skill_count: config.skillCount,
+      memory_bytes: config.memoryBytes,
+      session_bytes: resolution.fixture.sessionBytes,
+      skill_file_count: config.skillFileCount,
+      skill_md_bytes: config.skillMdBytes,
+      skill_tree_bytes: config.skillTreeBytes,
+    },
+    measurement_limits: [
+      "Storage and R2 network download is excluded from timed preparation.",
+      "The representative file counts and byte totals match the current installed skill tree, but file contents are synthetic.",
+      "No model request, executable extension, or agent tool is invoked.",
+    ],
+    network_download_measured: false,
+    profile: args.profile,
+    runtime: {
+      arch: process.arch,
+      instance_id: probeInstanceState().instanceId,
+      node_version: process.version,
+      platform: process.platform,
+      process_uptime_ms: process.uptime() * 1000,
+      region: args.region,
+      rss_bytes_after: currentRss(),
+      rss_bytes_before: rssBytesBefore,
+      tmp_dir: tmpdir(),
+    },
+    samples,
+  };
+}

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -402,6 +402,14 @@ export {
   type TestChatEventRetentionContract,
 } from "./test-chat-event-retention";
 export {
+  piPreparationProbeProfileSchema,
+  piPreparationProbeResponseSchema,
+  testPiPreparationProbeContract,
+  type PiPreparationProbeProfile,
+  type PiPreparationProbeResponse,
+  type TestPiPreparationProbeContract,
+} from "./test-pi-preparation-probe";
+export {
   testSlackStateContract,
   testSlackStateErrorSchema,
   testSlackStateResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-pi-preparation-probe.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-pi-preparation-probe.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const piPreparationProbeProfileSchema = z.enum([
+  "minimal",
+  "representative",
+  "session-16-mib",
+  "session-64-mib",
+  "assets-32-mib",
+]);
+
+const durationSchema = z.number().nonnegative();
+
+const officialPreparationSchema = z.object({
+  agent_session_create_ms: durationSchema,
+  agents_file_count: z.int().nonnegative(),
+  diagnostic_count: z.int().nonnegative(),
+  discovered_skill_count: z.int().nonnegative(),
+  model_runtime_create_ms: durationSchema,
+  session_entry_count: z.int().nonnegative(),
+  session_header_cwd: z.string().nullable(),
+  session_list_ms: durationSchema,
+  session_open_ms: durationSchema,
+  session_persisted: z.boolean(),
+  session_services_create_ms: durationSchema,
+  settings_manager_create_ms: durationSchema,
+  total_ms: durationSchema,
+});
+
+export const piPreparationProbeResponseSchema = z.object({
+  ok: z.literal(true),
+  fixture: z.object({
+    agents_bytes: z.int().positive(),
+    archive_bytes: z.int().positive(),
+    build_ms: durationSchema,
+    cache_hit: z.boolean(),
+    expected_skill_count: z.int().positive(),
+    memory_bytes: z.int().nonnegative(),
+    session_bytes: z.int().positive(),
+    skill_file_count: z.int().positive(),
+    skill_md_bytes: z.int().positive(),
+    skill_tree_bytes: z.int().positive(),
+  }),
+  measurement_limits: z.array(z.string()),
+  network_download_measured: z.literal(false),
+  profile: piPreparationProbeProfileSchema,
+  runtime: z.object({
+    arch: z.string(),
+    instance_id: z.uuid(),
+    node_version: z.string(),
+    platform: z.string(),
+    process_uptime_ms: durationSchema,
+    region: z.string().nullable(),
+    rss_bytes_after: z.int().positive(),
+    rss_bytes_before: z.int().positive(),
+    tmp_dir: z.string(),
+  }),
+  samples: z.array(
+    z.object({
+      archive_extract_ms: durationSchema,
+      checkpoint_bytes: z.int().positive(),
+      checkpoint_read_ms: durationSchema,
+      cleanup_ms: durationSchema,
+      lease_create_ms: durationSchema,
+      official: officialPreparationSchema,
+      peak_rss_bytes: z.int().positive(),
+      preparation_ms: durationSchema,
+      session_write_ms: durationSchema,
+      total_ms: durationSchema,
+    }),
+  ),
+});
+
+export const testPiPreparationProbeContract = c.router({
+  run: {
+    method: "POST",
+    path: "/api/test/pi-preparation-probe",
+    body: z.object({
+      profile: piPreparationProbeProfileSchema,
+      iterations: z.int().min(1).max(5).default(1),
+      rebuild_fixture: z.boolean().default(false),
+    }),
+    responses: {
+      200: piPreparationProbeResponseSchema,
+      404: z.string(),
+    },
+    summary: "Measure native Pi filesystem preparation in preview",
+  },
+});
+
+export type PiPreparationProbeProfile = z.infer<
+  typeof piPreparationProbeProfileSchema
+>;
+export type PiPreparationProbeResponse = z.infer<
+  typeof piPreparationProbeResponseSchema
+>;
+export type TestPiPreparationProbeContract =
+  typeof testPiPreparationProbeContract;

--- a/turbo/packages/api-contracts/src/contracts/test-pi-preparation-probe.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-pi-preparation-probe.ts
@@ -12,6 +12,8 @@ export const piPreparationProbeProfileSchema = z.enum([
   "assets-32-mib",
 ]);
 
+export const piPreparationProbeModeSchema = z.enum(["filesystem", "memory"]);
+
 const durationSchema = z.number().nonnegative();
 
 const officialPreparationSchema = z.object({
@@ -34,7 +36,7 @@ export const piPreparationProbeResponseSchema = z.object({
   ok: z.literal(true),
   fixture: z.object({
     agents_bytes: z.int().positive(),
-    archive_bytes: z.int().positive(),
+    archive_bytes: z.int().nonnegative(),
     build_ms: durationSchema,
     cache_hit: z.boolean(),
     expected_skill_count: z.int().positive(),
@@ -45,6 +47,7 @@ export const piPreparationProbeResponseSchema = z.object({
     skill_tree_bytes: z.int().positive(),
   }),
   measurement_limits: z.array(z.string()),
+  mode: piPreparationProbeModeSchema,
   network_download_measured: z.literal(false),
   profile: piPreparationProbeProfileSchema,
   runtime: z.object({
@@ -80,6 +83,7 @@ export const testPiPreparationProbeContract = c.router({
     path: "/api/test/pi-preparation-probe",
     body: z.object({
       profile: piPreparationProbeProfileSchema,
+      mode: piPreparationProbeModeSchema.default("filesystem"),
       iterations: z.int().min(1).max(5).default(1),
       rebuild_fixture: z.boolean().default(false),
     }),
@@ -87,9 +91,13 @@ export const testPiPreparationProbeContract = c.router({
       200: piPreparationProbeResponseSchema,
       404: z.string(),
     },
-    summary: "Measure native Pi filesystem preparation in preview",
+    summary: "Measure native Pi filesystem or memory preparation in preview",
   },
 });
+
+export type PiPreparationProbeMode = z.infer<
+  typeof piPreparationProbeModeSchema
+>;
 
 export type PiPreparationProbeProfile = z.infer<
   typeof piPreparationProbeProfileSchema

--- a/turbo/packages/pi-agent-runtime/src/memory-resource-loader.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/memory-resource-loader.test.ts
@@ -1,0 +1,101 @@
+import { createReadTool } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+
+import {
+  PiMemoryFileStore,
+  PiMemoryResourceLoader,
+} from "./memory-resource-loader";
+import {
+  createPiNativeSessionFixture,
+  measurePiMemoryPreparation,
+} from "./preparation-probe";
+
+describe("Pi memory resource loader", () => {
+  it("projects native resources and serves skill bodies from logical paths", async () => {
+    const skillPath = "/virtual/agent/skills/probe/SKILL.md";
+    const fileStore = new PiMemoryFileStore([
+      {
+        content: Buffer.from("# Probe\n\nMEMORY_SKILL_BODY\n"),
+        path: skillPath,
+      },
+    ]);
+    const loader = new PiMemoryResourceLoader({
+      agentsFiles: [
+        { content: "MEMORY_AGENTS", path: "/virtual/workspace/AGENTS.md" },
+      ],
+      skills: [
+        {
+          baseDir: "/virtual/agent/skills/probe",
+          description: "Probe memory-backed resources",
+          filePath: skillPath,
+          name: "probe",
+        },
+      ],
+    });
+
+    expect(loader.getAgentsFiles().agentsFiles).toEqual([
+      { content: "MEMORY_AGENTS", path: "/virtual/workspace/AGENTS.md" },
+    ]);
+    expect(loader.getSkills().skills[0]).toMatchObject({
+      description: "Probe memory-backed resources",
+      filePath: skillPath,
+      name: "probe",
+    });
+
+    const read = createReadTool("/virtual/workspace", {
+      operations: fileStore.readOperations(),
+    });
+    const result = await read.execute("probe-call", { path: skillPath });
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        text: expect.stringContaining("MEMORY_SKILL_BODY"),
+        type: "text",
+      }),
+    ]);
+  });
+
+  it("hydrates native Pi JSONL without creating a persisted session", async () => {
+    const cwd = "/virtual/workspace";
+    const agentDir = "/virtual/agent";
+    const sessionId = "00000000-0000-4000-8000-000000000001";
+    const skillPath = `${agentDir}/skills/probe/SKILL.md`;
+    const measured = await measurePiMemoryPreparation({
+      agentDir,
+      cwd,
+      files: [
+        {
+          content: Buffer.from("# Probe\n\nMEMORY_SKILL_BODY\n"),
+          path: skillPath,
+        },
+      ],
+      logicalCwd: cwd,
+      resources: {
+        agentsFiles: [{ content: "MEMORY_AGENTS", path: `${cwd}/AGENTS.md` }],
+        skills: [
+          {
+            baseDir: `${agentDir}/skills/probe`,
+            description: "Probe memory-backed resources",
+            filePath: skillPath,
+            name: "probe",
+          },
+        ],
+      },
+      sessionId,
+      sessionJsonl: createPiNativeSessionFixture({
+        logicalCwd: cwd,
+        sessionId,
+        targetBytes: 1024,
+      }),
+    });
+
+    expect(measured.official).toMatchObject({
+      agentsFileCount: 1,
+      diagnosticCount: 0,
+      discoveredSkillCount: 1,
+      sessionHeaderCwd: cwd,
+      sessionListMs: 0,
+      sessionPersisted: false,
+    });
+    expect(measured.checkpoint.toString("utf8")).toContain(sessionId);
+  });
+});

--- a/turbo/packages/pi-agent-runtime/src/memory-resource-loader.ts
+++ b/turbo/packages/pi-agent-runtime/src/memory-resource-loader.ts
@@ -1,0 +1,181 @@
+import { resolve } from "node:path";
+
+import {
+  createExtensionRuntime,
+  createSyntheticSourceInfo,
+  type PromptTemplate,
+  type ReadOperations,
+  type ResourceLoader,
+  type Skill,
+} from "@earendil-works/pi-coding-agent";
+
+export interface PiMemorySkillInput {
+  readonly baseDir: string;
+  readonly description: string;
+  readonly disableModelInvocation?: boolean;
+  readonly filePath: string;
+  readonly name: string;
+  readonly source?: string;
+}
+
+export interface PiMemoryResourceSnapshot {
+  readonly agentsFiles: readonly {
+    readonly content: string;
+    readonly path: string;
+  }[];
+  readonly appendSystemPrompt?: readonly string[];
+  readonly prompts?: readonly PromptTemplate[];
+  readonly skills: readonly PiMemorySkillInput[];
+  readonly systemPrompt?: string;
+}
+
+export interface PiMemoryFileInput {
+  readonly content: Uint8Array;
+  readonly path: string;
+}
+
+/**
+ * Pi's stable ResourceLoader surface backed by an already-discovered snapshot.
+ *
+ * Discovery and validation should happen when the snapshot is produced. Runtime
+ * construction only projects that result into Pi, so no temporary directory is
+ * required and Pi still receives its native Skill and AGENTS.md shapes.
+ */
+export class PiMemoryResourceLoader implements ResourceLoader {
+  readonly #agentsFiles: Array<{
+    readonly content: string;
+    readonly path: string;
+  }>;
+  readonly #appendSystemPrompt: string[];
+  readonly #extensionResult = {
+    errors: [],
+    extensions: [],
+    runtime: createExtensionRuntime(),
+  };
+  readonly #prompts: PromptTemplate[];
+  readonly #skills: Skill[];
+  readonly #systemPrompt: string | undefined;
+
+  constructor(snapshot: PiMemoryResourceSnapshot) {
+    this.#agentsFiles = snapshot.agentsFiles.map((file) => {
+      return { ...file };
+    });
+    this.#appendSystemPrompt = [...(snapshot.appendSystemPrompt ?? [])];
+    this.#prompts = [...(snapshot.prompts ?? [])];
+    this.#skills = snapshot.skills.map((skill) => {
+      return {
+        baseDir: skill.baseDir,
+        description: skill.description,
+        disableModelInvocation: skill.disableModelInvocation ?? false,
+        filePath: skill.filePath,
+        name: skill.name,
+        sourceInfo: createSyntheticSourceInfo(skill.filePath, {
+          baseDir: skill.baseDir,
+          scope: "user",
+          source: skill.source ?? "vm0-memory",
+        }),
+      };
+    });
+    this.#systemPrompt = snapshot.systemPrompt;
+  }
+
+  getExtensions() {
+    return this.#extensionResult;
+  }
+
+  getSkills() {
+    return { diagnostics: [], skills: this.#skills };
+  }
+
+  getPrompts() {
+    return { diagnostics: [], prompts: this.#prompts };
+  }
+
+  getThemes() {
+    return { diagnostics: [], themes: [] };
+  }
+
+  getAgentsFiles() {
+    return { agentsFiles: this.#agentsFiles };
+  }
+
+  getSystemPrompt(): string | undefined {
+    return this.#systemPrompt;
+  }
+
+  getSystemPromptSource(): undefined {
+    return undefined;
+  }
+
+  getAppendSystemPrompt(): string[] {
+    return this.#appendSystemPrompt;
+  }
+
+  getAppendSystemPromptSources(): [] {
+    return [];
+  }
+
+  extendResources(): void {
+    // Executable extensions are intentionally disabled for the API memory path.
+  }
+
+  async reload(): Promise<void> {
+    // The immutable snapshot is replaced as a unit by constructing a new loader.
+  }
+}
+
+function missingFile(path: string): NodeJS.ErrnoException {
+  const error = new Error(`ENOENT: no such in-memory file, open '${path}'`);
+  return Object.assign(error, { code: "ENOENT", path });
+}
+
+/** Read-only logical file namespace used by Pi's pluggable read operations. */
+export class PiMemoryFileStore {
+  readonly #files = new Map<string, Buffer>();
+
+  constructor(files: readonly PiMemoryFileInput[]) {
+    for (const file of files) {
+      const path = resolve(file.path);
+      if (this.#files.has(path)) {
+        throw new Error(`Duplicate in-memory Pi file: ${path}`);
+      }
+      this.#files.set(
+        path,
+        Buffer.from(
+          file.content.buffer as ArrayBuffer,
+          file.content.byteOffset,
+          file.content.byteLength,
+        ),
+      );
+    }
+  }
+
+  has(path: string): boolean {
+    return this.#files.has(resolve(path));
+  }
+
+  read(path: string): Buffer {
+    const resolvedPath = resolve(path);
+    const content = this.#files.get(resolvedPath);
+    if (!content) {
+      throw missingFile(resolvedPath);
+    }
+    return Buffer.from(content);
+  }
+
+  readOperations(): ReadOperations {
+    return {
+      access: async (path) => {
+        if (!this.has(path)) {
+          throw missingFile(resolve(path));
+        }
+      },
+      detectImageMimeType: async () => {
+        return null;
+      },
+      readFile: async (path) => {
+        return this.read(path);
+      },
+    };
+  }
+}

--- a/turbo/packages/pi-agent-runtime/src/node.ts
+++ b/turbo/packages/pi-agent-runtime/src/node.ts
@@ -1,9 +1,19 @@
 export { runPiOfficialRpcMode } from "./rpc";
 export {
   createPiNativeSessionFixture,
+  measurePiMemoryPreparation,
   measurePiOfficialPreparation,
+  type PiMemoryPreparationProbeInput,
+  type PiMemoryPreparationProbeResult,
   type PiNativeSessionFixtureInput,
   type PiOfficialPreparationProbeInput,
   type PiOfficialPreparationProbeResult,
 } from "./preparation-probe";
+export {
+  PiMemoryFileStore,
+  PiMemoryResourceLoader,
+  type PiMemoryFileInput,
+  type PiMemoryResourceSnapshot,
+  type PiMemorySkillInput,
+} from "./memory-resource-loader";
 export * from "./index";

--- a/turbo/packages/pi-agent-runtime/src/node.ts
+++ b/turbo/packages/pi-agent-runtime/src/node.ts
@@ -1,2 +1,9 @@
 export { runPiOfficialRpcMode } from "./rpc";
+export {
+  createPiNativeSessionFixture,
+  measurePiOfficialPreparation,
+  type PiNativeSessionFixtureInput,
+  type PiOfficialPreparationProbeInput,
+  type PiOfficialPreparationProbeResult,
+} from "./preparation-probe";
 export * from "./index";

--- a/turbo/packages/pi-agent-runtime/src/preparation-probe.ts
+++ b/turbo/packages/pi-agent-runtime/src/preparation-probe.ts
@@ -5,6 +5,7 @@ import {
   SessionManager,
   SettingsManager,
 } from "@earendil-works/pi-coding-agent";
+import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
 
 export interface PiOfficialPreparationProbeInput {
   readonly agentDir: string;
@@ -154,6 +155,12 @@ export async function measurePiOfficialPreparation(
     settingsManagerCreateMs,
     totalMs: elapsedMs(totalStartedAt),
   };
+  // The Vite server bundle can retain cleanupSessionResources from Pi's
+  // compatibility barrel without scheduling its module initializer. Register
+  // a no-op through Pi's core entrypoint so dispose exercises the real cleanup
+  // path with the registry initialized.
+  const unregisterProbeResource = registerSessionResourceCleanup(() => {});
   await created.session.dispose();
+  unregisterProbeResource();
   return result;
 }

--- a/turbo/packages/pi-agent-runtime/src/preparation-probe.ts
+++ b/turbo/packages/pi-agent-runtime/src/preparation-probe.ts
@@ -1,11 +1,23 @@
 import {
   createAgentSessionFromServices,
   createAgentSessionServices,
+  createReadToolDefinition,
+  migrateSessionEntries,
   ModelRuntime,
+  parseSessionEntries,
   SessionManager,
   SettingsManager,
+  type FileEntry,
+  type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { registerSessionResourceCleanup } from "@earendil-works/pi-ai";
+
+import {
+  PiMemoryFileStore,
+  PiMemoryResourceLoader,
+  type PiMemoryFileInput,
+  type PiMemoryResourceSnapshot,
+} from "./memory-resource-loader";
 
 export interface PiOfficialPreparationProbeInput {
   readonly agentDir: string;
@@ -37,8 +49,39 @@ export interface PiNativeSessionFixtureInput {
   readonly targetBytes: number;
 }
 
+export interface PiMemoryPreparationProbeInput {
+  readonly agentDir: string;
+  readonly cwd: string;
+  readonly files: readonly PiMemoryFileInput[];
+  readonly logicalCwd: string;
+  readonly resources: PiMemoryResourceSnapshot;
+  readonly sessionId: string;
+  readonly sessionJsonl: Uint8Array;
+}
+
+export interface PiMemoryPreparationProbeResult {
+  readonly checkpoint: Buffer;
+  readonly checkpointMaterializeMs: number;
+  readonly official: PiOfficialPreparationProbeResult;
+  readonly preparationMs: number;
+}
+
 function elapsedMs(startedAt: number): number {
   return performance.now() - startedAt;
+}
+
+function serializePiSession(sessionManager: SessionManager): Buffer {
+  const header = sessionManager.getHeader();
+  if (!header) {
+    throw new Error("Pi preparation probe session has no header");
+  }
+  return Buffer.from(
+    `${[header, ...sessionManager.getEntries()]
+      .map((entry) => {
+        return JSON.stringify(entry);
+      })
+      .join("\n")}\n`,
+  );
 }
 
 /** Create a valid native Pi JSONL fixture without writing it to disk. */
@@ -70,6 +113,56 @@ export function createPiNativeSessionFixture(
       })
       .join("\n")}\n`,
   );
+}
+
+interface SessionManagerProbeInternals {
+  _buildIndex(): void;
+  fileEntries: FileEntry[];
+  flushed: boolean;
+  sessionId: string;
+}
+
+/**
+ * Preview-only bridge for measuring the API design against Pi 0.84.1.
+ *
+ * Pi already keeps preloaded entries internally, but its public in-memory
+ * factory can only create an empty session. The production implementation must
+ * use an upstream fromJSONL/fromEntries factory instead of reaching into these
+ * private fields.
+ */
+function hydratePiSessionForMemoryProbe(
+  sessionJsonl: Uint8Array,
+  logicalCwd: string,
+  expectedSessionId: string,
+): SessionManager {
+  const jsonlBuffer = Buffer.isBuffer(sessionJsonl)
+    ? sessionJsonl
+    : Buffer.from(
+        sessionJsonl.buffer as ArrayBuffer,
+        sessionJsonl.byteOffset,
+        sessionJsonl.byteLength,
+      );
+  const entries = parseSessionEntries(jsonlBuffer.toString("utf8"));
+  migrateSessionEntries(entries);
+  const header = entries[0];
+  if (header?.type !== "session") {
+    throw new Error("Pi preparation probe JSONL has no native session header");
+  }
+  if (header.id !== expectedSessionId) {
+    throw new Error(
+      `Pi preparation probe expected session ${expectedSessionId}, received ${header.id}`,
+    );
+  }
+
+  const sessionManager = SessionManager.inMemory(logicalCwd, {
+    id: header.id,
+  });
+  const internals = sessionManager as unknown as SessionManagerProbeInternals;
+  internals.fileEntries = entries;
+  internals.sessionId = header.id;
+  internals.flushed = true;
+  internals._buildIndex();
+  return sessionManager;
 }
 
 /**
@@ -163,4 +256,104 @@ export async function measurePiOfficialPreparation(
   await created.session.dispose();
   unregisterProbeResource();
   return result;
+}
+
+/**
+ * Measure Pi construction from an already-prewarmed resource snapshot and
+ * native JSONL bytes. No physical project, agent, or session path is created.
+ */
+export async function measurePiMemoryPreparation(
+  input: PiMemoryPreparationProbeInput,
+): Promise<PiMemoryPreparationProbeResult> {
+  const totalStartedAt = performance.now();
+
+  const modelRuntimeStartedAt = performance.now();
+  const modelRuntime = await ModelRuntime.create({
+    allowModelNetwork: false,
+    modelsPath: null,
+    refreshOnCreate: false,
+  });
+  const modelRuntimeCreateMs = elapsedMs(modelRuntimeStartedAt);
+
+  const settingsManagerStartedAt = performance.now();
+  const settingsManager = SettingsManager.inMemory();
+  const settingsManagerCreateMs = elapsedMs(settingsManagerStartedAt);
+
+  const sessionServicesStartedAt = performance.now();
+  const fileStore = new PiMemoryFileStore(input.files);
+  const resourceLoader = new PiMemoryResourceLoader(input.resources);
+  const services = {
+    agentDir: input.agentDir,
+    cwd: input.cwd,
+    diagnostics: [],
+    modelRuntime,
+    resourceLoader,
+    settingsManager,
+  };
+  const memoryReadTool = createReadToolDefinition(input.cwd, {
+    operations: fileStore.readOperations(),
+  }) as unknown as ToolDefinition;
+  const sessionServicesCreateMs = elapsedMs(sessionServicesStartedAt);
+
+  const sessionOpenStartedAt = performance.now();
+  const sessionManager = hydratePiSessionForMemoryProbe(
+    input.sessionJsonl,
+    input.logicalCwd,
+    input.sessionId,
+  );
+  const sessionOpenMs = elapsedMs(sessionOpenStartedAt);
+
+  const agentSessionStartedAt = performance.now();
+  const created = await createAgentSessionFromServices({
+    customTools: [memoryReadTool],
+    services,
+    sessionManager,
+    tools: ["read"],
+  });
+  const agentSessionCreateMs = elapsedMs(agentSessionStartedAt);
+
+  const { agentsFiles } = resourceLoader.getAgentsFiles();
+  const { skills } = resourceLoader.getSkills();
+  const firstSkill = skills[0];
+  if (firstSkill && !fileStore.has(firstSkill.filePath)) {
+    throw new Error(`Pi memory skill body is missing: ${firstSkill.filePath}`);
+  }
+  if (
+    firstSkill &&
+    !created.session.systemPrompt.includes(firstSkill.filePath)
+  ) {
+    throw new Error(
+      "Pi did not project the memory skill into its system prompt",
+    );
+  }
+
+  const official: PiOfficialPreparationProbeResult = {
+    agentSessionCreateMs,
+    agentsFileCount: agentsFiles.length,
+    diagnosticCount: services.diagnostics.length,
+    discoveredSkillCount: skills.length,
+    modelRuntimeCreateMs,
+    sessionEntryCount: sessionManager.getEntries().length,
+    sessionHeaderCwd: sessionManager.getHeader()?.cwd ?? null,
+    sessionListMs: 0,
+    sessionOpenMs,
+    sessionPersisted: sessionManager.isPersisted(),
+    sessionServicesCreateMs,
+    settingsManagerCreateMs,
+    totalMs: elapsedMs(totalStartedAt),
+  };
+
+  const unregisterProbeResource = registerSessionResourceCleanup(() => {});
+  await created.session.dispose();
+  unregisterProbeResource();
+  const preparationMs = elapsedMs(totalStartedAt);
+
+  const checkpointStartedAt = performance.now();
+  const checkpoint = serializePiSession(sessionManager);
+  return {
+    checkpoint,
+    checkpointMaterializeMs: elapsedMs(checkpointStartedAt),
+    official,
+    preparationMs,
+  };
 }

--- a/turbo/packages/pi-agent-runtime/src/preparation-probe.ts
+++ b/turbo/packages/pi-agent-runtime/src/preparation-probe.ts
@@ -1,0 +1,159 @@
+import {
+  createAgentSessionFromServices,
+  createAgentSessionServices,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+export interface PiOfficialPreparationProbeInput {
+  readonly agentDir: string;
+  readonly cwd: string;
+  readonly logicalCwd: string;
+  readonly sessionDir: string;
+  readonly sessionId: string;
+}
+
+export interface PiOfficialPreparationProbeResult {
+  readonly agentSessionCreateMs: number;
+  readonly agentsFileCount: number;
+  readonly diagnosticCount: number;
+  readonly discoveredSkillCount: number;
+  readonly modelRuntimeCreateMs: number;
+  readonly sessionEntryCount: number;
+  readonly sessionHeaderCwd: string | null;
+  readonly sessionListMs: number;
+  readonly sessionOpenMs: number;
+  readonly sessionPersisted: boolean;
+  readonly sessionServicesCreateMs: number;
+  readonly settingsManagerCreateMs: number;
+  readonly totalMs: number;
+}
+
+export interface PiNativeSessionFixtureInput {
+  readonly logicalCwd: string;
+  readonly sessionId: string;
+  readonly targetBytes: number;
+}
+
+function elapsedMs(startedAt: number): number {
+  return performance.now() - startedAt;
+}
+
+/** Create a valid native Pi JSONL fixture without writing it to disk. */
+export function createPiNativeSessionFixture(
+  input: PiNativeSessionFixtureInput,
+): Buffer {
+  const sessionManager = SessionManager.inMemory(input.logicalCwd, {
+    id: input.sessionId,
+  });
+  const chunk = "p".repeat(1024 * 1024);
+  let payloadBytes = 0;
+  while (payloadBytes < input.targetBytes) {
+    const remaining = input.targetBytes - payloadBytes;
+    const payload =
+      remaining >= chunk.length ? chunk : chunk.slice(0, remaining);
+    sessionManager.appendCustomEntry("preparation-probe-padding", payload);
+    payloadBytes += payload.length;
+  }
+  const entries = [
+    sessionManager.getHeader(),
+    ...sessionManager.getEntries(),
+  ].filter((entry) => {
+    return entry !== null;
+  });
+  return Buffer.from(
+    `${entries
+      .map((entry) => {
+        return JSON.stringify(entry);
+      })
+      .join("\n")}\n`,
+  );
+}
+
+/**
+ * Measure the official Pi service and session construction used by the API
+ * preparation experiment. This never invokes a model or enables agent tools.
+ */
+export async function measurePiOfficialPreparation(
+  input: PiOfficialPreparationProbeInput,
+): Promise<PiOfficialPreparationProbeResult> {
+  const totalStartedAt = performance.now();
+
+  const modelRuntimeStartedAt = performance.now();
+  const modelRuntime = await ModelRuntime.create({
+    allowModelNetwork: false,
+    modelsPath: null,
+    refreshOnCreate: false,
+  });
+  const modelRuntimeCreateMs = elapsedMs(modelRuntimeStartedAt);
+
+  const settingsManagerStartedAt = performance.now();
+  const settingsManager = SettingsManager.create(input.cwd, input.agentDir, {
+    projectTrusted: false,
+  });
+  const settingsManagerCreateMs = elapsedMs(settingsManagerStartedAt);
+
+  const sessionServicesStartedAt = performance.now();
+  const services = await createAgentSessionServices({
+    cwd: input.cwd,
+    agentDir: input.agentDir,
+    settingsManager,
+    modelRuntime,
+    resourceLoaderOptions: {
+      noExtensions: true,
+      noPromptTemplates: true,
+      noThemes: true,
+    },
+  });
+  const sessionServicesCreateMs = elapsedMs(sessionServicesStartedAt);
+
+  const sessionListStartedAt = performance.now();
+  const sessionInfo = (
+    await SessionManager.list(input.logicalCwd, input.sessionDir)
+  ).find((candidate) => {
+    return candidate.id === input.sessionId;
+  });
+  const sessionListMs = elapsedMs(sessionListStartedAt);
+  if (!sessionInfo) {
+    throw new Error(
+      `Pi preparation probe session ${input.sessionId} is missing`,
+    );
+  }
+
+  const sessionOpenStartedAt = performance.now();
+  const sessionManager = SessionManager.open(
+    sessionInfo.path,
+    input.sessionDir,
+    input.logicalCwd,
+  );
+  const sessionOpenMs = elapsedMs(sessionOpenStartedAt);
+
+  const agentSessionStartedAt = performance.now();
+  const created = await createAgentSessionFromServices({
+    services,
+    sessionManager,
+    noTools: "all",
+  });
+  const agentSessionCreateMs = elapsedMs(agentSessionStartedAt);
+
+  const { agentsFiles } = services.resourceLoader.getAgentsFiles();
+  const { skills } = services.resourceLoader.getSkills();
+  const result: PiOfficialPreparationProbeResult = {
+    agentSessionCreateMs,
+    agentsFileCount: agentsFiles.length,
+    diagnosticCount: services.diagnostics.length,
+    discoveredSkillCount: skills.length,
+    modelRuntimeCreateMs,
+    sessionEntryCount: sessionManager.getEntries().length,
+    sessionHeaderCwd: sessionManager.getHeader()?.cwd ?? null,
+    sessionListMs,
+    sessionOpenMs,
+    sessionPersisted: sessionManager.isPersisted(),
+    sessionServicesCreateMs,
+    settingsManagerCreateMs,
+    totalMs: elapsedMs(totalStartedAt),
+  };
+  await created.session.dispose();
+  return result;
+}


### PR DESCRIPTION
## Purpose

Preview-only measurement probe for running the official Pi filesystem and session preparation path inside the API server.

This PR does not change product behavior and must not be merged. The probe route is limited to test/preview deployments and returns 404 in production.

## What it measures

- Materialize a canonical /home/user/.pi/agent and /home/user/workspace layout in ephemeral storage
- Extract skill, AGENTS.md, and memory fixtures matching the current installed file counts and byte totals
- Restore a native Pi JSONL session created by SessionManager
- Run the official Pi resource loader, skill and AGENTS.md discovery, SessionManager.list/open, and AgentSession construction
- Read the resulting JSONL checkpoint and clean up the lease
- Exercise representative, 16 MiB and 64 MiB session, and 32 MiB asset-pressure profiles

No model request, executable extension, or agent tool runs. Storage/R2 download time is explicitly excluded and reported as such.

## Local verification

- pnpm -F @okouai/pi-agent-runtime check-types
- pnpm -F @okouai/api-contracts check-types
- pnpm -F api check-types
- pnpm -F @okouai/pi-agent-runtime lint
- pnpm -F @okouai/api-contracts lint
- pnpm -F api lint
- pnpm -F api build
- Targeted integration test reaches the shared test setup but cannot run locally because PostgreSQL is unavailable on localhost:5432

## Preview-only warning

Do not merge this PR. It exists only to create a realistic API Preview environment for measurements and will remain open for inspection.