### PR TITLE
refactor(rust): centralize sandbox start command prerequisites

### DIFF
--- a/crates/runner/src/cmd/setup/mod.rs
+++ b/crates/runner/src/cmd/setup/mod.rs
@@ -31,19 +31,7 @@ const SETUP_READ_TIMEOUT: Duration = Duration::from_secs(60);
 const SETUP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const ROOT_UID: u32 = 0;
-const START_SYSTEM_DEPENDENCIES: [&str; 11] = [
-    "ip",
-    "iptables",
-    "iptables-save",
-    "iptables-restore",
-    "ip6tables",
-    "ip6tables-save",
-    "ip6tables-restore",
-    "sysctl",
-    "dnsmasq",
-    "mkfs.ext4",
-    "openssl",
-];
+const RUNNER_START_SYSTEM_DEPENDENCIES: [&str; 2] = ["dnsmasq", "openssl"];
 const OTHER_COMMAND_SYSTEM_DEPENDENCIES: [&str; 3] = ["pgrep", "debootstrap", "flock"];
 
 struct ProducedSetupArtifact {
@@ -108,7 +96,8 @@ fn check_architecture() -> RunnerResult<&'static str> {
 
 /// Returns names of missing required dependencies.
 fn check_system_dependencies() -> Vec<&'static str> {
-    let missing_required: Vec<&str> = START_SYSTEM_DEPENDENCIES
+    let start_system_dependencies = start_system_dependencies();
+    let missing_required: Vec<&str> = start_system_dependencies
         .iter()
         .filter(|dep| which::which(dep).is_err())
         .copied()
@@ -136,6 +125,12 @@ fn check_system_dependencies() -> Vec<&'static str> {
     }
 
     missing_required
+}
+
+fn start_system_dependencies() -> Vec<&'static str> {
+    let mut dependencies = sandbox_fc::runtime_required_commands();
+    dependencies.extend(RUNNER_START_SYSTEM_DEPENDENCIES);
+    dependencies
 }
 
 async fn create_directories(paths: &HomePaths) -> RunnerResult<()> {
@@ -1051,9 +1046,10 @@ mod tests {
     #[test]
     fn check_system_dependencies_only_returns_known_deps() {
         let missing = check_system_dependencies();
+        let known = start_system_dependencies();
         for dep in &missing {
             assert!(
-                START_SYSTEM_DEPENDENCIES.contains(dep),
+                known.contains(dep),
                 "unexpected dependency reported as missing: {dep}"
             );
         }
@@ -1061,22 +1057,17 @@ mod tests {
 
     #[test]
     fn runner_start_dependencies_include_openssl_for_proxy_ca_validation() {
-        assert!(START_SYSTEM_DEPENDENCIES.contains(&"openssl"));
+        assert!(RUNNER_START_SYSTEM_DEPENDENCIES.contains(&"openssl"));
         assert!(!OTHER_COMMAND_SYSTEM_DEPENDENCIES.contains(&"openssl"));
     }
 
     #[test]
-    fn runner_start_dependencies_include_dual_stack_firewall_tools() {
-        for dependency in [
-            "iptables",
-            "iptables-save",
-            "iptables-restore",
-            "ip6tables",
-            "ip6tables-save",
-            "ip6tables-restore",
-        ] {
-            assert!(START_SYSTEM_DEPENDENCIES.contains(&dependency));
+    fn start_dependencies_include_sandbox_runtime_commands() {
+        let start_dependencies = start_system_dependencies();
+        for dependency in sandbox_fc::runtime_required_commands() {
+            assert!(start_dependencies.contains(&dependency));
         }
+        assert!(start_dependencies.contains(&"conntrack"));
     }
 
     #[test]

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -66,6 +66,7 @@ pub use network::{
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,
 };
+pub use prerequisites::runtime_required_commands;
 pub use runtime::{FirecrackerRuntime, FirecrackerRuntimeProvider};
 pub use sandbox::FirecrackerSandbox;
 pub use snapshot::{

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -74,6 +74,18 @@ const SNAPSHOT_PRIVATE_MOUNT_RESTORE_COMMANDS: &[&str] = &["unshare", "bash", "m
 const COW_POOL_SNAPSHOT_RESTORE_COMMANDS: &[&str] = &["cp"];
 const WORKSPACE_IMAGE_CREATE_COMMANDS: &[&str] = &["mkfs.ext4"];
 
+/// Return host commands required across Firecracker runtime modes.
+///
+/// This conservative aggregate covers fresh and snapshot-restoring factories
+/// plus DNS-filtered networking. Runtime entry points still validate their
+/// narrower, mode-specific command sets.
+pub fn runtime_required_commands() -> Vec<&'static str> {
+    let mut command_groups = FACTORY_FRESH_COMMAND_GROUPS.to_vec();
+    command_groups.extend_from_slice(FACTORY_SNAPSHOT_RESTORE_COMMAND_GROUPS);
+    command_groups.push(DNS_INPUT_FILTER_COMMANDS);
+    required_commands_for_groups(&command_groups)
+}
+
 /// Verify that all required system prerequisites are present.
 ///
 /// Checks firecracker binary, kernel, rootfs, `/dev/kvm`, runtime directory,
@@ -634,6 +646,25 @@ mod tests {
         for mode in modes {
             let commands = required_commands(&mode);
             assert!(commands.contains(&"conntrack"), "mode: {mode:?}");
+        }
+    }
+
+    #[test]
+    fn runtime_commands_cover_factory_modes_and_dns_networking() {
+        let runtime_commands = runtime_required_commands();
+        let snapshot = snapshot_config();
+        let modes = [
+            PrerequisiteMode::FactoryFresh,
+            PrerequisiteMode::FactorySnapshotRestore { snapshot },
+        ];
+
+        for mode in modes {
+            for command in required_commands(&mode) {
+                assert!(runtime_commands.contains(&command), "mode: {mode:?}");
+            }
+        }
+        for command in network_commands(true) {
+            assert!(runtime_commands.contains(&command));
         }
     }
 


### PR DESCRIPTION
## Summary

- expose an ordered, deduplicated Firecracker runtime command aggregate derived from the existing mode-specific prerequisite groups
- make `runner setup` combine that provider-owned aggregate with runner-owned `dnsmasq` and `openssl` requirements
- cover every factory mode and DNS-filtered networking so setup now reports `conntrack` and the other snapshot-restore commands without duplicate literals

## Scope

- keeps mode-specific `sandbox-fc` checks authoritative and unchanged
- preserves setup ordering and existing required/optional diagnostics
- changes no API protocol, queue payload, persisted state, or independently deployed component boundary

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sandbox-fc -p runner --all-features --no-deps`
- `cargo test -p sandbox-fc --all-targets --all-features` (804 passed)
- `cargo test -p runner --all-targets --all-features` (3201 passed, 20 ignored)
- `git diff --check`

Closes #28134
