### PR TITLE
fix(platform): keep virtual thread rows visible after refresh

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
@@ -41,12 +41,16 @@ function getFixedVirtualRange({
   viewportHeight: number;
 }) {
   const localScrollTop = Math.max(0, scrollTop - scrollMargin);
-  const firstVisibleIndex = Math.floor(
+  const requestedFirstVisibleIndex = Math.floor(
     localScrollTop / CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
   );
   const visibleCount = Math.max(
     1,
     Math.ceil(viewportHeight / CHAT_THREAD_VIRTUAL_ROW_HEIGHT),
+  );
+  const firstVisibleIndex = Math.min(
+    requestedFirstVisibleIndex,
+    Math.max(0, itemCount - visibleCount),
   );
   const startIndex = Math.max(
     0,
@@ -90,7 +94,7 @@ export const sidebarChatThreadWindow$ = computed(
       scrollMetrics.clientHeight || scrollViewport?.clientHeight;
     const viewportHeight =
       measuredViewportHeight || CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT;
-    const scrollTop = scrollMetrics.scrollTop;
+    const scrollTop = scrollViewport?.scrollTop ?? scrollMetrics.scrollTop;
     const { startIndex, endIndex } = getFixedVirtualRange({
       itemCount: chatThreads.length,
       scrollMargin,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1399,6 +1399,69 @@ describe("zero sidebar", () => {
     });
   });
 
+  it("keeps virtualized chats visible after deletion refreshes a clamped viewport", async () => {
+    prepareDefaultAgent();
+    const overflowThreads = Array.from({ length: 23 }, (_, index) => {
+      return createThread(
+        `b3000000-0000-4000-a000-${String(index).padStart(12, "0")}`,
+        `Refresh overflow ${index + 1}`,
+      );
+    });
+    mockSidebarThreadStory(
+      [
+        createThread(EXISTING_THREAD_ID, "Release plan"),
+        createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
+      ],
+      [
+        ...overflowThreads,
+        createThread(ARCHIVED_THREAD_ID, "Archived context"),
+      ],
+    );
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("sidebar-chat-threads-virtual-list"),
+      ).toBeInTheDocument();
+    });
+
+    const scrollArea = screen.getByTestId("sidebar-scroll-area");
+    Object.defineProperties(scrollArea, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1000 },
+      scrollTop: { configurable: true, value: 780, writable: true },
+    });
+    fireEvent.scroll(scrollArea);
+
+    await waitFor(() => {
+      expect(
+        within(sidebar()).getByText("Archived context"),
+      ).toBeInTheDocument();
+    });
+    expect(within(sidebar()).queryByText("Release plan")).toBeNull();
+
+    openThreadMenu("Archived context");
+    click(menuItemByText("Delete chat"));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Delete chat?",
+    });
+    click(buttonByText("Delete", dialog));
+
+    // Model a browser-clamped live offset without another scroll event.
+    scrollArea.scrollTop = 0;
+
+    await waitFor(() => {
+      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
+      expect(
+        within(sidebar()).queryByText("Archived context"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("does not scroll the current chat into view from pointer focus after virtual scrolling", async () => {
     prepareDefaultAgent();
     const overflowThreads = Array.from({ length: 23 }, (_, index) => {


### PR DESCRIPTION
## Summary

- use the mounted sidebar viewport's live scroll offset when thread data recomputes
- clamp the virtual window to the refreshed item count before applying overscan
- cover deletion after a browser-clamped offset through the Platform page boundary

## Problem

Thread deletion and refresh can change the virtual list height while ccstate still holds metrics from the previous scroll event. The browser may clamp the live DOM offset without another scroll event, leaving the computed window outside the refreshed list and rendering no rows until the user scrolls.

## Scope

This changes only Platform sidebar virtualization. It does not change deletion APIs, event synchronization, persistence, or deployment contracts, and it adds no observer, timer, or dependency.

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx src/signals/__tests__/zero-sidebar-state.test.ts` (73 passed)
- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit hook: Prettier and full Knip passed

Closes #28141
