### PR TITLE
fix(python): bound iana tld updater response reads

### DIFF
--- a/crates/runner/mitm-addon/scripts/update_x_tlds.py
+++ b/crates/runner/mitm-addon/scripts/update_x_tlds.py
@@ -20,6 +20,7 @@ SOURCE_HOST = "data.iana.org"
 SOURCE_PATH = "/TLD/tlds-alpha-by-domain.txt"
 SOURCE_URL = f"https://{SOURCE_HOST}{SOURCE_PATH}"
 FETCH_TIMEOUT_SECONDS = 30
+MAX_SOURCE_BYTES = 64 * 1024
 ADDON_ROOT = Path(__file__).resolve().parents[1]
 OUTPUT_PATH = ADDON_ROOT / "src/usage/providers/connectors/x_tlds.py"
 VERSION_RE = re.compile(r"^# Version (?P<version>\d+), Last Updated (?P<timestamp>.+)$")
@@ -72,7 +73,12 @@ def fetch_source() -> str:
         with opener.open(request, timeout=FETCH_TIMEOUT_SECONDS) as response:
             if response.status != HTTPStatus.OK:
                 raise TldFetchError(f"failed to fetch {SOURCE_URL}: HTTP {response.status}")
-            return response.read().decode("utf-8")
+            body = response.read(MAX_SOURCE_BYTES + 1)
+            if len(body) > MAX_SOURCE_BYTES:
+                raise TldFetchError(
+                    f"failed to fetch {SOURCE_URL}: response body exceeds {MAX_SOURCE_BYTES} bytes"
+                )
+            return body.decode("utf-8")
     except urllib.error.HTTPError as exc:
         with exc:
             raise TldFetchError(f"failed to fetch {SOURCE_URL}: HTTP {exc.code}") from exc

--- a/crates/runner/mitm-addon/scripts/update_x_tlds.py
+++ b/crates/runner/mitm-addon/scripts/update_x_tlds.py
@@ -78,6 +78,9 @@ def fetch_source() -> str:
                 raise TldFetchError(
                     f"failed to fetch {SOURCE_URL}: response body exceeds {MAX_SOURCE_BYTES} bytes"
                 )
+            remaining = response.length
+            if remaining is not None and remaining > 0:
+                raise http.client.IncompleteRead(body, remaining)
             return body.decode("utf-8")
     except urllib.error.HTTPError as exc:
         with exc:

--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -63,6 +63,7 @@ class _ReadFailureOpener:
 
 class _InvalidUtf8Response:
     status = update_x_tlds.HTTPStatus.OK
+    length = None
 
     def __enter__(self) -> _InvalidUtf8Response:
         return self
@@ -82,8 +83,9 @@ class _InvalidUtf8Opener:
 class _BodyResponse:
     status = update_x_tlds.HTTPStatus.OK
 
-    def __init__(self, body: bytes) -> None:
+    def __init__(self, body: bytes, *, declared_length: int | None = None) -> None:
         self._body = io.BytesIO(body)
+        self.length = declared_length
         self.read_amounts: list[int] = []
 
     def __enter__(self) -> _BodyResponse:
@@ -94,7 +96,10 @@ class _BodyResponse:
 
     def read(self, amount: int) -> bytes:
         self.read_amounts.append(amount)
-        return self._body.read(amount)
+        body = self._body.read(amount)
+        if self.length is not None:
+            self.length -= len(body)
+        return body
 
 
 class _BodyOpener:
@@ -254,6 +259,29 @@ def test_update_generated_rejects_oversized_network_source_without_replacing_out
         update_x_tlds.TldFetchError,
         match=rf"response body exceeds {update_x_tlds.MAX_SOURCE_BYTES} bytes",
     ):
+        update_x_tlds.update_generated(None)
+
+    assert response.read_amounts == [update_x_tlds.MAX_SOURCE_BYTES + 1]
+    assert output.read_text(encoding="utf-8") == original
+
+
+def test_update_generated_rejects_truncated_network_source_without_replacing_output(
+    tmp_path, monkeypatch
+):
+    body = b"# Version 1, Last Updated test\nCOM\n"
+    response = _BodyResponse(body, declared_length=len(body) + 1)
+    opener = _BodyOpener(response)
+    output = tmp_path / "x_tlds.py"
+    original = "# existing generated snapshot\n"
+    output.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+    monkeypatch.setattr(
+        update_x_tlds.urllib.request,
+        "build_opener",
+        lambda *handlers: opener,
+    )
+
+    with pytest.raises(update_x_tlds.TldFetchError, match="IncompleteRead"):
         update_x_tlds.update_generated(None)
 
     assert response.read_amounts == [update_x_tlds.MAX_SOURCE_BYTES + 1]

--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -52,7 +52,7 @@ class _ReadFailureResponse:
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
         return None
 
-    def read(self) -> bytes:
+    def read(self, amount: int) -> bytes:
         raise http.client.IncompleteRead(b"partial")
 
 
@@ -70,13 +70,39 @@ class _InvalidUtf8Response:
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
         return None
 
-    def read(self) -> bytes:
+    def read(self, amount: int) -> bytes:
         return b"\xff"
 
 
 class _InvalidUtf8Opener:
     def open(self, request: object, timeout: int) -> _InvalidUtf8Response:
         return _InvalidUtf8Response()
+
+
+class _BodyResponse:
+    status = update_x_tlds.HTTPStatus.OK
+
+    def __init__(self, body: bytes) -> None:
+        self._body = io.BytesIO(body)
+        self.read_amounts: list[int] = []
+
+    def __enter__(self) -> _BodyResponse:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None
+
+    def read(self, amount: int) -> bytes:
+        self.read_amounts.append(amount)
+        return self._body.read(amount)
+
+
+class _BodyOpener:
+    def __init__(self, response: _BodyResponse) -> None:
+        self._response = response
+
+    def open(self, request: object, timeout: int) -> _BodyResponse:
+        return self._response
 
 
 def _build_failing_opener(*handlers: object) -> _FailingOpener:
@@ -97,6 +123,13 @@ def _build_invalid_utf8_opener(*handlers: object) -> _InvalidUtf8Opener:
 
 def _source_text(version: str, tlds: Iterable[str]) -> str:
     return f"# Version {version}, Last Updated test\n" + "\n".join(sorted(tlds)) + "\n"
+
+
+def _source_body_at_limit() -> bytes:
+    prefix = b"# Version 1, Last Updated test\nCOM\n#"
+    suffix = b"\n"
+    padding_size = update_x_tlds.MAX_SOURCE_BYTES - len(prefix) - len(suffix)
+    return prefix + b"x" * padding_size + suffix
 
 
 def _write_generated_snapshot(path: Path) -> None:
@@ -182,6 +215,48 @@ def test_update_generated_rejects_malformed_source_without_replacing_output(tmp_
     with pytest.raises(ValueError, match="version header"):
         update_x_tlds.update_generated(source)
 
+    assert output.read_text(encoding="utf-8") == original
+
+
+def test_update_generated_accepts_network_source_at_limit(tmp_path, monkeypatch):
+    response = _BodyResponse(_source_body_at_limit())
+    opener = _BodyOpener(response)
+    output = tmp_path / "x_tlds.py"
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+    monkeypatch.setattr(
+        update_x_tlds.urllib.request,
+        "build_opener",
+        lambda *handlers: opener,
+    )
+
+    assert update_x_tlds.update_generated(None) == 0
+
+    assert response.read_amounts == [update_x_tlds.MAX_SOURCE_BYTES + 1]
+    assert output.read_text(encoding="utf-8") == update_x_tlds.render_module("1", ("com",))
+
+
+def test_update_generated_rejects_oversized_network_source_without_replacing_output(
+    tmp_path, monkeypatch
+):
+    response = _BodyResponse(_source_body_at_limit() + b"x")
+    opener = _BodyOpener(response)
+    output = tmp_path / "x_tlds.py"
+    original = "# existing generated snapshot\n"
+    output.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+    monkeypatch.setattr(
+        update_x_tlds.urllib.request,
+        "build_opener",
+        lambda *handlers: opener,
+    )
+
+    with pytest.raises(
+        update_x_tlds.TldFetchError,
+        match=rf"response body exceeds {update_x_tlds.MAX_SOURCE_BYTES} bytes",
+    ):
+        update_x_tlds.update_generated(None)
+
+    assert response.read_amounts == [update_x_tlds.MAX_SOURCE_BYTES + 1]
     assert output.read_text(encoding="utf-8") == original
 
 


### PR DESCRIPTION
## Summary

- cap successful IANA TLD source reads at 64 KiB plus one overflow-detection byte
- report oversized sources through the existing `TldFetchError` path before decoding or parsing
- preserve incomplete fixed-length response failures after switching to a bounded read
- cover accepted at-limit, rejected over-limit, and truncated network updates, including preservation of existing output

## Scope

- no `Content-Length` precheck or custom streaming abstraction
- no generated TLD snapshot, runtime billing behavior, API, protocol, or persisted-state changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_update_x_tlds.py` (37 passed)
- `uv run --no-sync python -m pytest tests/` (6389 passed)
- `lefthook run pre-commit`

Closes #28259
