### PR TITLE
refactor(api): neutralize run and model provider route naming

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -105,7 +105,7 @@ import { mcpConnectorsRoutes } from "./routes/mcp-connectors";
 import { weatherRoutes } from "./routes/weather";
 import { modelPoliciesRoutes } from "./routes/model-policies";
 import { modelProviderGatewayRoutes } from "./routes/model-provider-gateways";
-import { zeroModelProvidersRoutes } from "./routes/zero-model-providers";
+import { modelProvidersRoutes } from "./routes/model-providers";
 import { onboardingCompleteRoutes } from "./routes/onboarding-complete";
 import { onboardingStatusRoutes } from "./routes/onboarding-status";
 import { orgInviteRoutes } from "./routes/org-invite";
@@ -120,7 +120,7 @@ import { realtimeTokenRoutes } from "./routes/realtime-token";
 import { imageRecognitionRoutes } from "./routes/image-recognition";
 import { translationRoutes } from "./routes/translation";
 import { runDetailRoutes } from "./routes/run-detail";
-import { zeroRunsRoutes } from "./routes/zero-runs";
+import { runsRoutes } from "./routes/runs";
 import { runsCancelRoutes } from "./routes/runs-cancel";
 import { meModelProvidersDeleteRoutes } from "./routes/me-model-providers-delete";
 import { meModelProviderAccountRoutes } from "./routes/me-model-provider-accounts";
@@ -304,7 +304,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...browserAuthorizationRoutes,
   ...modelPoliciesRoutes,
   ...modelProviderGatewayRoutes,
-  ...zeroModelProvidersRoutes,
+  ...modelProvidersRoutes,
   ...meModelProvidersDeleteRoutes,
   ...meModelProviderAccountRoutes,
   ...meModelProvidersListRoutes,
@@ -320,7 +320,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...imageRecognitionRoutes,
   ...translationRoutes,
   ...runDetailRoutes,
-  ...zeroRunsRoutes,
+  ...runsRoutes,
   ...runsCancelRoutes,
   ...onboardingCompleteRoutes,
   ...onboardingStatusRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -146,14 +146,14 @@ import { chatEventsRoutes } from "../chat-events";
 import { chatThreadRoutes } from "../chat-threads";
 import { mailRoutes } from "../mail";
 import { modelProviderGatewayRoutes } from "../model-provider-gateways";
-import { zeroModelProvidersRoutes } from "../zero-model-providers";
+import { modelProvidersRoutes } from "../model-providers";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...chatEventsRoutes,
   ...chatThreadRoutes,
   ...mailRoutes,
   ...modelProviderGatewayRoutes,
-  ...zeroModelProvidersRoutes,
+  ...modelProvidersRoutes,
 ]);
 
 /**
@@ -1009,7 +1009,7 @@ function modelProviderSecretPlaceholder(
 }
 
 function modelProvidersClient() {
-  return setupApp({ context, routes: zeroModelProvidersRoutes })(
+  return setupApp({ context, routes: modelProvidersRoutes })(
     modelProvidersMainContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-execute-morning-briefs.test.ts
@@ -54,7 +54,7 @@ import { readAgentRunCallbacks$ } from "./helpers/agent-run-callback";
 import { cronExecuteMorningBriefsRoutes } from "../cron-execute-morning-briefs";
 import { emailMorningBriefUnsubscribeRoutes } from "../email-morning-brief-unsubscribe";
 import { chatThreadRoutes } from "../chat-threads";
-import { zeroModelProvidersRoutes } from "../zero-model-providers";
+import { modelProvidersRoutes } from "../model-providers";
 import { morningBriefRoutes } from "../morning-brief";
 import { userPreferencesRoutes } from "../user-preferences";
 
@@ -62,7 +62,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...cronExecuteMorningBriefsRoutes,
   ...emailMorningBriefUnsubscribeRoutes,
   ...chatThreadRoutes,
-  ...zeroModelProvidersRoutes,
+  ...modelProvidersRoutes,
   ...morningBriefRoutes,
   ...userPreferencesRoutes,
 ]);
@@ -244,7 +244,7 @@ function morningBriefTriggerClient() {
 }
 
 function modelProvidersByTypeClient() {
-  return setupApp({ context, routes: zeroModelProvidersRoutes })(
+  return setupApp({ context, routes: modelProvidersRoutes })(
     modelProvidersByTypeContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
@@ -32,7 +32,7 @@ import { integrationsPhoneUploadInitRoutes } from "../../integrations-phone-uplo
 import { integrationsPhoneDownloadFileRoutes } from "../../integrations-phone-download-file";
 import { logsRoutes } from "../../logs";
 import { modelPoliciesRoutes } from "../../model-policies";
-import { zeroModelProvidersRoutes } from "../../zero-model-providers";
+import { modelProvidersRoutes } from "../../model-providers";
 
 const TEST_APP_ROUTES = Object.freeze([
   ...integrationsPhoneDownloadFileRoutes,
@@ -40,7 +40,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...integrationsPhoneUploadInitRoutes,
   ...logsRoutes,
   ...modelPoliciesRoutes,
-  ...zeroModelProvidersRoutes,
+  ...modelProvidersRoutes,
 ]);
 
 export const AGENTPHONE_BDD_AGENT_ID = "agt-bdd-agentphone";
@@ -452,7 +452,7 @@ export function createAgentPhoneBddApi(context: TestContext) {
     async switchDefaultModelRouteToOpenRouter(
       actor: ApiTestUser,
     ): Promise<void> {
-      const providers = setupApp({ context, routes: zeroModelProvidersRoutes })(
+      const providers = setupApp({ context, routes: modelProvidersRoutes })(
         modelProvidersMainContract,
       );
       const upserted = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device-support.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device-support.ts
@@ -18,7 +18,7 @@ import { featureSwitchesRoutes } from "../../feature-switches";
 import { meModelProvidersDeleteRoutes } from "../../me-model-providers-delete";
 import { meModelProviderAccountRoutes } from "../../me-model-provider-accounts";
 import { meModelProvidersListRoutes } from "../../me-model-providers-list";
-import { zeroModelProvidersRoutes } from "../../zero-model-providers";
+import { modelProvidersRoutes } from "../../model-providers";
 import { userPreferencesRoutes } from "../../user-preferences";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
@@ -33,7 +33,7 @@ const authDeviceSupportRoutes: readonly RouteEntry[] = [
   ...meModelProviderAccountRoutes,
   ...meModelProvidersDeleteRoutes,
   ...meModelProvidersListRoutes,
-  ...zeroModelProvidersRoutes,
+  ...modelProvidersRoutes,
   ...userPreferencesRoutes,
 ];
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
@@ -46,7 +46,7 @@ import { agentsRoutes } from "../../agents";
 import { billingStatusRoutes } from "../../billing-status";
 import { claudeCodeDeviceAuthRoutes } from "../../claude-code-device-auth";
 import { codexDeviceAuthRoutes } from "../../codex-device-auth";
-import { zeroModelProvidersRoutes } from "../../zero-model-providers";
+import { modelProvidersRoutes } from "../../model-providers";
 import { realtimeTokenRoutes } from "../../realtime-token";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
@@ -82,7 +82,7 @@ const authDeviceRoutes: readonly RouteEntry[] = [
   ...billingStatusRoutes,
   ...claudeCodeDeviceAuthRoutes,
   ...codexDeviceAuthRoutes,
-  ...zeroModelProvidersRoutes,
+  ...modelProvidersRoutes,
   ...realtimeTokenRoutes,
 ];
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -78,7 +78,7 @@ import { integrationsTelegramMessageRoutes } from "../../integrations-telegram-m
 import { integrationsTelegramUploadCompleteRoutes } from "../../integrations-telegram-upload-complete";
 import { integrationsTelegramUploadInitRoutes } from "../../integrations-telegram-upload-init";
 import { modelPoliciesRoutes } from "../../model-policies";
-import { zeroModelProvidersRoutes } from "../../zero-model-providers";
+import { modelProvidersRoutes } from "../../model-providers";
 import { slackChannelsRoutes } from "../../slack-channels";
 import { slackCommandsRoutes } from "../../slack-commands";
 import { slackConnectRoutes } from "../../slack-connect";
@@ -108,7 +108,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...integrationsTelegramUploadInitRoutes,
   ...integrationsTelegramRoutes,
   ...modelPoliciesRoutes,
-  ...zeroModelProvidersRoutes,
+  ...modelProvidersRoutes,
   ...slackChannelsRoutes,
   ...slackCommandsRoutes,
   ...slackConnectRoutes,
@@ -1241,7 +1241,7 @@ export function createBddIntegrationApi(context: TestContext) {
     },
 
     async configureSlackRunModelPolicies(actor: ApiTestUser): Promise<void> {
-      const providers = setupApp({ context, routes: zeroModelProvidersRoutes })(
+      const providers = setupApp({ context, routes: modelProvidersRoutes })(
         modelProvidersMainContract,
       );
       const anthropic = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -43,7 +43,7 @@ import { meModelProvidersListRoutes } from "../../me-model-providers-list";
 import { meModelProvidersResetSubscriptionRoutes } from "../../me-model-providers-reset-subscription";
 import { meModelProvidersUpsertRoutes } from "../../me-model-providers-upsert";
 import { modelPoliciesRoutes } from "../../model-policies";
-import { zeroModelProvidersRoutes } from "../../zero-model-providers";
+import { modelProvidersRoutes } from "../../model-providers";
 import { orgLogoRoutes } from "../../org-logo";
 import { pushSubscriptionsRoutes } from "../../push-subscriptions";
 import { userPreferencesRoutes } from "../../user-preferences";
@@ -441,7 +441,7 @@ export function createMiscRoutesApi(context: TestContext) {
 
     async listModelProviders(actor: ApiTestUser) {
       return await accept(
-        setupApp({ context, routes: zeroModelProvidersRoutes })(
+        setupApp({ context, routes: modelProvidersRoutes })(
           modelProvidersMainContract,
         ).list({
           headers: authenticate(context, actor),
@@ -455,7 +455,7 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (200 | 201 | 400 | 401 | 403 | 404 | 500)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroModelProvidersRoutes })(
+        setupApp({ context, routes: modelProvidersRoutes })(
           modelProvidersMainContract,
         ).upsert({
           headers: authenticate(context, actor),
@@ -471,7 +471,7 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (200 | 201 | 400 | 401 | 403 | 404 | 500)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroModelProvidersRoutes })(
+        setupApp({ context, routes: modelProvidersRoutes })(
           modelProvidersMainContract,
         ).upsert({
           headers: authenticate(context, actor),
@@ -486,7 +486,7 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (204 | 401 | 403 | 404 | 500)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroModelProvidersRoutes })(
+        setupApp({ context, routes: modelProvidersRoutes })(
           modelProvidersByTypeContract,
         ).delete({
           headers: authenticate(context, actor),
@@ -502,7 +502,7 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly (204 | 401 | 403 | 404 | 500)[],
     ) {
       return await accept(
-        setupApp({ context, routes: zeroModelProvidersRoutes })(
+        setupApp({ context, routes: modelProvidersRoutes })(
           modelProvidersByTypeContract,
         ).delete({
           headers: authenticate(context, actor),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -70,10 +70,10 @@ import { webhooksStripeRoutes } from "../../webhooks-stripe";
 import { agentsRoutes } from "../../agents";
 import { billingStatusRoutes } from "../../billing-status";
 import { modelPoliciesRoutes } from "../../model-policies";
-import { zeroModelProvidersRoutes } from "../../zero-model-providers";
+import { modelProvidersRoutes } from "../../model-providers";
 import { runDetailRoutes } from "../../run-detail";
 import { runsCancelRoutes } from "../../runs-cancel";
-import { zeroRunsRoutes } from "../../zero-runs";
+import { runsRoutes } from "../../runs";
 import { runFixtureContract, runFixtureRoutes } from "../../test-run-fixture";
 import { testBillingReconciliationStateRoutes } from "../../test-billing-reconciliation-state";
 import { userPermissionGrantsRoutes } from "../../user-permission-grants";
@@ -153,10 +153,10 @@ const runRoutes = [
   ...webhooksStripeRoutes,
   ...billingStatusRoutes,
   ...modelPoliciesRoutes,
-  ...zeroModelProvidersRoutes,
+  ...modelProvidersRoutes,
   ...runDetailRoutes,
   ...runFixtureRoutes,
-  ...zeroRunsRoutes,
+  ...runsRoutes,
   ...runsCancelRoutes,
   ...agentsRoutes,
   ...userPermissionGrantsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/model-providers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-providers.test.ts
@@ -16,7 +16,7 @@ import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { webhooksAgentFirewallAuthRoutes } from "../webhooks-agent-firewall-auth";
-import { zeroModelProvidersRoutes } from "../zero-model-providers";
+import { modelProvidersRoutes } from "../model-providers";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
@@ -238,7 +238,7 @@ async function markOrgCodexProviderStaleViaFirewall(
 
 describe("GET /api/zero/model-providers", () => {
   it("returns 401 when the request is unauthenticated", async () => {
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -251,7 +251,7 @@ describe("GET /api/zero/model-providers", () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, null);
 
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -268,7 +268,7 @@ describe("GET /api/zero/model-providers", () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
 
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -284,7 +284,7 @@ describe("GET /api/zero/model-providers", () => {
     const fixture = uniqueOrgUser("zmp-list-member");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
 
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -302,7 +302,7 @@ describe("GET /api/zero/model-providers", () => {
 
     mocks.clerk.session(userId, orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -329,7 +329,7 @@ describe("GET /api/zero/model-providers", () => {
 
     mocks.clerk.session(userId, orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -355,7 +355,7 @@ describe("GET /api/zero/model-providers", () => {
 
     mocks.clerk.session(userId, orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -399,7 +399,7 @@ describe("GET /api/zero/model-providers", () => {
 
     mocks.clerk.session(userId, orgId, "org:admin");
 
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -429,7 +429,7 @@ describe("GET /api/zero/model-providers", () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, orgId);
 
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -458,7 +458,7 @@ describe("GET /api/zero/model-providers", () => {
       sub: "expired",
     });
 
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -494,7 +494,7 @@ describe("GET /api/zero/model-providers", () => {
 
 describe("POST /api/zero/model-providers", () => {
   it("returns 401 when the request is unauthenticated", async () => {
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -512,7 +512,7 @@ describe("POST /api/zero/model-providers", () => {
   it("returns 401 when the authenticated session has no organization", async () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, null);
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -530,7 +530,7 @@ describe("POST /api/zero/model-providers", () => {
   it("returns 403 when the caller is not an org admin", async () => {
     const fixture = uniqueOrgUser("zmp-upsert-member");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -550,7 +550,7 @@ describe("POST /api/zero/model-providers", () => {
   it("creates and updates an org single-secret provider", async () => {
     const fixture = uniqueOrgUser("zmp-upsert-single");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -597,7 +597,7 @@ describe("POST /api/zero/model-providers", () => {
   it("rejects whitespace-only org single-secret provider secrets", async () => {
     const fixture = uniqueOrgUser("zmp-upsert-blank-secret");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -629,7 +629,7 @@ describe("POST /api/zero/model-providers", () => {
   it("creates org-level AWS Bedrock multi-auth provider", async () => {
     const fixture = uniqueOrgUser("zmp-upsert-bedrock");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -680,7 +680,7 @@ describe("POST /api/zero/model-providers", () => {
   it("rejects invalid multi-auth shape for single-secret providers", async () => {
     const fixture = uniqueOrgUser("zmp-upsert-bad-multi");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -701,7 +701,7 @@ describe("POST /api/zero/model-providers", () => {
 
   it("creates an openai-api-key provider by default", async () => {
     const fixture = uniqueOrgUser("zmp-openai");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -732,7 +732,7 @@ describe("POST /api/zero/model-providers", () => {
   it("does not mark provider rows as defaults across frameworks", async () => {
     const fixture = uniqueOrgUser("zmp-cross-framework");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -778,7 +778,7 @@ describe("POST /api/zero/model-providers", () => {
   it("creates a vm0 no-secret org provider", async () => {
     const fixture = uniqueOrgUser("zmp-vm0");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -820,7 +820,7 @@ describe("POST /api/zero/model-providers", () => {
         });
       }),
     );
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -853,7 +853,7 @@ describe("POST /api/zero/model-providers", () => {
   it("handles codex auth_json claim variants through provider upsert", async () => {
     const fixture = uniqueOrgUser("zmp-codex-claims");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -920,7 +920,7 @@ describe("POST /api/zero/model-providers", () => {
   it("returns typed codex auth_json validation errors", async () => {
     const fixture = uniqueOrgUser("zmp-codex-invalid");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -993,7 +993,7 @@ describe("POST /api/zero/model-providers", () => {
   it("returns typed codex auth_json validation errors for token claims", async () => {
     const fixture = uniqueOrgUser("zmp-codex-token-invalid");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -1033,7 +1033,7 @@ describe("POST /api/zero/model-providers", () => {
       exp: Math.floor(now() / 1000) - 60,
       sub: "expired",
     });
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
 
@@ -1090,7 +1090,7 @@ describe("POST /api/zero/model-providers", () => {
 
 describe("DELETE /api/zero/model-providers/:type", () => {
   it("returns 401 when unauthenticated", async () => {
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersByTypeContract,
     );
 
@@ -1105,7 +1105,7 @@ describe("DELETE /api/zero/model-providers/:type", () => {
   it("returns 401 when the authenticated session has no organization", async () => {
     const userId = `user_${randomUUID()}`;
     mocks.clerk.session(userId, null);
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersByTypeContract,
     );
 
@@ -1123,7 +1123,7 @@ describe("DELETE /api/zero/model-providers/:type", () => {
   it("returns 403 for non-admin members", async () => {
     const fixture = uniqueOrgUser("zmp-delete-member");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersByTypeContract,
     );
 
@@ -1143,7 +1143,7 @@ describe("DELETE /api/zero/model-providers/:type", () => {
   it("returns 404 when the target provider is absent", async () => {
     const fixture = uniqueOrgUser("zmp-delete-missing");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const client = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const client = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersByTypeContract,
     );
 
@@ -1161,12 +1161,12 @@ describe("DELETE /api/zero/model-providers/:type", () => {
   it("deletes an org single-secret provider", async () => {
     const fixture = uniqueOrgUser("zmp-delete-legacy");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const mainClient = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const mainClient = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
     const byTypeClient = setupApp({
       context,
-      routes: zeroModelProvidersRoutes,
+      routes: modelProvidersRoutes,
     })(modelProvidersByTypeContract);
 
     await accept(
@@ -1209,12 +1209,12 @@ describe("DELETE /api/zero/model-providers/:type", () => {
   it("deletes a codex auth_json provider", async () => {
     const fixture = uniqueOrgUser("zmp-delete-multiauth");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const mainClient = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const mainClient = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
     const byTypeClient = setupApp({
       context,
-      routes: zeroModelProvidersRoutes,
+      routes: modelProvidersRoutes,
     })(modelProvidersByTypeContract);
 
     await accept(
@@ -1260,12 +1260,12 @@ describe("DELETE /api/zero/model-providers/:type", () => {
   it("does not promote another provider when deleting a provider", async () => {
     const fixture = uniqueOrgUser("zmp-delete-default");
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
-    const mainClient = setupApp({ context, routes: zeroModelProvidersRoutes })(
+    const mainClient = setupApp({ context, routes: modelProvidersRoutes })(
       modelProvidersMainContract,
     );
     const byTypeClient = setupApp({
       context,
-      routes: zeroModelProvidersRoutes,
+      routes: modelProvidersRoutes,
     })(modelProvidersByTypeContract);
 
     await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -48,7 +48,7 @@ import {
 } from "../../../test-fixtures/chat-events";
 import { chatEventsRoutes } from "../chat-events";
 import { chatThreadRoutes } from "../chat-threads";
-import { zeroModelProvidersRoutes } from "../zero-model-providers";
+import { modelProvidersRoutes } from "../model-providers";
 import { workflowAutomationsRoutes } from "../workflow-automations";
 import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 import { webhooksWorkflowAutomationsRoutes } from "../webhooks-workflow-automations";
@@ -58,7 +58,7 @@ const TEST_APP_ROUTES = Object.freeze([
   ...webhooksWorkflowAutomationsRoutes,
   ...chatEventsRoutes,
   ...chatThreadRoutes,
-  ...zeroModelProvidersRoutes,
+  ...modelProvidersRoutes,
   ...workflowAutomationsRoutes,
 ]);
 
@@ -110,7 +110,7 @@ function chatEventsClient() {
 }
 
 function modelProvidersByTypeClient() {
-  return setupApp({ context, routes: zeroModelProvidersRoutes })(
+  return setupApp({ context, routes: modelProvidersRoutes })(
     modelProvidersByTypeContract,
   );
 }

--- a/turbo/apps/api/src/signals/routes/model-providers.ts
+++ b/turbo/apps/api/src/signals/routes/model-providers.ts
@@ -198,7 +198,7 @@ const deleteModelProviderInner$ = command(
   },
 );
 
-export const zeroModelProvidersRoutes: readonly RouteEntry[] = [
+export const modelProvidersRoutes: readonly RouteEntry[] = [
   {
     route: modelProvidersMainContract.list,
     handler: authRoute(

--- a/turbo/apps/api/src/signals/routes/runs.ts
+++ b/turbo/apps/api/src/signals/routes/runs.ts
@@ -66,7 +66,7 @@ const getRunQueueInner$ = computed(async (get) => {
   return { status: 200 as const, body: queue };
 });
 
-export const zeroRunsRoutes: readonly RouteEntry[] = [
+export const runsRoutes: readonly RouteEntry[] = [
   {
     route: runsQueueContract.getQueue,
     handler: authRoute(runReadAuth, getRunQueueInner$),


### PR DESCRIPTION
## What

Phase 2 naming cleanup under the naming model in #26873, following the `-routes` contract convention recorded on #27432 and the precedent set by #27866 / #27868 / #27870 / #27930.

Renames the two remaining branded API route modules and their single route-registry export each.

| Old | New |
|---|---|
| `routes/zero-runs.ts` | `routes/runs.ts` |
| `zeroRunsRoutes` | `runsRoutes` |
| `routes/zero-model-providers.ts` | `routes/model-providers.ts` |
| `zeroModelProvidersRoutes` | `modelProvidersRoutes` |

Both files move via `git mv` and are recorded as renames (97% / 98% similarity); the only in-file change is the export identifier. All callers — `signals/route.ts` plus 10 test/BDD-helper modules — move with them.

## What this explicitly does NOT touch

- **`packages/api-contracts` — zero files changed.** `git diff --stat` against the package is empty. The contract identifiers these modules import (`runRunnerContract`, `runsByIdContract`, `runsQueueContract`, `modelProvidersMainContract`, `modelProvidersByTypeContract`) had already migrated and are correct as-is.
- **No other route module renamed.** `routes/zero-runs-cancel.ts` was already renamed on `main`; `routes/run-detail.ts` is a separate module. Nothing else in `routes/` moves.
- **`services/zero-runs-create.service.ts` untouched** — still held by open PR #28185 and registered in the #26938 preflight consumer registry.
- **No HTTP path literals** — neither module carries one; the paths live in the contracts package and are already canonical `/api/okou/**`.
- **Registered route order unchanged.** Both spreads in `ROUTES` stay in exactly their original positions (`modelProvidersRoutes` still between `modelProviderGatewayRoutes` and `meModelProvidersDeleteRoutes`; `runsRoutes` still between `runDetailRoutes` and `runsCancelRoutes`), since order affects matching.
- **No behavior change** to run queueing, telemetry, runner assignment or model-provider resolution. No request/response shape or capability string changed (`agent-run:read` is untouched).
- **No compatibility alias or old-path re-export left behind.**

### One deliberate non-change

`services/codex-auth-json-paste-handler.ts:158` keeps its `"api:zero-model-providers"` logger name. That is an operational/telemetry identifier in a service module, not a module specifier — #27432's naming model excludes operational uses, and this PR's non-goals exclude telemetry changes. Likewise the unrelated `packages/db` `test:zero-runs-stage-6` migration script is out of scope.

## Verification

- `pnpm check-types` — 14/14 tasks pass.
- `pnpm knip` — exits 0; no findings reference the renamed modules.
- `prettier --check` on all changed files — clean.
- Repository-wide: `zeroRunsRoutes` and `zeroModelProvidersRoutes` return **0** matches; no `routes/zero-runs` or `routes/zero-model-providers` specifier remains.
- Per repo convention, the full local vitest suite was not run; relying on the PR pipeline.

Closes #28205

🤖 Generated with [Claude Code](https://claude.com/claude-code)