### PR TITLE
fix(api-contracts): declare billing checkout preview in the okou namespace

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/__tests__/api-namespace-declarations.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/api-namespace-declarations.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { brandedApiNamespace } from "../api-namespaces";
+import * as apiContracts from "../index";
+
+interface DeclaredRoute {
+  readonly declaration: string;
+  readonly method: string;
+  readonly path: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function toDeclaredRoute(
+  declaration: string,
+  value: unknown,
+): DeclaredRoute | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const { method, path } = value;
+  if (typeof method !== "string" || typeof path !== "string") {
+    return undefined;
+  }
+  return { declaration, method, path };
+}
+
+/**
+ * Enumerates every route declared by a contract exported from the package
+ * barrel. Walking the barrel rather than the source files means a route added
+ * to an already-exported contract is covered without touching this test.
+ */
+function declaredRoutes(): readonly DeclaredRoute[] {
+  const routes: DeclaredRoute[] = [];
+  for (const [exportName, exported] of Object.entries(apiContracts)) {
+    if (!isRecord(exported)) {
+      continue;
+    }
+    for (const [routeName, route] of Object.entries(exported)) {
+      const declared = toDeclaredRoute(`${exportName}.${routeName}`, route);
+      if (declared) {
+        routes.push(declared);
+      }
+    }
+  }
+  return routes;
+}
+
+describe("branded API namespace declarations", () => {
+  const routes = declaredRoutes();
+
+  it("enumerates branded contract routes through the package barrel", () => {
+    const brandedRoutes = routes.filter(({ path }) => {
+      return brandedApiNamespace(path) !== undefined;
+    });
+
+    expect(brandedRoutes.length).toBeGreaterThan(100);
+    expect(
+      brandedRoutes.some(({ method, path }) => {
+        return (
+          method === "POST" &&
+          path === "/api/okou/billing/concurrency-checkout/preview"
+        );
+      }),
+    ).toBe(true);
+  });
+
+  it("declares every branded contract path in the Okou namespace", () => {
+    const legacyDeclarations = routes
+      .filter(({ path }) => {
+        return brandedApiNamespace(path) === "zero";
+      })
+      .map(({ declaration, method, path }) => {
+        return `${declaration} declares ${method} ${path}`;
+      });
+
+    expect(
+      legacyDeclarations,
+      "A declared contract path is the URL its ts-rest clients request, so a /api/zero/ declaration makes current clients produce legacy-namespace traffic. Declare branded paths as /api/okou/...; the /api/zero/ alias exists only for already-released clients.",
+    ).toStrictEqual([]);
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/billing.ts
@@ -965,7 +965,7 @@ export type BillingUsagePackMigrationContract =
 export const billingConcurrencyCheckoutContract = c.router({
   preview: {
     method: "POST",
-    path: "/api/zero/billing/concurrency-checkout/preview",
+    path: "/api/okou/billing/concurrency-checkout/preview",
     headers: authHeadersSchema,
     body: concurrencyCheckoutPreviewRequestSchema,
     responses: {


### PR DESCRIPTION
Closes #28350

## What changed

`billingConcurrencyCheckoutContract.preview` was the only branded contract path in `packages/api-contracts` declared under `/api/zero/`. It now declares the canonical branded path:

```ts
path: "/api/okou/billing/concurrency-checkout/preview",
```

The declared path is what a ts-rest client uses to build its request URL, and `apps/platform/src/signals/zero-page/billing.ts` imports this contract — so the current Platform build was actively producing legacy-namespace traffic inside a single checkout flow (`preview` on `/api/zero/...`, the adjacent `create` on `/api/okou/...`).

Safe to ship alone: `apiNamespaceAliasPaths()` still registers both namespaces, so already-loaded bundles keep reaching `/api/zero/...`. The Rust and Python binding generators do not include this path.

## Guard

New assertion test at `packages/api-contracts/src/contracts/__tests__/api-namespace-declarations.test.ts`:

- Enumerates route declarations through the existing barrel (`src/contracts/index.ts`), not by scanning files.
- Fails if any enumerated contract declares a path beginning with `/api/zero/`, with a message explaining that the declaration is what clients send.
- A non-vacuity check asserts the walk actually yields branded routes and includes the corrected preview route, so a broken walk cannot make the assertion pass silently.

Per the issue, the existing `no-non-zero-api` ESLint rule was left untouched — extending it to the contracts package would reject the neutral `/api/webhooks/**`, `/api/integrations/**`, and `/api/connectors/**` namespaces that #28278 is introducing.

`apiNamespaceAliasPaths()`, `BRANDED_API_NAMESPACE_PATHS`, the `/api/zero/**` aliases, and every other contract path are unchanged.

## Coverage note for the reviewer

`src/contracts/index.ts` re-exports from 125 of the package's 170 contract modules; 66 of the 291 contract routers (for example everything in `./browser`) are consumed only through the `./contracts/*` subpath export and never appear in the barrel. The new assertion therefore guards the barrel-reachable contracts, which includes the route fixed here. Closing that remaining gap would mean either broadening the barrel or enumerating modules some other way — out of scope here, and worth a follow-up if you want the guard to be exhaustive.

## Verification

Local dependency installation is blocked in this environment (the npm registry is not reachable from the run), so lint, type-check, and vitest were not run locally; CI covers them. Existing coverage that exercises this change:

- `apps/api/src/__tests__/api-namespace-compatibility.test.ts` asserts every route in `ROUTES` registers symmetric `/api/okou/...` and `/api/zero/...` paths against the same handler and schema, independent of which namespace the contract declares.
- `apps/api/src/signals/routes/__tests__/billing-checkout.test.ts` and the Platform billing/queue tests drive the route through the contract object, so they follow the declared path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
