### PR TITLE
fix(core): disable shared chat database for staff org

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -96,6 +96,7 @@ describe("getAllFeatureStates", () => {
     });
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.SharedChatDatabase]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatForward]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatMarkUnread]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatQuoteOnlyFeedback]).toBe(true);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -364,7 +364,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Share canonical ChatEvent and ChatThreadEvent synchronization across same-revision browser tabs.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ComposerImeSubmitFlush]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
## Summary

- remove the staff-org allowlist from `SharedChatDatabase` so the switch remains off by default for every org
- assert the disabled staff-org rollout state in the feature-switch matrix test

## Context

This is a rollout mitigation while the underlying stale SharedWorker and IndexedDB recovery bug in #28179 remains unresolved. It does not close that issue or change persisted user overrides.

## Verification

- `npx --yes prettier@3.8.1 --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `git diff --check`
- Targeted Vitest deferred to PR CI because this fresh checkout has no workspace dependencies installed
