### PR TITLE
perf(runner): reserve axiom channel before serialization

### DIFF
--- a/crates/runner/src/axiom_layer.rs
+++ b/crates/runner/src/axiom_layer.rs
@@ -192,8 +192,7 @@ where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
     fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
-        let value = serialize_event(event);
-        if self.tx.try_send(Msg::Event(value)).is_err() {
+        let Ok(permit) = self.tx.try_reserve() else {
             // Bounded-channel full or dispatcher gone. Emit a periodic
             // best-effort diagnostic under `INTERNAL_TARGET`; if tracing
             // observes it, the Axiom per-layer filter keeps it out of remote
@@ -206,7 +205,10 @@ where
                     "axiom channel full",
                 );
             }
-        }
+            return;
+        };
+
+        permit.send(Msg::Event(serialize_event(event)));
     }
 }
 

--- a/crates/runner/src/axiom_layer_tests.rs
+++ b/crates/runner/src/axiom_layer_tests.rs
@@ -6,7 +6,7 @@
 //! endpoint with the TS-compatible payload shape.
 //!
 
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::time::Duration;
@@ -33,6 +33,15 @@ struct RecordedEvent {
 #[derive(Clone, Default)]
 struct RecordingLayer {
     events: Arc<Mutex<Vec<RecordedEvent>>>,
+}
+
+struct FormattingProbe<'a>(&'a AtomicUsize);
+
+impl std::fmt::Debug for FormattingProbe<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fetch_add(1, Ordering::Relaxed);
+        formatter.write_str("formatted")
+    }
 }
 
 impl RecordingLayer {
@@ -450,6 +459,27 @@ fn burst_past_channel_cap_drops_without_blocking() {
         CHANNEL_CAP,
         "the bounded channel must drop every event beyond its capacity",
     );
+}
+
+#[test]
+fn rejected_events_are_not_serialized() {
+    let (tx, receiver) = tokio::sync::mpsc::channel(1);
+    assert!(tx.try_send(super::Msg::Event(json!({}))).is_ok());
+
+    let layer = AxiomLayer {
+        tx,
+        dropped: AtomicU64::new(0),
+    };
+    let subscriber = tracing_subscriber::registry().with(with_ingest_filter(layer));
+    let formatting_count = AtomicUsize::new(0);
+
+    let _sub = tracing::subscriber::set_default(subscriber);
+    tracing::warn!(probe = ?FormattingProbe(&formatting_count), "full channel");
+    assert_eq!(formatting_count.load(Ordering::Relaxed), 0);
+
+    drop(receiver);
+    tracing::warn!(probe = ?FormattingProbe(&formatting_count), "closed channel");
+    assert_eq!(formatting_count.load(Ordering::Relaxed), 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- reserve a bounded Axiom channel slot before serializing WARN/ERROR events
- keep full and closed channel rejection on the existing drop counter and local diagnostic path
- add a `Debug` side-effect regression test proving rejected events are not formatted

## Scope

- preserves the existing admitted-event JSON payload and sibling local tracing behavior
- does not change Axiom batching, HTTP timeout, shutdown, retry, filter, or channel capacity behavior
- does not change APIs, persisted state, runner protocols, or deployment compatibility boundaries

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner axiom_layer::tests`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit workspace Rust formatting, documentation, Clippy, file-size, and commit-message checks

Closes #28124
