### PR TITLE
test(api): cover connector account label requirements

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import {
   zeroConnectorManualGrantContract,
+  zeroConnectorNoAuthGrantContract,
   zeroConnectorsBySlugContract,
   zeroConnectorsMainContract,
 } from "@okouai/api-contracts/contracts/zero-connectors";
@@ -250,6 +251,57 @@ describe("POST /api/zero/connectors/:connectorSlug/manual-grant", () => {
     );
 
     expect(response.status).toBe(400);
+  });
+
+  it("requires account labels for manual and no-auth additions", async () => {
+    await seedFixture();
+    const manualClient = setupApp({ context, routes: connectorsRoutes })(
+      zeroConnectorManualGrantContract,
+    );
+    const noAuthClient = setupApp({ context, routes: connectorsRoutes })(
+      zeroConnectorNoAuthGrantContract,
+    );
+
+    const manual = await accept(
+      manualClient.connect({
+        params: { connectorSlug: "openai" },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add" },
+          values: { apiKey: "sk-unlabeled" },
+        },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+    expect(manual.body.error.message).toBe(
+      "Account display name is required when adding a manual connector account",
+    );
+
+    const noAuth = await accept(
+      noAuthClient.connect({
+        params: { connectorSlug: "openai" },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add" },
+        },
+        headers: authHeaders(),
+      }),
+      [400],
+    );
+    expect(noAuth.body.error.message).toBe(
+      "Account display name is required when adding a no-auth connector account",
+    );
+
+    const list = await accept(
+      setupApp({ context, routes: connectorsRoutes })(
+        zeroConnectorsMainContract,
+      ).list({ headers: authHeaders() }),
+      [200],
+    );
+    expect(list.body.connectors).not.toContainEqual(
+      expect.objectContaining({ slug: "openai" }),
+    );
   });
 
   it("connects a first-time manual grant connector with connector-owned state", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -2027,6 +2027,18 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
         admin,
         definition,
       );
+      const unlabeled = await connectorsApi.requestSetCustomConnectorValues(
+        admin,
+        connector.id,
+        [{ key: "secret", kind: "secret", value: "unlabeled-secret" }],
+        [400],
+        { intent: "add" },
+      );
+      expectApiError(unlabeled.body);
+      expect(unlabeled.body.error.message).toBe(
+        "Account display name is required when adding a custom connector account",
+      );
+
       const connected = await connectorsApi.requestSetCustomConnectorValues(
         admin,
         connector.id,
@@ -2133,6 +2145,18 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       agent.agentId,
       [expectedGrant],
       [200],
+    );
+
+    const unlabeledAdd = await connectorsApi.requestStartCustomConnectorOAuth2(
+      member,
+      created.id,
+      [400],
+      agent.agentId,
+      { intent: "add" },
+    );
+    expectApiError(unlabeledAdd.body);
+    expect(unlabeledAdd.body.error.message).toBe(
+      "Account display name is required when adding a custom connector account",
     );
 
     const authorizationUrl = await connectorsApi.startCustomConnectorOAuth2(

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -2038,6 +2038,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       expect(unlabeled.body.error.message).toBe(
         "Account display name is required when adding a custom connector account",
       );
+      await expect(
+        connectorsApi.readCustomConnector(admin, connector.id),
+      ).resolves.toMatchObject({ connected: false });
 
       const connected = await connectorsApi.requestSetCustomConnectorValues(
         admin,
@@ -2158,6 +2161,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expect(unlabeledAdd.body.error.message).toBe(
       "Account display name is required when adding a custom connector account",
     );
+    await expect(
+      connectorsApi.readCustomConnector(member, created.id),
+    ).resolves.toMatchObject({ connected: false });
 
     const authorizationUrl = await connectorsApi.startCustomConnectorOAuth2(
       member,


### PR DESCRIPTION
## Summary

- cover missing account labels for built-in manual and no-auth additions
- cover the same validation for custom HTTP/MCP manual and generic custom OAuth additions
- verify rejected built-in and custom requests do not create a connector connection

## Scope

This is a test-only follow-up to #28251. It does not change connector account contracts or production behavior.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts --maxWorkers=4 --silent=passed-only` (100 tests)
- `pnpm exec prettier --write apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip`
- pre-commit repository type checks, Knip, Prettier, and file-size checks

Closes #28316

Parent: #22832
