### PR TITLE
fix(teams): carry the oauth redirect uri in state and emit the final callback

### DIFF
--- a/turbo/apps/api/src/signals/route-entry.ts
+++ b/turbo/apps/api/src/signals/route-entry.ts
@@ -43,8 +43,9 @@ function routeEntryWithPath(entry: RouteEntry, path: string): RouteEntry {
  * webhooks join `/api/webhooks/**` beside the other providers.
  *
  * Step 1 only makes these paths routable: each one adds a second way to reach
- * the handler that already serves its branded path. No producer emits a final
- * URL yet, so switching them is #28278 step 3, after the consoles are updated.
+ * the handler that already serves its branded path. Producers switch one at a
+ * time in #28278 step 3, once the provider console holds the final URL; the
+ * Teams OAuth callback switched in #28300.
  */
 const FINAL_PROVIDER_CONSOLE_PATHS: Readonly<Record<string, string>> = {
   "GET /api/okou/slack/oauth/callback":

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -176,11 +176,13 @@ describe("Teams OAuth API routes", () => {
     const state = JSON.parse(redirectUrl.searchParams.get("state")!) as {
       readonly orgId: string;
       readonly publicBrand: string;
+      readonly redirectUri: string;
       readonly userId: string;
     };
     expect(state).toStrictEqual({
       orgId: "org_1",
       publicBrand: "vm0",
+      redirectUri: `${API_ORIGIN}/api/zero/teams/oauth/callback`,
       userId: "user_1",
     });
   });
@@ -249,6 +251,62 @@ describe("Teams OAuth API routes", () => {
       connectUrl: null,
       tenantId: fixture.teamsTenantId,
     });
+  });
+
+  it("exchanges the code with the redirect URI recorded in the connect state", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    await seedMembership(fixture.orgId, fixture.userId, "admin");
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const recordedRedirectUri =
+      "https://pr-1-api.vm7.ai/api/zero/teams/oauth/callback";
+    mockMicrosoftOAuth({
+      tenantId: fixture.teamsTenantId,
+      aadObjectId: fixture.teamsAadObjectId,
+      userPrincipalName: fixture.teamsUserPrincipalName,
+      expectedRedirectUri: recordedRedirectUri,
+    });
+
+    const response = await appRequest(
+      callbackPath({
+        code: "valid-code",
+        state: {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          redirectUri: recordedRedirectUri,
+        },
+      }),
+      { origin: API_ORIGIN },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain(
+      `${APP_ORIGIN}/settings/teams?status=connected`,
+    );
+  });
+
+  it("falls back to the legacy callback URI for state without a redirect URI", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    await seedMembership(fixture.orgId, fixture.userId, "admin");
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    mockMicrosoftOAuth({
+      tenantId: fixture.teamsTenantId,
+      aadObjectId: fixture.teamsAadObjectId,
+      userPrincipalName: fixture.teamsUserPrincipalName,
+      expectedRedirectUri: `${API_ORIGIN}/api/zero/teams/oauth/callback`,
+    });
+
+    const response = await appRequest(
+      callbackPath({
+        code: "valid-code",
+        state: { orgId: fixture.orgId, userId: fixture.userId },
+      }),
+      { origin: API_ORIGIN },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain(
+      `${APP_ORIGIN}/settings/teams?status=connected`,
+    );
   });
 
   it("rejects OAuth users when the org is already bound to another Microsoft tenant", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -24,6 +24,7 @@ const context = testContext();
 const mocks = createRouteMocks(context);
 const store = createStore();
 const API_ORIGIN = "https://api.vm0.ai";
+const OKOU_API_ORIGIN = "https://api.okou.ai";
 const WEB_ORIGIN = "https://www.vm0.ai";
 const APP_ORIGIN = "https://app.vm0.test";
 const MICROSOFT_TOKEN_URL =
@@ -168,7 +169,7 @@ describe("Teams OAuth API routes", () => {
       "test-microsoft-client-id",
     );
     expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-      `${API_ORIGIN}/api/zero/teams/oauth/callback`,
+      `${API_ORIGIN}/api/integrations/teams/oauth/callback`,
     );
     expect(redirectUrl.searchParams.get("scope")).toBe(
       "openid profile email User.Read",
@@ -182,7 +183,7 @@ describe("Teams OAuth API routes", () => {
     expect(state).toStrictEqual({
       orgId: "org_1",
       publicBrand: "vm0",
-      redirectUri: `${API_ORIGIN}/api/zero/teams/oauth/callback`,
+      redirectUri: `${API_ORIGIN}/api/integrations/teams/oauth/callback`,
       userId: "user_1",
     });
   });
@@ -199,8 +200,29 @@ describe("Teams OAuth API routes", () => {
       "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     );
     expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-      `${API_ORIGIN}/api/zero/teams/oauth/callback`,
+      `${API_ORIGIN}/api/integrations/teams/oauth/callback`,
     );
+  });
+
+  it("projects the callback origin onto the Okou brand host", async () => {
+    const response = await appRequest(
+      "/api/zero/teams/oauth/connect?orgId=org_1&userId=user_1",
+      { origin: OKOU_API_ORIGIN },
+    );
+
+    expect(response.status).toBe(307);
+    const redirectUrl = new URL(response.headers.get("location")!);
+    expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
+      `${OKOU_API_ORIGIN}/api/integrations/teams/oauth/callback`,
+    );
+    const state = JSON.parse(redirectUrl.searchParams.get("state")!) as {
+      readonly publicBrand: string;
+      readonly redirectUri: string;
+    };
+    expect(state).toMatchObject({
+      publicBrand: "okou",
+      redirectUri: `${OKOU_API_ORIGIN}/api/integrations/teams/oauth/callback`,
+    });
   });
 
   it("rejects connect requests without org and user state", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -169,7 +169,7 @@ describe("Teams OAuth API routes", () => {
       "test-microsoft-client-id",
     );
     expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-      `${API_ORIGIN}/api/integrations/teams/oauth/callback`,
+      `${API_ORIGIN}/api/zero/teams/oauth/callback`,
     );
     expect(redirectUrl.searchParams.get("scope")).toBe(
       "openid profile email User.Read",
@@ -183,7 +183,7 @@ describe("Teams OAuth API routes", () => {
     expect(state).toStrictEqual({
       orgId: "org_1",
       publicBrand: "vm0",
-      redirectUri: `${API_ORIGIN}/api/integrations/teams/oauth/callback`,
+      redirectUri: `${API_ORIGIN}/api/zero/teams/oauth/callback`,
       userId: "user_1",
     });
   });
@@ -200,7 +200,7 @@ describe("Teams OAuth API routes", () => {
       "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     );
     expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
-      `${API_ORIGIN}/api/integrations/teams/oauth/callback`,
+      `${API_ORIGIN}/api/zero/teams/oauth/callback`,
     );
   });
 
@@ -222,6 +222,30 @@ describe("Teams OAuth API routes", () => {
     expect(state).toMatchObject({
       publicBrand: "okou",
       redirectUri: `${OKOU_API_ORIGIN}/api/integrations/teams/oauth/callback`,
+    });
+  });
+
+  // api.vm0.ai and /api/zero/** retire together, so the VM0 brand never moves
+  // to the canonical namespace. Pin the exact registered value as a literal:
+  // a refactor that moves it off this string breaks Microsoft's allowlist.
+  it("leaves the VM0 brand authorization URI on the registered legacy value", async () => {
+    const response = await appRequest(
+      "/api/zero/teams/oauth/connect?orgId=org_1&userId=user_1",
+      { origin: API_ORIGIN },
+    );
+
+    expect(response.status).toBe(307);
+    const redirectUrl = new URL(response.headers.get("location")!);
+    const state = JSON.parse(redirectUrl.searchParams.get("state")!) as {
+      readonly publicBrand: string;
+      readonly redirectUri: string;
+    };
+    expect(redirectUrl.searchParams.get("redirect_uri")).toBe(
+      "https://api.vm0.ai/api/zero/teams/oauth/callback",
+    );
+    expect(state).toMatchObject({
+      publicBrand: "vm0",
+      redirectUri: "https://api.vm0.ai/api/zero/teams/oauth/callback",
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/teams-oauth.ts
@@ -172,19 +172,30 @@ function parseOAuthState(state: string | undefined): OAuthState | null {
 }
 
 /**
- * The Microsoft app registration holds the brand-projected final path. Project
- * here rather than in `getOAuthApiOrigin`, whose other caller builds the
- * built-in connector callback that is already registered with every provider.
+ * `api.vm0.ai` and `/api/zero/**` retire together, so the VM0 brand keeps the
+ * legacy path. Only the Okou brand moves to the canonical namespace. Both
+ * values are already registered in the Microsoft app registration, so this
+ * ships with no provider-console change.
+ *
+ * Project here rather than in `getOAuthApiOrigin`, whose other caller builds
+ * the built-in connector callback that is already registered with every
+ * provider.
  */
 function callbackRedirectUri(origin: string, publicBrand: PublicBrand): string {
-  return `${apiUrlForPublicBrand(origin, publicBrand)}/api/integrations/teams/oauth/callback`;
+  return publicBrand === "okou"
+    ? `${apiUrlForPublicBrand(origin, "okou")}/api/integrations/teams/oauth/callback`
+    : `${apiUrlForPublicBrand(origin, "vm0")}/api/zero/teams/oauth/callback`;
 }
 
 /**
  * Rollout fallback for #28300. State written by the previous API build carries
- * no redirect URI, and that build sent this exact value. Microsoft rejects a
- * token request whose redirect_uri differs from the authorization request, so
- * an authorization started before this deploy can only be completed against it.
+ * no redirect URI, and that build sent this exact value for both brands: the
+ * unprojected origin plus the legacy path. Microsoft rejects a token request
+ * whose redirect_uri differs from the authorization request, so an
+ * authorization started before this deploy can only be completed against it.
+ *
+ * Only Okou-brand authorizations actually depend on this. The VM0 brand keeps
+ * emitting the legacy path above, so its old and new values are identical.
  *
  * Surface: a browser-held Microsoft consent page, so it is bounded by the old
  * web/app client window of ~2 days rather than by the API deploy gap. The

--- a/turbo/apps/api/src/signals/routes/teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/teams-oauth.ts
@@ -181,11 +181,19 @@ function callbackRedirectUri(origin: string, publicBrand: PublicBrand): string {
 }
 
 /**
- * State written before #28300 carries no redirect URI, and the build that wrote
- * it sent this exact value. Microsoft rejects a token request whose redirect_uri
- * differs from the authorization request, so an authorization started on the
- * previous build can only be completed against it. Remove once no state
- * predating #28300 can still be presented.
+ * Rollout fallback for #28300. State written by the previous API build carries
+ * no redirect URI, and that build sent this exact value. Microsoft rejects a
+ * token request whose redirect_uri differs from the authorization request, so
+ * an authorization started before this deploy can only be completed against it.
+ *
+ * Surface: a browser-held Microsoft consent page, so it is bounded by the old
+ * web/app client window of ~2 days rather than by the API deploy gap. The
+ * authorization request is not persisted anywhere and carries no expiry of our
+ * own, so nothing shortens that window.
+ *
+ * Removable once no authorization started before this deploy can still be
+ * presented, and the previous build is outside the production rollback window.
+ * Follow-up: #28303.
  */
 function legacyCallbackRedirectUri(origin: string): string {
   return `${origin}/api/zero/teams/oauth/callback`;

--- a/turbo/apps/api/src/signals/routes/teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/teams-oauth.ts
@@ -1,7 +1,10 @@
 import { command } from "ccstate";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { teamsOauthContract } from "@okouai/api-contracts/contracts/teams-oauth";
-import { appUrlForPublicBrand } from "@okouai/core/public-brand";
+import {
+  apiUrlForPublicBrand,
+  appUrlForPublicBrand,
+} from "@okouai/core/public-brand";
 import { z } from "zod";
 
 import { env } from "../../lib/env";
@@ -168,8 +171,13 @@ function parseOAuthState(state: string | undefined): OAuthState | null {
   };
 }
 
-function callbackRedirectUri(origin: string): string {
-  return `${origin}/api/zero/teams/oauth/callback`;
+/**
+ * The Microsoft app registration holds the brand-projected final path. Project
+ * here rather than in `getOAuthApiOrigin`, whose other caller builds the
+ * built-in connector callback that is already registered with every provider.
+ */
+function callbackRedirectUri(origin: string, publicBrand: PublicBrand): string {
+  return `${apiUrlForPublicBrand(origin, publicBrand)}/api/integrations/teams/oauth/callback`;
 }
 
 /**
@@ -343,7 +351,7 @@ const connectOauth$ = command(({ get }) => {
 
   // Record the redirect URI this authorization actually sends, so the token
   // exchange can repeat it instead of recomputing a value that may have moved.
-  const redirectUri = callbackRedirectUri(origin);
+  const redirectUri = callbackRedirectUri(origin, publicBrand);
   const stateObj: {
     orgId: string;
     userId: string;

--- a/turbo/apps/api/src/signals/routes/teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/teams-oauth.ts
@@ -40,6 +40,7 @@ interface OAuthState {
   readonly userId: string | null;
   readonly prompt: string | null;
   readonly publicBrand: PublicBrand;
+  readonly redirectUri: string | null;
 }
 
 interface MicrosoftTeamsUserInfo {
@@ -140,6 +141,7 @@ function parseOAuthState(state: string | undefined): OAuthState | null {
       userId: null,
       prompt: null,
       publicBrand: "vm0",
+      redirectUri: null,
     };
   }
 
@@ -150,6 +152,7 @@ function parseOAuthState(state: string | undefined): OAuthState | null {
       userId: null,
       prompt: null,
       publicBrand: "vm0",
+      redirectUri: null,
     };
   }
 
@@ -161,10 +164,22 @@ function parseOAuthState(state: string | undefined): OAuthState | null {
     // Old web/app OAuth state can omit publicBrand for about two days.
     // Remove this VM0 default in #27660 after legacy states have drained.
     publicBrand: record.publicBrand === "okou" ? "okou" : "vm0",
+    redirectUri: optionalString(record.redirectUri),
   };
 }
 
 function callbackRedirectUri(origin: string): string {
+  return `${origin}/api/zero/teams/oauth/callback`;
+}
+
+/**
+ * State written before #28300 carries no redirect URI, and the build that wrote
+ * it sent this exact value. Microsoft rejects a token request whose redirect_uri
+ * differs from the authorization request, so an authorization started on the
+ * previous build can only be completed against it. Remove once no state
+ * predating #28300 can still be presented.
+ */
+function legacyCallbackRedirectUri(origin: string): string {
   return `${origin}/api/zero/teams/oauth/callback`;
 }
 
@@ -326,15 +341,20 @@ const connectOauth$ = command(({ get }) => {
     return jsonErrorResponse("Missing orgId or userId", 400);
   }
 
+  // Record the redirect URI this authorization actually sends, so the token
+  // exchange can repeat it instead of recomputing a value that may have moved.
+  const redirectUri = callbackRedirectUri(origin);
   const stateObj: {
     orgId: string;
     userId: string;
     prompt?: string;
     publicBrand: PublicBrand;
+    redirectUri: string;
   } = {
     orgId: query.orgId,
     userId,
     publicBrand,
+    redirectUri,
   };
   if (query.prompt) {
     stateObj.prompt = truncatePrompt(query.prompt);
@@ -342,7 +362,7 @@ const connectOauth$ = command(({ get }) => {
 
   const authUrl = new URL(MICROSOFT_AUTHORIZATION_URL);
   authUrl.searchParams.set("client_id", credentials.clientId);
-  authUrl.searchParams.set("redirect_uri", callbackRedirectUri(origin));
+  authUrl.searchParams.set("redirect_uri", redirectUri);
   authUrl.searchParams.set("response_type", "code");
   authUrl.searchParams.set("scope", MICROSOFT_TEAMS_CONNECT_SCOPES.join(" "));
   authUrl.searchParams.set("state", JSON.stringify(stateObj));
@@ -353,7 +373,6 @@ const connectOauth$ = command(({ get }) => {
 
 const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
   const request = get(request$).raw;
-  const origin = getOAuthApiOrigin(request);
   const credentials = microsoftCredentials();
   if (!credentials) {
     return jsonErrorResponse(
@@ -390,7 +409,9 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
         clientId: credentials.clientId,
         clientSecret: credentials.clientSecret,
         code: query.code,
-        redirectUri: callbackRedirectUri(origin),
+        redirectUri:
+          state.redirectUri ??
+          legacyCallbackRedirectUri(getOAuthApiOrigin(request)),
       },
       signal,
     ),


### PR DESCRIPTION
## Why the state fix is the primary change

`routes/teams-oauth.ts` recomputed the redirect URI at token-exchange time instead of reusing the one the authorization request actually sent. OAuth 2.0 requires the two to be identical and Microsoft enforces it, so **changing the emitted value is unsafe on its own**:

```
user starts connect   → old build emits api.vm0.ai/api/zero/teams/oauth/callback
  ...user authorizes at Microsoft, tens of seconds...
  ...new build ships in that window...
Microsoft redirects   → new build receives it, recomputes api.okou.ai/api/integrations/...
token exchange        → Microsoft rejects: redirect_uri mismatch
```

The authorization code is already consumed at that point, so the user has to start over.

The first commit removes the race; the second changes what is emitted. They are split so the ordering is visible in review.

### 1. `fix(teams): carry the oauth redirect uri in the connect state`

`connectOauth$` now records the exact redirect URI it sends in the OAuth state, and `callbackOauth$` reuses `state.redirectUri` at exchange time. This is the pattern the Feishu flow already uses (`routes/feishu-oauth.ts:848`).

State written by the previous build has no such field. It falls back to the legacy value, `${getOAuthApiOrigin(request)}/api/zero/teams/oauth/callback` — unprojected, exactly what the previous build sent — so authorizations spanning the deploy still complete. `legacyCallbackRedirectUri` carries a comment stating the fallback is removable only once no state predating this change can still be presented.

### 2. `fix(teams): emit the final teams oauth callback with brand projection`

The authorization request now emits the canonical path for the Okou brand, with the origin projected through `apiUrlForPublicBrand`.

`api.vm0.ai` and `/api/zero/**` retire together, so **the VM0 brand does not migrate its callback path** — moving it would require registering a new Redirect URI for a brand that is going away.

| Brand | redirect_uri | Registered today |
|---|---|---|
| okou | `https://api.okou.ai/api/integrations/teams/oauth/callback` | yes |
| vm0 | `https://api.vm0.ai/api/zero/teams/oauth/callback` | yes |

**Both values are already registered, so this ships with no Microsoft app-registration change.** The VM0-brand redirect URI is byte-identical to what production emits today, so the deploy window only affects Okou-brand authorizations — exactly what commit 1 protects.

`apiUrlForPublicBrand` maps `api.vm0.ai` ↔ `api.okou.ai` and leaves every other host untouched, so preview and development origins are unaffected. This also fixes a pre-existing defect: an Okou-brand user was previously redirected to the legacy brand host, because `getOAuthApiOrigin()` returns `VM0_API_BACKEND_URL` verbatim.

The projection is applied at the Teams call site only. `getOAuthApiOrigin()` is unchanged, because its other caller (`routes/connector-oauth-origin.ts:26`) builds `/api/connectors/:connectorSlug/callback`, a URL already in its final shape and registered with more than a hundred third-party providers.

## Prerequisite verified

`/api/integrations/teams/oauth/callback` is routable on `main` — added by #28283 (`signals/route-entry.ts:53`) for #28279, which is closed.

## No provider-console change required

An earlier revision of this PR emitted `/api/integrations/**` for both brands, which would have required registering `https://api.vm0.ai/api/integrations/teams/oauth/callback` in the Microsoft app registration before merge. That requirement is **withdrawn** — see the correction on #28300. Keeping the VM0 brand on its existing registered value removes the external prerequisite entirely.

`https://api.vm0.ai/api/zero/teams/oauth/callback` must stay registered. It is no longer only a drain-window acceptor: it is now the **live producer target for the VM0 brand**.

### Ordering constraint for #26701

`/api/zero/teams/oauth/callback` cannot be retired by #26701 Phase C3 until `api.vm0.ai` stops serving the VM0 brand. The route is an active producer target, not legacy drainage.

## Fallbacks

- `apps/api/src/signals/routes/teams-oauth.ts` — `legacyCallbackRedirectUri()`, used as `state.redirectUri ?? legacyCallbackRedirectUri(getOAuthApiOrigin(request))`. Protects an authorization started on the previous API build, whose state carries no redirect URI, from being exchanged against a recomputed value Microsoft would reject. **Only Okou-brand authorizations depend on it** — the VM0 brand keeps emitting the legacy path, so its old and new values are identical. Surface: a browser-held Microsoft consent page, so it is bounded by the **old web/app client window of ~2 days**, not by the API deploy gap — the authorization request is not persisted and carries no expiry of our own. Removal condition: no authorization started before this deploy can still be presented, and the previous build is outside the production rollback window. Follow-up: #28303.

**Reverse direction (rollback), Okou brand only:** state written by this build names `/api/integrations/...`, and a rolled-back build ignores the field and recomputes `/api/zero/...`, so Microsoft rejects the exchange. This is inherent to changing an emitted `redirect_uri` and is not fixable from this side, which is why the fallback is sized by the rollback window as well. VM0-brand authorizations are unaffected in both directions, because the value does not change for that brand.

## Coverage

`signals/routes/__tests__/teams-oauth.test.ts`:

- the emitted `redirect_uri` and the recorded `state.redirectUri` per brand — `api.okou.ai/api/integrations/...` for okou, `api.vm0.ai/api/zero/...` for vm0;
- a dedicated case pinning the VM0-brand authorization URI to its registered literal, so a later refactor cannot silently move it off the allowlist;
- the token exchange uses the value recorded in the state, asserted with a preview origin the handler would never recompute;
- state without the field still exchanges successfully against the legacy URI.

## Scope check

- `getOAuthApiOrigin()` unchanged; `routes/connector-oauth-origin.ts` untouched.
- Slack and Feishu producers untouched.
- No route removed. `/api/zero/teams/oauth/callback` and `/api/okou/teams/oauth/callback` keep serving; the contract path is unchanged and the namespace aliases still expand it.
- The five inbound webhook endpoints untouched.

The only change outside `teams-oauth.ts` is a doc-comment correction in `signals/route-entry.ts`, which said no producer emits a final URL yet. One now does.

Closes #28300
