### PR TITLE
fix: route managed deepseek models through openrouter

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -961,7 +961,6 @@ jobs:
           DEV_MODEL_ANTHROPIC_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
           DEV_MODEL_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY }}
           DEV_MODEL_OPENROUTER_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          DEV_MODEL_DEEPSEEK_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           DEV_MODEL_MOONSHOT_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           DEV_MODEL_MINIMAX_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
@@ -977,7 +976,6 @@ jobs:
             DEV_MODEL_ANTHROPIC_KEY
             DEV_MODEL_OPENAI_KEY
             DEV_MODEL_OPENROUTER_KEY
-            DEV_MODEL_DEEPSEEK_KEY
             DEV_MODEL_MOONSHOT_KEY
             DEV_MODEL_MINIMAX_KEY
           )

--- a/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
@@ -182,7 +182,15 @@ run_real_claude_steer() {
 
     run runner_api_curl "/api/okou/runs/${run_id}/context"
     assert_success
-    run jq -e '.cliAgentType == "pi"' <<<"$output"
+    run jq -e '
+        .cliAgentType == "pi" and
+        .piModelConfig == {
+            provider: "openrouter",
+            baseUrl: "https://openrouter.ai/api/v1",
+            model: "deepseek/deepseek-v4-flash",
+            apiKeyEnv: "OPENAI_API_KEY"
+        }
+    ' <<<"$output"
     assert_success
 }
 

--- a/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
@@ -184,12 +184,13 @@ run_real_claude_steer() {
     assert_success
     run jq -e '
         .cliAgentType == "pi" and
-        .piModelConfig == {
-            provider: "openrouter",
-            baseUrl: "https://openrouter.ai/api/v1",
-            model: "deepseek/deepseek-v4-flash",
-            apiKeyEnv: "OPENAI_API_KEY"
-        }
+        .environment.OPENAI_BASE_URL == "https://openrouter.ai/api/v1" and
+        .environment.OPENAI_MODEL == "deepseek/deepseek-v4-flash" and
+        any(
+            .firewalls[];
+            .kind == "builtin" and
+            .name == "model-provider:openrouter-codex"
+        )
     ' <<<"$output"
     assert_success
 }

--- a/turbo/apps/api/src/scripts/__tests__/dev-seed.test.ts
+++ b/turbo/apps/api/src/scripts/__tests__/dev-seed.test.ts
@@ -37,17 +37,16 @@ describe("buildVm0ApiKeys", () => {
     ]);
   });
 
-  it("builds DeepSeek dev seed rows from DEV_MODEL_DEEPSEEK_KEY", () => {
-    const deepSeekKeys = buildVendorKeys("deepseek", {
-      DEV_MODEL_DEEPSEEK_KEY: "dev-deepseek-key",
-      DEEPSEEK_API_KEY: "provider-deepseek-key",
+  it("builds OpenRouter dev seed rows from DEV_MODEL_OPENROUTER_KEY", () => {
+    const openRouterKeys = buildVendorKeys("openrouter", {
+      DEV_MODEL_OPENROUTER_KEY: "dev-openrouter-key",
     });
 
-    expect(deepSeekKeys).toStrictEqual([
+    expect(openRouterKeys).toStrictEqual([
       {
-        apiKey: "dev-deepseek-key",
+        apiKey: "dev-openrouter-key",
         label: "dev-seed",
-        vendor: "deepseek",
+        vendor: "openrouter",
       },
     ]);
   });
@@ -63,21 +62,6 @@ describe("buildVm0ApiKeys", () => {
         apiKey: "dev-openai-key",
         label: "dev-seed",
         vendor: "openai",
-      },
-    ]);
-  });
-
-  it("falls back to DEEPSEEK_API_KEY for DeepSeek dev seed rows", () => {
-    const deepSeekKeys = buildVendorKeys("deepseek", {
-      DEV_MODEL_DEEPSEEK_KEY: "",
-      DEEPSEEK_API_KEY: "provider-deepseek-key",
-    });
-
-    expect(deepSeekKeys).toStrictEqual([
-      {
-        apiKey: "provider-deepseek-key",
-        label: "dev-seed",
-        vendor: "deepseek",
       },
     ]);
   });

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -400,8 +400,8 @@ const USAGE_PRICING: readonly (typeof usagePricing.$inferInsert)[] = [
     ["tokens.cache_read", usd(1), 1_000_000],
     ["tokens.cache_creation", usd(12.5), 1_000_000],
   ]),
-  // DeepSeek API pricing retrieved 2026-07-31 from:
-  // https://api-docs.deepseek.com/quick_start/pricing/
+  // Canonical VM0 customer credit pricing for managed DeepSeek V4 Flash.
+  // Keep this product rate independent of the selected upstream route.
   ...usageGroup("model", "deepseek-v4-flash", [
     ["tokens.input", usd(0.14), 1_000_000],
     ["tokens.output", usd(0.28), 1_000_000],
@@ -668,9 +668,6 @@ function getVendorApiKeyEnvVars(vendor: string): string[] {
   }
   if (vendor === "openai") {
     return [envVar, "OPENAI_API_KEY"];
-  }
-  if (vendor === "deepseek") {
-    return [envVar, "DEEPSEEK_API_KEY"];
   }
   return [envVar];
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4844,17 +4844,19 @@ describe("CHAT-02: model-first provider policies", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   }, 90_000);
 
-  it("routes vm0 DeepSeek through native Responses env bindings", async () => {
+  it("routes vm0 DeepSeek through OpenRouter Pi bindings", async () => {
+    const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const keyFixtureId = randomUUID();
+    const requestedApiKey = `vm0-key-bdd-dev-seed-${keyFixtureId}`;
 
-    // Keep a second DeepSeek fixture owner alive to cover vendor-unique row
+    // Keep a second OpenRouter fixture owner alive to cover vendor-unique row
     // arbitration instead of relying on another test file's scheduling.
     await seedVm0ManagedModelKey("deepseek-v4-flash");
-    await acquireBddVm0ApiKey({
+    const selectedApiKey = await acquireBddVm0ApiKey({
       fixtureId: keyFixtureId,
-      vendor: "deepseek",
-      apiKey: `vm0-key-bdd-dev-seed-${keyFixtureId}`,
+      vendor: "openrouter",
+      apiKey: requestedApiKey,
     });
 
     let runId: string | null = null;
@@ -4863,14 +4865,22 @@ describe("CHAT-02: model-first provider policies", () => {
         await api.requestCancelRun(actor, runId, [200]);
       }
     };
-    const releaseVm0DeepSeekKey = async () => {
+    const releaseVm0OpenRouterKey = async () => {
       await releaseBddVm0ApiKey({ fixtureId: keyFixtureId });
     };
     const cleanupRunAndKeys = async () => {
-      await Promise.all([releaseVm0DeepSeekKey(), cancelRunIfCreated()]);
+      await Promise.all([releaseVm0OpenRouterKey(), cancelRunIfCreated()]);
     };
 
     await (async () => {
+      if (!actor.orgId) {
+        throw new Error("Expected an organization-scoped chat actor");
+      }
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId: actor.orgId },
+        { [FeatureSwitchKey.PiLoop]: true },
+      );
       await api.updateOrgModelPolicies(actor, [
         {
           model: "deepseek-v4-flash",
@@ -4888,13 +4898,62 @@ describe("CHAT-02: model-first provider policies", () => {
       });
       runId = run.runId;
 
-      const { claim } = await claimChatRun(runnerGroup, run.runId);
-      const environment = claimEnvironment(claim);
-      expect(environment.OPENAI_API_KEY).toBe(
-        modelProviderSecretPlaceholder("deepseek", "DEEPSEEK_API_KEY"),
+      const { claim, sandboxHeaders } = await claimChatRun(
+        runnerGroup,
+        run.runId,
       );
-      expect(environment.OPENAI_BASE_URL).toBe("https://api.deepseek.com/");
-      expect(environment.OPENAI_MODEL).toBe("deepseek-v4-flash");
+      const environment = claimEnvironment(claim);
+      expect(claim.cliAgentType).toBe("pi");
+      expect(environment.OPENAI_API_KEY).toBe(
+        modelProviderSecretPlaceholder(
+          "openrouter-codex",
+          "OPENROUTER_API_KEY",
+        ),
+      );
+      expect(environment.OPENAI_BASE_URL).toBe("https://openrouter.ai/api/v1");
+      expect(environment.OPENAI_MODEL).toBe("deepseek/deepseek-v4-flash");
+      expect(claim.firewalls).toContainEqual(
+        expect.objectContaining({
+          kind: "builtin",
+          name: "model-provider:openrouter-codex",
+        }),
+      );
+      expect(claim.billableFirewalls).toContain(
+        "model-provider:openrouter-codex",
+      );
+      expect(claim.piModelConfig).toStrictEqual({
+        provider: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+        model: "deepseek/deepseek-v4-flash",
+        apiKeyEnv: "OPENAI_API_KEY",
+      });
+      expect(claim.modelUsageProvider).toBe("deepseek-v4-flash");
+
+      if (!claim.encryptedSecrets) {
+        throw new Error("Expected OpenRouter claim to carry encrypted secrets");
+      }
+      const resolved = await fw.requestFirewallAuth(
+        sandboxHeaders,
+        {
+          encryptedSecrets: claim.encryptedSecrets,
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate("OPENROUTER_API_KEY")}`,
+          },
+          secretConnectorMap: claim.secretConnectorMap ?? undefined,
+          secretConnectorMetadataMap:
+            claim.secretConnectorMetadataMap ?? undefined,
+        },
+        [200],
+      );
+      if (resolved.status !== 200) {
+        throw new Error("Expected OpenRouter firewall auth to resolve");
+      }
+      expect(resolved.body.headers.Authorization).toBe(
+        `Bearer ${selectedApiKey}`,
+      );
+      expect(resolved.body.resolvedSecrets).toStrictEqual([
+        "OPENROUTER_API_KEY",
+      ]);
     })().then(cleanupRunAndKeys, async (error: unknown) => {
       await cleanupRunAndKeys();
       throw error;

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   getModelProviderFirewall,
+  getVm0ApiModel,
   getVm0ConcreteProviderType,
   type ModelProviderType,
   type SupportedRunModel,
@@ -6563,7 +6564,9 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       await api.heartbeatRunner(runnerGroup);
       const claim = await api.claimRunnerJob(sent.body.runId);
       expect(claim.cliAgentType).toBe("codex");
-      expect(claim.environment).toMatchObject({ OPENAI_MODEL: model });
+      expect(claim.environment).toMatchObject({
+        OPENAI_MODEL: getVm0ApiModel(model),
+      });
       expect(claim.modelUsageProvider).toBe(model);
       await api.requestCancelRun(actor, sent.body.runId, [200]);
     }
@@ -6764,9 +6767,12 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, sent.body.runId, [200]);
   });
 
-  it.each(["deepseek-v4-flash", "deepseek-v4-pro"] as const)(
-    "claims vm0 %s runs with the Responses adapter",
-    async (selectedModel) => {
+  it.each([
+    ["deepseek-v4-flash", "deepseek/deepseek-v4-flash"],
+    ["deepseek-v4-pro", "deepseek/deepseek-v4-pro"],
+  ] as const)(
+    "claims vm0 %s runs through OpenRouter",
+    async (selectedModel, apiModel) => {
       const api = createRunsApi(context);
       const chat = createChatFilesBddApi(context);
       await seedVm0ManagedModelKey(selectedModel);
@@ -6801,35 +6807,21 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       expect(claim.cliAgentType).toBe("codex");
       expect(claim.environment).toMatchObject({
         OPENAI_API_KEY: modelProviderPlaceholder(
-          "deepseek",
-          "DEEPSEEK_API_KEY",
+          "openrouter-codex",
+          "OPENROUTER_API_KEY",
         ),
-        OPENAI_BASE_URL: "https://api.deepseek.com/",
-        OPENAI_MODEL: selectedModel,
+        OPENAI_BASE_URL: "https://openrouter.ai/api/v1",
+        OPENAI_MODEL: apiModel,
       });
       expect(claim.environment).not.toHaveProperty("ANTHROPIC_MODEL");
-      expect(claim.codexRuntimeConfig).toMatchObject({
-        providerId: "deepseek",
-        name: "DeepSeek",
-        baseUrl: "https://api.deepseek.com/",
-        envKey: "OPENAI_API_KEY",
-        wireApi: "responses",
-        supportsWebsockets: false,
-        modelCatalog: {
-          models: expect.arrayContaining([
-            expect.objectContaining({
-              slug: selectedModel,
-              default_reasoning_level: "high",
-            }),
-          ]),
-        },
-      });
       expect(
         claim.firewalls?.map((firewall) => {
           return firewallEntryName(firewall);
         }),
-      ).toContain("model-provider:deepseek");
-      expect(claim.billableFirewalls).toContain("model-provider:deepseek");
+      ).toContain("model-provider:openrouter-codex");
+      expect(claim.billableFirewalls).toContain(
+        "model-provider:openrouter-codex",
+      );
       expect(claim.modelUsageProvider).toBe(selectedModel);
 
       await api.requestCancelRun(actor, sent.body.runId, [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -6814,6 +6814,29 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
         OPENAI_MODEL: apiModel,
       });
       expect(claim.environment).not.toHaveProperty("ANTHROPIC_MODEL");
+      expect(claim.codexRuntimeConfig).toMatchObject({
+        providerId: "openrouter-codex",
+        name: "OpenRouter (Codex)",
+        baseUrl: "https://openrouter.ai/api/v1",
+        envKey: "OPENAI_API_KEY",
+        requiresOpenaiAuth: false,
+        wireApi: "responses",
+        supportsWebsockets: false,
+      });
+      const catalogModels = claim.codexRuntimeConfig?.modelCatalog?.models;
+      if (!Array.isArray(catalogModels) || catalogModels.length !== 1) {
+        throw new Error(
+          `Expected one OpenRouter Codex catalog model for ${selectedModel}`,
+        );
+      }
+      expect(catalogModels[0]).toMatchObject({
+        slug: apiModel,
+        input_modalities: ["text"],
+        base_instructions: expect.stringContaining("You are Codex"),
+        model_messages: {
+          instructions_template: expect.stringContaining("You are Codex"),
+        },
+      });
       expect(
         claim.firewalls?.map((firewall) => {
           return firewallEntryName(firewall);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -27,6 +27,7 @@ import {
 import { modelProviderSurfaceProtocolSchema } from "@okouai/api-contracts/contracts/zero-model-provider-gateways";
 import {
   getDefaultModel,
+  getModelProviderCodexCatalogForModel,
   getModelProviderCodexRuntimeConfig,
   getModelProviderEnvBindings,
   getModelImageInputSupport,
@@ -2301,18 +2302,43 @@ async function vm0ModelProviderEnvironment(
   if (!apiKey || !secretName) {
     return null;
   }
-  const codexRuntimeConfig = getModelProviderCodexRuntimeConfig(concreteType);
+  const environment = providerEnvironmentFromSecretRefs(
+    concreteType,
+    secretName,
+    apiKey,
+    apiModel,
+  );
+  let codexRuntimeConfig = getModelProviderCodexRuntimeConfig(concreteType);
+  if (!codexRuntimeConfig) {
+    const modelCatalog = getModelProviderCodexCatalogForModel(
+      selectedModel,
+      apiModel,
+    );
+    if (modelCatalog) {
+      const baseUrl = environment.OPENAI_BASE_URL;
+      if (!baseUrl) {
+        throw new Error(
+          `Missing OPENAI_BASE_URL for VM0 Codex provider ${concreteType}`,
+        );
+      }
+      codexRuntimeConfig = {
+        providerId: concreteType,
+        name: MODEL_PROVIDER_TYPES[concreteType].label,
+        baseUrl,
+        envKey: "OPENAI_API_KEY",
+        requiresOpenaiAuth: false,
+        wireApi: "responses",
+        supportsWebsockets: false,
+        modelCatalog,
+      };
+    }
+  }
 
   return {
     id: null,
     type: "vm0",
     concreteType,
-    environment: providerEnvironmentFromSecretRefs(
-      concreteType,
-      secretName,
-      apiKey,
-      apiModel,
-    ),
+    environment,
     secrets: { [secretName]: apiKey },
     selectedModel,
     ...(codexRuntimeConfig ? { codexRuntimeConfig } : {}),

--- a/turbo/apps/api/src/signals/services/model-provider-gateway-runtime.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-gateway-runtime.ts
@@ -1,6 +1,5 @@
 import {
-  getModelProviderCodexRuntimeConfig,
-  getVm0ConcreteProviderType,
+  getModelProviderCodexCatalogForModel,
   MODEL_PROVIDER_ENV_PLACEHOLDERS,
   type ModelProviderCodexRuntimeConfig,
   type ModelProviderType,
@@ -81,28 +80,10 @@ export function compileModelProviderGatewayRuntime(
     };
   }
 
-  const sourceCatalog = getModelProviderCodexRuntimeConfig(
-    getVm0ConcreteProviderType(args.logicalModel),
-  )?.modelCatalog;
-  const sourceModels = sourceCatalog?.models;
-  const sourceModel = Array.isArray(sourceModels)
-    ? sourceModels.find((model: unknown): model is Record<string, unknown> => {
-        return (
-          typeof model === "object" &&
-          model !== null &&
-          !Array.isArray(model) &&
-          "slug" in model &&
-          model.slug === args.logicalModel
-        );
-      })
-    : undefined;
-  const modelCatalog =
-    sourceCatalog && sourceModel
-      ? {
-          ...sourceCatalog,
-          models: [{ ...sourceModel, slug: args.upstreamModel }],
-        }
-      : undefined;
+  const modelCatalog = getModelProviderCodexCatalogForModel(
+    args.logicalModel,
+    args.upstreamModel,
+  );
 
   return {
     type,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -498,11 +498,19 @@ describe("model-first canonical catalog", () => {
     expect(getProviderRuntimeModel("vm0", "gpt-5.6-sol")).toBe("gpt-5.6-sol");
     expect(getVm0ConcreteProviderType("gpt-5.6-sol")).toBe("openai-api-key");
     expect(getVm0Vendor("gpt-5.6-sol")).toBe("openai");
-    expect(getVm0ConcreteProviderType("deepseek-v4-pro")).toBe("deepseek");
-    expect(getVm0Vendor("deepseek-v4-pro")).toBe("deepseek");
     expect(getProviderRuntimeModel("openrouter-api-key", "custom/model")).toBe(
       "custom/model",
     );
+  });
+
+  it.each([
+    ["deepseek-v4-flash", "deepseek/deepseek-v4-flash"],
+    ["deepseek-v4-pro", "deepseek/deepseek-v4-pro"],
+  ] as const)("routes vm0 managed %s through OpenRouter", (model, apiModel) => {
+    expect(getVm0ConcreteProviderType(model)).toBe("openrouter-codex");
+    expect(getVm0Vendor(model)).toBe("openrouter");
+    expect(getVm0ApiModel(model)).toBe(apiModel);
+    expect(getProviderRuntimeModel("vm0", model)).toBe(apiModel);
   });
 
   it.each([

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -259,12 +259,14 @@ export const VM0_MODEL_TO_PROVIDER: Record<string, Vm0ModelConfig> = {
     vendor: "anthropic",
   },
   "deepseek-v4-flash": {
-    concreteType: "deepseek",
-    vendor: "deepseek",
+    concreteType: "openrouter-codex",
+    vendor: "openrouter",
+    apiModel: "deepseek/deepseek-v4-flash",
   },
   "deepseek-v4-pro": {
-    concreteType: "deepseek",
-    vendor: "deepseek",
+    concreteType: "openrouter-codex",
+    vendor: "openrouter",
+    apiModel: "deepseek/deepseek-v4-pro",
   },
   "gpt-5.6-sol": {
     concreteType: "openai-api-key",

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -1073,6 +1073,42 @@ export function getModelProviderCodexRuntimeConfig(
 }
 
 /**
+ * Project a provider-owned Codex catalog record onto the model ID used at
+ * runtime. Returns undefined when no provider has authoritative metadata for
+ * the logical model.
+ */
+export function getModelProviderCodexCatalogForModel(
+  logicalModel: string,
+  runtimeModel: string,
+): Record<string, unknown> | undefined {
+  for (const type of getProvidersForModel(logicalModel)) {
+    const sourceCatalog =
+      MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS[type]?.modelCatalog;
+    const sourceModels = sourceCatalog?.models;
+    const sourceModel = Array.isArray(sourceModels)
+      ? sourceModels.find(
+          (model: unknown): model is Record<string, unknown> => {
+            return (
+              typeof model === "object" &&
+              model !== null &&
+              !Array.isArray(model) &&
+              "slug" in model &&
+              model.slug === logicalModel
+            );
+          },
+        )
+      : undefined;
+    if (sourceCatalog && sourceModel) {
+      return {
+        ...sourceCatalog,
+        models: [{ ...sourceModel, slug: runtimeModel }],
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
  * Get the upstream base URL for a model provider type.
  *
  * Returns the framework-appropriate upstream base URL from envBindings —

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -508,7 +508,7 @@ export const MODEL_PROVIDER_TYPES = {
   },
   // Codex-framework twin of openrouter-api-key. Same upstream gateway (OpenRouter)
   // and same API key (shared secretName), but routes through OpenRouter's
-  // OpenAI-compatible endpoint surface for GPT models that codex CLI requires.
+  // OpenAI-compatible endpoint surface for models that use the Codex framework.
   // Pairing rule: the claude-code entry serves Anthropic Messages API
   // (/v1/messages); this codex entry serves OpenAI Chat Completions / Responses
   // (/v1/chat/completions, /v1/responses) under the same /api/v1 prefix.

--- a/turbo/packages/core/src/model-display-name.ts
+++ b/turbo/packages/core/src/model-display-name.ts
@@ -21,7 +21,7 @@ const MODEL_DISPLAY_NAMES = Object.freeze<Record<string, string>>({
   "anthropic/claude-sonnet-4.5": "Claude Sonnet 4.5",
   "anthropic/claude-opus-4.5": "Claude Opus 4.5",
   "anthropic/claude-haiku-4.5": "Claude Haiku 4.5",
-  // DeepSeek (native)
+  // Canonical DeepSeek model IDs
   "deepseek-v4-flash": "DeepSeek V4 Flash",
   "deepseek-v4-pro": "DeepSeek V4 Pro",
   // MiniMax via shared gateways


### PR DESCRIPTION
## Summary

- Route VM0-managed DeepSeek V4 Flash and Pro through the existing `openrouter-codex` provider with qualified OpenRouter model IDs.
- Preserve the authoritative DeepSeek Codex catalog through managed OpenRouter and custom Responses gateway aliases, including text-only input capabilities and model instructions.
- Align preview key seeding and workflow requirements with the active OpenRouter vendor while keeping canonical VM0 customer pricing unchanged.
- Cover built-in key selection, secret and firewall resolution, Pi/Codex configuration, upstream aliases, and canonical usage attribution; extend the real Pi smoke assertion.

## Scope

- Direct DeepSeek BYOK remains on the native `deepseek` provider.
- This does not add automatic provider fallback, schema or runner protocol changes, or pricing changes.
- Existing run snapshots keep their resolved route; newly created runs follow the OpenRouter mapping.

## Validation

- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts --maxWorkers=1 --silent=passed-only` (149 passed)
- `pnpm -F api exec vitest run src/scripts/__tests__/dev-seed.test.ts --maxWorkers=1 --silent=passed-only` (3 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/model-provider-gateways.test.ts --maxWorkers=1 --silent=passed-only` (7 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1 --silent=passed-only` (110 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only` (164 passed)
- `pnpm turbo run lint --filter=@okouai/api-contracts --filter=@okouai/core --filter=api --concurrency=1`
- `pnpm check-types`
- `pnpm knip`
- Vendored Bats parse/count for `run-t10-real-claude-smoke.bats`
- YAML parse for `.github/workflows/turbo.yml`
- Lefthook pre-commit and commit-message hooks

The repository workflow structure test could not run locally because this container does not provide Ruby; required PR CI, including the live real-runner smoke, remains the rollout gate. Production rollout also requires a funded built-in OpenRouter credential.

Closes #28143
