### PR TITLE
fix(runner): reject pre-tls proxy bytes in firewall auth

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -15,7 +15,7 @@ import urllib.request
 from contextlib import suppress
 from dataclasses import dataclass, field
 from email.message import Message
-from typing import NamedTuple, Protocol, cast
+from typing import NamedTuple, Protocol
 
 import h11
 import mitmproxy_rs
@@ -93,10 +93,6 @@ class FirewallAuthApiError(Exception):
 class _AddressResolver(Protocol):
     async def lookup_ip(self, host: str) -> list[str]:
         raise NotImplementedError
-
-
-class _CPythonStreamReader(Protocol):
-    _buffer: bytearray
 
 
 class _ResolvedAddress(NamedTuple):
@@ -384,9 +380,9 @@ async def _abort_connection_attempts(
             _abort_socket(attempt.result())
 
 
-async def _open_connected_stream(
+async def _open_connected_socket(
     addresses: tuple[_ResolvedAddress, ...],
-) -> _ConnectedStream:
+) -> socket.socket:
     if not addresses:
         raise OSError("Firewall auth connection failed")
 
@@ -441,15 +437,7 @@ async def _open_connected_stream(
                 await _abort_connection_attempts(tuple(attempts))
                 attempts.clear()
                 unclaimed_sockets.clear()
-                try:
-                    reader, writer = await asyncio.open_connection(
-                        sock=winner_socket,
-                        limit=_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES,
-                    )
-                except BaseException:
-                    _abort_socket(winner_socket)
-                    raise
-                return _ConnectedStream(reader, writer, winner_socket)
+                return winner_socket
 
             if not attempts:
                 if next_address_index >= len(addresses):
@@ -481,10 +469,25 @@ def _abort_stream(stream: _ConnectedStream) -> None:
         _abort_socket(stream.socket)
 
 
-async def _read_proxy_connect_status(reader: asyncio.StreamReader) -> int:
+async def _read_proxy_connect_status(sock: socket.socket) -> tuple[int, bool]:
+    loop = asyncio.get_running_loop()
+    buffer = bytearray()
     total_header_bytes = 0
     while True:
-        header_block = await reader.readuntil(b"\r\n\r\n")
+        header_end = buffer.find(b"\r\n\r\n")
+        if header_end < 0:
+            remaining_bytes = _MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES - total_header_bytes
+            if len(buffer) > remaining_bytes:
+                raise ValueError("Firewall auth HTTP proxy response headers too large")
+            chunk = await loop.sock_recv(sock, remaining_bytes + 1 - len(buffer))
+            if not chunk:
+                raise asyncio.IncompleteReadError(bytes(buffer), None)
+            buffer.extend(chunk)
+            continue
+
+        header_end += len(b"\r\n\r\n")
+        header_block = bytes(buffer[:header_end])
+        del buffer[:header_end]
         total_header_bytes += len(header_block)
         if total_header_bytes > _MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES:
             raise ValueError("Firewall auth HTTP proxy response headers too large")
@@ -497,12 +500,11 @@ async def _read_proxy_connect_status(reader: asyncio.StreamReader) -> int:
         except ValueError as exc:
             raise ValueError("Invalid firewall auth HTTP proxy response") from exc
         if not _HTTP_STATUS_INFORMATIONAL_MIN <= status < _HTTP_STATUS_SUCCESS_MIN:
-            return status
+            return status, bool(buffer)
 
 
 async def _establish_proxy_tunnel(
-    writer: asyncio.StreamWriter,
-    reader: asyncio.StreamReader,
+    sock: socket.socket,
     plan: _ConnectionPlan,
 ) -> None:
     lines = [
@@ -511,33 +513,37 @@ async def _establish_proxy_tunnel(
     ]
     if plan.proxy_authorization is not None:
         lines.append(f"Proxy-Authorization: {plan.proxy_authorization}")
-    writer.write(("\r\n".join(lines) + "\r\n\r\n").encode("latin-1"))
-    await writer.drain()
-    status = await _read_proxy_connect_status(reader)
+    loop = asyncio.get_running_loop()
+    await loop.sock_sendall(sock, ("\r\n".join(lines) + "\r\n\r\n").encode("latin-1"))
+    status, has_trailing_data = await _read_proxy_connect_status(sock)
     if not _HTTP_STATUS_SUCCESS_MIN <= status < _HTTP_STATUS_REDIRECTION_MIN:
         raise OSError(f"Firewall auth HTTP proxy CONNECT failed with status {status}")
-    cast(asyncio.Transport, writer.transport).pause_reading()
-    # asyncio has no public nonblocking buffer query. Keep this check adjacent to
-    # the caller's start_tls() call so proxy plaintext cannot enter this reader.
-    if cast(_CPythonStreamReader, reader)._buffer:
+    if has_trailing_data:
         raise ValueError("Firewall auth HTTP proxy sent data before TLS")
 
 
 async def _open_stream(plan: _ConnectionPlan) -> _ConnectedStream:
     addresses = await _resolve_addresses(plan.connect_host, plan.connect_port)
-    stream = await _open_connected_stream(addresses)
+    sock = await _open_connected_socket(addresses)
     try:
         if plan.use_proxy_tunnel:
-            await _establish_proxy_tunnel(stream.writer, stream.reader, plan)
+            await _establish_proxy_tunnel(sock, plan)
         if plan.origin_scheme == "https":
-            await stream.writer.start_tls(
-                _get_https_context(),
+            reader, writer = await asyncio.open_connection(
+                sock=sock,
+                limit=_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES,
+                ssl=_get_https_context(),
                 server_hostname=plan.origin_host,
             )
+        else:
+            reader, writer = await asyncio.open_connection(
+                sock=sock,
+                limit=_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES,
+            )
     except BaseException:
-        _abort_stream(stream)
+        _abort_socket(sock)
         raise
-    return stream
+    return _ConnectedStream(reader, writer, sock)
 
 
 def _request_headers(

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -15,7 +15,7 @@ import urllib.request
 from contextlib import suppress
 from dataclasses import dataclass, field
 from email.message import Message
-from typing import NamedTuple, Protocol
+from typing import NamedTuple, Protocol, cast
 
 import h11
 import mitmproxy_rs
@@ -93,6 +93,10 @@ class FirewallAuthApiError(Exception):
 class _AddressResolver(Protocol):
     async def lookup_ip(self, host: str) -> list[str]:
         raise NotImplementedError
+
+
+class _CPythonStreamReader(Protocol):
+    _buffer: bytearray
 
 
 class _ResolvedAddress(NamedTuple):
@@ -512,6 +516,11 @@ async def _establish_proxy_tunnel(
     status = await _read_proxy_connect_status(reader)
     if not _HTTP_STATUS_SUCCESS_MIN <= status < _HTTP_STATUS_REDIRECTION_MIN:
         raise OSError(f"Firewall auth HTTP proxy CONNECT failed with status {status}")
+    cast(asyncio.Transport, writer.transport).pause_reading()
+    # asyncio has no public nonblocking buffer query. Keep this check adjacent to
+    # the caller's start_tls() call so proxy plaintext cannot enter this reader.
+    if cast(_CPythonStreamReader, reader)._buffer:
+        raise ValueError("Firewall auth HTTP proxy sent data before TLS")
 
 
 async def _open_stream(plan: _ConnectionPlan) -> _ConnectedStream:

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -212,20 +212,40 @@ async def _close_test_writer(writer: asyncio.StreamWriter) -> None:
         await writer.wait_closed()
 
 
-async def _write_success_response(
-    writer: asyncio.StreamWriter,
+def _success_response_bytes(
     *,
     headers: dict[str, str] | None = None,
-) -> None:
+) -> bytes:
     body = json.dumps(firewall_auth_success_response(headers or {})).encode()
-    writer.write(
+    return (
         b"HTTP/1.1 200 OK\r\n"
         + f"Content-Length: {len(body)}\r\n".encode("ascii")
         + b"Content-Type: application/json\r\nConnection: close\r\n\r\n"
         + body
     )
+
+
+async def _write_success_response(
+    writer: asyncio.StreamWriter,
+    *,
+    headers: dict[str, str] | None = None,
+) -> None:
+    writer.write(_success_response_bytes(headers=headers))
     await writer.drain()
     await _close_test_writer(writer)
+
+
+async def _relay_test_stream(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    try:
+        with suppress(ConnectionError):
+            while data := await reader.read(64 * 1024):
+                writer.write(data)
+                await writer.drain()
+    finally:
+        await _close_test_writer(writer)
 
 
 async def _trickle_until_peer_disconnect(
@@ -1848,21 +1868,15 @@ class TestFirewallAuthAsyncTransport:
                     "127.0.0.1",
                     origin_port,
                 )
-                client_writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                client_writer.write(
+                    b"HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 Connection Established\r\n\r\n"
+                )
                 await client_writer.drain()
-
-                async def relay(
-                    reader: asyncio.StreamReader,
-                    writer: asyncio.StreamWriter,
-                ) -> None:
-                    while data := await reader.read(64 * 1024):
-                        writer.write(data)
-                        await writer.drain()
 
                 try:
                     await asyncio.gather(
-                        relay(client_reader, origin_writer),
-                        relay(origin_reader, client_writer),
+                        _relay_test_stream(client_reader, origin_writer),
+                        _relay_test_stream(origin_reader, client_writer),
                     )
                 finally:
                     await _close_test_writer(origin_writer)
@@ -1898,3 +1912,88 @@ class TestFirewallAuthAsyncTransport:
         assert origin_requests[0].target == "/api/webhooks/agent/firewall/auth"
         assert origin_requests[0].headers["authorization"] == "Bearer tok-xyz"
         assert "proxy-authorization" not in origin_requests[0].headers
+
+    async def test_https_proxy_connect_rejects_pre_tls_response_bytes(
+        self,
+        mitm_ctx,
+        tmp_path: Path,
+    ):
+        server_context, client_context = _create_tls_contexts(tmp_path)
+        origin_requests: list[_RawHttpRequest] = []
+        proxy_requests: list[_RawHttpRequest] = []
+        proxy_peer_closed = asyncio.Event()
+
+        async def handle_origin(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            origin_requests.append(await _read_raw_http_request(reader))
+            await _write_success_response(writer)
+
+        async with _run_test_server(handle_origin, ssl_context=server_context) as origin_port:
+
+            async def handle_proxy(
+                client_reader: asyncio.StreamReader,
+                client_writer: asyncio.StreamWriter,
+            ) -> None:
+                proxy_requests.append(await _read_raw_http_request(client_reader))
+                origin_reader, origin_writer = await asyncio.open_connection(
+                    "127.0.0.1",
+                    origin_port,
+                )
+                client_writer.write(
+                    b"HTTP/1.1 200 Connection Established\r\n\r\n"
+                    + _success_response_bytes(
+                        headers={"Authorization": "Bearer proxy-forged-token"}
+                    )
+                )
+                await client_writer.drain()
+
+                async def relay_client_to_origin() -> None:
+                    try:
+                        await _relay_test_stream(client_reader, origin_writer)
+                    finally:
+                        proxy_peer_closed.set()
+
+                try:
+                    await asyncio.gather(
+                        relay_client_to_origin(),
+                        _relay_test_stream(origin_reader, client_writer),
+                    )
+                finally:
+                    await _close_test_writer(origin_writer)
+                    await _close_test_writer(client_writer)
+
+            async with _run_test_server(handle_proxy) as proxy_port:
+                proxy_environment = {
+                    "https_proxy": f"http://127.0.0.1:{proxy_port}",
+                    "HTTPS_PROXY": "",
+                    "all_proxy": "",
+                    "ALL_PROXY": "",
+                    "no_proxy": "",
+                    "NO_PROXY": "",
+                }
+                with (
+                    patch.dict(os.environ, proxy_environment),
+                    patch.object(auth_client, "_https_context", client_context),
+                    patch.object(platform_api, "VERCEL_BYPASS", ""),
+                    mitm_ctx(api_url=f"https://localhost:{origin_port}"),
+                    pytest.raises(
+                        ValueError,
+                        match=r"^Firewall auth HTTP proxy sent data before TLS$",
+                    ),
+                ):
+                    await auth_client.fetch_firewall_headers(
+                        firewall_auth_request(
+                            auth_headers={
+                                "Authorization": "Bearer ${{ secrets.TOKEN }}",
+                            }
+                        )
+                    )
+
+                await asyncio.wait_for(proxy_peer_closed.wait(), timeout=2.0)
+
+        assert len(proxy_requests) == 1
+        assert proxy_requests[0].method == "CONNECT"
+        assert proxy_requests[0].target == f"localhost:{origin_port}"
+        assert origin_requests == []

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -43,6 +43,10 @@ _EMPTY_PROXY_ENVIRONMENT = {
 }
 
 
+def _https_proxy_environment(proxy_url: str) -> dict[str, str]:
+    return _EMPTY_PROXY_ENVIRONMENT | {"https_proxy": proxy_url}
+
+
 @dataclass(frozen=True)
 class _RawHttpRequest:
     method: str
@@ -1841,6 +1845,126 @@ class TestFirewallAuthAsyncTransport:
         assert origin.request_count == 1
         assert proxy.request_count == 0
 
+    async def test_https_proxy_connect_failure_preserves_status_with_response_body(
+        self,
+        mitm_ctx,
+    ):
+        proxy_requests: list[_RawHttpRequest] = []
+        response_body = b"proxy authentication required"
+
+        async def handle_proxy(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            proxy_requests.append(await _read_raw_http_request(reader))
+            writer.write(
+                b"HTTP/1.1 407 Proxy Authentication Required\r\n"
+                + f"Content-Length: {len(response_body)}\r\n\r\n".encode("ascii")
+                + response_body
+            )
+            await writer.drain()
+            await _close_test_writer(writer)
+
+        async with _run_test_server(handle_proxy) as proxy_port:
+            with (
+                patch.dict(
+                    os.environ,
+                    _https_proxy_environment(f"http://127.0.0.1:{proxy_port}"),
+                ),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+                mitm_ctx(api_url="https://platform.example"),
+                pytest.raises(
+                    OSError,
+                    match=r"^Firewall auth HTTP proxy CONNECT failed with status 407$",
+                ) as exc_info,
+            ):
+                await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+        assert len(proxy_requests) == 1
+        assert proxy_requests[0].method == "CONNECT"
+        assert proxy_requests[0].target == "platform.example"
+        assert response_body.decode() not in str(exc_info.value)
+
+    async def test_https_proxy_connect_bounds_response_headers_and_closes_socket(
+        self,
+        mitm_ctx,
+    ):
+        proxy_requests: list[_RawHttpRequest] = []
+        proxy_peer_closed = asyncio.Event()
+
+        async def handle_proxy(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            proxy_requests.append(await _read_raw_http_request(reader))
+            writer.write(
+                b"HTTP/1.1 100 Continue\r\nX-Fill: "
+                + b"x" * auth_client._MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES
+            )
+            with suppress(ConnectionError):
+                await writer.drain()
+            with suppress(ConnectionResetError):
+                while await reader.read(64 * 1024):
+                    pass
+            proxy_peer_closed.set()
+            await _close_test_writer(writer)
+
+        async with _run_test_server(handle_proxy) as proxy_port:
+            with (
+                patch.dict(
+                    os.environ,
+                    _https_proxy_environment(f"http://127.0.0.1:{proxy_port}"),
+                ),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+                mitm_ctx(api_url="https://platform.example"),
+                pytest.raises(
+                    ValueError,
+                    match=r"^Firewall auth HTTP proxy response headers too large$",
+                ),
+            ):
+                await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+            await asyncio.wait_for(proxy_peer_closed.wait(), timeout=2.0)
+
+        assert len(proxy_requests) == 1
+        assert proxy_requests[0].method == "CONNECT"
+        assert proxy_requests[0].target == "platform.example"
+
+    async def test_total_deadline_aborts_stalled_https_proxy_connect(
+        self,
+        mitm_ctx,
+    ):
+        connect_received = asyncio.Event()
+        proxy_peer_closed = asyncio.Event()
+
+        async def handle_proxy(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            await _read_raw_http_request(reader)
+            connect_received.set()
+            with suppress(ConnectionResetError):
+                while await reader.read(64 * 1024):
+                    pass
+            proxy_peer_closed.set()
+            await _close_test_writer(writer)
+
+        async with _run_test_server(handle_proxy) as proxy_port:
+            with (
+                patch.dict(
+                    os.environ,
+                    _https_proxy_environment(f"http://127.0.0.1:{proxy_port}"),
+                ),
+                patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.1),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+                mitm_ctx(api_url="https://platform.example"),
+                pytest.raises(auth_client.FirewallAuthDeadlineExceededError),
+            ):
+                await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+            await asyncio.wait_for(connect_received.wait(), timeout=2.0)
+            await asyncio.wait_for(proxy_peer_closed.wait(), timeout=2.0)
+
     async def test_https_proxy_connect_preserves_origin_tls_and_isolates_credentials(
         self,
         mitm_ctx,
@@ -1884,16 +2008,8 @@ class TestFirewallAuthAsyncTransport:
 
             async with _run_test_server(handle_proxy) as proxy_port:
                 proxy_url = f"http://proxy-user:proxy-password@127.0.0.1:{proxy_port}"
-                proxy_environment = {
-                    "https_proxy": proxy_url,
-                    "HTTPS_PROXY": "",
-                    "all_proxy": "",
-                    "ALL_PROXY": "",
-                    "no_proxy": "",
-                    "NO_PROXY": "",
-                }
                 with (
-                    patch.dict(os.environ, proxy_environment),
+                    patch.dict(os.environ, _https_proxy_environment(proxy_url)),
                     patch.object(auth_client, "_https_context", client_context),
                     patch.object(platform_api, "VERCEL_BYPASS", ""),
                     mitm_ctx(api_url=f"https://localhost:{origin_port}"),
@@ -1965,16 +2081,11 @@ class TestFirewallAuthAsyncTransport:
                     await _close_test_writer(client_writer)
 
             async with _run_test_server(handle_proxy) as proxy_port:
-                proxy_environment = {
-                    "https_proxy": f"http://127.0.0.1:{proxy_port}",
-                    "HTTPS_PROXY": "",
-                    "all_proxy": "",
-                    "ALL_PROXY": "",
-                    "no_proxy": "",
-                    "NO_PROXY": "",
-                }
                 with (
-                    patch.dict(os.environ, proxy_environment),
+                    patch.dict(
+                        os.environ,
+                        _https_proxy_environment(f"http://127.0.0.1:{proxy_port}"),
+                    ),
                     patch.object(auth_client, "_https_context", client_context),
                     patch.object(platform_api, "VERCEL_BYPASS", ""),
                     mitm_ctx(api_url=f"https://localhost:{origin_port}"),


### PR DESCRIPTION
## Summary

- establish HTTPS proxy CONNECT on the connected raw socket before creating an asyncio stream
- parse informational and final CONNECT responses with an explicit bounded buffer and reject bytes over-read after an accepted 2xx
- create the TLS stream only after the plaintext CONNECT phase completes, so proxy plaintext can never enter the origin response reader
- preserve non-2xx CONNECT status errors, the total request deadline, address racing, and socket cleanup

## Scope

- does not change API, queue, persisted-state, runner/backend protocol, dependency, or proxy configuration contracts

## Testing

- focused HTTPS proxy CONNECT integration tests (5 passed)
- `python -m pytest tests/test_firewall_auth_client.py` (94 passed)
- `uv lock --check`
- `uv sync --locked`
- `ruff format --check .`
- `ruff check .`
- `basedpyright -p .`
- `python -m pytest tests/` (6372 passed)

Closes #28129
