### PR TITLE
fix(ci): avoid apt in workflow lint

### DIFF
--- a/.github/scripts/tests/audit-okou-cli-cutover-test.sh
+++ b/.github/scripts/tests/audit-okou-cli-cutover-test.sh
@@ -7,12 +7,21 @@ audit_script="${repo_root}/.github/scripts/audit-okou-cli-cutover.sh"
 security_workflow="${repo_root}/.github/workflows/security.yml"
 turbo_workflow="${repo_root}/.github/workflows/turbo.yml"
 
-install_line="$(grep -nF 'sudo apt-get install -y --no-install-recommends ansible-core ripgrep' "${security_workflow}" | cut -d: -f1 || true)"
+ripgrep_step_line="$(grep -nF -- '- name: Install ripgrep' "${security_workflow}" | cut -d: -f1 || true)"
+ripgrep_download_line="$(grep -nF 'BurntSushi/ripgrep/releases/download/' "${security_workflow}" | cut -d: -f1 || true)"
 audit_step_line="$(grep -nF -- '- name: Audit Okou CLI cutover' "${security_workflow}" | cut -d: -f1 || true)"
 audit_run_line="$(grep -nF 'run: .github/scripts/audit-okou-cli-cutover.sh' "${security_workflow}" | cut -d: -f1 || true)"
-if [[ -z "${install_line}" || -z "${audit_step_line}" || -z "${audit_run_line}" ||
-  "${audit_step_line}" -le "${install_line}" || "${audit_run_line}" -le "${audit_step_line}" ]]; then
-  echo "Security CI does not run the Okou cutover audit after installing ripgrep" >&2
+if [[ -z "${ripgrep_step_line}" || -z "${ripgrep_download_line}" ||
+  -z "${audit_step_line}" || -z "${audit_run_line}" ||
+  "${ripgrep_download_line}" -le "${ripgrep_step_line}" ||
+  "${audit_step_line}" -le "${ripgrep_download_line}" ||
+  "${audit_run_line}" -le "${audit_step_line}" ]]; then
+  echo "Security CI does not run the Okou cutover audit after installing verified ripgrep" >&2
+  exit 1
+fi
+actionlint_job="$(sed -n '/^  actionlint:/,/^  gitleaks:/p' "${security_workflow}")"
+if grep -Fq 'apt-get' <<< "${actionlint_job}"; then
+  echo "Workflow Lint must not install dependencies through apt" >&2
   exit 1
 fi
 if grep -Fq 'run: .github/scripts/audit-okou-cli-cutover.sh' "${turbo_workflow}"; then

--- a/.github/scripts/tests/release-tool-downloads-test.sh
+++ b/.github/scripts/tests/release-tool-downloads-test.sh
@@ -25,12 +25,14 @@ assert_not_contains() {
   fi
 }
 
-if [[ "$(grep -Fc 'bash .github/scripts/download-verified.sh' "$security_workflow")" != "2" ]]; then
-  echo "Expected both security tool installers to use download-verified.sh" >&2
+if [[ "$(grep -Fc 'bash .github/scripts/download-verified.sh' "$security_workflow")" != "3" ]]; then
+  echo "Expected all security tool installers to use download-verified.sh" >&2
   exit 1
 fi
 assert_contains "$security_workflow" "ACTIONLINT_VERSION=1.7.12"
 assert_contains "$security_workflow" "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+assert_contains "$security_workflow" "RIPGREP_VERSION=14.1.1"
+assert_contains "$security_workflow" "4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e"
 assert_contains "$security_workflow" "GITLEAKS_VERSION=8.30.1"
 assert_contains "$security_workflow" "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
 assert_not_contains "$security_workflow" "download-actionlint.bash"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -213,10 +213,22 @@ jobs:
             "$archive"
           tar -xzf "$archive" actionlint
 
-      - name: Install workflow test dependencies
+      - name: Install ripgrep
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ansible-core ripgrep
+          RIPGREP_VERSION=14.1.1
+          RIPGREP_SHA256=4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e
+          archive="$RUNNER_TEMP/ripgrep.tar.gz"
+          bin_dir="$RUNNER_TEMP/ripgrep-bin"
+          bash .github/scripts/download-verified.sh \
+            "https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/ripgrep-${RIPGREP_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            "$RIPGREP_SHA256" \
+            "$archive"
+          mkdir -p "$bin_dir"
+          tar -xzf "$archive" \
+            --strip-components=1 \
+            -C "$bin_dir" \
+            "ripgrep-${RIPGREP_VERSION}-x86_64-unknown-linux-musl/rg"
+          echo "$bin_dir" >> "$GITHUB_PATH"
 
       - name: Audit Okou CLI cutover
         run: .github/scripts/audit-okou-cli-cutover.sh


### PR DESCRIPTION
## Summary

- remove the runtime `apt-get` dependency from the `Workflow Lint` job
- install pinned ripgrep 14.1.1 through the existing bounded, checksum-verified downloader
- enforce the verified ripgrep ordering and apt-free workflow contract in existing integration tests

## Scope

- keep the existing 8-minute job timeout unchanged
- continue using the Ansible version preinstalled on GitHub-hosted Ubuntu runners
- do not skip or change any workflow script tests

## Validation

- downloaded, verified, extracted, and executed the pinned ripgrep artifact
- `bash -n .github/scripts/tests/audit-okou-cli-cutover-test.sh .github/scripts/tests/release-tool-downloads-test.sh`
- `bash .github/scripts/tests/audit-okou-cli-cutover-test.sh`
- `bash .github/scripts/tests/release-tool-downloads-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `shellcheck .github/scripts/tests/audit-okou-cli-cutover-test.sh .github/scripts/tests/release-tool-downloads-test.sh`
- `actionlint`
- `git diff --check`
- lefthook file-size and commit-message checks
