### PR TITLE
perf(runner): bound axiom debug field formatting

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -70,6 +70,43 @@ const AXIOM_SUFFIX_ENV: &str = "AXIOM_DATASET_SUFFIX";
 /// from looping back into this layer and re-flooding the dispatcher.
 const INTERNAL_TARGET: &str = "runner::axiom_layer::internal";
 
+#[derive(Default)]
+struct BoundedDebugOutput {
+    value: String,
+    truncated: bool,
+}
+
+impl BoundedDebugOutput {
+    fn finish(mut self) -> String {
+        if self.truncated {
+            self.value.push_str("…[truncated]");
+        }
+        self.value
+    }
+}
+
+impl std::fmt::Write for BoundedDebugOutput {
+    fn write_str(&mut self, value: &str) -> std::fmt::Result {
+        if self.truncated {
+            return Err(std::fmt::Error);
+        }
+
+        let remaining = DEBUG_FIELD_MAX_BYTES - self.value.len();
+        if value.len() <= remaining {
+            self.value.push_str(value);
+            return Ok(());
+        }
+
+        let mut end = remaining;
+        while !value.is_char_boundary(end) {
+            end -= 1;
+        }
+        self.value.push_str(&value[..end]);
+        self.truncated = true;
+        Err(std::fmt::Error)
+    }
+}
+
 /// Holds the dispatcher task. `shutdown().await` drains the queue; dropping
 /// without calling `shutdown` leaves the tokio runtime to abort the task.
 ///
@@ -330,19 +367,10 @@ fn serialize_event(event: &Event<'_>) -> Value {
         fn record_debug(&mut self, f: &Field, v: &dyn std::fmt::Debug) {
             // Cap per-field size so a user who logs a huge struct via `?v`
             // can't blow past Axiom's body limit or starve the dispatcher.
-            let mut s = String::new();
-            let _ = write!(s, "{v:?}");
-            if s.len() > DEBUG_FIELD_MAX_BYTES {
-                // Truncate on a char boundary so the resulting String is
-                // still valid UTF-8.
-                let mut cut = DEBUG_FIELD_MAX_BYTES;
-                while !s.is_char_boundary(cut) {
-                    cut -= 1;
-                }
-                s.truncate(cut);
-                s.push_str("…[truncated]");
-            }
-            self.0.insert(f.name().into(), Value::String(s));
+            let mut output = BoundedDebugOutput::default();
+            let _ = write!(output, "{v:?}");
+            self.0
+                .insert(f.name().into(), Value::String(output.finish()));
         }
     }
 

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -6,14 +6,14 @@
 //! endpoint with the TS-compatible payload shape.
 //!
 
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::Duration;
 
 use super::{
-    AxiomLayer, CHANNEL_CAP, INTERNAL_TARGET, init_from_env_values, init_with_base_url,
-    with_ingest_filter,
+    AxiomLayer, CHANNEL_CAP, DEBUG_FIELD_MAX_BYTES, INTERNAL_TARGET, init_from_env_values,
+    init_with_base_url, with_ingest_filter,
 };
 use httpmock::Method::POST;
 use httpmock::MockServer;
@@ -507,6 +507,53 @@ async fn non_success_ingest_response_does_not_hang_shutdown_or_panic() {
 }
 
 // -- Debug field truncation (DEBUG_FIELD_MAX_BYTES = 4 KiB) ------------------
+
+#[tokio::test]
+async fn debug_field_formatting_stops_after_reaching_limit() {
+    const CHUNK_BYTES: usize = 8;
+    const TOTAL_CHUNKS: usize = 10_000;
+
+    struct IncrementalDebug<'a>(&'a AtomicUsize);
+
+    impl std::fmt::Debug for IncrementalDebug<'_> {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            for _ in 0..TOTAL_CHUNKS {
+                self.0.fetch_add(1, Ordering::Relaxed);
+                formatter.write_str("12345678")?;
+            }
+            Ok(())
+        }
+    }
+
+    let server = MockServer::start_async().await;
+    let (ingest, captured) = capture_axiom_ingest(&server).await;
+    let formatted_chunks = AtomicUsize::new(0);
+
+    let (layer, guard) =
+        init_with_base_url(&server.base_url(), "t", "test").expect("init must succeed");
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
+    {
+        let _sub = tracing::subscriber::set_default(subscriber);
+        tracing::warn!(
+            value = ?IncrementalDebug(&formatted_chunks),
+            "bounded-formatting",
+        );
+    }
+    guard.shutdown().await;
+
+    ingest.assert_calls_async(1).await;
+    let events = captured.events();
+    let event = event_with_message(&events, "bounded-formatting");
+    assert!(
+        string_field(event, "value").contains("…[truncated]"),
+        "oversized incrementally formatted field should include the truncation marker: {event:#?}",
+    );
+    assert_eq!(
+        formatted_chunks.load(Ordering::Relaxed),
+        DEBUG_FIELD_MAX_BYTES / CHUNK_BYTES + 1,
+        "formatting should stop on the first chunk beyond the byte limit instead of visiting all {TOTAL_CHUNKS} chunks",
+    );
+}
 
 #[tokio::test]
 async fn debug_field_over_limit_is_truncated_with_marker() {


### PR DESCRIPTION
## Summary

- bound runner Axiom `Debug` formatting with a standard-library writer that retains at most the configured 4 KiB prefix
- preserve valid UTF-8, the existing truncation marker, exact-limit behavior, and the serialized payload shape
- add an Axiom-layer integration regression proving incremental formatting stops on the first write beyond the limit

## Explicit exclusions

- no changes to channel admission or the separate overload behavior tracked by #28124
- no API, protocol, persisted-data, dependency, or rollout changes

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner debug_field_formatting_stops_after_reaching_limit`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps`
- `cargo test -p runner` (3184 passed, 20 existing ignored child-process fixtures, 0 failed)

Closes #28125
