### PR TITLE
ci: parallelize playwright e2e projects

### DIFF
--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -149,10 +149,33 @@ playwright = turbo_jobs.fetch("cli-e2e-02-playwright")
 playwright_cleanup = playwright.fetch("steps").find do |step|
   step["name"] == "Cleanup Playwright E2E accounts"
 end
-raise "missing Playwright E2E account finalizer" unless playwright_cleanup
-unless playwright_cleanup.fetch("if") == "always()" &&
-    playwright_cleanup.fetch("run").include?("cleanup-generation playwright,paid-onboarding")
-  raise "Playwright cleanup must always target only its current-generation roles"
+if playwright_cleanup
+  raise "Playwright matrix lanes must not reconcile their shared generation"
+end
+
+playwright_finalizer = turbo_jobs.fetch("cli-e2e-02-playwright-finalize")
+unless Array(playwright_finalizer["needs"]).include?("cli-e2e-02-playwright")
+  raise "Playwright finalizer must wait for every matrix lane"
+end
+playwright_finalizer_condition = playwright_finalizer.fetch("if")
+unless playwright_finalizer_condition.include?("always()") &&
+    playwright_finalizer_condition.include?(
+      "needs.cli-e2e-02-playwright.result != 'skipped'",
+    )
+  raise "Playwright finalizer must run after terminal matrix outcomes"
+end
+playwright_finalizer_steps = playwright_finalizer.fetch("steps")
+playwright_cleanup = playwright_finalizer_steps.find do |step|
+  step["name"] == "Cleanup Playwright E2E accounts"
+end
+unless playwright_cleanup && playwright_cleanup.fetch("if") == "always()" &&
+    playwright_cleanup.fetch("run").include?(
+      "cleanup-generation playwright,paid-onboarding",
+    )
+  raise "Playwright final cleanup must reconcile only its current-generation roles"
+end
+unless playwright_finalizer_steps.last == playwright_cleanup
+  raise "Playwright generation cleanup must be the final finalizer step"
 end
 
 runner_cleanup = turbo_jobs.fetch("cli-e2e-03-runner-cleanup")

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -13,6 +13,7 @@ RUNNER_HELPERS=(
 )
 RUNNER_TOKEN="${REPO_ROOT}/e2e/playwright/runner-token.ts"
 RUNNER_MOCK_CLAUDE_BOOTSTRAP="${REPO_ROOT}/e2e/playwright/runner-mock-claude-bootstrap.bash"
+PLAYWRIGHT_CONFIG="${REPO_ROOT}/e2e/playwright/playwright.config.ts"
 
 fail() {
   echo "FAIL: $1" >&2
@@ -37,6 +38,10 @@ grep -Fq "RUNNER_GROUP: \${{ format('vm0/development-{0}', needs.prepare.outputs
 if grep -Fq 'playwright-staging' "$WORKFLOW"; then
   fail "main Playwright runs must not use a group outside the staging API default"
 fi
+grep -Fq '["list"]' "$PLAYWRIGHT_CONFIG" ||
+  fail "Playwright CI must retain human-readable list reporting"
+grep -Fq '["blob", { outputDir: "blob-report" }]' "$PLAYWRIGHT_CONFIG" ||
+  fail "Playwright CI must emit mergeable blob reports"
 if grep -R -Fq '/api/test/' "$RUNNER_TESTS" "${RUNNER_HELPERS[@]}"; then
   fail "runner E2E coverage must use supported public APIs"
 fi
@@ -65,6 +70,7 @@ jobs = workflow.fetch("jobs")
 prepare = jobs.fetch("prepare")
 stripe_listener = jobs.fetch("deploy-stripe-listener")
 playwright = jobs.fetch("cli-e2e-02-playwright")
+playwright_finalizer = jobs.fetch("cli-e2e-02-playwright-finalize")
 account_prepare = jobs.fetch("cli-e2e-03-runner-prepare")
 bootstrap = jobs.fetch("cli-e2e-03-runner-bootstrap")
 runner = jobs.fetch("cli-e2e-03-runner")
@@ -78,6 +84,73 @@ fixture_test_index = playwright_step_names.index(
 unless browser_install_index && fixture_test_index &&
     browser_install_index < fixture_test_index
   raise "Playwright browsers must be installed before browser fixture tests"
+end
+
+unless playwright.dig("strategy", "fail-fast") == false
+  raise "Playwright project lanes must not fail fast"
+end
+expected_playwright_projects = %w[features paid-onboarding billing-transitions]
+unless playwright.dig("strategy", "matrix", "project") ==
+    expected_playwright_projects
+  raise "Playwright matrix must contain the three independent projects"
+end
+expected_playwright_group =
+  "cli-e2e-02-playwright-${{ matrix.project }}-${{ needs.prepare.outputs.job-ref }}"
+unless playwright.dig("concurrency", "group") == expected_playwright_group
+  raise "each Playwright project must keep an independent concurrency group"
+end
+playwright_run = playwright.fetch("steps").find do |step|
+  step["name"] == "Run Playwright E2E tests"
+end
+unless playwright_run&.fetch("run", "")&.include?(
+    '--project="${{ matrix.project }}"',
+  )
+  raise "each Playwright lane must select only its matrix project"
+end
+playwright_blob_upload = playwright.fetch("steps").find do |step|
+  step["name"] == "Upload Playwright blob report"
+end
+unless playwright_blob_upload && playwright_blob_upload.fetch("if") == "always()" &&
+    playwright_blob_upload.dig("with", "name") ==
+      "playwright-blob-${{ matrix.project }}" &&
+    playwright_blob_upload.dig("with", "path") ==
+      "e2e/playwright/blob-report/"
+  raise "each Playwright lane must always upload its uniquely named blob report"
+end
+
+unless Array(playwright_finalizer["needs"]).include?("cli-e2e-02-playwright")
+  raise "Playwright report finalizer must wait for every matrix lane"
+end
+finalizer_steps = playwright_finalizer.fetch("steps")
+download_index = finalizer_steps.index do |step|
+  step["name"] == "Download Playwright blob reports"
+end
+merge_index = finalizer_steps.index do |step|
+  step["name"] == "Merge Playwright HTML report"
+end
+upload_index = finalizer_steps.index do |step|
+  step["name"] == "Upload Playwright HTML report"
+end
+unless download_index && merge_index && upload_index &&
+    download_index < merge_index && merge_index < upload_index
+  raise "Playwright finalizer must download, merge, then upload reports"
+end
+download_step = finalizer_steps.fetch(download_index)
+unless download_step.dig("with", "pattern") == "playwright-blob-*" &&
+    download_step.dig("with", "merge-multiple") == true
+  raise "Playwright finalizer must combine every lane blob artifact"
+end
+merge_step = finalizer_steps.fetch(merge_index)
+unless merge_step.fetch("run").include?(
+    "playwright merge-reports --reporter=html all-blob-reports",
+  )
+  raise "Playwright finalizer must build one HTML report from lane blobs"
+end
+upload_step = finalizer_steps.fetch(upload_index)
+unless upload_step.fetch("if") == "always()" &&
+    upload_step.dig("with", "name") == "playwright-report" &&
+    upload_step.dig("with", "path") == "e2e/playwright-report/"
+  raise "Playwright finalizer must always publish the merged HTML report"
 end
 
 expected_browser_install =
@@ -537,6 +610,8 @@ end
 
 gate_needs = Array(jobs.fetch("ci-gate-turbo")["needs"])
 %w[
+  cli-e2e-02-playwright
+  cli-e2e-02-playwright-finalize
   cli-e2e-03-runner-prepare
   cli-e2e-03-runner-bootstrap
   cli-e2e-03-runner
@@ -562,6 +637,13 @@ end
 ].each do |job_name|
   expected = "check_result \"#{job_name}\" \"${{ needs.#{job_name}.result }}\" \"$RUNNER_E2E_SKIP_ALLOWED\""
   raise "CI gate must check #{job_name} with RUNNER_E2E_SKIP_ALLOWED" unless gate_script.include?(expected)
+end
+%w[
+  cli-e2e-02-playwright
+  cli-e2e-02-playwright-finalize
+].each do |job_name|
+  expected = "check_result \"#{job_name}\" \"${{ needs.#{job_name}.result }}\" \"${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}\""
+  raise "CI gate must check #{job_name} with the browser E2E policy" unless gate_script.include?(expected)
 end
 RUBY
 

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -89,33 +89,50 @@ end
 unless playwright.dig("strategy", "fail-fast") == false
   raise "Playwright project lanes must not fail fast"
 end
-expected_playwright_projects = %w[features paid-onboarding billing-transitions]
-unless playwright.dig("strategy", "matrix", "project") ==
-    expected_playwright_projects
-  raise "Playwright matrix must contain the three independent projects"
+expected_playwright_lanes = [
+  { "lane" => "features", "project" => "features" },
+  { "lane" => "paid-onboarding", "project" => "paid-onboarding" },
+  {
+    "lane" => "billing-transitions-1",
+    "project" => "billing-transitions",
+    "shard" => "1/2",
+  },
+  {
+    "lane" => "billing-transitions-2",
+    "project" => "billing-transitions",
+    "shard" => "2/2",
+  },
+]
+unless playwright.dig("strategy", "matrix", "include") ==
+    expected_playwright_lanes
+  raise "Playwright matrix must shard the measured billing bottleneck"
 end
 expected_playwright_group =
-  "cli-e2e-02-playwright-${{ matrix.project }}-${{ needs.prepare.outputs.job-ref }}"
+  "cli-e2e-02-playwright-${{ matrix.lane }}-${{ needs.prepare.outputs.job-ref }}"
 unless playwright.dig("concurrency", "group") == expected_playwright_group
-  raise "each Playwright project must keep an independent concurrency group"
+  raise "each Playwright lane must keep an independent concurrency group"
 end
 unless playwright.dig("concurrency", "cancel-in-progress") == true
-  raise "superseding runs must cancel only their matching Playwright project"
+  raise "superseding runs must cancel only their matching Playwright lane"
 end
 playwright_run = playwright.fetch("steps").find do |step|
   step["name"] == "Run Playwright E2E tests"
 end
-unless playwright_run&.fetch("run", "")&.include?(
-    '--project="${{ matrix.project }}"',
-  )
-  raise "each Playwright lane must select only its matrix project"
+unless playwright_run&.fetch("shell") == "bash" &&
+    playwright_run.fetch("run").include?('--project="$PLAYWRIGHT_PROJECT"') &&
+    playwright_run.fetch("run").include?('--shard="$PLAYWRIGHT_SHARD"') &&
+    playwright_run.dig("env", "PLAYWRIGHT_PROJECT") ==
+      "${{ matrix.project }}" &&
+    playwright_run.dig("env", "PLAYWRIGHT_SHARD") ==
+      "${{ matrix.shard || '' }}"
+  raise "each Playwright lane must select its matrix project and optional shard"
 end
 playwright_blob_upload = playwright.fetch("steps").find do |step|
   step["name"] == "Upload Playwright blob report"
 end
 unless playwright_blob_upload && playwright_blob_upload.fetch("if") == "always()" &&
     playwright_blob_upload.dig("with", "name") ==
-      "playwright-blob-${{ matrix.project }}" &&
+      "playwright-blob-${{ matrix.lane }}" &&
     playwright_blob_upload.dig("with", "path") ==
       "e2e/playwright/blob-report/"
   raise "each Playwright lane must always upload its uniquely named blob report"

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -99,6 +99,9 @@ expected_playwright_group =
 unless playwright.dig("concurrency", "group") == expected_playwright_group
   raise "each Playwright project must keep an independent concurrency group"
 end
+unless playwright.dig("concurrency", "cancel-in-progress") == true
+  raise "superseding runs must cancel only their matching Playwright project"
+end
 playwright_run = playwright.fetch("steps").find do |step|
   step["name"] == "Run Playwright E2E tests"
 end

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1872,10 +1872,10 @@ jobs:
         needs.deploy-runner-start.result == 'success'
       )
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
       - name: Install pnpm
@@ -1961,7 +1961,7 @@ jobs:
           fi
       - name: Upload Playwright blob report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-blob-${{ matrix.project }}
           path: e2e/playwright/blob-report/
@@ -1977,8 +1977,8 @@ jobs:
     needs: [prepare, cli-e2e-02-playwright]
     if: always() && needs.cli-e2e-02-playwright.result != 'skipped'
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
       - name: Install pnpm
@@ -1986,7 +1986,7 @@ jobs:
       - name: Install E2E dependencies
         run: cd e2e && pnpm install --frozen-lockfile
       - name: Download Playwright blob reports
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: playwright-blob-*
           path: e2e/all-blob-reports
@@ -1997,7 +1997,7 @@ jobs:
           --reporter=html all-blob-reports
       - name: Upload Playwright HTML report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: e2e/playwright-report/

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1835,8 +1835,15 @@ jobs:
   cli-e2e-02-playwright:
     runs-on: ubuntu-latest
     timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - features
+          - paid-onboarding
+          - billing-transitions
     concurrency:
-      group: cli-e2e-02-playwright-${{ needs.prepare.outputs.job-ref }}
+      group: cli-e2e-02-playwright-${{ matrix.project }}-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     needs:
       - prepare
@@ -1928,7 +1935,10 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Run Playwright E2E tests
         continue-on-error: ${{ vars.CI_CHECK_BROWSER_E2E != '1' }}
-        run: cd e2e && npx playwright test --config playwright/playwright.config.ts
+        run: >-
+          cd e2e && npx playwright test
+          --config playwright/playwright.config.ts
+          --project="${{ matrix.project }}"
         env:
           VM0_API_BACKEND_URL: ${{ needs.deploy-api.outputs.preview-url }}
           OKOU_APP_URL: ${{ needs.deploy-app.outputs.preview-url }}
@@ -1937,14 +1947,6 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-      - name: Cleanup Playwright E2E accounts
-        if: always()
-        run: >-
-          cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
-          cleanup-generation playwright,paid-onboarding
-        env:
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
       - name: Print Stripe webhook forwarding log
         if: always() && github.event_name == 'push' && needs.prepare.outputs.job-ref != 'staging'
         run: |
@@ -1957,16 +1959,58 @@ jobs:
           if [[ -f /tmp/stripe-listen.pid ]]; then
             kill "$(cat /tmp/stripe-listen.pid)" 2>/dev/null || true
           fi
-      - name: Upload Playwright report
+      - name: Upload Playwright blob report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-blob-${{ matrix.project }}
+          path: e2e/playwright/blob-report/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  cli-e2e-02-playwright-finalize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    concurrency:
+      group: cli-e2e-02-playwright-finalize-${{ needs.prepare.outputs.job-ref }}
+      cancel-in-progress: true
+    needs: [prepare, cli-e2e-02-playwright]
+    if: always() && needs.cli-e2e-02-playwright.result != 'skipped'
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Install pnpm
+        run: corepack enable pnpm
+      - name: Install E2E dependencies
+        run: cd e2e && pnpm install --frozen-lockfile
+      - name: Download Playwright blob reports
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: playwright-blob-*
+          path: e2e/all-blob-reports
+          merge-multiple: true
+      - name: Merge Playwright HTML report
+        run: >-
+          cd e2e && pnpm exec playwright merge-reports
+          --reporter=html all-blob-reports
+      - name: Upload Playwright HTML report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report
-          path: |
-            e2e/playwright-report/
-            e2e/test-results/
+          path: e2e/playwright-report/
           retention-days: 7
           if-no-files-found: ignore
+      - name: Cleanup Playwright E2E accounts
+        if: always()
+        run: >-
+          cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
+          cleanup-generation playwright,paid-onboarding
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
 
   # Build one self-contained package archive per checked-out commit and upload
   # it to the same canonical R2 bucket used by deploy-app. The ready marker is
@@ -2971,6 +3015,7 @@ jobs:
       - deploy-cli
       - cli-e2e-02-browser
       - cli-e2e-02-playwright
+      - cli-e2e-02-playwright-finalize
       - cli-e2e-01-serial
       - cli-e2e-03-runner-prepare
       - cli-e2e-03-runner-bootstrap
@@ -3080,6 +3125,7 @@ jobs:
           check_result "deploy-cli" "${{ needs.deploy-cli.result }}" "$CF_APP_SKIP_ALLOWED"
           check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-02-playwright" "${{ needs.cli-e2e-02-playwright.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
+          check_result "cli-e2e-02-playwright-finalize" "${{ needs.cli-e2e-02-playwright-finalize.result }}" "${{ vars.CI_CHECK_BROWSER_E2E == '1' && 'true' || 'informational' }}"
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
           check_result "cli-e2e-03-runner-prepare" "${{ needs.cli-e2e-03-runner-prepare.result }}" "$RUNNER_E2E_SKIP_ALLOWED"
           check_result "cli-e2e-03-runner-bootstrap" "${{ needs.cli-e2e-03-runner-bootstrap.result }}" "$RUNNER_E2E_SKIP_ALLOWED"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1833,17 +1833,25 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test+${{ github.run_id }}-${{ github.run_attempt }}+browser@vm0-e2e.ai
   cli-e2e-02-playwright:
+    name: cli-e2e-02-playwright (${{ matrix.lane }})
     runs-on: ubuntu-latest
     timeout-minutes: 8
     strategy:
       fail-fast: false
       matrix:
-        project:
-          - features
-          - paid-onboarding
-          - billing-transitions
+        include:
+          - lane: features
+            project: features
+          - lane: paid-onboarding
+            project: paid-onboarding
+          - lane: billing-transitions-1
+            project: billing-transitions
+            shard: 1/2
+          - lane: billing-transitions-2
+            project: billing-transitions
+            shard: 2/2
     concurrency:
-      group: cli-e2e-02-playwright-${{ matrix.project }}-${{ needs.prepare.outputs.job-ref }}
+      group: cli-e2e-02-playwright-${{ matrix.lane }}-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     needs:
       - prepare
@@ -1935,11 +1943,20 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Run Playwright E2E tests
         continue-on-error: ${{ vars.CI_CHECK_BROWSER_E2E != '1' }}
-        run: >-
-          cd e2e && npx playwright test
-          --config playwright/playwright.config.ts
-          --project="${{ matrix.project }}"
+        shell: bash
+        run: |
+          args=(
+            --config playwright/playwright.config.ts
+            --project="$PLAYWRIGHT_PROJECT"
+          )
+          if [[ -n "$PLAYWRIGHT_SHARD" ]]; then
+            args+=(--shard="$PLAYWRIGHT_SHARD")
+          fi
+          cd e2e
+          pnpm exec playwright test "${args[@]}"
         env:
+          PLAYWRIGHT_PROJECT: ${{ matrix.project }}
+          PLAYWRIGHT_SHARD: ${{ matrix.shard || '' }}
           VM0_API_BACKEND_URL: ${{ needs.deploy-api.outputs.preview-url }}
           OKOU_APP_URL: ${{ needs.deploy-app.outputs.preview-url }}
           ZERO_APP_URL: ${{ needs.deploy-app.outputs.preview-url }}
@@ -1963,7 +1980,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-blob-${{ matrix.project }}
+          name: playwright-blob-${{ matrix.lane }}
           path: e2e/playwright/blob-report/
           retention-days: 7
           if-no-files-found: ignore

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -57,6 +57,9 @@ export default defineConfig({
   testDir: "./tests",
   globalSetup: "./global-setup",
   globalTeardown: "./global-teardown",
+  reporter: process.env.CI
+    ? [["list"], ["blob", { outputDir: "blob-report" }]]
+    : "list",
   timeout: 120_000,
   use: {
     baseURL: appUrl,


### PR DESCRIPTION
## Summary

- run Playwright E2E in four independent CI lanes based on measured runtime: `features`, `paid-onboarding`, and two native shards of the 3m21s `billing-transitions` bottleneck
- publish a uniquely named blob report from every lane and merge them into one HTML report with per-test timing
- move shared-generation Clerk cleanup into an after-matrix finalizer and preserve the existing browser E2E gate policy
- add executable workflow contracts for lane isolation, billing sharding, reporting, cleanup ordering, and CI-gate coverage

## Compatibility

- preserves the `features` project's `setup` dependency and all current deployment prerequisites
- uses Playwright's test-group sharding instead of test-title filters, so billing coverage remains complete as tests evolve
- keeps exact-owner teardown inside each Playwright lane
- does not change product APIs, persisted data, runner protocols, or test coverage

## Validation

- `cd turbo && pnpm -F @okouai/db db:migrate`
- `cd e2e && pnpm check-types`
- `cd e2e && pnpm test`
- `cd turbo && pnpm exec prettier --check ../.github/workflows/turbo.yml ../e2e/playwright/playwright.config.ts`
- `bash -n .github/scripts/tests/clerk-test-resource-workflow-test.sh .github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- listed `billing-transitions` with `--shard=1/2` and `--shard=2/2`; each lane selects two distinct tests and together they cover all four tests
- generated shard-specific CI blob reports and verified their filenames include the shard ordinal
- prior submitted head completed the full Turbo workflow successfully; measured lane times were 57s for `paid-onboarding`, 1m45s for `features`, and 3m21s for `billing-transitions`

Closes #28240
