### PR TITLE
test(runner): synchronize heartbeat coalescing triggers

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -978,6 +978,7 @@ enum SignalSource {
 #[derive(Debug, PartialEq, Eq)]
 enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
+    RoutineHeartbeatRequested { mode: RunnerMode },
     WorkspaceCacheChangeObserved,
     DestroyTasksDrainEntered,
     DestroyTasksDrainCompleted,
@@ -1111,6 +1112,10 @@ impl StartLoopTestObserver {
         self.record(StartLoopEvent::BudgetExhaustedReactorEntered);
     }
 
+    fn notify_routine_heartbeat_requested(&self, mode: RunnerMode) {
+        self.record(StartLoopEvent::RoutineHeartbeatRequested { mode });
+    }
+
     fn notify_workspace_cache_change_observed(&self) {
         self.record(StartLoopEvent::WorkspaceCacheChangeObserved);
     }
@@ -1173,6 +1178,26 @@ impl StartLoopTestObserver {
             matches!(event, StartLoopEvent::BudgetExhaustedReactorEntered).then_some(())
         })
         .await;
+    }
+
+    async fn wait_routine_heartbeat_requested_after(
+        &self,
+        cursor: StartLoopCursor,
+        mode: RunnerMode,
+        timeout: Duration,
+    ) -> StartLoopCursor {
+        let ((), cursor) = self
+            .wait_after(cursor, timeout, "routine heartbeat request", |event| {
+                matches!(
+                    event,
+                    StartLoopEvent::RoutineHeartbeatRequested {
+                        mode: observed_mode,
+                    } if *observed_mode == mode
+                )
+                .then_some(())
+            })
+            .await;
+        cursor
     }
 
     async fn wait_workspace_cache_change_observed_after(
@@ -2026,6 +2051,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             _ = heartbeat_tick.tick() => {
                 let live_mode = *mode_rx.borrow();
                 heartbeat.request(live_mode)?;
+                #[cfg(test)]
+                test_hooks
+                    .test_observer
+                    .notify_routine_heartbeat_requested(live_mode);
             }
             _ = sleep_until_optional_instant(pending_finalizing_deadline),
                 if pending_finalizing_candidate.is_some() && mode == RunnerMode::Running =>

--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -155,14 +155,27 @@ async fn heartbeat_triggers_coalesce_into_one_current_mode_follow_up() {
         *mode = RunnerMode::Draining;
         false
     });
-    let status_path = env._temp_dir.path().join("status.json");
+    let second_tick_cursor = env.start_observer.cursor();
     tokio::time::advance(HEARTBEAT_PERIOD).await;
-    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
+    env.start_observer
+        .wait_routine_heartbeat_requested_after(
+            second_tick_cursor,
+            RunnerMode::Draining,
+            Duration::from_secs(5),
+        )
+        .await;
 
     // A further tick while the first request is blocked must collapse into
     // the same dirty follow-up rather than overlap or queue another payload.
+    let third_tick_cursor = env.start_observer.cursor();
     tokio::time::advance(HEARTBEAT_PERIOD).await;
-    tokio::task::yield_now().await;
+    env.start_observer
+        .wait_routine_heartbeat_requested_after(
+            third_tick_cursor,
+            RunnerMode::Draining,
+            Duration::from_secs(5),
+        )
+        .await;
     assert_eq!(env.handle.heartbeat_count(), 1);
     assert_eq!(env.handle.max_heartbeat_in_flight(), 1);
 


### PR DESCRIPTION
## Summary

- add a test-only main-loop event after routine heartbeat requests enter the controller
- synchronize the coalescing regression test with cursor-based observer waits
- preserve the exact heartbeat count, live mode, snapshot sequence, state, and single-flight assertions

## Why

The test previously used one `yield_now()` as proof that a ready timer branch had run. Under scheduler pressure, the blocked heartbeat could complete first, allowing the delayed timer branch to create a legitimate third single-flight request. The new event establishes the required ordering directly.

## Scope

This changes test instrumentation and integration-test synchronization only. Production heartbeat behavior, protocols, and runtime scheduling are unchanged.

## Validation

- `cargo fmt --all -- --check`
- focused heartbeat coalescing test repeated 100 times
- `cargo test -p runner --bin runner --all-features` (`3200 passed`, `20 ignored`)
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- Rust pre-commit hooks (workspace formatting, Clippy, and documentation)

Closes #28241
