### PR TITLE
refactor: remove chat smooth auto scroll feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -509,7 +509,6 @@ function createJump(
   store: LocatorStore,
   threadId: string,
   scrollContainer$: Computed<HTMLElement | null>,
-  setIgnoreContentResizeScroll$: Command<void, [boolean]>,
   signal: AbortSignal,
 ) {
   const resetLandedSignal$ = resetSignal();
@@ -520,7 +519,6 @@ function createJump(
     if (!container || !turn) {
       return;
     }
-    set(setIgnoreContentResizeScroll$, false);
     L.debug("jump to turn", { threadId, turnIndex });
     container.scrollTo({
       top: Math.max(0, turn.top - container.clientHeight * JUMP_VIEWPORT_RATIO),
@@ -886,24 +884,16 @@ export function createChatConversationLocatorSignals(
   {
     threadId,
     scrollContainer$,
-    setIgnoreContentResizeScroll$,
   }: {
     threadId: string;
     scrollContainer$: Computed<HTMLElement | null>;
-    setIgnoreContentResizeScroll$: Command<void, [boolean]>;
   },
   signal: AbortSignal,
 ): ChatConversationLocatorSignals {
   const store = createStore();
   const recompute$ = createRecompute(store, scrollContainer$);
   const paint$ = createPaint(store);
-  const jumpToTurn$ = createJump(
-    store,
-    threadId,
-    scrollContainer$,
-    setIgnoreContentResizeScroll$,
-    signal,
-  );
+  const jumpToTurn$ = createJump(store, threadId, scrollContainer$, signal);
   const railOnRef$ = createRailOnRef(store, threadId, scrollContainer$, {
     recompute$,
     paint$,

--- a/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-panel-signals.ts
@@ -171,8 +171,6 @@ export interface ChatPanelSignals {
   // True when the event list is scrolled away from the bottom - drives the
   // feature-gated scroll-to-bottom button. Read-only outside scroll signals.
   readonly awayFromBottom$: Computed<boolean>;
-  readonly ignoreContentResizeScroll$: Computed<boolean>;
-  readonly setIgnoreContentResizeScroll$: Command<void, [boolean]>;
   readonly composer: ComposerSignals;
   readonly feedback: ChatThreadFeedbackSignals;
   readonly sharing: ChatThreadSharingSignals;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -5,7 +5,6 @@ import { onDomEventFn, onRef } from "../utils.ts";
 
 const L = logger("AutoScroll");
 const AT_BOTTOM_THRESHOLD_PX = 10;
-const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 const SCROLL_ANCHOR_ATTRIBUTE = "data-chat-scroll-anchor-event-id";
 const SCROLL_COMMIT_REVISION_ATTRIBUTE = "data-chat-scroll-commit-revision";
 const SCROLL_COMMIT_TO_TAIL_ATTRIBUTE = "data-chat-scroll-commit-to-tail";
@@ -43,8 +42,6 @@ export interface ChatThreadScrollSignals {
   readonly scrollContainer$: Computed<HTMLElement | null>;
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   readonly awayFromBottom$: Computed<boolean>;
-  readonly ignoreContentResizeScroll$: Computed<boolean>;
-  readonly setIgnoreContentResizeScroll$: Command<void, [boolean]>;
   readonly readRenderedThreadScrollPosition$: Command<
     ThreadScrollPosition | null,
     []
@@ -87,17 +84,6 @@ function isAtBottom(container: HTMLElement): boolean {
   return (
     container.scrollHeight - container.scrollTop - container.clientHeight <=
     AT_BOTTOM_THRESHOLD_PX
-  );
-}
-
-function maximumScrollTop(container: HTMLElement): number {
-  return Math.max(0, container.scrollHeight - container.clientHeight);
-}
-
-function prefersReducedMotion(container: HTMLElement): boolean {
-  return (
-    container.ownerDocument.defaultView?.matchMedia(REDUCED_MOTION_QUERY)
-      .matches ?? false
   );
 }
 
@@ -217,21 +203,6 @@ interface ScrollRuntime {
   // event measure as "not at the bottom" and park the thread on an anchor
   // nobody chose.
   programmaticScrollTop: number | null;
-  smoothAutoScrollTarget: number | null;
-}
-
-function clearSmoothAutoScrollRuntime(runtime: ScrollRuntime): void {
-  runtime.smoothAutoScrollTarget = null;
-}
-
-function smoothScrollToBottom(
-  runtime: ScrollRuntime,
-  container: HTMLElement,
-): void {
-  const target = maximumScrollTop(container);
-  runtime.programmaticScrollTop = null;
-  runtime.smoothAutoScrollTarget = target;
-  container.scrollTo({ top: target, behavior: "smooth" });
 }
 
 function createInternalScrollSignals(
@@ -240,21 +211,10 @@ function createInternalScrollSignals(
   afterThreadScrollPositionChanged$: Command<Promise<void>, [AbortSignal]>,
 ) {
   const internalScrollContainer$ = state<HTMLElement | null>(null);
-  const internalIgnoreContentResizeScroll$ = state(false);
   const scrollContainer$ = computed((get) => {
     return get(internalScrollContainer$);
   });
   const { threadScrollPosition$, awayFromBottom$ } = position;
-  const ignoreContentResizeScroll$ = computed((get) => {
-    return get(internalIgnoreContentResizeScroll$);
-  });
-  const setIgnoreContentResizeScroll$ = command(
-    ({ get, set }, ignore: boolean): void => {
-      if (get(internalIgnoreContentResizeScroll$) !== ignore) {
-        set(internalIgnoreContentResizeScroll$, ignore);
-      }
-    },
-  );
 
   // The held position feeds the render window, so every write below runs the
   // window's ensure step afterwards — parsing is command-driven, and this is
@@ -351,8 +311,6 @@ function createInternalScrollSignals(
     scrollContainer$,
     threadScrollPosition$,
     awayFromBottom$,
-    ignoreContentResizeScroll$,
-    setIgnoreContentResizeScroll$,
     readRenderedThreadScrollPosition$,
     syncThreadScrollPosition$,
     clearThreadScrollPosition$,
@@ -363,49 +321,17 @@ function createInternalScrollSignals(
 
 type InternalScrollSignals = ReturnType<typeof createInternalScrollSignals>;
 
-function createContentResizeRestoreSignal(
-  threadId: string,
-  scroll: InternalScrollSignals,
-  runtime: ScrollRuntime,
-  restoreAfterResize$: Command<Promise<void>, [AbortSignal]>,
-) {
-  return command(async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    if (!runtime.initialized) {
-      return;
-    }
-    if (get(scroll.ignoreContentResizeScroll$)) {
-      const container = get(scroll.scrollContainer$);
-      if (!container) {
-        throw new Error("Chat scroll container is not mounted");
-      }
-      if (isAtBottom(container)) {
-        clearSmoothAutoScrollRuntime(runtime);
-        set(scroll.setIgnoreContentResizeScroll$, false);
-        return;
-      }
-      if (runtime.smoothAutoScrollTarget !== maximumScrollTop(container)) {
-        smoothScrollToBottom(runtime, container);
-      }
-      return;
-    }
-    L.debug("content resize scroll restore", { threadId });
-    await set(restoreAfterResize$, signal);
-  });
-}
-
 function createScrollNavigationSignals(
   threadId: string,
   scroll: InternalScrollSignals,
   runtime: ScrollRuntime,
   pendingScrollAfterRenderRequest$: Computed<ScrollAfterRenderRequest | null>,
 ) {
-  const scrollTo$ = command(({ get, set }, position: ThreadScrollPosition) => {
+  const scrollTo$ = command(({ get }, position: ThreadScrollPosition) => {
     const container = get(scroll.scrollContainer$);
     if (!container) {
       throw new Error("Chat scroll container is not mounted");
     }
-    set(scroll.setIgnoreContentResizeScroll$, false);
-    clearSmoothAutoScrollRuntime(runtime);
     if (!scrollToPosition(runtime, container, position)) {
       throw new Error(
         `Chat scroll target is not rendered: ${position.targetEventId}`,
@@ -413,6 +339,7 @@ function createScrollNavigationSignals(
     }
     runtime.initialized = true;
   });
+
   const scrollToBottom$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       const container = get(scroll.scrollContainer$);
@@ -426,8 +353,6 @@ function createScrollNavigationSignals(
         heldTargetEventId:
           get(scroll.threadScrollPosition$)?.targetEventId ?? null,
       });
-      set(scroll.setIgnoreContentResizeScroll$, false);
-      clearSmoothAutoScrollRuntime(runtime);
       // The DOM write happens before the awaited state clear so the jump is
       // part of the current task and cannot paint at the old offset first.
       applyScrollTop(runtime, container, container.scrollHeight);
@@ -435,14 +360,13 @@ function createScrollNavigationSignals(
       await set(scroll.clearThreadScrollPosition$, signal);
     },
   );
+
   const scrollToTop$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       const container = get(scroll.scrollContainer$);
       if (!container) {
         throw new Error("Chat scroll container is not mounted");
       }
-      set(scroll.setIgnoreContentResizeScroll$, false);
-      clearSmoothAutoScrollRuntime(runtime);
       applyScrollTop(runtime, container, 0);
       runtime.initialized = true;
       await set(scroll.syncThreadScrollPosition$, container, true, signal);
@@ -462,8 +386,6 @@ function createScrollNavigationSignals(
         throw new Error("Chat scroll container is not mounted");
       }
       if (position) {
-        set(scroll.setIgnoreContentResizeScroll$, false);
-        clearSmoothAutoScrollRuntime(runtime);
         if (scrollToPosition(runtime, container, position)) {
           runtime.initialized = true;
           return;
@@ -510,16 +432,21 @@ function createScrollNavigationSignals(
     },
   );
 
-  // Content growth normally restores in the same frame that produced it.
-  // While smooth tail-follow is active, the render commit already owns the
-  // motion, so this observer only retargets that animation when the bottom
-  // moves. Otherwise ResizeObserver's before-paint delivery keeps the existing
-  // exact anchor-or-tail correction and avoids a one-frame flash.
-  const restoreAfterContentResize$ = createContentResizeRestoreSignal(
-    threadId,
-    scroll,
-    runtime,
-    restoreAfterResize$,
+  // Content growth restores in the same frame that produced it. ResizeObserver
+  // callbacks run after layout and before paint, so a scroll written here is
+  // part of that frame; waiting for the next one would paint the grown content
+  // at the old offset first, which reads as a flash before the view snaps back.
+  // Deliberately outside `resizeScheduled`: sharing that flag would fold this
+  // restore into the deferred pass, which is the frame of delay it exists to
+  // avoid.
+  const restoreAfterContentResize$ = command(
+    async ({ set }, signal: AbortSignal): Promise<void> => {
+      if (!runtime.initialized) {
+        return;
+      }
+      L.debug("content resize scroll restore", { threadId });
+      await set(restoreAfterResize$, signal);
+    },
   );
 
   return {
@@ -536,7 +463,6 @@ function createRenderScrollSignals(
   threadId: string,
   scroll: InternalScrollSignals,
   runtime: ScrollRuntime,
-  smoothAutoScrollEnabled$: Computed<boolean>,
 ) {
   const internalPendingRequest$ = state<ScrollAfterRenderRequest | null>(null);
   const pendingScrollAfterRenderRequest$ = computed((get) => {
@@ -579,29 +505,14 @@ function createRenderScrollSignals(
           SCROLL_COMMIT_TO_TAIL_ATTRIBUTE,
         );
         if (commitToTail) {
-          const smooth =
-            runtime.initialized &&
-            get(smoothAutoScrollEnabled$) &&
-            !prefersReducedMotion(container) &&
-            !isAtBottom(container);
-          set(scroll.setIgnoreContentResizeScroll$, smooth);
-          if (smooth) {
-            smoothScrollToBottom(runtime, container);
-          } else {
-            clearSmoothAutoScrollRuntime(runtime);
-            applyScrollTop(runtime, container, container.scrollHeight);
-          }
-        } else {
-          set(scroll.setIgnoreContentResizeScroll$, false);
-          clearSmoothAutoScrollRuntime(runtime);
-          if (
-            !request.position ||
-            !scrollToPosition(runtime, container, request.position)
-          ) {
-            throw new Error(
-              `Chat scroll target is not rendered: ${request.position?.targetEventId ?? "none"}`,
-            );
-          }
+          applyScrollTop(runtime, container, container.scrollHeight);
+        } else if (
+          !request.position ||
+          !scrollToPosition(runtime, container, request.position)
+        ) {
+          throw new Error(
+            `Chat scroll target is not rendered: ${request.position?.targetEventId ?? "none"}`,
+          );
         }
         runtime.initialized = true;
         set(clearPendingRequest$, revision);
@@ -613,8 +524,8 @@ function createRenderScrollSignals(
           scrollTop: container.scrollTop,
         });
         if (commitToTail) {
-          // After selecting the initial instant position or starting the later
-          // smooth motion: the render window can now resume following the tail.
+          // After the DOM write: the commit runs during React's ref phase, and
+          // the offset must be applied before this frame paints.
           await set(scroll.clearThreadScrollPosition$, signal);
         }
       },
@@ -654,77 +565,14 @@ function createRenderScrollSignals(
 
 type ScrollNavigationSignals = ReturnType<typeof createScrollNavigationSignals>;
 
-function isUserScrollKey(key: string): boolean {
-  return (
-    key === "PageUp" ||
-    key === "PageDown" ||
-    key === "ArrowUp" ||
-    key === "ArrowDown" ||
-    key === "Home" ||
-    key === "End" ||
-    key === " "
-  );
-}
-
-function createInterruptSmoothAutoScrollSignal(
-  scroll: InternalScrollSignals,
-  runtime: ScrollRuntime,
-) {
-  return command(
-    async (
-      { get, set },
-      container: HTMLElement,
-      signal: AbortSignal,
-    ): Promise<void> => {
-      if (!get(scroll.ignoreContentResizeScroll$)) {
-        return;
-      }
-      applyScrollTop(runtime, container, container.scrollTop);
-      clearSmoothAutoScrollRuntime(runtime);
-      set(scroll.setIgnoreContentResizeScroll$, false);
-      await set(scroll.syncThreadScrollPosition$, container, true, signal);
-    },
-  );
-}
-
-function attachSmoothAutoScrollInterruptionListeners(
-  container: HTMLElement,
-  interrupt: (event: Event) => void,
-  signal: AbortSignal,
-): void {
-  const handleKeyDown = (event: KeyboardEvent) => {
-    if (isUserScrollKey(event.key)) {
-      interrupt(event);
-    }
-  };
-  container.addEventListener("wheel", interrupt, { passive: true });
-  container.addEventListener("touchmove", interrupt, { passive: true });
-  container.addEventListener("pointerdown", interrupt, { passive: true });
-  container.addEventListener("keydown", handleKeyDown, { passive: true });
-  signal.addEventListener(
-    "abort",
-    () => {
-      container.removeEventListener("wheel", interrupt);
-      container.removeEventListener("touchmove", interrupt);
-      container.removeEventListener("pointerdown", interrupt);
-      container.removeEventListener("keydown", handleKeyDown);
-    },
-    { once: true },
-  );
-}
-
 function createScrollContainerOnRef(
   threadId: string,
   scroll: InternalScrollSignals,
   navigation: ScrollNavigationSignals,
   runtime: ScrollRuntime,
 ) {
-  const interruptSmoothAutoScroll$ = createInterruptSmoothAutoScrollSignal(
-    scroll,
-    runtime,
-  );
   return onRef(
-    command(({ get, set }, container: HTMLElement, signal: AbortSignal) => {
+    command(({ set }, container: HTMLElement, signal: AbortSignal) => {
       set(scroll.bindScrollContainer$, container);
       L.debug("container bound", {
         threadId,
@@ -742,19 +590,6 @@ function createScrollContainerOnRef(
           // too. Where they sit says nothing about where the thread sits.
           return;
         }
-        if (get(scroll.ignoreContentResizeScroll$)) {
-          if (!isAtBottom(container)) {
-            return;
-          }
-          clearSmoothAutoScrollRuntime(runtime);
-          set(scroll.setIgnoreContentResizeScroll$, false);
-          return set(
-            scroll.syncThreadScrollPosition$,
-            container,
-            false,
-            signal,
-          );
-        }
         const programmatic =
           runtime.programmaticScrollTop === container.scrollTop;
         if (!programmatic) {
@@ -771,9 +606,6 @@ function createScrollContainerOnRef(
           signal,
         );
       });
-      const handleSmoothInterruption = onDomEventFn((_event: Event) => {
-        return set(interruptSmoothAutoScroll$, container, signal);
-      });
       const scheduleRestoreAfterResize = () => {
         set(navigation.scheduleRestoreAfterResize$, signal);
       };
@@ -783,11 +615,6 @@ function createScrollContainerOnRef(
         capture: true,
         passive: true,
       });
-      attachSmoothAutoScrollInterruptionListeners(
-        container,
-        handleSmoothInterruption,
-        signal,
-      );
       resizeObserver.observe(container);
       container.ownerDocument.defaultView?.visualViewport?.addEventListener(
         "resize",
@@ -810,8 +637,6 @@ function createScrollContainerOnRef(
           set(scroll.clearScrollContainer$, container);
           runtime.initialized = false;
           runtime.programmaticScrollTop = null;
-          clearSmoothAutoScrollRuntime(runtime);
-          set(scroll.setIgnoreContentResizeScroll$, false);
           L.debug("container unbound", { threadId });
         },
         { once: true },
@@ -861,26 +686,19 @@ export function createChatThreadScrollSignals(
   threadId: string,
   position: ThreadScrollPositionSignals,
   afterThreadScrollPositionChanged$: Command<Promise<void>, [AbortSignal]>,
-  smoothAutoScrollEnabled$: Computed<boolean>,
 ): ChatThreadScrollSignals {
   const runtime: ScrollRuntime = {
     initialized: false,
     resizeScheduled: false,
     latestRenderRequestRevision: 0,
     programmaticScrollTop: null,
-    smoothAutoScrollTarget: null,
   };
   const scroll = createInternalScrollSignals(
     threadId,
     position,
     afterThreadScrollPositionChanged$,
   );
-  const render = createRenderScrollSignals(
-    threadId,
-    scroll,
-    runtime,
-    smoothAutoScrollEnabled$,
-  );
+  const render = createRenderScrollSignals(threadId, scroll, runtime);
   const navigation = createScrollNavigationSignals(
     threadId,
     scroll,
@@ -903,8 +721,6 @@ export function createChatThreadScrollSignals(
     scrollContainer$: scroll.scrollContainer$,
     threadScrollPosition$: scroll.threadScrollPosition$,
     awayFromBottom$: scroll.awayFromBottom$,
-    ignoreContentResizeScroll$: scroll.ignoreContentResizeScroll$,
-    setIgnoreContentResizeScroll$: scroll.setIgnoreContentResizeScroll$,
     readRenderedThreadScrollPosition$: scroll.readRenderedThreadScrollPosition$,
     autoScroll$: render.autoScroll$,
     scrollTo$: navigation.scrollTo$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2297,9 +2297,6 @@ function createChatThreadMessagePipeline(
   // position state: the render window computes from the read-only position
   // view, and the scroll signals that write the position are wired afterwards
   // with the window's ensure step.
-  const smoothAutoScrollEnabled$ = computed((get): boolean => {
-    return get(featureSwitch$)[FeatureSwitchKey.ChatSmoothAutoScroll] ?? false;
-  });
   const position = createThreadScrollPositionSignals(threadId);
   const resources = createPagedEventResources(
     threadId,
@@ -2330,7 +2327,6 @@ function createChatThreadMessagePipeline(
     threadId,
     position,
     renderWindow.ensureVisibleEventTrees$,
-    smoothAutoScrollEnabled$,
   );
   const initialEventsReady$ = state(false);
   const effects = createEventChangeEffects(
@@ -4019,8 +4015,6 @@ function createChatPanelSignalsWithDraft(
     {
       threadId,
       scrollContainer$: messages.scroll.scrollContainer$,
-      setIgnoreContentResizeScroll$:
-        messages.scroll.setIgnoreContentResizeScroll$,
     },
     signal,
   );
@@ -4046,9 +4040,6 @@ function createChatPanelSignalsWithDraft(
     scrollContainer$: messages.scroll.scrollContainer$,
     threadScrollPosition$: messages.scroll.threadScrollPosition$,
     awayFromBottom$: messages.scroll.awayFromBottom$,
-    ignoreContentResizeScroll$: messages.scroll.ignoreContentResizeScroll$,
-    setIgnoreContentResizeScroll$:
-      messages.scroll.setIgnoreContentResizeScroll$,
     scrollTo$: messages.scroll.scrollTo$,
     scrollToTop$: messages.scroll.scrollToTop$,
     scrollToBottom$: messages.scroll.scrollToBottom$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-scroll-position.test.tsx
@@ -40,11 +40,6 @@ interface ResizeObserverController {
   trigger: (target: Element) => void;
 }
 
-interface SmoothScrollController {
-  readonly calls: readonly ScrollToOptions[];
-  finish: (container: HTMLElement) => void;
-}
-
 const CHAT_VIEWPORT_TOP = 100;
 
 function domRect(top: number, height: number): DOMRect {
@@ -237,41 +232,6 @@ function installChatLayout(layouts: ReadonlyMap<string, ThreadLayout>): void {
     },
     { once: true },
   );
-}
-
-function installSmoothScroll(): SmoothScrollController {
-  const prototype = HTMLElement.prototype;
-  const scrollToDescriptor = Object.getOwnPropertyDescriptor(
-    prototype,
-    "scrollTo",
-  );
-  const calls: ScrollToOptions[] = [];
-
-  Object.defineProperty(prototype, "scrollTo", {
-    configurable: true,
-    value(this: HTMLElement, options: ScrollToOptions): void {
-      calls.push(options);
-    },
-  });
-  context.signal.addEventListener(
-    "abort",
-    () => {
-      restorePrototypeProperty(prototype, "scrollTo", scrollToDescriptor);
-    },
-    { once: true },
-  );
-
-  return {
-    calls,
-    finish: (container) => {
-      const top = calls.at(-1)?.top;
-      if (top === undefined) {
-        throw new Error("No smooth scroll to finish");
-      }
-      container.scrollTop = top;
-      fireEvent.scroll(container);
-    },
-  };
 }
 
 function installImmediateAnimationFrames(): void {
@@ -729,7 +689,6 @@ describe("chat scroll position", () => {
       initialEvents,
       appendedEvents,
     });
-    const smoothScroll = installSmoothScroll();
     installChatLayout(
       new Map([
         [
@@ -756,13 +715,7 @@ describe("chat scroll position", () => {
       ]),
     );
 
-    detachedSetupPage({
-      context,
-      path: `/chats/${threadId}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ChatSmoothAutoScroll]: false,
-      },
-    });
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
 
     const container = await waitFor(() => {
       expect(screen.getByText("tail-follow message 7")).toBeInTheDocument();
@@ -776,111 +729,6 @@ describe("chat scroll position", () => {
     await waitFor(() => {
       expect(screen.getByText("tail-follow message 8")).toBeInTheDocument();
       expect(container.scrollTop).toBe(800);
-      expect(smoothScroll.calls).toHaveLength(0);
-    });
-  });
-
-  it("smoothly follows later messages without letting content resize snap to the tail", async () => {
-    const threadId = "b0000000-0000-4000-a000-000000000817";
-    const initialEvents = simpleUserEvents(threadId, "smooth-tail", 8);
-    const appendedEvents = simpleUserEvents(threadId, "smooth-tail", 9).slice(
-      8,
-    );
-    const { publishAppendedEvents } = mockLiveThread({
-      threadId,
-      initialEvents,
-      appendedEvents,
-    });
-    const smoothScroll = installSmoothScroll();
-    const resizeObserver = installResizeObserver();
-    let lateGrowth = 0;
-    installChatLayout(
-      new Map([
-        [
-          threadId,
-          {
-            clientHeight: () => {
-              return 300;
-            },
-            scrollHeight: () => {
-              const rendered = document.body.textContent?.includes(
-                "smooth-tail message 8",
-              )
-                ? 1100
-                : 1000;
-              return rendered + lateGrowth;
-            },
-            eventRect: (eventId) => {
-              const index = Number(eventId.split("-").at(-1));
-              return Number.isFinite(index)
-                ? { top: index * 100, height: 80 }
-                : undefined;
-            },
-          },
-        ],
-      ]),
-    );
-
-    detachedSetupPage({
-      context,
-      path: `/chats/${threadId}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ChatSmoothAutoScroll]: true,
-      },
-    });
-
-    const container = await waitFor(() => {
-      expect(screen.getByText("smooth-tail message 7")).toBeInTheDocument();
-      const current = chatScrollContainer();
-      expect(current.scrollTop).toBe(700);
-      expect(smoothScroll.calls).toHaveLength(0);
-      return current;
-    });
-
-    await publishAppendedEvents();
-
-    await waitFor(() => {
-      expect(screen.getByText("smooth-tail message 8")).toBeInTheDocument();
-      expect(smoothScroll.calls).toStrictEqual([
-        { top: 800, behavior: "smooth" },
-      ]);
-      expect(container.scrollTop).toBe(700);
-    });
-    const messageContainer = container.querySelector(
-      "[data-message-container]",
-    );
-    if (!messageContainer) {
-      throw new Error("Chat message container not found");
-    }
-
-    // The observer delivery for the event batch is already represented by the
-    // active smooth target, so it must not replace the animation with an
-    // immediate scroll.
-    resizeObserver.trigger(messageContainer);
-    expect(smoothScroll.calls).toHaveLength(1);
-    expect(container.scrollTop).toBe(700);
-
-    // Content that grows while the animation is active retargets that same
-    // smooth scroll instead of snapping or abandoning the tail.
-    lateGrowth = 400;
-    resizeObserver.trigger(messageContainer);
-    expect(smoothScroll.calls).toStrictEqual([
-      { top: 800, behavior: "smooth" },
-      { top: 1200, behavior: "smooth" },
-    ]);
-    expect(container.scrollTop).toBe(700);
-
-    smoothScroll.finish(container);
-    await waitFor(() => {
-      expect(container.scrollTop).toBe(1200);
-      expect(document.querySelector("[data-scroll-to-bottom]")).toBeNull();
-    });
-
-    lateGrowth = 500;
-    resizeObserver.trigger(messageContainer);
-    await waitFor(() => {
-      expect(container.scrollTop).toBe(1300);
-      expect(smoothScroll.calls).toHaveLength(2);
     });
   });
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -103,7 +103,6 @@ describe("getAllFeatureStates", () => {
     expect(
       staffOrgStates[FeatureSwitchKey.ChatRunContinuationPresentation],
     ).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.ChatSmoothAutoScroll]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
@@ -138,7 +137,6 @@ describe("getAllFeatureStates", () => {
     expect(
       otherOrgStates[FeatureSwitchKey.ChatRunContinuationPresentation],
     ).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.ChatSmoothAutoScroll]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -60,7 +60,6 @@ export enum FeatureSwitchKey {
   ChatMarkUnread = "chatMarkUnread",
   ChatQuoteOnlyFeedback = "chatQuoteOnlyFeedback",
   ChatRunContinuationPresentation = "chatRunContinuationPresentation",
-  ChatSmoothAutoScroll = "chatSmoothAutoScroll",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   HomeStartCards = "homeStartCards",
   ConnectorDiscovery = "connectorDiscovery",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -399,13 +399,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ChatSmoothAutoScroll]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Smoothly follow new chat content after the thread's initial scroll position is committed.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.EmojiPickerCategoryRail]: {
     maintainer: "tongx@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- abandon `ChatSmoothAutoScroll` and permanently retain the switch-off behavior: new tail content is aligned immediately instead of starting a smooth animation
- remove the feature key and registry entry, switch plumbing, smooth-scroll runtime state, resize retargeting, interruption listeners, and smooth-only test fixtures
- restore the direct instant tail-follow test and preserve unrelated smooth scrolling in the conversation locator and emoji picker

## Terminal state and history

- Terminal state: `abandoned`
- Decision basis: Ethan requested removal on 2026-08-20 because the smooth-scroll feature has too many bugs
- Introducing commit: `f5352bd9d3079a713918f325480ac9ea0cdad806` (`feat(chat): smooth automatic tail scrolling (#27290)`)
- `chat-conversation-locator.ts`, `chat-thread-scroll.ts`, and `chat-scroll-position.test.tsx` now exactly match the introducing commit's parent because those files had no later changes
- The remaining evolved files remove only the lines introduced by `f5352bd9`; the complete 431-line change set matches the introducing commit in reverse

## Behavior retained and removed

Retained:

- the pre-feature instant tail commit path
- existing anchored scroll restoration, explicit top/bottom navigation, late-content growth handling, and conversation-locator scrolling

Removed:

- smooth automatic tail following after the initial scroll commit
- smooth target retargeting during content resize
- wheel, touch, pointer, and keyboard interruption handling used only by the smooth animation
- reduced-motion gating and smooth-scroll-only runtime/state plumbing
- `FeatureSwitchKey.ChatSmoothAutoScroll`, its registry config, feature-state assertions, and true/false test overrides

## Search and Knip audit

- Exact searches for `ChatSmoothAutoScroll`, `chatSmoothAutoScroll`, `smoothAutoScroll`, `ignoreContentResizeScroll`, `setIgnoreContentResizeScroll`, `smoothAutoScrollTarget`, `REDUCED_MOTION_QUERY`, `installSmoothScroll`, and `smooth-tail` return no code hits
- Broader smooth-scroll hits are limited to the independent emoji picker, the pre-existing conversation locator, and historical generated changelog entries; those are intentionally retained
- Knip baseline: exit 0 with 46 configuration hints and no unused file/export/type/dependency findings
- Knip after cleanup: identical exit 0 with the same 46 configuration hints and no new findings

## Test cleanup

- removed the feature-switch false/true matrix and the smooth-scroll controller fixture
- removed the smooth-tail animation/resize-retargeting test
- retained the product-level test that directly verifies immediate tail following

## Verification

- `pnpm exec prettier --write` on all 8 changed files
- `git diff --check`
- `pnpm --filter @okouai/app exec vitest run src/views/zero-page/__tests__/chat-scroll-position.test.tsx` — 21 passed
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` — 24 passed
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/core lint`
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/core check-types`
- `pnpm knip` before and after cleanup

Full local Vitest was intentionally not run and no local dev server was started, per repository policy. The PR pipeline owns the full suite.
