### PR TITLE
fix(sandbox-fc): bound cow pool sparse copies

### DIFF
--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
 
@@ -152,10 +153,14 @@ impl StreamOutputPolicy {
 }
 
 /// Format a human-readable display string for a command invocation.
-fn format_command_display(program: &str, args: &[&str]) -> String {
+fn format_command_display<P, A>(program: &P, args: &[A]) -> String
+where
+    P: AsRef<OsStr> + ?Sized,
+    A: AsRef<OsStr>,
+{
     let mut parts = Vec::with_capacity(args.len() + 1);
-    parts.push(program);
-    parts.extend_from_slice(args);
+    parts.push(program.as_ref().to_string_lossy());
+    parts.extend(args.iter().map(|arg| arg.as_ref().to_string_lossy()));
     parts.join(" ")
 }
 
@@ -202,7 +207,24 @@ pub async fn exec_status_with_timeout(
     args: &[&str],
     timeout: Duration,
 ) -> Result<(), CommandError> {
-    let cmd_display = format_command_display(program, args);
+    exec_status(program, args, timeout).await
+}
+
+/// Execute a command with native OS arguments and bounded runtime, discarding stdout.
+pub async fn exec_status_os_with_timeout(
+    program: &OsStr,
+    args: &[&OsStr],
+    timeout: Duration,
+) -> Result<(), CommandError> {
+    exec_status(program, args, timeout).await
+}
+
+async fn exec_status<P, A>(program: P, args: &[A], timeout: Duration) -> Result<(), CommandError>
+where
+    P: AsRef<OsStr>,
+    A: AsRef<OsStr>,
+{
+    let cmd_display = format_command_display(&program, args);
 
     let output =
         command_output_with_policy(program, args, timeout, CommandOutputPolicy::status_only())
@@ -265,12 +287,16 @@ async fn command_output_with_timeout(
     .await
 }
 
-async fn command_output_with_policy(
-    program: &str,
-    args: &[&str],
+async fn command_output_with_policy<P, A>(
+    program: P,
+    args: &[A],
     timeout: Duration,
     output_policy: CommandOutputPolicy,
-) -> std::result::Result<CommandOutput, CommandRunError> {
+) -> std::result::Result<CommandOutput, CommandRunError>
+where
+    P: AsRef<OsStr>,
+    A: AsRef<OsStr>,
+{
     command_output_with_policy_and_exit_notifier(
         program,
         args,
@@ -298,13 +324,17 @@ async fn command_output_with_timeout_with_exit_notifier(
     .await
 }
 
-async fn command_output_with_policy_and_exit_notifier(
-    program: &str,
-    args: &[&str],
+async fn command_output_with_policy_and_exit_notifier<P, A>(
+    program: P,
+    args: &[A],
     timeout: Duration,
     output_policy: CommandOutputPolicy,
     open_exit_notifier: impl FnOnce(&Child) -> ChildExitNotifier,
-) -> std::result::Result<CommandOutput, CommandRunError> {
+) -> std::result::Result<CommandOutput, CommandRunError>
+where
+    P: AsRef<OsStr>,
+    A: AsRef<OsStr>,
+{
     let mut command = Command::new(program);
     command
         .args(args)
@@ -865,6 +895,42 @@ mod tests {
 
         assert!(err.detail.contains("status-failed"), "err was: {err}");
         assert_eq!(err.exit_code, Some(7));
+    }
+
+    #[tokio::test]
+    async fn exec_status_os_with_timeout_preserves_non_utf8_argument() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .path()
+            .join(std::ffi::OsString::from_vec(b"native-\xff".to_vec()));
+        std::fs::write(&path, b"present").unwrap();
+        let args = [OsStr::new("-e"), path.as_os_str()];
+
+        exec_status_os_with_timeout(OsStr::new("test"), &args, Duration::from_secs(1))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn exec_status_os_with_timeout_bounds_failure_stderr() {
+        let script = format!(
+            "head -c {} /dev/zero | tr '\\0' x >&2; exit 9",
+            DEFAULT_DIAGNOSTIC_OUTPUT_LIMIT_BYTES + 1
+        );
+        let args = [OsStr::new("-c"), OsStr::new(&script)];
+
+        let err = exec_status_os_with_timeout(OsStr::new("sh"), &args, Duration::from_secs(1))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.exit_code, Some(9));
+        assert_eq!(
+            err.detail.len(),
+            DEFAULT_DIAGNOSTIC_OUTPUT_LIMIT_BYTES + "\n[output truncated]".len()
+        );
+        assert!(err.detail.ends_with("\n[output truncated]"));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -71,7 +71,7 @@ use slot::{PrewarmedSlot, destroy_slot_async};
 /// Number of ready COW slots to keep warm in steady state.
 const BUFFER_SIZE: usize = 4;
 
-/// Maximum simultaneous blocking slot creation workers.
+/// Maximum simultaneous slot creation tasks.
 const MAX_CONCURRENT_SLOT_CREATIONS: usize = 4;
 
 /// Maximum simultaneous prepared-slot teardowns during producer shutdown.

--- a/crates/sandbox-fc/src/cow_pool/actor.rs
+++ b/crates/sandbox-fc/src/cow_pool/actor.rs
@@ -82,7 +82,7 @@ impl CowPoolHandle {
         response.await.map_err(|_| CowPoolError::ActorStopped)?
     }
 
-    /// Clean up the producer. Pending blocking creation workers are drained.
+    /// Clean up the producer. Pending slot creation tasks are drained.
     pub(crate) async fn cleanup(&self) {
         let (done, done_rx) = oneshot::channel();
         if self.cleanup.send(done).is_ok() {

--- a/crates/sandbox-fc/src/cow_pool/create.rs
+++ b/crates/sandbox-fc/src/cow_pool/create.rs
@@ -1,14 +1,18 @@
+use std::ffi::OsStr;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tracing::info;
 
 use super::{
     CowPoolConfig, CowPoolError, PreparedCowSlot, PrewarmedSlot, SlotSpawner, destroy_slot_async,
 };
+use crate::command;
 use crate::duration::duration_ms;
+
+const COW_SPARSE_COPY_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[derive(Clone)]
 pub(super) struct CowFileConfig {
@@ -38,9 +42,7 @@ pub(super) fn default_slot_spawner() -> SlotSpawner {
 async fn prepare_slot(config: CowPoolConfig) -> Result<PreparedCowSlot, CowPoolError> {
     let file_started = Instant::now();
     let create_config = CowFileConfig::from(&config);
-    let slot = tokio::task::spawn_blocking(move || create_slot(&create_config))
-        .await
-        .map_err(|error| CowPoolError::CowFileCreation(format!("join: {error}")))??;
+    let slot = create_slot(&create_config).await?;
     let file_elapsed_ms = duration_ms(file_started.elapsed());
 
     let nbd_started = Instant::now();
@@ -67,14 +69,21 @@ async fn prepare_slot(config: CowPoolConfig) -> Result<PreparedCowSlot, CowPoolE
 }
 
 /// Create a pre-warmed slot: workspace directory + COW file.
-pub(super) fn create_slot(config: &CowFileConfig) -> Result<PrewarmedSlot, CowPoolError> {
+pub(super) async fn create_slot(config: &CowFileConfig) -> Result<PrewarmedSlot, CowPoolError> {
+    create_slot_with_copy_timeout(config, COW_SPARSE_COPY_TIMEOUT).await
+}
+
+pub(super) async fn create_slot_with_copy_timeout(
+    config: &CowFileConfig,
+    copy_timeout: Duration,
+) -> Result<PrewarmedSlot, CowPoolError> {
     let id = uuid::Uuid::new_v4().to_string();
     let workspace = config.workspaces_dir.join(&id);
     let cow_file = workspace.join("cow.img");
 
-    if let Err(e) = create_cow_file(config, &workspace, &cow_file) {
+    if let Err(e) = create_cow_file(config, &workspace, &cow_file, copy_timeout).await {
         // Best-effort cleanup: remove any partially-created workspace.
-        let _ = std::fs::remove_dir_all(&workspace);
+        let _ = tokio::fs::remove_dir_all(&workspace).await;
         return Err(e);
     }
 
@@ -82,31 +91,41 @@ pub(super) fn create_slot(config: &CowFileConfig) -> Result<PrewarmedSlot, CowPo
 }
 
 /// Create the COW file: sparse-copy from golden image or allocate fresh.
-fn create_cow_file(
+async fn create_cow_file(
     config: &CowFileConfig,
     workspace: &Path,
     cow_file: &Path,
+    copy_timeout: Duration,
 ) -> Result<(), CowPoolError> {
-    std::fs::create_dir_all(workspace).map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
+    tokio::fs::create_dir_all(workspace)
+        .await
+        .map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
     match &config.golden_cow {
         Some(golden) => {
             let expected_blocks = validate_base_size(config.base_size)?;
-            sparse_copy(golden, cow_file)?;
-            ensure_owner_read_write(cow_file)?;
-            let cow_file_len = std::fs::metadata(cow_file)
+            sparse_copy(golden, cow_file, copy_timeout).await?;
+            ensure_owner_read_write(cow_file).await?;
+            let cow_file_len = tokio::fs::metadata(cow_file)
+                .await
                 .map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?
                 .len();
             // Snapshot restore requires the dirty bitmap sidecar to preserve COW reads.
             let golden_bitmap = nbd_cow::cow::bitmap_path_for(golden);
             let cow_bitmap = nbd_cow::cow::bitmap_path_for(cow_file);
-            sparse_copy(&golden_bitmap, &cow_bitmap)?;
-            validate_cow_bitmap(&cow_bitmap, cow_file_len, expected_blocks)?;
+            sparse_copy(&golden_bitmap, &cow_bitmap, copy_timeout).await?;
+            tokio::task::spawn_blocking(move || {
+                validate_cow_bitmap(&cow_bitmap, cow_file_len, expected_blocks)
+            })
+            .await
+            .map_err(|e| CowPoolError::CowFileCreation(format!("bitmap validation join: {e}")))??;
         }
         None => {
             validate_base_size(config.base_size)?;
-            let f = std::fs::File::create(cow_file)
+            let f = tokio::fs::File::create(cow_file)
+                .await
                 .map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
             f.set_len(config.base_size)
+                .await
                 .map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
         }
     }
@@ -147,34 +166,30 @@ fn validate_base_size(base_size: u64) -> Result<usize, CowPoolError> {
     Ok(expected_blocks)
 }
 
-fn ensure_owner_read_write(path: &Path) -> Result<(), CowPoolError> {
-    let metadata =
-        std::fs::metadata(path).map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
+async fn ensure_owner_read_write(path: &Path) -> Result<(), CowPoolError> {
+    let metadata = tokio::fs::metadata(path)
+        .await
+        .map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
     let mut permissions = metadata.permissions();
     let mode = permissions.mode();
     let mode_with_owner_rw = mode | 0o600;
     if mode_with_owner_rw != mode {
         permissions.set_mode(mode_with_owner_rw);
-        std::fs::set_permissions(path, permissions)
+        tokio::fs::set_permissions(path, permissions)
+            .await
             .map_err(|e| CowPoolError::CowFileCreation(e.to_string()))?;
     }
     Ok(())
 }
 
-/// Synchronous sparse copy via `cp --sparse=always`.
-fn sparse_copy(src: &Path, dst: &Path) -> Result<(), CowPoolError> {
-    let output = std::process::Command::new("cp")
-        .arg("--sparse=always")
-        .arg("--")
-        .arg(src)
-        .arg(dst)
-        .output()
-        .map_err(|e| CowPoolError::CowFileCreation(format!("exec cp: {e}")))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(CowPoolError::CowFileCreation(format!(
-            "cp --sparse=always failed: {stderr}"
-        )));
-    }
-    Ok(())
+async fn sparse_copy(src: &Path, dst: &Path, timeout: Duration) -> Result<(), CowPoolError> {
+    let args = [
+        OsStr::new("--sparse=always"),
+        OsStr::new("--"),
+        src.as_os_str(),
+        dst.as_os_str(),
+    ];
+    command::exec_status_os_with_timeout(OsStr::new("cp"), &args, timeout)
+        .await
+        .map_err(|e| CowPoolError::CowFileCreation(e.to_string()))
 }

--- a/crates/sandbox-fc/src/cow_pool/tests.rs
+++ b/crates/sandbox-fc/src/cow_pool/tests.rs
@@ -1,4 +1,4 @@
-use super::create::{CowFileConfig, create_slot};
+use super::create::{CowFileConfig, create_slot, create_slot_with_copy_timeout};
 use super::state::CowPool;
 use super::*;
 use std::collections::VecDeque;
@@ -1191,25 +1191,95 @@ async fn warmup_with_bad_config_does_not_panic() {
     handle.cleanup().await;
 }
 
-#[test]
-fn create_slot_with_nonexistent_golden_cow_fails() {
+#[tokio::test]
+async fn create_slot_with_nonexistent_golden_cow_fails() {
     let tmp = tempfile::tempdir().unwrap();
     let config = CowFileConfig {
         workspaces_dir: tmp.path().to_owned(),
         base_size: 64 * 1024 * 1024,
         golden_cow: Some(PathBuf::from("/nonexistent/golden.img")),
     };
-    let err = create_slot(&config).unwrap_err();
+    let err = create_slot(&config).await.unwrap_err();
+    assert!(matches!(err, CowPoolError::CowFileCreation(_)));
     assert!(
-        matches!(err, CowPoolError::CowFileCreation(_)),
-        "expected CowFileCreation, got {err}"
+        err.to_string()
+            .contains("command failed: cp --sparse=always --"),
+        "expected bounded command failure, got {err}"
     );
     let entries: Vec<_> = std::fs::read_dir(tmp.path()).unwrap().collect();
     assert_eq!(entries.len(), 0);
 }
 
-#[test]
-fn create_slot_with_bad_golden_bitmap_removes_partial_workspace() {
+#[tokio::test]
+async fn create_slot_stalled_copy_times_out_and_removes_partial_workspace() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspaces = tmp.path().join("workspaces");
+    let golden = tmp.path().join("stalled-golden.img");
+    nix::unistd::mkfifo(
+        &golden,
+        nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+    )
+    .unwrap();
+    let config = CowFileConfig {
+        workspaces_dir: workspaces.clone(),
+        base_size: nbd_cow::BLOCK_SIZE as u64,
+        golden_cow: Some(golden),
+    };
+
+    let err = create_slot_with_copy_timeout(&config, Duration::from_millis(50))
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("timed out after 50ms"),
+        "expected copy timeout, got {err}"
+    );
+    let entries: Vec<_> = std::fs::read_dir(&workspaces).unwrap().collect();
+    assert_eq!(entries.len(), 0);
+}
+
+#[tokio::test]
+async fn cleanup_completes_after_stalled_copy_timeout() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspaces = tmp.path().join("workspaces");
+    let golden = tmp.path().join("cleanup-stalled-golden.img");
+    nix::unistd::mkfifo(
+        &golden,
+        nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+    )
+    .unwrap();
+    let file_config = CowFileConfig {
+        workspaces_dir: workspaces.clone(),
+        base_size: nbd_cow::BLOCK_SIZE as u64,
+        golden_cow: Some(golden),
+    };
+    let spawner: SlotSpawner = Arc::new(move |_config| {
+        let file_config = file_config.clone();
+        tokio::spawn(async move {
+            create_slot_with_copy_timeout(&file_config, Duration::from_millis(50))
+                .await
+                .map(PreparedCowSlot::new_for_test)
+        })
+    });
+    let pool = test_pool_with_spawner(test_config(tmp.path()), 1, 1, 1, Duration::ZERO, spawner);
+    let handle = CowPoolHandle::new_for_test(pool);
+    let warmup = tokio::spawn({
+        let handle = handle.clone();
+        async move { handle.warmup().await }
+    });
+    wait_for_snapshot(&handle, |snapshot| snapshot.pending == 1).await;
+
+    tokio::time::timeout(Duration::from_secs(2), handle.cleanup())
+        .await
+        .expect("cleanup remained blocked after copy timeout");
+    warmup.await.unwrap();
+
+    let entries: Vec<_> = std::fs::read_dir(&workspaces).unwrap().collect();
+    assert_eq!(entries.len(), 0);
+}
+
+#[tokio::test]
+async fn create_slot_with_bad_golden_bitmap_removes_partial_workspace() {
     let tmp = tempfile::tempdir().unwrap();
     let workspaces = tmp.path().join("workspaces");
     let golden = tmp.path().join("golden.img");
@@ -1221,7 +1291,7 @@ fn create_slot_with_bad_golden_bitmap_removes_partial_workspace() {
         base_size: 64 * 1024 * 1024,
         golden_cow: Some(golden),
     };
-    let err = create_slot(&config).unwrap_err();
+    let err = create_slot(&config).await.unwrap_err();
     assert!(
         matches!(err, CowPoolError::CowFileCreation(_)),
         "expected CowFileCreation, got {err}"
@@ -1230,8 +1300,8 @@ fn create_slot_with_bad_golden_bitmap_removes_partial_workspace() {
     assert_eq!(entries.len(), 0);
 }
 
-#[test]
-fn create_slot_with_golden_cow_without_bitmap_fails() {
+#[tokio::test]
+async fn create_slot_with_golden_cow_without_bitmap_fails() {
     let tmp = tempfile::tempdir().unwrap();
     let workspaces = tmp.path().join("workspaces");
     let golden = tmp.path().join("golden.img");
@@ -1242,7 +1312,7 @@ fn create_slot_with_golden_cow_without_bitmap_fails() {
         base_size: 64 * 1024 * 1024,
         golden_cow: Some(golden),
     };
-    let err = create_slot(&config).unwrap_err();
+    let err = create_slot(&config).await.unwrap_err();
     assert!(
         matches!(err, CowPoolError::CowFileCreation(_)),
         "expected CowFileCreation, got {err}"
@@ -1251,8 +1321,8 @@ fn create_slot_with_golden_cow_without_bitmap_fails() {
     assert_eq!(entries.len(), 0);
 }
 
-#[test]
-fn create_slot_with_invalid_golden_bitmap_removes_partial_workspace() {
+#[tokio::test]
+async fn create_slot_with_invalid_golden_bitmap_removes_partial_workspace() {
     let tmp = tempfile::tempdir().unwrap();
     let workspaces = tmp.path().join("workspaces");
     let golden = tmp.path().join("golden.img");
@@ -1265,7 +1335,7 @@ fn create_slot_with_invalid_golden_bitmap_removes_partial_workspace() {
         base_size: nbd_cow::BLOCK_SIZE as u64,
         golden_cow: Some(golden),
     };
-    let err = create_slot(&config).unwrap_err();
+    let err = create_slot(&config).await.unwrap_err();
     assert!(
         matches!(err, CowPoolError::CowFileCreation(_)),
         "expected CowFileCreation, got {err}"
@@ -1274,8 +1344,8 @@ fn create_slot_with_invalid_golden_bitmap_removes_partial_workspace() {
     assert_eq!(entries.len(), 0);
 }
 
-#[test]
-fn create_slot_with_dirty_bitmap_beyond_golden_cow_removes_partial_workspace() {
+#[tokio::test]
+async fn create_slot_with_dirty_bitmap_beyond_golden_cow_removes_partial_workspace() {
     let tmp = tempfile::tempdir().unwrap();
     let workspaces = tmp.path().join("workspaces");
     let golden = tmp.path().join("golden.img");
@@ -1288,7 +1358,7 @@ fn create_slot_with_dirty_bitmap_beyond_golden_cow_removes_partial_workspace() {
         base_size: nbd_cow::BLOCK_SIZE as u64,
         golden_cow: Some(golden),
     };
-    let err = create_slot(&config).unwrap_err();
+    let err = create_slot(&config).await.unwrap_err();
     assert!(
         matches!(err, CowPoolError::CowFileCreation(_)),
         "expected CowFileCreation, got {err}"
@@ -1297,8 +1367,8 @@ fn create_slot_with_dirty_bitmap_beyond_golden_cow_removes_partial_workspace() {
     assert_eq!(entries.len(), 0);
 }
 
-#[test]
-fn create_slot_with_non_utf8_golden_cow_copies_bitmap() {
+#[tokio::test]
+async fn create_slot_with_non_utf8_golden_cow_copies_bitmap() {
     let tmp = tempfile::tempdir().unwrap();
     let workspaces = tmp.path().join("workspaces");
     let golden_name = OsString::from_vec(b"golden-\xff.img".to_vec());
@@ -1312,7 +1382,7 @@ fn create_slot_with_non_utf8_golden_cow_copies_bitmap() {
         base_size: nbd_cow::BLOCK_SIZE as u64,
         golden_cow: Some(golden),
     };
-    let slot = create_slot(&config).unwrap();
+    let slot = create_slot(&config).await.unwrap();
     let cow_bitmap = nbd_cow::cow::bitmap_path_for(&slot.cow_file());
     assert_eq!(
         std::fs::read(cow_bitmap).unwrap(),
@@ -1321,8 +1391,8 @@ fn create_slot_with_non_utf8_golden_cow_copies_bitmap() {
     destroy_slot_sync(slot);
 }
 
-#[test]
-fn create_slot_with_read_only_golden_cow_makes_workspace_cow_writable() {
+#[tokio::test]
+async fn create_slot_with_read_only_golden_cow_makes_workspace_cow_writable() {
     let tmp = tempfile::tempdir().unwrap();
     let workspaces = tmp.path().join("workspaces");
     let golden = tmp.path().join("golden.img");
@@ -1336,7 +1406,7 @@ fn create_slot_with_read_only_golden_cow_makes_workspace_cow_writable() {
         base_size: nbd_cow::BLOCK_SIZE as u64,
         golden_cow: Some(golden),
     };
-    let slot = create_slot(&config).unwrap();
+    let slot = create_slot(&config).await.unwrap();
     let cow_file = slot.cow_file();
 
     assert_eq!(
@@ -1351,11 +1421,11 @@ fn create_slot_with_read_only_golden_cow_makes_workspace_cow_writable() {
     destroy_slot_sync(slot);
 }
 
-#[test]
-fn create_slot_fresh_mode_creates_cow_file() {
+#[tokio::test]
+async fn create_slot_fresh_mode_creates_cow_file() {
     let tmp = tempfile::tempdir().unwrap();
     let config = test_file_config(tmp.path());
-    let slot = create_slot(&config).unwrap();
+    let slot = create_slot(&config).await.unwrap();
     let cow_file = slot.cow_file();
     assert!(cow_file.exists());
     let meta = std::fs::metadata(&cow_file).unwrap();
@@ -1363,8 +1433,8 @@ fn create_slot_fresh_mode_creates_cow_file() {
     destroy_slot_sync(slot);
 }
 
-#[test]
-fn create_slot_fresh_mode_rejects_empty_base_size() {
+#[tokio::test]
+async fn create_slot_fresh_mode_rejects_empty_base_size() {
     let tmp = tempfile::tempdir().unwrap();
     let workspaces = tmp.path().join("workspaces");
     let config = CowFileConfig {
@@ -1373,7 +1443,7 @@ fn create_slot_fresh_mode_rejects_empty_base_size() {
         golden_cow: None,
     };
 
-    let err = create_slot(&config).unwrap_err();
+    let err = create_slot(&config).await.unwrap_err();
 
     assert!(
         err.to_string().contains("base image size is empty"),
@@ -1383,8 +1453,8 @@ fn create_slot_fresh_mode_rejects_empty_base_size() {
     assert_eq!(entries.len(), 0);
 }
 
-#[test]
-fn create_slot_fresh_mode_rejects_unaligned_base_size() {
+#[tokio::test]
+async fn create_slot_fresh_mode_rejects_unaligned_base_size() {
     let tmp = tempfile::tempdir().unwrap();
     let workspaces = tmp.path().join("workspaces");
     let config = CowFileConfig {
@@ -1393,7 +1463,7 @@ fn create_slot_fresh_mode_rejects_unaligned_base_size() {
         golden_cow: None,
     };
 
-    let err = create_slot(&config).unwrap_err();
+    let err = create_slot(&config).await.unwrap_err();
 
     assert!(
         err.to_string().contains("not a multiple"),
@@ -1403,11 +1473,11 @@ fn create_slot_fresh_mode_rejects_unaligned_base_size() {
     assert_eq!(entries.len(), 0);
 }
 
-#[test]
-fn destroy_slot_sync_removes_workspace() {
+#[tokio::test]
+async fn destroy_slot_sync_removes_workspace() {
     let tmp = tempfile::tempdir().unwrap();
     let config = test_file_config(tmp.path());
-    let slot = create_slot(&config).unwrap();
+    let slot = create_slot(&config).await.unwrap();
     let ws = slot.workspace().to_owned();
     assert!(ws.exists());
     destroy_slot_sync(slot);


### PR DESCRIPTION
## Summary

- add a native `OsStr` status-only command entry point backed by the existing timeout, process-group, and bounded-output lifecycle
- make COW file preparation async and route both golden COW and bitmap sparse copies through that boundary with a 300-second deadline
- preserve non-UTF-8 paths, bitmap validation, owner-write repair, and partial-workspace cleanup while covering real stalled-copy and pool-cleanup behavior

## Scope

- no COW image or bitmap format changes
- no NBD lifecycle or pool capacity changes
- no API, protocol, schema, persisted-data, migration, or deployment-order changes

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- pre-commit hook: workspace Cargo format, Clippy, documentation, and file-size checks

Closes #28127
