### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -112,8 +112,8 @@ ROOTFS_DIR=""
 CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
-GO_VERSION="1.26.6"
-CLAUDE_CODE_VERSION="2.1.235"
+GO_VERSION="1.26.7"
+CLAUDE_CODE_VERSION="2.1.237"
 CODEX_CLI_VERSION="0.148.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"


### PR DESCRIPTION
## Summary
Updates pinned package versions in `crates/runner/scripts/build-template.sh`.

## Updated
- Go: `1.26.6` → `1.26.7`
- Claude Code CLI: `2.1.235` → `2.1.237`

## Verified already latest (no change)
- Codex CLI: `0.148.0`
- Google Workspace CLI: `0.22.5`
- xurl: `1.3.1`
- agent-browser: `0.33.0-vm0.1`
- pnpm: `11.22.0`
- Chromium (bookworm-security): `151.0.7922.137-1~deb12u1`

## Notes
- Ubuntu base (`noble`) intentionally left unchanged.
- Claude Code `2.1.237` manifest confirmed to include `linux-x64` and `linux-arm64` platforms.
- Go `1.26.7` tarballs confirmed for `linux-amd64` and `linux-arm64`.