### PR TITLE
refactor(runner): route host oom probe through bounded commands

### DIFF
--- a/crates/runner/src/bounded_command.rs
+++ b/crates/runner/src/bounded_command.rs
@@ -145,11 +145,6 @@ impl BoundedChild {
             None => Err("child"),
         }
     }
-
-    #[cfg(test)]
-    fn pid(&self) -> Option<u32> {
-        self.child.as_ref().and_then(Child::id)
-    }
 }
 
 impl Drop for BoundedChild {
@@ -414,7 +409,14 @@ mod tests {
             CommandOutputCapture::StdoutAndStderr,
             Duration::from_secs(1),
         ));
-        let (pid, starttime) = wait_for_recorded_process(&pid_path).await?;
+        let (pid, starttime) = match wait_for_recorded_process(&pid_path).await {
+            Ok(process) => process,
+            Err(error) => {
+                task.abort();
+                let _ = task.await;
+                return Err(error);
+            }
+        };
 
         let outcome = task.await.unwrap().unwrap();
 
@@ -434,7 +436,14 @@ mod tests {
             CommandOutputCapture::StdoutAndStderr,
             Duration::from_secs(60),
         ));
-        let (pid, starttime) = wait_for_recorded_process(&pid_path).await?;
+        let (pid, starttime) = match wait_for_recorded_process(&pid_path).await {
+            Ok(process) => process,
+            Err(error) => {
+                task.abort();
+                let _ = task.await;
+                return Err(error);
+            }
+        };
 
         task.abort();
         assert!(matches!(task.await, Err(error) if error.is_cancelled()));
@@ -479,27 +488,6 @@ mod tests {
         assert!(output.status.success());
         assert!(output.stdout.is_empty());
         assert_eq!(output.stderr, b"stderr");
-    }
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn kill_and_reap_child_reaps_running_child() {
-        let mut command = Command::new("sleep");
-        command.arg("60");
-        let mut child = BoundedChild::spawn(&mut command).unwrap();
-        let pid = child.pid().unwrap();
-        let starttime = read_process_stat(pid)
-            .await
-            .unwrap_or_else(|| panic!("read initial process stat for pid {pid}"))
-            .starttime;
-
-        kill_and_reap_child("sleep", &mut child).await.unwrap();
-
-        let observed = read_process_stat(pid).await;
-        assert!(
-            !matches!(&observed, Some(stat) if stat.starttime == starttime),
-            "killed child pid {pid} was not reaped: {observed:?}"
-        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/runner/src/bounded_command.rs
+++ b/crates/runner/src/bounded_command.rs
@@ -3,11 +3,14 @@ use std::process::{ExitStatus, Output, Stdio};
 use std::time::Duration;
 
 use tokio::io::AsyncReadExt;
-use tokio::process::Command;
+use tokio::process::{Child, Command};
 use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
+use crate::child_cleanup::kill_and_reap_child_on_drop;
+
 const COMMAND_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+const BOUNDED_COMMAND_CHILD_LABEL: &str = "bounded command";
 
 #[derive(Debug)]
 pub(crate) enum BoundedCommandOutcome<T> {
@@ -33,8 +36,7 @@ pub(crate) async fn run_bounded(
     program: &str,
     timeout: Duration,
 ) -> Result<BoundedCommandOutcome<ExitStatus>, BoundedCommandError> {
-    command.kill_on_drop(true);
-    let mut child = command.spawn().map_err(BoundedCommandError::Spawn)?;
+    let mut child = BoundedChild::spawn(&mut command).map_err(BoundedCommandError::Spawn)?;
 
     match tokio::time::timeout(timeout, child.wait()).await {
         Ok(Ok(status)) => Ok(BoundedCommandOutcome::Exited(status)),
@@ -67,10 +69,9 @@ pub(crate) async fn run_output_bounded(
             command.stdout(Stdio::piped()).stderr(Stdio::piped());
         }
     }
-    command.kill_on_drop(true);
 
-    let mut child = command.spawn().map_err(BoundedCommandError::Spawn)?;
-    let mut output_tasks = match ChildOutputTasks::from_child(&mut child, capture) {
+    let mut child = BoundedChild::spawn(&mut command).map_err(BoundedCommandError::Spawn)?;
+    let mut output_tasks = match child.output_tasks(capture) {
         Ok(output_tasks) => output_tasks,
         Err(stream) => {
             return match kill_and_reap_child(program, &mut child).await {
@@ -106,6 +107,55 @@ pub(crate) async fn run_output_bounded(
         stdout,
         stderr,
     }))
+}
+
+struct BoundedChild {
+    child: Option<Child>,
+}
+
+impl BoundedChild {
+    fn spawn(command: &mut Command) -> io::Result<Self> {
+        command.spawn().map(|child| Self { child: Some(child) })
+    }
+
+    async fn wait(&mut self) -> io::Result<ExitStatus> {
+        let result = match self.child.as_mut() {
+            Some(child) => child.wait().await,
+            None => Err(io::Error::other("bounded command child is not owned")),
+        };
+        if result.is_ok() {
+            self.child = None;
+        }
+        result
+    }
+
+    fn start_kill(&mut self) -> io::Result<()> {
+        match self.child.as_mut() {
+            Some(child) => child.start_kill(),
+            None => Err(io::Error::other("bounded command child is not owned")),
+        }
+    }
+
+    fn output_tasks(
+        &mut self,
+        capture: CommandOutputCapture,
+    ) -> Result<ChildOutputTasks, &'static str> {
+        match self.child.as_mut() {
+            Some(child) => ChildOutputTasks::from_child(child, capture),
+            None => Err("child"),
+        }
+    }
+
+    #[cfg(test)]
+    fn pid(&self) -> Option<u32> {
+        self.child.as_ref().and_then(Child::id)
+    }
+}
+
+impl Drop for BoundedChild {
+    fn drop(&mut self) {
+        kill_and_reap_child_on_drop(BOUNDED_COMMAND_CHILD_LABEL, &mut self.child);
+    }
 }
 
 enum ChildOutputTasks {
@@ -198,6 +248,12 @@ impl ChildOutputTasks {
     }
 }
 
+impl Drop for ChildOutputTasks {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
 async fn read_child_output<R>(mut reader: R) -> io::Result<Vec<u8>>
 where
     R: tokio::io::AsyncRead + Unpin,
@@ -238,10 +294,7 @@ fn output_task_timeout(program: &str, stream: &str) -> BoundedCommandError {
     ))
 }
 
-async fn kill_and_reap_child(
-    program: &str,
-    child: &mut tokio::process::Child,
-) -> Result<(), String> {
+async fn kill_and_reap_child(program: &str, child: &mut BoundedChild) -> Result<(), String> {
     let kill_error = child.start_kill().err();
     let deadline = Instant::now() + COMMAND_CLEANUP_TIMEOUT;
     match tokio::time::timeout_at(deadline, child.wait()).await {
@@ -265,6 +318,60 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     use crate::process::read_process_stat;
+    #[cfg(target_os = "linux")]
+    use std::path::Path;
+
+    #[cfg(target_os = "linux")]
+    const PROCESS_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(2);
+
+    #[cfg(target_os = "linux")]
+    fn pid_recording_command(pid_path: &Path) -> Command {
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("printf '%s' \"$$\" > \"$1\"; exec sleep 60")
+            .arg("sh")
+            .arg(pid_path);
+        command
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn wait_for_recorded_process(pid_path: &Path) -> io::Result<(u32, u64)> {
+        let deadline = std::time::Instant::now() + PROCESS_OBSERVATION_TIMEOUT;
+        loop {
+            match tokio::fs::read_to_string(pid_path).await {
+                Ok(raw_pid) => {
+                    let pid = raw_pid.trim().parse::<u32>().map_err(io::Error::other)?;
+                    if let Some(stat) = read_process_stat(pid).await {
+                        return Ok((pid, stat.starttime));
+                    }
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(io::Error::other(format!(
+                    "timed out waiting for command pid in {}",
+                    pid_path.display()
+                )));
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn wait_for_process_exit(pid: u32, starttime: u64) -> io::Result<()> {
+        let deadline = std::time::Instant::now() + PROCESS_OBSERVATION_TIMEOUT;
+        while matches!(read_process_stat(pid).await, Some(stat) if stat.starttime == starttime) {
+            if std::time::Instant::now() >= deadline {
+                return Err(io::Error::other(format!(
+                    "timed out waiting for process {pid} to be reaped"
+                )));
+            }
+            tokio::task::yield_now().await;
+        }
+        Ok(())
+    }
 
     #[tokio::test]
     async fn status_command_times_out_after_reaping_child() {
@@ -293,6 +400,45 @@ mod tests {
         .unwrap();
 
         assert!(matches!(outcome, BoundedCommandOutcome::TimedOut));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn output_command_timeout_reaps_recorded_child() -> io::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_path = temp_dir.path().join("pid");
+        let command = pid_recording_command(&pid_path);
+        let task = tokio::spawn(run_output_bounded(
+            command,
+            "sh",
+            CommandOutputCapture::StdoutAndStderr,
+            Duration::from_secs(1),
+        ));
+        let (pid, starttime) = wait_for_recorded_process(&pid_path).await?;
+
+        let outcome = task.await.unwrap().unwrap();
+
+        assert!(matches!(outcome, BoundedCommandOutcome::TimedOut));
+        wait_for_process_exit(pid, starttime).await
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn output_command_cancellation_reaps_recorded_child() -> io::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_path = temp_dir.path().join("pid");
+        let command = pid_recording_command(&pid_path);
+        let task = tokio::spawn(run_output_bounded(
+            command,
+            "sh",
+            CommandOutputCapture::StdoutAndStderr,
+            Duration::from_secs(60),
+        ));
+        let (pid, starttime) = wait_for_recorded_process(&pid_path).await?;
+
+        task.abort();
+        assert!(matches!(task.await, Err(error) if error.is_cancelled()));
+        wait_for_process_exit(pid, starttime).await
     }
 
     #[tokio::test]
@@ -338,12 +484,10 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn kill_and_reap_child_reaps_running_child() {
-        let mut child = Command::new("sleep")
-            .arg("60")
-            .kill_on_drop(true)
-            .spawn()
-            .unwrap();
-        let pid = child.id().unwrap();
+        let mut command = Command::new("sleep");
+        command.arg("60");
+        let mut child = BoundedChild::spawn(&mut command).unwrap();
+        let pid = child.pid().unwrap();
         let starttime = read_process_stat(pid)
             .await
             .unwrap_or_else(|| panic!("read initial process stat for pid {pid}"))

--- a/crates/runner/src/executor/diagnostics/oom.rs
+++ b/crates/runner/src/executor/diagnostics/oom.rs
@@ -1,103 +1,13 @@
-use std::io;
-use std::process::{Output, Stdio};
 use std::time::Duration;
 
-use tokio::io::AsyncReadExt;
-use tokio::process::{Child, Command};
+use tokio::process::Command;
 use tracing::warn;
 
-use crate::child_cleanup::kill_and_reap_child_on_drop;
+use crate::bounded_command::{
+    BoundedCommandError, BoundedCommandOutcome, CommandOutputCapture, run_output_bounded,
+};
 
 const HOST_OOM_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
-
-struct HostOomDiagnostic {
-    child: Option<Child>,
-}
-
-impl HostOomDiagnostic {
-    fn spawn(command: &mut Command) -> io::Result<Self> {
-        let child = command
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
-        Ok(Self { child: Some(child) })
-    }
-
-    #[cfg(test)]
-    fn pid(&self) -> Option<u32> {
-        self.child.as_ref().and_then(Child::id)
-    }
-
-    async fn output(mut self, timeout: Duration) -> io::Result<Option<Output>> {
-        let (mut stdout, mut stderr) = {
-            let child = self
-                .child
-                .as_mut()
-                .ok_or_else(|| io::Error::other("host OOM diagnostic child is not owned"))?;
-            let stdout = child
-                .stdout
-                .take()
-                .ok_or_else(|| io::Error::other("host OOM diagnostic stdout is not piped"))?;
-            let stderr = child
-                .stderr
-                .take()
-                .ok_or_else(|| io::Error::other("host OOM diagnostic stderr is not piped"))?;
-            (stdout, stderr)
-        };
-        let result = {
-            let child = self
-                .child
-                .as_mut()
-                .ok_or_else(|| io::Error::other("host OOM diagnostic child is not owned"))?;
-            tokio::time::timeout(timeout, async move {
-                let mut stdout_bytes = Vec::new();
-                let mut stderr_bytes = Vec::new();
-                let (status, _, _) = tokio::try_join!(
-                    child.wait(),
-                    stdout.read_to_end(&mut stdout_bytes),
-                    stderr.read_to_end(&mut stderr_bytes),
-                )?;
-                Ok::<Output, io::Error>(Output {
-                    status,
-                    stdout: stdout_bytes,
-                    stderr: stderr_bytes,
-                })
-            })
-            .await
-        };
-
-        match result {
-            Ok(Ok(output)) => {
-                self.child = None;
-                Ok(Some(output))
-            }
-            Ok(Err(error)) => {
-                self.kill_and_reap().await;
-                Err(error)
-            }
-            Err(_) => {
-                self.kill_and_reap().await;
-                Ok(None)
-            }
-        }
-    }
-
-    async fn kill_and_reap(&mut self) {
-        let Some(child) = self.child.as_mut() else {
-            return;
-        };
-        let _ = child.start_kill();
-        if child.wait().await.is_ok() {
-            self.child = None;
-        }
-    }
-}
-
-impl Drop for HostOomDiagnostic {
-    fn drop(&mut self) {
-        kill_and_reap_child_on_drop("host OOM diagnostic", &mut self.child);
-    }
-}
 
 /// Returns true if dmesg output indicates an OOM kill.
 pub(in crate::executor) fn dmesg_indicates_oom(stdout: &str) -> bool {
@@ -112,35 +22,34 @@ pub(in crate::executor) fn dmesg_indicates_oom(stdout: &str) -> bool {
 /// returning. Returns `false` when the command exits unsuccessfully, execution
 /// fails, or the operation times out.
 pub(in crate::executor) async fn check_host_oom(pid: u32) -> bool {
-    let diagnostic = match HostOomDiagnostic::spawn(&mut Command::new("dmesg")) {
-        Ok(diagnostic) => diagnostic,
-        Err(error) => {
-            warn!(pid, error = %error, "failed to run dmesg for OOM check");
-            return false;
-        }
-    };
-    check_host_oom_diagnostic(pid, diagnostic, HOST_OOM_CHECK_TIMEOUT).await
+    check_host_oom_command(pid, Command::new("dmesg"), HOST_OOM_CHECK_TIMEOUT).await
 }
 
-async fn check_host_oom_diagnostic(
-    pid: u32,
-    diagnostic: HostOomDiagnostic,
-    timeout: Duration,
-) -> bool {
-    let result = diagnostic.output(timeout).await;
-    match result {
-        Ok(Some(out)) if out.status.success() => {
-            host_dmesg_indicates_oom(&String::from_utf8_lossy(&out.stdout), pid)
+async fn check_host_oom_command(pid: u32, command: Command, timeout: Duration) -> bool {
+    match run_output_bounded(
+        command,
+        "dmesg",
+        CommandOutputCapture::StdoutAndStderr,
+        timeout,
+    )
+    .await
+    {
+        Ok(BoundedCommandOutcome::Exited(output)) if output.status.success() => {
+            host_dmesg_indicates_oom(&String::from_utf8_lossy(&output.stdout), pid)
         }
-        Ok(Some(out)) => {
-            warn!(pid, exit_code = out.status.code(), "dmesg failed");
+        Ok(BoundedCommandOutcome::Exited(output)) => {
+            warn!(pid, exit_code = output.status.code(), "dmesg failed");
             false
         }
-        Ok(None) => {
+        Ok(BoundedCommandOutcome::TimedOut) => {
             warn!(pid, "host dmesg OOM check timed out");
             false
         }
-        Err(error) => {
+        Err(BoundedCommandError::Spawn(error) | BoundedCommandError::Wait(error)) => {
+            warn!(pid, error = %error, "failed to run dmesg for OOM check");
+            false
+        }
+        Err(BoundedCommandError::Lifecycle(error)) => {
             warn!(pid, error = %error, "failed to run dmesg for OOM check");
             false
         }
@@ -177,77 +86,27 @@ pub(in crate::executor) fn host_dmesg_indicates_oom(dmesg: &str, pid: u32) -> bo
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
-    use crate::process::read_process_stat;
 
-    const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
-
-    async fn process_starttime(pid: u32) -> Option<u64> {
-        read_process_stat(pid).await.map(|stat| stat.starttime)
-    }
-
-    async fn wait_for_process_exit(pid: u32, starttime: u64) -> io::Result<()> {
-        tokio::time::timeout(PROCESS_EXIT_TIMEOUT, async {
-            while process_starttime(pid).await == Some(starttime) {
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .map_err(|_| {
-            io::Error::other(format!(
-                "timed out waiting for diagnostic process {pid} to be reaped"
-            ))
-        })
-    }
-
-    fn long_lived_diagnostic() -> io::Result<HostOomDiagnostic> {
+    #[tokio::test]
+    async fn timed_out_command_is_not_oom_evidence() {
         let mut command = Command::new("sleep");
         command.arg("60");
-        HostOomDiagnostic::spawn(&mut command)
+
+        assert!(!check_host_oom_command(42, command, Duration::ZERO).await);
     }
 
     #[tokio::test]
-    async fn timeout_kills_and_reaps_diagnostic_child() -> io::Result<()> {
-        let diagnostic = long_lived_diagnostic()?;
-        let child_pid = diagnostic
-            .pid()
-            .ok_or_else(|| io::Error::other("diagnostic process must be running"))?;
-        let starttime = process_starttime(child_pid)
-            .await
-            .ok_or_else(|| io::Error::other("diagnostic process must exist"))?;
+    async fn unsuccessful_command_is_not_oom_evidence() {
+        let command = Command::new("false");
 
-        assert!(!check_host_oom_diagnostic(42, diagnostic, Duration::ZERO).await);
-        assert_ne!(process_starttime(child_pid).await, Some(starttime));
-        Ok(())
+        assert!(!check_host_oom_command(42, command, Duration::from_secs(2)).await);
     }
 
     #[tokio::test]
-    async fn cancellation_kills_and_reaps_diagnostic_child() -> io::Result<()> {
-        let diagnostic = long_lived_diagnostic()?;
-        let child_pid = diagnostic
-            .pid()
-            .ok_or_else(|| io::Error::other("diagnostic process must be running"))?;
-        let starttime = process_starttime(child_pid)
-            .await
-            .ok_or_else(|| io::Error::other("diagnostic process must exist"))?;
-        let task = tokio::spawn(check_host_oom_diagnostic(
-            42,
-            diagnostic,
-            Duration::from_secs(60),
-        ));
-
-        task.abort();
-        assert!(matches!(task.await, Err(error) if error.is_cancelled()));
-        wait_for_process_exit(child_pid, starttime).await?;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn successful_diagnostic_captures_stdout_for_oom_detection() -> io::Result<()> {
+    async fn successful_command_captures_stdout_for_oom_detection() {
         let mut command = Command::new("printf");
         command.arg("oom-kill:task=firecracker,pid=42");
-        let diagnostic = HostOomDiagnostic::spawn(&mut command)?;
 
-        assert!(check_host_oom_diagnostic(42, diagnostic, Duration::from_secs(2)).await);
-        Ok(())
+        assert!(check_host_oom_command(42, command, Duration::from_secs(2)).await);
     }
 }


### PR DESCRIPTION
## Summary

- add cancellation-safe child ownership to the shared bounded-command boundary
- abort bounded output readers on caller cancellation
- route the host `dmesg` OOM probe through the shared boundary and remove its duplicate process wrapper
- preserve the OOM timeout, warning categories, conservative fallback, and PID-specific parsing

## Scope

This changes bounded one-shot runner subprocesses only. It does not change long-lived process owners, APIs, protocols, schemas, configuration, or persisted data.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features`
- focused bounded-command and OOM diagnostic tests

Closes #28089
