### PR TITLE
fix: surface invitation purchase rejection reasons

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -10714,6 +10714,146 @@ describe("usage pack allocation management", () => {
     expect(response.body.error.code).toBe("NOT_FOUND");
   });
 
+  it("explains when an invitation purchase targets an existing member", async () => {
+    const existingMemberUserId = `user_${randomUUID()}`;
+    const existingMemberEmail = `existing-${randomUUID()}@example.test`;
+    await seedManagedUsagePack([
+      { userId: existingMemberUserId, usagePackUsd: 20 },
+    ]);
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [
+          {
+            publicUserData: {
+              userId: existingMemberUserId,
+              identifier: existingMemberEmail,
+            },
+            createdAt: now(),
+          },
+        ],
+      },
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+
+    const response = await accept(
+      setupApp({ context, routes: orgInviteRoutes })(
+        orgInviteContract,
+      ).previewPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          email: existingMemberEmail,
+          role: "member",
+          usagePackUsd: 20,
+        },
+      }),
+      [409],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      code: "INVITATION_PURCHASE_INVITEE_UNAVAILABLE",
+      message: "This person is already a member or has a pending invitation.",
+    });
+  });
+
+  it("explains when an invitation package has no prorated amount due", async () => {
+    const existingMemberUserId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([
+      { userId: existingMemberUserId, usagePackUsd: 20 },
+    ]);
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      managedUsagePackSubscription(
+        fixture,
+        new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      ),
+    );
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      {
+        data: [
+          {
+            publicUserData: {
+              userId: existingMemberUserId,
+              identifier: `${existingMemberUserId}@example.test`,
+            },
+            createdAt: now(),
+          },
+        ],
+      },
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+    mockUsagePackChangePreviews(0, 2000);
+
+    const response = await accept(
+      setupApp({ context, routes: orgInviteRoutes })(
+        orgInviteContract,
+      ).previewPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          email: `zero-proration-${randomUUID()}@example.test`,
+          role: "member",
+          usagePackUsd: 20,
+        },
+      }),
+      [409],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      code: "INVITATION_PURCHASE_NO_AMOUNT_DUE",
+      message:
+        "This member package has no charge to collect right now. Try again after your billing period renews.",
+    });
+  });
+
+  it("asks the buyer to restore a canceling subscription before inviting", async () => {
+    const existingMemberUserId = `user_${randomUUID()}`;
+    const fixture = await seedManagedUsagePack([
+      { userId: existingMemberUserId, usagePackUsd: 20 },
+    ]);
+    const endingSubscription = {
+      ...managedUsagePackSubscription(
+        fixture,
+        new Map([[TEST_PRICE_USAGE_PACK_20, 1]]),
+      ),
+      cancel_at: fixture.billingPeriod.end,
+      cancel_at_period_end: true,
+    };
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      endingSubscription,
+    );
+    await postManagedUsagePackEvent(
+      "customer.subscription.updated",
+      endingSubscription,
+    );
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
+      { data: [] },
+    );
+    context.mocks.clerk.organizations.getOrganizationInvitationList.mockResolvedValue(
+      { data: [] },
+    );
+
+    const response = await accept(
+      setupApp({ context, routes: orgInviteRoutes })(
+        orgInviteContract,
+      ).previewPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          email: `canceling-${randomUUID()}@example.test`,
+          role: "member",
+          usagePackUsd: 20,
+        },
+      }),
+      [409],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      code: "INVITATION_PURCHASE_SUBSCRIPTION_CANCELING",
+      message: "Restore your subscription before purchasing a member package.",
+    });
+  });
+
   it("prices an invitation from only the added package proration", async () => {
     const existingMemberUserId = `user_${randomUUID()}`;
     const fixture = await seedManagedUsagePack([
@@ -11061,7 +11201,11 @@ describe("usage pack allocation management", () => {
       }),
       [409],
     );
-    expect(supersededConfirmation.body.error.code).toBe("CONFLICT");
+    expect(supersededConfirmation.body.error).toStrictEqual({
+      code: "INVITATION_PURCHASE_INACTIVE",
+      message:
+        "This invitation purchase is no longer active. Review the invitation again.",
+    });
     expect(context.mocks.stripe.invoices.create).not.toHaveBeenCalled();
 
     const metadata = {
@@ -11228,6 +11372,28 @@ describe("usage pack allocation management", () => {
         usagePackUsd: 20,
       }),
     ]);
+  });
+
+  it("rejects an invalid invitation payment preview with a stable error", async () => {
+    const purchase = await beginInvitationPurchase();
+
+    const response = await accept(
+      setupApp({ context, routes: orgInviteRoutes })(
+        orgInviteContract,
+      ).confirmPurchase({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { purchaseId: purchase.purchaseId },
+        body: { paymentMethodPreviewToken: "invalid-preview-token" },
+      }),
+      [409],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      code: "INVITATION_PURCHASE_PREVIEW_INVALID",
+      message:
+        "This invitation purchase preview is no longer valid. Review the invitation again.",
+    });
+    expect(context.mocks.stripe.invoices.create).not.toHaveBeenCalled();
   });
 
   it("returns a hosted invoice for a pending invitation payment to an older client", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -10711,7 +10711,9 @@ describe("usage pack allocation management", () => {
       [404],
     );
 
-    expect(response.body.error.code).toBe("NOT_FOUND");
+    expect(response.body.error.code).toBe(
+      "INVITATION_PURCHASE_SUBSCRIPTION_NOT_FOUND",
+    );
   });
 
   it("explains when an invitation purchase targets an existing member", async () => {

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -180,7 +180,7 @@ function invitationPurchaseError(args: {
   >;
 }) {
   const error = INVITATION_PURCHASE_ERRORS[args.reason];
-  log.info("Usage pack invitation purchase rejected", {
+  log.debug("Usage pack invitation purchase rejected", {
     ...args.diagnostics,
     type: "usage_pack_invitation_purchase_rejected",
     phase: args.phase,

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -114,7 +114,8 @@ const INVITATION_PURCHASE_ERRORS = {
   preview_expired: {
     status: 400,
     code: "INVITATION_PURCHASE_PREVIEW_EXPIRED",
-    message: "This invitation purchase preview expired. Review the invitation again.",
+    message:
+      "This invitation purchase preview expired. Review the invitation again.",
   },
   preview_invalid: {
     status: 409,
@@ -137,7 +138,8 @@ const INVITATION_PURCHASE_ERRORS = {
   purchase_not_found: {
     status: 404,
     code: "INVITATION_PURCHASE_NOT_FOUND",
-    message: "Invitation purchase not found. Review the invitation and try again.",
+    message:
+      "Invitation purchase not found. Review the invitation and try again.",
   },
   subscription_canceling: {
     status: 409,
@@ -147,7 +149,8 @@ const INVITATION_PURCHASE_ERRORS = {
   subscription_changed: {
     status: 409,
     code: "INVITATION_PURCHASE_SUBSCRIPTION_CHANGED",
-    message: "Your usage pack subscription changed. Review the invitation again.",
+    message:
+      "Your usage pack subscription changed. Review the invitation again.",
   },
   subscription_not_found: {
     status: 404,

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -1,16 +1,18 @@
 import { command } from "ccstate";
+import type { UsagePackUsd } from "@okouai/api-contracts/contracts/billing";
 import { orgInviteContract } from "@okouai/api-contracts/contracts/org-member-routes";
+import type { OrgRole } from "@okouai/api-contracts/contracts/org-members";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 
 import { env, optionalEnv } from "../../lib/env";
 import { billingRedirectAllowed } from "../../lib/billing-redirect";
+import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import {
   badRequestMessage,
   conflict,
-  notFound,
   providerUnavailable,
 } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -28,6 +30,7 @@ import {
   createUsagePackInvitationPreview,
   revokeUsagePackInvitationPurchase,
   usagePackInvitationPurchaseSchemaAvailable,
+  type UsagePackInvitationPurchaseConflictReason,
 } from "../services/usage-pack-invitation-purchase.service";
 import { activeUsagePackBillingContext } from "../services/usage-pack-subscription.service";
 import {
@@ -37,6 +40,8 @@ import {
   type BillingPurchasePaymentMethod,
 } from "../services/billing-payment-method.service";
 import type { RouteEntry } from "../route-entry";
+
+const log = logger("api:zero:org-invite");
 
 const adminRequired = Object.freeze({
   status: 403 as const,
@@ -57,6 +62,142 @@ const memberInvitationUpgradeRequired = Object.freeze({
     }),
   }),
 });
+
+type InvitationPurchaseErrorReason =
+  | UsagePackInvitationPurchaseConflictReason
+  | "preview_expired"
+  | "preview_invalid"
+  | "purchase_not_found"
+  | "subscription_not_found";
+
+interface InvitationPurchaseErrorDefinition {
+  readonly status: 400 | 404 | 409;
+  readonly code: string;
+  readonly message: string;
+}
+
+const INVITATION_PURCHASE_ERRORS = {
+  billing_period_ending: {
+    status: 409,
+    code: "INVITATION_PURCHASE_BILLING_PERIOD_ENDING",
+    message:
+      "This billing period is ending too soon to complete the purchase. Try again after it renews.",
+  },
+  billing_state_changed: {
+    status: 409,
+    code: "INVITATION_PURCHASE_BILLING_STATE_CHANGED",
+    message:
+      "Billing changed while this invitation was being purchased. Review the invitation and try again.",
+  },
+  invitee_unavailable: {
+    status: 409,
+    code: "INVITATION_PURCHASE_INVITEE_UNAVAILABLE",
+    message: "This person is already a member or has a pending invitation.",
+  },
+  no_amount_due: {
+    status: 409,
+    code: "INVITATION_PURCHASE_NO_AMOUNT_DUE",
+    message:
+      "This member package has no charge to collect right now. Try again after your billing period renews.",
+  },
+  no_credits: {
+    status: 409,
+    code: "INVITATION_PURCHASE_NO_CREDITS",
+    message:
+      "This purchase would not add any credits. Choose a larger member package or try again after renewal.",
+  },
+  payment_method_changed: {
+    status: 409,
+    code: "INVITATION_PURCHASE_PAYMENT_METHOD_CHANGED",
+    message: "Your payment method changed. Review the invitation again.",
+  },
+  preview_expired: {
+    status: 400,
+    code: "INVITATION_PURCHASE_PREVIEW_EXPIRED",
+    message: "This invitation purchase preview expired. Review the invitation again.",
+  },
+  preview_invalid: {
+    status: 409,
+    code: "INVITATION_PURCHASE_PREVIEW_INVALID",
+    message:
+      "This invitation purchase preview is no longer valid. Review the invitation again.",
+  },
+  purchase_in_progress: {
+    status: 409,
+    code: "INVITATION_PURCHASE_IN_PROGRESS",
+    message:
+      "Another purchase for this invitation is already in progress. Wait a moment and try again.",
+  },
+  purchase_inactive: {
+    status: 409,
+    code: "INVITATION_PURCHASE_INACTIVE",
+    message:
+      "This invitation purchase is no longer active. Review the invitation again.",
+  },
+  purchase_not_found: {
+    status: 404,
+    code: "INVITATION_PURCHASE_NOT_FOUND",
+    message: "Invitation purchase not found. Review the invitation and try again.",
+  },
+  subscription_canceling: {
+    status: 409,
+    code: "INVITATION_PURCHASE_SUBSCRIPTION_CANCELING",
+    message: "Restore your subscription before purchasing a member package.",
+  },
+  subscription_changed: {
+    status: 409,
+    code: "INVITATION_PURCHASE_SUBSCRIPTION_CHANGED",
+    message: "Your usage pack subscription changed. Review the invitation again.",
+  },
+  subscription_not_found: {
+    status: 404,
+    code: "INVITATION_PURCHASE_SUBSCRIPTION_NOT_FOUND",
+    message:
+      "Usage pack subscription not found. Review your billing settings and try again.",
+  },
+  subscription_unavailable: {
+    status: 409,
+    code: "INVITATION_PURCHASE_SUBSCRIPTION_UNAVAILABLE",
+    message:
+      "Your usage pack subscription is no longer available. Review your billing settings and try again.",
+  },
+} satisfies Readonly<
+  Record<InvitationPurchaseErrorReason, InvitationPurchaseErrorDefinition>
+>;
+
+function invitationPurchaseError(args: {
+  readonly phase: "preview" | "confirm";
+  readonly reason: InvitationPurchaseErrorReason;
+  readonly orgId: string;
+  readonly purchaseId?: string;
+  readonly usagePackUsd?: UsagePackUsd;
+  readonly role?: OrgRole;
+  readonly diagnostics?: Readonly<
+    Record<string, string | number | boolean | null>
+  >;
+}) {
+  const error = INVITATION_PURCHASE_ERRORS[args.reason];
+  log.info("Usage pack invitation purchase rejected", {
+    ...args.diagnostics,
+    type: "usage_pack_invitation_purchase_rejected",
+    phase: args.phase,
+    reason: args.reason,
+    errorCode: error.code,
+    orgId: args.orgId,
+    ...(args.purchaseId ? { purchaseId: args.purchaseId } : {}),
+    ...(args.usagePackUsd ? { usagePackUsd: args.usagePackUsd } : {}),
+    ...(args.role ? { role: args.role } : {}),
+  });
+  return {
+    status: error.status,
+    body: {
+      error: {
+        message: error.message,
+        code: error.code,
+      },
+    },
+  };
+}
 
 const inviteBody$ = bodyResultOf(orgInviteContract.invite);
 
@@ -241,18 +382,36 @@ const purchasePreviewInner$ = command(
       signal,
     );
     if (result.status === "not_found") {
-      return notFound("Usage pack subscription not found");
+      return invitationPurchaseError({
+        phase: "preview",
+        reason: "subscription_not_found",
+        orgId: auth.orgId,
+        usagePackUsd: body.data.usagePackUsd,
+        role: body.data.role,
+      });
     }
     if (result.status === "conflict") {
-      return conflict(
-        "This invitation cannot be purchased in the current billing state",
-      );
+      return invitationPurchaseError({
+        phase: "preview",
+        reason: result.reason,
+        orgId: auth.orgId,
+        usagePackUsd: body.data.usagePackUsd,
+        role: body.data.role,
+        diagnostics: result.diagnostics,
+      });
     }
     if (previewEnabled && body.data.returnUrl) {
       const billing = await activeUsagePackBillingContext(db, auth.orgId);
       signal.throwIfAborted();
       if (!billing) {
-        return notFound("Usage pack subscription not found");
+        return invitationPurchaseError({
+          phase: "preview",
+          reason: "subscription_not_found",
+          orgId: auth.orgId,
+          purchaseId: result.preview.purchaseId,
+          usagePackUsd: body.data.usagePackUsd,
+          role: body.data.role,
+        });
       }
       const route = await routeBillingPurchasePreview(
         {
@@ -381,7 +540,12 @@ const purchaseConfirmInner$ = command(
         signal,
       );
       if (revalidated.kind === "invalid_preview") {
-        return conflict("Invitation purchase preview is no longer valid");
+        return invitationPurchaseError({
+          phase: "confirm",
+          reason: "preview_invalid",
+          orgId: auth.orgId,
+          purchaseId,
+        });
       }
       paymentMethod = revalidated.paymentMethod;
     }
@@ -392,15 +556,29 @@ const purchaseConfirmInner$ = command(
       signal,
     );
     if (result.status === "not_found") {
-      return notFound("Invitation purchase not found");
+      return invitationPurchaseError({
+        phase: "confirm",
+        reason: "purchase_not_found",
+        orgId: auth.orgId,
+        purchaseId,
+      });
     }
     if (result.status === "expired") {
-      return badRequestMessage("Invitation purchase preview expired");
+      return invitationPurchaseError({
+        phase: "confirm",
+        reason: "preview_expired",
+        orgId: auth.orgId,
+        purchaseId,
+      });
     }
     if (result.status === "conflict") {
-      return conflict(
-        "This invitation cannot be purchased in the current billing state",
-      );
+      return invitationPurchaseError({
+        phase: "confirm",
+        reason: result.reason,
+        orgId: auth.orgId,
+        purchaseId,
+        diagnostics: result.diagnostics,
+      });
     }
     if (result.status === "pending_payment") {
       return {

--- a/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
@@ -190,6 +190,11 @@ interface PrepareUsagePackInvitationPurchaseArgs {
   readonly usagePackUsd: UsagePackUsd;
 }
 
+interface NewUsagePackInvitationPurchaseInput {
+  readonly email: string;
+  readonly stripePriceId: string;
+}
+
 type PrepareUsagePackInvitationPurchaseResult =
   | {
       readonly status: "ready";
@@ -516,10 +521,10 @@ async function prepareNewUsagePackInvitationPurchase(
   db: Db,
   subscription: UsagePackSubscriptionRow,
   args: PrepareUsagePackInvitationPurchaseArgs,
-  email: string,
-  stripePriceId: string,
+  input: NewUsagePackInvitationPurchaseInput,
   signal: AbortSignal,
 ): Promise<PrepareUsagePackInvitationPurchaseResult> {
+  const { email, stripePriceId } = input;
   const catalog = await loadUsagePackCatalog();
   const catalogItem = catalog.find((item) => {
     return item.usagePackUsd === args.usagePackUsd;
@@ -679,8 +684,7 @@ async function prepareUsagePackInvitationPurchase(
     db,
     subscription,
     args,
-    email,
-    stripePriceId,
+    { email, stripePriceId },
     signal,
   );
 }

--- a/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
@@ -181,6 +181,15 @@ interface PreparedUsagePackInvitationPurchase {
   readonly expiresAt: Date;
 }
 
+interface PrepareUsagePackInvitationPurchaseArgs {
+  readonly orgId: string;
+  readonly inviterUserId: string;
+  readonly publicBrand: PublicBrand;
+  readonly email: string;
+  readonly role: OrgRole;
+  readonly usagePackUsd: UsagePackUsd;
+}
+
 type PrepareUsagePackInvitationPurchaseResult =
   | {
       readonly status: "ready";
@@ -503,66 +512,14 @@ function preparedInvitationPurchaseFromRow(
   };
 }
 
-async function prepareUsagePackInvitationPurchase(
+async function prepareNewUsagePackInvitationPurchase(
   db: Db,
-  clerk: ClerkClient,
-  args: {
-    readonly orgId: string;
-    readonly inviterUserId: string;
-    readonly publicBrand: PublicBrand;
-    readonly email: string;
-    readonly role: OrgRole;
-    readonly usagePackUsd: UsagePackUsd;
-  },
+  subscription: UsagePackSubscriptionRow,
+  args: PrepareUsagePackInvitationPurchaseArgs,
+  email: string,
+  stripePriceId: string,
   signal: AbortSignal,
 ): Promise<PrepareUsagePackInvitationPurchaseResult> {
-  const subscription = await currentUsagePackSubscriptionForOrg(db, args.orgId);
-  if (!subscription?.stripeSubscriptionId) {
-    return { status: "not_found" };
-  }
-  if (subscription.cancelAtPeriodEnd) {
-    return {
-      status: "conflict",
-      reason: "subscription_canceling",
-      diagnostics: {
-        subscriptionStatus: subscription.subscriptionStatus,
-        cancelAtPeriodEnd: true,
-      },
-    };
-  }
-  const email = normalizedEmail(args.email);
-  if (await emailAlreadyBelongsToOrg(clerk, args.orgId, email)) {
-    return {
-      status: "conflict",
-      reason: "invitee_unavailable",
-      diagnostics: {},
-    };
-  }
-  signal.throwIfAborted();
-
-  const stripePriceId = activeUsagePackPriceId(args.usagePackUsd);
-  if (!stripePriceId) {
-    throw new Error(`Usage pack $${args.usagePackUsd} Price is not configured`);
-  }
-  const reusablePurchase = await reusablePendingInvitationPurchase(db, {
-    subscriptionId: subscription.id,
-    orgId: args.orgId,
-    email,
-    role: args.role,
-    inviterUserId: args.inviterUserId,
-    publicBrand: args.publicBrand,
-    usagePackUsd: args.usagePackUsd,
-    stripePriceId,
-  });
-  if (reusablePurchase?.stripeCheckoutExpiresAt) {
-    return {
-      status: "ready",
-      purchase: preparedInvitationPurchaseFromRow(
-        reusablePurchase,
-        reusablePurchase.stripeCheckoutExpiresAt,
-      ),
-    };
-  }
   const catalog = await loadUsagePackCatalog();
   const catalogItem = catalog.find((item) => {
     return item.usagePackUsd === args.usagePackUsd;
@@ -663,6 +620,69 @@ async function prepareUsagePackInvitationPurchase(
       expiresAt: new Date(checkoutExpiresAt * 1000),
     },
   };
+}
+
+async function prepareUsagePackInvitationPurchase(
+  db: Db,
+  clerk: ClerkClient,
+  args: PrepareUsagePackInvitationPurchaseArgs,
+  signal: AbortSignal,
+): Promise<PrepareUsagePackInvitationPurchaseResult> {
+  const subscription = await currentUsagePackSubscriptionForOrg(db, args.orgId);
+  if (!subscription?.stripeSubscriptionId) {
+    return { status: "not_found" };
+  }
+  if (subscription.cancelAtPeriodEnd) {
+    return {
+      status: "conflict",
+      reason: "subscription_canceling",
+      diagnostics: {
+        subscriptionStatus: subscription.subscriptionStatus,
+        cancelAtPeriodEnd: true,
+      },
+    };
+  }
+  const email = normalizedEmail(args.email);
+  if (await emailAlreadyBelongsToOrg(clerk, args.orgId, email)) {
+    return {
+      status: "conflict",
+      reason: "invitee_unavailable",
+      diagnostics: {},
+    };
+  }
+  signal.throwIfAborted();
+
+  const stripePriceId = activeUsagePackPriceId(args.usagePackUsd);
+  if (!stripePriceId) {
+    throw new Error(`Usage pack $${args.usagePackUsd} Price is not configured`);
+  }
+  const reusablePurchase = await reusablePendingInvitationPurchase(db, {
+    subscriptionId: subscription.id,
+    orgId: args.orgId,
+    email,
+    role: args.role,
+    inviterUserId: args.inviterUserId,
+    publicBrand: args.publicBrand,
+    usagePackUsd: args.usagePackUsd,
+    stripePriceId,
+  });
+  if (reusablePurchase?.stripeCheckoutExpiresAt) {
+    return {
+      status: "ready",
+      purchase: preparedInvitationPurchaseFromRow(
+        reusablePurchase,
+        reusablePurchase.stripeCheckoutExpiresAt,
+      ),
+    };
+  }
+  return prepareNewUsagePackInvitationPurchase(
+    db,
+    subscription,
+    args,
+    email,
+    stripePriceId,
+    signal,
+  );
 }
 
 export async function createUsagePackInvitationPreview(
@@ -1370,6 +1390,111 @@ function invitationPurchaseConfirmState(
   return { status: "ready", purchase };
 }
 
+async function expireInvitationPurchasePreviewIfNeeded(
+  db: Db,
+  purchase: UsagePackInvitationPurchaseRow,
+): Promise<boolean> {
+  const expiresAt = purchase.stripeCheckoutExpiresAt;
+  if (expiresAt && expiresAt > nowDate()) {
+    return false;
+  }
+  await db
+    .update(usagePackInvitationPurchases)
+    .set({
+      status: "failed",
+      failureReason: "preview_expired",
+      updatedAt: nowDate(),
+    })
+    .where(
+      and(
+        eq(usagePackInvitationPurchases.id, purchase.id),
+        eq(usagePackInvitationPurchases.status, "checkout_pending"),
+      ),
+    );
+  return true;
+}
+
+type InvitationPurchaseSubscriptionState =
+  | {
+      readonly status: "ready";
+      readonly subscription: UsagePackSubscriptionRow;
+      readonly stripeSubscriptionId: string;
+    }
+  | {
+      readonly status: "conflict";
+      readonly result: UsagePackInvitationPurchaseConflictResult;
+    };
+
+function invitationPurchaseSubscriptionState(
+  subscription: UsagePackSubscriptionRow | null,
+  purchase: UsagePackInvitationPurchaseRow,
+): InvitationPurchaseSubscriptionState {
+  const stripeSubscriptionId = subscription?.stripeSubscriptionId;
+  if (!subscription || !stripeSubscriptionId) {
+    return {
+      status: "conflict",
+      result: {
+        status: "conflict",
+        reason: "subscription_unavailable",
+        diagnostics: {
+          subscriptionStatus: subscription?.subscriptionStatus ?? null,
+          hasStripeSubscriptionId: Boolean(stripeSubscriptionId),
+        },
+      },
+    };
+  }
+  if (subscription.id !== purchase.usagePackSubscriptionId) {
+    return {
+      status: "conflict",
+      result: {
+        status: "conflict",
+        reason: "subscription_changed",
+        diagnostics: {
+          subscriptionStatus: subscription.subscriptionStatus,
+        },
+      },
+    };
+  }
+  if (subscription.cancelAtPeriodEnd) {
+    return {
+      status: "conflict",
+      result: {
+        status: "conflict",
+        reason: "subscription_canceling",
+        diagnostics: {
+          subscriptionStatus: subscription.subscriptionStatus,
+          cancelAtPeriodEnd: true,
+        },
+      },
+    };
+  }
+  return { status: "ready", subscription, stripeSubscriptionId };
+}
+
+function invitationPurchasePaymentMethodConflict(
+  paymentMethod: BillingPurchasePaymentMethod | undefined,
+  route: Awaited<ReturnType<typeof resolveBillingPurchaseRoute>>,
+): UsagePackInvitationPurchaseConflictResult | null {
+  if (
+    !paymentMethod ||
+    (route.kind === "preview" &&
+      paymentMethod.paymentMethodId === route.paymentMethodId &&
+      paymentMethod.paymentMethodType === route.paymentMethodType)
+  ) {
+    return null;
+  }
+  return {
+    status: "conflict",
+    reason: "payment_method_changed",
+    diagnostics: {
+      paymentRoute: route.kind,
+      expectedPaymentMethodType: paymentMethod.paymentMethodType,
+      currentPaymentMethodType:
+        route.kind === "preview" ? route.paymentMethodType : null,
+    },
+  };
+}
+
 export async function confirmUsagePackInvitationPurchase(
   db: Db,
   clerk: ClerkClient,
@@ -1388,21 +1513,7 @@ export async function confirmUsagePackInvitationPurchase(
     return purchaseState.result;
   }
   const { purchase } = purchaseState;
-  const expiresAt = purchase.stripeCheckoutExpiresAt;
-  if (!expiresAt || expiresAt <= nowDate()) {
-    await db
-      .update(usagePackInvitationPurchases)
-      .set({
-        status: "failed",
-        failureReason: "preview_expired",
-        updatedAt: nowDate(),
-      })
-      .where(
-        and(
-          eq(usagePackInvitationPurchases.id, purchase.id),
-          eq(usagePackInvitationPurchases.status, "checkout_pending"),
-        ),
-      );
+  if (await expireInvitationPurchasePreviewIfNeeded(db, purchase)) {
     return { status: "expired" };
   }
   if (
@@ -1423,68 +1534,38 @@ export async function confirmUsagePackInvitationPurchase(
     db,
     purchase.orgId,
   );
-  if (!subscription?.stripeSubscriptionId) {
-    return {
-      status: "conflict",
-      reason: "subscription_unavailable",
-      diagnostics: {
-        subscriptionStatus: subscription?.subscriptionStatus ?? null,
-        hasStripeSubscriptionId: Boolean(subscription?.stripeSubscriptionId),
-      },
-    };
+  const subscriptionState = invitationPurchaseSubscriptionState(
+    subscription,
+    purchase,
+  );
+  if (subscriptionState.status === "conflict") {
+    return subscriptionState.result;
   }
-  if (subscription.id !== purchase.usagePackSubscriptionId) {
-    return {
-      status: "conflict",
-      reason: "subscription_changed",
-      diagnostics: {
-        subscriptionStatus: subscription.subscriptionStatus,
-      },
-    };
-  }
-  if (subscription.cancelAtPeriodEnd) {
-    return {
-      status: "conflict",
-      reason: "subscription_canceling",
-      diagnostics: {
-        subscriptionStatus: subscription.subscriptionStatus,
-        cancelAtPeriodEnd: true,
-      },
-    };
-  }
+  const { subscription: activeSubscription, stripeSubscriptionId } =
+    subscriptionState;
   const stripe = getStripeClient();
   const route = await resolveBillingPurchaseRoute(
     {
       stripe,
       supportsInAppPreview: true,
-      customerId: subscription.stripeCustomerId,
-      subscriptionId: subscription.stripeSubscriptionId,
+      customerId: activeSubscription.stripeCustomerId,
+      subscriptionId: stripeSubscriptionId,
     },
     signal,
   );
-  if (
-    args.paymentMethod &&
-    (route.kind === "checkout" ||
-      args.paymentMethod.paymentMethodId !== route.paymentMethodId ||
-      args.paymentMethod.paymentMethodType !== route.paymentMethodType)
-  ) {
-    return {
-      status: "conflict",
-      reason: "payment_method_changed",
-      diagnostics: {
-        paymentRoute: route.kind,
-        expectedPaymentMethodType: args.paymentMethod.paymentMethodType,
-        currentPaymentMethodType:
-          route.kind === "preview" ? route.paymentMethodType : null,
-      },
-    };
+  const paymentMethodConflict = invitationPurchasePaymentMethodConflict(
+    args.paymentMethod,
+    route,
+  );
+  if (paymentMethodConflict) {
+    return paymentMethodConflict;
   }
   const paymentMethod =
     args.paymentMethod ?? (route.kind === "preview" ? route : undefined);
   const metadata = checkoutMetadata(purchase.id);
   const invoice = await stripe.invoices.create(
     {
-      customer: subscription.stripeCustomerId,
+      customer: activeSubscription.stripeCustomerId,
       auto_advance: false,
       ...(paymentMethod
         ? stripeBillingPurchasePaymentParams(paymentMethod)
@@ -1497,7 +1578,7 @@ export async function confirmUsagePackInvitationPurchase(
   await stripe.invoiceItems.create(
     {
       invoice: invoice.id,
-      customer: subscription.stripeCustomerId,
+      customer: activeSubscription.stripeCustomerId,
       amount: purchase.expectedAmountCents,
       currency: purchase.currency,
       description: `Member usage pack for ${purchase.normalizedEmail}`,

--- a/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-invitation-purchase.service.ts
@@ -89,6 +89,29 @@ type UsagePackInvitationPurchaseStatus =
 type WriteTx = Parameters<Parameters<Db["transaction"]>[0]>[0];
 type StripeObjectReference = string | { readonly id: string };
 
+export type UsagePackInvitationPurchaseConflictReason =
+  | "billing_period_ending"
+  | "billing_state_changed"
+  | "invitee_unavailable"
+  | "no_amount_due"
+  | "no_credits"
+  | "payment_method_changed"
+  | "purchase_in_progress"
+  | "purchase_inactive"
+  | "subscription_canceling"
+  | "subscription_changed"
+  | "subscription_unavailable";
+
+type UsagePackInvitationPurchaseDiagnostics = Readonly<
+  Record<string, string | number | boolean | null>
+>;
+
+interface UsagePackInvitationPurchaseConflictResult {
+  readonly status: "conflict";
+  readonly reason: UsagePackInvitationPurchaseConflictReason;
+  readonly diagnostics: UsagePackInvitationPurchaseDiagnostics;
+}
+
 interface PendingInvitationPurchaseArgs {
   readonly subscription: UsagePackSubscriptionRow;
   readonly orgId: string;
@@ -141,14 +164,14 @@ type CreateUsagePackInvitationPreviewResult =
       readonly preview: OrgInvitationPurchasePreviewResponse;
     }
   | { readonly status: "not_found" }
-  | { readonly status: "conflict" };
+  | UsagePackInvitationPurchaseConflictResult;
 
 type ConfirmUsagePackInvitationPurchaseResult =
   | { readonly status: "confirmed" }
   | { readonly status: "pending_payment"; readonly hostedInvoiceUrl: string }
   | { readonly status: "not_found" }
   | { readonly status: "expired" }
-  | { readonly status: "conflict" };
+  | UsagePackInvitationPurchaseConflictResult;
 
 interface PreparedUsagePackInvitationPurchase {
   readonly preview: UsagePackAllocationAdditionPreview;
@@ -164,7 +187,7 @@ type PrepareUsagePackInvitationPurchaseResult =
       readonly purchase: PreparedUsagePackInvitationPurchase;
     }
   | { readonly status: "not_found" }
-  | { readonly status: "conflict" };
+  | UsagePackInvitationPurchaseConflictResult;
 
 type RevokeUsagePackInvitationResult =
   | { readonly status: "not_found" }
@@ -498,11 +521,22 @@ async function prepareUsagePackInvitationPurchase(
     return { status: "not_found" };
   }
   if (subscription.cancelAtPeriodEnd) {
-    return { status: "conflict" };
+    return {
+      status: "conflict",
+      reason: "subscription_canceling",
+      diagnostics: {
+        subscriptionStatus: subscription.subscriptionStatus,
+        cancelAtPeriodEnd: true,
+      },
+    };
   }
   const email = normalizedEmail(args.email);
   if (await emailAlreadyBelongsToOrg(clerk, args.orgId, email)) {
-    return { status: "conflict" };
+    return {
+      status: "conflict",
+      reason: "invitee_unavailable",
+      diagnostics: {},
+    };
   }
   signal.throwIfAborted();
 
@@ -545,7 +579,15 @@ async function prepareUsagePackInvitationPurchase(
     signal,
   );
   if (preview.amountCents <= 0) {
-    return { status: "conflict" };
+    return {
+      status: "conflict",
+      reason: "no_amount_due",
+      diagnostics: {
+        amountCents: preview.amountCents,
+        currency: preview.currency,
+        currentPeriodEnd: preview.currentPeriodEnd.toISOString(),
+      },
+    };
   }
   const stripe = getStripeClient();
   const price = await stripe.prices.retrieve(stripePriceId, {
@@ -567,11 +609,25 @@ async function prepareUsagePackInvitationPurchase(
     (catalogItem.bonusCredits * preview.amountCents) / unitAmountCents,
   );
   if (purchasedCredits <= 0) {
-    return { status: "conflict" };
+    return {
+      status: "conflict",
+      reason: "no_credits",
+      diagnostics: {
+        amountCents: preview.amountCents,
+        unitAmountCents,
+        purchasedCredits,
+      },
+    };
   }
   const checkoutExpiresAt = checkoutExpiration(preview.currentPeriodEnd);
   if (checkoutExpiresAt === null) {
-    return { status: "conflict" };
+    return {
+      status: "conflict",
+      reason: "billing_period_ending",
+      diagnostics: {
+        currentPeriodEnd: preview.currentPeriodEnd.toISOString(),
+      },
+    };
   }
 
   const purchaseId = await insertPendingInvitationPurchase(db, {
@@ -590,7 +646,11 @@ async function prepareUsagePackInvitationPurchase(
     checkoutExpiresAt,
   });
   if (!purchaseId) {
-    return { status: "conflict" };
+    return {
+      status: "conflict",
+      reason: "purchase_in_progress",
+      diagnostics: {},
+    };
   }
   signal.throwIfAborted();
   return {
@@ -1295,7 +1355,17 @@ function invitationPurchaseConfirmState(
     purchase.status !== "checkout_pending" ||
     purchase.stripeCheckoutSessionId
   ) {
-    return { status: "complete", result: { status: "conflict" } };
+    return {
+      status: "complete",
+      result: {
+        status: "conflict",
+        reason: "purchase_inactive",
+        diagnostics: {
+          purchaseStatus: purchase.status,
+          hasCheckoutSession: purchase.stripeCheckoutSessionId !== null,
+        },
+      },
+    };
   }
   return { status: "ready", purchase };
 }
@@ -1342,19 +1412,45 @@ export async function confirmUsagePackInvitationPurchase(
       purchase.normalizedEmail,
     )
   ) {
-    return { status: "conflict" };
+    return {
+      status: "conflict",
+      reason: "invitee_unavailable",
+      diagnostics: {},
+    };
   }
   signal.throwIfAborted();
   const subscription = await currentUsagePackSubscriptionForOrg(
     db,
     purchase.orgId,
   );
-  if (
-    !subscription?.stripeSubscriptionId ||
-    subscription.id !== purchase.usagePackSubscriptionId ||
-    subscription.cancelAtPeriodEnd
-  ) {
-    return { status: "conflict" };
+  if (!subscription?.stripeSubscriptionId) {
+    return {
+      status: "conflict",
+      reason: "subscription_unavailable",
+      diagnostics: {
+        subscriptionStatus: subscription?.subscriptionStatus ?? null,
+        hasStripeSubscriptionId: Boolean(subscription?.stripeSubscriptionId),
+      },
+    };
+  }
+  if (subscription.id !== purchase.usagePackSubscriptionId) {
+    return {
+      status: "conflict",
+      reason: "subscription_changed",
+      diagnostics: {
+        subscriptionStatus: subscription.subscriptionStatus,
+      },
+    };
+  }
+  if (subscription.cancelAtPeriodEnd) {
+    return {
+      status: "conflict",
+      reason: "subscription_canceling",
+      diagnostics: {
+        subscriptionStatus: subscription.subscriptionStatus,
+        cancelAtPeriodEnd: true,
+      },
+    };
   }
   const stripe = getStripeClient();
   const route = await resolveBillingPurchaseRoute(
@@ -1372,7 +1468,16 @@ export async function confirmUsagePackInvitationPurchase(
       args.paymentMethod.paymentMethodId !== route.paymentMethodId ||
       args.paymentMethod.paymentMethodType !== route.paymentMethodType)
   ) {
-    return { status: "conflict" };
+    return {
+      status: "conflict",
+      reason: "payment_method_changed",
+      diagnostics: {
+        paymentRoute: route.kind,
+        expectedPaymentMethodType: args.paymentMethod.paymentMethodType,
+        currentPaymentMethodType:
+          route.kind === "preview" ? route.paymentMethodType : null,
+      },
+    };
   }
   const paymentMethod =
     args.paymentMethod ?? (route.kind === "preview" ? route : undefined);
@@ -1419,7 +1524,11 @@ export async function confirmUsagePackInvitationPurchase(
     throw new Error("Invitation invoice payment was not recorded");
   }
   if (!handled.orgId) {
-    return { status: "conflict" };
+    return {
+      status: "conflict",
+      reason: "billing_state_changed",
+      diagnostics: {},
+    };
   }
   return { status: "confirmed" };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-members-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-members-tab.test.tsx
@@ -589,6 +589,8 @@ describe("organization members settings", () => {
     mockUsagePackManagement();
     mockUsagePackCatalog();
     let previewCount = 0;
+    const purchaseError =
+      "Your payment method changed. Review the invitation again.";
     context.mocks.api(
       orgInviteContract.previewPurchase,
       ({ body, respond }) => {
@@ -613,8 +615,8 @@ describe("organization members settings", () => {
     context.mocks.api(orgInviteContract.confirmPurchase, ({ respond }) => {
       return respond(409, {
         error: {
-          code: "CONFLICT",
-          message: "Invitation purchase preview is no longer valid",
+          code: "INVITATION_PURCHASE_PAYMENT_METHOD_CHANGED",
+          message: purchaseError,
         },
       });
     });
@@ -649,6 +651,7 @@ describe("organization members settings", () => {
 
     const firstDialog = await openPurchase("first@example.com");
     click(buttonByText("Pay and invite", firstDialog));
+    await expect(screen.findByText(purchaseError)).resolves.toBeInTheDocument();
     await within(firstDialog).findByText(
       "Could not purchase this member package. Review your billing details and try again.",
     );


### PR DESCRIPTION
## Summary

- replace the generic invitation billing conflict with stable per-reason API codes and actionable messages that the shared client surfaces as error toasts
- emit structured debug logs to Axiom for expected preview and confirmation rejections, including safe billing diagnostics without invitee email or payment-method identifiers
- distinguish subscription, invitee, proration, purchase-state, preview, and payment-method changes across the purchase flow

## Verification

- added API integration coverage for existing members, zero proration, canceling subscriptions, superseded purchases, and invalid payment previews
- added platform page coverage that verifies the server rejection message is shown as a toast
- local format, lint, typecheck, and targeted Vitest execution were blocked because the sandbox supply-chain policy returned HTTP 424 while installing workspace dependencies; PR CI is required