### PR TITLE
fix(api): run queued automation events before goal continuation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -547,7 +547,7 @@ describe("workflow queue", () => {
     await runsApi.requestCancelRun(scenario.actor, user.body.runId, [200]);
   });
 
-  it("runs a pending goal continuation before a newer automation event on the same thread", async () => {
+  it("runs a newer automation event before a pending goal continuation on the same thread", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     const goal = await createActiveGoalQueueEventFixture({
@@ -555,29 +555,37 @@ describe("workflow queue", () => {
       orgId: scenario.orgId,
       userId: scenario.userId,
       agentId: scenario.agentId,
-      objective: "finish before the automation event",
-      objectiveBrief: "Finish before the automation event",
+      objective: "continue after the automation event",
+      objectiveBrief: "Continue after the automation event",
     });
 
-    expectAcceptedWithoutRun(
-      await postWorkflowWebhook(automation, "goal wins queue priority"),
+    const workflowRunId = await expectAcceptedRunId(
+      await postWorkflowWebhook(automation, "automation wins queue priority"),
+      automation.threadId,
     );
-    const goalQueue = await readGoalQueueStateFixture(automation.threadId);
-    expect(goalQueue.runIds).toHaveLength(1);
-    expect(goalQueue.eventIds).toContain(goal.eventId);
-    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(0);
+    const queuedGoal = await readGoalQueueStateFixture(automation.threadId);
+    expect(queuedGoal.runIds).toHaveLength(0);
+    expect(queuedGoal.eventIds).toContain(goal.eventId);
     await expect(
       pendingAutomationEvents(automation.threadId),
-    ).resolves.toHaveLength(1);
+    ).resolves.toHaveLength(0);
 
-    const [goalRunId] = goalQueue.runIds;
+    // A goal that self-continues after every run would otherwise leave no idle
+    // window for the automation event, so the deferred goal must still run once
+    // the automation ahead of it reaches a terminal state.
+    await completeRunThroughSandbox(scenario, workflowRunId);
+    const drainedGoal = await readGoalQueueStateFixture(automation.threadId);
+    expect(drainedGoal.runIds).toHaveLength(1);
+    expect(drainedGoal.eventIds).toContain(goal.eventId);
+
+    const [goalRunId] = drainedGoal.runIds;
     if (!goalRunId) {
       throw new Error("Expected the goal continuation to create a run");
     }
     await runsApi.requestCancelRun(scenario.actor, goalRunId, [200]);
   });
 
-  it("lets a goal continuation preempt an automation event during final queue claim", async () => {
+  it("keeps an automation event ahead of a goal continuation during final queue claim", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     const admissionLock = await holdOrgAdmissionLockFixture({
@@ -600,8 +608,8 @@ describe("workflow queue", () => {
       orgId: scenario.orgId,
       userId: scenario.userId,
       agentId: scenario.agentId,
-      objective: "preempt the preparing automation event",
-      objectiveBrief: "Preempt the preparing automation event",
+      objective: "wait behind the preparing automation event",
+      objectiveBrief: "Wait behind the preparing automation event",
     });
     const goalDrain = drainChatThreadQueueFixture({
       threadId: automation.threadId,
@@ -612,24 +620,22 @@ describe("workflow queue", () => {
     admissionLock.release();
     const [workflowResult] = await Promise.all([workflowRequest, goalDrain]);
     await admissionLock.done;
-    expectAcceptedWithoutRun(workflowResult);
+    const workflowRunId = await expectAcceptedRunId(
+      workflowResult,
+      automation.threadId,
+    );
 
     const goalQueue = await readGoalQueueStateFixture(automation.threadId);
-    expect(goalQueue.runIds).toHaveLength(1);
+    expect(goalQueue.runIds).toHaveLength(0);
     expect(goalQueue.eventIds).toContain(goal.eventId);
-    await expect(workflowRunIds(automation.threadId)).resolves.toHaveLength(0);
     await expect(
       pendingAutomationEvents(automation.threadId),
-    ).resolves.toHaveLength(1);
+    ).resolves.toHaveLength(0);
 
-    const [goalRunId] = goalQueue.runIds;
-    if (!goalRunId) {
-      throw new Error("Expected the preempting goal to create a run");
-    }
-    await runsApi.requestCancelRun(scenario.actor, goalRunId, [200]);
+    await runsApi.requestCancelRun(scenario.actor, workflowRunId, [200]);
   });
 
-  it("continues to workflow automation after revoking a higher-priority invalid goal", async () => {
+  it("revokes an invalid goal event once the automation ahead of it completes", async () => {
     const scenario = await setup();
     const automation = await createWebhookAutomation(scenario);
     const goal = await createActiveGoalQueueEventFixture({
@@ -643,12 +649,14 @@ describe("workflow queue", () => {
     await pauseGoalQueueTargetFixture(goal.goalId);
 
     const workflowRunId = await expectAcceptedRunId(
-      await postWorkflowWebhook(automation, "run after invalid goal"),
+      await postWorkflowWebhook(automation, "run before invalid goal"),
       automation.threadId,
     );
     await expect(
       readWorkflowRunTriggerSourceFixture(workflowRunId),
     ).resolves.toBe("automation-event");
+
+    await completeRunThroughSandbox(scenario, workflowRunId);
     const events = await wf.readThreadEvents(automation.threadId);
     expect(events).toContainEqual(
       expect.objectContaining({
@@ -658,8 +666,6 @@ describe("workflow queue", () => {
     );
     const goalQueue = await readGoalQueueStateFixture(automation.threadId);
     expect(goalQueue.runIds).toHaveLength(0);
-
-    await runsApi.requestCancelRun(scenario.actor, workflowRunId, [200]);
   });
 
   it("does not let the stale sweep race a newly admitted automation event", async () => {

--- a/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-event-queue.service.ts
@@ -97,18 +97,20 @@ export function pendingChatQueueEventCondition(db: ChatQueueReadDb) {
 export function chatQueueEventPriority(): SQL {
   return sql`CASE ${chatEvents.eventType}
     WHEN 'input.prompt' THEN 0
-    WHEN 'input.goal' THEN 1
-    WHEN 'input.automation' THEN 2
+    WHEN 'input.automation' THEN 1
+    WHEN 'input.goal' THEN 2
     ELSE 3
   END`;
 }
 
 /**
  * List one thread's pending queue in its authoritative database order. User
- * input keeps absolute priority over goal continuation; goal continuation stays
- * ahead of automation input. Each class is FIFO by the original event timestamp
- * and id. Keep the sort in PostgreSQL so sub-millisecond timestamp precision
- * matches the final queue-claim queries.
+ * input keeps absolute priority over the rest; automation input stays ahead of
+ * goal continuation, because a goal continues itself after every run and would
+ * otherwise leave no idle window for an automation event to be claimed. Each
+ * class is FIFO by the original event timestamp and id. Keep the sort in
+ * PostgreSQL so sub-millisecond timestamp precision matches the final
+ * queue-claim queries.
  */
 export async function listPendingChatQueueEvents(
   db: ChatQueueReadDb,

--- a/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-queue-drain.service.ts
@@ -108,7 +108,7 @@ export async function notifyRunningChatRunOfPendingInput(
 /**
  * The single per-thread scheduler entry: terminal run callbacks, cancel,
  * resume, and the stale sweep all converge here. User messages are attempted
- * first; goal continuation remains second and workflow automation third. Each
+ * first; workflow automation remains second and goal continuation third. Each
  * later drain observes a newly-created active run and stops. The final claims
  * serialize on the same thread row and fold pending events by class priority,
  * then original `created_at` and id.
@@ -140,17 +140,6 @@ export const drainChatThreadQueueForThread$ = command(
       signal,
     );
     signal.throwIfAborted();
-    await set(
-      drainGoalQueueForThread$,
-      {
-        chatThreadId: input.chatThreadId,
-        apiStartTime,
-        dispatchFailedCallbacks: input.dispatchFailedCallbacks,
-        queueItemCreatedBefore: input.queueItemCreatedBefore,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
     const workflowResult = await set(
       drainWorkflowQueueForThread$,
       {
@@ -161,6 +150,17 @@ export const drainChatThreadQueueForThread$ = command(
         ...(input.automationEventLaunch
           ? { automationEventLaunch: input.automationEventLaunch }
           : {}),
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+    await set(
+      drainGoalQueueForThread$,
+      {
+        chatThreadId: input.chatThreadId,
+        apiStartTime,
+        dispatchFailedCallbacks: input.dispatchFailedCallbacks,
+        queueItemCreatedBefore: input.queueItemCreatedBefore,
       },
       signal,
     );


### PR DESCRIPTION
## Summary

Closes #28078. Queued automation events were never claimed on a thread with an active goal.

`chatQueueEventPriority()` ranked `input.goal` (1) ahead of `input.automation` (2). A goal appends a new continuation event after every run, so such a thread never goes idle and class 2 was never reached. In the reported thread two `chat-run-finished` events waited ~10h and ~8.5h; an earlier batch of 24 events was only cleared as `input.rejected` after a manual interrupt.

The failure is structural: `chat-run-finished` automations exist to wake a controller thread, and a controller thread is exactly the kind of thread that runs a goal loop, so the wake-up could never reach the thread that needed it.

## Approach

Swap the two classes so the order is user input → automation input → goal continuation.

- `chat-event-queue.service.ts:chatQueueEventPriority` — `input.automation` becomes 1 and `input.goal` becomes 2. Every claim path (`loadNextUnclaimedQueuedUserMessage`, `loadNextWorkflowQueueEvent`, `loadNextGoalQueueEvent`, and the final locked claims in `chat-queued-event.service.ts`) already reads the head of this one ordering and bails when the head is not its own class, so this CASE is the single behavioral change.
- `chat-thread-queue-drain.service.ts:drainChatThreadQueueForThread$` — the drain calls now run workflow automation before goal continuation, matching the new class order. The command still returns the workflow drain result.
- `hasPendingUserChatQueueEvent` is untouched, so user prompts keep absolute priority.

A deferred goal event is not lost: it stays pending and is claimed on the next drain once the automation run ahead of it reaches a terminal state, which the updated tests now assert.

The composer already renders the active goal below queued automation events and tells the user it "only runs once the queue drains" (`zero-chat-composer.tsx`), so this also removes a disagreement between the product surface and the scheduler.

## Trade-off

This moves the theoretical starvation risk to the other side: a thread receiving automation events faster than its runs complete would keep a goal waiting. That is far less likely than the current failure — automation events are discrete and infrequent, while goal continuation regenerates every turn by design — and #28078 records the fully FIFO alternative if that ever becomes a real problem.

## Deployment compatibility

Runtime scheduling only: no schema, contract, queue payload, or persisted shape changes. During rollout two API versions can briefly disagree about which pending class to claim first for the same thread; both take the head under their own CASE while holding the same row locks, so the only effect is transient ordering, and no event is dropped or double-claimed.

## Testing

- `pnpm exec prettier@3.8.1` on the touched files
- `workflow-queue.test.ts` — inverted the two tests that encoded the old order and extended the first one to assert the deferred goal still runs after the automation run completes:
  - "runs a newer automation event before a pending goal continuation on the same thread"
  - "keeps an automation event ahead of a goal continuation during final queue claim"
- `workflow-queue.test.ts` — "revokes an invalid goal event once the automation ahead of it completes": the previous version relied on the goal being the higher-priority head, which no longer happens, so the invalid-goal revocation is now asserted at the point the goal queue actually takes its turn.
- "keeps a user prompt ahead of a pending goal continuation" is unchanged and still passes as written.
- Full suite left to the PR pipeline per repo preference.
