### PR TITLE
test(e2e): isolate zendesk auth probe from ipv6 dns

### DIFF
--- a/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
+++ b/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
@@ -32,11 +32,21 @@ teardown() {
 
     local prompt
     prompt=$(cat <<'EOF'
+set -euo pipefail
 printf 'ZENDESK_API_TOKEN=%s\n' "$ZENDESK_API_TOKEN"
 printf 'ZENDESK_EMAIL=%s\n' "$ZENDESK_EMAIL"
 printf 'ZENDESK_SUBDOMAIN=%s\n' "$ZENDESK_SUBDOMAIN"
-curl --silent --show-error --max-time 5 --output /dev/null "https://__SUBDOMAIN__.zendesk.com/api/v2/users/me.json" || true
-printf 'ZENDESK_REQUEST_SENT\n'
+# Raw DNS has dedicated runner coverage. Keep this firewall-auth probe on IPv4
+# so an unavailable AAAA response cannot block an otherwise valid request.
+if curl --ipv4 --silent --show-error --max-time 5 \
+    --output /dev/null \
+    "https://__SUBDOMAIN__.zendesk.com/api/v2/users/me.json"; then
+    printf 'ZENDESK_REQUEST_SENT\n'
+else
+    curl_status=$?
+    printf 'ZENDESK_REQUEST_FAILED=%s\n' "$curl_status"
+    exit "$curl_status"
+fi
 EOF
 )
     prompt="${prompt//__SUBDOMAIN__/$subdomain}"
@@ -50,9 +60,12 @@ EOF
     echo "$output"
     assert_success
 
-    run runner_e2e_wait_for_chat_text "$THREAD_ID" "$RUN_ID" ZENDESK_REQUEST_SENT
+    # Both outcomes use this prefix so a transport failure surfaces without
+    # waiting for a success marker that can no longer be emitted.
+    run runner_e2e_wait_for_chat_text "$THREAD_ID" "$RUN_ID" ZENDESK_REQUEST_
     echo "$output"
     assert_success
+    assert_output --partial "ZENDESK_REQUEST_SENT"
     assert_output --partial "ZENDESK_API_TOKEN=zkTkn_CoffeeSafeLocalCoffeeSafeLocalCoffeeSa"
     assert_output --partial "ZENDESK_EMAIL=runner-e2e@vm0.ai"
     assert_output --partial "ZENDESK_SUBDOMAIN=${subdomain}"


### PR DESCRIPTION
## Summary

- constrain the Zendesk firewall-auth probe to IPv4 while preserving the real test-specific Zendesk hostname and normal proxy path
- stop suppressing DNS and transport failures so the success marker proves transport completion
- emit a common success/failure prefix before exit so request failures surface without a second 90-second firewall-log wait
- keep the variable-base, safe-secret, header-auth, and run-owned firewall telemetry assertions unchanged

## Root cause evidence

The triggering merge-group failure is [Turbo run 32239660015](https://github.com/vm0-ai/vm0/actions/runs/32239660015), substantive job [96028884602](https://github.com/vm0-ai/vm0/actions/runs/32239660015/job/96028884602).

- the first Zendesk A query received two IPv4 answers about 21 ms later
- the paired AAAA query produced no resolver result; at the five-second boundary curl retried resolution and exited with `Resolving timed out after 5000 milliseconds`
- no Zendesk HTTP request was produced, so firewall auth and request telemetry were never reached; the later helper timeout was downstream fallout
- a separate fresh sandbox on the same runner instance timed out in a direct UDP DNS probe in the same second, while an adjacent merge-group job passed this exact Zendesk test concurrently on another runner
- the represented PR changes only guest-contract test code, and its PR-head run plus adjacent merge-group runs passed this shard

This is the same dropped-AAAA failure shape addressed for SerpAPI in #27826. That repair intentionally left Zendesk unchanged until separate failure evidence existed; this run provides that evidence.

## Invariant preservation

The probe still resolves a unique Zendesk variable base through guest DNS, establishes TLS to the real hostname, traverses the intended proxy/firewall path, injects the connector-owned header authentication, and requires the correct run-owned allowed firewall event. Raw UDP/TCP DNS behavior remains owned by the dedicated network-telemetry E2E.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (13/13 tasks)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (12/12 tasks)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/run-t03-firewall-zendesk.bats` (five consecutive passes; one test discovered each time)
- extracted prompt success/failure marker simulation (five consecutive passes; curl status 6 is terminal, emits `ZENDESK_REQUEST_FAILED=6`, and never emits the sent marker)
- related Bats discovery for the SerpAPI counterpart and runner-context shard companion
- `git diff --check`

Browser/preview validation is not applicable: this change has no browser surface and the runner Bats suite is CI-only. The deployed `cli-e2e-03-runner` Turbo shard is the acceptance-level integration gate.
