### PR TITLE
perf(python): resolve jsonl flush paths once per watcher

### DIFF
--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -114,9 +114,13 @@ def start_runner_jsonl_flush_worker() -> None:
         if _jsonl_flush_worker is not None and _jsonl_flush_worker.is_alive():
             return
 
+        marker_directory = Path(__file__).resolve().parent
+        request_path = marker_directory / _JSONL_FLUSH_REQUEST_FILE
+        state_path = marker_directory / _JSONL_FLUSH_STATE_FILE
         _jsonl_flush_stop.clear()
         worker = threading.Thread(
             target=_run_runner_jsonl_flush_worker,
+            args=(request_path, state_path),
             name="runner-jsonl-flush",
             daemon=True,
         )
@@ -128,12 +132,12 @@ def stop_runner_jsonl_flush_worker_for_tests() -> None:
     _stop_runner_jsonl_flush_worker()
 
 
-def _run_runner_jsonl_flush_worker() -> None:
+def _run_runner_jsonl_flush_worker(request_path: Path, state_path: Path) -> None:
     """Observe current-generation JSONL markers independently of usage."""
     while True:
-        _flush_jsonl_for_runner_request()
+        _flush_jsonl_for_runner_request(request_path, state_path)
         if _jsonl_flush_stop.wait(RUNNER_JSONL_FLUSH_POLL_SECONDS):
-            _flush_jsonl_for_runner_request()
+            _flush_jsonl_for_runner_request(request_path, state_path)
             return
 
 
@@ -224,10 +228,10 @@ def _flush_delivery_work(*, trigger: _DeliveryFlushTrigger) -> None:
     codex_output_timing.retry_all_pending()
 
 
-def _flush_jsonl_for_runner_request() -> None:
+def _flush_jsonl_for_runner_request(request_path: Path, state_path: Path) -> None:
     global _last_jsonl_flush_request_id
 
-    request = _read_jsonl_flush_request()
+    request = _read_jsonl_flush_request(request_path)
     if request is None:
         return
 
@@ -246,15 +250,19 @@ def _flush_jsonl_for_runner_request() -> None:
         pending = 1
         ctx.log.warn(f"Failed to flush JSONL logs after runner request ({type(exc).__name__})")
     finally:
-        state_written = _write_jsonl_flush_state(log_path, flush_request_id, pending=pending)
+        state_written = _write_jsonl_flush_state(
+            state_path,
+            log_path,
+            flush_request_id,
+            pending=pending,
+        )
         if state_written and (pending == 0 or timed_out):
             _last_jsonl_flush_request_id = flush_request_id
 
 
-def _read_jsonl_flush_request() -> tuple[str, str] | None:
-    marker_path = Path(__file__).resolve().parent / _JSONL_FLUSH_REQUEST_FILE
+def _read_jsonl_flush_request(request_path: Path) -> tuple[str, str] | None:
     request = runner_flush_request.read_runner_flush_request(
-        marker_path,
+        request_path,
         get_usage_state_id=usage.current_usage_state_id,
     )
     if request is None:
@@ -279,12 +287,12 @@ def _is_safe_jsonl_flush_request_id(flush_request_id: str) -> bool:
 
 
 def _write_jsonl_flush_state(
+    state_path: Path,
     log_path: str,
     flush_request_id: str,
     *,
     pending: int = 0,
 ) -> bool:
-    state_path = Path(__file__).resolve().parent / _JSONL_FLUSH_STATE_FILE
     state = {
         "pid": os.getpid(),
         "usageStateId": usage.current_usage_state_id(),

--- a/crates/runner/mitm-addon/tests/test_runner_flush_request.py
+++ b/crates/runner/mitm-addon/tests/test_runner_flush_request.py
@@ -195,12 +195,10 @@ class TestRunnerFlushRequest:
                 assert usage.read_usage_flush_request_id() is None
                 return
 
-            with patch.object(
-                runner_flush_lifecycle,
-                "__file__",
-                str(runner_flush_request_files.lifecycle_file),
-            ):
-                runner_flush_lifecycle._flush_jsonl_for_runner_request()
+            runner_flush_lifecycle._flush_jsonl_for_runner_request(
+                runner_flush_request_files.jsonl_flush_request_path,
+                runner_flush_request_files.jsonl_flush_state_path,
+            )
 
             assert not runner_flush_request_files.jsonl_flush_state_path.exists()
 

--- a/crates/runner/mitm-addon/tests/test_runner_jsonl_flush.py
+++ b/crates/runner/mitm-addon/tests/test_runner_jsonl_flush.py
@@ -99,25 +99,26 @@ def wait_for_jsonl_flush_state(
 def running_jsonl_flush_worker(files: RunnerJsonlFlushFiles) -> Iterator[None]:
     with patch.object(runner_flush_lifecycle, "__file__", str(files.lifecycle_file)):
         runner_flush_lifecycle.start_runner_jsonl_flush_worker()
-        try:
-            yield
-        finally:
-            runner_flush_lifecycle.stop_runner_jsonl_flush_worker_for_tests()
+    try:
+        yield
+    finally:
+        runner_flush_lifecycle.stop_runner_jsonl_flush_worker_for_tests()
 
 
 class TestRunnerJsonlFlush:
     """Tests for the independently polled JSONL flush protocol."""
 
-    def test_jsonl_watcher_acknowledges_flush_request(
+    def test_jsonl_watcher_acknowledges_request_in_startup_directory(
         self, runner_jsonl_flush_files: RunnerJsonlFlushFiles
     ):
-        log_path = runner_jsonl_flush_files.write_jsonl_flush_request()
+        log_path = runner_jsonl_flush_files.network_log_path
         logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
 
         with (
             patch.object(logging_utils.ctx, "log", MagicMock(), create=True),
             running_jsonl_flush_worker(runner_jsonl_flush_files),
         ):
+            runner_jsonl_flush_files.write_jsonl_flush_request()
             state = wait_for_jsonl_flush_state(runner_jsonl_flush_files)
 
         entry = json.loads(log_path.read_text().strip())
@@ -166,13 +167,13 @@ class TestRunnerJsonlFlush:
         log = MagicMock()
 
         with (
-            patch.object(
-                runner_flush_lifecycle, "__file__", str(runner_jsonl_flush_files.lifecycle_file)
-            ),
             patch.object(logging_utils, "flush_log_path", side_effect=RuntimeError("secret")),
             patch.object(runner_flush_lifecycle.ctx, "log", log, create=True),
         ):
-            runner_flush_lifecycle._flush_jsonl_for_runner_request()
+            runner_flush_lifecycle._flush_jsonl_for_runner_request(
+                runner_jsonl_flush_files.jsonl_flush_request_path,
+                runner_jsonl_flush_files.jsonl_flush_state_path,
+            )
 
         state = json.loads(runner_jsonl_flush_files.jsonl_flush_state_path.read_text())
         assert state == {


### PR DESCRIPTION
## Summary

- resolve the JSONL request and state marker paths once when the addon watcher starts
- pass those immutable paths through immediate, periodic, and final observations instead of resolving the module location on every poll
- preserve temporary-directory isolation by proving that a worker keeps its startup directory after the test `__file__` patch ends

## Scope

- preserves marker filenames and schemas, poll and flush timeouts, parsing and validation, retry behavior, readiness publication, and shutdown ordering
- does not change Rust, public APIs, queues, billing, persisted state, migrations, frontend, or CLI behavior

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_runner_jsonl_flush.py tests/test_runner_flush_request.py tests/test_addon_configuration.py tests/test_done_hook.py` (58 passed)
- `uv run --no-sync python -m pytest tests/` (6391 passed)
- `lefthook run pre-commit`

A local CPython 3.14.0/aarch64 missing-marker benchmark improved from a 25.981 microsecond median on `main` to 12.290 microseconds on this branch; exact results are environment-dependent.

Closes #28293
