### PR TITLE
feat(platform): import a deck as a presentation template from the picker

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -616,7 +616,7 @@
       "illustration": "Illustration",
       "illustrationPreview": "{{title}} Illustrationsvorschau",
       "importDeck": "Eigenes Deck importieren",
-      "importDeckHint": "PPTX oder PDF",
+      "importDeckHint": "(.pptx, .pdf)",
       "multiAccent": "Multi-Akzent",
       "nextSlide": "Vorschau der nächsten Folie",
       "noMatches": "Keine Übereinstimmungen",

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -615,6 +615,8 @@
       "htmlPreview": "{{title}} HTML-Vorschau",
       "illustration": "Illustration",
       "illustrationPreview": "{{title}} Illustrationsvorschau",
+      "importDeck": "Eigenes Deck importieren",
+      "importDeckHint": "PPTX oder PDF",
       "multiAccent": "Multi-Akzent",
       "nextSlide": "Vorschau der nächsten Folie",
       "noMatches": "Keine Übereinstimmungen",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -616,7 +616,7 @@
       "illustration": "Illustration",
       "illustrationPreview": "{{title}} illustration preview",
       "importDeck": "Import your own deck",
-      "importDeckHint": "PPTX or PDF",
+      "importDeckHint": "(.pptx, .pdf)",
       "multiAccent": "Multi-accent",
       "nextSlide": "Preview next slide",
       "noMatches": "No matches",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -615,6 +615,8 @@
       "htmlPreview": "{{title}} HTML preview",
       "illustration": "Illustration",
       "illustrationPreview": "{{title}} illustration preview",
+      "importDeck": "Import your own deck",
+      "importDeckHint": "PPTX or PDF",
       "multiAccent": "Multi-accent",
       "nextSlide": "Preview next slide",
       "noMatches": "No matches",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -633,7 +633,7 @@
       "illustration": "Ilustración",
       "illustrationPreview": "Vista previa de la ilustración {{title}}",
       "importDeck": "Importa tu propia presentación",
-      "importDeckHint": "PPTX o PDF",
+      "importDeckHint": "(.pptx, .pdf)",
       "multiAccent": "Multiacentos",
       "nextSlide": "Vista previa de la diapositiva siguiente",
       "noMatches": "Sin coincidencias",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -632,6 +632,8 @@
       "htmlPreview": "Vista previa HTML de {{title}}",
       "illustration": "Ilustración",
       "illustrationPreview": "Vista previa de la ilustración {{title}}",
+      "importDeck": "Importa tu propia presentación",
+      "importDeckHint": "PPTX o PDF",
       "multiAccent": "Multiacentos",
       "nextSlide": "Vista previa de la diapositiva siguiente",
       "noMatches": "Sin coincidencias",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -633,7 +633,7 @@
       "illustration": "Illustration",
       "illustrationPreview": "Aperçu de l'illustration {{title}}",
       "importDeck": "Importer votre propre présentation",
-      "importDeckHint": "PPTX ou PDF",
+      "importDeckHint": "(.pptx, .pdf)",
       "multiAccent": "Multi-accents",
       "nextSlide": "Aperçu de la diapositive suivante",
       "noMatches": "Aucun résultat",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -632,6 +632,8 @@
       "htmlPreview": "Aperçu HTML de {{title}}",
       "illustration": "Illustration",
       "illustrationPreview": "Aperçu de l'illustration {{title}}",
+      "importDeck": "Importer votre propre présentation",
+      "importDeckHint": "PPTX ou PDF",
       "multiAccent": "Multi-accents",
       "nextSlide": "Aperçu de la diapositive suivante",
       "noMatches": "Aucun résultat",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -615,6 +615,8 @@
       "htmlPreview": "{{title}} HTML पूर्वावलोकन",
       "illustration": "चित्रण",
       "illustrationPreview": "{{title}} चित्रण पूर्वावलोकन",
+      "importDeck": "अपना डेक इंपोर्ट करें",
+      "importDeckHint": "PPTX या PDF",
       "multiAccent": "बहु-उच्चारण",
       "nextSlide": "अगली स्लाइड का पूर्वावलोकन करें",
       "noMatches": "कोई मेल नहीं",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -616,7 +616,7 @@
       "illustration": "चित्रण",
       "illustrationPreview": "{{title}} चित्रण पूर्वावलोकन",
       "importDeck": "अपना डेक इंपोर्ट करें",
-      "importDeckHint": "PPTX या PDF",
+      "importDeckHint": "(.pptx, .pdf)",
       "multiAccent": "बहु-उच्चारण",
       "nextSlide": "अगली स्लाइड का पूर्वावलोकन करें",
       "noMatches": "कोई मेल नहीं",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -615,6 +615,8 @@
       "htmlPreview": "pratinjau HTML {{title}}",
       "illustration": "Ilustrasi",
       "illustrationPreview": "pratinjau ilustrasi {{title}}",
+      "importDeck": "Impor dek Anda sendiri",
+      "importDeckHint": "PPTX atau PDF",
       "multiAccent": "Multi-aksen",
       "nextSlide": "Pratinjau slide berikutnya",
       "noMatches": "Tidak ada hasil",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -616,7 +616,7 @@
       "illustration": "Ilustrasi",
       "illustrationPreview": "pratinjau ilustrasi {{title}}",
       "importDeck": "Impor dek Anda sendiri",
-      "importDeckHint": "PPTX atau PDF",
+      "importDeckHint": "(.pptx, .pdf)",
       "multiAccent": "Multi-aksen",
       "nextSlide": "Pratinjau slide berikutnya",
       "noMatches": "Tidak ada hasil",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -633,7 +633,7 @@
       "illustration": "Illustrazione",
       "illustrationPreview": "{{title}} anteprima dell'illustrazione",
       "importDeck": "Importa la tua presentazione",
-      "importDeckHint": "PPTX o PDF",
+      "importDeckHint": "(.pptx, .pdf)",
       "multiAccent": "Multiaccento",
       "nextSlide": "Anteprima della diapositiva successiva",
       "noMatches": "Nessuna corrispondenza",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -632,6 +632,8 @@
       "htmlPreview": "{{title}} HTML anteprima",
       "illustration": "Illustrazione",
       "illustrationPreview": "{{title}} anteprima dell'illustrazione",
+      "importDeck": "Importa la tua presentazione",
+      "importDeckHint": "PPTX o PDF",
       "multiAccent": "Multiaccento",
       "nextSlide": "Anteprima della diapositiva successiva",
       "noMatches": "Nessuna corrispondenza",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -615,6 +615,8 @@
       "htmlPreview": "{{title}} HTML プレビュー",
       "illustration": "イラストレーション",
       "illustrationPreview": "{{title}} イラストのプレビュー",
+      "importDeck": "自分のデッキをインポート",
+      "importDeckHint": "PPTX または PDF",
       "multiAccent": "マルチアクセント",
       "nextSlide": "次のスライドをプレビューする",
       "noMatches": "一致しません",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -616,7 +616,7 @@
       "illustration": "イラストレーション",
       "illustrationPreview": "{{title}} イラストのプレビュー",
       "importDeck": "自分のデッキをインポート",
-      "importDeckHint": "PPTX または PDF",
+      "importDeckHint": "(.pptx, .pdf)",
       "multiAccent": "マルチアクセント",
       "nextSlide": "次のスライドをプレビューする",
       "noMatches": "一致しません",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -615,6 +615,8 @@
       "htmlPreview": "{{title}} HTML 미리보기",
       "illustration": "일러스트레이션",
       "illustrationPreview": "{{title}} 일러스트레이션 미리보기",
+      "importDeck": "내 덱 가져오기",
+      "importDeckHint": "PPTX 또는 PDF",
       "multiAccent": "다중 악센트",
       "nextSlide": "다음 슬라이드 미리보기",
       "noMatches": "일치하는 항목 없음",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -616,7 +616,7 @@
       "illustration": "일러스트레이션",
       "illustrationPreview": "{{title}} 일러스트레이션 미리보기",
       "importDeck": "내 덱 가져오기",
-      "importDeckHint": "PPTX 또는 PDF",
+      "importDeckHint": "(.pptx, .pdf)",
       "multiAccent": "다중 악센트",
       "nextSlide": "다음 슬라이드 미리보기",
       "noMatches": "일치하는 항목 없음",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -633,7 +633,7 @@
       "illustration": "Ilustração",
       "illustrationPreview": "Visualização da ilustração {{title}}",
       "importDeck": "Importe sua própria apresentação",
-      "importDeckHint": "PPTX ou PDF",
+      "importDeckHint": "(.pptx, .pdf)",
       "multiAccent": "Várias cores de destaque",
       "nextSlide": "Visualizar próximo slide",
       "noMatches": "Nenhum resultado",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -632,6 +632,8 @@
       "htmlPreview": "Visualização HTML de {{title}}",
       "illustration": "Ilustração",
       "illustrationPreview": "Visualização da ilustração {{title}}",
+      "importDeck": "Importe sua própria apresentação",
+      "importDeckHint": "PPTX ou PDF",
       "multiAccent": "Várias cores de destaque",
       "nextSlide": "Visualizar próximo slide",
       "noMatches": "Nenhum resultado",

--- a/turbo/apps/platform/src/signals/zero-page/presentation-template-import.ts
+++ b/turbo/apps/platform/src/signals/zero-page/presentation-template-import.ts
@@ -1,0 +1,52 @@
+import { command, computed } from "ccstate";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import type { ComposerSignals } from "./composer-signals.ts";
+
+/**
+ * Decks a user can hand over. Both end up as ordered page images the same way,
+ * so nothing downstream distinguishes them.
+ */
+export const PRESENTATION_TEMPLATE_IMPORT_ACCEPT = ".pptx,.pdf";
+
+/**
+ * The message the deck is sent with.
+ *
+ * Kept as a plain sentence on purpose: importing a template is not a special
+ * protocol, it is a chat message with a file attached, and the user should be
+ * able to read what was said on their behalf — and edit it before sending if
+ * they want something different.
+ */
+const PRESENTATION_TEMPLATE_IMPORT_PROMPT =
+  "Analyse this deck and save its visual language as a reusable presentation template.";
+
+export const presentationTemplateImportEnabled$ = computed((get) => {
+  return get(featureSwitch$)[FeatureSwitchKey.PresentationTemplates] ?? false;
+});
+
+/**
+ * Attach the deck to the composer and send it.
+ *
+ * This deliberately reuses the ordinary composer path rather than adding an
+ * upload protocol of its own: the deck becomes a chat attachment, the message
+ * is sent, and the existing new-thread flow creates the thread and navigates
+ * into it. The user then watches the analysis happen and can interrupt or
+ * follow up, which a background job could not offer.
+ */
+export const importPresentationTemplateDeck$ = command(
+  async (
+    { get, set },
+    args: { readonly signals: ComposerSignals; readonly file: File },
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const { signals, file } = args;
+    await set(signals.draft.uploadAttachment$, file, signal);
+    signal.throwIfAborted();
+    set(signals.draft.setDraftInput$, PRESENTATION_TEMPLATE_IMPORT_PROMPT);
+
+    const action = await get(signals.submission.primaryAction$);
+    signal.throwIfAborted();
+    return await set(signals.submission.submitCurrentInput$, action, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/presentation-template-import.ts
+++ b/turbo/apps/platform/src/signals/zero-page/presentation-template-import.ts
@@ -15,8 +15,7 @@ export const PRESENTATION_TEMPLATE_IMPORT_ACCEPT = ".pptx,.pdf";
  *
  * Kept as a plain sentence on purpose: importing a template is not a special
  * protocol, it is a chat message with a file attached, and the user should be
- * able to read what was said on their behalf — and edit it before sending if
- * they want something different.
+ * able to read what was said on their behalf in the thread they land in.
  */
 const PRESENTATION_TEMPLATE_IMPORT_PROMPT =
   "Analyse this deck and save its visual language as a reusable presentation template.";
@@ -41,8 +40,18 @@ export const importPresentationTemplateDeck$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     const { signals, file } = args;
+    const before = new Set(get(signals.draft.attachments$));
     await set(signals.draft.uploadAttachment$, file, signal);
     signal.throwIfAborted();
+    // A failed upload resolves normally: the composer drops the attachment and
+    // toasts. Sending now would ask for an analysis of a deck that never
+    // arrived, so stop at the error the user was already shown.
+    const attached = get(signals.draft.attachments$).some((attachment) => {
+      return !before.has(attachment);
+    });
+    if (!attached) {
+      return false;
+    }
     set(signals.draft.setDraftInput$, PRESENTATION_TEMPLATE_IMPORT_PROMPT);
 
     const action = await get(signals.submission.primaryAction$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3381,6 +3381,66 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("does not send the import message when the deck upload fails", async () => {
+    const user = userEvent.setup({ delay: null });
+    const sentPrompts: (string | undefined)[] = [];
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      onRunCreate(body) {
+        sentPrompts.push(body.prompt);
+      },
+    });
+    context.mocks.upload.success({
+      id: "upload-deck",
+      filename: "brand-system.pptx",
+      contentType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      size: 2048,
+      url: "https://cdn.vm7.io/artifacts/test/upload-deck/brand-system.pptx",
+    });
+    context.mocks.http.put("https://mock-upload.r2.test/upload-deck", () => {
+      return new Response(null, { status: 500 });
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+    const importInput = await waitFor(() => {
+      return screen.getByLabelText("Import your own deck");
+    });
+
+    await user.upload(
+      importInput,
+      new File(["deck"], "brand-system.pptx", {
+        type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to upload brand-system.pptx"),
+      ).toBeInTheDocument();
+    });
+
+    // The deck never arrived, so nothing is sent on the user's behalf. A plain
+    // message afterwards is the only run, which pins that the import stopped at
+    // the upload error instead of asking for an analysis of a missing file.
+    const composer = await screen.findByRole("textbox", { name: "Message" });
+    await sendMessageInUI(user, composer, "Never mind the deck");
+
+    await waitFor(() => {
+      expect(sentPrompts).toEqual(["Never mind the deck"]);
+    });
+  });
+
   it("hides the deck import entry when the switch is off", async () => {
     mockChatLifecycle(context, { threadId: THREAD_ID });
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3437,7 +3437,7 @@ describe("chat composer templates", () => {
     await sendMessageInUI(user, composer, "Never mind the deck");
 
     await waitFor(() => {
-      expect(sentPrompts).toEqual(["Never mind the deck"]);
+      expect(sentPrompts).toStrictEqual(["Never mind the deck"]);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-template-picker.test.tsx
@@ -3322,4 +3322,79 @@ describe("chat composer templates", () => {
       expect(composerInlineTemplates()).toHaveLength(0);
     });
   });
+  it("imports an uploaded deck as an ordinary chat message", async () => {
+    const user = userEvent.setup({ delay: null });
+    let sentPrompt: string | undefined;
+    let sentMessage: UserMessageDocument | undefined;
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      onRunCreate(body) {
+        sentPrompt = body.prompt;
+        sentMessage = body.userMessage;
+      },
+    });
+    context.mocks.upload.success({
+      id: "upload-deck",
+      filename: "brand-system.pptx",
+      contentType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      size: 2048,
+      url: "https://cdn.vm7.io/artifacts/test/upload-deck/brand-system.pptx",
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.PresentationTemplates]: true },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+    const importInput = await waitFor(() => {
+      return screen.getByLabelText("Import your own deck");
+    });
+
+    await user.upload(
+      importInput,
+      new File(["deck"], "brand-system.pptx", {
+        type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      }),
+    );
+
+    // Choosing a deck closes the picker and sends it: the import is a chat
+    // message with the deck attached, not a separate upload flow.
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(sentPrompt).toContain("reusable presentation template");
+      expect(sentMessage?.parts).toContainEqual(
+        expect.objectContaining({
+          type: "file",
+          fileId: "upload-deck",
+          filenameSnapshot: "brand-system.pptx",
+        }),
+      );
+    });
+  });
+
+  it("hides the deck import entry when the switch is off", async () => {
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByLabelText("Import your own deck"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4863,8 +4863,8 @@ function PptImportCard({
         />
       </span>
       <span className={TEMPLATE_TILE_CAPTION}>
-        <span className={TEMPLATE_TILE_NAME}>
-          {label}
+        <span className={TEMPLATE_TILE_NAME}>{label}</span>
+        <span className="shrink-0 text-xs text-muted-foreground">
           {t(($) => {
             return $.artifacts.templates.importDeckHint;
           })}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -18,6 +18,11 @@ import {
 import { useTranslation } from "react-i18next";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { i18n } from "../../i18n/index.ts";
+import {
+  importPresentationTemplateDeck$,
+  presentationTemplateImportEnabled$,
+  PRESENTATION_TEMPLATE_IMPORT_ACCEPT,
+} from "../../signals/zero-page/presentation-template-import.ts";
 import { desktopProductDisplayName } from "../../i18n/desktop-product.ts";
 import { equalArrays } from "../../lib/equality.ts";
 import { ensurePushSubscription$ } from "../../lib/push-notifications.ts";
@@ -36,6 +41,7 @@ import {
   Monitor,
   Paperclip,
   Palette,
+  FileUp,
   Play,
   Plug,
   Plus,
@@ -4802,12 +4808,63 @@ function IllustrationTemplateGrid({
   );
 }
 
+/**
+ * Hands the chosen deck to the composer, which attaches it, sends it, and
+ * navigates into the new thread. Importing is the ordinary chat path with the
+ * message written for the user, not a separate upload flow.
+ */
+function PptImportCard({
+  signals,
+  onImported,
+}: {
+  signals: ComposerSignals;
+  onImported: () => void;
+}) {
+  const { t } = useTranslation();
+  const pageSignal = useGet(pageSignal$);
+  const importDeck = useSet(importPresentationTemplateDeck$);
+  const label = t(($) => {
+    return $.artifacts.templates.importDeck;
+  });
+  return (
+    <label
+      data-presentation-template-import=""
+      className="flex aspect-video cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-muted/30 text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
+    >
+      <FileUp className="size-6" aria-hidden="true" />
+      <span className="text-sm font-medium">{label}</span>
+      <span className="text-xs">
+        {t(($) => {
+          return $.artifacts.templates.importDeckHint;
+        })}
+      </span>
+      <input
+        type="file"
+        className="sr-only"
+        accept={PRESENTATION_TEMPLATE_IMPORT_ACCEPT}
+        aria-label={label}
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0];
+          // Clear the input so choosing the same deck again still fires.
+          event.currentTarget.value = "";
+          if (!file) {
+            return;
+          }
+          onImported();
+          detach(importDeck({ signals, file }, pageSignal), Reason.DomCallback);
+        }}
+      />
+    </label>
+  );
+}
+
 function PptTemplateGrid({
   items,
   runtime,
   value,
   onSelect,
   onPreview,
+  onImported,
   signals,
 }: {
   items: readonly PresentationTemplateItem[];
@@ -4815,10 +4872,15 @@ function PptTemplateGrid({
   value: GenerationTemplateRequest | undefined;
   onSelect: (item: PresentationTemplateItem, colorSystemId?: string) => void;
   onPreview: (item: PresentationTemplateItem, slideIndex?: number) => void;
+  onImported: () => void;
   signals: ComposerSignals;
 }) {
+  const importEnabled = useGet(presentationTemplateImportEnabled$);
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {importEnabled ? (
+        <PptImportCard signals={signals} onImported={onImported} />
+      ) : null}
       {items.map((item) => {
         return (
           <PptCard
@@ -5230,6 +5292,7 @@ function TemplatePickerDialog({
                   }
                   onSelectPresentation={handleSelectPresentation}
                   onPreviewPresentation={handlePreview}
+                  onImportedPresentation={closeTemplatePicker}
                   onSelectWebsite={handleSelectWebsite}
                   onPreviewWebsite={handlePreviewWebsite}
                   onSelectIllustration={handleSelectIllustration}
@@ -5267,6 +5330,7 @@ function TemplatePickerCategoryContent({
   onRestorePresentationScroll,
   onSelectPresentation,
   onPreviewPresentation,
+  onImportedPresentation,
   onSelectWebsite,
   onPreviewWebsite,
   onSelectIllustration,
@@ -5300,6 +5364,7 @@ function TemplatePickerCategoryContent({
     item: PresentationTemplateItem,
     slideIndex?: number,
   ) => void;
+  onImportedPresentation: () => void;
   onSelectWebsite: (item: WebsiteTemplateItem) => void;
   onPreviewWebsite: (item: WebsiteTemplateItem) => void;
   onSelectIllustration: (item: IllustrationTemplateItem) => void;
@@ -5330,6 +5395,7 @@ function TemplatePickerCategoryContent({
             value={value}
             onSelect={onSelectPresentation}
             onPreview={onPreviewPresentation}
+            onImported={onImportedPresentation}
             runtime={runtime}
             signals={signals}
           />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -41,7 +41,6 @@ import {
   Monitor,
   Paperclip,
   Palette,
-  FileUp,
   Play,
   Plug,
   Plus,
@@ -4829,31 +4828,48 @@ function PptImportCard({
   return (
     <label
       data-presentation-template-import=""
-      className="flex aspect-video cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-muted/30 text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
+      className={TEMPLATE_TILE_WRAPPER}
     >
-      <FileUp className="size-6" aria-hidden="true" />
-      <span className="text-sm font-medium">{label}</span>
-      <span className="text-xs">
-        {t(($) => {
-          return $.artifacts.templates.importDeckHint;
-        })}
+      <span
+        className={cn(
+          TEMPLATE_TILE_MEDIA,
+          TEMPLATE_TILE_RING,
+          "block aspect-video bg-muted/40 transition-colors duration-150 group-hover/tile:bg-muted/60 group-active/tile:bg-muted/80 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-inset has-[:focus-visible]:ring-ring",
+        )}
+      >
+        <Plus
+          className="absolute left-1/2 top-1/2 size-10 -translate-x-1/2 -translate-y-1/2 text-muted-foreground transition-colors duration-150 group-hover/tile:text-foreground"
+          strokeWidth={1.5}
+          aria-hidden
+        />
+        <input
+          type="file"
+          className="sr-only"
+          accept={PRESENTATION_TEMPLATE_IMPORT_ACCEPT}
+          aria-label={label}
+          onChange={(event) => {
+            const file = event.currentTarget.files?.[0];
+            // Clear the input so choosing the same deck again still fires.
+            event.currentTarget.value = "";
+            if (!file) {
+              return;
+            }
+            onImported();
+            detach(
+              importDeck({ signals, file }, pageSignal),
+              Reason.DomCallback,
+            );
+          }}
+        />
       </span>
-      <input
-        type="file"
-        className="sr-only"
-        accept={PRESENTATION_TEMPLATE_IMPORT_ACCEPT}
-        aria-label={label}
-        onChange={(event) => {
-          const file = event.currentTarget.files?.[0];
-          // Clear the input so choosing the same deck again still fires.
-          event.currentTarget.value = "";
-          if (!file) {
-            return;
-          }
-          onImported();
-          detach(importDeck({ signals, file }, pageSignal), Reason.DomCallback);
-        }}
-      />
+      <span className={TEMPLATE_TILE_CAPTION}>
+        <span className={TEMPLATE_TILE_NAME}>
+          {label}
+          {t(($) => {
+            return $.artifacts.templates.importDeckHint;
+          })}
+        </span>
+      </span>
     </label>
   );
 }


### PR DESCRIPTION
Part of #28252. The last of the three; #28280 deleted the old renderer, #28298 added `publish`.

## The entry point that was missing

The platform has never called the presentation-template API at all — the picker's slides tab only ever listed the built-in catalog from `@okouai/core`. There was no way to hand over a deck.

Now the slides tab starts with an import card. Choosing a `.pptx` or `.pdf`:

```
attach it to the composer  →  write the message  →  send
```

That is the whole feature.

## Why there is no upload code here

Because there does not need to be any. Importing a template is a chat message with a file attached, so it reuses what the composer already has:

- `draft.uploadAttachment$` — the same path a dragged file takes, with the same chip and the same progress
- `submission.submitCurrentInput$` → the existing new-thread send, which creates the thread, resolves the attachments, and **navigates into it**

The user lands in a thread they can watch, interrupt, and follow up in. A background job could not offer that, and it is why the flow was reshaped in #28252.

The message is a plain sentence — "Analyse this deck and save its visual language as a reusable presentation template." — not a specification, so the owner can read what was said on their behalf.

## Placement

`TemplatePickerDialog` is already at its complexity budget and carries a comment saying so, so the card is a small self-contained component appended to `PptTemplateGrid` instead. `onImportedPresentation` is threaded through to close the picker.

Behind `PresentationTemplates`, which is off, so nothing renders today.

## Tests

Two cases in the existing picker suite, driving the real composer:

- choosing a deck closes the picker and sends a message whose `userMessage` carries the uploaded file part, with the import prompt
- with the switch off, the card is not in the dialog

The first assertion initially looked for `attachFiles` on the run body and found nothing — attachments travel inside `userMessage`, which is what it checks now.

## Checks

`pnpm format`, `pnpm check-types` (14/14), `pnpm turbo run lint` (13/13), `pnpm knip` — all clean. The whole `chat-composer-template-picker` suite passes (34 tests).

Lint caught a floating promise in the change handler; it uses `detach(..., Reason.DomCallback)` like the rest of the file. Knip caught the prompt constant being exported without a second consumer.

Strings are added in all ten locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
