### PR TITLE
fix(guest-agent): fail artifact checkpoint on unreadable entries

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -7,14 +7,11 @@ use api_contracts::generated::constants::storages::{
 };
 use flate2::Compression;
 use flate2::write::GzEncoder;
-use guest_common::log_warn;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, Metadata};
 use std::io::{self, Read};
 use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
-
-const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// Walk directory and compute SHA-256 for each file, skipping `.git` and `.vm0`.
 #[cfg(target_os = "linux")]
@@ -42,10 +39,12 @@ fn walk_dir(
     out: &mut Vec<FileEntry>,
     path_bytes: &mut u64,
 ) -> Result<(), ArchiveError> {
-    let entries = match current.read_dir() {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
-    };
+    let entries = current
+        .read_dir()
+        .map_err(|source| ArchiveError::DirectoryRead {
+            path: relative.to_string(),
+            source,
+        })?;
     walk_entries(current, relative, entries, out, path_bytes)
 }
 
@@ -57,66 +56,93 @@ fn walk_entries(
     out: &mut Vec<FileEntry>,
     path_bytes: &mut u64,
 ) -> Result<(), ArchiveError> {
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        if is_excluded_artifact_entry(&name) {
-            continue;
-        }
+    for entry in entries {
+        let entry = entry.map_err(|source| ArchiveError::DirectoryEntryRead {
+            parent: artifact_directory_path(relative).to_string(),
+            source,
+        })?;
+        walk_entry(current, relative, entry, out, path_bytes)?;
+    }
+    Ok(())
+}
 
-        let (try_directory, try_file) = match entry.file_type() {
-            Ok(file_type) => (file_type.is_dir(), file_type.is_file()),
-            Err(_) => (true, true),
-        };
-        if try_directory && let Ok(dir) = current.open_child_dir(&name) {
-            let name_str = artifact_path_component(&name, relative)?;
-            let rel = relative_artifact_path(relative, name_str);
-            walk_dir(&dir, &rel, out, path_bytes)?;
-            continue;
-        }
-        if !try_file {
-            continue;
-        }
+#[cfg(target_os = "linux")]
+fn walk_entry(
+    current: &Dir,
+    relative: &str,
+    entry: fs::DirEntry,
+    out: &mut Vec<FileEntry>,
+    path_bytes: &mut u64,
+) -> Result<(), ArchiveError> {
+    let name = entry.file_name();
+    if is_excluded_artifact_entry(&name) {
+        return Ok(());
+    }
 
-        let Ok(file) = current.open_child_file(&name) else {
-            continue;
-        };
-        let Ok(metadata) = file.metadata() else {
-            continue;
-        };
-        if !metadata.is_file() {
-            continue;
-        }
+    let file_type = entry
+        .file_type()
+        .map_err(|source| ArchiveError::EntryType {
+            path: artifact_entry_display_path(relative, &name),
+            source,
+        })?;
+    if file_type.is_dir() {
         let name_str = artifact_path_component(&name, relative)?;
         let rel = relative_artifact_path(relative, name_str);
-        let observed_files = u64::try_from(out.len())
-            .unwrap_or(u64::MAX)
-            .saturating_add(1);
-        let observed_path_bytes =
-            path_bytes.saturating_add(u64::try_from(rel.len()).unwrap_or(u64::MAX));
-        if observed_files > STORAGE_MANIFEST_MAX_FILES
-            || observed_path_bytes > STORAGE_MANIFEST_MAX_PATH_BYTES
-        {
-            return Err(ArchiveError::ManifestLimitExceeded {
-                observed_files,
-                max_files: STORAGE_MANIFEST_MAX_FILES,
-                observed_path_bytes,
-                max_path_bytes: STORAGE_MANIFEST_MAX_PATH_BYTES,
-            });
-        }
-        match compute_file_hash_from_reader(file) {
-            Ok((hash, size)) => {
-                *path_bytes = observed_path_bytes;
-                out.push(FileEntry {
-                    path: rel,
-                    hash,
-                    size,
-                });
+        let dir = match current.open_child_dir(&name) {
+            Ok(dir) => dir,
+            Err(source) if is_excluded_root_lost_found(relative, &name, &source) => return Ok(()),
+            Err(source) => {
+                return Err(ArchiveError::DirectoryOpen { path: rel, source });
             }
-            Err(e) => {
-                log_warn!(LOG_TAG, "Could not process file {rel}: {e}");
-            }
-        }
+        };
+        return walk_dir(&dir, &rel, out, path_bytes);
     }
+    if !file_type.is_file() {
+        return Ok(());
+    }
+
+    let name_str = artifact_path_component(&name, relative)?;
+    let rel = relative_artifact_path(relative, name_str);
+    let file = current
+        .open_child_file(&name)
+        .map_err(|source| ArchiveError::Open {
+            path: rel.clone(),
+            source,
+        })?;
+    let metadata = file.metadata().map_err(|source| ArchiveError::Metadata {
+        path: rel.clone(),
+        source,
+    })?;
+    if !metadata.is_file() {
+        return Err(ArchiveError::NonRegular { path: rel });
+    }
+
+    let observed_files = u64::try_from(out.len())
+        .unwrap_or(u64::MAX)
+        .saturating_add(1);
+    let observed_path_bytes =
+        path_bytes.saturating_add(u64::try_from(rel.len()).unwrap_or(u64::MAX));
+    if observed_files > STORAGE_MANIFEST_MAX_FILES
+        || observed_path_bytes > STORAGE_MANIFEST_MAX_PATH_BYTES
+    {
+        return Err(ArchiveError::ManifestLimitExceeded {
+            observed_files,
+            max_files: STORAGE_MANIFEST_MAX_FILES,
+            observed_path_bytes,
+            max_path_bytes: STORAGE_MANIFEST_MAX_PATH_BYTES,
+        });
+    }
+    let (hash, size) =
+        compute_file_hash_from_reader(file).map_err(|source| ArchiveError::FileRead {
+            path: rel.clone(),
+            source,
+        })?;
+    *path_bytes = observed_path_bytes;
+    out.push(FileEntry {
+        path: rel,
+        hash,
+        size,
+    });
     Ok(())
 }
 
@@ -126,11 +152,34 @@ fn is_excluded_artifact_entry(name: &std::ffi::OsStr) -> bool {
 }
 
 #[cfg(target_os = "linux")]
+fn is_excluded_root_lost_found(relative: &str, name: &std::ffi::OsStr, error: &io::Error) -> bool {
+    relative.is_empty()
+        && name == std::ffi::OsStr::new("lost+found")
+        && error.kind() == io::ErrorKind::PermissionDenied
+}
+
+#[cfg(target_os = "linux")]
 fn relative_artifact_path(parent: &str, component: &str) -> String {
     if parent.is_empty() {
         component.to_string()
     } else {
         format!("{parent}/{component}")
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn artifact_directory_path(relative: &str) -> &str {
+    if relative.is_empty() { "." } else { relative }
+}
+
+#[cfg(target_os = "linux")]
+fn artifact_entry_display_path(parent: &str, name: &std::ffi::OsStr) -> String {
+    match name.to_str() {
+        Some(component) => format!("{:?}", relative_artifact_path(parent, component)),
+        None => format!(
+            "under {:?} for component {name:?}",
+            artifact_directory_path(parent)
+        ),
     }
 }
 
@@ -178,6 +227,14 @@ pub(super) enum ArchiveError {
     RootOpen { path: PathBuf, source: io::Error },
     #[error("failed to read artifact root {}: {source}", path.display())]
     RootRead { path: PathBuf, source: io::Error },
+    #[error("failed to open artifact directory {path:?}: {source}")]
+    DirectoryOpen { path: String, source: io::Error },
+    #[error("failed to read artifact directory {path:?}: {source}")]
+    DirectoryRead { path: String, source: io::Error },
+    #[error("failed to read artifact directory entry under {parent:?}: {source}")]
+    DirectoryEntryRead { parent: String, source: io::Error },
+    #[error("failed to inspect artifact entry {path}: {source}")]
+    EntryType { path: String, source: io::Error },
     #[cfg(not(target_os = "linux"))]
     #[error(
         "artifact root access requires Linux no-follow path opening: {}",
@@ -223,6 +280,8 @@ pub(super) enum ArchiveError {
     },
     #[error("failed to open {path:?}: {source}")]
     Open { path: String, source: io::Error },
+    #[error("failed to read artifact file {path:?}: {source}")]
+    FileRead { path: String, source: io::Error },
     #[error("failed to append {path:?} to archive: {source}")]
     Append { path: String, source: io::Error },
     #[error("failed to verify archived content for {path:?}: {source}")]
@@ -731,6 +790,95 @@ mod tests {
 
         assert!(paths.contains(&"real.txt"));
         assert!(!paths.contains(&"pipe"));
+    }
+
+    #[test]
+    fn collect_file_metadata_rejects_unreadable_regular_file() {
+        const TEST_NAME: &str =
+            "artifact::archive::tests::collect_file_metadata_rejects_unreadable_regular_file";
+        if !crate::run_unprivileged_test(TEST_NAME).unwrap() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let unreadable = root.join("secret.txt");
+        std::fs::write(root.join("kept.txt"), "kept").unwrap();
+        std::fs::write(&unreadable, "secret").unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = collect_file_metadata(root.to_str().unwrap());
+
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("failed to open \"secret.txt\""),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn collect_file_metadata_rejects_unreadable_nested_directory() {
+        const TEST_NAME: &str =
+            "artifact::archive::tests::collect_file_metadata_rejects_unreadable_nested_directory";
+        if !crate::run_unprivileged_test(TEST_NAME).unwrap() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let unreadable = root.join("nested/lost+found");
+        std::fs::create_dir_all(&unreadable).unwrap();
+        std::fs::write(root.join("kept.txt"), "kept").unwrap();
+        std::fs::write(unreadable.join("secret.txt"), "secret").unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = collect_file_metadata(root.to_str().unwrap());
+
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let error = result.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("failed to open artifact directory \"nested/lost+found\""),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn collect_file_metadata_skips_unreadable_root_lost_found() {
+        const TEST_NAME: &str =
+            "artifact::archive::tests::collect_file_metadata_skips_unreadable_root_lost_found";
+        if !crate::run_unprivileged_test(TEST_NAME).unwrap() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let lost_found = root.join("lost+found");
+        std::fs::create_dir(&lost_found).unwrap();
+        std::fs::write(root.join("kept.txt"), "kept").unwrap();
+        std::fs::set_permissions(&lost_found, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = collect_file_metadata(root.to_str().unwrap());
+
+        std::fs::set_permissions(&lost_found, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let files = result.unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "kept.txt");
+    }
+
+    #[test]
+    fn collect_file_metadata_includes_readable_root_lost_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir(root.join("lost+found")).unwrap();
+        std::fs::write(root.join("lost+found/recovered.txt"), "recovered").unwrap();
+
+        let files = collect_file_metadata(root.to_str().unwrap()).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "lost+found/recovered.txt");
     }
 
     #[test]

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -442,6 +442,69 @@ mod tests {
         commit.assert_calls(0);
     }
 
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn artifact_snapshot_unreadable_file_fails_before_storage_api_calls() {
+        use std::os::unix::fs::PermissionsExt;
+
+        const TEST_NAME: &str = "checkpoint::artifact::tests::artifact_snapshot_unreadable_file_fails_before_storage_api_calls";
+        if !crate::run_unprivileged_test(TEST_NAME).unwrap() {
+            return;
+        }
+
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let upload = server.mock(|when, then| {
+            when.method(PUT);
+            then.status(200);
+        });
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join("artifact");
+        let unreadable = mount.join("secret.txt");
+        std::fs::create_dir(&mount).unwrap();
+        std::fs::write(mount.join("kept.txt"), "kept").unwrap();
+        std::fs::write(&unreadable, "secret").unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let entries = vec![env::ArtifactEnv {
+            name: "workspace".to_string(),
+            mount_path: mount.to_string_lossy().into_owned(),
+            storage_id: "storage-id".to_string(),
+            version_id: "parent-version".to_string(),
+            missing_root_policy: None,
+        }];
+
+        let result = snapshot_artifact_entries(&http, "test-run", &entries).await;
+
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let error = result.unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("Failed to walk artifact files"),
+            "got: {message}"
+        );
+        assert!(message.contains("secret.txt"), "got: {message}");
+        prepare.assert_calls(0);
+        upload.assert_calls(0);
+        commit.assert_calls(0);
+    }
+
     #[tokio::test]
     async fn artifact_snapshot_enforces_manifest_boundaries_before_storage_api_calls() {
         use api_contracts::generated::constants::storages::{

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -53,3 +53,40 @@ pub(crate) fn lock_system_log_test_state() -> tokio::sync::MutexGuard<'static, (
 pub(crate) async fn lock_system_log_test_state_async() -> tokio::sync::MutexGuard<'static, ()> {
     SYSTEM_LOG_TEST_MUTEX.lock().await
 }
+
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) fn run_unprivileged_test(test_name: &str) -> Result<bool, String> {
+    const TEST_ENV: &str = "VM0_GUEST_AGENT_UNPRIVILEGED_TEST";
+    const UNPRIVILEGED_ID: u32 = 65_534;
+
+    if std::env::var(TEST_ENV).as_deref() == Ok(test_name) {
+        return Ok(true);
+    }
+    // SAFETY: `geteuid` only reads the effective process credential.
+    if unsafe { libc::geteuid() } != 0 {
+        return Ok(true);
+    }
+
+    use std::os::unix::process::CommandExt;
+
+    let current_exe = std::env::current_exe()
+        .map_err(|error| format!("failed to locate test executable: {error}"))?;
+    let output = std::process::Command::new(current_exe)
+        .arg("--exact")
+        .arg(test_name)
+        .arg("--nocapture")
+        .env(TEST_ENV, test_name)
+        .gid(UNPRIVILEGED_ID)
+        .uid(UNPRIVILEGED_ID)
+        .output()
+        .map_err(|error| format!("failed to launch unprivileged test {test_name}: {error}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() || !stdout.contains("1 passed") {
+        return Err(format!(
+            "unprivileged test {test_name} failed with {}; stdout:\n{stdout}\nstderr:\n{stderr}",
+            output.status
+        ));
+    }
+    Ok(false)
+}


### PR DESCRIPTION
## Summary

- fail artifact manifest collection on nested directory enumeration, entry inspection, regular-file open/metadata, and file read errors
- preserve `.git`, `.vm0`, symlink, FIFO, and root-level inaccessible `lost+found` exclusions
- add real permission regressions and verify unreadable artifacts fail before storage prepare, upload, or commit calls

## Tests

- `cargo test -p guest-agent --lib artifact::archive::tests --jobs 1`
- `cargo test -p guest-agent --lib checkpoint::artifact::tests --jobs 1`
- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features --jobs 1 -- -D warnings`
- `cargo doc -p guest-agent --all-features --no-deps --jobs 1`
- `cargo test -p guest-agent --jobs 1`

Closes #28090
