### PR TITLE
feat: simplify model picker trigger and category switch

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4240,6 +4240,7 @@
         "categoryChat": "Chat",
         "categoryImage": "Bild",
         "categoryVideo": "Video",
+        "chatModels": "Chatmodelle",
         "fast": "Schnell",
         "fastImpact": "1,5× Modellgeschwindigkeit · 2,5× Credit-Nutzung",
         "imageModels": "Bildmodelle",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4240,6 +4240,7 @@
         "categoryChat": "Chat",
         "categoryImage": "Image",
         "categoryVideo": "Video",
+        "chatModels": "Chat models",
         "fast": "Fast",
         "fastImpact": "1.5× model speed · 2.5× credit usage",
         "imageModels": "Image models",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -4290,6 +4290,7 @@
         "categoryChat": "Chat",
         "categoryImage": "Imagen",
         "categoryVideo": "Vídeo",
+        "chatModels": "Modelos de chat",
         "fast": "Rápido",
         "fastImpact": "1,5× velocidad del modelo · 2,5× uso de créditos",
         "imageModels": "Modelos de imagen",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -4290,6 +4290,7 @@
         "categoryChat": "Chat",
         "categoryImage": "Image",
         "categoryVideo": "Vidéo",
+        "chatModels": "Modèles de chat",
         "fast": "Rapide",
         "fastImpact": "Vitesse du modèle 1,5× · consommation de crédits 2,5×",
         "imageModels": "Modèles d’image",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4240,6 +4240,7 @@
         "categoryChat": "चैट",
         "categoryImage": "इमेज",
         "categoryVideo": "वीडियो",
+        "chatModels": "चैट मॉडल",
         "fast": "तेज़",
         "fastImpact": "1.5× मॉडल गति · 2.5× क्रेडिट उपयोग",
         "imageModels": "इमेज मॉडल",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4239,6 +4239,7 @@
         "categoryChat": "Chat",
         "categoryImage": "Gambar",
         "categoryVideo": "Video",
+        "chatModels": "Model chat",
         "fast": "Cepat",
         "fastImpact": "Kecepatan model 1,5× · penggunaan kredit 2,5×",
         "imageModels": "Model gambar",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -4290,6 +4290,7 @@
         "categoryChat": "Chat",
         "categoryImage": "Immagini",
         "categoryVideo": "Video",
+        "chatModels": "Modelli chat",
         "fast": "Veloce",
         "fastImpact": "Velocità del modello 1,5× · consumo di crediti 2,5×",
         "imageModels": "Modelli di immagini",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4239,6 +4239,7 @@
         "categoryChat": "チャット",
         "categoryImage": "画像",
         "categoryVideo": "動画",
+        "chatModels": "チャットモデル",
         "fast": "速い",
         "fastImpact": "モデル速度 1.5× · クレジット消費 2.5×",
         "imageModels": "画像モデル",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4239,6 +4239,7 @@
         "categoryChat": "채팅",
         "categoryImage": "이미지",
         "categoryVideo": "동영상",
+        "chatModels": "채팅 모델",
         "fast": "빠름",
         "fastImpact": "모델 속도 1.5× · 크레딧 사용량 2.5×",
         "imageModels": "이미지 모델",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -4290,6 +4290,7 @@
         "categoryChat": "Chat",
         "categoryImage": "Imagem",
         "categoryVideo": "Vídeo",
+        "chatModels": "Modelos de chat",
         "fast": "Rápido",
         "fastImpact": "Velocidade do modelo 1,5× · uso de créditos 2,5×",
         "imageModels": "Modelos de imagem",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx
@@ -128,7 +128,7 @@ function categoryTab(
   root: ParentNode = document,
 ): HTMLElement | undefined {
   return queryAllByRoleFast("radio", root).find((candidate) => {
-    return candidate.textContent?.replace(/\s+/gu, " ").trim() === name;
+    return candidate.getAttribute("aria-label") === name;
   });
 }
 
@@ -339,7 +339,7 @@ describe("chat composer models", () => {
       categoryTab: "Video",
     },
   ])(
-    "keeps the mobile model brand icon and hides the desktop icon when $kind model selection is enabled",
+    "keeps the model brand icon on the trigger when $kind model selection is enabled",
     async ({ featureSwitch, categoryTab }) => {
       const user = userEvent.setup({ delay: null });
       context.mocks.browser.matchMedia(true);
@@ -360,12 +360,12 @@ describe("chat composer models", () => {
       await waitFor(() => {
         expect(
           queryAllByRoleFast("radio").find((radio) => {
-            return (
-              radio.textContent?.replace(/\s+/gu, " ").trim() === categoryTab
-            );
+            return radio.getAttribute("aria-label") === categoryTab;
           }),
         ).toBeInTheDocument();
       });
+      // The trigger reads the same whether or not media categories are on: the
+      // selected model's brand mark on both layouts, and no mode glyph.
       expect(
         Array.from(
           modelPicker.querySelectorAll<HTMLImageElement>("img"),
@@ -373,7 +373,8 @@ describe("chat composer models", () => {
             return icon.width;
           },
         ),
-      ).toStrictEqual([18]);
+      ).toStrictEqual([18, 16]);
+      expect(modelPicker.querySelector(".lucide-message-circle")).toBeNull();
     },
   );
 
@@ -4285,7 +4286,8 @@ describe("chat composer video model", () => {
     const variant = queryAllByRoleFast("radio").find((candidate) => {
       return (
         candidate.getAttribute("aria-checked") === "true" &&
-        candidate.hasAttribute("aria-label")
+        candidate.hasAttribute("aria-label") &&
+        candidate.textContent?.trim()
       );
     });
     return variant?.getAttribute("aria-label") ?? undefined;
@@ -4545,7 +4547,9 @@ describe("chat composer video model", () => {
     expect(videoPanelButton("Seedance 2.0 fast")).toBeUndefined();
     expect(videoPanelButton("Seedance 2.0 Mini")).toBeUndefined();
     const variantSegments = queryAllByRoleFast("radio").filter((candidate) => {
-      return candidate.hasAttribute("aria-label");
+      return (
+        candidate.hasAttribute("aria-label") && candidate.textContent?.trim()
+      );
     });
     expect(
       variantSegments.map((candidate) => {
@@ -4591,13 +4595,11 @@ describe("chat composer video model", () => {
     const chatModelButton = await findComposerModel("Claude Fable 5");
     expect(screen.getAllByRole("combobox")).toHaveLength(1);
     expect(chatModelButton).toHaveAttribute("aria-expanded", "false");
-    const chatModeIcon = chatModelButton.querySelector(
-      ".lucide-message-circle",
-    );
-    expect(chatModeIcon).toBeInTheDocument();
-    expect(chatModeIcon).toHaveAttribute("width", "16");
-    expect(chatModeIcon).toHaveAttribute("height", "16");
-    expect(chatModelButton).toHaveTextContent(/·\s*Claude Fable 5/);
+    // The trigger names the model and nothing else -- no mode glyph, no
+    // category word.
+    expect(chatModelButton.querySelector(".lucide-message-circle")).toBeNull();
+    expect(chatModelButton).toHaveTextContent("Claude Fable 5");
+    expect(chatModelButton).not.toHaveTextContent("·");
     expect(chatModelButton).not.toHaveTextContent("Chat");
     expect(videoCategoryTab()).toBeUndefined();
 
@@ -4660,7 +4662,10 @@ describe("chat composer video model", () => {
     expect(
       queryAllByRoleFast("radio")
         .filter((candidate) => {
-          return candidate.hasAttribute("aria-label");
+          return (
+            candidate.hasAttribute("aria-label") &&
+            candidate.textContent?.trim()
+          );
         })
         .map((candidate) => {
           return candidate.getAttribute("aria-label");

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -146,8 +146,6 @@ interface ModelProviderPickerProps {
    * the normal label on larger screens.
    */
   mobileIconTrigger?: boolean;
-  /** Optional desktop-only mode label shown before the selected model. */
-  desktopModeLabel?: string;
   /** Controlled open state for programmatic toggle (e.g. keyboard shortcut). */
   open?: boolean;
   /** Callback when the open state changes. */
@@ -235,12 +233,10 @@ function ProBadge() {
 
 function ResponsiveTriggerContent({
   mobileIcon,
-  showDesktopIcon,
   iconType,
   label,
 }: {
   mobileIcon: boolean;
-  showDesktopIcon: boolean;
   iconType: ModelProviderType | undefined;
   label: ReactNode;
 }) {
@@ -257,9 +253,7 @@ function ResponsiveTriggerContent({
         )}
       </span>
       <span className="hidden min-w-0 sm:inline-flex sm:items-center sm:gap-1.5">
-        {showDesktopIcon && iconType && (
-          <ProviderIcon type={iconType} size={16} />
-        )}
+        {iconType && <ProviderIcon type={iconType} size={16} />}
         {label}
       </span>
     </span>
@@ -389,14 +383,12 @@ function ModelFirstTriggerLabel({
   selection,
   placeholder,
   mobileIcon,
-  showDesktopIcon,
   codexFastModeEnabled,
   fastLabel,
 }: {
   selection: ModelProviderSelection | null;
   placeholder: string;
   mobileIcon: boolean;
-  showDesktopIcon: boolean;
   codexFastModeEnabled: boolean;
   fastLabel: string;
 }) {
@@ -404,7 +396,6 @@ function ModelFirstTriggerLabel({
     return (
       <ResponsiveTriggerContent
         mobileIcon={mobileIcon}
-        showDesktopIcon={showDesktopIcon}
         iconType={undefined}
         label={<span>{placeholder}</span>}
       />
@@ -414,7 +405,6 @@ function ModelFirstTriggerLabel({
   return (
     <ResponsiveTriggerContent
       mobileIcon={mobileIcon}
-      showDesktopIcon={showDesktopIcon}
       iconType={iconType}
       label={
         <span className="min-w-0 truncate">
@@ -430,46 +420,10 @@ function ModelFirstTriggerLabel({
   );
 }
 
-function ModelFirstTriggerContent({
-  desktopModeLabel,
-  selection,
-  placeholder,
-  mobileIcon,
-  codexFastModeEnabled,
-  fastLabel,
-}: {
-  desktopModeLabel: string | undefined;
-  selection: ModelProviderSelection | null;
-  placeholder: string;
-  mobileIcon: boolean;
-  codexFastModeEnabled: boolean;
-  fastLabel: string;
-}) {
-  return (
-    <span className="flex min-w-0 items-center gap-1.5">
-      {desktopModeLabel && (
-        <span className="hidden shrink-0 sm:inline-flex sm:items-center sm:gap-1.5">
-          <MessageCircle size={16} aria-hidden="true" />
-          <span aria-hidden="true">·</span>
-        </span>
-      )}
-      <ModelFirstTriggerLabel
-        selection={selection}
-        placeholder={placeholder}
-        mobileIcon={mobileIcon}
-        showDesktopIcon={desktopModeLabel === undefined}
-        codexFastModeEnabled={codexFastModeEnabled}
-        fastLabel={fastLabel}
-      />
-    </span>
-  );
-}
-
 function ModelFirstDisabledPickerLabel({
   value,
   placeholder,
   mobileIconTrigger,
-  desktopModeLabel,
   triggerClassName,
   userPreference,
   policies,
@@ -481,7 +435,6 @@ function ModelFirstDisabledPickerLabel({
   | "placeholder"
   | "compactTrigger"
   | "mobileIconTrigger"
-  | "desktopModeLabel"
   | "triggerClassName"
 > & {
   placeholder: string;
@@ -507,8 +460,7 @@ function ModelFirstDisabledPickerLabel({
         stripInteractiveClasses(triggerClassName),
       )}
     >
-      <ModelFirstTriggerContent
-        desktopModeLabel={desktopModeLabel}
+      <ModelFirstTriggerLabel
         selection={resolved}
         placeholder={placeholder}
         mobileIcon={mobileIconTrigger}
@@ -722,12 +674,15 @@ function ModelFirstPolicyItems({
   modelCapabilities,
   codexFastModeEnabled,
   showSeparator = true,
+  showModelsLabel = true,
 }: {
   policies: OrgModelPolicy[];
   selection: ModelProviderSelection | null;
   modelCapabilities: ModelPlanCapabilities;
   codexFastModeEnabled: boolean;
   showSeparator?: boolean;
+  /** When false, the media-model header already carries the category title. */
+  showModelsLabel?: boolean;
 }) {
   const { t } = useTranslation();
   const explicitSelectedModel = selection?.selectedModel ?? null;
@@ -759,11 +714,13 @@ function ModelFirstPolicyItems({
         </div>
       ) : (
         <SelectGroup>
-          <SelectLabel className="pl-2 pr-8 py-1.5 text-xs font-medium text-muted-foreground">
-            {t(($) => {
-              return $.settings.models.picker.models;
-            })}
-          </SelectLabel>
+          {showModelsLabel && (
+            <SelectLabel className="pl-2 pr-8 py-1.5 text-xs font-medium text-muted-foreground">
+              {t(($) => {
+                return $.settings.models.picker.models;
+              })}
+            </SelectLabel>
+          )}
           {policies.map((policy) => {
             return (
               <ModelFirstPolicyRow
@@ -1146,18 +1103,38 @@ function MediaModelPanelRow({ option }: { option: MediaModelPanelOption }) {
 }
 
 function MediaModelPanel({ category }: { category: MediaModelPanelCategory }) {
-  const { t } = useTranslation();
   return (
     <SelectGroup>
-      <SelectLabel className="py-1.5 pl-2 pr-8 text-xs font-medium text-muted-foreground">
-        {t(($) => {
-          return $.settings.models.picker.models;
-        })}
-      </SelectLabel>
       {category.options.map((option) => {
         return <MediaModelPanelRow key={option.key} option={option} />;
       })}
     </SelectGroup>
+  );
+}
+
+/**
+ * The list header carries the category title beside the category switch on one
+ * row, so the switch stays quiet: it borrows the label's height instead of
+ * adding a band of its own above it. It is rendered once for the whole popover
+ * (rather than once per panel) so switching category keeps the same switch.
+ */
+function ModelPickerListHeader({
+  label,
+  categorySwitch,
+}: {
+  label: string;
+  categorySwitch: ReactNode;
+}) {
+  return (
+    // Pinned so switching category never means scrolling back up for the
+    // switch. The negative margins bleed the row over the list's own `p-1`
+    // inset so rows scroll under an opaque surface rather than beside it.
+    <div className="sticky top-0 z-10 -mx-1 -mt-1 flex items-center gap-2 bg-card py-1 pl-3 pr-2">
+      <span className="min-w-0 flex-1 truncate text-xs font-medium text-muted-foreground">
+        {label}
+      </span>
+      {categorySwitch}
+    </div>
   );
 }
 
@@ -1168,55 +1145,60 @@ const MEDIA_MODEL_CATEGORY_ICONS = {
 
 const CHAT_CATEGORY_VALUE = "chat";
 
+// Icon-only, and trackless: three glyphs sitting straight on the popover
+// surface. A filled track was the darkest thing in a popover otherwise made of
+// quiet rows, and the labels it carried repeated the group label beside it.
+// The selected glyph takes the shared selected layer, which reads on any
+// surface and reverses in dark, in place of the raised segment fill.
+const MEDIA_MODEL_CATEGORY_SEGMENT_CLASS =
+  "w-7 px-0 data-checked:bg-state-selected data-checked:shadow-none";
+
 /**
- * Category switch for the popover. This strip used to live in the composer as a
- * filled track holding three controls, which read as heavy for a row of quiet
+ * Category switch for the popover. It used to live in the composer as a filled
+ * track holding three controls, which read as heavy for a row of quiet
  * controls; the composer keeps one trigger and the split happens here instead.
- * Every viewport gets the same strip -- mobile previously drilled into a nested
- * category from a root menu, which was a second way to express one choice.
+ * Every viewport gets the same switch -- mobile previously drilled into a
+ * nested category from a root menu, which was a second way to express one
+ * choice.
  */
-function MediaModelCategoryTabs({ panel }: { panel: MediaModelPanelState }) {
+function MediaModelCategorySwitch({ panel }: { panel: MediaModelPanelState }) {
   const { t } = useTranslation();
   return (
-    // Pinned so switching category never means scrolling back up for the strip.
-    // The negative margins bleed it over the list's own `p-1` inset so rows
-    // scroll under an opaque surface rather than beside it.
-    <div className="sticky top-0 z-10 -mx-1 -mt-1 bg-card p-1">
-      <SegmentControl
-        size="xs"
-        className="w-full"
+    <SegmentControl
+      size="xs"
+      className="shrink-0 gap-0.5 bg-transparent p-0"
+      aria-label={t(($) => {
+        return $.settings.models.picker.models;
+      })}
+      value={panel.activeCategory ?? CHAT_CATEGORY_VALUE}
+      onValueChange={(next: string) => {
+        panel.onActiveCategoryChange(
+          next === CHAT_CATEGORY_VALUE ? null : (next as MediaModelCategoryId),
+        );
+      }}
+    >
+      <SegmentControlItem
+        value={CHAT_CATEGORY_VALUE}
         aria-label={t(($) => {
-          return $.settings.models.picker.models;
+          return $.settings.models.picker.categoryChat;
         })}
-        value={panel.activeCategory ?? CHAT_CATEGORY_VALUE}
-        onValueChange={(next: string) => {
-          panel.onActiveCategoryChange(
-            next === CHAT_CATEGORY_VALUE
-              ? null
-              : (next as MediaModelCategoryId),
-          );
-        }}
+        className={MEDIA_MODEL_CATEGORY_SEGMENT_CLASS}
       >
-        <SegmentControlItem value={CHAT_CATEGORY_VALUE} className="flex-1">
-          <MessageCircle size={16} aria-hidden="true" />
-          {t(($) => {
-            return $.settings.models.picker.categoryChat;
-          })}
-        </SegmentControlItem>
-        {panel.categories.map((category) => {
-          return (
-            <SegmentControlItem
-              key={category.id}
-              value={category.id}
-              className="flex-1"
-            >
-              {MEDIA_MODEL_CATEGORY_ICONS[category.id]}
-              {category.tabLabel}
-            </SegmentControlItem>
-          );
-        })}
-      </SegmentControl>
-    </div>
+        <MessageCircle size={16} aria-hidden="true" />
+      </SegmentControlItem>
+      {panel.categories.map((category) => {
+        return (
+          <SegmentControlItem
+            key={category.id}
+            value={category.id}
+            aria-label={category.tabLabel}
+            className={MEDIA_MODEL_CATEGORY_SEGMENT_CLASS}
+          >
+            {MEDIA_MODEL_CATEGORY_ICONS[category.id]}
+          </SegmentControlItem>
+        );
+      })}
+    </SegmentControl>
   );
 }
 
@@ -1241,6 +1223,7 @@ function ModelFirstModelPickerContentLayout({
   fastLabel,
   mediaModelPanel,
 }: ModelFirstModelPickerContentBaseProps) {
+  const { t } = useTranslation();
   const activeMediaModelCategoryId = mediaModelPanel?.activeCategory;
   const activeMediaModelCategory = mediaModelPanel?.categories.find(
     (category) => {
@@ -1280,19 +1263,28 @@ function ModelFirstModelPickerContentLayout({
           })}
         </SelectItem>
       )}
-      {mediaModelPanel && <MediaModelCategoryTabs panel={mediaModelPanel} />}
+      {mediaModelPanel && (
+        <ModelPickerListHeader
+          label={
+            activeMediaModelCategory?.label ??
+            t(($) => {
+              return $.settings.models.picker.chatModels;
+            })
+          }
+          categorySwitch={<MediaModelCategorySwitch panel={mediaModelPanel} />}
+        />
+      )}
       {mediaModelPanel && activeMediaModelCategory ? (
         <MediaModelPanel category={activeMediaModelCategory} />
       ) : (
-        <>
-          <ModelFirstPolicyItems
-            policies={policies}
-            selection={selection}
-            modelCapabilities={modelCapabilities}
-            codexFastModeEnabled={codexFastModeEnabled}
-            showSeparator={false}
-          />
-        </>
+        <ModelFirstPolicyItems
+          policies={policies}
+          selection={selection}
+          modelCapabilities={modelCapabilities}
+          codexFastModeEnabled={codexFastModeEnabled}
+          showSeparator={false}
+          showModelsLabel={!mediaModelPanel}
+        />
       )}
     </SelectContent>
   );
@@ -1364,7 +1356,6 @@ function ModelFirstSelectPicker({
   placeholder,
   triggerClassName,
   mobileIconTrigger,
-  desktopModeLabel,
   modelCapabilities,
   codexFastModeEnabled,
   fastLabel,
@@ -1379,7 +1370,6 @@ function ModelFirstSelectPicker({
   placeholder: string;
   triggerClassName: string | undefined;
   mobileIconTrigger: boolean;
-  desktopModeLabel: string | undefined;
   modelCapabilities: ModelPlanCapabilities;
   codexFastModeEnabled: boolean;
   fastLabel: string;
@@ -1407,8 +1397,7 @@ function ModelFirstSelectPicker({
         className={cn("h-9 w-full", triggerClassName)}
       >
         <SelectValue placeholder={placeholder}>
-          <ModelFirstTriggerContent
-            desktopModeLabel={desktopModeLabel}
+          <ModelFirstTriggerLabel
             selection={state.selection}
             placeholder={placeholder}
             mobileIcon={mobileIconTrigger}
@@ -1441,7 +1430,6 @@ function SubscribedModelFirstModelPicker({
   triggerClassName,
   compactTrigger,
   mobileIconTrigger,
-  desktopModeLabel,
   open,
   onOpenChange,
   modal,
@@ -1489,7 +1477,6 @@ function SubscribedModelFirstModelPicker({
         placeholder={placeholder}
         compactTrigger={compactTrigger}
         mobileIconTrigger={mobileIconTrigger}
-        desktopModeLabel={desktopModeLabel}
         triggerClassName={triggerClassName}
         userPreference={resolveDefaultSelection ? userPreference : null}
         policies={resolveDefaultSelection ? state.selectablePolicies : []}
@@ -1535,7 +1522,6 @@ function SubscribedModelFirstModelPicker({
       placeholder={placeholder}
       triggerClassName={triggerClassName}
       mobileIconTrigger={mobileIconTrigger}
-      desktopModeLabel={desktopModeLabel}
       modelCapabilities={modelCapabilities}
       codexFastModeEnabled={codexFastModeEnabled}
       fastLabel={fastLabel}
@@ -1770,7 +1756,6 @@ function EnabledExplicitModelFirstModelPicker(
       placeholder={props.placeholder}
       triggerClassName={props.triggerClassName}
       mobileIconTrigger={props.mobileIconTrigger}
-      desktopModeLabel={props.desktopModeLabel}
       modelCapabilities={DEFAULT_MODEL_PLAN_CAPABILITIES}
       codexFastModeEnabled={props.codexFastModeEnabled ?? false}
       fastLabel={props.fastLabel}
@@ -1798,7 +1783,6 @@ function ModelFirstModelPicker(
         placeholder={props.placeholder}
         compactTrigger={props.compactTrigger}
         mobileIconTrigger={props.mobileIconTrigger}
-        desktopModeLabel={props.desktopModeLabel}
         triggerClassName={props.triggerClassName}
         userPreference={null}
         policies={[]}
@@ -1835,7 +1819,6 @@ export function ModelProviderPicker({
   triggerClassName,
   compactTrigger = false,
   mobileIconTrigger = false,
-  desktopModeLabel,
   open,
   onOpenChange,
   modal,
@@ -1860,7 +1843,6 @@ export function ModelProviderPicker({
     triggerClassName,
     compactTrigger,
     mobileIconTrigger,
-    desktopModeLabel,
     open,
     onOpenChange,
     modal,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -7437,11 +7437,6 @@ function ComposerRunModelPickerControl({
   const modelPickerOpen = useGet(signals.model.modelPickerOpen$);
   const setModelPickerOpen = useSet(signals.model.setModelPickerOpen$);
   const setLifecycleRef = useSet(signals.model.desktopModelPickerLifecycleRef$);
-  const desktopModeLabel = mediaModelPanel
-    ? t(($) => {
-        return $.appShell.sidebar.chat;
-      })
-    : undefined;
   return (
     <div ref={setLifecycleRef} className="contents sm:relative sm:flex">
       <ModelProviderPicker
@@ -7453,7 +7448,6 @@ function ComposerRunModelPickerControl({
         triggerClassName={composerModelPickerTriggerClassName()}
         compactTrigger
         mobileIconTrigger
-        desktopModeLabel={desktopModeLabel}
         open={modelPickerOpen}
         modal={mediaModelPanel ? !desktopLayout : undefined}
         onOpenChange={(open) => {


### PR DESCRIPTION
## Summary

Refines the composer model picker in two places:

- **Trigger** — drops the desktop-only mode glyph so the trigger reads as the selected model's brand mark + name in every layout. Removes the now-unused `desktopModeLabel` chain.
- **Popover** — replaces the filled gray category track with an icon-only switch that sits beside the category title (Chat models / Image models / Video models). The switch is rendered once for the whole popover so switching category keeps the same control.

## Verification

- `pnpm --filter @okouai/app run check-types` — clean
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-composer-model-selection-and-providers.test.tsx` — 79 passed
