### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1177,7 +1177,28 @@ stream_max_retries = 0
     )
 
 
-def run_codex(codex_home, *args):
+def send_app_server_message(process, message):
+    process.stdin.write(json.dumps(message) + "\n")
+    process.stdin.flush()
+
+
+def read_app_server_message(process):
+    line = process.stdout.readline()
+    assert line, "Codex app-server closed stdout before completing the turn"
+    return json.loads(line)
+
+
+def wait_for_app_server_response(process, response_id, messages):
+    while True:
+        message = read_app_server_message(process)
+        messages.append(message)
+        if message.get("id") != response_id:
+            continue
+        assert "error" not in message, message
+        return message["result"]
+
+
+def run_codex_app_server(codex_home, prompt, resume_id=None):
     env = os.environ.copy()
     env.update(
         {
@@ -1188,21 +1209,113 @@ def run_codex(codex_home, *args):
             "no_proxy": "127.0.0.1,localhost",
         }
     )
-    return subprocess.run(
+    process = subprocess.Popen(
         [
             current_codex,
-            "exec",
-            *args,
-            "--skip-git-repo-check",
-            "--json",
+            "app-server",
+            "--listen",
+            "stdio://",
         ],
         cwd="/home/user/workspace",
         env=env,
-        capture_output=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        timeout=30,
-        check=False,
     )
+    messages = []
+    send_app_server_message(
+        process,
+        {
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "clientInfo": {
+                    "name": "vm0-runner-compatibility-probe",
+                    "title": None,
+                    "version": "0",
+                },
+                "capabilities": {
+                    "experimentalApi": True,
+                    "requestAttestation": False,
+                },
+            },
+        },
+    )
+    wait_for_app_server_response(process, 1, messages)
+    send_app_server_message(process, {"method": "initialized"})
+
+    thread_params = {
+        "cwd": "/home/user/workspace",
+        "approvalPolicy": "never",
+        "approvalsReviewer": "user",
+        "sandbox": "danger-full-access",
+        "config": {"features.memories": True},
+        "model": "gpt-5.1-codex-mini",
+        "modelProvider": "mock",
+    }
+    thread_method = "thread/start"
+    if resume_id is not None:
+        thread_method = "thread/resume"
+        thread_params["threadId"] = resume_id
+    send_app_server_message(
+        process,
+        {"id": 2, "method": thread_method, "params": thread_params},
+    )
+    thread_result = wait_for_app_server_response(process, 2, messages)
+    thread = thread_result["thread"]
+    thread_id = thread["id"]
+    assert thread["historyMode"] == "legacy", thread
+
+    send_app_server_message(
+        process,
+        {
+            "id": 3,
+            "method": "turn/start",
+            "params": {
+                "threadId": thread_id,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": prompt,
+                        "text_elements": [],
+                    }
+                ],
+                "cwd": "/home/user/workspace",
+                "approvalPolicy": "never",
+                "approvalsReviewer": "user",
+                "sandboxPolicy": {"type": "dangerFullAccess"},
+                "model": "gpt-5.1-codex-mini",
+            },
+        },
+    )
+    turn_result = wait_for_app_server_response(process, 3, messages)
+    turn_id = turn_result["turn"]["id"]
+    while True:
+        message = read_app_server_message(process)
+        messages.append(message)
+        if (
+            message.get("method") == "turn/completed"
+            and message.get("params", {}).get("threadId") == thread_id
+            and message.get("params", {}).get("turn", {}).get("id")
+            == turn_id
+        ):
+            break
+
+    process.stdin.close()
+    return_code = process.wait(timeout=10)
+    stderr = process.stderr.read()
+    assert return_code == 0, stderr
+    return {
+        "thread_id": thread_id,
+        "turn_id": turn_id,
+        "messages": messages,
+        "stderr": stderr,
+    }
+
+
+def app_server_output(result):
+    return json.dumps(result["messages"]) + "\n" + result["stderr"]
 
 
 def zstd_compress(history_bytes):
@@ -1272,13 +1385,12 @@ def resume_history(
     original_size = history_file.stat().st_size
 
     requests.clear()
-    resumed = run_codex(
+    resumed = run_codex_app_server(
         codex_home,
-        "resume",
-        session_id,
         append_token,
+        session_id,
     )
-    output = resumed.stdout + resumed.stderr
+    output = app_server_output(resumed)
     assert (
         f"no rollout found for thread id {session_id}" not in output.lower()
     ), output
@@ -1325,17 +1437,7 @@ def probe_current_codex(
         "Codex did not reconstruct compact replacement history"
     )
 
-    started = [
-        json.loads(line)
-        for line in resumed.stdout.splitlines()
-        if line.startswith("{")
-    ]
-    thread_started = [
-        event
-        for event in started
-        if event.get("type") == "thread.started"
-    ]
-    assert thread_started and thread_started[0].get("thread_id") == session_id, (
+    assert resumed["thread_id"] == session_id, (
         "Codex changed the resumed thread ID"
     )
 
@@ -1384,13 +1486,12 @@ def probe_zstd_materialization(
     compressed_history_file.write_bytes(zstd_compress(candidate_bytes))
 
     requests.clear()
-    resumed = run_codex(
+    resumed = run_codex_app_server(
         codex_home,
-        "resume",
-        session_id,
         append_token,
+        session_id,
     )
-    output = resumed.stdout + resumed.stderr
+    output = app_server_output(resumed)
     assert (
         f"no rollout found for thread id {session_id}" not in output.lower()
     ), output
@@ -1411,17 +1512,7 @@ def probe_zstd_materialization(
         "Codex did not append to the materialized rollout"
     )
 
-    started = [
-        json.loads(line)
-        for line in resumed.stdout.splitlines()
-        if line.startswith("{")
-    ]
-    thread_started = [
-        event
-        for event in started
-        if event.get("type") == "thread.started"
-    ]
-    assert thread_started and thread_started[0].get("thread_id") == session_id, (
+    assert resumed["thread_id"] == session_id, (
         "Codex changed the zstd-restored thread ID"
     )
 
@@ -1438,7 +1529,7 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
 
         seed_home = root / "seed" / ".codex"
         write_config(seed_home, port)
-        run_codex(
+        run_codex_app_server(
             seed_home,
             seed_token,
         )
@@ -1451,13 +1542,12 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
         candidate_relative_path = source.relative_to(
             seed_home / "sessions"
         )
-        compacting_turn = run_codex(
+        compacting_turn = run_codex_app_server(
             seed_home,
-            "resume",
-            session_id,
             compacting_turn_token,
+            session_id,
         )
-        compacting_output = compacting_turn.stdout + compacting_turn.stderr
+        compacting_output = app_server_output(compacting_turn)
         assert (
             f"no rollout found for thread id {session_id}"
             not in compacting_output.lower()
@@ -1471,12 +1561,11 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
             for index, record in enumerate(records)
             if event_type(record) in {"task_complete", "turn_complete"}
         )
-        removed_completion = records.pop(complete_index)
+        records.pop(complete_index)
         records.insert(
             complete_index,
             {
                 "timestamp": "2026-01-01T00:00:00.000Z",
-                "ordinal": removed_completion["ordinal"],
                 "type": "compacted",
                 "payload": {
                     "message": summary_token,
@@ -1522,13 +1611,12 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
             ).encode()
         )
 
-        candidate_turn = run_codex(
+        candidate_turn = run_codex_app_server(
             seed_home,
-            "resume",
-            session_id,
             candidate_turn_token,
+            session_id,
         )
-        candidate_output = candidate_turn.stdout + candidate_turn.stderr
+        candidate_output = app_server_output(candidate_turn)
         assert (
             f"no rollout found for thread id {session_id}"
             not in candidate_output.lower()

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1209,109 +1209,118 @@ def run_codex_app_server(codex_home, prompt, resume_id=None):
             "no_proxy": "127.0.0.1,localhost",
         }
     )
-    process = subprocess.Popen(
-        [
-            current_codex,
-            "app-server",
-            "--listen",
-            "stdio://",
-        ],
-        cwd="/home/user/workspace",
-        env=env,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    messages = []
-    send_app_server_message(
-        process,
-        {
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "clientInfo": {
-                    "name": "vm0-runner-compatibility-probe",
-                    "title": None,
-                    "version": "0",
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stderr_file:
+        process = subprocess.Popen(
+            [
+                current_codex,
+                "app-server",
+                "--listen",
+                "stdio://",
+            ],
+            cwd="/home/user/workspace",
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=stderr_file,
+            text=True,
+        )
+        try:
+            messages = []
+            send_app_server_message(
+                process,
+                {
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "clientInfo": {
+                            "name": "vm0-runner-compatibility-probe",
+                            "title": None,
+                            "version": "0",
+                        },
+                        "capabilities": {
+                            "experimentalApi": True,
+                            "requestAttestation": False,
+                        },
+                    },
                 },
-                "capabilities": {
-                    "experimentalApi": True,
-                    "requestAttestation": False,
-                },
-            },
-        },
-    )
-    wait_for_app_server_response(process, 1, messages)
-    send_app_server_message(process, {"method": "initialized"})
+            )
+            wait_for_app_server_response(process, 1, messages)
+            send_app_server_message(process, {"method": "initialized"})
 
-    thread_params = {
-        "cwd": "/home/user/workspace",
-        "approvalPolicy": "never",
-        "approvalsReviewer": "user",
-        "sandbox": "danger-full-access",
-        "config": {"features.memories": True},
-        "model": "gpt-5.1-codex-mini",
-        "modelProvider": "mock",
-    }
-    thread_method = "thread/start"
-    if resume_id is not None:
-        thread_method = "thread/resume"
-        thread_params["threadId"] = resume_id
-    send_app_server_message(
-        process,
-        {"id": 2, "method": thread_method, "params": thread_params},
-    )
-    thread_result = wait_for_app_server_response(process, 2, messages)
-    thread = thread_result["thread"]
-    thread_id = thread["id"]
-    assert thread["historyMode"] == "legacy", thread
-
-    send_app_server_message(
-        process,
-        {
-            "id": 3,
-            "method": "turn/start",
-            "params": {
-                "threadId": thread_id,
-                "input": [
-                    {
-                        "type": "text",
-                        "text": prompt,
-                        "text_elements": [],
-                    }
-                ],
+            thread_params = {
                 "cwd": "/home/user/workspace",
                 "approvalPolicy": "never",
                 "approvalsReviewer": "user",
-                "sandboxPolicy": {"type": "dangerFullAccess"},
+                "sandbox": "danger-full-access",
+                "config": {"features.memories": True},
                 "model": "gpt-5.1-codex-mini",
-            },
-        },
-    )
-    turn_result = wait_for_app_server_response(process, 3, messages)
-    turn_id = turn_result["turn"]["id"]
-    while True:
-        message = read_app_server_message(process)
-        messages.append(message)
-        if (
-            message.get("method") == "turn/completed"
-            and message.get("params", {}).get("threadId") == thread_id
-            and message.get("params", {}).get("turn", {}).get("id")
-            == turn_id
-        ):
-            break
+                "modelProvider": "mock",
+            }
+            thread_method = "thread/start"
+            if resume_id is not None:
+                thread_method = "thread/resume"
+                thread_params["threadId"] = resume_id
+            send_app_server_message(
+                process,
+                {"id": 2, "method": thread_method, "params": thread_params},
+            )
+            thread_result = wait_for_app_server_response(process, 2, messages)
+            thread = thread_result["thread"]
+            thread_id = thread["id"]
+            assert thread["historyMode"] == "legacy", thread
 
-    process.stdin.close()
-    return_code = process.wait(timeout=10)
-    stderr = process.stderr.read()
-    assert return_code == 0, stderr
-    return {
-        "thread_id": thread_id,
-        "turn_id": turn_id,
-        "messages": messages,
-        "stderr": stderr,
-    }
+            send_app_server_message(
+                process,
+                {
+                    "id": 3,
+                    "method": "turn/start",
+                    "params": {
+                        "threadId": thread_id,
+                        "input": [
+                            {
+                                "type": "text",
+                                "text": prompt,
+                                "text_elements": [],
+                            }
+                        ],
+                        "cwd": "/home/user/workspace",
+                        "approvalPolicy": "never",
+                        "approvalsReviewer": "user",
+                        "sandboxPolicy": {"type": "dangerFullAccess"},
+                        "model": "gpt-5.1-codex-mini",
+                    },
+                },
+            )
+            turn_result = wait_for_app_server_response(process, 3, messages)
+            turn_id = turn_result["turn"]["id"]
+            while True:
+                message = read_app_server_message(process)
+                messages.append(message)
+                if (
+                    message.get("method") == "turn/completed"
+                    and message.get("params", {}).get("threadId") == thread_id
+                    and message.get("params", {}).get("turn", {}).get("id")
+                    == turn_id
+                ):
+                    break
+
+            process.stdin.close()
+            return_code = process.wait(timeout=10)
+            stderr_file.seek(0)
+            stderr = stderr_file.read()
+            assert return_code == 0, stderr
+            return {
+                "thread_id": thread_id,
+                "turn_id": turn_id,
+                "messages": messages,
+                "stderr": stderr,
+            }
+        finally:
+            if process.poll() is None:
+                process.kill()
+            process.wait()
+            process.stdin.close()
+            process.stdout.close()
 
 
 def app_server_output(result):

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1129,6 +1129,26 @@ seed_token = "CODEX-COMPACT-SEED-TOKEN"
 compacting_turn_token = "CODEX-COMPACTING-TURN-TOKEN"
 candidate_turn_token = "CODEX-COMPACT-CANDIDATE-TURN-TOKEN"
 append_token = "CODEX-COMPACT-APPEND-TOKEN"
+# [sync:codex-app-server-compatibility-params] Keep in sync with initialize in
+# codex_app_server.rs, thread/turn params in codex_app_server_backend.rs, and
+# IGNORED_NOTIFICATION_METHODS in codex_app_server_events.rs.
+opt_out_notification_methods = [
+    "command/exec/outputDelta",
+    "process/outputDelta",
+    "process/exited",
+    "item/agentMessage/delta",
+    "item/plan/delta",
+    "item/commandExecution/outputDelta",
+    "item/commandExecution/terminalInteraction",
+    "item/fileChange/outputDelta",
+    "item/fileChange/patchUpdated",
+    "item/mcpToolCall/progress",
+    "item/reasoning/summaryTextDelta",
+    "item/reasoning/summaryPartAdded",
+    "item/reasoning/textDelta",
+    "thread/realtime/transcript/delta",
+    "thread/realtime/outputAudio/delta",
+]
 requests = []
 current_codex = shutil.which("codex")
 assert current_codex is not None, "bundled Codex is not on PATH"
@@ -1233,19 +1253,25 @@ def run_codex_app_server(codex_home, prompt, resume_id=None):
                     "method": "initialize",
                     "params": {
                         "clientInfo": {
-                            "name": "vm0-runner-compatibility-probe",
+                            "name": "vm0-guest-agent",
                             "title": None,
                             "version": "0",
                         },
                         "capabilities": {
                             "experimentalApi": True,
                             "requestAttestation": False,
+                            "optOutNotificationMethods": (
+                                opt_out_notification_methods
+                            ),
                         },
                     },
                 },
             )
             wait_for_app_server_response(process, 1, messages)
-            send_app_server_message(process, {"method": "initialized"})
+            send_app_server_message(
+                process,
+                {"method": "initialized", "params": None},
+            )
 
             thread_params = {
                 "cwd": "/home/user/workspace",
@@ -1311,7 +1337,6 @@ def run_codex_app_server(codex_home, prompt, resume_id=None):
             assert return_code == 0, stderr
             return {
                 "thread_id": thread_id,
-                "turn_id": turn_id,
                 "messages": messages,
                 "stderr": stderr,
             }

--- a/.github/scripts/runner-behavior-exec.sh
+++ b/.github/scripts/runner-behavior-exec.sh
@@ -1471,11 +1471,12 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
             for index, record in enumerate(records)
             if event_type(record) in {"task_complete", "turn_complete"}
         )
-        records.pop(complete_index)
+        removed_completion = records.pop(complete_index)
         records.insert(
             complete_index,
             {
                 "timestamp": "2026-01-01T00:00:00.000Z",
+                "ordinal": removed_completion["ordinal"],
                 "type": "compacted",
                 "payload": {
                     "message": summary_token,
@@ -1550,7 +1551,10 @@ with tempfile.TemporaryDirectory(prefix="codex-compact-smoke-") as temp_root:
             len(candidate_starts) >= 3
             and len(candidate_completions) == 2
             and candidate_starts[-1] == candidate_completions[-1]
-        ), "failed to build a compacting turn delimited by the next turn"
+        ), (
+            "failed to build a compacting turn delimited by the next turn\n"
+            f"{candidate_output}"
+        )
         full_lines = source.read_bytes().splitlines(keepends=True)
         full_records = [json.loads(line) for line in full_lines]
         compact_index = max(

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -1266,6 +1266,40 @@ mod tests {
     }
 
     #[test]
+    fn failed_turn_completed_classifies_misalignment_policy_violation() {
+        let event = mapped_event(
+            "turn/completed",
+            json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "status": "failed",
+                    "error": {
+                        "message": "This request violates the provider's alignment policy.",
+                        "codexErrorInfo": "misalignmentPolicyViolation"
+                    },
+                    "startedAt": 10,
+                    "completedAt": 20,
+                    "durationMs": 1000
+                }
+            }),
+        );
+
+        assert_eq!(
+            event["turn"]["error"]["codex_error_info"],
+            "misalignmentPolicyViolation"
+        );
+        assert_eq!(
+            events::masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(events::CodexFailureDiagnostic {
+                event_type: "turn.completed",
+                message: "This request violates the provider's alignment policy.".to_string(),
+                failure_reason: Some(FailureReason::SafetyPolicyRefusal),
+            })
+        );
+    }
+
+    #[test]
     fn interrupted_turn_completed_stays_turn_completed() {
         let event = mapped_event(
             "turn/completed",

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -276,7 +276,7 @@ fn codex_error_info_failure_reason(error: &Value) -> Option<FailureReason> {
     match codex_error_info_variant(error)? {
         "serverOverloaded" => Some(FailureReason::ProviderOverloaded),
         "usageLimitExceeded" => Some(FailureReason::UsageLimit),
-        "cyberPolicy" => Some(FailureReason::SafetyPolicyRefusal),
+        "cyberPolicy" | "misalignmentPolicyViolation" => Some(FailureReason::SafetyPolicyRefusal),
         _ => None,
     }
 }

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,8 +113,8 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.6"
-CLAUDE_CODE_VERSION="2.1.234"
-CODEX_CLI_VERSION="0.147.0"
+CLAUDE_CODE_VERSION="2.1.235"
+CODEX_CLI_VERSION="0.148.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
 AGENT_BROWSER_VERSION="0.33.0-vm0.1"


### PR DESCRIPTION
## Summary

- Update pinned rootfs package versions in `crates/runner/scripts/build-template.sh`.
- Exercise Codex compact/resume compatibility through the same `codex app-server` JSON-RPC interface used by the guest agent.
- Verify legacy rollout mode, compacted-history reconstruction, thread identity, turn boundaries, and zstd rollout materialization with Codex 0.147.0 and 0.148.0.
- Classify the Codex 0.148.0 `misalignmentPolicyViolation` error as `safety_policy_refusal`.
- Keep the app-server compatibility probe from blocking on a full stderr pipe and terminate its child process on failures.

## Updated

- Claude Code CLI: `2.1.234` → `2.1.235`
- Codex CLI: `0.147.0` → `0.148.0`

## Checked (no newer version available)

- Go: `1.26.6`
- Google Workspace CLI: `0.22.5`
- xurl: `1.3.1`
- agent-browser: `0.33.0-vm0.1`
- pnpm: `11.22.0`
- Chromium: `151.0.7922.137-1~deb12u1`

## Validation

- `bash -n .github/scripts/runner-behavior-exec.sh`
- `shellcheck .github/scripts/runner-behavior-exec.sh`
- `./scripts/check-file-size.sh .github/scripts/runner-behavior-exec.sh`
- App-server compact/resume probe with Codex 0.147.0 and 0.148.0
- `cargo fmt --all`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent --no-deps`
- `cargo test -p guest-agent --lib failed_turn_completed_classifies_misalignment_policy_violation`
- `cargo test -p guest-agent --quiet`
- `git diff --check`
