### PR TITLE
feat(platform): rename the Works nav entry to Channels

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -442,7 +442,7 @@
         "newChat": "Neuer Chat",
         "settings": "Einstellungen",
         "workflows": "Workflows",
-        "works": "Einsatzorte von {{agentName}}"
+        "works": "Kanäle von {{agentName}}"
       },
       "rail": {
         "new": "Neu",
@@ -5391,7 +5391,7 @@
     },
     "connected": "Verbunden",
     "connectedWithDetail": "Verbunden ({{detail}})",
-    "documentTitle": "Funktioniert",
+    "documentTitle": "Kanäle",
     "feishuConnected": "Feishu hat erfolgreich eine Verbindung hergestellt",
     "github": {
       "adminInstall": "Bitten Sie einen Organisationsadministrator, die GitHub-App zu installieren",
@@ -5401,7 +5401,7 @@
     },
     "header": {
       "description": "Verbinden Sie sich über diese Kanäle mit {{displayName}}",
-      "title": "Wo {{displayName}} funktioniert"
+      "title": "Kanäle von {{displayName}}"
     },
     "slack": {
       "adminInstall": "Bitten Sie Ihren Administrator, die Slack-Integration zu installieren",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -442,12 +442,12 @@
         "newChat": "New chat",
         "settings": "Settings",
         "workflows": "Workflows",
-        "works": "Where {{agentName}} works"
+        "works": "{{agentName}}'s channels"
       },
       "rail": {
         "new": "New",
         "workflows": "Workflows",
-        "works": "Works"
+        "works": "Channels"
       },
       "searchConversations": "Search conversations",
       "workspaceSwitcher": {
@@ -5391,7 +5391,7 @@
     },
     "connected": "Connected",
     "connectedWithDetail": "Connected ({{detail}})",
-    "documentTitle": "Works",
+    "documentTitle": "Channels",
     "feishuConnected": "Feishu connected successfully",
     "github": {
       "adminInstall": "Ask an organization admin to install the GitHub App",
@@ -5401,7 +5401,7 @@
     },
     "header": {
       "description": "Connect with {{displayName}} through these channels",
-      "title": "Where {{displayName}} works"
+      "title": "{{displayName}}'s channels"
     },
     "slack": {
       "adminInstall": "Ask your admin to install the Slack integration",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -456,12 +456,12 @@
         "newChat": "Nuevo chat",
         "settings": "Configuración",
         "workflows": "Flujos de trabajo",
-        "works": "Dónde trabaja {{agentName}}"
+        "works": "Canales de {{agentName}}"
       },
       "rail": {
         "new": "Nuevo",
         "workflows": "Flujos de trabajo",
-        "works": "Integraciones"
+        "works": "Canales"
       },
       "searchConversations": "Buscar conversaciones",
       "workspaceSwitcher": {
@@ -5449,7 +5449,7 @@
     },
     "connected": "Conectado",
     "connectedWithDetail": "Conectado ({{detail}})",
-    "documentTitle": "Integraciones",
+    "documentTitle": "Canales",
     "feishuConnected": "Feishu conectado con éxito",
     "github": {
       "adminInstall": "Pide a un administrador de la organización que instale la aplicación de GitHub",
@@ -5459,7 +5459,7 @@
     },
     "header": {
       "description": "Conecta con {{displayName}} a través de estos canales",
-      "title": "Dónde trabaja {{displayName}}"
+      "title": "Canales de {{displayName}}"
     },
     "slack": {
       "adminInstall": "Pide a tu administrador que instale la integración de Slack",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -456,12 +456,12 @@
         "newChat": "Nouveau chat",
         "settings": "Paramètres",
         "workflows": "Workflows",
-        "works": "Où {{agentName}} travaille"
+        "works": "Canaux de {{agentName}}"
       },
       "rail": {
         "new": "Nouveau",
         "workflows": "Workflows",
-        "works": "Travail"
+        "works": "Canaux"
       },
       "searchConversations": "Rechercher des conversations",
       "workspaceSwitcher": {
@@ -5449,7 +5449,7 @@
     },
     "connected": "Connecté",
     "connectedWithDetail": "Connecté ({{detail}})",
-    "documentTitle": "Fonctionne",
+    "documentTitle": "Canaux",
     "feishuConnected": "Feishu connecté avec succès",
     "github": {
       "adminInstall": "Demandez à un administrateur de l’organisation d’installer l’application GitHub",
@@ -5459,7 +5459,7 @@
     },
     "header": {
       "description": "Connecter avec {{displayName}} via ces canaux",
-      "title": "Où {{displayName}} travaille"
+      "title": "Canaux de {{displayName}}"
     },
     "slack": {
       "adminInstall": "Demandez à votre administrateur d'installer l'intégration Slack",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -442,12 +442,12 @@
         "newChat": "नई चैट",
         "settings": "सेटिंग्स",
         "workflows": "वर्कफ़्लो",
-        "works": "जहां {{agentName}} काम करता है"
+        "works": "{{agentName}} के चैनल"
       },
       "rail": {
         "new": "नया",
         "workflows": "वर्कफ़्लो",
-        "works": "काम करता है"
+        "works": "चैनल"
       },
       "searchConversations": "वार्तालाप खोजें",
       "workspaceSwitcher": {
@@ -5391,7 +5391,7 @@
     },
     "connected": "जुड़े हुए",
     "connectedWithDetail": "कनेक्टेड ({{detail}})",
-    "documentTitle": "काम करता है",
+    "documentTitle": "चैनल",
     "feishuConnected": "Feishu सफलतापूर्वक कनेक्ट हुआ",
     "github": {
       "adminInstall": "किसी संगठन एडमिन से GitHub ऐप इंस्टॉल करने के लिए कहें",
@@ -5401,7 +5401,7 @@
     },
     "header": {
       "description": "इन चैनलों के माध्यम से {{displayName}} से जुड़ें",
-      "title": "जहां {{displayName}} काम करता है"
+      "title": "{{displayName}} के चैनल"
     },
     "slack": {
       "adminInstall": "अपने व्यवस्थापक से Slack एकीकरण स्थापित करने के लिए कहें",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -442,12 +442,12 @@
         "newChat": "Chat baru",
         "settings": "Pengaturan",
         "workflows": "Alur kerja",
-        "works": "Tempat {{agentName}} bekerja"
+        "works": "Saluran {{agentName}}"
       },
       "rail": {
         "new": "Baru",
         "workflows": "Alur kerja",
-        "works": "Bekerja"
+        "works": "Saluran"
       },
       "searchConversations": "Cari percakapan",
       "workspaceSwitcher": {
@@ -5390,7 +5390,7 @@
     },
     "connected": "Terhubung",
     "connectedWithDetail": "Terhubung ({{detail}})",
-    "documentTitle": "Berfungsi",
+    "documentTitle": "Saluran",
     "feishuConnected": "Feishu berhasil terhubung",
     "github": {
       "adminInstall": "Minta admin organisasi untuk menginstal aplikasi GitHub",
@@ -5400,7 +5400,7 @@
     },
     "header": {
       "description": "Hubungkan dengan {{displayName}} melalui saluran ini",
-      "title": "Tempat {{displayName}} bekerja"
+      "title": "Saluran {{displayName}}"
     },
     "slack": {
       "adminInstall": "Minta admin Anda untuk memasang integrasi Slack",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -456,12 +456,12 @@
         "newChat": "Nuova chat",
         "settings": "Impostazioni",
         "workflows": "Flussi di lavoro",
-        "works": "Dove lavora {{agentName}}"
+        "works": "Canali di {{agentName}}"
       },
       "rail": {
         "new": "Nuovo",
         "workflows": "Flussi di lavoro",
-        "works": "Integrazioni"
+        "works": "Canali"
       },
       "searchConversations": "Cerca conversazioni",
       "workspaceSwitcher": {
@@ -5449,7 +5449,7 @@
     },
     "connected": "Connesso",
     "connectedWithDetail": "Connesso ({{detail}})",
-    "documentTitle": "Integrazioni",
+    "documentTitle": "Canali",
     "feishuConnected": "Feishu si è connesso correttamente",
     "github": {
       "adminInstall": "Chiedi a un amministratore dell'organizzazione di installare l'app GitHub",
@@ -5459,7 +5459,7 @@
     },
     "header": {
       "description": "Connettiti con {{displayName}} attraverso questi canali",
-      "title": "Dove lavora {{displayName}}"
+      "title": "Canali di {{displayName}}"
     },
     "slack": {
       "adminInstall": "Chiedi al tuo amministratore di installare l'integrazione Slack",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -442,12 +442,12 @@
         "newChat": "새 채팅",
         "settings": "설정",
         "workflows": "워크플로",
-        "works": "{{agentName}}가(이) 작업하는 곳"
+        "works": "{{agentName}}의 채널"
       },
       "rail": {
         "new": "새로 만들기",
         "workflows": "워크플로",
-        "works": "작업"
+        "works": "채널"
       },
       "searchConversations": "대화 검색",
       "workspaceSwitcher": {
@@ -5390,7 +5390,7 @@
     },
     "connected": "연결됨",
     "connectedWithDetail": "연결됨 ({{detail}})",
-    "documentTitle": "작업",
+    "documentTitle": "채널",
     "feishuConnected": "Feishu가 성공적으로 연결되었습니다",
     "github": {
       "adminInstall": "조직 관리자에게 GitHub 앱 설치를 요청하세요",
@@ -5400,7 +5400,7 @@
     },
     "header": {
       "description": "{{displayName}}와(과) 다음 채널을 통해 연결됨",
-      "title": "{{displayName}}가(이) 작동하는 곳"
+      "title": "{{displayName}}의 채널"
     },
     "slack": {
       "adminInstall": "관리자에게 Slack 통합 설치를 요청하세요",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -456,12 +456,12 @@
         "newChat": "Novo chat",
         "settings": "Configurações",
         "workflows": "Fluxos de trabalho",
-        "works": "Onde {{agentName}} trabalha"
+        "works": "Canais de {{agentName}}"
       },
       "rail": {
         "new": "Novo",
         "workflows": "Fluxos de trabalho",
-        "works": "Trabalha"
+        "works": "Canais"
       },
       "searchConversations": "Buscar conversas",
       "workspaceSwitcher": {
@@ -5449,7 +5449,7 @@
     },
     "connected": "Conectado",
     "connectedWithDetail": "Conectado ({{detail}})",
-    "documentTitle": "Integrações",
+    "documentTitle": "Canais",
     "feishuConnected": "Feishu conectado com sucesso",
     "github": {
       "adminInstall": "Peça a um administrador da organização para instalar o app do GitHub",
@@ -5459,7 +5459,7 @@
     },
     "header": {
       "description": "Conecte-se com {{displayName}} por estes canais",
-      "title": "Onde {{displayName}} trabalha"
+      "title": "Canais de {{displayName}}"
     },
     "slack": {
       "adminInstall": "Peça ao administrador para instalar a integração com o Slack",


### PR DESCRIPTION
## What

Renames the sidebar entry currently labelled **Works** to **Channels**, across all ten locales.

| | before | after |
|---|---|---|
| Rail caption | `Works` | `Channels` |
| Expanded nav | `Where {agent} works` | `{agent}'s channels` |
| Page title | `Where {agent} works` | `{agent}'s channels` |
| Document title | `Works` | `Channels` |

## Why

`Works` was a truncation of the expanded label `Where {agent} works`. Standing alone under an icon it reads as a noun ("artworks", "engineering works"), and it shares its first four letters with **Workflows** two rows above, so the two are hard to tell apart at a glance.

The page behind it lists Slack, Microsoft Teams, GitHub, Feishu, Telegram, Strapi and AgentPhone — the places the agent can be reached from or triggered by. `Channels` names that directly, and keeps a clean split from **Connectors** (what the agent can call).

The ambiguity had already leaked into the translations. Several locales had read the English as a verb:

- de-DE — `Funktioniert` ("it functions")
- fr-FR — `Fonctionne` / `Travail`
- id-ID — `Berfungsi` / `Bekerja`
- ko-KR — `{name}가(이) 작동하는 곳` ("where {name} operates", as of a machine)
- pt-BR — `Trabalha`
- hi-IN — `काम करता है`

All ten now use the channel wording each locale was already using in the page description (`…through these channels`). `ja-JP` keeps 連携先 — it was already correct and is coherent across all four of its strings, so that file is untouched.

Every new caption fits the rail: the longest is `Channels` at 8 characters, still shorter than the existing `Connectors`.

## Scope

Copy only. The `/works` route, the `works` nav id, the page layout and all behaviour are unchanged — no redirects needed, no links break.

## Left out, on purpose

- **The route.** `/works` → `/channels` would be more consistent but breaks existing links; happy to do it as a follow-up with a redirect.
- **The rail icon.** That entry renders Slack's colour logo (`iconImg: slackIcon`) even though seven destinations sit on the page. Swapping it for the neutral `LayoutGrid` already wired up as the fallback is a visual change, so it is not bundled into a copy rename.

## Test plan

No behavioural change and no test asserts these strings. Verified by inspection that the four keys resolve in all ten locale files and that the `{{agentName}}` / `{{displayName}}` interpolations are preserved at all three call sites (`zero-sidebar.tsx`, `zero-mobile-breadcrumb.ts`, `zero-works-page.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)