### PR TITLE
fix(python): bound request header name work

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -109,17 +109,17 @@ from request_authority import AuthorityValidationError, TrustedAuthority, get_tr
 
 # HTTP status boundaries used in response-phase classification.
 _HTTP_STATUS_UNAUTHORIZED = 401
-_HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE = 431
 _HTTP_STATUS_BAD_GATEWAY = 502
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 _HTTP_OWS_CHARS = " \t"
-_MAX_REQUEST_HEADER_NAME_BYTES = 4096
 
 # Request-header phase state.
 # Creator: requestheaders() and header-phase stream/auth helpers.
 # Consumer: request() and terminal cleanup.
 # Release: auth marker is popped by terminal cleanup.
 # _REQUEST_HEADERS_TERMINATED is a flow-local sentinel for request() early exit.
+_HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE = 431
+_MAX_REQUEST_HEADER_NAME_BYTES = 4096
 _REQUEST_HEADERS_TERMINATED = "_request_headers_terminated"
 _FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS = "_firewall_auth_applied_in_requestheaders"
 _STALE_FIREWALL_AUTHORIZATION_METADATA_KEYS = (

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -109,9 +109,11 @@ from request_authority import AuthorityValidationError, TrustedAuthority, get_tr
 
 # HTTP status boundaries used in response-phase classification.
 _HTTP_STATUS_UNAUTHORIZED = 401
+_HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE = 431
 _HTTP_STATUS_BAD_GATEWAY = 502
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 _HTTP_OWS_CHARS = " \t"
+_MAX_REQUEST_HEADER_NAME_BYTES = 4096
 
 # Request-header phase state.
 # Creator: requestheaders() and header-phase stream/auth helpers.
@@ -746,6 +748,19 @@ def client_disconnected(client: connection.Client) -> None:
 def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     """Handle request-header-only decisions before mitmproxy buffers bodies."""
     request_end_stream = mitmproxy_compat.take_request_end_stream(flow)
+    request_header_fields = flow.request.headers.fields
+    if any(len(name) > _MAX_REQUEST_HEADER_NAME_BYTES for name, _value in request_header_fields):
+        # Mitmproxy performs an Expect lookup after this hook, so rejected names
+        # must be gone before control returns while ordinary protocol fields stay.
+        flow.request.headers.fields = tuple(
+            (name, value)
+            for name, value in request_header_fields
+            if len(name) <= _MAX_REQUEST_HEADER_NAME_BYTES
+        )
+        flow.response = http.Response.make(_HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE)
+        flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+        return None
+
     codex_model_catalog_cache.capture_and_strip_prefetch_marker(flow)
     connector_intent.capture_and_strip(flow)
 
@@ -1303,15 +1318,15 @@ async def request(flow: http.HTTPFlow) -> None:
     `request_classification.classify_request()`, which owns the canonical decision
     order. This hook dispatches the current-state result.
     """
-    codex_model_catalog_cache.capture_and_strip_prefetch_marker(flow)
-    connector_intent.capture_and_strip(flow)
-
     if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
         aws_sigv4_body_admission.release_from_flow(flow)
         release_aws_sigv4_request_inspection(flow)
         request_classification.pop_cached_classification(flow)
         return
+
+    codex_model_catalog_cache.capture_and_strip_prefetch_marker(flow)
+    connector_intent.capture_and_strip(flow)
 
     if flow.response is not None or flow.error is not None:
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)

--- a/crates/runner/mitm-addon/tests/test_request_header_names.py
+++ b/crates/runner/mitm-addon/tests/test_request_header_names.py
@@ -1,0 +1,103 @@
+"""Request-header field-name admission integration tests."""
+
+import connector_intent
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+from tests.requestheaders_helpers import _assert_no_request_stream
+
+_MAX_REQUEST_HEADER_NAME_BYTES = 4096
+_BROWSER_USER_AGENT = (
+    b"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    b"(KHTML, like Gecko) HeadlessChrome/126.0.0.0 Safari/537.36"
+)
+
+
+class _LowerGuardHeaderName(bytes):
+    def lower(self) -> bytes:
+        raise AssertionError("over-budget request header name must not be lowercased")
+
+
+async def test_requestheaders_rejects_over_budget_names_before_header_processing(real_flow):
+    retained_fields = (
+        (b"Host", b"example.com"),
+        (b"Expect", b"100-continue"),
+        (b"X-Trace", b"first"),
+        (b"x-trace", b"second"),
+        (b"x-VM0-Connector-Intent", b"primary"),
+        (b"x-VM0-Codex-Model-Catalog-Prefetch", b"1"),
+    )
+    flow = real_flow(
+        with_response=False,
+        request_headers=mitm_addon.http.Headers(
+            [
+                *retained_fields,
+                (
+                    _LowerGuardHeaderName(b"X" * (_MAX_REQUEST_HEADER_NAME_BYTES + 1)),
+                    b"rejected",
+                ),
+                (b"Y" * (_MAX_REQUEST_HEADER_NAME_BYTES + 2), b"also-rejected"),
+            ]
+        ),
+    )
+
+    assert mitm_addon.requestheaders(flow) is None
+
+    assert flow.response is not None
+    assert flow.response.status_code == 431
+    assert flow.response.content == b""
+    assert flow.request.headers.fields == retained_fields
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    _assert_no_request_stream(flow)
+
+    await mitm_addon.request(flow)
+
+    assert flow.request.headers.fields == retained_fields
+    assert connector_intent.from_flow(flow) == connector_intent.ABSENT
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+
+
+async def test_requestheaders_accepts_name_budget_and_preserves_existing_header_behavior(
+    registry_file,
+    real_flow,
+    mitm_ctx,
+):
+    boundary_name = b"X" * _MAX_REQUEST_HEADER_NAME_BYTES
+    repeated_fields = (
+        (b"X-Trace", b"first"),
+        (b"x-trace", b"second"),
+    )
+    flow = real_flow(
+        with_response=False,
+        request_headers=mitm_addon.http.Headers(
+            [
+                (b"hOsT", b"example.com"),
+                (b"uSeR-aGeNt", _BROWSER_USER_AGENT),
+                *repeated_fields,
+                (boundary_name, b"accepted"),
+                (b"x-VM0-Connector-Intent", b"primary"),
+                (b"x-VM0-Codex-Model-Catalog-Prefetch", b"1"),
+            ]
+        ),
+    )
+
+    with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
+        assert mitm_addon.requestheaders(flow) is None
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert (boundary_name, b"accepted") in flow.request.headers.fields
+    assert all(field in flow.request.headers.fields for field in repeated_fields)
+    assert (b"hOsT", b"example.com") in flow.request.headers.fields
+    assert (b"uSeR-aGeNt", _BROWSER_USER_AGENT) in flow.request.headers.fields
+    assert all(
+        name
+        not in (
+            b"x-VM0-Connector-Intent",
+            b"x-VM0-Codex-Model-Catalog-Prefetch",
+        )
+        for name, _value in flow.request.headers.fields
+    )
+    assert connector_intent.from_flow(flow) == connector_intent.ConnectorIntent(
+        "present", "primary"
+    )
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"

--- a/crates/runner/mitm-addon/tests/test_request_header_names.py
+++ b/crates/runner/mitm-addon/tests/test_request_header_names.py
@@ -100,4 +100,6 @@ async def test_requestheaders_accepts_name_budget_and_preserves_existing_header_
     assert connector_intent.from_flow(flow) == connector_intent.ConnectorIntent(
         "present", "primary"
     )
+    assert flow.metadata[metadata_keys.BROWSER_USER_AGENT] is True
+    assert flow.metadata["_codex_model_catalog_prefetch_request"] is True
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"


### PR DESCRIPTION
## Summary

- reject raw request header field names above an inclusive 4,096-byte addon work budget before private-header capture or case-insensitive lookup
- remove rejected raw fields before returning to mitmproxy, preserve every in-budget field, and return an empty HTTP 431 response
- make the later request hook honor request-header terminal state before repeating private-header capture
- cover the exact boundary, guarded no-`lower()` rejection, ordinary duplicate fields, mixed-case Host/User-Agent, connector intent, and Codex prefetch behavior with real mitmproxy flows

## Explicit exclusions

- this does not bound mitmproxy's pre-hook HTTP/1 buffering, regex validation, or initial lowercase conversion
- this does not add a total request-head byte limit, field-count limit, or new value limits
- no public API, runner/backend protocol, persisted format, migration, feature switch, or staged rollout changes

## Benchmark

Inputs were constructed outside measurement under the locked CPython 3.14 environment. Timing is the median of seven calls; allocation tracing was measured separately.

| Raw irrelevant name | Existing four scans | New entry rejection | Existing peak | New peak |
| ---: | ---: | ---: | ---: | ---: |
| 1 MiB | 1.053 ms | 0.013417 ms | 1 MiB | 0.004934 MiB |
| 5 MiB | 5.508 ms | 0.013750 ms | 5 MiB | 0.004858 MiB |
| 16 MiB | 17.912 ms | 0.015083 ms | 16 MiB | 0.004293 MiB |
| 33 MiB | 47.228 ms | 0.014083 ms | 33 MiB | 0.004263 MiB |

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_request_header_names.py` (2 passed)
- `uv run --no-sync python -m pytest tests/` (6,393 passed)

Closes #28330
