### PR TITLE
refactor(contracts): neutralize connector catalog contract naming

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
 
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogListResponse,
   type PublicConnectorCatalogStatusResponse,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import { zeroFeatureSwitchesContract } from "@okouai/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { createStore } from "ccstate";
@@ -165,7 +165,7 @@ describe("GET /api/zero/connector-catalog", () => {
 
   it("returns 401 when not authenticated", async () => {
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(client.list({ headers: {} }), [401]);
 
@@ -176,7 +176,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(`user_${randomUUID()}`, null);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.list({ headers: { authorization: "Bearer clerk-session" } }),
@@ -190,7 +190,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.list({ headers: { authorization: "Bearer clerk-session" } }),
@@ -208,7 +208,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.list({ headers: { authorization: "Bearer clerk-session" } }),
@@ -247,7 +247,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const headers = { authorization: "Bearer clerk-session" };
     const listResponse = await accept(client.list({ headers }), [200]);
@@ -302,7 +302,7 @@ describe("GET /api/zero/connector-catalog", () => {
     });
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.list({ headers: { authorization: `Bearer ${token}` } }),
@@ -334,7 +334,7 @@ describe("GET /api/zero/connector-catalog", () => {
     });
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.list({ headers: { authorization: `Bearer ${token}` } }),
@@ -349,7 +349,7 @@ describe("GET /api/zero/connector-catalog", () => {
 
   it("returns 401 for diagnostics when not authenticated", async () => {
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(client.diagnostics({ headers: {} }), [401]);
 
@@ -360,7 +360,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(`user_${randomUUID()}`, null);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.diagnostics({
@@ -394,7 +394,7 @@ describe("GET /api/zero/connector-catalog", () => {
     });
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.diagnostics({
@@ -410,7 +410,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.diagnostics({
@@ -435,7 +435,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.diagnostics({
@@ -465,7 +465,7 @@ describe("GET /api/zero/connector-catalog", () => {
 
   it("returns 401 for catalog status when not authenticated", async () => {
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(client.status({ headers: {} }), [401]);
 
@@ -476,7 +476,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(`user_${randomUUID()}`, null);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.status({ headers: { authorization: "Bearer clerk-session" } }),
@@ -490,7 +490,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.discovery({
@@ -512,7 +512,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const headers = { authorization: "Bearer clerk-session" };
     const featured = await accept(
@@ -571,7 +571,7 @@ describe("GET /api/zero/connector-catalog", () => {
     });
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.status({ headers: { authorization: `Bearer ${token}` } }),
@@ -590,7 +590,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.status({ headers: { authorization: "Bearer clerk-session" } }),
@@ -650,7 +650,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.status({ headers: { authorization: "Bearer clerk-session" } }),
@@ -692,7 +692,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.status({ headers: { authorization: "Bearer clerk-session" } }),
@@ -733,7 +733,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.status({ headers: { authorization: "Bearer clerk-session" } }),
@@ -774,7 +774,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.status({ headers: { authorization: "Bearer clerk-session" } }),
@@ -807,7 +807,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.get({
@@ -840,7 +840,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.get({
@@ -870,7 +870,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.get({
@@ -905,7 +905,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const listResponse = await accept(
       client.list({ headers: { authorization: "Bearer clerk-session" } }),
@@ -930,7 +930,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.get({
@@ -951,7 +951,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const connectorSlug = "x".repeat(65);
     const detailResponse = await accept(
@@ -982,7 +982,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.get({
@@ -1022,7 +1022,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.get({
@@ -1049,7 +1049,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.get({
@@ -1073,7 +1073,7 @@ describe("GET /api/zero/connector-catalog", () => {
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const response = await accept(
       client.permissions({

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
@@ -5,7 +5,7 @@ import {
   zeroConnectorOpenIdStartContract,
   zeroConnectorsBySlugContract,
 } from "@okouai/api-contracts/contracts/zero-connectors";
-import { zeroConnectorCatalogContract } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import { connectorCatalogContract } from "@okouai/api-contracts/contracts/connector-catalog";
 import { steamPlayerContract } from "@okouai/api-contracts/contracts/steam-player";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
@@ -315,7 +315,7 @@ describe("Steam OpenID connector", () => {
     mockSession(actor);
 
     const client = setupApp({ context, routes: connectorCatalogRoutes })(
-      zeroConnectorCatalogContract,
+      connectorCatalogContract,
     );
     const visible = await accept(
       client.status({ headers: authHeaders() }),

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -14,7 +14,7 @@ import {
   zeroConnectorOpenIdStartContract,
   zeroConnectorsSearchContract,
 } from "@okouai/api-contracts/contracts/zero-connectors";
-import { zeroConnectorCatalogContract } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import { connectorCatalogContract } from "@okouai/api-contracts/contracts/connector-catalog";
 import { connectorCheckContract } from "@okouai/api-contracts/contracts/connector-check";
 import { zeroFeatureSwitchesContract } from "@okouai/api-contracts/contracts/zero-feature-switches";
 import { zeroUserPermissionGrantsContract } from "@okouai/api-contracts/contracts/zero-user-permission-grants";
@@ -1393,7 +1393,7 @@ function cronClient() {
 
 function diagnosticsClient() {
   return setupApp({ context, routes: connectorCatalogRoutes })(
-    zeroConnectorCatalogContract,
+    connectorCatalogContract,
   );
 }
 
@@ -1718,7 +1718,7 @@ describe("connector catalog valid lifecycle", () => {
     const callsBeforePublicCatalog = context.mocks.s3.send.mock.calls.length;
     const publicCatalog = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -1752,7 +1752,7 @@ describe("connector catalog valid lifecycle", () => {
     const catalogClient = setupApp({
       context,
       routes: connectorCatalogRoutes,
-    })(zeroConnectorCatalogContract);
+    })(connectorCatalogContract);
     const searchClient = setupApp({ context, routes: connectorsRoutes })(
       zeroConnectorsSearchContract,
     );
@@ -1913,7 +1913,7 @@ describe("connector catalog valid lifecycle", () => {
     zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
     const response = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).permissions({
         params: { connectorSlug: release.connectorSlug },
         headers: { authorization: "Bearer clerk-session" },
@@ -1938,7 +1938,7 @@ describe("connector catalog valid lifecycle", () => {
     const catalogClient = setupApp({
       context,
       routes: connectorCatalogRoutes,
-    })(zeroConnectorCatalogContract);
+    })(connectorCatalogContract);
     const callsBeforePublicReads = context.mocks.s3.send.mock.calls.length;
 
     const [list, detail] = await Promise.all([
@@ -1976,7 +1976,7 @@ describe("connector catalog valid lifecycle", () => {
     zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
     const digestResponse = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -1997,7 +1997,7 @@ describe("connector catalog valid lifecycle", () => {
     });
     const jsonResponse = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -2024,7 +2024,7 @@ describe("connector catalog valid lifecycle", () => {
     });
     const identityResponse = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -2045,7 +2045,7 @@ describe("connector catalog valid lifecycle", () => {
     });
     const nonObjectResponse = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -2069,7 +2069,7 @@ describe("connector catalog valid lifecycle", () => {
     });
     const schemaResponse = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -2092,7 +2092,7 @@ describe("connector catalog valid lifecycle", () => {
     });
     const shapeResponse = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -2122,7 +2122,7 @@ describe("connector catalog valid lifecycle", () => {
     zeroMocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
     const semanticResponse = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -2145,7 +2145,7 @@ describe("connector catalog valid lifecycle", () => {
     expect(corruptedEvaluations).toHaveLength(1);
     const compatibilityResponse = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -2165,7 +2165,7 @@ describe("connector catalog valid lifecycle", () => {
     expect(remainingEvaluations).toHaveLength(0);
     const missingResponse = await accept(
       setupApp({ context, routes: connectorCatalogRoutes })(
-        zeroConnectorCatalogContract,
+        connectorCatalogContract,
       ).list({
         headers: { authorization: "Bearer clerk-session" },
       }),
@@ -2237,7 +2237,7 @@ describe("connector catalog valid lifecycle", () => {
     const catalogClient = setupApp({
       context,
       routes: connectorCatalogRoutes,
-    })(zeroConnectorCatalogContract);
+    })(connectorCatalogContract);
     const featureClient = setupApp({
       context,
       routes: featureSwitchesRoutes,
@@ -4434,7 +4434,7 @@ describe("connector catalog valid lifecycle", () => {
     const catalogClient = setupApp({
       context,
       routes: connectorCatalogRoutes,
-    })(zeroConnectorCatalogContract);
+    })(connectorCatalogContract);
     const connected = await accept(catalogClient.status({ headers }), [200]);
     expect(connected.body.connectors[0]).toMatchObject({
       slug: "datadog",
@@ -4495,7 +4495,7 @@ describe("connector catalog valid lifecycle", () => {
     const catalogClient = setupApp({
       context,
       routes: connectorCatalogRoutes,
-    })(zeroConnectorCatalogContract);
+    })(connectorCatalogContract);
     const headers = { authorization: "Bearer clerk-session" };
 
     const catalogResponse = await accept(
@@ -5286,7 +5286,7 @@ describe("connector catalog executable compatibility", () => {
     const catalogClient = setupApp({
       context,
       routes: connectorCatalogRoutes,
-    })(zeroConnectorCatalogContract);
+    })(connectorCatalogContract);
     const beforeReconciliation = await accept(
       catalogClient.list({ headers }),
       [200],
@@ -5529,7 +5529,7 @@ describe("connector catalog executable compatibility", () => {
     const catalogClient = setupApp({
       context,
       routes: connectorCatalogRoutes,
-    })(zeroConnectorCatalogContract);
+    })(connectorCatalogContract);
     const featureClient = setupApp({
       context,
       routes: featureSwitchesRoutes,
@@ -5825,7 +5825,7 @@ describe("connector catalog executable compatibility", () => {
     const catalogClient = setupApp({
       context,
       routes: connectorCatalogRoutes,
-    })(zeroConnectorCatalogContract);
+    })(connectorCatalogContract);
     const headers = { authorization: "Bearer clerk-session" };
     expect(
       (await accept(catalogClient.list({ headers }), [200])).body,

--- a/turbo/apps/api/src/signals/routes/connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/connector-catalog.ts
@@ -1,4 +1,4 @@
-import { zeroConnectorCatalogContract } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import { connectorCatalogContract } from "@okouai/api-contracts/contracts/connector-catalog";
 import { getAllFeatureStates } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { command } from "ccstate";
@@ -145,7 +145,7 @@ const listConnectorCatalogStatusInner$ = command(
 const discoverConnectorCatalogInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
-    const query = get(queryOf(zeroConnectorCatalogContract.discovery));
+    const query = get(queryOf(connectorCatalogContract.discovery));
     const context = await set(connectorCatalogRequestContext$);
     signal.throwIfAborted();
     if (!context.featureStates[FeatureSwitchKey.ConnectorDiscovery]) {
@@ -216,7 +216,7 @@ const getConnectorCatalogInner$ = command(
     }
     signal.throwIfAborted();
 
-    const params = get(pathParamsOf(zeroConnectorCatalogContract.get));
+    const params = get(pathParamsOf(connectorCatalogContract.get));
     const connector = await settleConnectorCatalogRead(
       getPublicConnectorCatalogStatus({
         db: context.db,
@@ -242,7 +242,7 @@ const getConnectorCatalogPermissionsInner$ = command(
     const context = await set(connectorCatalogRequestContext$);
     signal.throwIfAborted();
 
-    const params = get(pathParamsOf(zeroConnectorCatalogContract.permissions));
+    const params = get(pathParamsOf(connectorCatalogContract.permissions));
     const permissions = await settleConnectorCatalogRead(
       getPublicConnectorCatalogPermissionDetail({
         db: context.db,
@@ -264,30 +264,30 @@ const getConnectorCatalogPermissionsInner$ = command(
 
 export const connectorCatalogRoutes: readonly RouteEntry[] = [
   {
-    route: zeroConnectorCatalogContract.list,
+    route: connectorCatalogContract.list,
     handler: authRoute(connectorCatalogAuth, listConnectorCatalogInner$),
   },
   {
-    route: zeroConnectorCatalogContract.status,
+    route: connectorCatalogContract.status,
     handler: authRoute(connectorCatalogAuth, listConnectorCatalogStatusInner$),
   },
   {
-    route: zeroConnectorCatalogContract.discovery,
+    route: connectorCatalogContract.discovery,
     handler: authRoute(connectorCatalogAuth, discoverConnectorCatalogInner$),
   },
   {
-    route: zeroConnectorCatalogContract.diagnostics,
+    route: connectorCatalogContract.diagnostics,
     handler: authRoute(
       connectorCatalogDiagnosticsAuth,
       getConnectorCatalogDiagnosticsInner$,
     ),
   },
   {
-    route: zeroConnectorCatalogContract.get,
+    route: connectorCatalogContract.get,
     handler: authRoute(connectorCatalogAuth, getConnectorCatalogInner$),
   },
   {
-    route: zeroConnectorCatalogContract.permissions,
+    route: connectorCatalogContract.permissions,
     handler: authRoute(
       connectorCatalogAuth,
       getConnectorCatalogPermissionsInner$,

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -9,7 +9,7 @@ import {
   zeroConnectorsMainContract,
   zeroConnectorsSearchContract,
 } from "@okouai/api-contracts/contracts/zero-connectors";
-import type { PublicConnectorCatalogDetail } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogDetail } from "@okouai/api-contracts/contracts/connector-catalog";
 import { connectorOauthStates } from "@okouai/db/schema/connector-oauth-state";
 
 import { authContext$, organizationAuthContext$ } from "../auth/auth-context";

--- a/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-action-resolver.service.ts
@@ -6,7 +6,7 @@ import type {
 import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogDetail,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import type { ConnectorAuthMethodRuntimeConfig } from "@okouai/connectors/connector-config";
 
 import { logger } from "../../lib/log";

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -14,7 +14,7 @@ import type {
   PublicConnectorCatalogPermissionSummary,
   PublicConnectorCatalogStatusItem,
   PublicConnectorCatalogStatusResponse,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   connectorCatalogActiveSnapshot,
   connectorCatalogCompatibilityEvaluation,

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -5,7 +5,7 @@ import type {
   PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogStatusItem,
   PublicConnectorCatalogStatusResponse,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 
 import type { ReadonlyDb } from "../external/db";
 import type { ConnectorFeatureStates } from "./connector-catalog-feature-states";

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -5,7 +5,7 @@ import type {
 import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogDetail,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   getConnectorAuthProviderRegistrationCapabilities,
   type ConnectorAuthProviderRegistrationCapability,

--- a/turbo/apps/cli/src/commands/__tests__/helpers/connector-catalog.ts
+++ b/turbo/apps/cli/src/commands/__tests__/helpers/connector-catalog.ts
@@ -6,7 +6,7 @@ import type {
   PublicConnectorCatalogManualField,
   PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 
 function permissionSummary(): PublicConnectorCatalogStatusItem["permissionSummary"] {
   return {

--- a/turbo/apps/cli/src/commands/connector/public-catalog.ts
+++ b/turbo/apps/cli/src/commands/connector/public-catalog.ts
@@ -1,4 +1,4 @@
-import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { ConnectorCatalogStatus } from "../../lib/api/domains/connectors";
 
 export type PublicConnectorStatus = ConnectorCatalogStatus;

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -9,12 +9,12 @@ import {
   zeroConnectorsMainContract,
 } from "@okouai/api-contracts/contracts/zero-connectors";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogListResponse,
   type PublicConnectorCatalogPermissionDetail,
   type PublicConnectorCatalogStatusItem,
   type PublicConnectorCatalogStatusResponse,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   connectorCheckContract,
   type ConnectorCheckDiagnosticResult,
@@ -68,7 +68,7 @@ export async function listConnectors(): Promise<ZeroConnectorListResponse> {
 
 export async function listConnectorCatalog(): Promise<ZeroConnectorCatalogListResponse> {
   const config = await getClientConfig();
-  const client = initClient(zeroConnectorCatalogContract, config);
+  const client = initClient(connectorCatalogContract, config);
 
   const result = await client.list({ headers: {} });
 
@@ -81,7 +81,7 @@ export async function listConnectorCatalog(): Promise<ZeroConnectorCatalogListRe
 
 export async function listConnectorCatalogStatus(): Promise<ZeroConnectorCatalogStatusResponse> {
   const config = await getClientConfig();
-  const client = initClient(zeroConnectorCatalogContract, config);
+  const client = initClient(connectorCatalogContract, config);
 
   const result = await client.status({ headers: {} });
 
@@ -96,7 +96,7 @@ export async function getConnectorCatalogPermissions(
   connectorSlug: string,
 ): Promise<ConnectorCatalogPermissionDetail | null> {
   const config = await getClientConfig();
-  const client = initClient(zeroConnectorCatalogContract, config);
+  const client = initClient(connectorCatalogContract, config);
 
   const result = await client.permissions({
     params: { connectorSlug },

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -7,7 +7,7 @@ import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogItem,
   PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -9,13 +9,13 @@ import type {
   ConnectorResponse,
 } from "@okouai/api-contracts/contracts/connector-schemas";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogAuthMethodDetail,
   type PublicConnectorCatalogConnection,
   type PublicConnectorCatalogConnectionStatus,
   type PublicConnectorCatalogPermissionDetail,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   zeroConnectorExternalCodeSessionContract,
   zeroConnectorManualGrantContract,
@@ -313,7 +313,7 @@ export const apiConnectorsHandlers = [
     });
   }),
 
-  mockApi(zeroConnectorCatalogContract.status, ({ respond }) => {
+  mockApi(connectorCatalogContract.status, ({ respond }) => {
     const connectors = mockConnectorCatalogStatus();
     return respond(200, {
       connectors,
@@ -321,7 +321,7 @@ export const apiConnectorsHandlers = [
     });
   }),
 
-  mockApi(zeroConnectorCatalogContract.discovery, ({ query, respond }) => {
+  mockApi(connectorCatalogContract.discovery, ({ query, respond }) => {
     const allConnectors = mockConnectorCatalogStatus();
     const keyword = query.keyword?.trim().toLowerCase();
     const connectors = keyword
@@ -345,7 +345,7 @@ export const apiConnectorsHandlers = [
     return respond(200, { connectors: [] });
   }),
 
-  mockApi(zeroConnectorCatalogContract.diagnostics, ({ respond }) => {
+  mockApi(connectorCatalogContract.diagnostics, ({ respond }) => {
     return respond(200, {
       state: "stale",
       active: {
@@ -389,7 +389,7 @@ export const apiConnectorsHandlers = [
 
   // Keep this parameterized route after the static /diagnostics route so the
   // mock server does not interpret "diagnostics" as a connector slug.
-  mockApi(zeroConnectorCatalogContract.get, ({ params, respond }) => {
+  mockApi(connectorCatalogContract.get, ({ params, respond }) => {
     const connector = mockConnectorCatalogStatus().find((candidate) => {
       return candidate.slug === params.connectorSlug;
     });
@@ -401,7 +401,7 @@ export const apiConnectorsHandlers = [
     return respond(200, { connector });
   }),
 
-  mockApi(zeroConnectorCatalogContract.permissions, ({ params, respond }) => {
+  mockApi(connectorCatalogContract.permissions, ({ params, respond }) => {
     const permissions = mockPermissionDetail(params.connectorSlug);
     if (!permissions) {
       return respond(404, {

--- a/turbo/apps/platform/src/mocks/handlers/connector-catalog-fixtures.ts
+++ b/turbo/apps/platform/src/mocks/handlers/connector-catalog-fixtures.ts
@@ -4,7 +4,7 @@ import type {
   PublicConnectorCatalogIcon,
   PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogPermissionSummary,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import type {
   ConnectorAuthMethodId,
   ConnectorSlug,

--- a/turbo/apps/platform/src/signals/connector-domain.ts
+++ b/turbo/apps/platform/src/signals/connector-domain.ts
@@ -2,7 +2,7 @@ import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connecto
 import type {
   PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import type { UserPermissionGrantResponse } from "@okouai/api-contracts/contracts/zero-user-permission-grants";
 import type {
   WorkflowConnectorReadinessEntry,

--- a/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-callback-page-setup.ts
@@ -6,7 +6,7 @@ import { zeroCustomConnectorOAuth2Contract } from "@okouai/api-contracts/contrac
 import {
   publicConnectorCatalogIconSchema,
   type PublicConnectorCatalogIcon,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import { CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY } from "@okouai/connectors/app-oauth-callback";
 import {
   connectorSlugSchema,

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting-page-setup.ts
@@ -5,7 +5,7 @@ import {
 import {
   publicConnectorCatalogIconSchema,
   type PublicConnectorCatalogIcon,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import { command } from "ccstate";
 import { createElement } from "react";
 import { i18n } from "../../i18n/index.ts";

--- a/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/connector-redirecting.ts
@@ -1,5 +1,5 @@
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
-import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/connector-catalog";
 import { command, computed, state } from "ccstate";
 import { delay } from "signal-timers";
 import { IN_VITEST } from "../../env.ts";

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -4,9 +4,9 @@ import {
   zeroConnectorsBySlugContract,
 } from "@okouai/api-contracts/contracts/zero-connectors";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogStatusResponse,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { zeroClient$ } from "../api-client";
@@ -45,7 +45,7 @@ export const connectorCatalogStatus$ = computed(async (get) => {
   get(featureSwitch$);
 
   const createClient = get(zeroClient$);
-  const client = createClient(zeroConnectorCatalogContract);
+  const client = createClient(connectorCatalogContract);
   const result = await accept(client.status(), [200]);
   return result.body;
 });
@@ -71,7 +71,7 @@ export function relatedConnectorCatalog(
     get(connectorsReloadVersion$);
     const keyword = get(keyword$).trim();
     const createClient = get(zeroClient$);
-    const client = createClient(zeroConnectorCatalogContract);
+    const client = createClient(connectorCatalogContract);
     const result = await accept(
       client.discovery({ query: keyword ? { keyword } : {} }),
       [200],
@@ -93,7 +93,7 @@ export function connectorCatalogItemBySlug(
     }
 
     const createClient = get(zeroClient$);
-    const client = createClient(zeroConnectorCatalogContract);
+    const client = createClient(connectorCatalogContract);
     const result = await accept(
       client.get({ params: { connectorSlug } }),
       [200, 404],

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -1,6 +1,6 @@
 import { computed, type Computed } from "ccstate";
 import { connectorSlugSchema } from "@okouai/api-contracts/contracts/connector-identity";
-import { zeroConnectorCatalogContract } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import { connectorCatalogContract } from "@okouai/api-contracts/contracts/connector-catalog";
 import { accept } from "../lib/accept.ts";
 import { zeroClient$ } from "./api-client.ts";
 import type { PlatformConnectorPermissionMetadata } from "./connector-domain.ts";
@@ -23,7 +23,7 @@ export function firewallPermissionMetadataByConnector(
     get(featureSwitch$);
 
     const createClient = get(zeroClient$);
-    const client = createClient(zeroConnectorCatalogContract);
+    const client = createClient(connectorCatalogContract);
     const result = await accept(
       client.permissions({
         params: { connectorSlug: key },

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-catalog-diagnostics.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-catalog-diagnostics.ts
@@ -1,5 +1,5 @@
 import type { ConnectorCatalogDiagnostics } from "@okouai/api-contracts/contracts/connector-catalog-diagnostics";
-import { zeroConnectorCatalogContract } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import { connectorCatalogContract } from "@okouai/api-contracts/contracts/connector-catalog";
 import { command, computed, state } from "ccstate";
 
 import { accept } from "../../../lib/accept.ts";
@@ -17,7 +17,7 @@ export const connectorCatalogDiagnostics$ = computed(
   async (get): Promise<ConnectorCatalogDiagnostics | null> => {
     get(internalConnectorCatalogDiagnosticsReload$);
     const createClient = get(zeroClient$);
-    const client = createClient(zeroConnectorCatalogContract);
+    const client = createClient(connectorCatalogContract);
     const result = await accept(client.diagnostics(), [200, 403, 404]);
 
     return result.status === 200 ? result.body : null;

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
@@ -1,5 +1,5 @@
 import { command, computed, state } from "ccstate";
-import type { PublicConnectorCatalogCategoryMetadata } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogCategoryMetadata } from "@okouai/api-contracts/contracts/connector-catalog";
 
 export interface ConnectorCategorySection<T> {
   category: string;

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -34,7 +34,7 @@ import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogConnectionStatus,
   PublicConnectorCatalogIcon,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   connectors$,
   deleteConnector$,

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -13,9 +13,9 @@ import {
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type { UserMessageDocument } from "@okouai/api-contracts/contracts/chat-threads";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   zeroConnectorManualGrantContract,
   zeroConnectorOauthStartContract,
@@ -171,7 +171,7 @@ function mockGithubCatalogItem(
     singleAuthCodeAuthMethodId: "oauth",
     connectNotice: null,
   };
-  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+  context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
     return respond(200, { connectors: [github] });
   });
 }
@@ -440,7 +440,7 @@ describe("onboarding flow", () => {
 
   it("allows draft creation before required connectors are connected", async () => {
     mockOnboardingNeeded();
-    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
       return respond(200, { connectors: [] });
     });
     detachedSetupPage({

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -3,9 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { chatEventsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { zeroAgentsByIdContract } from "@okouai/api-contracts/contracts/zero-agents";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogPermissionDetail,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   zeroUserPermissionGrantsContract,
   type UserPermissionGrantResponse,
@@ -91,7 +91,7 @@ describe("permission allow page", () => {
       });
     });
     context.mocks.api(
-      zeroConnectorCatalogContract.permissions,
+      connectorCatalogContract.permissions,
       ({ params, respond }) => {
         expect(params.connectorSlug).toBe("slack");
         return respond(200, {
@@ -215,14 +215,11 @@ describe("permission allow page", () => {
         visibility: "public",
       });
     });
-    context.mocks.api(
-      zeroConnectorCatalogContract.permissions,
-      ({ respond }) => {
-        return respond(404, {
-          error: { message: "Connector not found", code: "NOT_FOUND" },
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.permissions, ({ respond }) => {
+      return respond(404, {
+        error: { message: "Connector not found", code: "NOT_FOUND" },
+      });
+    });
 
     detachedSetupPage({
       context,
@@ -503,7 +500,7 @@ describe("permission allow page", () => {
       });
     });
     context.mocks.api(
-      zeroConnectorCatalogContract.permissions,
+      connectorCatalogContract.permissions,
       ({ params, respond }) => {
         expect(params.connectorSlug).toBe("slack");
         return respond(200, {

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -2,11 +2,11 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogPermissionDetail,
   type PublicConnectorCatalogPermissionSummary,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   chatThreadByIdContract,
   chatThreadEventsContract,
@@ -1291,7 +1291,7 @@ describe("team page navigation", () => {
 
   it("hides connector permission management when catalog status has no permissions", async () => {
     mockTeamAPIs();
-    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
       return respond(200, {
         connectors: [
           axiomCatalogStatusItem({
@@ -1424,27 +1424,24 @@ describe("team page navigation", () => {
       }),
       { name: "memberships.read" },
     ];
-    context.mocks.api(
-      zeroConnectorCatalogContract.permissions,
-      ({ respond }) => {
-        const permissions = {
-          connectorSlug: "cloudflare",
-          label: "Cloudflare",
-          icon: {
-            url: "https://icons.example.test/cloudflare.svg",
-            invertInDarkMode: false,
-          },
-          permissionCount: paginatedPermissions.length,
-          permissions: paginatedPermissions,
-          categories: null,
-          defaultPolicy: {
-            permissionDefault: "allow",
-            unknownPolicy: "deny",
-          },
-        } satisfies PublicConnectorCatalogPermissionDetail;
-        return respond(200, { permissions });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.permissions, ({ respond }) => {
+      const permissions = {
+        connectorSlug: "cloudflare",
+        label: "Cloudflare",
+        icon: {
+          url: "https://icons.example.test/cloudflare.svg",
+          invertInDarkMode: false,
+        },
+        permissionCount: paginatedPermissions.length,
+        permissions: paginatedPermissions,
+        categories: null,
+        defaultPolicy: {
+          permissionDefault: "allow",
+          unknownPolicy: "deny",
+        },
+      } satisfies PublicConnectorCatalogPermissionDetail;
+      return respond(200, { permissions });
+    });
     const capturedApplies: ApplyUserPermissionGrantsRequest[] = [];
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
       return respond(200, []);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-connector-connect.test.tsx
@@ -1,9 +1,9 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   zeroCustomConnectorValuesContract,
   zeroCustomConnectorsContract,
@@ -191,7 +191,7 @@ function mcpCustomConnector(
 function mockCatalog(
   connectors: readonly PublicConnectorCatalogStatusItem[],
 ): void {
-  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+  context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
     return respond(200, { connectors: [...connectors] });
   });
 }
@@ -773,7 +773,7 @@ describe("chat composer connector connection", () => {
     const discoveryKeywords: (string | undefined)[] = [];
     let fullCatalogRequests = 0;
     context.mocks.api(
-      zeroConnectorCatalogContract.discovery,
+      connectorCatalogContract.discovery,
       ({ query, respond }) => {
         discoveryKeywords.push(query.keyword);
         return respond(200, {
@@ -782,7 +782,7 @@ describe("chat composer connector connection", () => {
         });
       },
     );
-    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
       fullCatalogRequests += 1;
       return respond(200, { connectors: [github, axiom] });
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -19,9 +19,9 @@ import { zeroAgentsByIdContract } from "@okouai/api-contracts/contracts/zero-age
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import { zeroAgentCustomConnectorsContract } from "@okouai/api-contracts/contracts/zero-agent-custom-connectors";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import { zeroUserPermissionGrantsContract } from "@okouai/api-contracts/contracts/zero-user-permission-grants";
 import { claudeCodeDeviceAuthContract } from "@okouai/api-contracts/contracts/claude-code-device-auth";
 import { codexDeviceAuthContract } from "@okouai/api-contracts/contracts/codex-device-auth";
@@ -3145,7 +3145,7 @@ describe("chat composer models", () => {
       },
     );
     context.mocks.api(
-      zeroConnectorCatalogContract.discovery,
+      connectorCatalogContract.discovery,
       async ({ respond, withSignal }) => {
         discoveryRequestCount += 1;
         if (discoveryRequestCount > 1) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-event-action-cards.test.tsx
@@ -12,10 +12,10 @@ import {
 import { zeroAgentsByIdContract } from "@okouai/api-contracts/contracts/zero-agents";
 import { mailContract } from "@okouai/api-contracts/contracts/mail";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogPermissionDetail,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import {
   zeroAgentCustomConnectorsContract,
@@ -156,7 +156,7 @@ function mockConnectorCatalogStatus(
 ): void {
   // Register the dynamic slug route first so the subsequently registered
   // static /status route takes precedence in runtime MSW handlers.
-  context.mocks.api(zeroConnectorCatalogContract.get, ({ params, respond }) => {
+  context.mocks.api(connectorCatalogContract.get, ({ params, respond }) => {
     const connector = connectors.find((candidate) => {
       return candidate.slug === params.connectorSlug;
     });
@@ -166,7 +166,7 @@ function mockConnectorCatalogStatus(
           error: { message: "Connector not found", code: "NOT_FOUND" },
         });
   });
-  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+  context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
     return respond(200, { connectors: [...connectors] });
   });
 }
@@ -368,7 +368,7 @@ describe("chat event action cards", () => {
       throw new Error("Catalog request did not start");
     };
     context.mocks.api(
-      zeroConnectorCatalogContract.get,
+      connectorCatalogContract.get,
       async ({ deferred, respond }) => {
         const catalogDeferred = deferred<void>();
         resolveCatalog = () => {
@@ -1321,7 +1321,7 @@ describe("chat event action cards", () => {
         reconnectReason: "authorization_expired_or_revoked",
       }),
     ]);
-    context.mocks.api(zeroConnectorCatalogContract.get, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.get, ({ respond }) => {
       return respond(200, {
         connector: publicConnectorStatusItem({
           slug: "gmail",
@@ -1441,7 +1441,7 @@ describe("chat event action cards", () => {
     });
     context.mocks.browser.open(authWindow);
     context.mocks.data.connectors([]);
-    context.mocks.api(zeroConnectorCatalogContract.get, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.get, ({ respond }) => {
       return respond(200, {
         connector: publicConnectorStatusItem({
           slug: "github",
@@ -1553,7 +1553,7 @@ describe("chat event action cards", () => {
     let connected = false;
     let authorized = false;
     let connectCalls = 0;
-    context.mocks.api(zeroConnectorCatalogContract.get, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.get, ({ respond }) => {
       return respond(200, {
         connector: publicConnectorStatusItem({
           slug: "stripe",
@@ -1747,7 +1747,7 @@ describe("chat event action cards", () => {
         reconnectReason: "authorization_expired_or_revoked",
       }),
     ]);
-    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
       catalogRequests += 1;
       return respond(200, {
         connectors: [
@@ -1989,7 +1989,7 @@ describe("chat event action cards", () => {
     ]);
     mockAgentConnectorAuthorizations([]);
     context.mocks.api(
-      zeroConnectorCatalogContract.permissions,
+      connectorCatalogContract.permissions,
       ({ params, respond }) => {
         expect(params.connectorSlug).toBe("slack");
         return respond(200, {
@@ -2130,7 +2130,7 @@ describe("chat event action cards", () => {
     const capturedPermissionGrantBodies: unknown[] = [];
 
     context.mocks.api(
-      zeroConnectorCatalogContract.permissions,
+      connectorCatalogContract.permissions,
       ({ params, respond }) => {
         expect(params.connectorSlug).toBe("google-sheets");
         return respond(200, {
@@ -2278,23 +2278,20 @@ describe("chat event action cards", () => {
       userMessage?: unknown;
     }[] = [];
 
-    context.mocks.api(
-      zeroConnectorCatalogContract.permissions,
-      ({ respond }) => {
-        return respond(200, {
-          permissions: catalogPermissionDetail({
-            connectorSlug: "slack",
-            label: "Slack",
-            permissions: [
-              {
-                name: "channels.read",
-                description: "Read channels",
-              },
-            ],
-          }),
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.permissions, ({ respond }) => {
+      return respond(200, {
+        permissions: catalogPermissionDetail({
+          connectorSlug: "slack",
+          label: "Slack",
+          permissions: [
+            {
+              name: "channels.read",
+              description: "Read channels",
+            },
+          ],
+        }),
+      });
+    });
     context.mocks.api(
       zeroUserPermissionGrantsContract.apply,
       ({ body, respond }) => {
@@ -2493,14 +2490,14 @@ describe("chat event action cards", () => {
     let connected = false;
     let authorized = false;
     let fullCatalogRequests = 0;
-    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
       fullCatalogRequests += 1;
       return respond(200, { connectors: [] });
     });
-    context.mocks.api(zeroConnectorCatalogContract.discovery, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.discovery, ({ respond }) => {
       return respond(200, { connectors: [], totalConnectorCount: 347 });
     });
-    context.mocks.api(zeroConnectorCatalogContract.get, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.get, ({ respond }) => {
       return respond(200, {
         connector: publicConnectorStatusItem({
           slug: "future-connector",
@@ -2616,14 +2613,11 @@ describe("chat event action cards", () => {
     const threadId = "e4000000-0000-4000-a000-000000000013";
     context.mocks.browser.url(`https://app.vm0.ai/chats/${threadId}`);
     const permissionAuthorizeUrl = `https://app.okou.ai/agents/${AGENT_ID}/permissions?connectorSlug=hidden-connector&permission=hidden.permission&action=allow&expiresIn=1h`;
-    context.mocks.api(
-      zeroConnectorCatalogContract.permissions,
-      ({ respond }) => {
-        return respond(404, {
-          error: { message: "Connector not found", code: "NOT_FOUND" },
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.permissions, ({ respond }) => {
+      return respond(404, {
+        error: { message: "Connector not found", code: "NOT_FOUND" },
+      });
+    });
     mockChatLifecycle(context, {
       threadId,
       threadTitle: "Hidden permission metadata",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/settings-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor, within } from "@testing-library/react";
-import { zeroConnectorCatalogContract } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import { connectorCatalogContract } from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   type UserLocale,
   type UserPreferencesResponse,
@@ -918,41 +918,38 @@ describe("settings dialog", () => {
 
   it("refreshes connector catalog diagnostics on every Debug entry", async () => {
     let requestCount = 0;
-    context.mocks.api(
-      zeroConnectorCatalogContract.diagnostics,
-      ({ respond }) => {
-        requestCount += 1;
-        const requestedAt = "2026-08-19T04:00:00.000Z";
-        return respond(200, {
-          state: "current",
-          active: {
-            catalogVersion: `2026-08-19.${requestCount}`,
-            catalogDigest: `sha256:${"a".repeat(64)}`,
-            activatedAt: requestedAt,
-          },
-          lastAttempt: {
-            at: requestedAt,
-            outcome: "accepted",
-            failureCode: null,
-            reusedCachedRejection: false,
-          },
-          lastSuccessAt: requestedAt,
-          rejectedCandidate: null,
-          filtering: {
-            capabilityDigest: `sha256:${"b".repeat(64)}`,
-            evaluatedAt: requestedAt,
-            stale: false,
-            filteredAuthMethods: [],
-          },
-          credentialStorage: {
-            missingConnectorVersions: 0,
-            unownedConnectorSecrets: 0,
-            unownedConnectorVariables: 0,
-            unresolvedBridgeCredentials: 0,
-          },
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.diagnostics, ({ respond }) => {
+      requestCount += 1;
+      const requestedAt = "2026-08-19T04:00:00.000Z";
+      return respond(200, {
+        state: "current",
+        active: {
+          catalogVersion: `2026-08-19.${requestCount}`,
+          catalogDigest: `sha256:${"a".repeat(64)}`,
+          activatedAt: requestedAt,
+        },
+        lastAttempt: {
+          at: requestedAt,
+          outcome: "accepted",
+          failureCode: null,
+          reusedCachedRejection: false,
+        },
+        lastSuccessAt: requestedAt,
+        rejectedCandidate: null,
+        filtering: {
+          capabilityDigest: `sha256:${"b".repeat(64)}`,
+          evaluatedAt: requestedAt,
+          stale: false,
+          filteredAuthMethods: [],
+        },
+        credentialStorage: {
+          missingConnectorVersions: 0,
+          unownedConnectorSecrets: 0,
+          unownedConnectorVariables: 0,
+          unresolvedBridgeCredentials: 0,
+        },
+      });
+    });
 
     await openDialog("admin", "debug");
 
@@ -1006,39 +1003,36 @@ describe("settings dialog", () => {
   });
 
   it("does not describe an uncached rejection as a fresh evaluation", async () => {
-    context.mocks.api(
-      zeroConnectorCatalogContract.diagnostics,
-      ({ respond }) => {
-        return respond(200, {
-          state: "stale",
-          active: {
-            catalogVersion: "2026-07-25.1",
-            catalogDigest: `sha256:${"a".repeat(64)}`,
-            activatedAt: "2026-07-25T01:00:00.000Z",
-          },
-          lastAttempt: {
-            at: "2026-07-25T02:00:00.000Z",
-            outcome: "rejected",
-            failureCode: "source-unavailable",
-            reusedCachedRejection: false,
-          },
-          lastSuccessAt: "2026-07-25T01:00:00.000Z",
-          rejectedCandidate: null,
-          filtering: {
-            capabilityDigest: `sha256:${"b".repeat(64)}`,
-            evaluatedAt: "2026-07-25T01:00:00.000Z",
-            stale: false,
-            filteredAuthMethods: [],
-          },
-          credentialStorage: {
-            missingConnectorVersions: 0,
-            unownedConnectorSecrets: 0,
-            unownedConnectorVariables: 0,
-            unresolvedBridgeCredentials: 0,
-          },
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.diagnostics, ({ respond }) => {
+      return respond(200, {
+        state: "stale",
+        active: {
+          catalogVersion: "2026-07-25.1",
+          catalogDigest: `sha256:${"a".repeat(64)}`,
+          activatedAt: "2026-07-25T01:00:00.000Z",
+        },
+        lastAttempt: {
+          at: "2026-07-25T02:00:00.000Z",
+          outcome: "rejected",
+          failureCode: "source-unavailable",
+          reusedCachedRejection: false,
+        },
+        lastSuccessAt: "2026-07-25T01:00:00.000Z",
+        rejectedCandidate: null,
+        filtering: {
+          capabilityDigest: `sha256:${"b".repeat(64)}`,
+          evaluatedAt: "2026-07-25T01:00:00.000Z",
+          stale: false,
+          filteredAuthMethods: [],
+        },
+        credentialStorage: {
+          missingConnectorVersions: 0,
+          unownedConnectorSecrets: 0,
+          unownedConnectorVariables: 0,
+          unresolvedBridgeCredentials: 0,
+        },
+      });
+    });
 
     await openDialog("admin", "debug");
 
@@ -1052,17 +1046,14 @@ describe("settings dialog", () => {
   });
 
   it("keeps Debug settings usable when diagnostics are unavailable", async () => {
-    context.mocks.api(
-      zeroConnectorCatalogContract.diagnostics,
-      ({ respond }) => {
-        return respond(404, {
-          error: {
-            message: "Connector catalog diagnostics are unavailable",
-            code: "NOT_FOUND",
-          },
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.diagnostics, ({ respond }) => {
+      return respond(404, {
+        error: {
+          message: "Connector catalog diagnostics are unavailable",
+          code: "NOT_FOUND",
+        },
+      });
+    });
 
     await openDialog("admin", "debug");
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/thread-sidebar.test.tsx
@@ -19,7 +19,7 @@ import {
   browserContract,
   type BrowserSession,
 } from "@okouai/api-contracts/contracts/browser";
-import { zeroConnectorCatalogContract } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import { connectorCatalogContract } from "@okouai/api-contracts/contracts/connector-catalog";
 import { mailContract } from "@okouai/api-contracts/contracts/mail";
 import { describe, expect, it, vi } from "vitest";
 
@@ -540,7 +540,7 @@ describe("thread-owned utility sidebar", () => {
       ]),
     );
     context.mocks.data.connectors([googleDriveConnector()]);
-    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
       return respond(200, { connectors: [] });
     });
     context.mocks.http.get(markdownUrl, () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-callback-page.test.tsx
@@ -1,6 +1,6 @@
 import { connectorsSlugCallbackContract } from "@okouai/api-contracts/contracts/connectors-slug-callback";
 import { zeroCustomConnectorOAuth2Contract } from "@okouai/api-contracts/contracts/zero-custom-connectors";
-import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/connector-catalog";
 import { CONNECTOR_APP_OAUTH_CALLBACK_METADATA_STORAGE_KEY } from "@okouai/connectors/app-oauth-callback";
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -27,10 +27,10 @@ import {
   zeroConnectorsMainContract,
 } from "@okouai/api-contracts/contracts/zero-connectors";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogCategoryMetadata,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import { zeroFeatureSwitchesContract } from "@okouai/api-contracts/contracts/zero-feature-switches";
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import { zeroUserPermissionGrantsContract } from "@okouai/api-contracts/contracts/zero-user-permission-grants";
@@ -392,7 +392,7 @@ function mockPublicConnectorStatus(
   connectors: readonly PublicConnectorCatalogStatusItem[],
   categoryMetadata?: PublicConnectorCatalogCategoryMetadata,
 ): void {
-  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+  context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
     return respond(200, {
       connectors: [...connectors],
       ...(categoryMetadata ? { categoryMetadata } : {}),
@@ -631,7 +631,7 @@ describe("connectors page", () => {
     const discoveryKeywords: (string | undefined)[] = [];
     let legacyStatusRequests = 0;
     context.mocks.api(
-      zeroConnectorCatalogContract.discovery,
+      connectorCatalogContract.discovery,
       ({ query, respond }) => {
         discoveryKeywords.push(query.keyword);
         return respond(200, {
@@ -640,7 +640,7 @@ describe("connectors page", () => {
         });
       },
     );
-    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
       legacyStatusRequests += 1;
       return respond(200, { connectors: [github, slack] });
     });
@@ -2857,7 +2857,7 @@ describe("connectors page", () => {
     ];
     let catalogStatusRequestCount = 0;
     let manualGrantConnectResponded = false;
-    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
       catalogStatusRequestCount += 1;
       return respond(200, { connectors: [...catalogStatusItems] });
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -6,9 +6,9 @@ import {
 } from "@okouai/api-contracts/contracts/zero-connectors";
 import { chatEventsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
@@ -73,7 +73,7 @@ function publicStatusItem(args: {
 function mockPublicConnectorStatus(
   connectors: readonly PublicConnectorCatalogStatusItem[],
 ): void {
-  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+  context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
     return respond(200, { connectors: [...connectors] });
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -20,9 +20,9 @@ import {
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import { screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -56,7 +56,7 @@ function mockPublicConnectorStatus(
 function mockPublicConnectorStatuses(
   connectors: readonly PublicConnectorCatalogStatusItem[],
 ): void {
-  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+  context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
     return respond(200, { connectors: [...connectors] });
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-feishu-oauth-callback-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-feishu-oauth-callback-page.test.tsx
@@ -1,8 +1,8 @@
 import { feishuOauthContract } from "@okouai/api-contracts/contracts/feishu-oauth";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -48,7 +48,7 @@ describe("feishu OAuth callback page", () => {
       "https://applink.feishu.cn/client/bot/open?appId=cli_test";
     const locationAssign = context.mocks.browser.locationAssign();
     let callbackQuery: unknown;
-    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
       return respond(200, { connectors: [feishuConnectorStatus()] });
     });
     context.mocks.api(feishuOauthContract.callback, ({ query, respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -1,8 +1,8 @@
 import { screen, waitForElementToBeRemoved } from "@testing-library/react";
 import {
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
@@ -56,7 +56,7 @@ function publicConnectorStatusItem(
 }
 
 function mockConnectorCatalogStatus(connectorSlugs: readonly string[]): void {
-  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+  context.mocks.api(connectorCatalogContract.status, ({ respond }) => {
     return respond(200, {
       connectors: connectorSlugs.map(publicConnectorStatusItem),
     });
@@ -216,18 +216,15 @@ describe("zero ideation page", () => {
 
     const catalogRequested = context.mocks.deferred<void>();
     const catalogReady = context.mocks.deferred<void>();
-    context.mocks.api(
-      zeroConnectorCatalogContract.status,
-      async ({ respond }) => {
-        catalogRequested.resolve();
-        await catalogReady.promise;
-        return respond(200, {
-          connectors: ["github", "sentry", "axiom", "plausible", "slack"].map(
-            publicConnectorStatusItem,
-          ),
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.status, async ({ respond }) => {
+      catalogRequested.resolve();
+      await catalogReady.promise;
+      return respond(200, {
+        connectors: ["github", "sentry", "axiom", "plausible", "slack"].map(
+          publicConnectorStatusItem,
+        ),
+      });
+    });
     context.store.set(reloadConnectors$);
 
     await catalogRequested.promise;
@@ -241,15 +238,12 @@ describe("zero ideation page", () => {
 
   it("does not treat pending catalog status as an empty catalog", async () => {
     const catalogReady = context.mocks.deferred<void>();
-    context.mocks.api(
-      zeroConnectorCatalogContract.status,
-      async ({ respond }) => {
-        await catalogReady.promise;
-        return respond(200, {
-          connectors: [],
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.status, async ({ respond }) => {
+      await catalogReady.promise;
+      return respond(200, {
+        connectors: [],
+      });
+    });
 
     detachedSetupPage({
       context,
@@ -269,15 +263,12 @@ describe("zero ideation page", () => {
 
   it("fails closed when catalog status errors on the ideas page", async () => {
     const catalogReady = context.mocks.deferred<void>();
-    context.mocks.api(
-      zeroConnectorCatalogContract.status,
-      async ({ respond }) => {
-        await catalogReady.promise;
-        return respond(403, {
-          error: { message: "Forbidden", code: "FORBIDDEN" },
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.status, async ({ respond }) => {
+      await catalogReady.promise;
+      return respond(403, {
+        error: { message: "Forbidden", code: "FORBIDDEN" },
+      });
+    });
 
     detachedSetupPage({
       context,
@@ -314,15 +305,12 @@ describe("zero ideation page", () => {
     ).resolves.toBeInTheDocument();
 
     const catalogReady = context.mocks.deferred<void>();
-    context.mocks.api(
-      zeroConnectorCatalogContract.status,
-      async ({ respond }) => {
-        await catalogReady.promise;
-        return respond(403, {
-          error: { message: "Forbidden", code: "FORBIDDEN" },
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.status, async ({ respond }) => {
+      await catalogReady.promise;
+      return respond(403, {
+        error: { message: "Forbidden", code: "FORBIDDEN" },
+      });
+    });
     context.store.set(reloadConnectors$);
 
     expect(screen.getByText("Daily standup report")).toBeInTheDocument();
@@ -450,18 +438,15 @@ describe("zero ideation page", () => {
 
     const catalogRequested = context.mocks.deferred<void>();
     const catalogReady = context.mocks.deferred<void>();
-    context.mocks.api(
-      zeroConnectorCatalogContract.status,
-      async ({ respond }) => {
-        catalogRequested.resolve();
-        await catalogReady.promise;
-        return respond(200, {
-          connectors: ["github", "sentry", "axiom", "plausible", "slack"].map(
-            publicConnectorStatusItem,
-          ),
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.status, async ({ respond }) => {
+      catalogRequested.resolve();
+      await catalogReady.promise;
+      return respond(200, {
+        connectors: ["github", "sentry", "axiom", "plausible", "slack"].map(
+          publicConnectorStatusItem,
+        ),
+      });
+    });
     context.store.set(reloadConnectors$);
 
     await catalogRequested.promise;
@@ -475,15 +460,12 @@ describe("zero ideation page", () => {
 
   it("does not treat pending catalog status as empty for suggested prompts", async () => {
     const catalogReady = context.mocks.deferred<void>();
-    context.mocks.api(
-      zeroConnectorCatalogContract.status,
-      async ({ respond }) => {
-        await catalogReady.promise;
-        return respond(200, {
-          connectors: [],
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.status, async ({ respond }) => {
+      await catalogReady.promise;
+      return respond(200, {
+        connectors: [],
+      });
+    });
 
     detachedSetupPage({
       context,
@@ -501,15 +483,12 @@ describe("zero ideation page", () => {
 
   it("fails closed when catalog status errors for suggested prompts", async () => {
     const catalogReady = context.mocks.deferred<void>();
-    context.mocks.api(
-      zeroConnectorCatalogContract.status,
-      async ({ respond }) => {
-        await catalogReady.promise;
-        return respond(403, {
-          error: { message: "Forbidden", code: "FORBIDDEN" },
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.status, async ({ respond }) => {
+      await catalogReady.promise;
+      return respond(403, {
+        error: { message: "Forbidden", code: "FORBIDDEN" },
+      });
+    });
 
     detachedSetupPage({
       context,
@@ -546,15 +525,12 @@ describe("zero ideation page", () => {
     expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(3);
 
     const catalogReady = context.mocks.deferred<void>();
-    context.mocks.api(
-      zeroConnectorCatalogContract.status,
-      async ({ respond }) => {
-        await catalogReady.promise;
-        return respond(403, {
-          error: { message: "Forbidden", code: "FORBIDDEN" },
-        });
-      },
-    );
+    context.mocks.api(connectorCatalogContract.status, async ({ respond }) => {
+      await catalogReady.promise;
+      return respond(403, {
+        error: { message: "Forbidden", code: "FORBIDDEN" },
+      });
+    });
     context.store.set(reloadConnectors$);
 
     const loadingButtons = queryAllByRoleFast("button", promptGrid);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -26,7 +26,7 @@ import type { FormEvent, ReactElement } from "react";
 import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogStartOption,
-} from "@okouai/api-contracts/contracts/zero-connector-catalog";
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import type { PlatformConnectorCatalogStatusItem } from "../../../../signals/connector-domain.ts";
 import {
   connectFlowConnectorSlug$,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -1,5 +1,5 @@
 import { Plug } from "lucide-react";
-import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/connector-catalog";
 import { cn } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/launch-connector-connect.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/launch-connector-connect.ts
@@ -1,5 +1,5 @@
 import type { ConnectorAuthMethodId } from "@okouai/api-contracts/contracts/connector-identity";
-import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/connector-catalog";
 
 import type { PlatformConnectorCatalogStatusItem } from "../../../../signals/connector-domain.ts";
 import { getConnectorStatusDirectConnectMethod } from "../../../../signals/zero-page/settings/connectors.ts";

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -26,7 +26,7 @@ import {
   Input,
 } from "@okouai/ui";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
-import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/connector-catalog";
 import { groupFirewallMetadataPermissionsByCategory } from "@okouai/connectors/firewall-metadata/policy";
 import {
   UNKNOWN_PERMISSION_GRANT,

--- a/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/mail-draft-card.tsx
@@ -3,7 +3,7 @@ import type {
   MailDraft,
   MailDraftStatus,
 } from "@okouai/api-contracts/contracts/mail";
-import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/connector-catalog";
 import { cn } from "@okouai/ui";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-callback-page.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle, Check, Loader2 } from "lucide-react";
-import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/connector-catalog";
 import { Button } from "@okouai/ui/components/ui/button";
 import { useTranslation } from "react-i18next";
 import { ZeroConnectorFlowCard } from "./zero-connector-flow-card.tsx";

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-flow-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-flow-card.tsx
@@ -1,4 +1,4 @@
-import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { ReactNode } from "react";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ProductBrandMarkLink } from "./zero-directed-shared.tsx";

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-redirecting-page.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle, ArrowLeft, Loader2 } from "lucide-react";
-import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogIcon } from "@okouai/api-contracts/contracts/connector-catalog";
 import { Button } from "@okouai/ui/components/ui/button";
 import { useGet } from "ccstate-react";
 import { useTranslation } from "react-i18next";

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -11,7 +11,7 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { Search, Plus, Filter, ChevronDown, Check } from "lucide-react";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
-import type { PublicConnectorCatalogCategoryMetadata } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogCategoryMetadata } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import type { TeamComposeItem } from "@okouai/api-contracts/contracts/zero-team";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -5,7 +5,7 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
-import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -5,7 +5,7 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
-import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/zero-connector-catalog";
+import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/connector-catalog";
 import type {
   CustomConnectorResponse,
   CustomConnectorSlug,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
@@ -12,7 +12,7 @@ import {
   userConnectorEnabledSlugsSchema,
   userConnectorUpdateSchema,
 } from "../user-connectors";
-import { zeroConnectorCatalogContract } from "../zero-connector-catalog";
+import { connectorCatalogContract } from "../connector-catalog";
 import {
   connectorCheckDiagnosticResultSchema,
   connectorCheckRequestSchema,
@@ -166,12 +166,12 @@ describe("connector client response contracts", () => {
       }),
     ).toMatchObject({ connectors: [{ slug: "github" }] });
     expect(
-      zeroConnectorCatalogContract.list.responses[200].parse({
+      connectorCatalogContract.list.responses[200].parse({
         connectors: [catalogItem],
       }),
     ).toMatchObject({ connectors: [{ slug: "github" }] });
     expect(
-      zeroConnectorCatalogContract.permissions.responses[200].parse({
+      connectorCatalogContract.permissions.responses[200].parse({
         permissions: {
           connectorSlug: "github",
           label: "GitHub",
@@ -369,7 +369,7 @@ describe("connector path parameter contracts", () => {
       params: { connectorSlug: "github" },
       headers: {},
     });
-    await initClient(zeroConnectorCatalogContract, config).permissions({
+    await initClient(connectorCatalogContract, config).permissions({
       params: { connectorSlug: "github" },
       headers: {},
     });

--- a/turbo/packages/api-contracts/src/contracts/connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-catalog.ts
@@ -237,7 +237,7 @@ export type PublicConnectorCatalogPermissionDetailResponse = z.infer<
   typeof publicConnectorCatalogPermissionDetailResponseSchema
 >;
 
-export const zeroConnectorCatalogContract = c.router({
+export const connectorCatalogContract = c.router({
   list: {
     method: "GET",
     path: "/api/okou/connector-catalog",
@@ -320,4 +320,4 @@ export const zeroConnectorCatalogContract = c.router({
   },
 });
 
-export type ZeroConnectorCatalogContract = typeof zeroConnectorCatalogContract;
+export type ConnectorCatalogContract = typeof connectorCatalogContract;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1023,7 +1023,7 @@ export {
 } from "./zero-connectors";
 export {
   publicConnectorCatalogIconSchema,
-  zeroConnectorCatalogContract,
+  connectorCatalogContract,
   type PublicConnectorCatalogAuthMethodDetail,
   type PublicConnectorCatalogAuthMethodSummary,
   type PublicConnectorCatalogDetail,
@@ -1040,8 +1040,8 @@ export {
   type PublicConnectorCatalogStartOption,
   type PublicConnectorCatalogStatusItem,
   type PublicConnectorCatalogStatusResponse,
-  type ZeroConnectorCatalogContract,
-} from "./zero-connector-catalog";
+  type ConnectorCatalogContract,
+} from "./connector-catalog";
 export {
   connectorCheckContract,
   connectorCheckDiagnosticResultSchema,

--- a/turbo/packages/api-contracts/src/contracts/workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/workflows.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { connectorSlugSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
-import { publicConnectorCatalogIconSchema } from "./zero-connector-catalog";
+import { publicConnectorCatalogIconSchema } from "./connector-catalog";
 
 const c = initContract();
 


### PR DESCRIPTION
## Summary

Phase 2 contract naming cleanup (parent #26873, tracker #27432). This moves the connector catalog contract module to a domain-neutral name and renames its two branded declarations, updating every caller and the `contracts/index.ts` re-export block atomically.

It is a pure rename. No HTTP `path:` literal, method, header/request/response schema, enum value, status code, connector slug, catalog entry identifier, icon asset key, diagnostics field name or persisted identity changes. No compatibility alias and no old-path re-export is left behind.

## Old → new mapping

| Old | New |
|---|---|
| `contracts/zero-connector-catalog.ts` | `contracts/connector-catalog.ts` |
| `zeroConnectorCatalogContract` | `connectorCatalogContract` |
| `ZeroConnectorCatalogContract` | `ConnectorCatalogContract` |

That is the whole map. The module's other twenty exports — the connector catalog entry schemas, the icon types and the diagnostics shapes — were already neutral and are byte-identical. Git detects the module at 98% similarity with exactly two changed lines, one per renamed declaration.

Because `@okouai/api-contracts` exports the wildcard subpath `./contracts/*`, the module filename is compile-time public API, so all `@okouai/api-contracts/contracts/zero-connector-catalog` specifiers were updated in the same commit.

## Explicitly not touched

- **The twenty already-neutral exports**, including `PublicConnectorCatalogIcon`, `publicConnectorCatalogIconSchema`, `PublicConnectorCatalogAuthMethodDetail`, `PublicConnectorCatalogCategoryMetadata` and the rest. Callers that import only those changed on the import specifier line and nowhere else.
- **`contracts/zero-connectors.ts`, `zero-custom-connectors.ts`, `zero-agent-custom-connectors.ts`** — owned by other in-flight issues. `zero-connectors.ts` occupies the barrel block immediately above this one (`index.ts:1008-1023`); its block is untouched here.
- **The `"zero-connector-catalog-at-3b45e4e"` string literals** in `apps/api/src/signals/services/historical-product-builder.ts`, `apps/api/src/test-fixtures/historical-agent-composes.ts` and `packages/db/scripts/test-agent-compose-consolidation-preflight.ts`. These are historical product-builder variant IDs pinned to source commit `3b45e4e`, i.e. persisted data identifiers, not module specifiers. They are outside the naming map and are left byte-identical.
- **`contracts/zero-workflows.ts`** — only its import specifier on line 5 changed, because it imports the already-neutral `publicConnectorCatalogIconSchema` from this module. Nothing in that module is renamed.
- #27987 and #25722.

## Formatting note

The shorter identifier lets Prettier collapse call arguments that previously had to wrap, mostly `context.mocks.api(...)` and `mockApi(...)` calls in the platform and API test files. `git diff -U0 -w` over the whole change reports no removed or added line that is not either the rename itself or one of those reflows, so every file is exactly `old file + rename map + prettier`.

## Verification

- `pnpm -F @okouai/api-contracts check-types` — passes
- `pnpm -F api check-types` — passes
- `pnpm -F @okouai/app check-types` — passes
- `pnpm -F @okouai/cli check-types` — passes
- `pnpm turbo run lint --filter=@okouai/api-contracts --filter=api --filter=@okouai/app --filter=@okouai/cli` — 10/10 tasks successful, 0 errors. The 47 `@okouai/app` warnings are pre-existing and were confirmed present on `main` in files this PR does not semantically change.
- `pnpm knip` — exit 0, only the pre-existing configuration hints
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/connector-client-contract.test.ts` — 9/9 passed
- Repository-wide grep confirms no `zeroConnectorCatalogContract` or `ZeroConnectorCatalogContract` identifier and no `contracts/zero-connector-catalog` specifier remains

Full-repository test coverage is left to the PR pipeline.

Closes #28207
