### PR TITLE
fix(platform): update connector count to 1100+

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -658,7 +658,7 @@ describe("connectors page", () => {
       screen.findByTestId("connector-card-label"),
     ).resolves.toHaveTextContent("GitHub");
     await expect(
-      screen.findByText("Connect 1000+ services for your agents to use."),
+      screen.findByText("Connect 1100+ services for your agents to use."),
     ).resolves.toBeInTheDocument();
 
     await fill(await screen.findByPlaceholderText("Find connectors"), "Slack");
@@ -692,7 +692,7 @@ describe("connectors page", () => {
     });
 
     await expect(
-      screen.findByText("Connect 1000+ services for your agents to use."),
+      screen.findByText("Connect 1100+ services for your agents to use."),
     ).resolves.toBeInTheDocument();
   });
 
@@ -721,7 +721,7 @@ describe("connectors page", () => {
       screen.findByText("Connect third-party services for your agents to use."),
     ).resolves.toBeInTheDocument();
     expect(
-      screen.queryByText("Connect 1000+ services for your agents to use."),
+      screen.queryByText("Connect 1100+ services for your agents to use."),
     ).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -1039,7 +1039,7 @@ export function ZeroConnectorsPage() {
                   ($) => {
                     return $.connectors.catalog.descriptionWithCount;
                   },
-                  { value: "1000+" },
+                  { value: "1100+" },
                 )}
               </p>
             ) : (


### PR DESCRIPTION
## Summary

- update the connector catalog description from `1000+` to `1100+` services
- keep the existing page-level assertions aligned with the displayed copy

## Scope

- no connector catalog data, discovery behavior, or feature-switch behavior changes

## Validation

- `pnpm prettier --check apps/platform/src/views/zero-page/zero-connectors-page.tsx apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
