### PR TITLE
test(runner): eliminate bounded command pid file race

### DIFF
--- a/crates/runner/src/bounded_command.rs
+++ b/crates/runner/src/bounded_command.rs
@@ -324,7 +324,7 @@ mod tests {
         let mut command = Command::new("sh");
         command
             .arg("-c")
-            .arg("printf '%s' \"$$\" > \"$1\"; exec sleep 60")
+            .arg("printf '%s' \"$$\" > \"$1.tmp\"; mv \"$1.tmp\" \"$1\"; exec sleep 60")
             .arg("sh")
             .arg(pid_path);
         command


### PR DESCRIPTION
## Summary

- write the helper child PID to a temporary file before atomically renaming it into place
- prevent the observer from reading the zero-byte window created by shell redirection
- keep the existing timeout and cancellation behavior unchanged; the 60-second child is killed after the test timeout rather than awaited to completion

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets --all-features` (3183 passed, 20 ignored; integration test passed)
- repeated `bounded_command::tests::output_command_timeout_reaps_recorded_child` 20 times (20/20 passed)
- pre-commit workspace Cargo fmt, Clippy, and doc checks