### PR TITLE
docs(runner): document workspace image cache gc policy

### DIFF
--- a/crates/runner/src/cmd/workspace_image_cache.rs
+++ b/crates/runner/src/cmd/workspace_image_cache.rs
@@ -32,7 +32,16 @@ enum WorkspaceImageCacheCommand {
     /// Status-category, temporary-path, and size summary values are lower bounds
     /// when `lockedEntries` is greater than zero.
     List(WorkspaceImageCacheListArgs),
-    /// Clean up workspace image cache entries
+    /// Clean up workspace image cache entries.
+    ///
+    /// The first phase removes stale, unusable, and temporary cache contents before evaluating
+    /// capacity. It may also evict valid reusable entries, oldest-first, when the cache exceeds
+    /// its maximum byte budget, filesystem free space falls below the minimum, or the cache
+    /// exceeds the 1,024-entry cap. When budget pressure triggers eviction, it continues until
+    /// the post-GC target and minimum-free-space thresholds are met. Locked entries are skipped
+    /// during reusable-entry eviction, and candidates are revalidated before deletion. Use
+    /// `--dry-run` to evaluate this same policy and report prospective cleanup without deleting
+    /// data.
     Gc(WorkspaceImageCacheGcArgs),
 }
 
@@ -55,7 +64,7 @@ struct WorkspaceImageCacheListArgs {
 
 #[derive(Args)]
 struct WorkspaceImageCacheGcArgs {
-    /// Show what would be deleted without actually deleting.
+    /// Evaluate the same cleanup policy and report what would be deleted without deleting data.
     #[arg(long)]
     dry_run: bool,
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -492,6 +492,31 @@ mod tests {
     }
 
     #[test]
+    fn workspace_image_cache_help_documents_gc_eviction_policy() {
+        let error = Cli::try_parse_from(["runner", "workspace-image-cache", "gc", "--help"])
+            .err()
+            .expect("workspace-image-cache gc --help should exit through clap");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let help = error
+            .to_string()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(help.contains(
+            "first phase removes stale, unusable, and temporary cache contents before evaluating capacity"
+        ));
+        assert!(help.contains("valid reusable entries, oldest-first"));
+        assert!(help.contains("maximum byte budget"));
+        assert!(help.contains("minimum-free-space thresholds"));
+        assert!(help.contains("post-GC target"));
+        assert!(help.contains("1,024-entry cap"));
+        assert!(help.contains("Locked entries are skipped during reusable-entry eviction"));
+        assert!(help.contains("`--dry-run` to evaluate this same policy"));
+        assert!(help.contains("without deleting data"));
+    }
+
+    #[test]
     fn service_unit_state_command_is_registered() {
         assert!(
             Cli::try_parse_from([


### PR DESCRIPTION
## Summary

- Document the workspace image cache GC cleanup phases, reusable-entry eviction triggers, ordering, thresholds, locking, and dry-run behavior in CLI help.
- Add a regression test for the generated `workspace-image-cache gc --help` contract.

## Scope

This changes operator-facing help and test coverage only. GC behavior, thresholds, locking, and deletion logic are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p runner --tests`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- Built the runner binary with a low-memory linker and verified `runner workspace-image-cache gc --help` output as root.

The focused test `cargo test -p runner --bin runner workspace_image_cache_help_documents_gc_eviction_policy -- --exact` was attempted twice, but the test harness linker was killed with `SIGKILL` in this 3.8 GiB, swapless environment. Compilation-only checks and the actual binary help output passed; CI should run the test harness in its normal environment.

Closes #28084
