### PR TITLE
refactor(api): neutralize presentation template contract and route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -179,7 +179,7 @@ import { teamRoutes } from "./routes/team";
 import { uploadsCompleteRoutes } from "./routes/uploads-complete";
 import { uploadsMultipartRoutes } from "./routes/uploads-multipart";
 import { uploadsPrepareRoutes } from "./routes/uploads-prepare";
-import { zeroPresentationTemplatesRoutes } from "./routes/zero-presentation-templates";
+import { presentationTemplatesRoutes } from "./routes/presentation-templates";
 import { usageMembersRoutes } from "./routes/usage-members";
 import { usageRecordRoutes } from "./routes/usage-record";
 import { userPreferencesRoutes } from "./routes/user-preferences";
@@ -380,7 +380,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...uploadsCompleteRoutes,
   ...uploadsMultipartRoutes,
   ...uploadsPrepareRoutes,
-  ...zeroPresentationTemplatesRoutes,
+  ...presentationTemplatesRoutes,
   ...registryResourceDownloadRoutes,
   ...usageMembersRoutes,
   ...usageRecordRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/presentation-templates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/presentation-templates.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { zeroPresentationTemplatesContract } from "@okouai/api-contracts/contracts/zero-presentation-templates";
+import { presentationTemplatesContract } from "@okouai/api-contracts/contracts/presentation-templates";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -10,7 +10,7 @@ import { mockEnv } from "../../../lib/env";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
-import { zeroPresentationTemplatesRoutes } from "../zero-presentation-templates";
+import { presentationTemplatesRoutes } from "../presentation-templates";
 
 const context = testContext();
 const bdd = createBddApi(context);
@@ -32,8 +32,8 @@ async function enablePresentationTemplates(actor: ApiTestUser): Promise<void> {
 }
 
 function templateClient() {
-  return setupApp({ context, routes: zeroPresentationTemplatesRoutes })(
-    zeroPresentationTemplatesContract,
+  return setupApp({ context, routes: presentationTemplatesRoutes })(
+    presentationTemplatesContract,
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/presentation-templates.ts
+++ b/turbo/apps/api/src/signals/routes/presentation-templates.ts
@@ -1,5 +1,5 @@
 import { command, computed } from "ccstate";
-import { zeroPresentationTemplatesContract } from "@okouai/api-contracts/contracts/zero-presentation-templates";
+import { presentationTemplatesContract } from "@okouai/api-contracts/contracts/presentation-templates";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { presentationTemplates } from "@okouai/db/schema/presentation-template";
@@ -112,7 +112,7 @@ const listInner$ = computed(async (get) => {
   return { status: 200 as const, body: summaries };
 });
 
-const getParams$ = pathParamsOf(zeroPresentationTemplatesContract.get);
+const getParams$ = pathParamsOf(presentationTemplatesContract.get);
 const getInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
   if (!(await get(presentationTemplatesEnabled$))) {
@@ -148,8 +148,8 @@ const getInner$ = computed(async (get) => {
   };
 });
 
-const updateParams$ = pathParamsOf(zeroPresentationTemplatesContract.update);
-const updateBody$ = bodyResultOf(zeroPresentationTemplatesContract.update);
+const updateParams$ = pathParamsOf(presentationTemplatesContract.update);
+const updateBody$ = bodyResultOf(presentationTemplatesContract.update);
 const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   if (!(await get(presentationTemplatesEnabled$))) {
@@ -199,7 +199,7 @@ const updateInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   };
 });
 
-const deleteParams$ = pathParamsOf(zeroPresentationTemplatesContract.delete);
+const deleteParams$ = pathParamsOf(presentationTemplatesContract.delete);
 const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   if (!(await get(presentationTemplatesEnabled$))) {
@@ -220,21 +220,21 @@ const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     : templateNotFound(params.templateId);
 });
 
-export const zeroPresentationTemplatesRoutes: readonly RouteEntry[] = [
+export const presentationTemplatesRoutes: readonly RouteEntry[] = [
   {
-    route: zeroPresentationTemplatesContract.list,
+    route: presentationTemplatesContract.list,
     handler: authRoute(templateReadAuth, listInner$),
   },
   {
-    route: zeroPresentationTemplatesContract.get,
+    route: presentationTemplatesContract.get,
     handler: authRoute(templateReadAuth, getInner$),
   },
   {
-    route: zeroPresentationTemplatesContract.update,
+    route: presentationTemplatesContract.update,
     handler: authRoute(templateWriteAuth, updateInner$),
   },
   {
-    route: zeroPresentationTemplatesContract.delete,
+    route: presentationTemplatesContract.delete,
     handler: authRoute(templateWriteAuth, deleteInner$),
   },
 ];

--- a/turbo/apps/api/src/signals/services/presentation-template-data.service.ts
+++ b/turbo/apps/api/src/signals/services/presentation-template-data.service.ts
@@ -1,4 +1,4 @@
-import type { PresentationTemplateSummary } from "@okouai/api-contracts/contracts/zero-presentation-templates";
+import type { PresentationTemplateSummary } from "@okouai/api-contracts/contracts/presentation-templates";
 import { presentationTemplates } from "@okouai/db/schema/presentation-template";
 import { and, desc, eq, ne } from "drizzle-orm";
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1737,10 +1737,10 @@ export {
   PRESENTATION_TEMPLATE_PAGE_CONTENT_TYPE,
   PRESENTATION_TEMPLATE_SOURCE_CONTENT_TYPE,
   presentationTemplateStatusSchema,
-  zeroPresentationTemplatesContract,
+  presentationTemplatesContract,
   type PresentationTemplateSummary,
-  type ZeroPresentationTemplatesContract,
-} from "./zero-presentation-templates";
+  type PresentationTemplatesContract,
+} from "./presentation-templates";
 export {
   goalsContract,
   goalCreateRequestSchema,

--- a/turbo/packages/api-contracts/src/contracts/presentation-templates.ts
+++ b/turbo/packages/api-contracts/src/contracts/presentation-templates.ts
@@ -50,7 +50,7 @@ const updatePresentationTemplateBodySchema = z.object({
   title: z.string().trim().min(1).max(255),
 });
 
-export const zeroPresentationTemplatesContract = c.router({
+export const presentationTemplatesContract = c.router({
   list: {
     method: "GET",
     path: "/api/okou/presentation-templates",
@@ -109,8 +109,8 @@ export const zeroPresentationTemplatesContract = c.router({
   },
 });
 
-export type ZeroPresentationTemplatesContract =
-  typeof zeroPresentationTemplatesContract;
+export type PresentationTemplatesContract =
+  typeof presentationTemplatesContract;
 export type PresentationTemplateSummary = z.infer<
   typeof presentationTemplateSummarySchema
 >;


### PR DESCRIPTION
## Summary

Phase 2 naming cleanup (parent: #27432; naming model: #26873).

This is a **reflux cleanup**, not a historical leftover: PR #27172 merged at 2026-08-18T07:35Z and introduced three new old-branded paths into a tree that was otherwise already being cleared. This PR renames them to neutral names in one shot.

## Mapping

| Old | New |
|---|---|
| `contracts/zero-presentation-templates.ts` | `contracts/presentation-templates.ts` |
| `zeroPresentationTemplatesContract` | `presentationTemplatesContract` |
| `ZeroPresentationTemplatesContract` | `PresentationTemplatesContract` |
| `routes/zero-presentation-templates.ts` | `routes/presentation-templates.ts` |
| `zeroPresentationTemplatesRoutes` | `presentationTemplatesRoutes` |
| `routes/__tests__/zero-presentation-templates.test.ts` | `routes/__tests__/presentation-templates.test.ts` |

## Call sites updated

- `apps/api/src/signals/route.ts` — import specifier and registry spread identifier only; **the registered route order is unchanged**.
- `apps/api/src/signals/services/presentation-template-data.service.ts` — type-only import specifier only.
- `packages/api-contracts/src/contracts/index.ts` — barrel block at the same position.

## Non-goals (explicitly untouched)

- Every already-neutral export in the contract module — byte limits, page limits, content-type literals, `presentationTemplateStatusSchema`, `PresentationTemplateSummary`.
- Every `path:` literal (already canonical `/api/okou/**`), method, header schema, request/response schema, and status code.
- Presentation template behavior, storage keys, and the upload flow.
- `contracts/presentation-images.ts` — a different module.
- No compatibility alias or old-path re-export is left behind.

## Conflict note

PR #26947 (still open) modifies all three of these files and its added lines contain new references to the old identifiers and import specifiers. Per the issue, this rename is not scoped down to avoid that conflict — #26947 must rebase to fix its own failing checks and will absorb the rename then. This PR does not touch #26947 or its branch.

## Verification

- `pnpm -F @okouai/api-contracts check-types` — clean
- `pnpm -F api check-types` — clean (core, bootstrap, tests, bootstrap-wiring)
- `pnpm knip` — no new findings
- `eslint` and `prettier --check` on all changed files — clean
- No `zeroPresentationTemplates*` / `ZeroPresentationTemplates*` identifier and no `zero-presentation-templates` specifier remains repository-wide

Full-repo validation is left to the PR pipeline.

Closes #27978
