### PR TITLE
feat(app): add conversation search shortcut

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -1,14 +1,19 @@
 import { command, computed, state } from "ccstate";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { detachedNavigateTo$ } from "../route.ts";
 import { ROUTES, type RouteKey } from "../route-paths.ts";
 import { localStorageSignals } from "../external/local-storage.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 import { setupGlobalShortcut } from "../../lib/setup-global-shortcut.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
 import { activeRoute$ } from "../active-route.ts";
 import { eventDrivenChatThreads$ } from "../chat-page/chat-thread-event-sourcing.ts";
 import { setChatShortcutHelpOpen$ } from "../chat-page/chat-shortcut-help.ts";
-import { openAgentListDialog$ } from "./zero-sidebar-state.ts";
+import {
+  openAgentListDialog$,
+  openThreeColumnSearchDialog$,
+} from "./zero-sidebar-state.ts";
 import { displayedPinnedAgents$ } from "./zero-pinned-agents.ts";
 import { writeToClipboard } from "./clipboard.ts";
 import { isStandaloneMode } from "./settings/connectors.ts";
@@ -131,13 +136,24 @@ export const toggleSidebarOff$ = command(({ get, set }) => {
 });
 
 export const setupGlobalKeyboardShortcuts$ = command(
-  ({ set }, signal: AbortSignal) => {
+  ({ get, set }, signal: AbortSignal) => {
     setupGlobalShortcut(
       {
         "mod+b": {
           allowInEditableTarget: true,
           run: () => {
             set(toggleSidebarOff$);
+          },
+        },
+        "mod+k": {
+          allowInEditableTarget: true,
+          shouldHandle: () => {
+            return (
+              get(featureSwitch$)[FeatureSwitchKey.ThreeColumnNav] ?? false
+            );
+          },
+          run: () => {
+            set(openThreeColumnSearchDialog$);
           },
         },
         "mod+l": {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -2372,6 +2372,61 @@ describe("zero sidebar", () => {
     expect(within(dialog).getByText("Support Agent")).toBeInTheDocument();
   });
 
+  it("opens three-column conversation search with mod+k from the composer", async () => {
+    prepareAgentTeam();
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ThreeColumnNav]: true,
+      },
+    });
+
+    await screen.findByPlaceholderText(PLACEHOLDER);
+    const composer = mountedComposer();
+    composer.focus();
+    const event = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    composer.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBeTruthy();
+    const dialog = await screen.findByRole("dialog", {
+      name: "Search chats and messages...",
+    });
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it("leaves mod+k to the browser without three-column navigation", async () => {
+    prepareAgentTeam();
+
+    setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await waitFor(() => {
+      expect(sidebar()).toBeInTheDocument();
+    });
+    const event = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBeFalsy();
+    expect(
+      screen.queryByRole("dialog", {
+        name: "Search chats and messages...",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it("moves to the next pinned agent chat from the composer", async () => {
     prepareAgentTeam();
     context.mocks.data.userPreferences({
@@ -3109,6 +3164,10 @@ describe("zero sidebar", () => {
     expect(within(list).getByText("Chat")).toBeInTheDocument();
     const searchButton = within(list).getByLabelText("Search conversations");
     const newChatButton = within(list).getByLabelText("New chat");
+    expect(searchButton).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Meta+K Control+K",
+    );
     const searchIcon = searchButton.querySelector("svg");
     const newChatIcon = newChatButton.querySelector("svg");
     if (!(searchIcon instanceof SVGElement)) {

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
   cn,
+  getShortcutLabel,
 } from "@okouai/ui";
 import { settingsIconAssetUrl } from "./components/settings/settings-icon-assets.ts";
 import {
@@ -774,6 +775,7 @@ function ChatListColumn() {
   const searchLabel = t(($) => {
     return $.appShell.sidebar.searchConversations;
   });
+  const searchShortcutLabel = getShortcutLabel("mod+k");
   const newChatLabel = t(($) => {
     return $.appShell.sidebar.navigation.newChat;
   });
@@ -807,6 +809,7 @@ function ChatListColumn() {
                     openThreeColumnSearch();
                   }}
                   aria-label={searchLabel}
+                  aria-keyshortcuts="Meta+K Control+K"
                   variant="quiet"
                   size="icon-sm"
                 >
@@ -814,7 +817,10 @@ function ChatListColumn() {
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom">
-                <p className="text-xs">{searchLabel}</p>
+                <p className="text-xs">
+                  {searchLabel}
+                  <span aria-hidden="true">{` · ${searchShortcutLabel}`}</span>
+                </p>
               </TooltipContent>
             </Tooltip>
             <Tooltip>


### PR DESCRIPTION
## Summary

- open the three-column conversation spotlight with Cmd/Ctrl+K, including while the composer is focused
- preserve the browser shortcut when three-column navigation is disabled
- expose the shortcut in the search tooltip and accessibility metadata

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx --maxWorkers=1` (71 passed)

Local browser QA was not run because the repository guidance says not to start a local dev server unless explicitly requested.
