### PR TITLE
fix(ci): tolerate superseded run cancellation failures

### DIFF
--- a/.github/scripts/cancel-superseded-merge-group-runs.sh
+++ b/.github/scripts/cancel-superseded-merge-group-runs.sh
@@ -201,25 +201,21 @@ while IFS= read -r run_record; do
           --jq '.status'
       )
       if [ "$current_status" != "completed" ]; then
-        # GitHub can wedge a run so that it keeps reporting an active status
-        # while refusing force cancellation with HTTP 409. A run only claims
-        # the shared pr-N runner once it starts a job, so a wedged run whose
-        # latest attempt started no job cannot be the writer this barrier
-        # protects against, and it would never reach "completed" for the
-        # barrier below. Skip it; every other cancel failure still fails closed.
+        # A run only claims the shared pr-N runner once a job starts. GitHub
+        # creates queued job records before that point, so count jobs that have
+        # left queued rather than treating every record as started work.
         if ! started_jobs=$(
           gh api --method GET \
             "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
-            --jq '.total_count' 2>&1
+            --jq '[.jobs[]? | select(.status != "queued")] | length' 2>&1
         ); then
           started_jobs=""
         fi
-        if [[ "$cancel_error" == *"HTTP 409"* ]] && [ "$started_jobs" = "0" ]; then
-          echo "skipping wedged ${selected_run_label} ${run_id}: reported ${current_status} with no started job"
+        if [ "$started_jobs" = "0" ]; then
+          echo "skipping uncancellable ${selected_run_label} ${run_id}: reported ${current_status} with no started job"
           continue
         fi
-        echo "failed to cancel ${selected_run_label} ${run_id}: ${cancel_error}" >&2
-        exit 1
+        echo "::warning::failed to cancel ${selected_run_label} ${run_id}; awaiting terminal state: ${cancel_error}" >&2
       fi
     fi
   fi
@@ -227,7 +223,7 @@ while IFS= read -r run_record; do
 done <<<"$selected_runs"
 
 if $cancel_selected_runs && [ "${#run_ids[@]}" -eq 0 ]; then
-  echo "All ${selected_runs_label} were wedged without starting a job; nothing to await."
+  echo "All ${selected_runs_label} were uncancellable without starting a job; nothing to await."
   exit 0
 fi
 

--- a/.github/scripts/cancel-superseded-merge-group-runs.sh
+++ b/.github/scripts/cancel-superseded-merge-group-runs.sh
@@ -69,13 +69,24 @@ if [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
-pr_head=$(
+if ! pr_head=$(
   gh api --method GET \
     "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" \
-    --jq '[.head.ref, .head.repo.full_name] | @tsv'
-)
+    --jq '[.head.ref, .head.repo.full_name] | @tsv' 2>&1
+); then
+  if $cancel_selected_runs; then
+    echo "::warning::failed to resolve PR #${pr_number} head; continuing without cancellation: ${pr_head}" >&2
+    exit 0
+  fi
+  echo "failed to resolve PR #${pr_number} head: ${pr_head}" >&2
+  exit 1
+fi
 IFS=$'\t' read -r pr_head_ref pr_head_repository <<<"$pr_head"
 if [ -z "$pr_head_ref" ] || [ -z "$pr_head_repository" ]; then
+  if $cancel_selected_runs; then
+    echo "::warning::failed to resolve head repository and ref for PR #${pr_number}; continuing without cancellation" >&2
+    exit 0
+  fi
   echo "failed to resolve head repository and ref for PR #${pr_number}" >&2
   exit 1
 fi
@@ -92,12 +103,14 @@ discover_selected_runs() {
   local status
 
   for status in "${active_statuses[@]}"; do
-    gh api --method GET \
+    if ! gh api --method GET \
       "repos/${GITHUB_REPOSITORY}/actions/runs" \
       -f "status=${status}" \
       -f per_page=100 \
       --paginate \
-      --slurp
+      --slurp; then
+      return 1
+    fi
   done |
     jq -r \
       --argjson current_run_id "$GITHUB_RUN_ID" \
@@ -147,7 +160,14 @@ discovery_started_at=$SECONDS
 # Each status filter is a separate API snapshot. Require the selected run IDs
 # to stabilize so a run changing statuses cannot fall between those snapshots.
 while true; do
-  discovered_runs=$(discover_selected_runs)
+  if ! discovered_runs=$(discover_selected_runs 2>&1); then
+    if $cancel_selected_runs; then
+      echo "::warning::failed to discover ${selected_runs_label}; continuing without cancellation: ${discovered_runs}" >&2
+      exit 0
+    fi
+    echo "failed to discover ${selected_runs_label}: ${discovered_runs}" >&2
+    exit 1
+  fi
   discovered_run_ids=$(printf '%s\n' "$discovered_runs" | cut -f1)
 
   if $have_previous_run_ids; then
@@ -211,11 +231,18 @@ started_at=$SECONDS
 while true; do
   pending_runs=()
   for run_id in "${run_ids[@]}"; do
-    current_status=$(
+    if ! current_status=$(
       gh api --method GET \
         "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
-        --jq '.status'
-    )
+        --jq '.status' 2>&1
+    ); then
+      if $cancel_selected_runs; then
+        echo "::warning::failed to query ${selected_run_label} ${run_id}; continuing without a terminal-state barrier: ${current_status}" >&2
+        exit 0
+      fi
+      echo "failed to query ${selected_run_label} ${run_id}: ${current_status}" >&2
+      exit 1
+    fi
     if [ "$current_status" != "completed" ]; then
       pending_runs+=("${run_id}:${current_status}")
     fi

--- a/.github/scripts/cancel-superseded-merge-group-runs.sh
+++ b/.github/scripts/cancel-superseded-merge-group-runs.sh
@@ -195,35 +195,15 @@ while IFS= read -r run_record; do
       gh api --method POST \
         "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/force-cancel" 2>&1
     ); then
-      current_status=$(
-        gh api --method GET \
-          "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
-          --jq '.status'
-      )
-      if [ "$current_status" != "completed" ]; then
-        # A run only claims the shared pr-N runner once a job starts. GitHub
-        # creates queued job records before that point, so count jobs that have
-        # left queued rather than treating every record as started work.
-        if ! started_jobs=$(
-          gh api --method GET \
-            "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
-            --jq '[.jobs[]? | select(.status != "queued")] | length' 2>&1
-        ); then
-          started_jobs=""
-        fi
-        if [ "$started_jobs" = "0" ]; then
-          echo "skipping uncancellable ${selected_run_label} ${run_id}: reported ${current_status} with no started job"
-          continue
-        fi
-        echo "::warning::failed to cancel ${selected_run_label} ${run_id}; awaiting terminal state: ${cancel_error}" >&2
-      fi
+      echo "::warning::failed to cancel ${selected_run_label} ${run_id}; continuing without cancellation: ${cancel_error}" >&2
+      continue
     fi
   fi
   run_ids+=("$run_id")
 done <<<"$selected_runs"
 
 if $cancel_selected_runs && [ "${#run_ids[@]}" -eq 0 ]; then
-  echo "All ${selected_runs_label} were uncancellable without starting a job; nothing to await."
+  echo "All ${selected_runs_label} failed cancellation; continuing without a terminal-state barrier."
   exit 0
 fi
 

--- a/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
+++ b/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
@@ -21,12 +21,10 @@ printf '%s\n' "$*" >>"$MOCK_GH_LOG"
 endpoint=""
 method="GET"
 status_filter=""
-jq_filter=""
 previous=""
 for argument in "$@"; do
   case "$previous" in
     --method) method=$argument ;;
-    --jq) jq_filter=$argument ;;
   esac
   case "$argument" in
     repos/*) endpoint=$argument ;;
@@ -94,34 +92,7 @@ JSON
       touch "$MOCK_RUNS_RELEASED"
     fi
     ;;
-  repos/vm0-ai/vm0/actions/runs/*/jobs)
-    run_id=${endpoint%/jobs}
-    run_id=${run_id##*/}
-    [ "$jq_filter" = '[.jobs[]? | select(.status != "queued")] | length' ] || {
-      echo "unexpected jobs jq filter: ${jq_filter}" >&2
-      exit 1
-    }
-    case " ${MOCK_CANCEL_FAILURE_RUN_IDS:-} " in
-      *" $run_id "*)
-        if [ "${MOCK_JOBS_QUERY_FAILURE:-0}" = "1" ]; then
-          echo 'gh: Failed to list jobs (HTTP 500)' >&2
-          exit 1
-        fi
-        printf '%s\n' "${MOCK_STARTED_JOB_COUNT:-0}"
-        ;;
-      *) printf '0\n' ;;
-    esac
-    ;;
   repos/vm0-ai/vm0/actions/runs/*)
-    run_id=${endpoint##*/}
-    case " ${MOCK_CANCEL_FAILURE_RUN_IDS:-} " in
-      *" $run_id "*)
-        if [ "${MOCK_STARTED_JOB_COUNT:-0}" = "0" ] && [ ! -f "$MOCK_RUNS_RELEASED" ]; then
-          printf 'queued\n'
-          exit 0
-        fi
-        ;;
-    esac
     if [ "${MOCK_DELAY_COMPLETION:-0}" = "1" ] && [ ! -f "$MOCK_RUNS_RELEASED" ]; then
       printf 'in_progress\n'
     else
@@ -290,18 +261,20 @@ rm -f "${tmp_dir}/runs-released"
 output=$(
   run_cancel \
     MOCK_CANCEL_FAILURE_RUN_IDS=100 \
-    MOCK_STARTED_JOB_COUNT=0 \
     MOCK_DELAY_COMPLETION=1 \
-    MOCK_FORCE_CANCEL_COMPLETION=1
+    MOCK_FORCE_CANCEL_COMPLETION=1 2>&1
 )
-grep -q "skipping uncancellable superseded run 100" <<<"$output" ||
-  fail "expected an uncancellable run with no started job to be skipped"
-# The uncancellable run reports "queued", so the barrier could only complete
-# if the run was excluded from it rather than merely skipped during cancel.
+grep -q "failed to cancel superseded run 100; continuing without cancellation" <<<"$output" ||
+  fail "expected a cancellation API failure to become a warning"
 grep -q "All superseded CI runs completed" <<<"$output" ||
   fail "expected the barrier to still complete for the remaining runs"
 [ ! -s "${tmp_dir}/sleep.log" ] ||
-  fail "skipped unstarted run must not be polled by the completion barrier"
+  fail "a failed cancellation target must not enter the completion barrier"
+if grep -Fq \
+  'api --method GET repos/vm0-ai/vm0/actions/runs/100' \
+  "${tmp_dir}/gh.log"; then
+  fail "a failed cancellation target must not receive follow-up API queries"
+fi
 
 : >"${tmp_dir}/gh.log"
 : >"${tmp_dir}/cancel.log"
@@ -309,44 +282,11 @@ grep -q "All superseded CI runs completed" <<<"$output" ||
 rm -f "${tmp_dir}/runs-released"
 output=$(
   run_cancel \
-    MOCK_CANCEL_FAILURE_RUN_IDS=100 \
-    MOCK_STARTED_JOB_COUNT=1 \
-    MOCK_DELAY_COMPLETION=1 2>&1
+    MOCK_CANCEL_FAILURE_RUN_IDS="100 110 120" 2>&1
 )
-grep -q "failed to cancel superseded run 100; awaiting terminal state" <<<"$output" ||
-  fail "expected a cancellation failure with started work to become a warning"
-grep -q "100:in_progress" <<<"$output" ||
-  fail "expected an uncancellable run with started work to remain in the barrier"
-[ "$(wc -l <"${tmp_dir}/sleep.log")" -eq 1 ] ||
-  fail "started work must reach terminal state before the handoff completes"
-
-: >"${tmp_dir}/gh.log"
-: >"${tmp_dir}/cancel.log"
-: >"${tmp_dir}/sleep.log"
-rm -f "${tmp_dir}/runs-released"
-output=$(
-  run_cancel \
-    MOCK_CANCEL_FAILURE_RUN_IDS=100 \
-    MOCK_JOBS_QUERY_FAILURE=1 \
-    MOCK_DELAY_COMPLETION=1 2>&1
-)
-grep -q "100:queued" <<<"$output" ||
-  fail "unknown job state must retain the uncancellable run in the barrier"
-[ "$(wc -l <"${tmp_dir}/sleep.log")" -eq 1 ] ||
-  fail "unknown job state must reach terminal run state before handoff"
-
-: >"${tmp_dir}/gh.log"
-: >"${tmp_dir}/cancel.log"
-: >"${tmp_dir}/sleep.log"
-rm -f "${tmp_dir}/runs-released"
-output=$(
-  run_cancel \
-    MOCK_CANCEL_FAILURE_RUN_IDS="100 110 120" \
-    MOCK_STARTED_JOB_COUNT=0
-)
-grep -q "nothing to await" <<<"$output" ||
-  fail "expected an all-unstarted target set to exit without a completion barrier"
+grep -q "continuing without a terminal-state barrier" <<<"$output" ||
+  fail "expected all failed cancellations to exit without a completion barrier"
 [ ! -s "${tmp_dir}/sleep.log" ] ||
-  fail "an all-unstarted target set must not poll"
+  fail "failed cancellation targets must not poll"
 
 echo "cancel-superseded-merge-group-runs tests passed"

--- a/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
+++ b/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
@@ -21,10 +21,12 @@ printf '%s\n' "$*" >>"$MOCK_GH_LOG"
 endpoint=""
 method="GET"
 status_filter=""
+jq_filter=""
 previous=""
 for argument in "$@"; do
   case "$previous" in
     --method) method=$argument ;;
+    --jq) jq_filter=$argument ;;
   esac
   case "$argument" in
     repos/*) endpoint=$argument ;;
@@ -95,6 +97,10 @@ JSON
   repos/vm0-ai/vm0/actions/runs/*/jobs)
     run_id=${endpoint%/jobs}
     run_id=${run_id##*/}
+    [ "$jq_filter" = '[.jobs[]? | select(.status != "queued")] | length' ] || {
+      echo "unexpected jobs jq filter: ${jq_filter}" >&2
+      exit 1
+    }
     case " ${MOCK_CANCEL_FAILURE_RUN_IDS:-} " in
       *" $run_id "*)
         if [ "${MOCK_JOBS_QUERY_FAILURE:-0}" = "1" ]; then

--- a/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
+++ b/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
@@ -82,9 +82,9 @@ JSON
     run_id=${endpoint%/force-cancel}
     run_id=${run_id##*/}
     printf '%s\n' "$run_id" >>"$MOCK_CANCEL_LOG"
-    case " ${MOCK_WEDGED_RUN_IDS:-} " in
+    case " ${MOCK_CANCEL_FAILURE_RUN_IDS:-} " in
       *" $run_id "*)
-        echo 'gh: Cannot cancel a workflow re-run that has not yet queued. (HTTP 409)' >&2
+        echo 'gh: Failed to cancel workflow run (HTTP 500)' >&2
         exit 1
         ;;
     esac
@@ -95,17 +95,25 @@ JSON
   repos/vm0-ai/vm0/actions/runs/*/jobs)
     run_id=${endpoint%/jobs}
     run_id=${run_id##*/}
-    case " ${MOCK_WEDGED_RUN_IDS:-} " in
-      *" $run_id "*) printf '%s\n' "${MOCK_WEDGED_JOB_COUNT:-0}" ;;
+    case " ${MOCK_CANCEL_FAILURE_RUN_IDS:-} " in
+      *" $run_id "*)
+        if [ "${MOCK_JOBS_QUERY_FAILURE:-0}" = "1" ]; then
+          echo 'gh: Failed to list jobs (HTTP 500)' >&2
+          exit 1
+        fi
+        printf '%s\n' "${MOCK_STARTED_JOB_COUNT:-0}"
+        ;;
       *) printf '0\n' ;;
     esac
     ;;
   repos/vm0-ai/vm0/actions/runs/*)
     run_id=${endpoint##*/}
-    case " ${MOCK_WEDGED_RUN_IDS:-} " in
+    case " ${MOCK_CANCEL_FAILURE_RUN_IDS:-} " in
       *" $run_id "*)
-        printf 'queued\n'
-        exit 0
+        if [ "${MOCK_STARTED_JOB_COUNT:-0}" = "0" ] && [ ! -f "$MOCK_RUNS_RELEASED" ]; then
+          printf 'queued\n'
+          exit 0
+        fi
         ;;
     esac
     if [ "${MOCK_DELAY_COMPLETION:-0}" = "1" ] && [ ! -f "$MOCK_RUNS_RELEASED" ]; then
@@ -272,29 +280,67 @@ fi
 : >"${tmp_dir}/gh.log"
 : >"${tmp_dir}/cancel.log"
 : >"${tmp_dir}/sleep.log"
-output=$(run_cancel MOCK_WEDGED_RUN_IDS=100 MOCK_WEDGED_JOB_COUNT=0)
-grep -q "skipping wedged superseded run 100" <<<"$output" ||
+rm -f "${tmp_dir}/runs-released"
+output=$(
+  run_cancel \
+    MOCK_CANCEL_FAILURE_RUN_IDS=100 \
+    MOCK_STARTED_JOB_COUNT=0 \
+    MOCK_DELAY_COMPLETION=1 \
+    MOCK_FORCE_CANCEL_COMPLETION=1
+)
+grep -q "skipping uncancellable superseded run 100" <<<"$output" ||
   fail "expected an uncancellable run with no started job to be skipped"
-# The wedged run reports "queued" forever, so the barrier could only complete
+# The uncancellable run reports "queued", so the barrier could only complete
 # if the run was excluded from it rather than merely skipped during cancel.
 grep -q "All superseded CI runs completed" <<<"$output" ||
   fail "expected the barrier to still complete for the remaining runs"
 [ ! -s "${tmp_dir}/sleep.log" ] ||
-  fail "skipped wedged run must not be polled by the completion barrier"
-
-: >"${tmp_dir}/gh.log"
-: >"${tmp_dir}/cancel.log"
-if run_cancel MOCK_WEDGED_RUN_IDS=100 MOCK_WEDGED_JOB_COUNT=3 >/dev/null 2>&1; then
-  fail "an uncancellable run that already started a job must fail closed"
-fi
+  fail "skipped unstarted run must not be polled by the completion barrier"
 
 : >"${tmp_dir}/gh.log"
 : >"${tmp_dir}/cancel.log"
 : >"${tmp_dir}/sleep.log"
-output=$(run_cancel MOCK_WEDGED_RUN_IDS="100 110 120" MOCK_WEDGED_JOB_COUNT=0)
+rm -f "${tmp_dir}/runs-released"
+output=$(
+  run_cancel \
+    MOCK_CANCEL_FAILURE_RUN_IDS=100 \
+    MOCK_STARTED_JOB_COUNT=1 \
+    MOCK_DELAY_COMPLETION=1 2>&1
+)
+grep -q "failed to cancel superseded run 100; awaiting terminal state" <<<"$output" ||
+  fail "expected a cancellation failure with started work to become a warning"
+grep -q "100:in_progress" <<<"$output" ||
+  fail "expected an uncancellable run with started work to remain in the barrier"
+[ "$(wc -l <"${tmp_dir}/sleep.log")" -eq 1 ] ||
+  fail "started work must reach terminal state before the handoff completes"
+
+: >"${tmp_dir}/gh.log"
+: >"${tmp_dir}/cancel.log"
+: >"${tmp_dir}/sleep.log"
+rm -f "${tmp_dir}/runs-released"
+output=$(
+  run_cancel \
+    MOCK_CANCEL_FAILURE_RUN_IDS=100 \
+    MOCK_JOBS_QUERY_FAILURE=1 \
+    MOCK_DELAY_COMPLETION=1 2>&1
+)
+grep -q "100:queued" <<<"$output" ||
+  fail "unknown job state must retain the uncancellable run in the barrier"
+[ "$(wc -l <"${tmp_dir}/sleep.log")" -eq 1 ] ||
+  fail "unknown job state must reach terminal run state before handoff"
+
+: >"${tmp_dir}/gh.log"
+: >"${tmp_dir}/cancel.log"
+: >"${tmp_dir}/sleep.log"
+rm -f "${tmp_dir}/runs-released"
+output=$(
+  run_cancel \
+    MOCK_CANCEL_FAILURE_RUN_IDS="100 110 120" \
+    MOCK_STARTED_JOB_COUNT=0
+)
 grep -q "nothing to await" <<<"$output" ||
-  fail "expected an all-wedged target set to exit without a completion barrier"
+  fail "expected an all-unstarted target set to exit without a completion barrier"
 [ ! -s "${tmp_dir}/sleep.log" ] ||
-  fail "an all-wedged target set must not poll"
+  fail "an all-unstarted target set must not poll"
 
 echo "cancel-superseded-merge-group-runs tests passed"

--- a/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
+++ b/.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh
@@ -35,9 +35,17 @@ done
 
 case "$endpoint" in
   repos/vm0-ai/vm0/pulls/42)
+    if [ "${MOCK_PR_LOOKUP_FAILURE:-0}" = "1" ]; then
+      echo 'gh: failed to resolve PR head (HTTP 500)' >&2
+      exit 1
+    fi
     printf 'feature/safe-shared-runner\tvm0-ai/vm0\n'
     ;;
   repos/vm0-ai/vm0/actions/runs)
+    if [ "${MOCK_DISCOVERY_FAILURE_STATUS:-}" = "$status_filter" ]; then
+      echo 'gh: failed to list workflow runs (HTTP 500)' >&2
+      exit 1
+    fi
     if [ "${MOCK_NO_TARGETS:-0}" = "1" ]; then
       printf '[{"workflow_runs":[]}]\n'
       exit 0
@@ -93,6 +101,13 @@ JSON
     fi
     ;;
   repos/vm0-ai/vm0/actions/runs/*)
+    run_id=${endpoint##*/}
+    case " ${MOCK_RUN_STATUS_FAILURE_RUN_IDS:-} " in
+      *" $run_id "*)
+        echo 'gh: failed to query workflow run (HTTP 500)' >&2
+        exit 1
+        ;;
+    esac
     if [ "${MOCK_DELAY_COMPLETION:-0}" = "1" ] && [ ! -f "$MOCK_RUNS_RELEASED" ]; then
       printf 'in_progress\n'
     else
@@ -288,5 +303,34 @@ grep -q "continuing without a terminal-state barrier" <<<"$output" ||
   fail "expected all failed cancellations to exit without a completion barrier"
 [ ! -s "${tmp_dir}/sleep.log" ] ||
   fail "failed cancellation targets must not poll"
+
+: >"${tmp_dir}/gh.log"
+: >"${tmp_dir}/cancel.log"
+output=$(run_cancel MOCK_PR_LOOKUP_FAILURE=1 2>&1)
+grep -q "failed to resolve PR #42 head; continuing without cancellation" <<<"$output" ||
+  fail "expected a PR lookup API failure to become a warning"
+[ ! -s "${tmp_dir}/cancel.log" ] ||
+  fail "a PR lookup API failure must not attempt cancellation"
+
+: >"${tmp_dir}/gh.log"
+: >"${tmp_dir}/cancel.log"
+output=$(run_cancel MOCK_DISCOVERY_FAILURE_STATUS=queued 2>&1)
+grep -q "failed to discover superseded CI runs; continuing without cancellation" <<<"$output" ||
+  fail "expected a run discovery API failure to become a warning"
+[ ! -s "${tmp_dir}/cancel.log" ] ||
+  fail "a run discovery API failure must not attempt cancellation"
+
+: >"${tmp_dir}/gh.log"
+: >"${tmp_dir}/cancel.log"
+: >"${tmp_dir}/sleep.log"
+output=$(run_cancel MOCK_RUN_STATUS_FAILURE_RUN_IDS=100 2>&1)
+grep -q "failed to query superseded run 100; continuing without a terminal-state barrier" <<<"$output" ||
+  fail "expected a run status API failure to become a warning"
+[ ! -s "${tmp_dir}/sleep.log" ] ||
+  fail "a run status API failure must release the completion barrier"
+
+if run_closed_pr_cleanup MOCK_DISCOVERY_FAILURE_STATUS=queued >/dev/null 2>&1; then
+  fail "closed-PR cleanup must fail closed when run discovery fails"
+fi
 
 echo "cancel-superseded-merge-group-runs tests passed"


### PR DESCRIPTION
## Summary

- make GitHub API failures warning-only throughout superseded-run cancellation
- skip cancellation when PR lookup or active-run discovery fails
- exclude failed cancellation targets without follow-up queries and release the barrier when status polling fails
- retain the terminal-state barrier for successfully cancelled runs while GitHub remains queryable
- keep closed-PR cleanup fail-closed to protect resources that may still be in use

## Accepted risk

A GitHub API failure may leave an older run executing concurrently with the newer run against the same PR-scoped resources. This PR intentionally prioritizes current CI availability over strict ownership handoff when GitHub cannot discover, cancel, or verify the old run. Existing lifecycle locks and downstream checks remain unchanged but do not guarantee that every overlap is harmless.

## Exclusions

- no API retries or fallback endpoint
- no changes to run selection, PR matching, application APIs, runner protocols, or persisted state
- no suppression of the terminal-state timeout when GitHub calls succeed but a cancelled run remains active
- no fail-open behavior for closed-PR cleanup

## Validation

- `bash -n .github/scripts/cancel-superseded-merge-group-runs.sh .github/scripts/tests/cancel-superseded-merge-group-runs-test.sh`
- `shellcheck .github/scripts/cancel-superseded-merge-group-runs.sh .github/scripts/tests/cancel-superseded-merge-group-runs-test.sh`
- `.github/scripts/tests/cancel-superseded-merge-group-runs-test.sh`
- `.github/scripts/tests/runner-lifecycle-lock-test.sh`
- `.github/scripts/tests/runner-lifecycle-ownership-workflow-test.sh`
- `.github/scripts/tests/runner-image-workflow-test.sh`
- `git diff --check`
- `./scripts/check-file-size.sh .github/scripts/cancel-superseded-merge-group-runs.sh .github/scripts/tests/cancel-superseded-merge-group-runs-test.sh`

Closes #28138
