### PR TITLE
refactor(python): centralize blocking classification dispatch

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1208,11 +1208,10 @@ def _clear_stale_firewall_authorization_metadata(flow: http.HTTPFlow) -> None:
         flow.metadata.pop(key, None)
 
 
-def _block_current_firewall_authorization(
+def _block_request_classification(
     flow: http.HTTPFlow,
-    classification: request_classification.RequestClassification,
+    classification: request_classification.BlockingRequestClassification,
 ) -> None:
-    _clear_stale_firewall_authorization_metadata(flow)
     if classification.kind == "registry_unavailable":
         _block_registry_unavailable(flow, classification.registry_unavailable)
         return
@@ -1236,6 +1235,17 @@ def _block_current_firewall_authorization(
         return
     if classification.kind == "public_destination_denied":
         _block_public_destination_denied(flow, classification.public_destination_denial)
+        return
+    _unhandled_request_classification(classification)
+
+
+def _block_current_firewall_authorization(
+    flow: http.HTTPFlow,
+    classification: request_classification.RequestClassification,
+) -> None:
+    _clear_stale_firewall_authorization_metadata(flow)
+    if isinstance(classification, request_classification.BlockingRequestClassification):
+        _block_request_classification(flow, classification)
         return
     _block_firewall_authorization_changed(
         flow,
@@ -1330,19 +1340,12 @@ async def request(flow: http.HTTPFlow) -> None:
         if classification.kind == "no_client_ip":
             ctx.log.warn("No client IP available, passing through")
             return
-        if classification.kind == "registry_unavailable":
-            _block_registry_unavailable(flow, classification.registry_unavailable)
-            return
-        if classification.kind == "stale_tls_admission":
-            _block_stale_tls_admission(flow, reason=classification.stale_tls_reason)
-            return
-        if classification.kind == "invalid_registry_vm":
-            _block_invalid_registry_vm(flow, classification.invalid_vm)
+        if isinstance(classification, request_classification.BlockingRequestClassification):
+            if isinstance(classification, request_classification.PublicDestinationDenied):
+                terminal_usage.release_tracked_flow(flow)
+            _block_request_classification(flow, classification)
             return
         if classification.kind == "pass_through":
-            return
-        if classification.kind == "authority_denied":
-            _block_authority_validation_error(flow, classification.authority_error)
             return
         if classification.kind == "api_allow":
             if not _admit_platform_api_request(flow):
@@ -1350,25 +1353,12 @@ async def request(flow: http.HTTPFlow) -> None:
                 return
             flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
             return
-        if classification.kind == "platform_path_denied":
-            _block_platform_path_denied(flow)
-            return
         if classification.kind == "browser_allow":
             # Browser-originated traffic intentionally bypasses connector
             # firewall handling. User-Agent is the short-term heuristic for that
             # business passthrough, not trusted provenance.
             flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
             flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
-            return
-        if classification.kind == "firewall_ambiguous":
-            _set_firewall_ambiguous_response(flow, classification.firewall_ambiguous)
-            return
-        if classification.kind == "firewall_block":
-            _set_firewall_block_response(flow, classification.firewall_block)
-            return
-        if classification.kind == "public_destination_denied":
-            terminal_usage.release_tracked_flow(flow)
-            _block_public_destination_denied(flow, classification.public_destination_denial)
             return
         if classification.kind == "firewall_policy_allow":
             prepare_firewall_metadata(

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -209,22 +209,26 @@ class Allow:
 
 
 # This must remain a runtime union because cached metadata is validated with
-# ``isinstance`` before it is returned to request handling.
-RequestClassification = (
-    NoClientIp
-    | PassThrough
-    | RegistryUnavailable
+# ``isinstance`` before it is returned to request handling. Blocking members
+# own a canonical local response in both primary dispatch and revalidation.
+BlockingRequestClassification = (
+    RegistryUnavailable
     | StaleTlsAdmission
     | InvalidRegistryVm
     | AuthorityDenied
-    | ApiAllow
     | PlatformPathDenied
-    | BrowserAllow
     | FirewallAmbiguous
     | FirewallBlock
+    | PublicDestinationDenied
+)
+RequestClassification = (
+    NoClientIp
+    | PassThrough
+    | BlockingRequestClassification
+    | ApiAllow
+    | BrowserAllow
     | FirewallAllow
     | FirewallPolicyAllow
-    | PublicDestinationDenied
     | Allow
 )
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 from pathlib import Path
-from typing import Literal, cast, get_args
+from typing import Literal, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -13,12 +13,8 @@ import auth
 import auth_base_forwarder
 import connector_intent
 import flow_metadata_keys as metadata_keys
-import matching
 import mitm_addon
-import registry
-import request_authority
 import request_classification
-import terminal_usage
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.firewall_helpers import cancel_pending_task
@@ -38,175 +34,6 @@ _RESOLVED_AUTH_BASE = "https://webhook.example.com/deliver"
 _CUSTOM_CONNECTOR_ID = "550e8400-e29b-41d4-a716-446655440000"
 _CANDIDATE_BUILTIN_NAME = "github"
 _CANDIDATE_CUSTOM_NAME = "custom_connector_550e8400e29b41d4a716446655440000"
-_BLOCKING_CLASSIFICATIONS: tuple[request_classification.BlockingRequestClassification, ...] = (
-    request_classification.RegistryUnavailable(
-        registry.RegistryUnavailable(
-            reason="registry_read_failed",
-            message="Proxy registry could not be read",
-        )
-    ),
-    request_classification.StaleTlsAdmission(
-        stale_tls_reason="registry_entry_missing",
-    ),
-    request_classification.InvalidRegistryVm(
-        registry.InvalidVmEntry(
-            reason="invalid_vm_entry",
-            message="Proxy registry VM entry is invalid",
-        )
-    ),
-    request_classification.AuthorityDenied(
-        vm_info={},
-        authority_error=request_authority.AuthorityValidationError(
-            "authority_mismatch",
-            message="Request authority does not match TLS SNI",
-            sni="api.example.com",
-            request_host="other.example.com",
-            host_header="other.example.com",
-            request_port=443,
-            fallback_url="https://other.example.com/items",
-        ),
-    ),
-    request_classification.PlatformPathDenied(vm_info={}),
-    request_classification.FirewallAmbiguous(
-        vm_info={},
-        firewall_ambiguous=matching.FirewallAmbiguous(
-            method="POST",
-            path="/items/123",
-            candidates=("primary", "secondary"),
-            reason="connector_intent_required",
-        ),
-    ),
-    request_classification.FirewallBlock(
-        vm_info={},
-        firewall_block=matching.FirewallBlock(
-            base="https://api.example.com",
-            name="example",
-            method="POST",
-            path="/items/123",
-            permissions=("items-write",),
-            reason="permission_denied",
-        ),
-    ),
-    request_classification.PublicDestinationDenied(
-        vm_info={},
-        public_destination_denial=request_classification.PublicDestinationDenial(
-            name="example",
-            base="https://api.example.com",
-            trusted_authority_host="api.example.com",
-            destination_host="127.0.0.1",
-            reason="non_public_destination",
-        ),
-    ),
-)
-_BLOCKING_RESPONSE_METADATA_KEYS = (
-    metadata_keys.ORIGINAL_URL,
-    metadata_keys.FIREWALL_ACTION,
-    metadata_keys.FIREWALL_ERROR,
-    metadata_keys.FIREWALL_BASE,
-    metadata_keys.FIREWALL_NAME,
-    metadata_keys.FIREWALL_PERMISSION,
-    metadata_keys.CONNECTOR_ROUTE_REASON,
-    metadata_keys.CONNECTOR_ROUTE_CANDIDATES,
-)
-_BLOCKING_RESPONSE_STATUS_AND_ERROR = {
-    "registry_unavailable": (503, "registry_unavailable"),
-    "stale_tls_admission": (503, "stale_tls_admission"),
-    "invalid_registry_vm": (503, "invalid_registry_vm"),
-    "authority_denied": (403, "authority_mismatch"),
-    "platform_path_denied": (403, "unsafe_platform_path"),
-    "firewall_ambiguous": (409, "ambiguous_connector_route"),
-    "firewall_block": (403, "permission_denied"),
-    "public_destination_denied": (403, "unsafe_public_destination"),
-}
-
-
-def _blocking_dispatch_flow(real_flow) -> http.HTTPFlow:
-    flow = real_flow(
-        with_response=False,
-        client_ip=_CLIENT_IP,
-        host="api.example.com",
-        method="POST",
-        path="/items/123?visible=1",
-    )
-    flow.metadata[metadata_keys.ORIGINAL_URL] = flow.request.pretty_url
-    return flow
-
-
-def _blocking_response_snapshot(flow: http.HTTPFlow) -> tuple[object, ...]:
-    assert flow.response is not None
-    assert flow.response.content is not None
-    return (
-        flow.response.status_code,
-        json.loads(flow.response.content),
-        {
-            key: flow.metadata[key]
-            for key in _BLOCKING_RESPONSE_METADATA_KEYS
-            if key in flow.metadata
-        },
-        flow.request.stream,
-    )
-
-
-def test_blocking_dispatch_cases_cover_runtime_union() -> None:
-    assert {type(classification) for classification in _BLOCKING_CLASSIFICATIONS} == set(
-        get_args(request_classification.BlockingRequestClassification)
-    )
-
-
-@pytest.mark.parametrize(
-    "classification",
-    _BLOCKING_CLASSIFICATIONS,
-    ids=[classification.kind for classification in _BLOCKING_CLASSIFICATIONS],
-)
-async def test_blocking_dispatch_matches_primary_and_revalidation(
-    real_flow,
-    monkeypatch,
-    classification: request_classification.BlockingRequestClassification,
-) -> None:
-    primary_flow = _blocking_dispatch_flow(real_flow)
-    revalidation_flow = _blocking_dispatch_flow(real_flow)
-    revalidation_flow.metadata[metadata_keys.AUTH_URL_REWRITE] = "stale"
-
-    if isinstance(classification, request_classification.PublicDestinationDenied):
-        terminal_usage.track_flow_if_needed(primary_flow, True, False)
-        terminal_usage.track_flow_if_needed(revalidation_flow, True, False)
-
-    monkeypatch.setattr(
-        mitm_addon,
-        "_request_classification_for_flow",
-        lambda _flow: classification,
-    )
-    await mitm_addon.request(primary_flow)
-    mitm_addon._block_current_firewall_authorization(revalidation_flow, classification)
-
-    assert primary_flow.response is not None
-    assert primary_flow.response.content is not None
-    expected_status, expected_error = _BLOCKING_RESPONSE_STATUS_AND_ERROR[classification.kind]
-    assert primary_flow.response.status_code == expected_status
-    assert json.loads(primary_flow.response.content)["error"] == expected_error
-    assert _blocking_response_snapshot(primary_flow) == _blocking_response_snapshot(
-        revalidation_flow
-    )
-    assert metadata_keys.AUTH_URL_REWRITE not in revalidation_flow.metadata
-    if isinstance(classification, request_classification.FirewallAmbiguous):
-        assert primary_flow.metadata[metadata_keys.CONNECTOR_ROUTE_REASON] == (
-            "connector_intent_required"
-        )
-        assert primary_flow.metadata[metadata_keys.CONNECTOR_ROUTE_CANDIDATES] == [
-            "primary",
-            "secondary",
-        ]
-    if isinstance(classification, request_classification.FirewallBlock):
-        assert primary_flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.example.com"
-        assert primary_flow.metadata[metadata_keys.FIREWALL_NAME] == "example"
-        assert primary_flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "items-write"
-    if isinstance(classification, request_classification.PublicDestinationDenied):
-        assert primary_flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.example.com"
-        assert primary_flow.metadata[metadata_keys.FIREWALL_NAME] == "example"
-        assert primary_flow.request.stream is False
-        assert "_usage_flow_tracked" not in primary_flow.metadata
-        assert revalidation_flow.metadata["_usage_flow_tracked"] is True
-        terminal_usage.release_tracked_flow(revalidation_flow)
 
 
 def _registry_vm(
@@ -216,6 +43,7 @@ def _registry_vm(
     allow_repos: bool = True,
     allow_unrelated_orgs: bool = False,
     auth_base: bool = False,
+    enforce_public_destination: bool = False,
 ) -> dict[str, object]:
     allowed_permissions = ["repos-write"] if allow_repos else []
     denied_permissions = [] if allow_repos else ["repos-write"]
@@ -234,19 +62,22 @@ def _registry_vm(
             "query": {"managed": "${{ secrets.GITHUB_TOKEN }}"},
         }
         api_base = "https://api.github.com"
+    api_entry: dict[str, object] = {
+        "base": api_base,
+        "auth": auth_config,
+        "permissions": [
+            {"name": "repos-write", "rules": ["POST /repos/{path+}"]},
+            {"name": "orgs-write", "rules": ["POST /orgs/{path+}"]},
+        ],
+    }
+    if enforce_public_destination:
+        api_entry["hostPolicy"] = {"kind": "publicDestination"}
 
     return _single_firewall_vm(
         tmp_path,
         run_id=run_id,
         firewall_name=_FIREWALL_NAME,
-        api_entry={
-            "base": api_base,
-            "auth": auth_config,
-            "permissions": [
-                {"name": "repos-write", "rules": ["POST /repos/{path+}"]},
-                {"name": "orgs-write", "rules": ["POST /orgs/{path+}"]},
-            ],
-        },
+        api_entry=api_entry,
         network_policy={
             "allow": allowed_permissions,
             "deny": denied_permissions,
@@ -406,6 +237,7 @@ def _firewall_flow(
     make_tls_data,
     *,
     auth_base: bool = False,
+    upstream_endpoint: tuple[str, int] = ("172.66.0.243", 443),
 ) -> tuple[http.HTTPFlow, tls.ClientHelloData]:
     host = "placeholder.example.com" if auth_base else "api.github.com"
     flow = real_flow(
@@ -424,7 +256,6 @@ def _firewall_flow(
     )
     client_id = f"client-firewall-auth-revalidation-{'base' if auth_base else 'ordinary'}"
     flow.client_conn.id = client_id
-    upstream_endpoint = ("172.66.0.243", 443)
     mark_connected_tls_upstream(
         flow,
         sni=host,
@@ -569,6 +400,80 @@ async def test_registry_change_during_auth_blocks_old_authorization(
     assert flow.request.path == original_path
     assert flow.request.headers.get("Authorization") is None
     _assert_current_denial(flow, registry_mutation)
+
+
+async def test_public_destination_policy_added_during_auth_blocks_private_destination(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+    monkeypatch,
+):
+    registry_path = _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        vm_info=_registry_vm(tmp_path),
+    )
+    private_endpoint = ("10.0.0.1", 443)
+    flow, tls_data = _firewall_flow(
+        real_flow,
+        make_tls_data,
+        upstream_endpoint=private_endpoint,
+    )
+    original_path = flow.request.path
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return _resolved_firewall_auth()
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+
+    request_task: asyncio.Task[None] | None = None
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        request_task = asyncio.create_task(mitm_addon.request(flow))
+        try:
+            await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+            _publish_registry(
+                registry_path,
+                vm_info=_registry_vm(tmp_path, enforce_public_destination=True),
+            )
+            release_auth_resolution.set()
+            await asyncio.gather(request_task)
+        finally:
+            release_auth_resolution.set()
+            await cancel_pending_task(request_task)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.request.headers.get("Host") == "api.github.com"
+    assert flow.request.headers.get("Content-Length") == str(STREAM_BUFFER_LIMIT + 1)
+    assert flow.request.headers.get("Accept-Encoding") == "identity"
+    assert flow.request.path == original_path
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.response.content is not None
+    assert json.loads(flow.response.content) == {
+        "error": "unsafe_public_destination",
+        "message": "Request blocked: publicDestination resolved to a non-public destination",
+        "name": _FIREWALL_NAME,
+        "base": "https://api.github.com",
+        "destination_host": private_endpoint[0],
+        "trusted_authority_host": "api.github.com",
+        "reason": "non_public_destination",
+    }
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "unsafe_public_destination"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == _FIREWALL_NAME
+    assert flow.request.stream is False
+    assert flow.request.headers.get("Authorization") is None
+    assert flow.request.query.get("managed") is None
+    assert flow.metadata.get(metadata_keys.FIREWALL_AUTH_CACHE_KEY) is None
+    assert "_usage_flow_tracked" not in flow.metadata
 
 
 @pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal, cast, get_args
 from unittest.mock import AsyncMock
 
 import pytest
@@ -13,8 +13,12 @@ import auth
 import auth_base_forwarder
 import connector_intent
 import flow_metadata_keys as metadata_keys
+import matching
 import mitm_addon
+import registry
+import request_authority
 import request_classification
+import terminal_usage
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.firewall_helpers import cancel_pending_task
@@ -34,6 +38,175 @@ _RESOLVED_AUTH_BASE = "https://webhook.example.com/deliver"
 _CUSTOM_CONNECTOR_ID = "550e8400-e29b-41d4-a716-446655440000"
 _CANDIDATE_BUILTIN_NAME = "github"
 _CANDIDATE_CUSTOM_NAME = "custom_connector_550e8400e29b41d4a716446655440000"
+_BLOCKING_CLASSIFICATIONS: tuple[request_classification.BlockingRequestClassification, ...] = (
+    request_classification.RegistryUnavailable(
+        registry.RegistryUnavailable(
+            reason="registry_read_failed",
+            message="Proxy registry could not be read",
+        )
+    ),
+    request_classification.StaleTlsAdmission(
+        stale_tls_reason="registry_entry_missing",
+    ),
+    request_classification.InvalidRegistryVm(
+        registry.InvalidVmEntry(
+            reason="invalid_vm_entry",
+            message="Proxy registry VM entry is invalid",
+        )
+    ),
+    request_classification.AuthorityDenied(
+        vm_info={},
+        authority_error=request_authority.AuthorityValidationError(
+            "authority_mismatch",
+            message="Request authority does not match TLS SNI",
+            sni="api.example.com",
+            request_host="other.example.com",
+            host_header="other.example.com",
+            request_port=443,
+            fallback_url="https://other.example.com/items",
+        ),
+    ),
+    request_classification.PlatformPathDenied(vm_info={}),
+    request_classification.FirewallAmbiguous(
+        vm_info={},
+        firewall_ambiguous=matching.FirewallAmbiguous(
+            method="POST",
+            path="/items/123",
+            candidates=("primary", "secondary"),
+            reason="connector_intent_required",
+        ),
+    ),
+    request_classification.FirewallBlock(
+        vm_info={},
+        firewall_block=matching.FirewallBlock(
+            base="https://api.example.com",
+            name="example",
+            method="POST",
+            path="/items/123",
+            permissions=("items-write",),
+            reason="permission_denied",
+        ),
+    ),
+    request_classification.PublicDestinationDenied(
+        vm_info={},
+        public_destination_denial=request_classification.PublicDestinationDenial(
+            name="example",
+            base="https://api.example.com",
+            trusted_authority_host="api.example.com",
+            destination_host="127.0.0.1",
+            reason="non_public_destination",
+        ),
+    ),
+)
+_BLOCKING_RESPONSE_METADATA_KEYS = (
+    metadata_keys.ORIGINAL_URL,
+    metadata_keys.FIREWALL_ACTION,
+    metadata_keys.FIREWALL_ERROR,
+    metadata_keys.FIREWALL_BASE,
+    metadata_keys.FIREWALL_NAME,
+    metadata_keys.FIREWALL_PERMISSION,
+    metadata_keys.CONNECTOR_ROUTE_REASON,
+    metadata_keys.CONNECTOR_ROUTE_CANDIDATES,
+)
+_BLOCKING_RESPONSE_STATUS_AND_ERROR = {
+    "registry_unavailable": (503, "registry_unavailable"),
+    "stale_tls_admission": (503, "stale_tls_admission"),
+    "invalid_registry_vm": (503, "invalid_registry_vm"),
+    "authority_denied": (403, "authority_mismatch"),
+    "platform_path_denied": (403, "unsafe_platform_path"),
+    "firewall_ambiguous": (409, "ambiguous_connector_route"),
+    "firewall_block": (403, "permission_denied"),
+    "public_destination_denied": (403, "unsafe_public_destination"),
+}
+
+
+def _blocking_dispatch_flow(real_flow) -> http.HTTPFlow:
+    flow = real_flow(
+        with_response=False,
+        client_ip=_CLIENT_IP,
+        host="api.example.com",
+        method="POST",
+        path="/items/123?visible=1",
+    )
+    flow.metadata[metadata_keys.ORIGINAL_URL] = flow.request.pretty_url
+    return flow
+
+
+def _blocking_response_snapshot(flow: http.HTTPFlow) -> tuple[object, ...]:
+    assert flow.response is not None
+    assert flow.response.content is not None
+    return (
+        flow.response.status_code,
+        json.loads(flow.response.content),
+        {
+            key: flow.metadata[key]
+            for key in _BLOCKING_RESPONSE_METADATA_KEYS
+            if key in flow.metadata
+        },
+        flow.request.stream,
+    )
+
+
+def test_blocking_dispatch_cases_cover_runtime_union() -> None:
+    assert {type(classification) for classification in _BLOCKING_CLASSIFICATIONS} == set(
+        get_args(request_classification.BlockingRequestClassification)
+    )
+
+
+@pytest.mark.parametrize(
+    "classification",
+    _BLOCKING_CLASSIFICATIONS,
+    ids=[classification.kind for classification in _BLOCKING_CLASSIFICATIONS],
+)
+async def test_blocking_dispatch_matches_primary_and_revalidation(
+    real_flow,
+    monkeypatch,
+    classification: request_classification.BlockingRequestClassification,
+) -> None:
+    primary_flow = _blocking_dispatch_flow(real_flow)
+    revalidation_flow = _blocking_dispatch_flow(real_flow)
+    revalidation_flow.metadata[metadata_keys.AUTH_URL_REWRITE] = "stale"
+
+    if isinstance(classification, request_classification.PublicDestinationDenied):
+        terminal_usage.track_flow_if_needed(primary_flow, True, False)
+        terminal_usage.track_flow_if_needed(revalidation_flow, True, False)
+
+    monkeypatch.setattr(
+        mitm_addon,
+        "_request_classification_for_flow",
+        lambda _flow: classification,
+    )
+    await mitm_addon.request(primary_flow)
+    mitm_addon._block_current_firewall_authorization(revalidation_flow, classification)
+
+    assert primary_flow.response is not None
+    assert primary_flow.response.content is not None
+    expected_status, expected_error = _BLOCKING_RESPONSE_STATUS_AND_ERROR[classification.kind]
+    assert primary_flow.response.status_code == expected_status
+    assert json.loads(primary_flow.response.content)["error"] == expected_error
+    assert _blocking_response_snapshot(primary_flow) == _blocking_response_snapshot(
+        revalidation_flow
+    )
+    assert metadata_keys.AUTH_URL_REWRITE not in revalidation_flow.metadata
+    if isinstance(classification, request_classification.FirewallAmbiguous):
+        assert primary_flow.metadata[metadata_keys.CONNECTOR_ROUTE_REASON] == (
+            "connector_intent_required"
+        )
+        assert primary_flow.metadata[metadata_keys.CONNECTOR_ROUTE_CANDIDATES] == [
+            "primary",
+            "secondary",
+        ]
+    if isinstance(classification, request_classification.FirewallBlock):
+        assert primary_flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.example.com"
+        assert primary_flow.metadata[metadata_keys.FIREWALL_NAME] == "example"
+        assert primary_flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "items-write"
+    if isinstance(classification, request_classification.PublicDestinationDenied):
+        assert primary_flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.example.com"
+        assert primary_flow.metadata[metadata_keys.FIREWALL_NAME] == "example"
+        assert primary_flow.request.stream is False
+        assert "_usage_flow_tracked" not in primary_flow.metadata
+        assert revalidation_flow.metadata["_usage_flow_tracked"] is True
+        terminal_usage.release_tracked_flow(revalidation_flow)
 
 
 def _registry_vm(


### PR DESCRIPTION
## Summary

- define a runtime-usable `BlockingRequestClassification` subset for the eight classifications that own canonical local responses
- route primary request dispatch and post-wait firewall authorization revalidation through one exhaustive response selector
- preserve caller-owned stale metadata cleanup, public-destination usage release, and the non-blocking revalidation 409 fallback
- exercise post-auth-wait HTTP 503, firewall HTTP 403, generic HTTP 409, and public-destination metadata through real request-hook integration flows

## Scope

This refactor does not change local response construction, HTTP status codes, response bodies, proxy logging, queue/API/database contracts, persisted state, or deployment compatibility. Non-blocking request outcomes and allow paths remain caller-owned.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_handler_firewall_auth_revalidation.py` (15 passed)
- affected primary request-handler suites (225 passed)
- `uv run --no-sync python -m pytest tests/` (6,391 passed)

Closes #28289
