### PR TITLE
test(ci): wait for runner journal visibility

### DIFF
--- a/.github/scripts/runner-behavior-keep-alive.sh
+++ b/.github/scripts/runner-behavior-keep-alive.sh
@@ -246,10 +246,19 @@ fi
 wait "$OVERLAP_EXEC_PID" 2>/dev/null || true
 OVERLAP_EXEC_PID=""
 
-OVERLAP_LOGS=$(sudo journalctl --no-pager \
-  "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
-  || fail "failed to read overlap runner logs"
-grep -F 'normal operations busy while preparing park' <<<"$OVERLAP_LOGS" >/dev/null \
+OVERLAP_BUSY_LOGGED=false
+for _ in $(seq 1 10); do
+  OVERLAP_LOGS=$(sudo journalctl --no-pager \
+    "_SYSTEMD_INVOCATION_ID=$INVOCATION_ID" 2>&1) \
+    || fail "failed to read overlap runner logs"
+  if grep -F 'normal operations busy while preparing park' \
+    <<<"$OVERLAP_LOGS" >/dev/null; then
+    OVERLAP_BUSY_LOGGED=true
+    break
+  fi
+  sleep 0.5
+done
+[ "$OVERLAP_BUSY_LOGGED" = true ] \
   || fail "overlapping runner exec did not reject idle admission as busy"
 
 echo "--- Overlap turn 2: busy sandbox was not reused ---"


### PR DESCRIPTION
## Summary

- Poll the runner service journal for up to five seconds after the overlapping exec terminates.
- Keep requiring the exact busy-fence log message before the test can pass.
- Preserve the existing assertions that the rejected exec terminates and its sandbox is not reused.

## Scope

This changes only the runner keep-alive CI integration script. It does not change runner behavior, add a job-level retry, or skip any assertion.

## Validation

- `bash -n .github/scripts/runner-behavior-keep-alive.sh`
- `shellcheck .github/scripts/runner-behavior-keep-alive.sh`
- `git diff --check`
- `./scripts/check-file-size.sh .github/scripts/runner-behavior-keep-alive.sh`

The metal-host lane-D integration test will run in PR CI.

Closes #28112
