### PR TITLE
fix(ably-subscriber): refresh expired token before reconnect

### DIFF
--- a/crates/ably-subscriber/src/connection/event_loop.rs
+++ b/crates/ably-subscriber/src/connection/event_loop.rs
@@ -247,6 +247,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: CloseRec
 
     'outer: loop {
         let mut disconnected_sent = false;
+        let mut refresh_token = false;
         let mut immediate_retry = false;
         let mut disconnect_reason = None;
         let mut close_before_reconnect = false;
@@ -283,11 +284,15 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: CloseRec
                     {
                         match send_attach(&mut p, &mut close_rx).await {
                             LoopAction::Stop => return,
-                            LoopAction::Reconnect { disconnected_event } => {
+                            LoopAction::Reconnect {
+                                disconnected_event,
+                                refresh_token: action_refresh_token,
+                            } => {
                                 record_reconnect_disconnected_event(
                                     &mut disconnected_sent,
                                     disconnected_event,
                                 );
+                                refresh_token |= action_refresh_token;
                                 immediate_retry = true;
                                 break;
                             }
@@ -386,11 +391,15 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: CloseRec
                     {
                         match send_attach(&mut p, &mut close_rx).await {
                             LoopAction::Stop => return,
-                            LoopAction::Reconnect { disconnected_event } => {
+                            LoopAction::Reconnect {
+                                disconnected_event,
+                                refresh_token: action_refresh_token,
+                            } => {
                                 record_reconnect_disconnected_event(
                                     &mut disconnected_sent,
                                     disconnected_event,
                                 );
+                                refresh_token |= action_refresh_token;
                                 immediate_retry = true;
                                 break;
                             }
@@ -403,11 +412,15 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: CloseRec
                         Some(Ok(tungstenite::Message::Binary(data))) => match decode_msg(&data) {
                             Ok(msg) => match handle_message(&mut p, msg, &mut close_rx).await {
                                 LoopAction::Stop => return,
-                                LoopAction::Reconnect { disconnected_event } => {
+                                LoopAction::Reconnect {
+                                    disconnected_event,
+                                    refresh_token: action_refresh_token,
+                                } => {
                                     record_reconnect_disconnected_event(
                                         &mut disconnected_sent,
                                         disconnected_event,
                                     );
+                                    refresh_token |= action_refresh_token;
                                     immediate_retry = true;
                                     break;
                                 }
@@ -550,7 +563,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: CloseRec
                     }
                     continue;
                 }
-                result = attempt_reconnect(&mut p) => result,
+                result = attempt_reconnect(&mut p, refresh_token) => result,
             };
 
             match reconnect_result {
@@ -617,6 +630,7 @@ enum LoopAction {
     Stop,
     Reconnect {
         disconnected_event: DisconnectedEvent,
+        refresh_token: bool,
     },
 }
 
@@ -661,6 +675,7 @@ async fn send_attach(p: &mut EventLoopState, close_rx: &mut CloseReceiver) -> Lo
             close_websocket_transport(p);
             return LoopAction::Reconnect {
                 disconnected_event: DisconnectedEvent::Pending,
+                refresh_token: false,
             };
         }
     };
@@ -670,6 +685,7 @@ async fn send_attach(p: &mut EventLoopState, close_rx: &mut CloseReceiver) -> Lo
         tracing::warn!("Missing websocket transport for attach");
         return LoopAction::Reconnect {
             disconnected_event: DisconnectedEvent::Pending,
+            refresh_token: false,
         };
     };
     let send_result = tokio::select! {
@@ -691,6 +707,7 @@ async fn send_attach(p: &mut EventLoopState, close_rx: &mut CloseReceiver) -> Lo
             close_websocket_transport(p);
             LoopAction::Reconnect {
                 disconnected_event: DisconnectedEvent::Pending,
+                refresh_token: false,
             }
         }
         Err(_) => {
@@ -698,6 +715,7 @@ async fn send_attach(p: &mut EventLoopState, close_rx: &mut CloseReceiver) -> Lo
             close_websocket_transport(p);
             LoopAction::Reconnect {
                 disconnected_event: DisconnectedEvent::Pending,
+                refresh_token: false,
             }
         }
     }
@@ -764,6 +782,10 @@ async fn handle_message(
             // of retriability. The server may send DISCONNECTED with a non-
             // retriable error (e.g. 429 rate limit) but still expect the client
             // to reconnect after backoff. Only connection-level ERROR is fatal.
+            let refresh_token = msg
+                .error
+                .as_ref()
+                .is_some_and(|error| error.code == error_code::TOKEN_EXPIRED);
             let reason = Some(protocol_disconnect_reason(msg.error));
             p.session.notify_protocol_disconnected();
             close_websocket_transport(p);
@@ -773,6 +795,7 @@ async fn handle_message(
             }
             return LoopAction::Reconnect {
                 disconnected_event: DisconnectedEvent::Sent,
+                refresh_token,
             };
         }
         action::ERROR => {
@@ -987,15 +1010,18 @@ async fn renew_token(p: &mut EventLoopState) -> Result<(), Error> {
 /// channel attach attempt has produced a definitive outcome. If the server
 /// responds DETACHED to the ATTACH, the connected transport is kept and the
 /// caller moves the channel into suspended retry, matching ably-js.
-async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, Error> {
+async fn attempt_reconnect(
+    p: &mut EventLoopState,
+    refresh_token: bool,
+) -> Result<ReconnectOutcome, Error> {
     let reconnect_timeout = p.timing.reconnect_timeout;
     let (connected_msg, mut transport, new_token) =
         tokio::time::timeout(reconnect_timeout, async {
             let use_resume = p.session.can_resume();
 
-            // For fresh connects, obtain a new token up front (kept in a local until
-            // we know the transport connected).
-            let new_token = if !use_resume {
+            // Obtain a new token for fresh connects or after the server rejects
+            // the active token. Keep it local until the transport connects.
+            let new_token = if refresh_token || !use_resume {
                 let token_request = (p.get_token)().await.map_err(Error::TokenFetch)?;
                 Some(exchange_token(&p.http, &token_request, &p.rest_host).await?)
             } else {
@@ -1256,7 +1282,8 @@ mod tests {
         assert_eq!(
             action,
             LoopAction::Reconnect {
-                disconnected_event: DisconnectedEvent::Sent
+                disconnected_event: DisconnectedEvent::Sent,
+                refresh_token: false,
             }
         );
         match event_rx.try_recv().expect("disconnected event") {
@@ -1372,7 +1399,8 @@ mod tests {
         assert_eq!(
             action,
             LoopAction::Reconnect {
-                disconnected_event: DisconnectedEvent::Pending
+                disconnected_event: DisconnectedEvent::Pending,
+                refresh_token: false,
             }
         );
         assert_event_channel_empty(&mut event_rx);
@@ -1403,7 +1431,8 @@ mod tests {
         assert_eq!(
             action,
             LoopAction::Reconnect {
-                disconnected_event: DisconnectedEvent::Pending
+                disconnected_event: DisconnectedEvent::Pending,
+                refresh_token: false,
             }
         );
         assert_event_channel_empty(&mut event_rx);

--- a/crates/ably-subscriber/src/protocol.rs
+++ b/crates/ably-subscriber/src/protocol.rs
@@ -28,6 +28,7 @@ pub mod action {
 }
 
 pub mod error_code {
+    pub const TOKEN_EXPIRED: i32 = 40142;
     pub const FAILED: i32 = 80000;
     pub const TIMEOUT: i32 = 80014;
     pub const CHANNEL_OPERATION_FAILED: i32 = 90000;

--- a/crates/ably-subscriber/tests/integration/reconnect.rs
+++ b/crates/ably-subscriber/tests/integration/reconnect.rs
@@ -704,7 +704,7 @@ async fn token_expired_disconnected_refreshes_token_and_resumes() {
     let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
 
-        // Send DISCONNECTED with a non-retriable error (401 + non-connection code)
+        // Expire the active token before its local expiry timestamp.
         let disconnected = ProtocolMessage {
             action: action::DISCONNECTED,
             error: Some(ErrorInfo {

--- a/crates/ably-subscriber/tests/integration/reconnect.rs
+++ b/crates/ably-subscriber/tests/integration/reconnect.rs
@@ -645,17 +645,62 @@ async fn disconnected_event_is_not_delayed_by_transport_close() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-/// ably-js always reconnects on mid-session DISCONNECTED regardless of
-/// retriability — the server may send 429 or 401 but still expect the
-/// client to backoff-and-retry. Only connection-level ERROR is fatal.
 #[tokio::test]
-async fn non_retriable_disconnected_triggers_reconnect() {
+async fn token_expired_disconnected_refreshes_token_and_resumes() {
+    struct ReconnectUriCapture(tokio::sync::oneshot::Sender<String>);
+
+    impl tungstenite::handshake::server::Callback for ReconnectUriCapture {
+        fn on_request(
+            self,
+            request: &tungstenite::handshake::server::Request,
+            response: tungstenite::handshake::server::Response,
+        ) -> Result<
+            tungstenite::handshake::server::Response,
+            tungstenite::handshake::server::ErrorResponse,
+        > {
+            self.0.send(request.uri().to_string()).unwrap();
+            Ok(response)
+        }
+    }
+
     let http = MockServer::start();
     let ws = MockAblyServer::start().await.unwrap();
-    mock_token_endpoint(&http, "testKey.testId");
+
+    let now = now_ms();
+    let initial_body = serde_json::to_vec(&serde_json::json!({
+        "token": "expired-token",
+        "expires": now + 3_600_000,
+        "issued": now,
+    }))
+    .unwrap();
+    let refreshed_body = serde_json::to_vec(&serde_json::json!({
+        "token": "refreshed-token",
+        "expires": now + 3_600_000,
+        "issued": now,
+    }))
+    .unwrap();
+    let call_count = std::sync::Mutex::new(0u32);
+    let token_mock = http.mock(|when, then| {
+        when.method(POST).path("/keys/testKey.testId/requestToken");
+        then.respond_with(move |_request: &HttpMockRequest| {
+            let mut count = call_count.lock().unwrap();
+            let body = if *count == 0 {
+                &initial_body
+            } else {
+                &refreshed_body
+            };
+            *count += 1;
+            HttpMockResponse::builder()
+                .status(201)
+                .header("content-type", "application/json")
+                .body(body.clone())
+                .build()
+        });
+    });
 
     let ws_port = ws.port;
     let (after_reconnect_seen_tx, after_reconnect_seen_rx) = tokio::sync::oneshot::channel::<()>();
+    let (reconnect_uri_tx, reconnect_uri_rx) = tokio::sync::oneshot::channel::<String>();
     let server_task = tokio::spawn(async move {
         let mut conn = ws.accept_and_handshake("ch", "conn-1").await.unwrap();
 
@@ -676,21 +721,58 @@ async fn non_retriable_disconnected_triggers_reconnect() {
         .unwrap();
         expect_websocket_close_frame(&mut conn).await.unwrap();
 
-        // Client should reconnect (fresh connect with new token)
-        let mut conn2 = ws.accept_and_handshake("ch", "conn-2").await.unwrap();
+        let (tcp, _) = ws.listener.accept().await.unwrap();
+        let mut conn2 =
+            tokio_tungstenite::accept_hdr_async(tcp, ReconnectUriCapture(reconnect_uri_tx))
+                .await
+                .unwrap();
+
+        let connected = ProtocolMessage {
+            action: action::CONNECTED,
+            connection_id: Some("conn-1".into()),
+            connection_key: Some("conn-1!key".into()),
+            connection_details: Some(ConnectionDetails {
+                connection_key: Some("conn-1!key".into()),
+                connection_state_ttl: Some(120_000),
+                max_idle_interval: Some(15_000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&connected).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
+        let attach = expect_protocol_msg(&mut conn2, "ATTACH after token refresh")
+            .await
+            .unwrap();
+        assert_eq!(attach.action, action::ATTACH);
+        assert_eq!(attach.channel.as_deref(), Some("ch"));
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-0".into()),
+            ..Default::default()
+        };
+        conn2
+            .send(tungstenite::Message::Binary(
+                encode_msg(&attached).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+
         send_message(
             &mut conn2,
             "ch",
-            "after-non-retriable-disconnect",
+            "after-token-refresh",
             serde_json::json!("ok"),
         )
         .await
         .unwrap();
-        wait_for_test_observation(
-            after_reconnect_seen_rx,
-            "after-non-retriable-disconnect message",
-        )
-        .await;
+        wait_for_test_observation(after_reconnect_seen_rx, "after-token-refresh message").await;
     });
 
     let mut timing = TimingConfig::default();
@@ -723,12 +805,25 @@ async fn non_retriable_disconnected_triggers_reconnect() {
     let event = expect_event(&mut sub, "message").await.unwrap();
     match event {
         Event::Message(msg) => {
-            assert_eq!(msg.name.as_deref(), Some("after-non-retriable-disconnect"));
+            assert_eq!(msg.name.as_deref(), Some("after-token-refresh"));
             after_reconnect_seen_tx.send(()).unwrap();
         }
         other => panic!("expected Message, got {other:?}"),
     }
 
+    let reconnect_uri = reconnect_uri_rx.await.unwrap();
+    let reconnect_url = url::Url::parse(&format!("ws://localhost{reconnect_uri}")).unwrap();
+    let access_token = reconnect_url
+        .query_pairs()
+        .find(|(name, _)| name == "access_token")
+        .map(|(_, value)| value.into_owned());
+    let resume = reconnect_url
+        .query_pairs()
+        .find(|(name, _)| name == "resume")
+        .map(|(_, value)| value.into_owned());
+    assert_eq!(access_token.as_deref(), Some("refreshed-token"));
+    assert_eq!(resume.as_deref(), Some("conn-1!key"));
+    token_mock.assert_calls(2);
     join_server_task(server_task, "mock server").await.unwrap();
 }
 


### PR DESCRIPTION
## Summary

- force a fresh Ably token exchange after a mid-session `DISCONNECTED` with error code `40142`
- preserve the existing connection resume key while using the refreshed credential
- verify the token exchange count and reconnect WebSocket query through the public subscription integration path

## Scope

This change handles the documented token-expired code only. It does not broaden renewal to other Ably token errors, add a pending-token cache, or change public subscriber, runner, persistence, or deployment contracts.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p ably-subscriber --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p ably-subscriber --no-deps`
- `cargo test -p ably-subscriber`

Closes #28258
