### PR TITLE
perf(runner): attribute claim response read and decode latency

### DIFF
--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -139,7 +139,7 @@ async fn run_finalizing_claim(
     } = request;
     let run_id = claimed.context().run_id;
     let mut pre_spawn_timing =
-        RunnerPreSpawnTiming::start_at(claim_returned_at, claimed.api_claim_request_elapsed());
+        RunnerPreSpawnTiming::start_at(claim_returned_at, claimed.api_claim_timing());
     pre_spawn_timing.mark_task_enqueued();
     let started_at = Instant::now();
     let mut reserved_exact = None;

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -319,7 +319,7 @@ pub(super) async fn handle_discovered_job(
         return DiscoveredJobResult::completed(true);
     }
     let mut pre_spawn_timing =
-        RunnerPreSpawnTiming::start_at(claim_returned_at, claimed.api_claim_request_elapsed());
+        RunnerPreSpawnTiming::start_at(claim_returned_at, claimed.api_claim_timing());
     let started_at = Instant::now();
     let resume_session_error = validate_resume_session_id(claimed.context()).err();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::ResumeSessionValidation, started_at);

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -9,6 +9,7 @@ use guest_contracts::epoch_milliseconds::{
 use tracing::warn;
 
 use crate::guest_timezone::GuestTimezoneAssumption;
+use crate::provider::ApiClaimTiming;
 use crate::telemetry::{JobTelemetry, RunnerStartupPath};
 use crate::types::{ExecutionContext, SandboxReuseResult, WorkspaceReuseResult};
 use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
@@ -156,7 +157,7 @@ impl RunnerPreSpawnPhaseDurations {
 
 pub(crate) struct RunnerPreSpawnTiming {
     claim_returned_at: Instant,
-    api_claim_request_elapsed: Option<Duration>,
+    api_claim_timing: Option<ApiClaimTiming>,
     phase_durations: RunnerPreSpawnPhaseDurations,
     task_enqueued_at: Option<Instant>,
     exact_reuse_speculation: Option<ExactReuseSpeculationTiming>,
@@ -192,11 +193,11 @@ impl RunnerPreSpawnTiming {
 
     pub(crate) fn start_at(
         claim_returned_at: Instant,
-        api_claim_request_elapsed: Option<Duration>,
+        api_claim_timing: Option<ApiClaimTiming>,
     ) -> Self {
         Self {
             claim_returned_at,
-            api_claim_request_elapsed,
+            api_claim_timing,
             phase_durations: RunnerPreSpawnPhaseDurations::default(),
             task_enqueued_at: None,
             exact_reuse_speculation: None,
@@ -233,8 +234,25 @@ impl RunnerPreSpawnTiming {
     }
 
     fn record_collected_phases(&self, telemetry: &mut JobTelemetry, executor_started_at: Instant) {
-        if let Some(duration) = self.api_claim_request_elapsed {
-            telemetry.record("runner_claim_http_request", duration, true, None);
+        if let Some(timing) = self.api_claim_timing {
+            telemetry.record(
+                "runner_claim_http_request",
+                timing.request_elapsed(),
+                true,
+                None,
+            );
+            telemetry.record(
+                "runner_claim_response_body_read",
+                timing.response_body_read_elapsed(),
+                true,
+                None,
+            );
+            telemetry.record(
+                "runner_claim_response_decode",
+                timing.response_decode_elapsed(),
+                true,
+                None,
+            );
         }
         for phase in RunnerPreSpawnPhase::ALL {
             if let Some(duration) = self.phase_durations.get(phase) {

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -25,6 +25,7 @@ use super::support::{
 use crate::guest_timezone::GuestTimezoneAssumption;
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::ids::RunId;
+use crate::provider::ApiClaimTiming;
 use crate::run_cancellation::RunCancellationSignals;
 use crate::telemetry::{JobTelemetry, RunnerStartupPath};
 use crate::types::{SandboxReuseResult, WorkspaceReuseResult};
@@ -156,6 +157,23 @@ fn assert_action_duration(telemetry: &JobTelemetry, action: &str, duration_ms: u
         .find(|op| op.0 == action)
         .unwrap_or_else(|| panic!("expected telemetry action {action}, got: {ops:?}"));
     assert_eq!(op.1, duration_ms, "{action} duration");
+}
+
+fn assert_action_once_with_duration(telemetry: &JobTelemetry, action: &str, duration_ms: u64) {
+    let ops = telemetry.pending_ops_with_duration_snapshot();
+    let matching: Vec<_> = ops.iter().filter(|op| op.0 == action).collect();
+    assert_eq!(matching.len(), 1, "expected one {action}, got: {ops:?}");
+    assert_eq!(matching[0].1, duration_ms, "{action} duration");
+}
+
+fn assert_lacks_api_claim_timing(telemetry: &JobTelemetry) {
+    for action in [
+        "runner_claim_http_request",
+        "runner_claim_response_body_read",
+        "runner_claim_response_decode",
+    ] {
+        assert_lacks_action(telemetry, action);
+    }
 }
 
 struct ObservedStartSandbox {
@@ -517,8 +535,14 @@ fn assert_pre_spawn_phase_actions_succeeded(telemetry: &JobTelemetry) {
 }
 
 fn pre_spawn_timing_with_phases() -> RunnerPreSpawnTiming {
-    let mut timing =
-        RunnerPreSpawnTiming::start_at(Instant::now(), Some(Duration::from_millis(42)));
+    let mut timing = RunnerPreSpawnTiming::start_at(
+        Instant::now(),
+        Some(ApiClaimTiming::new(
+            Duration::from_millis(42),
+            Duration::from_millis(7),
+            Duration::from_millis(3),
+        )),
+    );
     for (phase, duration_ms) in [
         (RunnerPreSpawnPhase::ResumeSessionValidation, 1),
         (RunnerPreSpawnPhase::SessionHistoryMaterializerStart, 2),
@@ -614,7 +638,7 @@ async fn execute_job_records_sandbox_reuse_miss_in_telemetry() {
     assert_eq!(reuse_events.len(), 1);
     assert_eq!(reuse_events[0].0, "sandbox_reuse_miss");
     assert_lacks_action(&telemetry, "runner_claim_to_executor_start");
-    assert_lacks_action(&telemetry, "runner_claim_http_request");
+    assert_lacks_api_claim_timing(&telemetry);
     assert_lacks_action(&telemetry, "runner_claim_resume_session_validation");
     assert_lacks_action(&telemetry, "runner_claim_task_schedule_wait");
     assert_action_success(&telemetry, "runner_fresh_sandbox_start", true);
@@ -699,6 +723,8 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
 
     for action in [
         "runner_claim_http_request",
+        "runner_claim_response_body_read",
+        "runner_claim_response_decode",
         "runner_claim_to_executor_start",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
@@ -719,7 +745,9 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     ] {
         assert_has_action(&telemetry, action);
     }
-    assert_action_duration(&telemetry, "runner_claim_http_request", 42);
+    assert_action_once_with_duration(&telemetry, "runner_claim_http_request", 42);
+    assert_action_once_with_duration(&telemetry, "runner_claim_response_body_read", 7);
+    assert_action_once_with_duration(&telemetry, "runner_claim_response_decode", 3);
     assert_action_duration(&telemetry, "workspace_drive_mount_guest_exec", 23);
     assert_lacks_action(&telemetry, "workspace_drive_mount_guest_exec_unavailable");
     assert!(
@@ -1057,6 +1085,8 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
 
     for action in [
         "runner_claim_http_request",
+        "runner_claim_response_body_read",
+        "runner_claim_response_decode",
         "runner_claim_to_executor_start",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
@@ -1070,7 +1100,9 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     ] {
         assert_has_action(&telemetry, action);
     }
-    assert_action_duration(&telemetry, "runner_claim_http_request", 42);
+    assert_action_once_with_duration(&telemetry, "runner_claim_http_request", 42);
+    assert_action_once_with_duration(&telemetry, "runner_claim_response_body_read", 7);
+    assert_action_once_with_duration(&telemetry, "runner_claim_response_decode", 3);
     assert_pre_spawn_phase_actions_succeeded(&telemetry);
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_prepare");
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_factory_create");
@@ -1121,7 +1153,7 @@ async fn start_process_failure_records_phase_failure_without_spawn_completion() 
 
     assert_action_success(&telemetry, "runner_agent_start_process", false);
     assert_action_success(&telemetry, "agent_execute", false);
-    assert_lacks_action(&telemetry, "runner_claim_http_request");
+    assert_lacks_api_claim_timing(&telemetry);
     assert_lacks_action(&telemetry, "runner_executor_start_to_spawn");
     assert_lacks_action(&telemetry, "runner_claim_to_spawn");
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -34,8 +34,8 @@ use super::builtin_firewall_catalog::{
 };
 use super::connector_runtime_sync::ConnectorRuntimeSyncHandle;
 use super::{
-    ClaimedJob, CompletionAuth, CompletionAuthError, CompletionReportTiming, JobCandidate,
-    JobDiscoverySource, JobProvider, RunnerPreference, RunnerPreferenceClaimState,
+    ApiClaimTiming, ClaimedJob, CompletionAuth, CompletionAuthError, CompletionReportTiming,
+    JobCandidate, JobDiscoverySource, JobProvider, RunnerPreference, RunnerPreferenceClaimState,
     parse_runner_preference,
 };
 use crate::active_input::{ActiveInputNotifications, ActiveInputSource};
@@ -133,6 +133,13 @@ enum ClaimApiError {
     ResponseRead(String),
     #[error("claim response decode failed: {0}")]
     ResponseDecode(String),
+}
+
+#[cfg_attr(test, derive(Debug))]
+struct SuccessfulClaimResponse {
+    context: ExecutionContext,
+    response_body_read_elapsed: Duration,
+    response_decode_elapsed: Duration,
 }
 
 #[derive(Clone, Copy)]
@@ -635,7 +642,16 @@ impl JobProvider for ApiProvider {
         let claim_result = self.api.claim(&candidate, &self.runner_identity).await;
         let claim_request_elapsed = claim_request_started_at.elapsed();
         match claim_result {
-            Ok(Some(ctx)) => {
+            Ok(Some(SuccessfulClaimResponse {
+                context: ctx,
+                response_body_read_elapsed,
+                response_decode_elapsed,
+            })) => {
+                let api_claim_timing = ApiClaimTiming::new(
+                    claim_request_elapsed,
+                    response_body_read_elapsed,
+                    response_decode_elapsed,
+                );
                 let active_input_source = (ctx.cli_agent_type != "pi"
                     && supports_thread_active_input(ctx.reuse_key.as_deref()))
                 .then(|| {
@@ -651,10 +667,10 @@ impl JobProvider for ApiProvider {
                         run_id,
                         ctx,
                         active_input_source,
-                        claim_request_elapsed,
+                        api_claim_timing,
                     )
                 } else {
-                    ClaimedJob::api(run_id, ctx, claim_request_elapsed)
+                    ClaimedJob::api(run_id, ctx, api_claim_timing)
                 } {
                     Ok(claimed) => claimed,
                     Err(error) => {
@@ -1037,7 +1053,7 @@ impl ApiClient {
         &self,
         candidate: &JobCandidate,
         runner_identity: &RunnerProcessIdentity,
-    ) -> Result<Option<ExecutionContext>, ClaimApiError> {
+    ) -> Result<Option<SuccessfulClaimResponse>, ClaimApiError> {
         let run_id = candidate.run_id();
         let body = claim_request_body(candidate, runner_identity);
         let run_id = run_id.to_string();
@@ -1061,20 +1077,28 @@ impl ApiClient {
         }
 
         let resp = check_api_status(resp, "claim").await?;
+        let response_body_read_started_at = Instant::now();
         let body = resp
             .bytes()
             .await
             .map_err(|error| ClaimApiError::ResponseRead(error.to_string()))?;
-        let ctx = decode_api_json_bytes(&body).map_err(ClaimApiError::ResponseDecode)?;
+        let response_body_read_elapsed = response_body_read_started_at.elapsed();
+        let response_decode_started_at = Instant::now();
+        let context = decode_api_json_bytes(&body).map_err(ClaimApiError::ResponseDecode)?;
+        let response_decode_elapsed = response_decode_started_at.elapsed();
 
-        Ok(Some(ctx))
+        Ok(Some(SuccessfulClaimResponse {
+            context,
+            response_body_read_elapsed,
+            response_decode_elapsed,
+        }))
     }
 
     #[cfg(test)]
     async fn claim_for_test(
         &self,
         candidate: &JobCandidate,
-    ) -> Result<Option<ExecutionContext>, ClaimApiError> {
+    ) -> Result<Option<SuccessfulClaimResponse>, ClaimApiError> {
         let runner_identity =
             RunnerProcessIdentity::new("550e8400-e29b-41d4-a716-446655440000".parse().unwrap(), 7)
                 .unwrap();
@@ -3909,7 +3933,14 @@ mod tests {
             ))
             .await
             .expect("shared current claim response should decode");
-        assert!(claimed.api_claim_request_elapsed().is_some());
+        let claim_timing = claimed
+            .api_claim_timing()
+            .expect("successful API claim should retain timing");
+        assert!(
+            claim_timing.request_elapsed()
+                >= claim_timing.response_body_read_elapsed()
+                    + claim_timing.response_decode_elapsed()
+        );
         let context = claimed.context();
 
         assert_eq!(context.run_id, run_id);

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -516,7 +516,40 @@ pub struct ClaimedJob {
     context: ExecutionContext,
     completion_auth: CompletionAuth,
     active_input_source: Option<ActiveInputSource>,
-    api_claim_request_elapsed: Option<Duration>,
+    api_claim_timing: Option<ApiClaimTiming>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ApiClaimTiming {
+    request_elapsed: Duration,
+    response_body_read_elapsed: Duration,
+    response_decode_elapsed: Duration,
+}
+
+impl ApiClaimTiming {
+    pub(crate) const fn new(
+        request_elapsed: Duration,
+        response_body_read_elapsed: Duration,
+        response_decode_elapsed: Duration,
+    ) -> Self {
+        Self {
+            request_elapsed,
+            response_body_read_elapsed,
+            response_decode_elapsed,
+        }
+    }
+
+    pub(crate) const fn request_elapsed(self) -> Duration {
+        self.request_elapsed
+    }
+
+    pub(crate) const fn response_body_read_elapsed(self) -> Duration {
+        self.response_body_read_elapsed
+    }
+
+    pub(crate) const fn response_decode_elapsed(self) -> Duration {
+        self.response_decode_elapsed
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -543,22 +576,22 @@ impl ClaimedJob {
     pub(crate) fn api(
         expected_run_id: RunId,
         context: ExecutionContext,
-        api_claim_request_elapsed: Duration,
+        api_claim_timing: ApiClaimTiming,
     ) -> Result<Self, ClaimedJobRunIdMismatch> {
-        Self::api_with_optional_source(expected_run_id, context, None, api_claim_request_elapsed)
+        Self::api_with_optional_source(expected_run_id, context, None, api_claim_timing)
     }
 
     pub(crate) fn api_with_active_input_source(
         expected_run_id: RunId,
         context: ExecutionContext,
         active_input_source: ActiveInputSource,
-        api_claim_request_elapsed: Duration,
+        api_claim_timing: ApiClaimTiming,
     ) -> Result<Self, ClaimedJobRunIdMismatch> {
         Self::api_with_optional_source(
             expected_run_id,
             context,
             Some(active_input_source),
-            api_claim_request_elapsed,
+            api_claim_timing,
         )
     }
 
@@ -566,7 +599,7 @@ impl ClaimedJob {
         expected_run_id: RunId,
         context: ExecutionContext,
         active_input_source: Option<ActiveInputSource>,
-        api_claim_request_elapsed: Duration,
+        api_claim_timing: ApiClaimTiming,
     ) -> Result<Self, ClaimedJobRunIdMismatch> {
         Self::validate_run_id(expected_run_id, &context)?;
         let completion_auth =
@@ -575,7 +608,7 @@ impl ClaimedJob {
             context,
             completion_auth,
             active_input_source,
-            api_claim_request_elapsed: Some(api_claim_request_elapsed),
+            api_claim_timing: Some(api_claim_timing),
         })
     }
 
@@ -597,7 +630,7 @@ impl ClaimedJob {
             context,
             completion_auth: CompletionAuth::local(),
             active_input_source,
-            api_claim_request_elapsed: None,
+            api_claim_timing: None,
         })
     }
 
@@ -611,8 +644,8 @@ impl ClaimedJob {
         &self.context
     }
 
-    pub(crate) fn api_claim_request_elapsed(&self) -> Option<Duration> {
-        self.api_claim_request_elapsed
+    pub(crate) fn api_claim_timing(&self) -> Option<ApiClaimTiming> {
+        self.api_claim_timing
     }
 
     #[cfg(test)]
@@ -785,6 +818,14 @@ mod tests {
         ctx
     }
 
+    fn api_claim_timing() -> ApiClaimTiming {
+        ApiClaimTiming::new(
+            Duration::from_millis(10),
+            Duration::from_millis(2),
+            Duration::from_millis(3),
+        )
+    }
+
     #[test]
     fn claimed_job_rejects_mismatched_api_context() {
         let expected_run_id = RunId::nil();
@@ -793,7 +834,7 @@ mod tests {
         let Err(err) = ClaimedJob::api(
             expected_run_id,
             minimal_context(context_run_id),
-            Duration::from_millis(1),
+            api_claim_timing(),
         ) else {
             panic!("mismatched context must be rejected");
         };
@@ -811,12 +852,23 @@ mod tests {
     fn claimed_job_accepts_matching_api_context() {
         let run_id = RunId::nil();
 
-        let claimed = ClaimedJob::api(run_id, minimal_context(run_id), Duration::from_millis(1))
+        let claimed = ClaimedJob::api(run_id, minimal_context(run_id), api_claim_timing())
             .expect("matching context is valid");
+        assert_eq!(claimed.api_claim_timing(), Some(api_claim_timing()));
         let (context, completion_auth, active_input_source) = claimed.into_parts();
 
         assert_eq!(context.run_id, run_id);
         assert!(active_input_source.is_none());
         assert!(completion_auth.matches_sandbox_token_for_test(run_id, "sandbox-token"));
+    }
+
+    #[test]
+    fn claimed_job_local_context_has_no_api_claim_timing() {
+        let run_id = RunId::nil();
+
+        let claimed = ClaimedJob::local(run_id, minimal_context(run_id))
+            .expect("matching local context is valid");
+
+        assert!(claimed.api_claim_timing().is_none());
     }
 }


### PR DESCRIPTION
## Summary

- measure successful claim response-body read and execution-context JSON decode durations at their exact Runner HTTP client boundaries
- carry the complete claim timing as one validated `ClaimedJob` value through ordinary and finalizing startup
- emit the existing claim parent plus two fixed child actions through job-owned telemetry
- cover fresh, reused, API-backed, local, and missing-timing behavior at existing integration boundaries

## Exclusions

- no claim request, response, retry, cooldown, authorization, billing, or run-selection behavior changes
- no API, database, queue, persisted-state, GuestAgent, or deployment-order changes
- no response content, context data, identity, URL, token, dynamic label, or arbitrary error telemetry
- no transport, codec, compression, or runtime optimization; this PR only adds attribution

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --no-deps`
- `cargo test -p runner` (3,198 passed; 20 ignored; 0 failed, plus guest inventory passed)
- `lefthook run pre-commit`
- `git diff --check`

Closes #28164

Parent context: #27735
