### PR TITLE
refactor(rust): centralize process output validation

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3734,6 +3734,7 @@ name = "vsock-host"
 version = "0.17.84"
 dependencies = [
  "nix",
+ "sandbox",
  "shell-quote",
  "tokio",
  "tracing",

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2490,6 +2490,7 @@ impl Sandbox for FirecrackerSandbox {
         let operation = SandboxOperation::StartProcess;
         let vsock = self.begin_guest_operation(operation).await?;
         Self::validate_exec_env_keys(operation, request.env)?;
+        request.output.validate()?;
 
         let start_future = async move {
             vsock

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -2233,6 +2233,122 @@ fn invalid_start_process_env_key_returns_operation_error() {
     }
 }
 
+#[tokio::test]
+async fn start_process_output_rejects_invalid_stream_configuration() {
+    let sandbox = test_sandbox_with_state(SandboxState::Running);
+    let guest = attach_mock_shutdown_guest(&sandbox).await;
+
+    for (output, expected_message) in [
+        (
+            ProcessOutputMode::Stream {
+                stream_limit_bytes: 1024,
+                chunk_limit_bytes: 0,
+                queue_capacity: 1,
+                stderr_capture_limit_bytes: None,
+            },
+            "process stream chunk limit must be positive",
+        ),
+        (
+            ProcessOutputMode::Stream {
+                stream_limit_bytes: 1024,
+                chunk_limit_bytes: 16,
+                queue_capacity: 0,
+                stderr_capture_limit_bytes: None,
+            },
+            "process stream queue capacity must be positive",
+        ),
+        (
+            ProcessOutputMode::Stream {
+                stream_limit_bytes: 1024,
+                chunk_limit_bytes: 16,
+                queue_capacity: ProcessOutputMode::MAX_QUEUE_CAPACITY + 1,
+                stderr_capture_limit_bytes: None,
+            },
+            "process stream queue capacity must be at most 8192",
+        ),
+    ] {
+        let error = match sandbox
+            .start_process(&StartProcessRequest {
+                cmd: "agent",
+                timeout: Duration::from_secs(5),
+                env: &[],
+                sudo: false,
+                output,
+                control: ProcessControlMode::None,
+            })
+            .await
+        {
+            Ok(_) => panic!("invalid stream configuration should be rejected"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+
+        assert_operation_error(
+            error,
+            SandboxOperation::StartProcess,
+            SandboxOperationReason::Other,
+        );
+        assert!(message.contains(expected_message), "got: {message}");
+
+        let mut unexpected_frame = [0u8; 1];
+        let read_error = guest.try_read(&mut unexpected_frame).unwrap_err();
+        assert_eq!(read_error.kind(), io::ErrorKind::WouldBlock);
+    }
+}
+
+#[tokio::test]
+async fn start_process_output_accepts_maximum_queue_capacity() {
+    let sandbox = test_sandbox_with_state(SandboxState::Running);
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let output = ProcessOutputMode::Stream {
+        stream_limit_bytes: 0,
+        chunk_limit_bytes: 16,
+        queue_capacity: ProcessOutputMode::MAX_QUEUE_CAPACITY,
+        stderr_capture_limit_bytes: None,
+    };
+    let request = StartProcessRequest {
+        cmd: "agent",
+        timeout: Duration::from_secs(5),
+        env: &[],
+        sudo: false,
+        output,
+        control: ProcessControlMode::None,
+    };
+
+    let start_process = sandbox.start_process(&request);
+    let acknowledge_start = async {
+        let start = read_vsock_message(&mut guest).await;
+        assert_eq!(start.msg_type, vsock_proto::MSG_EXEC_START);
+        let decoded = vsock_proto::decode_exec_start(&start.payload).unwrap();
+        assert_eq!(
+            decoded.stdout,
+            ExecOutputPolicy::Stream {
+                limit_bytes: 0,
+                chunk_limit_bytes: 16,
+            }
+        );
+
+        let payload = vsock_proto::encode_exec_started(73).unwrap();
+        let response =
+            vsock_proto::encode(vsock_proto::MSG_EXEC_STARTED, start.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+        start.seq
+    };
+    let (handle, exec_seq) = tokio::join!(start_process, acknowledge_start);
+    let handle = handle.unwrap();
+
+    assert!(handle.has_stdout_receiver());
+    send_exec_exit(&mut guest, exec_seq).await;
+    let exit = sandbox
+        .wait_process(handle, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(
+        exit.termination,
+        sandbox::ExecTermination::Exited { exit_code: 0 }
+    );
+}
+
 #[test]
 fn operation_error_preserves_file_operation_context_for_guest_failures() {
     for operation in [SandboxOperation::ReadFile, SandboxOperation::CopyFile] {

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -359,27 +359,6 @@ fn apply_exec_output_limits(mut result: ExecResult, limits: ExecOutputLimits) ->
     result
 }
 
-fn validate_start_process_output(output: ProcessOutputMode) -> Result<()> {
-    match output {
-        ProcessOutputMode::Stream {
-            chunk_limit_bytes: 0,
-            ..
-        } => Err(SandboxError::Operation {
-            operation: SandboxOperation::StartProcess,
-            reason: SandboxOperationReason::Other,
-            message: "process stream chunk limit must be positive".to_string(),
-        }),
-        ProcessOutputMode::Stream {
-            queue_capacity: 0, ..
-        } => Err(SandboxError::Operation {
-            operation: SandboxOperation::StartProcess,
-            reason: SandboxOperationReason::Other,
-            message: "process stream queue capacity must be positive".to_string(),
-        }),
-        ProcessOutputMode::Buffered { .. } | ProcessOutputMode::Stream { .. } => Ok(()),
-    }
-}
-
 #[async_trait]
 impl Sandbox for MockSandbox {
     fn id(&self) -> &str {
@@ -871,7 +850,7 @@ impl Sandbox for MockSandbox {
             wait_lifecycle_gate(&overrides.process.start_process_lifecycle_gate).await;
         }
         validate_mock_exec_env_keys(SandboxOperation::StartProcess, request.env)?;
-        validate_start_process_output(request.output)?;
+        request.output.validate()?;
         if let Some(overrides) = &self.overrides {
             overrides
                 .process

--- a/crates/sandbox-mock/src/tests/process.rs
+++ b/crates/sandbox-mock/src/tests/process.rs
@@ -290,26 +290,40 @@ async fn structured_process_control_distinguishes_timeout_write_state() {
 }
 
 #[tokio::test]
-async fn start_process_rejects_invalid_stream_configuration() {
-    let runtime = MockSandboxRuntime::new();
-    let factory = runtime.create_factory(test_factory_config()).await.unwrap();
-    let sandbox = factory.create(test_sandbox_config()).await.unwrap();
+async fn start_process_validates_stream_configuration() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
 
-    for output in [
-        ProcessOutputMode::Stream {
-            stream_limit_bytes: 1024,
-            chunk_limit_bytes: 0,
-            queue_capacity: 1,
-            stderr_capture_limit_bytes: None,
-        },
-        ProcessOutputMode::Stream {
-            stream_limit_bytes: 1024,
-            chunk_limit_bytes: 16,
-            queue_capacity: 0,
-            stderr_capture_limit_bytes: None,
-        },
+    for (output, expected_message) in [
+        (
+            ProcessOutputMode::Stream {
+                stream_limit_bytes: 1024,
+                chunk_limit_bytes: 0,
+                queue_capacity: 1,
+                stderr_capture_limit_bytes: None,
+            },
+            "process stream chunk limit must be positive",
+        ),
+        (
+            ProcessOutputMode::Stream {
+                stream_limit_bytes: 1024,
+                chunk_limit_bytes: 16,
+                queue_capacity: 0,
+                stderr_capture_limit_bytes: None,
+            },
+            "process stream queue capacity must be positive",
+        ),
+        (
+            ProcessOutputMode::Stream {
+                stream_limit_bytes: 1024,
+                chunk_limit_bytes: 16,
+                queue_capacity: ProcessOutputMode::MAX_QUEUE_CAPACITY + 1,
+                stderr_capture_limit_bytes: None,
+            },
+            "process stream queue capacity must be at most 8192",
+        ),
     ] {
-        match sandbox
+        let error = match sandbox
             .start_process(&StartProcessRequest {
                 cmd: "agent",
                 timeout: Duration::from_secs(5),
@@ -321,15 +335,39 @@ async fn start_process_rejects_invalid_stream_configuration() {
             .await
         {
             Ok(_) => panic!("invalid stream configuration should be rejected"),
-            Err(SandboxError::Operation {
-                operation, reason, ..
-            }) => {
-                assert_eq!(operation, SandboxOperation::StartProcess);
-                assert_eq!(reason, SandboxOperationReason::Other);
-            }
-            Err(other) => panic!("expected start_process operation error, got {other:?}"),
-        }
+            Err(error) => error,
+        };
+        assert_operation_error(
+            error,
+            SandboxOperation::StartProcess,
+            SandboxOperationReason::Other,
+            expected_message,
+        );
     }
+    assert!(overrides.start_process_calls().is_empty());
+
+    let output = ProcessOutputMode::Stream {
+        stream_limit_bytes: 0,
+        chunk_limit_bytes: 16,
+        queue_capacity: ProcessOutputMode::MAX_QUEUE_CAPACITY,
+        stderr_capture_limit_bytes: None,
+    };
+    let handle = sandbox
+        .start_process(&StartProcessRequest {
+            cmd: "agent",
+            timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+            output,
+            control: ProcessControlMode::None,
+        })
+        .await
+        .unwrap();
+
+    assert!(handle.has_stdout_receiver());
+    let calls = overrides.start_process_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls.first().unwrap().output, output);
 }
 
 #[tokio::test]

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -824,6 +824,9 @@ pub enum ProcessOutputMode {
         chunk_limit_bytes: u32,
         /// Capacity of the host-side stdout delivery queue.
         ///
+        /// This must be positive and no larger than
+        /// [`MAX_QUEUE_CAPACITY`](ProcessOutputMode::MAX_QUEUE_CAPACITY).
+        ///
         /// This bounds host buffering for delivered chunks. It is not a
         /// guarantee that a slow caller applies backpressure to the guest; host
         /// delivery overflow is reported through [`ProcessExit::stream_overflowed`].
@@ -854,8 +857,10 @@ impl ProcessOutputMode {
     pub const DEFAULT_STREAM_LIMIT_BYTES: u32 = 64 * 1024 * 1024;
     /// Default maximum size of each streamed process stdout chunk.
     pub const DEFAULT_CHUNK_LIMIT_BYTES: u32 = 64 * 1024;
+    /// Maximum supported host queue capacity for process stdout chunks.
+    pub const MAX_QUEUE_CAPACITY: usize = 8192;
     /// Default bounded host queue capacity for process stdout chunks.
-    pub const DEFAULT_QUEUE_CAPACITY: usize = 8192;
+    pub const DEFAULT_QUEUE_CAPACITY: usize = Self::MAX_QUEUE_CAPACITY;
 
     /// Return buffered output mode with the supplied capture limits.
     pub const fn buffered(output_limits: ExecOutputLimits) -> Self {
@@ -883,6 +888,41 @@ impl ProcessOutputMode {
             chunk_limit_bytes: Self::DEFAULT_CHUNK_LIMIT_BYTES,
             queue_capacity: Self::DEFAULT_QUEUE_CAPACITY,
             stderr_capture_limit_bytes: Some(stderr_capture_limit_bytes),
+        }
+    }
+
+    /// Validate this mode for [`Sandbox::start_process`](crate::Sandbox::start_process).
+    ///
+    /// Stream chunk limits and queue capacities must be positive, and queue
+    /// capacities must not exceed [`MAX_QUEUE_CAPACITY`](Self::MAX_QUEUE_CAPACITY).
+    pub fn validate(self) -> crate::Result<()> {
+        match self {
+            Self::Stream {
+                chunk_limit_bytes: 0,
+                ..
+            } => Err(crate::SandboxError::Operation {
+                operation: crate::SandboxOperation::StartProcess,
+                reason: crate::SandboxOperationReason::Other,
+                message: "process stream chunk limit must be positive".into(),
+            }),
+            Self::Stream {
+                queue_capacity: 0, ..
+            } => Err(crate::SandboxError::Operation {
+                operation: crate::SandboxOperation::StartProcess,
+                reason: crate::SandboxOperationReason::Other,
+                message: "process stream queue capacity must be positive".into(),
+            }),
+            Self::Stream { queue_capacity, .. } if queue_capacity > Self::MAX_QUEUE_CAPACITY => {
+                Err(crate::SandboxError::Operation {
+                    operation: crate::SandboxOperation::StartProcess,
+                    reason: crate::SandboxOperationReason::Other,
+                    message: format!(
+                        "process stream queue capacity must be at most {}",
+                        Self::MAX_QUEUE_CAPACITY
+                    ),
+                })
+            }
+            Self::Buffered { .. } | Self::Stream { .. } => Ok(()),
         }
     }
 

--- a/crates/vsock-host/Cargo.toml
+++ b/crates/vsock-host/Cargo.toml
@@ -6,10 +6,11 @@ description = "Vsock host client for Firecracker VM communication"
 
 [dependencies]
 nix = { workspace = true, features = ["net"] }
+sandbox.workspace = true
+shell-quote.workspace = true
 tokio = { workspace = true, features = ["net", "io-util", "time", "rt", "macros", "sync", "fs"] }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-shell-quote.workspace = true
 vsock-proto.workspace = true
 
 [dev-dependencies]

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -39,7 +39,7 @@ const DEFAULT_EXEC_STREAM_CAPACITY: usize = 32;
 // Provides 64 MiB of headroom at the guest drainer's 8 KiB read granularity.
 // Larger bounded copies rely on concurrent draining and fail explicitly if
 // the queue overflows rather than reserving unbounded memory.
-pub(crate) const MAX_EXEC_STREAM_CAPACITY: usize = 8192;
+pub(crate) const MAX_EXEC_STREAM_CAPACITY: usize = sandbox::ProcessOutputMode::MAX_QUEUE_CAPACITY;
 const EXEC_OPERATION_LABEL_LOG_PREFIX_MAX_BYTES: usize = 100;
 const EXEC_OPERATION_CLOSE_ACTIVE_LOG_LIMIT: usize = 16;
 const EXEC_OPERATION_FRAME_WRITE_SLOW_THRESHOLD: Duration = Duration::from_millis(500);


### PR DESCRIPTION
## Summary

- define the canonical `ProcessOutputMode` stream validation contract and maximum queue capacity in `sandbox`
- apply the shared validation in both mock and Firecracker `start_process` paths with consistent operation errors
- keep the lower-level vsock safety check while deriving its limit from the shared API contract
- add backend boundary coverage for zero, maximum, and oversized queue capacities plus zero chunk limits

## Scope

- no vsock protocol, persisted-state, or deployment compatibility changes
- buffered output behavior remains unchanged

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p sandbox -p sandbox-mock -p sandbox-fc -p vsock-host`
- `cargo test --workspace --all-features`

Closes #28257
