### PR TITLE
fix(guest): isolate managed claude config from user home

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -154,6 +154,10 @@ pub mod runners {
 
     /// Runner and guest filesystem path constants shared across Rust and TypeScript.
     pub mod paths {
+        /// Canonical directory for VM0-managed Claude Code configuration and session state inside runner guests.
+        /// Guest launch, session capture, runner restore, and API-managed mounts use this shared path independently of the user HOME environment.
+        pub const CANONICAL_CLAUDE_CONFIG_DIR: &str = "/home/user/.claude";
+
         /// Canonical directory for VM0-managed Codex state inside runner guests.
         /// Guest auth, runtime configuration, session capture, and runner restore use this shared path independently of the user HOME environment.
         pub const CANONICAL_CODEX_HOME_DIR: &str = "/home/user/.codex";

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -325,6 +325,7 @@ pub(super) struct CliRuntimeConfig<'a> {
     use_mock_codex: bool,
     mock_codex_path: Cow<'a, str>,
     home_dir: Cow<'a, str>,
+    claude_config_dir: Cow<'a, str>,
     codex_home_dir: Cow<'a, str>,
     api_url: Cow<'a, str>,
     api_start_time: Cow<'a, str>,
@@ -395,6 +396,7 @@ impl<'a> CliRuntimeConfig<'a> {
             use_mock_codex: config.use_mock_codex,
             mock_codex_path: Cow::Borrowed(&config.mock_codex_path),
             home_dir: Cow::Borrowed(&config.home_dir),
+            claude_config_dir: Cow::Borrowed(&config.claude_config_dir),
             codex_home_dir: Cow::Borrowed(&config.codex_home_dir),
             api_url: Cow::Borrowed(&config.api_url),
             api_start_time: Cow::Borrowed(&config.api_start_time),
@@ -928,9 +930,16 @@ async fn execute_cli_inner(
         .kill_on_drop(true);
 
     let mut child_env_values = child_env::values_for_runtime(runtime);
-    if matches!(runtime.framework, env::Framework::Pi) {
-        write_pi_launch_payload_file(runtime)?;
-        child_env_values.extend(pi_child_env_values(runtime));
+    match runtime.framework {
+        env::Framework::ClaudeCode => child_env_values.push((
+            "CLAUDE_CONFIG_DIR".to_string(),
+            runtime.claude_config_dir.to_string(),
+        )),
+        env::Framework::Pi => {
+            write_pi_launch_payload_file(runtime)?;
+            child_env_values.extend(pi_child_env_values(runtime));
+        }
+        env::Framework::Codex => {}
     }
     // Suppress Claude CLI features that are unnecessary or harmful in a
     // sandbox: startup network calls (statsig, Datadog, Segment, GCS update
@@ -1984,6 +1993,7 @@ mod tests {
             use_mock_codex: false,
             mock_codex_path: String::new(),
             home_dir: "/tmp/home".to_string(),
+            claude_config_dir: "/tmp/claude-config".to_string(),
             codex_home_dir: "/tmp/codex-home".to_string(),
             artifacts: Vec::new(),
             feature_flags: HashMap::new(),
@@ -2022,6 +2032,7 @@ mod tests {
             use_mock_codex: false,
             mock_codex_path: Cow::Borrowed(""),
             home_dir: Cow::Borrowed("/tmp/home"),
+            claude_config_dir: Cow::Borrowed("/tmp/claude-config"),
             codex_home_dir: Cow::Borrowed("/tmp/codex-home"),
             api_url: Cow::Borrowed(""),
             api_start_time: Cow::Borrowed(""),

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use api_contracts::generated::{
-    constants::runners::paths::CANONICAL_CODEX_HOME_DIR,
+    constants::runners::paths::{CANONICAL_CLAUDE_CONFIG_DIR, CANONICAL_CODEX_HOME_DIR},
     types::runners::storage::ArtifactEntryMissingRootPolicy,
 };
 
@@ -20,6 +20,8 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 const USER_ENV_FILE_ENV_KEY: &str = guest_contracts::env::USER_ENV_FILE_ENV;
 const RUN_PAYLOAD_FILE_ENV_KEY: &str = guest_contracts::env::RUN_PAYLOAD_FILE_ENV;
 const POST_RESULT_CLEANUP_MAX_SECS: u64 = 60 * 60;
+#[cfg(debug_assertions)]
+const TEST_CLAUDE_CONFIG_DIR_ENV_KEY: &str = "VM0_TEST_CLAUDE_CONFIG_DIR";
 #[cfg(debug_assertions)]
 const TEST_CODEX_HOME_DIR_ENV_KEY: &str = "VM0_TEST_CODEX_HOME_DIR";
 
@@ -195,6 +197,8 @@ pub struct GuestConfigRaw {
     pub runtime_home: Option<PathBuf>,
     pub guest_runtime_dir: Option<PathBuf>,
     #[cfg(debug_assertions)]
+    pub test_claude_config_dir: Option<PathBuf>,
+    #[cfg(debug_assertions)]
     pub test_codex_home_dir: Option<PathBuf>,
     pub stuck_tool_timeout_secs: String,
     pub post_result_sigterm_grace_secs: String,
@@ -233,6 +237,10 @@ impl GuestConfigRaw {
             home: std::env::var("HOME").ok(),
             runtime_home: std::env::var_os("HOME").map(PathBuf::from),
             guest_runtime_dir,
+            #[cfg(debug_assertions)]
+            test_claude_config_dir: std::env::var_os(TEST_CLAUDE_CONFIG_DIR_ENV_KEY)
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from),
             #[cfg(debug_assertions)]
             test_codex_home_dir: std::env::var_os(TEST_CODEX_HOME_DIR_ENV_KEY)
                 .filter(|value| !value.is_empty())
@@ -287,6 +295,7 @@ pub struct GuestConfig {
     pub use_mock_codex: bool,
     pub mock_codex_path: String,
     pub home_dir: String,
+    pub claude_config_dir: String,
     pub codex_home_dir: String,
     pub artifacts: Vec<ArtifactEnv>,
     pub feature_flags: HashMap<String, bool>,
@@ -331,6 +340,7 @@ impl GuestConfig {
         user_env: HashMap<String, String>,
     ) -> Result<Self, String> {
         let home_dir = resolve_home_dir(&user_env, raw.home.as_deref())?;
+        let claude_config_dir = resolve_claude_config_dir(&raw);
         let codex_home_dir = resolve_codex_home_dir(&raw);
         let artifacts = parse_artifacts_value(&payload.artifacts)
             .map_err(|e| format!("parse {} JSON: {e}", guest_contracts::env::ARTIFACTS_ENV))?;
@@ -375,6 +385,7 @@ impl GuestConfig {
                 DEFAULT_MOCK_CODEX_PATH,
             ),
             home_dir,
+            claude_config_dir,
             codex_home_dir,
             artifacts,
             feature_flags,
@@ -655,6 +666,24 @@ fn resolve_home_dir(
 }
 
 #[cfg(debug_assertions)]
+fn resolve_claude_config_dir(raw: &GuestConfigRaw) -> String {
+    if let Some(path) = raw
+        .test_claude_config_dir
+        .as_deref()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        return path.to_string_lossy().into_owned();
+    }
+
+    CANONICAL_CLAUDE_CONFIG_DIR.to_string()
+}
+
+#[cfg(not(debug_assertions))]
+fn resolve_claude_config_dir(_raw: &GuestConfigRaw) -> String {
+    CANONICAL_CLAUDE_CONFIG_DIR.to_string()
+}
+
+#[cfg(debug_assertions)]
 fn resolve_codex_home_dir(raw: &GuestConfigRaw) -> String {
     if let Some(path) = raw
         .test_codex_home_dir
@@ -896,6 +925,7 @@ mod tests {
         assert!(config.use_mock_codex);
         assert_eq!(config.mock_codex_path, DEFAULT_MOCK_CODEX_PATH);
         assert_eq!(config.home_dir, "/home/vm0");
+        assert_eq!(config.claude_config_dir, CANONICAL_CLAUDE_CONFIG_DIR);
         assert_eq!(config.codex_home_dir, CANONICAL_CODEX_HOME_DIR);
         assert_eq!(config.stuck_tool_timeout_secs, 7);
         assert_eq!(config.post_result_sigterm_grace, Duration::from_secs(8));
@@ -934,6 +964,7 @@ mod tests {
         let config = GuestConfig::from_raw(raw).unwrap();
 
         assert_eq!(config.home_dir, "/home/from-user-env");
+        assert_eq!(config.claude_config_dir, CANONICAL_CLAUDE_CONFIG_DIR);
         assert_eq!(config.codex_home_dir, CANONICAL_CODEX_HOME_DIR);
         assert_eq!(
             config.user_env.get("OPENAI_MODEL").map(String::as_str),
@@ -941,6 +972,20 @@ mod tests {
         );
         assert!(!user_env_path.exists());
         assert!(!user_env_dir.exists());
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn guest_config_from_raw_uses_captured_test_claude_config_dir() {
+        let (_tmp, raw) = raw_config_fixture_with_default_run_payload();
+        let raw = GuestConfigRaw {
+            test_claude_config_dir: Some(PathBuf::from("/tmp/captured-claude-config")),
+            ..raw
+        };
+
+        let config = GuestConfig::from_raw(raw).unwrap();
+
+        assert_eq!(config.claude_config_dir, "/tmp/captured-claude-config");
     }
 
     #[cfg(debug_assertions)]
@@ -1091,6 +1136,7 @@ mod tests {
         let config = GuestConfig::from_raw(raw).unwrap();
 
         assert_eq!(config.home_dir, "/home/from-user-env");
+        assert_eq!(config.claude_config_dir, CANONICAL_CLAUDE_CONFIG_DIR);
         assert_eq!(
             config.user_env.get("OPENAI_MODEL").map(String::as_str),
             Some("gpt-runtime-home")
@@ -1115,6 +1161,7 @@ mod tests {
         let config = GuestConfig::from_raw(raw).unwrap();
 
         assert_eq!(config.home_dir, "");
+        assert_eq!(config.claude_config_dir, CANONICAL_CLAUDE_CONFIG_DIR);
         assert_eq!(config.codex_home_dir, CANONICAL_CODEX_HOME_DIR);
     }
 

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -29,26 +29,13 @@ impl SessionHistoryLaunchSource {
     /// finalized CLI child environment and explicit working directory.
     pub(crate) fn for_config(config: &GuestConfig) -> Self {
         match config.framework {
-            Framework::ClaudeCode => {
-                let config_dir = config
-                    .user_env
-                    .get("CLAUDE_CONFIG_DIR")
-                    .filter(|value| !value.is_empty())
-                    .cloned()
-                    .unwrap_or_else(|| {
-                        Path::new(&config.home_dir)
-                            .join(".claude")
-                            .to_string_lossy()
-                            .into_owned()
-                    });
-                Self::ClaudeCode {
-                    config_dir: normalized_absolute_launch_path(
-                        &config_dir,
-                        paths::CANONICAL_WORKING_DIR,
-                    ),
-                    working_dir: paths::CANONICAL_WORKING_DIR.to_string(),
-                }
-            }
+            Framework::ClaudeCode => Self::ClaudeCode {
+                config_dir: normalized_absolute_launch_path(
+                    &config.claude_config_dir,
+                    paths::CANONICAL_WORKING_DIR,
+                ),
+                working_dir: paths::CANONICAL_WORKING_DIR.to_string(),
+            },
             Framework::Codex => Self::Codex {
                 sessions_dir: normalized_absolute_launch_path(
                     &Path::new(&config.codex_home_dir)

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -6,7 +6,8 @@ mod common;
 use guest_agent::cli;
 use guest_agent::masker::SecretMasker;
 use guest_agent::run_context::GuestRuntime;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
 
 #[tokio::test]
 async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
@@ -20,6 +21,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         .to_str()
         .ok_or("test user HOME path must be UTF-8")?
         .to_string();
+    let rejected_config_dir = tmp.path().join("rejected-claude-config");
 
     unsafe {
         common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
@@ -53,6 +55,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             "VM0_API_BACKEND_URL": "https://user-env.example.invalid",
             "OPENAI_API_KEY": "sk-user",
             "HOME": user_home_str,
+            "CLAUDE_CONFIG_DIR": rejected_config_dir,
             "NODE_EXTRA_CA_CERTS": "/tmp/user-ca.pem",
         }))?,
     )?;
@@ -64,6 +67,18 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert!(!user_env_path.exists());
     assert!(!user_env_dir.exists());
     assert_eq!(runtime.config.home_dir, user_home_str);
+    assert_eq!(
+        runtime.config.claude_config_dir,
+        tmp.path().join(".claude").to_string_lossy()
+    );
+    assert_eq!(
+        runtime
+            .config
+            .user_env
+            .get("CLAUDE_CONFIG_DIR")
+            .map(String::as_str),
+        rejected_config_dir.to_str()
+    );
 
     unsafe {
         std::env::set_var("VM0_PROMPT", "stale prompt after runtime construction");
@@ -107,6 +122,10 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     assert_eq!(
         cli_env.get("HOME").map(String::as_str),
         Some(user_home_str.as_str())
+    );
+    assert_eq!(
+        cli_env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
+        Some(runtime.config.claude_config_dir.as_str())
     );
     assert_eq!(
         cli_env.get("NODE_EXTRA_CA_CERTS").map(String::as_str),
@@ -161,5 +180,103 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             .contains_key(guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV)
     );
 
+    let session_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
+    let canonical_history = Path::new(&runtime.config.claude_config_dir)
+        .join("projects/-home-user-workspace")
+        .join(format!("{}.jsonl", session_id.trim()));
+    assert!(canonical_history.exists());
+    assert!(!common::claude_history_path_for_home(&user_home, session_id.trim()).exists());
+    assert!(
+        !rejected_config_dir
+            .join("projects/-home-user-workspace")
+            .join(format!("{}.jsonl", session_id.trim()))
+            .exists()
+    );
+
+    assert_home_value_reaches_claude(
+        &mock,
+        &tmp.path().join("relative-home-case"),
+        "relative-home",
+    )
+    .await?;
+    assert_home_value_reaches_claude(&mock, &tmp.path().join("empty-home-case"), "").await?;
+
+    Ok(())
+}
+
+async fn assert_home_value_reaches_claude(
+    mock: &Path,
+    workdir: &Path,
+    home: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let claude_config_dir = workdir.join(".claude");
+    let rejected_config_dir = workdir.join("rejected-claude-config");
+    let instructions_path = claude_config_dir.join("CLAUDE.md");
+    let skill_path = claude_config_dir.join("skills/test-skill/SKILL.md");
+    let memory_path = claude_config_dir
+        .join("projects/-home-user-workspace/memory")
+        .join("MEMORY.md");
+    for path in [&instructions_path, &skill_path, &memory_path] {
+        std::fs::create_dir_all(path.parent().ok_or("managed file must have a parent")?)?;
+        std::fs::write(path, "managed")?;
+    }
+
+    let observed_home = workdir.join("observed-home");
+    let observed_config_dir = workdir.join("observed-claude-config-dir");
+    let prompt = format!(
+        "test -f \"$CLAUDE_CONFIG_DIR/CLAUDE.md\" && test -f \"$CLAUDE_CONFIG_DIR/skills/test-skill/SKILL.md\" && test -f \"$CLAUDE_CONFIG_DIR/projects/-home-user-workspace/memory/MEMORY.md\" && printf '%s' \"$HOME\" > {} && printf '%s' \"$CLAUDE_CONFIG_DIR\" > {}",
+        observed_home.display(),
+        observed_config_dir.display(),
+    );
+
+    unsafe {
+        common::setup_env(mock, workdir, &prompt, 3, 1)?;
+    }
+    let run_id = std::env::var(guest_contracts::env::RUN_ID_ENV)?;
+    let runtime_dir = guest_contracts::runtime_paths::run_dir_from_env(&run_id)?;
+    let user_env = HashMap::from([
+        ("HOME".to_string(), home.to_string()),
+        (
+            "CLAUDE_CONFIG_DIR".to_string(),
+            rejected_config_dir.to_string_lossy().into_owned(),
+        ),
+    ]);
+    unsafe {
+        common::set_user_env_file_env_for_test(&runtime_dir, &user_env)?;
+    }
+
+    let runtime = GuestRuntime::from_process_env()?;
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_disabled(
+        &runtime.config.run_id,
+        &runtime.config.prompt,
+    );
+    let result = cli::execute_cli_with_active_input_for_config(
+        &SecretMasker::from_raw(""),
+        common::spawn_dummy_heartbeat(),
+        runtime.http.clone(),
+        active_input.into_writer(),
+        &runtime.config,
+        &runtime.paths,
+    )
+    .await?;
+
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    assert_eq!(std::fs::read_to_string(observed_home)?, home);
+    assert_eq!(
+        std::fs::read_to_string(observed_config_dir)?,
+        claude_config_dir.to_string_lossy()
+    );
+
+    let session_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
+    let history_path = claude_config_dir
+        .join("projects/-home-user-workspace")
+        .join(format!("{}.jsonl", session_id.trim()));
+    assert!(history_path.exists());
+    assert!(
+        !rejected_config_dir
+            .join("projects/-home-user-workspace")
+            .join(format!("{}.jsonl", session_id.trim()))
+            .exists()
+    );
     Ok(())
 }

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1030,6 +1030,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         process_control_ipc::BOOTSTRAP_ENV,
         guest_contracts::process_containment::WORKLOAD_CGROUP_PROCS_ENDPOINT_ENV,
         "VM0_TEST_ALLOW_UNMANAGED_PROCESS_CONTROL",
+        "VM0_TEST_CLAUDE_CONFIG_DIR",
         "VM0_TEST_CODEX_HOME_DIR",
         "MOCK_CODEX_APP_SERVER_SCENARIO",
     ] {
@@ -1271,10 +1272,11 @@ pub unsafe fn setup_env(
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         // Redirect HOME so the mock's session-history write
-        // (`$HOME/.claude/projects/.../<session>.jsonl`) stays inside
+        // (`$CLAUDE_CONFIG_DIR/projects/.../<session>.jsonl`) stays inside
         // the tempdir and gets cleaned up with it, instead of
         // accumulating in the dev's real ~/.claude on every run.
         std::env::set_var("HOME", workdir);
+        std::env::set_var("VM0_TEST_CLAUDE_CONFIG_DIR", workdir.join(".claude"));
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
     ensure_canonical_workspace_for_test()?;

--- a/crates/guest-agent/tests/integration/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/success.rs
@@ -1050,6 +1050,7 @@ async fn success_checkpoint_uses_explicit_runtime_after_process_env_changes() {
         api_token: "test-token-abc123".to_string(),
         cli_agent_type: "claude-code".to_string(),
         home: Some(home_dir.to_string_lossy().into_owned()),
+        test_claude_config_dir: Some(home_dir.join(".claude")),
         run_payload_file: run_payload_file.to_string_lossy().into_owned(),
         guest_runtime_dir: Some(runtime_dir.clone()),
         ..guest_agent::env::GuestConfigRaw::default()

--- a/crates/guest-agent/tests/integration/checkpoint/support.rs
+++ b/crates/guest-agent/tests/integration/checkpoint/support.rs
@@ -51,18 +51,7 @@ pub(super) fn checkpoint_session_metadata(
     let source = match runtime.config.framework {
         guest_agent::env::Framework::ClaudeCode => Some(
             guest_contracts::session_history_identity::SessionHistorySourceRef::ClaudeCode {
-                config_dir: runtime
-                    .config
-                    .user_env
-                    .get("CLAUDE_CONFIG_DIR")
-                    .filter(|value| !value.is_empty())
-                    .cloned()
-                    .unwrap_or_else(|| {
-                        std::path::Path::new(&runtime.config.home_dir)
-                            .join(".claude")
-                            .to_string_lossy()
-                            .into_owned()
-                    }),
+                config_dir: runtime.config.claude_config_dir.clone(),
                 working_dir: guest_agent::paths::CANONICAL_WORKING_DIR.to_string(),
                 session_id: session_id.clone(),
             },
@@ -132,10 +121,7 @@ pub(super) fn write_literal_session_history(
 ) -> Result<tempfile::TempDir, String> {
     let session_id_file = session_id_file();
     let dir = tempfile::tempdir().map_err(|e| format!("create temp history dir: {e}"))?;
-    runtime.config.user_env.insert(
-        "CLAUDE_CONFIG_DIR".to_string(),
-        dir.path().to_string_lossy().into_owned(),
-    );
+    runtime.config.claude_config_dir = dir.path().to_string_lossy().into_owned();
     let history_path = claude_history_path(dir.path(), session_id);
     let history_parent = history_path
         .parent()
@@ -185,10 +171,7 @@ pub(super) fn write_prunable_claude_history(
 
     let history_dir =
         tempfile::tempdir().map_err(|error| format!("create history dir: {error}"))?;
-    runtime.config.user_env.insert(
-        "CLAUDE_CONFIG_DIR".to_string(),
-        history_dir.path().to_string_lossy().into_owned(),
-    );
+    runtime.config.claude_config_dir = history_dir.path().to_string_lossy().into_owned();
     let history_path = claude_history_path(history_dir.path(), session_id);
     let history_parent = history_path
         .parent()

--- a/crates/guest-mock-claude/src/transcript.rs
+++ b/crates/guest-mock-claude/src/transcript.rs
@@ -12,8 +12,8 @@ pub(crate) fn generate_session_id() -> String {
 
 /// Build the session history file path and create the directory.
 ///
-/// Claude Code stores session history at: `{home}/.claude/projects/-{path}/{session_id}.jsonl`
-fn build_session_history_path(session_id: &str, home: &str) -> Option<String> {
+/// Claude Code stores session history at: `{config_dir}/projects/-{path}/{session_id}.jsonl`
+fn build_session_history_path(session_id: &str, config_dir: &str) -> Option<String> {
     if !is_valid_cli_agent_session_id(session_id) {
         return None;
     }
@@ -21,8 +21,7 @@ fn build_session_history_path(session_id: &str, home: &str) -> Option<String> {
     let project_name = CANONICAL_WORKING_DIR
         .trim_start_matches('/')
         .replace('/', "-");
-    let session_dir = PathBuf::from(home)
-        .join(".claude")
+    let session_dir = PathBuf::from(config_dir)
         .join("projects")
         .join(format!("-{project_name}"));
 
@@ -38,10 +37,18 @@ fn build_session_history_path(session_id: &str, home: &str) -> Option<String> {
     )
 }
 
-/// Create session history using `$HOME` from the environment.
+/// Create session history using Claude Code's effective config directory.
 pub(crate) fn create_session_history(session_id: &str) -> Option<String> {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string());
-    build_session_history_path(session_id, &home)
+    let config_dir = std::env::var("CLAUDE_CONFIG_DIR")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| {
+            PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_string()))
+                .join(".claude")
+                .to_string_lossy()
+                .into_owned()
+        });
+    build_session_history_path(session_id, &config_dir)
 }
 
 #[derive(Default)]
@@ -168,30 +175,32 @@ mod tests {
     #[test]
     fn session_history_path_structure() {
         let dir = tempfile::tempdir().unwrap();
-        let home = dir.path().to_str().unwrap();
+        let config_dir = dir.path().join("claude-config");
+        let config_dir = config_dir.to_str().unwrap();
 
-        let result = build_session_history_path("test-session-123", home);
+        let result = build_session_history_path("test-session-123", config_dir);
 
-        let expected =
-            format!("{home}/.claude/projects/-home-user-workspace/test-session-123.jsonl");
+        let expected = format!("{config_dir}/projects/-home-user-workspace/test-session-123.jsonl");
         assert_eq!(result, Some(expected));
     }
 
     #[test]
     fn session_history_creates_directory() {
         let dir = tempfile::tempdir().unwrap();
-        let home = dir.path().to_str().unwrap();
+        let config_dir = dir.path().join("claude-config");
+        let config_dir_str = config_dir.to_str().unwrap();
 
-        let _ = build_session_history_path("test-session", home);
+        let _ = build_session_history_path("test-session", config_dir_str);
 
-        let expected_dir = dir.path().join(".claude/projects/-home-user-workspace");
+        let expected_dir = config_dir.join("projects/-home-user-workspace");
         assert!(expected_dir.exists());
     }
 
     #[test]
     fn session_history_path_rejects_non_contract_session_ids() {
         let dir = tempfile::tempdir().unwrap();
-        let home = dir.path().to_str().unwrap();
+        let config_dir = dir.path().join("claude-config");
+        let config_dir_str = config_dir.to_str().unwrap();
 
         for session_id in [
             "",
@@ -206,11 +215,14 @@ mod tests {
             "session.with.dot",
             "é",
         ] {
-            assert_eq!(build_session_history_path(session_id, home), None);
+            assert_eq!(build_session_history_path(session_id, config_dir_str), None);
         }
         let overlong_id = "a".repeat(129);
-        assert_eq!(build_session_history_path(&overlong_id, home), None);
-        assert!(!dir.path().join(".claude").exists());
+        assert_eq!(
+            build_session_history_path(&overlong_id, config_dir_str),
+            None
+        );
+        assert!(!config_dir.exists());
     }
 
     #[test]

--- a/crates/guest-mock-claude/tests/support/mod.rs
+++ b/crates/guest-mock-claude/tests/support/mod.rs
@@ -86,7 +86,9 @@ impl Drop for StreamJsonChild {
 }
 
 pub fn mock_claude() -> Command {
-    Command::new(env!("CARGO_BIN_EXE_guest-mock-claude"))
+    let mut command = Command::new(env!("CARGO_BIN_EXE_guest-mock-claude"));
+    command.env_remove("CLAUDE_CONFIG_DIR");
+    command
 }
 
 pub fn spawn_managed_mock_child(command: &mut Command) -> std::io::Result<ProcessGroupChild> {

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -16,7 +16,9 @@ use super::env::validate_resume_session_id;
 use super::{RunnerError, RunnerResult};
 use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::types::{ExecutionContext, ResumeSessionHistoryRefKind};
-use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+use api_contracts::generated::constants::runners::paths::{
+    CANONICAL_CLAUDE_CONFIG_DIR, CANONICAL_WORKING_DIR,
+};
 
 impl RestoredSessionIdentity {
     pub(crate) fn from_context(context: &ExecutionContext) -> Option<Self> {
@@ -206,7 +208,7 @@ pub(super) async fn restore_claude_session(
     let project_name = CANONICAL_WORKING_DIR
         .trim_start_matches('/')
         .replace('/', "-");
-    let session_dir = format!("/home/user/.claude/projects/-{project_name}");
+    let session_dir = format!("{CANONICAL_CLAUDE_CONFIG_DIR}/projects/-{project_name}");
     let session_id = session.cli_agent_session_id();
     let session_path = format!("{session_dir}/{session_id}.jsonl");
 

--- a/crates/runner/src/storage_plan.rs
+++ b/crates/runner/src/storage_plan.rs
@@ -39,7 +39,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 use api_contracts::generated::{
-    constants::runners::paths::CANONICAL_CODEX_HOME_DIR,
+    constants::runners::paths::{CANONICAL_CLAUDE_CONFIG_DIR, CANONICAL_CODEX_HOME_DIR},
     types::runners::storage::ArtifactEntryMissingRootPolicy,
 };
 use guest_contracts::storage_manifest as wire;
@@ -48,7 +48,6 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::storage_manifest::StorageManifest;
 
-const CLAUDE_FRAMEWORK_HOME: &str = "/home/user/.claude";
 const AGENT_INSTRUCTIONS_STORAGE_NAME_PREFIX: &str = "agent-instructions@";
 
 /// The semantic actions required to apply one canonical storage manifest.
@@ -576,7 +575,7 @@ fn record_removed_artifacts<'a>(
 }
 
 fn is_framework_home_path(path: &str) -> bool {
-    matches!(path, CANONICAL_CODEX_HOME_DIR | CLAUDE_FRAMEWORK_HOME)
+    matches!(path, CANONICAL_CLAUDE_CONFIG_DIR | CANONICAL_CODEX_HOME_DIR)
 }
 
 fn is_removed_framework_home_instruction(path: &str, fingerprint: &StorageFingerprint) -> bool {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { command, computed, type Computed } from "ccstate";
 import {
+  CANONICAL_CLAUDE_CONFIG_DIR,
   CANONICAL_CODEX_HOME_DIR,
   CANONICAL_CODEX_MEMORY_MOUNT_PATH,
   CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
@@ -1123,7 +1124,7 @@ function prepareAdditionalVolumesWithSource(
 function frameworkSkillsMountPath(framework: SupportedFramework): string {
   return framework === "codex"
     ? `${CANONICAL_CODEX_HOME_DIR}/skills`
-    : "/home/user/.claude/skills";
+    : `${CANONICAL_CLAUDE_CONFIG_DIR}/skills`;
 }
 
 function skillMountPath(skillsRoot: string, skillName: string): string {

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -1,4 +1,5 @@
 import {
+  CANONICAL_CLAUDE_CONFIG_DIR,
   CANONICAL_CODEX_HOME_DIR,
   PI_AGENT_DIR,
   type StoredStorageMountEntry,
@@ -975,7 +976,7 @@ function instructionsMountPath(framework: SupportedFramework | "pi"): string {
   }
   return framework === "codex"
     ? CANONICAL_CODEX_HOME_DIR
-    : "/home/user/.claude";
+    : CANONICAL_CLAUDE_CONFIG_DIR;
 }
 
 function instructionsFilename(framework: SupportedFramework | "pi"): string {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -1,5 +1,6 @@
 import { PLAN_UPGRADE_CLI_HINT } from "@okouai/api-contracts/contracts/errors";
 import {
+  CANONICAL_CLAUDE_CONFIG_DIR,
   CANONICAL_CODEX_HOME_DIR,
   CANONICAL_WORKING_DIR,
 } from "@okouai/api-contracts/contracts/runners";
@@ -405,7 +406,7 @@ function buildAgentToolsPrompt(args: {
     "- Multiple access actions: do not use callback commands or URLs when the turn needs multiple connector or permission actions. Return all generated links in one response, one link per line, using only ordinary non-callback links, and wait for the user to finish all of them.",
     "- Inspect yourself: `okou whoami` for identity and permissions, `okou agent view $OKOU_AGENT_ID --instructions` for your current settings.",
     "- When the user asks to change your behavior, update your own configuration (instructions, tone, description): `okou agent edit --help`.",
-    `- Manage workflows with \`okou workflow --help\`. Create or update a durable workflow with \`okou workflow create|edit <name>\`, passing the workflow body via \`--instruction <text>\` or \`--instruction-file <path>\`; its \`SKILL.md\` is synthesized from the name, description, and instruction. \`--dir <path>\` uploads supplementary files only and must not contain a \`SKILL.md\` (it is rejected). Local changes or newly-created workflow folders under \`${CANONICAL_CODEX_HOME_DIR}/skills\` or \`/home/user/.claude/skills\` are runtime-only and will not persist, sync back, or affect future runs.`,
+    `- Manage workflows with \`okou workflow --help\`. Create or update a durable workflow with \`okou workflow create|edit <name>\`, passing the workflow body via \`--instruction <text>\` or \`--instruction-file <path>\`; its \`SKILL.md\` is synthesized from the name, description, and instruction. \`--dir <path>\` uploads supplementary files only and must not contain a \`SKILL.md\` (it is rejected). Local changes or newly-created workflow folders under \`${CANONICAL_CODEX_HOME_DIR}/skills\` or \`${CANONICAL_CLAUDE_CONFIG_DIR}/skills\` are runtime-only and will not persist, sync back, or affect future runs.`,
   ].join("\n");
 }
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -658,6 +658,7 @@ export {
   storedExecutionContextSchema,
   secretConnectorMetadataSchema,
   secretConnectorMetadataMapSchema,
+  CANONICAL_CLAUDE_CONFIG_DIR,
   CANONICAL_CODEX_HOME_DIR,
   CANONICAL_CODEX_MEMORY_MOUNT_PATH,
   CANONICAL_CODEX_SESSIONS_DIR,

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -20,13 +20,14 @@ const apiStartTimeSchema = z.number().int().min(MIN_EPOCH_MS_TIMESTAMP);
 
 export const CANONICAL_GUEST_HOME_DIR = "/home/user";
 export const CANONICAL_WORKING_DIR = `${CANONICAL_GUEST_HOME_DIR}/workspace`;
+export const CANONICAL_CLAUDE_CONFIG_DIR = `${CANONICAL_GUEST_HOME_DIR}/.claude`;
 export const CANONICAL_CODEX_HOME_DIR = `${CANONICAL_GUEST_HOME_DIR}/.codex`;
 export const CANONICAL_CODEX_SESSIONS_DIR = `${CANONICAL_CODEX_HOME_DIR}/sessions`;
 const CANONICAL_CLAUDE_PROJECT_NAME = CANONICAL_WORKING_DIR.replace(
   /^\//,
   "",
 ).replace(/\//g, "-");
-export const CANONICAL_CLAUDE_MEMORY_MOUNT_PATH = `${CANONICAL_GUEST_HOME_DIR}/.claude/projects/-${CANONICAL_CLAUDE_PROJECT_NAME}/memory`;
+export const CANONICAL_CLAUDE_MEMORY_MOUNT_PATH = `${CANONICAL_CLAUDE_CONFIG_DIR}/projects/-${CANONICAL_CLAUDE_PROJECT_NAME}/memory`;
 export const CANONICAL_CODEX_MEMORY_MOUNT_PATH = `${CANONICAL_CODEX_HOME_DIR}/memories`;
 export const PI_AGENT_DIR = `${CANONICAL_GUEST_HOME_DIR}/.pi/agent`;
 export const CANONICAL_PI_SESSION_DIR = `${PI_AGENT_DIR}/sessions/--home-user-workspace--`;

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../../contracts/client-headers";
 import {
   ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES,
+  CANONICAL_CLAUDE_CONFIG_DIR,
   CANONICAL_CODEX_HOME_DIR,
   CANONICAL_CODEX_SESSIONS_DIR,
   CANONICAL_GUEST_HOME_DIR,
@@ -56,6 +57,11 @@ const codexOauthPlaceholders =
 const canonicalGuestHomeDirDoc = [
   "Canonical home directory path expected for the sandbox user inside runner guests.",
   "Rust and TypeScript components use this shared contract value when building runner guest paths.",
+] as const;
+
+const canonicalClaudeConfigDirDoc = [
+  "Canonical directory for VM0-managed Claude Code configuration and session state inside runner guests.",
+  "Guest launch, session capture, runner restore, and API-managed mounts use this shared path independently of the user HOME environment.",
 ] as const;
 
 const canonicalCodexHomeDirDoc = [
@@ -314,6 +320,12 @@ const expectedBindings = [
   },
   {
     rustModulePath: ["runners", "paths"],
+    rustConstName: "CANONICAL_CLAUDE_CONFIG_DIR",
+    value: rustString(CANONICAL_CLAUDE_CONFIG_DIR),
+    rustDoc: canonicalClaudeConfigDirDoc,
+  },
+  {
+    rustModulePath: ["runners", "paths"],
     rustConstName: "CANONICAL_CODEX_HOME_DIR",
     value: rustString(CANONICAL_CODEX_HOME_DIR),
     rustDoc: canonicalCodexHomeDirDoc,
@@ -498,6 +510,12 @@ describe("Rust constant bindings", () => {
     );
     expect(firstRender).toContain(
       `pub const CANONICAL_GUEST_HOME_DIR: &str = "${CANONICAL_GUEST_HOME_DIR}";`,
+    );
+    expect(firstRender).toContain(
+      "/// Canonical directory for VM0-managed Claude Code configuration and session state inside runner guests.",
+    );
+    expect(firstRender).toContain(
+      `pub const CANONICAL_CLAUDE_CONFIG_DIR: &str = "${CANONICAL_CLAUDE_CONFIG_DIR}";`,
     );
     expect(firstRender).toContain(
       "/// Canonical directory for VM0-managed Codex state inside runner guests.",

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -16,6 +16,7 @@ import {
 } from "../contracts/client-headers";
 import {
   ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES,
+  CANONICAL_CLAUDE_CONFIG_DIR,
   CANONICAL_CODEX_HOME_DIR,
   CANONICAL_CODEX_SESSIONS_DIR,
   CANONICAL_GUEST_HOME_DIR,
@@ -395,6 +396,15 @@ export const rustConstantBindings = [
     rustDoc: [
       "Canonical home directory path expected for the sandbox user inside runner guests.",
       "Rust and TypeScript components use this shared contract value when building runner guest paths.",
+    ],
+  },
+  {
+    rustModulePath: runnerPathsModule,
+    rustConstName: "CANONICAL_CLAUDE_CONFIG_DIR",
+    value: rustString(CANONICAL_CLAUDE_CONFIG_DIR),
+    rustDoc: [
+      "Canonical directory for VM0-managed Claude Code configuration and session state inside runner guests.",
+      "Guest launch, session capture, runner restore, and API-managed mounts use this shared path independently of the user HOME environment.",
     ],
   },
   {


### PR DESCRIPTION
## Summary

- define one shared canonical Claude Code config directory for TypeScript and Rust consumers
- force Claude child processes, session capture, runner restore, and API-managed mounts to use that directory independently of user `HOME` and `CLAUDE_CONFIG_DIR`
- make the mock Claude transcript follow the effective config directory and cover absolute, relative, and empty user `HOME` values

## Compatibility and scope

- keeps the existing `/home/user/.claude` on-disk location and introduces no API, database, or runner protocol change
- preserves the user-provided `HOME`; only the VM0-owned Claude config root is overridden for Claude Code
- does not migrate, symlink, or clean state written by earlier runs to user-selected locations

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p guest-agent --release`
- `cargo check -p guest-agent --all-targets --all-features`
- `cargo clippy -p api-contracts -p guest-mock-claude -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p api-contracts -p guest-mock-claude -p guest-agent -p runner --no-deps --all-features`
- `cargo test --quiet -p guest-agent --all-targets --all-features`
- `cargo test --quiet -p guest-mock-claude -p runner --all-targets --all-features`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts test -- --maxWorkers=1`
- `pnpm knip --workspace @okouai/api-contracts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'mounts workflows for claude-code zero agents' --maxWorkers=1`
- repository pre-commit hooks, including full-workspace Knip and TypeScript type checks

Closes #28284
