### PR TITLE
fix(api): stop terminal drive refresh polling

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -3463,7 +3463,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
         return file.id === csvId;
       })?.googleDriveSync,
     ).toMatchObject({ status: "synced", id: "drive-file-refreshed" });
-    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    await chat.listThreadArtifacts(actor, run.threadId);
     expect(successfulRefresh.refreshBodies).toHaveLength(1);
     expect(refreshedList.authorizationHeaders).toStrictEqual([
       "Bearer drive-access-drive-ok",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -46,7 +46,6 @@ import {
   insertChatThreadEventTransactionFixture,
   setChatThreadVideoModelFixture,
 } from "../../../test-fixtures/chat-thread-events";
-import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
 import { setAgentRunCreatedAtFixture } from "../../../test-fixtures/run-deletion";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -384,6 +383,21 @@ async function allThreadEvents(actor: ApiTestUser) {
     throw new Error("Expected chat thread events to load");
   }
   return response.body.events;
+}
+
+type ThreadArtifacts = Awaited<ReturnType<typeof chat.listThreadArtifacts>>;
+
+function expectDriveStatuses(
+  artifacts: ThreadArtifacts,
+  status: "disconnected" | "unknown",
+): void {
+  const files = artifacts.runs.flatMap((run) => {
+    return run.files;
+  });
+  expect(files.length).toBeGreaterThan(0);
+  for (const file of files) {
+    expect(file.googleDriveSync).toStrictEqual({ status });
+  }
 }
 
 /** Cheapest visible message writer: the no-credit send persists a searchable
@@ -3343,9 +3357,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
 
     // A connected Drive still needs to be enabled for the thread's agent.
     artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    for (const file of artifacts.runs[0]?.files ?? []) {
-      expect(file.googleDriveSync).toStrictEqual({ status: "disconnected" });
-    }
+    expectDriveStatuses(artifacts, "disconnected");
     const disabledForAgent = await chat.requestSyncThreadArtifact(
       actor,
       run.threadId,
@@ -3415,17 +3427,177 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     expect(listRecorder.queries[0]).toContain("vm0Artifact");
     expect(listRecorder.queries[0]).toContain(run.threadId);
 
-    // Drive 401 with no refresh credentials resolves to "unknown".
-    mockOptionalEnv("GOOGLE_OAUTH_CLIENT_ID", undefined);
-    mockOptionalEnv("GOOGLE_OAUTH_CLIENT_SECRET", undefined);
-    await installApiTestConnectorCatalog();
+    // A successful refresh is persisted, so the next poll uses the refreshed
+    // access token without another token request.
+    const successfulRefresh = mockGoogleDriveConnectorOAuth({
+      refreshOutcome: {
+        type: "ok",
+        accessToken: "drive-access-refreshed",
+      },
+    });
+    const refreshedList = mockGoogleDriveFilesList((request) => {
+      if (
+        request.headers.get("authorization") !== "Bearer drive-access-refreshed"
+      ) {
+        return { status: 401 };
+      }
+      return {
+        status: 200,
+        files: [
+          {
+            id: "drive-file-refreshed",
+            name: "data.csv",
+            appProperties: {
+              vm0Artifact: "true",
+              vm0ThreadId: run.threadId,
+              vm0RunId: run.runId,
+              vm0FileId: csvId,
+            },
+          },
+        ],
+      };
+    });
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expect(
+      artifacts.runs[0]?.files.find((file) => {
+        return file.id === csvId;
+      })?.googleDriveSync,
+    ).toMatchObject({ status: "synced", id: "drive-file-refreshed" });
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expect(successfulRefresh.refreshBodies).toHaveLength(1);
+    expect(refreshedList.authorizationHeaders).toStrictEqual([
+      "Bearer drive-access-drive-ok",
+      "Bearer drive-access-refreshed",
+      "Bearer drive-access-refreshed",
+    ]);
+
+    // Transient OAuth failures remain connected and retry on later polls.
+    const transientRefresh = mockGoogleDriveConnectorOAuth({
+      refreshOutcome: { type: "server-error" },
+    });
+    mockGoogleDriveFilesList(() => {
+      return { status: 401 };
+    });
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+      expectDriveStatuses(artifacts, "unknown");
+    }
+    expect(transientRefresh.refreshBodies).toHaveLength(2);
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "google-drive"),
+    ).resolves.toMatchObject({ connectionStatus: "connected" });
+
+    // A terminal failure is persisted and immediately becomes disconnected.
+    // The stored state prevents both Drive and token requests on later polls.
+    const terminalRefresh = mockGoogleDriveConnectorOAuth();
+    const terminalList = mockGoogleDriveFilesList(() => {
+      return { status: 401 };
+    });
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expectDriveStatuses(artifacts, "disconnected");
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "google-drive"),
+    ).resolves.toMatchObject({
+      connectionStatus: "reconnect-required",
+      reconnectReason: "authorization_expired_or_revoked",
+    });
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expectDriveStatuses(artifacts, "disconnected");
+    expect(terminalRefresh.refreshBodies).toHaveLength(1);
+    expect(terminalList.authorizationHeaders).toHaveLength(1);
+
+    // Reconnecting clears the terminal state and restores normal status
+    // resolution before another terminal provider failure occurs.
+    const reconnectStart = await connectorsApi.startOauth(
+      actor,
+      "google-drive",
+      "oauth",
+    );
+    await connectorsApi.completeOauthCallback("google-drive", {
+      code: "drive-reconnected",
+      state: stateFromAuthorizationUrl(reconnectStart.authorizationUrl),
+    });
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "google-drive"),
+    ).resolves.toMatchObject({
+      connectionStatus: "connected",
+      reconnectReason: null,
+    });
+    mockGoogleDriveFilesList((request) => {
+      if (
+        request.headers.get("authorization") !==
+        "Bearer drive-access-drive-reconnected"
+      ) {
+        return { status: 401 };
+      }
+      return {
+        status: 200,
+        files: [
+          {
+            id: "drive-file-reconnected",
+            name: "data.csv",
+            appProperties: {
+              vm0Artifact: "true",
+              vm0ThreadId: run.threadId,
+              vm0RunId: run.runId,
+              vm0FileId: csvId,
+            },
+          },
+        ],
+      };
+    });
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expect(
+      artifacts.runs[0]?.files.find((file) => {
+        return file.id === csvId;
+      })?.googleDriveSync,
+    ).toMatchObject({ status: "synced", id: "drive-file-reconnected" });
+
+    // Google session-control expiry retains its precise reconnect reason.
+    const sessionExpiredRefresh = mockGoogleDriveConnectorOAuth({
+      refreshOutcome: {
+        type: "invalid-grant",
+        errorSubtype: "invalid_rapt",
+      },
+    });
     mockGoogleDriveFilesList(() => {
       return { status: 401 };
     });
     artifacts = await chat.listThreadArtifacts(actor, run.threadId);
-    for (const file of artifacts.runs[0]?.files ?? []) {
-      expect(file.googleDriveSync).toStrictEqual({ status: "disconnected" });
-    }
+    expectDriveStatuses(artifacts, "disconnected");
+    expect(sessionExpiredRefresh.refreshBodies).toHaveLength(1);
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "google-drive"),
+    ).resolves.toMatchObject({
+      connectionStatus: "reconnect-required",
+      reconnectReason: "provider_session_expired",
+    });
+
+    // Unknown subtypes stay terminal without inventing a reconnect reason.
+    const unknownSubtypeRefresh = mockGoogleDriveConnectorOAuth({
+      refreshOutcome: {
+        type: "invalid-grant",
+        errorSubtype: "unknown_subtype",
+      },
+    });
+    const secondReconnectStart = await connectorsApi.startOauth(
+      actor,
+      "google-drive",
+      "oauth",
+    );
+    await connectorsApi.completeOauthCallback("google-drive", {
+      code: "drive-reconnected-again",
+      state: stateFromAuthorizationUrl(secondReconnectStart.authorizationUrl),
+    });
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    expectDriveStatuses(artifacts, "disconnected");
+    expect(unknownSubtypeRefresh.refreshBodies).toHaveLength(1);
+    await expect(
+      connectorsApi.readConnectorBySlug(actor, "google-drive"),
+    ).resolves.toMatchObject({
+      connectionStatus: "reconnect-required",
+      reconnectReason: null,
+    });
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(run.runId, sandboxHeaders);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -474,29 +474,63 @@ interface GoogleDriveConnectorOAuthOptions {
    * connector has no refresh path (Drive 401s then resolve to "unknown").
    */
   readonly omitRefreshToken?: boolean;
+  readonly refreshOutcome?:
+    | { readonly type: "ok"; readonly accessToken: string }
+    | { readonly type: "server-error" }
+    | {
+        readonly type: "invalid-grant";
+        readonly errorSubtype?: string;
+      };
+}
+
+interface GoogleDriveConnectorOAuthRecorder {
+  readonly refreshBodies: URLSearchParams[];
 }
 
 /**
  * Google Drive connector OAuth provider boundary: env client credentials,
- * the oauth2 token endpoint (authorization_code exchanges succeed; refresh
- * grants fail with invalid_grant so refresh outcomes stay deterministic),
- * and the Google userinfo endpoint.
+ * the oauth2 token endpoint with configurable refresh outcomes, and the
+ * Google userinfo endpoint.
  */
 export function mockGoogleDriveConnectorOAuth(
   options: GoogleDriveConnectorOAuthOptions = {},
-): void {
+): GoogleDriveConnectorOAuthRecorder {
   mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
   mockOptionalEnv("GOOGLE_OAUTH_CLIENT_ID", "google-client-id");
   mockOptionalEnv("GOOGLE_OAUTH_CLIENT_SECRET", "google-client-secret");
+  const recorded: GoogleDriveConnectorOAuthRecorder = { refreshBodies: [] };
 
   server.use(
     http.post(GOOGLE_OAUTH_TOKEN_URL, async ({ request }) => {
       const body = new URLSearchParams(await request.text());
       if (body.get("grant_type") !== "authorization_code") {
+        recorded.refreshBodies.push(body);
+        const outcome = options.refreshOutcome ?? {
+          type: "invalid-grant",
+        };
+        if (outcome.type === "ok") {
+          return HttpResponse.json({
+            access_token: outcome.accessToken,
+            expires_in: 3600,
+            token_type: "Bearer",
+          });
+        }
+        if (outcome.type === "server-error") {
+          return HttpResponse.json(
+            {
+              error: "server_error",
+              error_description: "Temporary Google OAuth failure",
+            },
+            { status: 503 },
+          );
+        }
         return HttpResponse.json(
           {
             error: "invalid_grant",
             error_description: "Refresh is not granted by this fixture",
+            ...(outcome.errorSubtype === undefined
+              ? {}
+              : { error_subtype: outcome.errorSubtype }),
           },
           { status: 400 },
         );
@@ -521,6 +555,7 @@ export function mockGoogleDriveConnectorOAuth(
       });
     }),
   );
+  return recorded;
 }
 
 interface GmailConnectorOAuthOptions {
@@ -617,6 +652,7 @@ type GoogleDriveFilesListResponse =
   | { readonly status: 401 | 500 };
 
 interface GoogleDriveFilesListRecorder {
+  readonly authorizationHeaders: (string | null)[];
   readonly queries: string[];
 }
 
@@ -627,14 +663,18 @@ interface GoogleDriveFilesListRecorder {
  * under an AbortSignal.timeout(2000).
  */
 export function mockGoogleDriveFilesList(
-  respond: () => GoogleDriveFilesListResponse,
+  respond: (request: Request) => GoogleDriveFilesListResponse,
 ): GoogleDriveFilesListRecorder {
-  const recorded: GoogleDriveFilesListRecorder = { queries: [] };
+  const recorded: GoogleDriveFilesListRecorder = {
+    authorizationHeaders: [],
+    queries: [],
+  };
 
   server.use(
     http.get(GOOGLE_DRIVE_FILES_URL, ({ request }) => {
+      recorded.authorizationHeaders.push(request.headers.get("authorization"));
       recorded.queries.push(new URL(request.url).searchParams.get("q") ?? "");
-      const response = respond();
+      const response = respond(request);
       if (response.status !== 200) {
         return new HttpResponse(null, { status: response.status });
       }

--- a/turbo/apps/api/src/signals/routes/chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads.ts
@@ -267,33 +267,37 @@ const listChatThreadUnreadsInner$ = computed(async (get) => {
   return { status: 200 as const, body: { unreads: [...unreads] } };
 });
 
-const listChatThreadArtifactsInner$ = computed(async (get) => {
-  const auth = get(authContext$);
-  const params = get(pathParamsOf(chatThreadArtifactsContract.list));
-  const [runs, lookup] = await Promise.all([
-    get(
-      chatThreadArtifacts({
-        threadId: params.threadId,
-        userId: auth.userId,
-      }),
-    ),
-    get(
-      googleDriveArtifactStatusLookup({
-        threadId: params.threadId,
-        orgId: auth.orgId,
-        userId: auth.userId,
-      }),
-    ),
-  ]);
-  if (!runs) {
-    return chatThreadNotFound();
-  }
+const listChatThreadArtifactsInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(authContext$);
+    const params = get(pathParamsOf(chatThreadArtifactsContract.list));
+    const [runs, lookup] = await Promise.all([
+      get(
+        chatThreadArtifacts({
+          threadId: params.threadId,
+          userId: auth.userId,
+        }),
+      ),
+      set(
+        googleDriveArtifactStatusLookup({
+          threadId: params.threadId,
+          orgId: auth.orgId,
+          userId: auth.userId,
+        }),
+        signal,
+      ),
+    ]);
+    signal.throwIfAborted();
+    if (!runs) {
+      return chatThreadNotFound();
+    }
 
-  return {
-    status: 200 as const,
-    body: { runs: applyGoogleDriveArtifactSyncStatuses(runs, lookup) },
-  };
-});
+    return {
+      status: 200 as const,
+      body: { runs: applyGoogleDriveArtifactSyncStatuses(runs, lookup) },
+    };
+  },
+);
 
 const searchChatInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);

--- a/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
@@ -1,5 +1,7 @@
 import type { FeatureSwitchContext } from "@okouai/core/feature-switch";
+import type { ConnectorReconnectReason } from "@okouai/api-contracts/contracts/connector-schemas";
 import { refreshConnectorAuthProviderAccessTokenWithMethod } from "@okouai/connectors/auth-providers";
+import { isOAuthProviderHttpError } from "@okouai/connectors/auth-providers/oauth/error";
 import { resolveConnectorAuthClient } from "@okouai/connectors/connector-auth-method";
 import { connectors } from "@okouai/db/schema/connector";
 import { secrets } from "@okouai/db/schema/secret";
@@ -77,7 +79,8 @@ type ConnectorCredentialRefreshResult =
         | "invalid-output"
         | "missing-input"
         | "not-refreshable"
-        | "provider-failed";
+        | "provider-failed"
+        | "reconnect-required";
     };
 
 interface ConnectorCredentialRefreshArgs {
@@ -98,6 +101,10 @@ type ConnectorRefreshTokenAccess = Extract<
   ConnectorRuntimeMethod["method"]["access"],
   { readonly kind: "refresh-token" }
 >;
+
+interface TerminalOAuthRefreshFailure {
+  readonly reconnectReason: ConnectorReconnectReason | null;
+}
 
 function parseOauthScopes(value: string | null): readonly string[] | null {
   return value === null ? null : oauthScopesSchema.parse(JSON.parse(value));
@@ -454,20 +461,25 @@ async function markConnectorCredentialNeedsReconnectAfterRefreshFailure(
     readonly connection: ConnectorCredentialConnection;
     readonly db: Db;
     readonly orgId: string;
+    readonly reconnectReason: ConnectorReconnectReason | null;
     readonly userId: string;
   },
   signal: AbortSignal,
-): Promise<void> {
-  await args.db.transaction(async (tx) => {
+): Promise<boolean> {
+  const updated = await args.db.transaction(async (tx) => {
     await lockConnectorState(tx, {
       orgId: args.orgId,
       userId: args.userId,
       connectorSlug: args.connection.connectorSlug,
     });
     signal.throwIfAborted();
-    await tx
+    const [row] = await tx
       .update(connectors)
-      .set({ needsReconnect: true, updatedAt: sql`clock_timestamp()` })
+      .set({
+        needsReconnect: true,
+        reconnectReason: args.reconnectReason,
+        updatedAt: sql`clock_timestamp()`,
+      })
       .where(
         and(
           eq(connectors.id, args.connection.connectorId),
@@ -477,9 +489,57 @@ async function markConnectorCredentialNeedsReconnectAfterRefreshFailure(
           eq(connectors.authMethod, args.connection.runtimeMethod.authMethodId),
           eq(sql`${connectors.updatedAt}::text`, args.connection.stateRevision),
         ),
-      );
+      )
+      .returning({ id: connectors.id });
+    return row !== undefined;
   });
   signal.throwIfAborted();
+  return updated;
+}
+
+function terminalOAuthRefreshFailure(
+  error: unknown,
+): TerminalOAuthRefreshFailure | null {
+  if (
+    !isOAuthProviderHttpError(error) ||
+    error.oauthError !== "invalid_grant"
+  ) {
+    return null;
+  }
+  if (error.oauthErrorSubtype === "invalid_rapt") {
+    return { reconnectReason: "provider_session_expired" };
+  }
+  return {
+    reconnectReason: error.oauthErrorSubtype
+      ? null
+      : "authorization_expired_or_revoked",
+  };
+}
+
+async function terminalConnectorCredentialRefreshFailure(
+  args: ConnectorCredentialRefreshArgs,
+  error: unknown,
+  signal: AbortSignal,
+): Promise<ConnectorCredentialRefreshResult | null> {
+  const terminalFailure = terminalOAuthRefreshFailure(error);
+  if (terminalFailure === null) {
+    return null;
+  }
+  if (!args.persist) {
+    return { kind: "reconnect-required" };
+  }
+  const updated =
+    await markConnectorCredentialNeedsReconnectAfterRefreshFailure(
+      {
+        connection: args.connection,
+        db: args.persist.db,
+        orgId: args.orgId,
+        reconnectReason: terminalFailure.reconnectReason,
+        userId: args.userId,
+      },
+      signal,
+    );
+  return { kind: updated ? "reconnect-required" : "connection-changed" };
 }
 
 async function connectorCredentialRefreshFailure(
@@ -493,6 +553,7 @@ async function connectorCredentialRefreshFailure(
         connection: args.connection,
         db: args.persist.db,
         orgId: args.orgId,
+        reconnectReason: null,
         userId: args.userId,
       },
       signal,
@@ -600,6 +661,14 @@ export async function refreshConnectorCredentialAccess(
       authMethodId: args.connection.runtimeMethod.authMethodId,
       error: refreshed.error,
     });
+    const terminalFailure = await terminalConnectorCredentialRefreshFailure(
+      args,
+      refreshed.error,
+      signal,
+    );
+    if (terminalFailure !== null) {
+      return terminalFailure;
+    }
     return await connectorCredentialRefreshFailure(
       args,
       "provider-failed",

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { command, computed, type Computed } from "ccstate";
+import { command, computed, type Command, type Computed } from "ccstate";
 import type {
   ChatThreadArtifactGoogleDriveSync,
   ChatThreadArtifactRun,
@@ -23,7 +23,7 @@ import { ZipArchive } from "archiver";
 import { env, optionalEnv } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
 import { isArtifactKeyV2 } from "../../lib/file-url";
-import { db$, type ReadonlyDb } from "../external/db";
+import { db$, type Db, type ReadonlyDb, writeDb$ } from "../external/db";
 import { downloadHostedSitesS3Buffer, downloadS3Buffer } from "../external/s3";
 import {
   createDeferredPromise,
@@ -83,6 +83,11 @@ interface ConnectorTokens {
   readonly connection: ConnectorCredentialConnection;
   readonly needsReconnect: boolean;
 }
+
+type DriveRefreshResult =
+  | { readonly type: "ok"; readonly accessToken: string }
+  | { readonly type: "reconnect-required" }
+  | { readonly type: "unavailable" };
 
 function artifactKey(runId: string, fileId: string): string {
   return `${runId}:${fileId}`;
@@ -171,9 +176,10 @@ async function refreshDriveAccessToken(
     readonly featureSwitchContext: FeatureSwitchContext;
     readonly orgId: string;
     readonly userId: string;
+    readonly writeDb?: Db;
   },
   signal: AbortSignal,
-): Promise<string | null> {
+): Promise<DriveRefreshResult> {
   const refreshed = await refreshConnectorCredentialAccess(
     {
       connection: args.connection,
@@ -182,10 +188,16 @@ async function refreshDriveAccessToken(
       orgId: args.orgId,
       userId: args.userId,
       runtimeEnvironmentName: GOOGLE_DRIVE_ACCESS_TOKEN_ENVIRONMENT_NAME,
+      ...(args.writeDb === undefined ? {} : { persist: { db: args.writeDb } }),
     },
     signal,
   );
-  return refreshed.kind === "ok" ? refreshed.accessToken : null;
+  if (refreshed.kind === "ok") {
+    return { type: "ok", accessToken: refreshed.accessToken };
+  }
+  return refreshed.kind === "reconnect-required"
+    ? { type: "reconnect-required" }
+    : { type: "unavailable" };
 }
 
 type DriveListResult =
@@ -235,9 +247,12 @@ async function listArtifactFilesWithRefresh(
     readonly tokens: ConnectorTokens;
     readonly threadId: string;
     readonly userId: string;
+    readonly writeDb: Db;
   },
   signal: AbortSignal,
-): Promise<z.infer<typeof driveFileSchema>[] | "unauthorized"> {
+): Promise<
+  z.infer<typeof driveFileSchema>[] | "reconnect-required" | "unauthorized"
+> {
   const first = await listArtifactFiles(
     {
       accessToken: args.tokens.accessToken,
@@ -248,22 +263,26 @@ async function listArtifactFilesWithRefresh(
   if (first.type === "ok") {
     return first.files;
   }
-  const refreshedAccessToken = await refreshDriveAccessToken(
+  const refreshed = await refreshDriveAccessToken(
     {
       connection: args.tokens.connection,
       db: args.db,
       featureSwitchContext: args.featureSwitchContext,
       orgId: args.orgId,
       userId: args.userId,
+      writeDb: args.writeDb,
     },
     signal,
   );
-  if (!refreshedAccessToken) {
+  if (refreshed.type === "reconnect-required") {
+    return "reconnect-required";
+  }
+  if (refreshed.type === "unavailable") {
     return "unauthorized";
   }
   const second = await listArtifactFiles(
     {
-      accessToken: refreshedAccessToken,
+      accessToken: refreshed.accessToken,
       threadId: args.threadId,
     },
     signal,
@@ -332,41 +351,41 @@ export function applyGoogleDriveArtifactSyncStatuses(
 /**
  * Compute the Drive sync status lookup for a chat thread's artifacts.
  *
- * Token persistence is intentionally deferred. The selected runtime method is
- * still rechecked through the provider registry, but a successful refresh is
- * used only for this retry and is not written back to connector storage. This
- * keeps the route handler a read-only `computed`. Drive status check is a UI
- * poll, not a hot path; refresh tokens don't rotate (Google), so the cost is
- * one extra RTT per stale-token request.
- * Track in epic #12290 follow-up if telemetry shows this matters.
+ * The lookup persists a successful refresh so later polls use the current
+ * access token. A terminal OAuth failure persists reconnect state for the
+ * exact credential revision and immediately projects as disconnected.
  */
 export function googleDriveArtifactStatusLookup(args: {
   readonly threadId: string;
   readonly orgId: string | undefined;
   readonly userId: string;
-}): Computed<Promise<DriveStatusLookup>> {
-  return computed(async (get): Promise<DriveStatusLookup> => {
+}): Command<Promise<DriveStatusLookup>, [AbortSignal]> {
+  return command(async ({ get, set }, signal): Promise<DriveStatusLookup> => {
     if (!args.orgId) {
       return { type: "disconnected" };
     }
     const db = get(db$);
+    const writeDb = set(writeDb$);
     const authorized = await threadAllowsGoogleDriveArtifactSync(db, {
       orgId: args.orgId,
       userId: args.userId,
       threadId: args.threadId,
     });
+    signal.throwIfAborted();
     if (!authorized) {
       return { type: "disconnected" };
     }
     const featureSwitchOverrides = await get(
       userFeatureSwitchOverrides(args.orgId, args.userId),
     );
+    signal.throwIfAborted();
     const featureSwitchContext = {
       orgId: args.orgId,
       userId: args.userId,
       overrides: featureSwitchOverrides,
     };
     const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
     const tokens = await loadDriveTokens(
       db,
       args.orgId,
@@ -374,13 +393,17 @@ export function googleDriveArtifactStatusLookup(args: {
       featureSwitchContext,
       snapshot,
     );
+    signal.throwIfAborted();
     if (!tokens || tokens.needsReconnect) {
       return { type: "disconnected" };
     }
     // Schema-parse failure or transient network error — treat as "unknown"
-    // rather than failing the whole artifacts response. AbortError from the
-    // 2s timeout intentionally propagates under the project-wide ban on
-    // swallowing aborts.
+    // rather than failing the whole artifacts response. Request aborts still
+    // propagate; the status deadline remains an unknown provider outcome.
+    const providerSignal = AbortSignal.any([
+      signal,
+      AbortSignal.timeout(GOOGLE_DRIVE_STATUS_TIMEOUT_MS),
+    ]);
     const files = await tapError(
       listArtifactFilesWithRefresh(
         {
@@ -390,15 +413,20 @@ export function googleDriveArtifactStatusLookup(args: {
           tokens,
           threadId: args.threadId,
           userId: args.userId,
+          writeDb,
         },
-        AbortSignal.timeout(GOOGLE_DRIVE_STATUS_TIMEOUT_MS),
+        providerSignal,
       ),
     );
+    signal.throwIfAborted();
     if (files === undefined) {
       return { type: "unknown" };
     }
     if (files === "unauthorized") {
       return { type: "unknown" };
+    }
+    if (files === "reconnect-required") {
+      return { type: "disconnected" };
     }
     return { type: "ready", syncedByKey: buildStatusMap(files) };
   });
@@ -1135,9 +1163,9 @@ export const syncArtifactToGoogleDrive$ = command(
         signal,
       );
       signal.throwIfAborted();
-      if (refreshed) {
+      if (refreshed.type === "ok") {
         result = await uploadArtifactWithToken({
-          accessToken: refreshed,
+          accessToken: refreshed.accessToken,
           publicBrand: args.publicBrand,
           threadId: args.threadId,
           runId: args.runId,


### PR DESCRIPTION
## Summary

- classify structured OAuth `invalid_grant` refresh failures as reconnect-required while preserving Google reconnect reasons
- persist successful Drive status refreshes and terminal reconnect state under the existing connector revision guard
- stop later Drive status polls from repeating terminal token refreshes while leaving transient failures retryable

## Scope

- keeps existing public artifact and connector response contracts unchanged
- does not add retry loops, backoff, schema changes, frontend changes, or runner protocol changes
- leaves artifact and presentation upload persistence behavior unchanged

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts src/signals/routes/__tests__/integrations-slack-upload-complete.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm knip`
- pre-commit hook: Prettier, Knip, full Turbo workspace type checks, file-size check, and commitlint

Closes #28146
