### PR TITLE
fix(api): brand google drive artifact folders

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
@@ -19,6 +19,7 @@ import {
   chatThreadArtifactsContract,
   type ChatEvent,
 } from "@okouai/api-contracts/contracts/chat-threads";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -145,6 +146,7 @@ function okouToken(args: {
   readonly orgId: string;
   readonly runId: string;
   readonly capabilities?: readonly string[];
+  readonly publicBrand?: PublicBrand;
 }): string {
   const seconds = Math.floor(now() / 1000);
   return signSandboxJwtForTests({
@@ -153,6 +155,7 @@ function okouToken(args: {
     orgId: args.orgId,
     runId: args.runId,
     capabilities: (args.capabilities ?? ["slack:write"]) as never,
+    ...(args.publicBrand ? { publicBrand: args.publicBrand } : {}),
     iat: seconds,
     exp: seconds + 60,
   });
@@ -739,6 +742,42 @@ describe("POST /api/okou/integrations/slack/upload-file/complete", () => {
       expect(okouDriveSync.body.name).toBe("report.csv");
     }
 
+    const okouRunDriveSync = await accept(
+      vm0DriveClient.syncGoogleDrive({
+        headers: {
+          authorization: `Bearer ${okouToken({
+            userId,
+            orgId,
+            runId,
+            capabilities: ["file:write"],
+            publicBrand: "okou",
+          })}`,
+        },
+        params: { threadId },
+        body: { runId, fileId: canonicalAssetId },
+      }),
+      [200],
+    );
+    expect(okouRunDriveSync.body.name).toBe("report.csv");
+
+    const vm0RunDriveSync = await accept(
+      okouDriveClient.syncGoogleDrive({
+        headers: {
+          authorization: `Bearer ${okouToken({
+            userId,
+            orgId,
+            runId,
+            capabilities: ["file:write"],
+            publicBrand: "vm0",
+          })}`,
+        },
+        params: { threadId },
+        body: { runId, fileId: canonicalAssetId },
+      }),
+      [200],
+    );
+    expect(vm0RunDriveSync.body.name).toBe("report.csv");
+
     expect(driveFolders).toHaveLength(4);
     expect(
       driveFolders
@@ -749,7 +788,9 @@ describe("POST /api/okou/integrations/slack/upload-file/complete", () => {
           return folder.name;
         }),
     ).toStrictEqual(["vm0-artifact", "Okou Artifacts"]);
-    expect(driveUploadBodies).toHaveLength(3);
+    expect(driveUploadBodies).toHaveLength(5);
+    expect(driveUploadBodies[3]).toContain('"parents":["drive-folder-4"]');
+    expect(driveUploadBodies[4]).toContain('"parents":["drive-folder-2"]');
     for (const body of driveUploadBodies) {
       expect(body).toContain(`"vm0Artifact":"true"`);
       expect(body).toContain(`"vm0ThreadId":"${threadId}"`);

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts
@@ -15,7 +15,10 @@ import {
   integrationsSlackUploadInitContract,
   integrationsSlackUploadMaterializeContract,
 } from "@okouai/api-contracts/contracts/integrations";
-import type { ChatEvent } from "@okouai/api-contracts/contracts/chat-threads";
+import {
+  chatThreadArtifactsContract,
+  type ChatEvent,
+} from "@okouai/api-contracts/contracts/chat-threads";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -47,8 +50,15 @@ import {
 import { integrationsSlackUploadCompleteRoutes } from "../integrations-slack-upload-complete";
 import { integrationsSlackUploadInitRoutes } from "../integrations-slack-upload-init";
 import { integrationsSlackUploadMaterializeRoutes } from "../integrations-slack-upload-materialize";
+import { chatThreadsArtifactsSyncRoutes } from "../chat-threads-artifacts-sync";
 
 type CompletedChatEvent = Extract<ChatEvent, { eventType: "run.completed" }>;
+
+interface DriveFolderFixture {
+  readonly id: string;
+  readonly name: string;
+  readonly parentFolderId: string | null;
+}
 
 const context = testContext();
 const store = createStore();
@@ -639,26 +649,49 @@ describe("POST /api/okou/integrations/slack/upload-file/complete", () => {
       "google-drive",
     ]);
 
-    let folderCount = 0;
+    const driveFolders: DriveFolderFixture[] = [];
     const driveUploadBodies: string[] = [];
+    const driveUploadContentTypes: (string | null)[] = [];
     server.use(
-      http.get("https://www.googleapis.com/drive/v3/files", () => {
-        return HttpResponse.json({ files: [] });
+      http.get("https://www.googleapis.com/drive/v3/files", ({ request }) => {
+        const query = new URL(request.url).searchParams.get("q");
+        if (!query) {
+          throw new Error("Expected Google Drive folder query");
+        }
+        const folder = driveFolders.find((candidate) => {
+          const parentClause = candidate.parentFolderId
+            ? `'${candidate.parentFolderId}' in parents`
+            : "'root' in parents";
+          return (
+            query.includes(`name = '${candidate.name}'`) &&
+            query.includes(parentClause)
+          );
+        });
+        return HttpResponse.json({ files: folder ? [folder] : [] });
       }),
       http.post(
         "https://www.googleapis.com/drive/v3/files",
         async ({ request }) => {
-          const body = (await request.json()) as { name?: string };
-          folderCount += 1;
-          return HttpResponse.json({
-            id: `drive-folder-${String(folderCount)}`,
-            name: body.name ?? "folder",
-          });
+          const body = (await request.json()) as {
+            readonly name?: string;
+            readonly parents?: readonly string[];
+          };
+          if (!body.name) {
+            throw new Error("Expected Google Drive folder name");
+          }
+          const folder = {
+            id: `drive-folder-${String(driveFolders.length + 1)}`,
+            name: body.name,
+            parentFolderId: body.parents?.[0] ?? null,
+          };
+          driveFolders.push(folder);
+          return HttpResponse.json(folder);
         },
       ),
       http.post(
         "https://www.googleapis.com/upload/drive/v3/files",
         async ({ request }) => {
+          driveUploadContentTypes.push(request.headers.get("content-type"));
           driveUploadBodies.push(await request.text());
           return HttpResponse.json({
             id: "drive-canonical-asset",
@@ -669,10 +702,18 @@ describe("POST /api/okou/integrations/slack/upload-file/complete", () => {
         },
       ),
     );
-    const driveSync = await chatApi.requestSyncThreadArtifact(
-      actorFor({ orgId, userId }),
-      threadId,
-      { runId, fileId: canonicalAssetId },
+    mocks.clerk.session(userId, orgId);
+    const vm0DriveClient = setupApp({
+      baseUrl: "https://api.vm0.ai",
+      context,
+      routes: chatThreadsArtifactsSyncRoutes,
+    })(chatThreadArtifactsContract);
+    const driveSync = await accept(
+      vm0DriveClient.syncGoogleDrive({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId },
+        body: { runId, fileId: canonicalAssetId },
+      }),
       [200],
     );
     expect(driveSync.body).toStrictEqual({
@@ -680,8 +721,46 @@ describe("POST /api/okou/integrations/slack/upload-file/complete", () => {
       name: "report.csv",
       webViewLink: "https://drive.google.com/file/d/drive-canonical-asset/view",
     });
-    expect(driveUploadBodies).toHaveLength(1);
-    expect(driveUploadBodies[0]).toContain(`"vm0FileId":"${canonicalAssetId}"`);
+
+    const okouDriveClient = setupApp({
+      baseUrl: "https://api.okou.ai",
+      context,
+      routes: chatThreadsArtifactsSyncRoutes,
+    })(chatThreadArtifactsContract);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const okouDriveSync = await accept(
+        okouDriveClient.syncGoogleDrive({
+          headers: { authorization: "Bearer clerk-session" },
+          params: { threadId },
+          body: { runId, fileId: canonicalAssetId },
+        }),
+        [200],
+      );
+      expect(okouDriveSync.body.name).toBe("report.csv");
+    }
+
+    expect(driveFolders).toHaveLength(4);
+    expect(
+      driveFolders
+        .filter((folder) => {
+          return folder.parentFolderId === null;
+        })
+        .map((folder) => {
+          return folder.name;
+        }),
+    ).toStrictEqual(["vm0-artifact", "Okou Artifacts"]);
+    expect(driveUploadBodies).toHaveLength(3);
+    for (const body of driveUploadBodies) {
+      expect(body).toContain(`"vm0Artifact":"true"`);
+      expect(body).toContain(`"vm0ThreadId":"${threadId}"`);
+      expect(body).toContain(`"vm0RunId":"${runId}"`);
+      expect(body).toContain(`"vm0FileId":"${canonicalAssetId}"`);
+    }
+    expect(
+      driveUploadContentTypes.every((contentType) => {
+        return contentType?.startsWith("multipart/related; boundary=vm0-");
+      }),
+    ).toBeTruthy();
 
     const claim = await claimRun(runnerGroup, runId);
     await completeRun({

--- a/turbo/apps/api/src/signals/routes/chat-threads-artifacts-sync.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-artifacts-sync.ts
@@ -49,7 +49,12 @@ export const chatThreadsArtifactsSyncRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadArtifactsContract.syncGoogleDrive,
     handler: authRoute(
-      { requireOrganization: true, missingOrganizationStatus: 401 },
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "file:write",
+        accept: ["session", "pat", "zero"],
+      },
       syncInner$,
     ),
   },

--- a/turbo/apps/api/src/signals/routes/chat-threads-artifacts-sync.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-artifacts-sync.ts
@@ -3,6 +3,7 @@ import { chatThreadArtifactsContract } from "@okouai/api-contracts/contracts/cha
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { publicBrand$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { isBadRequestResponse, isNotFoundResponse } from "../../lib/error";
 import { syncArtifactToGoogleDrive$ } from "../services/google-drive-artifact-sync.service";
@@ -28,6 +29,8 @@ const syncInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       threadId: params.threadId,
       runId: bodyResult.data.runId,
       fileId: bodyResult.data.fileId,
+      publicBrand:
+        auth.tokenType === "zero" ? auth.publicBrand : get(publicBrand$),
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -5,6 +5,7 @@ import type {
   ChatThreadArtifactGoogleDriveSync,
   ChatThreadArtifactRun,
 } from "@okouai/api-contracts/contracts/chat-threads";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import type { FeatureSwitchContext } from "@okouai/core/feature-switch";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatEvents } from "@okouai/db/schema/chat-event";
@@ -881,10 +882,13 @@ async function ensureDriveFolder(args: {
 
 async function ensureArtifactFolder(args: {
   readonly accessToken: string;
+  readonly publicBrand: PublicBrand;
   readonly threadId: string;
 }): Promise<DriveTokenResult<string>> {
   let parentFolderId: string | null = null;
-  for (const name of ["vm0-artifact", `chat-${args.threadId}`]) {
+  const rootFolderName =
+    args.publicBrand === "okou" ? "Okou Artifacts" : "vm0-artifact";
+  for (const name of [rootFolderName, `chat-${args.threadId}`]) {
     const folder = await ensureDriveFolder({
       accessToken: args.accessToken,
       parentFolderId,
@@ -960,6 +964,7 @@ async function uploadDriveFile(args: {
 
 async function uploadArtifactWithToken(args: {
   readonly accessToken: string;
+  readonly publicBrand: PublicBrand;
   readonly threadId: string;
   readonly runId: string;
   readonly fileId: string;
@@ -969,6 +974,7 @@ async function uploadArtifactWithToken(args: {
 }): Promise<DriveTokenResult<Response>> {
   const folder = await ensureArtifactFolder({
     accessToken: args.accessToken,
+    publicBrand: args.publicBrand,
     threadId: args.threadId,
   });
   if (folder.type === "unauthorized") {
@@ -1031,6 +1037,7 @@ export const syncArtifactToGoogleDrive$ = command(
       readonly threadId: string;
       readonly runId: string;
       readonly fileId: string;
+      readonly publicBrand: PublicBrand;
     },
     signal: AbortSignal,
   ): Promise<
@@ -1106,6 +1113,7 @@ export const syncArtifactToGoogleDrive$ = command(
 
     let result = await uploadArtifactWithToken({
       accessToken: tokens.accessToken,
+      publicBrand: args.publicBrand,
       threadId: args.threadId,
       runId: args.runId,
       fileId: args.fileId,
@@ -1130,6 +1138,7 @@ export const syncArtifactToGoogleDrive$ = command(
       if (refreshed) {
         result = await uploadArtifactWithToken({
           accessToken: refreshed,
+          publicBrand: args.publicBrand,
           threadId: args.threadId,
           runId: args.runId,
           fileId: args.fileId,


### PR DESCRIPTION
## Summary

- derive the Google Drive artifact root folder from the authenticated run or request public brand
- create and reuse `Okou Artifacts` for Okou requests while preserving `vm0-artifact` for VM0 requests
- cover both API hostnames, repeated Okou syncs, legacy VM0 folder coexistence, and unchanged internal Drive metadata

## Compatibility

- existing Google Drive folders are never renamed or moved
- VM0 requests continue to create and reuse `vm0-artifact`
- `vm0Artifact`, `vm0ThreadId`, `vm0RunId`, `vm0FileId`, and the `vm0-*` multipart boundary remain technical compatibility identifiers

## Verification

- `pnpm format`
- `pnpm --filter api run lint`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts` — the new VM0/Okou Drive assertions completed successfully; the file finished with 10 passing tests and 2 pre-existing runner-claim steps returning 404 in the locally migrated database, so the seeded PR pipeline remains the final integration check

Refs #27750
