### PR TITLE
fix(python): track generator advancement failures

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/ast_helpers.py
@@ -453,14 +453,15 @@ def _static_truth_value(node: ast.AST) -> bool | None:
     return None
 
 
-def _iteration_may_raise(node: ast.AST) -> bool:
-    """Return whether obtaining or advancing this iterable may invoke user code."""
+def _iteration_may_raise(node: ast.AST, *, advances: bool) -> bool:
+    """Return whether obtaining and optionally advancing this iterable may invoke user code."""
+    if isinstance(node, ast.GeneratorExp):
+        return advances
     if isinstance(
         node,
         (
             ast.Dict,
             ast.DictComp,
-            ast.GeneratorExp,
             ast.JoinedStr,
             ast.List,
             ast.ListComp,

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -1015,7 +1015,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def _visit_for_statement(self, node: ast.For | ast.AsyncFor) -> bool:
         self._record_metadata_merge_key_violations(node.iter)
         self.visit(node.iter)
-        iteration_may_raise = isinstance(node, ast.AsyncFor) or _iteration_may_raise(node.iter)
+        iteration_may_raise = isinstance(node, ast.AsyncFor) or _iteration_may_raise(
+            node.iter, advances=True
+        )
         if iteration_may_raise:
             self._record_implicit_exception_aliases()
         base_aliases = set(self._metadata_aliases)
@@ -1377,7 +1379,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         first_generator, *remaining_generators = generators
         self._record_metadata_merge_key_violations(first_generator.iter)
         self.visit(first_generator.iter)
-        if first_generator.is_async or _iteration_may_raise(first_generator.iter):
+        if first_generator.is_async or _iteration_may_raise(
+            first_generator.iter, advances=not deferred
+        ):
             self._record_implicit_exception_aliases()
         if not first_generator.is_async and _iterable_is_statically_empty(first_generator.iter):
             return
@@ -1411,7 +1415,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for generator in remaining_generators if body_is_reachable else []:
             self._record_metadata_merge_key_violations(generator.iter)
             self.visit(generator.iter)
-            if generator.is_async or _iteration_may_raise(generator.iter):
+            if generator.is_async or _iteration_may_raise(generator.iter, advances=True):
                 self._record_implicit_exception_aliases()
             if not generator.is_async and _iterable_is_statically_empty(generator.iter):
                 body_is_reachable = False
@@ -1442,5 +1446,5 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def _record_later_comprehension_iterations(self, generators: list[ast.comprehension]) -> None:
         for generator in reversed(generators):
-            if generator.is_async or _iteration_may_raise(generator.iter):
+            if generator.is_async or _iteration_may_raise(generator.iter, advances=True):
                 self._record_implicit_exception_aliases()

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.base.py.txt
@@ -623,3 +623,20 @@ def function_decorator_application_before_return_is_suppressible(flow, manager):
 
         return
     return metadata["firewall_base"]
+
+
+def nested_generator_construction_stays_deferred(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        values = (item for item in (operation() for _item in (None,)))
+        metadata = {}
+    return metadata["vm_run_id"]
+
+
+def later_generator_advance_preserves_body_alias(flow, manager):
+    metadata = {}
+    with manager:
+        for _item in (1 / divisor for divisor in (1, 0)):
+            metadata = flow.metadata
+        metadata = {}
+    return metadata["vm_run_id"]

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/implicit_exception_flow.expected.txt
@@ -41,3 +41,4 @@ implicit_exception_flow.py:586: use metadata_keys.VM_RUN_ID for flow.metadata ac
 implicit_exception_flow.py:598: use metadata_keys.FIREWALL_NAME for flow.metadata access
 implicit_exception_flow.py:613: use metadata_keys.ORIGINAL_URL for flow.metadata access
 implicit_exception_flow.py:625: use metadata_keys.FIREWALL_BASE for flow.metadata access
+implicit_exception_flow.py:642: use metadata_keys.VM_RUN_ID for flow.metadata access


### PR DESCRIPTION
## Summary

- distinguish iterator acquisition from advancement in the flow metadata linter
- retain metadata aliases when a later generator-expression advance raises after a loop body runs
- preserve deferred construction for nested generator expressions

## Scope

The private iterable fallibility helper now requires each caller to declare whether the current execution phase advances the iterable. Generator expressions are safe when only their iterator is acquired and conservatively fallible when advanced. Existing classifications for eager built-in and dynamic iterables are unchanged.

This PR does not add body-level generator precision, change runtime addon behavior, or modify APIs, persisted state, protocols, dependencies, migrations, or deployment contracts.

## Testing

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_flow_metadata_key_contract.py -q` (21 passed)
- `uv run --no-sync python -m pytest tests/` (6333 passed)

Closes #28088
