### PR TITLE
fix(app): classify queued automation events by event type

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/composer-signals.ts
@@ -2,6 +2,7 @@ import type {
   ChatRunVideoOptionsRequest,
   GenerationTemplateRequest,
   PersistedAttachment,
+  UserMessageDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { foldActiveChatGoalObjective } from "@okouai/api-contracts/contracts/chat-events";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -117,18 +118,11 @@ export type ComposerPrimaryAction =
   | "stop"
   | "disabled";
 
-export type ComposerPendingEvent =
-  | {
-      readonly kind: "message";
-      readonly id: string;
-      readonly text: string;
-    }
-  | {
-      readonly kind: "automation";
-      readonly id: string;
-      readonly workflowName: string;
-      readonly automationBrief: string | undefined;
-    };
+export interface ComposerPendingEvent {
+  readonly kind: "message" | "automation";
+  readonly id: string;
+  readonly text: string;
+}
 
 interface ComposerWorkflowSignals extends ComposerWorkflowEditorSignals {
   readonly createWorkflowPrompt$: Command<Promise<void>, [AbortSignal]>;
@@ -593,6 +587,25 @@ export function createComposerSignals(
   };
 }
 
+/**
+ * Automation events fired by a watched chat run carry an agent-run source
+ * annotation instead of an automation part, so the document text is the label
+ * whenever no workflow annotation survived.
+ */
+function pendingAutomationEventText(
+  userMessage: UserMessageDocument | undefined,
+): string {
+  const automationPart = userMessage?.parts.find((part) => {
+    return part.type === "automation";
+  });
+  if (automationPart?.type === "automation") {
+    return (
+      automationPart.automationBrief ?? automationPart.workflowName
+    ).trim();
+  }
+  return (messageDocumentToDisplayText(userMessage) ?? "").trim();
+}
+
 function createComposerChatEventSignals(chatEvents$: Computed<ChatEvent[]>) {
   const semanticEvents$ = computed((get) => {
     return semanticChatEventsFromChatEvents(get(chatEvents$));
@@ -632,31 +645,19 @@ function createComposerChatEventSignals(chatEvents$: Computed<ChatEvent[]>) {
     (get): Promise<readonly ComposerPendingEvent[]> => {
       return Promise.resolve(
         queuedEventsFromSemanticEvents(get(semanticEvents$)).map((event) => {
-          if (event.eventType === "input.automation") {
-            const automationPart = event.userMessage?.parts.find((part) => {
-              return part.type === "automation";
-            });
-            if (!automationPart || automationPart.type !== "automation") {
-              return {
+          return event.eventType === "input.automation"
+            ? {
+                kind: "automation" as const,
+                id: event.id,
+                text: pendingAutomationEventText(event.userMessage),
+              }
+            : {
                 kind: "message" as const,
                 id: event.id,
-                text: "",
+                text: (
+                  messageDocumentToDisplayText(event.userMessage) ?? ""
+                ).trim(),
               };
-            }
-            return {
-              kind: "automation" as const,
-              id: event.id,
-              workflowName: automationPart.workflowName,
-              automationBrief: automationPart.automationBrief,
-            };
-          }
-          return {
-            kind: "message" as const,
-            id: event.id,
-            text: (
-              messageDocumentToDisplayText(event.userMessage) ?? ""
-            ).trim(),
-          };
         }),
       );
     },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
@@ -18,6 +18,11 @@ const context = testContext();
 const THREAD_ID = "d0000000-0000-4000-a000-0000000000aa";
 const EVENT_ID_1 = "f0000001-0000-4000-a000-000000000001";
 const EVENT_ID_2 = "f0000002-0000-4000-a000-000000000002";
+const SOURCE_EVENT_ID = "f0000003-0000-4000-a000-000000000003";
+const SOURCE_RUN_ID = "e0000001-0000-4000-a000-000000000001";
+const SOURCE_THREAD_ID = "e0000002-0000-4000-a000-000000000002";
+const SOURCE_AGENT_ID = "e0000003-0000-4000-a000-000000000003";
+const SOURCE_EVENT_TEXT = "A run in the watched chat thread completed.";
 
 function buttonByLabel(label: string): HTMLElement {
   const button = queryAllByRoleFast("button").find((candidate) => {
@@ -27,6 +32,70 @@ function buttonByLabel(label: string): HTMLElement {
     throw new Error(`${label} button not found`);
   }
   return button;
+}
+
+/**
+ * A chat-run-finished automation replaces its workflow annotation with the
+ * watched run's source annotation, so the queued document carries no
+ * automation part.
+ */
+function setupSourceAnnotatedAutomationPage({
+  onRecallEventAppend,
+}: {
+  onRecallEventAppend?: (body: {
+    revokesEventId: string;
+    clientEventId: string;
+  }) => void;
+} = {}): void {
+  mockChatLifecycle(context, {
+    threadId: THREAD_ID,
+    threadTitle: "Workflow queue thread",
+    chatEvents: [
+      {
+        id: "msg-workflow-running-user",
+        role: "user",
+        content: "Automation run",
+        runId: "run-workflow-1",
+        createdAt: "2026-07-10T00:59:00Z",
+      },
+      {
+        id: "msg-workflow-running-assistant",
+        role: "assistant",
+        content: null,
+        runId: "run-workflow-1",
+        createdAt: "2026-07-10T00:59:01Z",
+      },
+      {
+        id: SOURCE_EVENT_ID,
+        eventType: "input.automation",
+        content: null,
+        userMessage: {
+          version: 1,
+          parts: [
+            { type: "text", text: SOURCE_EVENT_TEXT },
+            {
+              type: "source",
+              kind: "agent",
+              runId: SOURCE_RUN_ID,
+              threadId: SOURCE_THREAD_ID,
+              agentId: SOURCE_AGENT_ID,
+              titleSnapshot: "Watched chat run",
+              href: `/chats/${SOURCE_THREAD_ID}#run-${SOURCE_RUN_ID}`,
+            },
+          ],
+        },
+        runId: undefined,
+        createdAt: "2026-07-10T01:03:00Z",
+      },
+    ],
+    activeRunIds: ["run-workflow-1"],
+    onRecallEventAppend,
+  });
+
+  detachedSetupPage({
+    context,
+    path: `/chats/${THREAD_ID}`,
+  });
 }
 
 function setupWorkflowQueuePage({
@@ -187,6 +256,38 @@ describe("workflow queue panel", () => {
       );
       expect(screen.queryByText("customer-followup")).not.toBeInTheDocument();
       expect(screen.getByText("Webhook event third")).toBeInTheDocument();
+    });
+  });
+
+  it("queues a source-annotated automation event as an event row", async () => {
+    setupSourceAnnotatedAutomationPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("1 event waiting")).toBeInTheDocument();
+    });
+    expect(screen.getByText(SOURCE_EVENT_TEXT)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Pending automation event"),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+  });
+
+  it("skips a source-annotated automation event", async () => {
+    let recall: { revokesEventId: string; clientEventId: string } | undefined;
+    setupSourceAnnotatedAutomationPage({
+      onRecallEventAppend: (body) => {
+        recall = body;
+      },
+    });
+    await waitFor(() => {
+      expect(screen.getByText(SOURCE_EVENT_TEXT)).toBeInTheDocument();
+    });
+
+    click(buttonByLabel("Skip automation event"));
+
+    await waitFor(() => {
+      expect(recall?.revokesEventId).toBe(SOURCE_EVENT_ID);
+      expect(screen.queryByText(SOURCE_EVENT_TEXT)).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -660,18 +660,11 @@ function PendingItemsStrip({ signals }: { signals: ComposerSignals }) {
   const cancelActiveGoal = useSet(signals.goal.cancelActiveGoal$);
   const openActiveGoal = useSet(signals.goal.openActiveGoal$);
   const pageSignal = useGet(pageSignal$);
-  const queued = pendingEvents.flatMap((event) => {
-    return event.kind === "message" ? [{ id: event.id, text: event.text }] : [];
+  const queued = pendingEvents.filter((event) => {
+    return event.kind === "message";
   });
-  const events = pendingEvents.flatMap((event) => {
-    return event.kind === "automation"
-      ? [
-          {
-            id: event.id,
-            text: event.automationBrief ?? event.workflowName,
-          },
-        ]
-      : [];
+  const events = pendingEvents.filter((event) => {
+    return event.kind === "automation";
   });
   const activeGoal = activeGoalObjective
     ? { objective: activeGoalObjective }
@@ -751,7 +744,12 @@ function PendingItemsStrip({ signals }: { signals: ComposerSignals }) {
             <ComposerStripRow
               key={event.id}
               kind="automation-event"
-              text={event.text}
+              text={
+                event.text ||
+                t(($) => {
+                  return $.chat.queue.automationEvent;
+                })
+              }
               onRemove={() => {
                 detach(
                   removeAutomationEvent(event.id, pageSignal),


### PR DESCRIPTION
## Summary

Fixes #28076. Queued `chat-run-finished` automation events rendered as blank rows in the composer's pending-items strip.

#26805 replaces the workflow annotation of those events with the watched run's agent-run source annotation, so their queued document legitimately carries no `automation` part. The composer strip inferred the row kind from that part's presence instead of from `eventType`, and fell into a defensive branch returning `{ kind: "message", text: "" }`. That branch was unreachable before #26805 and has been taken by every `chat-run-finished` automation event since.

Three user-visible consequences, all from that one misclassification:

- empty row text;
- the queued-message glyph and "N messages waiting" wording instead of the automation icon and "N events waiting";
- `×` routed to `removeQueuedMessage$ → recallMessage$`, which early-returns for anything that is not `input.prompt`, so the rows could not be dismissed.

## Approach

Classify by `event.eventType`, which is the reliable discriminant, and derive the label with `automationBrief ?? workflowName ?? document display text`. `ComposerPendingEvent` collapses to `{ kind, id, text }` since both variants now carry the same shape, and the strip falls back to the existing `chat.queue.automationEvent` label if a document yields no text at all.

The write path is deliberately unchanged. The persisted `[text, source]` shape is what #26805 intended: `userMessageAnnotationRenderPart()` and `isWorkflowUserMessage()` pick the message bubble's single annotation by taking the *first* non-content part, so re-adding the `automation` part would flip the bubble, the run-group fold label and the fold display text back to workflow rendering unless source-over-automation precedence were added at each site.

## Behavior

Automation events with a workflow annotation keep their current label and icon. Source-annotated automation events now render as automation rows with the event text ("A run in the watched chat thread completed."), count toward the event counter, and dismiss through `skipAutomationEvent$`.

## Fallbacks

- `zero-chat-composer.tsx:PendingItemsStrip` — renders the existing `chat.queue.automationEvent` label when a queued `input.automation` yields no text. The `input.automation` row projection makes `userMessage` optional, so a document-less event is contract-reachable and would otherwise render the blank row this PR removes. Surface: none — presentational empty-state label (`docs/fallback.md` §6.4), no cross-version window. Removal condition: not applicable; it is not a rollout fallback and has no follow-up.

## Testing

- `pnpm exec prettier@3.8.1 --check` on the touched files
- Added two `workflow-queue-panel` page tests covering a pending `input.automation` whose document is `[text, source]`: row classification, label, counter wording, and skip behavior
- Full suite left to the PR pipeline per repo preference
