### PR TITLE
fix(api): resolve exact connector credential sources

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8182,6 +8182,12 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
         appSecret: "lark-app-secret",
       },
     );
+    const wrongTargetConnection = await connectors.connectManualGrant(
+      actor,
+      "figma",
+      "api-token",
+      { accessToken: "unrelated-figma-token" },
+    );
     await api.enableAgentConnectors(actor, agentId, ["lark"]);
 
     const run = await api.createRun(actor, {
@@ -8216,6 +8222,34 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
         sourceId: connected.id,
       }),
     );
+    const larkTarget = claim.connectorRuntimeTargets.find((target) => {
+      return target.kind === "builtin" && target.connectorSlug === "lark";
+    });
+    if (!larkTarget || larkTarget.kind !== "builtin") {
+      throw new Error("Expected the lark runtime target");
+    }
+    const [exactRuntime] = await api.syncConnectorRuntime(run.runId, {
+      targets: [larkTarget],
+    });
+    expect(exactRuntime).toMatchObject({
+      target: { kind: "builtin", connectorSlug: "lark" },
+      state: "available",
+    });
+    const [legacyRuntime] = await api.syncConnectorRuntime(run.runId, {
+      targets: [{ kind: "builtin", connectorSlug: "lark" }],
+    });
+    expect(legacyRuntime).toMatchObject({
+      target: { kind: "builtin", connectorSlug: "lark" },
+      state: "available",
+    });
+    const [missingExactRuntime] = await api.syncConnectorRuntime(run.runId, {
+      targets: [{ ...larkTarget, sourceId: wrongTargetConnection.id }],
+    });
+    expect(missingExactRuntime).toStrictEqual({
+      target: { kind: "builtin", connectorSlug: "lark" },
+      state: "unresolved",
+      reason: "connector-unavailable",
+    });
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
@@ -8343,6 +8377,29 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       [400],
     );
     expect(conflictingSource.status).toBe(400);
+
+    const missingExactSource = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          Authorization: `Bearer \${{ secrets.GOOGLE_ADS_TOKEN }}`,
+        },
+        secretConnectorMap: claim.secretConnectorMap ?? undefined,
+        secretConnectorMetadataMap: {
+          ...claim.secretConnectorMetadataMap,
+          GOOGLE_ADS_TOKEN: {
+            sourceType: "connector",
+            sourceId: randomUUID(),
+          },
+        },
+      },
+      [424],
+    );
+    if (missingExactSource.status !== 424) {
+      throw new Error("Expected a missing exact built-in connector source");
+    }
+    expect(missingExactSource.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
@@ -8835,6 +8892,12 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       { key: "secret", kind: "secret", value: "custom-secret-value" },
       { key: "tenant", kind: "variable", value: "acme" },
     ]);
+    const wrongTargetConnection = await connectors.connectManualGrant(
+      actor,
+      "figma",
+      "api-token",
+      { accessToken: "unrelated-custom-source" },
+    );
     await connectors.updateAgentCustomConnectors(actor, agentId, [custom.id]);
 
     const run = await api.createRun(actor, {
@@ -8912,6 +8975,30 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       headers: { Authorization: "Bearer custom-secret-value" },
       expiresAt: null,
     });
+
+    const [missingExactRuntime] = await api.syncConnectorRuntime(run.runId, {
+      targets: [{ ...target, sourceId: wrongTargetConnection.id }],
+    });
+    expect(missingExactRuntime).toStrictEqual({
+      target: targetIdentity,
+      state: "absent",
+      reason: "connector-unavailable",
+    });
+    const missingExactAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        ...currentAuthBody,
+        matchedFirewall: {
+          ...currentAuthBody.matchedFirewall,
+          sourceId: randomUUID(),
+        },
+      },
+      [424],
+    );
+    if (missingExactAuth.status !== 424) {
+      throw new Error("Expected a missing exact custom connector source");
+    }
+    expect(missingExactAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
 
     await connectors.setCustomConnectorSecret(
       actor,
@@ -9003,7 +9090,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       headers: { Authorization: "Bearer recovered-custom-secret-value" },
     });
 
-    await connectors.disconnectCustomConnector(actor, custom.id);
+    await deleteCustomConnectorCredentialValues(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: custom.id,
+    });
     const [missingCredentialsRuntime] = await api.syncConnectorRuntime(
       run.runId,
       { targets: [target] },
@@ -9096,14 +9187,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const [incompatibleRuntime] = await api.syncConnectorRuntime(run.runId, {
       targets: [target],
     });
-    const incompatibleAvailable =
-      availableCustomConnectorRuntime(incompatibleRuntime);
-    expect(incompatibleAvailable.firewall).toStrictEqual(
-      updatedAvailable.firewall,
-    );
-    expect(incompatibleAvailable.networkPolicy).toStrictEqual(
-      updatedAvailable.networkPolicy,
-    );
+    expect(incompatibleRuntime).toStrictEqual({
+      target: targetIdentity,
+      state: "absent",
+      reason: "connector-unavailable",
+    });
     const incompatibleAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       currentAuthBody,
@@ -9125,15 +9213,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       run.runId,
       { targets: [target] },
     );
-    const incompatibleAuthMethodAvailable = availableCustomConnectorRuntime(
-      incompatibleAuthMethodRuntime,
-    );
-    expect(incompatibleAuthMethodAvailable.firewall).toStrictEqual(
-      updatedAvailable.firewall,
-    );
-    expect(incompatibleAuthMethodAvailable.networkPolicy).toStrictEqual(
-      updatedAvailable.networkPolicy,
-    );
+    expect(incompatibleAuthMethodRuntime).toStrictEqual({
+      target: targetIdentity,
+      state: "absent",
+      reason: "connector-unavailable",
+    });
     const incompatibleAuthMethod = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       currentAuthBody,
@@ -9232,6 +9316,16 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     }
     expect(orphanedFieldAuth.body.error).toMatchObject({
       code: "CONNECTOR_NOT_CONFIGURED",
+    });
+
+    await connectors.disconnectCustomConnector(actor, custom.id);
+    const [deletedExactRuntime] = await api.syncConnectorRuntime(run.runId, {
+      targets: [target],
+    });
+    expect(deletedExactRuntime).toStrictEqual({
+      target: targetIdentity,
+      state: "absent",
+      reason: "connector-unavailable",
     });
 
     await api.requestCancelRun(actor, run.runId, [200]);
@@ -9373,11 +9467,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       }),
     );
 
-    const target = {
-      kind: "custom" as const,
-      customConnectorId: mcp.id,
-      baseUrlVars: {},
-    };
+    const target = mcpTarget;
     const [initialResult] = await api.syncConnectorRuntime(run.runId, {
       targets: [target],
     });
@@ -9402,6 +9492,26 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     expect(initialAuth.body).toMatchObject({
       headers: { Authorization: "Bearer mcp-runtime-token" },
+    });
+    const [legacySourceResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [
+        {
+          kind: "custom",
+          customConnectorId: mcp.id,
+          baseUrlVars: {},
+        },
+      ],
+    });
+    expect(
+      availableCustomConnectorRuntime(legacySourceResult).firewall,
+    ).toStrictEqual(initialRuntime.firewall);
+    const [missingExactResult] = await api.syncConnectorRuntime(run.runId, {
+      targets: [{ ...target, sourceId: randomUUID() }],
+    });
+    expect(missingExactResult).toStrictEqual({
+      target: { kind: "custom", customConnectorId: mcp.id },
+      state: "absent",
+      reason: "connector-unavailable",
     });
 
     await connectors.updateFeatureSwitches(actor, {
@@ -9439,7 +9549,14 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       unknownPolicy: "allow",
     });
 
-    await connectors.disconnectCustomConnector(actor, mcp.id);
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped MCP actor");
+    }
+    await deleteCustomConnectorCredentialValues(context, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customConnectorId: mcp.id,
+    });
     const [disconnectedResult] = await api.syncConnectorRuntime(run.runId, {
       targets: [target],
     });
@@ -10303,6 +10420,23 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       runtime,
       fw.encryptedSecretsBody({}),
     );
+    const missingExactOAuth = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        ...currentAuthBody,
+        forceRefresh: true,
+        matchedFirewall: {
+          ...currentAuthBody.matchedFirewall,
+          sourceId: randomUUID(),
+        },
+      },
+      [424],
+    );
+    if (missingExactOAuth.status !== 424) {
+      throw new Error("Expected a missing exact custom OAuth source");
+    }
+    expect(missingExactOAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+    expect(provider.tokenBodies).toHaveLength(1);
 
     const firstRefreshAt = now() + 2 * 3_600_000;
     mockNow(firstRefreshAt);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -255,6 +255,10 @@ import {
   type ConnectorCredentialReadGroup,
 } from "./connector-credential-access.service";
 import {
+  connectorAccountTargetKey,
+  resolveConnectorAccounts,
+} from "./connector-account-resolution.service";
+import {
   defaultFirewallPolicyForPermissionIndex,
   networkPolicyForFirewallPolicy,
 } from "./firewall-network-policy.service";
@@ -3753,7 +3757,7 @@ function storedConnectorSnapshotQuery(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorSlugs: readonly ConnectorSlug[];
+    readonly connectorIds: readonly string[];
   },
 ) {
   const selectedConnectors = db.$with("stored_connector_candidates").as(
@@ -3782,7 +3786,7 @@ function storedConnectorSnapshotQuery(
           eq(connectors.orgId, args.orgId),
           eq(connectors.userId, args.userId),
           isNotNull(connectors.connectorSlug),
-          inArray(connectors.connectorSlug, args.allowedConnectorSlugs),
+          inArray(connectors.id, args.connectorIds),
         ),
       ),
   );
@@ -3861,7 +3865,7 @@ async function loadStoredConnectorSnapshotRows(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly allowedConnectorSlugs: readonly ConnectorSlug[];
+    readonly connectorIds: readonly string[];
     readonly timingDimensions: ApiDispatchTimingDimensions;
   },
   timing?: ApiDispatchTimingCollector,
@@ -4007,12 +4011,33 @@ async function loadStoredConnectorMaterializationSnapshot(
   const baseTimingDimensions = storedConnectorTimingDimensions({
     scopeSource: args.scopeSource,
   });
+  const accountResolutions = await resolveConnectorAccounts(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    requests: args.allowedConnectorSlugs.map((connectorSlug) => {
+      return {
+        target: { kind: "builtin" as const, connectorSlug },
+        selection: { kind: "default" as const },
+      };
+    }),
+  });
+  const connectorIds = args.allowedConnectorSlugs.flatMap((connectorSlug) => {
+    const resolution = accountResolutions.get(
+      connectorAccountTargetKey({ kind: "builtin", connectorSlug }),
+    );
+    return resolution?.kind === "resolved"
+      ? [resolution.account.connectorId]
+      : [];
+  });
+  if (connectorIds.length === 0) {
+    return null;
+  }
   const rows = await loadStoredConnectorSnapshotRows(
     db,
     {
       orgId: args.orgId,
       userId: args.userId,
-      allowedConnectorSlugs: args.allowedConnectorSlugs,
+      connectorIds,
       timingDimensions: baseTimingDimensions,
     },
     timing,
@@ -4697,10 +4722,33 @@ async function loadCustomConnectorContext(
     return emptyCustomConnectorRuntimeContext();
   }
 
+  const accountResolutions = await resolveConnectorAccounts(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    requests: args.allowedCustomConnectorIds.map((customConnectorId) => {
+      return {
+        target: { kind: "custom" as const, customConnectorId },
+        selection: { kind: "default" as const },
+      };
+    }),
+  });
+  const memberConnectorIdsByCustomConnectorId = new Map<string, string>();
+  for (const customConnectorId of args.allowedCustomConnectorIds) {
+    const resolution = accountResolutions.get(
+      connectorAccountTargetKey({ kind: "custom", customConnectorId }),
+    );
+    if (resolution?.kind === "resolved") {
+      memberConnectorIdsByCustomConnectorId.set(
+        customConnectorId,
+        resolution.account.connectorId,
+      );
+    }
+  }
   const rows = await loadCustomConnectorRuntimeData(db, {
     orgId: args.orgId,
     userId: args.userId,
     connectorIds: args.allowedCustomConnectorIds,
+    memberConnectorIdsByCustomConnectorId,
     measure: async (step, operation) => {
       const actionType =
         step === "connectorRows"

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -106,6 +106,11 @@ import {
   type ConnectorCredentialAccess,
 } from "./connector-credential-access.service";
 import {
+  connectorAccountTargetKey,
+  resolveConnectorAccounts,
+  type ConnectorAccountResolutionRequest,
+} from "./connector-account-resolution.service";
+import {
   CustomConnectorOAuth2TokenRefreshError,
   resolveCurrentCustomConnectorOAuth2AccessToken,
 } from "./custom-connector-oauth2.service";
@@ -1237,11 +1242,28 @@ async function loadConnectorAccessStates(
   db: Db,
   orgId: string,
   userId: string,
-  connectorSlugs: readonly string[],
+  requests: readonly ConnectorAccountResolutionRequest[],
   snapshot: ConnectorRuntimeSnapshot,
 ): Promise<Map<string, ConnectorAccessState>> {
   const result = new Map<string, ConnectorAccessState>();
-  if (connectorSlugs.length === 0) {
+  if (requests.length === 0) {
+    return result;
+  }
+
+  const accountResolutions = await resolveConnectorAccounts(db, {
+    orgId,
+    userId,
+    requests,
+  });
+  const connectorIds = requests.flatMap((request) => {
+    const resolution = accountResolutions.get(
+      connectorAccountTargetKey(request.target),
+    );
+    return resolution?.kind === "resolved"
+      ? [resolution.account.connectorId]
+      : [];
+  });
+  if (connectorIds.length === 0) {
     return result;
   }
 
@@ -1262,7 +1284,7 @@ async function loadConnectorAccessStates(
         eq(connectors.orgId, orgId),
         eq(connectors.userId, userId),
         isNotNull(connectors.connectorSlug),
-        inArray(connectors.connectorSlug, [...connectorSlugs]),
+        inArray(connectors.id, connectorIds),
       ),
     );
 
@@ -1573,7 +1595,10 @@ async function loadCurrentSourceStateSnapshot(args: {
     args.db,
     args.orgId,
     args.userId,
-    connectorSlugs,
+    builtinConnectorAccountRequestsForMetadata({
+      connectorSlugs,
+      metadataByAccessSource: args.metadataByAccessSource,
+    }),
     args.connectorCatalogSnapshot,
   );
   return {
@@ -2047,6 +2072,11 @@ async function loadConnectorRefreshStateRow(
   lockRow: boolean,
 ): Promise<RefreshStateRow | null> {
   const connectorSlug = args.accessSourceKey;
+  const connectorId =
+    args.connectorAccessBySlug.get(connectorSlug)?.connectorId;
+  if (connectorId === undefined) {
+    return null;
+  }
   const query = db
     .select({
       authMethod: connectors.authMethod,
@@ -2065,6 +2095,7 @@ async function loadConnectorRefreshStateRow(
       and(
         eq(connectors.orgId, args.orgId),
         eq(connectors.userId, args.userId),
+        eq(connectors.id, connectorId),
         eq(connectors.connectorSlug, connectorSlug),
       ),
     );
@@ -2364,6 +2395,11 @@ async function markRefreshFailure(
   }
 
   const connectorSlug = args.accessSourceKey;
+  const connectorId =
+    args.connectorAccessBySlug.get(connectorSlug)?.connectorId;
+  if (connectorId === undefined) {
+    return;
+  }
   await args.db
     .update(connectors)
     .set(
@@ -2379,6 +2415,7 @@ async function markRefreshFailure(
       and(
         eq(connectors.orgId, args.orgId),
         eq(connectors.userId, args.userId),
+        eq(connectors.id, connectorId),
         eq(connectors.connectorSlug, connectorSlug),
       ),
     );
@@ -3616,6 +3653,79 @@ function firewallAuthReferencedConnectorSlugs(args: {
   ];
 }
 
+function builtinConnectorAccountRequestsForMetadata(args: {
+  readonly connectorSlugs: readonly string[];
+  readonly metadataByAccessSource: ReadonlyMap<string, SecretConnectorMetadata>;
+}): readonly ConnectorAccountResolutionRequest[] {
+  return args.connectorSlugs.map((connectorSlug) => {
+    const metadata = resolveRefreshMetadata(
+      connectorSlug,
+      args.metadataByAccessSource.get(connectorSlug),
+    );
+    return {
+      target: { kind: "builtin", connectorSlug },
+      selection:
+        metadata.sourceId === undefined
+          ? { kind: "legacy-singleton" }
+          : { kind: "exact", sourceId: metadata.sourceId },
+    };
+  });
+}
+
+function builtinConnectorSourceIdsForFirewall(args: {
+  readonly body: FirewallAuthBody;
+  readonly referencedSecretKeys: ReadonlySet<string>;
+  readonly connectorSlug: string;
+}): ReadonlySet<string> {
+  const sourceIds = new Set<string>();
+  const matchedFirewall = args.body.matchedFirewall;
+  if (
+    matchedFirewall?.connectorSlug === args.connectorSlug &&
+    matchedFirewall.sourceId !== undefined
+  ) {
+    sourceIds.add(matchedFirewall.sourceId);
+  }
+  for (const key of args.referencedSecretKeys) {
+    const accessSourceKey = args.body.secretConnectorMap?.[key];
+    if (accessSourceKey !== args.connectorSlug) {
+      continue;
+    }
+    const metadata = resolveRefreshMetadata(
+      accessSourceKey,
+      args.body.secretConnectorMetadataMap?.[key],
+    );
+    if (
+      metadata.sourceType === "connector" &&
+      metadata.sourceId !== undefined
+    ) {
+      sourceIds.add(metadata.sourceId);
+    }
+  }
+  return sourceIds;
+}
+
+function builtinConnectorAccountRequestsForFirewall(args: {
+  readonly body: FirewallAuthBody;
+  readonly referencedSecretKeys: ReadonlySet<string>;
+}): readonly ConnectorAccountResolutionRequest[] {
+  return firewallAuthReferencedConnectorSlugs({
+    body: args.body,
+    referencedSecretKeys: new Set(args.referencedSecretKeys),
+  }).map((connectorSlug) => {
+    const [sourceId] = builtinConnectorSourceIdsForFirewall({
+      ...args,
+      connectorSlug,
+    });
+    return {
+      target: { kind: "builtin", connectorSlug },
+      selection:
+        sourceId === undefined
+          ? { kind: "legacy-singleton" }
+          : { kind: "exact", sourceId },
+    };
+  });
+}
+
 function matchedBuiltinConnectorVariableAliases(args: {
   readonly connectorSlug: ConnectorSlug | undefined;
   readonly connectorAccessBySlug: ReadonlyMap<string, ConnectorAccessState>;
@@ -3681,7 +3791,7 @@ async function prepareFirewallAuthResolutionContext(args: {
     args.db,
     args.orgId,
     args.auth.userId,
-    firewallAuthReferencedConnectorSlugs({
+    builtinConnectorAccountRequestsForFirewall({
       body: args.body,
       referencedSecretKeys: referenced.secrets,
     }),
@@ -4294,7 +4404,10 @@ async function refreshExpiredTokens(
           args.db,
           args.orgId,
           args.auth.userId,
-          connectorSlugs,
+          builtinConnectorAccountRequestsForMetadata({
+            connectorSlugs,
+            metadataByAccessSource,
+          }),
           args.connectorCatalogSnapshot,
         )),
       ])
@@ -4529,14 +4642,14 @@ function hasEmptyAwsSigv4Credential(
 type CurrentCustomConnectorAuthRef =
   | {
       readonly secretName: string;
-      readonly connectorId: string;
+      readonly memberConnectorId: string;
       readonly kind: "secret";
       readonly key: string;
       readonly encryptedValue: string | null;
     }
   | {
       readonly secretName: string;
-      readonly connectorId: string;
+      readonly memberConnectorId: string;
       readonly kind: "variable";
       readonly key: string;
       readonly value: string | null;
@@ -4550,16 +4663,56 @@ type CurrentCustomConnectorAuthRefsResolution =
     }
   | { readonly kind: "unavailable" };
 
+async function resolveCurrentCustomConnectorMemberId(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly customConnectorId: string;
+  readonly sourceId?: string;
+}): Promise<string | undefined> {
+  const target = {
+    kind: "custom" as const,
+    customConnectorId: args.customConnectorId,
+  };
+  const accountResolutions = await resolveConnectorAccounts(args.db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    requests: [
+      {
+        target,
+        selection:
+          args.sourceId === undefined
+            ? { kind: "legacy-singleton" }
+            : { kind: "exact", sourceId: args.sourceId },
+      },
+    ],
+  });
+  const accountResolution = accountResolutions.get(
+    connectorAccountTargetKey(target),
+  );
+  return accountResolution?.kind === "resolved"
+    ? accountResolution.account.connectorId
+    : undefined;
+}
+
 async function loadCurrentCustomConnectorAuthRefs(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
   readonly customConnectorId: string;
+  readonly sourceId?: string;
 }): Promise<CurrentCustomConnectorAuthRefsResolution> {
+  const memberConnectorId = await resolveCurrentCustomConnectorMemberId(args);
+  if (memberConnectorId === undefined) {
+    return { kind: "unavailable" };
+  }
   const [runtime] = await loadCustomConnectorRuntimeData(args.db, {
     orgId: args.orgId,
     userId: args.userId,
     connectorIds: [args.customConnectorId],
+    memberConnectorIdsByCustomConnectorId: new Map([
+      [args.customConnectorId, memberConnectorId],
+    ]),
   });
   if (!runtime) {
     return { kind: "unavailable" };
@@ -4568,6 +4721,9 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
     return { kind: "unavailable" };
   }
   if (runtime.credentialAccess.kind === "absent") {
+    return { kind: "unavailable" };
+  }
+  if (runtime.credentialAccess.memberConnectorId !== memberConnectorId) {
     return { kind: "unavailable" };
   }
 
@@ -4599,14 +4755,14 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
       value.kind === "secret"
         ? {
             secretName,
-            connectorId: runtime.connector.id,
+            memberConnectorId,
             kind: "secret",
             key: value.key,
             encryptedValue: value.encryptedValue,
           }
         : {
             secretName,
-            connectorId: runtime.connector.id,
+            memberConnectorId,
             kind: "variable",
             key: value.key,
             value: value.value,
@@ -4622,14 +4778,14 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
       field.kind === "secret"
         ? {
             secretName,
-            connectorId: runtime.connector.id,
+            memberConnectorId,
             kind: "secret",
             key: field.key,
             encryptedValue: null,
           }
         : {
             secretName,
-            connectorId: runtime.connector.id,
+            memberConnectorId,
             kind: "variable",
             key: field.key,
             value: null,
@@ -4644,7 +4800,7 @@ async function loadCurrentCustomConnectorAuthRefs(args: {
     });
     refs.set(secretName, {
       secretName,
-      connectorId: runtime.connector.id,
+      memberConnectorId,
       kind: "secret",
       key: CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_RUNTIME_KEY,
       encryptedValue: null,
@@ -4686,6 +4842,7 @@ async function prepareCurrentCustomConnectorFirewallAuth(args: {
   readonly orgId: string;
   readonly referenced: ReferencedAuthKeys;
   readonly customConnectorId: string;
+  readonly sourceId?: string;
   readonly routingVariables: Record<string, string>;
 }): Promise<FirewallAuthPreparation<PreparedCustomFirewallAuth>> {
   // The trusted host already matched this request against its effective
@@ -4697,6 +4854,7 @@ async function prepareCurrentCustomConnectorFirewallAuth(args: {
     orgId: args.orgId,
     userId: args.auth.userId,
     customConnectorId: args.customConnectorId,
+    ...(args.sourceId === undefined ? {} : { sourceId: args.sourceId }),
   });
   if (authRefsResolution.kind === "unavailable") {
     return { ok: false, response: connectorNotConfigured() };
@@ -4807,7 +4965,8 @@ async function resolveCurrentCustomConnectorSecrets(args: {
           db: args.db,
           orgId: args.auth.orgId,
           userId: args.auth.userId,
-          connectorId: ref.connectorId,
+          customConnectorId: args.prepared.customConnectorId,
+          memberConnectorId: ref.memberConnectorId,
           featureContext: args.prepared.featureSwitchContext,
           forceRefresh: args.forceRefresh,
         },
@@ -4831,7 +4990,7 @@ async function resolveCurrentCustomConnectorSecrets(args: {
       ? Math.floor(accessToken.value.tokenExpiresAt.getTime() / 1000)
       : null;
     if (accessToken.value.status === "refreshed") {
-      refreshedConnectors.push(ref.connectorId);
+      refreshedConnectors.push(args.prepared.customConnectorId);
       refreshedSecrets.push(alias);
     }
     currentSecrets[alias] = await decryptStoredSecretValue(
@@ -5127,28 +5286,15 @@ function matchedConnectorSourceConflicts(args: {
   readonly body: FirewallAuthBody;
   readonly referencedSecretKeys: ReadonlySet<string>;
 }): boolean {
-  const matchedFirewall = args.body.matchedFirewall;
-  if (
-    matchedFirewall?.connectorSlug === undefined ||
-    matchedFirewall.sourceId === undefined
-  ) {
-    return false;
-  }
-  const connectorSlug = matchedFirewall.connectorSlug;
-  const sourceId = matchedFirewall.sourceId;
-  return [...args.referencedSecretKeys].some((key) => {
-    const accessSourceKey = args.body.secretConnectorMap?.[key];
-    if (accessSourceKey !== connectorSlug) {
-      return false;
-    }
-    const metadata = resolveRefreshMetadata(
-      accessSourceKey,
-      args.body.secretConnectorMetadataMap?.[key],
-    );
+  return firewallAuthReferencedConnectorSlugs({
+    body: args.body,
+    referencedSecretKeys: new Set(args.referencedSecretKeys),
+  }).some((connectorSlug) => {
     return (
-      metadata.sourceType === "connector" &&
-      metadata.sourceId !== undefined &&
-      metadata.sourceId !== sourceId
+      builtinConnectorSourceIdsForFirewall({
+        ...args,
+        connectorSlug,
+      }).size > 1
     );
   });
 }
@@ -5193,6 +5339,9 @@ export async function resolveFirewallAuth(
         orgId,
         referenced,
         customConnectorId,
+        ...(matchedFirewall.sourceId === undefined
+          ? {}
+          : { sourceId: matchedFirewall.sourceId }),
         routingVariables: matchedFirewall.routingVariables,
       })
     : await prepareNonCustomFirewallAuth({

--- a/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
@@ -1,0 +1,390 @@
+import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/connector-accounts";
+import { connectors } from "@okouai/db/schema/connector";
+import {
+  and,
+  eq,
+  inArray,
+  isNotNull,
+  lte,
+  or,
+  sql,
+  type SQL,
+} from "drizzle-orm";
+
+import { pgIntegerDecoder } from "../../lib/db-structured-result";
+import { logger } from "../../lib/log";
+import type { ReadonlyDb } from "../external/db";
+
+const L = logger("connector-account-resolution");
+
+export type ConnectorAccountSelectionMode =
+  | { readonly kind: "exact"; readonly sourceId: string }
+  | { readonly kind: "default" }
+  | { readonly kind: "legacy-singleton" };
+
+export interface ConnectorAccountResolutionRequest {
+  readonly target: ConnectorAccountTarget;
+  readonly selection: ConnectorAccountSelectionMode;
+}
+
+interface ResolvedConnectorAccount {
+  readonly authMethod: string;
+  readonly connectorId: string;
+  readonly storageVersion: number;
+  readonly target: ConnectorAccountTarget;
+}
+
+type ConnectorAccountResolution =
+  | {
+      readonly kind: "resolved";
+      readonly account: ResolvedConnectorAccount;
+    }
+  | { readonly kind: "missing" }
+  | { readonly kind: "mismatch" }
+  | { readonly kind: "missing-default" }
+  | { readonly kind: "ambiguous" };
+
+interface ConnectorAccountIdentityRow {
+  readonly authMethod: string;
+  readonly connectorId: string;
+  readonly connectorSlug: string | null;
+  readonly customConnectorId: string | null;
+  readonly storageVersion: number;
+}
+
+export function connectorAccountTargetKey(
+  target: ConnectorAccountTarget,
+): string {
+  return target.kind === "builtin"
+    ? `builtin:${target.connectorSlug}`
+    : `custom:${target.customConnectorId}`;
+}
+
+function connectorAccountTargetFromRow(
+  row: ConnectorAccountIdentityRow,
+): ConnectorAccountTarget {
+  if (row.connectorSlug !== null && row.customConnectorId === null) {
+    return { kind: "builtin", connectorSlug: row.connectorSlug };
+  }
+  if (row.customConnectorId !== null && row.connectorSlug === null) {
+    return { kind: "custom", customConnectorId: row.customConnectorId };
+  }
+  throw new Error("Expected exactly one connector account target");
+}
+
+function selectionModesMatch(
+  left: ConnectorAccountSelectionMode,
+  right: ConnectorAccountSelectionMode,
+): boolean {
+  return (
+    left.kind === right.kind &&
+    (left.kind !== "exact" ||
+      (right.kind === "exact" && left.sourceId === right.sourceId))
+  );
+}
+
+function normalizeRequests(
+  requests: readonly ConnectorAccountResolutionRequest[],
+): ReadonlyMap<string, ConnectorAccountResolutionRequest> {
+  const normalized = new Map<string, ConnectorAccountResolutionRequest>();
+  for (const request of requests) {
+    const key = connectorAccountTargetKey(request.target);
+    const existing = normalized.get(key);
+    if (
+      existing &&
+      !selectionModesMatch(existing.selection, request.selection)
+    ) {
+      throw new Error(
+        "Conflicting connector account selections for one target",
+      );
+    }
+    normalized.set(key, request);
+  }
+  return normalized;
+}
+
+function targetCondition(
+  targets: readonly ConnectorAccountTarget[],
+): SQL | undefined {
+  const connectorSlugs = targets.flatMap((target) => {
+    return target.kind === "builtin" ? [target.connectorSlug] : [];
+  });
+  const customConnectorIds = targets.flatMap((target) => {
+    return target.kind === "custom" ? [target.customConnectorId] : [];
+  });
+  return or(
+    connectorSlugs.length > 0
+      ? and(
+          isNotNull(connectors.connectorSlug),
+          inArray(connectors.connectorSlug, connectorSlugs),
+        )
+      : undefined,
+    customConnectorIds.length > 0
+      ? and(
+          isNotNull(connectors.customConnectorId),
+          inArray(connectors.customConnectorId, customConnectorIds),
+        )
+      : undefined,
+  );
+}
+
+function identitySelection() {
+  return {
+    authMethod: connectors.authMethod,
+    connectorId: connectors.id,
+    connectorSlug: connectors.connectorSlug,
+    customConnectorId: connectors.customConnectorId,
+    storageVersion: connectors.storageVersion,
+  };
+}
+
+async function loadExactRows(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly requests: readonly ConnectorAccountResolutionRequest[];
+  },
+): Promise<readonly ConnectorAccountIdentityRow[]> {
+  const sourceIds = args.requests.flatMap((request) => {
+    return request.selection.kind === "exact"
+      ? [request.selection.sourceId]
+      : [];
+  });
+  if (sourceIds.length === 0) {
+    return [];
+  }
+  return await db
+    .select(identitySelection())
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        inArray(connectors.id, sourceIds),
+      ),
+    );
+}
+
+async function loadDefaultRows(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly requests: readonly ConnectorAccountResolutionRequest[];
+  },
+): Promise<readonly ConnectorAccountIdentityRow[]> {
+  const targets = args.requests.flatMap((request) => {
+    return request.selection.kind === "default" ? [request.target] : [];
+  });
+  if (targets.length === 0) {
+    return [];
+  }
+  return await db
+    .select(identitySelection())
+    .from(connectors)
+    .where(
+      and(
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        eq(connectors.isDefault, true),
+        targetCondition(targets),
+      ),
+    );
+}
+
+async function loadLegacyRows(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly requests: readonly ConnectorAccountResolutionRequest[];
+  },
+): Promise<readonly ConnectorAccountIdentityRow[]> {
+  const targets = args.requests.flatMap((request) => {
+    return request.selection.kind === "legacy-singleton"
+      ? [request.target]
+      : [];
+  });
+  if (targets.length === 0) {
+    return [];
+  }
+  const ranked = db.$with("legacy_connector_account_candidates").as(
+    db
+      .select({
+        ...identitySelection(),
+        selectionRank: sql`row_number() over (
+            partition by ${connectors.connectorSlug}, ${connectors.customConnectorId}
+            order by ${connectors.id}
+          )::integer`
+          .mapWith(pgIntegerDecoder)
+          .as("selection_rank"),
+      })
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          targetCondition(targets),
+        ),
+      ),
+  );
+  return await db
+    .with(ranked)
+    .select({
+      authMethod: ranked.authMethod,
+      connectorId: ranked.connectorId,
+      connectorSlug: ranked.connectorSlug,
+      customConnectorId: ranked.customConnectorId,
+      storageVersion: ranked.storageVersion,
+    })
+    .from(ranked)
+    .where(lte(ranked.selectionRank, 2));
+}
+
+function rowsByTarget(
+  rows: readonly ConnectorAccountIdentityRow[],
+): ReadonlyMap<string, readonly ConnectorAccountIdentityRow[]> {
+  const grouped = new Map<string, ConnectorAccountIdentityRow[]>();
+  for (const row of rows) {
+    const key = connectorAccountTargetKey(connectorAccountTargetFromRow(row));
+    const values = grouped.get(key) ?? [];
+    values.push(row);
+    grouped.set(key, values);
+  }
+  return grouped;
+}
+
+function resolved(
+  row: ConnectorAccountIdentityRow,
+): ConnectorAccountResolution {
+  return {
+    kind: "resolved",
+    account: {
+      authMethod: row.authMethod,
+      connectorId: row.connectorId,
+      storageVersion: row.storageVersion,
+      target: connectorAccountTargetFromRow(row),
+    },
+  };
+}
+
+export async function resolveConnectorAccounts(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly requests: readonly ConnectorAccountResolutionRequest[];
+  },
+): Promise<ReadonlyMap<string, ConnectorAccountResolution>> {
+  const requests = normalizeRequests(args.requests);
+  if (requests.size === 0) {
+    return new Map();
+  }
+  const normalizedRequests = [...requests.values()];
+  const [exactRows, defaultRows, legacyRows] = await Promise.all([
+    loadExactRows(db, { ...args, requests: normalizedRequests }),
+    loadDefaultRows(db, { ...args, requests: normalizedRequests }),
+    loadLegacyRows(db, { ...args, requests: normalizedRequests }),
+  ]);
+  const exactById = new Map(
+    exactRows.map((row) => {
+      return [row.connectorId, row] as const;
+    }),
+  );
+  const defaultByTarget = rowsByTarget(defaultRows);
+  const legacyByTarget = rowsByTarget(legacyRows);
+  const resolutions = new Map<string, ConnectorAccountResolution>();
+  for (const [key, request] of requests) {
+    if (request.selection.kind === "exact") {
+      const row = exactById.get(request.selection.sourceId);
+      resolutions.set(
+        key,
+        !row
+          ? { kind: "missing" }
+          : connectorAccountTargetKey(connectorAccountTargetFromRow(row)) ===
+              key
+            ? resolved(row)
+            : { kind: "mismatch" },
+      );
+      continue;
+    }
+    const rows =
+      request.selection.kind === "default"
+        ? defaultByTarget.get(key)
+        : legacyByTarget.get(key);
+    if (!rows || rows.length === 0) {
+      resolutions.set(
+        key,
+        request.selection.kind === "default"
+          ? { kind: "missing-default" }
+          : { kind: "missing" },
+      );
+    } else if (rows.length > 1) {
+      resolutions.set(key, { kind: "ambiguous" });
+    } else {
+      const [row] = rows;
+      if (!row) {
+        throw new Error("Expected one resolved connector account");
+      }
+      resolutions.set(key, resolved(row));
+    }
+  }
+  const outcomeCounts = {
+    resolved: 0,
+    missing: 0,
+    mismatch: 0,
+    missingDefault: 0,
+    ambiguous: 0,
+  };
+  for (const resolution of resolutions.values()) {
+    switch (resolution.kind) {
+      case "resolved": {
+        outcomeCounts.resolved += 1;
+        break;
+      }
+      case "missing": {
+        outcomeCounts.missing += 1;
+        break;
+      }
+      case "mismatch": {
+        outcomeCounts.mismatch += 1;
+        break;
+      }
+      case "missing-default": {
+        outcomeCounts.missingDefault += 1;
+        break;
+      }
+      case "ambiguous": {
+        outcomeCounts.ambiguous += 1;
+        break;
+      }
+    }
+  }
+  L.debug("Resolved connector accounts", {
+    requestCount: requests.size,
+    exactRequestCount: normalizedRequests.filter((request) => {
+      return request.selection.kind === "exact";
+    }).length,
+    defaultRequestCount: normalizedRequests.filter((request) => {
+      return request.selection.kind === "default";
+    }).length,
+    legacyRequestCount: normalizedRequests.filter((request) => {
+      return request.selection.kind === "legacy-singleton";
+    }).length,
+    ...outcomeCounts,
+  });
+  return resolutions;
+}
+
+export function resolvedConnectorAccountIdsByTarget(
+  resolutions: ReadonlyMap<string, ConnectorAccountResolution>,
+): ReadonlyMap<string, string> {
+  const resolved = new Map<string, string>();
+  for (const [targetKey, resolution] of resolutions) {
+    if (resolution.kind === "resolved") {
+      resolved.set(targetKey, resolution.account.connectorId);
+    }
+  }
+  return resolved;
+}

--- a/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
@@ -20,6 +20,8 @@ const L = logger("connector-account-resolution");
 export type ConnectorAccountSelectionMode =
   | { readonly kind: "exact"; readonly sourceId: string }
   | { readonly kind: "default" }
+  // Compatibility for source-less Runner and firewall payloads. Remove in
+  // #27695 after every run admitted before source propagation has drained.
   | { readonly kind: "legacy-singleton" };
 
 export interface ConnectorAccountResolutionRequest {

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -22,6 +22,12 @@ import { loadConnectorRuntimeSnapshot } from "./connector-catalog-runtime.servic
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { resolveActiveNetworkPolicyRefreshes } from "./user-permission-grants.service";
 import { loadCustomConnectorRuntimeData } from "./custom-connector.service";
+import {
+  connectorAccountTargetKey,
+  resolveConnectorAccounts,
+  resolvedConnectorAccountIdsByTarget,
+} from "./connector-account-resolution.service";
+import { resolveConnectorCredentialAccess } from "./connector-credential-access.service";
 
 const L = logger("connector-runtime-sync");
 
@@ -71,10 +77,49 @@ function builtinUnresolvedResult(
 async function loadCustomSnapshot(args: {
   readonly db: Db;
   readonly scope: ConnectorRuntimeScope;
-  readonly customConnectorIds: readonly string[];
+  readonly registrations: readonly Extract<
+    ConnectorRuntimeTargetRegistration,
+    { readonly kind: "custom" }
+  >[];
 }) {
   return await args.db.transaction(
     async (tx) => {
+      const customConnectorIds = args.registrations.map((registration) => {
+        return registration.customConnectorId;
+      });
+      const accountResolutions = await resolveConnectorAccounts(tx, {
+        orgId: args.scope.orgId,
+        userId: args.scope.userId,
+        requests: args.registrations.map((registration) => {
+          return {
+            target: {
+              kind: "custom" as const,
+              customConnectorId: registration.customConnectorId,
+            },
+            selection:
+              registration.sourceId === undefined
+                ? { kind: "legacy-singleton" as const }
+                : {
+                    kind: "exact" as const,
+                    sourceId: registration.sourceId,
+                  },
+          };
+        }),
+      });
+      const resolvedAccountIds =
+        resolvedConnectorAccountIdsByTarget(accountResolutions);
+      const memberConnectorIdsByCustomConnectorId = new Map<string, string>();
+      for (const customConnectorId of customConnectorIds) {
+        const memberConnectorId = resolvedAccountIds.get(
+          connectorAccountTargetKey({ kind: "custom", customConnectorId }),
+        );
+        if (memberConnectorId) {
+          memberConnectorIdsByCustomConnectorId.set(
+            customConnectorId,
+            memberConnectorId,
+          );
+        }
+      }
       const connectorCatalogSnapshot = await loadConnectorRuntimeSnapshot(tx);
       const featureSwitchContext = await loadUserFeatureSwitchContext(
         tx,
@@ -84,7 +129,8 @@ async function loadCustomSnapshot(args: {
       const runtimeRows = await loadCustomConnectorRuntimeData(tx, {
         orgId: args.scope.orgId,
         userId: args.scope.userId,
-        connectorIds: args.customConnectorIds,
+        connectorIds: customConnectorIds,
+        memberConnectorIdsByCustomConnectorId,
       });
       const grantRows = await tx
         .select({
@@ -97,10 +143,7 @@ async function loadCustomSnapshot(args: {
             eq(userCustomConnectors.orgId, args.scope.orgId),
             eq(userCustomConnectors.userId, args.scope.userId),
             eq(userCustomConnectors.agentId, args.scope.agentId),
-            inArray(
-              userCustomConnectors.customConnectorId,
-              args.customConnectorIds,
-            ),
+            inArray(userCustomConnectors.customConnectorId, customConnectorIds),
           ),
         );
       const grants = new Map(
@@ -125,6 +168,7 @@ async function loadCustomSnapshot(args: {
         connectorCatalogSnapshot,
         featureSwitchContext,
         customTargets,
+        accountResolutions,
       };
     },
     { isolationLevel: "repeatable read", accessMode: "read only" },
@@ -142,12 +186,17 @@ async function resolveCustomTarget(args: {
     kind: "custom" as const,
     customConnectorId: args.registration.customConnectorId,
   };
+  const accountResolution = args.snapshot.accountResolutions.get(
+    connectorAccountTargetKey(target),
+  );
+  if (accountResolution?.kind !== "resolved") {
+    return customAbsentResult(target, "connector-unavailable");
+  }
   const custom = args.snapshot.customTargets.get(target.customConnectorId);
   if (!custom) {
     return customAbsentResult(target, "connector-unavailable");
   }
   if (custom.row.credentialAccess.kind === "incompatible") {
-    // Credential compatibility gates auth resolution, not definition-owned policy.
     L.debug("Custom connector credential storage is incompatible", {
       customConnectorId: target.customConnectorId,
       memberConnectorId: custom.row.credentialAccess.memberConnectorId,
@@ -160,6 +209,10 @@ async function resolveCustomTarget(args: {
       definitionStorageVersion:
         custom.row.credentialAccess.definitionStorageVersion,
     });
+    return customAbsentResult(target, "connector-unavailable");
+  }
+  if (custom.row.credentialAccess.kind === "absent") {
+    return customAbsentResult(target, "connector-unavailable");
   }
   const row = custom.row;
   const permissionBundle = await loadEffectiveCustomConnectorPermissionBundle({
@@ -204,9 +257,7 @@ async function resolveCustomTarget(args: {
     state: "available" as const,
     firewall: {
       ...state.firewall,
-      ...(args.registration.sourceId === undefined
-        ? {}
-        : { sourceId: args.registration.sourceId }),
+      sourceId: accountResolution.account.connectorId,
     },
     networkPolicy: state.networkPolicy,
     baseUrlVars: { ...resolvedTarget.baseUrlVars },
@@ -221,23 +272,52 @@ export async function resolveConnectorRuntimeTargets(args: {
   const builtinConnectorSlugs = args.targets.flatMap((target) => {
     return target.kind === "builtin" ? [target.connectorSlug] : [];
   });
-  const customConnectorIds = args.targets.flatMap((target) => {
-    return target.kind === "custom" ? [target.customConnectorId] : [];
+  const customRegistrations = args.targets.flatMap((target) => {
+    return target.kind === "custom" ? [target] : [];
   });
-  const [builtinRefreshes, customSnapshot] = await Promise.all([
-    resolveActiveNetworkPolicyRefreshes(
-      args.db,
-      args.scope,
-      builtinConnectorSlugs,
-    ),
-    customConnectorIds.length > 0
-      ? loadCustomSnapshot({
-          db: args.db,
-          scope: args.scope,
-          customConnectorIds,
-        })
-      : undefined,
-  ]);
+  const builtinCatalogSnapshot =
+    builtinConnectorSlugs.length > 0
+      ? await loadConnectorRuntimeSnapshot(args.db)
+      : undefined;
+  const [builtinRefreshes, builtinAccountResolutions, customSnapshot] =
+    await Promise.all([
+      resolveActiveNetworkPolicyRefreshes(
+        args.db,
+        args.scope,
+        builtinConnectorSlugs,
+        builtinCatalogSnapshot,
+      ),
+      resolveConnectorAccounts(args.db, {
+        orgId: args.scope.orgId,
+        userId: args.scope.userId,
+        requests: args.targets.flatMap((registration) => {
+          return registration.kind === "builtin"
+            ? [
+                {
+                  target: {
+                    kind: "builtin" as const,
+                    connectorSlug: registration.connectorSlug,
+                  },
+                  selection:
+                    registration.sourceId === undefined
+                      ? { kind: "legacy-singleton" as const }
+                      : {
+                          kind: "exact" as const,
+                          sourceId: registration.sourceId,
+                        },
+                },
+              ]
+            : [];
+        }),
+      }),
+      customRegistrations.length > 0
+        ? loadCustomSnapshot({
+            db: args.db,
+            scope: args.scope,
+            registrations: customRegistrations,
+          })
+        : undefined,
+    ]);
   const builtinByTarget = new Map(
     builtinRefreshes.map((refresh) => {
       return [
@@ -265,9 +345,26 @@ export async function resolveConnectorRuntimeTargets(args: {
       kind: "builtin" as const,
       connectorSlug: registration.connectorSlug,
     };
+    const accountResolution = builtinAccountResolutions.get(
+      connectorAccountTargetKey(target),
+    );
+    const credentialAccess =
+      accountResolution?.kind === "resolved" && builtinCatalogSnapshot
+        ? resolveConnectorCredentialAccess({
+            snapshot: builtinCatalogSnapshot,
+            stored: {
+              authMethodId: accountResolution.account.authMethod,
+              connectorId: accountResolution.account.connectorId,
+              connectorSlug: registration.connectorSlug,
+              orgId: args.scope.orgId,
+              storageVersion: accountResolution.account.storageVersion,
+              userId: args.scope.userId,
+            },
+          })
+        : undefined;
     const refresh = builtinByTarget.get(connectorRuntimeTargetKey(target));
     results.push(
-      refresh
+      refresh && credentialAccess?.kind === "ok"
         ? {
             target,
             state: "available",
@@ -286,7 +383,7 @@ export async function resolveConnectorRuntimeTargets(args: {
   L.debug("Resolved connector runtime targets", {
     targetCount: args.targets.length,
     builtinTargetCount: builtinConnectorSlugs.length,
-    customTargetCount: customConnectorIds.length,
+    customTargetCount: customRegistrations.length,
     availableCount: stateCounts.available,
     absentCount: stateCounts.absent,
     unresolvedCount: stateCounts.unresolved,

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -120,6 +120,7 @@ function customConnectorStoredConnectionsQuery(
     readonly orgId: string;
     readonly userId: string;
     readonly connectorIds?: readonly string[];
+    readonly memberConnectorIds?: readonly string[];
   },
 ) {
   return db
@@ -189,6 +190,9 @@ function customConnectorStoredConnectionsQuery(
         eq(connectors.userId, args.userId),
         args.connectorIds
           ? inArray(connectors.customConnectorId, [...args.connectorIds])
+          : undefined,
+        args.memberConnectorIds
+          ? inArray(connectors.id, [...args.memberConnectorIds])
           : undefined,
       ),
     );
@@ -260,20 +264,23 @@ function currentCustomConnectorStoredConnectionIsRuntimeAvailable(
 function customConnectorCredentialAccesses(
   definitions: readonly CustomConnectorCredentialDefinition[],
   rows: readonly CustomConnectorStoredConnection[],
+  memberConnectorIdsByCustomConnectorId: ReadonlyMap<string, string>,
 ): ReadonlyMap<string, CustomConnectorCredentialAccess> {
-  const memberByConnectorId = new Map<
-    string,
-    CustomConnectorStoredConnection
-  >();
+  const memberById = new Map<string, CustomConnectorStoredConnection>();
   for (const row of rows) {
-    memberByConnectorId.set(row.customConnectorId, row);
+    memberById.set(row.id, row);
   }
 
   const accesses = new Map<string, CustomConnectorCredentialAccess>();
   const now = nowDate();
   for (const definition of definitions) {
-    const member = memberByConnectorId.get(definition.id);
-    if (!member) {
+    const memberConnectorId = memberConnectorIdsByCustomConnectorId.get(
+      definition.id,
+    );
+    const member = memberConnectorId
+      ? memberById.get(memberConnectorId)
+      : undefined;
+    if (!member || member.customConnectorId !== definition.id) {
       accesses.set(definition.id, { kind: "absent" });
     } else if (
       member.definitionAuthMethod === definition.authMode &&
@@ -305,14 +312,17 @@ function customConnectorCredentialAccesses(
 function customConnectorRuntimeStorageSnapshot(
   definitions: readonly CustomConnectorCredentialDefinition[],
   rows: readonly CustomConnectorRuntimeStorageRow[],
+  memberConnectorIdsByCustomConnectorId: ReadonlyMap<string, string>,
 ): CustomConnectorRuntimeStorageSnapshot {
   const connectionsById = new Map<string, CustomConnectorStoredConnection>();
   for (const row of rows) {
     connectionsById.set(row.id, row);
   }
-  const accesses = customConnectorCredentialAccesses(definitions, [
-    ...connectionsById.values(),
-  ]);
+  const accesses = customConnectorCredentialAccesses(
+    definitions,
+    [...connectionsById.values()],
+    memberConnectorIdsByCustomConnectorId,
+  );
   const expectedByMemberConnectorId = new Map(
     definitions.flatMap((definition) => {
       const access = accesses.get(definition.id);
@@ -462,6 +472,7 @@ export async function loadCurrentCustomConnectorStoredValues(
     readonly orgId: string;
     readonly userId: string;
     readonly definitions: readonly CustomConnectorCredentialDefinition[];
+    readonly memberConnectorIdsByCustomConnectorId: ReadonlyMap<string, string>;
   },
 ): Promise<CustomConnectorRuntimeStorageSnapshot> {
   if (args.definitions.length === 0) {
@@ -471,11 +482,25 @@ export async function loadCurrentCustomConnectorStoredValues(
   const connectorIds = args.definitions.map((definition) => {
     return definition.id;
   });
+  const memberConnectorIds = args.definitions.flatMap((definition) => {
+    const memberConnectorId = args.memberConnectorIdsByCustomConnectorId.get(
+      definition.id,
+    );
+    return memberConnectorId ? [memberConnectorId] : [];
+  });
+  if (memberConnectorIds.length === 0) {
+    return customConnectorRuntimeStorageSnapshot(
+      args.definitions,
+      [],
+      args.memberConnectorIdsByCustomConnectorId,
+    );
+  }
   const storedConnections = db.$with("custom_connector_runtime_connections").as(
     customConnectorStoredConnectionsQuery(db, {
       orgId: args.orgId,
       userId: args.userId,
       connectorIds,
+      memberConnectorIds,
     }),
   );
   const secretQuery = db
@@ -559,7 +584,11 @@ export async function loadCurrentCustomConnectorStoredValues(
       storedValues,
       eq(storedValues.memberConnectorId, storedConnections.id),
     );
-  return customConnectorRuntimeStorageSnapshot(args.definitions, rows);
+  return customConnectorRuntimeStorageSnapshot(
+    args.definitions,
+    rows,
+    args.memberConnectorIdsByCustomConnectorId,
+  );
 }
 
 export async function loadConnectedCustomConnectorConnections(

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -821,7 +821,8 @@ async function loadConnection(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly connectorId: string;
+  readonly customConnectorId: string;
+  readonly memberConnectorId: string;
   readonly storageVersion: number;
   readonly lockRow?: boolean;
 }): Promise<StoredConnection | null> {
@@ -834,7 +835,8 @@ async function loadConnection(args: {
     .from(connectors)
     .where(
       and(
-        eq(connectors.customConnectorId, args.connectorId),
+        eq(connectors.id, args.memberConnectorId),
+        eq(connectors.customConnectorId, args.customConnectorId),
         eq(connectors.orgId, args.orgId),
         eq(connectors.userId, args.userId),
         eq(connectors.authMethod, "oauth"),
@@ -845,7 +847,7 @@ async function loadConnection(args: {
             .from(orgCustomConnectors)
             .where(
               and(
-                eq(orgCustomConnectors.id, args.connectorId),
+                eq(orgCustomConnectors.id, args.customConnectorId),
                 eq(orgCustomConnectors.orgId, args.orgId),
                 eq(orgCustomConnectors.authMode, "oauth"),
                 eq(orgCustomConnectors.storageVersion, args.storageVersion),
@@ -882,7 +884,7 @@ async function loadConnection(args: {
     .where(
       and(
         eq(connectors.id, connection.id),
-        eq(connectors.customConnectorId, args.connectorId),
+        eq(connectors.customConnectorId, args.customConnectorId),
         eq(connectors.orgId, args.orgId),
         eq(connectors.userId, args.userId),
         eq(connectors.authMethod, "oauth"),
@@ -973,6 +975,7 @@ interface ResolveCustomConnectorOAuth2AccessTokenArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly connector: CustomConnectorRow;
+  readonly memberConnectorId: string;
   readonly featureContext: FeatureSwitchContext;
   readonly forceRefresh?: boolean;
 }
@@ -989,7 +992,8 @@ async function resolveCustomConnectorOAuth2AccessToken(
     db: args.db,
     orgId: args.orgId,
     userId: args.userId,
-    connectorId: args.connector.id,
+    customConnectorId: args.connector.id,
+    memberConnectorId: args.memberConnectorId,
     storageVersion: args.connector.storageVersion,
   });
   signal.throwIfAborted();
@@ -1010,7 +1014,8 @@ async function resolveCustomConnectorOAuth2AccessToken(
       db: tx,
       orgId: args.orgId,
       userId: args.userId,
-      connectorId: args.connector.id,
+      customConnectorId: args.connector.id,
+      memberConnectorId: args.memberConnectorId,
       storageVersion: args.connector.storageVersion,
       lockRow: true,
     });
@@ -1103,7 +1108,7 @@ async function resolveCustomConnectorOAuth2AccessToken(
 async function loadLiveCustomConnector(args: {
   readonly db: Db;
   readonly orgId: string;
-  readonly connectorId: string;
+  readonly customConnectorId: string;
 }): Promise<CustomConnectorRow | null> {
   const [row] = await args.db
     .select({
@@ -1120,7 +1125,7 @@ async function loadLiveCustomConnector(args: {
     )
     .where(
       and(
-        eq(orgCustomConnectors.id, args.connectorId),
+        eq(orgCustomConnectors.id, args.customConnectorId),
         eq(orgCustomConnectors.orgId, args.orgId),
         eq(orgCustomConnectors.enabled, true),
       ),
@@ -1136,7 +1141,8 @@ export async function resolveCurrentCustomConnectorOAuth2AccessToken(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
-    readonly connectorId: string;
+    readonly customConnectorId: string;
+    readonly memberConnectorId: string;
     readonly featureContext: FeatureSwitchContext;
     readonly forceRefresh?: boolean;
   },

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -3152,6 +3152,7 @@ export async function loadCustomConnectorRuntimeData(
     readonly orgId: string;
     readonly userId: string;
     readonly connectorIds: readonly string[] | undefined;
+    readonly memberConnectorIdsByCustomConnectorId: ReadonlyMap<string, string>;
     readonly measure?: CustomConnectorRuntimeDataTimingMeasure;
   },
 ): Promise<
@@ -3215,6 +3216,8 @@ export async function loadCustomConnectorRuntimeData(
       orgId: args.orgId,
       userId: args.userId,
       definitions,
+      memberConnectorIdsByCustomConnectorId:
+        args.memberConnectorIdsByCustomConnectorId,
     });
     const valuesByConnectorId = new Map<string, StoredValueRow[]>();
     for (const value of runtimeStorage.values) {


### PR DESCRIPTION
## Summary

- add a shared batched connector-account resolver with exact, default, and legacy-singleton selection modes
- make new-run admission select default built-in, custom HTTP, and custom MCP credential rows by exact ID
- make runtime sync and firewall auth validate source IDs and keep secret reads, refresh writes, and reconnect updates on the selected row
- keep custom connector definitions, aliases, routing, permissions, firewall names, and MCP identity definition-scoped

## Compatibility and scope

- `sourceId` remains optional for old queued runs and runners; source-less payloads work only while an owner/target has exactly one row
- missing, wrong-target, deleted, ambiguous, or incompatible sources fail closed without selecting another account
- singleton indexes, connector writers, thread selection, account lifecycle APIs, and UI remain unchanged

## Validation

- `pnpm -F @okouai/db db:migrate`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api build`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm knip`
- pre-commit hook: Prettier, Knip, and full Turbo type checking

Closes #27687

Parent: #22832
