### PR TITLE
fix(billing): price member invitations incrementally

### DIFF
--- a/e2e/playwright/tests/billing-transitions.spec.ts
+++ b/e2e/playwright/tests/billing-transitions.spec.ts
@@ -355,13 +355,14 @@ test("restored Team plan preserves package and concurrency changes", async ({
   );
 });
 
-test("paid invitation purchases and revokes a pending member package", async ({
+test("paid invitations charge one package each and revoke pending packages", async ({
   page,
 }) => {
   test.setTimeout(360_000);
 
   await withBillingOwner(page, "E2E Paid Member Invitation", async (owner) => {
-    const inviteeEmail = generateTestEmail("paid-onboarding");
+    const firstInviteeEmail = generateTestEmail("paid-onboarding");
+    const secondInviteeEmail = generateTestEmail("paid-onboarding");
     await buyUsagePackPlan(page, "pro");
     await expectUsagePackState(page, owner, owner.userId, {
       pendingChange: null,
@@ -377,15 +378,35 @@ test("paid invitation purchases and revokes a pending member package", async ({
     });
     await expectUsagePackCreditsUi(page);
 
-    await purchasePaidInvitation(page, inviteeEmail, 50);
-    await expectPendingInvitationState(page, owner, inviteeEmail, {
-      email: inviteeEmail,
+    const firstAmountCents = await purchasePaidInvitation(
+      page,
+      firstInviteeEmail,
+      20,
+    );
+    await expectPendingInvitationState(page, owner, firstInviteeEmail, {
+      email: firstInviteeEmail,
       role: "member",
-      usagePackUsd: 50,
+      usagePackUsd: 20,
     });
 
-    await revokePaidInvitation(page, inviteeEmail);
-    await expectPendingInvitationState(page, owner, inviteeEmail, null);
+    const secondAmountCents = await purchasePaidInvitation(
+      page,
+      secondInviteeEmail,
+      20,
+    );
+    await expectPendingInvitationState(page, owner, secondInviteeEmail, {
+      email: secondInviteeEmail,
+      role: "member",
+      usagePackUsd: 20,
+    });
+    expect(Math.abs(secondAmountCents - firstAmountCents)).toBeLessThanOrEqual(
+      1,
+    );
+
+    await revokePaidInvitation(page, firstInviteeEmail);
+    await expectPendingInvitationState(page, owner, firstInviteeEmail, null);
+    await revokePaidInvitation(page, secondInviteeEmail);
+    await expectPendingInvitationState(page, owner, secondInviteeEmail, null);
   });
 });
 
@@ -598,7 +619,7 @@ async function purchasePaidInvitation(
   page: Page,
   email: string,
   usagePackUsd: UsagePackUsd,
-): Promise<void> {
+): Promise<number> {
   const settings = await openPeopleSettings(page);
   await settings
     .getByRole("button", { name: "Add member", exact: true })
@@ -612,12 +633,39 @@ async function purchasePaidInvitation(
   await page
     .getByRole("option", { name: USAGE_PACK_OPTION_PATTERNS[usagePackUsd] })
     .click();
+  const previewResponsePromise = page.waitForResponse(
+    (response) => {
+      return (
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname ===
+          "/api/okou/org/invite/purchase/preview"
+      );
+    },
+    { timeout: STATE_TIMEOUT_MS },
+  );
   await invite.getByRole("button", { name: "Continue", exact: true }).click();
+  const previewResponse = await previewResponsePromise;
+  expect(previewResponse.status()).toBe(200);
+  const previewBody = requireRecord(
+    await previewResponse.json(),
+    "invitation purchase preview",
+  );
+  const immediateAmountCents = requireNumber(
+    previewBody.immediateAmountCents,
+    "invitation purchase amount",
+  );
+  expect(immediateAmountCents).toBeGreaterThan(0);
+  expect(immediateAmountCents).toBeLessThanOrEqual(usagePackUsd * 100);
 
   const review = page.getByRole("dialog", { name: "Review invitation" });
   await expect(review).toBeVisible({ timeout: 30_000 });
   await expect(review.getByText(email, { exact: true })).toBeVisible();
   await expect(review.getByText(/^Member · /u)).toBeVisible();
+  await expect(
+    review.getByText(`$${(immediateAmountCents / 100).toFixed(2)}`, {
+      exact: true,
+    }),
+  ).toBeVisible();
   const responsePromise = page.waitForResponse(
     (response) => {
       return (
@@ -642,6 +690,7 @@ async function purchasePaidInvitation(
     row.getByText(`$${usagePackUsd}/month`, { exact: true }),
   ).toBeVisible();
   await expect(row.getByText("Pending", { exact: true })).toBeVisible();
+  return immediateAmountCents;
 }
 
 async function revokePaidInvitation(page: Page, email: string): Promise<void> {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -38,7 +38,10 @@ import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
-import { mockStripeClient } from "../../external/stripe-client";
+import {
+  mockStripeClient,
+  type StripeInvoiceCreatePreviewParams,
+} from "../../external/stripe-client";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
 import {
@@ -5247,6 +5250,63 @@ describe("usage pack allocation management", () => {
     }
   }
 
+  type PreviewSubscriptionDetails = NonNullable<
+    StripeInvoiceCreatePreviewParams["subscription_details"]
+  >;
+
+  function previewSubscriptionDetails(
+    input: unknown,
+  ): PreviewSubscriptionDetails | null {
+    if (typeof input !== "object" || input === null) {
+      return null;
+    }
+    const details = Reflect.get(input, "subscription_details");
+    if (
+      typeof details !== "object" ||
+      details === null ||
+      !Array.isArray(Reflect.get(details, "items"))
+    ) {
+      return null;
+    }
+    return details as PreviewSubscriptionDetails;
+  }
+
+  function previewTargetPriceId(
+    details: PreviewSubscriptionDetails | null,
+  ): string | null {
+    const item = details?.items.at(-1);
+    if (!item) {
+      return null;
+    }
+    if ("price" in item && item.price) {
+      return item.price;
+    }
+    return "id" in item && item.id?.startsWith("si_") ? item.id.slice(3) : null;
+  }
+
+  function mockUsagePackProrationLines(
+    details: PreviewSubscriptionDetails | null,
+    amountCents: number,
+  ) {
+    const targetPriceId = previewTargetPriceId(details);
+    const prorationTimestamp = details?.proration_date;
+    if (!targetPriceId || typeof prorationTimestamp !== "number") {
+      return [];
+    }
+    return [
+      {
+        id: `il_preview_${randomUUID()}`,
+        amount: amountCents,
+        price: { id: targetPriceId },
+        period: { start: prorationTimestamp },
+        parent: {
+          type: "subscription_item_details" as const,
+          subscription_item_details: { proration: true },
+        },
+      },
+    ];
+  }
+
   function mockUsagePackChangePreviews(
     immediateAmountCents: number,
     nextRecurringAmountCents: number,
@@ -5266,12 +5326,22 @@ describe("usage pack allocation management", () => {
       ) {
         throw new Error("Recurring previews cannot include prorations");
       }
+      const immediate =
+        "preview_mode" in input && input.preview_mode === "next";
+      const subscriptionDetails = previewSubscriptionDetails(input);
       return Promise.resolve({
-        amount_due:
-          "preview_mode" in input && input.preview_mode === "next"
-            ? immediateAmountCents
-            : nextRecurringAmountCents,
+        id: `in_preview_${randomUUID()}`,
+        amount_due: immediate ? immediateAmountCents : nextRecurringAmountCents,
         currency: "usd",
+        lines: {
+          has_more: false,
+          data: immediate
+            ? mockUsagePackProrationLines(
+                subscriptionDetails,
+                immediateAmountCents,
+              )
+            : [],
+        },
       });
     });
   }
@@ -9520,6 +9590,106 @@ describe("usage pack allocation management", () => {
     );
 
     expect(response.body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("prices an invitation from only the added package proration", async () => {
+    const existingMemberUserId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([
+      { userId: existingMemberUserId, usagePackUsd: 20 },
+    ]);
+    const email = `incremental-invite-${randomUUID()}@example.test`;
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      managedUsagePackSubscription(
+        fixture,
+        new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      ),
+    );
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [
+          {
+            publicUserData: {
+              userId: existingMemberUserId,
+              identifier: `${existingMemberUserId}@example.test`,
+            },
+            createdAt: now(),
+          },
+        ],
+      },
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    context.mocks.stripe.invoices.createPreview.mockImplementation((input) => {
+      const details = previewSubscriptionDetails(input);
+      const prorationTimestamp = details?.proration_date;
+      if (!details || typeof prorationTimestamp !== "number") {
+        throw new Error("Expected an invitation proration timestamp");
+      }
+      expect(details.items).toStrictEqual([
+        { id: `si_${TEST_PRICE_USAGE_PACK_20}`, quantity: 2 },
+      ]);
+      return Promise.resolve({
+        id: `in_preview_${randomUUID()}`,
+        amount_due: 4000,
+        currency: "usd",
+        lines: {
+          has_more: false,
+          data: [
+            {
+              id: `il_renewal_${randomUUID()}`,
+              amount: 4000,
+              price: { id: TEST_PRICE_USAGE_PACK_20 },
+              period: {
+                start: fixture.billingPeriod.end,
+                end: fixture.billingPeriod.end + 30 * 86_400,
+              },
+              parent: {
+                type: "subscription_item_details" as const,
+                subscription_item_details: { proration: false },
+              },
+            },
+            {
+              id: `il_proration_${randomUUID()}`,
+              amount: 2000,
+              price: { id: TEST_PRICE_USAGE_PACK_20 },
+              period: {
+                start: prorationTimestamp,
+                end: fixture.billingPeriod.end,
+              },
+              parent: {
+                type: "subscription_item_details" as const,
+                subscription_item_details: { proration: true },
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    const response = await accept(
+      setupApp({ context, routes: orgInviteRoutes })(
+        orgInviteContract,
+      ).previewPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { email, role: "member", usagePackUsd: 20 },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      purchaseId: expect.any(String),
+      usagePackUsd: 20,
+      immediateAmountCents: 2000,
+      currency: "usd",
+      purchasedCredits: 20_000,
+      bonusCredits: 400,
+      totalCredits: 20_400,
+      currentPeriodEnd: new Date(
+        fixture.billingPeriod.end * 1000,
+      ).toISOString(),
+      expiresAt: expect.any(String),
+    });
   });
 
   it("creates fresh Setup Checkouts when an invitation preview return URL changes", async () => {

--- a/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-allocation-change.service.ts
@@ -33,7 +33,9 @@ import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 import {
   getStripeClient,
+  type StripeClient,
   type StripeInvoice,
+  type StripeInvoiceLine,
   type StripePriceRecurring,
   type StripeRef,
   type StripeSchedulePhaseDiscountParam,
@@ -62,6 +64,7 @@ import {
 
 const PREVIEW_TTL_MS = 15 * 60 * 1000;
 const CHANGE_RECONCILIATION_DELAY_MS = 5 * 60 * 1000;
+const STRIPE_INVOICE_LINE_PAGE_SIZE = 100;
 const CREDITS_PER_DOLLAR = 1000;
 const CREDITS_PER_CENT = CREDITS_PER_DOLLAR / 100;
 const OPEN_CHANGE_STATUSES = [
@@ -731,6 +734,73 @@ function safeInvoiceAmount(invoice: StripeInvoice, label: string): number {
   return invoice.amount_due;
 }
 
+function invoiceLineAmountWithTax(line: StripeInvoiceLine): number {
+  const exclusiveTax = (line.taxes ?? []).reduce((total, tax) => {
+    return tax.tax_behavior === "exclusive" ? total + tax.amount : total;
+  }, 0);
+  const amount = line.amount + exclusiveTax;
+  if (!Number.isSafeInteger(amount)) {
+    throw new Error("Stripe usage pack preview line has an invalid amount");
+  }
+  return amount;
+}
+
+async function listCompleteInvoiceLines(
+  stripe: StripeClient,
+  invoice: StripeInvoice,
+  signal: AbortSignal,
+): Promise<readonly StripeInvoiceLine[]> {
+  if (!invoice.lines.has_more) {
+    return invoice.lines.data;
+  }
+  const lines: StripeInvoiceLine[] = [];
+  let startingAfter: string | undefined;
+  while (true) {
+    const page = await stripe.invoices.listLineItems(invoice.id, {
+      limit: STRIPE_INVOICE_LINE_PAGE_SIZE,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+    signal.throwIfAborted();
+    lines.push(...page.data);
+    if (!page.has_more) {
+      return lines;
+    }
+    const last = page.data.at(-1);
+    if (!last?.id) {
+      throw new Error(
+        `Stripe invoice ${invoice.id} returned an incomplete line-item page`,
+      );
+    }
+    startingAfter = last.id;
+  }
+}
+
+function usagePackAllocationAdditionAmount(
+  invoice: StripeInvoice,
+  lines: readonly StripeInvoiceLine[],
+  stripePriceId: string,
+  prorationTimestamp: number,
+): number {
+  const prorationLines = lines.filter((line) => {
+    return (
+      invoiceLinePriceId(line) === stripePriceId &&
+      invoiceLineIsProration(line) &&
+      line.period.start === prorationTimestamp
+    );
+  });
+  const amount = prorationLines.reduce((total, line) => {
+    return total + invoiceLineAmountWithTax(line);
+  }, 0);
+  if (
+    invoice.currency.length !== 3 ||
+    prorationLines.length === 0 ||
+    !Number.isSafeInteger(amount)
+  ) {
+    throw new Error("Stripe invitation preview has an invalid amount");
+  }
+  return Math.max(0, amount);
+}
+
 export async function lockUsagePackBillingOrg(
   tx: Pick<WriteTx, "execute">,
   orgId: string,
@@ -1288,8 +1358,15 @@ export async function previewUsagePackAllocationAddition(
     },
   });
   signal.throwIfAborted();
+  const previewLines = await listCompleteInvoiceLines(stripe, preview, signal);
+  signal.throwIfAborted();
   return {
-    amountCents: safeInvoiceAmount(preview, "invitation"),
+    amountCents: usagePackAllocationAdditionAmount(
+      preview,
+      previewLines,
+      args.stripePriceId,
+      prorationTimestamp,
+    ),
     currency: preview.currency,
     currentPeriodStart: new Date(period.start * 1000),
     currentPeriodEnd: new Date(period.end * 1000),


### PR DESCRIPTION
## Summary

- calculate paid invitation previews from the matching Stripe proration lines instead of the full invoice total
- include exclusive tax and handle paginated preview lines consistently
- add API regression coverage and a Playwright E2E scenario for two consecutive $20 member invitations

## Verification

- `pnpm format`
- workspace lint and `pnpm knip`
- API and app TypeScript checks
- E2E TypeScript check
- `vitest run src/signals/routes/__tests__/billing-checkout.test.ts` (161 passed)

## Root cause

The invitation preview returned Stripe's full `amount_due`. Once an organization already had one $20 member package, that total included the existing renewal line plus the new package proration, so the second invitation displayed $40. The preview now sums only the new package's immediate proration lines.
