### PR TITLE
fix(api): centralize clerk backend api read retries

### DIFF
--- a/turbo/apps/api/src/signals/external/clerk-membership-requests.ts
+++ b/turbo/apps/api/src/signals/external/clerk-membership-requests.ts
@@ -2,7 +2,12 @@ import { z } from "zod";
 
 import { env } from "../../lib/env";
 import { startUntrackedBestEffortCleanup } from "../utils";
-import { ClerkRateLimitError } from "./clerk";
+import {
+  ClerkRateLimitError,
+  createClerkReadContext,
+  retryClerkRead,
+  type ClerkReadContext,
+} from "./clerk";
 
 const CLERK_API_BASE = "https://api.clerk.com/v1";
 
@@ -33,7 +38,7 @@ function cancelUnusedResponseBody(response: Response): void {
  * Returns [] when Clerk responds 404 (the membership_requests feature is not
  * enabled for the org). Throws on any other non-OK response.
  */
-export async function fetchClerkMembershipRequests(
+async function requestClerkMembershipRequests(
   orgId: string,
   signal: AbortSignal,
 ): Promise<readonly ClerkMembershipRequestData[]> {
@@ -62,6 +67,20 @@ export async function fetchClerkMembershipRequests(
   }
   const body = clerkMembershipRequestsResponseSchema.parse(await res.json());
   return body.data;
+}
+
+export async function fetchClerkMembershipRequests(
+  orgId: string,
+  context: ClerkReadContext = createClerkReadContext(),
+  signal: AbortSignal = new AbortController().signal,
+): Promise<readonly ClerkMembershipRequestData[]> {
+  return await retryClerkRead(
+    () => {
+      return requestClerkMembershipRequests(orgId, signal);
+    },
+    context,
+    signal,
+  );
 }
 
 export async function acceptClerkMembershipRequest(args: {

--- a/turbo/apps/api/src/signals/external/clerk-organization-lists.ts
+++ b/turbo/apps/api/src/signals/external/clerk-organization-lists.ts
@@ -1,7 +1,9 @@
-import type {
-  ClerkOrganizationInvitation,
-  ClerkOrganizationMembership,
-  ClerkOrganizationsApi,
+import {
+  createClerkReadContext,
+  type ClerkOrganizationInvitation,
+  type ClerkOrganizationMembership,
+  type ClerkOrganizationsApi,
+  type ClerkReadContext,
 } from "./clerk";
 
 const ORGANIZATION_LIST_PAGE_SIZE = 100;
@@ -9,17 +11,22 @@ const ORGANIZATION_LIST_PAGE_SIZE = 100;
 export async function listAllOrganizationMemberships(
   organizations: Pick<ClerkOrganizationsApi, "getOrganizationMembershipList">,
   organizationId: string,
-  signal?: AbortSignal,
+  context: ClerkReadContext = createClerkReadContext(),
+  signal: AbortSignal = new AbortController().signal,
 ): Promise<ClerkOrganizationMembership[]> {
   const memberships: ClerkOrganizationMembership[] = [];
   for (let offset = 0; ; offset += ORGANIZATION_LIST_PAGE_SIZE) {
-    signal?.throwIfAborted();
-    const page = await organizations.getOrganizationMembershipList({
-      organizationId,
-      limit: ORGANIZATION_LIST_PAGE_SIZE,
-      offset,
-    });
-    signal?.throwIfAborted();
+    signal.throwIfAborted();
+    const page = await organizations.getOrganizationMembershipList(
+      {
+        organizationId,
+        limit: ORGANIZATION_LIST_PAGE_SIZE,
+        offset,
+      },
+      context,
+      signal,
+    );
+    signal.throwIfAborted();
     memberships.push(...page.data);
     if (page.data.length < ORGANIZATION_LIST_PAGE_SIZE) {
       return memberships;
@@ -30,18 +37,23 @@ export async function listAllOrganizationMemberships(
 export async function listAllPendingOrganizationInvitations(
   organizations: Pick<ClerkOrganizationsApi, "getOrganizationInvitationList">,
   organizationId: string,
-  signal?: AbortSignal,
+  context: ClerkReadContext = createClerkReadContext(),
+  signal: AbortSignal = new AbortController().signal,
 ): Promise<ClerkOrganizationInvitation[]> {
   const invitations: ClerkOrganizationInvitation[] = [];
   for (let offset = 0; ; offset += ORGANIZATION_LIST_PAGE_SIZE) {
-    signal?.throwIfAborted();
-    const page = await organizations.getOrganizationInvitationList({
-      organizationId,
-      status: ["pending"],
-      limit: ORGANIZATION_LIST_PAGE_SIZE,
-      offset,
-    });
-    signal?.throwIfAborted();
+    signal.throwIfAborted();
+    const page = await organizations.getOrganizationInvitationList(
+      {
+        organizationId,
+        status: ["pending"],
+        limit: ORGANIZATION_LIST_PAGE_SIZE,
+        offset,
+      },
+      context,
+      signal,
+    );
+    signal.throwIfAborted();
     invitations.push(...page.data);
     if (page.data.length < ORGANIZATION_LIST_PAGE_SIZE) {
       return invitations;

--- a/turbo/apps/api/src/signals/external/clerk.ts
+++ b/turbo/apps/api/src/signals/external/clerk.ts
@@ -77,17 +77,25 @@ export type ClerkOrganizationInvitationStatus =
   | "expired";
 
 export interface ClerkUsersApi {
-  getUserList(params?: {
-    userId?: string[];
-    emailAddress?: string[];
-    limit?: number;
-    offset?: number;
-  }): Promise<ClerkPaginated<ClerkUser>>;
-  getOrganizationMembershipList(params: {
-    userId: string;
-    limit?: number;
-    offset?: number;
-  }): Promise<ClerkPaginated<ClerkOrganizationMembership>>;
+  getUserList(
+    params?: {
+      userId?: string[];
+      emailAddress?: string[];
+      limit?: number;
+      offset?: number;
+    },
+    context?: ClerkReadContext,
+    signal?: AbortSignal,
+  ): Promise<ClerkPaginated<ClerkUser>>;
+  getOrganizationMembershipList(
+    params: {
+      userId: string;
+      limit?: number;
+      offset?: number;
+    },
+    context?: ClerkReadContext,
+    signal?: AbortSignal,
+  ): Promise<ClerkPaginated<ClerkOrganizationMembership>>;
   updateUserMetadata(
     userId: string,
     params: {
@@ -98,20 +106,32 @@ export interface ClerkUsersApi {
 }
 
 export interface ClerkOrganizationsApi {
-  getOrganization(params: {
-    organizationId: string;
-  }): Promise<ClerkOrganization>;
-  getOrganizationMembershipList(params: {
-    organizationId: string;
-    limit?: number;
-    offset?: number;
-  }): Promise<ClerkPaginated<ClerkOrganizationMembership>>;
-  getOrganizationInvitationList(params: {
-    organizationId: string;
-    status?: ClerkOrganizationInvitationStatus[];
-    limit?: number;
-    offset?: number;
-  }): Promise<ClerkPaginated<ClerkOrganizationInvitation>>;
+  getOrganization(
+    params: {
+      organizationId: string;
+    },
+    context?: ClerkReadContext,
+    signal?: AbortSignal,
+  ): Promise<ClerkOrganization>;
+  getOrganizationMembershipList(
+    params: {
+      organizationId: string;
+      limit?: number;
+      offset?: number;
+    },
+    context?: ClerkReadContext,
+    signal?: AbortSignal,
+  ): Promise<ClerkPaginated<ClerkOrganizationMembership>>;
+  getOrganizationInvitationList(
+    params: {
+      organizationId: string;
+      status?: ClerkOrganizationInvitationStatus[];
+      limit?: number;
+      offset?: number;
+    },
+    context?: ClerkReadContext,
+    signal?: AbortSignal,
+  ): Promise<ClerkPaginated<ClerkOrganizationInvitation>>;
   createOrganizationInvitation(params: {
     organizationId: string;
     emailAddress: string;
@@ -186,13 +206,13 @@ const CLERK_READ_MAX_ATTEMPTS = 3;
 const CLERK_READ_MAX_TOTAL_DELAY_MS = 15_000;
 const CLERK_READ_MAX_JITTER_MS = 250;
 
-export interface ClerkReadRetryBudget {
+export interface ClerkReadContext {
   readonly remainingDelayMs: () => number;
 }
 
-export function createClerkReadRetryBudget(
-  currentTimeMs: () => number,
-): ClerkReadRetryBudget {
+export function createClerkReadContext(
+  currentTimeMs: () => number = Date.now,
+): ClerkReadContext {
   const deadlineAtMs = currentTimeMs() + CLERK_READ_MAX_TOTAL_DELAY_MS;
   return {
     remainingDelayMs: () => {
@@ -219,11 +239,11 @@ export function clerkRateLimit(error: unknown): ClerkRateLimit | null {
   };
 }
 
-/** Retry a Clerk operation only after the caller has identified it as a read. */
+/** Apply the shared 429 policy inside a Clerk external read adapter. */
 export async function retryClerkRead<T>(
   read: () => Promise<T>,
-  signal: AbortSignal,
-  budget: ClerkReadRetryBudget,
+  context: ClerkReadContext = createClerkReadContext(),
+  signal: AbortSignal = new AbortController().signal,
 ): Promise<T> {
   let totalDelayMs = 0;
   for (let attempt = 1; ; attempt += 1) {
@@ -241,7 +261,7 @@ export async function retryClerkRead<T>(
     const retryAfterMs = rateLimit.retryAfterSeconds * 1000;
     const remainingDelayMs = Math.min(
       CLERK_READ_MAX_TOTAL_DELAY_MS - totalDelayMs,
-      budget.remainingDelayMs(),
+      context.remainingDelayMs(),
     );
     if (retryAfterMs > remainingDelayMs) {
       throw result.error;
@@ -277,8 +297,109 @@ const clerkSdk = singleton(() => {
   });
 });
 
+function clerkRead<T>(
+  read: () => Promise<T>,
+  context: ClerkReadContext | undefined,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  return retryClerkRead(
+    read,
+    context ?? createClerkReadContext(),
+    signal ?? new AbortController().signal,
+  );
+}
+
+const clerkClient = singleton((): ClerkClient => {
+  const sdk = clerkSdk();
+  return {
+    users: {
+      getUserList: (params, context, signal) => {
+        return clerkRead(
+          () => {
+            return sdk.users.getUserList(params);
+          },
+          context,
+          signal,
+        );
+      },
+      getOrganizationMembershipList: (params, context, signal) => {
+        return clerkRead(
+          () => {
+            return sdk.users.getOrganizationMembershipList(params);
+          },
+          context,
+          signal,
+        );
+      },
+      updateUserMetadata: (userId, params) => {
+        return sdk.users.updateUserMetadata(userId, params);
+      },
+    },
+    organizations: {
+      getOrganization: (params, context, signal) => {
+        return clerkRead(
+          () => {
+            return sdk.organizations.getOrganization(params);
+          },
+          context,
+          signal,
+        );
+      },
+      getOrganizationMembershipList: (params, context, signal) => {
+        return clerkRead(
+          () => {
+            return sdk.organizations.getOrganizationMembershipList(params);
+          },
+          context,
+          signal,
+        );
+      },
+      getOrganizationInvitationList: (params, context, signal) => {
+        return clerkRead(
+          () => {
+            return sdk.organizations.getOrganizationInvitationList(params);
+          },
+          context,
+          signal,
+        );
+      },
+      createOrganizationInvitation: (params) => {
+        return sdk.organizations.createOrganizationInvitation(params);
+      },
+      revokeOrganizationInvitation: (params) => {
+        return sdk.organizations.revokeOrganizationInvitation(params);
+      },
+      updateOrganizationMembership: (params) => {
+        return sdk.organizations.updateOrganizationMembership(params);
+      },
+      deleteOrganizationMembership: (params) => {
+        return sdk.organizations.deleteOrganizationMembership(params);
+      },
+      updateOrganization: (organizationId, params) => {
+        return sdk.organizations.updateOrganization(organizationId, params);
+      },
+      updateOrganizationLogo: (organizationId, params) => {
+        return sdk.organizations.updateOrganizationLogo(organizationId, params);
+      },
+      deleteOrganization: (organizationId) => {
+        return sdk.organizations.deleteOrganization(organizationId);
+      },
+    },
+    signInTokens: {
+      createSignInToken: (params) => {
+        return sdk.signInTokens.createSignInToken(params);
+      },
+    },
+    m2m: {
+      createToken: (params) => {
+        return sdk.m2m.createToken(params);
+      },
+    },
+  };
+});
+
 export const clerk$: Computed<ClerkClient> = computed((): ClerkClient => {
-  return clerkSdk();
+  return clerkClient();
 });
 
 export type OrganizationMembershipList =

--- a/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
@@ -14,6 +14,15 @@ const mocks = createRouteMocks(context);
 
 const RECORDED_AT_ISO = "2026-05-30T12:00:00.000Z";
 
+class ClerkApiResponseTestError extends Error {
+  static readonly kind = "ClerkAPIResponseError";
+  readonly status = 429;
+
+  constructor(readonly retryAfter: number) {
+    super("Clerk Backend API rate limit exceeded");
+  }
+}
+
 function client() {
   return setupApp({ context, routes: acquisitionAttributionRoutes })(
     acquisitionAttributionContract,
@@ -87,6 +96,38 @@ describe("POST /api/zero/attribution/signup", () => {
           },
         },
       },
+    );
+  });
+
+  it("retries the Clerk user read before writing attribution", async () => {
+    mockNow(new Date(RECORDED_AT_ISO));
+    const userId = `user_${randomUUID()}`;
+    mocks.clerk.session(userId, null);
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+    context.mocks.clerk.users.getUserList
+      .mockRejectedValueOnce(new ClerkApiResponseTestError(2))
+      .mockResolvedValue({
+        data: [{ id: userId, privateMetadata: {} }],
+      });
+    context.mocks.clerk.users.updateUserMetadata.mockResolvedValue({});
+
+    const response = await accept(
+      client().recordSignup({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          attribution: {
+            vm0_source: "presentation",
+          },
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ recorded: true });
+    expect(context.mocks.clerk.users.getUserList).toHaveBeenCalledTimes(2);
+    expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(1);
+    expect(context.mocks.clerk.users.updateUserMetadata).toHaveBeenCalledTimes(
+      1,
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -5910,6 +5910,65 @@ describe("usage pack allocation management", () => {
     });
   }
 
+  function mockSavedCardInvitationPayment(
+    purchase: InvitationPurchaseFixture,
+  ): string {
+    const paymentMethodId = `pm_invite_${randomUUID()}`;
+    const invoiceId = `in_invite_${randomUUID()}`;
+    const paymentIntentId = `pi_invite_${randomUUID()}`;
+    const metadata = {
+      purpose: "usage_pack_invitation_purchase",
+      usagePackInvitationPurchaseId: purchase.purchaseId,
+    };
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+      ...managedUsagePackSubscription(
+        purchase.fixture,
+        new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      ),
+      default_payment_method: paymentMethodId,
+    });
+    context.mocks.stripe.invoices.create.mockResolvedValue({
+      id: invoiceId,
+      metadata,
+      status: "draft",
+      hosted_invoice_url: null,
+    });
+    context.mocks.stripe.invoiceItems.create.mockResolvedValue({
+      id: `ii_invite_${randomUUID()}`,
+    });
+    context.mocks.stripe.invoices.finalizeInvoice.mockResolvedValue({
+      id: invoiceId,
+      status: "open",
+      hosted_invoice_url: `https://invoice.stripe.test/${invoiceId}`,
+    });
+    context.mocks.stripe.invoices.pay.mockResolvedValue({
+      id: invoiceId,
+      status: "paid",
+    });
+    context.mocks.stripe.invoices.retrieve.mockResolvedValue({
+      id: invoiceId,
+      customer: purchase.fixture.customerId,
+      metadata,
+      status: "paid",
+      paid: true,
+      currency: "usd",
+      status_transitions: { paid_at: Math.floor(now() / 1000) },
+      payments: {
+        data: [
+          {
+            status: "paid",
+            amount_paid: 1000,
+            payment: {
+              type: "payment_intent",
+              payment_intent: paymentIntentId,
+            },
+          },
+        ],
+      },
+    });
+    return paymentIntentId;
+  }
+
   async function postClerkInvitationAccepted(args: {
     readonly purchase: InvitationPurchaseFixture;
     readonly invitationId: string;
@@ -11352,7 +11411,7 @@ describe("usage pack allocation management", () => {
     );
   });
 
-  it("previews and confirms an invitation with the saved payment method", async () => {
+  it("recovers a saved-card invitation from a transient post-payment Clerk rate limit", async () => {
     mockEnv("APP_URL", "https://app.vm0.ai");
     const existingMemberUserId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([
@@ -11521,6 +11580,32 @@ describe("usage pack allocation management", () => {
       },
     };
     context.mocks.stripe.invoices.retrieve.mockResolvedValue(paidInvoice);
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockClear();
+    context.mocks.clerk.organizations.getOrganizationMembershipList
+      .mockResolvedValueOnce({
+        data: [
+          {
+            publicUserData: {
+              userId: existingMemberUserId,
+              identifier: `${existingMemberUserId}@example.test`,
+            },
+            createdAt: now(),
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new ClerkApiResponseTestError(2))
+      .mockResolvedValue({
+        data: [
+          {
+            publicUserData: {
+              userId: existingMemberUserId,
+              identifier: `${existingMemberUserId}@example.test`,
+            },
+            createdAt: now(),
+          },
+        ],
+      });
 
     const confirmed = await accept(
       client.confirmPurchase({
@@ -11532,6 +11617,10 @@ describe("usage pack allocation management", () => {
     );
 
     expect(confirmed.body.message).toBe("Invitation purchased and sent");
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(3);
+    expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(1);
     expect(context.mocks.stripe.invoices.create).toHaveBeenCalledWith(
       {
         customer: fixture.customerId,
@@ -11641,6 +11730,281 @@ describe("usage pack allocation management", () => {
         usagePackUsd: 20,
       }),
     ]);
+  });
+
+  it("returns a retryable 503 before starting payment when Clerk rate limits persist", async () => {
+    const purchase = await beginInvitationPurchase();
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockClear();
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
+      new ClerkApiResponseTestError(7),
+    );
+    context.mocks.stripe.invoices.createPreview.mockClear();
+
+    const response = await accept(
+      setupApp({ context, routes: orgInviteRoutes })(
+        orgInviteContract,
+      ).previewPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          email: `rate-limited-${randomUUID()}@example.test`,
+          role: "member",
+          usagePackUsd: 20,
+        },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Billing organization members are temporarily unavailable",
+        code: "PROVIDER_UNAVAILABLE",
+      },
+    });
+    expect(response.headers.get("Retry-After")).toBe("7");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(3);
+    expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(2);
+    expect(context.mocks.stripe.invoices.createPreview).not.toHaveBeenCalled();
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+    expect(
+      (
+        await readUsagePackState(
+          purchase.fixture.orgId,
+          purchase.fixture.usagePackSubscriptionId,
+        )
+      ).invitationPurchases,
+    ).toHaveLength(1);
+  });
+
+  it("preserves non-rate-limit Clerk invitation purchase failures", async () => {
+    const purchase = await beginInvitationPurchase();
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockClear();
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
+      new Error("Clerk membership read failed"),
+    );
+    context.mocks.stripe.invoices.createPreview.mockClear();
+
+    const response = await accept(
+      setupApp({ context, routes: orgInviteRoutes })(
+        orgInviteContract,
+      ).previewPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          email: `failed-${randomUUID()}@example.test`,
+          role: "member",
+          usagePackUsd: 20,
+        },
+      }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    expect(response.headers.get("Retry-After")).toBeNull();
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(1);
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+    expect(context.mocks.stripe.invoices.createPreview).not.toHaveBeenCalled();
+    expect(
+      (
+        await readUsagePackState(
+          purchase.fixture.orgId,
+          purchase.fixture.usagePackSubscriptionId,
+        )
+      ).invitationPurchases,
+    ).toHaveLength(1);
+  });
+
+  it("stops Clerk retries when an invitation purchase is cancelled", async () => {
+    await beginInvitationPurchase();
+    const controller = new AbortController();
+    const retryStarted = createDeferredPromise<void>(context.signal);
+    let retrySignal: AbortSignal | undefined;
+    context.mocks.signalTimers.delay.mockImplementation((_ms, options) => {
+      const signal = options?.signal;
+      if (!signal) {
+        throw new Error("Expected Clerk retry delay to receive a signal");
+      }
+      retrySignal = signal;
+      retryStarted.resolve();
+      return createDeferredPromise<void>(signal).promise;
+    });
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockClear();
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
+      new ClerkApiResponseTestError(1),
+    );
+    context.mocks.stripe.invoices.createPreview.mockClear();
+    const request = setupApp({ context, routes: orgInviteRoutes })(
+      orgInviteContract,
+    ).previewPurchase({
+      headers: { authorization: "Bearer clerk-session" },
+      body: {
+        email: `cancelled-${randomUUID()}@example.test`,
+        role: "member",
+        usagePackUsd: 20,
+      },
+      fetchOptions: { signal: controller.signal },
+    });
+
+    await retryStarted.promise;
+    const abortError = new Error("invitation purchase cancelled");
+    abortError.name = "AbortError";
+    controller.abort(abortError);
+    expect(retrySignal?.aborted).toBeTruthy();
+    const response = await accept(request, [500]);
+
+    expect(response.status).toBe(500);
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(1);
+    expect(context.mocks.stripe.invoices.createPreview).not.toHaveBeenCalled();
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("resumes invitation creation after a persistent post-payment Clerk rate limit", async () => {
+    const purchase = await beginInvitationPurchase();
+    const paymentIntentId = mockSavedCardInvitationPayment(purchase);
+    const invitationId = `inv_resumed_${randomUUID()}`;
+    const existingMember = {
+      publicUserData: {
+        userId: purchase.existingMemberUserId,
+        identifier: `${purchase.existingMemberUserId}@example.test`,
+      },
+      createdAt: now(),
+    };
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockClear();
+    context.mocks.clerk.organizations.getOrganizationMembershipList
+      .mockResolvedValueOnce({ data: [existingMember] })
+      .mockRejectedValue(new ClerkApiResponseTestError(9));
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    const client = setupApp({ context, routes: orgInviteRoutes })(
+      orgInviteContract,
+    );
+
+    const limited = await accept(
+      client.confirmPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { purchaseId: purchase.purchaseId },
+        body: {},
+      }),
+      [503],
+    );
+
+    expect(limited.headers.get("Retry-After")).toBe("9");
+    expect(limited.headers.get("Cache-Control")).toBe("no-store");
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(3);
+    expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(1);
+    const paid = await readUsagePackState(
+      purchase.fixture.orgId,
+      purchase.fixture.usagePackSubscriptionId,
+    );
+    expect(paid.invitationPurchases[0]).toStrictEqual(
+      expect.objectContaining({
+        status: "payment_succeeded",
+        stripePaymentIntentId: paymentIntentId,
+        clerkInvitationId: null,
+        allocationId: null,
+      }),
+    );
+    expect(context.mocks.stripe.invoices.create).toHaveBeenCalledTimes(1);
+    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledTimes(1);
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).not.toHaveBeenCalled();
+
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockClear();
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      { data: [existingMember] },
+    );
+    context.mocks.clerk.organizations.createOrganizationInvitation.mockResolvedValueOnce(
+      {
+        id: invitationId,
+        emailAddress: purchase.email,
+        organizationId: purchase.fixture.orgId,
+        status: "pending",
+      },
+    );
+    const resumed = await accept(
+      client.confirmPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { purchaseId: purchase.purchaseId },
+        body: {},
+      }),
+      [200],
+    );
+
+    expect(resumed.body.message).toBe("Invitation purchased and sent");
+    expect(context.mocks.stripe.invoices.create).toHaveBeenCalledTimes(1);
+    expect(context.mocks.stripe.invoices.pay).toHaveBeenCalledTimes(1);
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).toHaveBeenCalledTimes(1);
+    const completed = await readUsagePackState(
+      purchase.fixture.orgId,
+      purchase.fixture.usagePackSubscriptionId,
+    );
+    expect(completed.invitationPurchases[0]).toStrictEqual(
+      expect.objectContaining({
+        status: "invitation_pending",
+        clerkInvitationId: invitationId,
+      }),
+    );
+  });
+
+  it("does not reclassify a Clerk invitation mutation rate limit as a retryable read", async () => {
+    const purchase = await beginInvitationPurchase();
+    mockSavedCardInvitationPayment(purchase);
+    const existingMember = {
+      publicUserData: {
+        userId: purchase.existingMemberUserId,
+        identifier: `${purchase.existingMemberUserId}@example.test`,
+      },
+      createdAt: now(),
+    };
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      { data: [existingMember] },
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    context.mocks.clerk.organizations.createOrganizationInvitation.mockRejectedValueOnce(
+      new ClerkApiResponseTestError(4),
+    );
+
+    const response = await accept(
+      setupApp({ context, routes: orgInviteRoutes })(
+        orgInviteContract,
+      ).confirmPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { purchaseId: purchase.purchaseId },
+        body: {},
+      }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    expect(response.headers.get("Retry-After")).toBeNull();
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+    expect(
+      context.mocks.clerk.organizations.createOrganizationInvitation,
+    ).toHaveBeenCalledTimes(1);
+    const state = await readUsagePackState(
+      purchase.fixture.orgId,
+      purchase.fixture.usagePackSubscriptionId,
+    );
+    expect(state.invitationPurchases[0]?.status).toBe("creating_invitation");
   });
 
   it("rejects an invalid invitation payment preview with a stable error", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -145,6 +145,15 @@ const TEST_PRICE_CUSTOM_CREDIT_UNIT = "price_test_custom_credit_unit";
 const TEST_PRICE_CONCURRENCY = "price_test_concurrency";
 const STRIPE_WEBHOOK_SECRET = "whsec_checkout_test";
 
+class ClerkApiResponseTestError extends Error {
+  static readonly kind = "ClerkAPIResponseError";
+  readonly status = 429;
+
+  constructor(readonly retryAfter: number) {
+    super("Clerk Backend API rate limit exceeded");
+  }
+}
+
 interface BillingOrgFixture {
   readonly orgId: string;
   readonly userId: string;
@@ -261,6 +270,15 @@ function createOrgFixture(orgId = `org_${randomUUID()}`): BillingOrgFixture {
   return {
     orgId,
     userId: `user_${randomUUID()}`,
+  };
+}
+
+function usagePackCheckoutBody(memberId: string) {
+  return {
+    tier: "pro" as const,
+    memberUsagePacks: [{ memberId, usagePackUsd: 20 as const }],
+    successUrl: `${APP_ORIGIN}/billing?billing=success`,
+    cancelUrl: `${APP_ORIGIN}/billing?billing=canceled`,
   };
 }
 
@@ -2475,6 +2493,222 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
       limit: 100,
       offset: 100,
     });
+  });
+
+  it("recovers usage pack checkout from a transient Clerk rate limit", async () => {
+    const fixture = createOrgFixture();
+    const checkoutSessionId = `cs_${randomUUID()}`;
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UsagePackPlans]: true,
+    });
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+    context.mocks.clerk.organizations.getOrganizationMembershipList
+      .mockRejectedValueOnce(new ClerkApiResponseTestError(2))
+      .mockResolvedValue({
+        data: [
+          {
+            role: "org:admin",
+            publicUserData: { userId: fixture.userId },
+            createdAt: now(),
+          },
+        ],
+      });
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    context.mocks.stripe.customers.create.mockResolvedValueOnce({
+      id: `cus_${randomUUID()}`,
+    });
+    context.mocks.stripe.checkout.sessions.create.mockResolvedValueOnce({
+      id: checkoutSessionId,
+      url: "https://checkout.stripe.com/session/usage-pack-recovered",
+    });
+
+    const response = await accept(
+      setupApp({ context, routes: billingCheckoutRoutes })(
+        billingUsagePackCheckoutContract,
+      ).create({
+        body: usagePackCheckoutBody(fixture.userId),
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const checkoutCall =
+      context.mocks.stripe.checkout.sessions.create.mock.calls[0];
+    const usagePackSubscriptionId = checkoutCall
+      ? stripeInputMetadata(checkoutCall[0]).usagePackSubscriptionId
+      : undefined;
+    if (!usagePackSubscriptionId) {
+      throw new Error("Checkout did not expose its usage pack subscription ID");
+    }
+    onTestFinished(async () => {
+      await usagePackStateAction({
+        action: "cleanup",
+        orgId: fixture.orgId,
+        usagePackSubscriptionId,
+        deleteGrants: true,
+        deleteOrgMetadata: true,
+      });
+    });
+
+    expect(response.body).toStrictEqual({
+      url: "https://checkout.stripe.com/session/usage-pack-recovered",
+    });
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(2);
+    expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(1);
+    expect(context.mocks.stripe.checkout.sessions.create).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it("returns a non-cacheable 503 when Clerk rate limits persist", async () => {
+    const fixture = createOrgFixture();
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UsagePackPlans]: true,
+    });
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
+      new ClerkApiResponseTestError(7),
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+
+    const response = await accept(
+      setupApp({ context, routes: billingCheckoutRoutes })(
+        billingUsagePackCheckoutContract,
+      ).create({
+        body: usagePackCheckoutBody(fixture.userId),
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Billing organization members are temporarily unavailable",
+        code: "PROVIDER_UNAVAILABLE",
+      },
+    });
+    expect(response.headers.get("Retry-After")).toBe("7");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(3);
+    expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(2);
+    expect(context.mocks.stripe.customers.create).not.toHaveBeenCalled();
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("stops sibling Clerk pagination after checkout directory exhaustion", async () => {
+    const fixture = createOrgFixture();
+    const invitationPage = createDeferredPromise<{
+      readonly data: readonly {
+        readonly id: string;
+        readonly emailAddress: string;
+        readonly role: string;
+        readonly createdAt: number;
+      }[];
+    }>(context.signal);
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UsagePackPlans]: true,
+    });
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
+      new ClerkApiResponseTestError(1),
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockReturnValueOnce(
+      invitationPage.promise,
+    );
+
+    const response = await accept(
+      setupApp({ context, routes: billingCheckoutRoutes })(
+        billingUsagePackCheckoutContract,
+      ).create({
+        body: usagePackCheckoutBody(fixture.userId),
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [503],
+    );
+
+    expect(response.headers.get("Retry-After")).toBe("1");
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(3);
+    expect(
+      context.mocks.clerk.organizations.getOrganizationInvitationList,
+    ).toHaveBeenCalledTimes(1);
+    expect(context.mocks.stripe.customers.create).not.toHaveBeenCalled();
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).not.toHaveBeenCalled();
+
+    invitationPage.resolve({
+      data: Array.from({ length: 100 }, (_, index) => {
+        return {
+          id: `inv_${index}`,
+          emailAddress: `pending-${index}@example.com`,
+          role: "org:member",
+          createdAt: now(),
+        };
+      }),
+    });
+    await invitationPage.promise;
+    expect(
+      context.mocks.clerk.organizations.getOrganizationInvitationList,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops Clerk retries when usage pack checkout is cancelled", async () => {
+    const fixture = createOrgFixture();
+    const controller = new AbortController();
+    const retryStarted = createDeferredPromise<void>(context.signal);
+    let retrySignal: AbortSignal | undefined;
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UsagePackPlans]: true,
+    });
+    context.mocks.signalTimers.delay.mockImplementation((_ms, options) => {
+      const signal = options?.signal;
+      if (!signal) {
+        throw new Error("Expected Clerk retry delay to receive a signal");
+      }
+      retrySignal = signal;
+      retryStarted.resolve();
+      return createDeferredPromise<void>(signal).promise;
+    });
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
+      new ClerkApiResponseTestError(1),
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    const request = setupApp({ context, routes: billingCheckoutRoutes })(
+      billingUsagePackCheckoutContract,
+    ).create({
+      body: usagePackCheckoutBody(fixture.userId),
+      headers: { authorization: "Bearer clerk-session" },
+      fetchOptions: { signal: controller.signal },
+    });
+
+    await retryStarted.promise;
+    const abortError = new Error("usage pack checkout cancelled");
+    abortError.name = "AbortError";
+    controller.abort(abortError);
+    const response = await accept(request, [500]);
+
+    expect(response.status).toBe(500);
+    expect(retrySignal?.aborted).toBeTruthy();
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(1);
+    expect(context.mocks.stripe.customers.create).not.toHaveBeenCalled();
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).not.toHaveBeenCalled();
   });
 
   it.each(["pro", "team"] as const)(

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -2604,6 +2604,39 @@ describe("POST /api/zero/billing/usage-pack-checkout", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("preserves non-rate-limit Clerk checkout failures", async () => {
+    const fixture = createOrgFixture();
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.UsagePackPlans]: true,
+    });
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
+      new Error("Clerk membership read failed"),
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+
+    const response = await accept(
+      setupApp({ context, routes: billingCheckoutRoutes })(
+        billingUsagePackCheckoutContract,
+      ).create({
+        body: usagePackCheckoutBody(fixture.userId),
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(1);
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+    expect(context.mocks.stripe.customers.create).not.toHaveBeenCalled();
+    expect(
+      context.mocks.stripe.checkout.sessions.create,
+    ).not.toHaveBeenCalled();
+  });
+
   it("stops sibling Clerk pagination after checkout directory exhaustion", async () => {
     const fixture = createOrgFixture();
     const invitationPage = createDeferredPromise<{

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -1,4 +1,4 @@
-import { command } from "ccstate";
+import { command, type Command } from "ccstate";
 import {
   billingCheckoutContract,
   billingUsagePackCatalogContract,
@@ -18,8 +18,8 @@ import { eq } from "drizzle-orm";
 import { optionalEnv } from "../../lib/env";
 import { billingRedirectAllowed } from "../../lib/billing-redirect";
 import { logger } from "../../lib/log";
-import { nowDate } from "../../lib/time";
-import { settle } from "../utils";
+import { now, nowDate } from "../../lib/time";
+import { onRejection, settle } from "../utils";
 import {
   badRequestMessage,
   conflict,
@@ -28,8 +28,15 @@ import {
 } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { requestSignal$, setResHeader$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
-import { clerk$, type ClerkClient } from "../external/clerk";
+import {
+  clerk$,
+  clerkRateLimit,
+  createClerkReadRetryBudget,
+  retryClerkRead,
+  type ClerkClient,
+} from "../external/clerk";
 import {
   listAllOrganizationMemberships,
   listAllPendingOrganizationInvitations,
@@ -125,6 +132,86 @@ const SIGNUP_ATTRIBUTION_KEY = "signup_attribution";
 const USAGE_PACK_PLAN_ENDING_MESSAGE =
   "Your Plan is scheduled to end before this usage pack change can take effect. Restore your Plan first, then try again.";
 const log = logger("api:zero:billing-checkout");
+
+const billingClerkUnavailable$ = command(
+  ({ set }, retryAfterSeconds: number) => {
+    set(setResHeader$, "Retry-After", String(retryAfterSeconds));
+    set(setResHeader$, "Cache-Control", "no-store");
+    return providerUnavailable(
+      "Billing organization members are temporarily unavailable",
+    );
+  },
+);
+
+function withBillingClerkRateLimit<T>(
+  handler$: Command<Promise<T>, [AbortSignal]>,
+): Command<Promise<T | ReturnType<typeof providerUnavailable>>, [AbortSignal]> {
+  return command(async ({ set }, signal: AbortSignal) => {
+    const result = await settle(set(handler$, signal), signal);
+    if (result.ok) {
+      return result.value;
+    }
+    const rateLimit = clerkRateLimit(result.error);
+    if (!rateLimit) {
+      throw result.error;
+    }
+    return set(billingClerkUnavailable$, rateLimit.retryAfterSeconds);
+  });
+}
+
+type BillingOrganizationMemberships = Awaited<
+  ReturnType<typeof listAllOrganizationMemberships>
+>;
+type BillingOrganizationInvitations = Awaited<
+  ReturnType<typeof listAllPendingOrganizationInvitations>
+>;
+
+interface BillingOrganizationDirectory {
+  readonly memberships: BillingOrganizationMemberships;
+  readonly invitations: BillingOrganizationInvitations;
+}
+
+async function loadBillingOrganizationDirectory(
+  clerk: ClerkClient,
+  orgId: string,
+  signal: AbortSignal,
+): Promise<BillingOrganizationDirectory> {
+  const retryBudget = createClerkReadRetryBudget(now);
+  const controller = new AbortController();
+  const readSignal = AbortSignal.any([signal, controller.signal]);
+  const [memberships, invitations] = await onRejection(
+    Promise.all([
+      retryClerkRead(
+        () => {
+          return listAllOrganizationMemberships(
+            clerk.organizations,
+            orgId,
+            readSignal,
+          );
+        },
+        readSignal,
+        retryBudget,
+      ),
+      retryClerkRead(
+        () => {
+          return listAllPendingOrganizationInvitations(
+            clerk.organizations,
+            orgId,
+            readSignal,
+          );
+        },
+        readSignal,
+        retryBudget,
+      ),
+    ]),
+    () => {
+      controller.abort();
+    },
+  );
+  controller.abort();
+  signal.throwIfAborted();
+  return { memberships, invitations };
+}
 
 type UsagePackSubscriptionChangePreviewResult = Awaited<
   ReturnType<typeof previewUsagePackSubscriptionChange>
@@ -245,9 +332,17 @@ async function validateUsagePackSubscriptionMembers(
   if (!args.memberAdditionSchemaAvailable) {
     return "member_additions_unavailable";
   }
-  const memberships = await listAllOrganizationMemberships(
-    args.clerk.organizations,
-    args.orgId,
+  const retryBudget = createClerkReadRetryBudget(now);
+  const memberships = await retryClerkRead(
+    () => {
+      return listAllOrganizationMemberships(
+        args.clerk.organizations,
+        args.orgId,
+        signal,
+      );
+    },
+    signal,
+    retryBudget,
   );
   signal.throwIfAborted();
   const activeMemberIds = memberships.map((membership) => {
@@ -414,10 +509,11 @@ async function loadUsagePackCheckoutAllocations(
 ): Promise<readonly UsagePackCheckoutAllocation[] | null> {
   const catalog = await loadUsagePackCatalog();
   signal.throwIfAborted();
-  const [memberships, invitations] = await Promise.all([
-    listAllOrganizationMemberships(args.clerk.organizations, args.orgId),
-    listAllPendingOrganizationInvitations(args.clerk.organizations, args.orgId),
-  ]);
+  const { memberships, invitations } = await loadBillingOrganizationDirectory(
+    args.clerk,
+    args.orgId,
+    signal,
+  );
   signal.throwIfAborted();
   return usagePackCheckoutAllocations(
     args.selections,
@@ -774,14 +870,16 @@ const usagePackCheckoutAuthed$ = command(
       );
     }
 
+    const readSignal = AbortSignal.any([signal, get(requestSignal$)]);
     const allocations = await loadUsagePackCheckoutAllocations(
       {
         clerk,
         orgId: auth.orgId,
         selections: body.memberUsagePacks,
       },
-      signal,
+      readSignal,
     );
+    signal.throwIfAborted();
     if (!allocations) {
       return badRequestMessage(
         "Organization members changed; refresh billing and try again",
@@ -890,7 +988,7 @@ const usagePackCheckout$ = command(async ({ set }, signal: AbortSignal) => {
   return await set(
     authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
-      usagePackCheckoutAuthed$,
+      withBillingClerkRateLimit(usagePackCheckoutAuthed$),
     ),
     signal,
   );
@@ -1210,13 +1308,12 @@ const usagePackMigrationPreviewAuthed$ = command(
       return providerUnavailable("Usage pack migration is not ready");
     }
     const clerk = get(clerk$);
-    const [memberships, invitations] = await Promise.all([
-      listAllOrganizationMemberships(clerk.organizations, access.auth.orgId),
-      listAllPendingOrganizationInvitations(
-        clerk.organizations,
-        access.auth.orgId,
-      ),
-    ]);
+    const readSignal = AbortSignal.any([signal, get(requestSignal$)]);
+    const { memberships, invitations } = await loadBillingOrganizationDirectory(
+      clerk,
+      access.auth.orgId,
+      readSignal,
+    );
     signal.throwIfAborted();
     const result = await previewUsagePackSubscriptionMigration(
       db,
@@ -1268,13 +1365,12 @@ const usagePackMigrationConfirmAuthed$ = command(
       return providerUnavailable("Usage pack migration is not ready");
     }
     const clerk = get(clerk$);
-    const [memberships, invitations] = await Promise.all([
-      listAllOrganizationMemberships(clerk.organizations, access.auth.orgId),
-      listAllPendingOrganizationInvitations(
-        clerk.organizations,
-        access.auth.orgId,
-      ),
-    ]);
+    const readSignal = AbortSignal.any([signal, get(requestSignal$)]);
+    const { memberships, invitations } = await loadBillingOrganizationDirectory(
+      clerk,
+      access.auth.orgId,
+      readSignal,
+    );
     signal.throwIfAborted();
     const ownerIds = usagePackMigrationOwners(
       memberships,
@@ -1331,13 +1427,12 @@ const usagePackMigrationRevisionPreviewAuthed$ = command(
       return providerUnavailable("Usage pack migration is not ready");
     }
     const clerk = get(clerk$);
-    const [memberships, invitations] = await Promise.all([
-      listAllOrganizationMemberships(clerk.organizations, access.auth.orgId),
-      listAllPendingOrganizationInvitations(
-        clerk.organizations,
-        access.auth.orgId,
-      ),
-    ]);
+    const readSignal = AbortSignal.any([signal, get(requestSignal$)]);
+    const { memberships, invitations } = await loadBillingOrganizationDirectory(
+      clerk,
+      access.auth.orgId,
+      readSignal,
+    );
     signal.throwIfAborted();
     const result = await previewUsagePackSubscriptionMigrationRevision(
       db,
@@ -1393,13 +1488,12 @@ const usagePackMigrationRevisionConfirmAuthed$ = command(
       return providerUnavailable("Usage pack migration is not ready");
     }
     const clerk = get(clerk$);
-    const [memberships, invitations] = await Promise.all([
-      listAllOrganizationMemberships(clerk.organizations, access.auth.orgId),
-      listAllPendingOrganizationInvitations(
-        clerk.organizations,
-        access.auth.orgId,
-      ),
-    ]);
+    const readSignal = AbortSignal.any([signal, get(requestSignal$)]);
+    const { memberships, invitations } = await loadBillingOrganizationDirectory(
+      clerk,
+      access.auth.orgId,
+      readSignal,
+    );
     signal.throwIfAborted();
     const result = await confirmUsagePackSubscriptionMigrationRevision(
       db,
@@ -1536,6 +1630,7 @@ const usagePackSubscriptionChangePreviewAuthed$ = command(
     if (!management) {
       return notFound("Usage pack subscription not found");
     }
+    const readSignal = AbortSignal.any([signal, get(requestSignal$)]);
     const memberValidation = await validateUsagePackSubscriptionMembers(
       {
         clerk: get(clerk$),
@@ -1546,8 +1641,9 @@ const usagePackSubscriptionChangePreviewAuthed$ = command(
         }),
         memberAdditionSchemaAvailable: memberAdditionSchema,
       },
-      signal,
+      readSignal,
     );
+    signal.throwIfAborted();
     if (memberValidation === "member_additions_unavailable") {
       return providerUnavailable("Usage pack member additions are not ready");
     }
@@ -1704,7 +1800,7 @@ const usagePackSubscriptionChangePreview$ = command(
     return await set(
       authRoute(
         { requireOrganization: true, missingOrganizationStatus: 401 },
-        usagePackSubscriptionChangePreviewAuthed$,
+        withBillingClerkRateLimit(usagePackSubscriptionChangePreviewAuthed$),
       ),
       signal,
     );
@@ -1732,7 +1828,7 @@ const usagePackMigrationPreview$ = command(
     return await set(
       authRoute(
         { requireOrganization: true, missingOrganizationStatus: 401 },
-        usagePackMigrationPreviewAuthed$,
+        withBillingClerkRateLimit(usagePackMigrationPreviewAuthed$),
       ),
       signal,
     );
@@ -1747,7 +1843,7 @@ const usagePackMigrationConfirm$ = command(
     return await set(
       authRoute(
         { requireOrganization: true, missingOrganizationStatus: 401 },
-        usagePackMigrationConfirmAuthed$,
+        withBillingClerkRateLimit(usagePackMigrationConfirmAuthed$),
       ),
       signal,
     );
@@ -1762,7 +1858,7 @@ const usagePackMigrationRevisionPreview$ = command(
     return await set(
       authRoute(
         { requireOrganization: true, missingOrganizationStatus: 401 },
-        usagePackMigrationRevisionPreviewAuthed$,
+        withBillingClerkRateLimit(usagePackMigrationRevisionPreviewAuthed$),
       ),
       signal,
     );
@@ -1777,7 +1873,7 @@ const usagePackMigrationRevisionConfirm$ = command(
     return await set(
       authRoute(
         { requireOrganization: true, missingOrganizationStatus: 401 },
-        usagePackMigrationRevisionConfirmAuthed$,
+        withBillingClerkRateLimit(usagePackMigrationRevisionConfirmAuthed$),
       ),
       signal,
     );

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -1,4 +1,4 @@
-import { command, type Command } from "ccstate";
+import { command } from "ccstate";
 import {
   billingCheckoutContract,
   billingUsagePackCatalogContract,
@@ -18,8 +18,8 @@ import { eq } from "drizzle-orm";
 import { optionalEnv } from "../../lib/env";
 import { billingRedirectAllowed } from "../../lib/billing-redirect";
 import { logger } from "../../lib/log";
-import { now, nowDate } from "../../lib/time";
-import { onRejection, settle } from "../utils";
+import { nowDate } from "../../lib/time";
+import { settle } from "../utils";
 import {
   badRequestMessage,
   conflict,
@@ -28,19 +28,9 @@ import {
 } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { requestSignal$, setResHeader$ } from "../context/hono";
+import { requestSignal$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
-import {
-  clerk$,
-  clerkRateLimit,
-  createClerkReadRetryBudget,
-  retryClerkRead,
-  type ClerkClient,
-} from "../external/clerk";
-import {
-  listAllOrganizationMemberships,
-  listAllPendingOrganizationInvitations,
-} from "../external/clerk-organization-lists";
+import { clerk$, type ClerkClient } from "../external/clerk";
 import { db$, writeDb$, type Db } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import {
@@ -90,6 +80,10 @@ import {
   type UsagePackMigrationOwner,
 } from "../services/usage-pack-subscription-migration.service";
 import { usagePackInvitationPurchaseSchemaAvailable } from "../services/usage-pack-invitation-purchase.service";
+import {
+  loadBillingOrganizationDirectory,
+  loadBillingOrganizationMemberships,
+} from "../services/billing-clerk-directory.service";
 import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import { reconcilePaidStripeInvoice$ } from "../services/webhooks-stripe.service";
 import {
@@ -97,6 +91,7 @@ import {
   parseStoredSignupAttribution,
 } from "../services/acquisition-attribution.service";
 import type { RouteEntry } from "../route-entry";
+import { withBillingClerkRateLimit } from "./billing-clerk-rate-limit";
 
 const adminRequired = Object.freeze({
   status: 403 as const,
@@ -132,116 +127,6 @@ const SIGNUP_ATTRIBUTION_KEY = "signup_attribution";
 const USAGE_PACK_PLAN_ENDING_MESSAGE =
   "Your Plan is scheduled to end before this usage pack change can take effect. Restore your Plan first, then try again.";
 const log = logger("api:zero:billing-checkout");
-
-const billingClerkUnavailable$ = command(
-  ({ set }, retryAfterSeconds: number) => {
-    set(setResHeader$, "Retry-After", String(retryAfterSeconds));
-    set(setResHeader$, "Cache-Control", "no-store");
-    return providerUnavailable(
-      "Billing organization members are temporarily unavailable",
-    );
-  },
-);
-
-class BillingClerkReadRateLimitError extends Error {
-  constructor(
-    readonly retryAfterSeconds: number,
-    cause: unknown,
-  ) {
-    super("Billing Clerk read rate limit exhausted", { cause });
-    this.name = "BillingClerkReadRateLimitError";
-  }
-}
-
-async function billingClerkRead<T>(
-  read: Promise<T>,
-  signal: AbortSignal,
-): Promise<T> {
-  const result = await settle(read, signal);
-  if (result.ok) {
-    return result.value;
-  }
-  const rateLimit = clerkRateLimit(result.error);
-  if (!rateLimit) {
-    throw result.error;
-  }
-  throw new BillingClerkReadRateLimitError(
-    rateLimit.retryAfterSeconds,
-    result.error,
-  );
-}
-
-function withBillingClerkRateLimit<T>(
-  handler$: Command<Promise<T>, [AbortSignal]>,
-): Command<Promise<T | ReturnType<typeof providerUnavailable>>, [AbortSignal]> {
-  return command(async ({ set }, signal: AbortSignal) => {
-    const result = await settle(set(handler$, signal), signal);
-    if (result.ok) {
-      return result.value;
-    }
-    if (!(result.error instanceof BillingClerkReadRateLimitError)) {
-      throw result.error;
-    }
-    return set(billingClerkUnavailable$, result.error.retryAfterSeconds);
-  });
-}
-
-type BillingOrganizationMemberships = Awaited<
-  ReturnType<typeof listAllOrganizationMemberships>
->;
-type BillingOrganizationInvitations = Awaited<
-  ReturnType<typeof listAllPendingOrganizationInvitations>
->;
-
-interface BillingOrganizationDirectory {
-  readonly memberships: BillingOrganizationMemberships;
-  readonly invitations: BillingOrganizationInvitations;
-}
-
-async function loadBillingOrganizationDirectory(
-  clerk: ClerkClient,
-  orgId: string,
-  signal: AbortSignal,
-): Promise<BillingOrganizationDirectory> {
-  const retryBudget = createClerkReadRetryBudget(now);
-  const controller = new AbortController();
-  const readSignal = AbortSignal.any([signal, controller.signal]);
-  const [memberships, invitations] = await billingClerkRead(
-    onRejection(
-      Promise.all([
-        retryClerkRead(
-          () => {
-            return listAllOrganizationMemberships(
-              clerk.organizations,
-              orgId,
-              readSignal,
-            );
-          },
-          readSignal,
-          retryBudget,
-        ),
-        retryClerkRead(
-          () => {
-            return listAllPendingOrganizationInvitations(
-              clerk.organizations,
-              orgId,
-              readSignal,
-            );
-          },
-          readSignal,
-          retryBudget,
-        ),
-      ]),
-      () => {
-        controller.abort();
-      },
-    ),
-    signal,
-  );
-  controller.abort();
-  signal.throwIfAborted();
-  return { memberships, invitations };
-}
 
 type UsagePackSubscriptionChangePreviewResult = Awaited<
   ReturnType<typeof previewUsagePackSubscriptionChange>
@@ -362,19 +247,9 @@ async function validateUsagePackSubscriptionMembers(
   if (!args.memberAdditionSchemaAvailable) {
     return "member_additions_unavailable";
   }
-  const retryBudget = createClerkReadRetryBudget(now);
-  const memberships = await billingClerkRead(
-    retryClerkRead(
-      () => {
-        return listAllOrganizationMemberships(
-          args.clerk.organizations,
-          args.orgId,
-          signal,
-        );
-      },
-      signal,
-      retryBudget,
-    ),
+  const memberships = await loadBillingOrganizationMemberships(
+    args.clerk,
+    args.orgId,
     signal,
   );
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -30,7 +30,11 @@ import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { requestSignal$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
-import { clerk$, type ClerkClient } from "../external/clerk";
+import {
+  clerk$,
+  createClerkReadContext,
+  type ClerkClient,
+} from "../external/clerk";
 import { db$, writeDb$, type Db } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
 import {
@@ -161,10 +165,14 @@ async function signupAttributionForUser(
 ): Promise<ReturnType<typeof adAttributionMetadataSchema.parse> | undefined> {
   const usersResult = await settle(
     Promise.resolve(
-      clerk.users.getUserList({
-        userId: [userId],
-        limit: 1,
-      }),
+      clerk.users.getUserList(
+        {
+          userId: [userId],
+          limit: 1,
+        },
+        undefined,
+        signal,
+      ),
     ),
     signal,
   );
@@ -250,6 +258,7 @@ async function validateUsagePackSubscriptionMembers(
   const memberships = await loadBillingOrganizationMemberships(
     args.clerk,
     args.orgId,
+    createClerkReadContext(),
     signal,
   );
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -143,6 +143,34 @@ const billingClerkUnavailable$ = command(
   },
 );
 
+class BillingClerkReadRateLimitError extends Error {
+  constructor(
+    readonly retryAfterSeconds: number,
+    cause: unknown,
+  ) {
+    super("Billing Clerk read rate limit exhausted", { cause });
+    this.name = "BillingClerkReadRateLimitError";
+  }
+}
+
+async function billingClerkRead<T>(
+  read: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  const result = await settle(read, signal);
+  if (result.ok) {
+    return result.value;
+  }
+  const rateLimit = clerkRateLimit(result.error);
+  if (!rateLimit) {
+    throw result.error;
+  }
+  throw new BillingClerkReadRateLimitError(
+    rateLimit.retryAfterSeconds,
+    result.error,
+  );
+}
+
 function withBillingClerkRateLimit<T>(
   handler$: Command<Promise<T>, [AbortSignal]>,
 ): Command<Promise<T | ReturnType<typeof providerUnavailable>>, [AbortSignal]> {
@@ -151,11 +179,10 @@ function withBillingClerkRateLimit<T>(
     if (result.ok) {
       return result.value;
     }
-    const rateLimit = clerkRateLimit(result.error);
-    if (!rateLimit) {
+    if (!(result.error instanceof BillingClerkReadRateLimitError)) {
       throw result.error;
     }
-    return set(billingClerkUnavailable$, rateLimit.retryAfterSeconds);
+    return set(billingClerkUnavailable$, result.error.retryAfterSeconds);
   });
 }
 
@@ -179,34 +206,37 @@ async function loadBillingOrganizationDirectory(
   const retryBudget = createClerkReadRetryBudget(now);
   const controller = new AbortController();
   const readSignal = AbortSignal.any([signal, controller.signal]);
-  const [memberships, invitations] = await onRejection(
-    Promise.all([
-      retryClerkRead(
-        () => {
-          return listAllOrganizationMemberships(
-            clerk.organizations,
-            orgId,
-            readSignal,
-          );
-        },
-        readSignal,
-        retryBudget,
-      ),
-      retryClerkRead(
-        () => {
-          return listAllPendingOrganizationInvitations(
-            clerk.organizations,
-            orgId,
-            readSignal,
-          );
-        },
-        readSignal,
-        retryBudget,
-      ),
-    ]),
-    () => {
-      controller.abort();
-    },
+  const [memberships, invitations] = await billingClerkRead(
+    onRejection(
+      Promise.all([
+        retryClerkRead(
+          () => {
+            return listAllOrganizationMemberships(
+              clerk.organizations,
+              orgId,
+              readSignal,
+            );
+          },
+          readSignal,
+          retryBudget,
+        ),
+        retryClerkRead(
+          () => {
+            return listAllPendingOrganizationInvitations(
+              clerk.organizations,
+              orgId,
+              readSignal,
+            );
+          },
+          readSignal,
+          retryBudget,
+        ),
+      ]),
+      () => {
+        controller.abort();
+      },
+    ),
+    signal,
   );
   controller.abort();
   signal.throwIfAborted();
@@ -333,16 +363,19 @@ async function validateUsagePackSubscriptionMembers(
     return "member_additions_unavailable";
   }
   const retryBudget = createClerkReadRetryBudget(now);
-  const memberships = await retryClerkRead(
-    () => {
-      return listAllOrganizationMemberships(
-        args.clerk.organizations,
-        args.orgId,
-        signal,
-      );
-    },
+  const memberships = await billingClerkRead(
+    retryClerkRead(
+      () => {
+        return listAllOrganizationMemberships(
+          args.clerk.organizations,
+          args.orgId,
+          signal,
+        );
+      },
+      signal,
+      retryBudget,
+    ),
     signal,
-    retryBudget,
   );
   signal.throwIfAborted();
   const activeMemberIds = memberships.map((membership) => {

--- a/turbo/apps/api/src/signals/routes/billing-clerk-rate-limit.ts
+++ b/turbo/apps/api/src/signals/routes/billing-clerk-rate-limit.ts
@@ -1,0 +1,31 @@
+import { command, type Command } from "ccstate";
+
+import { providerUnavailable } from "../../lib/error";
+import { setResHeader$ } from "../context/hono";
+import { BillingClerkReadRateLimitError } from "../services/billing-clerk-directory.service";
+import { settle } from "../utils";
+
+const billingClerkUnavailable$ = command(
+  ({ set }, retryAfterSeconds: number) => {
+    set(setResHeader$, "Retry-After", String(retryAfterSeconds));
+    set(setResHeader$, "Cache-Control", "no-store");
+    return providerUnavailable(
+      "Billing organization members are temporarily unavailable",
+    );
+  },
+);
+
+export function withBillingClerkRateLimit<T>(
+  handler$: Command<Promise<T>, [AbortSignal]>,
+): Command<Promise<T | ReturnType<typeof providerUnavailable>>, [AbortSignal]> {
+  return command(async ({ set }, signal: AbortSignal) => {
+    const result = await settle(set(handler$, signal), signal);
+    if (result.ok) {
+      return result.value;
+    }
+    if (!(result.error instanceof BillingClerkReadRateLimitError)) {
+      throw result.error;
+    }
+    return set(billingClerkUnavailable$, result.error.retryAfterSeconds);
+  });
+}

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -18,7 +18,7 @@ import {
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
-import { publicBrand$ } from "../context/hono";
+import { publicBrand$, requestSignal$ } from "../context/hono";
 import { clerk$ } from "../external/clerk";
 import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
@@ -40,6 +40,7 @@ import {
   type BillingPurchasePaymentMethod,
 } from "../services/billing-payment-method.service";
 import type { RouteEntry } from "../route-entry";
+import { withBillingClerkRateLimit } from "./billing-clerk-rate-limit";
 
 const log = logger("api:zero:org-invite");
 
@@ -371,6 +372,7 @@ const purchasePreviewInner$ = command(
         "returnUrl must match the platform origin for in-app billing",
       );
     }
+    const readSignal = AbortSignal.any([signal, get(requestSignal$)]);
     const result = await createUsagePackInvitationPreview(
       set(writeDb$),
       get(clerk$),
@@ -382,8 +384,10 @@ const purchasePreviewInner$ = command(
         usagePackUsd: body.data.usagePackUsd,
         publicBrand: get(publicBrand$),
       },
-      signal,
+      readSignal,
     );
+    signal.throwIfAborted();
+    readSignal.throwIfAborted();
     if (result.status === "not_found") {
       return invitationPurchaseError({
         phase: "preview",
@@ -552,12 +556,15 @@ const purchaseConfirmInner$ = command(
       }
       paymentMethod = revalidated.paymentMethod;
     }
+    const readSignal = AbortSignal.any([signal, get(requestSignal$)]);
     const result = await confirmUsagePackInvitationPurchase(
       set(writeDb$),
       get(clerk$),
       { orgId: auth.orgId, purchaseId, paymentMethod },
-      signal,
+      readSignal,
     );
+    signal.throwIfAborted();
+    readSignal.throwIfAborted();
     if (result.status === "not_found") {
       return invitationPurchaseError({
         phase: "confirm",
@@ -618,14 +625,14 @@ export const orgInviteRoutes: readonly RouteEntry[] = [
     route: orgInviteContract.previewPurchase,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
-      purchasePreviewInner$,
+      withBillingClerkRateLimit(purchasePreviewInner$),
     ),
   },
   {
     route: orgInviteContract.confirmPurchase,
     handler: authRoute(
       { requireOrganization: true, missingOrganizationStatus: 401 },
-      purchaseConfirmInner$,
+      withBillingClerkRateLimit(purchaseConfirmInner$),
     ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/billing-clerk-directory.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-clerk-directory.service.ts
@@ -1,10 +1,8 @@
-import { now } from "../../lib/time";
 import {
   clerkRateLimit,
-  createClerkReadRetryBudget,
-  retryClerkRead,
+  createClerkReadContext,
   type ClerkClient,
-  type ClerkReadRetryBudget,
+  type ClerkReadContext,
 } from "../external/clerk";
 import {
   listAllOrganizationMemberships,
@@ -43,21 +41,11 @@ async function billingClerkRead<T>(
 export async function loadBillingOrganizationMemberships(
   clerk: ClerkClient,
   orgId: string,
-  signal: AbortSignal,
-  retryBudget: ClerkReadRetryBudget = createClerkReadRetryBudget(now),
+  context: ClerkReadContext = createClerkReadContext(),
+  signal: AbortSignal = new AbortController().signal,
 ): Promise<Awaited<ReturnType<typeof listAllOrganizationMemberships>>> {
   return await billingClerkRead(
-    retryClerkRead(
-      () => {
-        return listAllOrganizationMemberships(
-          clerk.organizations,
-          orgId,
-          signal,
-        );
-      },
-      signal,
-      retryBudget,
-    ),
+    listAllOrganizationMemberships(clerk.organizations, orgId, context, signal),
     signal,
   );
 }
@@ -65,20 +53,15 @@ export async function loadBillingOrganizationMemberships(
 export async function loadBillingOrganizationPendingInvitations(
   clerk: ClerkClient,
   orgId: string,
-  signal: AbortSignal,
-  retryBudget: ClerkReadRetryBudget = createClerkReadRetryBudget(now),
+  context: ClerkReadContext = createClerkReadContext(),
+  signal: AbortSignal = new AbortController().signal,
 ): Promise<Awaited<ReturnType<typeof listAllPendingOrganizationInvitations>>> {
   return await billingClerkRead(
-    retryClerkRead(
-      () => {
-        return listAllPendingOrganizationInvitations(
-          clerk.organizations,
-          orgId,
-          signal,
-        );
-      },
+    listAllPendingOrganizationInvitations(
+      clerk.organizations,
+      orgId,
+      context,
       signal,
-      retryBudget,
     ),
     signal,
   );
@@ -98,17 +81,17 @@ export async function loadBillingOrganizationDirectory(
   orgId: string,
   signal: AbortSignal,
 ): Promise<BillingOrganizationDirectory> {
-  const retryBudget = createClerkReadRetryBudget(now);
   const controller = new AbortController();
   const readSignal = AbortSignal.any([signal, controller.signal]);
+  const readContext = createClerkReadContext();
   const [memberships, invitations] = await onRejection(
     Promise.all([
-      loadBillingOrganizationMemberships(clerk, orgId, readSignal, retryBudget),
+      loadBillingOrganizationMemberships(clerk, orgId, readContext, readSignal),
       loadBillingOrganizationPendingInvitations(
         clerk,
         orgId,
+        readContext,
         readSignal,
-        retryBudget,
       ),
     ]),
     () => {

--- a/turbo/apps/api/src/signals/services/billing-clerk-directory.service.ts
+++ b/turbo/apps/api/src/signals/services/billing-clerk-directory.service.ts
@@ -1,0 +1,121 @@
+import { now } from "../../lib/time";
+import {
+  clerkRateLimit,
+  createClerkReadRetryBudget,
+  retryClerkRead,
+  type ClerkClient,
+  type ClerkReadRetryBudget,
+} from "../external/clerk";
+import {
+  listAllOrganizationMemberships,
+  listAllPendingOrganizationInvitations,
+} from "../external/clerk-organization-lists";
+import { onRejection, settle } from "../utils";
+
+export class BillingClerkReadRateLimitError extends Error {
+  constructor(
+    readonly retryAfterSeconds: number,
+    cause: unknown,
+  ) {
+    super("Billing Clerk read rate limit exhausted", { cause });
+    this.name = "BillingClerkReadRateLimitError";
+  }
+}
+
+async function billingClerkRead<T>(
+  read: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  const result = await settle(read, signal);
+  if (result.ok) {
+    return result.value;
+  }
+  const rateLimit = clerkRateLimit(result.error);
+  if (!rateLimit) {
+    throw result.error;
+  }
+  throw new BillingClerkReadRateLimitError(
+    rateLimit.retryAfterSeconds,
+    result.error,
+  );
+}
+
+export async function loadBillingOrganizationMemberships(
+  clerk: ClerkClient,
+  orgId: string,
+  signal: AbortSignal,
+  retryBudget: ClerkReadRetryBudget = createClerkReadRetryBudget(now),
+): Promise<Awaited<ReturnType<typeof listAllOrganizationMemberships>>> {
+  return await billingClerkRead(
+    retryClerkRead(
+      () => {
+        return listAllOrganizationMemberships(
+          clerk.organizations,
+          orgId,
+          signal,
+        );
+      },
+      signal,
+      retryBudget,
+    ),
+    signal,
+  );
+}
+
+export async function loadBillingOrganizationPendingInvitations(
+  clerk: ClerkClient,
+  orgId: string,
+  signal: AbortSignal,
+  retryBudget: ClerkReadRetryBudget = createClerkReadRetryBudget(now),
+): Promise<Awaited<ReturnType<typeof listAllPendingOrganizationInvitations>>> {
+  return await billingClerkRead(
+    retryClerkRead(
+      () => {
+        return listAllPendingOrganizationInvitations(
+          clerk.organizations,
+          orgId,
+          signal,
+        );
+      },
+      signal,
+      retryBudget,
+    ),
+    signal,
+  );
+}
+
+interface BillingOrganizationDirectory {
+  readonly memberships: Awaited<
+    ReturnType<typeof listAllOrganizationMemberships>
+  >;
+  readonly invitations: Awaited<
+    ReturnType<typeof listAllPendingOrganizationInvitations>
+  >;
+}
+
+export async function loadBillingOrganizationDirectory(
+  clerk: ClerkClient,
+  orgId: string,
+  signal: AbortSignal,
+): Promise<BillingOrganizationDirectory> {
+  const retryBudget = createClerkReadRetryBudget(now);
+  const controller = new AbortController();
+  const readSignal = AbortSignal.any([signal, controller.signal]);
+  const [memberships, invitations] = await onRejection(
+    Promise.all([
+      loadBillingOrganizationMemberships(clerk, orgId, readSignal, retryBudget),
+      loadBillingOrganizationPendingInvitations(
+        clerk,
+        orgId,
+        readSignal,
+        retryBudget,
+      ),
+    ]),
+    () => {
+      controller.abort();
+    },
+  );
+  controller.abort();
+  signal.throwIfAborted();
+  return { memberships, invitations };
+}

--- a/turbo/apps/api/src/signals/services/org-data.service.ts
+++ b/turbo/apps/api/src/signals/services/org-data.service.ts
@@ -22,9 +22,8 @@ import { usagePackUsdSchema } from "@okouai/api-contracts/contracts/billing";
 import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import {
   clerk$,
-  createClerkReadRetryBudget,
-  retryClerkRead,
-  type ClerkReadRetryBudget,
+  createClerkReadContext,
+  type ClerkReadContext,
   type ClerkUser,
 } from "../external/clerk";
 import {
@@ -640,8 +639,8 @@ async function fetchUserProfileMap(
   db: Db,
   client: ReturnType<typeof clerk$.read>,
   userIds: readonly string[],
+  context: ClerkReadContext,
   signal: AbortSignal,
-  retryBudget: ClerkReadRetryBudget,
 ): Promise<Map<string, ClerkUserProfile>> {
   const map = new Map<string, ClerkUserProfile>();
   const uniqueUserIds = [...new Set(userIds)];
@@ -687,18 +686,16 @@ async function fetchUserProfileMap(
     offset < userIdsToFetch.length;
     offset += CLERK_USER_LIST_BATCH_SIZE
   ) {
-    const users = await retryClerkRead(
-      () => {
-        return client.users.getUserList({
-          userId: userIdsToFetch.slice(
-            offset,
-            offset + CLERK_USER_LIST_BATCH_SIZE,
-          ),
-          limit: CLERK_USER_LIST_BATCH_SIZE,
-        });
+    const users = await client.users.getUserList(
+      {
+        userId: userIdsToFetch.slice(
+          offset,
+          offset + CLERK_USER_LIST_BATCH_SIZE,
+        ),
+        limit: CLERK_USER_LIST_BATCH_SIZE,
       },
+      context,
       signal,
-      retryBudget,
     );
     for (const user of users.data) {
       const email = userPrimaryEmail(user);
@@ -740,43 +737,31 @@ async function fetchUserProfileMap(
 async function fetchOrgMemberDirectory(
   client: ReturnType<typeof clerk$.read>,
   orgId: string,
+  context: ClerkReadContext,
   signal: AbortSignal,
-  retryBudget: ClerkReadRetryBudget,
 ) {
   const controller = new AbortController();
   const readSignal = AbortSignal.any([signal, controller.signal]);
   const [organization, memberships, invitations] = await onRejection(
     Promise.all([
-      retryClerkRead(
-        () => {
-          return client.organizations.getOrganization({
-            organizationId: orgId,
-          });
+      client.organizations.getOrganization(
+        {
+          organizationId: orgId,
         },
+        context,
         readSignal,
-        retryBudget,
       ),
-      retryClerkRead(
-        () => {
-          return listAllOrganizationMemberships(
-            client.organizations,
-            orgId,
-            readSignal,
-          );
-        },
+      listAllOrganizationMemberships(
+        client.organizations,
+        orgId,
+        context,
         readSignal,
-        retryBudget,
       ),
-      retryClerkRead(
-        () => {
-          return listAllPendingOrganizationInvitations(
-            client.organizations,
-            orgId,
-            readSignal,
-          );
-        },
+      listAllPendingOrganizationInvitations(
+        client.organizations,
+        orgId,
+        context,
         readSignal,
-        retryBudget,
       ),
     ]),
     () => {
@@ -792,15 +777,13 @@ async function fetchOrgMembershipRequests(
   db: Db,
   client: ReturnType<typeof clerk$.read>,
   orgId: string,
+  context: ClerkReadContext,
   signal: AbortSignal,
-  retryBudget: ClerkReadRetryBudget,
 ): Promise<NonNullable<OrgMembersResponse["membershipRequests"]>> {
-  const requestsData = await retryClerkRead(
-    () => {
-      return fetchClerkMembershipRequests(orgId, signal);
-    },
+  const requestsData = await fetchClerkMembershipRequests(
+    orgId,
+    context,
     signal,
-    retryBudget,
   );
   const requestProfiles = await fetchUserProfileMap(
     db,
@@ -808,8 +791,8 @@ async function fetchOrgMembershipRequests(
     requestsData.map((request) => {
       return request.public_user_data.user_id;
     }),
+    context,
     signal,
-    retryBudget,
   );
   return requestsData.map((request) => {
     const userId = request.public_user_data.user_id;
@@ -834,10 +817,11 @@ export const orgMembersList$ = command(
   ): Promise<OrgMembersResponse> => {
     const client = get(clerk$);
     const db = get(db$) as Db;
-    const retryBudget = createClerkReadRetryBudget(now);
+    const readContext = createClerkReadContext(now);
 
     const { organization, memberships, invitations } =
-      await fetchOrgMemberDirectory(client, args.orgId, signal, retryBudget);
+      await fetchOrgMemberDirectory(client, args.orgId, readContext, signal);
+    signal.throwIfAborted();
 
     const membersWithUserIds = memberships.map((membership) => {
       return {
@@ -853,9 +837,10 @@ export const orgMembersList$ = command(
       membersWithUserIds.map((member) => {
         return member.userId;
       }),
+      readContext,
       signal,
-      retryBudget,
     );
+    signal.throwIfAborted();
 
     const memberList: OrgMember[] = membersWithUserIds.map((member) => {
       const profile = memberProfiles.get(member.userId);
@@ -929,8 +914,8 @@ export const orgMembersList$ = command(
             db,
             client,
             args.orgId,
+            readContext,
             signal,
-            retryBudget,
           )
         : [];
 

--- a/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
@@ -27,12 +27,12 @@ import {
 
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
-import { nowDate } from "../../lib/time";
+import { now, nowDate } from "../../lib/time";
 import {
-  listAllOrganizationMemberships,
-  listAllPendingOrganizationInvitations,
-} from "../external/clerk-organization-lists";
-import type { ClerkClient } from "../external/clerk";
+  createClerkReadRetryBudget,
+  type ClerkClient,
+  type ClerkReadRetryBudget,
+} from "../external/clerk";
 import type { Db } from "../external/db";
 import {
   getStripeClient,
@@ -61,6 +61,13 @@ import {
   stripeBillingPurchasePaymentParams,
   type BillingPurchasePaymentMethod,
 } from "./billing-payment-method.service";
+import {
+  BillingClerkReadRateLimitError,
+  loadBillingOrganizationDirectory,
+  loadBillingOrganizationMemberships,
+  loadBillingOrganizationPendingInvitations,
+} from "./billing-clerk-directory.service";
+import { onRejection } from "../utils";
 
 const PURPOSE = "usage_pack_invitation_purchase";
 const PURCHASE_ID_METADATA_KEY = "usagePackInvitationPurchaseId";
@@ -389,11 +396,13 @@ async function emailAlreadyBelongsToOrg(
   clerk: ClerkClient,
   orgId: string,
   email: string,
+  signal: AbortSignal,
 ): Promise<boolean> {
-  const [memberships, invitations] = await Promise.all([
-    listAllOrganizationMemberships(clerk.organizations, orgId),
-    listAllPendingOrganizationInvitations(clerk.organizations, orgId),
-  ]);
+  const { memberships, invitations } = await loadBillingOrganizationDirectory(
+    clerk,
+    orgId,
+    signal,
+  );
   return (
     memberships.some((membership) => {
       return clerkMembershipIdentity(membership)?.email === email;
@@ -648,7 +657,7 @@ async function prepareUsagePackInvitationPurchase(
     };
   }
   const email = normalizedEmail(args.email);
-  if (await emailAlreadyBelongsToOrg(clerk, args.orgId, email)) {
+  if (await emailAlreadyBelongsToOrg(clerk, args.orgId, email, signal)) {
     return {
       status: "conflict",
       reason: "invitee_unavailable",
@@ -965,17 +974,51 @@ async function persistInvitation(
   });
 }
 
+async function releaseInvitationCreationClaimAfterReadLimit(
+  db: Db,
+  purchaseId: string,
+  error: unknown,
+): Promise<void> {
+  if (!(error instanceof BillingClerkReadRateLimitError)) {
+    return;
+  }
+  await db
+    .update(usagePackInvitationPurchases)
+    .set({ status: "payment_succeeded", updatedAt: nowDate() })
+    .where(
+      and(
+        eq(usagePackInvitationPurchases.id, purchaseId),
+        eq(usagePackInvitationPurchases.status, "creating_invitation"),
+        isNull(usagePackInvitationPurchases.clerkInvitationId),
+        isNull(usagePackInvitationPurchases.allocationId),
+      ),
+    );
+}
+
 async function ensurePaidInvitationCreated(
   db: Db,
   clerk: ClerkClient,
   purchaseId: string,
   allowRecovery: boolean,
+  signal: AbortSignal,
 ): Promise<void> {
+  signal.throwIfAborted();
   const purchase = await claimInvitationCreation(db, purchaseId, allowRecovery);
   if (!purchase) {
     return;
   }
-  const membership = await membershipForPurchase(clerk, purchase);
+  signal.throwIfAborted();
+  const retryBudget = createClerkReadRetryBudget(now);
+  const membership = await onRejection(
+    membershipForPurchase(clerk, purchase, signal, retryBudget),
+    async (error) => {
+      await releaseInvitationCreationClaimAfterReadLimit(
+        db,
+        purchase.id,
+        error,
+      );
+    },
+  );
   if (membership) {
     await handleUsagePackInvitationAccepted(db, {
       orgId: purchase.orgId,
@@ -989,9 +1032,20 @@ async function ensurePaidInvitationCreated(
     });
     return;
   }
-  const pending = await listAllPendingOrganizationInvitations(
-    clerk.organizations,
-    purchase.orgId,
+  const pending = await onRejection(
+    loadBillingOrganizationPendingInvitations(
+      clerk,
+      purchase.orgId,
+      signal,
+      retryBudget,
+    ),
+    async (error) => {
+      await releaseInvitationCreationClaimAfterReadLimit(
+        db,
+        purchase.id,
+        error,
+      );
+    },
   );
   const existing = pending.find((invitation) => {
     return clerkInvitationPurchaseId(invitation) === purchase.id;
@@ -1213,12 +1267,13 @@ async function handleRecordedPayment(
   db: Db,
   clerk: ClerkClient,
   purchase: UsagePackInvitationPurchaseRow,
+  signal: AbortSignal,
 ): Promise<void> {
   if (purchase.status === "refund_pending") {
     await refundPurchase(db, purchase.id, false);
     return;
   }
-  await ensurePaidInvitationCreated(db, clerk, purchase.id, false);
+  await ensurePaidInvitationCreated(db, clerk, purchase.id, false, signal);
 }
 
 export async function handleUsagePackInvitationCheckoutPaid(
@@ -1226,6 +1281,7 @@ export async function handleUsagePackInvitationCheckoutPaid(
   clerk: ClerkClient,
   session: UsagePackInvitationCheckoutSessionInput,
   paidAt: Date,
+  signal: AbortSignal,
 ): Promise<{ readonly handled: boolean; readonly orgId: string | null }> {
   const purchaseId = purchaseIdFromMetadata(session.metadata);
   if (!purchaseId) {
@@ -1256,7 +1312,7 @@ export async function handleUsagePackInvitationCheckoutPaid(
     currency: session.currency,
     paidAt,
   });
-  await handleRecordedPayment(db, clerk, purchase);
+  await handleRecordedPayment(db, clerk, purchase, signal);
   return { handled: true, orgId: purchase.orgId };
 }
 
@@ -1265,6 +1321,7 @@ export async function handleUsagePackInvitationPaymentIntentSucceeded(
   clerk: ClerkClient,
   paymentIntent: StripePaymentIntent,
   paidAt: Date,
+  signal: AbortSignal,
 ): Promise<{ readonly handled: boolean; readonly orgId: string | null }> {
   const purchaseId = purchaseIdFromMetadata(paymentIntent.metadata);
   if (!purchaseId) {
@@ -1285,7 +1342,7 @@ export async function handleUsagePackInvitationPaymentIntentSucceeded(
     currency: paymentIntent.currency,
     paidAt,
   });
-  await handleRecordedPayment(db, clerk, purchase);
+  await handleRecordedPayment(db, clerk, purchase, signal);
   return { handled: true, orgId: purchase.orgId };
 }
 
@@ -1316,6 +1373,7 @@ export async function handleUsagePackInvitationInvoicePaid(
   db: Db,
   clerk: ClerkClient,
   invoiceInput: Pick<StripeInvoice, "id" | "metadata">,
+  signal: AbortSignal,
 ): Promise<{ readonly handled: boolean; readonly orgId: string | null }> {
   const purchaseId = purchaseIdFromMetadata(invoiceInput.metadata);
   if (!purchaseId) {
@@ -1348,7 +1406,7 @@ export async function handleUsagePackInvitationInvoicePaid(
     currency: invoice.currency,
     paidAt,
   });
-  await handleRecordedPayment(db, clerk, purchase);
+  await handleRecordedPayment(db, clerk, purchase, signal);
   return { handled: true, orgId: purchase.orgId };
 }
 
@@ -1363,12 +1421,18 @@ function invitationPurchaseConfirmState(
   | {
       readonly status: "complete";
       readonly result: ConfirmUsagePackInvitationPurchaseResult;
+    }
+  | {
+      readonly status: "resume_invitation";
+      readonly purchase: UsagePackInvitationPurchaseRow;
     } {
   if (!purchase || purchase.orgId !== orgId) {
     return { status: "complete", result: { status: "not_found" } };
   }
+  if (purchase.status === "payment_succeeded") {
+    return { status: "resume_invitation", purchase };
+  }
   if (
-    purchase.status === "payment_succeeded" ||
     purchase.status === "creating_invitation" ||
     purchase.status === "invitation_pending" ||
     ACCEPTED_PURCHASE_STATUSES.has(purchase.status)
@@ -1499,6 +1563,77 @@ function invitationPurchasePaymentMethodConflict(
   };
 }
 
+interface BillUsagePackInvitationPurchaseArgs {
+  readonly purchase: UsagePackInvitationPurchaseRow;
+  readonly subscription: UsagePackSubscriptionRow;
+  readonly paymentMethod: BillingPurchasePaymentMethod | undefined;
+}
+
+async function billUsagePackInvitationPurchase(
+  db: Db,
+  clerk: ClerkClient,
+  args: BillUsagePackInvitationPurchaseArgs,
+  signal: AbortSignal,
+): Promise<ConfirmUsagePackInvitationPurchaseResult> {
+  const { purchase, subscription, paymentMethod } = args;
+  const stripe = getStripeClient();
+  const metadata = checkoutMetadata(purchase.id);
+  const invoice = await stripe.invoices.create(
+    {
+      customer: subscription.stripeCustomerId,
+      auto_advance: false,
+      ...(paymentMethod
+        ? stripeBillingPurchasePaymentParams(paymentMethod)
+        : {}),
+      metadata,
+    },
+    { idempotencyKey: `usage-pack-invitation:${purchase.id}:invoice` },
+  );
+  signal.throwIfAborted();
+  await stripe.invoiceItems.create(
+    {
+      invoice: invoice.id,
+      customer: subscription.stripeCustomerId,
+      amount: purchase.expectedAmountCents,
+      currency: purchase.currency,
+      description: `Member usage pack for ${purchase.normalizedEmail}`,
+    },
+    { idempotencyKey: `usage-pack-invitation:${purchase.id}:invoice-item` },
+  );
+  signal.throwIfAborted();
+  const payment = await completeBillingOperationInvoice(
+    stripe,
+    invoice,
+    `usage-pack-invitation:${purchase.id}`,
+    signal,
+    { payOpenInvoice: true },
+  );
+  if (payment.status === "pending_payment") {
+    return payment;
+  }
+  const handled = await handleUsagePackInvitationInvoicePaid(
+    db,
+    clerk,
+    {
+      id: invoice.id,
+      metadata: invoice.metadata,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+  if (!handled.handled) {
+    throw new Error("Invitation invoice payment was not recorded");
+  }
+  if (!handled.orgId) {
+    return {
+      status: "conflict",
+      reason: "billing_state_changed",
+      diagnostics: {},
+    };
+  }
+  return { status: "confirmed" };
+}
+
 export async function confirmUsagePackInvitationPurchase(
   db: Db,
   clerk: ClerkClient,
@@ -1516,6 +1651,17 @@ export async function confirmUsagePackInvitationPurchase(
   if (purchaseState.status === "complete") {
     return purchaseState.result;
   }
+  if (purchaseState.status === "resume_invitation") {
+    await ensurePaidInvitationCreated(
+      db,
+      clerk,
+      purchaseState.purchase.id,
+      false,
+      signal,
+    );
+    signal.throwIfAborted();
+    return { status: "confirmed" };
+  }
   const { purchase } = purchaseState;
   if (await expireInvitationPurchasePreviewIfNeeded(db, purchase)) {
     return { status: "expired" };
@@ -1525,6 +1671,7 @@ export async function confirmUsagePackInvitationPurchase(
       clerk,
       purchase.orgId,
       purchase.normalizedEmail,
+      signal,
     )
   ) {
     return {
@@ -1566,56 +1713,12 @@ export async function confirmUsagePackInvitationPurchase(
   }
   const paymentMethod =
     args.paymentMethod ?? (route.kind === "preview" ? route : undefined);
-  const metadata = checkoutMetadata(purchase.id);
-  const invoice = await stripe.invoices.create(
-    {
-      customer: activeSubscription.stripeCustomerId,
-      auto_advance: false,
-      ...(paymentMethod
-        ? stripeBillingPurchasePaymentParams(paymentMethod)
-        : {}),
-      metadata,
-    },
-    { idempotencyKey: `usage-pack-invitation:${purchase.id}:invoice` },
-  );
-  signal.throwIfAborted();
-  await stripe.invoiceItems.create(
-    {
-      invoice: invoice.id,
-      customer: activeSubscription.stripeCustomerId,
-      amount: purchase.expectedAmountCents,
-      currency: purchase.currency,
-      description: `Member usage pack for ${purchase.normalizedEmail}`,
-    },
-    { idempotencyKey: `usage-pack-invitation:${purchase.id}:invoice-item` },
-  );
-  signal.throwIfAborted();
-  const payment = await completeBillingOperationInvoice(
-    stripe,
-    invoice,
-    `usage-pack-invitation:${purchase.id}`,
+  return await billUsagePackInvitationPurchase(
+    db,
+    clerk,
+    { purchase, subscription: activeSubscription, paymentMethod },
     signal,
-    { payOpenInvoice: true },
   );
-  if (payment.status === "pending_payment") {
-    return payment;
-  }
-  const handled = await handleUsagePackInvitationInvoicePaid(db, clerk, {
-    id: invoice.id,
-    metadata: invoice.metadata,
-  });
-  signal.throwIfAborted();
-  if (!handled.handled) {
-    throw new Error("Invitation invoice payment was not recorded");
-  }
-  if (!handled.orgId) {
-    return {
-      status: "conflict",
-      reason: "billing_state_changed",
-      diagnostics: {},
-    };
-  }
-  return { status: "confirmed" };
 }
 
 export async function handleUsagePackInvitationCheckoutFailed(
@@ -1932,10 +2035,14 @@ export async function handleUsagePackInvitationAccepted(
 async function membershipForPurchase(
   clerk: ClerkClient,
   purchase: UsagePackInvitationPurchaseRow,
+  signal: AbortSignal,
+  retryBudget: ClerkReadRetryBudget = createClerkReadRetryBudget(now),
 ): Promise<ClerkMembershipIdentity | null> {
-  const memberships = await listAllOrganizationMemberships(
-    clerk.organizations,
+  const memberships = await loadBillingOrganizationMemberships(
+    clerk,
     purchase.orgId,
+    signal,
+    retryBudget,
   );
   return (
     memberships.map(clerkMembershipIdentity).find((identity) => {
@@ -1948,10 +2055,16 @@ async function revokeAndRefundPurchase(
   db: Db,
   clerk: ClerkClient,
   purchase: UsagePackInvitationPurchaseRow,
-  signal: AbortSignal | undefined,
+  signal: AbortSignal,
 ): Promise<"accepted" | "revoked"> {
-  const membership = await membershipForPurchase(clerk, purchase);
-  signal?.throwIfAborted();
+  const retryBudget = createClerkReadRetryBudget(now);
+  const membership = await membershipForPurchase(
+    clerk,
+    purchase,
+    signal,
+    retryBudget,
+  );
+  signal.throwIfAborted();
   if (membership) {
     await handleUsagePackInvitationAccepted(
       db,
@@ -1973,11 +2086,13 @@ async function revokeAndRefundPurchase(
       : "accepted";
   }
   if (purchase.clerkInvitationId) {
-    const pending = await listAllPendingOrganizationInvitations(
-      clerk.organizations,
+    const pending = await loadBillingOrganizationPendingInvitations(
+      clerk,
       purchase.orgId,
+      signal,
+      retryBudget,
     );
-    signal?.throwIfAborted();
+    signal.throwIfAborted();
     if (
       pending.some((invitation) => {
         return invitation.id === purchase.clerkInvitationId;
@@ -1987,7 +2102,7 @@ async function revokeAndRefundPurchase(
         organizationId: purchase.orgId,
         invitationId: purchase.clerkInvitationId,
       });
-      signal?.throwIfAborted();
+      signal.throwIfAborted();
     }
   }
   const [markedForRefund] = await db
@@ -2098,7 +2213,7 @@ export async function reconcileUsagePackInvitationPurchases(
     switch (purchase.status) {
       case "payment_succeeded":
       case "creating_invitation": {
-        await ensurePaidInvitationCreated(db, clerk, purchase.id, true);
+        await ensurePaidInvitationCreated(db, clerk, purchase.id, true, signal);
         reconciled += 1;
         break;
       }
@@ -2108,7 +2223,7 @@ export async function reconcileUsagePackInvitationPurchases(
           reconciled += 1;
           break;
         }
-        const membership = await membershipForPurchase(clerk, purchase);
+        const membership = await membershipForPurchase(clerk, purchase, signal);
         signal.throwIfAborted();
         if (membership && purchase.clerkInvitationId) {
           await handleUsagePackInvitationAccepted(

--- a/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
@@ -27,11 +27,11 @@ import {
 
 import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import { env } from "../../lib/env";
-import { now, nowDate } from "../../lib/time";
+import { nowDate } from "../../lib/time";
 import {
-  createClerkReadRetryBudget,
+  createClerkReadContext,
   type ClerkClient,
-  type ClerkReadRetryBudget,
+  type ClerkReadContext,
 } from "../external/clerk";
 import type { Db } from "../external/db";
 import {
@@ -1008,9 +1008,9 @@ async function ensurePaidInvitationCreated(
     return;
   }
   signal.throwIfAborted();
-  const retryBudget = createClerkReadRetryBudget(now);
+  const readContext = createClerkReadContext();
   const membership = await onRejection(
-    membershipForPurchase(clerk, purchase, signal, retryBudget),
+    membershipForPurchase(clerk, purchase, readContext, signal),
     async (error) => {
       await releaseInvitationCreationClaimAfterReadLimit(
         db,
@@ -1036,8 +1036,8 @@ async function ensurePaidInvitationCreated(
     loadBillingOrganizationPendingInvitations(
       clerk,
       purchase.orgId,
+      readContext,
       signal,
-      retryBudget,
     ),
     async (error) => {
       await releaseInvitationCreationClaimAfterReadLimit(
@@ -2035,14 +2035,14 @@ export async function handleUsagePackInvitationAccepted(
 async function membershipForPurchase(
   clerk: ClerkClient,
   purchase: UsagePackInvitationPurchaseRow,
-  signal: AbortSignal,
-  retryBudget: ClerkReadRetryBudget = createClerkReadRetryBudget(now),
+  context: ClerkReadContext = createClerkReadContext(),
+  signal: AbortSignal = new AbortController().signal,
 ): Promise<ClerkMembershipIdentity | null> {
   const memberships = await loadBillingOrganizationMemberships(
     clerk,
     purchase.orgId,
+    context,
     signal,
-    retryBudget,
   );
   return (
     memberships.map(clerkMembershipIdentity).find((identity) => {
@@ -2057,12 +2057,12 @@ async function revokeAndRefundPurchase(
   purchase: UsagePackInvitationPurchaseRow,
   signal: AbortSignal,
 ): Promise<"accepted" | "revoked"> {
-  const retryBudget = createClerkReadRetryBudget(now);
+  const readContext = createClerkReadContext();
   const membership = await membershipForPurchase(
     clerk,
     purchase,
+    readContext,
     signal,
-    retryBudget,
   );
   signal.throwIfAborted();
   if (membership) {
@@ -2089,8 +2089,8 @@ async function revokeAndRefundPurchase(
     const pending = await loadBillingOrganizationPendingInvitations(
       clerk,
       purchase.orgId,
+      readContext,
       signal,
-      retryBudget,
     );
     signal.throwIfAborted();
     if (
@@ -2223,7 +2223,12 @@ export async function reconcileUsagePackInvitationPurchases(
           reconciled += 1;
           break;
         }
-        const membership = await membershipForPurchase(clerk, purchase, signal);
+        const membership = await membershipForPurchase(
+          clerk,
+          purchase,
+          createClerkReadContext(),
+          signal,
+        );
         signal.throwIfAborted();
         if (membership && purchase.clerkInvitationId) {
           await handleUsagePackInvitationAccepted(

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -3792,12 +3792,14 @@ async function handleCheckoutCompleted(
   getClerk: ClerkClientProvider,
   session: CheckoutSessionInput,
   paidAt: Date,
+  signal: AbortSignal,
 ): Promise<CheckoutCompletedOutcome> {
   const usagePackInvitation = await handleUsagePackInvitationCheckoutPaid(
     db,
     getClerk(),
     session,
     paidAt,
+    signal,
   );
   if (usagePackInvitation.handled) {
     return {
@@ -3989,6 +3991,7 @@ async function handleInvoicePaid(
   db: Db,
   getClerk: ClerkClientProvider,
   invoice: InvoiceInput,
+  signal: AbortSignal,
 ): Promise<string | null> {
   const migrationResult = await handleUsagePackMigrationInvoicePaid(
     db,
@@ -4002,6 +4005,7 @@ async function handleInvoicePaid(
     db,
     getClerk(),
     invoice,
+    signal,
   );
   if (invitationResult.handled) {
     return invitationResult.orgId;
@@ -4924,7 +4928,7 @@ export async function reconcileStripeSubscriptionSnapshot(
     signal,
   );
   const invoiceOrgId = paidInvoice
-    ? await handleInvoicePaid(db, getClerk, paidInvoice)
+    ? await handleInvoicePaid(db, getClerk, paidInvoice, signal)
     : null;
   signal.throwIfAborted();
   if (invoiceOrgId) {
@@ -5000,6 +5004,7 @@ export const reconcilePaidStripeCheckoutSession$ = command(
       getClerk,
       input.session,
       input.paidAt,
+      signal,
     );
     signal.throwIfAborted();
 
@@ -5026,7 +5031,7 @@ export const reconcilePaidStripeInvoice$ = command(
     const getClerk = (): ClerkClient => {
       return get(clerk$);
     };
-    const orgId = await handleInvoicePaid(db, getClerk, invoice);
+    const orgId = await handleInvoicePaid(db, getClerk, invoice, signal);
     signal.throwIfAborted();
     if (!orgId) {
       return null;
@@ -5069,6 +5074,7 @@ export const handleStripeWebhookEvent$ = command(
             getClerk(),
             event.object,
             new Date(event.created * 1000),
+            signal,
           );
         signal.throwIfAborted();
         if (usagePackInvitation.handled) {
@@ -5087,6 +5093,7 @@ export const handleStripeWebhookEvent$ = command(
           getClerk,
           event.object,
           new Date(event.created * 1000),
+          signal,
         );
         signal.throwIfAborted();
         drainOrgId = result.drainOrgId;
@@ -5103,6 +5110,7 @@ export const handleStripeWebhookEvent$ = command(
           db,
           getClerk,
           event.object,
+          signal,
         );
         signal.throwIfAborted();
         drainOrgId = paidDrainOrgId;


### PR DESCRIPTION
## Summary

- make the vm0-owned Clerk client gateway automatically retry all five mirrored idempotent Backend API reads after `429` responses
- keep one bounded retry policy at the external boundary: at most three attempts, `Retry-After` plus jitter, a 15-second shared delay budget, and abort-aware waits
- apply the same policy inside complete organization-list pagination and the direct membership-request GET adapter without nested route/service retry loops
- keep every Clerk mutation as an explicit one-shot delegate; no invitation, membership, organization, token, or metadata write is retried
- retain billing-specific terminal `503 PROVIDER_UNAVAILABLE` mapping and post-payment invitation recovery above the gateway

## Scope

- existing Clerk read callers receive bounded `429` recovery without opting in at each route or service
- workflows that own cancellation or multiple Clerk reads can pass a final `AbortSignal` and share one deadline context across pages, siblings, or sequential reads
- only `429` responses are retried; network failures, other HTTP statuses, authentication failures, validation failures, and mutations keep their current behavior
- no global Clerk rate limiter, cache, circuit breaker, database schema change, or frontend/API success-contract change

## Validation

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/acquisition-attribution.test.ts --silent=passed-only` (4 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/org-team.bdd.test.ts --silent=passed-only` (10 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/billing-checkout.test.ts --silent=passed-only` (196 passed, including the latest `main` invitation-conflict coverage)
- before the final rebase, the full API suite passed 3206 tests and all nine contention-related timeouts passed in one-worker reruns; the exact rebased head is covered by the focused suites and static checks above

Closes #28273
