### PR TITLE
docs(guest-agent): document heartbeat interval contract

### DIFF
--- a/crates/guest-agent/src/heartbeat.rs
+++ b/crates/guest-agent/src/heartbeat.rs
@@ -38,6 +38,22 @@ pub async fn heartbeat_loop_for_run(
 }
 
 /// Like [`heartbeat_loop_for_run`] but with a configurable interval.
+///
+/// When `http` has API configuration, `interval` must be non-zero. Tokio's
+/// first interval tick is immediately ready, so the first heartbeat is
+/// attempted when the loop starts rather than after one full interval.
+///
+/// The timer uses [`MissedTickBehavior::Delay`]. If an HTTP cycle takes longer
+/// than `interval`, one overdue heartbeat may run after the cycle completes,
+/// but accumulated overdue ticks are not replayed as a burst. The next
+/// heartbeat then waits one full interval after that overdue tick completes.
+///
+/// # Panics
+///
+/// Panics if `http` has API configuration and `interval` is zero, because the
+/// underlying Tokio interval requires a non-zero duration. When no API is
+/// configured, the function returns after shutdown without constructing a
+/// timer.
 pub async fn heartbeat_loop_for_run_with_interval(
     run_id: String,
     http: HttpClient,


### PR DESCRIPTION
## Summary

- Document the non-zero interval precondition and zero-duration panic contract for `heartbeat_loop_for_run_with_interval`.
- Document the immediate first heartbeat and `MissedTickBehavior::Delay` cadence after slow HTTP cycles.

## Scope

Documentation only. Runtime behavior, public signatures, timer policy, and existing tests are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration heartbeat::heartbeat_does_not_replay_overdue_ticks_after_slow_request` — passed
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration heartbeat::` — 5 passed

The package-wide `cargo test --manifest-path crates/Cargo.toml -p guest-agent` was also attempted, but its linker stopped with `No space left on device` while compiling the full set of integration targets. The focused heartbeat integration tests passed after removing only the regenerable build artifacts from the fresh checkout.

Closes #28132
