### PR TITLE
fix(db): bound checkpoint preflight validation

### DIFF
--- a/.github/workflows/agent-compose-consolidation-preflight.yml
+++ b/.github/workflows/agent-compose-consolidation-preflight.yml
@@ -40,6 +40,7 @@ jobs:
           NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
         run: |
           set -euo pipefail
+          database_resolution_failure='{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v7","status":"failed","failureGates":["probe.database_resolution"],"probe":{"failurePhase":"configuration","phaseDurationsMs":{"configuration":0,"repositoryInventory":0,"databaseConnection":0,"transactionStart":0,"transactionConfiguration":0,"capabilities":0,"danglingStart":0,"identity":0,"agentExecutionPlans":0,"versions":0,"heads":0,"runs":0,"checkpointInventory":0,"checkpointStorageReferences":0,"conversations":0,"catalogDependencies":0,"danglingEnd":0,"transactionCleanup":0,"classification":0}}}'
           if ! database_url=$(
             neonctl connection-string production \
               --project-id "$NEON_PROJECT_ID" \
@@ -49,7 +50,7 @@ jobs:
               --ssl verify-full \
               2>/dev/null
           ); then
-            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v7","status":"failed","failureGates":["probe.database_resolution"]}'
+            printf '%s\n' "$database_resolution_failure"
             exit 1
           fi
           if [[ -z "$database_url" ||
@@ -57,7 +58,7 @@ jobs:
                 "$database_url" == *$'\r'* ||
                 ( "$database_url" != postgres://* &&
                   "$database_url" != postgresql://* ) ]]; then
-            echo '{"schemaVersion":"vm0.agent-compose-consolidation-preflight.v7","status":"failed","failureGates":["probe.database_resolution"]}'
+            printf '%s\n' "$database_resolution_failure"
             exit 1
           fi
           WORKFLOW_COMMAND_DATA="${database_url//%/%25}"

--- a/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/agent-compose-consolidation-preflight.ts
@@ -61,6 +61,36 @@ const DEFAULT_LOCK_TIMEOUT_MS = 1000;
 const DEFAULT_STATEMENT_TIMEOUT_MS = 30_000;
 const DEFAULT_EXPECTED_DANGLING_HEAD_COUNT = 17;
 const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
+const MAX_REPORTED_PHASE_DURATION_MS = DEFAULT_STATEMENT_TIMEOUT_MS;
+export const PREFLIGHT_PHASES = [
+  "configuration",
+  "repositoryInventory",
+  "databaseConnection",
+  "transactionStart",
+  "transactionConfiguration",
+  "capabilities",
+  "danglingStart",
+  "identity",
+  "agentExecutionPlans",
+  "versions",
+  "heads",
+  "runs",
+  "checkpointInventory",
+  "checkpointStorageReferences",
+  "conversations",
+  "catalogDependencies",
+  "danglingEnd",
+  "transactionCleanup",
+  "classification",
+] as const;
+
+type PreflightPhase = (typeof PREFLIGHT_PHASES)[number];
+type PreflightFailurePhase = PreflightPhase | "none" | "unknown";
+
+export interface PreflightProbeEvidence {
+  readonly failurePhase: PreflightFailurePhase;
+  readonly phaseDurationsMs: Readonly<Record<PreflightPhase, number>>;
+}
 // Protected v6 run 32203970280 at d570536126e6137eb3423573623f8abbdf6be0c6
 // emitted this exact aggregate before the nullable cutover. It remains bounded
 // evidence, not an append-only membership gate: approved Run deletion cascades
@@ -478,6 +508,10 @@ const PREFLIGHT_V7_OUTPUT_ALLOWLIST = [
   ...setOutputPaths("checkpoints.transition.acceptedV6LegacySnapshotEvidence"),
   ...comparisonOutputPaths("checkpoints.transition.legacySnapshotLineage"),
   ...setOutputPaths("checkpoints.transition.legacySnapshotGrowth"),
+  "probe.failurePhase",
+  ...PREFLIGHT_PHASES.map((phase) => {
+    return `probe.phaseDurationsMs.${phase}`;
+  }),
 ];
 
 /** Every and only approved scalar/array path in a complete v7 result. */
@@ -529,6 +563,19 @@ export interface CheckpointInventoryRow
   readonly conversationReferenceValid: boolean;
   readonly sessionReferenceValid: boolean;
   readonly storageReferenceValid: boolean;
+}
+
+interface CheckpointCoreInventoryRow
+  extends QueryResultRow, LaunchSnapshotCheckpointInventoryRow {
+  readonly id: string;
+  readonly preCutover: boolean;
+  readonly runReferenceValid: boolean;
+  readonly conversationReferenceValid: boolean;
+  readonly sessionReferenceValid: boolean;
+}
+
+interface InvalidCheckpointStorageReferenceRow extends QueryResultRow {
+  readonly id: string;
 }
 
 export type ConversationInventoryRow = QueryResultRow &
@@ -598,11 +645,62 @@ export interface ReadOnlySnapshotOptions {
 
 export class SanitizedPreflightError extends Error {
   readonly gate: string;
+  readonly probe: PreflightProbeEvidence | undefined;
 
-  constructor(gate: string) {
+  constructor(gate: string, probe?: PreflightProbeEvidence) {
     super(gate);
     this.name = "SanitizedPreflightError";
     this.gate = gate;
+    this.probe = probe;
+  }
+}
+
+function emptyPhaseDurations(): Record<PreflightPhase, number> {
+  return Object.fromEntries(
+    PREFLIGHT_PHASES.map((phase) => {
+      return [phase, 0] as const;
+    }),
+  ) as Record<PreflightPhase, number>;
+}
+
+function emptyProbeEvidence(
+  failurePhase: PreflightFailurePhase = "none",
+): PreflightProbeEvidence {
+  return {
+    failurePhase,
+    phaseDurationsMs: emptyPhaseDurations(),
+  };
+}
+
+class PreflightPhaseRecorder {
+  readonly #phaseDurationsMs = emptyPhaseDurations();
+  #failurePhase: PreflightFailurePhase = "none";
+
+  async measure<Value>(
+    phase: PreflightPhase,
+    operation: () => Promise<Value>,
+  ): Promise<Value> {
+    const startedAt = process.hrtime.bigint();
+    try {
+      return await operation();
+    } catch (error) {
+      this.#failurePhase = phase;
+      throw error;
+    } finally {
+      const elapsedNs = process.hrtime.bigint() - startedAt;
+      const elapsedMs = Math.ceil(Number(elapsedNs) / 1_000_000);
+      this.#phaseDurationsMs[phase] = Math.min(
+        MAX_REPORTED_PHASE_DURATION_MS,
+        Math.max(1, elapsedMs),
+      );
+    }
+  }
+
+  evidence(): PreflightProbeEvidence {
+    return {
+      failurePhase: this.#failurePhase,
+      phaseDurationsMs: { ...this.#phaseDurationsMs },
+    };
   }
 }
 
@@ -615,6 +713,9 @@ const SAFE_OUTPUT_LITERALS: ReadonlySet<string> = new Set([
   "stable",
   "supported",
   "repeatable read",
+  "none",
+  "unknown",
+  ...PREFLIGHT_PHASES,
 ]);
 const SAFE_FAILURE_GATE_PATTERN = /^[A-Za-z]+(?:[._][A-Za-z]+)*$/u;
 const SAFE_DIGEST_PATTERN = /^[0-9a-f]{64}$/u;
@@ -649,7 +750,12 @@ function hasSafeAggregateValues(value: unknown, pathPrefix = ""): boolean {
     });
   }
   if (typeof value === "number") {
-    return Number.isSafeInteger(value) && value >= 0;
+    return (
+      Number.isSafeInteger(value) &&
+      value >= 0 &&
+      (!pathPrefix.startsWith("probe.phaseDurationsMs.") ||
+        value <= MAX_REPORTED_PHASE_DURATION_MS)
+    );
   }
   if (typeof value === "boolean") return true;
   if (typeof value !== "string") return false;
@@ -676,31 +782,44 @@ function assertNotAborted(signal: AbortSignal | undefined): void {
   if (signal?.aborted) throw new SanitizedPreflightError("probe.cancelled");
 }
 
-function classifyThrownError(error: unknown, fallbackGate: string): never {
-  if (error instanceof SanitizedPreflightError) throw error;
+function classifyThrownError(
+  error: unknown,
+  fallbackGate: string,
+  probe?: PreflightProbeEvidence,
+): never {
+  if (error instanceof SanitizedPreflightError) {
+    throw error.probe ? error : new SanitizedPreflightError(error.gate, probe);
+  }
   if (error instanceof DOMException && error.name === "AbortError") {
-    throw new SanitizedPreflightError("probe.cancelled");
+    throw new SanitizedPreflightError("probe.cancelled", probe);
   }
   const code = (error as { readonly code?: unknown } | null)?.code;
   if (code === "57014") {
-    throw new SanitizedPreflightError("probe.statement_timeout");
+    throw new SanitizedPreflightError("probe.statement_timeout", probe);
   }
   if (code === "55P03") {
-    throw new SanitizedPreflightError("probe.lock_timeout");
+    throw new SanitizedPreflightError("probe.lock_timeout", probe);
   }
-  throw new SanitizedPreflightError(fallbackGate);
+  throw new SanitizedPreflightError(fallbackGate, probe);
 }
 
 async function safeQuery<Row extends QueryResultRow>(
   client: Client,
   signal: AbortSignal | undefined,
+  phaseRecorder: PreflightPhaseRecorder,
+  phase: PreflightPhase,
   text: string,
   values?: readonly unknown[],
 ): Promise<readonly Row[]> {
-  assertNotAborted(signal);
-  const result = await client.query<Row>(text, values as unknown[] | undefined);
-  assertNotAborted(signal);
-  return result.rows;
+  return phaseRecorder.measure(phase, async () => {
+    assertNotAborted(signal);
+    const result = await client.query<Row>(
+      text,
+      values as unknown[] | undefined,
+    );
+    assertNotAborted(signal);
+    return result.rows;
+  });
 }
 
 interface CapabilityRow extends QueryResultRow {
@@ -714,6 +833,7 @@ interface CapabilityRow extends QueryResultRow {
 async function executeReadOnlySnapshotTransaction<Value>(
   client: Client,
   options: ReadOnlySnapshotOptions,
+  phaseRecorder: PreflightPhaseRecorder,
   body: (capabilities: PreflightCapabilities) => Promise<Value>,
 ): Promise<{
   readonly capabilities: PreflightCapabilities;
@@ -730,19 +850,25 @@ async function executeReadOnlySnapshotTransaction<Value>(
 
   try {
     assertNotAborted(options.signal);
-    await client.query(
-      "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
-    );
+    await phaseRecorder.measure("transactionStart", async () => {
+      return client.query(
+        "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+      );
+    });
     transactionStarted = true;
-    await client.query(
-      `SELECT
-         set_config('lock_timeout', $1, true),
-         set_config('statement_timeout', $2, true)`,
-      [`${lockTimeoutMs}ms`, `${statementTimeoutMs}ms`],
-    );
+    await phaseRecorder.measure("transactionConfiguration", async () => {
+      return client.query(
+        `SELECT
+           set_config('lock_timeout', $1, true),
+           set_config('statement_timeout', $2, true)`,
+        [`${lockTimeoutMs}ms`, `${statementTimeoutMs}ms`],
+      );
+    });
     const capabilityRows = await safeQuery<CapabilityRow>(
       client,
       options.signal,
+      phaseRecorder,
+      "capabilities",
       `SELECT
          current_setting('server_version_num')::integer AS "serverVersion",
          current_setting('transaction_read_only') = 'on' AS "readOnly",
@@ -778,26 +904,42 @@ async function executeReadOnlySnapshotTransaction<Value>(
 
   if (transactionStarted) {
     try {
-      await client.query("ROLLBACK");
+      await phaseRecorder.measure("transactionCleanup", async () => {
+        return client.query("ROLLBACK");
+      });
     } catch {
       if (options.signal?.aborted) {
-        throw new SanitizedPreflightError("probe.cancelled");
+        throw new SanitizedPreflightError(
+          "probe.cancelled",
+          phaseRecorder.evidence(),
+        );
       }
-      throw new SanitizedPreflightError("probe.transaction_cleanup");
+      throw new SanitizedPreflightError(
+        "probe.transaction_cleanup",
+        phaseRecorder.evidence(),
+      );
     }
   }
   if (options.signal?.aborted) {
-    throw new SanitizedPreflightError("probe.cancelled");
+    throw new SanitizedPreflightError(
+      "probe.cancelled",
+      phaseRecorder.evidence(),
+    );
   }
   if (bodyError !== undefined)
-    classifyThrownError(bodyError, "probe.inventory");
-  if (!result) throw new SanitizedPreflightError("probe.transaction_start");
+    classifyThrownError(bodyError, "probe.inventory", phaseRecorder.evidence());
+  if (!result)
+    throw new SanitizedPreflightError(
+      "probe.transaction_start",
+      phaseRecorder.evidence(),
+    );
   return result;
 }
 
-export async function withReadOnlySnapshot<Value>(
+async function withReadOnlySnapshotPhases<Value>(
   client: Client,
   options: ReadOnlySnapshotOptions,
+  phaseRecorder: PreflightPhaseRecorder,
   body: (capabilities: PreflightCapabilities) => Promise<Value>,
 ): Promise<{
   readonly capabilities: PreflightCapabilities;
@@ -814,10 +956,31 @@ export async function withReadOnlySnapshot<Value>(
   });
   if (options.signal?.aborted) cancelInFlightQuery();
   try {
-    return await executeReadOnlySnapshotTransaction(client, options, body);
+    return await executeReadOnlySnapshotTransaction(
+      client,
+      options,
+      phaseRecorder,
+      body,
+    );
   } finally {
     options.signal?.removeEventListener("abort", cancelInFlightQuery);
   }
+}
+
+export async function withReadOnlySnapshot<Value>(
+  client: Client,
+  options: ReadOnlySnapshotOptions,
+  body: (capabilities: PreflightCapabilities) => Promise<Value>,
+): Promise<{
+  readonly capabilities: PreflightCapabilities;
+  readonly value: Value;
+}> {
+  return withReadOnlySnapshotPhases(
+    client,
+    options,
+    new PreflightPhaseRecorder(),
+    body,
+  );
 }
 
 function frameTuple(parts: readonly string[]): string {
@@ -1927,6 +2090,7 @@ export function classifyPreflightInventory(
   capabilities: PreflightCapabilities,
   inventory: PreflightInventory,
   options: PreflightClassificationOptions = {},
+  probe: PreflightProbeEvidence = emptyProbeEvidence(),
 ) {
   const expectedApprovedCount = options.expectedApprovedArtifactCount ?? 6;
   const expectedDanglingCount =
@@ -2018,6 +2182,7 @@ export function classifyPreflightInventory(
     danglingHeads,
     dependencies,
     launchSnapshots: launchSnapshots.output,
+    probe,
   };
   assertPreflightOutputShape(result);
   return result;
@@ -2040,15 +2205,20 @@ ORDER BY "compose"."id"
 async function collectDatabaseInventory(
   client: Client,
   signal: AbortSignal | undefined,
+  phaseRecorder: PreflightPhaseRecorder,
 ): Promise<PreflightInventory> {
   const danglingStart = await safeQuery<DanglingInventoryRow>(
     client,
     signal,
+    phaseRecorder,
+    "danglingStart",
     DANGLING_QUERY,
   );
   const identity = await safeQuery<IdentityInventoryRow>(
     client,
     signal,
+    phaseRecorder,
+    "identity",
     `SELECT
        coalesce("compose"."id", "agent"."id")::text AS "id",
        "compose"."id" IS NOT NULL AS "composePresent",
@@ -2079,6 +2249,8 @@ async function collectDatabaseInventory(
   const agentExecutionPlans = await safeQuery<AgentExecutionPlanInventoryRow>(
     client,
     signal,
+    phaseRecorder,
+    "agentExecutionPlans",
     `WITH "attributedRunActivity" AS (
        SELECT
          "session"."agent_compose_id" AS "agentComposeId",
@@ -2137,6 +2309,8 @@ async function collectDatabaseInventory(
   const versions = await safeQuery<VersionInventoryRow>(
     client,
     signal,
+    phaseRecorder,
+    "versions",
     `SELECT
        "version"."id",
        "version"."compose_id"::text AS "composeId",
@@ -2151,6 +2325,8 @@ async function collectDatabaseInventory(
   const heads = await safeQuery<HeadInventoryRow>(
     client,
     signal,
+    phaseRecorder,
+    "heads",
     `SELECT
        "compose"."id"::text AS "composeId",
        "compose"."head_version_id" AS "headVersionId",
@@ -2165,6 +2341,8 @@ async function collectDatabaseInventory(
   const runs = await safeQuery<RunInventoryRow>(
     client,
     signal,
+    phaseRecorder,
+    "runs",
     `SELECT
        "run"."id"::text AS "id",
        "run"."agent_compose_version_id" AS "versionId",
@@ -2205,9 +2383,11 @@ async function collectDatabaseInventory(
        ON "version"."id" = "run"."agent_compose_version_id"
      ORDER BY "run"."id"`,
   );
-  const checkpoints = await safeQuery<CheckpointInventoryRow>(
+  const checkpointCoreRows = await safeQuery<CheckpointCoreInventoryRow>(
     client,
     signal,
+    phaseRecorder,
+    "checkpointInventory",
     `SELECT
        "checkpoint"."id"::text AS "id",
        "checkpoint"."run_id"::text AS "runId",
@@ -2220,87 +2400,7 @@ async function collectDatabaseInventory(
          "conversation"."id" IS NOT NULL AND
          "conversation"."run_id" = "checkpoint"."run_id"
        ) AS "conversationReferenceValid",
-       (
-         "session"."id" IS NOT NULL AND
-         "session"."conversation_id" = "checkpoint"."conversation_id"
-       ) AS "sessionReferenceValid",
-       CASE
-         WHEN "checkpoint"."storage_mounts" IS NULL THEN true
-         WHEN jsonb_typeof("checkpoint"."storage_mounts") <> 'array'
-           THEN false
-         ELSE NOT EXISTS (
-           SELECT 1
-           FROM jsonb_array_elements("checkpoint"."storage_mounts")
-             AS "entry"("mount")
-           LEFT JOIN "storages" AS "storage"
-             ON "storage"."id"::text = "entry"."mount" ->> 'storageId'
-             AND "storage"."org_id" = "entry"."mount" ->> 'orgId'
-             AND "storage"."user_id" = "entry"."mount" ->> 'userId'
-             AND "storage"."name" = "entry"."mount" ->> 'name'
-           LEFT JOIN "storage_versions" AS "storage_version"
-             ON "storage_version"."id" = "entry"."mount" ->> 'version'
-             AND "storage_version"."storage_id" = "storage"."id"
-           WHERE
-             jsonb_typeof("entry"."mount") <> 'object' OR
-             NOT (
-               "entry"."mount" ?& ARRAY[
-                 'orgId',
-                 'userId',
-                 'name',
-                 'storageId',
-                 'version',
-                 'mountPath'
-               ]
-             ) OR
-             (
-               "entry"."mount" -
-               'orgId' -
-               'userId' -
-               'name' -
-               'storageId' -
-               'version' -
-               'mountPath' -
-               'optional' -
-               'writeback' -
-               'instructionsTargetFilename' -
-               'missingRootPolicy'
-             ) <> '{}'::jsonb OR
-             jsonb_typeof("entry"."mount" -> 'orgId') <> 'string' OR
-             jsonb_typeof("entry"."mount" -> 'userId') <> 'string' OR
-             jsonb_typeof("entry"."mount" -> 'name') <> 'string' OR
-             jsonb_typeof("entry"."mount" -> 'storageId') <> 'string' OR
-             jsonb_typeof("entry"."mount" -> 'version') <> 'string' OR
-             jsonb_typeof("entry"."mount" -> 'mountPath') <> 'string' OR
-             (
-               "entry"."mount" ? 'optional' AND
-               jsonb_typeof("entry"."mount" -> 'optional') <> 'boolean'
-             ) OR
-             (
-               "entry"."mount" ? 'writeback' AND
-               jsonb_typeof("entry"."mount" -> 'writeback') <> 'boolean'
-             ) OR
-             (
-               "entry"."mount" ? 'instructionsTargetFilename' AND
-               jsonb_typeof(
-                 "entry"."mount" -> 'instructionsTargetFilename'
-               ) <> 'string'
-             ) OR
-             (
-               "entry"."mount" ? 'missingRootPolicy' AND
-               (
-                 jsonb_typeof(
-                   "entry"."mount" -> 'missingRootPolicy'
-                 ) <> 'string' OR
-                 "entry"."mount" ->> 'missingRootPolicy' NOT IN (
-                   'fail',
-                   'preserveParentVersion'
-                 )
-               )
-             ) OR
-             "storage"."id" IS NULL OR
-             "storage_version"."id" IS NULL
-         )
-       END AS "storageReferenceValid"
+       "session"."id" IS NOT NULL AS "sessionReferenceValid"
      FROM "checkpoints" AS "checkpoint"
      LEFT JOIN "agent_runs" AS "run"
        ON "run"."id" = "checkpoint"."run_id"
@@ -2311,9 +2411,120 @@ async function collectDatabaseInventory(
      ORDER BY "checkpoint"."id"`,
     [CHECKPOINT_PRE_CUTOVER_BOUNDARY],
   );
+  const invalidCheckpointStorageReferences =
+    await safeQuery<InvalidCheckpointStorageReferenceRow>(
+      client,
+      signal,
+      phaseRecorder,
+      "checkpointStorageReferences",
+      `WITH "invalidCheckpointStorageReferences" AS (
+         SELECT "checkpoint"."id"
+         FROM "checkpoints" AS "checkpoint"
+         WHERE
+           "checkpoint"."storage_mounts" IS NOT NULL AND
+           jsonb_typeof("checkpoint"."storage_mounts") <> 'array'
+         UNION
+         SELECT "checkpoint"."id"
+         FROM "checkpoints" AS "checkpoint"
+         CROSS JOIN LATERAL jsonb_array_elements(
+           CASE
+             WHEN jsonb_typeof("checkpoint"."storage_mounts") = 'array'
+               THEN "checkpoint"."storage_mounts"
+             ELSE '[]'::jsonb
+           END
+         ) AS "entry"("mount")
+         LEFT JOIN "storages" AS "storage"
+           ON "storage"."id"::text = "entry"."mount" ->> 'storageId'
+             AND "storage"."org_id" = "entry"."mount" ->> 'orgId'
+             AND "storage"."user_id" = "entry"."mount" ->> 'userId'
+             AND "storage"."name" = "entry"."mount" ->> 'name'
+         LEFT JOIN "storage_versions" AS "storage_version"
+           ON "storage_version"."id" = "entry"."mount" ->> 'version'
+           AND "storage_version"."storage_id" = "storage"."id"
+         WHERE
+           jsonb_typeof("entry"."mount") <> 'object' OR
+           NOT (
+             "entry"."mount" ?& ARRAY[
+               'orgId',
+               'userId',
+               'name',
+               'storageId',
+               'version',
+               'mountPath'
+             ]
+           ) OR
+           (
+             "entry"."mount" -
+             'orgId' -
+             'userId' -
+             'name' -
+             'storageId' -
+             'version' -
+             'mountPath' -
+             'optional' -
+             'writeback' -
+             'instructionsTargetFilename' -
+             'missingRootPolicy'
+           ) <> '{}'::jsonb OR
+           jsonb_typeof("entry"."mount" -> 'orgId') <> 'string' OR
+           jsonb_typeof("entry"."mount" -> 'userId') <> 'string' OR
+           jsonb_typeof("entry"."mount" -> 'name') <> 'string' OR
+           jsonb_typeof("entry"."mount" -> 'storageId') <> 'string' OR
+           jsonb_typeof("entry"."mount" -> 'version') <> 'string' OR
+           jsonb_typeof("entry"."mount" -> 'mountPath') <> 'string' OR
+           (
+             "entry"."mount" ? 'optional' AND
+             jsonb_typeof("entry"."mount" -> 'optional') <> 'boolean'
+           ) OR
+           (
+             "entry"."mount" ? 'writeback' AND
+             jsonb_typeof("entry"."mount" -> 'writeback') <> 'boolean'
+           ) OR
+           (
+             "entry"."mount" ? 'instructionsTargetFilename' AND
+             jsonb_typeof(
+               "entry"."mount" -> 'instructionsTargetFilename'
+             ) <> 'string'
+           ) OR
+           (
+             "entry"."mount" ? 'missingRootPolicy' AND
+             (
+               jsonb_typeof(
+                 "entry"."mount" -> 'missingRootPolicy'
+               ) <> 'string' OR
+               "entry"."mount" ->> 'missingRootPolicy' NOT IN (
+                 'fail',
+                 'preserveParentVersion'
+               )
+             )
+           ) OR
+           "storage"."id" IS NULL OR
+           "storage_version"."id" IS NULL
+       )
+       SELECT "invalid"."id"::text AS "id"
+       FROM "invalidCheckpointStorageReferences" AS "invalid"
+       ORDER BY "invalid"."id"`,
+    );
+  const invalidCheckpointStorageReferenceIds = new Set(
+    invalidCheckpointStorageReferences.map((row) => {
+      return row.id;
+    }),
+  );
+  const checkpoints: CheckpointInventoryRow[] = checkpointCoreRows.map(
+    (row) => {
+      return {
+        ...row,
+        storageReferenceValid: !invalidCheckpointStorageReferenceIds.has(
+          row.id,
+        ),
+      };
+    },
+  );
   const conversations = await safeQuery<ConversationInventoryRow>(
     client,
     signal,
+    phaseRecorder,
+    "conversations",
     `SELECT
        "conversation"."run_id"::text AS "runId",
        "conversation"."cli_agent_type" AS "framework"
@@ -2323,11 +2534,15 @@ async function collectDatabaseInventory(
   const catalogDependencies = await safeQuery<CatalogDependencyRow>(
     client,
     signal,
+    phaseRecorder,
+    "catalogDependencies",
     CATALOG_DEPENDENCY_QUERY,
   );
   const danglingEnd = await safeQuery<DanglingInventoryRow>(
     client,
     signal,
+    phaseRecorder,
+    "danglingEnd",
     DANGLING_QUERY,
   );
   return {
@@ -2352,54 +2567,110 @@ export async function executeAgentComposeConsolidationPreflight(args: {
   readonly lockTimeoutMs?: number;
   readonly statementTimeoutMs?: number;
 }) {
+  const phaseRecorder = new PreflightPhaseRecorder();
   let repositoryDependencies: RepositoryDependencyManifest;
   let runtimeContentConsumers: RuntimeContentConsumerManifest;
   try {
-    [repositoryDependencies, runtimeContentConsumers] = await Promise.all([
-      collectRepositoryDependencyManifest(args.repositoryRoot),
-      collectRuntimeContentConsumerManifest(args.repositoryRoot),
-    ]);
+    [repositoryDependencies, runtimeContentConsumers] =
+      await phaseRecorder.measure("repositoryInventory", async () => {
+        return Promise.all([
+          collectRepositoryDependencyManifest(args.repositoryRoot),
+          collectRuntimeContentConsumerManifest(args.repositoryRoot),
+        ]);
+      });
   } catch (error) {
-    classifyThrownError(error, "probe.repository_inventory");
+    classifyThrownError(
+      error,
+      "probe.repository_inventory",
+      phaseRecorder.evidence(),
+    );
   }
 
   const client = new Client({ connectionString: args.connectionString });
   client.on("error", () => {});
   try {
-    await client.connect();
+    await phaseRecorder.measure("databaseConnection", async () => {
+      return client.connect();
+    });
   } catch (error) {
-    classifyThrownError(error, "probe.database_connection");
+    classifyThrownError(
+      error,
+      "probe.database_connection",
+      phaseRecorder.evidence(),
+    );
   }
 
   try {
-    const snapshot = await withReadOnlySnapshot(
+    const snapshot = await withReadOnlySnapshotPhases(
       client,
       {
         signal: args.signal,
         lockTimeoutMs: args.lockTimeoutMs,
         statementTimeoutMs: args.statementTimeoutMs,
       },
+      phaseRecorder,
       async () => {
-        return collectDatabaseInventory(client, args.signal);
+        return collectDatabaseInventory(client, args.signal, phaseRecorder);
       },
     );
-    return classifyPreflightInventory(snapshot.capabilities, snapshot.value, {
-      ...args.classification,
-      observedRepositoryDependencies: repositoryDependencies,
-      observedRuntimeContentConsumers: runtimeContentConsumers,
-    });
+    const classified = await phaseRecorder.measure(
+      "classification",
+      async () => {
+        return classifyPreflightInventory(
+          snapshot.capabilities,
+          snapshot.value,
+          {
+            ...args.classification,
+            observedRepositoryDependencies: repositoryDependencies,
+            observedRuntimeContentConsumers: runtimeContentConsumers,
+          },
+          phaseRecorder.evidence(),
+        );
+      },
+    );
+    const result = { ...classified, probe: phaseRecorder.evidence() };
+    assertPreflightOutputShape(result);
+    return result;
   } catch (error) {
-    classifyThrownError(error, "probe.inventory");
+    classifyThrownError(error, "probe.inventory", phaseRecorder.evidence());
   } finally {
     await client.end().catch(() => {});
   }
+}
+
+function isSafeProbeEvidence(
+  value: PreflightProbeEvidence | undefined,
+): value is PreflightProbeEvidence {
+  if (
+    !value ||
+    !["none", "unknown", ...PREFLIGHT_PHASES].includes(value.failurePhase)
+  ) {
+    return false;
+  }
+  const durationEntries = Object.entries(value.phaseDurationsMs);
+  return (
+    durationEntries.length === PREFLIGHT_PHASES.length &&
+    PREFLIGHT_PHASES.every((phase) => {
+      const duration = value.phaseDurationsMs[phase];
+      return (
+        Number.isSafeInteger(duration) &&
+        duration >= 0 &&
+        duration <= MAX_REPORTED_PHASE_DURATION_MS
+      );
+    })
+  );
 }
 
 export function sanitizedFailureResult(error: unknown): {
   readonly schemaVersion: string;
   readonly status: "failed";
   readonly failureGates: readonly string[];
+  readonly probe: PreflightProbeEvidence;
 } {
+  const probe =
+    error instanceof SanitizedPreflightError && isSafeProbeEvidence(error.probe)
+      ? error.probe
+      : emptyProbeEvidence("unknown");
   return {
     schemaVersion: PREFLIGHT_SCHEMA_VERSION,
     status: "failed",
@@ -2408,6 +2679,7 @@ export function sanitizedFailureResult(error: unknown): {
         ? error.gate
         : "probe.unexpected",
     ],
+    probe,
   };
 }
 
@@ -2415,7 +2687,7 @@ async function runCli(): Promise<void> {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
     process.stdout.write(
-      `${JSON.stringify(sanitizedFailureResult(new SanitizedPreflightError("probe.configuration")))}\n`,
+      `${JSON.stringify(sanitizedFailureResult(new SanitizedPreflightError("probe.configuration", emptyProbeEvidence("configuration"))))}\n`,
     );
     process.exitCode = 1;
     return;

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -52,6 +52,7 @@ import {
 import { validateCheckpointAgentComposeSnapshotNullableStatic } from "./test-checkpoint-agent-compose-snapshot-nullable";
 import {
   PREFLIGHT_OUTPUT_ALLOWLIST,
+  PREFLIGHT_PHASES,
   SanitizedPreflightError,
   assertPreflightOutputShape,
   classifyPreflightInventory,
@@ -572,6 +573,7 @@ function testSchemaV4OutputContractRemainsByteStable(): void {
   const acceptedV4Paths = PREFLIGHT_OUTPUT_ALLOWLIST.filter((outputPath) => {
     return (
       !outputPath.startsWith("checkpoints.transition.") &&
+      !outputPath.startsWith("probe.") &&
       !outputPath.includes(".historicalProductBuilderOrigin.") &&
       !outputPath.includes(".applicationHistoricalProductBuilderEnvironment.")
     );
@@ -603,6 +605,7 @@ function testSchemaV5OutputContractRemainsByteStable(): void {
   const acceptedV5Paths = PREFLIGHT_OUTPUT_ALLOWLIST.filter((outputPath) => {
     return (
       !outputPath.startsWith("checkpoints.transition.") &&
+      !outputPath.startsWith("probe.") &&
       !v6Markers.some((marker) => {
         return outputPath.includes(marker);
       })
@@ -624,7 +627,10 @@ function testSchemaV5OutputContractRemainsByteStable(): void {
 /** Transition-only #28080 contract test; removed by #26938 Stage 8. */
 function testSchemaV6OutputContractRemainsByteStable(): void {
   const acceptedV6Paths = PREFLIGHT_OUTPUT_ALLOWLIST.filter((outputPath) => {
-    return !outputPath.startsWith("checkpoints.transition.");
+    return (
+      !outputPath.startsWith("checkpoints.transition.") &&
+      !outputPath.startsWith("probe.")
+    );
   });
   assert.deepEqual(
     fingerprintSortedSet(
@@ -3100,6 +3106,7 @@ function testOutputRedaction(): void {
     "danglingHeads",
     "dependencies",
     "launchSnapshots",
+    "probe",
   ]);
   assert.deepEqual(outputPaths(result), [...PREFLIGHT_OUTPUT_ALLOWLIST]);
   assertSafeAggregateValues(result);
@@ -3117,11 +3124,23 @@ function testOutputRedaction(): void {
     },
     (error: unknown) => {
       assert.ok(error instanceof SanitizedPreflightError);
-      assert.deepEqual(sanitizedFailureResult(error), {
-        schemaVersion: "vm0.agent-compose-consolidation-preflight.v7",
-        status: "failed",
-        failureGates: ["probe.output_shape"],
-      });
+      const sanitized = sanitizedFailureResult(error);
+      assert.equal(
+        sanitized.schemaVersion,
+        "vm0.agent-compose-consolidation-preflight.v7",
+      );
+      assert.equal(sanitized.status, "failed");
+      assert.deepEqual(sanitized.failureGates, ["probe.output_shape"]);
+      assert.equal(sanitized.probe.failurePhase, "unknown");
+      assert.deepEqual(Object.keys(sanitized.probe.phaseDurationsMs), [
+        ...PREFLIGHT_PHASES,
+      ]);
+      assert.deepEqual(
+        Object.values(sanitized.probe.phaseDurationsMs),
+        PREFLIGHT_PHASES.map(() => {
+          return 0;
+        }),
+      );
       assert.equal(
         JSON.stringify(sanitizedFailureResult(error)).includes(
           "never-emit-invalid-output-value",
@@ -3152,6 +3171,9 @@ function assertSafeAggregateValues(value: unknown, pathPrefix = ""): void {
   }
   if (typeof value === "number") {
     assert.equal(Number.isSafeInteger(value) && value >= 0, true);
+    if (pathPrefix.startsWith("probe.phaseDurationsMs.")) {
+      assert.ok(value <= 30_000);
+    }
     return;
   }
   if (typeof value === "boolean") return;
@@ -3169,6 +3191,9 @@ function assertSafeAggregateValues(value: unknown, pathPrefix = ""): void {
     "stable",
     "supported",
     "repeatable read",
+    "none",
+    "unknown",
+    ...PREFLIGHT_PHASES,
   ]);
   assert.equal(allowedClassifications.has(value as string), true);
 }
@@ -3625,7 +3650,12 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
   );
   assert.ok(inventoryStart >= 0 && inventoryEnd > inventoryStart);
   const inventorySource = preflightSource.slice(inventoryStart, inventoryEnd);
-  assert.equal(inventorySource.match(/safeQuery</gu)?.length, 10);
+  assert.equal(inventorySource.match(/safeQuery</gu)?.length, 11);
+  assert.match(inventorySource, /"checkpointStorageReferences"/u);
+  assert.match(
+    inventorySource,
+    /WITH "invalidCheckpointStorageReferences" AS \([\s\S]*CROSS JOIN LATERAL jsonb_array_elements/u,
+  );
 
   const historicalClassifierPath = path.join(
     repositoryRoot,
@@ -3824,7 +3854,17 @@ async function testDatabaseBoundariesForTimeZone(
         classification: executionOptions,
       });
       assert.equal(first.status, "passed");
-      assert.deepEqual(second, first);
+      const { probe: firstProbe, ...firstWithoutProbe } = first;
+      const { probe: secondProbe, ...secondWithoutProbe } = second;
+      assert.deepEqual(secondWithoutProbe, firstWithoutProbe);
+      assert.equal(firstProbe.failurePhase, "none");
+      assert.equal(secondProbe.failurePhase, "none");
+      assert.deepEqual(Object.keys(firstProbe.phaseDurationsMs), [
+        ...PREFLIGHT_PHASES,
+      ]);
+      assert.deepEqual(Object.keys(secondProbe.phaseDurationsMs), [
+        ...PREFLIGHT_PHASES,
+      ]);
 
       await withReadOnlySnapshot(client, {}, async () => {
         await assert.rejects(
@@ -4114,15 +4154,18 @@ async function testDatabaseBoundariesForTimeZone(
           readonly checkpointId: string;
         },
         checkpointCreatedAt: string,
+        createSession = true,
       ): Promise<void> => {
-        await client.query(
-          `INSERT INTO "agent_sessions" (
-             "id", "user_id", "org_id", "agent_compose_id"
-           ) VALUES (
-             $1, 'exercising-agent-user', 'exercising-agent-org', $2
-           )`,
-          [ids.sessionId, exercisingAgentId],
-        );
+        if (createSession) {
+          await client.query(
+            `INSERT INTO "agent_sessions" (
+               "id", "user_id", "org_id", "agent_compose_id"
+             ) VALUES (
+               $1, 'exercising-agent-user', 'exercising-agent-org', $2
+             )`,
+            [ids.sessionId, exercisingAgentId],
+          );
+        }
         await client.query(
           `INSERT INTO "agent_runs" (
              "id", "user_id", "org_id", "session_id", "status", "prompt",
@@ -4289,6 +4332,227 @@ async function testDatabaseBoundariesForTimeZone(
          WHERE "id" = $2`,
         [sharedVersionId, lineageSurvivor.checkpointId],
       );
+
+      const continuationSessionId = "00000000-0000-4000-8000-000000027643";
+      const earlierContinuation = {
+        sessionId: continuationSessionId,
+        runId: "00000000-0000-4000-8000-000000027644",
+        conversationId: "00000000-0000-4000-8000-000000027645",
+        checkpointId: "00000000-0000-4000-8000-000000027646",
+      } as const;
+      const latestContinuation = {
+        sessionId: continuationSessionId,
+        runId: "00000000-0000-4000-8000-000000027647",
+        conversationId: "00000000-0000-4000-8000-000000027648",
+        checkpointId: "00000000-0000-4000-8000-000000027649",
+      } as const;
+      await insertCheckpointLineageRun(
+        earlierContinuation,
+        "2026-08-19 01:00:02.000000",
+      );
+      await insertCheckpointLineageRun(
+        latestContinuation,
+        "2026-08-19 01:00:03.000000",
+        false,
+      );
+      const multiContinuation = await executeAgentComposeConsolidationPreflight(
+        {
+          connectionString: testUrl,
+          repositoryRoot,
+          classification: {
+            ...executionOptions,
+            expectedDanglingHeadCount: 1,
+          },
+        },
+      );
+      assert.equal(
+        multiContinuation.checkpoints.transition.sessionReferenceClosure
+          .classification,
+        "exact",
+      );
+      assert.equal(
+        multiContinuation.checkpoints.transition.conversationReferenceClosure
+          .classification,
+        "exact",
+      );
+      assert.equal(
+        multiContinuation.checkpoints.transition.legacySnapshotLineage
+          .classification,
+        "exact",
+      );
+
+      await client.query(
+        `UPDATE "checkpoints" SET "conversation_id" = $1 WHERE "id" = $2`,
+        [latestContinuation.conversationId, earlierContinuation.checkpointId],
+      );
+      const mismatchedConversation =
+        await executeAgentComposeConsolidationPreflight({
+          connectionString: testUrl,
+          repositoryRoot,
+          classification: {
+            ...executionOptions,
+            expectedDanglingHeadCount: 1,
+          },
+        });
+      gatePresent(mismatchedConversation, "checkpoints.conversation_reference");
+      assert.equal(
+        mismatchedConversation.checkpoints.transition.sessionReferenceClosure
+          .classification,
+        "exact",
+      );
+      await client.query(
+        `UPDATE "checkpoints" SET "conversation_id" = $1 WHERE "id" = $2`,
+        [earlierContinuation.conversationId, earlierContinuation.checkpointId],
+      );
+
+      // Normal Session deletion cascades through Runs and checkpoints. Bypass
+      // those FK triggers only in this isolated database to prove that a
+      // catalog-corrupt dangling Run still fails the Session closure.
+      await client.query(`SET session_replication_role = 'replica'`);
+      try {
+        const deletedSession = await client.query(
+          `DELETE FROM "agent_sessions" WHERE "id" = $1`,
+          [continuationSessionId],
+        );
+        assert.equal(deletedSession.rowCount, 1);
+      } finally {
+        await client.query(`RESET session_replication_role`);
+      }
+      const missingSession = await executeAgentComposeConsolidationPreflight({
+        connectionString: testUrl,
+        repositoryRoot,
+        classification: {
+          ...executionOptions,
+          expectedDanglingHeadCount: 1,
+        },
+      });
+      gatePresent(missingSession, "checkpoints.session_reference");
+      assert.equal(
+        missingSession.checkpoints.transition.conversationReferenceClosure
+          .classification,
+        "exact",
+      );
+      await client.query(
+        `INSERT INTO "agent_sessions" (
+           "id", "user_id", "org_id", "agent_compose_id", "conversation_id"
+         ) VALUES (
+           $1, 'exercising-agent-user', 'exercising-agent-org', $2, $3
+         )`,
+        [
+          continuationSessionId,
+          exercisingAgentId,
+          latestContinuation.conversationId,
+        ],
+      );
+
+      const storageId = "00000000-0000-4000-8000-000000027650";
+      const storageVersionId = "e".repeat(64);
+      const storageMount = {
+        orgId: "exercising-agent-org",
+        userId: "exercising-agent-user",
+        name: "checkpoint-storage",
+        storageId,
+        version: storageVersionId,
+        mountPath: "/home/oai/share/checkpoint-storage",
+      } as const;
+      await client.query(
+        `INSERT INTO "storages" (
+           "id", "user_id", "name", "org_id", "s3_prefix"
+         ) VALUES ($1, $2, $3, $4, 'checkpoint-storage-prefix')`,
+        [storageId, storageMount.userId, storageMount.name, storageMount.orgId],
+      );
+      await client.query(
+        `INSERT INTO "storage_versions" (
+           "id", "storage_id", "s3_key", "archive_size", "created_by"
+         ) VALUES ($1, $2, 'checkpoint-storage-key', 0, $3)`,
+        [storageVersionId, storageId, storageMount.userId],
+      );
+      await client.query(
+        `UPDATE "checkpoints" SET "storage_mounts" = $1::jsonb
+         WHERE "id" = $2`,
+        [JSON.stringify([storageMount]), latestContinuation.checkpointId],
+      );
+      const validStorageReference =
+        await executeAgentComposeConsolidationPreflight({
+          connectionString: testUrl,
+          repositoryRoot,
+          classification: {
+            ...executionOptions,
+            expectedDanglingHeadCount: 1,
+          },
+        });
+      assert.equal(
+        validStorageReference.checkpoints.transition.storageReferenceClosure
+          .classification,
+        "exact",
+      );
+
+      await client.query(
+        `UPDATE "checkpoints" SET "storage_mounts" = $1::jsonb
+         WHERE "id" = $2`,
+        [
+          JSON.stringify([{ ...storageMount, version: "f".repeat(64) }]),
+          latestContinuation.checkpointId,
+        ],
+      );
+      const missingStorageVersion =
+        await executeAgentComposeConsolidationPreflight({
+          connectionString: testUrl,
+          repositoryRoot,
+          classification: {
+            ...executionOptions,
+            expectedDanglingHeadCount: 1,
+          },
+        });
+      gatePresent(missingStorageVersion, "checkpoints.storage_reference");
+      await client.query(
+        `UPDATE "checkpoints" SET "storage_mounts" = $1::jsonb
+         WHERE "id" = $2`,
+        [JSON.stringify([storageMount]), latestContinuation.checkpointId],
+      );
+
+      await writer.query("BEGIN");
+      try {
+        await writer.query(`LOCK TABLE "storages" IN ACCESS EXCLUSIVE MODE`);
+        await assert.rejects(
+          executeAgentComposeConsolidationPreflight({
+            connectionString: testUrl,
+            repositoryRoot,
+            classification: {
+              ...executionOptions,
+              expectedDanglingHeadCount: 1,
+            },
+            statementTimeoutMs: 250,
+          }),
+          (error: unknown) => {
+            const failure = sanitizedFailureResult(error);
+            assert.deepEqual(failure.failureGates, ["probe.statement_timeout"]);
+            assert.equal(
+              failure.probe.failurePhase,
+              "checkpointStorageReferences",
+            );
+            assert.ok(
+              failure.probe.phaseDurationsMs.checkpointStorageReferences > 0,
+            );
+            assert.equal(failure.probe.phaseDurationsMs.conversations, 0);
+            const serializedFailure = JSON.stringify(failure);
+            for (const forbidden of [
+              storageId,
+              latestContinuation.runId,
+              latestContinuation.conversationId,
+              latestContinuation.checkpointId,
+              "checkpoint-storage",
+              "postgresql://",
+              "2026-08-19",
+            ]) {
+              assert.equal(serializedFailure.includes(forbidden), false);
+            }
+            return true;
+          },
+        );
+      } finally {
+        await writer.query("ROLLBACK");
+      }
 
       const baselineCatalog = await catalogRows(client);
       for (const kind of CATALOG_DEPENDENCY_KINDS) {

--- a/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
+++ b/turbo/packages/db/scripts/test-agent-compose-consolidation-preflight.ts
@@ -3610,6 +3610,35 @@ async function testRepositoryAndWorkflowValidators(): Promise<void> {
     /#27613 \+ #27656 \+ #27671 \+ #27792 \+ #28056 \+ #28070 \+ #28080/u,
   );
   assert.match(workflow, /vm0\.agent-compose-consolidation-preflight\.v7/u);
+  const databaseResolutionFailurePayloads = [
+    ...workflow.matchAll(/database_resolution_failure='([^'\n]+)'/gu),
+  ];
+  assert.equal(databaseResolutionFailurePayloads.length, 1);
+  const databaseResolutionFailurePayload =
+    databaseResolutionFailurePayloads[0]?.[1];
+  assert.ok(databaseResolutionFailurePayload);
+  const parsedDatabaseResolutionFailure: unknown = JSON.parse(
+    databaseResolutionFailurePayload,
+  );
+  const canonicalDatabaseResolutionFailure = sanitizedFailureResult(
+    new SanitizedPreflightError("probe.database_resolution", {
+      failurePhase: "configuration",
+      phaseDurationsMs: Object.fromEntries(
+        PREFLIGHT_PHASES.map((phase) => {
+          return [phase, 0] as const;
+        }),
+      ) as Record<(typeof PREFLIGHT_PHASES)[number], number>,
+    }),
+  );
+  assert.deepEqual(
+    parsedDatabaseResolutionFailure,
+    canonicalDatabaseResolutionFailure,
+  );
+  assert.equal(
+    workflow.match(/^\s+printf '%s\\n' "\$database_resolution_failure"$/gmu)
+      ?.length,
+    2,
+  );
   assert.equal(
     /vm0\.agent-compose-consolidation-preflight\.v[1-6]/u.test(workflow),
     false,


### PR DESCRIPTION
Issue #28080
Parent #26938

## Summary

- split the protected checkpoint preflight into timed, bounded phases and report only fixed phase names plus capped millisecond durations
- align both database-resolution workflow failure stubs with the canonical v7 probe payload and verify their shared redacted shape
- validate checkpoint Storage closure with one set-based expansion and joins so the aggregate-only read-only preflight remains within the existing 30-second statement bound
- treat Session closure as Session existence while continuing to require exact checkpoint Conversation-to-Run closure
- cover multiple continuation checkpoints on one Session, missing Session, mismatched checkpoint Conversation/Run, Storage closure, and deterministic statement-timeout redaction in both UTC and Asia/Shanghai

## Diagnosis

The protected v6 preflight completed against 131,986 checkpoints, while both protected v7 runs failed closed with only `probe.statement_timeout`. The v7 change had added the checkpoint Storage validation as a correlated per-checkpoint lookup inside the checkpoint inventory query. A local production-scale synthetic fixture (132,719 checkpoints with mounts) reproduced the old shape exceeding a reduced bound; the final set-based expansion/hash-join shape completed in about 0.30 seconds.

The fixed phase telemetry identifies the failing query on future attempts without exposing IDs, timestamps, snapshot content, Storage data, or connection details.

## Safety and compatibility

- retains repeatable-read, read-only execution, the 1-second lock timeout, and the 30-second per-statement timeout
- retains survivor lineage, launch-history completeness for NULL snapshots, transition partition/disjointness/union checks, and exact Run/Conversation/Storage closure
- leaves checkpoint application writes and migration 0949 unchanged
- preserves historical non-null snapshot bytes and the rolling fallback where old code can write snapshots, new code writes NULL, and rollback code can write snapshots again
- does not run the production preflight or perform production writes
- deliberately does not close #28080; controller production acceptance remains outstanding

## Verification

- `pnpm --filter @okouai/db check-types`
- `pnpm --filter @okouai/db lint`
- `pnpm exec prettier --check ../.github/workflows/agent-compose-consolidation-preflight.yml packages/db/scripts/agent-compose-consolidation-preflight.ts packages/db/scripts/test-agent-compose-consolidation-preflight.ts`
- static preflight and workflow contract validator, including both database-resolution failure stubs
- full DB-backed preflight validator, including UTC and Asia/Shanghai membership equivalence
- exact migration-0949 nullability validator
- `git diff --check origin/main...HEAD`
