### PR TITLE
perf(python): bound firewall auth identity ownership

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -50,6 +50,7 @@ from aws_sigv4 import (
 )
 from aws_sigv4_body_admission import MAX_AWS_SIGV4_REQUEST_BODY_BYTES
 from firewall_auth_cache import (
+    FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE,
     FirewallAuthCacheKey,
     FirewallAuthFetchSaturatedError,
     InvalidBillableAuthExpiryError,
@@ -307,6 +308,7 @@ def _build_firewall_auth_context(
             firewall_base=firewall_base,
             auth_request=auth_request,
         ),
+        registry_generation=_firewall_auth_registry_generation(vm_info),
     )
     flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = auth_cache_key
     return _FirewallAuthContext(
@@ -316,6 +318,13 @@ def _build_firewall_auth_context(
         auth_request=auth_request,
         auth_cache_key=auth_cache_key,
     )
+
+
+def _firewall_auth_registry_generation(vm_info: dict) -> int | None:
+    generation = getattr(vm_info, FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE, None)
+    if isinstance(generation, bool) or not isinstance(generation, int):
+        return None
+    return generation
 
 
 def _build_firewall_auth_identity(

--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -162,7 +162,7 @@ def clear_cached_firewall_headers(cache_key: FirewallAuthCacheKey) -> None:
         state.cache = None
 
 
-def evict_stale_cache_keys(active_run_generations: dict[str, int]) -> None:
+def reconcile_registry_cache_ownership(active_run_generations: dict[str, int]) -> None:
     """Reconcile cache ownership with the current registry generation."""
     _active_registry_generations.clear()
     _active_registry_generations.update(active_run_generations)

--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -28,6 +28,12 @@ class FirewallAuthCacheKey:
     run_id: str
     api_id: str
     auth_identity: str
+    registry_generation: int | None = field(
+        default=None,
+        compare=False,
+        hash=False,
+        repr=False,
+    )
 
 
 @dataclass
@@ -63,7 +69,12 @@ class FirewallAuthStateSnapshotForTests:
     last_force_refresh_monotonic_at: float | None = None
 
 
+FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE = "_firewall_auth_registry_generation"
+type _FirewallAuthScope = tuple[str, str]
+
 _auth_state: dict[FirewallAuthCacheKey, _FirewallAuthState] = {}
+_owned_auth_keys: dict[_FirewallAuthScope, FirewallAuthCacheKey] = {}
+_active_registry_generations: dict[str, int] = {}
 MAX_CONCURRENT_FIREWALL_AUTH_FETCHES = 4
 MAX_ADMITTED_FIREWALL_AUTH_FETCHES = 16
 _admitted_firewall_auth_fetches = 0
@@ -79,7 +90,23 @@ _FORCE_REFRESH_COOLDOWN_SECS = 120.0
 
 
 def _get_auth_state(cache_key: FirewallAuthCacheKey) -> _FirewallAuthState:
+    """Return owned state, or detached state for a superseded registry key."""
     state = _auth_state.get(cache_key)
+
+    registry_generation = cache_key.registry_generation
+    is_current_registry_generation = registry_generation is None or (
+        _active_registry_generations.get(cache_key.run_id) == registry_generation
+    )
+    if not is_current_registry_generation:
+        return state if state is not None else _FirewallAuthState()
+
+    scope = (cache_key.run_id, cache_key.api_id)
+    owned_key = _owned_auth_keys.get(scope)
+    if owned_key is not None and owned_key != cache_key:
+        _auth_state.pop(owned_key, None)
+        state = None
+
+    _owned_auth_keys[scope] = cache_key
     if state is None:
         state = _FirewallAuthState()
         _auth_state[cache_key] = state
@@ -135,16 +162,22 @@ def clear_cached_firewall_headers(cache_key: FirewallAuthCacheKey) -> None:
         state.cache = None
 
 
-def evict_stale_cache_keys(active_run_ids: set[str]) -> None:
-    """Remove cache entries for runs no longer in the registry."""
-    stale = [k for k in _auth_state if k.run_id not in active_run_ids]
-    for k in stale:
-        _auth_state.pop(k, None)
+def evict_stale_cache_keys(active_run_generations: dict[str, int]) -> None:
+    """Reconcile cache ownership with the current registry generation."""
+    _active_registry_generations.clear()
+    _active_registry_generations.update(active_run_generations)
+
+    stale_scopes = [scope for scope in _owned_auth_keys if scope[0] not in active_run_generations]
+    for scope in stale_scopes:
+        cache_key = _owned_auth_keys.pop(scope)
+        _auth_state.pop(cache_key, None)
 
 
 def evict_all_cache_keys() -> None:
     """Remove all auth cache entries when active registry ownership is unknown."""
     _auth_state.clear()
+    _owned_auth_keys.clear()
+    _active_registry_generations.clear()
 
 
 def reset_cache_for_tests() -> None:
@@ -153,6 +186,8 @@ def reset_cache_for_tests() -> None:
     global _firewall_auth_fetch_semaphore
 
     _auth_state.clear()
+    _owned_auth_keys.clear()
+    _active_registry_generations.clear()
     _admitted_firewall_auth_fetches = 0
     _firewall_auth_fetch_semaphore = None
 

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -10,7 +10,11 @@ from mitmproxy import ctx
 import matching
 import registry_firewalls
 import state_file
-from firewall_auth_cache import evict_all_cache_keys, evict_stale_cache_keys
+from firewall_auth_cache import (
+    FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE,
+    evict_all_cache_keys,
+    evict_stale_cache_keys,
+)
 
 VmContext = tuple[
     dict,
@@ -19,6 +23,10 @@ VmContext = tuple[
 ]
 type _RegistryFileKey = state_file.StateFileIdentity
 MAX_REGISTRY_BYTES = 16 * 1024 * 1024
+
+
+class _RegistryVmInfo(dict):
+    """Published VM mapping with private process-local ownership state."""
 
 
 class _RegistryFormatError(ValueError):
@@ -91,12 +99,23 @@ class _RegistryCacheState:
 
 
 _registry_state = _RegistryCacheState()
+_next_firewall_auth_registry_generation = 0
 
 
 def reset_cache_for_tests() -> None:
     """Reset module cache state between tests."""
+    global _next_firewall_auth_registry_generation
+
     _registry_state.reset()
+    _next_firewall_auth_registry_generation = 0
     registry_firewalls.reset_cache_for_tests()
+
+
+def _allocate_firewall_auth_registry_generation() -> int:
+    global _next_firewall_auth_registry_generation
+
+    _next_firewall_auth_registry_generation += 1
+    return _next_firewall_auth_registry_generation
 
 
 def _path_key(path: Path) -> str:
@@ -331,7 +350,8 @@ def _classify_registry_vms(
             invalid_vms[client_ip] = InvalidVmEntry("invalid_firewalls", str(e))
             continue
 
-        vm = dict(vm)
+        vm = _RegistryVmInfo(vm)
+        vm.pop(FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE, None)
         if resolved_firewalls.firewalls is not None:
             vm["firewalls"] = resolved_firewalls.firewalls
             if resolved_firewalls.builtin_cache_keys is not None:
@@ -503,9 +523,18 @@ def load_registry_state(registry_path: str) -> RegistryState:
         state.builtin_firewall_core_cache,
     )
 
-    # Evict cache entries for runs no longer in the registry.
-    active_run_ids = {vm["runId"] for vm in new_registry.values()}
-    evict_stale_cache_keys(active_run_ids)
+    firewall_auth_registry_generation = _allocate_firewall_auth_registry_generation()
+    for vm in new_registry.values():
+        setattr(
+            vm,
+            FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE,
+            firewall_auth_registry_generation,
+        )
+
+    active_run_generations = {
+        vm["runId"]: firewall_auth_registry_generation for vm in new_registry.values()
+    }
+    evict_stale_cache_keys(active_run_generations)
 
     state.snapshot = _RegistrySnapshot(
         new_registry,

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -13,7 +13,7 @@ import state_file
 from firewall_auth_cache import (
     FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE,
     evict_all_cache_keys,
-    evict_stale_cache_keys,
+    reconcile_registry_cache_ownership,
 )
 
 VmContext = tuple[
@@ -112,6 +112,7 @@ def reset_cache_for_tests() -> None:
 
 
 def _allocate_firewall_auth_registry_generation() -> int:
+    """Allocate ownership generations independently of registry path resets."""
     global _next_firewall_auth_registry_generation
 
     _next_firewall_auth_registry_generation += 1
@@ -534,7 +535,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
     active_run_generations = {
         vm["runId"]: firewall_auth_registry_generation for vm in new_registry.values()
     }
-    evict_stale_cache_keys(active_run_generations)
+    reconcile_registry_cache_ownership(active_run_generations)
 
     state.snapshot = _RegistrySnapshot(
         new_registry,

--- a/crates/runner/mitm-addon/tests/auth_state_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_state_helpers.py
@@ -13,11 +13,13 @@ def auth_cache_key(
     run_id: str = "run-1",
     api_id: str = "api-1",
     auth_identity: str = "auth-identity-1",
+    registry_generation: int | None = None,
 ) -> auth_cache.FirewallAuthCacheKey:
     return auth_cache.FirewallAuthCacheKey(
         run_id=run_id,
         api_id=api_id,
         auth_identity=auth_identity,
+        registry_generation=registry_generation,
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -388,8 +388,52 @@ class TestFirewallHeaderCache:
         assert endpoint.request_count == 2
         assert explicit["headers"] == {"Authorization": "Bearer explicit"}
         assert default["headers"] == {"Authorization": "Bearer default"}
-        assert require_cached_headers(explicit_key).headers == {"Authorization": "Bearer explicit"}
+        assert not has_auth_state(explicit_key)
         assert require_cached_headers(default_key).headers == {"Authorization": "Bearer default"}
+
+    async def test_stale_registry_generation_cannot_reacquire_replaced_identity(self):
+        old_key = auth_cache_key(auth_identity="old-auth", registry_generation=1)
+        new_key = auth_cache_key(auth_identity="new-auth", registry_generation=2)
+        auth_request = firewall_auth_request()
+        auth_fetch = AsyncMock(
+            side_effect=(
+                firewall_auth_success(headers={"Authorization": "Bearer old"}),
+                firewall_auth_success(headers={"Authorization": "Bearer new"}),
+                firewall_auth_success(headers={"Authorization": "Bearer detached-old"}),
+            )
+        )
+
+        with patch.object(auth_cache, "fetch_firewall_headers", auth_fetch):
+            auth_cache.evict_stale_cache_keys({"run-1": 1})
+            await auth_cache.get_firewall_headers(old_key, auth_request)
+
+            auth_cache.evict_stale_cache_keys({"run-1": 2})
+            await auth_cache.get_firewall_headers(new_key, auth_request)
+            stale_result = await auth_cache.get_firewall_headers(old_key, auth_request)
+
+        assert stale_result["headers"] == {"Authorization": "Bearer detached-old"}
+        assert not has_auth_state(old_key)
+        assert require_cached_headers(new_key).headers == {"Authorization": "Bearer new"}
+        assert auth_fetch.await_count == 3
+
+    async def test_same_identity_reuses_state_across_registry_generations(self):
+        old_key = auth_cache_key(registry_generation=1)
+        new_key = auth_cache_key(registry_generation=2)
+        auth_cache.evict_stale_cache_keys({"run-1": 1})
+        set_cached_headers(old_key, headers={"Authorization": "Bearer cached"})
+        mark_force_refresh(old_key)
+        set_last_force_refresh_monotonic_at(old_key, 123.0)
+
+        auth_cache.evict_stale_cache_keys({"run-1": 2})
+        auth_fetch = AsyncMock()
+        with patch.object(auth_cache, "fetch_firewall_headers", auth_fetch):
+            result = await auth_cache.get_firewall_headers(new_key, firewall_auth_request())
+
+        assert result["headers"] == {"Authorization": "Bearer cached"}
+        assert result["cache_hit"] is True
+        assert force_refresh_pending(new_key)
+        assert last_force_refresh_monotonic_at(new_key) == 123.0
+        auth_fetch.assert_not_awaited()
 
     def test_cached_header_snapshot_is_detached_from_internal_state(self):
         """Seeded inputs and returned snapshots cannot mutate live cache state."""
@@ -1012,7 +1056,7 @@ class TestGetFirewallHeaders:
         # No consume timestamp written when force-refresh didn't happen
         assert last_force_refresh_monotonic_at(cache_key) is None
 
-    async def test_force_refresh_marker_is_scoped_to_auth_identity(self, headers):
+    async def test_replacement_identity_does_not_inherit_force_refresh_marker(self, headers):
         old_key = auth_cache_key(auth_identity="old-auth")
         new_key = auth_cache_key(auth_identity="new-auth")
         mark_force_refresh(old_key)
@@ -1022,7 +1066,7 @@ class TestGetFirewallHeaders:
             await auth_cache.get_firewall_headers(new_key, firewall_auth_request())
 
         assert mock_fetch.call_args.kwargs["force_refresh"] is False
-        assert force_refresh_pending(old_key)
+        assert not has_auth_state(old_key)
         assert not force_refresh_pending(new_key)
 
     async def test_force_refresh_marker_ignored_on_cache_hit(self, headers):

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -404,10 +404,10 @@ class TestFirewallHeaderCache:
         )
 
         with patch.object(auth_cache, "fetch_firewall_headers", auth_fetch):
-            auth_cache.evict_stale_cache_keys({"run-1": 1})
+            auth_cache.reconcile_registry_cache_ownership({"run-1": 1})
             await auth_cache.get_firewall_headers(old_key, auth_request)
 
-            auth_cache.evict_stale_cache_keys({"run-1": 2})
+            auth_cache.reconcile_registry_cache_ownership({"run-1": 2})
             await auth_cache.get_firewall_headers(new_key, auth_request)
             stale_result = await auth_cache.get_firewall_headers(old_key, auth_request)
 
@@ -419,12 +419,12 @@ class TestFirewallHeaderCache:
     async def test_same_identity_reuses_state_across_registry_generations(self):
         old_key = auth_cache_key(registry_generation=1)
         new_key = auth_cache_key(registry_generation=2)
-        auth_cache.evict_stale_cache_keys({"run-1": 1})
+        auth_cache.reconcile_registry_cache_ownership({"run-1": 1})
         set_cached_headers(old_key, headers={"Authorization": "Bearer cached"})
         mark_force_refresh(old_key)
         set_last_force_refresh_monotonic_at(old_key, 123.0)
 
-        auth_cache.evict_stale_cache_keys({"run-1": 2})
+        auth_cache.reconcile_registry_cache_ownership({"run-1": 2})
         auth_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", auth_fetch):
             result = await auth_cache.get_firewall_headers(new_key, firewall_auth_request())

--- a/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
+++ b/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 import registry
+from firewall_auth_cache import FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE
 from tests.auth_state_helpers import (
     auth_cache_key,
     cached_headers,
@@ -23,16 +24,27 @@ class TestRegistryAuthCacheEviction:
         path_b = tmp_path / "registry-b.json"
         write_simple_registry(path_a, run_id="run-one")
         write_simple_registry(path_b, run_id="run-two")
-        registry.load_registry(str(path_a))
+        first_registry = registry.load_registry(str(path_a))
+        first_generation = getattr(
+            first_registry["10.200.0.1"],
+            FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE,
+        )
         cache_key = auth_cache_key(run_id="run-one", api_id="api-0")
         set_cached_headers(
             cache_key,
             headers={"Authorization": "Bearer old"},
         )
 
-        registry.load_registry(str(path_b))
+        second_registry = registry.load_registry(str(path_b))
+        second_generation = getattr(
+            second_registry["10.200.0.1"],
+            FIREWALL_AUTH_REGISTRY_GENERATION_ATTRIBUTE,
+        )
 
         assert not has_auth_state(cache_key)
+        assert type(first_generation) is int
+        assert type(second_generation) is int
+        assert second_generation > first_generation
 
     def test_evicts_header_cache_on_run_removal(self, registry_file):
         """When a run disappears from registry, its header cache entries are evicted."""

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from mitmproxy import connection
+from mitmproxy.test import tutils
 
 import auth
 import firewall_auth_cache as auth_cache
@@ -15,6 +16,12 @@ import mitm_addon
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.auth_state_helpers import (
+    cached_headers,
+    force_refresh_pending,
+    has_auth_state,
+    require_cached_headers,
+)
 from tests.firewall_helpers import cancel_pending_task
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import (
@@ -42,7 +49,8 @@ async def test_repeated_firewall_requests_reuse_snapshot_auth_identity(
         vm_fields={
             "_firewallAuthIdentityCache": {
                 "entries": {"forged": {"authIdentity": "caller-controlled"}}
-            }
+            },
+            "_firewall_auth_registry_generation": "caller-controlled",
         },
     )
     flows = [
@@ -72,6 +80,7 @@ async def test_repeated_firewall_requests_reuse_snapshot_auth_identity(
     second_key = flows[1].metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
     assert first_key == second_key
     assert first_key.auth_identity != "caller-controlled"
+    assert type(first_key.registry_generation) is int
     assert build_identity.call_count == 1
     auth_fetch.assert_awaited_once()
     assert flows[0].metadata[metadata_keys.AUTH_CACHE_HIT] is False
@@ -428,20 +437,17 @@ async def test_requestheaders_and_request_share_snapshot_auth_identity(
     assert normal_flow.request.headers["Authorization"] == "Bearer resolved"
 
 
-async def test_registry_reload_recomputes_firewall_auth_identity(tmp_path, real_flow, mitm_ctx):
+async def test_registry_reload_replaces_firewall_auth_identity(tmp_path, real_flow, mitm_ctx):
     reg_path = _write_github_firewall_registry(tmp_path)
-    first_flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="api.github.com",
-        path="/repos",
-    )
-    second_flow = real_flow(
-        with_response=False,
-        client_ip="10.200.0.5",
-        host="api.github.com",
-        path="/repos",
-    )
+    flows = [
+        real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos",
+        )
+        for _ in range(3)
+    ]
     auth_fetch = AsyncMock(return_value=_resolved_firewall_auth())
 
     with (
@@ -453,20 +459,173 @@ async def test_registry_reload_recomputes_firewall_auth_identity(tmp_path, real_
             wraps=auth._build_firewall_auth_identity,
         ) as build_identity,
     ):
-        await mitm_addon.request(first_flow)
+        for index, flow in enumerate(flows):
+            if index:
+                _write_github_firewall_registry(
+                    tmp_path,
+                    vm_fields={"encryptedSecrets": f"iv:tag:data-updated-{index}"},
+                )
+            await mitm_addon.request(flow)
+
+    keys = [flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] for flow in flows]
+    assert {key.run_id for key in keys} == {"run-conn-1"}
+    assert {key.api_id for key in keys} == {"run-conn-1:0"}
+    assert len({key.auth_identity for key in keys}) == 3
+    assert len({key.registry_generation for key in keys}) == 3
+    assert not has_auth_state(keys[0])
+    assert not has_auth_state(keys[1])
+    assert cached_headers(keys[2]) is not None
+    assert build_identity.call_count == 3
+    assert auth_fetch.await_count == 3
+
+
+async def test_registry_reload_reuses_unchanged_firewall_auth_identity(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    flows = [
+        real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos",
+        )
+        for _ in range(2)
+    ]
+    auth_fetch = AsyncMock(return_value=_resolved_firewall_auth())
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth_cache, "fetch_firewall_headers", auth_fetch),
+        patch.object(
+            auth,
+            "_build_firewall_auth_identity",
+            wraps=auth._build_firewall_auth_identity,
+        ) as build_identity,
+    ):
+        await mitm_addon.request(flows[0])
+        _write_github_firewall_registry(
+            tmp_path,
+            vm_fields={"captureNetworkBodies": False},
+        )
+        await mitm_addon.request(flows[1])
+
+    first_key = flows[0].metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+    second_key = flows[1].metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+    assert first_key == second_key
+    assert first_key.registry_generation != second_key.registry_generation
+    assert build_identity.call_count == 2
+    auth_fetch.assert_awaited_once()
+    assert flows[1].metadata[metadata_keys.AUTH_CACHE_HIT] is True
+
+
+async def test_superseded_fetch_completion_does_not_repopulate_auth_state(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    old_flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos",
+    )
+    new_flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path="/repos",
+    )
+    old_fetch_started = asyncio.Event()
+    release_old_fetch = asyncio.Event()
+
+    async def fetch_auth(
+        request: auth_client.FirewallAuthRequest,
+        *,
+        force_refresh: bool,
+    ) -> auth_client.FirewallAuthSuccess:
+        assert force_refresh is False
+        if request.encrypted_secrets == "iv:tag:data":
+            old_fetch_started.set()
+            await release_old_fetch.wait()
+            return auth_client.FirewallAuthSuccess(
+                payload=auth_client.FirewallAuthPayload(headers={"Authorization": "Bearer old"})
+            )
+        return auth_client.FirewallAuthSuccess(
+            payload=auth_client.FirewallAuthPayload(headers={"Authorization": "Bearer new"})
+        )
+
+    old_request: asyncio.Task[None] | None = None
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth_cache, "fetch_firewall_headers", side_effect=fetch_auth) as auth_fetch,
+    ):
+        old_request = asyncio.create_task(mitm_addon.request(old_flow))
+        try:
+            await asyncio.wait_for(old_fetch_started.wait(), timeout=1)
+            _write_github_firewall_registry(
+                tmp_path,
+                vm_fields={"encryptedSecrets": "iv:tag:data-updated"},
+            )
+            await mitm_addon.request(new_flow)
+
+            old_key = old_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+            new_key = new_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+            assert not has_auth_state(old_key)
+            assert cached_headers(new_key) is not None
+
+            release_old_fetch.set()
+            await asyncio.wait_for(old_request, timeout=1)
+        finally:
+            release_old_fetch.set()
+            await cancel_pending_task(old_request)
+
+    assert auth_fetch.await_count == 2
+    assert old_flow.response is None
+    assert old_flow.request.headers["Authorization"] == "Bearer old"
+    assert not has_auth_state(old_key)
+    assert require_cached_headers(new_key).headers == {"Authorization": "Bearer new"}
+
+
+async def test_superseded_401_does_not_mutate_current_auth_state(tmp_path, real_flow, mitm_ctx):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    flows = [
+        real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos",
+        )
+        for _ in range(2)
+    ]
+    auth_fetch = AsyncMock(
+        side_effect=(
+            auth_client.FirewallAuthSuccess(
+                payload=auth_client.FirewallAuthPayload(headers={"Authorization": "Bearer old"})
+            ),
+            auth_client.FirewallAuthSuccess(
+                payload=auth_client.FirewallAuthPayload(headers={"Authorization": "Bearer new"})
+            ),
+        )
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth_cache, "fetch_firewall_headers", auth_fetch),
+    ):
+        await mitm_addon.request(flows[0])
         _write_github_firewall_registry(
             tmp_path,
             vm_fields={"encryptedSecrets": "iv:tag:data-updated"},
         )
-        await mitm_addon.request(second_flow)
+        await mitm_addon.request(flows[1])
+        old_key = flows[0].metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+        new_key = flows[1].metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+        flows[0].response = tutils.tresp(status_code=401)
+        mitm_addon.response(flows[0])
 
-    first_key = first_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
-    second_key = second_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
-    assert first_key.run_id == second_key.run_id == "run-conn-1"
-    assert first_key.api_id == second_key.api_id == "run-conn-1:0"
-    assert first_key.auth_identity != second_key.auth_identity
-    assert build_identity.call_count == 2
-    assert auth_fetch.await_count == 2
+    assert not has_auth_state(old_key)
+    assert require_cached_headers(new_key).headers == {"Authorization": "Bearer new"}
+    assert not force_refresh_pending(new_key)
 
 
 async def test_local_response_preserves_shared_binding_for_concurrent_auth(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
@@ -519,6 +519,62 @@ async def test_registry_reload_reuses_unchanged_firewall_auth_identity(
     assert flows[1].metadata[metadata_keys.AUTH_CACHE_HIT] is True
 
 
+async def test_registry_reload_coalesces_unchanged_in_flight_firewall_auth(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    flows = [
+        real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos",
+        )
+        for _ in range(2)
+    ]
+    auth_fetch_started = asyncio.Event()
+    release_auth_fetch = asyncio.Event()
+
+    async def fetch_auth(
+        request: auth_client.FirewallAuthRequest,
+        *,
+        force_refresh: bool,
+    ) -> auth_client.FirewallAuthSuccess:
+        assert request.encrypted_secrets == "iv:tag:data"
+        assert force_refresh is False
+        auth_fetch_started.set()
+        await release_auth_fetch.wait()
+        return _resolved_firewall_auth()
+
+    requests: list[asyncio.Task[None] | None] = [None, None]
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth_cache, "fetch_firewall_headers", side_effect=fetch_auth) as auth_fetch,
+    ):
+        requests[0] = asyncio.create_task(mitm_addon.request(flows[0]))
+        try:
+            await asyncio.wait_for(auth_fetch_started.wait(), timeout=1)
+            _write_github_firewall_registry(
+                tmp_path,
+                vm_fields={"captureNetworkBodies": False},
+            )
+            requests[1] = asyncio.create_task(mitm_addon.request(flows[1]))
+            release_auth_fetch.set()
+            await asyncio.gather(*(request for request in requests if request is not None))
+        finally:
+            release_auth_fetch.set()
+            for request in requests:
+                await cancel_pending_task(request)
+
+    first_key = flows[0].metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+    second_key = flows[1].metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+    assert first_key == second_key
+    assert first_key.registry_generation != second_key.registry_generation
+    auth_fetch.assert_awaited_once()
+    assert flows[0].request.headers["Authorization"] == "Bearer resolved"
+    assert flows[1].request.headers["Authorization"] == "Bearer resolved"
+
+
 async def test_superseded_fetch_completion_does_not_repopulate_auth_state(
     tmp_path, real_flow, mitm_ctx
 ):


### PR DESCRIPTION
## Summary

- assign each published proxy registry snapshot a private, monotonic auth ownership generation without changing the public registry mapping
- retain one globally owned firewall auth identity per run/API scope while allowing equal content identities to reuse state across registry generations
- detach superseded in-flight state so existing requests can finish, while stale generations and delayed 401 responses cannot reacquire or mutate current ownership
- add integration coverage for repeated replacement, unchanged identity cache and in-flight reuse, stale lookup, in-flight completion, path switches, and superseded response recovery

## Scope

This change is limited to process-local Python mitmproxy auth-cache lifecycle state. It does not change public APIs, persisted registry JSON, runner protocols, credential identity material, or deployment sequencing.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 6374 passed
- `lefthook run pre-commit`
- `git diff --check`

Closes #28126
