### PR TITLE
fix(api): retain axiom partial ingest diagnostics

### DIFF
--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -12,6 +12,8 @@ import {
 
 const AXIOM_API_ORIGIN = "https://api.axiom.co";
 const AXIOM_QUERY_TIMEOUT_MS = 120_000;
+const AXIOM_INGEST_FAILURE_DETAIL_LIMIT = 3;
+const AXIOM_INGEST_FAILURE_ERROR_MAX_LENGTH = 512;
 
 const L = logger("api:axiom");
 
@@ -90,21 +92,54 @@ type DirectAxiomIngestResult =
   | { readonly configured: false }
   | { readonly configured: true };
 
+type DirectAxiomIngestErrorOptions =
+  | {
+      readonly reason: "http_status";
+      readonly dataset: string;
+      readonly status: number;
+    }
+  | {
+      readonly reason: "invalid_response";
+      readonly dataset: string;
+    }
+  | {
+      readonly reason: "partial_ingest";
+      readonly dataset: string;
+      readonly expected: number;
+      readonly ingested: number;
+      readonly failed: number;
+      readonly failureDetailsReturned: number;
+      readonly failureDetails: readonly AxiomIngestFailure[];
+      readonly failureDetailsOmitted: number;
+    };
+
 class DirectAxiomIngestError extends Error {
   readonly reason: "http_status" | "invalid_response" | "partial_ingest";
+  readonly dataset: string;
   readonly status?: number;
+  readonly expected?: number;
+  readonly ingested?: number;
+  readonly failed?: number;
+  readonly failureDetailsReturned?: number;
+  readonly failureDetails?: readonly AxiomIngestFailure[];
+  readonly failureDetailsOmitted?: number;
 
-  constructor(
-    message: string,
-    options: {
-      readonly reason: "http_status" | "invalid_response" | "partial_ingest";
-      readonly status?: number;
-    },
-  ) {
+  constructor(message: string, options: DirectAxiomIngestErrorOptions) {
     super(message);
     this.name = "DirectAxiomIngestError";
     this.reason = options.reason;
-    this.status = options.status;
+    this.dataset = options.dataset;
+    if (options.reason === "http_status") {
+      this.status = options.status;
+    }
+    if (options.reason === "partial_ingest") {
+      this.expected = options.expected;
+      this.ingested = options.ingested;
+      this.failed = options.failed;
+      this.failureDetailsReturned = options.failureDetailsReturned;
+      this.failureDetails = options.failureDetails;
+      this.failureDetailsOmitted = options.failureDetailsOmitted;
+    }
   }
 }
 
@@ -135,6 +170,14 @@ function isAxiomIngestStatus(value: unknown): value is AxiomIngestStatus {
       (Array.isArray(value.failures) &&
         value.failures.every(isAxiomIngestFailure)))
   );
+}
+
+function boundedAxiomIngestFailureError(error: string): string {
+  const normalized = error.replace(/\s+/g, " ").trim();
+  if (normalized.length <= AXIOM_INGEST_FAILURE_ERROR_MAX_LENGTH) {
+    return normalized;
+  }
+  return `${normalized.slice(0, AXIOM_INGEST_FAILURE_ERROR_MAX_LENGTH - 3)}...`;
 }
 
 function axiomIngestUrl(dataset: string): string {
@@ -175,6 +218,7 @@ export async function ingestAxiomDirect(
       `Axiom ingest failed with status ${response.status}`,
       {
         reason: "http_status",
+        dataset,
         status: response.status,
       },
     );
@@ -184,7 +228,7 @@ export async function ingestAxiomDirect(
   if (!isAxiomIngestStatus(payload)) {
     throw new DirectAxiomIngestError(
       "Axiom ingest returned an unexpected response shape",
-      { reason: "invalid_response" },
+      { reason: "invalid_response", dataset },
     );
   }
   if (
@@ -192,9 +236,28 @@ export async function ingestAxiomDirect(
     (payload.failures?.length ?? 0) !== 0 ||
     payload.ingested !== events.length
   ) {
+    const returnedFailureDetails = payload.failures ?? [];
+    const failureDetails = returnedFailureDetails
+      .slice(0, AXIOM_INGEST_FAILURE_DETAIL_LIMIT)
+      .map((failure) => {
+        return {
+          timestamp: failure.timestamp,
+          error: boundedAxiomIngestFailureError(failure.error),
+        };
+      });
     throw new DirectAxiomIngestError(
       `Axiom ingest accepted ${payload.ingested} of ${events.length} events with ${payload.failed} failed events and ${payload.failures?.length ?? 0} failure details`,
-      { reason: "partial_ingest" },
+      {
+        reason: "partial_ingest",
+        dataset,
+        expected: events.length,
+        ingested: payload.ingested,
+        failed: payload.failed,
+        failureDetailsReturned: returnedFailureDetails.length,
+        failureDetails,
+        failureDetailsOmitted:
+          returnedFailureDetails.length - failureDetails.length,
+      },
     );
   }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1662,6 +1662,161 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     ).toBeTruthy();
   });
 
+  it("logs bounded Axiom partial-ingest details without event payload values", async () => {
+    const { runId, headers } = await createEventWebhookRun(
+      "partial Axiom ingest diagnostics",
+    );
+    const submittedPayloadValue = `private-event-value-${randomUUID()}`;
+    const rawFailureError = `schema\nrule\t${"x".repeat(600)}`;
+    const normalizedFailureError = `schema rule ${"x".repeat(600)}`;
+    const expectedFailureError = `${normalizedFailureError.slice(0, 509)}...`;
+    const failureTimestamp = "2026-08-19T00:00:00.000Z";
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
+        () => {
+          return HttpResponse.json({
+            ingested: 1,
+            failed: 1,
+            failures: [
+              {
+                timestamp: failureTimestamp,
+                error: rawFailureError,
+              },
+            ],
+            processedBytes: 123,
+          });
+        },
+      ),
+    );
+
+    const response = await api.requestAgentEvents(
+      {
+        runId,
+        events: [
+          {
+            type: "system",
+            sequenceNumber: 10,
+            detail: submittedPayloadValue,
+          },
+          {
+            type: "result",
+            sequenceNumber: 11,
+            result: "DB-backed callback output",
+          },
+        ],
+      },
+      headers,
+      [200],
+    );
+    expect(response.body).toStrictEqual({
+      received: 2,
+      firstSequence: 10,
+      lastSequence: 11,
+    });
+    await flushWaitUntilForTest();
+
+    const logFields = context.mocks.axiomLogging.error.mock.calls.find(
+      ([message, fields]) => {
+        return (
+          message === "Optional Axiom trace delivery failed" &&
+          isUnknownRecord(fields) &&
+          fields.runId === runId
+        );
+      },
+    )?.[1];
+    if (!isUnknownRecord(logFields) || !isUnknownRecord(logFields.error)) {
+      throw new Error("Expected structured Axiom partial-ingest log fields");
+    }
+    expect(logFields).toMatchObject({
+      runId,
+      firstSequence: 10,
+      lastSequence: 11,
+    });
+    expect(logFields.error).toMatchObject({
+      name: "DirectAxiomIngestError",
+      reason: "partial_ingest",
+      dataset: "agent-run-events",
+      expected: 2,
+      ingested: 1,
+      failed: 1,
+      failureDetailsReturned: 1,
+      failureDetailsOmitted: 0,
+    });
+    expect(logFields.error.failureDetails).toStrictEqual([
+      {
+        timestamp: failureTimestamp,
+        error: expectedFailureError,
+      },
+    ]);
+    expect(expectedFailureError).toHaveLength(512);
+    expect(JSON.stringify(logFields)).not.toContain(submittedPayloadValue);
+  });
+
+  it("limits the number of logged Axiom partial-ingest details", async () => {
+    const { runId, headers } = await createEventWebhookRun(
+      "partial Axiom ingest detail limit",
+    );
+    const failures = Array.from({ length: 4 }, (_, index) => {
+      return {
+        timestamp: `2026-08-19T00:00:0${index}.000Z`,
+        error: `failure-${index + 1}`,
+      };
+    });
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
+        () => {
+          return HttpResponse.json({
+            ingested: 1,
+            failed: 4,
+            failures,
+            processedBytes: 123,
+          });
+        },
+      ),
+    );
+
+    const response = await api.requestAgentEvents(
+      {
+        runId,
+        events: Array.from({ length: 5 }, (_, sequenceNumber) => {
+          return { type: "system", sequenceNumber };
+        }),
+      },
+      headers,
+      [200],
+    );
+    expect(response.body).toStrictEqual({
+      received: 5,
+      firstSequence: 0,
+      lastSequence: 4,
+    });
+    await flushWaitUntilForTest();
+
+    const logFields = context.mocks.axiomLogging.error.mock.calls.find(
+      ([message, fields]) => {
+        return (
+          message === "Optional Axiom trace delivery failed" &&
+          isUnknownRecord(fields) &&
+          fields.runId === runId
+        );
+      },
+    )?.[1];
+    if (!isUnknownRecord(logFields) || !isUnknownRecord(logFields.error)) {
+      throw new Error("Expected structured Axiom partial-ingest log fields");
+    }
+    expect(logFields.error).toMatchObject({
+      expected: 5,
+      ingested: 1,
+      failed: 4,
+      failureDetailsReturned: 4,
+      failureDetailsOmitted: 1,
+    });
+    expect(logFields.error.failureDetails).toStrictEqual(failures.slice(0, 3));
+    expect(JSON.stringify(logFields)).not.toContain("failure-4");
+  });
+
   it("acknowledges events when the optional Axiom status is malformed", async () => {
     const { runId, headers } = await createEventWebhookRun(
       "malformed optional Axiom status",


### PR DESCRIPTION
## Summary

- retain dataset and expected/ingested/failed counts on partial Axiom ingest errors
- log at most three normalized failure details with a 512-character per-detail limit
- preserve optional agent-event webhook acknowledgement and cover both production-shaped and multi-failure responses

## Exclusions

- does not retry partially accepted batches or change required/optional delivery semantics
- does not fix the underlying Axiom rejection or recover historical rejected events
- leaves the issue open for post-deployment production verification

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --silent=passed-only`
- `git diff --check`
- pre-commit: `pnpm knip`, full `pnpm check-types`, file-size check, commitlint

Relates to #28081
