### PR TITLE
docs(nbd-cow): qualify abandoned device cleanup

### DIFF
--- a/crates/nbd-cow/src/device/mod.rs
+++ b/crates/nbd-cow/src/device/mod.rs
@@ -95,11 +95,13 @@ impl NbdCowDevice {
         }
     }
 
-    /// Mark the device as abandoned without performing cleanup.
+    /// Mark the device as abandoned without disconnecting the kernel device.
     ///
     /// Use as a last resort when netlink disconnect fails. Cancels tasks
-    /// and marks the device as disconnected so Drop becomes a no-op.
-    /// The device persists in the kernel until `runner gc` cleans it up.
+    /// and marks the device as disconnected so Drop becomes a no-op. The
+    /// kernel device remains connected until `runner gc` observes that the
+    /// connecting TID recorded in `/sys/block/nbdN/pid` no longer exists;
+    /// `runner gc` skips the device while that TID is still alive.
     pub fn abandon(&mut self) {
         tracing::warn!(
             device_index = self.device_index,

--- a/crates/nbd-cow/src/device/mod.rs
+++ b/crates/nbd-cow/src/device/mod.rs
@@ -99,9 +99,11 @@ impl NbdCowDevice {
     ///
     /// Use as a last resort when netlink disconnect fails. Cancels tasks
     /// and marks the device as disconnected so Drop becomes a no-op. The
-    /// kernel device remains connected until `runner gc` observes that the
-    /// connecting TID recorded in `/sys/block/nbdN/pid` no longer exists;
-    /// `runner gc` skips the device while that TID is still alive.
+    /// kernel device may remain connected after this method returns. `runner
+    /// gc` considers it eligible only after the connecting TID recorded in
+    /// `/sys/block/nbdN/pid` no longer exists; it skips the device while that
+    /// TID is still alive. The kernel may also disconnect an orphan with
+    /// pending I/O after its configured dead-connection timeout.
     pub fn abandon(&mut self) {
         tracing::warn!(
             device_index = self.device_index,

--- a/crates/nbd-cow/src/device/pooled.rs
+++ b/crates/nbd-cow/src/device/pooled.rs
@@ -459,10 +459,12 @@ impl PooledNbdCowDevice {
     /// Mark the device as abandoned and retire the pool lease as uncertain.
     ///
     /// The underlying [`NbdCowDevice::abandon`] leaves the kernel device
-    /// connected. `runner gc` can clean it up only after the connecting TID
-    /// recorded in `/sys/block/nbdN/pid` no longer exists; `runner gc` skips
-    /// the device while that TID is still alive. Retiring the pool lease does
-    /// not make the connected device immediately reusable.
+    /// connected. `runner gc` considers it eligible only after the connecting
+    /// TID recorded in `/sys/block/nbdN/pid` no longer exists; it skips the
+    /// device while that TID is still alive. The kernel may also disconnect an
+    /// orphan with pending I/O after its configured dead-connection timeout.
+    /// Retiring the pool lease does not make the connected device immediately
+    /// reusable.
     ///
     /// Must be called from a Tokio runtime.
     pub fn abandon(self) -> impl std::future::Future<Output = ()> + Send + 'static {

--- a/crates/nbd-cow/src/device/pooled.rs
+++ b/crates/nbd-cow/src/device/pooled.rs
@@ -458,6 +458,12 @@ impl PooledNbdCowDevice {
 
     /// Mark the device as abandoned and retire the pool lease as uncertain.
     ///
+    /// The underlying [`NbdCowDevice::abandon`] leaves the kernel device
+    /// connected. `runner gc` can clean it up only after the connecting TID
+    /// recorded in `/sys/block/nbdN/pid` no longer exists; `runner gc` skips
+    /// the device while that TID is still alive. Retiring the pool lease does
+    /// not make the connected device immediately reusable.
+    ///
     /// Must be called from a Tokio runtime.
     pub fn abandon(self) -> impl std::future::Future<Output = ()> + Send + 'static {
         let finalizer = Self::run_finalizer(async move {


### PR DESCRIPTION
## Summary

- Clarify that `NbdCowDevice::abandon` leaves the kernel NBD device connected.
- Document that `runner gc` can clean the device only after the recorded connecting TID no longer exists.
- Keep `PooledNbdCowDevice::abandon` consistent, including its uncertain pool-lease retirement semantics.

## Scope

- Documentation-only change in the public `nbd-cow` Rust API.
- No runtime behavior, orphan policy, pool state, or cleanup timing was changed.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `cd crates && cargo test -p nbd-cow --lib` (238 passed)

Closes #28123
