### PR TITLE
refactor(deploy): drop the legacy variable source fallback

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -123,13 +123,6 @@ runs:
           add_env "$1" "$(repo_secret "$2")"
         }
 
-        add_okou_var() {
-          local suffix="$1"
-          local value
-          value="$(first_non_empty "$(repo_var "OKOU_${suffix}")" "$(repo_var "ZERO_${suffix}")")"
-          add_env "OKOU_${suffix}" "$value"
-        }
-
         add_okou_secret() {
           local suffix="$1"
           local value
@@ -248,8 +241,8 @@ runs:
         add_var R2_HOSTED_SITES_BUCKET_NAME R2_HOSTED_SITES_BUCKET_NAME
         add_secret R2_HOSTED_SITES_ACCESS_KEY_ID R2_HOSTED_SITES_ACCESS_KEY_ID
         add_secret R2_HOSTED_SITES_SECRET_ACCESS_KEY R2_HOSTED_SITES_SECRET_ACCESS_KEY
-        add_okou_var HOST_DOMAIN
-        add_okou_var HOST_SCHEME
+        add_var OKOU_HOST_DOMAIN OKOU_HOST_DOMAIN
+        add_var OKOU_HOST_SCHEME OKOU_HOST_SCHEME
         add_secret SECRETS_ENCRYPTION_KEY SECRETS_ENCRYPTION_KEY
         add_secret SECRETS_KMS_KEY_ID SECRETS_KMS_KEY_ID
         add_var AWS_REGION AWS_REGION
@@ -398,7 +391,7 @@ runs:
           ONE_TIME_CAMPAIGN
         )
         for suffix in "${okou_price_var_suffixes[@]}"; do
-          add_okou_var "$suffix"
+          add_var "OKOU_${suffix}" "OKOU_${suffix}"
         done
         add_var ATOM_GRANT_PRICE ATOM_GRANT_PRICE
         add_secret AGENTPHONE_API_KEY AGENTPHONE_API_KEY

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -189,7 +189,8 @@ run_action() {
   repo_vars_json="$(jq -c '. + {OKOU_HOST_DOMAIN: "sites.test", OKOU_HOST_SCHEME: "https", OKOU_ONE_TIME_CAMPAIGN: "test-campaign"}' <<< "$repo_vars_json")"
   repo_secrets_json='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","ZERO_MAPS_GOOGLE_MAPS_TOKEN":"github-google-maps-token","ZERO_WEATHER_GOOGLE_WEATHER_TOKEN":"github-google-weather-token","ZERO_FINANCE_APIDOJO_TOKEN":"github-apidojo-token","ZERO_SEO_DATAFORSEO_LOGIN":"github-dataforseo-login","ZERO_SEO_DATAFORSEO_PASSWORD":"github-dataforseo-password","ZERO_BROWSER_USE_API_KEY":"github-browser-use-api-key","ZERO_SCRAPE_FIRECRAWL_TOKEN":"github-firecrawl-token","ZERO_WEB_SEARCH_PERPLEXITY_TOKEN":"github-perplexity-token","STEAM_WEB_API_KEY":"github-steam-web-api-key","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret","UNSPLASH_ACCESS_KEY":"github-unsplash-access-key","VM0_MACHINE_SECRET_KEY":"github-atom-machine-secret","MICROSOFT_TEAMS_BOT_APP_PASSWORD":"github-teams-bot-app-password","VERCEL_AUTOMATION_BYPASS_SECRET":"github-vercel-bypass-secret","CLOUDFLARE_BROWSER_RENDERING_API_TOKEN":"github-cloudflare-browser-rendering-token","ARTIFACT_PREVIEW_WAF_SECRET":"github-artifact-preview-waf-secret","JOGGAI_WEBHOOK_SECRET":"github-joggai-webhook-secret","STRIPE_WEBHOOK_SECRET":"github-stripe-billing-webhook-secret","STRIPE_AUTOMATION_WEBHOOK_SECRET":"github-stripe-automation-webhook-secret"}'
   if [[ "$branded_config" == "both" ]]; then
-    repo_vars_json="$(jq -c '. + {OKOU_HOST_DOMAIN: "okou-sites.test", OKOU_HOST_SCHEME: "http", OKOU_PRICE_PRO: "price_okou_pro", OKOU_ONE_TIME_CAMPAIGN: "okou-campaign"}' <<< "$repo_vars_json")"
+    # Secrets still resolve through first_non_empty(OKOU_*, ZERO_*), so this
+    # fixture supplies both brandings to pin canonical precedence.
     repo_secrets_json="$(jq -c '. + {OKOU_WEATHER_GOOGLE_WEATHER_TOKEN: "okou-google-weather-token", OKOU_SEO_DATAFORSEO_LOGIN: "okou-dataforseo-login", OKOU_BROWSER_USE_API_KEY: "okou-browser-use-api-key"}' <<< "$repo_secrets_json")"
   elif [[ "$branded_config" == "empty" ]]; then
     repo_vars_json="$(jq -c 'with_entries(select(.key | startswith("OKOU_") | not))' <<< "$repo_vars_json")"
@@ -313,10 +314,6 @@ assert_migrated_zero_outputs_absent "$precedence_env_file"
 assert_env_value "$precedence_env_file" OKOU_WEATHER_GOOGLE_WEATHER_TOKEN "okou-google-weather-token"
 assert_env_value "$precedence_env_file" OKOU_SEO_DATAFORSEO_LOGIN "okou-dataforseo-login"
 assert_env_value "$precedence_env_file" OKOU_BROWSER_USE_API_KEY "okou-browser-use-api-key"
-assert_env_value "$precedence_env_file" OKOU_HOST_DOMAIN "okou-sites.test"
-assert_env_value "$precedence_env_file" OKOU_HOST_SCHEME "http"
-assert_env_value "$precedence_env_file" OKOU_PRICE_PRO "price_okou_pro"
-assert_env_value "$precedence_env_file" OKOU_ONE_TIME_CAMPAIGN "okou-campaign"
 
 empty_dir="$(mktemp -d)"
 TEMP_DIRS+=("$empty_dir")

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -185,14 +185,14 @@ run_action() {
   local repo_vars_json
   local repo_secrets_json
 
-  repo_vars_json='{"GH_OAUTH_CLIENT_ID":"github-gh-client-id","SLACK_OAUTH_CLIENT_ID":"github-slack-client-id","VM0_API_BACKEND_URL":"https://api.github.test","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-var","FINICITY_PARTNER_ID":"github-finicity-partner-id","POSTHOG_KEY":"github-posthog-key","POSTHOG_HOST":"https://posthog.github.test","ATOM_URL":"https://atom.github.test","STRIPE_OAUTH_CLIENT_ID":"ca_test_connect_client","STRIPE_CONCURRENCY_PORTAL_CONFIGURATION_ID":"bpc_test_concurrency","MICROSOFT_TEAMS_BOT_APP_ID":"github-teams-bot-app-id","MICROSOFT_TEAMS_APP_TENANT_ID":"github-teams-app-tenant-id","ZERO_PRICE_PRO":"price_test_pro","ZERO_PRICE_TEAM":"price_test_team","ZERO_PRICE_USAGE_PACK_PLAN_PRO":"price_test_usage_pack_plan_pro","ZERO_PRICE_USAGE_PACK_PLAN_TEAM":"price_test_usage_pack_plan_team","ZERO_PRICE_USAGE_PACK_20":"price_test_usage_pack_20","ZERO_PRICE_USAGE_PACK_50":"price_test_usage_pack_50","ZERO_PRICE_USAGE_PACK_100":"price_test_usage_pack_100","ZERO_PRICE_USAGE_PACK_200":"price_test_usage_pack_200","ATOM_GRANT_PRICE":"price_test_atom_grant","ZERO_PRICE_CUSTOM_CREDITS":"price_test_custom_credits","ZERO_PRICE_CUSTOM_CREDIT_UNIT":"price_test_custom_credit_unit","ZERO_PRICE_CONCURRENCY":"price_test_concurrency","GMAIL_PUBSUB_TOPIC_NAME":"projects/github/topics/gmail","GMAIL_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/gmail","GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"gmail-push@github.test","GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME":"projects/github/topics/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"workspace-events-push@github.test"}'
-  repo_vars_json="$(jq -c '. + {ZERO_HOST_DOMAIN: "zero-sites.test", ZERO_HOST_SCHEME: "https", ZERO_ONE_TIME_CAMPAIGN: "zero-campaign"}' <<< "$repo_vars_json")"
+  repo_vars_json='{"GH_OAUTH_CLIENT_ID":"github-gh-client-id","SLACK_OAUTH_CLIENT_ID":"github-slack-client-id","VM0_API_BACKEND_URL":"https://api.github.test","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-var","FINICITY_PARTNER_ID":"github-finicity-partner-id","POSTHOG_KEY":"github-posthog-key","POSTHOG_HOST":"https://posthog.github.test","ATOM_URL":"https://atom.github.test","STRIPE_OAUTH_CLIENT_ID":"ca_test_connect_client","STRIPE_CONCURRENCY_PORTAL_CONFIGURATION_ID":"bpc_test_concurrency","MICROSOFT_TEAMS_BOT_APP_ID":"github-teams-bot-app-id","MICROSOFT_TEAMS_APP_TENANT_ID":"github-teams-app-tenant-id","OKOU_PRICE_PRO":"price_test_pro","OKOU_PRICE_TEAM":"price_test_team","OKOU_PRICE_USAGE_PACK_PLAN_PRO":"price_test_usage_pack_plan_pro","OKOU_PRICE_USAGE_PACK_PLAN_TEAM":"price_test_usage_pack_plan_team","OKOU_PRICE_USAGE_PACK_20":"price_test_usage_pack_20","OKOU_PRICE_USAGE_PACK_50":"price_test_usage_pack_50","OKOU_PRICE_USAGE_PACK_100":"price_test_usage_pack_100","OKOU_PRICE_USAGE_PACK_200":"price_test_usage_pack_200","ATOM_GRANT_PRICE":"price_test_atom_grant","OKOU_PRICE_CUSTOM_CREDITS":"price_test_custom_credits","OKOU_PRICE_CUSTOM_CREDIT_UNIT":"price_test_custom_credit_unit","OKOU_PRICE_CONCURRENCY":"price_test_concurrency","GMAIL_PUBSUB_TOPIC_NAME":"projects/github/topics/gmail","GMAIL_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/gmail","GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"gmail-push@github.test","GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME":"projects/github/topics/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"workspace-events-push@github.test"}'
+  repo_vars_json="$(jq -c '. + {OKOU_HOST_DOMAIN: "sites.test", OKOU_HOST_SCHEME: "https", OKOU_ONE_TIME_CAMPAIGN: "test-campaign"}' <<< "$repo_vars_json")"
   repo_secrets_json='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","ZERO_MAPS_GOOGLE_MAPS_TOKEN":"github-google-maps-token","ZERO_WEATHER_GOOGLE_WEATHER_TOKEN":"github-google-weather-token","ZERO_FINANCE_APIDOJO_TOKEN":"github-apidojo-token","ZERO_SEO_DATAFORSEO_LOGIN":"github-dataforseo-login","ZERO_SEO_DATAFORSEO_PASSWORD":"github-dataforseo-password","ZERO_BROWSER_USE_API_KEY":"github-browser-use-api-key","ZERO_SCRAPE_FIRECRAWL_TOKEN":"github-firecrawl-token","ZERO_WEB_SEARCH_PERPLEXITY_TOKEN":"github-perplexity-token","STEAM_WEB_API_KEY":"github-steam-web-api-key","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret","UNSPLASH_ACCESS_KEY":"github-unsplash-access-key","VM0_MACHINE_SECRET_KEY":"github-atom-machine-secret","MICROSOFT_TEAMS_BOT_APP_PASSWORD":"github-teams-bot-app-password","VERCEL_AUTOMATION_BYPASS_SECRET":"github-vercel-bypass-secret","CLOUDFLARE_BROWSER_RENDERING_API_TOKEN":"github-cloudflare-browser-rendering-token","ARTIFACT_PREVIEW_WAF_SECRET":"github-artifact-preview-waf-secret","JOGGAI_WEBHOOK_SECRET":"github-joggai-webhook-secret","STRIPE_WEBHOOK_SECRET":"github-stripe-billing-webhook-secret","STRIPE_AUTOMATION_WEBHOOK_SECRET":"github-stripe-automation-webhook-secret"}'
   if [[ "$branded_config" == "both" ]]; then
     repo_vars_json="$(jq -c '. + {OKOU_HOST_DOMAIN: "okou-sites.test", OKOU_HOST_SCHEME: "http", OKOU_PRICE_PRO: "price_okou_pro", OKOU_ONE_TIME_CAMPAIGN: "okou-campaign"}' <<< "$repo_vars_json")"
     repo_secrets_json="$(jq -c '. + {OKOU_WEATHER_GOOGLE_WEATHER_TOKEN: "okou-google-weather-token", OKOU_SEO_DATAFORSEO_LOGIN: "okou-dataforseo-login", OKOU_BROWSER_USE_API_KEY: "okou-browser-use-api-key"}' <<< "$repo_secrets_json")"
   elif [[ "$branded_config" == "empty" ]]; then
-    repo_vars_json="$(jq -c 'with_entries(select(.key | startswith("ZERO_") | not))' <<< "$repo_vars_json")"
+    repo_vars_json="$(jq -c 'with_entries(select(.key | startswith("OKOU_") | not))' <<< "$repo_vars_json")"
     repo_secrets_json="$(jq -c 'with_entries(select(.key | startswith("ZERO_") | not))' <<< "$repo_secrets_json")"
   fi
 
@@ -222,6 +222,12 @@ fi
 
 if ! oauth_client_config_prefixes | grep -qx SLACK; then
   fail "expected Slack OAuth client config to come from Doppler"
+fi
+
+# Variable sources are canonical-only. The secret half still falls back to
+# ZERO_* names, so this guard is scoped to variable reads.
+if grep -En '(repo_var|add_var [A-Z0-9_]+) "?ZERO_' "$ACTION"; then
+  fail "variable sources must read canonical OKOU_ names, not ZERO_"
 fi
 
 success_dir="$(mktemp -d)"
@@ -278,9 +284,9 @@ assert_env_value "$success_env_file" ATOM_GRANT_PRICE "price_test_atom_grant"
 assert_env_value "$success_env_file" OKOU_PRICE_CUSTOM_CREDITS "price_test_custom_credits"
 assert_env_value "$success_env_file" OKOU_PRICE_CUSTOM_CREDIT_UNIT "price_test_custom_credit_unit"
 assert_env_value "$success_env_file" OKOU_PRICE_CONCURRENCY "price_test_concurrency"
-assert_env_value "$success_env_file" OKOU_HOST_DOMAIN "zero-sites.test"
+assert_env_value "$success_env_file" OKOU_HOST_DOMAIN "sites.test"
 assert_env_value "$success_env_file" OKOU_HOST_SCHEME "https"
-assert_env_value "$success_env_file" OKOU_ONE_TIME_CAMPAIGN "zero-campaign"
+assert_env_value "$success_env_file" OKOU_ONE_TIME_CAMPAIGN "test-campaign"
 assert_env_value "$success_env_file" GMAIL_PUBSUB_TOPIC_NAME "projects/github/topics/gmail"
 assert_env_value "$success_env_file" GMAIL_PUBSUB_PUSH_AUDIENCE "https://api.github.test/api/webhooks/gmail"
 assert_env_value "$success_env_file" GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL "gmail-push@github.test"


### PR DESCRIPTION
## What this changes

`.github/actions/web-api-env/action.yml` read each branded variable family through `first_non_empty(OKOU_${suffix}, ZERO_${suffix})` and then emitted only the canonical `OKOU_${suffix}` key. That fallback is inert — the canonical variable exists at every level where its legacy counterpart exists — so it always selected the canonical value.

- Removed the `add_okou_var` helper.
- `add_okou_var HOST_DOMAIN` / `HOST_SCHEME` → `add_var OKOU_HOST_DOMAIN OKOU_HOST_DOMAIN` / `add_var OKOU_HOST_SCHEME OKOU_HOST_SCHEME`.
- The `okou_price_var_suffixes` loop now calls `add_var "OKOU_${suffix}" "OKOU_${suffix}"`.

`.github/scripts/tests/web-api-env-action-test.sh`:

- The **variable** fixtures now supply canonical `OKOU_*` names instead of `ZERO_*`. The two fixture values that were still `zero-`-branded became neutral (`sites.test`, `test-campaign`), with their two assertions updated to match.
- The `empty` branded-config case strips `OKOU_*` from the variable fixture (it previously stripped `ZERO_*`), so it still renders empty values.
- Added a guard, scoped to variable reads only, that fails if the action ever reads a `ZERO_` **variable** again. It deliberately does not match `repo_secret`.

## What this explicitly does NOT change

- **`add_okou_secret` and all four of its call sites are untouched.** Verified byte-identical against `main`; only their line numbers shift by 7. The secret half is still gated — canonical `OKOU_*` secrets were created on 2026-08-19 and need more release observations — and must not be removed in the same PR as the variable half.
- Every secret-related fallback assertion in the test is preserved verbatim, and `assert_migrated_zero_outputs_absent` still runs against all five rendered fixtures.
- The 14 legacy `ZERO_*` repository/`production` variables are **not** deleted. That is a separate configuration step after this ships and one release is observed.
- `turbo/apps/api/src/lib/env.ts` and its 22 application-level fallbacks are untouched.
- No rendered key name, value, or ordering changes.

## Verification

`.github/scripts/tests/web-api-env-action-test.sh` passes locally, and `bash -n` is clean.

Rendered output was compared before/after by extracting both versions of the action script and feeding them the **real** repository- and environment-scoped variable/secret *names* (synthetic values), for every app/environment combination:

| combination | keys | result |
|---|---|---|
| api / production | 210 | identical |
| web / production | 196 | identical |
| api / preview | 211 | identical |
| web / preview | 196 | identical |

No `ZERO_`-prefixed key is emitted in any combination.

## ⚠️ Prerequisite that had to be fixed first — please review

The issue lists **14** variable families, but `add_okou_var` actually had **15** call-site families: `okou_price_var_suffixes` also contains **`PRICE_CUSTOM`**, which the issue's inventory omitted.

`OKOU_PRICE_CUSTOM` did **not** exist at repository scope or in the `production` environment, while `ZERO_PRICE_CUSTOM` **did** exist in `production`. `promote-api-production` runs with `environment: production`, so production was rendering `OKOU_PRICE_CUSTOM` **only through the fallback this PR removes**. The first before/after comparison showed exactly one differing key:

```
- OKOU_PRICE_CUSTOM=<value of ZERO_PRICE_CUSTOM>
+ OKOU_PRICE_CUSTOM=
```

This would not have been caught by the application-level fallback in `env.ts` (`OKOU_PRICE_CUSTOM → ZERO_PRICE_CUSTOM`), because the renderer emits canonical keys only — `ZERO_PRICE_CUSTOM` is never present in the deployed environment file. `priceIdsSchema` is `.optional()`, so it would not have failed at boot; it would have silently emptied `env("OKOU_PRICE_CUSTOM")`, which `tierForKnownPlanPrice()` in `zero-billing-checkout.service.ts` uses to classify custom-plan subscriptions.

To make the issue's premise true for all 15 families, I created the missing canonical variable in the `production` environment with the **identical value**:

```
OKOU_PRICE_CUSTOM = <same value as ZERO_PRICE_CUSTOM>   # production environment, created 2026-08-19
```

This is additive and value-identical, so it is a no-op both before and after this merge, and it is reversible by deleting the variable. It was **not** created at repository scope, because `ZERO_PRICE_CUSTOM` does not exist there either and preview must keep rendering it empty (confirmed: preview output is identical).

After that change, all four combinations render identically, as shown in the table above.

Follow-up for #26701's sequencing: `PRICE_CUSTOM` should be added to the list of legacy variables to delete in the post-release configuration step, and the epic's "14 families" inventory is off by one.

Closes #28169
