### PR TITLE
fix(api): bypass stale network telemetry cache

### DIFF
--- a/turbo/apps/api/src/signals/external/__tests__/axiom.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/axiom.test.ts
@@ -34,7 +34,7 @@ describe("queryAxiom", () => {
     ]);
   });
 
-  it("sends the pagination cursor in the documented Axiom request body", async () => {
+  it("sends pagination cursor reads without using the Axiom cache", async () => {
     const { queryAxiom } =
       await vi.importActual<typeof import("../axiom")>("../axiom");
     const mocks = getApiTestMocks();
@@ -73,6 +73,7 @@ describe("queryAxiom", () => {
     const rows = await createStore().get(
       queryAxiom(apl, {
         cursor: "cursor-next-page",
+        noCache: true,
       }),
     );
 
@@ -84,7 +85,7 @@ describe("queryAxiom", () => {
           apl,
           cursor: "cursor-next-page",
         },
-        url: "https://api.axiom.co/v1/datasets/_apl?format=legacy",
+        url: "https://api.axiom.co/v1/datasets/_apl?format=legacy&nocache=true",
       },
     ]);
     expect(rows).toStrictEqual([

--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -246,9 +246,9 @@ export async function flushAxiom(
   }
 }
 
-// Minimal options surface. Agent-event reads bypass Axiom's per-request cache
-// while the frontend waits for the terminal event watermark; `cursor` is used
-// for Axiom-managed time pagination.
+// Minimal options surface. Fresh-read consumers bypass Axiom's per-request
+// cache while waiting for asynchronously ingested terminal data; `cursor` is
+// used for Axiom-managed time pagination.
 interface QueryAxiomOptions {
   readonly noCache?: boolean;
   readonly cursor?: string;

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1872,7 +1872,10 @@ function expectTimeCursorAxiomResume(
   },
 ): void {
   const apl = call[0];
-  expect(call[1]).toStrictEqual({ cursor: expected.cursor });
+  expect(call[1]).toStrictEqual({
+    cursor: expected.cursor,
+    noCache: true,
+  });
   expect(apl).toContain(`| order by _time ${expected.order}`);
   if (expected.hasCreatedAtBound) {
     expect(apl).toContain("| where _time >= datetime(");
@@ -2181,6 +2184,8 @@ describe("RUN-04: agent run telemetry families", () => {
       hasMore: true,
       nextCursor: expectedNextCursor,
     });
+    const networkQuery = axiomCallAt(axiomCallCount() - 1);
+    expect(networkQuery[1]).toStrictEqual({ noCache: true });
   });
 
   it("keeps same-timestamp network rows reachable across time cursor pages", async () => {

--- a/turbo/apps/api/src/signals/services/run-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/run-detail.service.ts
@@ -255,8 +255,11 @@ ${buildTimeCursorProjection()}
         queryAxiom(
           apl,
           previousCursorBoundary
-            ? { cursor: previousCursorBoundary.tieBreaker }
-            : undefined,
+            ? {
+                cursor: previousCursorBoundary.tieBreaker,
+                noCache: true,
+              }
+            : { noCache: true },
         ),
       )
     ).slice();


### PR DESCRIPTION
## Summary

- bypass Axiom's per-request cache for network telemetry reads, including cursor pagination
- preserve the existing continued-session credential refresh and firewall-observation assertions
- cover the fresh-read option at the run-read boundary and the Axiom request boundary

## Root cause

The failing connector-refresh run completed its continued session, returned its context successfully, and uploaded a network telemetry batch. Distributed traces show this ordering on the continued run:

1. `21:33:50.610Z`: continued run created
2. `21:33:52.395Z`: continued run completed
3. `21:33:53.361Z`: context read started and returned `200`
4. `21:33:54.161Z`: network telemetry upload started
5. `21:33:54.231Z`: the first network telemetry query started
6. `21:33:54.289Z`: Axiom ingest completed with `200`
7. `21:33:54.231Z`–`21:35:22.208Z`: 38 network reads returned `200`, but repeated the cached empty result
8. `21:35:25Z`: the firewall observation timed out

The nondeterministic boundary is whether the first read starts before the deferred telemetry ingest becomes query-visible. The passing initial run queried only after ingest completed. This is distinct from the existing `/context` timeout fingerprint: the context request succeeded here before the first absent network row.

The API already supports `nocache=true` for fresh Axiom reads. Network telemetry now uses that path so an early empty result cannot remain pinned throughout the bounded poll. The fix does not add retries, sleeps, timeout increases, skipped assertions, or detached cleanup.

## Failure and comparisons

- Triggering run: https://github.com/vm0-ai/vm0/actions/runs/32187817651
- Failing job: https://github.com/vm0-ai/vm0/actions/runs/32187817651/job/95876843703
- Same PR head passing run: https://github.com/vm0-ai/vm0/actions/runs/32187095191/job/95874351001
- Exact merge-parent passing run: https://github.com/vm0-ai/vm0/actions/runs/32185069362/job/95867964677
- Preceding adjacent passing run: https://github.com/vm0-ai/vm0/actions/runs/32184114648/job/95865346752

PR #28072 changed only app-factory schema-readiness cleanup and did not touch runner connector refresh, firewall handling, or telemetry. Open-PR and active-owner searches found no equivalent repair for this telemetry-cache fingerprint.

## Local validation

- `pnpm format`
- `pnpm exec prettier --check` on the four changed files
- `pnpm turbo run lint --concurrency=1 --log-order grouped --output-logs=errors-only`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- focused Axiom test file: 5/5 runs passed (2/2 tests each) with the repository env stubs and MSW setup, without a database or local service
- `git diff --check`

The standard API Vitest setup attempted to connect to local PostgreSQL before this unit file executed. No database or service was started; the database-backed run-read regression ran in the PR pipeline.

## Preview validation

- Deployed head: `29b3cf408f9b527d26bad98998f4da9c47f836f6`
- App/auth preview: https://pr-28074-app.omby.ai
- API preview: https://pr-28074-api.vm6.ai
- API `/health`: PASS (`status: ok`)
- App preview development sign-in page: PASS at 1280×900 in Headless Chrome 151; onboarding was not bypassed and no feature switches were enabled
- Exact runner shard with `run-t22-connector-refresh.bats`: PASS on the initial full run and PASS again after regenerating isolated runner accounts
  - https://github.com/vm0-ai/vm0/actions/runs/32192145714/job/95889610173
  - https://github.com/vm0-ai/vm0/actions/runs/32192145714/job/95892323097
- Full PR checks after the valid account-prepared rerun: 74 passing, 0 pending, 0 failing

A leaf-job-only rerun was not a valid additional sample: the prior successful cleanup had removed its one-time test identities, so both tests stopped in setup on upstream identity lookup before creating an agent. Repeating further requires rerunning account preparation and all runner shards rather than the narrow check, so validation stops at two valid deployed samples. Local focused coverage completed 5/5 runs.

Browser evidence: https://cdn.vm0.io/artifacts/43eu37nlkf.png
