### PR TITLE
refactor(api): neutralize built-in model runtime route naming

### DIFF
--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -318,11 +318,11 @@ import {
   type RunMetadataValues,
 } from "./agent-run-metadata-write.service";
 import {
-  hasIncompatibleVm0ModelRuntimeRoute,
-  vm0ModelRuntimeTarget,
+  hasIncompatibleBuiltInModelRuntimeRoute,
+  builtInModelRuntimeTarget,
   type ModelRuntimeSessionRoute,
-  type Vm0ModelRuntimeRoute,
-} from "./vm0-model-runtime-route.service";
+  type BuiltInModelRuntimeRoute,
+} from "./built-in-model-runtime-route.service";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const AUTO_MEMORY_ARTIFACT_NAME = MEMORY_ARTIFACT_NAME;
@@ -851,7 +851,7 @@ interface ResolvedModelProviderEnvironment {
   readonly secretConnectorMap?: Record<string, string>;
   readonly secretConnectorMetadataMap?: Record<string, SecretConnectorMetadata>;
   readonly codexRuntimeConfig?: ModelProviderCodexRuntimeConfig;
-  readonly vm0ModelRuntimeRoute?: Vm0ModelRuntimeRoute;
+  readonly builtInModelRuntimeRoute?: BuiltInModelRuntimeRoute;
 }
 
 type BuiltinRuntimeTargetRegistration = Extract<
@@ -947,7 +947,7 @@ export interface CreateAgentRunArgs {
   readonly modelProviderCredentialScope?: ModelProviderCredentialScope;
   readonly modelProviderType?: string;
   readonly selectedModelOverride?: string;
-  readonly vm0ModelRuntimeRoute?: Vm0ModelRuntimeRoute;
+  readonly builtInModelRuntimeRoute?: BuiltInModelRuntimeRoute;
   readonly codexServiceTier?: "fast";
   readonly callbacks?: readonly RunCallback[];
   readonly chatThreadId?: string;
@@ -2302,12 +2302,12 @@ async function multiAuthModelProviderEnvironment(
 async function vm0ModelProviderEnvironment(
   db: Db,
   selectedModel: string,
-  resolvedRoute?: Vm0ModelRuntimeRoute,
+  resolvedRoute?: BuiltInModelRuntimeRoute,
 ): Promise<ResolvedModelProviderEnvironment | null> {
   if (resolvedRoute && resolvedRoute.selectedModel !== selectedModel) {
     return null;
   }
-  let route: Vm0ModelRuntimeRoute;
+  let route: BuiltInModelRuntimeRoute;
   let key: { readonly id: string; readonly apiKey: string } | undefined;
   if (resolvedRoute) {
     [key] = await db
@@ -2317,7 +2317,7 @@ async function vm0ModelProviderEnvironment(
       .limit(1);
     route = resolvedRoute;
   } else {
-    const target = vm0ModelRuntimeTarget(selectedModel);
+    const target = builtInModelRuntimeTarget(selectedModel);
     [key] = await db
       .select({ id: builtInModelKeys.id, apiKey: builtInModelKeys.apiKey })
       .from(builtInModelKeys)
@@ -2356,7 +2356,7 @@ async function vm0ModelProviderEnvironment(
     ),
     secrets: { [secretName]: key.apiKey },
     selectedModel,
-    vm0ModelRuntimeRoute: route,
+    builtInModelRuntimeRoute: route,
     ...(codexRuntimeConfig ? { codexRuntimeConfig } : {}),
   };
 }
@@ -2369,7 +2369,7 @@ interface ResolveModelProviderEnvironmentArgs {
   readonly modelProviderCredentialScope?: ModelProviderCredentialScope;
   readonly modelProviderType?: string;
   readonly selectedModelOverride?: string;
-  readonly vm0ModelRuntimeRoute?: Vm0ModelRuntimeRoute;
+  readonly builtInModelRuntimeRoute?: BuiltInModelRuntimeRoute;
   readonly featureSwitchContext: FeatureSwitchContext;
 }
 
@@ -2667,7 +2667,7 @@ async function resolveCandidateModelProviderEnvironment(
     const provider = await vm0ModelProviderEnvironment(
       db,
       selectedModel,
-      args.vm0ModelRuntimeRoute,
+      args.builtInModelRuntimeRoute,
     );
     return provider?.concreteType &&
       getFrameworkForType(provider.concreteType) === args.framework
@@ -2738,7 +2738,7 @@ async function resolveModelProviderEnvironment(
     const provider = await vm0ModelProviderEnvironment(
       db,
       args.selectedModelOverride ?? MODEL_PROVIDER_TYPES.vm0.defaultModel,
-      args.vm0ModelRuntimeRoute,
+      args.builtInModelRuntimeRoute,
     );
     return provider?.concreteType &&
       getFrameworkForType(provider.concreteType) === args.framework
@@ -6019,7 +6019,7 @@ function launchRunMetadataValues(args: LaunchRunRowsArgs): RunMetadataValues {
   const metadata: ZeroRunMetadata = args.zeroRunMetadata ?? {};
   const modelPin =
     args.zeroRunModelPin ?? zeroRunModelProviderValues(args.modelProvider);
-  const runtimeRoute = args.modelProvider?.vm0ModelRuntimeRoute;
+  const runtimeRoute = args.modelProvider?.builtInModelRuntimeRoute;
   return normalizeRunMetadata({
     triggerSource: args.body.triggerSource,
     autonomyBudget: metadata.autonomyBudget,
@@ -7957,7 +7957,7 @@ async function resolveRunModelProvider(
         modelProviderCredentialScope: args.modelProviderCredentialScope,
         modelProviderType: args.modelProviderType,
         selectedModelOverride: args.selectedModelOverride,
-        vm0ModelRuntimeRoute: args.vm0ModelRuntimeRoute,
+        builtInModelRuntimeRoute: args.builtInModelRuntimeRoute,
         featureSwitchContext: options.featureSwitchContext,
       })
     : null;
@@ -8813,8 +8813,8 @@ function resolveCompatibleDirectResumeSession(args: {
   if (!args.resolved.resumeSessionModelRoute) {
     return args.resolved;
   }
-  const runtimeRoute = args.modelProvider?.vm0ModelRuntimeRoute;
-  const incompatible = hasIncompatibleVm0ModelRuntimeRoute({
+  const runtimeRoute = args.modelProvider?.builtInModelRuntimeRoute;
+  const incompatible = hasIncompatibleBuiltInModelRuntimeRoute({
     previous: args.resolved.resumeSessionModelRoute,
     next: {
       modelProvider: args.modelProvider?.type ?? null,

--- a/turbo/apps/api/src/signals/services/built-in-model-runtime-route.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-model-runtime-route.service.ts
@@ -9,14 +9,14 @@ import { eq } from "drizzle-orm";
 
 import type { Db } from "../external/db";
 
-interface Vm0ModelRuntimeTarget {
+interface BuiltInModelRuntimeTarget {
   readonly selectedModel: string;
   readonly providerType: ModelProviderType;
   readonly upstreamModel: string;
   readonly vendor: string;
 }
 
-export interface Vm0ModelRuntimeRoute {
+export interface BuiltInModelRuntimeRoute {
   readonly selectedModel: string;
   readonly providerType: ModelProviderType;
   readonly upstreamModel: string;
@@ -29,9 +29,9 @@ export interface ModelRuntimeSessionRoute {
   readonly modelRuntimeModel: string | null;
 }
 
-export function vm0ModelRuntimeTarget(
+export function builtInModelRuntimeTarget(
   selectedModel: string,
-): Vm0ModelRuntimeTarget {
+): BuiltInModelRuntimeTarget {
   return {
     selectedModel,
     providerType: getVm0ConcreteProviderType(selectedModel),
@@ -40,11 +40,11 @@ export function vm0ModelRuntimeTarget(
   };
 }
 
-export async function resolveVm0ModelRuntimeRoute(
+export async function resolveBuiltInModelRuntimeRoute(
   db: Db,
   selectedModel: string,
-): Promise<Vm0ModelRuntimeRoute | null> {
-  const target = vm0ModelRuntimeTarget(selectedModel);
+): Promise<BuiltInModelRuntimeRoute | null> {
+  const target = builtInModelRuntimeTarget(selectedModel);
   const [key] = await db
     .select({ id: builtInModelKeys.id })
     .from(builtInModelKeys)
@@ -60,7 +60,7 @@ export async function resolveVm0ModelRuntimeRoute(
     : null;
 }
 
-export function hasIncompatibleVm0ModelRuntimeRoute(args: {
+export function hasIncompatibleBuiltInModelRuntimeRoute(args: {
   readonly previous: ModelRuntimeSessionRoute;
   readonly next: ModelRuntimeSessionRoute;
 }): boolean {

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -112,9 +112,9 @@ import { registerCanonicalWebInputAssets } from "./canonical-asset.service";
 import { resolveArtifactObject$ } from "./artifact-storage.service";
 import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
 import {
-  resolveVm0ModelRuntimeRoute,
-  type Vm0ModelRuntimeRoute,
-} from "./vm0-model-runtime-route.service";
+  resolveBuiltInModelRuntimeRoute,
+  type BuiltInModelRuntimeRoute,
+} from "./built-in-model-runtime-route.service";
 import {
   chatEventTypeIn,
   runOwnedChatEventCondition,
@@ -201,7 +201,7 @@ type ModelFirstProviderAdmission = Awaited<
 interface ResolvedRunConfiguration {
   readonly modelPin: ThreadModelPin;
   readonly providerAdmission: ModelFirstProviderAdmission;
-  readonly vm0ModelRuntimeRoute?: Vm0ModelRuntimeRoute;
+  readonly builtInModelRuntimeRoute?: BuiltInModelRuntimeRoute;
   readonly codexServiceTier: "fast" | undefined;
 }
 
@@ -900,7 +900,7 @@ function emptyModelFirstThreadPin(): ThreadModelPin {
   };
 }
 
-async function withVm0ModelRuntimeRoute(
+async function withBuiltInModelRuntimeRoute(
   db: Db,
   configuration: ResolvedRunConfiguration,
 ): Promise<ResolvedRunConfiguration | NormalSendFailure> {
@@ -916,12 +916,12 @@ async function withVm0ModelRuntimeRoute(
       "No model provider configured: no VM0 managed model is selected",
     );
   }
-  const vm0ModelRuntimeRoute = await resolveVm0ModelRuntimeRoute(
+  const builtInModelRuntimeRoute = await resolveBuiltInModelRuntimeRoute(
     db,
     selectedModel,
   );
-  return vm0ModelRuntimeRoute
-    ? { ...configuration, vm0ModelRuntimeRoute }
+  return builtInModelRuntimeRoute
+    ? { ...configuration, builtInModelRuntimeRoute }
     : providerUnavailable(
         "No model provider configured: no VM0 managed model key is configured",
       );
@@ -987,7 +987,7 @@ async function resolveExplicitRunConfiguration(params: {
   if (codexServiceTierError) {
     return codexServiceTierError;
   }
-  return await withVm0ModelRuntimeRoute(params.db, {
+  return await withBuiltInModelRuntimeRoute(params.db, {
     modelPin,
     providerAdmission,
     codexServiceTier: codexServiceTierForRun({
@@ -1516,11 +1516,14 @@ async function resolveThread(params: {
     if ("status" in persisted) {
       return persisted;
     }
-    const resolvedRunConfiguration = await withVm0ModelRuntimeRoute(params.db, {
-      modelPin: persisted.pin,
-      providerAdmission: persisted.providerAdmission,
-      codexServiceTier: persisted.runCodexServiceTier,
-    });
+    const resolvedRunConfiguration = await withBuiltInModelRuntimeRoute(
+      params.db,
+      {
+        modelPin: persisted.pin,
+        providerAdmission: persisted.providerAdmission,
+        codexServiceTier: persisted.runCodexServiceTier,
+      },
+    );
     if ("status" in resolvedRunConfiguration) {
       return resolvedRunConfiguration;
     }
@@ -2993,7 +2996,7 @@ function buildCreateZeroRunArgs(params: {
   const {
     modelPin,
     providerAdmission,
-    vm0ModelRuntimeRoute,
+    builtInModelRuntimeRoute,
     codexServiceTier,
   } = prepared.runConfiguration;
   const webChatSessionPromptContext: WebChatSessionPromptContext = {
@@ -3014,7 +3017,7 @@ function buildCreateZeroRunArgs(params: {
     modelProviderCredentialScope:
       modelPin.modelProviderCredentialScope ?? undefined,
     selectedModelOverride: modelPin.selectedModel ?? undefined,
-    ...(vm0ModelRuntimeRoute ? { vm0ModelRuntimeRoute } : {}),
+    ...(builtInModelRuntimeRoute ? { builtInModelRuntimeRoute } : {}),
     zeroRunModelPin: {
       modelProvider: providerAdmission.effectiveModelProvider ?? null,
       modelProviderId: modelPin.modelProviderId,
@@ -3025,8 +3028,8 @@ function buildCreateZeroRunArgs(params: {
       selectedModel: modelPin.selectedModel,
       modelProvider: providerAdmission.effectiveModelProvider ?? null,
       modelProviderId: modelPin.modelProviderId,
-      modelRuntimeProvider: vm0ModelRuntimeRoute?.providerType ?? null,
-      modelRuntimeModel: vm0ModelRuntimeRoute?.upstreamModel ?? null,
+      modelRuntimeProvider: builtInModelRuntimeRoute?.providerType ?? null,
+      modelRuntimeModel: builtInModelRuntimeRoute?.upstreamModel ?? null,
       cliAgentType: providerAdmission.cliAgentType,
     },
     codexServiceTier,

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -20,7 +20,7 @@ import {
   pgBooleanDecoder,
 } from "../../lib/db-structured-result";
 import type { Db, ReadonlyDb } from "../external/db";
-import { hasIncompatibleVm0ModelRuntimeRoute } from "./vm0-model-runtime-route.service";
+import { hasIncompatibleBuiltInModelRuntimeRoute } from "./built-in-model-runtime-route.service";
 
 export interface ChatThreadSessionRoute {
   readonly selectedModel: string | null;
@@ -294,7 +294,7 @@ function shouldRotateCanonicalSession(args: {
   readonly nextRoute: ChatThreadSessionRoute;
 }): boolean {
   if (
-    hasIncompatibleVm0ModelRuntimeRoute({
+    hasIncompatibleBuiltInModelRuntimeRoute({
       previous: args.previousRoute,
       next: args.nextRoute,
     })

--- a/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
@@ -26,9 +26,9 @@ import { normalizeGoalObjectiveBrief } from "./goal-objective-brief-normalizatio
 import type { ModelFirstPin } from "./model-selection.service";
 import { createQueueFirstZeroRun$ } from "./zero-runs-create.service";
 import {
-  resolveVm0ModelRuntimeRoute,
-  type Vm0ModelRuntimeRoute,
-} from "./vm0-model-runtime-route.service";
+  resolveBuiltInModelRuntimeRoute,
+  type BuiltInModelRuntimeRoute,
+} from "./built-in-model-runtime-route.service";
 
 const log = logger("api:goal-queue-drain");
 const MAX_DRAIN_ATTEMPTS = 5;
@@ -77,7 +77,7 @@ type ModelContext =
       readonly ok: true;
       readonly modelPin: ModelFirstPin;
       readonly effectiveModelProvider: string | null | undefined;
-      readonly vm0ModelRuntimeRoute: Vm0ModelRuntimeRoute | undefined;
+      readonly builtInModelRuntimeRoute: BuiltInModelRuntimeRoute | undefined;
       readonly cliAgentType: string | null;
       readonly codexServiceTier: "fast" | undefined;
     }
@@ -154,7 +154,7 @@ function buildQueueFirstGoalRunInput(args: {
   const {
     modelPin,
     effectiveModelProvider,
-    vm0ModelRuntimeRoute,
+    builtInModelRuntimeRoute,
     cliAgentType,
     codexServiceTier,
   } = args.modelContext;
@@ -180,13 +180,13 @@ function buildQueueFirstGoalRunInput(args: {
     modelProviderCredentialScope:
       modelPin.modelProviderCredentialScope ?? undefined,
     selectedModelOverride: modelPin.selectedModel ?? undefined,
-    ...(vm0ModelRuntimeRoute ? { vm0ModelRuntimeRoute } : {}),
+    ...(builtInModelRuntimeRoute ? { builtInModelRuntimeRoute } : {}),
     threadSessionRoute: {
       selectedModel: modelPin.selectedModel,
       modelProvider: effectiveModelProvider ?? null,
       modelProviderId: modelPin.modelProviderId,
-      modelRuntimeProvider: vm0ModelRuntimeRoute?.providerType ?? null,
-      modelRuntimeModel: vm0ModelRuntimeRoute?.upstreamModel ?? null,
+      modelRuntimeProvider: builtInModelRuntimeRoute?.providerType ?? null,
+      modelRuntimeModel: builtInModelRuntimeRoute?.upstreamModel ?? null,
       cliAgentType,
     },
     codexServiceTier,
@@ -258,12 +258,12 @@ async function resolveModelContext(
 
   const effectiveModelProvider = providerAdmission.effectiveModelProvider;
   const selectedModel = pin.selectedModel;
-  const vm0ModelRuntimeRoute =
+  const builtInModelRuntimeRoute =
     effectiveModelProvider === "vm0" && selectedModel
-      ? await resolveVm0ModelRuntimeRoute(args.db, selectedModel)
+      ? await resolveBuiltInModelRuntimeRoute(args.db, selectedModel)
       : undefined;
   signal.throwIfAborted();
-  if (effectiveModelProvider === "vm0" && !vm0ModelRuntimeRoute) {
+  if (effectiveModelProvider === "vm0" && !builtInModelRuntimeRoute) {
     return {
       ok: false,
       failure: {
@@ -286,7 +286,7 @@ async function resolveModelContext(
     ok: true,
     modelPin: pin,
     effectiveModelProvider,
-    vm0ModelRuntimeRoute: vm0ModelRuntimeRoute ?? undefined,
+    builtInModelRuntimeRoute: builtInModelRuntimeRoute ?? undefined,
     cliAgentType: providerAdmission.cliAgentType,
     codexServiceTier: runCodexServiceTier,
   };

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -213,9 +213,9 @@ import {
 } from "./telegram-queued-launch-context.service";
 import type { Tx } from "../../lib/db-types";
 import {
-  resolveVm0ModelRuntimeRoute,
-  type Vm0ModelRuntimeRoute,
-} from "./vm0-model-runtime-route.service";
+  resolveBuiltInModelRuntimeRoute,
+  type BuiltInModelRuntimeRoute,
+} from "./built-in-model-runtime-route.service";
 
 const log = logger("callback:chat");
 const PG_FOREIGN_KEY_VIOLATION = "23503";
@@ -662,7 +662,7 @@ interface CreateQueuedChatRunInput {
   readonly queuedMessage: QueuedUserMessage;
   readonly modelPin: ModelFirstPin;
   readonly effectiveModelProvider: string | null | undefined;
-  readonly vm0ModelRuntimeRoute: Vm0ModelRuntimeRoute | undefined;
+  readonly builtInModelRuntimeRoute: BuiltInModelRuntimeRoute | undefined;
   readonly cliAgentType: string | null;
   readonly codexServiceTier: "fast" | undefined;
   readonly computerUseHostGrant: {
@@ -957,15 +957,16 @@ function buildQueuedCreateZeroRunArgs(
       selectedModel: input.modelPin.selectedModel,
     },
     zeroRunMetadata: { autonomyBudget: input.autonomyBudget },
-    ...(input.vm0ModelRuntimeRoute
-      ? { vm0ModelRuntimeRoute: input.vm0ModelRuntimeRoute }
+    ...(input.builtInModelRuntimeRoute
+      ? { builtInModelRuntimeRoute: input.builtInModelRuntimeRoute }
       : {}),
     threadSessionRoute: {
       selectedModel: input.modelPin.selectedModel,
       modelProvider: input.effectiveModelProvider ?? null,
       modelProviderId: input.modelPin.modelProviderId,
-      modelRuntimeProvider: input.vm0ModelRuntimeRoute?.providerType ?? null,
-      modelRuntimeModel: input.vm0ModelRuntimeRoute?.upstreamModel ?? null,
+      modelRuntimeProvider:
+        input.builtInModelRuntimeRoute?.providerType ?? null,
+      modelRuntimeModel: input.builtInModelRuntimeRoute?.upstreamModel ?? null,
       cliAgentType: input.cliAgentType,
     },
     body: {
@@ -2564,7 +2565,7 @@ async function buildQueuedPriorContext(args: {
 interface QueuedMessageModelRoute {
   readonly modelPin: ModelFirstPin;
   readonly effectiveModelProvider: string | null | undefined;
-  readonly vm0ModelRuntimeRoute: Vm0ModelRuntimeRoute | undefined;
+  readonly builtInModelRuntimeRoute: BuiltInModelRuntimeRoute | undefined;
   readonly cliAgentType: string | null;
   readonly codexServiceTier: "fast" | undefined;
 }
@@ -2608,11 +2609,11 @@ async function resolveQueuedMessageModelRoute(args: {
   const effectiveModelProvider =
     modelContext.providerAdmission.effectiveModelProvider;
   const selectedModel = modelContext.pin.selectedModel;
-  const vm0ModelRuntimeRoute =
+  const builtInModelRuntimeRoute =
     effectiveModelProvider === "vm0" && selectedModel
-      ? await resolveVm0ModelRuntimeRoute(args.db, selectedModel)
+      ? await resolveBuiltInModelRuntimeRoute(args.db, selectedModel)
       : undefined;
-  if (effectiveModelProvider === "vm0" && !vm0ModelRuntimeRoute) {
+  if (effectiveModelProvider === "vm0" && !builtInModelRuntimeRoute) {
     return {
       error: {
         code: "PROVIDER_UNAVAILABLE",
@@ -2625,7 +2626,7 @@ async function resolveQueuedMessageModelRoute(args: {
     route: {
       modelPin: modelContext.pin,
       effectiveModelProvider,
-      vm0ModelRuntimeRoute: vm0ModelRuntimeRoute ?? undefined,
+      builtInModelRuntimeRoute: builtInModelRuntimeRoute ?? undefined,
       cliAgentType: modelContext.providerAdmission.cliAgentType,
       codexServiceTier: modelContext.runCodexServiceTier,
     },
@@ -2665,9 +2666,9 @@ function loadQueuedMessageSessionState(
           modelProvider: modelRoute.effectiveModelProvider ?? null,
           modelProviderId: modelRoute.modelPin.modelProviderId,
           modelRuntimeProvider:
-            modelRoute.vm0ModelRuntimeRoute?.providerType ?? null,
+            modelRoute.builtInModelRuntimeRoute?.providerType ?? null,
           modelRuntimeModel:
-            modelRoute.vm0ModelRuntimeRoute?.upstreamModel ?? null,
+            modelRoute.builtInModelRuntimeRoute?.upstreamModel ?? null,
           cliAgentType: modelRoute.cliAgentType,
         },
       });
@@ -3174,7 +3175,7 @@ async function buildCreateQueuedChatRunInput(
     queuedMessage: args.queuedMessage,
     modelPin: modelRoute.modelPin,
     effectiveModelProvider: modelRoute.effectiveModelProvider,
-    vm0ModelRuntimeRoute: modelRoute.vm0ModelRuntimeRoute,
+    builtInModelRuntimeRoute: modelRoute.builtInModelRuntimeRoute,
     cliAgentType: modelRoute.cliAgentType,
     codexServiceTier: modelRoute.codexServiceTier,
     computerUseHostGrant,

--- a/turbo/apps/api/src/signals/services/workflow-automation-launch.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-launch.service.ts
@@ -27,9 +27,9 @@ import { loadComputerUseHostGrantForAutoSend } from "./chat-computer-use-host.se
 import type { WorkflowAutomationContext } from "./workflow-automation-context.service";
 import type { ChatAgentRunSourceAnnotation } from "./chat-user-message.service";
 import {
-  resolveVm0ModelRuntimeRoute,
-  type Vm0ModelRuntimeRoute,
-} from "./vm0-model-runtime-route.service";
+  resolveBuiltInModelRuntimeRoute,
+  type BuiltInModelRuntimeRoute,
+} from "./built-in-model-runtime-route.service";
 
 export type AutomationRow = typeof workflowAutomations.$inferSelect;
 
@@ -75,7 +75,7 @@ type ModelContext =
       readonly ok: true;
       readonly modelPin: ModelFirstPin;
       readonly effectiveModelProvider: string | null | undefined;
-      readonly vm0ModelRuntimeRoute: Vm0ModelRuntimeRoute | undefined;
+      readonly builtInModelRuntimeRoute: BuiltInModelRuntimeRoute | undefined;
       readonly cliAgentType: string | null;
       readonly codexServiceTier: "fast" | undefined;
     }
@@ -301,12 +301,12 @@ async function resolveModelContext(
 
   const effectiveModelProvider = providerAdmission.effectiveModelProvider;
   const selectedModel = pin.selectedModel;
-  const vm0ModelRuntimeRoute =
+  const builtInModelRuntimeRoute =
     effectiveModelProvider === "vm0" && selectedModel
-      ? await resolveVm0ModelRuntimeRoute(args.db, selectedModel)
+      ? await resolveBuiltInModelRuntimeRoute(args.db, selectedModel)
       : undefined;
   signal.throwIfAborted();
-  if (effectiveModelProvider === "vm0" && !vm0ModelRuntimeRoute) {
+  if (effectiveModelProvider === "vm0" && !builtInModelRuntimeRoute) {
     return {
       ok: false,
       failure: {
@@ -329,7 +329,7 @@ async function resolveModelContext(
     ok: true,
     modelPin: pin,
     effectiveModelProvider,
-    vm0ModelRuntimeRoute: vm0ModelRuntimeRoute ?? undefined,
+    builtInModelRuntimeRoute: builtInModelRuntimeRoute ?? undefined,
     cliAgentType: providerAdmission.cliAgentType,
     codexServiceTier: runCodexServiceTier,
   };
@@ -343,8 +343,9 @@ function workflowThreadSessionRoute(
     modelProvider: modelContext.effectiveModelProvider ?? null,
     modelProviderId: modelContext.modelPin.modelProviderId,
     modelRuntimeProvider:
-      modelContext.vm0ModelRuntimeRoute?.providerType ?? null,
-    modelRuntimeModel: modelContext.vm0ModelRuntimeRoute?.upstreamModel ?? null,
+      modelContext.builtInModelRuntimeRoute?.providerType ?? null,
+    modelRuntimeModel:
+      modelContext.builtInModelRuntimeRoute?.upstreamModel ?? null,
     cliAgentType: modelContext.cliAgentType,
   };
 }
@@ -596,7 +597,7 @@ export const launchQueuedWorkflowAutomation$ = command(
     const {
       modelPin,
       effectiveModelProvider,
-      vm0ModelRuntimeRoute,
+      builtInModelRuntimeRoute,
       codexServiceTier,
     } = modelContext;
 
@@ -644,7 +645,7 @@ export const launchQueuedWorkflowAutomation$ = command(
         modelProviderCredentialScope:
           modelPin.modelProviderCredentialScope ?? undefined,
         selectedModelOverride: modelPin.selectedModel ?? undefined,
-        ...(vm0ModelRuntimeRoute ? { vm0ModelRuntimeRoute } : {}),
+        ...(builtInModelRuntimeRoute ? { builtInModelRuntimeRoute } : {}),
         threadSessionRoute: workflowThreadSessionRoute(modelContext),
         codexServiceTier,
         appendSystemPrompt: runInput.appendSystemPrompt,

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -48,7 +48,7 @@ import {
   type ChatThreadSessionResolution,
   type ChatThreadSessionRoute,
 } from "./chat-session-continuity.service";
-import type { Vm0ModelRuntimeRoute } from "./vm0-model-runtime-route.service";
+import type { BuiltInModelRuntimeRoute } from "./built-in-model-runtime-route.service";
 import {
   ApiDispatchPhaseCollector,
   ApiDispatchTimingCollector,
@@ -180,7 +180,7 @@ interface CreateZeroRunCommandArgs {
   readonly modelProviderId?: string;
   readonly modelProviderCredentialScope?: ModelProviderCredentialScope;
   readonly selectedModelOverride?: string;
-  readonly vm0ModelRuntimeRoute?: Vm0ModelRuntimeRoute;
+  readonly builtInModelRuntimeRoute?: BuiltInModelRuntimeRoute;
   readonly codexServiceTier?: CodexServiceTier;
   readonly zeroRunMetadata?: ZeroRunMetadata;
   readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
@@ -856,8 +856,8 @@ function buildZeroCreateAgentRunArgs(args: {
     modelProviderCredentialScope: command.modelProviderCredentialScope,
     modelProviderType: command.body.modelProvider,
     selectedModelOverride: command.selectedModelOverride ?? agentSelectedModel,
-    ...(command.vm0ModelRuntimeRoute
-      ? { vm0ModelRuntimeRoute: command.vm0ModelRuntimeRoute }
+    ...(command.builtInModelRuntimeRoute
+      ? { builtInModelRuntimeRoute: command.builtInModelRuntimeRoute }
       : {}),
     ...(command.codexServiceTier === "fast"
       ? { codexServiceTier: command.codexServiceTier }


### PR DESCRIPTION
## Summary

Phase 2 naming cleanup under #26873. PR #28239 (`feat(api): persist managed runtime routes`) introduced `services/vm0-model-runtime-route.service.ts`, a new old-branded path in an otherwise cleared tree. This is regression cleanup, not legacy debt.

Every export in the module concerns the **built-in model provider's runtime route** — it queries `builtInModelKeys` from `@okouai/db/schema/built-in-model-key`, the table renamed in #28021 precisely because the product calls this route "built-in". The module's own identifiers were never updated to match. `built-in` follows the spelling established by #28021 and `contracts/built-in-generation.ts`.

## Mapping

| Old | New |
|---|---|
| `services/vm0-model-runtime-route.service.ts` | `services/built-in-model-runtime-route.service.ts` |
| `Vm0ModelRuntimeTarget` (module-internal) | `BuiltInModelRuntimeTarget` |
| `Vm0ModelRuntimeRoute` | `BuiltInModelRuntimeRoute` |
| `vm0ModelRuntimeTarget` | `builtInModelRuntimeTarget` |
| `resolveVm0ModelRuntimeRoute` | `resolveBuiltInModelRuntimeRoute` |
| `hasIncompatibleVm0ModelRuntimeRoute` | `hasIncompatibleBuiltInModelRuntimeRoute` |
| `vm0ModelRuntimeRoute` property, across callers | `builtInModelRuntimeRoute` |
| `withVm0ModelRuntimeRoute` in `chat-events.command.ts` | `withBuiltInModelRuntimeRoute` |

All eight target names were verified unused repository-wide before the rename.

Callers updated: `agent-run-create.service.ts`, `chat-session-continuity.service.ts`, `zero-runs-create.service.ts`, `internal-chat-run-callback.service.ts`, `goal-queue-drain.service.ts`, `workflow-automation-launch.service.ts`, `chat-events.command.ts`.

## Which `vm0` is a semantic value and is deliberately retained

`vm0` carries two different meanings in this module. **Only one of them is a brand.** The following are the **model-provider type identity**, persisted and wire-visible, and are byte-identical in this PR:

- **`"vm0"` string literals — every one unchanged.** `getProviderRuntimeModel("vm0", selectedModel)` uses it as the model-provider type id; `args.previous.modelProvider !== "vm0"` and `args.next.modelProvider !== "vm0"` compare against values persisted in `agent_runs.model_provider`. Renaming these would change matching behaviour against stored data, not a label.
- **`getVm0ConcreteProviderType` and `getVm0Vendor`**, imported from `contracts/model-providers` — the read-only fan-in boundary established by #27940. Untouched.
- **`agent_runs.vm0_model_key_id` and its Drizzle field `vm0ModelKeyId`** — added by #28239 in migration `0950_bent_vulture.sql`. CI rejects modification of a migration already on `main`; physical column naming belongs to separate migration work. Nothing about it is renamed.
- **`vm0ModelProviderEnvironment`** (local helper in `agent-run-create.service.ts`) — named for the `"vm0"` provider type it resolves, out of scope for this issue.

`ModelRuntimeSessionRoute` and the `modelRuntimeProvider` / `modelRuntimeModel` fields were already neutral and are unchanged.

## Verification

- No `Vm0ModelRuntime`, `vm0ModelRuntime`, or `vm0-model-runtime-route` identifier or path remains repository-wide.
- Occurrence counts for `getVm0ConcreteProviderType` (22), `getVm0Vendor` (19), `vm0ModelKeyId` (10), `vm0_model_key_id` (9), `vm0ModelProviderEnvironment` (3), `ModelRuntimeSessionRoute` (6), `modelRuntimeProvider` (32), `modelRuntimeModel` (32) are identical before and after.
- `git diff --stat` touches **no** file under `packages/db`, none under `migrations`, and not `contracts/model-providers.ts`.
- `services/zero-runs-create.service.ts` keeps its filename (still held by #28185, registered in the #26938 preflight consumer registry); only its import and property name changed.
- Whitespace-insensitive comparison confirms the diff is **the renames plus formatting only**. The single non-whitespace change is one Prettier-mandated trailing comma where a call in `chat-events.command.ts` broke multi-line under the longer identifier. No behaviour change to route resolution, session continuity, or model key lookup.
- No old-path re-export or compatibility alias left behind.

Closes #28262
