### PR TITLE
refactor(deploy): drop the legacy secret source fallback

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -123,13 +123,6 @@ runs:
           add_env "$1" "$(repo_secret "$2")"
         }
 
-        add_okou_secret() {
-          local suffix="$1"
-          local value
-          value="$(first_non_empty "$(repo_secret "OKOU_${suffix}")" "$(repo_secret "ZERO_${suffix}")")"
-          add_env "OKOU_${suffix}" "$value"
-        }
-
         add_oauth_client_config_key() {
           local key="$1"
           local value
@@ -355,12 +348,12 @@ runs:
           FINANCE_APIDOJO_TOKEN
         )
         for suffix in "${okou_provider_secret_suffixes[@]}"; do
-          add_okou_secret "$suffix"
+          add_secret "OKOU_${suffix}" "OKOU_${suffix}"
         done
         if [[ "$INPUT_APP" == "api" ]]; then
-          add_okou_secret SEO_DATAFORSEO_LOGIN
-          add_okou_secret SEO_DATAFORSEO_PASSWORD
-          add_okou_secret BROWSER_USE_API_KEY
+          add_secret OKOU_SEO_DATAFORSEO_LOGIN OKOU_SEO_DATAFORSEO_LOGIN
+          add_secret OKOU_SEO_DATAFORSEO_PASSWORD OKOU_SEO_DATAFORSEO_PASSWORD
+          add_secret OKOU_BROWSER_USE_API_KEY OKOU_BROWSER_USE_API_KEY
         fi
         add_secret STEAM_WEB_API_KEY STEAM_WEB_API_KEY
         add_secret FINICITY_APP_KEY FINICITY_APP_KEY

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -91,10 +91,7 @@ assert_no_fixture_secret_values() {
   local unexpected
   for unexpected in \
     "github-" \
-    "doppler-" \
-    "okou-google-weather-token" \
-    "okou-dataforseo-login" \
-    "okou-browser-use-api-key"; do
+    "doppler-"; do
     if [[ "$output" == *"$unexpected"* ]]; then
       fail "render output exposed a fixture secret value"
     fi
@@ -179,7 +176,7 @@ run_action() {
   local input_app="${3:-api}"
   local input_environment="${4:-preview}"
   local input_cli_pkg_url="${5-https://static.vm0.io/okou-cli/test-sha/package.tgz}"
-  local branded_config="${6:-legacy}"
+  local branded_config="${6:-canonical}"
   local action_script="${test_dir}/web-api-env-action.sh"
   local github_output="${test_dir}/github-output"
   local repo_vars_json
@@ -187,14 +184,10 @@ run_action() {
 
   repo_vars_json='{"GH_OAUTH_CLIENT_ID":"github-gh-client-id","SLACK_OAUTH_CLIENT_ID":"github-slack-client-id","VM0_API_BACKEND_URL":"https://api.github.test","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-var","FINICITY_PARTNER_ID":"github-finicity-partner-id","POSTHOG_KEY":"github-posthog-key","POSTHOG_HOST":"https://posthog.github.test","ATOM_URL":"https://atom.github.test","STRIPE_OAUTH_CLIENT_ID":"ca_test_connect_client","STRIPE_CONCURRENCY_PORTAL_CONFIGURATION_ID":"bpc_test_concurrency","MICROSOFT_TEAMS_BOT_APP_ID":"github-teams-bot-app-id","MICROSOFT_TEAMS_APP_TENANT_ID":"github-teams-app-tenant-id","OKOU_PRICE_PRO":"price_test_pro","OKOU_PRICE_TEAM":"price_test_team","OKOU_PRICE_USAGE_PACK_PLAN_PRO":"price_test_usage_pack_plan_pro","OKOU_PRICE_USAGE_PACK_PLAN_TEAM":"price_test_usage_pack_plan_team","OKOU_PRICE_USAGE_PACK_20":"price_test_usage_pack_20","OKOU_PRICE_USAGE_PACK_50":"price_test_usage_pack_50","OKOU_PRICE_USAGE_PACK_100":"price_test_usage_pack_100","OKOU_PRICE_USAGE_PACK_200":"price_test_usage_pack_200","ATOM_GRANT_PRICE":"price_test_atom_grant","OKOU_PRICE_CUSTOM_CREDITS":"price_test_custom_credits","OKOU_PRICE_CUSTOM_CREDIT_UNIT":"price_test_custom_credit_unit","OKOU_PRICE_CONCURRENCY":"price_test_concurrency","GMAIL_PUBSUB_TOPIC_NAME":"projects/github/topics/gmail","GMAIL_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/gmail","GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"gmail-push@github.test","GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME":"projects/github/topics/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"workspace-events-push@github.test"}'
   repo_vars_json="$(jq -c '. + {OKOU_HOST_DOMAIN: "sites.test", OKOU_HOST_SCHEME: "https", OKOU_ONE_TIME_CAMPAIGN: "test-campaign"}' <<< "$repo_vars_json")"
-  repo_secrets_json='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","ZERO_MAPS_GOOGLE_MAPS_TOKEN":"github-google-maps-token","ZERO_WEATHER_GOOGLE_WEATHER_TOKEN":"github-google-weather-token","ZERO_FINANCE_APIDOJO_TOKEN":"github-apidojo-token","ZERO_SEO_DATAFORSEO_LOGIN":"github-dataforseo-login","ZERO_SEO_DATAFORSEO_PASSWORD":"github-dataforseo-password","ZERO_BROWSER_USE_API_KEY":"github-browser-use-api-key","ZERO_SCRAPE_FIRECRAWL_TOKEN":"github-firecrawl-token","ZERO_WEB_SEARCH_PERPLEXITY_TOKEN":"github-perplexity-token","STEAM_WEB_API_KEY":"github-steam-web-api-key","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret","UNSPLASH_ACCESS_KEY":"github-unsplash-access-key","VM0_MACHINE_SECRET_KEY":"github-atom-machine-secret","MICROSOFT_TEAMS_BOT_APP_PASSWORD":"github-teams-bot-app-password","VERCEL_AUTOMATION_BYPASS_SECRET":"github-vercel-bypass-secret","CLOUDFLARE_BROWSER_RENDERING_API_TOKEN":"github-cloudflare-browser-rendering-token","ARTIFACT_PREVIEW_WAF_SECRET":"github-artifact-preview-waf-secret","JOGGAI_WEBHOOK_SECRET":"github-joggai-webhook-secret","STRIPE_WEBHOOK_SECRET":"github-stripe-billing-webhook-secret","STRIPE_AUTOMATION_WEBHOOK_SECRET":"github-stripe-automation-webhook-secret"}'
-  if [[ "$branded_config" == "both" ]]; then
-    # Secrets still resolve through first_non_empty(OKOU_*, ZERO_*), so this
-    # fixture supplies both brandings to pin canonical precedence.
-    repo_secrets_json="$(jq -c '. + {OKOU_WEATHER_GOOGLE_WEATHER_TOKEN: "okou-google-weather-token", OKOU_SEO_DATAFORSEO_LOGIN: "okou-dataforseo-login", OKOU_BROWSER_USE_API_KEY: "okou-browser-use-api-key"}' <<< "$repo_secrets_json")"
-  elif [[ "$branded_config" == "empty" ]]; then
+  repo_secrets_json='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","OKOU_MAPS_GOOGLE_MAPS_TOKEN":"github-google-maps-token","OKOU_WEATHER_GOOGLE_WEATHER_TOKEN":"github-google-weather-token","OKOU_FINANCE_APIDOJO_TOKEN":"github-apidojo-token","OKOU_SEO_DATAFORSEO_LOGIN":"github-dataforseo-login","OKOU_SEO_DATAFORSEO_PASSWORD":"github-dataforseo-password","OKOU_BROWSER_USE_API_KEY":"github-browser-use-api-key","OKOU_SCRAPE_FIRECRAWL_TOKEN":"github-firecrawl-token","OKOU_WEB_SEARCH_PERPLEXITY_TOKEN":"github-perplexity-token","STEAM_WEB_API_KEY":"github-steam-web-api-key","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret","UNSPLASH_ACCESS_KEY":"github-unsplash-access-key","VM0_MACHINE_SECRET_KEY":"github-atom-machine-secret","MICROSOFT_TEAMS_BOT_APP_PASSWORD":"github-teams-bot-app-password","VERCEL_AUTOMATION_BYPASS_SECRET":"github-vercel-bypass-secret","CLOUDFLARE_BROWSER_RENDERING_API_TOKEN":"github-cloudflare-browser-rendering-token","ARTIFACT_PREVIEW_WAF_SECRET":"github-artifact-preview-waf-secret","JOGGAI_WEBHOOK_SECRET":"github-joggai-webhook-secret","STRIPE_WEBHOOK_SECRET":"github-stripe-billing-webhook-secret","STRIPE_AUTOMATION_WEBHOOK_SECRET":"github-stripe-automation-webhook-secret"}'
+  if [[ "$branded_config" == "empty" ]]; then
     repo_vars_json="$(jq -c 'with_entries(select(.key | startswith("OKOU_") | not))' <<< "$repo_vars_json")"
-    repo_secrets_json="$(jq -c 'with_entries(select(.key | startswith("ZERO_") | not))' <<< "$repo_secrets_json")"
+    repo_secrets_json="$(jq -c 'with_entries(select(.key | startswith("OKOU_") | not))' <<< "$repo_secrets_json")"
   fi
 
   extract_action_script > "$action_script"
@@ -225,10 +218,10 @@ if ! oauth_client_config_prefixes | grep -qx SLACK; then
   fail "expected Slack OAuth client config to come from Doppler"
 fi
 
-# Variable sources are canonical-only. The secret half still falls back to
-# ZERO_* names, so this guard is scoped to variable reads.
-if grep -En '(repo_var|add_var [A-Z0-9_]+) "?ZERO_' "$ACTION"; then
-  fail "variable sources must read canonical OKOU_ names, not ZERO_"
+# Both the variable and the secret sources are canonical-only now, so no
+# source read in the action may name a legacy ZERO_ variable or secret.
+if grep -En '(repo_var|repo_secret|add_(var|secret) [A-Z0-9_]+) "?ZERO_' "$ACTION"; then
+  fail "environment sources must read canonical OKOU_ names, not ZERO_"
 fi
 
 success_dir="$(mktemp -d)"
@@ -303,17 +296,6 @@ assert_env_absent_value "$success_env_file" "github-slack-client-secret"
 assert_env_absent_value "$success_env_file" "github-posthog-key"
 assert_env_absent_value "$success_env_file" "github-cloudflare-browser-rendering-token"
 assert_env_absent_value "$success_env_file" "github-artifact-preview-waf-secret"
-
-precedence_dir="$(mktemp -d)"
-TEMP_DIRS+=("$precedence_dir")
-precedence_output="$(run_action "$(build_doppler_secrets_json)" "$precedence_dir" api preview "https://static.vm0.io/okou-cli/test-sha/package.tgz" both 2>&1)"
-precedence_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${precedence_dir}/github-output")"
-assert_contains "$precedence_output" "Rendered"
-assert_no_fixture_secret_values "$precedence_output"
-assert_migrated_zero_outputs_absent "$precedence_env_file"
-assert_env_value "$precedence_env_file" OKOU_WEATHER_GOOGLE_WEATHER_TOKEN "okou-google-weather-token"
-assert_env_value "$precedence_env_file" OKOU_SEO_DATAFORSEO_LOGIN "okou-dataforseo-login"
-assert_env_value "$precedence_env_file" OKOU_BROWSER_USE_API_KEY "okou-browser-use-api-key"
 
 empty_dir="$(mktemp -d)"
 TEMP_DIRS+=("$empty_dir")


### PR DESCRIPTION
## What this changes

`.github/actions/web-api-env/action.yml` read each branded secret family through `first_non_empty(OKOU_${suffix}, ZERO_${suffix})` and then emitted only the canonical `OKOU_${suffix}` key. That fallback is inert — every canonical secret exists at each level where its legacy counterpart exists — so it always selected the canonical value.

- Removed the `add_okou_secret` helper.
- The `okou_provider_secret_suffixes` loop now calls `add_secret "OKOU_${suffix}" "OKOU_${suffix}"`.
- The API-only block now calls `add_secret OKOU_SEO_DATAFORSEO_LOGIN OKOU_SEO_DATAFORSEO_LOGIN`, and the same shape for `OKOU_SEO_DATAFORSEO_PASSWORD` and `OKOU_BROWSER_USE_API_KEY`.

This is the secret-source counterpart to the merged #28178, and deliberately uses the same form so the two halves read alike.

`.github/scripts/tests/web-api-env-action-test.sh`:

- The **secret** fixture now supplies canonical `OKOU_*` names instead of `ZERO_*`. Only the fixture key branding changed; every fixture value and every rendered-value assertion is unchanged.
- The `empty` branded-config case strips `OKOU_*` from the secret fixture (it previously stripped `ZERO_*`), so those families still render as empty values.
- The existing `ZERO_`-read guard was scoped to variable reads with a comment explaining that the secret half still fell back. It now covers `repo_secret` / `add_secret` as well, so nothing in the action may name a legacy `ZERO_` source.
- The `both` fixture and the `precedence_*` block only existed to pin `OKOU_` over `ZERO_` precedence for secrets. With no fallback there is no precedence left to test, so both are removed.
- `assert_migrated_zero_outputs_absent` is unchanged and still runs against all four remaining rendered fixtures. `assert_no_fixture_secret_values` is unchanged apart from dropping the three `okou-*` literals that belonged to the deleted fixture; every remaining fixture secret value is still covered by its `github-` or `doppler-` prefix, so the guard's coverage is complete and no test prints a secret value.
- `branded_config`'s default was renamed `legacy` → `canonical`, since after #28178 and this change the default fixture is entirely canonical.

## No secrets are deleted, and why this is two steps

**The eight legacy `ZERO_*` secrets are not deleted by this PR**, at either repository scope or in the `production` environment. Verified still present after this change:

| level | legacy secrets still present |
|---|---|
| repository | `ZERO_BROWSER_USE_API_KEY`, `ZERO_FINANCE_APIDOJO_TOKEN`, `ZERO_SCRAPE_FIRECRAWL_TOKEN`, `ZERO_WEATHER_GOOGLE_WEATHER_TOKEN`, `ZERO_WEB_SEARCH_PERPLEXITY_TOKEN` |
| `production` | `ZERO_MAPS_GOOGLE_MAPS_TOKEN`, `ZERO_SCRAPE_FIRECRAWL_TOKEN`, `ZERO_SEO_DATAFORSEO_LOGIN`, `ZERO_SEO_DATAFORSEO_PASSWORD`, `ZERO_WEB_SEARCH_PERPLEXITY_TOKEN` |

The variable half could be finished in one step because variable values are readable through the API, so each legacy variable was confirmed byte-identical to its canonical counterpart before deletion. **Secret values cannot be read**, so that check is impossible here. The available evidence is name-and-level alignment plus the deployment smoke — enough to remove the fallback, not enough to also throw away the source.

If any of the eight canonical secret values was pasted incorrectly, this PR is exactly what surfaces it. While the legacy secrets still exist, recovery is a one-line revert. Deleting them in the same change would remove that safety net.

Deleting the eight legacy secrets is authorized only after this ships in a release and the eight capabilities are re-verified, per the gate decision in https://github.com/vm0-ai/vm0/issues/26701#issuecomment-5342453539. It is tracked separately.

## Verification

`.github/scripts/tests/web-api-env-action-test.sh` passes locally and `bash -n` is clean.

The premise was re-confirmed against live GitHub configuration: for all eight families, every level holding a `ZERO_*` secret also holds the matching `OKOU_*` secret. `promote-api-production` runs with `environment: production`; the preview jobs in `turbo.yml` set no job-level `environment:`, so preview resolves repository scope only. Both resolution scopes were checked.

Rendered output was compared before/after by extracting both versions of the action script and feeding them the **real** repository- and environment-scoped variable/secret *names* (synthetic values), for every app/environment combination:

| combination | keys | result |
|---|---|---|
| api / production | 210 | identical |
| web / production | 196 | identical |
| api / preview | 211 | identical |
| web / preview | 196 | identical |

No `ZERO_`-prefixed key is emitted in any combination, and in production all eight families resolve from their canonical secret. The three that render empty in preview (`OKOU_MAPS_GOOGLE_MAPS_TOKEN`, `OKOU_SEO_DATAFORSEO_LOGIN`, `OKOU_SEO_DATAFORSEO_PASSWORD`) were already empty on `main`, because neither branding exists at repository scope for them — the identical diff confirms this is not a regression.

Note that this comparison proves **source selection** is unchanged. It cannot prove the canonical secret *values* are correct, which is precisely why the legacy secrets stay.

## What this explicitly does NOT change

- No `ZERO_*` secret is deleted from repository scope or the `production` environment.
- `turbo/apps/api/src/lib/env.ts` and its 22 `OKOU_ENV_FALLBACKS` entries, still gated on the local-development migration.
- `add_var`, `add_secret`, `add_oauth_client_config_key` and every other non-`okou` helper.
- Any rendered key name, value, or ordering.
- Any Doppler-sourced value.

`git diff --stat` touches only the action and its test script.

Closes #28237
