### PR TITLE
feat(api): accept unbranded provider oauth callback paths

### DIFF
--- a/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
+++ b/turbo/apps/api/src/__tests__/api-namespace-compatibility.test.ts
@@ -5,7 +5,14 @@ import {
   assertUniqueRouteRegistrations,
   type RouteEntry,
   withApiNamespaceAliases,
+  withUnbrandedProviderOauthCallbacks,
 } from "../signals/route-entry";
+
+const UNBRANDED_PROVIDER_OAUTH_CALLBACK_SUFFIXES = [
+  "/slack/oauth/callback",
+  "/teams/oauth/callback",
+  "/feishu/oauth/callback",
+] as const;
 
 function routeKey(entry: RouteEntry): string {
   return `${entry.route.method} ${entry.route.path}`;
@@ -21,8 +28,20 @@ function requireBrandedRoute(): RouteEntry {
   return entry;
 }
 
+function requireCallbackRoute(suffix: string): RouteEntry {
+  const entry = ROUTES.find(({ route }) => {
+    return route.method === "GET" && route.path.endsWith(suffix);
+  });
+  if (!entry) {
+    throw new Error(`Expected a provider OAuth callback route for ${suffix}`);
+  }
+  return entry;
+}
+
 describe("API namespace compatibility", () => {
-  const registeredRoutes = withApiNamespaceAliases(ROUTES);
+  const registeredRoutes = withApiNamespaceAliases(
+    withUnbrandedProviderOauthCallbacks(ROUTES),
+  );
 
   it("registers symmetric Zero and Okou paths with the same handler and schema", () => {
     const registrationCounts = new Map<string, number>();
@@ -57,6 +76,48 @@ describe("API namespace compatibility", () => {
     expect(() => {
       assertUniqueRouteRegistrations(registeredRoutes);
     }).not.toThrow();
+  });
+
+  it("serves each provider OAuth callback from both branded namespaces and its unbranded path", () => {
+    for (const suffix of UNBRANDED_PROVIDER_OAUTH_CALLBACK_SUFFIXES) {
+      const source = requireCallbackRoute(suffix);
+      const paths = [
+        `/api/okou${suffix}`,
+        `/api/zero${suffix}`,
+        `/api${suffix}`,
+      ];
+
+      for (const path of paths) {
+        const matches = registeredRoutes.filter(({ route }) => {
+          return route.method === "GET" && route.path === path;
+        });
+        expect(matches).toHaveLength(1);
+        const match = matches[0];
+        if (!match) {
+          throw new Error(`Missing provider OAuth callback route for ${path}`);
+        }
+        expect(match.handler).toBe(source.handler);
+        expect(match.route).toStrictEqual({ ...source.route, path });
+      }
+    }
+  });
+
+  it("adds an unbranded path for the provider OAuth callbacks and nothing else", () => {
+    const brandedOnlyKeys = new Set(
+      withApiNamespaceAliases(ROUTES).map(routeKey),
+    );
+    const addedKeys = registeredRoutes
+      .map(routeKey)
+      .filter((key) => {
+        return !brandedOnlyKeys.has(key);
+      })
+      .sort();
+
+    expect(addedKeys).toStrictEqual(
+      UNBRANDED_PROVIDER_OAUTH_CALLBACK_SUFFIXES.map((suffix) => {
+        return `GET /api${suffix}`;
+      }).sort(),
+    );
   });
 
   it("keeps neutral health, webhook, and product-scoped Desktop routes single", () => {

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -41,6 +41,7 @@ import {
 import {
   type RouteEntry,
   withApiNamespaceAliases,
+  withUnbrandedProviderOauthCallbacks,
 } from "./signals/route-entry";
 import { configureChatRunFinishedEventDispatcher } from "./signals/services/chat-run-finished-event-registration.service";
 import type { UsagePricingResolution } from "./signals/context/usage-pricing-resolution";
@@ -605,7 +606,9 @@ export function createAppWithRoutes({
     app.get(`${path}/*`, redirectToApp);
   }
 
-  for (const { route, handler } of withApiNamespaceAliases(routes)) {
+  for (const { route, handler } of withApiNamespaceAliases(
+    withUnbrandedProviderOauthCallbacks(routes),
+  )) {
     app.on(
       route.method,
       route.path,

--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -1,5 +1,8 @@
 import type { AppRoute } from "@okouai/api-contracts/contracts/trpc-contract";
-import { apiNamespaceAliasPaths } from "@okouai/api-contracts/contracts/api-namespaces";
+import {
+  apiNamespaceAliasPaths,
+  BRANDED_API_NAMESPACE_PATHS,
+} from "@okouai/api-contracts/contracts/api-namespaces";
 import type { SignalRouteHandler } from "./context/route";
 
 export type { SignalRouteHandler };
@@ -34,6 +37,51 @@ function routeEntryWithPath(entry: RouteEntry, path: string): RouteEntry {
     route: { ...entry.route, path },
     handler: entry.handler,
   };
+}
+
+/**
+ * Stage 0 of #28278. Provider OAuth callbacks are also served at their final
+ * unbranded paths so the provider console allowlists — Feishu Open Platform,
+ * Slack app configuration, Microsoft identity platform app registration — are
+ * updated once instead of once per namespace. `/api/slack`, `/api/teams` and
+ * `/api/feishu` hold nothing else, so the final shape is reachable now.
+ *
+ * This list is exhaustive on purpose. Emitting an unbranded path for every
+ * branded route is Stage 2 of #28278, is gated on #26701, and would expose the
+ * whole product surface under a second path.
+ */
+const UNBRANDED_PROVIDER_OAUTH_CALLBACK_SUFFIXES = [
+  "/slack/oauth/callback",
+  "/teams/oauth/callback",
+  "/feishu/oauth/callback",
+] as const;
+
+function unbrandedProviderOauthCallbackPath(path: string): string | undefined {
+  for (const namespacePath of BRANDED_API_NAMESPACE_PATHS) {
+    for (const suffix of UNBRANDED_PROVIDER_OAUTH_CALLBACK_SUFFIXES) {
+      if (path === `${namespacePath}${suffix}`) {
+        return `/api${suffix}`;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Adds the unbranded path for each provider OAuth callback while keeping every
+ * branded path. Apply before `withApiNamespaceAliases` so a callback gains one
+ * unbranded entry rather than one per branded namespace.
+ */
+export function withUnbrandedProviderOauthCallbacks(
+  routes: readonly RouteEntry[],
+): readonly RouteEntry[] {
+  return routes.flatMap((entry) => {
+    const unbrandedPath = unbrandedProviderOauthCallbackPath(entry.route.path);
+    if (unbrandedPath === undefined) {
+      return [entry];
+    }
+    return [entry, routeEntryWithPath(entry, unbrandedPath)];
+  });
 }
 
 /**

--- a/turbo/apps/api/src/signals/routes/__tests__/unbranded-provider-oauth-callback.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/unbranded-provider-oauth-callback.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createAppWithRoutes } from "../../../app-factory-core";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
+import { testContext } from "../../../__tests__/test-context";
+import type { RouteEntry } from "../../route-entry";
+import { feishuOauthRoutes } from "../feishu-oauth";
+import { slackOauthRoutes } from "../slack-oauth";
+import { teamsOauthRoutes } from "../teams-oauth";
+
+const context = testContext();
+
+interface ProviderCallback {
+  readonly provider: string;
+  readonly suffix: string;
+  readonly routes: readonly RouteEntry[];
+  /**
+   * Error the branded callback already returns for a callback carrying no
+   * `code`. Feishu rejects the absent state first, Slack and Teams the code.
+   */
+  readonly missingCodeError: string;
+}
+
+const PROVIDER_CALLBACKS: readonly ProviderCallback[] = [
+  {
+    provider: "Slack",
+    suffix: "/slack/oauth/callback",
+    routes: slackOauthRoutes,
+    missingCodeError: "Missing authorization code",
+  },
+  {
+    provider: "Microsoft Teams",
+    suffix: "/teams/oauth/callback",
+    routes: teamsOauthRoutes,
+    missingCodeError: "Missing authorization code",
+  },
+  {
+    provider: "Feishu",
+    suffix: "/feishu/oauth/callback",
+    routes: feishuOauthRoutes,
+    missingCodeError: "Invalid or expired connect state",
+  },
+];
+
+function namespacedPaths(suffix: string): readonly string[] {
+  return [`/api/zero${suffix}`, `/api/okou${suffix}`, `/api${suffix}`];
+}
+
+async function callbackResponse(
+  target: ProviderCallback,
+  path: string,
+): Promise<{ readonly status: number; readonly body: unknown }> {
+  const app = createAppWithRoutes({
+    signal: context.signal,
+    routes: target.routes,
+  });
+  const response = await app.request(`http://api.test${path}`);
+  return { status: response.status, body: await response.json() };
+}
+
+describe("unbranded provider OAuth callbacks", () => {
+  beforeEach(() => {
+    mockEnv("SLACK_OAUTH_CLIENT_ID", "test-slack-client-id");
+    mockOptionalEnv("SLACK_OAUTH_CLIENT_SECRET", "test-slack-client-secret");
+    mockEnv("MICROSOFT_OAUTH_CLIENT_ID", "test-microsoft-client-id");
+    mockEnv("MICROSOFT_OAUTH_CLIENT_SECRET", "test-microsoft-client-secret");
+  });
+
+  for (const target of PROVIDER_CALLBACKS) {
+    it(`answers a ${target.provider} callback without a code identically on every namespace`, async () => {
+      for (const path of namespacedPaths(target.suffix)) {
+        const response = await callbackResponse(target, path);
+
+        expect(response.status).toBe(400);
+        expect(response.body).toStrictEqual({
+          error: target.missingCodeError,
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## What this does

Registers the three provider OAuth callbacks at their final unbranded paths, served by the **same handlers** that already serve the branded paths:

| Path | Method | Existing handler |
|---|---|---|
| `/api/slack/oauth/callback` | GET | `slackOauthContract.callback` |
| `/api/teams/oauth/callback` | GET | `teamsOauthContract.callback` |
| `/api/feishu/oauth/callback` | GET | `feishuOauthContract.callback` |

`withUnbrandedProviderOauthCallbacks()` in `apps/api/src/signals/route-entry.ts` adds one unbranded entry per callback via the existing `routeEntryWithPath`, and runs before `withApiNamespaceAliases()` so each callback gains exactly one unbranded path rather than one per branded namespace. Query parsing, state validation, error responses, redirect construction and status codes are unchanged — the unbranded path is an extra way to reach the same handler, not a new handler.

This is Stage 0 step 1 of #28278.

## What this deliberately does not do

- **No producer is switched.** `routes/slack-oauth.ts`, `routes/teams-oauth.ts` and `services/feishu-config.ts` still emit their current `/api/zero/**` callback URLs. Producer cutover is step 3 and must wait until the provider consoles accept the new `redirect_uri`; switching early makes the provider reject the redirect on its own authorization screen.
- **No provider console change.** Feishu Open Platform, the Slack app configuration and the Microsoft identity platform app registration are untouched. That is step 2 and needs an operator with admin access.
- **No existing callback path is removed or altered.** `/api/zero/**` and `/api/okou/**` keep working; stored OAuth registrations still hold those URLs, and their removal is gated on #26701.
- **The alias mechanism is not widened.** `apiNamespaceAliasPaths()` is untouched. The suffix list is exhaustive at three entries — emitting an unbranded path for every branded route is Stage 2 of #28278 and would expose all 359 `/api/okou/**` product routes under a second path.

## Coverage

- `signals/routes/__tests__/unbranded-provider-oauth-callback.test.ts` — for each provider, a callback with no `code` returns the identical status and body on `/api/zero/**`, `/api/okou/**` and the unbranded path, and specifically not a 404.
- `__tests__/api-namespace-compatibility.test.ts` — all three namespaces resolve to the same handler and the same route object for each callback; the registration set gains exactly these three paths and nothing else; `assertUniqueRouteRegistrations` still passes.

Closes #28279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
