### PR TITLE
fix(platform): show pinned agent drag handle only while dragging

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -3987,7 +3987,7 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("shows a drag handle on reorderable pinned agents but not on the lead agent", async () => {
+  it("shows drag handles only while a reorder drag is in flight", async () => {
     const pinnedAgentIds = prepareOverflowingPinnedAgents();
     context.mocks.data.userPreferences({ pinnedAgentIds });
 
@@ -4005,10 +4005,23 @@ describe("zero sidebar", () => {
     });
 
     expect(
-      within(pinnedAgentLink(grid, "Support Agent")).getByTestId(
+      within(grid).queryAllByTestId("pinned-agent-drag-handle"),
+    ).toHaveLength(0);
+
+    fireEvent.dragStart(pinnedAgentLink(grid, "Support Agent"), {
+      dataTransfer: createDataTransferStub(),
+    });
+
+    expect(
+      within(pinnedAgentLink(grid, "Operations Agent")).getByTestId(
         "pinned-agent-drag-handle",
       ),
     ).toBeInTheDocument();
+    expect(
+      within(pinnedAgentLink(grid, "Support Agent")).queryByTestId(
+        "pinned-agent-drag-handle",
+      ),
+    ).toBeNull();
     expect(
       within(pinnedAgentLink(grid, "Zero")).queryByTestId(
         "pinned-agent-drag-handle",

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -257,7 +257,9 @@ interface PinnedGridAgent {
 type PinnedDropSide = "before" | "after";
 
 /**
- * The drag handle shown above a pinned tile on hover. It is absolutely
+ * The drag handle shown above a pinned tile while a reorder drag is in flight.
+ * Hovering a tile leaves it untouched — the handle marks the reorderable slots
+ * once dragging starts, so browsing pinned agents stays quiet. It is absolutely
  * positioned so it costs no layout: the tile keeps its size and the avatar
  * never moves.
  *
@@ -270,7 +272,7 @@ function PinnedAgentDragHandle() {
     <span
       aria-hidden="true"
       data-testid="pinned-agent-drag-handle"
-      className="pointer-events-none absolute -top-[8px] left-1/2 z-10 flex -translate-x-1/2 flex-col gap-[2px] rounded border border-border bg-popover p-[3px] opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+      className="pointer-events-none absolute -top-[8px] left-1/2 z-10 flex -translate-x-1/2 flex-col gap-[2px] rounded border border-border bg-popover p-[3px]"
     >
       {[0, 1].map((row) => {
         return (
@@ -312,6 +314,7 @@ function PinnedAgentGridCard({
   const [, moveAgent] = useLoadableSet(movePinnedAgent$);
 
   const isDragging = draggingAgentId === agent.id;
+  const isDragInFlight = draggingAgentId !== null;
   const acceptsDrop =
     isReorderable && draggingAgentId !== null && draggingAgentId !== agent.id;
 
@@ -362,7 +365,9 @@ function PinnedAgentGridCard({
           : "text-sidebar-foreground hover:bg-state-hover"
       } ${isReorderable ? "cursor-grab active:cursor-grabbing" : ""}`}
     >
-      {isReorderable && !isDragging && <PinnedAgentDragHandle />}
+      {isReorderable && isDragInFlight && !isDragging && (
+        <PinnedAgentDragHandle />
+      )}
       {dropSide && (
         <span
           aria-hidden="true"


### PR DESCRIPTION
## Problem

The six-dot grip above a pinned agent tile was revealed on hover (`group-hover:opacity-100`), so it popped up during ordinary browsing of the pinned agents row — visual noise on a surface that is hovered constantly.

## Change

`PinnedAgentDragHandle` now renders only while a reorder drag is in flight, on the reorderable tiles that can accept the drop. The dragged tile keeps its dashed ghost with no grip, and the lead agent still never shows one.

- `zero-sidebar-pinned.tsx`: gate the handle on `draggingPinnedAgentId$` instead of hover; drop the opacity/hover classes.
- `zero-sidebar.test.tsx`: the handle test now asserts no handles at rest, and handles on the other reorderable tiles after `dragStart`.

Reordering itself is unchanged — the whole tile is the drag source, so nothing depends on grabbing the grip.

## Verification

Local `pnpm` install is blocked in this sandbox (npm registry unreachable), so the platform vitest suite runs in CI.