### PR TITLE
fix(ci): remove migration check ripgrep dependency

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -222,11 +222,11 @@ jobs:
             fi
           done
 
-          if printf '%s\n' "$CHANGED_FILES" | grep -qE '^turbo/packages/db/(src/(migrations|schema|jsonb-contracts)/|scripts/(migration-runner|test-migration-runner-timeouts)\.ts$)'; then
-            echo "Migration, schema, JSONB contract, or migration runner changes detected"
+          if printf '%s\n' "$CHANGED_FILES" | grep -qE '^turbo/packages/db/(src/(migrations|schema|jsonb-contracts)/|scripts/)'; then
+            echo "Migration, schema, JSONB contract, or database script changes detected"
             echo "migration-changed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No migration, schema, JSONB contract, or migration runner changes"
+            echo "No migration, schema, JSONB contract, or database script changes"
             echo "migration-changed=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -615,7 +615,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 12
-    # Only run when migration, schema, or persistent JSONB contract files changed
+    # Only run when migration, schema, persistent JSONB contract, or database script files changed
     if: needs.prepare.outputs.migration-changed == 'true'
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260622

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -3270,15 +3270,15 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
     false,
   );
   const historicalClassifierCallers = execFileSync(
-    "rg",
+    "git",
     [
+      "grep",
       "-l",
       "-F",
       "isExactHistoricalProductBuilderCandidate(",
-      "--glob",
-      "*.ts",
-      "turbo/apps/api/src/signals",
-      "turbo/packages/db/scripts",
+      "--",
+      ":(glob)turbo/apps/api/src/signals/**/*.ts",
+      ":(glob)turbo/packages/db/scripts/**/*.ts",
     ],
     { cwd: repositoryRoot, encoding: "utf8" },
   )


### PR DESCRIPTION
## Summary

- replace the migration consistency script's implicit `rg` dependency with `git grep`
- preserve the exact historical classifier caller validation
- run `test-migrate` whenever files under `turbo/packages/db/scripts/**` change

This fixes the merge-group failure that blocked #28066. It does not change application runtime behavior.

Closes #28094

## Validation

- `pnpm exec prettier --check ../.github/workflows/turbo.yml packages/db/scripts/test-agent-compose-consolidation-preflight.ts`
- `pnpm -F @okouai/db check-types`
- `pnpm -F @okouai/db lint`
- `pnpm -F @okouai/db test:migration-consistency`
- pre-commit Knip and full Turbo type checks
