### PR TITLE
refactor(guest-agent): drop the legacy agent context env key

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -78,7 +78,6 @@ use tokio_util::sync::CancellationToken;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
-const ZERO_AGENT_ID_ENV_KEY: &str = "ZERO_AGENT_ID";
 const OKOU_AGENT_ID_ENV_KEY: &str = "OKOU_AGENT_ID";
 const CLI_PACKAGE_URL_ENV_KEY: &str = "CLI_PKG_URL";
 const WEB_SEARCH_TOOL_NAME: &str = "WebSearch";
@@ -359,8 +358,7 @@ impl<'a> CliRuntimeConfig<'a> {
         } else {
             None
         };
-        let disable_builtin_web_search = config.user_env.contains_key(OKOU_AGENT_ID_ENV_KEY)
-            || config.user_env.contains_key(ZERO_AGENT_ID_ENV_KEY);
+        let disable_builtin_web_search = config.user_env.contains_key(OKOU_AGENT_ID_ENV_KEY);
         let disallowed_tools = disallowed_tools_with_builtin_web_search_disabled(
             &config.disallowed_tools,
             disable_builtin_web_search,
@@ -2191,23 +2189,21 @@ mod tests {
     }
 
     #[test]
-    fn codex_runtime_accepts_okou_and_zero_agent_contexts() {
-        for key in [super::OKOU_AGENT_ID_ENV_KEY, super::ZERO_AGENT_ID_ENV_KEY] {
-            let config = guest_config_for_agent_context(HashMap::from([(
-                key.to_string(),
-                "agent-test".to_string(),
-            )]));
-            let paths = crate::paths::GuestPaths::from_runtime_dir("/tmp/okou-env-test");
+    fn codex_runtime_accepts_okou_agent_context() {
+        let config = guest_config_for_agent_context(HashMap::from([(
+            super::OKOU_AGENT_ID_ENV_KEY.to_string(),
+            "agent-test".to_string(),
+        )]));
+        let paths = crate::paths::GuestPaths::from_runtime_dir("/tmp/okou-env-test");
 
-            let runtime = CliRuntimeConfig::from_config(&config, &paths, Instant::now()).unwrap();
+        let runtime = CliRuntimeConfig::from_config(&config, &paths, Instant::now()).unwrap();
 
-            assert!(runtime.disable_builtin_web_search);
-            assert!(
-                runtime
-                    .codex_startup_config_overrides()
-                    .contains(&super::CODEX_WEB_SEARCH_DISABLED_CONFIG.to_string())
-            );
-        }
+        assert!(runtime.disable_builtin_web_search);
+        assert!(
+            runtime
+                .codex_startup_config_overrides()
+                .contains(&super::CODEX_WEB_SEARCH_DISABLED_CONFIG.to_string())
+        );
     }
 
     #[test]

--- a/crates/guest-agent/tests/zero_web_search_policy.rs
+++ b/crates/guest-agent/tests/zero_web_search_policy.rs
@@ -75,7 +75,7 @@ fn build_runtime(
     let user_env_file = write_user_env_file(
         &runtime_dir,
         &HashMap::from([
-            ("ZERO_AGENT_ID", "agent-zero-web-search"),
+            ("OKOU_AGENT_ID", "agent-okou-web-search"),
             (
                 "TEST_ARGS_PATH",
                 args_path.to_str().ok_or("args path must be valid UTF-8")?,


### PR DESCRIPTION
## What this changes

`crates/guest-agent` no longer reads the legacy agent-context environment key `ZERO_AGENT_ID`.

The API strips every `ZERO_`-prefixed key from a run's user environment through `withoutLegacyZeroEntries` in `agent-run-create.service.ts` (six paths: request secrets, agent config environment, expanded environment, merged vars, merged secrets), and `agent-execution-plan.ts` declares `legacyRemovedPrefixes: ["ZERO_"]` as application-owned policy, enforced by `agent-environment-shadow.ts` and `agent-execution-authority.ts`. No writer can place `ZERO_AGENT_ID` into a run's user environment, so the second branch of `disable_builtin_web_search` was unreachable.

| Old | New |
|---|---|
| `const ZERO_AGENT_ID_ENV_KEY: &str = "ZERO_AGENT_ID";` | removed |
| `contains_key(OKOU_AGENT_ID_ENV_KEY) \|\| contains_key(ZERO_AGENT_ID_ENV_KEY)` | `contains_key(OKOU_AGENT_ID_ENV_KEY)` |
| `codex_runtime_accepts_okou_and_zero_agent_contexts` (loops over both keys) | `codex_runtime_accepts_okou_agent_context`, canonical key only, both assertions kept |

### One reference beyond the issue's inventory

The issue listed three references. There is a fourth: `crates/guest-agent/tests/zero_web_search_policy.rs:78` seeded the guest user environment with `ZERO_AGENT_ID` to trigger the policy, so it would have failed once the reader was removed. It is retargeted to `OKOU_AGENT_ID`, which keeps its end-to-end coverage of the same behavior on the canonical key. Its file and test names are untouched — renaming them is naming cleanup outside this issue's scope.

## What this deliberately does not touch

- `OKOU_AGENT_ID` handling and every behavior it drives: `disable_builtin_web_search`, `disallowed_tools_with_builtin_web_search_disabled`, and the Codex startup override.
- Any other `VM0_*` or `ZERO_*` constant in `crates/`. The 97 `VM0_*` keys are the internal runner/guest protocol contract, not a compatibility shim.
- The API-side stripping logic. It stays; only the now-unreachable reader is removed.
- Web-search behavior, disallowed tools, and Codex runtime configuration — all unchanged.

## Rollback safety

Rolling a runner image back to an older build is unaffected: an older guest binary carries its own copy of this code, so removing the read here cannot break a rollback.

## Verification

- `grep -rn "ZERO_AGENT_ID" crates/` → no matches.
- `cargo fmt -p guest-agent -- --check` → clean.
- `cargo clippy -p guest-agent --all-targets -- -D warnings` → clean.
- `cargo test -p guest-agent --lib cli::` → 132 passed, including `codex_runtime_accepts_okou_agent_context`.
- `cargo test -p guest-agent --test zero_web_search_policy` → 1 passed.

Parent: #26701 (gate lifted for this half: https://github.com/vm0-ai/vm0/issues/26701#issuecomment-5339483638)

Closes #28170
