### PR TITLE
refactor(python): centralize catalog cache fixtures

### DIFF
--- a/crates/runner/mitm-addon/tests/builtin_firewall_cache_helpers.py
+++ b/crates/runner/mitm-addon/tests/builtin_firewall_cache_helpers.py
@@ -1,0 +1,21 @@
+"""Helpers shared by valid built-in firewall catalog cache fixtures."""
+
+import json
+
+
+def serialize_builtin_firewall_catalog_cache(
+    *,
+    digest: str,
+    version: str,
+    firewalls: dict[str, dict],
+) -> str:
+    return json.dumps(
+        {
+            "schemaVersion": 1,
+            "catalogDigest": digest,
+            "catalogVersion": version,
+            "updatedAt": "2026-07-07T00:00:00.000Z",
+            "firewalls": firewalls,
+        },
+        sort_keys=True,
+    )

--- a/crates/runner/mitm-addon/tests/connector_diagnostic_helpers.py
+++ b/crates/runner/mitm-addon/tests/connector_diagnostic_helpers.py
@@ -1,11 +1,11 @@
 """Helpers for connector diagnostic hook lifecycle tests."""
 
-import json
 from pathlib import Path
 
 from mitmproxy import http
 
 import mitm_addon
+from tests.builtin_firewall_cache_helpers import serialize_builtin_firewall_catalog_cache
 from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
 
 CONNECTOR_DIAGNOSTIC_REQUEST_CHUNK = b"partial request"
@@ -107,17 +107,10 @@ def write_connector_diagnostic_catalog_cache(
     cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
     replacement_path = tmp_path / "builtin-firewall-catalog-cache.next.json"
     replacement_path.write_text(
-        json.dumps(
-            {
-                "schemaVersion": 1,
-                "catalogDigest": digest,
-                "catalogVersion": version,
-                "updatedAt": "2026-07-07T00:00:00.000Z",
-                "firewalls": (
-                    connector_diagnostic_test_firewalls() if firewalls is None else firewalls
-                ),
-            },
-            sort_keys=True,
+        serialize_builtin_firewall_catalog_cache(
+            digest=digest,
+            version=version,
+            firewalls=(connector_diagnostic_test_firewalls() if firewalls is None else firewalls),
         )
     )
     replacement_path.chmod(0o600)

--- a/crates/runner/mitm-addon/tests/registry_builtin_helpers.py
+++ b/crates/runner/mitm-addon/tests/registry_builtin_helpers.py
@@ -1,8 +1,7 @@
 """Helpers shared by built-in registry cache tests."""
 
-import json
-
 import matching
+from tests.builtin_firewall_cache_helpers import serialize_builtin_firewall_catalog_cache
 from tests.registry_helpers import (
     write_multi_vm_registry,
     write_trusted_catalog_cache_text,
@@ -57,15 +56,10 @@ def write_catalog_cache(
 ) -> None:
     write_trusted_catalog_cache_text(
         path,
-        json.dumps(
-            {
-                "schemaVersion": 1,
-                "catalogDigest": digest,
-                "catalogVersion": version,
-                "updatedAt": "2026-07-07T00:00:00.000Z",
-                "firewalls": firewalls,
-            },
-            sort_keys=True,
+        serialize_builtin_firewall_catalog_cache(
+            digest=digest,
+            version=version,
+            firewalls=firewalls,
         ),
     )
 

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -7,6 +7,7 @@ import pytest
 
 import builtin_host_policy
 import registry
+from tests.builtin_firewall_cache_helpers import serialize_builtin_firewall_catalog_cache
 from tests.registry_helpers import (
     assert_invalid_builtin_vm,
     write_trusted_catalog_cache_text,
@@ -56,17 +57,10 @@ def _cache_path_for_registry(path):
 def _write_catalog_cache(path, firewalls: dict[str, dict]) -> None:
     write_trusted_catalog_cache_text(
         path,
-        json.dumps(
-            {
-                "schemaVersion": 1,
-                "catalogDigest": (
-                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                ),
-                "catalogVersion": "catalog-test",
-                "updatedAt": "2026-07-07T00:00:00.000Z",
-                "firewalls": firewalls,
-            },
-            sort_keys=True,
+        serialize_builtin_firewall_catalog_cache(
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-test",
+            firewalls=firewalls,
         ),
     )
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_builtin_host_policy.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_builtin_host_policy.py
@@ -12,6 +12,7 @@ import registry
 import request_classification
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
+from tests.builtin_firewall_cache_helpers import serialize_builtin_firewall_catalog_cache
 from tests.registry_helpers import write_trusted_catalog_cache_text
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 from tests.requestheaders_helpers import (
@@ -96,36 +97,29 @@ def _write_resolved_host_policy_registry(
     )
     write_trusted_catalog_cache_text(
         tmp_path / "builtin-firewall-catalog-cache.json",
-        json.dumps(
-            {
-                "schemaVersion": 1,
-                "catalogDigest": (
-                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                ),
-                "catalogVersion": "catalog-test",
-                "updatedAt": "2026-07-07T00:00:00.000Z",
-                "firewalls": {
-                    firewall_name: {
-                        "name": firewall_name,
-                        "apis": [
-                            {
-                                "base": base,
-                                "auth": {
-                                    "headers": {"Authorization": "Bearer ${{ secrets.TEST_TOKEN }}"}
-                                },
-                                "hostPolicy": host_policy,
-                                "permissions": [
-                                    {
-                                        "name": "full-access",
-                                        "rules": ["ANY /{path+}"],
-                                    }
-                                ],
-                            }
-                        ],
-                    }
+        serialize_builtin_firewall_catalog_cache(
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-test",
+            firewalls={
+                firewall_name: {
+                    "name": firewall_name,
+                    "apis": [
+                        {
+                            "base": base,
+                            "auth": {
+                                "headers": {"Authorization": "Bearer ${{ secrets.TEST_TOKEN }}"}
+                            },
+                            "hostPolicy": host_policy,
+                            "permissions": [
+                                {
+                                    "name": "full-access",
+                                    "rules": ["ANY /{path+}"],
+                                }
+                            ],
+                        }
+                    ],
                 },
             },
-            sort_keys=True,
         ),
     )
     return registry_path


### PR DESCRIPTION
## Summary

- add a test-only serializer that owns the valid built-in firewall catalog-cache envelope and sorted JSON representation
- reuse it from registry, base-URL, host-policy, and connector-diagnostic fixture owners
- preserve trusted direct writes, connector `.next` permissions and atomic replacement, and explicit malformed fixtures

## Scope

This refactor changes test fixture construction only. It does not change the production cache parser, Rust publication, filesystem lifecycle, API contracts, persisted data, or deployment compatibility.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_registry_builtin_base_url_vars.py tests/test_request_handler_builtin_host_policy.py tests/test_connector_diagnostic_catalog_lifecycle.py tests/test_request_handler_connector_diagnostics.py tests/test_response_handler_connector_diagnostics.py` (151 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6390 passed)

Closes #28332
