### PR TITLE
test(guest-contracts): make runner-owned env namespace guard fail-closed

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -697,4 +697,84 @@ mod tests {
         ));
         assert!(!is_guest_agent_tuning_env_key(API_URL_ENV));
     }
+
+    /// Contract sources scanned for declared environment key constants.
+    ///
+    /// Every module declaring a `*_ENV` bootstrap key must be listed here, or
+    /// its keys escape the protection check below.
+    const CONTRACT_ENV_SOURCES: &[(&str, &str)] = &[
+        ("env.rs", include_str!("env.rs")),
+        ("runtime_paths.rs", include_str!("runtime_paths.rs")),
+        (
+            "process_containment.rs",
+            include_str!("process_containment.rs"),
+        ),
+    ];
+
+    /// Extracts every `pub const NAME_ENV: &str = "VALUE";` declaration from a
+    /// contract source as a `(name, value)` pair.
+    ///
+    /// Reading declarations out of the source keeps the check exhaustive. A
+    /// hand-maintained list would only cover the keys someone remembered to
+    /// register, which is the failure this check exists to prevent.
+    ///
+    /// Only declarations starting a line are matched, so prose mentioning the
+    /// pattern inside a comment is not treated as a declaration.
+    ///
+    /// Every current declaration occupies a single line. A `_ENV` declaration
+    /// this cannot parse yields an empty value, which fails the protection
+    /// check rather than being skipped, so an unparsed declaration fails closed.
+    fn declared_env_key_constants(source: &str) -> Vec<(&str, &str)> {
+        source
+            .lines()
+            .filter_map(|line| {
+                let declaration = line.trim_start().strip_prefix("pub const ")?;
+                let (name, rest) = declaration.split_once(':')?;
+                let name = name.trim();
+                if !name.ends_with("_ENV") {
+                    return None;
+                }
+                let (_, rest) = rest.split_once('=')?;
+                let value = rest
+                    .trim_start()
+                    .strip_prefix('"')
+                    .and_then(|literal| literal.split_once('"'))
+                    .map_or("", |(value, _)| value);
+                Some((name, value))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn every_declared_env_key_is_classified_for_user_env_protection() {
+        let mut unprotected = Vec::new();
+        let mut total = 0;
+
+        for (file, source) in CONTRACT_ENV_SOURCES {
+            let declared = declared_env_key_constants(source);
+            assert!(
+                !declared.is_empty(),
+                "{file} yielded no *_ENV declarations; the source scan is broken"
+            );
+            total += declared.len();
+
+            for (name, value) in declared {
+                if !is_runner_owned_env_key(value) {
+                    unprotected.push(format!("{file}: {name} = {value:?}"));
+                }
+            }
+        }
+
+        assert!(
+            total >= 37,
+            "expected at least 37 declared *_ENV keys across the contract sources, found {total}; \
+             lower this bound only when a key is deliberately removed"
+        );
+        assert!(
+            unprotected.is_empty(),
+            "these bootstrap env keys are not protected from user env injection. Add each to \
+             EXPLICIT_RUNNER_OWNED_ENV_KEYS, or keep the VM0_ prefix:\n  {}",
+            unprotected.join("\n  ")
+        );
+    }
 }


### PR DESCRIPTION
Closes #28196. Parent epic: #28180.

## Why

`is_runner_owned_env_key` (`crates/guest-contracts/src/env.rs:435-443`) is what stops user-supplied environment from spoofing runner-owned bootstrap state:

- `crates/runner/src/executor/env.rs:297` silently **filters** matching keys out of the guest user env.
- `crates/runner/src/cmd/local/submit.rs:594` **hard-rejects** them from `--env`.

It matches `key.starts_with("VM0_")`, so protection is automatic today: any runner-owned key is covered simply by being spelled `VM0_*`. The module doc at `env.rs:8-12` states the `OKOU_` namespace is deliberately **not** covered, and `crates/runner/src/executor/tests/env_tests.rs:759-760` asserts exactly that.

So every `VM0_* -> OKOU_*` rename in #28180 moves a key from automatic protection to manual registration in `EXPLICIT_RUNNER_OWNED_ENV_KEYS`. A forgotten registration is a silent env-injection hole with no failing test. The epic migrates 100+ names, so the guard is made fail-closed before any rename begins.

Analysis and evidence: https://github.com/vm0-ai/vm0/issues/28180#issuecomment-5339861301

## What

Adds a test to the existing `#[cfg(test)] mod tests` in `crates/guest-contracts/src/env.rs` that scans the three contract sources via `include_str!` for `pub const *_ENV: &str = "..."` declarations and asserts every value satisfies `is_runner_owned_env_key`.

The scan derives its input from source rather than a curated array. This repo already has the hand-maintained failure mode: `contract_names_match_wire_values` (`env.rs:470-490`) enumerates only 16 of 37 constants, omitting `API_TOKEN_ENV`, `PROMPT_ENV`, `SANDBOX_ID_ENV`, and `SECRET_VALUES_ENV`. A curated list would protect only the keys someone remembered to register, which is the failure this check exists to prevent.

Fail-open modes are closed off explicitly:

- A lower bound on total declarations found, so a non-matching parser cannot pass vacuously.
- A per-source non-empty assertion, so one broken source path cannot be masked by another source growing.
- A `_ENV` declaration the parser cannot read yields an empty value, which fails the check rather than being skipped.
- Only declarations starting a line are matched, so prose mentioning the pattern in a comment is not parsed as a declaration.

## Current state is clean

There are exactly 9 declared env keys that are not `VM0_`-prefixed, and all 9 are already registered: `OKOU_RUN_ID`, `OKOU_PI_SESSION_ID`, `OKOU_PI_LAUNCH_CONFIG`, `OKOU_PI_LAUNCH_PAYLOAD_FILE`, `OKOU_PI_MODEL_CONFIG`, `CLI_AGENT_TYPE`, `USE_MOCK_CLAUDE`, `USE_MOCK_CODEX`, `VERCEL_PROTECTION_BYPASS`. No pre-existing violation, so this lands green with no companion remediation.

## Verification

`cargo fmt --check` clean, `cargo clippy -p guest-contracts --all-targets -- -D warnings` clean, `cargo test -p guest-contracts --lib` green at 109 passed.

Each guard was verified by deliberately breaking it:

| Injected fault | Result |
|---|---|
| Unregistered `pub const CANARY_ENV: &str = "OKOU_CANARY";` | fails: `env.rs: CANARY_ENV = "OKOU_CANARY"` |
| Lower bound raised to 38 | fails: `expected at least 37 [...] found 37` — confirms the parser reads all 37, not a subset |
| `runtime_paths.rs` source replaced with `""` | fails: `runtime_paths.rs yielded no *_ENV declarations; the source scan is broken` |

All faults reverted; the committed state is green.

## Scope

Single hunk, 80 added lines, entirely inside the existing `#[cfg(test)]` module (`mod tests` opens at line 465, hunk begins at 700). Zero non-test lines changed.

Non-goals: no renames and no wire-value changes; no change to `is_runner_owned_env_key` or to `EXPLICIT_RUNNER_OWNED_ENV_KEYS` / `GUEST_AGENT_TUNING_ENV_KEYS` membership; no extension to `crates/runner/src/host_env.rs` (the 6 host-operator keys are a separate deployment-configuration concern); no backfill of `contract_names_match_wire_values`; not promoted to a lefthook/CI lint in this PR.

One design note carried from the issue: "is protected" and "may cross the user-env boundary" stay independent properties. `AGENT_EXECUTION_TIMEOUT_SECS_ENV` is `VM0_`-prefixed and protected but is not in `GUEST_AGENT_TUNING_ENV_KEYS`; collapsing the two would let a future tuning exemption silently remove protection.

## Coordination

#25722 also edits this file. Checked: it adds `CF_ACCESS_CLIENT_ID_ENV` and `CF_ACCESS_CLIENT_SECRET_ENV` and correctly registers both in the allowlist, so there is no semantic conflict and this check would pass for it. Its base predates the `NON_VM0_RUNNER_OWNED_ENV_KEYS` -> `EXPLICIT_RUNNER_OWNED_ENV_KEYS` rename on `main`, so it carries a rebase conflict it already owes regardless. `agent-compose-consolidation-preflight-consumers.ts` registers no `crates/guest-contracts` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
