### PR TITLE
perf(runner): share network log path ownership

### DIFF
--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -66,7 +66,7 @@ struct CloseGate {
 pub struct NetworkLogSession {
     manager: NetworkLogManager,
     source_ip: String,
-    path: PathBuf,
+    path: Arc<Path>,
     generation: u64,
     closed: bool,
 }
@@ -142,7 +142,7 @@ impl Drop for NetworkLogSession {
 
         let manager = self.manager.clone();
         let source_ip = self.source_ip.clone();
-        let path = self.path.clone();
+        let path = Arc::clone(&self.path);
         let generation = self.generation;
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             std::mem::drop(handle.spawn(async move {
@@ -626,13 +626,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pending_old_write_stays_on_old_path_after_reregister() {
+    async fn repeated_appends_share_path_and_stay_on_old_path_after_reregister() {
         let dir = tempfile::tempdir().unwrap();
         let old_path = dir.path().join("old.jsonl");
         let new_path = dir.path().join("new.jsonl");
         let started = Arc::new(Notify::new());
         let release = Arc::new(Semaphore::new(0));
-        let manager = NetworkLogManager::new_with_write_gate(started.clone(), release.clone());
+        let manager = NetworkLogManager::new_with_write_gate_and_config(
+            started.clone(),
+            release.clone(),
+            WriterConfig {
+                shards: 1,
+                queue_capacity: 4,
+                max_batch_rows: 1,
+                max_batch_bytes: DEFAULT_MAX_BATCH_BYTES,
+            },
+        );
 
         let _old_session = manager
             .register_source_ip("10.200.0.2", old_path.clone())
@@ -640,10 +649,23 @@ mod tests {
         let old_started = started.notified();
         assert!(
             manager
-                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"old.test"}))
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"old-1.test"}))
                 .await
         );
         old_started.await;
+        assert!(
+            manager
+                .append_for_ip("10.200.0.2", json!({"type":"dns","host":"old-2.test"}))
+                .await
+        );
+        assert!(
+            manager
+                .inner
+                .state
+                .source_and_pending_path_share_identity("10.200.0.2", &old_path)
+                .await,
+            "repeated appends should reuse the registered path allocation"
+        );
 
         manager.unregister_source_ip("10.200.0.2").await;
         let _new_session = manager
@@ -654,14 +676,25 @@ mod tests {
                 .append_for_ip("10.200.0.2", json!({"type":"dns","host":"new.test"}))
                 .await
         );
+        assert!(
+            manager
+                .inner
+                .state
+                .source_and_pending_path_share_identity("10.200.0.2", &new_path)
+                .await,
+            "re-registered source should share its new path allocation"
+        );
 
-        release.add_permits(2);
+        release.add_permits(3);
         manager.flush_path(&old_path).await;
         manager.flush_path(&new_path).await;
 
         let old_lines = read_json_lines(&old_path);
-        assert_eq!(old_lines.len(), 1);
-        assert_eq!(old_lines[0]["host"], "old.test");
+        let old_hosts: Vec<&str> = old_lines
+            .iter()
+            .map(|line| line["host"].as_str().unwrap())
+            .collect();
+        assert_eq!(old_hosts, ["old-1.test", "old-2.test"]);
 
         let new_lines = read_json_lines(&new_path);
         assert_eq!(new_lines.len(), 1);

--- a/crates/runner/src/network_log_manager/state.rs
+++ b/crates/runner/src/network_log_manager/state.rs
@@ -13,25 +13,25 @@ pub(super) struct NetworkLogState {
 #[derive(Default)]
 struct State {
     source_paths: HashMap<String, SourceState>,
-    pending_paths: HashMap<PathBuf, PathState>,
+    pending_paths: HashMap<Arc<Path>, PathState>,
     next_generation: u64,
 }
 
 enum SourceState {
     Active {
-        path: PathBuf,
+        path: Arc<Path>,
         generation: u64,
         writer_backpressure_observed: bool,
     },
     Draining {
-        path: PathBuf,
+        path: Arc<Path>,
         generation: u64,
         writer_backpressure_observed: bool,
     },
 }
 
 impl SourceState {
-    fn path(&self) -> &PathBuf {
+    fn path(&self) -> &Arc<Path> {
         match self {
             Self::Active { path, .. } | Self::Draining { path, .. } => path,
         }
@@ -44,7 +44,7 @@ impl SourceState {
     }
 
     fn matches(&self, path: &Path, generation: u64) -> bool {
-        self.generation() == generation && self.path() == path
+        self.generation() == generation && self.path().as_ref() == path
     }
 
     fn writer_backpressure_observed(&self) -> bool {
@@ -77,17 +77,17 @@ impl PathState {
 
 pub(super) struct SourceRegistration {
     pub(super) source_ip: String,
-    pub(super) path: PathBuf,
+    pub(super) path: Arc<Path>,
     pub(super) generation: u64,
 }
 
 pub(super) struct SourceSnapshot {
-    pub(super) path: PathBuf,
+    pub(super) path: Arc<Path>,
     generation: u64,
 }
 
 pub(super) struct AcceptedAppend {
-    path: PathBuf,
+    path: Arc<Path>,
     line: String,
 }
 
@@ -96,7 +96,7 @@ impl AcceptedAppend {
         self.line.len()
     }
 
-    pub(super) fn into_parts(self) -> (PathBuf, String) {
+    pub(super) fn into_parts(self) -> (Arc<Path>, String) {
         (self.path, self.line)
     }
 }
@@ -107,7 +107,7 @@ pub(super) struct PendingWriteCompletion {
 }
 
 impl PendingWriteCompletion {
-    pub(super) async fn complete_path(&self, path: PathBuf, count: usize) {
+    pub(super) async fn complete_path(&self, path: Arc<Path>, count: usize) {
         if let Some(state) = self.state.upgrade() {
             state.complete_path(path, count).await;
         }
@@ -129,10 +129,11 @@ impl NetworkLogState {
         let mut state = self.state.lock().await;
         state.next_generation += 1;
         let generation = state.next_generation;
+        let path: Arc<Path> = path.into();
         state.source_paths.insert(
             source_ip.clone(),
             SourceState::Active {
-                path: path.clone(),
+                path: Arc::clone(&path),
                 generation,
                 writer_backpressure_observed: false,
             },
@@ -155,13 +156,29 @@ impl NetworkLogState {
         self.state.lock().await.source_paths.contains_key(source_ip)
     }
 
+    #[cfg(test)]
+    pub(super) async fn source_and_pending_path_share_identity(
+        &self,
+        source_ip: &str,
+        path: &Path,
+    ) -> bool {
+        let state = self.state.lock().await;
+        let Some(source) = state.source_paths.get(source_ip) else {
+            return false;
+        };
+        let Some((pending_path, _)) = state.pending_paths.get_key_value(path) else {
+            return false;
+        };
+        Arc::ptr_eq(source.path(), pending_path)
+    }
+
     pub(super) async fn source_snapshot(&self, source_ip: &str) -> Option<SourceSnapshot> {
         let state = self.state.lock().await;
         state
             .source_paths
             .get(source_ip)
             .map(|source| SourceSnapshot {
-                path: source.path().clone(),
+                path: Arc::clone(source.path()),
                 generation: source.generation(),
             })
     }
@@ -174,16 +191,16 @@ impl NetworkLogState {
     ) -> Option<AcceptedAppend> {
         let mut state = self.state.lock().await;
         let source_state = state.source_paths.get(source_ip)?;
-        if !source_state.matches(&snapshot.path, snapshot.generation) {
+        if !source_state.matches(snapshot.path.as_ref(), snapshot.generation) {
             return None;
         }
         let path_state = state
             .pending_paths
-            .entry(snapshot.path.clone())
+            .entry(Arc::clone(&snapshot.path))
             .or_insert_with(PathState::new);
         path_state.pending += 1;
         Some(AcceptedAppend {
-            path: snapshot.path.clone(),
+            path: Arc::clone(&snapshot.path),
             line,
         })
     }
@@ -197,7 +214,7 @@ impl NetworkLogState {
         let Some(source_state) = state.source_paths.get_mut(source_ip) else {
             return;
         };
-        if !source_state.matches(&snapshot.path, snapshot.generation) {
+        if !source_state.matches(snapshot.path.as_ref(), snapshot.generation) {
             return;
         }
         match source_state {
@@ -225,11 +242,12 @@ impl NetworkLogState {
         if !source_state.matches(path, generation) {
             return false;
         }
+        let path = Arc::clone(source_state.path());
         let writer_backpressure_observed = source_state.writer_backpressure_observed();
         state.source_paths.insert(
             source_ip.to_string(),
             SourceState::Draining {
-                path: path.to_path_buf(),
+                path,
                 generation,
                 writer_backpressure_observed,
             },
@@ -281,13 +299,13 @@ impl NetworkLogState {
         }
     }
 
-    async fn complete_path(&self, path: PathBuf, count: usize) {
+    async fn complete_path(&self, path: Arc<Path>, count: usize) {
         if count == 0 {
             return;
         }
         let notify = {
             let mut state = self.state.lock().await;
-            let Some(path_state) = state.pending_paths.get_mut(&path) else {
+            let Some(path_state) = state.pending_paths.get_mut(path.as_ref()) else {
                 warn!(path = %path.display(), "network log write completed for unknown path");
                 return;
             };
@@ -305,7 +323,10 @@ impl NetworkLogState {
             }
 
             if path_state.pending == 0 {
-                state.pending_paths.remove(&path).map(|state| state.notify)
+                state
+                    .pending_paths
+                    .remove(path.as_ref())
+                    .map(|state| state.notify)
             } else {
                 None
             }

--- a/crates/runner/src/network_log_manager/writer.rs
+++ b/crates/runner/src/network_log_manager/writer.rs
@@ -1,6 +1,6 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -42,7 +42,7 @@ pub(super) struct WriterPool {
 }
 
 struct PathWriteBatch {
-    path: PathBuf,
+    path: Arc<Path>,
     lines: Vec<String>,
 }
 
@@ -171,8 +171,9 @@ async fn write_path_batch(
 
     let path = batch.path;
     let count = batch.lines.len();
-    let write_path = path.clone();
-    let result = tokio::task::spawn_blocking(move || append_lines(&write_path, &batch.lines)).await;
+    let write_path = Arc::clone(&path);
+    let result =
+        tokio::task::spawn_blocking(move || append_lines(write_path.as_ref(), &batch.lines)).await;
 
     match result {
         Ok(Ok(())) => {}


### PR DESCRIPTION
## Summary

- share each immutable network-log path with `Arc<Path>` across source state, snapshots, pending accounting, queued appends, writer batches, and completion
- preserve generation checks, value-based shard selection, pending flush barriers, and old-path ownership across source re-registration
- extend the gated manager integration test to verify repeated appends reuse one path allocation and remain routed to the old path after re-registration

## Out of scope

- no queue sizing, sharding, batching, serialization, filesystem append, drain, or upload behavior changes
- no API, protocol, payload, persisted-state, or deployment-boundary changes

## Validation

- `cargo test -p runner --all-features network_log_manager` (25 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --all-targets --all-features` (3200 passed, 20 ignored; guest inventory 1 passed)
- `git diff --check`
- pre-commit hooks and commitlint

Closes #28255
