### PR TITLE
fix(sandbox-fc): bound firecracker child file descriptor tables

### DIFF
--- a/crates/sandbox-fc/src/firecracker_process.rs
+++ b/crates/sandbox-fc/src/firecracker_process.rs
@@ -1,0 +1,62 @@
+//! Applies the shared process contract for Firecracker children.
+
+use std::io;
+use std::path::Path;
+use std::process::Stdio;
+
+use tokio::process::{Child, Command};
+
+/// Firecracker's jailer defaults both open-file limits to this value.
+const FIRECRACKER_NOFILE_LIMIT: libc::rlim_t = 2048;
+
+pub(crate) fn spawn_firecracker(mut command: Command, current_dir: &Path) -> io::Result<Child> {
+    command
+        .current_dir(current_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0)
+        .kill_on_drop(true);
+
+    // SAFETY: `setrlimit` is async-signal-safe and receives a valid pointer to
+    // child-local stack storage. The hook does not access shared process state.
+    unsafe {
+        command.pre_exec(|| {
+            let limit = libc::rlimit {
+                rlim_cur: FIRECRACKER_NOFILE_LIMIT,
+                rlim_max: FIRECRACKER_NOFILE_LIMIT,
+            };
+            if libc::setrlimit(libc::RLIMIT_NOFILE, &limit) == 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        });
+    }
+
+    command.spawn()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn spawned_child_inherits_jailer_nofile_limit() {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "ulimit -Sn; ulimit -Hn"]);
+
+        let output = spawn_firecracker(command, Path::new("/"))
+            .unwrap()
+            .wait_with_output()
+            .await
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "child failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8(output.stdout).unwrap(), "2048\n2048\n");
+    }
+}

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -34,6 +34,7 @@ mod cow_pool;
 mod duration;
 mod exec_operation_result;
 mod factory;
+mod firecracker_process;
 mod guest_dns_failure_diagnostics;
 mod guest_dns_probe;
 mod guest_dns_readiness;

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -44,6 +44,7 @@ use crate::exec_operation_result::{
     validate_exec_capture_timeout,
 };
 use crate::factory::InvariantConfig;
+use crate::firecracker_process::spawn_firecracker;
 use crate::guest_dns_failure_diagnostics::{
     GuestDnsFailureDiagnosticContext, capture_guest_dns_failure_diagnostics,
 };
@@ -1068,25 +1069,19 @@ impl FirecrackerSandbox {
     /// [`Sandbox::start`] remains responsible for cleanup when startup fails.
     async fn spawn_and_wait_for_api(
         &mut self,
-        mut command: tokio::process::Command,
+        command: tokio::process::Command,
         api_sock: &Path,
         runtime_cancel: CancellationToken,
         boot_mode: &str,
     ) -> sandbox::Result<ApiClient> {
-        let child = command
-            .current_dir(self.sandbox_paths.workspace())
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .process_group(0)
-            .kill_on_drop(true)
-            .spawn()
-            .map_err(|e| SandboxError::Start {
+        let child = spawn_firecracker(command, self.sandbox_paths.workspace()).map_err(|e| {
+            SandboxError::Start {
                 message: format!(
                     "spawn firecracker: {e} (boot_mode={boot_mode}, api_sock={})",
                     api_sock.display()
                 ),
-            })?;
+            }
+        })?;
 
         self.process_group_pid = child.id();
         self.runtime.set_process(monitor_process(

--- a/crates/sandbox-fc/src/snapshot/attempt/process.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/process.rs
@@ -8,6 +8,7 @@ use tokio::task::JoinHandle;
 use tracing::info;
 
 use crate::config::SnapshotConfig;
+use crate::firecracker_process::spawn_firecracker;
 use crate::process::kill_process_group;
 use crate::process_log::{
     PROCESS_LOG_RECORD_MAX_BYTES, PROCESS_LOG_RECORD_TRUNCATED, ProcessLogRecord,
@@ -83,7 +84,7 @@ impl Default for SnapshotProcess {
 
 impl SnapshotProcess {
     pub(super) fn spawn(&mut self, spawn: SnapshotProcessSpawn<'_>) -> std::io::Result<()> {
-        let mut child = build_command(
+        let command = build_command(
             SnapshotMountMode::Creation {
                 rootfs: BindMount::new(spawn.cow_device_path, spawn.drive_bind),
                 workspace: BindMount::new(spawn.workspace_image, spawn.workspace_drive_bind),
@@ -91,14 +92,8 @@ impl SnapshotProcess {
             spawn.network_name,
             spawn.binary_path,
             spawn.api_sock,
-        )
-        .current_dir(spawn.current_dir)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .process_group(0)
-        .kill_on_drop(true)
-        .spawn()?;
+        );
+        let mut child = spawn_firecracker(command, spawn.current_dir)?;
 
         // Stream stdout/stderr lines to tracing (same pattern as sandbox.rs).
         // Stderr is also retained in a bounded ring buffer so that an early


### PR DESCRIPTION
## Summary

- centralize the common process boundary for fresh-boot, snapshot-restore, and snapshot-creation Firecracker children
- set child soft and hard `RLIMIT_NOFILE` values to the Firecracker jailer's `2048` default before exec
- verify the production spawn boundary with a real child that reports its inherited limits

## Explicit exclusions

- keep the runner service's `LimitNOFILE=524288:524288` unchanged
- do not change the five-second API readiness deadline
- do not add launch retries or fresh-boot fallback

## Validation

- `cargo test -p sandbox-fc firecracker_process`
- `cargo clippy -p sandbox-fc --all-targets -- -D warnings`
- `cargo doc -p sandbox-fc --no-deps`
- `cargo test -p sandbox-fc` (807 unit tests, 1 integration test)
- pre-commit hooks: workspace Cargo formatting, documentation, Clippy, and file-size checks

Closes #28285
