### PR TITLE
perf(api): attribute accepted catalog cache misses

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1115,6 +1115,11 @@ function expectApiDispatchTimingEventsNotToLeak(
 function expectConnectorCatalogLoadTiming(args: {
   readonly events: readonly Record<string, unknown>[];
   readonly acceptedCacheOutcome: "hit" | "miss" | "in_flight";
+  readonly acceptedCacheMissReason:
+    | "process_empty"
+    | "catalog_identity_changed"
+    | "capability_identity_changed"
+    | undefined;
   readonly runtimeCacheOutcome: "hit" | "miss";
   readonly requestedConnectorCount: "known" | "not_applicable";
   readonly requestedConnectorCountBucket?: (typeof CONNECTOR_CATALOG_COUNT_BUCKETS)[number];
@@ -1143,6 +1148,17 @@ function expectConnectorCatalogLoadTiming(args: {
         args.materializedConnectorCountBucket,
       connector_catalog_validation_outcome: args.validation.outcome,
     }),
+  );
+  expect([
+    Object.prototype.hasOwnProperty.call(
+      event,
+      "connector_catalog_accepted_cache_miss_reason",
+    ),
+    event.connector_catalog_accepted_cache_miss_reason,
+  ]).toStrictEqual(
+    args.acceptedCacheMissReason === undefined
+      ? [false, undefined]
+      : [true, args.acceptedCacheMissReason],
   );
   const expectedValidationDimensions =
     args.validation.outcome === "full_fallback"
@@ -1852,6 +1868,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectConnectorCatalogLoadTiming({
       events: missingAuthorityEvents,
       acceptedCacheOutcome: "miss",
+      acceptedCacheMissReason: "process_empty",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
       requestedConnectorCountBucket: "2_4",
@@ -1916,6 +1933,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectConnectorCatalogLoadTiming({
       events: missingCompatibilityEvents,
       acceptedCacheOutcome: "miss",
+      acceptedCacheMissReason: "catalog_identity_changed",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
       materializedConnectorCountBucket: "1",
@@ -1981,6 +1999,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectConnectorCatalogLoadTiming({
       events: differentAuthorityEvents,
       acceptedCacheOutcome: "miss",
+      acceptedCacheMissReason: "catalog_identity_changed",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
       materializedConnectorCountBucket: "1",
@@ -2030,6 +2049,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectConnectorCatalogLoadTiming({
       events: cachedEvents,
       acceptedCacheOutcome: "hit",
+      acceptedCacheMissReason: undefined,
       runtimeCacheOutcome: "hit",
       requestedConnectorCount: "known",
       materializedConnectorCountBucket: "0",
@@ -2105,6 +2125,21 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         return outcome === "hit" || outcome === "in_flight";
       }),
     ).toHaveLength(1);
+    const missLoadEvent = concurrentLoadEvents.find((event) => {
+      return event.connector_catalog_accepted_cache_outcome === "miss";
+    });
+    const reusedLoadEvent = concurrentLoadEvents.find((event) => {
+      return event.connector_catalog_accepted_cache_outcome !== "miss";
+    });
+    if (missLoadEvent === undefined || reusedLoadEvent === undefined) {
+      throw new Error("Expected one catalog miss and one reused catalog load");
+    }
+    expect(missLoadEvent.connector_catalog_accepted_cache_miss_reason).toBe(
+      "catalog_identity_changed",
+    );
+    expect(reusedLoadEvent).not.toHaveProperty(
+      "connector_catalog_accepted_cache_miss_reason",
+    );
     expect(
       concurrentLoadEvents.map((event) => {
         return event.connector_catalog_validation_outcome;
@@ -2189,6 +2224,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectConnectorCatalogLoadTiming({
       events: apiDispatchTimingEventsForRun(firstRun.runId),
       acceptedCacheOutcome: "miss",
+      acceptedCacheMissReason: "catalog_identity_changed",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
       requestedConnectorCountBucket: "2_4",
@@ -2205,6 +2241,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectConnectorCatalogLoadTiming({
       events: apiDispatchTimingEventsForRun(repeatedRun.runId),
       acceptedCacheOutcome: "hit",
+      acceptedCacheMissReason: undefined,
       runtimeCacheOutcome: "hit",
       requestedConnectorCount: "known",
       requestedConnectorCountBucket: "2_4",
@@ -2221,6 +2258,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectConnectorCatalogLoadTiming({
       events: apiDispatchTimingEventsForRun(additionalRun.runId),
       acceptedCacheOutcome: "hit",
+      acceptedCacheMissReason: undefined,
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
       requestedConnectorCountBucket: "1",
@@ -2246,6 +2284,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectConnectorCatalogLoadTiming({
       events: apiDispatchTimingEventsForRun(rotatedRun.runId),
       acceptedCacheOutcome: "miss",
+      acceptedCacheMissReason: "catalog_identity_changed",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
       requestedConnectorCountBucket: "1",
@@ -2254,12 +2293,51 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       validation: { outcome: "attested" },
     });
     await api.requestCancelRun(actor, rotatedRun.runId, [200]);
+
+    const capabilityIdentityEnvName = "CALCOM_OAUTH_CLIENT_ID";
+    const capabilityIdentityEnvValue = "api-test-calcom-oauth-client-id";
+    mockOptionalEnv(capabilityIdentityEnvName, undefined);
+    await installApiTestConnectorCatalog({
+      catalogVersion: rotatedCatalogVersion,
+    });
+    const capabilityRotatedPrompt =
+      "materialize after capability identity rotation";
+    const capabilityRotatedRun = await createScopedRun(
+      capabilityRotatedPrompt,
+      ["x"],
+    );
+    const capabilityRotatedEvents = apiDispatchTimingEventsForRun(
+      capabilityRotatedRun.runId,
+    );
+    expectConnectorCatalogLoadTiming({
+      events: capabilityRotatedEvents,
+      acceptedCacheOutcome: "miss",
+      acceptedCacheMissReason: "capability_identity_changed",
+      runtimeCacheOutcome: "miss",
+      requestedConnectorCount: "known",
+      requestedConnectorCountBucket: "1",
+      materializedConnectorCountBucket: "1",
+      resolvedConnectorFraction: "up_to_25_percent",
+      validation: { outcome: "attested" },
+    });
+    expectApiDispatchTimingEventsNotToLeak(capabilityRotatedEvents, [
+      rotatedCatalogVersion,
+      capabilityRotatedPrompt,
+      agentId,
+      capabilityIdentityEnvName,
+      capabilityIdentityEnvValue,
+      "test-oauth-secret",
+      "fixture-confidential-secret",
+    ]);
+    await api.requestCancelRun(actor, capabilityRotatedRun.runId, [200]);
+
     await fw.seedTestConnector(actor, {
       connectorSlug: "x",
       authMethod: "oauth",
       accessToken: "x-filtered-access",
       refreshToken: "x-filtered-refresh",
     });
+    mockOptionalEnv(capabilityIdentityEnvName, capabilityIdentityEnvValue);
     await installApiTestConnectorCatalog({
       catalogVersion: `api-test-scoped-runtime-${randomUUID()}`,
     });
@@ -2278,6 +2356,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectConnectorCatalogLoadTiming({
       events: apiDispatchTimingEventsForRun(filteredRun.runId),
       acceptedCacheOutcome: "miss",
+      acceptedCacheMissReason: "catalog_identity_changed",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
       requestedConnectorCountBucket: "1",
@@ -7737,6 +7816,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expectConnectorCatalogLoadTiming({
       events: timingEvents,
       acceptedCacheOutcome: "miss",
+      acceptedCacheMissReason: "catalog_identity_changed",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
       requestedConnectorCountBucket: "1",
@@ -10251,6 +10331,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expectConnectorCatalogLoadTiming({
       events: apiDispatchTimingEventsForRun(restoredRun.runId),
       acceptedCacheOutcome: "miss",
+      acceptedCacheMissReason: "catalog_identity_changed",
       runtimeCacheOutcome: "miss",
       requestedConnectorCount: "known",
       requestedConnectorCountBucket: "0",

--- a/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-external-reader.service.ts
@@ -520,6 +520,17 @@ async function loadAcceptedConnectorCatalogSnapshotAttempt(
     return await existing;
   }
 
+  const completedIdentity = cache.completed?.catalog.identity;
+  timing?.recordAcceptedCacheMissReason(
+    completedIdentity === undefined
+      ? "process_empty"
+      : completedIdentity.sourceId !== currentIdentity.sourceId ||
+          completedIdentity.schemaVersion !== currentIdentity.schemaVersion ||
+          completedIdentity.catalogVersion !== currentIdentity.catalogVersion ||
+          completedIdentity.catalogDigest !== currentIdentity.catalogDigest
+        ? "catalog_identity_changed"
+        : "capability_identity_changed",
+  );
   timing?.recordAcceptedCacheOutcome("miss");
   const promise = loadCurrentCatalog({
     db,

--- a/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
@@ -5,6 +5,10 @@ import type {
 } from "./api-dispatch-timing.service";
 
 type AcceptedConnectorCatalogCacheOutcome = "hit" | "miss" | "in_flight";
+type AcceptedConnectorCatalogCacheMissReason =
+  | "process_empty"
+  | "catalog_identity_changed"
+  | "capability_identity_changed";
 type ConnectorRuntimeSnapshotCacheOutcome = "hit" | "miss";
 type ConnectorCatalogValidationResult =
   | { readonly outcome: "attested" }
@@ -136,6 +140,9 @@ export class ConnectorCatalogLoadTiming {
   private acceptedCacheOutcome:
     | AcceptedConnectorCatalogCacheOutcome
     | undefined;
+  private acceptedCacheMissReason:
+    | AcceptedConnectorCatalogCacheMissReason
+    | undefined;
   private runtimeCacheOutcome: ConnectorRuntimeSnapshotCacheOutcome | undefined;
   private validationResult: ConnectorCatalogValidationResult | undefined;
   private catalogRawSize: number | undefined;
@@ -159,6 +166,12 @@ export class ConnectorCatalogLoadTiming {
     ) {
       this.acceptedCacheOutcome = outcome;
     }
+  }
+
+  recordAcceptedCacheMissReason(
+    reason: AcceptedConnectorCatalogCacheMissReason,
+  ): void {
+    this.acceptedCacheMissReason ??= reason;
   }
 
   recordRuntimeCacheOutcome(
@@ -218,6 +231,12 @@ export class ConnectorCatalogLoadTiming {
         ? {}
         : {
             connector_catalog_accepted_cache_outcome: this.acceptedCacheOutcome,
+          }),
+      ...(this.acceptedCacheMissReason === undefined
+        ? {}
+        : {
+            connector_catalog_accepted_cache_miss_reason:
+              this.acceptedCacheMissReason,
           }),
       ...(this.runtimeCacheOutcome === undefined
         ? {}


### PR DESCRIPTION
## Summary

- classify accepted connector catalog cache misses as process-empty, catalog-identity change, or capability-identity change
- emit the bounded reason only on the request that owns the miss while preserving existing hit and in-flight semantics
- cover first-process, exact-hit, catalog rotation, capability rotation, simultaneous-change precedence, concurrency, and telemetry privacy through the run route integration suite

## Behavior and compatibility

This adds the optional low-cardinality `connector_catalog_accepted_cache_miss_reason` timing dimension. It does not emit catalog versions, digests, connector or process identities, user or tenant identities, or payload contents.

Catalog synchronization, validation and attestation, persistence, cache selection and concurrency, runtime materialization, request results, public contracts, queue payloads, Runner behavior, and publisher behavior are unchanged. Older API processes omit the dimension; rollback stops emitting it.

Persisted connector projections, publication coalescing, representation changes, and production cohort analysis remain deferred to the parent evidence gate.

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/connector-catalog-load-timing.service.ts apps/api/src/signals/services/connector-catalog-external-reader.service.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --silent=passed-only` (167 passed)
- pre-commit hook: full `pnpm knip`, full `pnpm check-types`, formatting, and file-size checks

Closes #28299

Parent context: #28275
