### PR TITLE
fix(model-provider): omit custom apply_patch from direct deepseek

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -3996,6 +3996,14 @@ describe("CHAT-02: model-first provider policies", () => {
         ]),
       },
     });
+    const directCatalogModels = claim.codexRuntimeConfig?.modelCatalog?.models;
+    if (!Array.isArray(directCatalogModels)) {
+      throw new Error("Expected a direct DeepSeek model catalog");
+    }
+    expect(directCatalogModels).toHaveLength(2);
+    for (const model of directCatalogModels) {
+      expect(model).not.toHaveProperty("apply_patch_tool_type");
+    }
 
     chatCallbacks.mockChatOutputEvents([]);
     await completeChatRunOk(run.runId, sandboxHeaders, {

--- a/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
@@ -568,6 +568,7 @@ describe("custom model provider gateway routes", () => {
       }
       expect(catalogModel).toMatchObject({
         slug: upstreamModel,
+        apply_patch_tool_type: "freeform",
         input_modalities: ["text"],
         base_instructions: expect.stringContaining("You are Codex"),
         model_messages: {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7027,6 +7027,9 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
           `Expected a native DeepSeek Codex catalog for ${selectedModel}`,
         );
       }
+      for (const model of catalogModels) {
+        expect(model).not.toHaveProperty("apply_patch_tool_type");
+      }
       expect(catalogModels).toContainEqual(
         expect.objectContaining({
           slug: selectedModel,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -5,6 +5,7 @@ import {
   hasModelSelection,
   getModels,
   getDefaultModel,
+  getModelProviderCodexCatalogForModel,
   getModelProviderCodexRuntimeConfig,
   getModelProviderEnvBindings,
   getFrameworkForType,
@@ -839,7 +840,8 @@ describe("deepseek Responses provider", () => {
   });
 
   it("configures the official DeepSeek Responses model catalog", () => {
-    expect(getModelProviderCodexRuntimeConfig("deepseek")).toMatchObject({
+    const runtimeConfig = getModelProviderCodexRuntimeConfig("deepseek");
+    expect(runtimeConfig).toMatchObject({
       providerId: "deepseek",
       name: "DeepSeek",
       baseUrl: "https://api.deepseek.com/",
@@ -875,7 +877,36 @@ describe("deepseek Responses provider", () => {
         ],
       },
     });
+    const directModels = runtimeConfig?.modelCatalog?.models;
+    if (!Array.isArray(directModels)) {
+      throw new Error("Expected a direct DeepSeek model catalog");
+    }
+    expect(directModels).toHaveLength(2);
+    for (const model of directModels) {
+      expect(model).not.toHaveProperty("apply_patch_tool_type");
+    }
   });
+
+  it.each([
+    ["deepseek-v4-flash", "gateway/deepseek-flash"],
+    ["deepseek-v4-pro", "gateway/deepseek-pro"],
+  ])(
+    "retains native apply_patch metadata when projecting %s for a compatible gateway",
+    (logicalModel, runtimeModel) => {
+      expect(
+        getModelProviderCodexCatalogForModel(logicalModel, runtimeModel),
+      ).toMatchObject({
+        models: [
+          expect.objectContaining({
+            slug: runtimeModel,
+            apply_patch_tool_type: "freeform",
+            default_reasoning_level: "high",
+            context_window: 1_048_576,
+          }),
+        ],
+      });
+    },
+  );
 
   it("scopes the firewall to the native Responses endpoint", () => {
     const config = MODEL_PROVIDER_FIREWALL_CONFIGS.deepseek;

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -41,6 +41,15 @@ const DEEPSEEK_MODEL_CATALOG = {
   ],
 };
 
+const DEEPSEEK_DIRECT_MODEL_CATALOG = {
+  ...DEEPSEEK_MODEL_CATALOG,
+  models: DEEPSEEK_MODEL_CATALOG.models.map((model) => {
+    const directModel: Record<string, unknown> = { ...model };
+    delete directModel.apply_patch_tool_type;
+    return directModel;
+  }),
+};
+
 export {
   MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS,
   SUPPORTED_RUN_MODELS,
@@ -104,6 +113,12 @@ export type ModelProviderCodexRuntimeConfig = z.infer<
   typeof modelProviderCodexRuntimeConfigSchema
 >;
 
+const MODEL_PROVIDER_CODEX_SOURCE_CATALOGS: Partial<
+  Record<ModelProviderType, Record<string, unknown>>
+> = {
+  deepseek: DEEPSEEK_MODEL_CATALOG,
+};
+
 const MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS: Partial<
   Record<ModelProviderType, ModelProviderCodexRuntimeConfig>
 > = {
@@ -115,7 +130,7 @@ const MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS: Partial<
     requiresOpenaiAuth: false,
     wireApi: "responses",
     supportsWebsockets: false,
-    modelCatalog: DEEPSEEK_MODEL_CATALOG,
+    modelCatalog: DEEPSEEK_DIRECT_MODEL_CATALOG,
   },
 };
 
@@ -1108,8 +1123,7 @@ export function getModelProviderCodexCatalogForModel(
   runtimeModel: string,
 ): Record<string, unknown> | undefined {
   for (const type of getProvidersForModel(logicalModel)) {
-    const sourceCatalog =
-      MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS[type]?.modelCatalog;
+    const sourceCatalog = MODEL_PROVIDER_CODEX_SOURCE_CATALOGS[type];
     const sourceModels = sourceCatalog?.models;
     const sourceModel = Array.isArray(sourceModels)
       ? sourceModels.find(


### PR DESCRIPTION
Closes #28274

## Problem

VM0's direct DeepSeek Codex configuration advertised `apply_patch_tool_type: "freeform"`. Codex serialized that as an OpenAI custom tool, but DeepSeek's SGLang-compatible endpoint only accepts function tools, so affected runs could fail validation before inference.

## Solution

- derive a restricted direct DeepSeek model catalog that omits `apply_patch_tool_type`
- retain the full DeepSeek metadata as the explicit source catalog for custom Responses gateways
- cover managed direct, direct BYOK, and custom gateway projections at their existing integration entry points

This does not change routing, runner or MITM behavior, persisted schemas, or API protocols, and it does not add a slow end-to-end suite.

## Validation

- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts --maxWorkers=1 --silent=passed-only` (165 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/model-provider-gateways.test.ts --maxWorkers=1 --silent=passed-only` (7 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts --maxWorkers=1 --silent=passed-only -t 'routes DeepSeek V4 Flash through the native Responses adapter'` (1 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 --silent=passed-only -t 'claims vm0 .* runs with the Responses adapter'` (2 passed)
- package lint and type checks for `@okouai/api-contracts` and `api`
- scoped Knip plus pre-commit full-repository Knip and type checks
- `git diff --check`

## Risk and rollout

- direct DeepSeek Codex runs no longer receive the native `apply_patch` tool; independent shell/exec tools remain available
- already-created run snapshots may retain the previous catalog, while newly created run contexts receive the restricted catalog
- custom Responses gateways continue to receive the full metadata, including freeform `apply_patch`
- a live credentialed Codex smoke test and production-log confirmation remain rollout checks because the local environment does not expose the required DeepSeek runner credential or `AXIOM_TOKEN`
