### PR TITLE
refactor(guest-download): unify integration child lifecycle

### DIFF
--- a/crates/guest-download/tests/integration/binary_logging/mod.rs
+++ b/crates/guest-download/tests/integration/binary_logging/mod.rs
@@ -1,3 +1,4 @@
+use crate::process;
 use crate::support::unique_run_id;
 use serde_json::Value;
 use std::ffi::OsStr;
@@ -8,7 +9,6 @@ use tempfile::TempDir;
 
 mod attribution;
 mod manifest_input;
-mod process;
 mod redaction;
 mod runtime_paths;
 

--- a/crates/guest-download/tests/integration/binary_logging/redaction.rs
+++ b/crates/guest-download/tests/integration/binary_logging/redaction.rs
@@ -1,4 +1,5 @@
 use super::{BinaryLoggingFixture, assert_download_total_success_present};
+use crate::process;
 use crate::support::{
     assert_does_not_contain_any, create_tar_gz, read_http_request_path, write_manifest,
 };
@@ -484,16 +485,7 @@ fn binary_timeout_terminates_child_and_connection_responder() {
     assert!(message.contains("stderr="));
     assert!(message.contains("[INFO] [sandbox:download] Downloading 1 items"));
     assert_eq!(accepted, 1);
-    let child_id = libc::pid_t::try_from(child_id).unwrap();
-    let mut status = 0;
-    // SAFETY: `child_id` came from the directly owned child, and the lifecycle
-    // helper returned only after reaping it. WNOHANG verifies no status remains.
-    let result = unsafe { libc::waitpid(child_id, &mut status, libc::WNOHANG) };
-    assert_eq!(result, -1);
-    assert_eq!(
-        io::Error::last_os_error().raw_os_error(),
-        Some(libc::ECHILD)
-    );
+    process::verify_child_reaped(child_id).unwrap();
 }
 
 #[test]

--- a/crates/guest-download/tests/integration/main.rs
+++ b/crates/guest-download/tests/integration/main.rs
@@ -4,4 +4,5 @@ mod binary_logging;
 mod cleanup;
 mod download;
 mod file_scheme;
+mod process;
 mod scheduling;

--- a/crates/guest-download/tests/integration/process.rs
+++ b/crates/guest-download/tests/integration/process.rs
@@ -8,8 +8,69 @@ const RUN_TIMEOUT: Duration = Duration::from_secs(10);
 const CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
 const CHILD_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
-pub(super) struct CommandExecution {
+pub(super) struct ChildExecution {
     child: Option<Child>,
+}
+
+impl ChildExecution {
+    pub(super) fn spawn(command: &mut Command) -> io::Result<Self> {
+        Ok(Self {
+            child: Some(command.spawn()?),
+        })
+    }
+
+    #[cfg(unix)]
+    pub(super) fn id(&self) -> io::Result<u32> {
+        self.child
+            .as_ref()
+            .map(Child::id)
+            .ok_or_else(|| io::Error::other("command execution lost its child"))
+    }
+
+    pub(super) fn wait_with_timeout(&mut self, timeout: Duration) -> io::Result<ExitStatus> {
+        let mut child = self
+            .child
+            .take()
+            .ok_or_else(|| io::Error::other("command execution lost its child"))?;
+        let deadline = Instant::now() + timeout;
+
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => return Ok(status),
+                Ok(None) => {}
+                Err(error) => {
+                    let cleanup = terminate_and_reap(child);
+                    return Err(io::Error::other(format!(
+                        "failed to observe guest-download completion: {error}; cleanup: {cleanup}"
+                    )));
+                }
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            std::thread::sleep(remaining.min(CHILD_WAIT_POLL_INTERVAL));
+        }
+
+        let cleanup = terminate_and_reap(child);
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("guest-download timed out after {timeout:?}; cleanup: {cleanup}"),
+        ))
+    }
+}
+
+impl Drop for ChildExecution {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.take() {
+            let _ = terminate_and_reap(child);
+        }
+    }
+}
+
+pub(super) struct CommandExecution {
+    child: ChildExecution,
     stdout: File,
     stderr: File,
 }
@@ -24,7 +85,7 @@ impl CommandExecution {
             .stderr(Stdio::from(stderr.try_clone()?));
 
         Ok(Self {
-            child: Some(command.spawn()?),
+            child: ChildExecution::spawn(command)?,
             stdout,
             stderr,
         })
@@ -32,10 +93,7 @@ impl CommandExecution {
 
     #[cfg(unix)]
     pub(super) fn id(&self) -> io::Result<u32> {
-        self.child
-            .as_ref()
-            .map(Child::id)
-            .ok_or_else(|| io::Error::other("command execution lost its child"))
+        self.child.id()
     }
 
     pub(super) fn wait(self) -> io::Result<Output> {
@@ -43,41 +101,16 @@ impl CommandExecution {
     }
 
     pub(super) fn wait_with_timeout(mut self, timeout: Duration) -> io::Result<Output> {
-        let mut child = self
-            .child
-            .take()
-            .ok_or_else(|| io::Error::other("command execution lost its child"))?;
-        let deadline = Instant::now() + timeout;
-
-        loop {
-            match child.try_wait() {
-                Ok(Some(status)) => return self.read_output(status),
-                Ok(None) => {}
-                Err(error) => {
-                    let cleanup = terminate_and_reap(child);
-                    let diagnostics = self.read_diagnostics();
-                    return Err(io::Error::other(format!(
-                        "failed to observe guest-download completion: {error}; cleanup: {cleanup}; \
-                         {diagnostics}"
-                    )));
-                }
+        match self.child.wait_with_timeout(timeout) {
+            Ok(status) => self.read_output(status),
+            Err(error) => {
+                let diagnostics = self.read_diagnostics();
+                Err(io::Error::new(
+                    error.kind(),
+                    format!("{error}; {diagnostics}"),
+                ))
             }
-
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                break;
-            }
-            std::thread::sleep(remaining.min(CHILD_WAIT_POLL_INTERVAL));
         }
-
-        let cleanup = terminate_and_reap(child);
-        let diagnostics = self.read_diagnostics();
-        Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            format!(
-                "guest-download timed out after {timeout:?}; cleanup: {cleanup}; {diagnostics}"
-            ),
-        ))
     }
 
     fn read_output(&mut self, status: ExitStatus) -> io::Result<Output> {
@@ -108,16 +141,28 @@ impl CommandExecution {
     }
 }
 
-impl Drop for CommandExecution {
-    fn drop(&mut self) {
-        if let Some(child) = self.child.take() {
-            let _ = terminate_and_reap(child);
-        }
-    }
-}
-
 pub(super) fn run(command: &mut Command) -> io::Result<Output> {
     CommandExecution::spawn(command, None)?.wait()
+}
+
+#[cfg(unix)]
+pub(super) fn verify_child_reaped(child_id: u32) -> Result<(), String> {
+    let child_id = libc::pid_t::try_from(child_id)
+        .map_err(|error| format!("child ID {child_id} does not fit pid_t: {error}"))?;
+    let mut status = 0;
+    // SAFETY: `child_id` came from the directly owned child, and the lifecycle
+    // helper returned only after reaping it. WNOHANG verifies no status remains.
+    let result = unsafe { libc::waitpid(child_id, &mut status, libc::WNOHANG) };
+    if result != -1 {
+        return Err(format!(
+            "waitpid returned {result} for reaped child {child_id}"
+        ));
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() != Some(libc::ECHILD) {
+        return Err(format!("waitpid failed for child {child_id}: {error}"));
+    }
+    Ok(())
 }
 
 fn stdin_file(stdin: Option<&[u8]>) -> io::Result<Stdio> {

--- a/crates/guest-download/tests/integration/scheduling.rs
+++ b/crates/guest-download/tests/integration/scheduling.rs
@@ -11,11 +11,13 @@
 //! failure detectors; they are not sleeps used to make scheduling happen.
 
 use crate::binary_logging::BinaryLoggingFixture;
+#[cfg(unix)]
+use crate::process;
+use crate::process::ChildExecution;
 use crate::support::{create_tar_gz, write_manifest};
 use httpmock::prelude::*;
 use httpmock::{HttpMockRequest, HttpMockResponse, Mock};
 use std::path::Path;
-use std::process::{Child, ExitStatus};
 use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
@@ -23,7 +25,7 @@ const REQUEST_START_TIMEOUT: Duration = Duration::from_secs(5);
 const BLOCKED_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const NEGATIVE_START_TIMEOUT: Duration = Duration::from_millis(300);
 const COMPLETION_TIMEOUT: Duration = Duration::from_secs(5);
-const CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
+const RESPONDER_CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
 const CHILD_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 fn gzip_response(body: Vec<u8>) -> HttpMockResponse {
@@ -442,11 +444,16 @@ fn create_numbered_storages(
 }
 
 struct GuestDownloadExecution {
-    child: Child,
+    child: ChildExecution,
     _runtime: BinaryLoggingFixture,
 }
 
 impl GuestDownloadExecution {
+    #[cfg(unix)]
+    fn id(&self) -> std::io::Result<u32> {
+        self.child.id()
+    }
+
     fn wait_for_completion(
         mut self,
         scenario: &str,
@@ -454,90 +461,24 @@ impl GuestDownloadExecution {
         release_gate: &ReleaseGate,
         observations: &RequestObservations,
     ) -> Result<(), String> {
-        let deadline = Instant::now() + timeout;
-        loop {
-            match self.child.try_wait() {
-                Ok(Some(status)) if status.success() => return Ok(()),
-                Ok(Some(status)) => {
-                    return Err(format!(
-                        "{scenario} guest-download exited with {status}; {}",
-                        observations.snapshot().describe()
-                    ));
-                }
-                Ok(None) => {}
-                Err(error) => {
-                    let snapshot = observations.snapshot();
-                    let cleanup = self.terminate_and_cleanup(release_gate, observations);
-                    return Err(format!(
-                        "{scenario} failed to observe guest-download completion: {error}; {}; \
-                         cleanup: {cleanup}",
-                        snapshot.describe()
-                    ));
-                }
+        match self.child.wait_with_timeout(timeout) {
+            Ok(status) if status.success() => Ok(()),
+            Ok(status) => Err(format!(
+                "{scenario} guest-download exited with {status}; {}",
+                observations.snapshot().describe()
+            )),
+            Err(error) => {
+                let snapshot = observations.snapshot();
+                release_gate.close();
+                let responders = match observations.wait_until_idle(RESPONDER_CLEANUP_TIMEOUT) {
+                    Ok(()) => "idle".to_owned(),
+                    Err(error) => format!("failed: {error}"),
+                };
+                Err(format!(
+                    "{scenario} {error}; {}; responders={responders}",
+                    snapshot.describe()
+                ))
             }
-
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                break;
-            }
-            std::thread::sleep(remaining.min(CHILD_WAIT_POLL_INTERVAL));
-        }
-
-        let snapshot = observations.snapshot();
-        let cleanup = self.terminate_and_cleanup(release_gate, observations);
-        Err(format!(
-            "{scenario} guest-download timed out after {timeout:?}; {}; cleanup: {cleanup}",
-            snapshot.describe()
-        ))
-    }
-
-    fn terminate_and_cleanup(
-        self,
-        release_gate: &ReleaseGate,
-        observations: &RequestObservations,
-    ) -> String {
-        let Self {
-            mut child,
-            _runtime,
-        } = self;
-        let kill = match child.kill() {
-            Ok(()) => "signal sent".to_owned(),
-            Err(error) => format!("failed: {error}"),
-        };
-        release_gate.close();
-        let reap = match reap_child_with_timeout(child, CLEANUP_TIMEOUT) {
-            Ok(status) => format!("completed with {status}"),
-            Err(error) => format!("failed: {error}"),
-        };
-        let responders = match observations.wait_until_idle(CLEANUP_TIMEOUT) {
-            Ok(()) => "idle".to_owned(),
-            Err(error) => format!("failed: {error}"),
-        };
-
-        format!("kill={kill}, reap={reap}, responders={responders}")
-    }
-}
-
-fn reap_child_with_timeout(mut child: Child, timeout: Duration) -> Result<ExitStatus, String> {
-    let (status_tx, status_rx) = mpsc::channel();
-    let reaper = std::thread::spawn(move || {
-        let _ = status_tx.send(child.wait());
-    });
-
-    match status_rx.recv_timeout(timeout) {
-        Ok(status) => {
-            reaper
-                .join()
-                .map_err(|_| "child reaper panicked".to_owned())?;
-            status.map_err(|error| format!("wait failed: {error}"))
-        }
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            drop(reaper);
-            Err(format!("child was not reaped within {timeout:?}"))
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            drop(reaper);
-            Err("child reaper exited without a status".to_owned())
         }
     }
 }
@@ -554,7 +495,7 @@ fn spawn_guest_download(
     let manifest = write_manifest(dir, &storage_refs, None)?;
     let manifest_path = path_to_string(&manifest)?;
     let runtime = BinaryLoggingFixture::new(scenario)?;
-    let child = runtime.command().arg(manifest_path).spawn()?;
+    let child = ChildExecution::spawn(runtime.command().arg(manifest_path))?;
     Ok(GuestDownloadExecution {
         child,
         _runtime: runtime,
@@ -611,6 +552,53 @@ fn completion_timeout_terminates_child_and_releases_responder() {
     assert!(error.contains("kill=signal sent"));
     assert!(error.contains("reap=completed with"));
     assert!(error.contains("responders=idle"));
+    assert_eq!(observations.active(), 0);
+    blocked_mock.assert();
+}
+
+#[cfg(unix)]
+#[test]
+fn dropping_unconsumed_execution_terminates_child_and_releases_responder() {
+    let server = MockServer::start();
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("blocked");
+    let body = create_tar_gz(&[("state.json", b"blocked")]).unwrap();
+    let (started_tx, started_rx) = mpsc::channel();
+    let release = ReleaseGate::new();
+    let observations = RequestObservations::new();
+    let blocked_mock = serve_blocked_archive(
+        &server,
+        "/blocked.tar.gz",
+        body,
+        move || {
+            started_tx
+                .send(())
+                .map_err(|e| format!("failed to send blocked start event: {e}"))
+        },
+        release.waiter(),
+        "blocked request".to_owned(),
+        observations.clone(),
+    );
+    let storages = vec![(
+        path_to_string(&mount).unwrap(),
+        server.url("/blocked.tar.gz"),
+    )];
+    let execution = spawn_guest_download(
+        stringify!(dropping_unconsumed_execution_terminates_child_and_releases_responder),
+        &dir,
+        &storages,
+    )
+    .unwrap();
+    let child_id = execution.id().unwrap();
+
+    started_rx.recv_timeout(REQUEST_START_TIMEOUT).unwrap();
+    drop(execution);
+    release.close();
+    observations
+        .wait_until_idle(RESPONDER_CLEANUP_TIMEOUT)
+        .unwrap();
+
+    process::verify_child_reaped(child_id).unwrap();
     assert_eq!(observations.active(), 0);
     blocked_mock.assert();
 }


### PR DESCRIPTION
## Summary

- centralize guest-download integration child spawning, completion polling, timeout handling, termination, bounded reaping, and drop cleanup in `ChildExecution`
- retain binary logging's stdin and captured stdout/stderr behavior through `CommandExecution`, while scheduling keeps inherited streams and responder diagnostics
- cover dropping an unconsumed blocked scheduling execution and verify that its child is reaped

## Scope

This is limited to the guest-download integration-test harness. It does not change production behavior, protocols, dependencies, or the existing reaper-thread mechanism.

## Validation

- `cargo test -p guest-download --test integration binary_timeout_terminates_child_and_connection_responder`
- `cargo test -p guest-download --test integration completion_timeout_terminates_child_and_releases_responder`
- `cargo test -p guest-download --test integration dropping_unconsumed_execution_terminates_child_and_releases_responder`
- `cargo fmt --all --check`
- `cargo clippy -p guest-download --all-targets -- -D warnings`
- `cargo doc -p guest-download --no-deps`
- `cargo test -p guest-download --test integration`
- `cargo test -p guest-download`
- pre-commit workspace Cargo formatting, documentation, Clippy, and file-size checks

Closes #28310
