### PR TITLE
fix: neutralize built-in model provider presentation

### DIFF
--- a/turbo/apps/api/src/signals/services/model-provider.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider.service.ts
@@ -2,6 +2,7 @@ import { command, computed, type Computed } from "ccstate";
 import {
   getAuthMethodsForType,
   getFrameworkForType,
+  getModelProviderPresentationLabel,
   getSecretNameForType,
   getSecretNamesForAuthMethod,
   getSecretsForAuthMethod,
@@ -379,7 +380,7 @@ function assertVm0OrgOnly(
 ): BadRequestResponse | null {
   if (type === "vm0" && userId !== ORG_SENTINEL_USER_ID) {
     return badRequestMessage(
-      "VM0 managed provider is org-only and cannot be configured per-user",
+      `${getModelProviderPresentationLabel(type)} provider is org-only and cannot be configured per-user`,
     );
   }
   return null;

--- a/turbo/apps/cli/src/commands/chat/__tests__/model.test.ts
+++ b/turbo/apps/cli/src/commands/chat/__tests__/model.test.ts
@@ -51,6 +51,19 @@ const MODEL_POLICIES_RESPONSE = {
       createdAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
     },
+    {
+      id: "00000000-0000-4000-8000-000000000103",
+      model: "deepseek-v4-flash",
+      modelLabel: "DeepSeek V4 Flash",
+      isDefault: false,
+      defaultProviderType: "vm0",
+      credentialScope: "org",
+      modelProviderId: null,
+      routeStatus: "valid",
+      routeStatusReason: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
   ],
 };
 
@@ -119,6 +132,8 @@ describe("okou chat model command", () => {
     expect(output).toContain("Chat thread loaded");
     expect(output).toContain("Model:  Claude Sonnet 5 (claude-sonnet-5)");
     expect(output).toContain("Switchable models:");
+    expect(output).toContain("provider: built-in (Built-in model; vm0)");
+    expect(output).not.toContain("VM0 Managed");
     expect(output).toContain(`okou chat model --thread ${THREAD_ID} <model>`);
   });
 

--- a/turbo/apps/cli/src/commands/model-provider/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/model-provider/__tests__/index.test.ts
@@ -93,6 +93,8 @@ describe("okou model-provider command", () => {
     expect(logCalls).toContain("Model Provider Routes:");
     expect(logCalls).toContain("Claude Sonnet 4.6");
     expect(logCalls).toContain("provider: built-in");
+    expect(logCalls).toContain("provider type: vm0 (Built-in model)");
+    expect(logCalls).not.toContain("VM0 Managed");
     expect(logCalls).toContain("GPT 5.6 Luna");
     expect(logCalls).toContain("provider: api key");
     expect(logCalls).toContain("GPT 5.5");

--- a/turbo/apps/cli/src/commands/model/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/model/__tests__/index.test.ts
@@ -75,7 +75,8 @@ describe("okou model command", () => {
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("Allowed Models:");
     expect(logCalls).toContain("Claude Sonnet 4.6");
-    expect(logCalls).toContain("provider: built-in");
+    expect(logCalls).toContain("provider: built-in (Built-in model; vm0)");
+    expect(logCalls).not.toContain("VM0 Managed");
     expect(logCalls).toContain("price tier: $$");
     expect(logCalls).toContain("GPT 5.5");
     expect(logCalls).toContain("provider: api key");

--- a/turbo/apps/cli/src/lib/domain/model-policy-display.ts
+++ b/turbo/apps/cli/src/lib/domain/model-policy-display.ts
@@ -1,5 +1,5 @@
 import {
-  MODEL_PROVIDER_TYPES,
+  getModelProviderPresentationLabel,
   type ModelProviderType,
   type OrgModelPolicy,
 } from "@okouai/api-contracts/contracts/model-providers";
@@ -21,7 +21,7 @@ export function getModelProviderRouteKind(
 }
 
 export function getModelProviderTypeLabel(type: ModelProviderType): string {
-  return MODEL_PROVIDER_TYPES[type].label;
+  return getModelProviderPresentationLabel(type);
 }
 
 export function formatModelProviderRoute(policy: OrgModelPolicy): string {

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
@@ -1,7 +1,7 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import {
-  MODEL_PROVIDER_TYPES,
+  getModelProviderPresentationLabel,
   type ModelProviderType,
 } from "@okouai/api-contracts/contracts/model-providers";
 import {
@@ -76,8 +76,7 @@ export const personalConfiguredProviders$ = computed(async (get) => {
 
 export const disconnectPersonalOAuthCredential$ = command(
   async ({ set }, providerType: ModelProviderType, signal: AbortSignal) => {
-    const providerLabel =
-      MODEL_PROVIDER_TYPES[providerType]?.label ?? providerType;
+    const providerLabel = getModelProviderPresentationLabel(providerType);
 
     const promise = (async () => {
       await set(deletePersonalModelProvider$, providerType, signal);

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -769,6 +769,15 @@ export const MODEL_PROVIDER_TYPES = {
   },
 } as const satisfies Record<ModelProviderType, unknown>;
 
+export function getModelProviderPresentationLabel(
+  type: ModelProviderType,
+): string {
+  if (type === "vm0") {
+    return "Built-in model";
+  }
+  return MODEL_PROVIDER_TYPES[type].label;
+}
+
 const MODEL_FIRST_PROVIDER_COMPATIBILITY = {
   "claude-fable-5": [
     "vm0",


### PR DESCRIPTION
## Summary

- present the internal `vm0` model route as `Built-in model` in non-localized API, CLI, and settings output
- centralize the presentation label in the model-provider contract and cover model, model-provider, and chat CLI output
- retain the internal `vm0` provider identifier, model mappings, and `VM0 Managed` configuration label for compatibility

Part of #27750.

## Verification

- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- segmented full type checks for non-API/Web packages, Web, and API
- targeted CLI model, model-provider, and chat tests (11 passed)
- targeted personal provider settings test (1 passed)