### PR TITLE
perf(api): scope connector runtime materialization

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -60,6 +60,7 @@ import {
   installApiTestConnectorCatalog,
   readApiTestConnectorCatalogCompatibilityEvaluations,
   readApiTestConnectorCatalogValidationAuthority,
+  replaceApiTestConnectorCatalogFilteredAuthMethods,
   replaceApiTestConnectorCatalogStoredBytes,
   setApiTestConnectorCatalogValidationAuthority,
 } from "../../../test-fixtures/connector-catalog";
@@ -1092,6 +1093,7 @@ function expectConnectorCatalogLoadTiming(args: {
   readonly runtimeCacheOutcome: "hit" | "miss";
   readonly requestedConnectorCount: "known" | "not_applicable";
   readonly requestedConnectorCountBucket?: (typeof CONNECTOR_CATALOG_COUNT_BUCKETS)[number];
+  readonly materializedConnectorCountBucket: (typeof CONNECTOR_CATALOG_COUNT_BUCKETS)[number];
   readonly resolvedConnectorFraction: (typeof CONNECTOR_CATALOG_RESOLVED_CONNECTOR_FRACTION_BUCKETS)[number];
   readonly validation:
     | { readonly outcome: "attested" | "not_run" }
@@ -1112,6 +1114,8 @@ function expectConnectorCatalogLoadTiming(args: {
       span_kind: "nested",
       connector_catalog_accepted_cache_outcome: args.acceptedCacheOutcome,
       connector_catalog_runtime_cache_outcome: args.runtimeCacheOutcome,
+      connector_catalog_materialized_connector_count_bucket:
+        args.materializedConnectorCountBucket,
       connector_catalog_validation_outcome: args.validation.outcome,
     }),
   );
@@ -1779,6 +1783,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
       requestedConnectorCountBucket: "2_4",
+      materializedConnectorCountBucket: "0",
       resolvedConnectorFraction: "none",
       validation: {
         outcome: "full_fallback",
@@ -1841,6 +1846,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       acceptedCacheOutcome: "miss",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
+      materializedConnectorCountBucket: "1",
       resolvedConnectorFraction: "up_to_25_percent",
       validation: {
         outcome: "full_fallback",
@@ -1905,6 +1911,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       acceptedCacheOutcome: "miss",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
+      materializedConnectorCountBucket: "1",
       resolvedConnectorFraction: "up_to_25_percent",
       validation: {
         outcome: "full_fallback",
@@ -1953,6 +1960,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       acceptedCacheOutcome: "hit",
       runtimeCacheOutcome: "hit",
       requestedConnectorCount: "known",
+      materializedConnectorCountBucket: "0",
       resolvedConnectorFraction: "up_to_25_percent",
       validation: { outcome: "not_run" },
     });
@@ -2037,6 +2045,20 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         }),
       ),
     ).toStrictEqual(new Set(["attested", "not_run"]));
+    expect(
+      new Set(
+        concurrentLoadEvents.map((event) => {
+          return event.connector_catalog_runtime_cache_outcome;
+        }),
+      ),
+    ).toStrictEqual(new Set(["miss", "hit"]));
+    expect(
+      new Set(
+        concurrentLoadEvents.map((event) => {
+          return event.connector_catalog_materialized_connector_count_bucket;
+        }),
+      ),
+    ).toStrictEqual(new Set(["0", "1"]));
     for (const event of concurrentLoadEvents) {
       expect(CONNECTOR_CATALOG_COMPRESSED_SIZE_BUCKETS).toContain(
         event.connector_catalog_compressed_size_bucket,
@@ -2059,6 +2081,153 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         "fixture-confidential-secret",
       ]);
     }
+  });
+
+  it("memoizes scoped runtime entries by exact catalog identity", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const fw = createFirewallApi(context);
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      `test-run-lifecycle-scoped-runtime-${randomUUID()}`,
+    );
+    const initialCatalogVersion = `api-test-scoped-runtime-${randomUUID()}`;
+    await installApiTestConnectorCatalog({
+      catalogVersion: initialCatalogVersion,
+    });
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const createScopedRun = async (
+      prompt: string,
+      allowedConnectorSlugs: readonly string[],
+    ) => {
+      return await api.createDirectRun(actor, {
+        ...zeroBackedDirectRunBody({ agentId, prompt }),
+        connectorScope: {
+          allowedConnectorSlugs,
+          allowedCustomConnectorIds: [],
+        },
+      });
+    };
+
+    const firstRun = await createScopedRun("cold scoped connector runtime", [
+      "x",
+      "x",
+      "catalog-runtime-unknown",
+    ]);
+    expectConnectorCatalogLoadTiming({
+      events: apiDispatchTimingEventsForRun(firstRun.runId),
+      acceptedCacheOutcome: "miss",
+      runtimeCacheOutcome: "miss",
+      requestedConnectorCount: "known",
+      requestedConnectorCountBucket: "2_4",
+      materializedConnectorCountBucket: "1",
+      resolvedConnectorFraction: "up_to_25_percent",
+      validation: { outcome: "attested" },
+    });
+    await api.requestCancelRun(actor, firstRun.runId, [200]);
+
+    const repeatedRun = await createScopedRun(
+      "warm repeated scoped connector runtime",
+      ["x", "x", "catalog-runtime-unknown"],
+    );
+    expectConnectorCatalogLoadTiming({
+      events: apiDispatchTimingEventsForRun(repeatedRun.runId),
+      acceptedCacheOutcome: "hit",
+      runtimeCacheOutcome: "hit",
+      requestedConnectorCount: "known",
+      requestedConnectorCountBucket: "2_4",
+      materializedConnectorCountBucket: "0",
+      resolvedConnectorFraction: "up_to_25_percent",
+      validation: { outcome: "not_run" },
+    });
+    await api.requestCancelRun(actor, repeatedRun.runId, [200]);
+
+    const additionalRun = await createScopedRun(
+      "materialize another scoped connector",
+      ["slack"],
+    );
+    expectConnectorCatalogLoadTiming({
+      events: apiDispatchTimingEventsForRun(additionalRun.runId),
+      acceptedCacheOutcome: "hit",
+      runtimeCacheOutcome: "miss",
+      requestedConnectorCount: "known",
+      requestedConnectorCountBucket: "1",
+      materializedConnectorCountBucket: "1",
+      resolvedConnectorFraction: "up_to_25_percent",
+      validation: { outcome: "not_run" },
+    });
+    await api.requestCancelRun(actor, additionalRun.runId, [200]);
+
+    const completeSearch = await connectors.searchConnectors(actor, "youtube");
+    expect(completeSearch.connectors).toContainEqual(
+      expect.objectContaining({ slug: "youtube" }),
+    );
+
+    const rotatedCatalogVersion = `api-test-scoped-runtime-${randomUUID()}`;
+    await installApiTestConnectorCatalog({
+      catalogVersion: rotatedCatalogVersion,
+    });
+    const rotatedRun = await createScopedRun(
+      "materialize after catalog identity rotation",
+      ["x"],
+    );
+    expectConnectorCatalogLoadTiming({
+      events: apiDispatchTimingEventsForRun(rotatedRun.runId),
+      acceptedCacheOutcome: "miss",
+      runtimeCacheOutcome: "miss",
+      requestedConnectorCount: "known",
+      requestedConnectorCountBucket: "1",
+      materializedConnectorCountBucket: "1",
+      resolvedConnectorFraction: "up_to_25_percent",
+      validation: { outcome: "attested" },
+    });
+    await api.requestCancelRun(actor, rotatedRun.runId, [200]);
+    await fw.seedTestConnector(actor, {
+      connectorSlug: "x",
+      authMethod: "oauth",
+      accessToken: "x-filtered-access",
+      refreshToken: "x-filtered-refresh",
+    });
+    await installApiTestConnectorCatalog({
+      catalogVersion: `api-test-scoped-runtime-${randomUUID()}`,
+    });
+    await replaceApiTestConnectorCatalogFilteredAuthMethods([
+      {
+        connectorSlug: "x",
+        authMethodId: "oauth",
+        reasons: ["missing-grant-provider"],
+      },
+    ]);
+
+    const filteredRun = await createScopedRun(
+      "omit a compatibility-filtered connector method",
+      ["x"],
+    );
+    expectConnectorCatalogLoadTiming({
+      events: apiDispatchTimingEventsForRun(filteredRun.runId),
+      acceptedCacheOutcome: "miss",
+      runtimeCacheOutcome: "miss",
+      requestedConnectorCount: "known",
+      requestedConnectorCountBucket: "1",
+      materializedConnectorCountBucket: "1",
+      resolvedConnectorFraction: "up_to_25_percent",
+      validation: { outcome: "attested" },
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const filteredClaim = await api.claimRunnerJob(filteredRun.runId);
+    expect(filteredClaim.environment ?? {}).not.toHaveProperty("X_TOKEN");
+    expect(filteredClaim.secretConnectorMap ?? {}).not.toHaveProperty(
+      "X_TOKEN",
+    );
+    expect(findFirewallEntry(filteredClaim.firewalls, "x")).toBeUndefined();
+    expect(filteredClaim.billableFirewalls).not.toContain("x");
+    expect(filteredClaim.networkPolicies ?? {}).not.toHaveProperty("x");
+    expect(filteredClaim).not.toHaveProperty("connectorPermissionBaseline");
+    expectClaimNetworkPolicyRefreshPath(
+      filteredRun.runId,
+      "no_builtin_targets",
+    );
+    await api.requestCancelRun(actor, filteredRun.runId, [200]);
   });
 
   it("keeps exact-empty create and claim independent from catalog availability", async () => {
@@ -7313,6 +7482,13 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
   it("injects oauth connector tokens with billable firewalls and resolvable secrets", async () => {
     const api = createRunsApi(context);
     const fw = createFirewallApi(context);
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      `test-run-lifecycle-zero-scoped-runtime-${randomUUID()}`,
+    );
+    await installApiTestConnectorCatalog({
+      catalogVersion: `api-test-zero-scoped-runtime-setup-${randomUUID()}`,
+    });
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     await fw.seedTestConnector(actor, {
@@ -7328,6 +7504,9 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     });
     const enabled = await api.enableAgentConnectors(actor, agentId, ["x"]);
     expect(enabled).toContain("x");
+    await installApiTestConnectorCatalog({
+      catalogVersion: `api-test-zero-scoped-runtime-run-${randomUUID()}`,
+    });
 
     const run = await api.createRun(actor, {
       agentId,
@@ -7339,6 +7518,16 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       timingEvents,
       API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
     );
+    expectConnectorCatalogLoadTiming({
+      events: timingEvents,
+      acceptedCacheOutcome: "miss",
+      runtimeCacheOutcome: "miss",
+      requestedConnectorCount: "known",
+      requestedConnectorCountBucket: "1",
+      materializedConnectorCountBucket: "1",
+      resolvedConnectorFraction: "up_to_25_percent",
+      validation: { outcome: "attested" },
+    });
     expectApiDispatchActions(
       timingEvents,
       API_DISPATCH_STORED_CONNECTOR_SNAPSHOT_ACTION_TYPES,
@@ -9609,6 +9798,13 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     createBddApi(context).acceptAgentStorageWrites();
     const connectors = createConnectorBddApi(context);
     const storages = createStoragesBddApi(context);
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      `test-run-lifecycle-custom-permission-runtime-${randomUUID()}`,
+    );
+    await installApiTestConnectorCatalog({
+      catalogVersion: `api-test-custom-permission-setup-${randomUUID()}`,
+    });
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     const slug = `_bdd-permission-skill-${randomUUID().slice(0, 8)}`;
     const custom = await connectors.createCustomConnector(actor, {
@@ -9706,6 +9902,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       { key: "workspace", kind: "variable", value: "restored" },
     ]);
     await api.requestCancelRun(actor, disconnectedRun.runId, [200]);
+    await installApiTestConnectorCatalog({
+      catalogVersion: `api-test-custom-permission-run-${randomUUID()}`,
+    });
 
     const restoredRun = await api.createRun(actor, {
       agentId,
@@ -9716,6 +9915,16 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       apiDispatchTimingEventsForRun(restoredRun.runId),
       API_DISPATCH_CONNECTOR_CATALOG_ALWAYS_ACTION_TYPES,
     );
+    expectConnectorCatalogLoadTiming({
+      events: apiDispatchTimingEventsForRun(restoredRun.runId),
+      acceptedCacheOutcome: "miss",
+      runtimeCacheOutcome: "miss",
+      requestedConnectorCount: "known",
+      requestedConnectorCountBucket: "0",
+      materializedConnectorCountBucket: "0",
+      resolvedConnectorFraction: "none",
+      validation: { outcome: "attested" },
+    });
     const restoredClaim = await api.claimRunnerJob(restoredRun.runId);
     const customApis = inlineFirewallApis(
       restoredClaim.firewalls,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -243,9 +243,9 @@ import {
 } from "./connector-credential-status.service";
 import {
   getConnectorRuntimeConnector,
-  loadConnectorRuntimeSnapshot,
+  loadConnectorRuntimeSelection,
   type ConnectorRuntimeMethod,
-  type ConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSelection,
 } from "./connector-catalog-runtime.service";
 import {
   connectorCredentialSecretReadCondition,
@@ -599,8 +599,8 @@ interface EffectiveConnectorScope {
 export type RunConnectorCatalogSelection =
   | { readonly kind: "empty" }
   | {
-      readonly kind: "complete";
-      readonly snapshot: ConnectorRuntimeSnapshot;
+      readonly kind: "scoped";
+      readonly selection: ConnectorRuntimeSelection;
     };
 
 export function isEmptyRunConnectorScope(scope: {
@@ -1161,7 +1161,7 @@ function buildLegacySystemSkillVolumes(
 
 function buildConnectorSkillVolumes(
   connectorSlugs: readonly ConnectorSlug[],
-  snapshot: ConnectorRuntimeSnapshot,
+  snapshot: ConnectorRuntimeSelection,
   skillsRoot: string,
 ): readonly PreparedAdditionalVolume[] {
   return connectorSlugs.flatMap((connectorSlug) => {
@@ -1235,10 +1235,10 @@ function buildInjectedSkillVolumes(
       buildLegacySystemSkillVolumes(seedSkillNames, skillsRoot),
       "system_skill",
     ) ?? []),
-    ...(args.connectorCatalogSelection.kind === "complete"
+    ...(args.connectorCatalogSelection.kind === "scoped"
       ? buildConnectorSkillVolumes(
           args.allowedConnectorSlugs,
-          args.connectorCatalogSelection.snapshot,
+          args.connectorCatalogSelection.selection,
           skillsRoot,
         )
       : []),
@@ -3061,7 +3061,7 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
 function allowedStoredConnectorRows(
   rows: readonly StoredConnectorRuntimeRowCandidate[],
   allowedConnectorSlugs: readonly ConnectorSlug[],
-  snapshot: ConnectorRuntimeSnapshot,
+  snapshot: ConnectorRuntimeSelection,
   now: Date,
 ): readonly StoredConnectorRuntimeRow[] {
   const validRows = rows.flatMap((row) => {
@@ -3698,7 +3698,7 @@ async function loadStoredConnectorMaterializationPlan(
     readonly userId: string;
     readonly allowedConnectorSlugs: readonly ConnectorSlug[];
     readonly scopeSource: ConnectorScopeSource;
-    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+    readonly connectorCatalogSnapshot: ConnectorRuntimeSelection;
   },
   timing?: ApiDispatchTimingCollector,
 ): Promise<StoredConnectorMaterializationSnapshot | null> {
@@ -3866,7 +3866,7 @@ async function loadStoredConnectorSnapshotRows(
 function buildStoredConnectorMaterializationPlan(args: {
   readonly connectorRows: readonly StoredConnectorRuntimeRowCandidate[];
   readonly allowedConnectorSlugs: readonly ConnectorSlug[];
-  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSelection;
 }): StoredConnectorMaterializationPlan | null {
   const allowedConnectorRows = allowedStoredConnectorRows(
     args.connectorRows,
@@ -3889,7 +3889,7 @@ function materializeStoredConnectorSnapshotRows(
   args: {
     readonly rows: readonly StoredConnectorMaterializationSnapshotRow[];
     readonly allowedConnectorSlugs: readonly ConnectorSlug[];
-    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+    readonly connectorCatalogSnapshot: ConnectorRuntimeSelection;
     readonly timingDimensions: ApiDispatchTimingDimensions;
   },
   timing?: ApiDispatchTimingCollector,
@@ -3974,7 +3974,7 @@ async function loadStoredConnectorMaterializationSnapshot(
     readonly userId: string;
     readonly allowedConnectorSlugs: readonly ConnectorSlug[];
     readonly scopeSource: ConnectorScopeSource;
-    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+    readonly connectorCatalogSnapshot: ConnectorRuntimeSelection;
   },
   timing?: ApiDispatchTimingCollector,
 ): Promise<StoredConnectorMaterializationSnapshot | null> {
@@ -4310,7 +4310,7 @@ function jsonArrayEqual(
 interface BuildCustomConnectorRuntimeContextArgs {
   readonly rows: CustomConnectorRuntimeDataRows;
   readonly featureSwitchContext: FeatureSwitchContext;
-  readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+  readonly connectorCatalogSnapshot: ConnectorRuntimeSelection;
   readonly grants: readonly AgentCustomConnectorGrant[] | undefined;
   readonly baseUrlVarsByConnectorId?: ReadonlyMap<
     string,
@@ -4378,7 +4378,7 @@ function unavailableCustomConnectorRuntimeRow(
 
 export async function loadEffectiveCustomConnectorPermissionBundle(args: {
   readonly row: CustomConnectorRuntimeDataRows[number];
-  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly snapshot: ConnectorRuntimeSelection;
 }): Promise<CustomConnectorPermissionBundle | null | undefined> {
   if (args.row.connector.kind === "mcp") {
     return null;
@@ -4393,7 +4393,7 @@ export async function loadEffectiveCustomConnectorPermissionBundle(args: {
   });
   return ref
     ? ((await loadCustomConnectorPermissionBundle({
-        snapshot: args.snapshot,
+        catalog: args.snapshot.serverFirewallMetadata,
         ref,
       })) ?? undefined)
     : null;
@@ -4662,7 +4662,7 @@ async function loadCustomConnectorContext(
       | readonly AgentCustomConnectorGrant[]
       | undefined;
     readonly featureSwitchContext: FeatureSwitchContext;
-    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+    readonly connectorCatalogSnapshot: ConnectorRuntimeSelection;
   },
   signal: AbortSignal,
   timing?: ApiDispatchTimingCollector,
@@ -4760,7 +4760,7 @@ function resolveConnectorNetworkPolicy(args: {
 }
 
 async function loadRequiredFirewallPermissionIndex(args: {
-  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly snapshot: ConnectorRuntimeSelection;
   readonly connectorSlug: string;
 }): Promise<ConnectorServerFirewallPermissionIndex> {
   const index = await args.snapshot.serverFirewalls.loadPermissionIndex(
@@ -4775,7 +4775,7 @@ async function loadRequiredFirewallPermissionIndex(args: {
 }
 
 function getRequiredFirewallExecutionMetadata(
-  snapshot: ConnectorRuntimeSnapshot,
+  snapshot: ConnectorRuntimeSelection,
   connectorSlug: string,
 ): ConnectorServerFirewallExecutionMetadata {
   const metadata = snapshot.serverFirewalls.getExecutionMetadata(connectorSlug);
@@ -4995,13 +4995,13 @@ interface BuiltinConnectorManifestSource {
 }
 
 function buildConnectorPermissionBaseline(
-  snapshot: ConnectorRuntimeSnapshot,
+  snapshot: ConnectorRuntimeSelection,
   sources: readonly BuiltinConnectorManifestSource[],
 ): StoredConnectorPermissionBaseline {
   const validationAuthority = currentConnectorCatalogValidatorIdentity();
   return {
     version: 1,
-    catalogIdentity: snapshot.acceptedSnapshot.identity,
+    catalogIdentity: snapshot.catalogIdentity,
     validationAuthority: {
       backendVersion: validationAuthority.backendVersion,
       buildCommitSha: validationAuthority.buildCommitSha,
@@ -5133,10 +5133,10 @@ function mergePermissionManifests(args: {
       return undefined;
     }
     if (args.connectorCatalogSelection.kind === "empty") {
-      throw new Error("Builtin connector sources require a complete catalog");
+      throw new Error("Builtin connector sources require a catalog selection");
     }
     return buildConnectorPermissionBaseline(
-      args.connectorCatalogSelection.snapshot,
+      args.connectorCatalogSelection.selection,
       args.builtinSources,
     );
   })();
@@ -5193,7 +5193,7 @@ async function buildPermissionManifest(
       if (args.connectorCatalogSelection.kind === "empty") {
         return [];
       }
-      const snapshot = args.connectorCatalogSelection.snapshot;
+      const snapshot = args.connectorCatalogSelection.selection;
       const connectorSlugs =
         args.connectorSlugs ??
         Object.keys(args.permissionPolicies ?? {}).filter((connectorSlug) => {
@@ -7949,7 +7949,7 @@ async function loadRunConnectorContexts(
     readonly orgId: string;
     readonly userId: string;
     readonly connectorScope: EffectiveConnectorScope;
-    readonly connectorCatalogSnapshot: ConnectorRuntimeSnapshot;
+    readonly connectorCatalogSnapshot: ConnectorRuntimeSelection;
     readonly featureSwitchContext: FeatureSwitchContext;
     readonly timing: ApiDispatchTimingCollector | undefined;
   },
@@ -8186,7 +8186,7 @@ interface PreparedRuntimeContext {
 
 function connectorScopeForRuntimeSnapshot(
   scope: EffectiveConnectorScope,
-  snapshot: ConnectorRuntimeSnapshot,
+  snapshot: ConnectorRuntimeSelection,
 ): EffectiveConnectorScope {
   return {
     ...scope,
@@ -8407,7 +8407,7 @@ async function prepareRunConnectorContexts(
             orgId: args.createArgs.orgId,
             userId: args.createArgs.userId,
             connectorScope: args.connectorScope,
-            connectorCatalogSnapshot: args.connectorCatalogSelection.snapshot,
+            connectorCatalogSnapshot: args.connectorCatalogSelection.selection,
             featureSwitchContext: args.featureSwitchContext,
             timing: args.timing,
           },
@@ -8459,7 +8459,7 @@ async function prepareRunRuntimeContext(
     readonly db: Db;
     readonly createArgs: CreateAgentRunArgs;
     readonly connectorScope: EffectiveConnectorScope;
-    readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
+    readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSelection;
     readonly timing: ApiDispatchTimingCollector;
     readonly bodyContext: PreparedRunBodyContext;
   },
@@ -8470,10 +8470,10 @@ async function prepareRunRuntimeContext(
   const connectorCatalogSelection = await connectorCatalogSelectionForRun(args);
   signal.throwIfAborted();
   const connectorScope =
-    connectorCatalogSelection.kind === "complete"
+    connectorCatalogSelection.kind === "scoped"
       ? connectorScopeForRuntimeSnapshot(
           args.connectorScope,
-          connectorCatalogSelection.snapshot,
+          connectorCatalogSelection.selection,
         )
       : args.connectorScope;
   const modelProvider = await resolvePreparedRunModelProvider(args, signal);
@@ -8581,20 +8581,20 @@ async function prepareRunRuntimeContext(
 
 async function connectorCatalogSelectionForRun(args: {
   readonly db: Db;
-  readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
+  readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSelection;
   readonly connectorScope: EffectiveConnectorScope;
   readonly timing: ApiDispatchTimingCollector;
 }): Promise<RunConnectorCatalogSelection> {
   if (isEmptyRunConnectorScope(args.connectorScope)) {
     return { kind: "empty" };
   }
-  const snapshot =
+  const selection =
     args.preloadedConnectorCatalogSnapshot ??
-    (await loadConnectorRuntimeSnapshot(args.db, {
+    (await loadConnectorRuntimeSelection(args.db, {
       timing: args.timing,
       requestedConnectorSlugs: args.connectorScope.allowedConnectorSlugs,
     }));
-  return { kind: "complete", snapshot };
+  return { kind: "scoped", selection };
 }
 
 function prepareRunOutputMetadata(args: {
@@ -8655,7 +8655,7 @@ interface PrepareRunContextInput {
   readonly preloadedFeatureSwitchContext: FeatureSwitchContext | undefined;
   readonly preloadedUserTimezone: string | null | undefined;
   readonly preloadedConnectorCatalogSnapshot:
-    | ConnectorRuntimeSnapshot
+    | ConnectorRuntimeSelection
     | undefined;
 }
 
@@ -9193,7 +9193,7 @@ interface PrepareAgentRunArgs {
   readonly preloadedFeatureSwitchContext?: FeatureSwitchContext;
   // Undefined means not preloaded; null is an authoritative missing value.
   readonly preloadedUserTimezone?: string | null;
-  readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSnapshot;
+  readonly preloadedConnectorCatalogSnapshot?: ConnectorRuntimeSelection;
 }
 
 interface CompleteAgentRunArgs {

--- a/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
@@ -138,6 +138,7 @@ export class ConnectorCatalogLoadTiming {
   private catalogCompressedSize: number | undefined;
   private connectorCount: number | undefined;
   private resolvedConnectorCount: number | undefined;
+  private materializedConnectorCount: number | undefined;
 
   constructor(
     private readonly collector: ApiDispatchTimingCollector,
@@ -176,6 +177,10 @@ export class ConnectorCatalogLoadTiming {
     this.catalogCompressedSize = args.compressedSize;
     this.connectorCount = args.connectorCount;
     this.resolvedConnectorCount = args.resolvedConnectorCount;
+  }
+
+  recordMaterializedConnectorCount(count: number): void {
+    this.materializedConnectorCount = count;
   }
 
   async measure<T>(
@@ -256,6 +261,13 @@ export class ConnectorCatalogLoadTiming {
         this.requestedConnectorCount === undefined
           ? "not_applicable"
           : countBucket(this.requestedConnectorCount),
+      ...(this.materializedConnectorCount === undefined
+        ? {}
+        : {
+            connector_catalog_materialized_connector_count_bucket: countBucket(
+              this.materializedConnectorCount,
+            ),
+          }),
     };
   }
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -46,7 +46,10 @@ import type { ConnectorFeatureStates } from "./connector-catalog-feature-states"
 import { ConnectorCatalogLoadTiming } from "./connector-catalog-load-timing.service";
 import {
   createAcceptedConnectorServerFirewallCatalog,
+  selectConnectorServerFirewalls,
   type ConnectorServerFirewallCatalog,
+  type ConnectorServerFirewallMetadataCatalog,
+  type ConnectorServerFirewallSelection,
 } from "./connector-server-firewall-catalog.service";
 
 export interface ConnectorRuntimeMethod {
@@ -66,10 +69,17 @@ export interface ConnectorRuntimeConnector {
   readonly skill: ConnectorCatalogSkill;
 }
 
-export interface ConnectorRuntimeSnapshot {
-  readonly acceptedSnapshot: AcceptedConnectorCatalogSnapshot;
+export interface ConnectorRuntimeSelection {
+  readonly catalogIdentity: ExternalCatalogIdentity;
   readonly connectors: ReadonlyMap<ConnectorSlug, ConnectorRuntimeConnector>;
+  readonly serverFirewalls: ConnectorServerFirewallSelection;
+  readonly serverFirewallMetadata: ConnectorServerFirewallMetadataCatalog;
+}
+
+export interface ConnectorRuntimeSnapshot extends ConnectorRuntimeSelection {
+  readonly acceptedSnapshot: AcceptedConnectorCatalogSnapshot;
   readonly serverFirewalls: ConnectorServerFirewallCatalog;
+  readonly serverFirewallMetadata: ConnectorServerFirewallCatalog;
 }
 
 function methodKey(connectorSlug: string, authMethodId: string): string {
@@ -441,114 +451,64 @@ function runtimeMethodEntry(args: {
   };
 }
 
-function runtimeConnectors(
+function runtimeConnector(
   acceptedSnapshot: AcceptedConnectorCatalogSnapshot,
-): ReadonlyMap<ConnectorSlug, ConnectorRuntimeConnector> {
-  const connectors = new Map<ConnectorSlug, ConnectorRuntimeConnector>();
-
-  for (const connector of acceptedSnapshot.artifact.connectors) {
-    const connectorSlug = connector.slug;
-    const catalogConnector = getAcceptedConnectorCatalogResolutionDetail({
-      snapshot: acceptedSnapshot,
-      connectorSlug,
-    });
-    if (catalogConnector === null) {
-      throw new Error("Accepted connector runtime relationship is incomplete");
+  connectorSlug: ConnectorSlug,
+): ConnectorRuntimeConnector {
+  const connector = acceptedSnapshot.connectorBySlug.get(connectorSlug);
+  if (connector === undefined) {
+    throw new Error("Accepted connector runtime source is unavailable");
+  }
+  const catalogConnector = getAcceptedConnectorCatalogResolutionDetail({
+    snapshot: acceptedSnapshot,
+    connectorSlug,
+  });
+  if (catalogConnector === null) {
+    throw new Error("Accepted connector runtime relationship is incomplete");
+  }
+  const catalogMethods = new Map(
+    catalogConnector.authMethods.map((method) => {
+      return [method.id, method];
+    }),
+  );
+  const methods = new Map<ConnectorAuthMethodId, ConnectorRuntimeMethod>();
+  const authoredVisibleMethodIds = new Set<ConnectorAuthMethodId>();
+  for (const method of connector.authMethods) {
+    if (method.visible) {
+      authoredVisibleMethodIds.add(method.id);
     }
-    const catalogMethods = new Map(
-      catalogConnector.authMethods.map((method) => {
-        return [method.id, method];
+    if (
+      !acceptedConnectorCatalogMethodIsCompatible({
+        snapshot: acceptedSnapshot,
+        connectorSlug,
+        authMethodId: method.id,
+      })
+    ) {
+      continue;
+    }
+    const catalogMethod = catalogMethods.get(method.id);
+    if (catalogMethod === undefined) {
+      throw new Error("Accepted connector auth method alignment is incomplete");
+    }
+    methods.set(
+      method.id,
+      runtimeMethodEntry({
+        connectorSlug,
+        catalogMethod,
+        method: runtimeMethod(method),
       }),
     );
-    const methods = new Map<ConnectorAuthMethodId, ConnectorRuntimeMethod>();
-    const authoredVisibleMethodIds = new Set<ConnectorAuthMethodId>();
-    for (const method of connector.authMethods) {
-      if (method.visible) {
-        authoredVisibleMethodIds.add(method.id);
-      }
-      if (
-        !acceptedConnectorCatalogMethodIsCompatible({
-          snapshot: acceptedSnapshot,
-          connectorSlug,
-          authMethodId: method.id,
-        })
-      ) {
-        continue;
-      }
-      const catalogMethod = catalogMethods.get(method.id);
-      if (catalogMethod === undefined) {
-        throw new Error(
-          "Accepted connector auth method alignment is incomplete",
-        );
-      }
-      methods.set(
-        method.id,
-        runtimeMethodEntry({
-          connectorSlug,
-          catalogMethod,
-          method: runtimeMethod(method),
-        }),
-      );
-    }
-    connectors.set(connectorSlug, {
-      connectorSlug,
-      catalogConnector,
-      methods,
-      authoredVisibleMethodIds,
-      skill: connector.skill,
-    });
   }
-  return connectors;
-}
-
-function runtimeSnapshot(
-  acceptedSnapshot: AcceptedConnectorCatalogSnapshot,
-  timing: ConnectorCatalogLoadTiming | undefined,
-): ConnectorRuntimeSnapshot {
-  const connectors = timing
-    ? timing.measureSync(
-        "api_dispatch_connector_catalog_materialize_runtime_snapshot",
-        () => {
-          return runtimeConnectors(acceptedSnapshot);
-        },
-      )
-    : runtimeConnectors(acceptedSnapshot);
-  const serverFirewalls = timing
-    ? timing.measureSync(
-        "api_dispatch_connector_catalog_materialize_server_firewalls",
-        () => {
-          return runtimeServerFirewalls(acceptedSnapshot, connectors);
-        },
-      )
-    : runtimeServerFirewalls(acceptedSnapshot, connectors);
   return {
-    acceptedSnapshot,
-    connectors,
-    serverFirewalls,
+    connectorSlug,
+    catalogConnector,
+    methods,
+    authoredVisibleMethodIds,
+    skill: connector.skill,
   };
 }
 
-function runtimeServerFirewalls(
-  acceptedSnapshot: AcceptedConnectorCatalogSnapshot,
-  connectors: ReadonlyMap<ConnectorSlug, ConnectorRuntimeConnector>,
-): ConnectorServerFirewallCatalog {
-  const runtimeMethodsBySlug = new Map(
-    [...connectors.entries()].map(([connectorSlug, connector]) => {
-      return [
-        connectorSlug,
-        [...connector.methods.values()].map((method) => {
-          return method.method;
-        }),
-      ];
-    }),
-  );
-  return createAcceptedConnectorServerFirewallCatalog({
-    artifact: acceptedSnapshot.artifact,
-    runtimeMethodsBySlug,
-  });
-}
-
-function runtimeSnapshotKey(identity: ExternalCatalogIdentity): string {
+function runtimeCatalogKey(identity: ExternalCatalogIdentity): string {
   return [
     identity.sourceId,
     identity.schemaVersion,
@@ -558,87 +518,202 @@ function runtimeSnapshotKey(identity: ExternalCatalogIdentity): string {
   ].join("\0");
 }
 
-interface RuntimeSnapshotCache {
-  key: string | undefined;
+interface ConnectorRuntimeState {
+  readonly acceptedSnapshot: AcceptedConnectorCatalogSnapshot;
+  readonly connectors: Map<ConnectorSlug, ConnectorRuntimeConnector>;
+  readonly serverFirewalls: ConnectorServerFirewallCatalog;
   snapshot: ConnectorRuntimeSnapshot | undefined;
 }
 
-const runtimeSnapshotCache = singleton((): RuntimeSnapshotCache => {
-  return { key: undefined, snapshot: undefined };
+interface RuntimeCatalogCache {
+  key: string | undefined;
+  state: ConnectorRuntimeState | undefined;
+}
+
+const runtimeCatalogCache = singleton((): RuntimeCatalogCache => {
+  return { key: undefined, state: undefined };
 });
 
-async function loadConnectorRuntimeSnapshotWithTiming(
-  db: ReadonlyDb,
-  timing: ConnectorCatalogLoadTiming | undefined,
-  requestedConnectorSlugs: readonly ConnectorSlug[] | undefined,
-): Promise<ConnectorRuntimeSnapshot> {
-  const acceptedSnapshot = await loadAcceptedConnectorCatalogSnapshot(
-    db,
-    timing,
-  );
-  const resolvedConnectorCount =
-    requestedConnectorSlugs === undefined
-      ? undefined
-      : new Set(
-          requestedConnectorSlugs.filter((connectorSlug) => {
-            return acceptedSnapshot.connectorBySlug.has(connectorSlug);
-          }),
-        ).size;
-  timing?.recordCatalogFacts({
-    rawSize: acceptedSnapshot.catalogRawSize,
-    compressedSize: acceptedSnapshot.catalogCompressedSize,
-    connectorCount: acceptedSnapshot.artifact.connectors.length,
-    resolvedConnectorCount,
-  });
-  const key = runtimeSnapshotKey(acceptedSnapshot.identity);
-  const cache = runtimeSnapshotCache();
-  if (cache.key === key && cache.snapshot !== undefined) {
-    timing?.recordRuntimeCacheOutcome("hit");
-    return cache.snapshot;
+function materializeConnectorRuntimeEntry(
+  acceptedSnapshot: AcceptedConnectorCatalogSnapshot,
+  connectors: Map<ConnectorSlug, ConnectorRuntimeConnector>,
+  connectorSlug: ConnectorSlug,
+): ConnectorRuntimeConnector {
+  const cached = connectors.get(connectorSlug);
+  if (cached !== undefined) {
+    return cached;
   }
-  timing?.recordRuntimeCacheOutcome("miss");
-  const snapshot = runtimeSnapshot(acceptedSnapshot, timing);
+  const connector = runtimeConnector(acceptedSnapshot, connectorSlug);
+  connectors.set(connectorSlug, connector);
+  return connector;
+}
+
+function connectorRuntimeState(
+  acceptedSnapshot: AcceptedConnectorCatalogSnapshot,
+  timing: ConnectorCatalogLoadTiming | undefined,
+): { readonly state: ConnectorRuntimeState; readonly created: boolean } {
+  const key = runtimeCatalogKey(acceptedSnapshot.identity);
+  const cache = runtimeCatalogCache();
+  if (cache.key === key && cache.state !== undefined) {
+    return { state: cache.state, created: false };
+  }
+  const connectors = new Map<ConnectorSlug, ConnectorRuntimeConnector>();
+  const createServerFirewalls = (): ConnectorServerFirewallCatalog => {
+    return createAcceptedConnectorServerFirewallCatalog({
+      artifact: acceptedSnapshot.artifact,
+      runtimeMethodsForSlug: (connectorSlug) => {
+        return [
+          ...materializeConnectorRuntimeEntry(
+            acceptedSnapshot,
+            connectors,
+            connectorSlug,
+          ).methods.values(),
+        ].map((method) => {
+          return method.method;
+        });
+      },
+    });
+  };
+  const state: ConnectorRuntimeState = {
+    acceptedSnapshot,
+    connectors,
+    serverFirewalls: timing
+      ? timing.measureSync(
+          "api_dispatch_connector_catalog_materialize_server_firewalls",
+          () => {
+            return createServerFirewalls();
+          },
+        )
+      : createServerFirewalls(),
+    snapshot: undefined,
+  };
   cache.key = key;
-  cache.snapshot = snapshot;
-  return snapshot;
+  cache.state = state;
+  return { state, created: true };
+}
+
+function acceptedRequestedConnectorSlugs(
+  acceptedSnapshot: AcceptedConnectorCatalogSnapshot,
+  requestedConnectorSlugs: readonly ConnectorSlug[],
+): readonly ConnectorSlug[] {
+  return [...new Set(requestedConnectorSlugs)].filter((connectorSlug) => {
+    return acceptedSnapshot.connectorBySlug.has(connectorSlug);
+  });
+}
+
+function selectedRuntimeConnectors(
+  state: ConnectorRuntimeState,
+  connectorSlugs: readonly ConnectorSlug[],
+): ReadonlyMap<ConnectorSlug, ConnectorRuntimeConnector> {
+  return new Map(
+    connectorSlugs.map(
+      (connectorSlug): [ConnectorSlug, ConnectorRuntimeConnector] => {
+        return [
+          connectorSlug,
+          materializeConnectorRuntimeEntry(
+            state.acceptedSnapshot,
+            state.connectors,
+            connectorSlug,
+          ),
+        ];
+      },
+    ),
+  );
+}
+
+export async function loadConnectorRuntimeSelection(
+  db: ReadonlyDb,
+  options: {
+    readonly timing: ApiDispatchTimingCollector;
+    readonly requestedConnectorSlugs: readonly ConnectorSlug[];
+  },
+): Promise<ConnectorRuntimeSelection> {
+  const timing = new ConnectorCatalogLoadTiming(
+    options.timing,
+    options.requestedConnectorSlugs.length,
+  );
+  return await timing.measureComplete(async () => {
+    const acceptedSnapshot = await loadAcceptedConnectorCatalogSnapshot(
+      db,
+      timing,
+    );
+    const connectorSlugs = acceptedRequestedConnectorSlugs(
+      acceptedSnapshot,
+      options.requestedConnectorSlugs,
+    );
+    timing.recordCatalogFacts({
+      rawSize: acceptedSnapshot.catalogRawSize,
+      compressedSize: acceptedSnapshot.catalogCompressedSize,
+      connectorCount: acceptedSnapshot.artifact.connectors.length,
+      resolvedConnectorCount: connectorSlugs.length,
+    });
+    const { state, created } = connectorRuntimeState(acceptedSnapshot, timing);
+    const missingConnectorSlugs = connectorSlugs.filter((connectorSlug) => {
+      return !state.connectors.has(connectorSlug);
+    });
+    const cacheMiss = created || missingConnectorSlugs.length > 0;
+    timing.recordRuntimeCacheOutcome(cacheMiss ? "miss" : "hit");
+    timing.recordMaterializedConnectorCount(missingConnectorSlugs.length);
+    if (cacheMiss) {
+      timing.measureSync(
+        "api_dispatch_connector_catalog_materialize_runtime_snapshot",
+        () => {
+          for (const connectorSlug of missingConnectorSlugs) {
+            materializeConnectorRuntimeEntry(
+              state.acceptedSnapshot,
+              state.connectors,
+              connectorSlug,
+            );
+          }
+        },
+      );
+    }
+    const connectors = selectedRuntimeConnectors(state, connectorSlugs);
+    return {
+      catalogIdentity: acceptedSnapshot.identity,
+      connectors,
+      serverFirewalls: selectConnectorServerFirewalls({
+        catalog: state.serverFirewalls,
+        connectorSlugs,
+      }),
+      serverFirewallMetadata: state.serverFirewalls,
+    };
+  });
 }
 
 export async function loadConnectorRuntimeSnapshot(
   db: ReadonlyDb,
-  options?: {
-    readonly timing: ApiDispatchTimingCollector;
-    readonly requestedConnectorSlugs: readonly ConnectorSlug[] | undefined;
-  },
 ): Promise<ConnectorRuntimeSnapshot> {
-  if (options === undefined) {
-    return await loadConnectorRuntimeSnapshotWithTiming(
-      db,
-      undefined,
-      undefined,
-    );
+  const acceptedSnapshot = await loadAcceptedConnectorCatalogSnapshot(db);
+  const { state } = connectorRuntimeState(acceptedSnapshot, undefined);
+  if (state.snapshot !== undefined) {
+    return state.snapshot;
   }
-  const timing = new ConnectorCatalogLoadTiming(
-    options.timing,
-    options.requestedConnectorSlugs?.length,
+  const connectorSlugs = acceptedSnapshot.artifact.connectors.map(
+    (connector) => {
+      return connector.slug;
+    },
   );
-  return await timing.measureComplete(async () => {
-    return await loadConnectorRuntimeSnapshotWithTiming(
-      db,
-      timing,
-      options.requestedConnectorSlugs,
-    );
-  });
+  const snapshot: ConnectorRuntimeSnapshot = {
+    acceptedSnapshot,
+    catalogIdentity: acceptedSnapshot.identity,
+    connectors: selectedRuntimeConnectors(state, connectorSlugs),
+    serverFirewalls: state.serverFirewalls,
+    serverFirewallMetadata: state.serverFirewalls,
+  };
+  state.snapshot = snapshot;
+  return snapshot;
 }
 
 export function getConnectorRuntimeConnector(
-  snapshot: ConnectorRuntimeSnapshot,
+  snapshot: ConnectorRuntimeSelection,
   connectorSlug: string,
 ): ConnectorRuntimeConnector | undefined {
   return snapshot.connectors.get(connectorSlug);
 }
 
 export function getConnectorRuntimeMethod(args: {
-  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly snapshot: ConnectorRuntimeSelection;
   readonly connectorSlug: string;
   readonly authMethodId: string;
   readonly requireExecutable?: boolean;

--- a/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-sync.service.ts
@@ -153,18 +153,12 @@ async function publishCatalogPermissionBundleWakeupsInner(args: {
   readonly previousSnapshot: ConnectorRuntimeSnapshot | undefined;
   readonly currentArtifact: ConnectorCatalogArtifact;
 }): Promise<void> {
-  const currentSnapshot = {
-    serverFirewalls: createAcceptedConnectorServerFirewallCatalog({
-      artifact: args.currentArtifact,
-      runtimeMethodsBySlug: new Map(
-        args.currentArtifact.connectors.flatMap((connector) => {
-          return connector.firewall.kind === "none"
-            ? []
-            : [[connector.slug, []] as const];
-        }),
-      ),
-    }),
-  };
+  const currentCatalog = createAcceptedConnectorServerFirewallCatalog({
+    artifact: args.currentArtifact,
+    runtimeMethodsForSlug: () => {
+      return [];
+    },
+  });
   const rows = await args.db
     .select({
       id: orgCustomConnectors.id,
@@ -210,12 +204,12 @@ async function publishCatalogPermissionBundleWakeupsInner(args: {
     const [previousBundle, currentBundle] = await Promise.all([
       args.previousSnapshot
         ? loadCustomConnectorPermissionBundle({
-            snapshot: args.previousSnapshot,
+            catalog: args.previousSnapshot.serverFirewallMetadata,
             ref,
           })
         : null,
       loadCustomConnectorPermissionBundle({
-        snapshot: currentSnapshot,
+        catalog: currentCatalog,
         ref,
       }),
     ]);

--- a/turbo/apps/api/src/signals/services/connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-access.service.ts
@@ -22,7 +22,7 @@ import type { ReadonlyDb } from "../external/db";
 import {
   getConnectorRuntimeMethod,
   type ConnectorRuntimeMethod,
-  type ConnectorRuntimeSnapshot,
+  type ConnectorRuntimeSelection,
 } from "./connector-catalog-runtime.service";
 
 const log = logger("api:connector-credential-access");
@@ -80,7 +80,7 @@ export function connectorCredentialStorageIsCompatible(args: {
 }
 
 export function resolveStoredConnectorRuntimeMethod(args: {
-  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly snapshot: ConnectorRuntimeSelection;
   readonly stored: {
     readonly authMethodId: string;
     readonly connectorId: string;
@@ -104,7 +104,7 @@ export function resolveStoredConnectorRuntimeMethod(args: {
 }
 
 export function resolveConnectorCredentialAccess(args: {
-  readonly snapshot: ConnectorRuntimeSnapshot;
+  readonly snapshot: ConnectorRuntimeSelection;
   readonly stored: ConnectorCredentialStoredIdentity;
 }): ConnectorCredentialAccessResult {
   const runtimeMethod = resolveStoredConnectorRuntimeMethod({

--- a/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
@@ -96,12 +96,8 @@ export interface ConnectorServerFirewallHostOwner {
   readonly label: string;
 }
 
-export interface ConnectorServerFirewallCatalog {
-  readonly connectorSlugs: readonly ConnectorSlug[];
+export interface ConnectorServerFirewallMetadataCatalog {
   has(connectorSlug: string): boolean;
-  getExecutionMetadata(
-    connectorSlug: string,
-  ): ConnectorServerFirewallExecutionMetadata | null;
   loadPermissionIndex(
     connectorSlug: string,
   ): Promise<ConnectorServerFirewallPermissionIndex | null>;
@@ -111,12 +107,24 @@ export interface ConnectorServerFirewallCatalog {
   loadRoutingMetadata(
     connectorSlug: string,
   ): Promise<ConnectorServerFirewallRoutingMetadata | null>;
+}
+
+export interface ConnectorServerFirewallSelection extends ConnectorServerFirewallMetadataCatalog {
+  getExecutionMetadata(
+    connectorSlug: string,
+  ): ConnectorServerFirewallExecutionMetadata | null;
+}
+
+export interface ConnectorServerFirewallCatalog extends ConnectorServerFirewallSelection {
+  readonly connectorSlugs: readonly ConnectorSlug[];
   getFixedHostOwner(host: string): ConnectorServerFirewallHostOwner | null;
 }
 
 interface AcceptedConnectorServerFirewallEntry {
   readonly connector: ConnectorCatalogArtifactConnector;
-  readonly methods: readonly ConnectorAuthMethodRuntimeConfig[];
+  readonly runtimeMethods: () =>
+    | readonly ConnectorAuthMethodRuntimeConfig[]
+    | undefined;
   firewall: AcceptedServerFirewall | undefined;
   routing: ConnectorCatalogFirewallRouting | undefined;
   permissionIndex: ConnectorServerFirewallPermissionIndex | undefined;
@@ -412,10 +420,9 @@ function acceptedRoutingMetadata(args: {
 
 function acceptedEntries(args: {
   readonly artifact: ConnectorCatalogArtifact;
-  readonly runtimeMethodsBySlug: ReadonlyMap<
-    ConnectorSlug,
-    readonly ConnectorAuthMethodRuntimeConfig[]
-  >;
+  readonly runtimeMethodsForSlug: (
+    connectorSlug: ConnectorSlug,
+  ) => readonly ConnectorAuthMethodRuntimeConfig[] | undefined;
 }): ReadonlyMap<ConnectorSlug, AcceptedConnectorServerFirewallEntry> {
   const entries = new Map<
     ConnectorSlug,
@@ -430,15 +437,11 @@ function acceptedEntries(args: {
         `Duplicate accepted connector server firewall: ${connector.slug}`,
       );
     }
-    const methods = args.runtimeMethodsBySlug.get(connector.slug);
-    if (!methods) {
-      throw new Error(
-        `Accepted connector server firewall runtime is missing: ${connector.slug}`,
-      );
-    }
     entries.set(connector.slug, {
       connector,
-      methods,
+      runtimeMethods: () => {
+        return args.runtimeMethodsForSlug(connector.slug);
+      },
       firewall: undefined,
       routing: undefined,
       permissionIndex: undefined,
@@ -505,10 +508,16 @@ function acceptedEntryExecutionMetadata(
   if (entry.executionMetadata !== undefined) {
     return entry.executionMetadata;
   }
+  const methods = entry.runtimeMethods();
+  if (methods === undefined) {
+    throw new Error(
+      `Accepted connector server firewall runtime is missing: ${entry.connector.slug}`,
+    );
+  }
   const executionMetadata = acceptedExecutionMetadata({
     firewall: acceptedEntryFirewall(entry),
     routing: acceptedEntryRouting(entry),
-    methods: entry.methods,
+    methods,
   });
   entry.executionMetadata = executionMetadata;
   return executionMetadata;
@@ -574,14 +583,13 @@ function acceptedFixedHostOwners(
 
 export function createAcceptedConnectorServerFirewallCatalog(args: {
   readonly artifact: ConnectorCatalogArtifact;
-  readonly runtimeMethodsBySlug: ReadonlyMap<
-    ConnectorSlug,
-    readonly ConnectorAuthMethodRuntimeConfig[]
-  >;
+  readonly runtimeMethodsForSlug: (
+    connectorSlug: ConnectorSlug,
+  ) => readonly ConnectorAuthMethodRuntimeConfig[] | undefined;
 }): ConnectorServerFirewallCatalog {
   const entries = acceptedEntries({
     artifact: args.artifact,
-    runtimeMethodsBySlug: args.runtimeMethodsBySlug,
+    runtimeMethodsForSlug: args.runtimeMethodsForSlug,
   });
   const connectorSlugs = [...entries.keys()].sort(compareStrings);
   let fixedHostOwners:
@@ -623,8 +631,44 @@ export function createAcceptedConnectorServerFirewallCatalog(args: {
   };
 }
 
-export async function expandConnectorServerFirewallPolicies(args: {
+export function selectConnectorServerFirewalls(args: {
   readonly catalog: ConnectorServerFirewallCatalog;
+  readonly connectorSlugs: readonly ConnectorSlug[];
+}): ConnectorServerFirewallSelection {
+  const selectedConnectorSlugs = new Set<string>(args.connectorSlugs);
+  const selectedEntryExists = (connectorSlug: string): boolean => {
+    return (
+      selectedConnectorSlugs.has(connectorSlug) &&
+      args.catalog.has(connectorSlug)
+    );
+  };
+  return {
+    has: selectedEntryExists,
+    getExecutionMetadata: (connectorSlug) => {
+      return selectedEntryExists(connectorSlug)
+        ? args.catalog.getExecutionMetadata(connectorSlug)
+        : null;
+    },
+    loadPermissionIndex: (connectorSlug) => {
+      return selectedEntryExists(connectorSlug)
+        ? args.catalog.loadPermissionIndex(connectorSlug)
+        : Promise.resolve(null);
+    },
+    getRoutingIndexMetadata: (connectorSlug) => {
+      return selectedEntryExists(connectorSlug)
+        ? args.catalog.getRoutingIndexMetadata(connectorSlug)
+        : null;
+    },
+    loadRoutingMetadata: (connectorSlug) => {
+      return selectedEntryExists(connectorSlug)
+        ? args.catalog.loadRoutingMetadata(connectorSlug)
+        : Promise.resolve(null);
+    },
+  };
+}
+
+export async function expandConnectorServerFirewallPolicies(args: {
+  readonly catalog: ConnectorServerFirewallMetadataCatalog;
   readonly stored: FirewallPolicies | null;
   readonly connectorSlugs: readonly string[];
 }): Promise<FirewallPolicies | null> {

--- a/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-server-firewall-catalog.service.ts
@@ -122,9 +122,7 @@ export interface ConnectorServerFirewallCatalog extends ConnectorServerFirewallS
 
 interface AcceptedConnectorServerFirewallEntry {
   readonly connector: ConnectorCatalogArtifactConnector;
-  readonly runtimeMethods: () =>
-    | readonly ConnectorAuthMethodRuntimeConfig[]
-    | undefined;
+  readonly runtimeMethods: () => readonly ConnectorAuthMethodRuntimeConfig[];
   firewall: AcceptedServerFirewall | undefined;
   routing: ConnectorCatalogFirewallRouting | undefined;
   permissionIndex: ConnectorServerFirewallPermissionIndex | undefined;
@@ -422,7 +420,7 @@ function acceptedEntries(args: {
   readonly artifact: ConnectorCatalogArtifact;
   readonly runtimeMethodsForSlug: (
     connectorSlug: ConnectorSlug,
-  ) => readonly ConnectorAuthMethodRuntimeConfig[] | undefined;
+  ) => readonly ConnectorAuthMethodRuntimeConfig[];
 }): ReadonlyMap<ConnectorSlug, AcceptedConnectorServerFirewallEntry> {
   const entries = new Map<
     ConnectorSlug,
@@ -508,16 +506,10 @@ function acceptedEntryExecutionMetadata(
   if (entry.executionMetadata !== undefined) {
     return entry.executionMetadata;
   }
-  const methods = entry.runtimeMethods();
-  if (methods === undefined) {
-    throw new Error(
-      `Accepted connector server firewall runtime is missing: ${entry.connector.slug}`,
-    );
-  }
   const executionMetadata = acceptedExecutionMetadata({
     firewall: acceptedEntryFirewall(entry),
     routing: acceptedEntryRouting(entry),
-    methods,
+    methods: entry.runtimeMethods(),
   });
   entry.executionMetadata = executionMetadata;
   return executionMetadata;
@@ -585,7 +577,7 @@ export function createAcceptedConnectorServerFirewallCatalog(args: {
   readonly artifact: ConnectorCatalogArtifact;
   readonly runtimeMethodsForSlug: (
     connectorSlug: ConnectorSlug,
-  ) => readonly ConnectorAuthMethodRuntimeConfig[] | undefined;
+  ) => readonly ConnectorAuthMethodRuntimeConfig[];
 }): ConnectorServerFirewallCatalog {
   const entries = acceptedEntries({
     artifact: args.artifact,

--- a/turbo/apps/api/src/signals/services/custom-connector-permission-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-permission-bundle.service.ts
@@ -8,7 +8,7 @@ import type {
   FirewallPolicyValue,
 } from "@okouai/connectors/firewall-types";
 
-import type { ConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+import type { ConnectorServerFirewallMetadataCatalog } from "./connector-server-firewall-catalog.service";
 import {
   FEISHU_CUSTOM_CONNECTOR_DEFAULT_POLICIES,
   FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF,
@@ -38,7 +38,7 @@ function customConnectorPermissionBundleSlug(
 }
 
 export async function loadCustomConnectorPermissionBundle(args: {
-  readonly snapshot: Pick<ConnectorRuntimeSnapshot, "serverFirewalls">;
+  readonly catalog: ConnectorServerFirewallMetadataCatalog;
   readonly ref: CustomConnectorPermissionBundleRef;
 }): Promise<CustomConnectorPermissionBundle | null> {
   if (args.ref === FEISHU_CUSTOM_CONNECTOR_PERMISSION_BUNDLE_REF) {
@@ -56,13 +56,13 @@ export async function loadCustomConnectorPermissionBundle(args: {
   }
 
   const connectorSlug = customConnectorPermissionBundleSlug(args.ref);
-  if (!connectorSlug || !args.snapshot.serverFirewalls.has(connectorSlug)) {
+  if (!connectorSlug || !args.catalog.has(connectorSlug)) {
     return null;
   }
 
   const [permissionIndex, routingMetadata] = await Promise.all([
-    args.snapshot.serverFirewalls.loadPermissionIndex(connectorSlug),
-    args.snapshot.serverFirewalls.loadRoutingMetadata(connectorSlug),
+    args.catalog.loadPermissionIndex(connectorSlug),
+    args.catalog.loadRoutingMetadata(connectorSlug),
   ]);
   if (!permissionIndex || !routingMetadata) {
     return null;

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -1487,7 +1487,7 @@ async function validatePermissionBundleRef(
   }
   const snapshot = await loadConnectorRuntimeSnapshot(db);
   const bundle = await loadCustomConnectorPermissionBundle({
-    snapshot,
+    catalog: snapshot.serverFirewallMetadata,
     ref: permissionBundleRef,
   });
   return bundle
@@ -2502,7 +2502,7 @@ export function getCustomConnectorPermissionBundle(args: {
     }
     const snapshot = await loadConnectorRuntimeSnapshot(db);
     const bundle = await loadCustomConnectorPermissionBundle({
-      snapshot,
+      catalog: snapshot.serverFirewallMetadata,
       ref: permissionBundleRef,
     });
     if (!bundle) {

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -425,7 +425,7 @@ async function validateExplicitPermissionNames(args: {
   }
 
   const bundle = await loadCustomConnectorPermissionBundle({
-    snapshot: args.snapshot,
+    catalog: args.snapshot.serverFirewallMetadata,
     ref: args.permissionBundleRef,
   });
   if (!bundle) {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -65,7 +65,7 @@ import {
   type UserInfo,
 } from "./run-bootstrap-context.service";
 import type { RunWorkflowRef } from "./workflow-data.service";
-import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.service";
+import { loadConnectorRuntimeSelection } from "./connector-catalog-runtime.service";
 import { expandConnectorServerFirewallPolicies } from "./connector-server-firewall-catalog.service";
 import type { QueueFirstRunAssociation } from "./chat-queued-event.service";
 import {
@@ -787,8 +787,8 @@ async function loadZeroRunPostAuthorizationContext(
     isEmptyRunConnectorScope(bootstrapContext)
       ? { kind: "empty" }
       : {
-          kind: "complete",
-          snapshot: await loadConnectorRuntimeSnapshot(db, {
+          kind: "scoped",
+          selection: await loadConnectorRuntimeSelection(db, {
             timing: args.timing,
             requestedConnectorSlugs: bootstrapContext.allowedConnectorSlugs,
           }),
@@ -805,7 +805,7 @@ async function loadZeroRunPostAuthorizationContext(
         return storedPermissionPolicies;
       }
       return await expandConnectorServerFirewallPolicies({
-        catalog: connectorCatalogSelection.snapshot.serverFirewalls,
+        catalog: connectorCatalogSelection.selection.serverFirewalls,
         stored: storedPermissionPolicies,
         connectorSlugs: [...bootstrapContext.allowedConnectorSlugs],
       });
@@ -1021,10 +1021,10 @@ const createAgentRunAfterZeroPreCreate$ = command(
           checkOrgPlanStatusBeforeContext: false,
           preloadedFeatureSwitchContext: input.featureSwitchContext,
           preloadedUserTimezone: input.userInfo.timezone,
-          ...(input.connectorCatalogSelection.kind === "complete"
+          ...(input.connectorCatalogSelection.kind === "scoped"
             ? {
                 preloadedConnectorCatalogSnapshot:
-                  input.connectorCatalogSelection.snapshot,
+                  input.connectorCatalogSelection.selection,
               }
             : {}),
         },


### PR DESCRIPTION
## Summary

- materialize connector runtime entries only for deduplicated accepted connector refs requested by a run
- reuse entries in one exact-catalog-identity cache bounded by catalog size while retaining a logically complete snapshot path
- separate selected firewall execution access from complete permission/routing metadata so custom connector bundles remain complete without materializing unrelated runtime auth
- route both direct/shared and Zero/Web run creation through the scoped selection and add a low-cardinality newly materialized count dimension

## Compatibility

- no database schema, persisted state, HTTP contract, queue payload, Runner protocol, credential format, or rollout-order change
- exact-empty catalog bypass, accepted catalog validation, compatibility filtering, global complete consumers, and fail-closed behavior remain unchanged

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api build`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1` (163 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts --maxWorkers=1` (70 passed)
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (3,119 passed; one unrelated chat-search projection assertion failed under the concurrent suite and passed immediately in a focused single-worker retry)
- pre-commit full-repository Knip and TypeScript checks
- `git diff --check`

Closes #28079

Parent: #27777
