### PR TITLE
refactor: cut over proven historical environment authority

### DIFF
--- a/.github/workflows/agent-compose-consolidation-preflight.yml
+++ b/.github/workflows/agent-compose-consolidation-preflight.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: bash
     steps:
-      # transition-validator: #27613 + #27656 + #27671 + #27792 + #28056; removal-owner: #26938 Stage 8
+      # transition-validator: #27613 + #27656 + #27671 + #27792 + #28056 + #28070; removal-owner: #26938 Stage 8
       # The workflow definition and implementation always come from main.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -49,7 +49,7 @@ jobs:
               --ssl verify-full \
               2>/dev/null
           ); then
-            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v5","status":"failed","failureGates":["probe.database_resolution"]}'
+            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v6","status":"failed","failureGates":["probe.database_resolution"]}'
             exit 1
           fi
           if [[ -z "$database_url" ||
@@ -57,7 +57,7 @@ jobs:
                 "$database_url" == *$'\r'* ||
                 ( "$database_url" != postgres://* &&
                   "$database_url" != postgresql://* ) ]]; then
-            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v5","status":"failed","failureGates":["probe.database_resolution"]}'
+            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v6","status":"failed","failureGates":["probe.database_resolution"]}'
             exit 1
           fi
           WORKFLOW_COMMAND_DATA="${database_url//%/%25}"

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -65,6 +65,7 @@ import {
 } from "../../../test-fixtures/connector-catalog";
 import { readStorageS3PrefixFixture } from "../../../test-fixtures/storage";
 import {
+  historicalProductBuilderContentFixture,
   readHistoricalAgentComposeHeadFixture,
   readRawHistoricalAgentComposeHeadFixture,
   replaceHistoricalAgentComposeHeadFixture,
@@ -12781,6 +12782,226 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       content: unsupportedFrameworkContent,
     });
     await api.requestCancelRun(actor, resumed.runId, [200]);
+  });
+
+  // Transition-only #28070 coverage; removed by #26938 Stage 8.
+  it("uses application environment authority for exact historical builder heads", async () => {
+    const appUrl = "https://app.stage-4e.example.test";
+    mockEnv("APP_URL", appUrl);
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Expected a historical-builder organization");
+    }
+    const canonicalHead = await readHistoricalAgentComposeHeadFixture(agentId);
+    if (!canonicalHead.content) {
+      throw new Error("Expected a canonical Agent head");
+    }
+
+    await connectors.connectManualGrant(actor, "gitlab", "api-token", {
+      accessToken: "glpat-stage-4e-current",
+      host: "gitlab-before-stage-4e.example.com",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["gitlab"]);
+
+    const baseline = await api.createRun(actor, {
+      agentId,
+      prompt: "establish the pre-transition session",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const baselinePoll = await api.pollRunner(runnerGroup);
+    expect(baselinePoll.body.job).toMatchObject({ runId: baseline.runId });
+    const baselineClaim = await api.claimRunnerJob(baseline.runId);
+    expect(baselineClaim.environment?.GITLAB_HOST).toBe(
+      "gitlab-before-stage-4e.example.com",
+    );
+    await api.requestCancelRun(actor, baseline.runId, [200]);
+
+    const historicalContent = historicalProductBuilderContentFixture(
+      canonicalHead.name,
+    );
+    const historicalHead = await replaceHistoricalAgentComposeHeadFixture(
+      {
+        composeId: agentId,
+        userId: actor.userId,
+        content: historicalContent,
+      },
+      context.signal,
+    );
+    await connectors.connectManualGrant(actor, "gitlab", "api-token", {
+      accessToken: "glpat-stage-4e-current",
+      host: "gitlab-stage-4e-current.example.com",
+    });
+
+    const continuationPrompt =
+      "continue with the exact latest historical builder head";
+    context.mocks.axiom.ingest.mockImplementation((dataset, events) => {
+      if (
+        dataset === "run-context" &&
+        Array.isArray(events) &&
+        events.some((event) => {
+          return isRecord(event) && event.prompt === continuationPrompt;
+        })
+      ) {
+        throw new Error("historical-builder observation failed");
+      }
+      return true;
+    });
+
+    const resumed = await api.createRun(actor, {
+      agentId,
+      sessionId: baseline.sessionId,
+      prompt: continuationPrompt,
+      modelProvider: "anthropic-api-key",
+    });
+    expect(resumed.sessionId).toBe(baseline.sessionId);
+    await api.heartbeatRunner(runnerGroup);
+    const resumedPoll = await api.pollRunner(runnerGroup);
+    expect(resumedPoll.body.job).toMatchObject({ runId: resumed.runId });
+    const resumedClaim = await api.claimRunnerJob(resumed.runId);
+    expect(resumedClaim.resumeSession).toBeNull();
+    await api.requestCancelRun(actor, resumed.runId, [200]);
+
+    const fresh = await api.createRun(actor, {
+      agentId,
+      prompt: "launch the exact historical builder head as a new Run",
+      modelProvider: "anthropic-api-key",
+    });
+    const freshTimingEvents = apiDispatchTimingEventsForRun(fresh.runId);
+    expectApiDispatchActions(
+      freshTimingEvents,
+      API_DISPATCH_TIMING_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      freshTimingEvents,
+      API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      freshTimingEvents,
+      API_DISPATCH_STORED_CONNECTOR_SNAPSHOT_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      freshTimingEvents,
+      API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES,
+    );
+    expectNoApiDispatchActions(freshTimingEvents, [
+      "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
+    ]);
+    for (const existingOwnerAction of [
+      "api_dispatch_resolve_compose_lookup_agent",
+      "api_dispatch_prepare_context_resolve_model_provider",
+      "api_dispatch_prepare_context_load_stored_connector_snapshot_rows",
+      "api_dispatch_prepare_context_load_builtin_permission_indexes",
+      "api_dispatch_prepare_storage_manifest_load_storage_index",
+    ]) {
+      expect(
+        freshTimingEvents.filter((event) => {
+          return event.op_type === existingOwnerAction;
+        }),
+      ).toHaveLength(1);
+    }
+    await api.heartbeatRunner(runnerGroup);
+    const freshPoll = await api.pollRunner(runnerGroup);
+    expect(freshPoll.body.job).toMatchObject({ runId: fresh.runId });
+    const freshClaim = await api.claimRunnerJob(fresh.runId);
+
+    for (const { run, claim } of [
+      { run: resumed, claim: resumedClaim },
+      { run: fresh, claim: freshClaim },
+    ]) {
+      expect(claim.agentComposeVersionId).toBe(historicalHead.versionId);
+      expect(claim.cliAgentType).toBe("claude-code");
+      expect(claim.environment).toMatchObject({
+        ANTHROPIC_API_KEY: modelProviderPlaceholder(
+          "anthropic-api-key",
+          "ANTHROPIC_API_KEY",
+        ),
+        ANTHROPIC_MODEL: "claude-sonnet-5",
+        GITLAB_TOKEN: connectorPlaceholder("gitlab", "GITLAB_TOKEN"),
+        GITLAB_HOST: "gitlab-stage-4e-current.example.com",
+        CLI_PKG_URL: "https://static.vm0.io/okou-cli/test-commit/package.tgz",
+        [WEBSITE_TEMPLATE_ARCHIVE_VERSION_ENV]: "previous",
+      });
+      expect(claim.vars).toMatchObject({
+        GITLAB_HOST: "gitlab-stage-4e-current.example.com",
+      });
+      expect(claim.secretConnectorMap).toMatchObject({
+        GITLAB_TOKEN: "gitlab",
+      });
+      expect(claim.secretValues ?? []).not.toContain("glpat-stage-4e-current");
+      expectCanonicalOkouRunEnvironment({
+        environment: claim.environment,
+        secretValues: claim.secretValues,
+        appUrl,
+        agentId,
+        userId: actor.userId,
+        orgId: actor.orgId,
+        runId: run.runId,
+      });
+      const serializedClaim = JSON.stringify(claim);
+      const serializedAuthorityEnvironment = JSON.stringify({
+        environment: claim.environment,
+        vars: claim.vars,
+        secretConnectorMap: claim.secretConnectorMap,
+      });
+      for (const discardedHistoricalBinding of [
+        "ADZUNA_APP_ID",
+        "ANTHROPIC_MANAGED_AGENTS_TOKEN",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "ZERO_AGENT_ID",
+        "ZERO_TOKEN",
+      ]) {
+        expect(serializedAuthorityEnvironment).not.toContain(
+          discardedHistoricalBinding,
+        );
+      }
+      expect(environmentShadowFieldsForRun(run.runId)).toStrictEqual({
+        environmentShadowClassification: "exact",
+        environmentShadowLegacyOnlyCountBucket: "0",
+        environmentShadowCandidateOnlyCountBucket: "0",
+        environmentShadowSharedValueDifferenceCountBucket: "0",
+      });
+      const authorityFields = agentExecutionAuthorityFieldsForRun(run.runId);
+      expect(authorityFields).toStrictEqual({
+        agentExecutionAuthority: "application",
+        agentExecutionAuthorityClassification:
+          "applicationHistoricalProductBuilderEnvironment",
+      });
+      const serializedAuthorityFields = JSON.stringify(authorityFields);
+      for (const forbidden of [
+        canonicalHead.name,
+        agentId,
+        run.runId,
+        "GITLAB_TOKEN",
+        "gitlab-stage-4e-current.example.com",
+      ]) {
+        expect(serializedAuthorityFields).not.toContain(forbidden);
+      }
+      expect(runContextSnapshotsForRun(run.runId)).toHaveLength(1);
+      expect(serializedClaim).not.toContain("agentExecutionAuthority");
+      expect(serializedClaim).not.toContain("environmentShadow");
+      await expect(
+        readRunLaunchSnapshotFixture(context, run.runId),
+      ).resolves.toStrictEqual({
+        exists: true,
+        launch_snapshot: {
+          schemaVersion: 1,
+          framework: "claude-code",
+          runnerProfile: DEFAULT_PROFILE,
+        },
+      });
+    }
+
+    await expect(
+      readRawHistoricalAgentComposeHeadFixture(agentId),
+    ).resolves.toStrictEqual({
+      headVersionId: historicalHead.versionId,
+      content: historicalContent,
+    });
+    await api.requestCancelRun(actor, fresh.runId, [200]);
   });
 
   it("classifies active legacy environment value shapes without exposing them", async () => {

--- a/turbo/apps/api/src/signals/services/agent-execution-authority.ts
+++ b/turbo/apps/api/src/signals/services/agent-execution-authority.ts
@@ -3,6 +3,7 @@ import { agentComposeApiContentSchema } from "@okouai/api-contracts/contracts/co
 
 import { computeComposeVersionId } from "./agent-compose-content";
 import { APPLICATION_OWNED_AGENT_EXECUTION_PLAN } from "./agent-execution-plan";
+import { isExactHistoricalProductBuilderCandidate } from "./historical-product-builder";
 
 export const AGENT_EXECUTION_PLAN_DIMENSIONS = [
   "danglingOrMissingHeadVersion",
@@ -25,6 +26,8 @@ export type AgentExecutionAuthority = "application" | "version_content";
 export type AgentExecutionAuthorityClassification =
   | "completeSemanticParity"
   | "applicationFrameworkFallback"
+  // Transition-only #28070 subtype; removed by #26938 Stage 8.
+  | "applicationHistoricalProductBuilderEnvironment"
   | AgentExecutionPlanDimension
   | "multipleDimensions";
 
@@ -390,6 +393,18 @@ export function classifyAgentExecutionAuthority(
       return dimensions.has(dimension);
     },
   );
+  if (
+    validated.classification === "supported" &&
+    orderedDimensions.length === 1 &&
+    orderedDimensions[0] === "systemEnvironmentDifferences" &&
+    isExactHistoricalProductBuilderCandidate(row)
+  ) {
+    return {
+      authority: "application",
+      classification: "applicationHistoricalProductBuilderEnvironment",
+      dimensions: [],
+    };
+  }
   if (orderedDimensions.length === 0) {
     return {
       authority: "application",

--- a/turbo/apps/api/src/signals/services/historical-product-builder.ts
+++ b/turbo/apps/api/src/signals/services/historical-product-builder.ts
@@ -1,10 +1,10 @@
 import { createHash } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { agentComposeApiContentSchema } from "@okouai/api-contracts/contracts/composes";
-import { computeComposeVersionId } from "../../../apps/api/src/signals/services/agent-compose-content";
+import { computeComposeVersionId } from "./agent-compose-content";
 
 /**
- * Transition-only evidence for #28056. Every definition in this file,
+ * Transition-only evidence for #28056 and #28070. Every definition in this file,
  * including the reviewed source fixture, classifier helpers, and review
  * fingerprint, is owned by #26938 Stage 8 removal.
  */
@@ -299,7 +299,7 @@ const ZERO_SECRET_BINDINGS = [
   "ZERO_TOKEN",
 ] as const;
 
-export interface HistoricalProductBuilderVariant {
+interface HistoricalProductBuilderVariant {
   readonly id: string;
   readonly identityBranding: "zero";
   readonly sourceCommit: string;
@@ -323,9 +323,9 @@ export const HISTORICAL_PRODUCT_BUILDER_VARIANTS = [
     id: "zero-connector-catalog-at-3b45e4e",
     identityBranding: "zero",
     sourceCommit: "3b45e4eab8f1ca26f7187800c6e475b198ec0f28",
-    sourcePullRequest: 14831,
+    sourcePullRequest: 14_831,
     removalCommit: "68a48441b4c05ccd25d9599dd2b4e7be808aa450",
-    removalPullRequest: 14820,
+    removalPullRequest: 14_820,
     eligibleConnectorCount: 229,
     environmentBindingCount: 281,
     variableBindingCount: 34,
@@ -335,7 +335,7 @@ export const HISTORICAL_PRODUCT_BUILDER_VARIANTS = [
   },
 ] as const satisfies readonly HistoricalProductBuilderVariant[];
 
-export type HistoricalProductBuilderVariantId =
+type HistoricalProductBuilderVariantId =
   (typeof HISTORICAL_PRODUCT_BUILDER_VARIANTS)[number]["id"];
 
 export interface HistoricalProductBuilderCandidate {
@@ -366,7 +366,7 @@ export function buildHistoricalProductBuilderContent(
   agentName: string,
 ): Record<string, unknown> {
   switch (variantId) {
-    case "zero-connector-catalog-at-3b45e4e":
+    case "zero-connector-catalog-at-3b45e4e": {
       return {
         version: "1",
         agents: {
@@ -377,6 +377,7 @@ export function buildHistoricalProductBuilderContent(
           },
         },
       };
+    }
   }
 }
 
@@ -454,7 +455,9 @@ export function isExactHistoricalProductBuilderCandidate(
     return false;
   }
   const agentEntries = Object.entries(parsed.data.agents);
-  if (agentEntries.length !== 1) return false;
+  if (agentEntries.length !== 1) {
+    return false;
+  }
   const activeAgentName = agentEntries[0]?.[0];
   if (
     activeAgentName === undefined ||
@@ -464,7 +467,9 @@ export function isExactHistoricalProductBuilderCandidate(
   }
 
   return HISTORICAL_PRODUCT_BUILDER_VARIANTS.some((variant) => {
-    if (!hasReviewedDefinition(variant)) return false;
+    if (!hasReviewedDefinition(variant)) {
+      return false;
+    }
     const expected = buildHistoricalProductBuilderContent(
       variant.id,
       row.agentName,

--- a/turbo/apps/api/src/test-fixtures/historical-agent-composes.ts
+++ b/turbo/apps/api/src/test-fixtures/historical-agent-composes.ts
@@ -10,6 +10,7 @@ import type { z } from "zod";
 
 import { db } from "../lib/db";
 import { nowDate } from "../lib/time";
+import { buildHistoricalProductBuilderContent } from "../signals/services/historical-product-builder";
 
 // Production Agent APIs intentionally do not expose internal Compose names,
 // immutable version ids, or arbitrary legacy version content. Surviving tests
@@ -23,6 +24,16 @@ type HistoricalAgentComposeContent = z.infer<
 interface HistoricalAgentComposeActor {
   readonly userId: string;
   readonly orgId: string;
+}
+
+/** Transition-only #28070 fixture; removed by #26938 Stage 8. */
+export function historicalProductBuilderContentFixture(
+  agentName: string,
+): Record<string, unknown> {
+  return buildHistoricalProductBuilderContent(
+    "zero-connector-catalog-at-3b45e4e",
+    agentName,
+  );
 }
 
 function sortObjectKeys(value: unknown): unknown {

--- a/turbo/packages/db/MIGRATIONS.md
+++ b/turbo/packages/db/MIGRATIONS.md
@@ -46,6 +46,8 @@ delete the workflow, probe, focused validator, and this entry together.
 | #27997                            | Framework-fallback preflight partition             | #26938 Stage 8 |
 | #28056                            | Historical product-builder classifier and variants | #26938 Stage 8 |
 | #28056                            | Historical product-builder preflight partition     | #26938 Stage 8 |
+| #28070                            | Historical builder environment authority telemetry | #26938 Stage 8 |
+| #28070                            | Historical builder v6 authority-lineage partition  | #26938 Stage 8 |
 
 <!-- vm0-transition-validator:#27613+#27656+#27671+#27792|agent-compose-consolidation-preflight|removal-owner:#26938-stage-8 -->
 <!-- vm0-transition-validator:#27896|agent-execution-authority-classifier-and-helpers|removal-owner:#26938-stage-8 -->
@@ -56,6 +58,8 @@ delete the workflow, probe, focused validator, and this entry together.
 <!-- vm0-transition-validator:#27997|framework-fallback-preflight-partition|removal-owner:#26938-stage-8 -->
 <!-- vm0-transition-validator:#28056|historical-product-builder-classifier-and-variants|removal-owner:#26938-stage-8 -->
 <!-- vm0-transition-validator:#28056|historical-product-builder-preflight-partition|removal-owner:#26938-stage-8 -->
+<!-- vm0-transition-validator:#28070|historical-product-builder-environment-authority-and-telemetry|removal-owner:#26938-stage-8 -->
+<!-- vm0-transition-validator:#28070|historical-product-builder-v6-authority-lineage-partition|removal-owner:#26938-stage-8 -->
 
 ## Migration patterns
 

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-consumers.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-consumers.ts
@@ -15,6 +15,7 @@ type RuntimeContentConsumerMode =
   | "first-plural-schema-parse"
   | "first-plural-framework-display"
   | "head-content-selection-and-type-projection"
+  | "historical-product-builder-authority-classifier"
   | "model-provider-binding-authority"
   | "raw-recursive-variable-secret-scan"
   | "recursive-reference-authority"
@@ -68,6 +69,30 @@ const REVIEWED_CONSUMERS: readonly ReviewedConsumer[] = [
       "validateFrameworkFallbackAgentExecutionPlanRow",
     ],
     variables: ["AGENT_EXECUTION_PLAN_DIMENSIONS"],
+  },
+  {
+    relativePath:
+      "turbo/apps/api/src/signals/services/historical-product-builder.ts",
+    mode: "historical-product-builder-authority-classifier",
+    interfaces: [
+      "HistoricalProductBuilderCandidate",
+      "HistoricalProductBuilderVariant",
+    ],
+    functions: [
+      "buildHistoricalProductBuilderContent",
+      "computeHistoricalProductBuilderReviewFingerprint",
+      "hasReviewedDefinition",
+      "historicalEnvironment",
+      "isExactHistoricalProductBuilderCandidate",
+      "isRecord",
+    ],
+    variables: [
+      "HISTORICAL_PRODUCT_BUILDER_VARIANTS",
+      "REVIEW_AGENT_NAME",
+      "REVIEW_FINGERPRINT_DOMAIN",
+      "ZERO_SECRET_BINDINGS",
+      "ZERO_VARIABLE_BINDINGS",
+    ],
   },
   {
     relativePath:
@@ -209,16 +234,18 @@ export const EXPECTED_RUNTIME_CONTENT_CONSUMER_MANIFEST: RuntimeContentConsumerM
       "schemaParse|turbo/apps/api/src/signals/services/agent-execution-authority.ts|1|0d5805cb82667cf087cffd9bd41358240d5b1a9ed36aca5617ef782810588ad7",
       "schemaParse|turbo/apps/api/src/signals/services/agent-execution-authority.ts|2|bc9d01f8197c2f9bc1e86be04a1f255c158608fe252eb6afcdc56c4f0d7bef35",
       "schemaParse|turbo/apps/api/src/signals/services/agent-instructions.service.ts|1|712fe12ea1d29b388940ea5921cabf4e2dd2dbc2229162e5210dba575ac256f9",
+      "schemaParse|turbo/apps/api/src/signals/services/historical-product-builder.ts|1|bc9d01f8197c2f9bc1e86be04a1f255c158608fe252eb6afcdc56c4f0d7bef35",
       "storageForwarding|turbo/apps/api/src/signals/services/agent-run-create.service.ts|1|14ef880a94a1bae38cf026d24cd1a98096a30e4a16df5a32a746f93fee32c04d",
       "zeroRunRawContentUse|turbo/apps/api/src/signals/services/zero-runs-create.service.ts|1|b59eb415f1b94645a15ac9a30463465caac4a5420b05052a4120ba65c9481e9b",
     ],
     reviewedConsumers: [
       "turbo/apps/api/src/signals/routes/integrations-slack.ts|raw-recursive-variable-secret-scan|1|0357a0f694d2882516d811fff5f28d57abb01a6df4f2bdcb1f8435d0827ea17f",
       "turbo/apps/api/src/signals/services/agent-environment-shadow.ts|compose-independent-environment-shadow|4|bb1c66722499e90deb9a6471567a6d374aefe0f68b878249d0fc4822ddaf3f13",
-      "turbo/apps/api/src/signals/services/agent-execution-authority.ts|application-authority-classifier|15|0277397383c5d7d07943056d597886fb096e10a283bbbef4039ef77def6e08e5",
+      "turbo/apps/api/src/signals/services/agent-execution-authority.ts|application-authority-classifier|15|5ba45d2323d6fc74359a77f3b2c99926ff0ad3dbf8a8e30a523a655cf3149d4a",
       "turbo/apps/api/src/signals/services/agent-instructions.service.ts|first-plural-schema-parse|2|5e0e03733f7327b9e719691adccd8ef9e643f7945e7a2011884b50c17cd0d5ca",
       "turbo/apps/api/src/signals/services/agent-run-create.service.ts|singular-or-first-plural-launch|17|3ba4be01b537988945707f15b9e9e8c60f67bcb8f212be00749e4343c7f2a336",
       "turbo/apps/api/src/signals/services/agent-run-storage.service.ts|singular-or-first-plural-storage-and-volumes|8|f892995687452b9c164950e90aab24e9da198326187dea19b646864d71d35cf9",
+      "turbo/apps/api/src/signals/services/historical-product-builder.ts|historical-product-builder-authority-classifier|14|7b8681f9a1922c125881223a9265b5b3642f5ceb74a410b7f21d1ee3694692f2",
       "turbo/apps/api/src/signals/services/logs.service.ts|first-plural-framework-display|1|ea68586f0591ce59e883d688f75c0a37ac6022e9eb4e5a2fb2cda1be037123ce",
       "turbo/apps/api/src/signals/services/teams-connect.service.ts|raw-recursive-variable-secret-scan|1|0357a0f694d2882516d811fff5f28d57abb01a6df4f2bdcb1f8435d0827ea17f",
       "turbo/apps/api/src/signals/services/telegram-data.service.ts|raw-recursive-variable-secret-scan|1|0357a0f694d2882516d811fff5f28d57abb01a6df4f2bdcb1f8435d0827ea17f",

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-fingerprint.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-fingerprint.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 
 export const PREFLIGHT_SCHEMA_VERSION =
-  "vm0.agent-compose-consolidation-preflight.v5";
+  "vm0.agent-compose-consolidation-preflight.v6";
 
 // Keep the accepted Stage 0 aggregate digests stable while the output schema
 // grows additively. New sets use their own domain strings at each call site.

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-manifest.ts
@@ -318,6 +318,7 @@ export const EXPECTED_REPOSITORY_DEPENDENCIES = {
     "turbo/apps/api/src/signals/services/github-queued-launch-context.service.ts|agentComposeId",
     "turbo/apps/api/src/signals/services/goal.service.ts|agentComposeId",
     "turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts|agentComposeId",
+    "turbo/apps/api/src/signals/services/historical-product-builder.ts|headVersionId",
     "turbo/apps/api/src/signals/services/integration-agent-response-presentation.service.ts|zeroAgents",
     "turbo/apps/api/src/signals/services/internal-agentphone-chat-run-callback.service.ts|agentComposeId",
     "turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts|agentComposeId,zeroAgents",
@@ -406,6 +407,8 @@ export const EXPECTED_REPOSITORY_DEPENDENCIES = {
     "#27997|framework-fallback-preflight-partition|removal-owner:#26938-stage-8",
     "#28056|historical-product-builder-classifier-and-variants|removal-owner:#26938-stage-8",
     "#28056|historical-product-builder-preflight-partition|removal-owner:#26938-stage-8",
+    "#28070|historical-product-builder-environment-authority-and-telemetry|removal-owner:#26938-stage-8",
+    "#28070|historical-product-builder-v6-authority-lineage-partition|removal-owner:#26938-stage-8",
   ],
 } as const satisfies RepositoryDependencyManifest;
 

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight-refinements.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight-refinements.ts
@@ -13,7 +13,7 @@ import {
   fingerprintSortedSet,
   type SetFingerprint,
 } from "./agent-compose-consolidation-preflight-fingerprint";
-import { isExactHistoricalProductBuilderCandidate } from "./agent-compose-consolidation-preflight-historical-product-builder";
+import { isExactHistoricalProductBuilderCandidate } from "../../../apps/api/src/signals/services/historical-product-builder";
 
 export const ENVIRONMENT_PRIMARY_CLASSES = [
   "variableReferenceOnly",
@@ -834,7 +834,9 @@ export function classifyExceptionRefinements(args: {
     string,
     readonly ExceptionRefinementInventoryRow[]
   >;
-  readonly environmentIds: readonly string[];
+  readonly legacyEnvironmentIds: readonly string[];
+  readonly residualEnvironmentIds: readonly string[];
+  readonly applicationHistoricalProductBuilderEnvironmentIds: readonly string[];
   readonly unsupportedIds: readonly string[];
   readonly unclassifiedIds: readonly string[];
   readonly failureGates: Set<string>;
@@ -850,7 +852,7 @@ export function classifyExceptionRefinements(args: {
   >();
   const environment = primaryClassification({
     domain: "agentExecutionPlans.refinements.systemEnvironmentDifferences",
-    parentIds: args.environmentIds,
+    parentIds: args.legacyEnvironmentIds,
     primaryClasses: ENVIRONMENT_PRIMARY_CLASSES,
     rowsById: args.rowsById,
     failureGates: args.failureGates,
@@ -870,7 +872,7 @@ export function classifyExceptionRefinements(args: {
       }),
     ),
   ];
-  const expectedOverlapUnionIds = args.environmentIds.filter((id) => {
+  const expectedOverlapUnionIds = args.legacyEnvironmentIds.filter((id) => {
     return (environmentClassifications.get(id)?.overlaps.size ?? 0) > 0;
   });
   const overlapUnionClosure = setComparison(
@@ -894,7 +896,7 @@ export function classifyExceptionRefinements(args: {
   const historicalProductBuilderOriginClassification = primaryClassification({
     domain:
       "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin",
-    parentIds: args.environmentIds,
+    parentIds: args.legacyEnvironmentIds,
     primaryClasses: HISTORICAL_PRODUCT_BUILDER_ORIGIN_CLASSES,
     rowsById: args.rowsById,
     failureGates: args.failureGates,
@@ -928,6 +930,70 @@ export function classifyExceptionRefinements(args: {
     args.failureGates.add(
       "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin.primaryDisjointnessClosure",
     );
+  }
+
+  const exactHistoricalProductBuilderIds =
+    historicalProductBuilderOriginClassification.idsByClass
+      .exactHistoricalProductBuilder;
+  const unprovenHistoricalProductBuilderIds = [
+    ...historicalProductBuilderOriginClassification.idsByClass
+      .referenceOnlyButUnproven,
+    ...historicalProductBuilderOriginClassification.idsByClass
+      .literalOrOtherUnproven,
+  ];
+  const legacyEnvironmentLineage = fingerprintSortedSet(
+    "agent-execution-plans:systemEnvironmentDifferences:agent-ids",
+    args.legacyEnvironmentIds,
+  );
+  const applicationAuthorityMembershipLineageClosure = setComparison(
+    "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin:application-authority-membership-lineage-closure",
+    exactHistoricalProductBuilderIds,
+    args.applicationHistoricalProductBuilderEnvironmentIds,
+    true,
+  );
+  const residualEnvironmentMembershipLineageClosure = setComparison(
+    "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin:residual-environment-membership-lineage-closure",
+    unprovenHistoricalProductBuilderIds,
+    args.residualEnvironmentIds,
+    true,
+  );
+  const authorityPartitionClosure = setComparison(
+    "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin:authority-partition-closure",
+    args.legacyEnvironmentIds,
+    [
+      ...args.applicationHistoricalProductBuilderEnvironmentIds,
+      ...args.residualEnvironmentIds,
+    ],
+    true,
+  );
+  const residualEnvironmentSet = new Set(args.residualEnvironmentIds);
+  const authorityIntersectionIds =
+    args.applicationHistoricalProductBuilderEnvironmentIds.filter((id) => {
+      return residualEnvironmentSet.has(id);
+    });
+  const authorityDisjointnessClosure = setComparison(
+    "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin:authority-disjointness-closure",
+    [],
+    authorityIntersectionIds,
+    true,
+  );
+  for (const [name, closure] of [
+    [
+      "applicationAuthorityMembershipLineageClosure",
+      applicationAuthorityMembershipLineageClosure,
+    ],
+    [
+      "residualEnvironmentMembershipLineageClosure",
+      residualEnvironmentMembershipLineageClosure,
+    ],
+    ["authorityPartitionClosure", authorityPartitionClosure],
+    ["authorityDisjointnessClosure", authorityDisjointnessClosure],
+  ] as const) {
+    if (closure.classification === "drift") {
+      args.failureGates.add(
+        `agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin.${name}`,
+      );
+    }
   }
 
   const unsupported = primaryClassification({
@@ -978,14 +1044,19 @@ export function classifyExceptionRefinements(args: {
       primaryUnionClosure: environment.unionClosure,
       overlapUnionClosure,
       activity: environment.activity,
-      /** Transition-only #28056 output; removed by #26938 Stage 8. */
+      /** Transition-only #28056 and #28070 output; removed by #26938 Stage 8. */
       historicalProductBuilderOrigin: {
+        legacyEnvironmentLineage,
         primary: historicalProductBuilderOriginClassification.primary,
         primaryPartitionClosure:
           historicalProductBuilderOriginClassification.partitionClosure,
         primaryDisjointnessClosure: originDisjointnessClosure,
         primaryUnionClosure:
           historicalProductBuilderOriginClassification.unionClosure,
+        applicationAuthorityMembershipLineageClosure,
+        residualEnvironmentMembershipLineageClosure,
+        authorityPartitionClosure,
+        authorityDisjointnessClosure,
         activity: historicalProductBuilderOriginClassification.activity,
       },
     },

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
@@ -409,12 +409,35 @@ const PREFLIGHT_V5_OUTPUT_ALLOWLIST = [
   ),
 ];
 
-/** Every and only approved scalar/array path in a complete v5 result. */
+/** Transition-only #28070 authority/lineage output; removed by #26938 Stage 8. */
+const PREFLIGHT_V6_OUTPUT_ALLOWLIST = [
+  ...setOutputPaths(
+    "agentExecutionPlans.applicationHistoricalProductBuilderEnvironment",
+  ),
+  ...setOutputPaths(
+    "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin.legacyEnvironmentLineage",
+  ),
+  ...comparisonOutputPaths(
+    "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin.applicationAuthorityMembershipLineageClosure",
+  ),
+  ...comparisonOutputPaths(
+    "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin.residualEnvironmentMembershipLineageClosure",
+  ),
+  ...comparisonOutputPaths(
+    "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin.authorityPartitionClosure",
+  ),
+  ...comparisonOutputPaths(
+    "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin.authorityDisjointnessClosure",
+  ),
+];
+
+/** Every and only approved scalar/array path in a complete v6 result. */
 export const PREFLIGHT_OUTPUT_ALLOWLIST = [
   ...PREFLIGHT_V2_OUTPUT_ALLOWLIST,
   ...PREFLIGHT_V3_OUTPUT_ALLOWLIST,
   ...PREFLIGHT_V4_OUTPUT_ALLOWLIST,
   ...PREFLIGHT_V5_OUTPUT_ALLOWLIST,
+  ...PREFLIGHT_V6_OUTPUT_ALLOWLIST,
 ].sort();
 
 export interface IdentityInventoryRow extends QueryResultRow {
@@ -1042,6 +1065,7 @@ function classifyAgentExecutionPlans(
   ) as Record<AgentExecutionPlanDimension, Set<string>>;
   const parityIds: string[] = [];
   const frameworkFallbackIds: string[] = [];
+  const historicalProductBuilderEnvironmentIds: string[] = [];
   const exceptionIds: string[] = [];
   const multiDimensionIds: string[] = [];
 
@@ -1052,6 +1076,11 @@ function classifyAgentExecutionPlans(
     if (decision.authority === "application") {
       if (decision.classification === "applicationFrameworkFallback") {
         frameworkFallbackIds.push(id);
+      } else if (
+        decision.classification ===
+        "applicationHistoricalProductBuilderEnvironment"
+      ) {
+        historicalProductBuilderEnvironmentIds.push(id);
       } else {
         parityIds.push(id);
       }
@@ -1072,7 +1101,12 @@ function classifyAgentExecutionPlans(
   const partitionClosure = cardinalityAwareComparison(
     "agent-execution-plans:partition-closure",
     expectedMatchedIds,
-    [...parityIds, ...frameworkFallbackIds, ...exceptionIds],
+    [
+      ...parityIds,
+      ...frameworkFallbackIds,
+      ...historicalProductBuilderEnvironmentIds,
+      ...exceptionIds,
+    ],
   );
   const dimensionUnionIds = [
     ...new Set(
@@ -1123,9 +1157,16 @@ function classifyAgentExecutionPlans(
     }
   }
 
+  const legacyEnvironmentIds = [
+    ...historicalProductBuilderEnvironmentIds,
+    ...dimensionIds.systemEnvironmentDifferences,
+  ];
   const refinements = classifyExceptionRefinements({
     rowsById,
-    environmentIds: [...dimensionIds.systemEnvironmentDifferences],
+    legacyEnvironmentIds,
+    residualEnvironmentIds: [...dimensionIds.systemEnvironmentDifferences],
+    applicationHistoricalProductBuilderEnvironmentIds:
+      historicalProductBuilderEnvironmentIds,
     unsupportedIds: [...dimensionIds.unsupportedOrInvalidContent],
     unclassifiedIds: [...dimensionIds.unclassifiedContent],
     failureGates,
@@ -1133,11 +1174,13 @@ function classifyAgentExecutionPlans(
 
   const dimensionOutput = Object.fromEntries(
     AGENT_EXECUTION_PLAN_DIMENSIONS.map((dimension) => {
+      const domain =
+        dimension === "systemEnvironmentDifferences"
+          ? "agent-execution-plans:v6:residual-system-environment-differences:agent-ids"
+          : `agent-execution-plans:${dimension}:agent-ids`;
       return [
         dimension,
-        fingerprintSortedSet(`agent-execution-plans:${dimension}:agent-ids`, [
-          ...dimensionIds[dimension],
-        ]),
+        fingerprintSortedSet(domain, [...dimensionIds[dimension]]),
       ];
     }),
   ) as Record<AgentExecutionPlanDimension, SetFingerprint>;
@@ -1154,6 +1197,10 @@ function classifyAgentExecutionPlans(
     applicationFrameworkFallback: fingerprintSortedSet(
       "agent-execution-plans:application-framework-fallback-agent-ids",
       frameworkFallbackIds,
+    ),
+    applicationHistoricalProductBuilderEnvironment: fingerprintSortedSet(
+      "agent-execution-plans:v6:application-historical-product-builder-environment-agent-ids",
+      historicalProductBuilderEnvironmentIds,
     ),
     exceptions: fingerprintSortedSet(
       "agent-execution-plans:exception-agent-ids",

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -33,7 +33,7 @@ import {
   computeHistoricalProductBuilderReviewFingerprint,
   isExactHistoricalProductBuilderCandidate,
   type HistoricalProductBuilderCandidate,
-} from "./agent-compose-consolidation-preflight-historical-product-builder";
+} from "../../../apps/api/src/signals/services/historical-product-builder";
 import {
   EXPECTED_RUNTIME_CONTENT_CONSUMER_MANIFEST,
   collectRuntimeContentConsumerManifest,
@@ -543,7 +543,10 @@ function testSchemaV3DomainsRemainByteStable(): void {
 /** Transition-only #28056 contract test; removed by #26938 Stage 8. */
 function testSchemaV4OutputContractRemainsByteStable(): void {
   const acceptedV4Paths = PREFLIGHT_OUTPUT_ALLOWLIST.filter((outputPath) => {
-    return !outputPath.includes(".historicalProductBuilderOrigin.");
+    return (
+      !outputPath.includes(".historicalProductBuilderOrigin.") &&
+      !outputPath.includes(".applicationHistoricalProductBuilderEnvironment.")
+    );
   });
   assert.equal(acceptedV4Paths.length, 874);
   assert.deepEqual(
@@ -555,6 +558,34 @@ function testSchemaV4OutputContractRemainsByteStable(): void {
       count: 874,
       digest:
         "24a68ad3c32b2d796e42477c2424a0dd8206f89e6c1ce5f0cdda4d418da47b94",
+    },
+  );
+}
+
+/** Transition-only #28070 contract test; removed by #26938 Stage 8. */
+function testSchemaV5OutputContractRemainsByteStable(): void {
+  const v6Markers = [
+    ".applicationHistoricalProductBuilderEnvironment.",
+    ".legacyEnvironmentLineage.",
+    ".applicationAuthorityMembershipLineageClosure.",
+    ".residualEnvironmentMembershipLineageClosure.",
+    ".authorityPartitionClosure.",
+    ".authorityDisjointnessClosure.",
+  ];
+  const acceptedV5Paths = PREFLIGHT_OUTPUT_ALLOWLIST.filter((outputPath) => {
+    return !v6Markers.some((marker) => {
+      return outputPath.includes(marker);
+    });
+  });
+  assert.deepEqual(
+    fingerprintSortedSet(
+      "agent-compose-consolidation-preflight:v5-output-paths",
+      acceptedV5Paths,
+    ),
+    {
+      count: 971,
+      digest:
+        "931140875c0a0d3c568166d61a680fedbd219f1d5bdffdbc5a660962263b49e1",
     },
   );
 }
@@ -1528,7 +1559,7 @@ function mutableHistoricalContent(agentName: string): {
   return { content, agent, environment };
 }
 
-/** Transition-only #28056 focused test; removed by #26938 Stage 8. */
+/** Transition-only #28056 and #28070 focused test; removed by #26938 Stage 8. */
 function testHistoricalProductBuilderVariantAndClassifier(): void {
   assert.equal(HISTORICAL_PRODUCT_BUILDER_VARIANTS.length, 1);
   const variant = HISTORICAL_PRODUCT_BUILDER_VARIANTS[0];
@@ -1590,6 +1621,11 @@ function testHistoricalProductBuilderVariantAndClassifier(): void {
   const exact = historicalCandidate(agentName);
   const unchanged = structuredClone(exact);
   assert.equal(isExactHistoricalProductBuilderCandidate(exact), true);
+  assert.deepEqual(classifyAgentExecutionAuthority(exact), {
+    authority: "application",
+    classification: "applicationHistoricalProductBuilderEnvironment",
+    dimensions: [],
+  });
   assert.deepEqual(exact, unchanged);
 
   const changedKey = mutableHistoricalContent(agentName);
@@ -1612,6 +1648,7 @@ function testHistoricalProductBuilderVariantAndClassifier(): void {
 
   const partial = mutableHistoricalContent(agentName);
   partial.agent.environment = {
+    GH_TOKEN: "${{ secrets.GH_TOKEN }}",
     ZERO_AGENT_ID: "${{ vars.ZERO_AGENT_ID }}",
     ZERO_TOKEN: "${{ secrets.ZERO_TOKEN }}",
   };
@@ -1712,42 +1749,58 @@ function testHistoricalProductBuilderVariantAndClassifier(): void {
     missingVersion,
     historicalCandidate(agentName, null),
   );
-  for (const candidate of unproven) {
+  for (const [index, candidate] of unproven.entries()) {
+    const unchangedCandidate = structuredClone(candidate);
     assert.equal(isExactHistoricalProductBuilderCandidate(candidate), false);
+    const authorityDecision = classifyAgentExecutionAuthority(candidate);
+    assert.equal(
+      authorityDecision.authority,
+      "version_content",
+      `unproven candidate ${index}: ${authorityDecision.classification}`,
+    );
+    assert.deepEqual(candidate, unchangedCandidate);
   }
 }
 
-/** Transition-only #28056 focused test; removed by #26938 Stage 8. */
+/** Transition-only #28056 and #28070 focused test; removed by #26938 Stage 8. */
 function testHistoricalProductBuilderOriginPartition(): void {
   const snapshot = new Date("2026-08-17T00:00:00.000Z");
   const id = (suffix: number): string => {
     return `00000000-0000-4000-8000-${suffix.toString().padStart(12, "0")}`;
   };
-  const exactId = id(800);
-  const exactName = "historical-origin-exact";
-  const rows: AgentExecutionPlanInventoryRow[] = [
-    executionPlanRow({
-      id: exactId,
-      agentName: exactName,
-      content: buildHistoricalProductBuilderContent(
-        "zero-connector-catalog-at-3b45e4e",
-        exactName,
-      ),
-      activitySnapshotTime: snapshot,
-      latestAttributedRunAt: snapshot,
-      currentHeadEverExercised: true,
-    }),
-  ];
+  const exactIds: string[] = [];
+  const legacyEnvironmentRows: AgentExecutionPlanInventoryRow[] = [];
+  for (let index = 0; index < 8; index += 1) {
+    const exactId = id(800 + index);
+    const exactName = `historical-origin-exact-${index}`;
+    exactIds.push(exactId);
+    legacyEnvironmentRows.push(
+      executionPlanRow({
+        id: exactId,
+        agentName: exactName,
+        content: buildHistoricalProductBuilderContent(
+          "zero-connector-catalog-at-3b45e4e",
+          exactName,
+        ),
+        activitySnapshotTime: snapshot,
+        latestAttributedRunAt:
+          index < 6 ? new Date("2026-06-15T00:00:00.000Z") : null,
+        currentHeadEverExercised: index < 5,
+      }),
+    );
+  }
   const referenceIds: string[] = [];
-  for (let index = 0; index < 657; index += 1) {
-    const rowId = id(801 + index);
+  for (let index = 0; index < 650; index += 1) {
+    const rowId = id(808 + index);
     const name = `historical-origin-reference-${index}`;
     const content = mutableAgentContent(name);
     content.agents[name]!.environment = {
       [`LEGACY_CONNECTOR_${index}`]: `\${{ secrets.LEGACY_CONNECTOR_${index} }}`,
     };
     referenceIds.push(rowId);
-    rows.push(executionPlanRow({ id: rowId, agentName: name, content }));
+    legacyEnvironmentRows.push(
+      executionPlanRow({ id: rowId, agentName: name, content }),
+    );
   }
   const literalId = id(1458);
   const literalName = "historical-origin-literal";
@@ -1755,7 +1808,7 @@ function testHistoricalProductBuilderOriginPartition(): void {
   literalContent.agents[literalName]!.environment = {
     LEGACY_LITERAL: "literal-value",
   };
-  rows.push(
+  legacyEnvironmentRows.push(
     executionPlanRow({
       id: literalId,
       agentName: literalName,
@@ -1765,25 +1818,124 @@ function testHistoricalProductBuilderOriginPartition(): void {
     }),
   );
 
+  const unclassifiedIds: string[] = [];
+  const unclassifiedRows: AgentExecutionPlanInventoryRow[] = [];
+  for (let index = 0; index < 167; index += 1) {
+    const rowId = id(1459 + index);
+    const name = `residual-content-${index}`;
+    const content = mutableAgentContent(name);
+    content.futureField = { reviewedRuntimeReachable: index };
+    unclassifiedIds.push(rowId);
+    unclassifiedRows.push(
+      executionPlanRow({ id: rowId, agentName: name, content }),
+    );
+  }
+  const unsupportedIds: string[] = [];
+  const unsupportedRows: AgentExecutionPlanInventoryRow[] = [];
+  for (let index = 0; index < 70; index += 1) {
+    const rowId = id(1626 + index);
+    unsupportedIds.push(rowId);
+    unsupportedRows.push(
+      executionPlanRow({
+        id: rowId,
+        agentName: `unsupported-content-${index}`,
+        content: { version: "1", agents: {} },
+      }),
+    );
+  }
+  const danglingIds: string[] = [];
+  const danglingRows: AgentExecutionPlanInventoryRow[] = [];
+  for (let index = 0; index < 17; index += 1) {
+    const rowId = id(1696 + index);
+    danglingIds.push(rowId);
+    danglingRows.push(
+      executionPlanRow({
+        id: rowId,
+        agentName: `dangling-head-${index}`,
+        content: null,
+        headVersionId: "a".repeat(64),
+        versionId: null,
+      }),
+    );
+  }
+  const rows = [
+    ...legacyEnvironmentRows,
+    ...unclassifiedRows,
+    ...unsupportedRows,
+    ...danglingRows,
+  ];
+
   const result = classifyPlanRows(rows);
   const environment =
     result.agentExecutionPlans.refinements.systemEnvironmentDifferences;
   const origin = environment.historicalProductBuilderOrigin;
   assert.equal(
     result.agentExecutionPlans.systemEnvironmentDifferences.count,
-    659,
+    651,
   );
   assert.equal(
     result.agentExecutionPlans.systemEnvironmentDifferences.digest,
     fingerprintSortedSet(
+      "agent-execution-plans:v6:residual-system-environment-differences:agent-ids",
+      [...referenceIds, literalId],
+    ).digest,
+  );
+  assert.equal(
+    result.agentExecutionPlans.applicationHistoricalProductBuilderEnvironment
+      .count,
+    8,
+  );
+  assert.equal(
+    result.agentExecutionPlans.applicationHistoricalProductBuilderEnvironment
+      .digest,
+    fingerprintSortedSet(
+      "agent-execution-plans:v6:application-historical-product-builder-environment-agent-ids",
+      exactIds,
+    ).digest,
+  );
+  assert.equal(result.agentExecutionPlans.exceptions.count, 905);
+  assert.equal(result.agentExecutionPlans.unclassifiedContent.count, 167);
+  assert.equal(
+    result.agentExecutionPlans.unclassifiedContent.digest,
+    fingerprintSortedSet(
+      "agent-execution-plans:unclassifiedContent:agent-ids",
+      unclassifiedIds,
+    ).digest,
+  );
+  assert.equal(
+    result.agentExecutionPlans.unsupportedOrInvalidContent.count,
+    70,
+  );
+  assert.equal(
+    result.agentExecutionPlans.unsupportedOrInvalidContent.digest,
+    fingerprintSortedSet(
+      "agent-execution-plans:unsupportedOrInvalidContent:agent-ids",
+      unsupportedIds,
+    ).digest,
+  );
+  assert.equal(
+    result.agentExecutionPlans.danglingOrMissingHeadVersion.count,
+    17,
+  );
+  assert.equal(
+    result.agentExecutionPlans.danglingOrMissingHeadVersion.digest,
+    fingerprintSortedSet(
+      "agent-execution-plans:danglingOrMissingHeadVersion:agent-ids",
+      danglingIds,
+    ).digest,
+  );
+  assert.equal(origin.legacyEnvironmentLineage.count, 659);
+  assert.equal(
+    origin.legacyEnvironmentLineage.digest,
+    fingerprintSortedSet(
       "agent-execution-plans:systemEnvironmentDifferences:agent-ids",
-      rows.map((row) => {
+      legacyEnvironmentRows.map((row) => {
         return row.id;
       }),
     ).digest,
   );
-  assert.equal(origin.primary.exactHistoricalProductBuilder.count, 1);
-  assert.equal(origin.primary.referenceOnlyButUnproven.count, 657);
+  assert.equal(origin.primary.exactHistoricalProductBuilder.count, 8);
+  assert.equal(origin.primary.referenceOnlyButUnproven.count, 650);
   assert.equal(origin.primary.literalOrOtherUnproven.count, 1);
   assert.equal(origin.primaryPartitionClosure.classification, "exact");
   assert.equal(origin.primaryPartitionClosure.expected.count, 659);
@@ -1797,7 +1949,7 @@ function testHistoricalProductBuilderOriginPartition(): void {
     origin.primary.exactHistoricalProductBuilder.digest,
     fingerprintSortedSet(
       "agentExecutionPlans.refinements.systemEnvironmentDifferences.historicalProductBuilderOrigin:primary:exactHistoricalProductBuilder:agent-ids",
-      [exactId],
+      exactIds,
     ).digest,
   );
   assert.equal(
@@ -1820,18 +1972,34 @@ function testHistoricalProductBuilderOriginPartition(): void {
   assert.ok(exactActivity);
   assert.ok(referenceActivity);
   assert.ok(literalActivity);
-  assert.equal(exactActivity.currentHeadEverExercised.count, 1);
-  assert.equal(exactActivity.latestAttributedRun.within7Days.count, 1);
+  assert.equal(exactActivity.currentHeadEverExercised.count, 5);
+  assert.equal(exactActivity.latestAttributedRun.over30Through90Days.count, 6);
+  assert.equal(exactActivity.latestAttributedRun.noAttributedRun.count, 2);
   assert.equal(
     referenceActivity.latestAttributedRun.noAttributedRun.count,
-    657,
+    650,
   );
   assert.equal(literalActivity.latestAttributedRun.over90Days.count, 1);
+  assert.equal(
+    origin.applicationAuthorityMembershipLineageClosure.classification,
+    "exact",
+  );
+  assert.equal(
+    origin.residualEnvironmentMembershipLineageClosure.classification,
+    "exact",
+  );
+  assert.equal(origin.authorityPartitionClosure.classification, "exact");
+  assert.equal(origin.authorityPartitionClosure.expected.count, 659);
+  assert.equal(origin.authorityPartitionClosure.observed.count, 659);
+  assert.equal(origin.authorityDisjointnessClosure.classification, "exact");
+  assert.equal(origin.authorityDisjointnessClosure.observed.count, 0);
 
   const duplicateFailureGates = new Set<string>();
   const duplicate = classifyExceptionRefinements({
-    rowsById: new Map([[exactId, [rows[0]!]]]),
-    environmentIds: [exactId, exactId],
+    rowsById: new Map([[exactIds[0]!, [legacyEnvironmentRows[0]!]]]),
+    legacyEnvironmentIds: [exactIds[0]!, exactIds[0]!],
+    residualEnvironmentIds: [],
+    applicationHistoricalProductBuilderEnvironmentIds: [exactIds[0]!],
     unsupportedIds: [],
     unclassifiedIds: [],
     failureGates: duplicateFailureGates,
@@ -1944,7 +2112,9 @@ function testEnvironmentExceptionRefinements(): void {
   const failureGates = new Set<string>();
   const forced = classifyExceptionRefinements({
     rowsById: new Map([[unclassifiedId, [unclassifiedRow]]]),
-    environmentIds: [unclassifiedId],
+    legacyEnvironmentIds: [unclassifiedId],
+    residualEnvironmentIds: [unclassifiedId],
+    applicationHistoricalProductBuilderEnvironmentIds: [],
     unsupportedIds: [],
     unclassifiedIds: [],
     failureGates,
@@ -2565,7 +2735,7 @@ function testOutputRedaction(): void {
     (error: unknown) => {
       assert.ok(error instanceof SanitizedPreflightError);
       assert.deepEqual(sanitizedFailureResult(error), {
-        schemaVersion: "vm0.agent-compose-consolidation-preflight.v5",
+        schemaVersion: "vm0.agent-compose-consolidation-preflight.v6",
         status: "failed",
         failureGates: ["probe.output_shape"],
       });
@@ -2608,7 +2778,7 @@ function assertSafeAggregateValues(value: unknown, pathPrefix = ""): void {
     return;
   }
   const allowedClassifications = new Set([
-    "vm0.agent-compose-consolidation-preflight.v5",
+    "vm0.agent-compose-consolidation-preflight.v6",
     "passed",
     "failed",
     "exact",
@@ -3027,10 +3197,13 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
       workflow.indexOf('>> "$GITHUB_OUTPUT"'),
   );
   assert.match(workflow, /scripts\/agent-compose-consolidation-preflight\.ts/u);
-  assert.match(workflow, /#27613 \+ #27656 \+ #27671 \+ #27792 \+ #28056/u);
-  assert.match(workflow, /vm0\.agent-compose-consolidation-preflight\.v5/u);
+  assert.match(
+    workflow,
+    /#27613 \+ #27656 \+ #27671 \+ #27792 \+ #28056 \+ #28070/u,
+  );
+  assert.match(workflow, /vm0\.agent-compose-consolidation-preflight\.v6/u);
   assert.equal(
-    /vm0\.agent-compose-consolidation-preflight\.v[1234]/u.test(workflow),
+    /vm0\.agent-compose-consolidation-preflight\.v[1-5]/u.test(workflow),
     false,
   );
   assert.equal(
@@ -3073,7 +3246,7 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
 
   const historicalClassifierPath = path.join(
     repositoryRoot,
-    "turbo/packages/db/scripts/agent-compose-consolidation-preflight-historical-product-builder.ts",
+    "turbo/apps/api/src/signals/services/historical-product-builder.ts",
   );
   const historicalClassifierSource = await fs.readFile(
     historicalClassifierPath,
@@ -3097,13 +3270,15 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
     false,
   );
   const historicalClassifierCallers = execFileSync(
-    "git",
+    "rg",
     [
-      "grep",
       "-l",
-      "agent-compose-consolidation-preflight-historical-product-builder",
-      "--",
+      "-F",
+      "isExactHistoricalProductBuilderCandidate(",
+      "--glob",
       "*.ts",
+      "turbo/apps/api/src/signals",
+      "turbo/packages/db/scripts",
     ],
     { cwd: repositoryRoot, encoding: "utf8" },
   )
@@ -3111,6 +3286,8 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
     .split("\n")
     .sort();
   assert.deepEqual(historicalClassifierCallers, [
+    "turbo/apps/api/src/signals/services/agent-execution-authority.ts",
+    "turbo/apps/api/src/signals/services/historical-product-builder.ts",
     "turbo/packages/db/scripts/agent-compose-consolidation-preflight-refinements.ts",
     "turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts",
   ]);
@@ -3702,6 +3879,7 @@ export async function validateAgentComposeConsolidationPreflightStatic(): Promis
   await validateLaunchSnapshotBackfillStatic();
   testSchemaV3DomainsRemainByteStable();
   testSchemaV4OutputContractRemainsByteStable();
+  testSchemaV5OutputContractRemainsByteStable();
   testApplicationOwnedPlanAndCanonicalCompatibility();
   testIdentityAndApprovedArtifacts();
   testVersionHeadRunAndCheckpointClassifications();


### PR DESCRIPTION
## Summary

- move the sealed Stage 4D historical product-builder variant and exact classifier into one production-safe module shared by runtime and protected preflight
- add the fail-closed `applicationHistoricalProductBuilderEnvironment` subtype only for supported, environment-only plan differences whose complete current head exactly matches the sealed variant
- preserve the original 659-row legacy environment lineage and 8/650/1 origin proof while publishing the live v6 authority split of 8 application / 651 residual environment and 905 total residual exceptions
- prove fresh application-owned provider, authorized Connector, system/Run, and runtime assembly for both a new Run and Session continuation without changing the existing Run creation owner

## Actual diff and authority boundary

The production behavior change is bounded to the shared classifier and `classifyAgentExecutionAuthority`. The existing `runtimeResolvedCompose` boundary in `agent-run-create.service.ts` already replaces application-authority content with a fresh `buildZeroAgentComposeContent` projection before persisted-environment loading, validation, expansion, stored-context construction, or Runner payload construction; this PR does not modify that service.

The new subtype requires all of the following before returning application authority:

- supported unstripped schema with exactly one normalized Agent
- current head and selected version identity equality
- content-addressed version hash equality
- only `systemEnvironmentDifferences` in the application-plan comparison
- whole-document equality to the single sealed repository-reconstructed builder variant

Changed keys, values, references, `vars`/`secrets` sources, missing/extra/partial/superset bindings, literal values, unknown fields, ambiguous Agents, hash/name/head/version drift, dangling heads, and every non-environment plan difference remain `version_content`.

## Caller inventory

- Production classifier caller: `agent-run-create.service.ts` calls `classifyAgentExecutionAuthority` once through `runtimeResolvedCompose`, itself called once by `prepareRunBodyContext` only for the product-Agent canonical runtime path.
- Protected preflight caller: `agent-compose-consolidation-preflight.ts` uses the same authority classifier for the live partition.
- Historical-lineage caller: `agent-compose-consolidation-preflight-refinements.ts` uses the same exact classifier to preserve the original 8/650/1 observation lineage.
- Test/static callers: `test-agent-compose-consolidation-preflight.ts` and the shared module's own definition.
- No non-product lower-level execution caller changes; `productAgentName === undefined` still bypasses this authority projection.
- No additional database, secret, Connector, provider, Storage, or permission query was added. Focused timing assertions retain each existing owner action exactly once.

## Protected v6 partition and closure

- Legacy observation lineage: 659, retaining the v5 domain and exact 8 `exactHistoricalProductBuilder` / 650 `referenceOnlyButUnproven` / 1 `literalOrOtherUnproven` proof.
- Live application subtype: 8, with a new domain-separated v6 fingerprint.
- Live residual `systemEnvironmentDifferences`: 651, exactly 650+1, with a new domain-separated v6 fingerprint and the environment failure gate retained.
- Live residual exceptions: 905 = 651 environment + 167 residual content + 70 unsupported/invalid + 17 dangling/missing head.
- The 167/70/17 domains remain unchanged.
- New membership-lineage, authority-partition, and authority-disjointness closures fail closed on drift; existing inventory, dimension-union, activity, dependency, consumer, checkpoint, version, identity, and launch-snapshot closures remain intact.
- The v5 output-path contract remains byte-stable, while workflow failure stubs, output allowlist, consumer manifest, safe fingerprint domains, and repository transition manifest advance atomically to v6.

## Open-PR overlap refreshed before push

- Full open-PR file intersection found only #27764 at `c463feb3119ec7e3c0d655e21d7904a60756164f` on `run-lifecycle.bdd.test.ts`; its billing import/test hunks are separate and untouched.
- #25722 remains open at `2aed1f0de2a54db881ca266151c1362ea6c9dd62`; its Cloudflare runtime work is not reproduced, and this PR does not edit `agent-run-create.service.ts`.
- #26947 remains open at `5a7f432bf14efda513c1eae377879e86f3fad45d`; its optional internal `runId` work is not reproduced, and this PR does not edit `agent-run-create.service.ts`.
- #28066 remains open at `35170970ced38ecf25834b852cd9ba4e036c85f7`; no account-storage schema or future Connector-selection semantics are imported.

## Acceptance self-review

- [x] Only exact Stage 4D sealed-builder heads can choose the new application subtype; no production identity allowlist or learned variant exists.
- [x] The historical 281-entry catalog stops at the existing authority boundary, and the current application owners assemble the launch environment.
- [x] The 650+1 unproven environment rows and the 167/70/17 exception domains retain version-content behavior.
- [x] New Run and continuation use the latest head and current Connector configuration; selected-version provenance and immutable launch snapshot remain exact and checkpoint-independent.
- [x] v6 proves the 659 lineage, 8/651 live split, 905 residual exceptions, unchanged other domains, and exact closure/disjointness without raw output.
- [x] No checkpoint, public/Runner wire, physical provenance field, schema/data, canonical-Agent, route, or lower-level service contract changes.
- [x] Focused coverage includes exact variants, adversarial near-matches, application assembly, continuation, provenance, snapshots, telemetry/redaction/failure isolation, manifests, and query isolation.
- [x] All classifier, v6 lineage, telemetry subtype, test, workflow, and manifest material is marked for #26938 Stage 8 removal.

## Validation

- `pnpm format`
- `NODE_OPTIONS='--max-old-space-size=3072' pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- post-rebase `api` / `@okouai/db` lint and type-check
- focused protected preflight/workflow/static validator via `validateAgentComposeConsolidationPreflightStatic()`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'uses application authority for framework-only historical heads|uses application environment authority for exact historical builder heads|classifies active legacy environment value shapes without exposing them'` (3 passed, 159 skipped)
- `git diff --check origin/main...HEAD`

No full local Vitest suite, development server, production release, protected production preflight, or production data operation was run.

## Transition fallback and removal ownership

Until #26938 Stage 8 removes this transition, the exact eight retain selected-version provenance and immutable historical heads, while every unproven environment and other exception remains on the explicit version-content fallback. Stage 8 owns removal of the sealed classifier/fixture, new authority and telemetry subtype, v6 lineage output and workflow assertions, focused tests, and both transition-manifest entries.

Closes #28070
Parent #26938
