### PR TITLE
style(platform): space out nav rail items and unclip captions

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -666,7 +666,7 @@ function LabeledRailLink({
         )}
       </span>
       <span
-        className={`max-w-full truncate px-0.5 text-[9px] font-medium leading-none ${
+        className={`max-w-full truncate px-0.5 text-[9px] font-medium leading-[14px] ${
           isActive ? "text-sidebar-foreground" : "text-sidebar-foreground/60"
         }`}
       >
@@ -715,7 +715,7 @@ function LabeledNavRail() {
         aria-label={t(($) => {
           return $.appShell.sidebar.ariaLabel;
         })}
-        className="flex min-h-0 w-full flex-1 flex-col items-center gap-2 overflow-y-auto pb-2"
+        className="flex min-h-0 w-full flex-1 flex-col items-center gap-3 overflow-y-auto pb-2"
       >
         {navItems.map((item) => {
           const isActive =


### PR DESCRIPTION
## What

Two tweaks to the labeled navigation rail (`ThreeColumnNav`):

- Nav item gap `gap-2` → `gap-3` (8px → 12px), so the icon tiles read as separate blocks instead of one dense stack.
- Caption `leading-none` → `leading-[14px]`. With `truncate` (`overflow: hidden`) and a 9px caption, a line-height of 1 makes the line box 9px tall while the glyph box needs 13px — descenders were sliced off, most visibly the `g` in "Agents".

## Why 14px

Measured the real glyph ink of every rail caption in all 10 locales at `500 9px "Noto Sans"`: max ascent 9px above the baseline, max descent 3px below (Hindi `आर्टिफ़ैक्ट्स`). With the font strut at ascent 10 / descent 3, the smallest clip-free line-height is 13px; 14px lands on a whole pixel with 1px of slack. Re-measured at 14px: zero clipped captions across all 60 locale captions.

## Before / after

![nav rail before and after](https://cdn.vm0.io/artifacts/mx0l0453ve.png)

Left: `g` bottoms out flat against the clip edge. Right: descender intact, items spaced.

## Checks

- `prettier@3.8.1 --check` on the changed file — clean
- `oxlint` with the `apps/platform` config — 0 warnings, 0 errors
- CSS-only change; existing rail tests assert caption text, not classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)