### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1c8a04cb31ba74d0115af5a890bb8c0d48fba64b52812fa13929a6ef0cc83c"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -387,7 +387,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "h2 0.3.27",
- "h2 0.4.16",
+ "h2 0.4.17",
  "http 0.2.12",
  "http 1.5.0",
  "http-body 0.4.6",
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483b858ff67522011c4786310c5cd8fd88d0be7ea3d5f1a48328446300c4269e"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1644,7 +1644,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.16",
+ "h2 0.4.17",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
@@ -4178,9 +4178,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",


### PR DESCRIPTION
## Summary

- update `aws-smithy-http-client` from 1.3.0 to 1.4.0
- update `aws-smithy-runtime` from 1.13.1 to 1.14.0
- update `aws-smithy-runtime-api` from 1.14.0 to 1.15.0
- update `h2` from 0.4.16 to 0.4.17
- update `zerovec` from 0.11.7 to 0.11.8
- keep manifests unchanged; no manual version bumps were needed

## Blocked dependencies

- `generic-array` remains at 0.14.7 because `crypto-common` 0.1.7 requires `generic-array = "=0.14.7"` through `digest` -> `crc-fast` -> `aws-smithy-checksums` -> `aws-sdk-s3` -> `runner`

## Validation

- `cargo test --workspace --exclude runner --no-fail-fast`: all other tests and doctests passed; `guest-agent --test process_control_env` failed with the same output-line assertion reproduced against the exact-head untouched lockfile
- `cargo check -p runner --all-targets`: passed on the final refreshed Rust source head
- `cargo test -p runner --no-fail-fast`: updated dependency compilation completed, but the final runner test-binary link was killed by SIGKILL in the 3.8 GiB, no-swap validation environment
