### PR TITLE
fix(python): handle x tld snapshot write failures

### DIFF
--- a/crates/runner/mitm-addon/scripts/update_x_tlds.py
+++ b/crates/runner/mitm-addon/scripts/update_x_tlds.py
@@ -40,6 +40,10 @@ class TldSourceError(ValueError):
     """Raised when an IANA TLD source cannot be read or parsed."""
 
 
+class TldWriteError(RuntimeError):
+    """Raised when the generated IANA TLD snapshot cannot be written."""
+
+
 class SnapshotComparison(NamedTuple):
     checked_version: str
     source_version: str
@@ -242,9 +246,18 @@ def write_generated_module(contents: str) -> None:
             tmp_path = Path(tmp_file.name)
             tmp_file.write(contents)
         tmp_path.replace(OUTPUT_PATH)
-    finally:
-        if tmp_path is not None and tmp_path.exists():
-            tmp_path.unlink()
+    except OSError as exc:
+        cleanup_error: OSError | None = None
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError as cleanup_exc:
+                cleanup_error = cleanup_exc
+
+        message = f"failed to write generated IANA TLD snapshot {OUTPUT_PATH}: {exc}"
+        if cleanup_error is not None:
+            message += f"; failed to remove temporary file {tmp_path}: {cleanup_error}"
+        raise TldWriteError(message) from exc
 
 
 def update_generated(source_file: Path | None) -> int:
@@ -286,6 +299,6 @@ def main() -> int:
                 parser.error("--check-source requires --source-file")
             return check_source(args.source_file)
         return update_generated(args.source_file)
-    except (TldFetchError, TldSourceError) as exc:
+    except (TldFetchError, TldSourceError, TldWriteError) as exc:
         sys.stderr.write(f"{exc}\n")
         return 1

--- a/crates/runner/mitm-addon/tests/test_update_x_tlds.py
+++ b/crates/runner/mitm-addon/tests/test_update_x_tlds.py
@@ -110,6 +110,20 @@ class _BodyOpener:
         return self._response
 
 
+class _FailingWriteTemporaryFile:
+    def __init__(self, path: Path) -> None:
+        self.name = str(path)
+
+    def __enter__(self) -> _FailingWriteTemporaryFile:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None
+
+    def write(self, contents: str) -> None:
+        raise OSError("simulated temporary write failure")
+
+
 def _build_failing_opener(*handlers: object) -> _FailingOpener:
     return _FailingOpener()
 
@@ -142,6 +156,17 @@ def _write_generated_snapshot(path: Path) -> None:
         update_x_tlds.render_module(IANA_TLD_VERSION, tuple(sorted(IANA_TLDS))),
         encoding="utf-8",
     )
+
+
+def _prepare_update_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str]:
+    source = tmp_path / "tlds.txt"
+    source.write_text("# Version 1, Last Updated test\nCOM\nORG\n", encoding="utf-8")
+    output = tmp_path / "x_tlds.py"
+    original = "# existing generated snapshot\n"
+    output.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", [str(_UPDATE_SCRIPT), "--source-file", str(source)])
+    monkeypatch.setattr(update_x_tlds, "OUTPUT_PATH", output)
+    return output, original
 
 
 def _run_update_script(*args: str) -> subprocess.CompletedProcess[str]:
@@ -452,6 +477,114 @@ def test_update_cli_reports_missing_source_file_without_replacing_output(
     assert captured.out == ""
     assert str(source) in captured.err
     assert "failed to read IANA TLD source file" in captured.err
+    assert "Traceback" not in captured.err
+    assert output.read_text(encoding="utf-8") == original
+
+
+def test_update_cli_reports_temporary_file_creation_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output, original = _prepare_update_cli(tmp_path, monkeypatch)
+
+    def fail_create(*args: object, **kwargs: object) -> None:
+        raise OSError("simulated temporary file creation failure")
+
+    monkeypatch.setattr(update_x_tlds.tempfile, "NamedTemporaryFile", fail_create)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        f"failed to write generated IANA TLD snapshot {output}: "
+        "simulated temporary file creation failure\n"
+    )
+    assert "Traceback" not in captured.err
+    assert output.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob(f".{output.name}.*.tmp")) == []
+
+
+def test_update_cli_reports_temporary_file_write_failure_and_removes_staged_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output, original = _prepare_update_cli(tmp_path, monkeypatch)
+    staged = tmp_path / f".{output.name}.injected.tmp"
+    staged.touch()
+    failing_file = _FailingWriteTemporaryFile(staged)
+
+    def open_failing_file(*args: object, **kwargs: object) -> _FailingWriteTemporaryFile:
+        return failing_file
+
+    monkeypatch.setattr(update_x_tlds.tempfile, "NamedTemporaryFile", open_failing_file)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        f"failed to write generated IANA TLD snapshot {output}: simulated temporary write failure\n"
+    )
+    assert "Traceback" not in captured.err
+    assert output.read_text(encoding="utf-8") == original
+    assert not staged.exists()
+
+
+def test_update_cli_reports_replace_failure_and_removes_staged_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output, original = _prepare_update_cli(tmp_path, monkeypatch)
+
+    def fail_replace(path: Path, target: Path) -> None:
+        raise OSError("simulated atomic replace failure")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        f"failed to write generated IANA TLD snapshot {output}: simulated atomic replace failure\n"
+    )
+    assert "Traceback" not in captured.err
+    assert output.read_text(encoding="utf-8") == original
+    assert list(tmp_path.glob(f".{output.name}.*.tmp")) == []
+
+
+def test_update_cli_preserves_replace_failure_when_staged_file_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output, original = _prepare_update_cli(tmp_path, monkeypatch)
+
+    def fail_replace(path: Path, target: Path) -> None:
+        raise OSError("simulated atomic replace failure")
+
+    def fail_unlink(path: Path, missing_ok: bool = False) -> None:
+        raise OSError("simulated temporary file cleanup failure")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+    monkeypatch.setattr(Path, "unlink", fail_unlink)
+
+    assert update_x_tlds.main() == 1
+
+    captured = capsys.readouterr()
+    staged_files = list(tmp_path.glob(f".{output.name}.*.tmp"))
+    assert len(staged_files) == 1
+    assert captured.out == ""
+    assert captured.err == (
+        f"failed to write generated IANA TLD snapshot {output}: "
+        "simulated atomic replace failure; "
+        f"failed to remove temporary file {staged_files[0]}: "
+        "simulated temporary file cleanup failure\n"
+    )
     assert "Traceback" not in captured.err
     assert output.read_text(encoding="utf-8") == original
 


### PR DESCRIPTION
## Summary

- translate expected X TLD snapshot create, write, close, replace, and cleanup failures into the updater's bounded CLI error contract
- remove the staged-file existence check and preserve the primary persistence failure when cleanup also fails
- add deterministic `main()` integration coverage for creation, write, replace, successful cleanup, and dual-failure behavior

## Scope

This does not change the generated snapshot, snapshot format, source fetching/parsing, runtime X billing behavior, APIs, schemas, or runner protocols.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_update_x_tlds.py` (`41 passed`)
- `uv run --no-sync python -m pytest tests/` (`6394 passed`)
- `lefthook run pre-commit`

Closes #28333
