### PR TITLE
docs(sandbox): document firecracker snapshot id constraints

### DIFF
--- a/crates/sandbox-fc/src/snapshot/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/mod.rs
@@ -40,6 +40,10 @@ use self::runtime::run_snapshot_workflow;
 /// discards the uncommitted artifacts and returns the original publish error;
 /// any discard error is intentionally suppressed.
 ///
+/// The `config.id` value must satisfy the Firecracker-specific socket-ID
+/// contract documented on [`FirecrackerSnapshotProvider`]. Invalid IDs are
+/// rejected as [`SnapshotError::Setup`] before snapshot-output cleanup.
+///
 /// The current Rust workflow spans orchestration in this module, live VM execution in
 /// `snapshot/runtime.rs`, resource ownership and cleanup in `snapshot/attempt/`, and stable
 /// artifact publication in `snapshot/publish.rs`:

--- a/crates/sandbox-fc/src/snapshot/provider.rs
+++ b/crates/sandbox-fc/src/snapshot/provider.rs
@@ -11,6 +11,18 @@ use super::{SnapshotError, create_uncommitted_snapshot};
 
 /// Firecracker-backed snapshot provider.
 ///
+/// Snapshot creation uses [`SnapshotCreateConfig::id`] as the runtime socket
+/// directory identifier. The ID must be a single, non-empty ASCII path segment
+/// containing only letters, digits, `.`, `-`, and `_`. Nested, parent-relative,
+/// and composite values such as `<rootfs>/<snapshot>` are invalid. The complete
+/// generated `/run/vm0/sock/<id>/vsock/vsock.sock` path must be at most 107
+/// bytes.
+///
+/// The provider validates this contract before checking prerequisites or
+/// cleaning snapshot output. Invalid IDs fail as `sandbox::SnapshotError::Setup`.
+/// Other [`SnapshotProvider`] implementations may impose different
+/// requirements on the same provider-neutral configuration type.
+///
 /// Stateless — can be created with zero cost and used immediately.
 pub struct FirecrackerSnapshotProvider;
 

--- a/crates/sandbox-fc/src/snapshot/provider.rs
+++ b/crates/sandbox-fc/src/snapshot/provider.rs
@@ -12,11 +12,11 @@ use super::{SnapshotError, create_uncommitted_snapshot};
 /// Firecracker-backed snapshot provider.
 ///
 /// Snapshot creation uses [`SnapshotCreateConfig::id`] as the runtime socket
-/// directory identifier. The ID must be a single, non-empty ASCII path segment
-/// containing only letters, digits, `.`, `-`, and `_`. Nested, parent-relative,
-/// and composite values such as `<rootfs>/<snapshot>` are invalid. The complete
-/// generated `/run/vm0/sock/<id>/vsock/vsock.sock` path must be at most 107
-/// bytes.
+/// directory identifier. The ID must be a single, non-empty normal ASCII path
+/// segment containing only letters, digits, `.`, `-`, and `_`. The special `.`
+/// and `..` components, nested, parent-relative, and composite values such as
+/// `<rootfs>/<snapshot>` are invalid. The complete generated
+/// `/run/vm0/sock/<id>/vsock/vsock.sock` path must be at most 107 bytes.
 ///
 /// The provider validates this contract before checking prerequisites or
 /// cleaning snapshot output. Invalid IDs fail as `sandbox::SnapshotError::Setup`.

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -5,7 +5,18 @@ use async_trait::async_trait;
 /// Configuration for creating a snapshot.
 #[derive(Debug)]
 pub struct SnapshotCreateConfig {
-    /// Unique identifier for this snapshot (used for runtime socket directory).
+    /// Unique identifier for this snapshot.
+    ///
+    /// The format is provider-specific. The Firecracker provider uses this
+    /// value as its runtime socket directory name and requires a single,
+    /// non-empty ASCII path segment containing only letters, digits, `.`, `-`,
+    /// and `_`. Nested or composite values such as `<rootfs>/<snapshot>` are
+    /// invalid, and the generated
+    /// `/run/vm0/sock/<id>/vsock/vsock.sock` path must be at most 107 bytes.
+    /// Invalid Firecracker IDs are reported as `SnapshotError::Setup` before
+    /// snapshot-output cleanup. Other providers may impose different
+    /// requirements; this provider-specific contract is not enforced by the
+    /// provider-neutral configuration type.
     pub id: String,
     /// Path to the sandbox backend binary (e.g., firecracker).
     pub binary_path: PathBuf,

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -9,9 +9,9 @@ pub struct SnapshotCreateConfig {
     ///
     /// The format is provider-specific. The Firecracker provider uses this
     /// value as its runtime socket directory name and requires a single,
-    /// non-empty ASCII path segment containing only letters, digits, `.`, `-`,
-    /// and `_`. Nested or composite values such as `<rootfs>/<snapshot>` are
-    /// invalid, and the generated
+    /// non-empty normal ASCII path segment containing only letters, digits,
+    /// `.`, `-`, and `_`. The special `.` and `..` components, nested or
+    /// composite values such as `<rootfs>/<snapshot>`, are invalid, and the generated
     /// `/run/vm0/sock/<id>/vsock/vsock.sock` path must be at most 107 bytes.
     /// Invalid Firecracker IDs are reported as `SnapshotError::Setup` before
     /// snapshot-output cleanup. Other providers may impose different


### PR DESCRIPTION
## Summary

- document the provider-specific Firecracker constraints for `SnapshotCreateConfig::id`
- describe the accepted ID grammar, generated vsock path limit, invalid composite IDs, and setup-error boundary
- expose the same contract from the public Firecracker creation entry points without changing runtime behavior

## Scope

Documentation-only Rustdoc changes in `sandbox` and `sandbox-fc`. This PR does not change validation logic, cleanup order, public signatures, provider-neutral behavior, tests, or deployment compatibility.

Closes #28311

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p sandbox -p sandbox-fc --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `cd crates && TMPDIR=/tmp cargo test -p sandbox -p sandbox-fc` (36 `sandbox` tests, 808 `sandbox-fc` tests, and doctests passed)
- `git diff --check`
