### PR TITLE
docs(python): document webhook delivery callback lifecycle

### DIFF
--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -375,6 +375,19 @@ def enqueue_webhook_delivery(
     If the executor has already been shut down (drain/shutdown race),
     falls back to synchronous delivery so the report is not silently lost.
 
+    When provided, ``delivery_outcome_callback`` is invoked exactly once for
+    an admitted payload after delivery reaches a final ``success``,
+    ``retryable_failure``, or ``permanent_failure`` outcome.  It is not
+    invoked when admission returns ``False`` or when enqueueing fails before
+    delivery ownership transfers.  Normal delivery invokes it on a webhook
+    executor worker; the executor-shutdown fallback invokes it synchronously
+    on the enqueueing thread.
+
+    The callback runs before the pending-report lease and delivery-capacity
+    slot are released.  Exceptions raised by the callback propagate through
+    the worker future or synchronous fallback, while the surrounding cleanup
+    still releases the owned counters.
+
     Returns whether the payload was admitted to delivery.  ``False`` means
     delivery was saturated and the caller still owns retry handling.
     """


### PR DESCRIPTION
## Summary

- Document the `delivery_outcome_callback` lifecycle on `enqueue_webhook_delivery()`.
- Clarify callback admission, final outcomes, worker versus synchronous-fallback execution, cleanup ordering, and exception propagation.

## Scope and exclusions

- Documentation-only change in `crates/runner/mitm-addon/src/usage/webhook.py`.
- No runtime delivery behavior, tests, dependencies, migrations, or compatibility paths changed.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_webhook_delivery_admission.py tests/test_usage_buffer_flush_failures.py` (31 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`

Closes #28083
