### PR TITLE
test(e2e): wait for usage-pack allocation activation

### DIFF
--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -1171,7 +1171,7 @@ async function readUsagePackSummary(
   page: Page,
   token: string,
   memberId: string,
-): Promise<UsagePackSummary> {
+): Promise<UsagePackSummary | null> {
   const body = requireRecord(
     await getApiJson(page, "/api/okou/billing/usage-pack-subscription", token),
     "usage-pack management",
@@ -1182,7 +1182,9 @@ async function readUsagePackSummary(
     })
     .find((value) => value.memberId === memberId);
   if (!allocation) {
-    throw new Error(`usage-pack allocation for member ${memberId} not found`);
+    // Checkout completion binds the subscription before invoice.paid activates
+    // allocations.
+    return null;
   }
 
   return {


### PR DESCRIPTION
## Failure evidence

- Turbo run: https://github.com/vm0-ai/vm0/actions/runs/32216795656 (attempt 1, workflow run 81471)
- Failed job: https://github.com/vm0-ai/vm0/actions/runs/32216795656/job/95960232055
- Merge-group SHA: `8bb14037affb943d15fb88f1466ca504c769936c`
- Parent main SHA: `53bcc411e5ca63f00eac1be61269940e1a43560c`
- Test: `[billing-transitions] › paid invitation purchases and revokes a pending member package`
- Failure: `usage-pack allocation for member <volatile user ID> not found`
- Same PR head and relevant base passed immediately beforehand in run https://github.com/vm0-ai/vm0/actions/runs/32216094763, job https://github.com/vm0-ai/vm0/actions/runs/32216094763/job/95958809056.

The represented PR (#28031) changes presentation-template import/API/DB/S3 code and is unrelated to billing. The failed parent already contains #28062; that repair synchronized the pending member row after paid-invitation completion, while this failure occurs earlier when checking the owner's initial plan allocation.

## Root cause

The checkout lifecycle intentionally has two observable phases:

1. Checkout completion binds the usage-pack subscription.
2. `invoice.paid` activates the allocation and grants credits.

The preview request log shows the target checkout POST succeeded with HTTP 200 at `2026-08-19T04:48:49.492Z` (client request ID `14d21f10-f44d-44e9-ae0f-5a7168091519`). The direct management read then succeeded with HTTP 200 at `04:49:02.015Z`, but its active-allocation list did not yet contain the owner. The test failed at `04:49:03.352Z`. No target request in this sequence returned 429 or 5xx. The Clerk `route.fetch: Test ended` warnings occurred more than a minute after the failure and are teardown/lifecycle noise.

`expectUsagePackState` already owns synchronization through `expect.poll`, but `readUsagePackSummary` threw when the allocation was temporarily absent. Playwright does not retry a rejected poll callback, so the legal intermediate state escaped the synchronization boundary after the first read.

## Fix

Return `null` for the one legal transient state where the requested active allocation is absent. The existing poll now continues until the exact expected allocation becomes visible.

This is deterministic because it fixes the observer at the earliest violated ownership boundary. HTTP failures, malformed API responses, and wrong allocation values still fail; the assertion, timeout, and poll intervals are unchanged. No retry, sleep, skip, swallowed transport error, or product behavior change is added.

## Duplicate guard

- Exact flaky key and error-text searches found no open repair PR.
- #27897 addresses a billing-settings route handoff.
- #28108 reconciles missed Stripe webhooks on a periodic fallback path; it does not make this immediate observer tolerate the valid checkout-to-invoice activation gap.

## Validation

- `cd e2e && npx --yes pnpm@10.33.4 check-types`
- `cd e2e && npx --yes pnpm@10.33.4 exec tsx --test playwright/lib/stripe-checkout.test.ts` (10 passed)
- Exact Playwright test discovery with `--grep ... --list` (1 test)
- Prettier check
- `git diff --check`
- Focused file-size check

The exact end-to-end case depends on deployed Clerk and Stripe services, so it is not runnable locally without services.

## Preview verification

- Deployed head: `70a168a12d0aade7a8d0e4d3e78753bbab994378`
- Reported App preview: `https://pr-28136-app.omby.ai`
- Reported API preview: `https://pr-28136-api.vm6.ai`
- Fresh Clerk test user and organization; normal explore onboarding; `usagePackPlans=true`
- Baseline Pro checkout completed through a Stripe `cs_test_` session. The management API returned `tier=pro` and one active owner allocation at `$20/month`.
- Five independent invitation cycles passed. Each used a unique email, selected `$50/month`, showed the email + `$50/month` + `Pending` in the People UI, returned `role=member` and `usagePackUsd=50` from the members API, revoked with HTTP 200, and then returned no matching invitation/allocation projection.
- All five purchase-preview, confirm, and revoke requests returned 200. No iteration left a pending row.

Evidence:

- [Structured verification report](https://cdn.vm0.io/artifacts/djlms11dyo.md)
- Allocated UI: [1](https://cdn.vm0.io/artifacts/1gaog4yspz.png), [2](https://cdn.vm0.io/artifacts/cefyde0l90.png), [3](https://cdn.vm0.io/artifacts/ubvho1v0ua.png), [4](https://cdn.vm0.io/artifacts/wqk9oz52c7.png), [5](https://cdn.vm0.io/artifacts/58c0okilla.png)
- [Final UI after the fifth revoke](https://cdn.vm0.io/artifacts/qj6r1fybu9.png)

The first PR pipeline attempt reached the repaired boundary, then one invitation-confirm request returned 500. Bounded request/server-log correlation identified the underlying cause as a Clerk `OrganizationAPI` `Too Many Requests` from `listAllOrganizationMemberships` (client request ID `e2405219-1863-46e9-8c03-789d821272c7`), not this change. The targeted rerun then passed all 27 tests in 4.1 minutes: https://github.com/vm0-ai/vm0/actions/runs/32218635527/job/95968268210.
