### PR TITLE
fix(app): refresh connector catalog diagnostics on debug entry

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-catalog-diagnostics.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-catalog-diagnostics.ts
@@ -1,12 +1,21 @@
 import type { ConnectorCatalogDiagnostics } from "@okouai/api-contracts/contracts/connector-catalog-diagnostics";
 import { zeroConnectorCatalogContract } from "@okouai/api-contracts/contracts/zero-connector-catalog";
-import { computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 
 import { accept } from "../../../lib/accept.ts";
 import { zeroClient$ } from "../../api-client.ts";
 
+const internalConnectorCatalogDiagnosticsReload$ = state(0);
+
+export const reloadConnectorCatalogDiagnostics$ = command(({ set }) => {
+  set(internalConnectorCatalogDiagnosticsReload$, (value) => {
+    return value + 1;
+  });
+});
+
 export const connectorCatalogDiagnostics$ = computed(
   async (get): Promise<ConnectorCatalogDiagnostics | null> => {
+    get(internalConnectorCatalogDiagnosticsReload$);
     const createClient = get(zeroClient$);
     const client = createClient(zeroConnectorCatalogContract);
     const result = await accept(client.diagnostics(), [200, 403, 404]);

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -5,6 +5,7 @@ import { reloadBillingStatus$, usagePackManagementAsync$ } from "../billing.ts";
 import { isOrgAdmin$ } from "../../org.ts";
 import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
 import { resetSignal } from "../../utils.ts";
+import { reloadConnectorCatalogDiagnostics$ } from "./connector-catalog-diagnostics.ts";
 import {
   clearBillingScrollTarget$,
   clearPendingLogo$,
@@ -98,6 +99,9 @@ export const settingsActiveSection$ = computed((get) => {
 
 export const setSettingsActiveSection$ = command(
   ({ get, set }, section: SettingsSection) => {
+    if (section === "debug" && get(internalActiveSection$) !== "debug") {
+      set(reloadConnectorCatalogDiagnostics$);
+    }
     set(internalActiveSection$, section);
     if (section !== "billing") {
       set(clearBillingScrollTarget$);
@@ -209,6 +213,9 @@ export const setSettingsDialogOpen$ = command(
     set(internalSettingsDialogSignal$, modalSignal);
     set(internalSettingsDialogSessionActive$, true);
     set(reloadBillingStatus$);
+    if (get(internalActiveSection$) === "debug") {
+      set(reloadConnectorCatalogDiagnostics$);
+    }
     set(internalSettingsDialogOpen$, true);
     await set(initProfileName$, modalSignal);
     pageSignal.throwIfAborted();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -17,6 +17,7 @@ import {
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { localeStorageKey } from "../../../i18n/locale-storage.ts";
 import { localStorageSignals } from "../../../signals/external/local-storage.ts";
+import { openSettingsDialogAt$ } from "../../../signals/zero-page/settings/settings-dialog.ts";
 import { billingStatus } from "./chat-composer-test-helpers.ts";
 
 const context = testContext();
@@ -913,6 +914,95 @@ describe("settings dialog", () => {
     expect(
       within(diagnostics).getByText("Unresolved bridge credentials"),
     ).toBeInTheDocument();
+  });
+
+  it("refreshes connector catalog diagnostics on every Debug entry", async () => {
+    let requestCount = 0;
+    context.mocks.api(
+      zeroConnectorCatalogContract.diagnostics,
+      ({ respond }) => {
+        requestCount += 1;
+        const requestedAt = "2026-08-19T04:00:00.000Z";
+        return respond(200, {
+          state: "current",
+          active: {
+            catalogVersion: `2026-08-19.${requestCount}`,
+            catalogDigest: `sha256:${"a".repeat(64)}`,
+            activatedAt: requestedAt,
+          },
+          lastAttempt: {
+            at: requestedAt,
+            outcome: "accepted",
+            failureCode: null,
+            reusedCachedRejection: false,
+          },
+          lastSuccessAt: requestedAt,
+          rejectedCandidate: null,
+          filtering: {
+            capabilityDigest: `sha256:${"b".repeat(64)}`,
+            evaluatedAt: requestedAt,
+            stale: false,
+            filteredAuthMethods: [],
+          },
+          credentialStorage: {
+            missingConnectorVersions: 0,
+            unownedConnectorSecrets: 0,
+            unownedConnectorVariables: 0,
+            unresolvedBridgeCredentials: 0,
+          },
+        });
+      },
+    );
+
+    await openDialog("admin", "debug");
+
+    await expect(
+      screen.findByText("2026-08-19.1"),
+    ).resolves.toBeInTheDocument();
+    expect(requestCount).toBe(1);
+
+    click(screen.getByRole("switch"));
+    await expect(
+      screen.findByText("Enabled for the next 3 runs"),
+    ).resolves.toBeInTheDocument();
+    expect(requestCount).toBe(1);
+
+    const dialog = screen.getByRole("dialog");
+    const dialogButton = (label: string): HTMLElement => {
+      const button = queryAllByRoleFast("button", dialog).find((candidate) => {
+        return (
+          candidate.textContent?.trim() === label ||
+          candidate.getAttribute("aria-label") === label
+        );
+      });
+      if (!button) {
+        throw new Error(`${label} button not found`);
+      }
+      return button;
+    };
+
+    click(dialogButton("Preference"));
+    await expect(
+      screen.findByRole("heading", { name: "Preference" }),
+    ).resolves.toBeInTheDocument();
+
+    click(dialogButton("Debug"));
+    await expect(
+      screen.findByText("2026-08-19.2"),
+    ).resolves.toBeInTheDocument();
+    expect(requestCount).toBe(2);
+
+    click(dialogButton("Close"));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    await context.store.set(openSettingsDialogAt$, "debug", context.signal);
+
+    await expect(
+      screen.findByText("2026-08-19.3"),
+    ).resolves.toBeInTheDocument();
+    expect(requestCount).toBe(3);
   });
 
   it("does not describe an uncached rejection as a fresh evaluation", async () => {


### PR DESCRIPTION
## Summary

- invalidate the memoized connector catalog diagnostics before each new Debug settings visit
- refresh on both Settings dialog reopen and in-dialog section re-entry without duplicating ordinary rerenders
- cover direct open, same-visit rerender, section re-entry, and dialog reopen in the page-level Settings integration test

## Scope

This repeats the existing database-backed diagnostics GET. It does not trigger external connector catalog synchronization or change any API, database, persisted-state, artifact, or runner contract.

## Validation

- `pnpm exec prettier --check apps/platform/src/signals/zero-page/settings/connector-catalog-diagnostics.ts apps/platform/src/signals/zero-page/settings/settings-dialog.ts apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/settings-dialog.test.tsx --maxWorkers=1 --silent=passed-only` (30 passed)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit hooks, including full Turbo Knip and type checks
- Full app Vitest run: 1,791 passed; one unrelated existing workflow test failed because it assumes the process timezone is UTC while the local environment is Asia/Shanghai. The unchanged test passes when rerun with `TZ=UTC`.

Closes #28122
