### PR TITLE
docs(python): document conditional bracketed-authority ipv6 predicate

### DIFF
--- a/crates/runner/mitm-addon/src/authority_utils.py
+++ b/crates/runner/mitm-addon/src/authority_utils.py
@@ -127,6 +127,17 @@ def authority_has_empty_port(netloc: str) -> bool:
 
 
 def bracketed_authority_host_is_ipv6(netloc: str) -> bool:
+    """Check that a bracketed authority host, if present, is IPv6.
+
+    This is a conditional bracket-syntax check, not general authority-host
+    validation. Malformed authorities for which ``raw_authority_host()``
+    returns ``None`` produce ``False``. Successfully parsed unbracketed hosts
+    produce ``True`` without hostname or IP validation. Bracketed IPv6 hosts
+    produce ``True``; bracketed IPv4 and non-IP hosts produce ``False``.
+
+    Callers must still apply the normalization and trust-boundary policy
+    checks required for their authority.
+    """
     raw_host = raw_authority_host(netloc)
     if raw_host is None:
         return False

--- a/crates/runner/mitm-addon/tests/test_authority_utils.py
+++ b/crates/runner/mitm-addon/tests/test_authority_utils.py
@@ -1,0 +1,23 @@
+"""Shared authority parsing contract tests."""
+
+import pytest
+
+import authority_utils
+
+
+@pytest.mark.parametrize(
+    ("netloc", "expected"),
+    [
+        pytest.param("", False, id="malformed-empty"),
+        pytest.param("[2001:db8::1", False, id="malformed-unclosed-bracket"),
+        pytest.param("example.com:443:8443", False, id="malformed-multiple-colons"),
+        pytest.param("not-an-ip", True, id="unbracketed-host-without-ip-validation"),
+        pytest.param("example.com:443", True, id="unbracketed-host-with-port"),
+        pytest.param("[2001:db8::1]", True, id="bracketed-ipv6"),
+        pytest.param("[2001:db8::1]:443", True, id="bracketed-ipv6-with-port"),
+        pytest.param("[127.0.0.1]", False, id="bracketed-ipv4"),
+        pytest.param("[v1.invalid]", False, id="bracketed-non-ip"),
+    ],
+)
+def test_bracketed_authority_host_is_ipv6_contract(netloc, expected):
+    assert authority_utils.bracketed_authority_host_is_ipv6(netloc) is expected


### PR DESCRIPTION
## Summary

- Document the conditional contract of `bracketed_authority_host_is_ipv6()` at the shared authority-parsing boundary.
- Add focused coverage for malformed, unbracketed, bracketed IPv6, and bracketed non-IPv6 authorities.

## Scope

The helper name, return values, caller flow, and all runtime validation branches are unchanged. The docstring explicitly states that unbracketed success does not validate a hostname and that callers retain trust-boundary-specific normalization and policy checks.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_authority_utils.py tests/test_auth_base_rewrite.py` — 135 passed
- `uv run --no-sync ruff format --check .` — passed
- `uv run --no-sync ruff check .` — passed
- `uv run --no-sync basedpyright -p .` — 0 errors, 0 warnings, 0 notes
- `uv run --no-sync python -m pytest tests/ -v` — 6398 passed, 1 pre-existing failure in `tests/test_request_handler_firewall_auth.py::test_registry_reload_replaces_firewall_auth_identity`

The full-suite failure reproduces on the base commit `ee3256f4d6` in an isolated worktree; it is outside this PR's changed files and scope.

Closes #28287
