### PR TITLE
test(e2e): keep dns telemetry probes runner-owned

### DIFF
--- a/e2e/tests/03-runner/run-t06-network-telemetry.bats
+++ b/e2e/tests/03-runner/run-t06-network-telemetry.bats
@@ -62,7 +62,9 @@ with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as connection:
     connection.sendto(b"vm0-udp-probe", ("192.0.2.1", 9999))
 print("UDP_PROBE_DONE")
 
-udp_query = dns_query(0x4501, "udp-dns.invalid")
+# Keep the protocol round trips on the runner-owned dnsmasq zone instead of
+# making an external upstream DNS response part of the test oracle.
+udp_query = dns_query(0x4501, "udp-dns.vm0-readiness.invalid")
 with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as connection:
     connection.settimeout(5)
     connection.sendto(udp_query, ("192.0.2.1", 53))
@@ -70,7 +72,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as connection:
 assert udp_response[:2] == udp_query[:2] and udp_response[2] & 0x80
 print("UDP_DNS_PROBE_DONE")
 
-tcp_query = dns_query(0x4502, "tcp-dns.invalid")
+tcp_query = dns_query(0x4502, "tcp-dns.vm0-readiness.invalid")
 with socket.create_connection(("192.0.2.1", 53), timeout=5) as connection:
     connection.sendall(struct.pack("!H", len(tcp_query)) + tcp_query)
     response_size = struct.unpack("!H", read_exact(connection, 2))[0]
@@ -147,12 +149,12 @@ EOF
                     .port == 9999) and
                 any(.[];
                     .type == "dns" and
-                    .host == "udp-dns.invalid" and
+                    .host == "udp-dns.vm0-readiness.invalid" and
                     .port == 53 and
                     .dns_event == "query") and
                 any(.[];
                     .type == "dns" and
-                    .host == "tcp-dns.invalid" and
+                    .host == "tcp-dns.vm0-readiness.invalid" and
                     .port == 53 and
                     .dns_event == "query") and
                 any(.[];
@@ -190,7 +192,8 @@ EOF
                 dns: [.[] |
                     select(
                         .type == "dns" and
-                        (.host == "udp-dns.invalid" or .host == "tcp-dns.invalid")) |
+                        (.host == "udp-dns.vm0-readiness.invalid" or
+                            .host == "tcp-dns.vm0-readiness.invalid")) |
                     {host, port, dns_event}],
                 replicate: [.[] |
                     select(.type == "http" and .host == "api.replicate.com") |


### PR DESCRIPTION
## Summary

- keep the UDP and TCP DNS telemetry probes on unique names in the runner-owned `vm0-readiness.invalid` zone
- preserve real DNS packets over both UDP and TCP through the sandbox redirect and dnsmasq
- keep the existing response validation and run-owned network telemetry assertions intact

## Root cause evidence

The [triggering Turbo job](https://github.com/vm0-ai/vm0/actions/runs/32239660015/job/96028884540) reached every earlier probe marker, then the UDP DNS socket timed out waiting for a response to `udp-dns.invalid`. The later UDP/TCP DNS markers were therefore absent before the BATS output assertion ran.

The same fresh sandbox completed runner-owned guest DNS readiness in 7 ms immediately before the agent probe, and the agent execution and sandbox finalization completed normally. The original synthetic `.invalid` names were outside dnsmasq's locally owned `vm0-readiness.invalid` wildcard, so dnsmasq had to forward them to an external upstream. That external response was the first nondeterministic dependency in the test oracle.

The represented PR, #28201, only changes guest-contract environment tests. Its PR-head Turbo run passed this shard, and two overlapping merge-group jobs also passed the exact test:

- [comparison job 96028771883](https://github.com/vm0-ai/vm0/actions/runs/32239658671/job/96028771883)
- [comparison job 96028364290](https://github.com/vm0-ai/vm0/actions/runs/32239657409/job/96028364290)

## Validation

- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/run-t06-network-telemetry.bats`
- `./scripts/check-file-size.sh e2e/tests/03-runner/run-t06-network-telemetry.bats`
- static occurrence guard: each new probe name appears exactly three times and the old bare names are absent
- `git diff --check`

The Runner BATS suite is CI-only, so the focused Turbo shard on this PR is the authoritative deployed-runner validation. A browser preview is not applicable because this invariant has no user-facing browser path. Repeating the service check five times would require rerunning the full Turbo workflow and would turn the validation into retries rather than a narrow check.
