### PR TITLE
fix(usage): bound model usage quantities

### DIFF
--- a/crates/runner/mitm-addon/src/model_websocket_usage.py
+++ b/crates/runner/mitm-addon/src/model_websocket_usage.py
@@ -248,7 +248,9 @@ def feed_usage(
     usage_result = inspection.usage
     inspection_error = inspection.usage_error
     if inspection_error is not None:
-        if isinstance(prewarm_state, _OpenAIResponsesPrewarmState):
+        if inspection_error == usage.OPENAI_RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR and isinstance(
+            prewarm_state, _OpenAIResponsesPrewarmState
+        ):
             _mark_correlation_ambiguous(flow, prewarm_state, "correlation_cap")
         log_proxy_entry(
             flow_metadata.proxy_log_path(flow.metadata),

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -66,6 +66,7 @@ from .openai_chat_completions import (
     extract_openai_chat_completions_usage_with_error_from_json,
 )
 from .openai_responses import (
+    OPENAI_RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR,
     OpenAIResponsesClientEvent,
     OpenAIResponsesEvent,
     OpenAIResponsesServerEventInspection,
@@ -98,6 +99,7 @@ from .providers.model_provider import (
 
 __all__ = [
     "DEFAULT_FLUSH_INTERVAL_SECONDS",
+    "OPENAI_RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR",
     "BufferedReportLease",
     "ModelUsageProtocol",
     "OpenAIResponsesClientEvent",

--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -5,13 +5,13 @@ JSON fallback.
 """
 
 from collections.abc import Callable
-from typing import TypeGuard
 
 import body_decoding
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
 
 from .json_selective import JsonSelectiveExtractor, ScalarField
 from .model_tokens import ANTHROPIC_USAGE_FIELD_CATEGORIES
+from .quantities import MAX_USAGE_QUANTITY, is_usage_quantity
 from .sse import SseUsageScanner
 
 _ANTHROPIC_MESSAGES_USAGE_EVENTS = frozenset(("message_start", "message_delta"))
@@ -29,7 +29,11 @@ _MODEL_JSON_SCALAR_FIELDS = {
     ("id",): ScalarField("string", max_bytes=1024),
     ("model",): ScalarField("string", max_bytes=1024),
     **{
-        ("usage", field): ScalarField("int", max_bytes=64)
+        ("usage", field): ScalarField(
+            "int",
+            max_bytes=64,
+            max_int_value=MAX_USAGE_QUANTITY,
+        )
         for field in ANTHROPIC_USAGE_FIELD_CATEGORIES
     },
 }
@@ -40,18 +44,22 @@ _ANTHROPIC_SSE_SCALAR_FIELDS = {
     ("message", "id"): ScalarField("string", max_bytes=1024),
     ("message", "model"): ScalarField("string", max_bytes=1024),
     **{
-        ("message", "usage", field): ScalarField("int", max_bytes=64)
+        ("message", "usage", field): ScalarField(
+            "int",
+            max_bytes=64,
+            max_int_value=MAX_USAGE_QUANTITY,
+        )
         for field in ANTHROPIC_USAGE_FIELD_CATEGORIES
     },
     **{
-        ("usage", field): ScalarField("int", max_bytes=64)
+        ("usage", field): ScalarField(
+            "int",
+            max_bytes=64,
+            max_int_value=MAX_USAGE_QUANTITY,
+        )
         for field in ANTHROPIC_USAGE_FIELD_CATEGORIES
     },
 }
-
-
-def _is_usage_quantity(value: object) -> TypeGuard[int]:
-    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
 
 
 def _store_selected_usage_values(values: dict, target: dict, prefix: tuple[str, ...]) -> None:
@@ -63,7 +71,7 @@ def _store_selected_usage_values(values: dict, target: dict, prefix: tuple[str, 
     """
     for raw_field, category in ANTHROPIC_USAGE_FIELD_CATEGORIES.items():
         value = values.get((*prefix, raw_field))
-        if _is_usage_quantity(value) and (value > 0 or category not in target):
+        if is_usage_quantity(value) and (value > 0 or category not in target):
             target[category] = value
 
 

--- a/crates/runner/mitm-addon/src/usage/buffer/logging.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/logging.py
@@ -45,6 +45,32 @@ type _UsageFlushPhase = Literal["started", "enqueued", "failed", "retained", "dr
 
 _RETRY_BUDGET_EXHAUSTED_REASON = "retry_budget_exhausted"
 _SHUTDOWN_RETAINED_WITHOUT_RETRY_REASON = "shutdown_retained_without_retry"
+_USAGE_QUANTITY_OUT_OF_RANGE_REASON = "usage_quantity_out_of_range"
+
+
+def _log_rejected_usage_quantity(
+    proxy_log_path: str,
+    run_id: str,
+    log_type: str,
+) -> None:
+    if log_type == "model_usage_observation":
+        log_proxy_entry(
+            proxy_log_path,
+            "warn",
+            "Model usage observation rejected outside exact-integer range",
+            type=log_type,
+            reason=_USAGE_QUANTITY_OUT_OF_RANGE_REASON,
+            run_id=run_id,
+        )
+        return
+    log_usage_underbilling(
+        proxy_log_path,
+        "Usage event rejected outside exact-integer range",
+        _USAGE_QUANTITY_OUT_OF_RANGE_REASON,
+        "confirmed",
+        run_id=run_id,
+        log_type=log_type,
+    )
 
 
 def _log_dropped_batches(

--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -81,7 +81,9 @@ from ..idempotency import (
     USAGE_OBSERVATION_NAMESPACE_AGGREGATE,
     derive_usage_idempotency_key,
 )
+from ..quantities import MAX_USAGE_QUANTITY, is_usage_quantity
 from ..webhook import WebhookDeliveryOutcome
+from .logging import _log_rejected_usage_quantity
 from .models import (
     MAX_AGGREGATE_BUCKETS,
     MAX_BUFFERED_SOURCE_EVENTS,
@@ -124,11 +126,14 @@ class _UsageBufferState:
         self._max_retained_batch_retries = max_retained_batch_retries
         self._buffer_id = str(uuid.uuid4())
         self._flush_sequence = 0
-        self._buckets: dict[_DestinationKey, dict[_AggregateKey, _AggregateBucket]] = {}
+        self._buckets: dict[
+            _DestinationKey,
+            dict[_AggregateKey, list[_AggregateBucket]],
+        ] = {}
         self._source_events: dict[_DestinationKey, list[_BufferedSourceEvent]] = {}
         self._observation_buckets: dict[
             _DestinationKey,
-            dict[_ObservationAggregateKey, _ObservationAggregateBucket],
+            dict[_ObservationAggregateKey, list[_ObservationAggregateBucket]],
         ] = {}
         self._source_observations: dict[_DestinationKey, list[_BufferedSourceObservation]] = {}
         # Keep source and atomic admission keys across flushes so lifecycle
@@ -167,6 +172,9 @@ class _UsageBufferState:
     ) -> int:
         if atomic_source_key is not None:
             events = tuple(events)
+            if any(not is_usage_quantity(event["quantity"]) for event in events):
+                _log_rejected_usage_quantity(proxy_log_path, run_id, log_type)
+                return 0
             batch_source_keys = {event["idempotencyKey"] for event in events}
             if (
                 atomic_source_key in self._seen_source_keys
@@ -175,7 +183,7 @@ class _UsageBufferState:
             ):
                 return 0
 
-        buckets: dict[_AggregateKey, _AggregateBucket] | None = None
+        buckets: dict[_AggregateKey, list[_AggregateBucket]] | None = None
         source_events: list[_BufferedSourceEvent] | None = None
         destination = _DestinationKey(
             url,
@@ -187,6 +195,9 @@ class _UsageBufferState:
         )
         accepted_count = 0
         for event in events:
+            if not is_usage_quantity(event["quantity"]):
+                _log_rejected_usage_quantity(proxy_log_path, run_id, log_type)
+                continue
             source_key = event["idempotencyKey"]
             if source_key in self._seen_source_keys:
                 continue
@@ -204,7 +215,10 @@ class _UsageBufferState:
                     provider=event["provider"],
                     category=event["category"],
                 )
-                bucket = buckets.setdefault(aggregate_key, _AggregateBucket())
+                segments = buckets.setdefault(aggregate_key, [])
+                if not segments or segments[-1].quantity + event["quantity"] > MAX_USAGE_QUANTITY:
+                    segments.append(_AggregateBucket())
+                bucket = segments[-1]
                 bucket.quantity += event["quantity"]
                 bucket.source_event_count += 1
             self._source_event_count += 1
@@ -237,10 +251,17 @@ class _UsageBufferState:
             False,
             "model_usage_observation",
         )
-        buckets: dict[_ObservationAggregateKey, _ObservationAggregateBucket] | None = None
+        buckets: dict[_ObservationAggregateKey, list[_ObservationAggregateBucket]] | None = None
         source_observations: list[_BufferedSourceObservation] | None = None
         accepted_count = 0
         for observation in observations:
+            if not _observation_has_safe_quantities(observation):
+                _log_rejected_usage_quantity(
+                    proxy_log_path,
+                    run_id,
+                    "model_usage_observation",
+                )
+                continue
             source_key = observation["idempotencyKey"]
             if source_key in self._seen_source_keys:
                 continue
@@ -261,7 +282,10 @@ class _UsageBufferState:
                     run_id=run_id,
                     model=observation["model"],
                 )
-                bucket = buckets.setdefault(aggregate_key, _ObservationAggregateBucket())
+                segments = buckets.setdefault(aggregate_key, [])
+                if not segments or not _observation_fits_segment(segments[-1], observation):
+                    segments.append(_ObservationAggregateBucket())
+                bucket = segments[-1]
                 bucket.input_tokens += observation["inputTokens"]
                 bucket.output_tokens += observation["outputTokens"]
                 bucket.cache_read_input_tokens += observation["cacheReadInputTokens"]
@@ -281,9 +305,13 @@ class _UsageBufferState:
     def should_flush(self) -> bool:
         if self._source_event_count >= MAX_BUFFERED_SOURCE_EVENTS:
             return True
-        aggregate_bucket_count = sum(len(buckets) for buckets in self._buckets.values())
+        aggregate_bucket_count = sum(
+            len(segments) for buckets in self._buckets.values() for segments in buckets.values()
+        )
         aggregate_bucket_count += sum(
-            len(buckets) for buckets in self._observation_buckets.values()
+            len(segments)
+            for buckets in self._observation_buckets.values()
+            for segments in buckets.values()
         )
         if aggregate_bucket_count >= MAX_AGGREGATE_BUCKETS:
             return True
@@ -293,8 +321,10 @@ class _UsageBufferState:
         count = 0
         for buckets in self._buckets.values():
             events_by_run: dict[str, int] = {}
-            for aggregate_key in buckets:
-                events_by_run[aggregate_key.run_id] = events_by_run.get(aggregate_key.run_id, 0) + 1
+            for aggregate_key, segments in buckets.items():
+                events_by_run[aggregate_key.run_id] = events_by_run.get(
+                    aggregate_key.run_id, 0
+                ) + len(segments)
             count += sum(
                 (event_count + USAGE_EVENT_BATCH_SIZE - 1) // USAGE_EVENT_BATCH_SIZE
                 for event_count in events_by_run.values()
@@ -311,10 +341,10 @@ class _UsageBufferState:
             )
         for buckets in self._observation_buckets.values():
             observations_by_run: dict[str, int] = {}
-            for aggregate_key in buckets:
-                observations_by_run[aggregate_key.run_id] = (
-                    observations_by_run.get(aggregate_key.run_id, 0) + 1
-                )
+            for aggregate_key, segments in buckets.items():
+                observations_by_run[aggregate_key.run_id] = observations_by_run.get(
+                    aggregate_key.run_id, 0
+                ) + len(segments)
             count += sum(
                 (observation_count + USAGE_EVENT_BATCH_SIZE - 1) // USAGE_EVENT_BATCH_SIZE
                 for observation_count in observations_by_run.values()
@@ -571,7 +601,7 @@ class _UsageBufferState:
 
     def _build_flush_batches(
         self,
-        buckets: dict[_DestinationKey, dict[_AggregateKey, _AggregateBucket]],
+        buckets: dict[_DestinationKey, dict[_AggregateKey, list[_AggregateBucket]]],
         flush_sequence: int,
     ) -> list[_FlushBatch]:
         batches: list[_FlushBatch] = []
@@ -659,7 +689,7 @@ class _UsageBufferState:
         self,
         buckets_by_destination: dict[
             _DestinationKey,
-            dict[_ObservationAggregateKey, _ObservationAggregateBucket],
+            dict[_ObservationAggregateKey, list[_ObservationAggregateBucket]],
         ],
         flush_sequence: int,
     ) -> list[_FlushBatch]:
@@ -679,24 +709,26 @@ class _UsageBufferState:
                 buckets_by_destination[destination],
                 key=lambda item: (item.run_id, item.model),
             ):
-                bucket = buckets_by_destination[destination][aggregate_key]
-                observations_by_run.setdefault(aggregate_key.run_id, []).append(
-                    _FlushEvent(
-                        payload={
-                            "idempotencyKey": self._observation_aggregate_idempotency_key(
-                                destination,
-                                aggregate_key,
-                                flush_sequence,
-                            ),
-                            "model": aggregate_key.model,
-                            "inputTokens": bucket.input_tokens,
-                            "outputTokens": bucket.output_tokens,
-                            "cacheReadInputTokens": bucket.cache_read_input_tokens,
-                            "cacheCreationInputTokens": bucket.cache_creation_input_tokens,
-                        },
-                        source_event_count=bucket.source_event_count,
+                segments = buckets_by_destination[destination][aggregate_key]
+                for segment_index, bucket in enumerate(segments):
+                    observations_by_run.setdefault(aggregate_key.run_id, []).append(
+                        _FlushEvent(
+                            payload={
+                                "idempotencyKey": self._observation_aggregate_idempotency_key(
+                                    destination,
+                                    aggregate_key,
+                                    flush_sequence,
+                                    segment_index,
+                                ),
+                                "model": aggregate_key.model,
+                                "inputTokens": bucket.input_tokens,
+                                "outputTokens": bucket.output_tokens,
+                                "cacheReadInputTokens": bucket.cache_read_input_tokens,
+                                "cacheCreationInputTokens": bucket.cache_creation_input_tokens,
+                            },
+                            source_event_count=bucket.source_event_count,
+                        )
                     )
-                )
             batches.extend(_observation_flush_batches(destination, observations_by_run))
         return batches
 
@@ -729,7 +761,7 @@ class _UsageBufferState:
     def _events_by_run(
         self,
         destination: _DestinationKey,
-        buckets: dict[_AggregateKey, _AggregateBucket],
+        buckets: dict[_AggregateKey, list[_AggregateBucket]],
         flush_sequence: int,
     ) -> dict[str, list[_FlushEvent]]:
         events_by_run: dict[str, list[_FlushEvent]] = {}
@@ -742,21 +774,25 @@ class _UsageBufferState:
                 item.category,
             ),
         ):
-            bucket = buckets[aggregate_key]
-            event = _FlushEvent(
-                payload={
-                    "idempotencyKey": self._aggregate_idempotency_key(
-                        destination, aggregate_key, flush_sequence
-                    ),
-                    destination.resource_field_name: aggregate_key.provider,
-                    "category": aggregate_key.category,
-                    "quantity": bucket.quantity,
-                },
-                source_event_count=bucket.source_event_count,
-            )
-            if destination.include_kind:
-                event.payload["kind"] = aggregate_key.kind
-            events_by_run.setdefault(aggregate_key.run_id, []).append(event)
+            segments = buckets[aggregate_key]
+            for segment_index, bucket in enumerate(segments):
+                event = _FlushEvent(
+                    payload={
+                        "idempotencyKey": self._aggregate_idempotency_key(
+                            destination,
+                            aggregate_key,
+                            flush_sequence,
+                            segment_index,
+                        ),
+                        destination.resource_field_name: aggregate_key.provider,
+                        "category": aggregate_key.category,
+                        "quantity": bucket.quantity,
+                    },
+                    source_event_count=bucket.source_event_count,
+                )
+                if destination.include_kind:
+                    event.payload["kind"] = aggregate_key.kind
+                events_by_run.setdefault(aggregate_key.run_id, []).append(event)
         return events_by_run
 
     def _aggregate_idempotency_key(
@@ -764,6 +800,7 @@ class _UsageBufferState:
         destination: _DestinationKey,
         aggregate_key: _AggregateKey,
         flush_sequence: int,
+        segment_index: int,
     ) -> str:
         return derive_usage_idempotency_key(
             USAGE_EVENT_NAMESPACE_AGGREGATE,
@@ -777,6 +814,7 @@ class _UsageBufferState:
                 aggregate_key.kind,
                 aggregate_key.provider,
                 aggregate_key.category,
+                str(segment_index),
             ),
         )
 
@@ -785,6 +823,7 @@ class _UsageBufferState:
         destination: _DestinationKey,
         aggregate_key: _ObservationAggregateKey,
         flush_sequence: int,
+        segment_index: int,
     ) -> str:
         return derive_usage_idempotency_key(
             USAGE_OBSERVATION_NAMESPACE_AGGREGATE,
@@ -796,8 +835,35 @@ class _UsageBufferState:
                 destination.proxy_log_path,
                 aggregate_key.run_id,
                 aggregate_key.model,
+                str(segment_index),
             ),
         )
+
+
+def _observation_has_safe_quantities(observation: ModelUsageObservation) -> bool:
+    return all(
+        is_usage_quantity(quantity)
+        for quantity in (
+            observation["inputTokens"],
+            observation["outputTokens"],
+            observation["cacheReadInputTokens"],
+            observation["cacheCreationInputTokens"],
+        )
+    )
+
+
+def _observation_fits_segment(
+    bucket: _ObservationAggregateBucket,
+    observation: ModelUsageObservation,
+) -> bool:
+    return (
+        bucket.input_tokens + observation["inputTokens"] <= MAX_USAGE_QUANTITY
+        and bucket.output_tokens + observation["outputTokens"] <= MAX_USAGE_QUANTITY
+        and bucket.cache_read_input_tokens + observation["cacheReadInputTokens"]
+        <= MAX_USAGE_QUANTITY
+        and bucket.cache_creation_input_tokens + observation["cacheCreationInputTokens"]
+        <= MAX_USAGE_QUANTITY
+    )
 
 
 def _observation_flush_batches(

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -73,6 +73,7 @@ _DEFAULT_MAX_DEPTH = 256
 _SLOW_SCALAR_BYTES_PER_WORK_UNIT = 32
 _DISCARDED_ASCII_BYTES_PER_WORK_UNIT = 64 * 1024
 JSON_WORK_LIMIT_EXCEEDED = "work limit exceeded"
+JSON_INTEGER_VALUE_LIMIT_EXCEEDED = "integer value limit exceeded"
 _JSON_STRING_OR_CONTAINER_RE = re.compile(rb'"(?:\\.|[^"\\])*"|[{}\[\]]', re.DOTALL)
 
 
@@ -114,7 +115,8 @@ class ScalarField:
     """Selected scalar field configuration.
 
     ``kind`` must be ``"string"``, ``"int"``, or ``"bool"``. ``max_bytes``
-    limits selected string and integer tokens; booleans use fixed JSON literals.
+    limits selected string and integer tokens; ``max_int_value`` optionally
+    limits selected integer values; booleans use fixed JSON literals.
     ``overflow_policy`` defaults to ``"error"``, which fails extraction with
     ``"string limit exceeded"`` or ``"number limit exceeded"``. Selected
     strings may use ``"discard"`` to stop retaining an oversized optional
@@ -124,6 +126,7 @@ class ScalarField:
     kind: ScalarKind
     max_bytes: int = 4096
     overflow_policy: ScalarOverflowPolicy = "error"
+    max_int_value: int | None = None
 
     def __post_init__(self) -> None:
         if self.kind not in ("string", "int", "bool"):
@@ -133,6 +136,10 @@ class ScalarField:
             raise ValueError("scalar field overflow_policy must be 'error' or 'discard'")
         if self.kind != "string" and self.overflow_policy == "discard":
             raise ValueError("scalar field overflow_policy 'discard' requires a string field")
+        if self.max_int_value is not None:
+            if self.kind != "int":
+                raise ValueError("scalar field max_int_value requires an integer field")
+            _validate_positive_int("scalar field max_int_value", self.max_int_value)
 
 
 @dataclass
@@ -1005,6 +1012,10 @@ class JsonSelectiveExtractor:
             self._error = "invalid number"
             return
         if state.selected and isinstance(value, int) and not isinstance(value, bool):
+            field = self.scalar_fields[state.path]
+            if field.max_int_value is not None and value > field.max_int_value:
+                self._error = JSON_INTEGER_VALUE_LIMIT_EXCEEDED
+                return
             self._record_scalar_consistency(state.path, value)
             self.values[state.path] = value
         self._value_complete()

--- a/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
+++ b/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
@@ -22,6 +22,7 @@ from .model_tokens import (
     MODEL_USAGE_CATEGORY_OUTPUT,
 )
 from .openai_tokens import is_usage_quantity, partition_input_tokens
+from .quantities import MAX_USAGE_QUANTITY
 from .sse import SseUsageScanner
 
 _CHAT_COMPLETIONS_MAX_WORK_UNITS = 65_536
@@ -39,7 +40,11 @@ _CHAT_COMPLETIONS_SCALAR_FIELDS = {
     ("model",): ScalarField("string", max_bytes=1024),
     ("service_tier",): ScalarField("string", max_bytes=1024),
     **{
-        (*prefix, field): ScalarField("int", max_bytes=64)
+        (*prefix, field): ScalarField(
+            "int",
+            max_bytes=64,
+            max_int_value=MAX_USAGE_QUANTITY,
+        )
         for prefix in _USAGE_PATHS
         for field in (
             "prompt_tokens",
@@ -48,7 +53,11 @@ _CHAT_COMPLETIONS_SCALAR_FIELDS = {
         )
     },
     **{
-        (*prefix, "prompt_tokens_details", field): ScalarField("int", max_bytes=64)
+        (*prefix, "prompt_tokens_details", field): ScalarField(
+            "int",
+            max_bytes=64,
+            max_int_value=MAX_USAGE_QUANTITY,
+        )
         for prefix in _USAGE_PATHS
         for field in ("cached_tokens", "cache_write_tokens")
     },

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -33,6 +33,7 @@ from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
 
 from .json_probe import TopLevelStringFieldProbeResult, probe_top_level_string_field
 from .json_selective import (
+    JSON_INTEGER_VALUE_LIMIT_EXCEEDED,
     JSON_WORK_LIMIT_EXCEEDED,
     JsonExtractionResult,
     JsonSelectiveExtractor,
@@ -47,6 +48,7 @@ from .model_tokens import (
 )
 from .openai_tokens import is_usage_quantity as _is_usage_quantity
 from .openai_tokens import partition_input_tokens as _partition_input_tokens
+from .quantities import MAX_USAGE_QUANTITY
 from .sse import SseUsageScanner
 
 # Terminal Responses events whose Response object may carry usage. WebSocket
@@ -138,7 +140,7 @@ _RESPONSES_EVENT_PREFILTER_MAX_BYTES = 4096
 # Bound dense syntax and slow scalar inspection while retaining the selective
 # parser's bulk-scan path for ordinary large content strings.
 _RESPONSES_MAX_WORK_UNITS = 65_536
-_RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR = "work_limit_exceeded"
+OPENAI_RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR = "work_limit_exceeded"
 _RESPONSES_CREATE_EVENT = "response.create"
 _RESPONSES_CREATED_EVENT = "response.created"
 _RESPONSES_ERROR_EVENT = "error"
@@ -209,10 +211,14 @@ _RESPONSES_RESPONSE_SCALAR_FIELDS = {
     ("id",): ScalarField("string", max_bytes=1024),
     ("model",): ScalarField("string", max_bytes=1024),
     ("service_tier",): ScalarField("string", max_bytes=1024),
-    ("usage", "input_tokens"): ScalarField("int", max_bytes=64),
-    ("usage", "output_tokens"): ScalarField("int", max_bytes=64),
-    ("usage", "input_tokens_details", "cached_tokens"): ScalarField("int", max_bytes=64),
-    ("usage", "input_tokens_details", "cache_write_tokens"): ScalarField("int", max_bytes=64),
+    ("usage", "input_tokens"): ScalarField("int", max_bytes=64, max_int_value=MAX_USAGE_QUANTITY),
+    ("usage", "output_tokens"): ScalarField("int", max_bytes=64, max_int_value=MAX_USAGE_QUANTITY),
+    ("usage", "input_tokens_details", "cached_tokens"): ScalarField(
+        "int", max_bytes=64, max_int_value=MAX_USAGE_QUANTITY
+    ),
+    ("usage", "input_tokens_details", "cache_write_tokens"): ScalarField(
+        "int", max_bytes=64, max_int_value=MAX_USAGE_QUANTITY
+    ),
 }
 
 _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS = {
@@ -327,10 +333,12 @@ def _usage_from_extraction(
 ) -> tuple[dict | None, str | None]:
     if not result.complete:
         error = (
-            _RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR
+            OPENAI_RESPONSES_WEBSOCKET_WORK_LIMIT_ERROR
             if result.error == JSON_WORK_LIMIT_EXCEEDED
             else None
         )
+        if result.error == JSON_INTEGER_VALUE_LIMIT_EXCEEDED:
+            error = result.error
         return None, error
 
     extracted_usage: dict = {}
@@ -984,9 +992,10 @@ def extract_openai_responses_usage_from_event(
     top-level ``type`` independently of ``event.event_type``.
 
     Returns ``(usage, None)`` when usage is extracted. Exhausting the selective
-    parser's work budget returns ``(None, "work_limit_exceeded")``; no other
-    inspection failure is surfaced. Known non-usage events, other incomplete or
-    malformed frames, and frames without extractable usage return ``(None, None)``.
+    parser's work budget returns ``(None, "work_limit_exceeded")`` and an
+    out-of-range selected usage integer returns the bounded parser error. Known
+    non-usage events, other incomplete or malformed frames, and frames without
+    extractable usage return ``(None, None)``.
     """
     inspection = inspect_openai_responses_server_event(event, include_lifecycle=False)
     return inspection.usage, inspection.usage_error

--- a/crates/runner/mitm-addon/src/usage/openai_tokens.py
+++ b/crates/runner/mitm-addon/src/usage/openai_tokens.py
@@ -1,11 +1,6 @@
 """Shared OpenAI-compatible token normalization."""
 
-from typing import TypeGuard
-
-
-def is_usage_quantity(value: object) -> TypeGuard[int]:
-    """Return whether a provider value is a nonnegative integer token count."""
-    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+from .quantities import is_usage_quantity
 
 
 def partition_input_tokens(

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -52,6 +52,7 @@ from ..model_tokens import (
     MODEL_USAGE_CATEGORY_INPUT,
     MODEL_USAGE_CATEGORY_OUTPUT,
 )
+from ..quantities import is_usage_quantity
 from ..reporting_context import UsageReportingContext, usage_reporting_context
 from ..underbilling import log_usage_underbilling
 
@@ -884,11 +885,11 @@ def _reported_model(flow: http.HTTPFlow, usage: dict) -> str:
 
 
 def _is_positive_int(value: object) -> TypeGuard[int]:
-    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+    return is_usage_quantity(value) and value > 0
 
 
 def _is_non_negative_int(value: object) -> TypeGuard[int]:
-    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+    return is_usage_quantity(value)
 
 
 def _positive_int_or_zero(value: object) -> int:

--- a/crates/runner/mitm-addon/src/usage/quantities.py
+++ b/crates/runner/mitm-addon/src/usage/quantities.py
@@ -1,0 +1,12 @@
+"""Exact integer contract for usage quantities."""
+
+from typing import TypeGuard
+
+MAX_USAGE_QUANTITY = (1 << 53) - 1
+
+
+def is_usage_quantity(value: object) -> TypeGuard[int]:
+    """Return whether a value is an exact nonnegative cross-layer quantity."""
+    return (
+        isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= MAX_USAGE_QUANTITY
+    )

--- a/crates/runner/mitm-addon/tests/test_json_selective_numbers.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_numbers.py
@@ -7,6 +7,7 @@ from typing import Literal, Never
 import pytest
 
 from usage.json_selective import (
+    JSON_INTEGER_VALUE_LIMIT_EXCEEDED,
     JsonExtractionResult,
     JsonSelectiveExtractor,
     Path,
@@ -247,6 +248,53 @@ def test_rejects_oversized_number_with_field_limit():
 
     assert result.complete is False
     assert result.error == "number limit exceeded"
+
+
+@pytest.mark.parametrize("feed_mode", ["whole", "bytewise"])
+def test_selected_integer_value_limit_accepts_boundary_and_rejects_larger_value(
+    feed_mode: _NumberFeedMode,
+):
+    maximum = 9_007_199_254_740_991
+    scalar_fields = {("usage", "input_tokens"): ScalarField("int", max_int_value=maximum)}
+
+    accepted = JsonSelectiveExtractor(scalar_fields=scalar_fields)
+    accepted_payload = f'{{"usage":{{"input_tokens":{maximum}}}}}'.encode()
+    for chunk in _number_chunks(
+        accepted_payload,
+        accepted_payload.index(str(maximum).encode()),
+        len(str(maximum)),
+        (),
+        feed_mode,
+    ):
+        accepted.feed(chunk)
+
+    accepted_result = accepted.finish()
+    assert accepted_result.complete is True
+    assert accepted_result.values == {("usage", "input_tokens"): maximum}
+
+    rejected = JsonSelectiveExtractor(scalar_fields=scalar_fields)
+    rejected_payload = f'{{"usage":{{"input_tokens":{maximum + 1}}}}}'.encode()
+    for chunk in _number_chunks(
+        rejected_payload,
+        rejected_payload.index(str(maximum + 1).encode()),
+        len(str(maximum + 1)),
+        (),
+        feed_mode,
+    ):
+        rejected.feed(chunk)
+
+    rejected_result = rejected.finish()
+    assert rejected_result.complete is False
+    assert rejected_result.error == JSON_INTEGER_VALUE_LIMIT_EXCEEDED
+    _assert_no_observations(rejected_result)
+
+
+def test_integer_value_limit_requires_integer_field():
+    with pytest.raises(
+        ValueError,
+        match="scalar field max_int_value requires an integer field",
+    ):
+        ScalarField("string", max_int_value=10)
 
 
 def test_rejects_oversized_unselected_number():

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -31,6 +31,8 @@ from tests.model_provider_response_helpers import (
     run_response,
     standard_success_payload,
 )
+from tests.usage_helpers import compact_observation_quantities
+from usage.quantities import MAX_USAGE_QUANTITY
 
 
 def _deterministic_low_ratio_text(size: int) -> str:
@@ -163,6 +165,108 @@ class TestModelProviderJsonStreaming:
         assert by_category == expected_event_quantities(
             provider_case,
             cache_write_tokens=cache_write_tokens,
+        )
+
+    @pytest.mark.parametrize(
+        "provider_case",
+        MODEL_PROVIDER_JSON_CASES,
+        ids=model_provider_json_case_id,
+    )
+    def test_full_pipeline_out_of_range_model_json_quantity_is_rejected(
+        self,
+        tmp_path,
+        real_flow,
+        provider_case,
+    ):
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow = model_provider_flow(
+            real_flow,
+            tmp_path,
+            provider_case,
+            proxy_log_path=proxy_log_path,
+        )
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            standard_success_payload(
+                provider_case,
+                input_tokens=MAX_USAGE_QUANTITY + 1,
+            )
+        )
+
+        webhook = run_response(flow, self._usage_webhook_api)
+
+        assert webhook.request_count == 0
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+        entries = read_jsonl_entries_after_flush(proxy_log_path)
+        [warning] = [
+            entry
+            for entry in entries
+            if entry.get("message") == "Model provider JSON usage extraction failed"
+        ]
+        assert warning["level"] == "warn"
+        assert warning["type"] == "usage_event"
+        assert warning["error"] == "integer value limit exceeded"
+
+    @pytest.mark.parametrize(
+        "provider_case",
+        MODEL_PROVIDER_JSON_CASES,
+        ids=model_provider_json_case_id,
+    )
+    def test_full_pipeline_exact_integer_boundary_is_reported(
+        self,
+        tmp_path,
+        real_flow,
+        provider_case,
+    ):
+        flow = model_provider_flow(
+            real_flow,
+            tmp_path,
+            provider_case,
+            proxy_log_path=tmp_path / "proxy.jsonl",
+        )
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            standard_success_payload(
+                provider_case,
+                input_tokens=MAX_USAGE_QUANTITY,
+            )
+        )
+
+        webhook = run_response(flow, self._usage_webhook_api)
+
+        input_categories = (
+            "tokens.input",
+            "tokens.cache_read",
+            "tokens.cache_creation",
+        )
+        assert (
+            sum(
+                event["quantity"]
+                for event in webhook.usage_events()
+                if event["category"].startswith(input_categories)
+            )
+            == MAX_USAGE_QUANTITY
+        )
+        observation_quantities = compact_observation_quantities(
+            webhook.model_usage_observation_events()
+        )
+        assert (
+            sum(
+                quantity
+                for category, quantity in observation_quantities.items()
+                if category.startswith(input_categories)
+            )
+            == MAX_USAGE_QUANTITY
         )
 
     @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_source_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_source_reporting.py
@@ -25,6 +25,7 @@ from tests.model_provider_websocket_helpers import (
     set_websocket_message,
 )
 from tests.usage_helpers import assert_usage_event_rows
+from usage.quantities import MAX_USAGE_QUANTITY
 
 
 @pytest.fixture(autouse=True)
@@ -282,6 +283,38 @@ class TestModelProviderWebSocketSourceReporting:
         ]
         assert_usage_event_rows(webhook.usage_events(), "provider", expected_rows)
         assert_usage_event_rows(webhook.model_usage_observation_events(), "model", expected_rows)
+
+    def test_model_websocket_out_of_range_quantity_warns_without_correlation_failure(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+
+        with self._usage_webhook_api() as webhook:
+            feed_websocket_server_message(
+                flow,
+                openai_websocket_usage_frame(
+                    "resp_out_of_range",
+                    input_tokens=MAX_USAGE_QUANTITY + 1,
+                    output_tokens=3,
+                ),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        assert webhook.request_count == 0
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
+        assert model_provider_usage_sources(flow) == {}
+        proxy_entries = read_jsonl_entries_after_flush(proxy_log)
+        [warning] = [
+            entry
+            for entry in proxy_entries
+            if entry.get("message") == "Model provider WebSocket usage extraction failed"
+        ]
+        assert warning["error"] == "integer value limit exceeded"
+        assert not any(entry.get("type") == "model_usage_correlation" for entry in proxy_entries)
 
     def test_model_websocket_text_frame_reports_usage(self, tmp_path, real_flow):
         flow = make_openai_responses_websocket_flow(real_flow, tmp_path)

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -17,6 +17,7 @@ from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import make_model_provider_flow
 from tests.stream_buffer_helpers import set_response_stream_buffer
 from tests.usage_helpers import compact_observation_quantities
+from usage.quantities import MAX_USAGE_QUANTITY
 
 
 def _chat_completions_flow(
@@ -262,6 +263,50 @@ class TestOpenAIChatCompletionsUsage:
         assert warnings[0]["usage_protocol"] == "openai_chat_completions_sse"
         assert warnings[0]["event"] == "eventless"
         assert warnings[0]["error"] == "incomplete json"
+
+    @pytest.mark.parametrize(
+        "input_tokens",
+        [MAX_USAGE_QUANTITY + 1, int("9" * 64)],
+        ids=("above-safe-integer", "maximum-width-integer"),
+    )
+    def test_out_of_range_sse_quantity_fails_closed_with_bounded_diagnostic(
+        self,
+        tmp_path,
+        real_flow,
+        input_tokens,
+    ):
+        flow = _chat_completions_flow(
+            tmp_path,
+            real_flow,
+            content_type="text/event-stream",
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(
+            b"data: "
+            + _chat_payload(
+                usage_payload={
+                    "prompt_tokens": input_tokens,
+                    "completion_tokens": 5,
+                }
+            )
+            + b"\n\ndata: [DONE]\n\n"
+        )
+
+        webhook = _run_response(flow, self._usage_webhook_api)
+
+        assert webhook.request_count == 0
+        warnings = [
+            entry
+            for entry in read_jsonl_entries_after_flush(
+                Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+            )
+            if entry.get("message") == "Model provider SSE usage extraction failed"
+        ]
+        assert len(warnings) == 1
+        assert warnings[0]["usage_protocol"] == "openai_chat_completions_sse"
+        assert warnings[0]["event"] == "eventless"
+        assert warnings[0]["error"] == "integer value limit exceeded"
 
     def test_malformed_sse_clears_prior_usage_before_terminal_reporting(
         self,

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
@@ -4,8 +4,10 @@ import uuid
 
 import usage
 import usage.buffer as usage_buffer
+from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.pending_helpers import assert_current_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event, observation
+from usage.quantities import MAX_USAGE_QUANTITY
 
 
 def test_flush_aggregates_same_bucket_and_dedupes_source_key(tmp_path):
@@ -42,6 +44,184 @@ def test_flush_aggregates_same_bucket_and_dedupes_source_key(tmp_path):
     ]
     uuid.UUID(payload["events"][0]["idempotencyKey"])
     assert enqueue.last_call.proxy_log_path == proxy_log_path
+
+
+def test_flush_segments_aggregate_before_quantity_exceeds_exact_integer_range(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [
+            event(source_key="source-1", quantity=MAX_USAGE_QUANTITY),
+            event(source_key="source-2", quantity=1),
+        ],
+        str(tmp_path / "proxy.jsonl"),
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    enqueue.assert_called_once()
+    events = enqueue.last_call.payload["events"]
+    assert [flushed_event["quantity"] for flushed_event in events] == [
+        MAX_USAGE_QUANTITY,
+        1,
+    ]
+    assert len({flushed_event["idempotencyKey"] for flushed_event in events}) == 2
+
+
+def test_flush_keeps_model_observation_source_vector_in_one_safe_segment(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    usage.buffer_model_usage_observations(
+        "https://api.test/api/webhooks/agent/model-usage-observation",
+        "token-a",
+        "run-1",
+        [
+            observation(
+                source_key="source-1",
+                input_tokens=MAX_USAGE_QUANTITY,
+                output_tokens=3,
+            ),
+            observation(
+                source_key="source-2",
+                input_tokens=1,
+                output_tokens=4,
+            ),
+        ],
+        str(tmp_path / "proxy.jsonl"),
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    enqueue.assert_called_once()
+    events = enqueue.last_call.payload["events"]
+    assert [
+        (flushed_event["inputTokens"], flushed_event["outputTokens"]) for flushed_event in events
+    ] == [(MAX_USAGE_QUANTITY, 3), (1, 4)]
+    assert len({flushed_event["idempotencyKey"] for flushed_event in events}) == 2
+
+
+def test_rejects_out_of_range_source_quantity_before_recording_idempotency(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    accepted_source_keys: set[str] = set()
+
+    assert (
+        usage.buffer_source_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [event(source_key="source-1", quantity=MAX_USAGE_QUANTITY + 1)],
+            str(proxy_log_path),
+            accepted_source_keys=accepted_source_keys,
+        )
+        == 0
+    )
+    assert accepted_source_keys == set()
+    assert (
+        usage.buffer_source_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [event(source_key="source-1", quantity=1)],
+            str(proxy_log_path),
+            accepted_source_keys=accepted_source_keys,
+        )
+        == 1
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    assert enqueue.last_call.payload["events"][0]["quantity"] == 1
+    [warning] = [
+        entry
+        for entry in read_jsonl_entries_after_flush(proxy_log_path)
+        if entry.get("reason") == "usage_quantity_out_of_range"
+    ]
+    assert warning["type"] == "usage_underbilling"
+    assert warning["underbilling_class"] == "confirmed"
+    assert "quantity" not in warning
+
+
+def test_out_of_range_atomic_group_rejects_every_member_before_idempotency(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    source_events = [
+        event(source_key="source-input", quantity=10),
+        event(
+            source_key="source-cache-read",
+            category="tokens.cache_read",
+            quantity=MAX_USAGE_QUANTITY + 1,
+        ),
+    ]
+
+    assert (
+        usage.buffer_source_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            source_events,
+            proxy_log_path,
+            atomic_source_key="input-partition-1",
+        )
+        == 0
+    )
+    source_events[1]["quantity"] = 4
+    assert (
+        usage.buffer_source_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            source_events,
+            proxy_log_path,
+            atomic_source_key="input-partition-1",
+        )
+        == 2
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    assert [flushed_event["quantity"] for flushed_event in enqueue.last_call.payload["events"]] == [
+        10,
+        4,
+    ]
+
+
+def test_rejects_out_of_range_model_observation_before_recording_idempotency(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = tmp_path / "proxy.jsonl"
+    accepted_source_keys: set[str] = set()
+
+    assert (
+        usage.buffer_source_model_usage_observations(
+            "https://api.test/api/webhooks/agent/model-usage-observation",
+            "token-a",
+            "run-1",
+            [
+                observation(
+                    source_key="source-1",
+                    cache_creation_input_tokens=MAX_USAGE_QUANTITY + 1,
+                )
+            ],
+            str(proxy_log_path),
+            accepted_source_keys=accepted_source_keys,
+        )
+        == 0
+    )
+    assert accepted_source_keys == set()
+    assert usage.flush_usage_events(trigger="test") == 0
+    enqueue.assert_not_called()
+    [warning] = [
+        entry
+        for entry in read_jsonl_entries_after_flush(proxy_log_path)
+        if entry.get("reason") == "usage_quantity_out_of_range"
+    ]
+    assert warning["type"] == "model_usage_observation"
+    assert warning["level"] == "warn"
+    assert "quantity" not in warning
 
 
 def test_model_usage_observation_buffer_uses_model_event_shape(tmp_path):
@@ -494,6 +674,32 @@ def test_flushes_when_aggregate_bucket_count_reaches_exact_bound(tmp_path):
     payload = enqueue.last_call.payload
     assert payload["runId"] == "run-1"
     assert len(payload["events"]) == usage_buffer.MAX_AGGREGATE_BUCKETS
+
+
+def test_flushes_when_safe_quantity_segments_reach_aggregate_bucket_bound(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+
+    accepted = usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [
+            event(
+                source_key=f"source-{index}",
+                quantity=MAX_USAGE_QUANTITY,
+            )
+            for index in range(usage_buffer.MAX_AGGREGATE_BUCKETS)
+        ],
+        str(tmp_path / "proxy.jsonl"),
+    )
+
+    assert accepted == usage_buffer.MAX_AGGREGATE_BUCKETS
+    enqueue.assert_called_once()
+    events = enqueue.last_call.payload["events"]
+    assert len(events) == usage_buffer.MAX_AGGREGATE_BUCKETS
+    assert all(flushed_event["quantity"] == MAX_USAGE_QUANTITY for flushed_event in events)
+    assert len({flushed_event["idempotencyKey"] for flushed_event in events}) == len(events)
 
 
 def test_flushes_when_model_observation_bucket_count_reaches_exact_bound(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -17,6 +17,7 @@ from tests.usage_buffer_helpers import (
     event,
     observation,
 )
+from usage.quantities import MAX_USAGE_QUANTITY
 
 
 def assert_usage_buffer_drained(enqueue: RecordingEnqueue) -> None:
@@ -76,6 +77,37 @@ def test_flush_failure_preserves_retryable_payload_with_same_idempotency_key(tmp
         reports=0,
         flush_request_id="enqueue-drained",
     )
+
+
+def test_segmented_aggregate_retry_preserves_payload_and_idempotency_keys(tmp_path):
+    enqueue = RecordingEnqueue(return_value=False)
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    usage.buffer_usage_events(
+        "https://api.test/api/webhooks/agent/usage-event",
+        "token-a",
+        "run-1",
+        [
+            event(source_key="source-1", quantity=MAX_USAGE_QUANTITY),
+            event(source_key="source-2", quantity=1),
+        ],
+        str(tmp_path / "proxy.jsonl"),
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 0
+    enqueue.assert_called_once()
+    retained_payload = enqueue.last_call.payload
+    assert [flushed_event["quantity"] for flushed_event in retained_payload["events"]] == [
+        MAX_USAGE_QUANTITY,
+        1,
+    ]
+
+    enqueue.return_value = True
+    enqueue.clear()
+    assert usage.flush_usage_events(trigger="test") == 1
+
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload == retained_payload
+    assert_usage_buffer_drained(enqueue)
 
 
 def test_partial_flush_failure_retains_only_unfinished_batch_after_completed_success(tmp_path):

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts
@@ -35,7 +35,7 @@ describe("agent usage event webhook", () => {
               kind: "connector",
               provider: "x",
               category: "tweet.read",
-              quantity: 1,
+              quantity: Number.MAX_SAFE_INTEGER,
             },
           ],
         },
@@ -56,5 +56,35 @@ describe("agent usage event webhook", () => {
         eventCount: 1,
       }),
     );
+  });
+
+  it("rejects a usage quantity above the exact integer range", async () => {
+    const runId = randomUUID();
+    const orgId = `org_usage_unsafe_${randomUUID().slice(0, 8)}`;
+    const userId = `user_usage_unsafe_${randomUUID().slice(0, 8)}`;
+    const sandboxToken = generateSandboxToken(userId, runId, orgId);
+
+    await accept(
+      setupApp({ context, routes: webhooksAgentHealthUsageTelemetryRoutes })(
+        webhookUsageEventContract,
+      ).send({
+        headers: { authorization: `Bearer ${sandboxToken}` },
+        body: {
+          runId,
+          events: [
+            {
+              idempotencyKey: randomUUID(),
+              kind: "connector",
+              provider: "x",
+              category: "tweet.read",
+              quantity: Number.MAX_SAFE_INTEGER + 1,
+            },
+          ],
+        },
+      }),
+      [400],
+    );
+
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -1052,7 +1052,7 @@ const webhookUsageEventItemSchema = z
     kind: z.enum(["connector", "model", "image"]),
     provider: z.string().min(1).max(100),
     category: z.string().min(1).max(100),
-    quantity: z.number().int().min(0),
+    quantity: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- enforce `Number.MAX_SAFE_INTEGER` as the exact cross-layer usage quantity limit
- reject out-of-range model counters across JSON, SSE, and WebSocket parsing with bounded diagnostics
- reject unsafe shared-buffer inputs before deduplication and split valid aggregate overflow into safe, retry-stable segments
- enforce the same maximum in the billing webhook contract

## Compatibility

- no request shape or database schema changes
- new runners remain compatible with older APIs
- the new API validation rejects only quantities that the JavaScript/Drizzle number path cannot represent exactly

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (6,407 passed)
- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @okouai/api-contracts test` (585 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-health-usage-telemetry.test.ts` (2 passed)
- `pnpm knip`

Closes #28331
