### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/shared-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/shared-threads.ts
@@ -156,19 +156,13 @@ const sharedThreadResponseSchema: ZodLikeSchema<SharedThreadResponse> =
     id: z.string().uuid(),
     title: z.string(),
     messages: z.array(sharedMessageZodSchema),
-    // On the web/app-to-API surface, an API rollback can omit this additive
-    // field while current browser clients remain live for about two days.
-    // Remove after that client/API window closes (tracked by #27660).
-    publicBrand: publicBrandSchema.default("vm0"),
+    publicBrand: publicBrandSchema,
   });
 
 const sharedThreadMetaResponseSchema: ZodLikeSchema<SharedThreadMetaResponse> =
   z.object({
     title: z.string(),
-    // The Pages worker may reach an API version from before publicBrand was
-    // added. Keep the old response legal for the same web/API rollback window
-    // of about two days, then remove it with #27660.
-    publicBrand: publicBrandSchema.default("vm0"),
+    publicBrand: publicBrandSchema,
   });
 
 const sharedThreadApiErrorSchema: ZodLikeSchema<ApiErrorResponse> =


### PR DESCRIPTION
Daily deployment-compatibility cleanup. One cohort survived evidence collection; everything else is inside its window, blocked, or has an evidence gap, and is listed at the bottom rather than split into a second PR.

## Cohort — require `publicBrand` in both shared-thread responses (#27660)

**Old → new boundary.** [PR #27200](https://github.com/vm0-ai/vm0/pull/27200) added `public_brand` to `shared_threads`. Both response schemas kept `publicBrandSchema.default("vm0")` so a current browser client, or the Pages worker rendering share links, could still parse a response from an API rolled back to a version that predates the field.

**What this actually removes.** `SharedThreadResponse` and `SharedThreadMetaResponse` already declare `publicBrand: PublicBrand` as **required** TypeScript fields. The `.default("vm0")` was therefore purely a *runtime parse-time* tolerance for a response that omits the value — which is precisely the rollout shim, and why `pnpm check-types` is unaffected by its removal.

**Producer proof, source-level.** `shared_threads.public_brand` is `text("public_brand").$type<PublicBrand>().default("vm0").notNull()`, and both readers in `shared-thread.service.ts` project the column directly (`publicBrand: sharedThreads.publicBrand`) rather than reconstructing it. There is no code path that can emit either response without the field.

**Window.** The surface is web/app-to-API, and the reachable direction is a **new parser reaching an older API** — i.e. the API rollback window, with ~2 days quoted because current browser clients stay live until refresh. #27200 merged 2026-08-17T07:03:27Z (`fa77b3e80fae`); `app/production` promoted `44934b36f181` at **2026-08-17T08:07:43Z** (verified to contain that commit) and `api/production` promoted at 08:06:15Z. At this run that is **~60.9 hours (2.54 days)**, past the ~2-day window, with roughly thirty `api/production` promotions since, so no rollback target still omits the field.

**Evidence gaps, recorded rather than smoothed over:**

- **MaskDB is not usable here.** `vm0-prod-ro` returns `shared_threads` with only **2 columns** and no `public_brand`. That is a degraded/stale schema view, not a statement about production — the same masked-branch lag I recorded on 2026-08-19 (and on 2026-08-13 for migration 0907's tables). The column's existence in production is instead established by the [#28072](https://github.com/vm0-ai/vm0/pull/28072) evidence merged yesterday: the public-brand readiness gate probed `shared_threads.public_brand` among thirteen tables as a whole-API kill switch, and production served 3,019,275 requests with 17 unrelated 503s, which is only possible if that probe returned true.
- **Axiom gives no coverage for this route.** A bounded query (`vm0-request-log-prod`, `2026-08-17T08:07:43Z → 2026-08-19T21:30:00Z`, `_time` predicate first) returned **no** `shared-threads` traffic at all; the OAuth routes in the same query were live (`/api/zero/slack/oauth/install` 34 requests, 0 5xx). Share links are a low-traffic surface, so this cohort rests on the source-level producer proof above, not on log observation. Saying so explicitly rather than presenting an empty result as confirmation.
- **The Pages worker is out of repo.** `sharedThreadMetaResponseSchema` has no in-repo consumer; only the API route registers `meta`. The worker that renders share-link metadata is not in this repository, so I cannot inspect its contract version or release cadence. It is affected only if it rebuilds against a stricter contract *and* then reaches a pre-#27200 API — and that rollback target is closed. Flagged because it is the one consumer this run could not verify directly.

**Persisted-data reasoning.** None applies: this changes a response parser only. No row is read, written, or migrated.

## Checks

Run once against the combined diff, with a local PostgreSQL 18 cluster created for this run and set to `UTC`:

- `pnpm format`; `pnpm check-types` (all tasks, no errors — expected, since the types already required the field); `pnpm knip` (exit 0); lint on `@okouai/api-contracts` and `@okouai/app` (both exit 0)
- `pnpm -F @okouai/app exec vitest run shared-thread-page.test.tsx chat-thread-sharing.test.tsx` → **7 passed** (the in-repo consumers of both schemas)
- `pnpm -F api exec vitest run chat-event-archive-consumers.test.ts` → **4 passed** (the API-side contract user)

Per repo guidance the full local Vitest suite was not run and no dev server was started.

## Open-PR overlap

**None.** No open PR touches `shared-threads.ts`.

Deferred this run, with the exact blocker:

- **#27660's OAuth half** (`slack-oauth.ts:137`, `teams-oauth.ts:162`) — deliberately left, and the comment there is misleading in a way worth correcting: it says "Old **web/app** OAuth state can omit publicBrand", but the platform never constructs these states. The API mints them from `publicBrand$` (`slack-oauth.ts:159`), so the real skew is API-version, not client-version. More importantly the shim is **not separable**: `record.publicBrand === "okou" ? "okou" : "vm0"` collapses *absent* and *malformed* into one branch, and `parseOAuthState` already returns a `vm0` default for a missing or unparseable state. Removing the rollout tolerance therefore cannot be done without also deciding new behavior for malformed input, which #27660 does not specify and which would change an OAuth callback from a friendly redirect to a 500.
- **#27356** zero-agent default-avatar bridge — window long closed, but `apps/api/src/signals/routes/agents.ts:322` still reads `avatarUrl: args.body.avatarUrl ?? null` while only the create path at line 399 uses `randomPresetAvatar()`; that upsert reaches its INSERT branch from the PUT route for a compose-backed agent with no `zero_agents` row. The trigger is compensating a live writer. **Fifth consecutive run reporting this; the unblocking change is one line.**
- **#27602 / #27796** integration identity contraction and **#26938** agent/compose consolidation — multi-stage programs with their own Stage-8 removal owners.
- **#26672 / #26519** Website template archive pins (`LatestWebsiteTemplates` still `enabled: false`), `PersonalModelProviderAccounts` fallbacks (still `enabled: false`) — product gates, not time windows.
- **#26487** route-entry Phase A (separately authorized only), **#25620** avatar flat-field read fallback (needs a jsonb backfill), and the `browser_*` identity contraction (MaskDB exposes no `browser_*` table, so `chat_thread_id` uniqueness across retained rows still cannot be proven).

Resolved since the last run without this workflow: **#26152** and **#26842** are both closed, ending a seven-run deferral chain across #26393 → #27128 → #27764.
