### PR TITLE
fix(runner): surface claude consumer terms acceptance failures

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -268,6 +268,11 @@ fn classify_cli_failure_reason(
         return Some(FailureReason::InsufficientCredits);
     }
     if matches!(framework, AgentFramework::ClaudeCode)
+        && is_claude_terms_acceptance_required_error(&normalized)
+    {
+        return Some(FailureReason::TermsAcceptanceRequired);
+    }
+    if matches!(framework, AgentFramework::ClaudeCode)
         && is_claude_invalid_credentials_error(&normalized)
     {
         return Some(FailureReason::InvalidCredentials);
@@ -368,6 +373,14 @@ fn has_insufficient_credits_response_envelope(normalized: &str) -> bool {
 fn is_claude_invalid_credentials_error(normalized: &str) -> bool {
     normalized.contains("failed to authenticate")
         && normalized.contains("api error: 401 invalid authentication credentials")
+}
+
+fn is_claude_terms_acceptance_required_error(normalized: &str) -> bool {
+    has_claude_api_status(normalized, "400")
+        && normalized.contains("consumer terms")
+        && normalized.contains("privacy policy")
+        && normalized.contains("accept")
+        && normalized.contains("claude.ai")
 }
 
 fn is_claude_provider_overloaded_error(normalized: &str) -> bool {

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -439,6 +439,82 @@ fn cli_failure_reason_ignores_generic_claude_401() {
 }
 
 #[test]
+fn cli_failure_reason_classifies_claude_terms_acceptance_required() {
+    let reason = classify_cli_failure_reason(
+        AgentFramework::ClaudeCode,
+        "API Error: 400 We've updated our Consumer Terms and Privacy Policy. You'll need to accept them in claude.ai with the email in /status to continue.",
+    );
+
+    assert_eq!(reason, Some(FailureReason::TermsAcceptanceRequired));
+}
+
+#[test]
+fn cli_failure_reason_classifies_claude_terms_acceptance_wording_variant() {
+    let reason = classify_cli_failure_reason(
+        AgentFramework::ClaudeCode,
+        "api error: 400 PLEASE ACCEPT the updated PRIVACY POLICY and CONSUMER TERMS at CLAUDE.AI before continuing.",
+    );
+
+    assert_eq!(reason, Some(FailureReason::TermsAcceptanceRequired));
+}
+
+#[test]
+fn cli_failure_reason_ignores_claude_terms_message_for_other_frameworks() {
+    let reason = classify_cli_failure_reason(
+        AgentFramework::Codex,
+        "API Error: 400 We've updated our Consumer Terms and Privacy Policy. Accept them in claude.ai to continue.",
+    );
+
+    assert_eq!(reason, None);
+}
+
+#[test]
+fn cli_failure_reason_ignores_incomplete_claude_terms_messages() {
+    for message in [
+        "We've updated our Consumer Terms and Privacy Policy. Accept them in claude.ai.",
+        "API Error: 400 We've updated our Service Terms and Privacy Policy. Accept them in claude.ai.",
+        "API Error: 400 We've updated our Consumer Terms. Accept them in claude.ai.",
+        "API Error: 400 We've updated our Consumer Terms and Privacy Policy. Review them in claude.ai.",
+        "API Error: 400 We've updated our Consumer Terms and Privacy Policy. Accept them to continue.",
+        "API Error: 400 request rejected by the provider",
+        "API Error: 400-error Consumer Terms and Privacy Policy must be accepted at claude.ai.",
+        "API Error: 4000 Consumer Terms and Privacy Policy must be accepted at claude.ai.",
+    ] {
+        let reason = classify_cli_failure_reason(AgentFramework::ClaudeCode, message);
+
+        assert_eq!(reason, None, "message: {message}");
+    }
+}
+
+#[test]
+fn cli_failure_reason_classifies_claude_result_terms_acceptance_diagnostic() {
+    let message = "API Error: 400 We've updated our Consumer Terms and Privacy Policy. You'll need to accept them in claude.ai with the email in /status to continue.";
+    let msg = cli_failure_message(
+        1,
+        &["background stderr noise".to_string()],
+        Some(&cli_diagnostic(message, FailureDetailSource::ClaudeResult)),
+    );
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("plain prompt"),
+    )
+    .with_cli_exit_code(1)
+    .with_failure_detail_source(msg.source);
+    let diagnostic = with_cli_failure_reason(diagnostic, &msg);
+
+    assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
+    assert_eq!(
+        diagnostic.failure_reason,
+        Some(FailureReason::TermsAcceptanceRequired)
+    );
+    assert_eq!(
+        diagnostic.failure_detail_source,
+        Some(FailureDetailSource::ClaudeResult)
+    );
+}
+
+#[test]
 fn cli_failure_reason_classifies_claude_provider_overloaded() {
     let reason = classify_cli_failure_reason(
         AgentFramework::ClaudeCode,

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -630,6 +630,8 @@ pub enum FailureReason {
     InvalidApiKey,
     /// The configured credentials are invalid.
     InvalidCredentials,
+    /// The provider account must accept updated consumer terms.
+    TermsAcceptanceRequired,
     /// The model context window was exhausted.
     ContextWindowExceeded,
     /// The provider stopped because an output-token limit was reached.
@@ -657,6 +659,7 @@ impl FailureReason {
             Self::InsufficientCredits => "insufficient_credits",
             Self::InvalidApiKey => "invalid_api_key",
             Self::InvalidCredentials => "invalid_credentials",
+            Self::TermsAcceptanceRequired => "terms_acceptance_required",
             Self::ContextWindowExceeded => "context_window_exceeded",
             Self::OutputTokenLimit => "output_token_limit",
             Self::ProviderOverloaded => "provider_overloaded",
@@ -1215,6 +1218,28 @@ mod tests {
 
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureReason"], "invalid_credentials");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_terms_acceptance_required_reason() {
+        assert_eq!(
+            FailureReason::TermsAcceptanceRequired.as_str(),
+            "terms_acceptance_required"
+        );
+
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::TermsAcceptanceRequired);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "terms_acceptance_required");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -395,6 +395,7 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
                 FailureReason::InsufficientCredits
                     | FailureReason::InvalidApiKey
                     | FailureReason::InvalidCredentials
+                    | FailureReason::TermsAcceptanceRequired
                     | FailureReason::ContextWindowExceeded
                     | FailureReason::OutputTokenLimit
                     | FailureReason::ProviderOverloaded
@@ -543,6 +544,7 @@ mod tests {
             FailureReason::InsufficientCredits,
             FailureReason::InvalidApiKey,
             FailureReason::InvalidCredentials,
+            FailureReason::TermsAcceptanceRequired,
             FailureReason::ContextWindowExceeded,
             FailureReason::OutputTokenLimit,
             FailureReason::ProviderOverloaded,
@@ -668,6 +670,7 @@ mod tests {
         for reason in [
             FailureReason::InvalidApiKey,
             FailureReason::InvalidCredentials,
+            FailureReason::TermsAcceptanceRequired,
             FailureReason::ContextWindowExceeded,
             FailureReason::OutputTokenLimit,
             FailureReason::ProviderOverloaded,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -295,6 +295,66 @@ describe("formatRunErrorForExternalSurface", () => {
     ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
   });
 
+  it("shows Claude Consumer Terms guidance without provider context", () => {
+    const rawRunError =
+      "API Error: 400 We've updated our Consumer Terms and Privacy Policy. You'll need to accept them in claude.ai with the email in /status to continue.";
+    const expectedMessage =
+      "Claude Code requires acceptance of updated Consumer Terms and Privacy Policy. Sign in to https://claude.ai with the Claude account connected in Model Providers, accept the updated terms and policy, then retry.";
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+      }),
+    ).toBe(expectedMessage);
+    expect(isActionableRunError(rawRunError)).toBe(true);
+    expect(isGenericRunErrorForDisplay(rawRunError)).toBe(false);
+    expect(isActionableRunError(expectedMessage)).toBe(true);
+    expect(isGenericRunErrorForDisplay(expectedMessage)).toBe(false);
+  });
+
+  it("appends Model Providers to Claude Consumer Terms guidance", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message:
+          "api error: 400 PLEASE ACCEPT the updated PRIVACY POLICY and CONSUMER TERMS at CLAUDE.AI before continuing.",
+        claudeCodeCredentialRecovery: {
+          modelProviderType: "claude-code-oauth-token",
+          modelProviderCredentialScope: "member",
+          canManageOrgModelProviders: false,
+          modelProvidersUrl: "https://app.example.test/?settings=model",
+        },
+      }),
+    ).toBe(
+      "Claude Code requires acceptance of updated Consumer Terms and Privacy Policy. Sign in to https://claude.ai with the Claude account connected in Model Providers, accept the updated terms and policy, then retry.\n\nOpen Model Providers: https://app.example.test/?settings=model",
+    );
+  });
+
+  it("keeps incomplete Claude Consumer Terms messages generic", () => {
+    for (const rawRunError of [
+      "We've updated our Consumer Terms and Privacy Policy. Accept them in claude.ai.",
+      "API Error: 400 We've updated our Service Terms and Privacy Policy. Accept them in claude.ai.",
+      "API Error: 400 We've updated our Consumer Terms. Accept them in claude.ai.",
+      "API Error: 400 We've updated our Consumer Terms and Privacy Policy. Review them in claude.ai.",
+      "API Error: 400 We've updated our Consumer Terms and Privacy Policy. Accept them to continue.",
+      "API Error: 400 request rejected by the provider",
+      "API Error: 400-error Consumer Terms and Privacy Policy must be accepted at claude.ai.",
+      "API Error: 4000 Consumer Terms and Privacy Policy must be accepted at claude.ai.",
+      "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      "API Error: 529 upstream failed",
+    ]) {
+      expect(
+        formatRunErrorForExternalSurface({
+          code: "UNKNOWN",
+          message: rawRunError,
+        }),
+      ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+      expect(isActionableRunError(rawRunError)).toBe(false);
+      expect(isGenericRunErrorForDisplay(rawRunError)).toBe(true);
+    }
+  });
+
   it("keeps unrelated Claude limit errors generic", () => {
     const unrelatedClaudeLimit =
       "Claude process memory limit reached while preparing the sandbox.";

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -170,6 +170,9 @@ const CLAUDE_CODE_ANTHROPIC_API_KEY_ADMIN_MESSAGE =
 const CLAUDE_CODE_ANTHROPIC_API_KEY_MEMBER_MESSAGE =
   "Claude Code could not authenticate with the configured Anthropic API key. Ask a workspace admin to update or replace the API key.";
 
+const CLAUDE_CODE_TERMS_ACCEPTANCE_REQUIRED_MESSAGE =
+  "Claude Code requires acceptance of updated Consumer Terms and Privacy Policy. Sign in to https://claude.ai with the Claude account connected in Model Providers, accept the updated terms and policy, then retry.";
+
 const CLAUDE_PROVIDER_OVERLOADED_FALLBACK_MODEL = "Claude Model";
 const CLAUDE_PROVIDER_OVERLOADED_GUIDANCE =
   "is overloaded. Please wait a few minutes and try again, or switch to another model.";
@@ -230,6 +233,7 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   CLAUDE_CODE_SUBSCRIPTION_RECONNECT_REQUIRED_MESSAGE,
   CLAUDE_CODE_ANTHROPIC_API_KEY_ADMIN_MESSAGE,
   CLAUDE_CODE_ANTHROPIC_API_KEY_MEMBER_MESSAGE,
+  CLAUDE_CODE_TERMS_ACCEPTANCE_REQUIRED_MESSAGE,
 ] as const;
 
 type ClaudeCodeCredentialRecovery = {
@@ -448,10 +452,24 @@ export function isClaudeCodeAuthenticationCredentialsError(
   );
 }
 
+function isClaudeCodeTermsAcceptanceRequiredError(
+  errorMessage: string,
+): boolean {
+  const normalized = errorMessage.toLowerCase();
+  return (
+    /api error:[\s:.-]*400(?![a-z0-9_-])/u.test(normalized) &&
+    normalized.includes("consumer terms") &&
+    normalized.includes("privacy policy") &&
+    normalized.includes("accept") &&
+    normalized.includes("claude.ai")
+  );
+}
+
 export function isActionableRunError(errorMessage: string): boolean {
   return (
     isCodexOAuthReconnectRequiredRunError(errorMessage) ||
     isClaudeCodeLimitError(errorMessage) ||
+    isClaudeCodeTermsAcceptanceRequiredError(errorMessage) ||
     hasActionableRunErrorSnippet(errorMessage)
   );
 }
@@ -532,6 +550,14 @@ export function formatRunErrorForExternalSurface(params: {
   });
   if (claudeOverloadedMessage !== undefined) {
     return claudeOverloadedMessage;
+  }
+
+  if (isClaudeCodeTermsAcceptanceRequiredError(errorMessage)) {
+    return withOptionalActionUrl(
+      CLAUDE_CODE_TERMS_ACCEPTANCE_REQUIRED_MESSAGE,
+      "Open Model Providers",
+      params.claudeCodeCredentialRecovery?.modelProvidersUrl,
+    );
   }
 
   if (


### PR DESCRIPTION
## Summary

- classify Claude Code Consumer Terms failures as `terms_acceptance_required`
- route the account-actionable CLI outcome to structured `INFO` runner logs
- show fixed Web and integration recovery guidance with an optional Model Providers link

## Scope

This keeps persisted raw errors unchanged and does not change agent execution retries, completion
webhooks, database state, API routes, account telemetry, or account identity logging.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p guest-contracts`
- `cargo test -p guest-agent failure_diagnostics`
- `cargo test -p runner expected_cli_failure_reasons_log_job_execution_failed_at_info`
- `cargo test -p runner info_level_reason_on_non_cli_failure_logs_job_execution_failed_at_error`
- `cargo clippy -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-contracts -p guest-agent -p runner --all-features --no-deps`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `pnpm exec prettier --check packages/api-contracts/src/contracts/errors.ts packages/api-contracts/src/contracts/__tests__/errors.test.ts`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test`
- `pnpm knip --workspace @okouai/api-contracts`
- `pnpm knip`
- `pnpm check-types`
- `./scripts/check-file-size.sh <changed-files>`

Closes #28276
