### PR TITLE
fix(composer): stop redundant feedback note dom writes during composition

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -275,9 +275,58 @@ function connectComposerFeedback(
  * ProseMirror as content changes, which can discard an in-flight IME
  * composition, so re-renders must not rewrite values that already match.
  */
-function setClassName(element: HTMLElement, className: string): void {
-  if (element.className !== className) {
-    element.className = className;
+function setClassName(
+  element: HTMLElement,
+  className: string,
+  skipUnchanged: boolean,
+): void {
+  if (skipUnchanged && element.className === className) {
+    return;
+  }
+  element.className = className;
+}
+
+interface FeedbackItemNodeViewElements {
+  readonly dom: HTMLElement;
+  readonly noteDom: HTMLElement;
+  readonly placeholderDom: HTMLElement;
+  readonly contentDOM: HTMLElement;
+  readonly quoteText: HTMLElement;
+}
+
+function renderFeedbackItemNodeView(
+  elements: FeedbackItemNodeViewElements,
+  nextNode: ProseMirrorNode,
+  skipUnchanged: boolean,
+): void {
+  const { dom, noteDom, placeholderDom, contentDOM, quoteText } = elements;
+  const { quote, showDivider, fill } = feedbackItemNodeAttributes(nextNode);
+  // The top padding is breathing room for the dashed divider, so only the
+  // items that draw one get it. The first item keeps the editor's own pt-4.
+  setClassName(
+    dom,
+    `flex flex-col gap-1.5 pb-1.5${
+      showDivider ? " border-t border-dashed border-border/60 pt-1.5" : ""
+    }`,
+    skipUnchanged,
+  );
+  setClassName(
+    noteDom,
+    `relative${fill ? " min-h-[96px]" : ""}`,
+    skipUnchanged,
+  );
+  const placeholderHidden = nodeText(nextNode).length > 0;
+  if (!skipUnchanged || placeholderDom.hidden !== placeholderHidden) {
+    placeholderDom.hidden = placeholderHidden;
+  }
+  setClassName(
+    contentDOM,
+    "relative w-full px-1 py-1 text-[0.9375rem] leading-snug " +
+      `text-foreground outline-none [&_p]:m-0${fill ? " min-h-[96px]" : ""}`,
+    skipUnchanged,
+  );
+  if (!skipUnchanged || quoteText.textContent !== quote) {
+    quoteText.textContent = quote;
   }
 }
 
@@ -589,6 +638,7 @@ function createFeedbackItemNodeView(
   node: ProseMirrorNode,
   removeFeedback: (id: number) => void,
   localizedUi: Set<() => void>,
+  skipUnchangedWrites: () => boolean,
 ): NodeView {
   const dom = document.createElement("div");
   dom.dataset.feedbackItem = "";
@@ -652,28 +702,11 @@ function createFeedbackItemNodeView(
     contentDOM.setAttribute("aria-label", placeholder);
   }
   function render(nextNode: ProseMirrorNode): void {
-    const { quote, showDivider, fill } = feedbackItemNodeAttributes(nextNode);
-    // The top padding is breathing room for the dashed divider, so only the
-    // items that draw one get it. The first item keeps the editor's own pt-4.
-    setClassName(
-      dom,
-      `flex flex-col gap-1.5 pb-1.5${
-        showDivider ? " border-t border-dashed border-border/60 pt-1.5" : ""
-      }`,
+    renderFeedbackItemNodeView(
+      { dom, noteDom, placeholderDom, contentDOM, quoteText },
+      nextNode,
+      skipUnchangedWrites(),
     );
-    setClassName(noteDom, `relative${fill ? " min-h-[96px]" : ""}`);
-    const placeholderHidden = nodeText(nextNode).length > 0;
-    if (placeholderDom.hidden !== placeholderHidden) {
-      placeholderDom.hidden = placeholderHidden;
-    }
-    setClassName(
-      contentDOM,
-      "relative w-full px-1 py-1 text-[0.9375rem] leading-snug " +
-        `text-foreground outline-none [&_p]:m-0${fill ? " min-h-[96px]" : ""}`,
-    );
-    if (quoteText.textContent !== quote) {
-      quoteText.textContent = quote;
-    }
   }
   removeButton.addEventListener("mousedown", (event) => {
     event.preventDefault();
@@ -1570,6 +1603,7 @@ interface WorkflowComposerRuntime {
   replaceFeedbackItems(items: readonly FeedbackItem[]): void;
   removeFeedback(id: number): void;
   localizedUi: Set<() => void>;
+  skipUnchangedNoteWrites: boolean;
 }
 
 function createTemplateAttachmentNode(
@@ -1741,6 +1775,9 @@ function createFeedbackItemNode(
             runtime.removeFeedback(id);
           },
           runtime.localizedUi,
+          () => {
+            return runtime.skipUnchangedNoteWrites;
+          },
         );
       };
     },
@@ -2098,6 +2135,7 @@ function createMountEditorCommand({
   return onRef(
     command(async ({ get, set }, element: HTMLElement, signal: AbortSignal) => {
       const includeQuoteOnlyFeedback = get(quoteOnlyFeedbackEnabled$);
+      runtime.skipUnchangedNoteWrites = get(composerImeSubmitFlushEnabled$);
       runtime.update = (updatedEditor) => {
         runtime.replaceFeedbackItems(
           feedbackItemsFromWorkflowComposer(updatedEditor),
@@ -2549,6 +2587,7 @@ function createWorkflowComposerRuntime(): WorkflowComposerRuntime {
     replaceFeedbackItems(_items: readonly FeedbackItem[]): void {},
     removeFeedback(_id: number): void {},
     localizedUi: new Set(),
+    skipUnchangedNoteWrites: false,
   };
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/tiptap-workflow-composer.ts
@@ -269,8 +269,23 @@ function connectComposerFeedback(
   });
 }
 
+/**
+ * Assigning an attribute queues a MutationObserver record even when the value
+ * is unchanged. Inside a node view's `contentDOM` those records are read by
+ * ProseMirror as content changes, which can discard an in-flight IME
+ * composition, so re-renders must not rewrite values that already match.
+ */
+function setClassName(element: HTMLElement, className: string): void {
+  if (element.className !== className) {
+    element.className = className;
+  }
+}
+
 interface EditorViewWithDomObserver extends EditorView {
-  readonly domObserver: { readonly flush: () => void };
+  readonly domObserver: {
+    readonly flush: () => void;
+    readonly forceFlush: () => void;
+  };
 }
 
 /**
@@ -284,9 +299,15 @@ interface EditorViewWithDomObserver extends EditorView {
  * internal and omits it from the published types, so it is reached through a
  * cast. A future rename must fail loudly here rather than silently restore the
  * truncated submission.
+ *
+ * Both calls are needed. `flush` returns early while a deferred flush is
+ * scheduled, which is the state a composition leaves behind, and `forceFlush`
+ * clears that timer but does nothing when no flush is pending.
  */
 function flushPendingDomChanges(editor: Editor): void {
-  (editor.view as EditorViewWithDomObserver).domObserver.flush();
+  const { domObserver } = editor.view as EditorViewWithDomObserver;
+  domObserver.forceFlush();
+  domObserver.flush();
 }
 
 function createReadInputForSubmissionCommand(
@@ -634,15 +655,25 @@ function createFeedbackItemNodeView(
     const { quote, showDivider, fill } = feedbackItemNodeAttributes(nextNode);
     // The top padding is breathing room for the dashed divider, so only the
     // items that draw one get it. The first item keeps the editor's own pt-4.
-    dom.className = `flex flex-col gap-1.5 pb-1.5${
-      showDivider ? " border-t border-dashed border-border/60 pt-1.5" : ""
-    }`;
-    noteDom.className = `relative${fill ? " min-h-[96px]" : ""}`;
-    placeholderDom.hidden = nodeText(nextNode).length > 0;
-    contentDOM.className =
+    setClassName(
+      dom,
+      `flex flex-col gap-1.5 pb-1.5${
+        showDivider ? " border-t border-dashed border-border/60 pt-1.5" : ""
+      }`,
+    );
+    setClassName(noteDom, `relative${fill ? " min-h-[96px]" : ""}`);
+    const placeholderHidden = nodeText(nextNode).length > 0;
+    if (placeholderDom.hidden !== placeholderHidden) {
+      placeholderDom.hidden = placeholderHidden;
+    }
+    setClassName(
+      contentDOM,
       "relative w-full px-1 py-1 text-[0.9375rem] leading-snug " +
-      `text-foreground outline-none [&_p]:m-0${fill ? " min-h-[96px]" : ""}`;
-    quoteText.textContent = quote;
+        `text-foreground outline-none [&_p]:m-0${fill ? " min-h-[96px]" : ""}`,
+    );
+    if (quoteText.textContent !== quote) {
+      quoteText.textContent = quote;
+    }
   }
   removeButton.addEventListener("mousedown", (event) => {
     event.preventDefault();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -1436,6 +1436,70 @@ describe("chat inline feedback", () => {
     await expect(findComposerEditor()).resolves.toBe(composerEditor);
   });
 
+  it("does not rewrite feedback note attributes while typing into it", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The rollout dates are unclear in this summary.";
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatEvents: [
+        {
+          id: "msg-feedback-rerender-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-rerender",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-rerender-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-rerender",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+    });
+
+    selectTextForInlineFeedback(await screen.findByText(assistantReply));
+    await user.click(await screen.findByText("Quote"));
+
+    const feedbackComment = await findFeedbackNote();
+    await user.click(feedbackComment);
+    await user.keyboard("first");
+    await waitFor(() => {
+      expect(feedbackComment).toHaveTextContent("first");
+    });
+
+    // Attribute writes inside the note are read by ProseMirror as content
+    // changes, so a re-render that rewrites unchanged values can discard an
+    // in-flight IME composition.
+    const attributeWrites: (string | null)[] = [];
+    const collect = (records: MutationRecord[]): void => {
+      for (const record of records) {
+        if (record.type === "attributes") {
+          attributeWrites.push(record.attributeName);
+        }
+      }
+    };
+    const observer = new MutationObserver(collect);
+    observer.observe(feedbackComment, { attributes: true });
+
+    await user.keyboard(" second");
+    await waitFor(() => {
+      expect(feedbackComment).toHaveTextContent("first second");
+    });
+    collect(observer.takeRecords());
+    observer.disconnect();
+
+    expect(attributeWrites).toStrictEqual([]);
+  });
+
   it("submits the committed inline feedback after IME composition ends", async () => {
     const user = userEvent.setup({ delay: null });
     const assistantReply = "The rollout dates are unclear in this summary.";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -1464,6 +1464,7 @@ describe("chat inline feedback", () => {
     detachedSetupPage({
       context,
       path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ComposerImeSubmitFlush]: true },
     });
 
     selectTextForInlineFeedback(await screen.findByText(assistantReply));

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -369,7 +369,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ComposerImeSubmitFlush]: {
     maintainer: "bingjie@vm0.ai",
     description:
-      "Flush pending IME DOM changes into the composer document before reading a submission.",
+      "Protect in-flight IME composition in the chat composer: skip unchanged feedback note DOM writes and flush pending DOM changes before reading a submission.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
## Summary

Follow-up to #28045, which did not fix the reported truncation. Device tracing narrowed the bug to the **inline feedback note**, not the plain composer, and to redundant DOM writes rather than a timing race.

Both protections are gated behind the existing **`composerImeSubmitFlush`** feature switch (off by default, staff orgs only), so with the switch off behavior is byte-for-byte unchanged:

- Skip `className` / `hidden` / `textContent` writes in the feedback note's node view when the value is unchanged.
- Call `domObserver.forceFlush()` before `flush()` when reading a submission.

## Evidence

A Safari Web Inspector trace on the reported iOS session, timestamps in seconds:

| t | event |
| --- | --- |
| 31.60 | `compositionend` — first segment |
| 32.09 | draft `PATCH` containing the first segment, so it reached the document |
| 31.76 | `compositionstart` — second segment |
| 33.31 | `compositionend` — second segment; the DOM holds both |
| 33.95 | `POST /chat/events` with a `prompt` containing **only the first segment** |

The send happened 0.64s after the second `compositionend`, far past the ~20ms prosemirror-view needs to run `endComposition`. The second segment never reached `editor.state.doc` at all, so this is not a race the composition gate can win.

## Cause

`createFeedbackItemNodeView`'s render ran on every document update and assigned four DOM values unconditionally. Assigning an attribute queues a `MutationObserver` record even when the value is unchanged, and the node view's `ignoreMutation` only ignores mutations whose target is outside `contentDOM`:

```ts
ignoreMutation(mutation) {
  return mutation.type !== "selection" && !contentDOM.contains(mutation.target);
}
```

`contentDOM.contains(contentDOM)` is `true`, so a re-render's `contentDOM.className = ...` was handed to ProseMirror as a content change inside the region the user was composing in — a documented way to lose an in-flight composition.

The `forceFlush` change addresses a second defect found while reading prosemirror-view 1.42.2: `DOMObserver.flush()` returns early when `this.flushingSoon > -1`, which is exactly the state a composition leaves behind, so #28045's `flush()` call could not make progress. `forceFlush()` clears that timer but is itself a no-op when nothing is pending, so both calls are needed.

## Feature switch

Both protections read `composerImeSubmitFlush`:

- The submit reader already gated `forceFlush`/`flush` on it.
- The node view now receives the resolved switch value (via `runtime.skipUnchangedNoteWrites`, set at mount) and only skips unchanged writes when it is on. With the switch off, the node view writes exactly as before this PR.

This keeps the whole IME-composition change contained to opt-in staff orgs until device verification, consistent with #28045's gating.

## Test plan

- Added `does not rewrite feedback note attributes while typing into it` in `chat-inline-feedback.test.tsx` (switch enabled). It observes attribute mutations on the note's `contentDOM` while typing and asserts none occur.
- **Verified as a real regression guard, and that the switch actually gates it**: with the switch enabled it passes; flipping the switch to `false` (old behavior) makes it fail; reverting only the value guards also makes it fail.
- `chat-inline-feedback.test.tsx` 31 passed, `chat-run-queue.test.tsx` 33 passed, `@okouai/app` + `@okouai/core` `check-types` clean, `pnpm format` clean, `pnpm turbo run lint` 13 tasks 0 errors.
- The `forceFlush` half stays untested; happy-dom has no deferred flush to force.
- Device verification still required: enable `composerImeSubmitFlush` in Lab, reproduce the two-segment composition on iOS, and confirm the full note is sent.
