### PR TITLE
fix(api): attribute direct axiom ingest failures

### DIFF
--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -4,7 +4,11 @@ import { Axiom } from "@axiomhq/js";
 import { env, optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { singleton } from "../../lib/singleton";
-import { startUntrackedBestEffortCleanup } from "../utils";
+import { now } from "../../lib/time";
+import {
+  settleIncludingAbort,
+  startUntrackedBestEffortCleanup,
+} from "../utils";
 import {
   getAxiomTokenEnvNameForApl,
   getAxiomTokenEnvNameForDataset,
@@ -14,6 +18,10 @@ const AXIOM_API_ORIGIN = "https://api.axiom.co";
 const AXIOM_QUERY_TIMEOUT_MS = 120_000;
 const AXIOM_INGEST_FAILURE_DETAIL_LIMIT = 3;
 const AXIOM_INGEST_FAILURE_ERROR_MAX_LENGTH = 512;
+const AXIOM_TRANSPORT_ERROR_MESSAGES = {
+  timeout: "Axiom ingest timed out",
+  transport_error: "Axiom ingest transport failed",
+} as const;
 
 const L = logger("api:axiom");
 
@@ -111,10 +119,24 @@ type DirectAxiomIngestErrorOptions =
       readonly failureDetailsReturned: number;
       readonly failureDetails: readonly AxiomIngestFailure[];
       readonly failureDetailsOmitted: number;
+    }
+  | {
+      readonly reason: "timeout" | "transport_error";
+      readonly dataset: string;
+      readonly eventCount: number;
+      readonly requestBytes: number;
+      readonly timeoutMs: number;
+      readonly elapsedMs: number;
+      readonly cause: unknown;
     };
 
 class DirectAxiomIngestError extends Error {
-  readonly reason: "http_status" | "invalid_response" | "partial_ingest";
+  readonly reason:
+    | "http_status"
+    | "invalid_response"
+    | "partial_ingest"
+    | "timeout"
+    | "transport_error";
   readonly dataset: string;
   readonly status?: number;
   readonly expected?: number;
@@ -123,9 +145,18 @@ class DirectAxiomIngestError extends Error {
   readonly failureDetailsReturned?: number;
   readonly failureDetails?: readonly AxiomIngestFailure[];
   readonly failureDetailsOmitted?: number;
+  readonly eventCount?: number;
+  readonly requestBytes?: number;
+  readonly timeoutMs?: number;
+  readonly elapsedMs?: number;
 
   constructor(message: string, options: DirectAxiomIngestErrorOptions) {
-    super(message);
+    super(
+      message,
+      options.reason === "timeout" || options.reason === "transport_error"
+        ? { cause: options.cause }
+        : undefined,
+    );
     this.name = "DirectAxiomIngestError";
     this.reason = options.reason;
     this.dataset = options.dataset;
@@ -139,6 +170,12 @@ class DirectAxiomIngestError extends Error {
       this.failureDetailsReturned = options.failureDetailsReturned;
       this.failureDetails = options.failureDetails;
       this.failureDetailsOmitted = options.failureDetailsOmitted;
+    }
+    if (options.reason === "timeout" || options.reason === "transport_error") {
+      this.eventCount = options.eventCount;
+      this.requestBytes = options.requestBytes;
+      this.timeoutMs = options.timeoutMs;
+      this.elapsedMs = options.elapsedMs;
     }
   }
 }
@@ -190,6 +227,7 @@ function axiomIngestUrl(dataset: string): string {
 export async function ingestAxiomDirect(
   dataset: string,
   events: readonly Record<string, unknown>[],
+  timeoutMs: number,
   signal: AbortSignal,
 ): Promise<DirectAxiomIngestResult> {
   const tokenEnvName = getAxiomTokenEnvNameForDataset(dataset);
@@ -198,17 +236,50 @@ export async function ingestAxiomDirect(
     return { configured: false };
   }
 
-  const response = await fetch(axiomIngestUrl(dataset), {
-    method: "POST",
-    redirect: "error",
-    headers: {
-      accept: "application/json",
-      authorization: `Bearer ${token}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(events),
-    signal,
-  });
+  const body = JSON.stringify(events);
+  const requestBytes = Buffer.byteLength(body, "utf8");
+  const startedAt = now();
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const requestSignal = AbortSignal.any([signal, timeoutSignal]);
+  const fetchResult = await settleIncludingAbort(
+    fetch(axiomIngestUrl(dataset), {
+      method: "POST",
+      redirect: "error",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body,
+      signal: requestSignal,
+    }),
+  );
+  if (!fetchResult.ok) {
+    if (
+      signal.aborted &&
+      requestSignal.aborted &&
+      requestSignal.reason === signal.reason
+    ) {
+      throw fetchResult.error;
+    }
+
+    const reason =
+      timeoutSignal.aborted &&
+      requestSignal.aborted &&
+      requestSignal.reason === timeoutSignal.reason
+        ? "timeout"
+        : "transport_error";
+    throw new DirectAxiomIngestError(AXIOM_TRANSPORT_ERROR_MESSAGES[reason], {
+      reason,
+      dataset,
+      eventCount: events.length,
+      requestBytes,
+      timeoutMs,
+      elapsedMs: Math.max(0, now() - startedAt),
+      cause: fetchResult.error,
+    });
+  }
+  const response = fetchResult.value;
 
   if (!response.ok) {
     if (response.body) {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -732,14 +732,14 @@ export function createWebhookCallbackApi(context: TestContext) {
       body: AgentTelemetryBody,
       headers: SandboxWebhookHeaders,
       statuses: readonly (200 | 400 | 401 | 404 | 500)[],
+      signal?: AbortSignal,
     ) {
       return await accept(
-        setupApp({ context, routes: webhooksAgentHealthUsageTelemetryRoutes })(
-          webhookTelemetryContract,
-        ).send({
-          headers,
-          body,
-        }),
+        setupApp({
+          context,
+          routes: webhooksAgentHealthUsageTelemetryRoutes,
+          signal,
+        })(webhookTelemetryContract).send({ headers, body }),
         statuses,
       );
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -9,7 +9,7 @@ import { HttpResponse, http } from "msw";
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
-import { now, nowDate } from "../../../lib/time";
+import { mockNow, now, nowDate } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { testContext } from "../../../__tests__/test-context";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -1609,9 +1609,15 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     const { runId, headers } = await createEventWebhookRun(
       "best-effort Axiom deadline",
     );
+    const submittedPayloadValue = `private-timeout-value-${randomUUID()}`;
+    const axiomToken = `xaat-timeout-${randomUUID()}`;
+    mockOptionalEnv("AXIOM_TOKEN_SESSIONS", axiomToken);
+    const startedAt = now();
+    mockNow(startedAt);
     const ingestStarted = createDeferredPromise<void>(context.signal);
     const releaseIngest = createDeferredPromise<void>(context.signal);
     const axiomDeadline = new AbortController();
+    let submittedBody = "";
     context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
       return milliseconds === 10_000 ? axiomDeadline.signal : undefined;
     });
@@ -1623,7 +1629,8 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
     server.use(
       http.post(
         "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
-        async () => {
+        async ({ request }) => {
+          submittedBody = await request.text();
           ingestStarted.resolve(undefined);
           await releaseIngest.promise;
           return HttpResponse.json(successfulAxiomIngestStatus(1));
@@ -1637,7 +1644,7 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
           {
             type: "result",
             sequenceNumber: 0,
-            result: "DB-backed callback output",
+            result: submittedPayloadValue,
           },
         ],
       },
@@ -1650,23 +1657,112 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
       lastSequence: 0,
     });
     await ingestStarted.promise;
+    mockNow(startedAt + 2345);
     axiomDeadline.abort(
       new DOMException("Axiom ingest deadline", "TimeoutError"),
     );
 
     releaseIngest.resolve(undefined);
     await flushWaitUntilForTest();
-    expect(
-      context.mocks.axiomLogging.error.mock.calls.some(([message, fields]) => {
+    const logFields = context.mocks.axiomLogging.error.mock.calls.find(
+      ([message, fields]) => {
         return (
           message === "Optional Axiom trace delivery failed" &&
-          typeof fields === "object" &&
-          fields !== null &&
-          "runId" in fields &&
+          isUnknownRecord(fields) &&
           fields.runId === runId
         );
-      }),
-    ).toBeTruthy();
+      },
+    )?.[1];
+    if (!isUnknownRecord(logFields) || !isUnknownRecord(logFields.error)) {
+      throw new Error("Expected structured Axiom timeout log fields");
+    }
+    expect(logFields.error).toMatchObject({
+      name: "DirectAxiomIngestError",
+      message: "Axiom ingest timed out",
+      reason: "timeout",
+      dataset: "agent-run-events",
+      eventCount: 1,
+      requestBytes: Buffer.byteLength(submittedBody, "utf8"),
+      timeoutMs: 10_000,
+      elapsedMs: 2345,
+      cause: {
+        name: "TimeoutError",
+        message: "Axiom ingest deadline",
+      },
+    });
+    expect(logFields.error.requestBytes).toBeGreaterThan(0);
+    const serializedLogFields = JSON.stringify(logFields);
+    expect(serializedLogFields).not.toContain(submittedPayloadValue);
+    expect(serializedLogFields).not.toContain(axiomToken);
+  });
+
+  it("logs safe dimensions for a non-parent Axiom transport failure", async () => {
+    const { runId, headers } = await createEventWebhookRun(
+      "best-effort Axiom transport failure",
+    );
+    const submittedPayloadValue = `private-transport-value-${randomUUID()}`;
+    const axiomToken = `xaat-transport-${randomUUID()}`;
+    mockOptionalEnv("AXIOM_TOKEN_SESSIONS", axiomToken);
+    let submittedBody = "";
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
+        async ({ request }) => {
+          submittedBody = await request.text();
+          return HttpResponse.error();
+        },
+      ),
+    );
+
+    const response = await api.requestAgentEvents(
+      {
+        runId,
+        events: [
+          {
+            type: "result",
+            sequenceNumber: 0,
+            result: submittedPayloadValue,
+          },
+        ],
+      },
+      headers,
+      [200],
+    );
+    expect(response.body).toStrictEqual({
+      received: 1,
+      firstSequence: 0,
+      lastSequence: 0,
+    });
+    await flushWaitUntilForTest();
+
+    const logFields = context.mocks.axiomLogging.error.mock.calls.find(
+      ([message, fields]) => {
+        return (
+          message === "Optional Axiom trace delivery failed" &&
+          isUnknownRecord(fields) &&
+          fields.runId === runId
+        );
+      },
+    )?.[1];
+    if (!isUnknownRecord(logFields) || !isUnknownRecord(logFields.error)) {
+      throw new Error("Expected structured Axiom transport log fields");
+    }
+    expect(logFields.error).toMatchObject({
+      name: "DirectAxiomIngestError",
+      message: "Axiom ingest transport failed",
+      reason: "transport_error",
+      dataset: "agent-run-events",
+      eventCount: 1,
+      requestBytes: Buffer.byteLength(submittedBody, "utf8"),
+      timeoutMs: 10_000,
+      elapsedMs: expect.any(Number),
+      cause: { name: "TypeError" },
+    });
+    expect(logFields.error.requestBytes).toBeGreaterThan(0);
+    expect(logFields.error.elapsedMs).toBeGreaterThanOrEqual(0);
+    const serializedLogFields = JSON.stringify(logFields);
+    expect(serializedLogFields).not.toContain(submittedPayloadValue);
+    expect(serializedLogFields).not.toContain(axiomToken);
   });
 
   it("logs bounded Axiom partial-ingest details without event payload values", async () => {
@@ -1872,6 +1968,141 @@ describe("WHCB-04: internal callback and event-consumer boundaries", () => {
 });
 
 describe("WHCB-05: sandbox agent webhook boundaries", () => {
+  it("returns 500 with structured diagnostics when telemetry ingest times out", async () => {
+    const { runId, headers } = await createEventWebhookRun(
+      "required Axiom telemetry deadline",
+    );
+    const submittedHost = `${randomUUID()}.timeout.example.test`;
+    const axiomToken = `xaat-telemetry-timeout-${randomUUID()}`;
+    mockOptionalEnv("AXIOM_TOKEN_TELEMETRY", axiomToken);
+    const startedAt = now();
+    mockNow(startedAt);
+    const ingestStarted = createDeferredPromise<void>(context.signal);
+    const releaseIngest = createDeferredPromise<void>(context.signal);
+    const axiomDeadline = new AbortController();
+    context.mocks.abortSignal.timeout.mockImplementation((milliseconds) => {
+      return milliseconds === 10_000 ? axiomDeadline.signal : undefined;
+    });
+    onTestFinished(() => {
+      if (!releaseIngest.settled()) {
+        releaseIngest.resolve(undefined);
+      }
+    });
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/sandbox-telemetry-network/ingest",
+        async () => {
+          ingestStarted.resolve(undefined);
+          await releaseIngest.promise;
+          return HttpResponse.json(successfulAxiomIngestStatus(1));
+        },
+      ),
+    );
+
+    const pendingResponse = api.requestAgentTelemetry(
+      {
+        runId,
+        networkLogs: [
+          { timestamp: nowDate().toISOString(), host: submittedHost },
+        ],
+      },
+      headers,
+      [500],
+    );
+    await ingestStarted.promise;
+    mockNow(startedAt + 3456);
+    axiomDeadline.abort(
+      new DOMException("Axiom telemetry deadline", "TimeoutError"),
+    );
+    releaseIngest.resolve(undefined);
+
+    const response = await pendingResponse;
+    expect(response.status).toBe(500);
+    const logFields = context.mocks.axiomLogging.error.mock.calls.find(
+      ([, fields]) => {
+        return (
+          isUnknownRecord(fields) &&
+          fields.type === "unhandled_request_error" &&
+          isUnknownRecord(fields.error) &&
+          fields.error.reason === "timeout"
+        );
+      },
+    )?.[1];
+    if (!isUnknownRecord(logFields) || !isUnknownRecord(logFields.error)) {
+      throw new Error("Expected structured telemetry timeout log fields");
+    }
+    expect(logFields.error).toMatchObject({
+      name: "DirectAxiomIngestError",
+      reason: "timeout",
+      dataset: "sandbox-telemetry-network",
+      eventCount: 1,
+      timeoutMs: 10_000,
+      elapsedMs: 3456,
+      cause: {
+        name: "TimeoutError",
+        message: "Axiom telemetry deadline",
+      },
+    });
+    const serializedLogFields = JSON.stringify(logFields);
+    expect(serializedLogFields).not.toContain(submittedHost);
+    expect(serializedLogFields).not.toContain(axiomToken);
+  });
+
+  it("preserves parent cancellation at the telemetry request boundary", async () => {
+    const { runId, headers } = await createEventWebhookRun(
+      "parent-cancelled Axiom telemetry",
+    );
+    const ingestStarted = createDeferredPromise<void>(context.signal);
+    const releaseIngest = createDeferredPromise<void>(context.signal);
+    const parentController = new AbortController();
+    onTestFinished(() => {
+      if (!releaseIngest.settled()) {
+        releaseIngest.resolve(undefined);
+      }
+    });
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/sandbox-telemetry-network/ingest",
+        async () => {
+          ingestStarted.resolve(undefined);
+          await releaseIngest.promise;
+          return HttpResponse.json(successfulAxiomIngestStatus(1));
+        },
+      ),
+    );
+
+    const pendingResponse = api.requestAgentTelemetry(
+      {
+        runId,
+        networkLogs: [
+          {
+            timestamp: nowDate().toISOString(),
+            host: `${randomUUID()}.parent-abort.example.test`,
+          },
+        ],
+      },
+      headers,
+      [500],
+      parentController.signal,
+    );
+    await ingestStarted.promise;
+    const parentAbort = new Error("Parent request cancelled");
+    parentAbort.name = "AbortError";
+    parentController.abort(parentAbort);
+    releaseIngest.resolve(undefined);
+
+    const response = await pendingResponse;
+    expect(response.status).toBe(500);
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+    expect(
+      context.mocks.axiomLogging.error.mock.calls.some(([, fields]) => {
+        return (
+          isUnknownRecord(fields) && fields.type === "unhandled_request_error"
+        );
+      }),
+    ).toBeFalsy();
+  });
+
   it("attributes sandbox operation telemetry to the optional runner name", async () => {
     const { runId, headers } = await createEventWebhookRun(
       `runner-name telemetry ${randomUUID()}`,

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -405,10 +405,8 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
         await ingestAxiomDirect(
           batch.dataset,
           batch.events,
-          AbortSignal.any([
-            signal,
-            AbortSignal.timeout(TELEMETRY_INGEST_TIMEOUT_MS),
-          ]),
+          TELEMETRY_INGEST_TIMEOUT_MS,
+          signal,
         );
       }),
     );

--- a/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-event-consumer-axiom.service.ts
@@ -255,15 +255,11 @@ export async function ingestAxiomEvents(
       eventData: eventDataForAxiom(payload.runId, event, encoder),
     };
   });
-  const ingestSignal = AbortSignal.any([
-    signal,
-    AbortSignal.timeout(AXIOM_EVENT_INGEST_TIMEOUT_MS),
-  ]);
-
   const result = await ingestAxiomDirect(
     getDatasetName(AGENT_RUN_EVENTS_DATASET),
     axiomEvents,
-    ingestSignal,
+    AXIOM_EVENT_INGEST_TIMEOUT_MS,
+    signal,
   );
   signal.throwIfAborted();
   if (!result.configured) {


### PR DESCRIPTION
## Summary

- move the direct Axiom deadline into `ingestAxiomDirect` so it can distinguish the configured deadline from parent cancellation
- emit payload-safe structured diagnostics for configured timeouts and other transport failures, including dataset, event count, exact request bytes, timeout budget, elapsed time, and original cause
- preserve raw parent aborts and existing HTTP, partial-ingest, acknowledgement, concurrency, and unconfigured-token behavior

## Scope

This PR intentionally does not change timeout values, add retries or queues, modify Axiom SDK batching, or change runner/GuestAgent protocols. It is the direct-ingest diagnostic slice of the broader investigation in #28261.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts` (56 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (167 passed)
- `pnpm knip` (passed via pre-commit; the isolated `--workspace api` mode reports cross-workspace exports that the full analysis resolves)
- pre-commit full Turbo type checks (14 packages passed)

Closes #28306
Parent context: #28261
