### PR TITLE
fix(platform): show exact connector catalog count

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
@@ -523,7 +523,7 @@ describe("GET /api/zero/connector-catalog", () => {
     assertPublicConnectorCatalogHasNoPrivateFields(featured.body);
     expect(featured.body.connectors.length).toBeGreaterThan(0);
     expect(featured.body.connectors.length).toBeLessThanOrEqual(100);
-    expect(featured.body.totalConnectorCount ?? 0).toBeGreaterThanOrEqual(
+    expect(featured.body.totalConnectorCount).toBeGreaterThanOrEqual(
       featured.body.connectors.length,
     );
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -7,6 +7,7 @@ import type {
   PublicConnectorCatalogConnection,
   PublicConnectorCatalogConnectionStatus,
   PublicConnectorCatalogDetail,
+  PublicConnectorCatalogDiscoveryResponse,
   PublicConnectorCatalogIcon,
   PublicConnectorCatalogItem,
   PublicConnectorCatalogListResponse,
@@ -139,6 +140,11 @@ export interface ConnectorCatalogReferenceMetadata {
 
 export interface ConnectorCatalogStatusRead {
   readonly status: PublicConnectorCatalogStatusResponse;
+  readonly referenceMetadata: readonly ConnectorCatalogReferenceMetadata[];
+}
+
+interface ConnectorCatalogDiscoveryRead {
+  readonly status: PublicConnectorCatalogDiscoveryResponse;
   readonly referenceMetadata: readonly ConnectorCatalogReferenceMetadata[];
 }
 
@@ -1080,19 +1086,25 @@ export async function listExternalPublicConnectorCatalogStatus(
 
 export async function discoverExternalPublicConnectorCatalogStatus(
   args: ExternalCatalogDiscoveryArgs,
-): Promise<ConnectorCatalogStatusRead> {
+): Promise<ConnectorCatalogDiscoveryRead> {
   const catalog = await loadAcceptedConnectorCatalogSnapshot(args.db);
   const effective = effectiveConnectors({
     catalog,
     featureStates: args.featureStates,
   });
-  return connectorCatalogStatusRead({
+  const read = connectorCatalogStatusRead({
     catalog,
     effective: discoveryEffectiveConnectors(effective, args),
     connectors: args.connectors,
     referenceConnectorSlugs: args.referenceConnectorSlugs,
-    totalConnectorCount: effective.length,
   });
+  return {
+    ...read,
+    status: {
+      ...read.status,
+      totalConnectorCount: effective.length,
+    },
+  };
 }
 
 function connectorCatalogStatusRead(args: {
@@ -1100,7 +1112,6 @@ function connectorCatalogStatusRead(args: {
   readonly effective: readonly EffectiveConnector[];
   readonly connectors: readonly ConnectorResponse[];
   readonly referenceConnectorSlugs: readonly string[];
-  readonly totalConnectorCount?: number;
 }): ConnectorCatalogStatusRead {
   const connectorsBySlug = new Map(
     args.connectors.map((connector) => {
@@ -1121,9 +1132,6 @@ function connectorCatalogStatusRead(args: {
         args.catalog,
         args.effective,
       ),
-      ...(args.totalConnectorCount === undefined
-        ? {}
-        : { totalConnectorCount: args.totalConnectorCount }),
     },
     referenceMetadata: referenceMetadataForCatalog(
       args.catalog,

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -2,6 +2,7 @@ import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connecto
 import type { ConnectorSearchItem } from "@okouai/api-contracts/contracts/zero-connectors";
 import type {
   PublicConnectorCatalogListResponse,
+  PublicConnectorCatalogDiscoveryResponse,
   PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogStatusItem,
   PublicConnectorCatalogStatusResponse,
@@ -75,7 +76,7 @@ export async function discoverPublicConnectorCatalogStatus(
     readonly connectors: readonly ConnectorResponse[];
     readonly keyword: string | undefined;
   },
-): Promise<PublicConnectorCatalogStatusResponse> {
+): Promise<PublicConnectorCatalogDiscoveryResponse> {
   const read = await discoverExternalPublicConnectorCatalogStatus({
     ...args,
     referenceConnectorSlugs: [],

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -5,6 +5,7 @@ import {
 } from "@okouai/api-contracts/contracts/zero-connectors";
 import {
   connectorCatalogContract,
+  type PublicConnectorCatalogDiscoveryResponse,
   type PublicConnectorCatalogStatusResponse,
 } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
@@ -61,7 +62,12 @@ export const connectorCatalogStatusBySlug$ = computed(async (get) => {
 
 export function relatedConnectorCatalog(
   keyword$: Computed<string>,
-): Computed<Promise<PublicConnectorCatalogStatusResponse>> {
+): Computed<
+  Promise<
+    | PublicConnectorCatalogDiscoveryResponse
+    | PublicConnectorCatalogStatusResponse
+  >
+> {
   return computed(async (get) => {
     const featureStates = get(featureSwitch$);
     if (!featureStates[FeatureSwitchKey.ConnectorDiscovery]) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -673,6 +673,38 @@ describe("connectors page", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not treat bounded discovery results as the catalog size", async () => {
+    mockConnectors([]);
+    context.mocks.api(zeroConnectorCatalogContract.discovery, ({ respond }) => {
+      return respond(200, {
+        connectors: [
+          publicStatusItem({
+            connectorSlug: "github",
+            label: "GitHub",
+            authMethods: [],
+          }),
+        ],
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: {
+        [FeatureSwitchKey.ConnectorDiscovery]: true,
+        [FeatureSwitchKey.ConnectorCatalogCount]: true,
+      },
+    });
+
+    await expect(
+      screen.findByTestId("connector-card-label"),
+    ).resolves.toHaveTextContent("GitHub");
+    expect(
+      screen.getByText("Connect third-party services for your agents to use."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/^Connect 1 service/)).not.toBeInTheDocument();
+  });
+
   it("shows the full connector catalog size in the page description", async () => {
     mockConnectors([]);
     mockPublicConnectorStatus([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -731,6 +731,32 @@ describe("connectors page", () => {
     ).resolves.toBeInTheDocument();
   });
 
+  it("prefers the reported catalog size over the response array length", async () => {
+    mockConnectors([]);
+    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+      return respond(200, {
+        connectors: [
+          publicStatusItem({
+            connectorSlug: "github",
+            label: "GitHub",
+            authMethods: [],
+          }),
+        ],
+        totalConnectorCount: 1234,
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorCatalogCount]: true },
+    });
+
+    await expect(
+      screen.findByText("Connect 1,234 services for your agents to use."),
+    ).resolves.toBeInTheDocument();
+  });
+
   it("keeps the catalog description count-free while the count loads", async () => {
     mockConnectors([]);
     let catalogRequestStarted = false;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -636,7 +636,7 @@ describe("connectors page", () => {
         discoveryKeywords.push(query.keyword);
         return respond(200, {
           connectors: query.keyword ? [slack] : [github],
-          totalConnectorCount: 347,
+          totalConnectorCount: 1234,
         });
       },
     );
@@ -658,7 +658,7 @@ describe("connectors page", () => {
       screen.findByTestId("connector-card-label"),
     ).resolves.toHaveTextContent("GitHub");
     await expect(
-      screen.findByText("Connect 1100+ services for your agents to use."),
+      screen.findByText("Connect 1,234 services for your agents to use."),
     ).resolves.toBeInTheDocument();
 
     await fill(await screen.findByPlaceholderText("Find connectors"), "Slack");
@@ -668,9 +668,12 @@ describe("connectors page", () => {
     });
     expect(discoveryKeywords).toContain("Slack");
     expect(legacyStatusRequests).toBe(0);
+    expect(
+      screen.getByText("Connect 1,234 services for your agents to use."),
+    ).toBeInTheDocument();
   });
 
-  it("shows the static connector catalog size in the page description", async () => {
+  it("shows the full connector catalog size in the page description", async () => {
     mockConnectors([]);
     mockPublicConnectorStatus([
       publicStatusItem({
@@ -692,7 +695,55 @@ describe("connectors page", () => {
     });
 
     await expect(
-      screen.findByText("Connect 1100+ services for your agents to use."),
+      screen.findByText("Connect 2 services for your agents to use."),
+    ).resolves.toBeInTheDocument();
+  });
+
+  it("keeps the catalog description count-free while the count loads", async () => {
+    mockConnectors([]);
+    let catalogRequestStarted = false;
+    let resolveCatalog = (): void => {
+      throw new Error("Catalog request did not start");
+    };
+    context.mocks.api(
+      zeroConnectorCatalogContract.discovery,
+      async ({ deferred, respond }) => {
+        const catalogDeferred = deferred<void>();
+        resolveCatalog = () => {
+          catalogDeferred.resolve();
+        };
+        catalogRequestStarted = true;
+        await catalogDeferred.promise;
+        return respond(200, {
+          connectors: [],
+          totalConnectorCount: 1234,
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: {
+        [FeatureSwitchKey.ConnectorDiscovery]: true,
+        [FeatureSwitchKey.ConnectorCatalogCount]: true,
+      },
+    });
+
+    await expect(
+      screen.findByText("Connect third-party services for your agents to use."),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByText("Connect 1,234 services for your agents to use."),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(catalogRequestStarted).toBeTruthy();
+    });
+
+    resolveCatalog();
+
+    await expect(
+      screen.findByText("Connect 1,234 services for your agents to use."),
     ).resolves.toBeInTheDocument();
   });
 
@@ -721,7 +772,7 @@ describe("connectors page", () => {
       screen.findByText("Connect third-party services for your agents to use."),
     ).resolves.toBeInTheDocument();
     expect(
-      screen.queryByText("Connect 1100+ services for your agents to use."),
+      screen.queryByText("Connect 2 services for your agents to use."),
     ).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -673,38 +673,6 @@ describe("connectors page", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not treat bounded discovery results as the catalog size", async () => {
-    mockConnectors([]);
-    context.mocks.api(zeroConnectorCatalogContract.discovery, ({ respond }) => {
-      return respond(200, {
-        connectors: [
-          publicStatusItem({
-            connectorSlug: "github",
-            label: "GitHub",
-            authMethods: [],
-          }),
-        ],
-      });
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorDiscovery]: true,
-        [FeatureSwitchKey.ConnectorCatalogCount]: true,
-      },
-    });
-
-    await expect(
-      screen.findByTestId("connector-card-label"),
-    ).resolves.toHaveTextContent("GitHub");
-    expect(
-      screen.getByText("Connect third-party services for your agents to use."),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/^Connect 1 service/)).not.toBeInTheDocument();
-  });
-
   it("shows the full connector catalog size in the page description", async () => {
     mockConnectors([]);
     mockPublicConnectorStatus([
@@ -731,32 +699,6 @@ describe("connectors page", () => {
     ).resolves.toBeInTheDocument();
   });
 
-  it("prefers the reported catalog size over the response array length", async () => {
-    mockConnectors([]);
-    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
-      return respond(200, {
-        connectors: [
-          publicStatusItem({
-            connectorSlug: "github",
-            label: "GitHub",
-            authMethods: [],
-          }),
-        ],
-        totalConnectorCount: 1234,
-      });
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.ConnectorCatalogCount]: true },
-    });
-
-    await expect(
-      screen.findByText("Connect 1,234 services for your agents to use."),
-    ).resolves.toBeInTheDocument();
-  });
-
   it("keeps the catalog description count-free while the count loads", async () => {
     mockConnectors([]);
     let catalogRequestStarted = false;
@@ -764,7 +706,7 @@ describe("connectors page", () => {
       throw new Error("Catalog request did not start");
     };
     context.mocks.api(
-      zeroConnectorCatalogContract.discovery,
+      connectorCatalogContract.discovery,
       async ({ deferred, respond }) => {
         const catalogDeferred = deferred<void>();
         resolveCatalog = () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -14,6 +14,7 @@ import { Search, Plus, Filter, ChevronDown, Check } from "lucide-react";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import type {
   PublicConnectorCatalogCategoryMetadata,
+  PublicConnectorCatalogDiscoveryResponse,
   PublicConnectorCatalogStatusResponse,
 } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
@@ -850,18 +851,18 @@ function connectorLabelForSlug(
 }
 
 function effectiveConnectorCatalogCount(
-  catalogStatusLoadable: Loadable<PublicConnectorCatalogStatusResponse>,
-  connectorDiscoveryEnabled: boolean,
+  catalogStatusLoadable: Loadable<
+    | PublicConnectorCatalogDiscoveryResponse
+    | PublicConnectorCatalogStatusResponse
+  >,
 ): number | null {
   if (catalogStatusLoadable.state !== "hasData") {
     return null;
   }
-  if (catalogStatusLoadable.data.totalConnectorCount !== undefined) {
+  if ("totalConnectorCount" in catalogStatusLoadable.data) {
     return catalogStatusLoadable.data.totalConnectorCount;
   }
-  return connectorDiscoveryEnabled
-    ? null
-    : catalogStatusLoadable.data.connectors.length;
+  return catalogStatusLoadable.data.connectors.length;
 }
 
 export function ZeroConnectorsPage() {
@@ -871,11 +872,8 @@ export function ZeroConnectorsPage() {
     filteredConnectorCatalogItems$,
   );
   const catalogStatusLoadable = useLastLoadable(connectorCatalogDiscovery$);
-  const featureSwitches = useGet(featureSwitch$);
   const connectorCatalogCountEnabled =
-    featureSwitches[FeatureSwitchKey.ConnectorCatalogCount] ?? false;
-  const connectorDiscoveryEnabled =
-    featureSwitches[FeatureSwitchKey.ConnectorDiscovery] ?? false;
+    useGet(featureSwitch$)[FeatureSwitchKey.ConnectorCatalogCount] ?? false;
   const pollingAuthCodeSlug = useGet(pollingOAuthAuthCodeConnectorSlug$);
   const pollingDeviceAuthSlug = useGet(pollingOAuthDeviceAuthConnectorSlug$);
   const connectFlowSlug = useGet(connectFlowConnectorSlug$);
@@ -919,7 +917,6 @@ export function ZeroConnectorsPage() {
       : [];
   const connectorCatalogCount = effectiveConnectorCatalogCount(
     catalogStatusLoadable,
-    connectorDiscoveryEnabled,
   );
   const categoryMetadata = localizeConnectorCategoryMetadata(
     catalogStatusLoadable.state === "hasData"

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -851,14 +851,15 @@ function connectorLabelForSlug(
 
 function effectiveConnectorCatalogCount(
   catalogStatusLoadable: Loadable<PublicConnectorCatalogStatusResponse>,
+  connectorDiscoveryEnabled: boolean,
 ): number | null {
   if (catalogStatusLoadable.state !== "hasData") {
     return null;
   }
-  return (
-    catalogStatusLoadable.data.totalConnectorCount ??
-    catalogStatusLoadable.data.connectors.length
-  );
+  if (connectorDiscoveryEnabled) {
+    return catalogStatusLoadable.data.totalConnectorCount ?? null;
+  }
+  return catalogStatusLoadable.data.connectors.length;
 }
 
 export function ZeroConnectorsPage() {
@@ -868,8 +869,11 @@ export function ZeroConnectorsPage() {
     filteredConnectorCatalogItems$,
   );
   const catalogStatusLoadable = useLastLoadable(connectorCatalogDiscovery$);
+  const featureSwitches = useGet(featureSwitch$);
   const connectorCatalogCountEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ConnectorCatalogCount] ?? false;
+    featureSwitches[FeatureSwitchKey.ConnectorCatalogCount] ?? false;
+  const connectorDiscoveryEnabled =
+    featureSwitches[FeatureSwitchKey.ConnectorDiscovery] ?? false;
   const pollingAuthCodeSlug = useGet(pollingOAuthAuthCodeConnectorSlug$);
   const pollingDeviceAuthSlug = useGet(pollingOAuthDeviceAuthConnectorSlug$);
   const connectFlowSlug = useGet(connectFlowConnectorSlug$);
@@ -913,6 +917,7 @@ export function ZeroConnectorsPage() {
       : [];
   const connectorCatalogCount = effectiveConnectorCatalogCount(
     catalogStatusLoadable,
+    connectorDiscoveryEnabled,
   );
   const categoryMetadata = localizeConnectorCategoryMetadata(
     catalogStatusLoadable.state === "hasData"

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -6,16 +6,21 @@ import {
   useSet,
   useLastLoadable,
   useLastResolved,
+  type Loadable,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { Search, Plus, Filter, ChevronDown, Check } from "lucide-react";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
-import type { PublicConnectorCatalogCategoryMetadata } from "@okouai/api-contracts/contracts/connector-catalog";
+import type {
+  PublicConnectorCatalogCategoryMetadata,
+  PublicConnectorCatalogStatusResponse,
+} from "@okouai/api-contracts/contracts/connector-catalog";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import type { TeamComposeItem } from "@okouai/api-contracts/contracts/team";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { Tabs, TabsList, TabsTrigger } from "@okouai/ui/components/ui/tabs";
+import { formatLocalizedNumber } from "../../i18n/format.ts";
 import {
   connectorsPageTab$,
   setConnectorsPageTab$,
@@ -844,6 +849,18 @@ function connectorLabelForSlug(
   );
 }
 
+function effectiveConnectorCatalogCount(
+  catalogStatusLoadable: Loadable<PublicConnectorCatalogStatusResponse>,
+): number | null {
+  if (catalogStatusLoadable.state !== "hasData") {
+    return null;
+  }
+  return (
+    catalogStatusLoadable.data.totalConnectorCount ??
+    catalogStatusLoadable.data.connectors.length
+  );
+}
+
 export function ZeroConnectorsPage() {
   const { t } = useTranslation();
   const relatedCatalogItemsLoadable = useLastLoadable(relatedCatalogItems$);
@@ -894,6 +911,9 @@ export function ZeroConnectorsPage() {
     filteredCatalogItemsLoadable.state === "hasData"
       ? filteredCatalogItemsLoadable.data
       : [];
+  const connectorCatalogCount = effectiveConnectorCatalogCount(
+    catalogStatusLoadable,
+  );
   const categoryMetadata = localizeConnectorCategoryMetadata(
     catalogStatusLoadable.state === "hasData"
       ? catalogStatusLoadable.data.categoryMetadata
@@ -1033,13 +1053,13 @@ export function ZeroConnectorsPage() {
                 return $.connectors.catalog.title;
               })}
             </h1>
-            {connectorCatalogCountEnabled ? (
+            {connectorCatalogCountEnabled && connectorCatalogCount !== null ? (
               <p className="mt-0.5 text-sm text-muted-foreground">
                 {t(
                   ($) => {
                     return $.connectors.catalog.descriptionWithCount;
                   },
-                  { value: "1100+" },
+                  { value: formatLocalizedNumber(connectorCatalogCount) },
                 )}
               </p>
             ) : (

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -856,10 +856,12 @@ function effectiveConnectorCatalogCount(
   if (catalogStatusLoadable.state !== "hasData") {
     return null;
   }
-  if (connectorDiscoveryEnabled) {
-    return catalogStatusLoadable.data.totalConnectorCount ?? null;
+  if (catalogStatusLoadable.data.totalConnectorCount !== undefined) {
+    return catalogStatusLoadable.data.totalConnectorCount;
   }
-  return catalogStatusLoadable.data.connectors.length;
+  return connectorDiscoveryEnabled
+    ? null
+    : catalogStatusLoadable.data.connectors.length;
 }
 
 export function ZeroConnectorsPage() {

--- a/turbo/packages/api-contracts/src/contracts/connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-catalog.ts
@@ -140,8 +140,12 @@ const publicConnectorCatalogDetailResponseSchema = z.object({
 const publicConnectorCatalogStatusResponseSchema = z.object({
   connectors: z.array(publicConnectorCatalogStatusItemSchema),
   categoryMetadata: publicConnectorCatalogCategoryMetadataSchema.optional(),
-  totalConnectorCount: z.number().int().nonnegative().optional(),
 });
+
+const publicConnectorCatalogDiscoveryResponseSchema =
+  publicConnectorCatalogStatusResponseSchema.extend({
+    totalConnectorCount: z.number().int().nonnegative(),
+  });
 
 const publicFirewallPolicyValueSchema = z.enum(["allow", "deny", "ask"]);
 
@@ -230,6 +234,9 @@ export type PublicConnectorCatalogStatusItem = z.infer<
 export type PublicConnectorCatalogStatusResponse = z.infer<
   typeof publicConnectorCatalogStatusResponseSchema
 >;
+export type PublicConnectorCatalogDiscoveryResponse = z.infer<
+  typeof publicConnectorCatalogDiscoveryResponseSchema
+>;
 export type PublicConnectorCatalogPermissionDetail = z.infer<
   typeof publicConnectorCatalogPermissionDetailSchema
 >;
@@ -268,7 +275,7 @@ export const connectorCatalogContract = c.router({
     headers: authHeadersSchema,
     query: z.object({ keyword: z.string().optional() }),
     responses: {
-      200: publicConnectorCatalogStatusResponseSchema,
+      200: publicConnectorCatalogDiscoveryResponseSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1028,6 +1028,7 @@ export {
   type PublicConnectorCatalogAuthMethodSummary,
   type PublicConnectorCatalogDetail,
   type PublicConnectorCatalogDetailResponse,
+  type PublicConnectorCatalogDiscoveryResponse,
   type PublicConnectorCatalogConnection,
   type PublicConnectorCatalogConnectionStatus,
   type PublicConnectorCatalogItem,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -429,7 +429,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.ConnectorCatalogCount]: {
     maintainer: "ethan@vm0.ai",
-    description: "Show an approximate connector catalog size.",
+    description: "Show the exact effective connector catalog size.",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
## Summary

- replace the hard-coded connector catalog claim with the localized effective count already returned by the catalog response
- give status and discovery endpoint-specific response contracts so bounded discovery requires its authoritative `totalConnectorCount`
- preserve the complete full-status path plus count-free loading and switch-disabled states without restoring number animation

## Compatibility

- no migration, additional request, animation, new feature switch, or wire behavior change
- discovery and its required total were introduced together; full status continues to derive the count from its complete connector list
- runtime API schema compatibility passes against the production schema
- `ConnectorCatalogCount` remains disabled by default and staff-scoped

## Fallbacks

- None. Discovery uses its required authoritative total, while full status uses the complete list length; these are the two explicit endpoint contracts.

## Validation

- `pnpm -F @okouai/api-contracts test -- --maxWorkers=4 --silent=passed-only` (585 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-catalog.test.ts --maxWorkers=4 --silent=passed-only` (32 passed)
- `pnpm -F @okouai/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx --maxWorkers=4 --silent=passed-only` (93 passed)
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=4 --silent=passed-only` (24 passed)
- Prettier on all changed Turbo files
- lint: `@okouai/api-contracts`, `api`, `@okouai/app`, and `@okouai/core`
- type checks: `@okouai/api-contracts`, `api`, `@okouai/app`, and `@okouai/core`
- `pnpm knip --workspace @okouai/api-contracts --workspace api --workspace @okouai/app`
- runtime API schema compatibility against `runtime-api-schema-prod`
- pre-commit hook: full Turbo Knip, full Turbo type checking, file-size check, and commitlint

Closes #28221
