### PR TITLE
fix(api): make connector consumers account-aware

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
@@ -18,6 +18,7 @@ import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import {
   seedConnectorStorageRow,
+  setConnectorDefaultState,
   setConnectorCredentialStorageState,
   setConnectorVariableOwner,
 } from "./helpers/connector-credential-storage-state";
@@ -614,6 +615,24 @@ describe("POST /api/zero/connectors/diagnostics/check", () => {
     const serialized = JSON.stringify(resolved.body);
     expect(serialized).not.toContain("REAP_API_BASE_URL");
     expect(serialized).not.toContain("reap-test-api-key");
+
+    await setConnectorDefaultState(context, {
+      orgId,
+      userId: owner.userId,
+      connectorId: reapConnectorId,
+      isDefault: false,
+    });
+    const nonDefault = await checkWithSession(owner, request);
+    expect(nonDefault.body).toMatchObject({
+      outcome: "unresolved-dynamic-base",
+      connector: { connectorSlug: "reap" },
+    });
+    await setConnectorDefaultState(context, {
+      orgId,
+      userId: owner.userId,
+      connectorId: reapConnectorId,
+      isDefault: true,
+    });
 
     await setConnectorCredentialStorageState(context, {
       connectorSlug: "reap",

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-list.test.ts
@@ -169,6 +169,17 @@ describe("GET /api/zero/connectors", () => {
       connectors: [],
       connectorProvidedBindings: [],
     });
+
+    const detail = await accept(
+      setupApp({ context, routes: connectorsRoutes })(
+        zeroConnectorsBySlugContract,
+      ).get({
+        params: { connectorSlug: "gitlab" },
+        headers: authHeaders(),
+      }),
+      [404],
+    );
+    expect(detail.body.error.code).toBe("NOT_FOUND");
   });
 
   it("skips stored connectors whose runtime method is unavailable", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-list.test.ts
@@ -14,7 +14,11 @@ import {
   invalidateApiTestConnectorCatalogCompatibility,
   installApiTestConnectorCatalog,
 } from "../../../test-fixtures/connector-catalog";
-import { seedConnectorStorageRow } from "./helpers/connector-credential-storage-state";
+import {
+  readConnectorCredentialStorageState,
+  seedConnectorStorageRow,
+  setConnectorDefaultState,
+} from "./helpers/connector-credential-storage-state";
 import { createRouteMocks } from "./helpers/route-test";
 import { connectorsRoutes } from "../connectors";
 
@@ -132,6 +136,39 @@ describe("GET /api/zero/connectors", () => {
         name: "GITLAB_TOKEN",
       }),
     );
+  });
+
+  it("projects only the default account for each connector target", async () => {
+    const fixture = seedAuthenticatedFixture();
+    seededFixtures.push(fixture);
+    await connectGitlab(fixture);
+    const state = await readConnectorCredentialStorageState(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "gitlab",
+    });
+    const connectorId = state.connector?.id;
+    if (!connectorId) {
+      throw new Error("Expected a stored GitLab connector account");
+    }
+    await setConnectorDefaultState(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorId,
+      isDefault: false,
+    });
+
+    const response = await accept(
+      setupApp({ context, routes: connectorsRoutes })(
+        zeroConnectorsMainContract,
+      ).list({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      connectors: [],
+      connectorProvidedBindings: [],
+    });
   });
 
   it("skips stored connectors whose runtime method is unavailable", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -60,6 +60,7 @@ import {
   readConnectorCredentialStorageState,
   readCustomConnectorCredentialStorageParent,
   readCustomConnectorOAuthStorageState,
+  setConnectorDefaultState,
   setCustomConnectorCredentialStorageState,
 } from "./helpers/connector-credential-storage-state";
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
@@ -1875,6 +1876,25 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await expect(
       connectorsApi.readCustomConnector(admin, created.id),
     ).resolves.toMatchObject({ connected: true });
+
+    const parent = await readCustomConnectorCredentialStorageParent(context, {
+      orgId: admin.orgId ?? "",
+      userId: admin.userId,
+      customConnectorId: created.id,
+    });
+    const memberConnectorId = parent.connector?.id;
+    if (!memberConnectorId) {
+      throw new Error("Expected a stored custom connector account");
+    }
+    await setConnectorDefaultState(context, {
+      orgId: admin.orgId ?? "",
+      userId: admin.userId,
+      connectorId: memberConnectorId,
+      isDefault: false,
+    });
+    await expect(
+      connectorsApi.readCustomConnector(admin, created.id),
+    ).resolves.toMatchObject({ connected: false });
 
     await connectorsApi.disconnectCustomConnector(admin, created.id);
     await expect(
@@ -6405,6 +6425,26 @@ describe("CONN-02: GitHub installation link after connector OAuth", () => {
     expect(afterLink.isConnected).toBeTruthy();
     expect(afterLink.connectedGithubUserId).toBe("42");
     expect(afterLink.connectedGithubUsername).toBe("bdd-github-user");
+
+    const connectorState = await readConnectorCredentialStorageState(context, {
+      orgId: admin.orgId ?? "",
+      userId: admin.userId,
+      connectorSlug: "github",
+    });
+    const connectorId = connectorState.connector?.id;
+    if (!connectorId) {
+      throw new Error("Expected a stored GitHub connector account");
+    }
+    await setConnectorDefaultState(context, {
+      orgId: admin.orgId ?? "",
+      userId: admin.userId,
+      connectorId,
+      isDefault: false,
+    });
+    const withoutDefault = await connectorsApi.readGithubIntegration(admin);
+    expect(withoutDefault.isConnected).toBeTruthy();
+    expect(withoutDefault.connectedGithubUserId).toBe("42");
+    expect(withoutDefault.connectedGithubUsername).toBeNull();
 
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "github:changed",

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -267,6 +267,21 @@ async function expectExactFeishuMemberConnector(args: {
     [200],
   );
   expect(identityMismatch.body.installations?.[0]?.isConnected).toBeFalsy();
+
+  await setConnectorExternalIdState(context, {
+    orgId,
+    userId: args.member.userId,
+    connectorId: memberConnectorId,
+    externalId: null,
+  });
+  const historicalExactLink = await accept(
+    args.client.getStatus({
+      headers: { authorization: "Bearer clerk-session" },
+    }),
+    [200],
+  );
+  expect(historicalExactLink.body.installations?.[0]?.isConnected).toBeTruthy();
+
   await setConnectorExternalIdState(context, {
     orgId,
     userId: args.member.userId,

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -58,7 +58,11 @@ import { readProjectedChatEvents } from "./helpers/chat-event-test-reader";
 import {
   clearFeishuConnectorOwnership,
   readCustomConnectorCredentialStorageParent,
+  readFeishuMemberConnectorState,
+  seedConnectorStorageRow,
   seedLegacyCustomFeishuOAuthState,
+  setConnectorExternalIdState,
+  setFeishuMemberConnectorLink,
 } from "./helpers/connector-credential-storage-state";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { createRouteMocks } from "./helpers/route-test";
@@ -93,6 +97,14 @@ const VERIFICATION_TOKEN = "feishu-test-verification-token";
 const APP_SECRET = "feishu-test-secret";
 const TENANT_KEY = "tenant_feishu_integration_test";
 const BOT_OPEN_ID = "ou_feishu_bot";
+
+function feishuConnectClient() {
+  return setupApp({ context, routes: feishuConnectRoutes })(
+    feishuConnectContract,
+  );
+}
+
+type FeishuConnectClient = ReturnType<typeof feishuConnectClient>;
 
 function mockAuthoritativeOrganizationMembers(
   actors: readonly ApiTestUser[],
@@ -210,6 +222,103 @@ function requireValue<T>(value: T | null | undefined, message: string): T {
     throw new Error(message);
   }
   return value;
+}
+
+async function expectExactFeishuMemberConnector(args: {
+  readonly client: FeishuConnectClient;
+  readonly installationId: string;
+  readonly member: ApiTestUser;
+}): Promise<void> {
+  const connected = await accept(
+    args.client.getStatus({
+      headers: { authorization: "Bearer clerk-session" },
+    }),
+    [200],
+  );
+  expect(connected.body.installations?.[0]?.isConnected).toBeTruthy();
+  expect(connected.body.installations?.[0]?.connectedUserName).toBe(
+    "Feishu User",
+  );
+  const orgId = requireValue(args.member.orgId, "Expected an organization");
+  const memberConnection = await readFeishuMemberConnectorState(context, {
+    orgId,
+    userId: args.member.userId,
+    installationId: args.installationId,
+  });
+  expect(memberConnection.feishu_member_connection).toMatchObject({
+    connector_external_id: "ou_oauth_user",
+    open_id: "ou_oauth_user",
+  });
+  const memberConnectorId = requireValue(
+    memberConnection.feishu_member_connection?.connector_id,
+    "Expected Feishu OAuth to persist exact account ownership",
+  );
+
+  await setConnectorExternalIdState(context, {
+    orgId,
+    userId: args.member.userId,
+    connectorId: memberConnectorId,
+    externalId: "ou_wrong_account",
+  });
+  const identityMismatch = await accept(
+    args.client.getStatus({
+      headers: { authorization: "Bearer clerk-session" },
+    }),
+    [200],
+  );
+  expect(identityMismatch.body.installations?.[0]?.isConnected).toBeFalsy();
+  await setConnectorExternalIdState(context, {
+    orgId,
+    userId: args.member.userId,
+    connectorId: memberConnectorId,
+    externalId: "ou_oauth_user",
+  });
+
+  const foreignConnectorId = await seedConnectorStorageRow(context, {
+    orgId,
+    userId: args.member.userId,
+    connectorSlug: "github",
+    authMethod: "oauth",
+    storageVersion: 1,
+  });
+  await setFeishuMemberConnectorLink(context, {
+    userId: args.member.userId,
+    installationId: args.installationId,
+    connectorId: foreignConnectorId,
+  });
+  const mismatched = await accept(
+    args.client.getStatus({
+      headers: { authorization: "Bearer clerk-session" },
+    }),
+    [200],
+  );
+  expect(mismatched.body.installations?.[0]?.isConnected).toBeFalsy();
+
+  await setFeishuMemberConnectorLink(context, {
+    userId: args.member.userId,
+    installationId: args.installationId,
+    connectorId: memberConnectorId,
+  });
+  const relinked = await accept(
+    args.client.getStatus({
+      headers: { authorization: "Bearer clerk-session" },
+    }),
+    [200],
+  );
+  expect(relinked.body.installations?.[0]?.isConnected).toBeTruthy();
+
+  await setFeishuMemberConnectorLink(context, {
+    userId: args.member.userId,
+    installationId: args.installationId,
+    connectorId: null,
+  });
+  const legacyUnlinked = await accept(
+    args.client.getStatus({
+      headers: { authorization: "Bearer clerk-session" },
+    }),
+    [200],
+  );
+  expect(legacyUnlinked.body.installations?.[0]?.isConnected).toBeTruthy();
 }
 
 function feishuConnectBody(connectUrl: string) {
@@ -2243,16 +2352,11 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
 
     mocks.clerk.session(member.userId, member.orgId, member.orgRole);
-    const connected = await accept(
-      client.getStatus({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-    expect(connected.body.installations?.[0]?.isConnected).toBeTruthy();
-    expect(connected.body.installations?.[0]?.connectedUserName).toBe(
-      "Feishu User",
-    );
+    await expectExactFeishuMemberConnector({
+      client,
+      installationId,
+      member,
+    });
     const connectedConnectorList = await accept(
       customConnectorClient.list({
         headers: { authorization: "Bearer clerk-session" },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -1365,7 +1365,7 @@ export function createConnectorBddApi(context: TestContext) {
     async deleteConnectorBySlug(
       actor: ApiTestUser,
       connectorSlug: ConnectorSlug,
-      statuses: readonly (204 | 401 | 404)[] = [204],
+      statuses: readonly (204 | 401 | 404 | 409)[] = [204],
     ): Promise<void> {
       const client = setupApp({ context, routes: connectorsRoutes })(
         zeroConnectorsBySlugContract,
@@ -2083,7 +2083,7 @@ export function createConnectorBddApi(context: TestContext) {
     async requestDisconnectCustomConnector(
       actor: ApiTestUser | null,
       connectorId: string,
-      statuses: readonly (204 | 401 | 403 | 404 | 500)[],
+      statuses: readonly (204 | 401 | 403 | 404 | 409 | 500)[],
     ) {
       const client = setupApp({
         context,
@@ -2101,7 +2101,7 @@ export function createConnectorBddApi(context: TestContext) {
     async disconnectCustomConnector(
       actor: ApiTestUser,
       connectorId: string,
-      statuses: readonly (204 | 401 | 404 | 500)[] = [204],
+      statuses: readonly (204 | 401 | 404 | 409 | 500)[] = [204],
     ): Promise<void> {
       await api.requestDisconnectCustomConnector(actor, connectorId, statuses);
     },
@@ -2109,7 +2109,7 @@ export function createConnectorBddApi(context: TestContext) {
     async requestDisconnectCustomConnectorWithToken(
       token: string,
       connectorId: string,
-      statuses: readonly (204 | 401 | 403 | 404 | 500)[],
+      statuses: readonly (204 | 401 | 403 | 404 | 409 | 500)[],
     ) {
       const client = setupApp({
         context,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -115,6 +115,38 @@ export async function clearFeishuConnectorOwnership(
   });
 }
 
+export async function readFeishuMemberConnectorState(
+  context: TestContext,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly installationId: string;
+  },
+): Promise<TestConnectorCredentialStorageStateActionResponse> {
+  return await postAction(context, {
+    action: "read-feishu-member-connector",
+    org_id: args.orgId,
+    user_id: args.userId,
+    installation_id: args.installationId,
+  });
+}
+
+export async function setFeishuMemberConnectorLink(
+  context: TestContext,
+  args: {
+    readonly userId: string;
+    readonly installationId: string;
+    readonly connectorId: string | null;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "set-feishu-member-connector-link",
+    user_id: args.userId,
+    installation_id: args.installationId,
+    connector_id: args.connectorId,
+  });
+}
+
 export async function seedLegacyCustomFeishuOAuthState(
   context: TestContext,
   args: {
@@ -241,6 +273,92 @@ export async function setConnectorCredentialStorageState(
       ? {}
       : { token_expires_at: args.tokenExpiresAt }),
   });
+}
+
+export async function setConnectorDefaultState(
+  context: TestContext,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId: string;
+    readonly isDefault: boolean;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "set-connector-default",
+    org_id: args.orgId,
+    user_id: args.userId,
+    connector_id: args.connectorId,
+    is_default: args.isDefault,
+  });
+}
+
+export async function setConnectorExternalIdState(
+  context: TestContext,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId: string;
+    readonly externalId: string | null;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "set-connector-external-id",
+    org_id: args.orgId,
+    user_id: args.userId,
+    connector_id: args.connectorId,
+    external_id: args.externalId,
+  });
+}
+
+export async function seedBuiltinThreadConnectorSelection(
+  context: TestContext,
+  args: {
+    readonly chatThreadId: string;
+    readonly connectorId: string;
+    readonly connectorSlug: string;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "seed-builtin-thread-selection",
+    chat_thread_id: args.chatThreadId,
+    connector_id: args.connectorId,
+    connector_slug: args.connectorSlug,
+  });
+}
+
+export async function seedCustomThreadConnectorSelection(
+  context: TestContext,
+  args: {
+    readonly chatThreadId: string;
+    readonly connectorId: string;
+    readonly customConnectorId: string;
+  },
+): Promise<void> {
+  await postAction(context, {
+    action: "seed-custom-thread-selection",
+    chat_thread_id: args.chatThreadId,
+    connector_id: args.connectorId,
+    custom_connector_id: args.customConnectorId,
+  });
+}
+
+export async function readThreadConnectorSelectionState(
+  context: TestContext,
+  args: {
+    readonly chatThreadId: string;
+    readonly connectorId: string;
+  },
+): Promise<boolean> {
+  const response = await postAction(context, {
+    action: "read-thread-selection",
+    chat_thread_id: args.chatThreadId,
+    connector_id: args.connectorId,
+  });
+  if (response.selection_exists === undefined) {
+    throw new Error("Thread connector selection state was not returned");
+  }
+  return response.selection_exists;
 }
 
 export async function setCustomConnectorCredentialStorageState(

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -375,45 +375,82 @@ describe("POST /api/zero/mail/drafts/link", () => {
       }),
     ).resolves.toBeFalsy();
 
-    const customConnectorId = randomUUID();
+    const disconnectCustomConnectorId = randomUUID();
+    const deleteCustomConnectorId = randomUUID();
     await seedCustomConnectorRuntimeConnectors(context, {
       orgId: fixture.actor.orgId ?? "",
       userId: fixture.actor.userId,
       agentId: fixture.agent.agentId,
       customConnectors: [
         {
-          id: customConnectorId,
-          slug: "_selection-cleanup",
-          displayName: "Selection cleanup",
-          prefixTemplate: "https://selection.example.com/",
+          id: disconnectCustomConnectorId,
+          slug: "_disconnect-selection-cleanup",
+          displayName: "Disconnect selection cleanup",
+          prefixTemplate: "https://disconnect-selection.example.com/",
+        },
+        {
+          id: deleteCustomConnectorId,
+          slug: "_delete-selection-cleanup",
+          displayName: "Delete selection cleanup",
+          prefixTemplate: "https://delete-selection.example.com/",
         },
       ],
     });
-    const customStorage = await readCustomConnectorCredentialStorageParent(
-      context,
-      {
+    const disconnectCustomStorage =
+      await readCustomConnectorCredentialStorageParent(context, {
         orgId: fixture.actor.orgId ?? "",
         userId: fixture.actor.userId,
-        customConnectorId,
-      },
-    );
-    const customMemberConnectorId = customStorage.connector?.id;
-    if (!customMemberConnectorId) {
-      throw new Error("Expected a stored custom connector account");
+        customConnectorId: disconnectCustomConnectorId,
+      });
+    const disconnectMemberConnectorId = disconnectCustomStorage.connector?.id;
+    if (!disconnectMemberConnectorId) {
+      throw new Error("Expected a custom connector account to disconnect");
     }
     await seedCustomThreadConnectorSelection(context, {
       chatThreadId: fixture.thread.id,
-      connectorId: customMemberConnectorId,
-      customConnectorId,
+      connectorId: disconnectMemberConnectorId,
+      customConnectorId: disconnectCustomConnectorId,
     });
-
-    await connectors.deleteCustomConnector(fixture.actor, customConnectorId);
+    await connectors.disconnectCustomConnector(
+      fixture.actor,
+      disconnectCustomConnectorId,
+    );
     await expect(
       readThreadConnectorSelectionState(context, {
         chatThreadId: fixture.thread.id,
-        connectorId: customMemberConnectorId,
+        connectorId: disconnectMemberConnectorId,
       }),
     ).resolves.toBeFalsy();
+
+    const deleteCustomStorage =
+      await readCustomConnectorCredentialStorageParent(context, {
+        orgId: fixture.actor.orgId ?? "",
+        userId: fixture.actor.userId,
+        customConnectorId: deleteCustomConnectorId,
+      });
+    const deleteMemberConnectorId = deleteCustomStorage.connector?.id;
+    if (!deleteMemberConnectorId) {
+      throw new Error("Expected a custom connector account to delete");
+    }
+    await seedCustomThreadConnectorSelection(context, {
+      chatThreadId: fixture.thread.id,
+      connectorId: deleteMemberConnectorId,
+      customConnectorId: deleteCustomConnectorId,
+    });
+    await connectors.deleteCustomConnector(
+      fixture.actor,
+      deleteCustomConnectorId,
+    );
+    await expect(
+      readThreadConnectorSelectionState(context, {
+        chatThreadId: fixture.thread.id,
+        connectorId: deleteMemberConnectorId,
+      }),
+    ).resolves.toBeFalsy();
+    await connectors.deleteCustomConnector(
+      fixture.actor,
+      disconnectCustomConnectorId,
+    );
   });
 
   it("links without injecting a duplicate card and sends without rebuilding MIME", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -20,7 +20,14 @@ import {
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createRouteMocks } from "./helpers/route-test";
 import {
+  readConnectorCredentialStorageState,
+  readCustomConnectorCredentialStorageParent,
+  readThreadConnectorSelectionState,
   seedConnectorStorageRow,
+  seedBuiltinThreadConnectorSelection,
+  seedCustomConnectorRuntimeConnectors,
+  seedCustomThreadConnectorSelection,
+  setConnectorDefaultState,
   setConnectorCredentialStorageState,
   setConnectorSecretOwner,
 } from "./helpers/connector-credential-storage-state";
@@ -308,6 +315,107 @@ async function linkDraft(
 }
 
 describe("POST /api/zero/mail/drafts/link", () => {
+  it("uses the default for new drafts while preserving and deleting an exact pinned account", async () => {
+    const fixture = await seedGmailMailCardFixture();
+    mockGmailDraftApi();
+    const linked = await linkDraft(fixture);
+    const storage = await readConnectorCredentialStorageState(context, {
+      orgId: fixture.actor.orgId ?? "",
+      userId: fixture.actor.userId,
+      connectorSlug: "gmail",
+    });
+    const connectorId = storage.connector?.id;
+    if (!connectorId) {
+      throw new Error("Expected a stored Gmail connector account");
+    }
+    await seedBuiltinThreadConnectorSelection(context, {
+      chatThreadId: fixture.thread.id,
+      connectorId,
+      connectorSlug: "gmail",
+    });
+    await setConnectorDefaultState(context, {
+      orgId: fixture.actor.orgId ?? "",
+      userId: fixture.actor.userId,
+      connectorId,
+      isDefault: false,
+    });
+
+    await accept(
+      client().getDraft({
+        headers: authHeaders(),
+        params: { mailDraftId: linked.body.mailDraftId },
+      }),
+      [200],
+    );
+
+    const newThread = await chat.createThread(fixture.actor, {
+      agentId: fixture.agent.agentId,
+      title: "Default Gmail projection",
+    });
+    const newDraft = await accept(
+      client().linkDraft({
+        headers: authHeaders(),
+        body: {
+          threadId: newThread.id,
+          agentId: fixture.agent.agentId,
+          gmailDraftId: GMAIL_DRAFT_ID,
+        },
+      }),
+      [409],
+    );
+    expect(newDraft.body.error.message).toBe(
+      "Connect and authorize Gmail for this agent first",
+    );
+
+    await connectors.deleteConnectorBySlug(fixture.actor, "gmail");
+    await expect(
+      readThreadConnectorSelectionState(context, {
+        chatThreadId: fixture.thread.id,
+        connectorId,
+      }),
+    ).resolves.toBeFalsy();
+
+    const customConnectorId = randomUUID();
+    await seedCustomConnectorRuntimeConnectors(context, {
+      orgId: fixture.actor.orgId ?? "",
+      userId: fixture.actor.userId,
+      agentId: fixture.agent.agentId,
+      customConnectors: [
+        {
+          id: customConnectorId,
+          slug: "_selection-cleanup",
+          displayName: "Selection cleanup",
+          prefixTemplate: "https://selection.example.com/",
+        },
+      ],
+    });
+    const customStorage = await readCustomConnectorCredentialStorageParent(
+      context,
+      {
+        orgId: fixture.actor.orgId ?? "",
+        userId: fixture.actor.userId,
+        customConnectorId,
+      },
+    );
+    const customMemberConnectorId = customStorage.connector?.id;
+    if (!customMemberConnectorId) {
+      throw new Error("Expected a stored custom connector account");
+    }
+    await seedCustomThreadConnectorSelection(context, {
+      chatThreadId: fixture.thread.id,
+      connectorId: customMemberConnectorId,
+      customConnectorId,
+    });
+
+    await connectors.deleteCustomConnector(fixture.actor, customConnectorId);
+    await expect(
+      readThreadConnectorSelectionState(context, {
+        chatThreadId: fixture.thread.id,
+        connectorId: customMemberConnectorId,
+      }),
+    ).resolves.toBeFalsy();
+  });
+
   it("links without injecting a duplicate card and sends without rebuilding MIME", async () => {
     mockEnv("APP_URL", "https://app.vm0.ai");
     const fixture = await seedGmailMailCardFixture();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -29,6 +29,7 @@ import {
 } from "./helpers/api-bdd";
 import { createBddIntegrationApi } from "./helpers/api-bdd-integrations";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
+import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import {
   createConnectorBddApi,
   manualHttpCustomConnectorCreateBody,
@@ -53,6 +54,11 @@ import {
   materializeHourlyUsage$,
   readUsageStorageCounts$,
 } from "./helpers/usage-state";
+import {
+  readCustomConnectorCredentialStorageParent,
+  readThreadConnectorSelectionState,
+  seedCustomThreadConnectorSelection,
+} from "./helpers/connector-credential-storage-state";
 
 const context = testContext();
 const api = createWebhookCallbackApi(context);
@@ -6539,6 +6545,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
 
   it("cleans up user state after a verified user.deleted event", async () => {
     const bdd = createBddApi(context);
+    const chat = createChatFilesBddApi(context);
     const runs = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
     const userConfig = createUserConfigBddApi(context);
@@ -6567,6 +6574,10 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       displayName: "BDD Doomed Agent",
       visibility: "private",
     });
+    const connectorSelectionThread = await chat.createThread(doomed, {
+      agentId: doomedAgent.agentId,
+      title: "BDD doomed connector selection",
+    });
     await runs.enableAgentConnectors(doomed, sharedAgent.agentId, ["openai"]);
     await connectors.connectManualGrant(
       peer,
@@ -6585,6 +6596,16 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       customManual.id,
       "doomed-custom-secret",
     );
+    const customManualStorage =
+      await readCustomConnectorCredentialStorageParent(context, {
+        orgId: orgOf(doomed),
+        userId: doomed.userId,
+        customConnectorId: customManual.id,
+      });
+    const customManualMemberConnectorId = customManualStorage.connector?.id;
+    if (!customManualMemberConnectorId) {
+      throw new Error("Expected the doomed custom connector account");
+    }
     await connectors.setCustomConnectorSecret(
       peer,
       customManual.id,
@@ -6645,6 +6666,11 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       modelProvider: "anthropic-api-key",
     });
     expect(run.status).toBe("pending");
+    await seedCustomThreadConnectorSelection(context, {
+      chatThreadId: connectorSelectionThread.id,
+      connectorId: customManualMemberConnectorId,
+      customConnectorId: customManual.id,
+    });
     await runs.claimRunnerJob(run.runId);
     await store.set(
       insertUsageEvent$,
@@ -6825,6 +6851,12 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       connected: false,
       configuredFieldKeys: [],
     });
+    await expect(
+      readThreadConnectorSelectionState(context, {
+        chatThreadId: connectorSelectionThread.id,
+        connectorId: customManualMemberConnectorId,
+      }),
+    ).resolves.toBeFalsy();
     await expect(
       connectors.readCustomConnector(peer, customManual.id),
     ).resolves.toMatchObject({

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -18,6 +18,7 @@ import { publicBrand$, request$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import {
   badRequestMessage,
+  conflict,
   notFound,
   providerUnavailable,
 } from "../../lib/error";
@@ -192,8 +193,11 @@ const deleteConnectorBySlugInner$ = command(
     );
     signal.throwIfAborted();
 
-    if (!deleted) {
+    if (deleted === "missing") {
       return notFound("Connector not found");
+    }
+    if (deleted === "ambiguous") {
+      return conflict("Multiple connector accounts require an exact choice");
     }
 
     return { status: 204 as const, body: undefined };

--- a/turbo/apps/api/src/signals/routes/feishu-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-browser-connect.ts
@@ -333,7 +333,10 @@ const getStatus$ = command(async ({ get, set }, signal: AbortSignal) => {
     };
   }
   const [connection] = await db
-    .select({ userId: feishuOrgConnections.userId })
+    .select({
+      userId: feishuOrgConnections.userId,
+      connectorId: feishuOrgConnections.connectorId,
+    })
     .from(feishuOrgConnections)
     .where(
       and(
@@ -352,6 +355,8 @@ const getStatus$ = command(async ({ get, set }, signal: AbortSignal) => {
       orgId: auth.orgId,
       userId: auth.userId,
       installationId: query.installationId,
+      memberConnectorId: connection.connectorId,
+      feishuOpenId: query.openId,
     }));
   signal.throwIfAborted();
   return {

--- a/turbo/apps/api/src/signals/routes/feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-oauth.ts
@@ -4,6 +4,7 @@ import { feishuOauthContract } from "@okouai/api-contracts/contracts/feishu-oaut
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import type { FeatureSwitchContext } from "@okouai/core/feature-switch";
 import { appUrlForPublicBrand } from "@okouai/core/public-brand";
+import { connectors } from "@okouai/db/schema/connector";
 import { feishuOrgConnections } from "@okouai/db/schema/feishu-org-connection";
 import { feishuOrgInstallations } from "@okouai/db/schema/feishu-org-installation";
 
@@ -423,7 +424,7 @@ async function persistFeishuOAuthConnection(
     if (!connection.connected) {
       return connection;
     }
-    await storeCustomConnectorOAuth2Connection(
+    const memberConnectorId = await storeCustomConnectorOAuth2Connection(
       {
         db: tx,
         orgId: args.state.orgId,
@@ -435,6 +436,19 @@ async function persistFeishuOAuthConnection(
       },
       signal,
     );
+    signal.throwIfAborted();
+    await tx
+      .update(feishuOrgConnections)
+      .set({ connectorId: memberConnectorId, updatedAt: nowDate() })
+      .where(eq(feishuOrgConnections.id, connection.connectionId));
+    await tx
+      .update(connectors)
+      .set({
+        externalId: args.userInfo.openId,
+        externalUsername: args.userInfo.name,
+        updatedAt: nowDate(),
+      })
+      .where(eq(connectors.id, memberConnectorId));
     signal.throwIfAborted();
     if (!args.installation.tenantKey && args.userInfo.tenantKey) {
       await tx

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -3,9 +3,11 @@ import {
   testConnectorCredentialStorageStateContract,
   type TestConnectorCredentialStorageStateActionBody,
 } from "@okouai/api-contracts/contracts/test-connector-credential-storage-state";
+import { chatThreadConnectorSelections } from "@okouai/db/schema/chat-thread-connector-selection";
 import { connectors } from "@okouai/db/schema/connector";
 import { connectorOauthStates } from "@okouai/db/schema/connector-oauth-state";
 import { feishuOrgInstallations } from "@okouai/db/schema/feishu-org-installation";
+import { feishuOrgConnections } from "@okouai/db/schema/feishu-org-connection";
 import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
 import { secrets } from "@okouai/db/schema/secret";
 import { userCustomConnectors } from "@okouai/db/schema/user-custom-connector";
@@ -304,6 +306,69 @@ async function clearFeishuConnectorOwnership(
       };
 }
 
+async function readFeishuMemberConnector(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"read-feishu-member-connector">,
+  signal: AbortSignal,
+) {
+  const [connection] = await db
+    .select({
+      connectorId: feishuOrgConnections.connectorId,
+      connectorExternalId: connectors.externalId,
+      openId: feishuOrgConnections.feishuOpenId,
+    })
+    .from(feishuOrgConnections)
+    .innerJoin(
+      feishuOrgInstallations,
+      and(
+        eq(feishuOrgInstallations.id, feishuOrgConnections.installationId),
+        eq(feishuOrgInstallations.orgId, body.org_id),
+      ),
+    )
+    .leftJoin(connectors, eq(connectors.id, feishuOrgConnections.connectorId))
+    .where(
+      and(
+        eq(feishuOrgConnections.installationId, body.installation_id),
+        eq(feishuOrgConnections.userId, body.user_id),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  return actionOk({
+    feishu_member_connection: connection
+      ? {
+          connector_id: connection.connectorId,
+          connector_external_id: connection.connectorExternalId,
+          open_id: connection.openId,
+        }
+      : null,
+  });
+}
+
+async function setFeishuMemberConnectorLink(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"set-feishu-member-connector-link">,
+  signal: AbortSignal,
+) {
+  const [updated] = await db
+    .update(feishuOrgConnections)
+    .set({ connectorId: body.connector_id })
+    .where(
+      and(
+        eq(feishuOrgConnections.installationId, body.installation_id),
+        eq(feishuOrgConnections.userId, body.user_id),
+      ),
+    )
+    .returning({ id: feishuOrgConnections.id });
+  signal.throwIfAborted();
+  return updated
+    ? actionOk()
+    : {
+        status: 400 as const,
+        body: { error: "Feishu member connection test fixture was not found" },
+      };
+}
+
 async function seedLegacyCustomFeishuOAuthState(
   db: Db,
   body: ConnectorCredentialStorageAction<"seed-legacy-custom-feishu-oauth-state">,
@@ -487,6 +552,103 @@ async function setConnectorState(
       };
 }
 
+async function setConnectorDefault(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"set-connector-default">,
+  signal: AbortSignal,
+) {
+  const [updated] = await db
+    .update(connectors)
+    .set({ isDefault: body.is_default })
+    .where(
+      and(
+        eq(connectors.id, body.connector_id),
+        eq(connectors.orgId, body.org_id),
+        eq(connectors.userId, body.user_id),
+      ),
+    )
+    .returning({ id: connectors.id });
+  signal.throwIfAborted();
+  return updated
+    ? actionOk()
+    : {
+        status: 400 as const,
+        body: { error: "Connector storage test fixture was not found" },
+      };
+}
+
+async function setConnectorExternalId(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"set-connector-external-id">,
+  signal: AbortSignal,
+) {
+  const [updated] = await db
+    .update(connectors)
+    .set({ externalId: body.external_id })
+    .where(
+      and(
+        eq(connectors.id, body.connector_id),
+        eq(connectors.orgId, body.org_id),
+        eq(connectors.userId, body.user_id),
+      ),
+    )
+    .returning({ id: connectors.id });
+  signal.throwIfAborted();
+  return updated
+    ? actionOk()
+    : {
+        status: 400 as const,
+        body: { error: "Connector storage test fixture was not found" },
+      };
+}
+
+async function seedBuiltinThreadSelection(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"seed-builtin-thread-selection">,
+  signal: AbortSignal,
+) {
+  await db.insert(chatThreadConnectorSelections).values({
+    chatThreadId: body.chat_thread_id,
+    connectorId: body.connector_id,
+    connectorSlug: body.connector_slug,
+  });
+  signal.throwIfAborted();
+  return actionOk();
+}
+
+async function seedCustomThreadSelection(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"seed-custom-thread-selection">,
+  signal: AbortSignal,
+) {
+  await db.insert(chatThreadConnectorSelections).values({
+    chatThreadId: body.chat_thread_id,
+    connectorId: body.connector_id,
+    customConnectorId: body.custom_connector_id,
+  });
+  signal.throwIfAborted();
+  return actionOk();
+}
+
+async function readThreadSelection(
+  db: Db,
+  body: ConnectorCredentialStorageAction<"read-thread-selection">,
+  signal: AbortSignal,
+) {
+  const [selection] = await db
+    .select({ connectorId: chatThreadConnectorSelections.connectorId })
+    .from(chatThreadConnectorSelections)
+    .where(
+      and(
+        eq(chatThreadConnectorSelections.chatThreadId, body.chat_thread_id),
+        eq(chatThreadConnectorSelections.connectorId, body.connector_id),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+  return actionOk({ selection_exists: Boolean(selection) });
+}
+
 async function setCustomParentState(
   db: Db,
   body: ConnectorCredentialStorageAction<"set-custom-parent-state">,
@@ -570,6 +732,39 @@ async function setVariableOwner(
       };
 }
 
+async function mutateConnectorAccountCompatibilityState(
+  db: Db,
+  body: TestConnectorCredentialStorageStateActionBody,
+  signal: AbortSignal,
+) {
+  switch (body.action) {
+    case "read-feishu-member-connector": {
+      return await readFeishuMemberConnector(db, body, signal);
+    }
+    case "set-feishu-member-connector-link": {
+      return await setFeishuMemberConnectorLink(db, body, signal);
+    }
+    case "set-connector-default": {
+      return await setConnectorDefault(db, body, signal);
+    }
+    case "set-connector-external-id": {
+      return await setConnectorExternalId(db, body, signal);
+    }
+    case "seed-builtin-thread-selection": {
+      return await seedBuiltinThreadSelection(db, body, signal);
+    }
+    case "seed-custom-thread-selection": {
+      return await seedCustomThreadSelection(db, body, signal);
+    }
+    case "read-thread-selection": {
+      return await readThreadSelection(db, body, signal);
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
 const mutateConnectorCredentialStorageState$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     if (!isTestEndpointAllowed(get(request$))) {
@@ -584,6 +779,14 @@ const mutateConnectorCredentialStorageState$ = command(
 
     const db = set(writeDb$);
     const body = bodyResult.data;
+    const compatibilityResult = await mutateConnectorAccountCompatibilityState(
+      db,
+      body,
+      signal,
+    );
+    if (compatibilityResult) {
+      return compatibilityResult;
+    }
     switch (body.action) {
       case "read": {
         return await readState(db, body, signal);

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -31,9 +31,10 @@ const actionBody$ = bodyResultOf(
 
 /**
  * This route is explicitly mounted only by tests. Connector owner/version
- * metadata has no production API, and cross-owner states cannot be constructed
- * through one. Keeping that exception here lets route tests exercise the real
- * public behavior without registering a production diagnostics surface.
+ * metadata, account links, and historical compatibility states have no
+ * production API, and cross-owner states cannot be constructed through one.
+ * Keeping that exception here lets route tests exercise the real public
+ * behavior without registering a production diagnostics surface.
  */
 type ConnectorCredentialStorageAction<
   TAction extends TestConnectorCredentialStorageStateActionBody["action"],

--- a/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
@@ -27,7 +27,7 @@ import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
 import { drainChatThreadQueueForThread$ } from "./chat-thread-queue-drain.service";
 import { buildFeishuChatOpenUrl } from "./feishu-config";
 import { ensureFeishuChatThreadRoute } from "./feishu-chat-ingress.service";
-import { hasFeishuCustomConnectorOAuthConnection } from "./feishu-custom-connector.service";
+import { resolveFeishuCustomConnectorOAuthConnection } from "./feishu-custom-connector.service";
 import {
   resolveIntegrationModelRouteForUser$,
   type IntegrationModelRoutePin,
@@ -186,6 +186,7 @@ async function loadConnection(
     .select({
       id: feishuOrgConnections.id,
       userId: feishuOrgConnections.userId,
+      connectorId: feishuOrgConnections.connectorId,
       feishuUserName: feishuOrgConnections.feishuUserName,
     })
     .from(feishuOrgConnections)
@@ -199,12 +200,14 @@ async function loadConnection(
   if (!connection) {
     return undefined;
   }
-  const hasOAuthConnection = await hasFeishuCustomConnectorOAuthConnection(db, {
+  const connectorId = await resolveFeishuCustomConnectorOAuthConnection(db, {
     orgId,
     userId: connection.userId,
     installationId: message.installationId,
+    memberConnectorId: connection.connectorId,
+    feishuOpenId: message.openId,
   });
-  return hasOAuthConnection ? connection : undefined;
+  return connectorId ? { ...connection, connectorId } : undefined;
 }
 
 async function markIngressProcessed(db: Db, ingressId: string): Promise<void> {

--- a/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
@@ -20,8 +20,9 @@ const L = logger("connector-account-resolution");
 export type ConnectorAccountSelectionMode =
   | { readonly kind: "exact"; readonly sourceId: string }
   | { readonly kind: "default" }
-  // Compatibility for source-less Runner and firewall payloads. Remove in
-  // #27695 after every run admitted before source propagation has drained.
+  // Target-only callers may act only while one account exists. Source-less
+  // runtime call sites are temporary and tracked for removal in #27695;
+  // legacy target-only mutation APIs keep this fail-closed singleton semantic.
   | { readonly kind: "legacy-singleton" };
 
 export interface ConnectorAccountResolutionRequest {

--- a/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
@@ -379,6 +379,27 @@ export async function resolveConnectorAccounts(
   return resolutions;
 }
 
+export async function resolveConnectorAccount(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly request: ConnectorAccountResolutionRequest;
+  },
+): Promise<ConnectorAccountResolution> {
+  const key = connectorAccountTargetKey(args.request.target);
+  const resolutions = await resolveConnectorAccounts(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    requests: [args.request],
+  });
+  const resolution = resolutions.get(key);
+  if (!resolution) {
+    throw new Error("Expected one connector account resolution");
+  }
+  return resolution;
+}
+
 export function resolvedConnectorAccountIdsByTarget(
   resolutions: ReadonlyMap<string, ConnectorAccountResolution>,
 ): ReadonlyMap<string, string> {

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -275,6 +275,7 @@ async function loadStoredRuntimeState(
             eq(connectors.orgId, args.orgId),
             eq(connectors.userId, args.userId),
             isNotNull(connectors.connectorSlug),
+            eq(connectors.isDefault, true),
           ),
         );
 

--- a/turbo/apps/api/src/signals/services/connector-credential-storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-storage-write.service.ts
@@ -1,7 +1,8 @@
+import { chatThreadConnectorSelections } from "@okouai/db/schema/chat-thread-connector-selection";
 import { connectors } from "@okouai/db/schema/connector";
 import { secrets } from "@okouai/db/schema/secret";
 import { variables } from "@okouai/db/schema/variable";
-import { eq, isNotNull, sql, type SQL } from "drizzle-orm";
+import { eq, inArray, isNotNull, sql, type SQL } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
@@ -40,6 +41,7 @@ interface ConnectorOwnedCredentialDeleteConditions {
 }
 
 interface ConnectorCredentialStorageDeleteConditions extends ConnectorOwnedCredentialDeleteConditions {
+  readonly selection: SQL;
   readonly connection: SQL;
 }
 
@@ -153,6 +155,8 @@ async function deleteConnectorCredentialStorageConnectionsWhere(
   conditions: ConnectorCredentialStorageDeleteConditions,
   signal: AbortSignal,
 ): Promise<void> {
+  await db.delete(chatThreadConnectorSelections).where(conditions.selection);
+  signal.throwIfAborted();
   await deleteConnectorOwnedCredentialRowsWhere(db, conditions, signal);
   await db.delete(connectors).where(conditions.connection);
   signal.throwIfAborted();
@@ -185,6 +189,10 @@ export async function deleteConnectorCredentialStorageConnection(
   await deleteConnectorCredentialStorageConnectionsWhere(
     db,
     {
+      selection: eq(
+        chatThreadConnectorSelections.connectorId,
+        args.connectorId,
+      ),
       secret: eq(secrets.connectorId, args.connectorId),
       variable: eq(variables.connectorId, args.connectorId),
       connection: eq(connectors.id, args.connectorId),
@@ -198,21 +206,55 @@ export async function deleteConnectorCredentialStorageConnectionsForOwner(
   owner: ConnectorOwnerScope,
   signal: AbortSignal,
 ): Promise<void> {
+  const connectorOwnerCondition =
+    owner.kind === "user"
+      ? eq(connectors.userId, owner.userId)
+      : eq(connectors.orgId, owner.orgId);
   const conditions: ConnectorCredentialStorageDeleteConditions =
     owner.kind === "user"
       ? {
+          selection: inArray(
+            chatThreadConnectorSelections.connectorId,
+            db
+              .select({ connectorId: connectors.id })
+              .from(connectors)
+              .where(connectorOwnerCondition),
+          ),
           secret: sql`${eq(secrets.userId, owner.userId)} AND ${isNotNull(secrets.connectorId)}`,
           variable: sql`${eq(variables.userId, owner.userId)} AND ${isNotNull(variables.connectorId)}`,
-          connection: eq(connectors.userId, owner.userId),
+          connection: connectorOwnerCondition,
         }
       : {
+          selection: inArray(
+            chatThreadConnectorSelections.connectorId,
+            db
+              .select({ connectorId: connectors.id })
+              .from(connectors)
+              .where(connectorOwnerCondition),
+          ),
           secret: sql`${eq(secrets.orgId, owner.orgId)} AND ${isNotNull(secrets.connectorId)}`,
           variable: sql`${eq(variables.orgId, owner.orgId)} AND ${isNotNull(variables.connectorId)}`,
-          connection: eq(connectors.orgId, owner.orgId),
+          connection: connectorOwnerCondition,
         };
   await deleteConnectorCredentialStorageConnectionsWhere(
     db,
     conditions,
     signal,
   );
+}
+
+export async function deleteConnectorSelectionsForCustomConnectorDefinition(
+  db: Db,
+  args: { readonly customConnectorId: string },
+  signal: AbortSignal,
+): Promise<void> {
+  await db
+    .delete(chatThreadConnectorSelections)
+    .where(
+      eq(
+        chatThreadConnectorSelections.customConnectorId,
+        args.customConnectorId,
+      ),
+    );
+  signal.throwIfAborted();
 }

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -79,6 +79,7 @@ import { cleanupGmailWatchesForConnector } from "./gmail-automation-event.servic
 import { cleanupGoogleCalendarWatchesForConnector } from "./google-calendar-automation-event.service";
 import { cleanupGoogleFormsWatchesForConnector } from "./google-forms-automation-event.service";
 import { reconcileConnectorAccountState } from "./connector-account-state.service";
+import { resolveConnectorAccount } from "./connector-account-resolution.service";
 import {
   replaceConnectorConnection,
   type StoredConnectorConnectionRow as StoredConnectorRow,
@@ -476,6 +477,7 @@ export function connectorList(args: {
           eq(connectors.orgId, args.orgId),
           eq(connectors.userId, args.userId),
           isNotNull(connectors.connectorSlug),
+          eq(connectors.isDefault, true),
         ),
       );
     const [storedRows, snapshot] = await Promise.all([
@@ -580,6 +582,7 @@ function storedConnectorBySlug(args: {
           eq(connectors.orgId, args.orgId),
           eq(connectors.userId, args.userId),
           eq(connectors.connectorSlug, args.connectorSlug),
+          eq(connectors.isDefault, true),
         ),
       )
       .limit(1);
@@ -730,6 +733,59 @@ async function cleanupConnectorWatchesForDisconnect(
   }
 }
 
+type ConnectorAccountForDeletion =
+  | { readonly kind: "missing" | "ambiguous" }
+  | {
+      readonly kind: "resolved";
+      readonly connector: {
+        readonly id: string;
+        readonly authMethod: string;
+        readonly storageVersion: number;
+      };
+    };
+
+async function loadConnectorAccountForDeletion(
+  db: Tx,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorSlug: string;
+    readonly sourceId?: string;
+  },
+  signal: AbortSignal,
+): Promise<ConnectorAccountForDeletion> {
+  const resolution = await resolveConnectorAccount(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    request: {
+      target: { kind: "builtin", connectorSlug: args.connectorSlug },
+      selection: args.sourceId
+        ? { kind: "exact", sourceId: args.sourceId }
+        : { kind: "legacy-singleton" },
+    },
+  });
+  signal.throwIfAborted();
+  if (resolution.kind === "ambiguous") {
+    return { kind: "ambiguous" };
+  }
+  if (resolution.kind !== "resolved") {
+    return { kind: "missing" };
+  }
+
+  const [connector] = await db
+    .select({
+      id: connectors.id,
+      authMethod: connectors.authMethod,
+      storageVersion: connectors.storageVersion,
+    })
+    .from(connectors)
+    .where(eq(connectors.id, resolution.account.connectorId))
+    .for("update")
+    .limit(1);
+  signal.throwIfAborted();
+  return connector ? { kind: "resolved", connector } : { kind: "missing" };
+}
+
 export const deleteConnectorLocalState$ = command(
   async (
     { get, set },
@@ -737,10 +793,11 @@ export const deleteConnectorLocalState$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly connectorSlug: string;
+      readonly sourceId?: string;
       readonly snapshot?: ConnectorRuntimeSnapshot | null;
     },
     signal: AbortSignal,
-  ): Promise<boolean> => {
+  ): Promise<"deleted" | "missing" | "ambiguous"> => {
     const writeDb = set(writeDb$);
     const snapshot =
       args.snapshot === undefined
@@ -769,27 +826,11 @@ export const deleteConnectorLocalState$ = command(
       });
       signal.throwIfAborted();
 
-      const [existing] = await tx
-        .select({
-          id: connectors.id,
-          authMethod: connectors.authMethod,
-          storageVersion: connectors.storageVersion,
-        })
-        .from(connectors)
-        .where(
-          and(
-            eq(connectors.orgId, args.orgId),
-            eq(connectors.userId, args.userId),
-            eq(connectors.connectorSlug, args.connectorSlug),
-          ),
-        )
-        .for("update")
-        .limit(1);
-      signal.throwIfAborted();
-
-      if (!existing) {
-        return { deleted: false, pendingTokenRevoke: null };
+      const account = await loadConnectorAccountForDeletion(tx, args, signal);
+      if (account.kind !== "resolved") {
+        return { kind: account.kind, pendingTokenRevoke: null };
       }
+      const existing = account.connector;
 
       let pendingTokenRevoke: PendingConnectorTokenRevoke | null = null;
       if (snapshot !== null && featureSwitchContext !== null) {
@@ -837,15 +878,15 @@ export const deleteConnectorLocalState$ = command(
         signal,
       );
 
-      return { deleted: true, pendingTokenRevoke };
+      return { kind: "deleted" as const, pendingTokenRevoke };
     });
     if (signal.aborted) {
       postCommitAbort ??= signal.reason;
     }
 
-    if (!deleteResult.deleted) {
+    if (deleteResult.kind !== "deleted") {
       throwCapturedAbort(postCommitAbort);
-      return false;
+      return deleteResult.kind;
     }
 
     await finalizeConnectorStateChangeAfterCommit(
@@ -859,7 +900,7 @@ export const deleteConnectorLocalState$ = command(
     );
     signal.throwIfAborted();
 
-    return true;
+    return "deleted";
   },
 );
 

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-access.service.ts
@@ -121,6 +121,7 @@ function customConnectorStoredConnectionsQuery(
     readonly userId: string;
     readonly connectorIds?: readonly string[];
     readonly memberConnectorIds?: readonly string[];
+    readonly defaultOnly?: boolean;
   },
 ) {
   return db
@@ -188,6 +189,7 @@ function customConnectorStoredConnectionsQuery(
       and(
         eq(connectors.orgId, args.orgId),
         eq(connectors.userId, args.userId),
+        args.defaultOnly ? eq(connectors.isDefault, true) : undefined,
         args.connectorIds
           ? inArray(connectors.customConnectorId, [...args.connectorIds])
           : undefined,
@@ -209,7 +211,10 @@ async function loadCustomConnectorStoredConnections(
   if (args.connectorIds?.length === 0) {
     return [];
   }
-  return await customConnectorStoredConnectionsQuery(db, args);
+  return await customConnectorStoredConnectionsQuery(db, {
+    ...args,
+    defaultOnly: true,
+  });
 }
 
 function customConnectorStoredConnectionIsCurrent(
@@ -407,6 +412,7 @@ export async function loadCurrentCustomConnectorValueMarkers(
         eq(secrets.type, "connector"),
         eq(secrets.orgId, args.orgId),
         eq(secrets.userId, args.userId),
+        eq(connectors.isDefault, true),
         args.connectorIds
           ? inArray(orgCustomConnectors.id, [...args.connectorIds])
           : undefined,
@@ -443,6 +449,7 @@ export async function loadCurrentCustomConnectorValueMarkers(
         eq(variables.type, "connector"),
         eq(variables.orgId, args.orgId),
         eq(variables.userId, args.userId),
+        eq(connectors.isDefault, true),
         args.connectorIds
           ? inArray(orgCustomConnectors.id, [...args.connectorIds])
           : undefined,

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
@@ -8,6 +8,7 @@ import {
   upsertConnectorOwnedSecret,
   upsertConnectorOwnedVariable,
 } from "./connector-credential-storage-write.service";
+import { resolveConnectorAccount } from "./connector-account-resolution.service";
 
 export type PreparedCustomConnectorValue =
   | {
@@ -89,13 +90,49 @@ export async function deleteCustomConnectorMemberConnection(
   db: Db,
   args: CustomConnectorMemberConnection,
   signal: AbortSignal,
-): Promise<void> {
+): Promise<"deleted" | "missing" | "ambiguous"> {
+  const resolution = await resolveConnectorAccount(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    request: {
+      target: { kind: "custom", customConnectorId: args.connectorId },
+      selection: { kind: "legacy-singleton" },
+    },
+  });
+  signal.throwIfAborted();
+  if (resolution.kind === "ambiguous") {
+    return "ambiguous";
+  }
+  if (resolution.kind !== "resolved") {
+    return "missing";
+  }
+  await deleteCustomConnectorMemberConnectionById(
+    db,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      connectorId: args.connectorId,
+      memberConnectorId: resolution.account.connectorId,
+    },
+    signal,
+  );
+  return "deleted";
+}
+
+export async function deleteCustomConnectorMemberConnectionById(
+  db: Db,
+  args: CustomConnectorMemberConnection & {
+    readonly memberConnectorId: string;
+  },
+  signal: AbortSignal,
+): Promise<boolean> {
   const [connection] = await db
     .select({ id: connectors.id })
     .from(connectors)
     .where(
       and(
         eq(connectors.customConnectorId, args.connectorId),
+        eq(connectors.id, args.memberConnectorId),
         eq(connectors.userId, args.userId),
         eq(connectors.orgId, args.orgId),
       ),
@@ -104,11 +141,12 @@ export async function deleteCustomConnectorMemberConnection(
     .limit(1);
   signal.throwIfAborted();
   if (!connection) {
-    return;
+    return false;
   }
   await deleteConnectorCredentialStorageConnection(
     db,
     { connectorId: connection.id },
     signal,
   );
+  return true;
 }

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -770,10 +770,10 @@ export async function storeCustomConnectorOAuth2Connection(
     readonly featureContext: FeatureSwitchContext;
   },
   signal: AbortSignal,
-): Promise<void> {
+): Promise<string> {
   const encrypted = await encryptTokenValues(args);
   signal.throwIfAborted();
-  await args.db.transaction(async (tx) => {
+  return await args.db.transaction(async (tx) => {
     await lockCustomConnectorOAuth2CredentialContract({
       db: tx,
       orgId: args.orgId,
@@ -781,7 +781,7 @@ export async function storeCustomConnectorOAuth2Connection(
       storageVersion: args.storageVersion,
     });
     signal.throwIfAborted();
-    await replaceConnectorConnection(
+    const connection = await replaceConnectorConnection(
       tx,
       {
         orgId: args.orgId,
@@ -805,6 +805,7 @@ export async function storeCustomConnectorOAuth2Connection(
       },
       signal,
     );
+    return connection.id;
   });
 }
 

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -39,7 +39,7 @@ import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
 
 import { clerk$ } from "../external/clerk";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
-import { badRequestMessage, notFound } from "../../lib/error";
+import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import { safeSync } from "../utils";
@@ -56,6 +56,7 @@ import {
   type PreparedCustomConnectorValue,
   upsertCustomConnectorStoredValues,
 } from "./custom-connector-credential-storage.service";
+import { deleteConnectorSelectionsForCustomConnectorDefinition } from "./connector-credential-storage-write.service";
 import { loadCustomConnectorPermissionBundle } from "./custom-connector-permission-bundle.service";
 import {
   customConnectorDefinitionHasConnectedConnection,
@@ -136,6 +137,7 @@ const CUSTOM_CONNECTOR_OAUTH_ACCESS_TOKEN_REFERENCE = "oauth.access_token";
 
 type BadRequestResponse = ReturnType<typeof badRequestMessage>;
 type NotFoundResponse = ReturnType<typeof notFound>;
+type ConflictResponse = ReturnType<typeof conflict>;
 type ForbiddenResponse = {
   readonly status: 403;
   readonly body: {
@@ -2371,6 +2373,11 @@ export const deleteCustomConnector$ = command(
       ) {
         return integrationManagedCustomConnectorMutationForbidden();
       }
+      await deleteConnectorSelectionsForCustomConnectorDefinition(
+        tx,
+        { customConnectorId: args.id },
+        signal,
+      );
       await tx
         .delete(orgCustomConnectors)
         .where(
@@ -2935,7 +2942,9 @@ export const disconnectCustomConnector$ = command(
       readonly connectorId: string;
     },
     signal: AbortSignal,
-  ): Promise<NotFoundResponse | ForbiddenResponse | undefined> => {
+  ): Promise<
+    NotFoundResponse | ConflictResponse | ForbiddenResponse | undefined
+  > => {
     const writeDb = set(writeDb$);
     let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
     const disconnected = await writeDb.transaction(async (tx) => {
@@ -2974,7 +2983,14 @@ export const disconnectCustomConnector$ = command(
       ) {
         return integrationManagedCustomConnectorMutationForbidden();
       }
-      await deleteCustomConnectorMemberConnection(tx, args, signal);
+      const result = await deleteCustomConnectorMemberConnection(
+        tx,
+        args,
+        signal,
+      );
+      if (result === "ambiguous") {
+        return conflict("Multiple connector accounts require an exact choice");
+      }
       return true;
     });
     if (signal.aborted) {

--- a/turbo/apps/api/src/signals/services/feishu-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-connect.service.ts
@@ -77,6 +77,8 @@ async function loadConnectedFeishuUsers(
     .select({
       installationId: feishuOrgConnections.installationId,
       userName: feishuOrgConnections.feishuUserName,
+      connectorId: feishuOrgConnections.connectorId,
+      feishuOpenId: feishuOrgConnections.feishuOpenId,
     })
     .from(feishuOrgConnections)
     .where(
@@ -96,6 +98,8 @@ async function loadConnectedFeishuUsers(
         orgId,
         userId,
         installationId: connection.installationId,
+        memberConnectorId: connection.connectorId,
+        feishuOpenId: connection.feishuOpenId,
       });
       return connected ? connection : null;
     }),

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { command } from "ccstate";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
 import { FEISHU_OAUTH_SCOPES } from "@okouai/api-contracts/contracts/feishu-connect";
 import { connectors } from "@okouai/db/schema/connector";
+import { feishuOrgConnections } from "@okouai/db/schema/feishu-org-connection";
 import { feishuOrgInstallations } from "@okouai/db/schema/feishu-org-installation";
 import { orgCustomConnectorOauthConfigs } from "@okouai/db/schema/org-custom-connector-oauth-config";
 import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
@@ -15,7 +16,8 @@ import {
   publishCustomConnectorOrganizationInvalidationAfterCommit,
   type CapturedConnectorClientInvalidationAbort,
 } from "./connector-client-invalidation.service";
-import { deleteCustomConnectorMemberConnection } from "./custom-connector-credential-storage.service";
+import { deleteCustomConnectorMemberConnectionById } from "./custom-connector-credential-storage.service";
+import { deleteConnectorSelectionsForCustomConnectorDefinition } from "./connector-credential-storage-write.service";
 import {
   commitPreparedCustomConnectorSkillStorage,
   prepareCustomConnectorSkillVolume$,
@@ -31,6 +33,7 @@ import {
 } from "./custom-connector-definition-selection";
 import type { Tx } from "../../lib/db-types";
 import type { PreparedServerSideVolume } from "./storage-volume-publication.service";
+import { resolveConnectorAccount } from "./connector-account-resolution.service";
 
 const FEISHU_API_PREFIX = "https://open.feishu.cn/open-apis/";
 const FEISHU_AUTHORIZATION_URL =
@@ -607,6 +610,11 @@ export const deleteFeishuInstallationAndCustomConnector$ = command(
       if (!connectorId) {
         return { installationDeleted: true, connectorId: null };
       }
+      await deleteConnectorSelectionsForCustomConnectorDefinition(
+        tx,
+        { customConnectorId: connectorId },
+        signal,
+      );
       const [deletedConnector] = await tx
         .delete(orgCustomConnectors)
         .where(
@@ -664,20 +672,95 @@ export async function hasFeishuCustomConnectorOAuthConnection(
     readonly orgId: string;
     readonly userId: string;
     readonly installationId: string;
+    readonly memberConnectorId?: string | null;
+    readonly feishuOpenId?: string;
   },
 ): Promise<boolean> {
-  const [connection] = await db
-    .select({ id: connectors.id })
+  return (await resolveFeishuCustomConnectorOAuthConnection(db, args)) !== null;
+}
+
+export async function resolveFeishuCustomConnectorOAuthConnection(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly installationId: string;
+    readonly memberConnectorId?: string | null;
+    readonly feishuOpenId?: string;
+  },
+): Promise<string | null> {
+  let memberConnectorId = args.memberConnectorId;
+  let feishuOpenId = args.feishuOpenId;
+  if (memberConnectorId === undefined || feishuOpenId === undefined) {
+    const connectionRows = await db
+      .select({
+        connectorId: feishuOrgConnections.connectorId,
+        feishuOpenId: feishuOrgConnections.feishuOpenId,
+      })
+      .from(feishuOrgConnections)
+      .where(
+        and(
+          eq(feishuOrgConnections.installationId, args.installationId),
+          eq(feishuOrgConnections.userId, args.userId),
+        ),
+      )
+      .limit(2);
+    if (connectionRows.length !== 1) {
+      return null;
+    }
+    const [connectionRow] = connectionRows;
+    if (
+      !connectionRow ||
+      (memberConnectorId !== undefined &&
+        memberConnectorId !== connectionRow.connectorId) ||
+      (feishuOpenId !== undefined &&
+        feishuOpenId !== connectionRow.feishuOpenId)
+    ) {
+      return null;
+    }
+    memberConnectorId = connectionRow.connectorId;
+    feishuOpenId = connectionRow.feishuOpenId;
+  }
+  if (feishuOpenId === undefined) {
+    return null;
+  }
+
+  const [installation] = await db
+    .select({ customConnectorId: feishuOrgInstallations.customConnectorId })
     .from(feishuOrgInstallations)
-    .innerJoin(
-      orgCustomConnectors,
+    .where(
       and(
-        eq(orgCustomConnectors.id, feishuOrgInstallations.customConnectorId),
-        eq(orgCustomConnectors.orgId, feishuOrgInstallations.orgId),
+        eq(feishuOrgInstallations.orgId, args.orgId),
+        eq(feishuOrgInstallations.id, args.installationId),
       ),
     )
+    .limit(1);
+  if (!installation?.customConnectorId) {
+    return null;
+  }
+
+  const resolution = await resolveConnectorAccount(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    request: {
+      target: {
+        kind: "custom",
+        customConnectorId: installation.customConnectorId,
+      },
+      selection: memberConnectorId
+        ? { kind: "exact", sourceId: memberConnectorId }
+        : { kind: "legacy-singleton" },
+    },
+  });
+  if (resolution.kind !== "resolved") {
+    return null;
+  }
+
+  const [connection] = await db
+    .select({ id: connectors.id })
+    .from(connectors)
     .innerJoin(
-      connectors,
+      orgCustomConnectors,
       and(
         eq(connectors.customConnectorId, orgCustomConnectors.id),
         eq(connectors.orgId, orgCustomConnectors.orgId),
@@ -694,15 +777,20 @@ export async function hasFeishuCustomConnectorOAuthConnection(
     )
     .where(
       and(
-        eq(feishuOrgInstallations.orgId, args.orgId),
-        eq(feishuOrgInstallations.id, args.installationId),
+        eq(orgCustomConnectors.id, installation.customConnectorId),
+        eq(orgCustomConnectors.orgId, args.orgId),
+        eq(connectors.id, resolution.account.connectorId),
         eq(connectors.userId, args.userId),
         eq(connectors.authMethod, "oauth"),
         eq(connectors.needsReconnect, false),
+        or(
+          isNull(connectors.externalId),
+          eq(connectors.externalId, feishuOpenId),
+        ),
       ),
     )
     .limit(1);
-  return Boolean(connection);
+  return connection?.id ?? null;
 }
 
 export async function disconnectFeishuCustomConnectorOAuthConnection(
@@ -711,11 +799,13 @@ export async function disconnectFeishuCustomConnectorOAuthConnection(
     readonly orgId: string;
     readonly userId: string;
     readonly installationId: string;
+    readonly memberConnectorId?: string | null;
+    readonly feishuOpenId?: string;
   },
   signal: AbortSignal,
 ): Promise<void> {
-  const [connector] = await db
-    .select({ id: feishuOrgInstallations.customConnectorId })
+  const [installation] = await db
+    .select({ customConnectorId: feishuOrgInstallations.customConnectorId })
     .from(feishuOrgInstallations)
     .where(
       and(
@@ -726,13 +816,28 @@ export async function disconnectFeishuCustomConnectorOAuthConnection(
     .for("update", { of: feishuOrgInstallations })
     .limit(1);
   signal.throwIfAborted();
-  if (!connector?.id) {
+  if (!installation?.customConnectorId) {
     return;
   }
-  await deleteCustomConnectorMemberConnection(
+  const memberConnectorId = await resolveFeishuCustomConnectorOAuthConnection(
     db,
     {
-      connectorId: connector.id,
+      orgId: args.orgId,
+      userId: args.userId,
+      installationId: args.installationId,
+      memberConnectorId: args.memberConnectorId,
+      feishuOpenId: args.feishuOpenId,
+    },
+  );
+  signal.throwIfAborted();
+  if (!memberConnectorId) {
+    return;
+  }
+  await deleteCustomConnectorMemberConnectionById(
+    db,
+    {
+      connectorId: installation.customConnectorId,
+      memberConnectorId,
       orgId: args.orgId,
       userId: args.userId,
     },

--- a/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-custom-connector.service.ts
@@ -747,6 +747,9 @@ export async function resolveFeishuCustomConnectorOAuthConnection(
         kind: "custom",
         customConnectorId: installation.customConnectorId,
       },
+      // Old API instances can leave this link null during the DB/API rollout
+      // window (observed maximum: ~102 minutes). Remove the exactly-one
+      // compatibility path after drain and #27695 tail reconciliation.
       selection: memberConnectorId
         ? { kind: "exact", sourceId: memberConnectorId }
         : { kind: "legacy-singleton" },
@@ -783,6 +786,9 @@ export async function resolveFeishuCustomConnectorOAuthConnection(
         eq(connectors.userId, args.userId),
         eq(connectors.authMethod, "oauth"),
         eq(connectors.needsReconnect, false),
+        // Migration 0946 created exact links before Feishu external identity
+        // was stored. Remove this persisted-state compatibility after #27695
+        // reconciles those historical null identities.
         or(
           isNull(connectors.externalId),
           eq(connectors.externalId, feishuOpenId),

--- a/turbo/apps/api/src/signals/services/feishu-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-dispatch.service.ts
@@ -103,6 +103,7 @@ export interface FeishuDispatchInstallation {
 export interface FeishuDispatchConnection {
   readonly id: string;
   readonly userId: string;
+  readonly connectorId: string;
   readonly feishuUserName: string | null;
 }
 
@@ -792,6 +793,8 @@ async function handleDisconnectCommand(
         orgId: args.installation.orgId,
         userId: args.connection.userId,
         installationId: args.message.installationId,
+        memberConnectorId: args.connection.connectorId,
+        feishuOpenId: args.message.openId,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -578,10 +578,18 @@ export async function linkGithubUser(
     const [connector] = await args.db
       .select({ externalId: connectors.externalId })
       .from(connectors)
+      .innerJoin(
+        githubInstallations,
+        and(
+          eq(githubInstallations.id, args.installRecordId),
+          eq(githubInstallations.orgId, connectors.orgId),
+        ),
+      )
       .where(
         and(
           eq(connectors.userId, args.userId),
           eq(connectors.connectorSlug, "github"),
+          eq(connectors.isDefault, true),
         ),
       )
       .limit(1);

--- a/turbo/apps/api/src/signals/services/integrations-github.service.ts
+++ b/turbo/apps/api/src/signals/services/integrations-github.service.ts
@@ -138,6 +138,7 @@ async function loadUserGithubConnectorUsername(args: {
   readonly db: ReadonlyDb;
   readonly orgId: string;
   readonly userId: string;
+  readonly githubUserId: string;
 }): Promise<string | null> {
   const [connector] = await args.db
     .select({ externalUsername: connectors.externalUsername })
@@ -147,6 +148,8 @@ async function loadUserGithubConnectorUsername(args: {
         eq(connectors.orgId, args.orgId),
         eq(connectors.userId, args.userId),
         eq(connectors.connectorSlug, "github"),
+        eq(connectors.isDefault, true),
+        eq(connectors.externalId, args.githubUserId),
       ),
     )
     .limit(1);
@@ -275,6 +278,7 @@ export const getGithubInstallation$ = command(
             db,
             orgId: auth.orgId,
             userId: auth.userId,
+            githubUserId: link.githubUserId,
           });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/mail-draft.service.ts
+++ b/turbo/apps/api/src/signals/services/mail-draft.service.ts
@@ -257,6 +257,7 @@ async function loadMailConnections(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
+  readonly sourceId?: string;
 }): Promise<readonly MailConnection[]> {
   const rows = await args.db
     .select({
@@ -287,6 +288,9 @@ async function loadMailConnections(args: {
         eq(userConnectors.userId, args.userId),
         eq(userConnectors.agentId, args.agentId),
         eq(userConnectors.connectorSlug, "gmail"),
+        args.sourceId
+          ? eq(connectors.id, args.sourceId)
+          : eq(connectors.isDefault, true),
       ),
     );
 
@@ -1041,6 +1045,7 @@ async function connectionForRow(args: {
     orgId: args.orgId,
     userId: args.userId,
     agentId: args.row.agentId,
+    sourceId: args.row.connectorId ?? undefined,
   });
   const linked = connections.find((connection) => {
     return connection.connectorId === args.row.connectorId;

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -388,6 +388,7 @@ const revokeOrgConnectorTokens$ = command(
     signal.throwIfAborted();
     const rows = await db
       .select({
+        connectorId: connectors.id,
         userId: connectors.userId,
         connectorSlug: sql`${connectors.connectorSlug}`
           .mapWith(pgTextDecoder)
@@ -406,6 +407,7 @@ const revokeOrgConnectorTokens$ = command(
           orgId,
           userId: row.userId,
           connectorSlug: row.connectorSlug,
+          sourceId: row.connectorId,
           snapshot,
         },
         signal,
@@ -425,6 +427,7 @@ const revokeUserConnectorTokens$ = command(
     signal.throwIfAborted();
     const rows = await db
       .select({
+        connectorId: connectors.id,
         orgId: connectors.orgId,
         connectorSlug: sql`${connectors.connectorSlug}`
           .mapWith(pgTextDecoder)
@@ -443,6 +446,7 @@ const revokeUserConnectorTokens$ = command(
           orgId: row.orgId,
           userId,
           connectorSlug: row.connectorSlug,
+          sourceId: row.connectorId,
           snapshot,
         },
         signal,

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -9,6 +9,12 @@ const connectorStateSchema = z.object({
   storage_version: z.number().int().positive(),
 });
 
+const feishuMemberConnectionStateSchema = z.object({
+  connector_id: z.uuid().nullable(),
+  connector_external_id: z.string().nullable(),
+  open_id: z.string(),
+});
+
 const secretStateSchema = z.object({
   name: z.string(),
   connector_id: z.uuid(),
@@ -57,6 +63,18 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       action: z.literal("clear-feishu-connector-ownership"),
       org_id: z.string(),
       installation_id: z.uuid(),
+    }),
+    z.object({
+      action: z.literal("read-feishu-member-connector"),
+      org_id: z.string(),
+      user_id: z.string(),
+      installation_id: z.uuid(),
+    }),
+    z.object({
+      action: z.literal("set-feishu-member-connector-link"),
+      user_id: z.string(),
+      installation_id: z.uuid(),
+      connector_id: z.uuid().nullable(),
     }),
     z.object({
       action: z.literal("seed-legacy-custom-feishu-oauth-state"),
@@ -111,6 +129,37 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       token_expires_at: z.iso.datetime().nullable().optional(),
     }),
     z.object({
+      action: z.literal("set-connector-default"),
+      org_id: z.string(),
+      user_id: z.string(),
+      connector_id: z.uuid(),
+      is_default: z.boolean(),
+    }),
+    z.object({
+      action: z.literal("set-connector-external-id"),
+      org_id: z.string(),
+      user_id: z.string(),
+      connector_id: z.uuid(),
+      external_id: z.string().nullable(),
+    }),
+    z.object({
+      action: z.literal("seed-builtin-thread-selection"),
+      chat_thread_id: z.uuid(),
+      connector_id: z.uuid(),
+      connector_slug: z.string(),
+    }),
+    z.object({
+      action: z.literal("seed-custom-thread-selection"),
+      chat_thread_id: z.uuid(),
+      connector_id: z.uuid(),
+      custom_connector_id: z.uuid(),
+    }),
+    z.object({
+      action: z.literal("read-thread-selection"),
+      chat_thread_id: z.uuid(),
+      connector_id: z.uuid(),
+    }),
+    z.object({
       action: z.literal("set-custom-parent-state"),
       org_id: z.string(),
       user_id: z.string(),
@@ -141,6 +190,10 @@ export const testConnectorCredentialStorageStateActionResponseSchema = z.object(
     connector: connectorStateSchema.nullable().optional(),
     connector_id: z.uuid().optional(),
     custom_oauth_state: customOauthStateSchema.nullable().optional(),
+    feishu_member_connection: feishuMemberConnectionStateSchema
+      .nullable()
+      .optional(),
+    selection_exists: z.boolean().optional(),
     secrets: z.array(secretStateSchema).optional(),
     variables: z.array(variableStateSchema).optional(),
   },

--- a/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connectors.ts
@@ -66,6 +66,7 @@ export const zeroConnectorsBySlugContract = c.router({
       204: c.noBody(),
       401: apiErrorSchema,
       404: apiErrorSchema,
+      409: apiErrorSchema,
     },
     summary: "Disconnect a connector (zero proxy)",
   },

--- a/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-custom-connectors.ts
@@ -450,6 +450,7 @@ export const zeroCustomConnectorConnectionContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
+      409: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Disconnect the calling user's custom connector connection",


### PR DESCRIPTION
## Summary

- project owner-level connector reads through the deterministic default account while preserving exact durable mail/run state
- make connector, definition, and owner cleanup selection-aware, and reject ambiguous legacy disconnects
- persist and use exact Feishu member connector ownership with bounded compatibility for historical incomplete links

## Scope

- does not remove the singleton indexes
- does not add sibling-account writers or thread-selection writes
- does not replace Feishu definition ownership or repeat the historical connector backfill

## Deployment

Deploy and drain this compatibility gate before enabling the sibling-account writers planned in #27690. The Feishu compatibility paths below are tracked for removal in #27695.

## Fallbacks

- `feishu-custom-connector.service.ts:resolveFeishuCustomConnectorOAuthConnection` — when an overlapping old API leaves `feishu_org_connections.connector_id` null, resolves only an exactly-one organization/user/definition-compatible member account. Surface: persisted backend state during the DB/API rollout window, whose observed maximum is ~102 minutes. Remove after old API instances have drained and #27695 tail reconciliation is complete.
- `feishu-custom-connector.service.ts:resolveFeishuCustomConnectorOAuthConnection` — accepts an exact migration-0946 connector link whose `connectors.external_id` is still null, while rejecting a populated identity that mismatches the Feishu `openId`. Surface: historical persisted state; it is not removable by elapsed rollout time alone. Remove after #27695 reconciles historical identities and verifies no eligible nulls remain.

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F @okouai/api-contracts lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F @okouai/api-contracts check-types`
- `cd turbo && pnpm knip`
- targeted API integration suite: 8 files, 200 tests passed
- `cd turbo && pnpm -F @okouai/api-contracts test`: 31 files, 585 tests passed
- pre-commit checks, including repository-wide type checking

Closes #27689

Parent: #22832
