### PR TITLE
perf(runner): reuse serialized firewall auth request

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -119,7 +119,6 @@ AWS_SIGV4_REQUEST_HEADER_FIELD_OVERHEAD_BYTES = 32
 MAX_AWS_SIGV4_REQUEST_HEADER_FIELDS = (
     MAX_AWS_SIGV4_REQUEST_HEADER_LIST_BYTES // AWS_SIGV4_REQUEST_HEADER_FIELD_OVERHEAD_BYTES
 )
-_FIREWALL_AUTH_IDENTITY_VERSION = 2
 _FIREWALL_AUTH_IDENTITY_CACHE_KEY = "_firewallAuthIdentityCache"
 _MISSING_AWS_SIGV4_ORIGINAL_URL = object()
 
@@ -345,7 +344,6 @@ def _build_firewall_auth_identity(
     normal_body = auth_request.to_bytes(force_refresh=False)
     sandbox_token_sha256 = hashlib.sha256(auth_request.sandbox_token.encode("utf-8")).hexdigest()
     material = {
-        "version": _FIREWALL_AUTH_IDENTITY_VERSION,
         "firewallName": firewall_name,
         "firewallBase": firewall_base,
         "authBodySha256": hashlib.sha256(normal_body).hexdigest(),

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -119,7 +119,7 @@ AWS_SIGV4_REQUEST_HEADER_FIELD_OVERHEAD_BYTES = 32
 MAX_AWS_SIGV4_REQUEST_HEADER_FIELDS = (
     MAX_AWS_SIGV4_REQUEST_HEADER_LIST_BYTES // AWS_SIGV4_REQUEST_HEADER_FIELD_OVERHEAD_BYTES
 )
-_FIREWALL_AUTH_IDENTITY_VERSION = 1
+_FIREWALL_AUTH_IDENTITY_VERSION = 2
 _FIREWALL_AUTH_IDENTITY_CACHE_KEY = "_firewallAuthIdentityCache"
 _MISSING_AWS_SIGV4_ORIGINAL_URL = object()
 
@@ -130,6 +130,14 @@ class _FirewallAuthIdentityCacheEntry:
 
     api_entry: dict = field(repr=False)
     auth_identity: str
+
+
+@dataclass(frozen=True)
+class _ResolvedFirewallAuthIdentity:
+    """Content identity and request-local body preparation for one lookup."""
+
+    auth_identity: str
+    auth_request: FirewallAuthRequest = field(repr=False)
 
 
 @dataclass
@@ -298,16 +306,17 @@ def _build_firewall_auth_context(
         firewall_billable=bool(flow.metadata[metadata_keys.FIREWALL_BILLABLE]),
         matched_firewall=matched_firewall,
     )
+    resolved_identity = _cached_firewall_auth_identity(
+        vm_info=vm_info,
+        api_entry=api_entry,
+        firewall_name=allow.name,
+        firewall_base=firewall_base,
+        auth_request=auth_request,
+    )
     auth_cache_key = FirewallAuthCacheKey(
         run_id=run_id,
         api_id=api_id,
-        auth_identity=_cached_firewall_auth_identity(
-            vm_info=vm_info,
-            api_entry=api_entry,
-            firewall_name=allow.name,
-            firewall_base=firewall_base,
-            auth_request=auth_request,
-        ),
+        auth_identity=resolved_identity.auth_identity,
         registry_generation=_firewall_auth_registry_generation(vm_info),
     )
     flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = auth_cache_key
@@ -315,7 +324,7 @@ def _build_firewall_auth_context(
         allow=allow,
         firewall_base=firewall_base,
         proxy_log_path=flow_metadata.proxy_log_path(flow.metadata),
-        auth_request=auth_request,
+        auth_request=resolved_identity.auth_request,
         auth_cache_key=auth_cache_key,
     )
 
@@ -332,17 +341,21 @@ def _build_firewall_auth_identity(
     firewall_name: str,
     firewall_base: str,
     auth_request: FirewallAuthRequest,
-) -> str:
+) -> _ResolvedFirewallAuthIdentity:
+    normal_body = auth_request.to_bytes(force_refresh=False)
     sandbox_token_sha256 = hashlib.sha256(auth_request.sandbox_token.encode("utf-8")).hexdigest()
     material = {
         "version": _FIREWALL_AUTH_IDENTITY_VERSION,
         "firewallName": firewall_name,
         "firewallBase": firewall_base,
-        "auth": auth_request.to_body(force_refresh=False),
+        "authBodySha256": hashlib.sha256(normal_body).hexdigest(),
         "sandboxTokenSha256": sandbox_token_sha256,
     }
     canonical_json = json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(canonical_json).hexdigest()
+    return _ResolvedFirewallAuthIdentity(
+        auth_identity=hashlib.sha256(canonical_json).hexdigest(),
+        auth_request=auth_request.with_prepared_normal_body(normal_body),
+    )
 
 
 def _cached_firewall_auth_identity(
@@ -352,7 +365,7 @@ def _cached_firewall_auth_identity(
     firewall_name: str,
     firewall_base: str,
     auth_request: FirewallAuthRequest,
-) -> str:
+) -> _ResolvedFirewallAuthIdentity:
     cache = vm_info.get(_FIREWALL_AUTH_IDENTITY_CACHE_KEY)
     if not isinstance(cache, _FirewallAuthIdentityCache):
         cache = _FirewallAuthIdentityCache()
@@ -361,18 +374,21 @@ def _cached_firewall_auth_identity(
     key = (id(api_entry), firewall_name, firewall_base)
     entry = cache.entries.get(key)
     if entry is not None and entry.api_entry is api_entry:
-        return entry.auth_identity
+        return _ResolvedFirewallAuthIdentity(
+            auth_identity=entry.auth_identity,
+            auth_request=auth_request,
+        )
 
-    auth_identity = _build_firewall_auth_identity(
+    resolved_identity = _build_firewall_auth_identity(
         firewall_name=firewall_name,
         firewall_base=firewall_base,
         auth_request=auth_request,
     )
     cache.entries[key] = _FirewallAuthIdentityCacheEntry(
         api_entry=api_entry,
-        auth_identity=auth_identity,
+        auth_identity=resolved_identity.auth_identity,
     )
-    return auth_identity
+    return resolved_identity
 
 
 def _request_method_forbids_managed_credentials(method: str) -> bool:

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -13,7 +13,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from contextlib import suppress
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from email.message import Message
 from typing import NamedTuple, Protocol
 
@@ -142,6 +142,7 @@ class FirewallAuthRequest:
     vars_map: dict | None = None
     firewall_billable: bool = False
     matched_firewall: dict | None = None
+    prepared_normal_body: bytes | None = field(default=None, repr=False, compare=False)
 
     def to_body(self, *, force_refresh: bool = False) -> dict:
         """Build the webhook JSON body while preserving omission semantics."""
@@ -168,6 +169,18 @@ class FirewallAuthRequest:
         if force_refresh:
             body["forceRefresh"] = True
         return body
+
+    def to_bytes(self, *, force_refresh: bool = False) -> bytes:
+        """Serialize the webhook body with stable content-derived bytes."""
+        return json.dumps(
+            self.to_body(force_refresh=force_refresh),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+    def with_prepared_normal_body(self, body: bytes) -> "FirewallAuthRequest":
+        """Attach normal request bytes for the request-local fetch path."""
+        return replace(self, prepared_normal_body=body)
 
 
 @dataclass(frozen=True)
@@ -908,7 +921,11 @@ async def fetch_firewall_headers(
     """
     api_url = platform_api.get_api_url()
     url = f"{api_url}/api/webhooks/agent/firewall/auth"
-    body = json.dumps(request.to_body(force_refresh=force_refresh)).encode()
+    body = (
+        request.prepared_normal_body
+        if not force_refresh and request.prepared_normal_body is not None
+        else request.to_bytes(force_refresh=force_refresh)
+    )
     req = platform_api.make_api_request(url, body, request.sandbox_token)
     plan = _build_connection_plan(req)
     timeout = asyncio.timeout(FIREWALL_AUTH_FETCH_DEADLINE_SECONDS)

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -339,7 +339,7 @@ def _aws_auth_cache_key(
             firewall_name=resolved_allow.name,
             firewall_base=resolved_api_entry["base"],
             auth_request=auth_request,
-        ),
+        ).auth_identity,
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth.py
@@ -16,6 +16,7 @@ import mitm_addon
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.auth_endpoint_helpers import FakeAuthEndpoint, firewall_auth_success_response
 from tests.auth_state_helpers import (
     cached_headers,
     force_refresh_pending,
@@ -87,6 +88,67 @@ async def test_repeated_firewall_requests_reuse_snapshot_auth_identity(
     assert flows[1].metadata[metadata_keys.AUTH_CACHE_HIT] is True
     assert flows[0].request.headers["Authorization"] == "Bearer resolved"
     assert flows[1].request.headers["Authorization"] == "Bearer resolved"
+
+
+async def test_initial_firewall_fetch_reuses_identity_request_bytes(tmp_path, real_flow, mitm_ctx):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(
+        firewall_auth_success_response({"Authorization": "Bearer initial"})
+    )
+    endpoint.queue_json_response(
+        firewall_auth_success_response({"Authorization": "Bearer refreshed"})
+    )
+    flows = [
+        real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            path="/repos",
+        )
+        for _ in range(3)
+    ]
+    serialized_force_refresh: list[bool] = []
+    original_to_bytes = auth_client.FirewallAuthRequest.to_bytes
+
+    def observe_to_bytes(
+        request: auth_client.FirewallAuthRequest,
+        *,
+        force_refresh: bool = False,
+    ) -> bytes:
+        serialized_force_refresh.append(force_refresh)
+        return original_to_bytes(request, force_refresh=force_refresh)
+
+    with (
+        endpoint.run(),
+        mitm_ctx(registry_path=str(reg_path), api_url=endpoint.api_url),
+        patch.object(auth_client.FirewallAuthRequest, "to_bytes", new=observe_to_bytes),
+    ):
+        await mitm_addon.request(flows[0])
+        cache_key = flows[0].metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+
+        await mitm_addon.request(flows[1])
+
+        auth_cache.clear_cached_firewall_headers(cache_key)
+        auth_cache.request_force_refresh(cache_key)
+        await mitm_addon.request(flows[2])
+
+    assert serialized_force_refresh == [False, True]
+    assert endpoint.request_count == 2
+    assert [flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] for flow in flows] == [
+        cache_key
+    ] * 3
+    assert flows[0].metadata[metadata_keys.AUTH_CACHE_HIT] is False
+    assert flows[1].metadata[metadata_keys.AUTH_CACHE_HIT] is True
+    assert flows[2].metadata[metadata_keys.AUTH_CACHE_HIT] is False
+    assert flows[0].request.headers["Authorization"] == "Bearer initial"
+    assert flows[1].request.headers["Authorization"] == "Bearer initial"
+    assert flows[2].request.headers["Authorization"] == "Bearer refreshed"
+
+    normal_body = endpoint.requests[0].json_body()
+    refreshed_body = endpoint.requests[1].json_body()
+    assert "forceRefresh" not in normal_body
+    assert refreshed_body == normal_body | {"forceRefresh": True}
 
 
 async def test_head_firewall_auth_failure_is_bodyless(tmp_path, real_flow, mitm_ctx, headers):


### PR DESCRIPTION
## Summary

- serialize the normal firewall-auth webhook body once on a first-use identity miss and reuse those bytes for the initial fetch
- derive a content identity from the canonical body digest while preserving firewall, sandbox-token, snapshot, and routing isolation
- keep prepared bytes request-local, leave the auth-cache API unchanged, and serialize forced-refresh bodies independently
- cover the real request-handler miss, cache-hit, and force-refresh lifecycle against the local fake auth endpoint

## Scope

- no registry, runner protocol, persisted-state, API schema, frontend, or backend change
- no change to auth-cache admission, singleflight, TTL, cancellation, or refresh ownership

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_request_handler_firewall_auth.py -q` (34 passed)
- `uv run --no-sync python -m pytest tests/test_auth_cache.py tests/test_firewall_auth_client.py -q` (146 passed)
- `uv run --no-sync python -m pytest tests/test_firewall_aws_sigv4_auth.py -q` (50 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6387 passed)
- `lefthook run pre-commit`

Closes #28144
